### PR TITLE
fix(ui): improve emoji picker accessibility in CommentsPanel

### DIFF
--- a/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
+++ b/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
@@ -151,7 +151,7 @@ const EmojiPickerButton: React.FC<{
       trigger="click"
       open={pickerOpen}
       onOpenChange={setPickerOpen}
-      placement="topLeft"
+      placement="right"
     >
       <Button
         type="text"


### PR DESCRIPTION
## Summary
- Changed emoji picker `placement` from `"topLeft"` to `"right"` in CommentsPanel
- Aligns with left sidebar context and matches working emoji pickers in SettingsModal

## Problem
The emoji picker in the CommentsPanel (left sidebar) was difficult to access:
- Configured with `placement="topLeft"` while positioned at the right edge of comments
- Created an awkward gap between trigger button and popover
- When moving mouse to the popover, users would lose hover state, causing the overlay to disappear

## Solution
Updated placement from `"topLeft"` to `"right"` to:
- Open popover directly to the right of the trigger button (into main content area)
- Eliminate the navigation gap
- Match the successful pattern used in other emoji pickers (EmojiPickerInput, SettingsModal)

## Test plan
- [ ] Test emoji picker in CommentsPanel - should open smoothly to the right
- [ ] Verify no hover state loss when moving to popover
- [ ] Check that picker doesn't clip at panel edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)