### PR TITLE
fix: use official GitHub CLI installation method in playground Dockerfile

### DIFF
--- a/.devcontainer/playground/Dockerfile
+++ b/.devcontainer/playground/Dockerfile
@@ -8,10 +8,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh)
-RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest | grep 'browser_download_url.*linux_amd64.tar.gz"' | cut -d'"' -f4)" | \
-    tar -xz -C /tmp && \
-    mv /tmp/gh_*/bin/gh /usr/local/bin/ && \
-    rm -rf /tmp/gh_*
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install foundation packages one at a time (more robust against npm hiccups)
 RUN npm install -g @anthropic-ai/claude-code@latest && \


### PR DESCRIPTION
## Summary

Fixes the GitHub CLI installation failure in the Codespaces playground Dockerfile that was causing the prebuild CI to fail.

## Problem

After fixing the 403 cache error (PR #80), the CI was failing at a different step:

```
curl: option : blank argument where content is expected
tar: Error is not recoverable: exiting now
ERROR: process "/bin/sh -c curl -fsSL ..." did not complete successfully: exit code: 2
```

The issue was in the GitHub CLI installation command (lines 11-14) which used a brittle curl/grep/tar approach with malformed quote escaping.

## Solution

Replaced the custom installation script with GitHub's official apt-based installation method:

- ✅ Uses GitHub's official apt repository and GPG keyring
- ✅ More reliable and maintainable
- ✅ Follows GitHub CLI's recommended installation approach
- ✅ No quote escaping issues

## Changes

Updated `.devcontainer/playground/Dockerfile` to use the official installation method from https://github.com/cli/cli/blob/trunk/docs/install_linux.md

## Testing

The CI prebuild should now complete successfully through the GitHub CLI installation step.

## Related

- Fixes error from https://github.com/preset-io/agor/actions/runs/19080569013/job/54507749584
- Follows up on PR #80 (cache fix) and PR #79 (Docker-in-Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)