### PR TITLE
fix(claude): implement stop command by storing Query reference for interrupt()

### DIFF
--- a/packages/core/src/tools/claude/prompt-service.ts
+++ b/packages/core/src/tools/claude/prompt-service.ts
@@ -177,6 +177,11 @@ export class ClaudePromptService {
       idleTimeoutMs: ClaudePromptService.IDLE_TIMEOUT_MS,
     });
 
+    // Store query reference for interruption via stopTask()
+    // This must happen BEFORE iteration starts so stopTask() can access it
+    this.activeQueries.set(sessionId, result);
+    console.log(`📌 Stored query reference for session ${sessionId.substring(0, 8)}`);
+
     try {
       for await (const msg of result) {
         // Check if stop was requested before processing message
@@ -232,9 +237,6 @@ export class ClaudePromptService {
         }
       }
     } catch (error) {
-      // Clean up query reference before re-throwing
-      this.activeQueries.delete(sessionId);
-
       const state = processor.getState();
 
       // Get actual error message from stderr if available
@@ -256,10 +258,11 @@ export class ClaudePromptService {
         stderr: stderrOutput || '(no stderr output)',
       });
       throw enhancedError;
+    } finally {
+      // Clean up query reference - always runs regardless of success/failure/stop
+      this.activeQueries.delete(sessionId);
+      console.log(`🧹 Cleaned up query reference for session ${sessionId.substring(0, 8)}`);
     }
-
-    // Clean up query reference
-    this.activeQueries.delete(sessionId);
   }
 
   /**
@@ -311,6 +314,10 @@ export class ClaudePromptService {
       idleTimeoutMs: ClaudePromptService.IDLE_TIMEOUT_MS,
     });
 
+    // Store query reference for interruption via stopTask()
+    this.activeQueries.set(sessionId, result);
+    console.log(`📌 Stored query reference for session ${sessionId.substring(0, 8)} (non-streaming)`);
+
     // Collect response messages from async generator
     // IMPORTANT: Keep assistant messages SEPARATE (don't merge into one)
     const assistantMessages: Array<{
@@ -334,37 +341,40 @@ export class ClaudePromptService {
         }
       | undefined;
 
-    for await (const msg of result) {
-      const events = await processor.process(msg);
+    try {
+      for await (const msg of result) {
+        const events = await processor.process(msg);
 
-      for (const event of events) {
-        // Only collect complete assistant messages
-        if (event.type === 'complete' && event.role === MessageRole.ASSISTANT) {
-          assistantMessages.push({
-            content: event.content,
-            toolUses: event.toolUses,
-          });
-        }
+        for (const event of events) {
+          // Only collect complete assistant messages
+          if (event.type === 'complete' && event.role === MessageRole.ASSISTANT) {
+            assistantMessages.push({
+              content: event.content,
+              toolUses: event.toolUses,
+            });
+          }
 
-        // Capture token usage from result events
-        if (event.type === 'result' && event.token_usage) {
-          tokenUsage = event.token_usage as {
-            input_tokens?: number;
-            output_tokens?: number;
-            cache_creation_tokens?: number;
-            cache_read_tokens?: number;
-          };
-        }
+          // Capture token usage from result events
+          if (event.type === 'result' && event.token_usage) {
+            tokenUsage = event.token_usage as {
+              input_tokens?: number;
+              output_tokens?: number;
+              cache_creation_tokens?: number;
+              cache_read_tokens?: number;
+            };
+          }
 
-        // Break on end event
-        if (event.type === 'end') {
-          break;
+          // Break on end event
+          if (event.type === 'end') {
+            break;
+          }
         }
       }
+    } finally {
+      // Clean up query reference - always runs regardless of success/failure/stop
+      this.activeQueries.delete(sessionId);
+      console.log(`🧹 Cleaned up query reference for session ${sessionId.substring(0, 8)} (non-streaming)`);
     }
-
-    // Clean up query reference
-    this.activeQueries.delete(sessionId);
 
     // Extract token counts from SDK result metadata
     return {


### PR DESCRIPTION
## Summary

Fixes the non-functional stop command for Claude Code agents. Previously, hitting stop would do nothing - the agent would continue running indefinitely.

## Root Cause

The `activeQueries` Map was declared but **never populated**:
- `setupQuery()` created the Query object but never stored it
- `stopTask()` tried to retrieve it via `activeQueries.get(sessionId)` → always `undefined`
- `queryObj.interrupt()` was never called → agent kept running

## Changes

**File**: `packages/core/src/tools/claude/prompt-service.ts`

1. **Store Query reference before iteration** (both streaming and non-streaming modes)
   - Added `this.activeQueries.set(sessionId, result)` before `for await` loops
   - Must happen BEFORE iteration starts so `stopTask()` can access it

2. **Guaranteed cleanup with finally blocks**
   - Replaced manual cleanup with `finally` blocks
   - Ensures reference is deleted on success, failure, or stop

## How It Works Now

```
User hits stop
  ↓
POST /sessions/:id/stop
  ↓
ClaudeTool.stopTask()
  ↓
ClaudePromptService.stopTask()
  ├─ Set stopRequested flag (for loop breaking)
  ├─ Get Query object from activeQueries ✅ NOW WORKS!
  ├─ Call await queryObj.interrupt() ✅ Interrupts SDK
  └─ Clean up activeQueries
  ↓
Agent stops gracefully (~1-2 seconds)
  ↓
Session status → IDLE
Task status → STOPPED
```

## Testing

1. Start a long-running task:
   ```bash
   pnpm -w agor session prompt <session-id> "Please analyze this entire codebase"
   ```

2. While running, stop it:
   ```bash
   curl -X POST http://localhost:3030/sessions/<session-id>/stop
   ```

3. Verify logs show:
   ```
   📌 Stored query reference for session 019a3af2
   🛑 Stopping task for session 019a3af2
   ✅ Stopped Claude execution for session 019a3af2
   🧹 Cleaned up query reference for session 019a3af2
   ```

4. Verify session status:
   ```bash
   pnpm -w agor session list  # Should show IDLE
   ```

## Edge Cases Handled

- **Session already stopped**: Finally block ensures cleanup even if stop fails
- **SDK error during execution**: Finally block ensures cleanup
- **Multiple stop requests**: First stop deletes reference, subsequent stops return "No active task"
- **Race between stop and completion**: Finally block runs regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)