### PR TITLE
feat: add usage analytics leaderboard endpoint with dynamic grouping

### DIFF
--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -1,0 +1,239 @@
+/**
+ * Leaderboard Service
+ *
+ * Provides usage analytics endpoint for token and cost tracking.
+ * Allows breakdown by user, worktree, and repo with flexible filtering and sorting.
+ */
+
+import {
+  and,
+  asc,
+  type Database,
+  desc,
+  eq,
+  type SQL,
+  sessions,
+  sql,
+  tasks,
+  worktrees,
+} from '@agor/core/db';
+
+interface Params {
+  query?: Record<string, unknown>;
+}
+
+export interface LeaderboardQuery {
+  // Filters
+  userId?: string;
+  worktreeId?: string;
+  repoId?: string;
+
+  // Time period (optional - ISO timestamps)
+  startDate?: string;
+  endDate?: string;
+
+  // Group by dimension (optional - defaults to all three)
+  groupBy?:
+    | 'user'
+    | 'worktree'
+    | 'repo'
+    | 'user,worktree'
+    | 'user,repo'
+    | 'worktree,repo'
+    | 'user,worktree,repo';
+
+  // Sorting
+  sortBy?: 'tokens' | 'cost';
+  sortOrder?: 'asc' | 'desc';
+
+  // Pagination
+  limit?: number;
+  offset?: number;
+}
+
+export interface LeaderboardEntry {
+  userId?: string;
+  userName?: string;
+  worktreeId?: string;
+  worktreeName?: string;
+  repoId?: string;
+  repoName?: string;
+  totalTokens: number;
+  totalCost: number;
+  taskCount: number;
+}
+
+export interface LeaderboardResult {
+  data: LeaderboardEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Leaderboard service
+ *
+ * Custom service that doesn't use DrizzleService adapter since we need
+ * custom aggregation queries.
+ */
+export class LeaderboardService {
+  private db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  /**
+   * Find leaderboard entries with filters and sorting
+   */
+  async find(params?: Params): Promise<LeaderboardResult> {
+    const query = (params?.query || {}) as LeaderboardQuery;
+
+    // Extract query params
+    const {
+      userId,
+      worktreeId,
+      repoId,
+      startDate,
+      endDate,
+      groupBy = 'user,worktree,repo',
+      sortBy = 'cost',
+      sortOrder = 'desc',
+      limit = 50,
+      offset = 0,
+    } = query;
+
+    // Parse groupBy dimensions
+    const dimensions = groupBy.split(',').map(d => d.trim());
+    const includeUser = dimensions.includes('user');
+    const includeWorktree = dimensions.includes('worktree');
+    const includeRepo = dimensions.includes('repo');
+
+    // Build WHERE conditions
+    const conditions: SQL[] = [];
+
+    if (userId) {
+      conditions.push(eq(tasks.created_by, userId));
+    }
+
+    if (worktreeId) {
+      conditions.push(eq(sessions.worktree_id, worktreeId));
+    }
+
+    if (repoId) {
+      conditions.push(eq(worktrees.repo_id, repoId));
+    }
+
+    if (startDate) {
+      const startMs = new Date(startDate).getTime();
+      conditions.push(sql`${tasks.created_at} >= ${startMs}`);
+    }
+
+    if (endDate) {
+      const endMs = new Date(endDate).getTime();
+      conditions.push(sql`${tasks.created_at} <= ${endMs}`);
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Build dynamic SELECT clause
+    // biome-ignore lint/suspicious/noExplicitAny: Dynamic SQL fields require any
+    const selectFields: Record<string, any> = {
+      totalTokens: sql<number>`COALESCE(SUM(CAST(json_extract(${tasks.data}, '$.usage.total_tokens') AS INTEGER)), 0)`,
+      totalCost: sql<number>`COALESCE(SUM(CAST(json_extract(${tasks.data}, '$.usage.estimated_cost_usd') AS REAL)), 0.0)`,
+      taskCount: sql<number>`COUNT(${tasks.task_id})`,
+    };
+
+    if (includeUser) {
+      selectFields.userId = tasks.created_by;
+    }
+    if (includeWorktree) {
+      selectFields.worktreeId = worktrees.worktree_id;
+      selectFields.worktreeName = worktrees.name;
+    }
+    if (includeRepo) {
+      selectFields.repoId = worktrees.repo_id;
+    }
+
+    // Build dynamic GROUP BY clause
+    // biome-ignore lint/suspicious/noExplicitAny: Dynamic SQL fields require any
+    const groupByFields: any[] = [];
+    if (includeUser) groupByFields.push(tasks.created_by);
+    if (includeWorktree) {
+      groupByFields.push(worktrees.worktree_id);
+      groupByFields.push(worktrees.name);
+    }
+    if (includeRepo) groupByFields.push(worktrees.repo_id);
+
+    // Build sorting
+    const sortField = sortBy === 'tokens' ? sql`total_tokens` : sql`total_cost`;
+    const orderClause = sortOrder === 'desc' ? desc(sortField) : asc(sortField);
+
+    // Execute aggregation query
+    const results = await this.db
+      .select(selectFields)
+      .from(tasks)
+      .innerJoin(sessions, eq(tasks.session_id, sessions.session_id))
+      .innerJoin(worktrees, eq(sessions.worktree_id, worktrees.worktree_id))
+      .where(whereClause)
+      .groupBy(...groupByFields)
+      .orderBy(orderClause)
+      .limit(limit)
+      .offset(offset);
+
+    // Build distinct count for pagination
+    const distinctParts: string[] = [];
+    if (includeUser) distinctParts.push(`${tasks.created_by}`);
+    if (includeWorktree) distinctParts.push(`${worktrees.worktree_id}`);
+    if (includeRepo) distinctParts.push(`${worktrees.repo_id}`);
+    const distinctExpr =
+      distinctParts.length > 0
+        ? sql`COUNT(DISTINCT ${sql.raw(distinctParts.join(" || '-' || "))})`
+        : sql`COUNT(*)`;
+
+    const countResult = await this.db
+      .select({
+        count: sql<number>`${distinctExpr}`,
+      })
+      .from(tasks)
+      .innerJoin(sessions, eq(tasks.session_id, sessions.session_id))
+      .innerJoin(worktrees, eq(sessions.worktree_id, worktrees.worktree_id))
+      .where(whereClause);
+
+    const total = countResult[0]?.count || 0;
+
+    // Transform results to match our interface
+    const data: LeaderboardEntry[] = results.map(row => ({
+      ...(includeUser && { userId: row.userId as string }),
+      ...(includeWorktree && {
+        worktreeId: row.worktreeId as string,
+        worktreeName: row.worktreeName as string,
+      }),
+      ...(includeRepo && { repoId: row.repoId as string }),
+      totalTokens: (row.totalTokens as number) || 0,
+      totalCost: (row.totalCost as number) || 0,
+      taskCount: (row.taskCount as number) || 0,
+    }));
+
+    return {
+      data,
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  /**
+   * Setup hooks for the service
+   */
+  async setup(_app: unknown, _path: string): Promise<void> {
+    // No setup needed for now
+  }
+}
+
+/**
+ * Service factory function
+ */
+export function createLeaderboardService(db: Database): LeaderboardService {
+  return new LeaderboardService(db);
+}

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -2,7 +2,7 @@
 
 // Drizzle ORM re-exports (so daemon doesn't import drizzle-orm directly)
 // Commonly used operators and utilities
-export { and, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
+export { and, asc, desc, eq, inArray, like, or, type SQL, sql } from 'drizzle-orm';
 
 // bcryptjs re-export (for password hashing in daemon)
 // bcryptjs is a CommonJS module, so we import the default and re-export specific functions


### PR DESCRIPTION
## Summary

Add new usage analytics leaderboard endpoint that provides token and cost tracking with flexible filtering, dynamic grouping, and sorting capabilities.

## Features

- **Dynamic Grouping**: Group by user, worktree, repo, or any combination
  - Examples: `groupBy=user`, `groupBy=worktree`, `groupBy=user,worktree,repo`
- **Flexible Filtering**: Filter by user ID, worktree ID, repo ID, and time period (start/end dates)
- **Sorting**: Sort by total tokens or estimated cost (ascending or descending)
- **Pagination**: Support for limit/offset pagination
- **Multiple Interfaces**:
  - REST API at `/leaderboard`
  - MCP tool: `agor_analytics_leaderboard`

## Technical Implementation

- Created `LeaderboardService` with dynamic Drizzle query builder
- Aggregates task usage data from `tasks.data.usage` JSON field
- Joins `tasks` → `sessions` → `worktrees` for complete breakdown
- Exports `asc` and `SQL` type from `@agor/core/db` for type safety
- Registered with read-only authentication hooks

## Example Queries

**Per-user totals:**
```
GET /leaderboard?groupBy=user&sortBy=cost&sortOrder=desc
```

**Per-worktree breakdown:**
```
GET /leaderboard?groupBy=worktree&limit=20
```

**Full breakdown with filters:**
```
GET /leaderboard?groupBy=user,worktree,repo&startDate=2025-01-01T00:00:00Z&endDate=2025-01-31T23:59:59Z
```

## Test Plan

- [x] Typecheck passes
- [x] Build succeeds  
- [x] Pre-commit hooks pass
- [ ] Test via REST API
- [ ] Test via MCP tool
- [ ] Verify dynamic grouping works correctly
- [ ] Verify filtering works correctly
- [ ] Verify sorting and pagination work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)