### PR TITLE
fix(git): enable credential helpers while preventing interactive prompts

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -164,6 +164,7 @@ async function main() {
 
   // Configure Git to fail fast instead of prompting for credentials
   // This prevents git operations from hanging indefinitely in automated environments
+  // while still allowing credential helpers (gh auth, SSH keys, credential stores) to work
   process.env.GIT_TERMINAL_PROMPT = '0'; // Disable terminal credential prompts
   process.env.GIT_ASKPASS = 'echo'; // Return empty for any password prompt
 


### PR DESCRIPTION
closes https://github.com/preset-io/agor/pull/90

Removes `credential.helper=` and `core.askpass=` from git configuration to allow host-level authentication (gh auth, SSH keys, credential stores) to work while still preventing interactive prompts.

## Problem

Previously, Agor disabled ALL credential helpers to prevent git operations from hanging in Docker environments. However, this also broke legitimate authentication methods like `gh auth login`, SSH keys, and git credential stores, forcing users to embed tokens in URLs.

## Solution

The environment variables `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=echo` (already set at daemon startup) are sufficient to prevent interactive prompts while still allowing credential helpers to work non-interactively.

## Testing

Verified that:
- Git with credential helpers works without prompting (gh auth tested)
- Git fails fast with "Authentication failed" when creds unavailable
- No hanging or interactive prompts in either case

## Impact

- ✅ Fixes FAQ documentation accuracy (gh auth now actually works)
- ✅ Enables SSH keys for authentication
- ✅ Enables credential stores (osxkeychain, wincred, etc.)
- ✅ Still fails fast in Docker/automated environments
- ✅ No interactive prompts

Addresses feedback from PR #90 discussion about credential handling by @rileydev.

## Files Changed

- `packages/core/src/git/index.ts` - Removed credential helper disabling config
- `apps/agor-daemon/src/index.ts` - Updated comment to clarify behavior

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)