### PR TITLE
fix(docker): build @agor/core before running CLI commands

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,10 @@ echo "🚀 Starting Agor development environment..."
 echo "📦 Checking dependencies..."
 CI=true pnpm install --reporter=append-only
 
+# Build @agor/core (required for CLI commands and daemon)
+echo "🔨 Building @agor/core..."
+pnpm --filter @agor/core build
+
 # Initialize database if it doesn't exist
 if [ ! -f /root/.agor/agor.db ]; then
   echo "📦 Initializing database..."


### PR DESCRIPTION
## Summary

- Added explicit build step for `@agor/core` in docker-entrypoint.sh after dependency installation
- Fixes MODULE_NOT_FOUND errors when CLI commands try to import from `@agor/core/dist/*`

## Problem

The docker entrypoint was failing during initialization because:
1. `pnpm install` runs (dependencies installed)
2. CLI command `user create-admin` runs immediately (imports from `@agor/core/dist/*`)
3. But `@agor/core` hasn't been built yet, so dist/ folder doesn't exist
4. MODULE_NOT_FOUND errors occur

The daemon's `pnpm dev` would eventually build core (via concurrently), but that happens **after** the CLI command has already failed.

## Solution

Build `@agor/core` once right after `pnpm install` and before any CLI operations. The daemon's watch mode will continue to rebuild core during development for hot-reload.

## Test plan

- [ ] Rebuild docker container: `DAEMON_PORT=3072 UI_PORT=5072 docker compose -p database-migrations up --build -d`
- [ ] Check logs for successful initialization: `docker compose -p database-migrations logs -f`
- [ ] Verify no MODULE_NOT_FOUND errors in the logs
- [ ] Verify admin user is created successfully
- [ ] Verify daemon and UI start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)