### PR TITLE
fix type error

### DIFF
--- a/STORIES.md
+++ b/STORIES.md
@@ -2,17 +2,26 @@
 
 ## Guiding principles
 
-### For Humans and Autonomous Agents
+### For Humans + Autonomous Agents
 
-agor needs to work for both humans (locally) and Tembo (background cloud tasks). While humans may prefer UI, Tembo platform would require a CLI or API/SDK. Ideally both humans and Tembo generate the same artifacts, so humans can transfer sessions to Tembo and vice versa - Tembo is just another dev.
+agor needs to work for both humans (locally) and Tembo (background cloud tasks).
+
+While humans may prefer UI, Tembo platform would require a CLI or API/SDK.
+
+Ideally both humans and Tembo generate the same artifacts,
+so humans can transfer sessions to Tembo and vice versa - Tembo is just another dev.
 
 ### Open source
 
-When I'm choosing AI development infrastructure, I want open source and vendor-neutral solutions, so I can avoid lock-in and contribute to community-driven improvements.
+When I'm choosing AI development infrastructure,
+I want open source and vendor-neutral solutions,
+so I can avoid lock-in and contribute to community-driven improvements.
 
 ### Coding Agent Agnostic
 
-When I'm context-switching between agents, I want zero conflicts and seamless transitions, so I can use the best tool for each specific task without workflow disruption.
+When I'm context-switching between agents,
+I want zero conflicts and seamless transitions,
+so I can use the best tool for each specific task without workflow disruption.
 
 ---
 
@@ -22,29 +31,41 @@ When I'm context-switching between agents, I want zero conflicts and seamless tr
 
 `agor session start --agent <agent> --concepts <concepts> --task <task>`
 
-When I want to start a coding agent session, I want a CLI that allows me to specify the agent, the context, and the task, so I can start a session with a single command from the terminal.
+When I want to start a coding agent session,
+I want a CLI that allows me to specify the agent, the context, and the task,
+so I can start a session with a single command from the terminal.
 
 ### Session Subtasks
 
 `agor session subtask <session-id>`
 
-When I have a complex task that requires focused subtasks, I want to spawn new sessions with specific agents and concepts, so I can tackle problems modularly while maintaining relationships to the parent work.
+When I have a complex task that requires focused subtasks,
+I want to spawn new sessions with specific agents and concepts,
+so I can tackle problems modularly while maintaining relationships to the parent work.
 
 ### Visual Interface
 
-When I'm working with multiple concurrent sessions, I want a unified interface that visually maps my sessions, so I use agents efficiently, understand what I have running at a glance, and build on past work.
+When I'm working with multiple concurrent sessions,
+I want a unified interface that visually maps my sessions,
+so I use agents efficiently, understand what I have running at a glance, and build on past work.
 
 ### Session Visualization
 
-When I want to understand which explorations succeeded or stalled, I want visual indicators in my session tree, so I can quickly identify productive patterns and dead ends.
+When I want to understand which explorations succeeded or stalled,
+I want visual indicators in my session tree,
+so I can quickly identify productive patterns and dead ends.
 
 ### Git Provenance
 
-When I complete AI-assisted coding sessions, I want to track which sessions produced which code changes, so I can understand the provenance of my codebase.
+When I complete AI-assisted coding sessions,
+I want to track which sessions produced which code changes,
+so I can understand the provenance of my codebase.
 
 ### Git History
 
-When I'm reviewing past work, I want to see git state and task checkpoints for each session, so I can understand the complete history of how code evolved.
+When I'm reviewing past work,
+I want to see git state and task checkpoints for each session,
+so I can understand the complete history of how code evolved.
 
 ## P2 - Session Management
 

--- a/apps/agor-cli/src/commands/mcp/add.ts
+++ b/apps/agor-cli/src/commands/mcp/add.ts
@@ -150,7 +150,7 @@ export default class McpAdd extends Command {
       this.log(`${chalk.green('✓')} MCP server added`);
       this.log('');
       this.log(chalk.bold('Server Details:'));
-      this.log(`  ${chalk.cyan('ID')}: ${server.mcp_server_id.substring(0, 8)}`);
+      this.log(`  ${chalk.cyan('ID')}: ${String(server.mcp_server_id).substring(0, 8)}`);
       this.log(`  ${chalk.cyan('Name')}: ${server.name}`);
       this.log(`  ${chalk.cyan('Transport')}: ${server.transport}`);
       this.log(`  ${chalk.cyan('Scope')}: ${server.scope}`);

--- a/apps/agor-cli/src/commands/mcp/list.ts
+++ b/apps/agor-cli/src/commands/mcp/list.ts
@@ -73,7 +73,7 @@ export default class McpList extends Command {
       // Add rows
       for (const server of servers) {
         table.push([
-          server.mcp_server_id.substring(0, 8),
+          String(server.mcp_server_id).substring(0, 8),
           server.display_name || server.name,
           server.transport,
           server.scope,

--- a/apps/agor-cli/src/commands/mcp/show.ts
+++ b/apps/agor-cli/src/commands/mcp/show.ts
@@ -54,7 +54,7 @@ export default class McpShow extends Command {
       this.log(chalk.bold(chalk.cyan('MCP Server Details')));
       this.log('');
       this.log(`${chalk.cyan('ID')}: ${server.mcp_server_id}`);
-      this.log(`${chalk.cyan('Short ID')}: ${server.mcp_server_id.substring(0, 8)}`);
+      this.log(`${chalk.cyan('Short ID')}: ${String(server.mcp_server_id).substring(0, 8)}`);
       this.log(`${chalk.cyan('Name')}: ${server.name}`);
 
       if (server.display_name) {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -4,7 +4,7 @@
  * Shared client library for connecting to agor-daemon from CLI and UI
  */
 
-import type { Board, Repo, Session, Task, User } from '@agor/core/types';
+import type { Board, MCPServer, Repo, Session, Task, User } from '@agor/core/types';
 import authentication from '@feathersjs/authentication-client';
 import type { Application, Paginated, Params } from '@feathersjs/feathers';
 import { feathers } from '@feathersjs/feathers';
@@ -20,6 +20,7 @@ export interface ServiceTypes {
   boards: Board;
   repos: Repo;
   users: User;
+  'mcp-servers': MCPServer;
 }
 
 /**


### PR DESCRIPTION
1)  The String() wrapper was added to mcp_server_id.substring(0, 8) calls in three files:
  - `apps/agor-cli/src/commands/mcp/add.ts:153`
  - `apps/agor-cli/src/commands/mcp/list.ts:76`
  - `apps/agor-cli/src/commands/mcp/show.ts:57`

  Why it was needed

  Looking at the type definition in /Users/ryw/code/agor/packages/core/src/types/mcp.ts:93, mcp_server_id is a branded type:

  `export type MCPServerID = UUID & { readonly __brand: 'MCPServerID' };`

  This is a branded UUID type for type safety. However, branded types are intersection types that extend the base type (string) with a brand property. When TypeScript sees .substring() being called on a branded type, it may not recognize that the branded type is fundamentally a string, causing a type error.

  The String() conversion explicitly coerces the branded type to a plain string, ensuring the .substring() method is available without TypeScript errors.

  This is a common pattern when working with branded types - you need to explicitly convert them back to their base type when using string methods.

---

2) also got another error that was solved by importing `MCPServer` on `packages/core/src/api/index.ts`