### PR TITLE
feat: add GitHub CLI to all Docker environments

### DIFF
--- a/.devcontainer/dev/Dockerfile
+++ b/.devcontainer/dev/Dockerfile
@@ -4,7 +4,14 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:20
 RUN apt-get update && apt-get install -y \
     sqlite3 \
     git \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) - download pre-built binary
+RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep 'browser_download_url.*linux_amd64.tar.gz"' | cut -d'"' -f4)" | \
+    tar -xz -C /tmp && \
+    mv /tmp/gh_*/bin/gh /usr/local/bin/ && \
+    rm -rf /tmp/gh_*
 
 # Install pnpm and AI coding agent CLIs (always get latest versions)
 RUN npm install -g pnpm@latest @anthropic-ai/claude-code@latest @google/gemini-cli@latest @openai/codex@latest

--- a/.devcontainer/playground/Dockerfile
+++ b/.devcontainer/playground/Dockerfile
@@ -4,7 +4,14 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:20 AS builder
 RUN apt-get update && apt-get install -y \
     sqlite3 \
     git \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) - download pre-built binary
+RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep 'browser_download_url.*linux_amd64.tar.gz"' | cut -d'"' -f4)" | \
+    tar -xz -C /tmp && \
+    mv /tmp/gh_*/bin/gh /usr/local/bin/ && \
+    rm -rf /tmp/gh_*
 
 # Install pnpm (use latest)
 RUN npm install -g pnpm@latest
@@ -37,7 +44,14 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:20
 RUN apt-get update && apt-get install -y \
     sqlite3 \
     git \
+    curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) - download pre-built binary
+RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep 'browser_download_url.*linux_amd64.tar.gz"' | cut -d'"' -f4)" | \
+    tar -xz -C /tmp && \
+    mv /tmp/gh_*/bin/gh /usr/local/bin/ && \
+    rm -rf /tmp/gh_*
 
 # Install pnpm and AI CLIs in production stage (always get latest versions)
 RUN npm install -g pnpm@latest @anthropic-ai/claude-code@latest @google/gemini-cli@latest @openai/codex@latest

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,14 @@ FROM node:20-slim
 RUN apt-get update && apt-get install -y \
   sqlite3 \
   git \
+  curl \
   && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) - download pre-built binary
+RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep 'browser_download_url.*linux_amd64.tar.gz"' | cut -d'"' -f4)" | \
+  tar -xz -C /tmp && \
+  mv /tmp/gh_*/bin/gh /usr/local/bin/ && \
+  rm -rf /tmp/gh_*
 
 # Install pnpm and AI coding agent CLIs (always get latest versions)
 RUN npm install -g pnpm@latest @anthropic-ai/claude-code@latest @google/gemini-cli@latest @openai/codex@latest


### PR DESCRIPTION
## Summary

- Install GitHub CLI (`gh`) in all three Dockerfiles to enable agents to perform GitHub operations
- Uses simple pre-built binary download approach (no GPG keys or complex setup)
- Tested with `docker compose build` - verified `gh` v2.82.1 is working

## Changes

Updated three Dockerfiles:
- `Dockerfile.dev` - Main development environment
- `.devcontainer/dev/Dockerfile` - Codespaces dev environment  
- `.devcontainer/playground/Dockerfile` - Codespaces playground (both builder and production stages)

## Implementation

Uses the simplest installation method:
```dockerfile
RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep 'browser_download_url.*linux_amd64.tar.gz"' | cut -d'"' -f4)" |     tar -xz -C /tmp &&     mv /tmp/gh_*/bin/gh /usr/local/bin/ &&     rm -rf /tmp/gh_*
```

- Downloads latest release directly from GitHub
- Extracts binary to `/usr/local/bin/`
- Added `curl` as a dependency
- No repository configuration or GPG keys needed

## Test Plan

- [x] Build Docker images with `docker compose build` - succeeded
- [x] Verify `gh --version` works in container - returned v2.82.1
- [x] Confirmed all three Dockerfiles build successfully

## Why This Matters

Agents like Claude Code, Codex, and Gemini can now use `gh` commands for:
- Creating and managing pull requests
- Working with issues  
- Managing releases
- Other GitHub operations directly from the container

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)