### PR TITLE
feat: add reusable CollapsibleText component for 'show more' pattern

### DIFF
--- a/apps/agor-ui/src/components/CollapsibleText/CollapsibleText.tsx
+++ b/apps/agor-ui/src/components/CollapsibleText/CollapsibleText.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Typography } from 'antd';
+import { TEXT_TRUNCATION } from '../../constants/ui';
+
+const { Paragraph } = Typography;
+
+export interface CollapsibleTextProps {
+  /**
+   * The text content to display
+   */
+  children: string;
+
+  /**
+   * Number of lines to show before truncating
+   * @default TEXT_TRUNCATION.DEFAULT_LINES (10)
+   */
+  maxLines?: number;
+
+  /**
+   * Whether to preserve whitespace and formatting
+   * @default false
+   */
+  preserveWhitespace?: boolean;
+
+  /**
+   * Additional CSS class name
+   */
+  className?: string;
+
+  /**
+   * Additional inline styles
+   */
+  style?: React.CSSProperties;
+
+  /**
+   * Whether the text is code (monospace font)
+   * @default false
+   */
+  code?: boolean;
+}
+
+/**
+ * CollapsibleText
+ *
+ * A reusable component for displaying long text with "show more/less" functionality.
+ * Uses Ant Design's Typography.Paragraph ellipsis feature for consistent UX.
+ *
+ * Usage:
+ * ```tsx
+ * <CollapsibleText maxLines={5}>
+ *   {longTextContent}
+ * </CollapsibleText>
+ * ```
+ *
+ * Features:
+ * - Configurable line limit (defaults to TEXT_TRUNCATION.DEFAULT_LINES)
+ * - Automatic "show more/less" controls
+ * - Preserves whitespace when needed (for code, formatted text)
+ * - Consistent with Ant Design patterns
+ */
+export const CollapsibleText: React.FC<CollapsibleTextProps> = ({
+  children,
+  maxLines = TEXT_TRUNCATION.DEFAULT_LINES,
+  preserveWhitespace = false,
+  className,
+  style,
+  code = false,
+}) => {
+  const computedStyle: React.CSSProperties = {
+    ...style,
+    ...(preserveWhitespace && { whiteSpace: 'pre-wrap' }),
+    ...(code && { fontFamily: 'monospace' }),
+  };
+
+  return (
+    <Paragraph
+      className={className}
+      style={computedStyle}
+      ellipsis={{
+        rows: maxLines,
+        expandable: true,
+        symbol: 'show more',
+      }}
+    >
+      {children}
+    </Paragraph>
+  );
+};

--- a/apps/agor-ui/src/components/CollapsibleText/index.ts
+++ b/apps/agor-ui/src/components/CollapsibleText/index.ts
@@ -1,0 +1,2 @@
+export { CollapsibleText } from './CollapsibleText';
+export type { CollapsibleTextProps } from './CollapsibleText';

--- a/apps/agor-ui/src/components/ThinkingBlock/ThinkingBlock.tsx
+++ b/apps/agor-ui/src/components/ThinkingBlock/ThinkingBlock.tsx
@@ -11,6 +11,8 @@
 import { BulbOutlined, DownOutlined, RightOutlined } from '@ant-design/icons';
 import { Collapse, Typography, theme } from 'antd';
 import type React from 'react';
+import { CollapsibleText } from '../CollapsibleText';
+import { TEXT_TRUNCATION } from '../../constants/ui';
 
 const { Text } = Typography;
 
