### PR TITLE
feat: add cross-tool subsession spawning with settings inheritance

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -659,7 +659,8 @@ async function main() {
   console.log('✅ Database ready');
 
   // Register core services
-  app.use('/sessions', createSessionsService(db));
+  // NOTE: Pass app instance for user preferences access (needed for cross-tool spawning)
+  app.use('/sessions', createSessionsService(db, app));
   app.use('/tasks', createTasksService(db));
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;
 

--- a/apps/agor-ui/src/templates/spawn_subsession.hbs
+++ b/apps/agor-ui/src/templates/spawn_subsession.hbs
@@ -1,4 +1,4 @@
-You have access to the Agor MCP tool 'agor_sessions_spawn' which creates a child session.
+INSTRUCTION: The user is requesting more information or wants to delegate a task. You MUST use the Agor MCP tool 'agor_sessions_spawn' to create a child session that will handle this request.
 
 USER REQUEST:
 """
@@ -6,17 +6,25 @@ USER REQUEST:
 """
 
 YOUR TASK:
-1. Analyze the user's request and identify what context from THIS session would be helpful for the new session
-2. Prepare a comprehensive, detailed prompt for the child session that includes:
-   - The user's core request
+You must call the agor_sessions_spawn MCP tool with a comprehensive prompt. Do NOT respond directly to the user.
+
+Steps:
+1. Analyze the user's request and identify what context from THIS session would be helpful
+2. Prepare a detailed prompt for the child session that includes:
+   - The user's core request with full context
    - Relevant context from this session (code locations, decisions made, patterns to follow)
    - Clear success criteria and expected outputs
-3. Use the agor_sessions_spawn MCP tool with your prepared prompt
+3. IMMEDIATELY use the agor_sessions_spawn MCP tool with your prepared prompt
 
 EXAMPLE:
 User: "add tests"
-Your prepared prompt: "Write Jest unit tests for the authentication module at src/auth/. Cover user registration validation, login flow with correct/incorrect credentials, token generation/validation, and password hashing security. Follow the existing test patterns in tests/auth/. Aim for 80%+ coverage. The auth module uses bcrypt for hashing and JWT for tokens."
+Correct response: Call agor_sessions_spawn with prompt:
+"Write Jest unit tests for the authentication module at src/auth/. Cover user registration validation, login flow with correct/incorrect credentials, token generation/validation, and password hashing security. Follow the existing test patterns in tests/auth/. Aim for 80%+ coverage. The auth module uses bcrypt for hashing and JWT for tokens."
 
-Important: Since the child session starts with a fresh context window, include ALL relevant context in your prepared prompt.
+CRITICAL:
+- Do NOT explain or respond directly to the user
+- ALWAYS use the MCP tool - this is mandatory
+- The child session starts fresh - include ALL relevant context in your prompt
+- After spawning, briefly acknowledge what the child session will do
 
-Proceed now.
+Proceed now by calling agor_sessions_spawn.


### PR DESCRIPTION
## Summary

Enhance the `agor_sessions_spawn` MCP tool to support spawning sessions with different agentic tools (e.g., Claude Code spawning Codex or vice versa).

## Changes

**Settings Inheritance Logic:**
- **Same tool**: Inherit parent's `permission_config` and `model_config`
- **Different tool**: Use user's preferred settings from `default_agentic_config`

**Implementation:**
- Update `SessionsService` to accept `Application` for user service access
- Implement intelligent settings inheritance in `spawn()` method
- Fetch user preferences when spawning different tools
- Graceful fallback to parent settings if preferences unavailable
- Improve `spawn_subsession.hbs` template with clearer instructions

## User Experience

When agents spawn subsessions with different tools, they automatically get the user's preferred configuration for that tool, making cross-tool orchestration seamless.

## Example Usage

```typescript
// Claude Code spawning Codex with user's preferred Codex settings
await mcp_agor_sessions_spawn({
  prompt: "Optimize this function for performance",
  agenticTool: "codex"  // Different from parent's claude-code
});

// Claude Code spawning another Claude Code session
// Inherits parent's permission mode and model config
await mcp_agor_sessions_spawn({
  prompt: "Write tests for this module"
  // agenticTool omitted - defaults to parent (claude-code)
});
```

## Test Plan

- [ ] Test spawning same tool (Claude Code → Claude Code)
- [ ] Test spawning different tool (Claude Code → Codex)
- [ ] Test spawning different tool (Codex → Claude Code)
- [ ] Verify user preferences are correctly applied
- [ ] Verify fallback to parent settings when preferences unavailable
- [ ] Test with users who have no default_agentic_config set

🤖 Generated with [Claude Code](https://claude.com/claude-code)