### PR TITLE
feat: add Docker-in-Docker support to Codespaces playground

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,13 @@
     "context": "..",
     "cacheFrom": ["ghcr.io/mistercrunch/agor-playground:latest"]
   },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
+      "moby": true,
+      "dockerDashComposeVersion": "v2"
+    }
+  },
   "containerEnv": {
     "VITE_CODESPACES": "true",
     "CORS_ORIGIN": "*"


### PR DESCRIPTION
## Summary

Adds Docker-in-Docker capability to the Codespaces playground using the official devcontainer feature.

## Changes

- Added `ghcr.io/devcontainers/features/docker-in-docker:2` feature to `.devcontainer/devcontainer.json`
- Configured with Docker Compose v2 support
- Uses Moby engine for Docker-in-Docker

## Benefits

This enables powerful containerized workflows within Codespaces:

- ✅ **Docker CLI and daemon** available inside the Codespace
- ✅ **Docker Compose v2** for multi-service orchestration
- ✅ **Isolated environments** per worktree using containers
- ✅ **Service dependencies** for testing (databases, Redis, etc.)
- ✅ **Agent tooling** - Let Claude/Gemini/Codex spawn containers as part of workflows

## Testing

After rebuilding the Codespace, verify with:

```bash
docker --version
docker compose version
docker ps
docker run hello-world
```

## Notes

- Uses Microsoft's official devcontainer feature (maintained and secure)
- Properly handles permissions for the `agor` user
- Minimal configuration changes
- Well-supported pattern in GitHub Codespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)