### PR TITLE
fix: ensure migrations run before admin user creation

### DIFF
--- a/apps/agor-cli/src/commands/user/create-admin.ts
+++ b/apps/agor-cli/src/commands/user/create-admin.ts
@@ -9,6 +9,7 @@ import {
   createDefaultAdminUser,
   DEFAULT_ADMIN_USER,
   getUserByEmail,
+  runMigrations,
 } from '@agor/core/db';
 import { Command } from '@oclif/core';
 import chalk from 'chalk';
@@ -27,6 +28,11 @@ export default class UserCreateAdmin extends Command {
 
       // Connect to database
       const db = createDatabase({ url: `file:${dbPath}` });
+
+      // Ensure migrations are run (idempotent, safe to run multiple times)
+      // This is critical for Docker environments where init --skip-if-exists
+      // might skip migrations if the directory already exists
+      await runMigrations(db);
 
       // Check if admin user already exists
       const existingAdmin = await getUserByEmail(db, DEFAULT_ADMIN_USER.email);

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -223,13 +223,7 @@ export function EnvironmentPill({
                 <Button
                   type="text"
                   size="small"
-                  icon={
-                    isProcessing && status === 'starting' ? (
-                      <LoadingOutlined />
-                    ) : (
-                      <PlayCircleOutlined />
-                    )
-                  }
+                  icon={<PlayCircleOutlined />}
                   onClick={event => {
                     event.stopPropagation();
                     if (!startDisabled) {
@@ -259,9 +253,7 @@ export function EnvironmentPill({
                 <Button
                   type="text"
                   size="small"
-                  icon={
-                    isProcessing && status === 'stopping' ? <LoadingOutlined /> : <StopOutlined />
-                  }
+                  icon={<StopOutlined />}
                   onClick={event => {
                     event.stopPropagation();
                     if (!stopDisabled) {

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -403,10 +403,10 @@ const WorktreeCard = ({
           </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <Typography.Text strong className="nodrag">
-              {worktree.name}
+              {repo.slug}
             </Typography.Text>
             <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              {worktree.ref}
+              {worktree.name}
             </Typography.Text>
           </div>
         </Space>


### PR DESCRIPTION
## Summary
- Fix Docker initialization issue by running migrations in `user create-admin` command
- Update WorktreeCard header to show repo slug + worktree name for better clarity
- Remove loading spinners from EnvironmentPill start/stop buttons

## Problem
In Docker environments, when `agor init --skip-if-exists` detected an existing `.agor` directory, it would skip all initialization including database migrations. This left the database file present but without any schema/tables. When `user create-admin` then tried to query the non-existent `users` table, it would fail.

## Solution
Modified `user create-admin` command to run migrations before attempting to create the admin user. This makes the command more robust and idempotent - it will ensure the database schema exists before trying to use it. Migrations are idempotent so running them multiple times is safe.

## Changes
1. **apps/agor-cli/src/commands/user/create-admin.ts**: Added `runMigrations()` call before querying/creating users
2. **apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx**: Changed header to show `repo.slug` + `worktree.name` instead of `worktree.name` + `worktree.ref`
3. **apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx**: Removed loading spinner state from start/stop buttons

## Testing
- ✅ Docker container starts successfully
- ✅ Database schema properly initialized
- ✅ Admin user created successfully
- ✅ Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)