### PR TITLE
feat(ui): persist prompt drafts per session across conversation switches

### DIFF
--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -100,6 +100,8 @@ interface SessionDrawerProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  promptDraft?: string; // Draft prompt text for this session
+  onUpdateDraft?: (draft: string) => void; // Update draft callback
 }
 
 const SessionDrawer = ({
@@ -126,10 +128,17 @@ const SessionDrawer = ({
   onStartEnvironment,
   onStopEnvironment,
   onViewLogs,
+  promptDraft = '',
+  onUpdateDraft,
 }: SessionDrawerProps) => {
   const { token } = theme.useToken();
   const { modal } = App.useApp();
-  const [inputValue, setInputValue] = React.useState('');
+
+  // Use prop-driven draft state instead of local state
+  const inputValue = promptDraft;
+  const setInputValue = (value: string) => {
+    onUpdateDraft?.(value);
+  };
 
   // Get agent-aware default permission mode (wrapped in useCallback for hook deps)
   const getDefaultPermissionMode = React.useCallback((agent?: string): PermissionMode => {
@@ -265,7 +274,7 @@ const SessionDrawer = ({
   const handleSendPrompt = () => {
     if (inputValue.trim()) {
       onSendPrompt?.(inputValue, permissionMode);
-      setInputValue('');
+      // Draft clearing is now handled by parent (App.tsx)
     }
   };
 
@@ -296,7 +305,7 @@ const SessionDrawer = ({
   const handleFork = () => {
     if (inputValue.trim()) {
       onFork?.(inputValue);
-      setInputValue('');
+      // Draft clearing is now handled by parent (App.tsx)
     }
   };
 
@@ -309,7 +318,7 @@ const SessionDrawer = ({
 
       // Send meta-prompt to the PARENT session (agent will use MCP tool)
       onSendPrompt?.(metaPrompt, permissionMode);
-      setInputValue('');
+      // Draft clearing is now handled by parent (App.tsx)
     }
   };
 

--- a/apps/agor-ui/src/components/mobile/MobileApp.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileApp.tsx
@@ -27,6 +27,8 @@ interface MobileAppProps {
   onToggleReaction?: (commentId: string, emoji: string) => void;
   onDeleteComment?: (commentId: string) => void;
   onLogout?: () => void;
+  promptDrafts: Map<string, string>;
+  onUpdateDraft: (sessionId: string, draft: string) => void;
 }
 
 export const MobileApp: React.FC<MobileAppProps> = ({
@@ -46,6 +48,8 @@ export const MobileApp: React.FC<MobileAppProps> = ({
   onToggleReaction,
   onDeleteComment,
   onLogout,
+  promptDrafts,
+  onUpdateDraft,
 }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -113,6 +117,8 @@ export const MobileApp: React.FC<MobileAppProps> = ({
               currentUser={user}
               onSendPrompt={onSendPrompt}
               onMenuClick={() => setDrawerOpen(true)}
+              promptDrafts={promptDrafts}
+              onUpdateDraft={onUpdateDraft}
             />
           }
         />

--- a/apps/agor-ui/src/components/mobile/MobilePromptInput.tsx
+++ b/apps/agor-ui/src/components/mobile/MobilePromptInput.tsx
@@ -1,6 +1,5 @@
 import { SendOutlined } from '@ant-design/icons';
 import { Button, Input } from 'antd';
-import { useState } from 'react';
 
 const { TextArea } = Input;
 
@@ -8,19 +7,27 @@ interface MobilePromptInputProps {
   onSend: (prompt: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  promptDraft?: string; // Draft prompt text for this session
+  onUpdateDraft?: (draft: string) => void; // Update draft callback
 }
 
 export const MobilePromptInput: React.FC<MobilePromptInputProps> = ({
   onSend,
   disabled = false,
   placeholder = 'Send a prompt...',
+  promptDraft = '',
+  onUpdateDraft,
 }) => {
-  const [prompt, setPrompt] = useState('');
+  // Use prop-driven draft state instead of local state
+  const prompt = promptDraft;
+  const setPrompt = (value: string) => {
+    onUpdateDraft?.(value);
+  };
 
   const handleSend = () => {
     if (prompt.trim() && !disabled) {
       onSend(prompt.trim());
-      setPrompt('');
+      // Draft clearing is now handled by parent (App.tsx)
     }
   };
 

--- a/apps/agor-ui/src/components/mobile/SessionPage.tsx
+++ b/apps/agor-ui/src/components/mobile/SessionPage.tsx
@@ -16,6 +16,8 @@ interface SessionPageProps {
   currentUser?: User | null;
   onSendPrompt?: (sessionId: string, prompt: string, permissionMode?: PermissionMode) => void;
   onMenuClick?: () => void;
+  promptDrafts: Map<string, string>;
+  onUpdateDraft: (sessionId: string, draft: string) => void;
 }
 
 export const SessionPage: React.FC<SessionPageProps> = ({
@@ -27,6 +29,8 @@ export const SessionPage: React.FC<SessionPageProps> = ({
   currentUser,
   onSendPrompt,
   onMenuClick,
+  promptDrafts,
+  onUpdateDraft,
 }) => {
   const { sessionId } = useParams<{ sessionId: string }>();
 
@@ -113,6 +117,8 @@ export const SessionPage: React.FC<SessionPageProps> = ({
         onSend={handleSendPrompt}
         disabled={session.status === 'running'}
         placeholder={session.status === 'running' ? 'Agent is working...' : 'Send a prompt...'}
+        promptDraft={sessionId ? promptDrafts.get(sessionId) || '' : ''}
+        onUpdateDraft={(draft: string) => sessionId && onUpdateDraft(sessionId, draft)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Implements per-session draft state management so users can type half a message in one conversation, switch to another, and return to find their draft intact.

## Changes

- **State Management**: Added `promptDrafts` Map to store drafts keyed by session ID
- **Desktop UI**: Updated SessionDrawer to use prop-driven draft state
- **Mobile UI**: Updated MobilePromptInput + SessionPage to use prop-driven draft state
- **Lifecycle**: Draft auto-clears on send/fork/spawn, persists on session switch

## Implementation Details

**Architecture:**
- Drafts stored in `Map<string, string>` at app level (main App.tsx)
- State lifted to parent, passed down as props to input components
- Memory efficient: empty drafts auto-deleted from Map

**Flow:**
1. User types in Session A → draft saved to Map
2. User switches to Session B → Session A draft remains in Map
3. User returns to Session A → draft restored from Map
4. User sends message → draft cleared from Map

## Benefits

✅ Simple, elegant solution using React state  
✅ Works across desktop and mobile UIs  
✅ Memory efficient (auto-cleanup)  
✅ No external dependencies  
✅ Clean separation of concerns  

## Testing

Manually tested:
- Type half message in conversation A
- Switch to conversation B, type different message
- Return to conversation A - original draft persists
- Send message - draft clears
- Works on both desktop drawer and mobile input

🤖 Generated with [Claude Code](https://claude.com/claude-code)