### PR TITLE
fix(ui): optimize footer spacing and pill widths for better space utilization

### DIFF
--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -245,7 +245,7 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
             size={size}
             placeholder="Sandbox"
             popupMatchSelectWidth={false}
-            style={{ minWidth: 100 }}
+            style={{ minWidth: 80 }}
             options={CODEX_SANDBOX_MODES.map(({ value, label, description }) => ({
               label,
               value,
@@ -258,7 +258,7 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
             size={size}
             placeholder="Approval"
             popupMatchSelectWidth={false}
-            style={{ minWidth: 100 }}
+            style={{ minWidth: 80 }}
             options={CODEX_APPROVAL_POLICIES.map(({ value, label, description }) => ({
               label,
               value,
@@ -274,7 +274,7 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
       <Select
         value={effectiveValue}
         onChange={onChange}
-        style={{ minWidth: width || 120 }}
+        style={{ minWidth: 100 }}
         size={size}
         suffixIcon={<SafetyOutlined />}
         popupMatchSelectWidth={false}

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -105,7 +105,7 @@ interface MessageCountPillProps extends BasePillProps {
 
 export const MessageCountPill: React.FC<MessageCountPillProps> = ({ count, style }) => (
   <Tag icon={<MessageOutlined />} color={PILL_COLORS.message} style={style}>
-    {count}
+    <span>{count}</span>
   </Tag>
 );
 

--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -656,7 +656,7 @@ const SessionDrawer = ({
             users={users}
           />
           <Space style={{ width: '100%', justifyContent: 'space-between' }}>
-            <Space size={8}>
+            <Space size={0}>
               {footerTimerTask && (
                 <TimerPill
                   status={footerTimerTask.status}


### PR DESCRIPTION
## Summary
- Reduce pill spacing in conversation footer from 8px to 0px for more compact layout
- Fix MessageCountPill spacing issue when count is 0 by wrapping in span
- Reduce PermissionModeSelector width (100px → 80px for Codex, 120px → 100px for Claude/Gemini)
- Maintain `popupMatchSelectWidth=false` to keep dropdown readable while input is compact

## Test plan
- [x] Verify pills in conversation footer have tighter spacing without touching
- [x] Verify MessageCountPill displays correctly when count is 0
- [x] Verify PermissionModeSelector is narrower but dropdown is still readable
- [x] Visual QA in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)