### PR TITLE
fix: restore auto-scroll to bottom when opening conversation drawer

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -140,12 +140,16 @@ export const ConversationView = React.memo<ConversationViewProps>(
         setExpandedTaskIds(prev => {
           // If no tasks expanded or last task changed, expand the last task
           if (prev.size === 0 || !prev.has(lastTaskId)) {
+            // Scroll to bottom after expansion is rendered
+            requestAnimationFrame(() => {
+              scrollToBottom();
+            });
             return new Set([lastTaskId]);
           }
           return prev;
         });
       }
-    }, [tasks]);
+    }, [tasks, scrollToBottom]);
 
     // Handle task expand/collapse
     const handleTaskExpandChange = useCallback((taskId: string, expanded: boolean) => {

--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -261,15 +261,16 @@ const SessionDrawer = ({
     }
   }, [session?.model_config?.thinkingMode]);
 
-  // Scroll to bottom when drawer opens
+  // Scroll to bottom when drawer opens or session changes
   React.useEffect(() => {
-    if (open && scrollToBottom) {
-      // Small delay to ensure content is rendered
-      setTimeout(() => {
+    if (open && scrollToBottom && session) {
+      // Longer delay to ensure tasks are loaded and content is rendered
+      const timeoutId = setTimeout(() => {
         scrollToBottom();
-      }, 100);
+      }, 300);
+      return () => clearTimeout(timeoutId);
     }
-  }, [open, scrollToBottom]);
+  }, [open, scrollToBottom, session?.session_id]);
 
   // Early return if no session (drawer should not be open without a session)
   // IMPORTANT: Must be after all hooks to satisfy Rules of Hooks


### PR DESCRIPTION
## Summary

- Fixes auto-scroll behavior that stopped working when switching sessions or opening the conversation drawer
- Ensures conversation always scrolls to the latest message when drawer opens or session changes

## Changes

**SessionDrawer.tsx:**
- Added `session_id` to effect dependencies to trigger scroll on session changes
- Increased delay from 100ms to 300ms to allow tasks to load before scrolling
- Added timeout cleanup to prevent memory leaks
- Added session existence guard

**ConversationView.tsx:**
- Added `requestAnimationFrame` scroll trigger when expanding last task
- Added `scrollToBottom` to effect dependencies for proper reactivity

## Test Plan

- [ ] Open conversation drawer → should scroll to bottom
- [ ] Switch between different sessions → should scroll to bottom on each switch
- [ ] Open drawer with a session that has many tasks → should scroll to bottom after tasks load
- [ ] Verify no console errors or memory leaks

## Behavior

The drawer now properly scrolls to the latest message when:
1. Opening the drawer for the first time
2. Switching between different sessions  
3. Tasks finish loading and the last task is expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)