### PR TITLE
feat(ui): add password quality requirements to user settings

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -499,7 +499,24 @@ export const UsersTable: React.FC<UsersTableProps> = ({
             rules={[
               { required: true, message: 'Please enter a password' },
               { min: 8, message: 'Password must be at least 8 characters' },
+              {
+                pattern: /[A-Z]/,
+                message: 'Password must contain at least one uppercase letter'
+              },
+              {
+                pattern: /[a-z]/,
+                message: 'Password must contain at least one lowercase letter'
+              },
+              {
+                pattern: /[0-9]/,
+                message: 'Password must contain at least one number'
+              },
+              {
+                pattern: /[^A-Za-z0-9]/,
+                message: 'Password must contain at least one special character'
+              },
             ]}
+            help="Minimum 8 characters with uppercase, lowercase, number, and special character"
           >
             <Input.Password placeholder="••••••••" />
           </Form.Item>
@@ -582,7 +599,30 @@ export const UsersTable: React.FC<UsersTableProps> = ({
                     <Input placeholder="user@example.com" />
                   </Form.Item>
 
-                  <Form.Item label="Password" name="password" help="Leave blank to keep current password">
+                  <Form.Item
+                    label="Password"
+                    name="password"
+                    help="Leave blank to keep current password. New password must be at least 8 characters with uppercase, lowercase, number, and special character"
+                    rules={[
+                      { min: 8, message: 'Password must be at least 8 characters' },
+                      {
+                        pattern: /[A-Z]/,
+                        message: 'Password must contain at least one uppercase letter'
+                      },
+                      {
+                        pattern: /[a-z]/,
+                        message: 'Password must contain at least one lowercase letter'
+                      },
+                      {
+                        pattern: /[0-9]/,
+                        message: 'Password must contain at least one number'
+                      },
+                      {
+                        pattern: /[^A-Za-z0-9]/,
+                        message: 'Password must contain at least one special character'
+                      },
+                    ]}
+                  >
                     <Input.Password placeholder="••••••••" />
                   </Form.Item>
 


### PR DESCRIPTION
## Summary
- Add password validation rules requiring uppercase, lowercase, number, and special character
- Apply validation to both create and edit user modals
- Add inline help text explaining password requirements

## Test plan
- [ ] Open Settings → Users → Create User
- [ ] Try creating user with weak password (e.g., "password") - should show validation errors
- [ ] Create user with strong password (e.g., "Password123!") - should succeed
- [ ] Edit existing user and try changing password to weak password - should show validation errors
- [ ] Edit existing user and change password to strong password - should succeed
- [ ] Leave password blank when editing - should allow update without password change

🤖 Generated with [Claude Code](https://claude.com/claude-code)