### PR TITLE
Fix rename board

### DIFF
--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -205,6 +205,8 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       await this.db
         .update(boards)
         .set({
+          name: insert.name,
+          slug: insert.slug,
           updated_at: new Date(),
           data: insert.data,
         })


### PR DESCRIPTION
**Problem**
When you renamed a board in the UI, the update wasn't persisting because the BoardRepository's `update()` method only updated the `updated_at` timestamp and the JSON data blob, but it didn't update the materialized name and slug columns.

**Root Cause**
In the boards table schema, name and slug are materialized columns (stored directly in the table) rather than being stored in the JSON data blob. The update statement at `packages/core/src/db/repositories/boards.ts:205-213` was missing these fields.

**Fix**

I updated the repository's `update()` method to include both name and slug fields in the database update:

```
await this.db
  .update(boards)
  .set({
    name: insert.name,      // ← Added
    slug: insert.slug,      // ← Added
    updated_at: new Date(),
    data: insert.data,
  })
  .where(eq(boards.board_id, fullId));
```
