### PR TITLE
fix: prevent environment pill from showing unhealthy during startup

### DIFF
--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -669,6 +669,14 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
             : error.message
           : 'Unknown error';
 
+      // During 'starting' state, don't mark as unhealthy - keep retrying
+      // Only mark as unhealthy when transitioning from healthy->unhealthy in 'running' state
+      if (currentStatus === 'starting') {
+        // Don't update health check during startup - wait for first success
+        // This prevents the UI from showing unhealthy state while environment is still starting
+        return worktree;
+      }
+
       const newHealthStatus = 'unhealthy';
 
       // Only log if health status changed or if this is an error


### PR DESCRIPTION
## Summary

Fixes an issue where the environment pill would briefly show a spinner during startup, then quickly switch to unhealthy state before the application was ready.

## Problem

When starting an environment:
1. Status changes from `stopped` → `starting` → `running`
2. Health checks begin after a 5-second grace period
3. If the app isn't ready yet, health checks fail and set `last_health_check.status = 'unhealthy'`
4. The UI combines `starting` status + `unhealthy` health check and shows orange "unhealthy" state instead of blue "starting" spinner

## Solution

Added a guard condition in the health check error handler (`apps/agor-daemon/src/services/worktrees.ts:674-678`) that prevents updating the health check status when the environment is in `'starting'` state.

Now:
- ✅ During startup, failed health checks are silently ignored (no state update)
- ✅ The UI continues showing the blue spinner with "Starting..." state  
- ✅ Only when the first health check succeeds does it transition to `'running'`
- ✅ Once in `'running'` state, failed health checks properly mark it as `'unhealthy'`

## Test plan

- [x] Start an environment and verify it shows blue spinner until first successful health check
- [x] Verify unhealthy status only appears after environment is running and health checks fail
- [x] Verify transition from starting → running happens on first successful health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)