### PR TITLE
refactor: replace string-based error handling with typed error classes

### DIFF
--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -42,6 +42,7 @@ export class BoardCommentsService extends DrizzleService<
     const commentsRepo = new BoardCommentsRepository(db);
     super(commentsRepo, {
       id: 'comment_id',
+      resourceType: 'BoardComment',
       paginate: {
         default: 100,
         max: 500,

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -27,6 +27,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     const boardRepo = new BoardRepository(db);
     super(boardRepo, {
       id: 'board_id',
+      resourceType: 'Board',
       paginate: {
         default: 50,
         max: 100,

--- a/apps/agor-daemon/src/services/mcp-servers.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.ts
@@ -44,6 +44,7 @@ export class MCPServersService extends DrizzleService<
     const mcpServerRepo = new MCPServerRepository(db);
     super(mcpServerRepo, {
       id: 'mcp_server_id',
+      resourceType: 'McpServer',
       paginate: {
         default: 50,
         max: 100,

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -29,6 +29,7 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
     const messagesRepo = new MessagesRepository(db);
     super(messagesRepo, {
       id: 'message_id',
+      resourceType: 'Message',
       paginate: {
         default: 100,
         max: 1000, // Allow larger page size for bulk message retrieval

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -31,6 +31,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const repoRepo = new RepoRepository(db);
     super(repoRepo, {
       id: 'repo_id',
+      resourceType: 'Repo',
       paginate: {
         default: 50,
         max: 100,

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -29,6 +29,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const sessionRepo = new SessionRepository(db);
     super(sessionRepo, {
       id: 'session_id',
+      resourceType: 'Session',
       paginate: {
         default: 50,
         max: 1000, // Increased from 100 to allow fetching more sessions

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -28,6 +28,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     const taskRepo = new TaskRepository(db);
     super(taskRepo, {
       id: 'task_id',
+      resourceType: 'Task',
       paginate: {
         default: 100,
         max: 500,

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -64,6 +64,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
     const worktreeRepo = new WorktreeRepository(db);
     super(worktreeRepo, {
       id: 'worktree_id',
+      resourceType: 'Worktree',
       paginate: {
         default: 50,
         max: 100,

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -6,6 +6,65 @@
  */
 
 /**
+ * Custom error classes for type-safe error handling
+ */
+
+/**
+ * Base class for all Agor errors
+ */
+export class AgorError extends Error {
+  constructor(message: string, public readonly code?: string) {
+    super(message);
+    this.name = this.constructor.name;
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
+/**
+ * Thrown when a resource is not found in the database
+ */
+export class NotFoundError extends AgorError {
+  constructor(resourceType: string, id: string) {
+    super(`${resourceType} not found: ${id}`, 'NOT_FOUND');
+    this.resourceType = resourceType;
+    this.id = id;
+  }
+
+  public readonly resourceType: string;
+  public readonly id: string;
+}
+
+/**
+ * Thrown when a resource already exists
+ */
+export class AlreadyExistsError extends AgorError {
+  constructor(resourceType: string, identifier: string) {
+    super(`${resourceType} already exists: ${identifier}`, 'ALREADY_EXISTS');
+  }
+}
+
+/**
+ * Thrown when validation fails
+ */
+export class ValidationError extends AgorError {
+  constructor(message: string, public readonly field?: string) {
+    super(message, 'VALIDATION_ERROR');
+  }
+}
+
+/**
+ * Thrown when an operation is not authorized
+ */
+export class UnauthorizedError extends AgorError {
+  constructor(message: string = 'Not authorized') {
+    super(message, 'UNAUTHORIZED');
+  }
+}
+
+/**
  * Extract error message from any value
  * Handles Error objects, strings, and unknown types
  */


### PR DESCRIPTION
## Summary

Replaces brittle string-based error handling with proper typed error classes, following Python-like exception patterns for type-safe error handling.

### Problem
- Health monitor was logging noisy errors for deleted worktrees (race condition between deletion and health checks)
- Error handling relied on string matching (`error.message.includes()`)
- No type safety for error handling

### Solution
Introduced custom error class hierarchy:
- `AgorError` - Base class with error codes
- `NotFoundError` - Type-safe "not found" errors with resourceType and id properties  
- `AlreadyExistsError`, `ValidationError`, `UnauthorizedError` - Ready for future use

### Changes

**Core Error Classes** (`packages/core/src/utils/errors.ts`)
- New error class hierarchy with proper stack traces
- Rich error context (resourceType, id fields)

**Drizzle Adapter** (`apps/agor-daemon/src/adapters/drizzle.ts`)
- Added `resourceType` option to all services
- Throws `NotFoundError` instead of generic `Error`
- Cleaned up redundant null checks

**Health Monitor** (`apps/agor-daemon/src/services/health-monitor.ts`)
- Uses `instanceof NotFoundError` instead of string matching
- Silently handles deleted worktree race condition (expected behavior)
- Optional DEBUG logging for troubleshooting

**All Services**
- Added resourceType to 8 services (Session, Task, Worktree, Repo, Message, McpServer, Board, BoardComment)

### Benefits
✅ Type-safe error handling with `instanceof` checks  
✅ Better IDE support (auto-completion, type checking)  
✅ Rich error context (resourceType, id properties)  
✅ Extensible for future error types  
✅ No more brittle string parsing  
✅ Silent cleanup of expected race conditions

## Test plan
- [x] Verify health monitoring stops cleanly for deleted worktrees (no error logs)
- [x] Test NotFoundError thrown correctly across all services
- [ ] Start daemon and delete a worktree with running environment
- [ ] Confirm no "health check failed" errors appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)