### PR TITLE
fix: remove cacheFrom to resolve 403 error in CI prebuild

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,7 @@
   // Cache bust: 2025-11-04-v7 - Version 0.6.10 - Fix double session save and clean console logs
   "build": {
     "dockerfile": "playground/Dockerfile",
-    "context": "..",
-    "cacheFrom": ["ghcr.io/mistercrunch/agor-playground:latest"]
+    "context": ".."
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {


### PR DESCRIPTION
## Summary

Fixes the 403 Forbidden error that was occurring during the CI prebuild step after merging the Docker-in-Docker PR.

## Problem

The CI prebuild workflow was failing with:
```
#12 ERROR: failed to configure registry cache importer: pulling from host ghcr.io failed with status code [manifests latest]: 403 Forbidden
```

This was caused by the `cacheFrom` line attempting to pull from `ghcr.io/mistercrunch/agor-playground:latest`, which either doesn't exist yet or lacks public access permissions.

## Solution

Removed the `cacheFrom` configuration from `.devcontainer/devcontainer.json`. This is safe because:

- ✅ `cacheFrom` is purely an optimization for faster builds
- ✅ The devcontainer will still build correctly without it
- ✅ Once the cache image is properly published, we can add it back

## Testing

The CI prebuild workflow should now complete successfully without the 403 error.

## Related

- Fixes error from https://github.com/preset-io/agor/actions/runs/19079780569/job/54504972503
- Related to merged PR #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)