### PR TITLE
fix(ui): remove undefined tooltip on session hover in WorktreeCard

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/buildSessionTree.ts
+++ b/apps/agor-ui/src/components/WorktreeCard/buildSessionTree.ts
@@ -64,9 +64,9 @@ export function buildSessionTree(sessions: Session[]): SessionTreeNode[] {
 
     const node: SessionTreeNode = {
       key: session.session_id,
+      title: '', // Empty string to prevent default tooltip (titleRender handles display)
       session,
       relationshipType,
-      // title will be rendered by titleRender prop
     };
 
     if (children.length > 0) {


### PR DESCRIPTION
## Summary
- Fixed issue where hovering over sessions in WorktreeCard showed `---` tooltip
- The `SessionTreeNode` was missing a `title` property, causing Ant Design Tree to display undefined
- Added empty string title since `titleRender` handles the actual display

## Changes
- `apps/agor-ui/src/components/WorktreeCard/buildSessionTree.ts`: Added `title: ''` property to prevent default tooltip

## Test plan
- [x] Hover over sessions in WorktreeCard
- [x] Verify no `---` tooltip appears
- [x] Verify session rendering still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)