### PR TITLE
feat: make `agor worktree cd` spawn interactive shell

### DIFF
--- a/apps/agor-cli/src/utils/shell.ts
+++ b/apps/agor-cli/src/utils/shell.ts
@@ -1,0 +1,69 @@
+/**
+ * Shell utilities for spawning interactive shells
+ */
+
+import { type ChildProcess, spawn } from 'node:child_process';
+
+export interface SpawnShellOptions {
+  /**
+   * Working directory for the shell
+   */
+  cwd: string;
+
+  /**
+   * Additional environment variables to set
+   */
+  env?: Record<string, string>;
+
+  /**
+   * Callback when shell exits
+   */
+  onExit?: (code: number | null) => void;
+
+  /**
+   * Callback on error
+   */
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Spawn an interactive shell in the specified directory.
+ *
+ * This will:
+ * - Use the user's preferred shell ($SHELL)
+ * - Run in interactive mode (loads .zshrc, .bashrc, etc.)
+ * - Inherit stdio for full interactivity
+ * - Preserve all environment variables
+ *
+ * @param options - Shell spawn options
+ * @returns The spawned child process
+ */
+export function spawnInteractiveShell(options: SpawnShellOptions): ChildProcess {
+  const { cwd, env = {}, onExit, onError } = options;
+
+  // Get user's preferred shell
+  const shell = process.env.SHELL || '/bin/bash';
+
+  // Spawn shell in interactive mode (-i flag)
+  // This ensures it loads the user's config files (.zshrc, .bashrc, etc.)
+  const shellProcess = spawn(shell, ['-i'], {
+    cwd,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+
+  // Handle exit
+  if (onExit) {
+    shellProcess.on('exit', onExit);
+  }
+
+  // Handle errors
+  if (onError) {
+    shellProcess.on('error', onError);
+  }
+
+  return shellProcess;
+}


### PR DESCRIPTION
## Summary

Changes default behavior of `agor worktree cd` to open a new shell in the worktree directory instead of just printing the path.

## Changes

- **Default behavior**: spawns interactive shell with user's `$SHELL`
- **New `--print` flag**: prints path only (for shell function use case)
- **Environment variables**: sets `AGOR_WORKTREE_ID` and `AGOR_WORKTREE_NAME` in spawned shell
- **UX improvements**: clear entry/exit messages

## Motivation

This provides a more intuitive UX - users can quickly "jump into" a worktree without needing a shell function wrapper:

```bash
# Before (required shell function)
wtcd() { cd "$(agor worktree cd "$1")"; }
wtcd abc123

# After (direct)
agor worktree cd abc123
# You're now in a new shell in the worktree!
# Type exit to return
```

## Shell Function Alternative

For users who prefer to stay in the same shell process, use the `--print` flag:

```bash
wtcd() { cd "$(agor worktree cd --print "$1")"; }
```

## Test Plan

- [x] Test default behavior spawns shell
- [x] Test `--print` flag prints path only
- [x] Test environment variables are set
- [x] Test with both full UUID and short ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)