### PR TITLE
fix: respect user permission preferences in prompt trigger sessions

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2010,6 +2010,7 @@ const SessionCanvas = ({
                 case 'prompt': {
                   await client.service(`sessions/${targetSessionId}/prompt`).create({
                     prompt: renderedTemplate,
+                    permissionMode,
                   });
                   console.log(`✓ Sent prompt to session ${targetSessionId.substring(0, 8)}`);
                   break;
@@ -2020,6 +2021,7 @@ const SessionCanvas = ({
                     .create({})) as Session;
                   await client.service(`sessions/${forkedSession.session_id}/prompt`).create({
                     prompt: renderedTemplate,
+                    permissionMode,
                   });
                   console.log(
                     `✓ Forked session and sent prompt to ${forkedSession.session_id.substring(0, 8)}`
@@ -2032,6 +2034,7 @@ const SessionCanvas = ({
                     .create({})) as Session;
                   await client.service(`sessions/${spawnedSession.session_id}/prompt`).create({
                     prompt: renderedTemplate,
+                    permissionMode,
                   });
                   console.log(
                     `✓ Spawned child session and sent prompt to ${spawnedSession.session_id.substring(0, 8)}`


### PR DESCRIPTION
## Summary
Fixed a bug where sessions created via zone prompt triggers were not respecting the user's configured permission mode (agentic tool configuration), despite the modal showing the correct settings.

## Problem
When users created a session by dragging a worktree onto a zone with a prompt trigger:
1. The modal displayed the correct user preferences (permission mode, model config, etc.)
2. The session was created with the correct `permission_config` stored in the database
3. BUT when the prompt executed, it was using a different permission mode

This created a confusing UX where the displayed settings didn't match the actual behavior.

## Root Causes
1. **UI issue**: The `SessionCanvas` component wasn't passing the `permissionMode` parameter when calling the `/sessions/:id/prompt` endpoint for zone trigger executions
2. **Backend issue**: The query builder had no fallback to the session's stored `permission_config.mode` if no explicit permission mode was provided in the request

## Changes
### Frontend (SessionCanvas.tsx)
- Pass `permissionMode` to prompt endpoint in all three zone trigger actions (prompt, fork, spawn)

### Backend (query-builder.ts)
- Add fallback to `session.permission_config?.mode` when no explicit `permissionMode` is provided
- Added logging to distinguish between explicit vs. fallback permission mode
- Removed duplicate declaration of `effectivePermissionMode`

## Test Plan
1. Set user default preferences for Claude Code (e.g., permission mode = "acceptEdits")
2. Create a zone with a prompt trigger
3. Drag a worktree onto the zone
4. Verify the modal shows the correct permission mode
5. Execute the trigger
6. Verify the session actually uses "acceptEdits" mode during execution

## Impact
- Fixes the disconnect between UI display and actual behavior
- Makes the zone trigger feature respect user preferences as intended
- Defensive fix ensures other parts of the codebase that don't pass permissionMode will still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>