### PR TITLE
feat: add autofocus to form modals for improved UX

### DIFF
--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -172,6 +172,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
           <TextArea
             rows={4}
             placeholder="e.g., Build a JWT authentication system with secure password storage..."
+            autoFocus
           />
         </Form.Item>
 

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -248,6 +248,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({ repos, onCreate, onUpdat
               <Input
                 placeholder="https://github.com/apache/superset.git"
                 onChange={handleUrlChange}
+                autoFocus
               />
             </Form.Item>
           )}

--- a/apps/agor-ui/src/components/WorktreeFormFields/WorktreeFormFields.tsx
+++ b/apps/agor-ui/src/components/WorktreeFormFields/WorktreeFormFields.tsx
@@ -128,7 +128,7 @@ export const WorktreeFormFields: React.FC<WorktreeFormFieldsProps> = ({
         validateTrigger={['onBlur', 'onChange']}
         tooltip="URL-friendly name (e.g., 'feat-auth', 'fix-cors')"
       >
-        <Input placeholder="feat-auth" />
+        <Input placeholder="feat-auth" autoFocus />
       </Form.Item>
 
       <Form.Item>


### PR DESCRIPTION
## Summary

- Added autofocus to repository creation modal (URL field)
- Added autofocus to worktree creation modal (name field)
- Added autofocus to session creation modal (initial prompt textarea)

## Rationale

Users can now immediately start typing when these modals open without needing to click into the input field first. This improves the UX flow by reducing friction in the creation workflows.

## Test plan

- [ ] Open repository creation modal → URL field should be focused
- [ ] Open worktree creation modal → Worktree name field should be focused
- [ ] Open session creation modal → Initial prompt textarea should be focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)