### PR TITLE
Docs: Update doc links to `agor.live` domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Orchestrate Claude Code, Codex, and Gemini sessions on a multiplayer canvas. Manage git worktrees, track AI conversations, and visualize your team's agentic work in real-time.
 
-**[Docs](https://mistercrunch.github.io/agor/)** | **[Discussions](https://github.com/mistercrunch/agor/discussions)**
+**[Docs](https://agor.live/)** | **[Discussions](https://github.com/mistercrunch/agor/discussions)**
 
 ---
 
@@ -203,13 +203,13 @@ graph TB
     Services --> Config
 ```
 
-**[Full Architecture Guide →](https://mistercrunch.github.io/agor/guide/architecture)**
+**[Full Architecture Guide →](https://agor.live/guide/architecture)**
 
 ---
 
 ## Development
 
-**[Development Guide →](https://mistercrunch.github.io/agor/guide/development)**
+**[Development Guide →](https://agor.live/guide/development)**
 
 Quick start:
 
@@ -241,4 +241,4 @@ Highlights:
 
 **Heavily prompted by [@mistercrunch](https://github.com/mistercrunch)** ([Preset](https://preset.io), [Apache Superset](https://github.com/apache/superset), [Apache Airflow](https://github.com/apache/airflow)), built by an army of Claudes.
 
-Read the story: [Making of Agor →](https://mistercrunch.github.io/agor/blog/making-of-agor)
+Read the story: [Making of Agor →](https://agor.live/blog/making-of-agor)

--- a/apps/agor-docs/README.md
+++ b/apps/agor-docs/README.md
@@ -88,6 +88,6 @@ Docs are automatically deployed to GitHub Pages on every push to `main` that cha
 gh workflow run deploy-docs.yml
 ```
 
-**Deployment URL:** https://mistercrunch.github.io/agor/
+**Deployment URL:** https://agor.live/
 
 Alternative options: Cloudflare Pages or Vercel (see [context/explorations/docs-website.md](../../context/explorations/docs-website.md))

--- a/context/concepts/docs-website.md
+++ b/context/concepts/docs-website.md
@@ -2,8 +2,8 @@
 
 **Status:** Live on GitHub Pages
 **Location:** `apps/agor-docs/`
-**Current URL:** https://mistercrunch.github.io/agor
-**Deployment:** GitHub Pages via GitHub Actions
+**Current URL:** https://agor.live
+**Deployment:** GitHub Pages via GitHub Actions (custom domain configured)
 
 ---
 
@@ -81,7 +81,7 @@ pnpm generate   # Regenerate CLI docs
 - Triggers on push to `main` (when `apps/agor-docs/**` or CLI commands change)
 - Builds with base path `/agor` (set via `NEXT_PUBLIC_BASE_PATH`)
 - Static export to `apps/agor-docs/out`
-- Auto-deploys to https://mistercrunch.github.io/agor
+- Auto-deploys to https://agor.live
 
 ## TODO: Migration to agor.live
 

--- a/context/explorations/launch-prep.md
+++ b/context/explorations/launch-prep.md
@@ -88,7 +88,7 @@ agor open
 
 - [ ] README on GitHub: hero image loads, Mermaid renders
 - [ ] All links valid (no 404s)
-- [ ] Docs site (mistercrunch.github.io/agor) loads
+- [ ] Docs site (agor.live) loads
 - [ ] Swagger at localhost:3030/docs works
 - [ ] Codespaces quickstart link functional
 
@@ -133,7 +133,7 @@ agor init && agor daemon start && agor open
 ```
 
 GitHub: github.com/mistercrunch/agor
-Docs: mistercrunch.github.io/agor
+Docs: agor.live
 License: BSL 1.1 (free for non-commercial, converts to Apache 2.0 after 4 years)
 
 Built in public over the last few months. Feedback welcome — especially from teams already juggling multiple AI tools.


### PR DESCRIPTION
Updates all references from `mistercrunch.github.io/agor` to `agor.live` across README, docs README, and context files.