### PR TITLE
fix: keep environment in 'starting' state until first successful health check

### DIFF
--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -429,12 +429,13 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
         access_urls = [{ name: 'App', url }];
       }
 
-      // Update status to 'running' - now rely on health checks to monitor
+      // Keep status as 'starting' - let health checks transition to 'running'
+      // The first successful health check will transition from 'starting' → 'running'
+      // This prevents premature "healthy" status before app is truly ready
       return await this.updateEnvironment(
         id,
         {
-          status: 'running',
-          process: undefined, // No subprocess to track
+          // Don't change status - keep as 'starting' until first successful health check
           access_urls,
         },
         params


### PR DESCRIPTION
## Summary

Fixes an issue where environments would prematurely show as "healthy" before the application was fully ready.

## Problem

After merging PR #107, we still had an issue with the environment pill showing incorrect states:

1. Push start button → shows "starting" (blue spinner) ✅
2. Start command completes → **immediately shows "healthy" (green)** ❌ 
3. A few seconds later → shows "unhealthy" (orange) ❌
4. After 1-2 minutes when app is truly ready → shows "healthy" (green) ✅

**Root cause:** After running the start command (e.g., `docker compose up -d`), the code immediately changed status from `'starting'` to `'running'` (line 436 in worktrees.ts). This caused the health monitor to start checking right away, and sometimes the app would respond with HTTP 200 even though it wasn't fully initialized yet.

## Solution

Keep the status as `'starting'` after the start command completes, and only transition to `'running'` when the first successful health check confirms the app is truly ready.

The health check system already handles this transition (worktrees.ts:640-647) - when a health check succeeds and status is `'starting'`, it transitions to `'running'`.

**Changes:**
- Removed `status: 'running'` assignment after start command completes
- Status now stays as `'starting'` until first successful health check
- Access URLs are still set immediately so the link is available

## Expected behavior now

1. Push start button → shows "starting" (blue spinner)
2. Start command completes → **continues showing "starting"** (blue spinner)
3. Health checks run every 5 seconds
4. First successful health check → transitions to "healthy" (green)
5. If subsequent checks fail → shows "unhealthy" (orange)

## Test plan

- [x] Start an environment and verify it shows blue spinner until truly ready
- [x] Verify it only shows "healthy" when the app actually responds successfully
- [x] Verify no premature "healthy" state during initialization
- [x] Verify transition from starting → healthy happens on first successful health check

## Related

- Follows up on #107 which prevented unhealthy status during startup
- This PR prevents premature healthy status during startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)