### PR TITLE
feat: improve WorktreeCard header layout and add running indicator

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -12,7 +12,7 @@ import {
   SubnodeOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Badge, Button, Card, Collapse, Space, Tag, Tree, Typography, theme } from 'antd';
+import { Badge, Button, Card, Collapse, Space, Spin, Tag, Tree, Typography, theme } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { DeleteWorktreePopconfirm } from '../DeleteWorktreePopconfirm';
 import { EnvironmentPill } from '../EnvironmentPill';
@@ -120,6 +120,9 @@ const WorktreeCard = ({
 
   // Build genealogy tree structure (only for manual sessions)
   const sessionTreeData = useMemo(() => buildSessionTree(manualSessions), [manualSessions]);
+
+  // Check if any session is running
+  const hasRunningSession = useMemo(() => sessions.some(s => s.status === 'running'), [sessions]);
 
   // Auto-expand all nodes on mount and when new nodes with children are added
   useEffect(() => {
@@ -397,16 +400,27 @@ const WorktreeCard = ({
         <Space size={8} align="center">
           <div
             className="drag-handle"
-            style={{ display: 'flex', alignItems: 'center', cursor: 'grab' }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              cursor: 'grab',
+              width: 32,
+              height: 32,
+              justifyContent: 'center',
+            }}
           >
-            <BranchesOutlined style={{ fontSize: 32, color: token.colorPrimary }} />
+            {hasRunningSession ? (
+              <Spin size="large" />
+            ) : (
+              <BranchesOutlined style={{ fontSize: 32, color: token.colorPrimary }} />
+            )}
           </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <Typography.Text strong className="nodrag">
-              {repo.slug}
+              {worktree.name}
             </Typography.Text>
             <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              {worktree.name}
+              {repo.slug}
             </Typography.Text>
           </div>
         </Space>


### PR DESCRIPTION
## Summary
- Swap header text: worktree name now on top, repo slug below for better visual hierarchy
- Add spinning indicator when any session in the worktree is running
- Fixed icon container size (32x32) to prevent layout jitter

## Visual Changes
- **Header text order**: Worktree name is now prominently displayed on top, with repo slug as secondary text below
- **Running indicator**: When any session in the worktree has `status === 'running'`, the branches icon is replaced with a large spinning indicator
- **No jitter**: Fixed container dimensions ensure smooth transitions between icon states

## Benefits
- Clearer visual hierarchy emphasizes the worktree name
- Easy to identify active worktrees at a glance, even when zoomed out on the board
- Consistent card sizing prevents layout shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)