### PR TITLE
feat: refactor user settings modal with top-level tabs

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -300,6 +300,10 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       await onUpdate?.(editingUser.user_id, {
         default_agentic_config: newConfig,
       });
+
+      // Close modal after successful save
+      setEditModalOpen(false);
+      setEditingUser(null);
     } catch (err) {
       console.error(`Failed to save ${tool} config:`, err);
       throw err;


### PR DESCRIPTION
## Summary

Refactors the user settings modal from nested collapsibles to a clean top-level tab interface with 6 tabs: General, API Keys, Env Vars, Claude Code, Codex, and Gemini.

## Problem

After #95 and #97, the user settings modal had a nested structure with agentic tool configs inside collapsibles. This was functional but not ideal UX - the nesting made it harder to navigate and the modal height would jump when switching between tools.

## Solution

Complete refactor to a flat tab structure:

### Before (Nested):
```
User Settings Modal
├─ General fields
└─ Default Agentic Settings (collapsible)
   ├─ Claude Code (nested tab)
   ├─ Codex (nested tab)  
   └─ Gemini (nested tab)
```

### After (Flat):
```
User Settings Modal
├─ General (tab)
├─ API Keys (tab)
├─ Env Vars (tab)
├─ Claude Code (tab)
├─ Codex (tab)
└─ Gemini (tab)
```

## Changes

### UI Refactoring (`UsersTable.tsx`)
- Removed `DefaultAgenticSettings.tsx` component (no longer needed)
- Added top-level `Tabs` component with 6 tabs
- Each agentic tool tab has its own `Form` instance with separate state
- Added unified `handleModalSave()` that routes based on active tab
- Removed individual save buttons from tab bodies, kept only "Clear Defaults"

### UX Improvements
- **Fixed-height modal** with scrollable body (no more jumpy height)
- **Unified Save button** in modal footer works for all tabs
- **Loading states** properly shown for each agentic tool tab
- **Modal closes after save** for better flow

### State Management
- Separate form instances: `claudeForm`, `codexForm`, `geminiForm`
- Each form maintains independent state
- Save button shows loading indicator based on active tab

## Testing

Verified full flow:
1. ✅ All 6 tabs render correctly
2. ✅ Forms prepopulate with saved values  
3. ✅ Save button works for each tab type
4. ✅ Modal closes after successful save
5. ✅ Settings persist across modal reopen
6. ✅ Clear Defaults button works
7. ✅ Fixed height prevents jumpy UI

## Related

- Builds on #95 (initial feature)
- Builds on #97 (persistence fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>