### PR TITLE
fix(ui): allow typing in prompt input while session is running

### DIFF
--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -382,7 +382,6 @@ const SessionDrawer = ({
             onChange={e => setInputValue(e.target.value)}
             placeholder="Send a prompt, fork, or create a subtask..."
             autoSize={{ minRows: 1, maxRows: 10 }}
-            disabled={isRunning}
             onPressEnter={e => {
               if (e.shiftKey) {
                 return;


### PR DESCRIPTION
Remove disabled state from TextArea in SessionDrawer to improve UX. Users can now compose their next prompt while waiting for current execution to complete. Send/Fork/Subtask buttons remain disabled during execution to prevent concurrent operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)