### PR TITLE
feat: add awaiting_permission status to sessions

### DIFF
--- a/apps/agor-cli/src/commands/session/list.ts
+++ b/apps/agor-cli/src/commands/session/list.ts
@@ -82,6 +82,7 @@ export default class SessionList extends BaseCommand {
   private formatStatus(status: Session['status']): string {
     const icons = {
       running: chalk.blue('●'),
+      awaiting_permission: chalk.yellow('⏸'),
       completed: chalk.green('✓'),
       failed: chalk.red('✗'),
       idle: chalk.gray('○'),
@@ -89,6 +90,7 @@ export default class SessionList extends BaseCommand {
 
     const labels = {
       running: chalk.blue('Running'),
+      awaiting_permission: chalk.yellow('Awaiting Permission'),
       completed: chalk.green('Done'),
       failed: chalk.red('Failed'),
       idle: chalk.gray('Idle'),

--- a/apps/agor-ui/src/components/TaskStatusIcon.tsx
+++ b/apps/agor-ui/src/components/TaskStatusIcon.tsx
@@ -3,8 +3,8 @@ import {
   CheckCircleOutlined,
   ClockCircleOutlined,
   CloseCircleOutlined,
-  LockOutlined,
   MinusCircleOutlined,
+  PauseCircleOutlined,
   StopOutlined,
 } from '@ant-design/icons';
 import { Spin, theme } from 'antd';
@@ -37,7 +37,7 @@ export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({ status, size = 1
     case TaskStatus.STOPPING:
       return <StopOutlined style={{ ...iconStyle, color: token.colorWarning }} />;
     case TaskStatus.AWAITING_PERMISSION:
-      return <LockOutlined style={{ ...iconStyle, color: token.colorWarning }} />;
+      return <PauseCircleOutlined style={{ ...iconStyle, color: token.colorWarning }} />;
     case TaskStatus.FAILED:
       return <CloseCircleOutlined style={{ ...iconStyle, color: token.colorError }} />;
     case TaskStatus.STOPPED:

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -29,7 +29,7 @@ export const sessions = sqliteTable(
 
     // Materialized for filtering/joins (cross-DB compatible)
     status: text('status', {
-      enum: ['idle', 'running', 'completed', 'failed'],
+      enum: ['idle', 'running', 'awaiting_permission', 'completed', 'failed'],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
       enum: ['claude-code', 'codex', 'gemini'],

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -14,6 +14,7 @@ import type { SessionID, TaskID, WorktreeID } from './id';
 export const SessionStatus = {
   IDLE: 'idle',
   RUNNING: 'running',
+  AWAITING_PERMISSION: 'awaiting_permission',
   COMPLETED: 'completed',
   FAILED: 'failed',
 } as const;


### PR DESCRIPTION
## Summary

When Claude requests a tool permission, the session status now accurately reflects that it's paused waiting for user input, instead of showing a spinning "running" indicator.

### Changes

- Add `awaiting_permission` to `SessionStatus` enum (types + schema)
- Update permission hooks to set session status when awaiting permission  
- Restore session status to `running` after user decision (approved or denied)
- Add `PauseCircleOutlined` icon (⏸️) in amber for awaiting permission state
- Update CLI session list command to display new status

### Visual Result

**Before**: Session shows spinning icon → looks like it's "thinking"  
**After**: Session shows pause icon in amber → clearly "waiting for you"

The pause icon clearly distinguishes "waiting for permission" from "actively running", improving UX when users need to approve tools.

### Test Plan

- [ ] Start a session and trigger a permission request
- [ ] Verify session card shows pause icon (⏸️) in amber
- [ ] Approve permission and verify session returns to running status
- [ ] Verify CLI `agor session list` shows "Awaiting Permission" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)