### PR TITLE
fix: use currentUser for session creation preferences

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -980,7 +980,7 @@ function AppContent() {
               )}
               <AgorApp
                 client={client}
-                user={user}
+                user={currentUser}
                 sessions={sessions}
                 tasks={tasks}
                 availableAgents={AVAILABLE_AGENTS}


### PR DESCRIPTION
## Summary

- Pass `currentUser` into `AgorApp` for session creation preferences.
- Keep the app-level user prop aligned with the resolved current user state.

## Tests

- Not run.