@@ -88,9 +90,13 @@ export const ThinkingBlock: React.FC<ThinkingBlockProps> = ({
             >
               <div style={{ color: token.colorTextTertiary }}>
                 {content ? (
-                  <Typography.Paragraph style={{ fontSize: 13, marginBottom: 0 }}>
+                  <CollapsibleText
+                    maxLines={TEXT_TRUNCATION.DEFAULT_LINES}
+                    preserveWhitespace
+                    style={{ fontSize: 13, marginBottom: 0 }}
+                  >
                     {content}
-                  </Typography.Paragraph>
+                  </CollapsibleText>
                 ) : (
                   <Text>Thinking...</Text>
                 )}

--- a/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
@@ -14,11 +14,10 @@
  */
 
 import type { ContentBlock as CoreContentBlock } from '@agor/core/types';
-import { Typography, theme } from 'antd';
+import { theme } from 'antd';
 import type React from 'react';
+import { CollapsibleText } from '../CollapsibleText';
 import { getToolRenderer } from './renderers';
-
-const { Paragraph } = Typography;
 
 interface ToolUseBlock {
   type: 'tool_use';
@@ -108,12 +107,11 @@ export const ToolUseRenderer: React.FC<ToolUseRendererProps> = ({ toolUse, toolR
           border: `1px solid ${isError ? token.colorErrorBorder : token.colorSuccessBorder}`,
         }}
       >
-        <Paragraph
-          ellipsis={{ rows: 10, expandable: true, symbol: 'show more' }}
+        <CollapsibleText
+          code
+          preserveWhitespace
           style={{
-            fontFamily: 'monospace',
             fontSize: 11,
-            whiteSpace: 'pre-wrap',
             margin: 0,
             ...((!hasContent && {
               fontStyle: 'italic',
@@ -122,7 +120,7 @@ export const ToolUseRenderer: React.FC<ToolUseRendererProps> = ({ toolUse, toolR
           }}
         >
           {hasContent ? resultText : '(no output)'}
-        </Paragraph>
+        </CollapsibleText>
       </div>
 
       {/* Tool input parameters (collapsible below result) */}

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EXAMPLE_CustomRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EXAMPLE_CustomRenderer.tsx
@@ -1,0 +1,118 @@
+/**
+ * EXAMPLE: Custom Tool Renderer with CollapsibleText
+ *
+ * This is an example showing how to create a custom renderer for a tool
+ * that displays long text output using the CollapsibleText component.
+ *
+ * To use this pattern:
+ * 1. Copy this file and rename it for your tool (e.g., BashRenderer.tsx)
+ * 2. Update the component name and logic
+ * 3. Register it in ./index.ts
+ */
+
+import { theme } from 'antd';
+import type React from 'react';
+import { CollapsibleText } from '../../CollapsibleText';
+import { TEXT_TRUNCATION } from '../../../constants/ui';
+import type { ToolRendererProps } from './index';
+
+/**
+ * Example Custom Renderer
+ *
+ * Shows how to use CollapsibleText for long tool outputs
+ */
+export const ExampleCustomRenderer: React.FC<ToolRendererProps> = ({
+  toolUseId,
+  input,
+  result,
+}) => {
+  const { token } = theme.useToken();
+
+  // Extract text content from result
+  const getResultText = (): string => {
+    if (!result) return '';
+
+    if (typeof result.content === 'string') {
+      return result.content;
+    }
+
+    if (Array.isArray(result.content)) {
+      return result.content
+        .filter((block: any): block is { type: 'text'; text: string } => block.type === 'text')
+        .map(block => block.text)
+        .join('\n\n');
+    }
+
+    return '';
+  };
+
+  const resultText = getResultText();
+  const isError = result?.is_error;
+
+  return (
+    <div>
+      {/* Your custom header/metadata here */}
+      <div style={{ marginBottom: token.sizeUnit, color: token.colorTextSecondary, fontSize: 12 }}>
+        Custom tool output:
+      </div>
+
+      {/* Tool output with CollapsibleText */}
+      <div
+        style={{
+          padding: token.sizeUnit * 1.5,
+          borderRadius: token.borderRadius,
+          background: isError ? 'rgba(255, 77, 79, 0.05)' : token.colorBgContainer,
+          border: `1px solid ${isError ? token.colorErrorBorder : token.colorBorder}`,
+        }}
+      >
+        {resultText ? (
+          <CollapsibleText
+            maxLines={TEXT_TRUNCATION.DEFAULT_LINES}
+            preserveWhitespace
+            code
+            style={{
+              fontSize: 12,
+              margin: 0,
+            }}
+          >
+            {resultText}
+          </CollapsibleText>
+        ) : (
+          <div style={{ fontStyle: 'italic', color: token.colorTextSecondary }}>
+            (no output)
+          </div>
+        )}
+      </div>
+
+      {/* Optional: Show input parameters */}
+      {input && Object.keys(input).length > 0 && (
+        <details style={{ marginTop: token.sizeUnit }}>
+          <summary style={{ cursor: 'pointer', fontSize: 11, color: token.colorTextSecondary }}>
+            Show input parameters
+          </summary>
+          <pre
+            style={{
+              marginTop: token.sizeUnit / 2,
+              background: token.colorBgLayout,
+              padding: token.sizeUnit,
+              borderRadius: token.borderRadius,
+              fontFamily: 'monospace',
+              fontSize: 10,
+              overflowX: 'auto',
+            }}
+          >
+            {JSON.stringify(input, null, 2)}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+};
+
+/**
+ * To register this renderer:
+ *
+ * In ./index.ts:
+ * import { ExampleCustomRenderer } from './EXAMPLE_CustomRenderer';
+ * TOOL_RENDERERS.set('YourToolName', ExampleCustomRenderer);
+ */

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/index.ts
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/index.ts
@@ -12,6 +12,17 @@
  * Example:
  *   import { MyToolRenderer } from './MyToolRenderer';
  *   TOOL_RENDERERS.set('MyTool', MyToolRenderer);
+ *
+ * For long text output, use the CollapsibleText component:
+ *   import { CollapsibleText } from '../../CollapsibleText';
+ *
+ *   // In your renderer:
+ *   <CollapsibleText maxLines={10} code preserveWhitespace>
+ *     {longOutputText}
+ *   </CollapsibleText>
+ *
+ * This ensures consistent "show more/less" behavior across all tools.
+ * See TEXT_TRUNCATION constants in src/constants/ui.ts for default limits.
  */
 
 import type React from 'react';

--- a/apps/agor-ui/src/constants/ui.ts
+++ b/apps/agor-ui/src/constants/ui.ts
@@ -1,0 +1,35 @@
+/**
+ * UI Constants
+ *
+ * Centralized constants for consistent UI behavior across components.
+ */
+
+/**
+ * Text Truncation Limits
+ *
+ * Used by CollapsibleText and other components to determine when to show
+ * "show more/less" controls for long content.
+ */
+export const TEXT_TRUNCATION = {
+  /**
+   * Default number of lines to show before truncating
+   * Used in tool outputs, thought bubbles, etc.
+   */
+  DEFAULT_LINES: 10,
+
+  /**
+   * Number of lines for compact displays (e.g., in collapsed states)
+   */
+  COMPACT_LINES: 3,
+
+  /**
+   * Default character limit for truncation
+   * Used when line-based truncation isn't appropriate
+   */
+  DEFAULT_CHARS: 500,
+
+  /**
+   * Character limit for preview text in collapsed states
+   */
+  PREVIEW_CHARS: 150,
+} as const;


### PR DESCRIPTION
## Summary
Implements a consistent text truncation pattern with "show more/less" functionality across the conversation view.

## Changes
- **Created `CollapsibleText` component** - Reusable component with configurable line limits
- **Added `TEXT_TRUNCATION` constants** - Centralized configuration (DEFAULT_LINES: 10, COMPACT_LINES: 3, etc.)
- **Updated `ToolUseRenderer`** - Uses CollapsibleText instead of hardcoded `rows: 10`
- **Updated `ThinkingBlock`** - Long thinking content now uses CollapsibleText
- **Added documentation** - Registry documentation + example custom renderer

## Benefits
✅ Consistent "show more/less" UX across all tool outputs and thinking blocks  
✅ Centralized configuration - change limits in one place  
✅ Reusable pattern for custom tool renderers  
✅ Preserves whitespace and code formatting  

## Files Changed
- `apps/agor-ui/src/constants/ui.ts` (new)
- `apps/agor-ui/src/components/CollapsibleText/` (new)
- `apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx`
- `apps/agor-ui/src/components/ThinkingBlock/ThinkingBlock.tsx`
- `apps/agor-ui/src/components/ToolUseRenderer/renderers/index.ts`
- `apps/agor-ui/src/components/ToolUseRenderer/renderers/EXAMPLE_CustomRenderer.tsx` (example)

## Test Plan
- [x] TypeScript type checking passes
- [x] Component uses Ant Design's Typography.Paragraph ellipsis feature
- [ ] Test with long tool outputs (>10 lines)
- [ ] Test with extended thinking content
- [ ] Verify "show more/less" functionality works correctly
- [ ] Test with custom tool renderers

🤖 Generated with [Claude Code](https://claude.com/claude-code)