### PR TITLE
fix: prevent UI resets and database overload on WebSocket reconnection

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -39,6 +39,8 @@ const { Content } = Layout;
 export interface AppProps {
   client: AgorClient | null;
   user?: User | null;
+  connected?: boolean;
+  connecting?: boolean;
   sessions: Session[];
   tasks: Record<string, Task[]>;
   availableAgents: AgenticToolOption[];
@@ -108,6 +110,8 @@ export interface AppProps {
 export const App: React.FC<AppProps> = ({
   client,
   user,
+  connected = false,
+  connecting = false,
   sessions,
   tasks,
   availableAgents,
@@ -401,6 +405,8 @@ export const App: React.FC<AppProps> = ({
         user={user}
         activeUsers={allActiveUsers}
         currentUserId={user?.user_id}
+        connected={connected}
+        connecting={connecting}
         onMenuClick={() => setListDrawerOpen(true)}
         onCommentsClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
         onSettingsClick={() => setSettingsOpen(true)}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -9,6 +9,7 @@ import {
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Badge, Button, Divider, Dropdown, Layout, Space, Tooltip, Typography, theme } from 'antd';
+import { ConnectionStatus } from '../ConnectionStatus';
 import { Facepile } from '../Facepile';
 import { ThemeSwitcher } from '../ThemeSwitcher';
 
@@ -19,6 +20,8 @@ export interface AppHeaderProps {
   user?: User | null;
   activeUsers?: ActiveUser[];
   currentUserId?: string;
+  connected?: boolean;
+  connecting?: boolean;
   onMenuClick?: () => void;
   onCommentsClick?: () => void;
   onSettingsClick?: () => void;
@@ -34,6 +37,8 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   user,
   activeUsers = [],
   currentUserId,
+  connected = false,
+  connecting = false,
   onMenuClick,
   onCommentsClick,
   onSettingsClick,
@@ -149,6 +154,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       </Space>
 
       <Space>
+        <ConnectionStatus connected={connected} connecting={connecting} />
         {activeUsers.length > 0 && (
           <>
             <Facepile

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -1,0 +1,114 @@
+import { CheckCircleOutlined, LoadingOutlined, WarningOutlined } from '@ant-design/icons';
+import { Space, Tag, Tooltip, theme } from 'antd';
+import { useEffect, useState } from 'react';
+
+export interface ConnectionStatusProps {
+  connected: boolean;
+  connecting: boolean;
+}
+
+/**
+ * ConnectionStatus - Shows real-time WebSocket connection status
+ *
+ * States:
+ * - Connected: Green checkmark (only shown briefly after reconnect)
+ * - Reconnecting: Yellow spinner (shown during reconnection)
+ * - Disconnected: Red warning (shown when connection lost)
+ *
+ * Auto-hides after 3 seconds when connected to reduce visual clutter
+ */
+export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({ connected, connecting }) => {
+  const { token } = theme.useToken();
+  const [showConnected, setShowConnected] = useState(false);
+  const [justReconnected, setJustReconnected] = useState(false);
+
+  // Track when we transition from connecting -> connected to show "Connected!" briefly
+  useEffect(() => {
+    if (connected && !connecting && justReconnected) {
+      setShowConnected(true);
+      const timer = setTimeout(() => {
+        setShowConnected(false);
+        setJustReconnected(false);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [connected, connecting, justReconnected]);
+
+  // Track reconnection events
+  useEffect(() => {
+    if (connecting && !connected) {
+      setJustReconnected(true);
+    }
+  }, [connecting, connected]);
+
+  // Don't show anything when normally connected (reduces clutter)
+  if (connected && !connecting && !showConnected) {
+    return null;
+  }
+
+  // Disconnected state
+  if (!connected && !connecting) {
+    return (
+      <Tooltip title="Connection lost. Waiting for daemon..." placement="bottom">
+        <Tag
+          icon={<WarningOutlined />}
+          color="error"
+          style={{
+            margin: 0,
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+          }}
+        >
+          <Space size={4}>
+            <span>Disconnected</span>
+          </Space>
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  // Reconnecting state
+  if (connecting || !connected) {
+    return (
+      <Tooltip title="Reconnecting to daemon..." placement="bottom">
+        <Tag
+          icon={<LoadingOutlined spin />}
+          color="warning"
+          style={{
+            margin: 0,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Space size={4}>
+            <span>Reconnecting</span>
+          </Space>
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  // Just reconnected - show success briefly
+  if (showConnected) {
+    return (
+      <Tooltip title="Connected to daemon" placement="bottom">
+        <Tag
+          icon={<CheckCircleOutlined />}
+          color="success"
+          style={{
+            margin: 0,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Space size={4}>
+            <span>Connected</span>
+          </Space>
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  return null;
+};

--- a/apps/agor-ui/src/components/ConnectionStatus/index.ts
+++ b/apps/agor-ui/src/components/ConnectionStatus/index.ts
@@ -1,0 +1,2 @@
+export type { ConnectionStatusProps } from './ConnectionStatus';
+export { ConnectionStatus } from './ConnectionStatus';

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -19,6 +19,7 @@ interface EnvironmentPillProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  connectionDisabled?: boolean; // Disable actions when disconnected
 }
 
 export function EnvironmentPill({
@@ -28,6 +29,7 @@ export function EnvironmentPill({
   onStartEnvironment,
   onStopEnvironment,
   onViewLogs,
+  connectionDisabled = false,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
   const hasConfig = !!repo.environment_config;
@@ -92,8 +94,15 @@ export function EnvironmentPill({
   const isStarting = status === 'starting';
   const isStopping = status === 'stopping';
   const canStop = status === 'running' || status === 'starting';
-  const startDisabled = !hasConfig || !onStartEnvironment || isStarting || isStopping || isRunning;
-  const stopDisabled = !hasConfig || !onStopEnvironment || isStopping || !canStop;
+  const startDisabled =
+    connectionDisabled ||
+    !hasConfig ||
+    !onStartEnvironment ||
+    isStarting ||
+    isStopping ||
+    isRunning;
+  const stopDisabled =
+    connectionDisabled || !hasConfig || !onStopEnvironment || isStopping || !canStop;
 
   // Build helpful tooltip based on inferred state
   const getTooltipText = () => {

--- a/apps/agor-ui/src/components/NewSessionButton/NewSessionButton.tsx
+++ b/apps/agor-ui/src/components/NewSessionButton/NewSessionButton.tsx
@@ -1,5 +1,6 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { FloatButton } from 'antd';
+import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 
 export interface NewSessionButtonProps {
   onClick?: () => void;
@@ -7,7 +8,12 @@ export interface NewSessionButtonProps {
 }
 
 export const NewSessionButton: React.FC<NewSessionButtonProps> = ({ onClick, hasRepos = true }) => {
-  const tooltip = hasRepos ? 'Create new worktree' : 'Create a repository first';
+  const connectionDisabled = useConnectionDisabled();
+  const tooltip = connectionDisabled
+    ? 'Disconnected from daemon'
+    : hasRepos
+      ? 'Create new worktree'
+      : 'Create a repository first';
 
   return (
     <FloatButton
@@ -15,6 +21,7 @@ export const NewSessionButton: React.FC<NewSessionButtonProps> = ({ onClick, has
       type="primary"
       onClick={onClick}
       tooltip={tooltip}
+      disabled={connectionDisabled}
       style={{ right: 24, top: 80 }}
     />
   );

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -11,6 +11,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { App, Button, Card, Collapse, Space, Tag, Typography } from 'antd';
+import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { CreatedByTag } from '../metadata';
 import TaskListItem from '../TaskListItem';
 import { TaskStatusIcon } from '../TaskStatusIcon';
@@ -54,6 +55,7 @@ const SessionCard = ({
   defaultExpanded = true,
 }: SessionCardProps) => {
   const { modal } = App.useApp();
+  const connectionDisabled = useConnectionDisabled();
 
   const handleDelete = () => {
     modal.confirm({
@@ -107,7 +109,7 @@ const SessionCard = ({
             type="text"
             icon={<PlusCircleOutlined />}
             size="small"
-            onClick={(e) => {
+            onClick={e => {
               e.stopPropagation();
               onSessionClick?.();
             }}
@@ -117,7 +119,7 @@ const SessionCard = ({
         </div>
       )}
 
-      {visibleTasks.map((task) => (
+      {visibleTasks.map(task => (
         <TaskListItem key={task.task_id} task={task} onClick={() => onTaskClick?.(task.task_id)} />
       ))}
     </div>
@@ -168,7 +170,7 @@ const SessionCard = ({
               <Tag
                 icon={<PushpinFilled />}
                 color="blue"
-                onClick={(e) => {
+                onClick={e => {
                   e.stopPropagation();
                   onUnpin?.(session.session_id);
                 }}
@@ -192,7 +194,7 @@ const SessionCard = ({
                 type="text"
                 size="small"
                 icon={<ExpandOutlined />}
-                onClick={(e) => {
+                onClick={e => {
                   e.stopPropagation();
                   onSessionClick();
                 }}
@@ -204,7 +206,7 @@ const SessionCard = ({
                 type="text"
                 size="small"
                 icon={<SettingOutlined />}
-                onClick={(e) => {
+                onClick={e => {
                   e.stopPropagation();
                   onOpenSettings(session.session_id);
                 }}
@@ -216,7 +218,8 @@ const SessionCard = ({
                 type="text"
                 size="small"
                 icon={<CloseOutlined />}
-                onClick={(e) => {
+                disabled={connectionDisabled}
+                onClick={e => {
                   e.stopPropagation();
                   handleDelete();
                 }}

--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -37,6 +37,7 @@ import {
   theme,
 } from 'antd';
 import React from 'react';
+import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useTasks } from '../../hooks/useTasks';
 import spawnSubsessionTemplate from '../../templates/spawn_subsession.hbs?raw';
 import { getContextWindowGradient } from '../../utils/contextWindow';
@@ -132,6 +133,7 @@ const SessionDrawer = ({
 }: SessionDrawerProps) => {
   const { token } = theme.useToken();
   const { modal, message } = App.useApp();
+  const connectionDisabled = useConnectionDisabled();
 
   // Per-session draft storage (persists across session switches, no parent re-renders!)
   const draftsRef = React.useRef<Map<string, string>>(new Map());
@@ -951,14 +953,14 @@ const SessionDrawer = ({
                   <Button
                     icon={<ForkOutlined />}
                     onClick={handleFork}
-                    disabled={isRunning || !inputValue.trim()}
+                    disabled={connectionDisabled || isRunning || !inputValue.trim()}
                   />
                 </Tooltip>
                 <Tooltip title={isRunning ? 'Session is running...' : 'Spawn Subsession'}>
                   <Button
                     icon={<BranchesOutlined />}
                     onClick={handleSubsession}
-                    disabled={isRunning || !inputValue.trim()}
+                    disabled={connectionDisabled || isRunning || !inputValue.trim()}
                   />
                 </Tooltip>
                 <Tooltip title={isRunning ? 'Queue Message' : 'Send Prompt'}>
@@ -966,7 +968,7 @@ const SessionDrawer = ({
                     type="primary"
                     icon={<SendOutlined />}
                     onClick={handleSendPrompt}
-                    disabled={!inputValue.trim()}
+                    disabled={connectionDisabled || !inputValue.trim()}
                   />
                 </Tooltip>
               </Space.Compact>

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -14,6 +14,7 @@ import {
 import type { MenuProps } from 'antd';
 import { Badge, Button, Card, Collapse, Space, Spin, Tag, Tree, Typography, theme } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
+import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { ArchiveDeleteWorktreeModal } from '../ArchiveDeleteWorktreeModal';
 import { EnvironmentPill } from '../EnvironmentPill';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
@@ -104,6 +105,7 @@ const WorktreeCard = ({
   defaultExpanded = true,
 }: WorktreeCardProps) => {
   const { token } = theme.useToken();
+  const connectionDisabled = useConnectionDisabled();
 
   // Fork/Spawn modal state
   const [forkSpawnModal, setForkSpawnModal] = useState<{
@@ -201,6 +203,7 @@ const WorktreeCard = ({
         key: 'fork',
         icon: <ForkOutlined />,
         label: 'Fork Session',
+        disabled: connectionDisabled,
         onClick: () => {
           setForkSpawnModal({
             open: true,
@@ -213,6 +216,7 @@ const WorktreeCard = ({
         key: 'spawn',
         icon: <SubnodeOutlined />,
         label: 'Spawn Subsession',
+        disabled: connectionDisabled,
         onClick: () => {
           setForkSpawnModal({
             open: true,
@@ -332,6 +336,7 @@ const WorktreeCard = ({
             type="default"
             size="small"
             icon={<PlusOutlined />}
+            disabled={connectionDisabled}
             onClick={e => {
               e.stopPropagation();
               onCreateSession(worktree.worktree_id);
@@ -538,6 +543,7 @@ const WorktreeCard = ({
                 type="text"
                 size="small"
                 icon={<DeleteOutlined />}
+                disabled={connectionDisabled}
                 onClick={e => {
                   e.stopPropagation();
                   setArchiveDeleteModalOpen(true);
@@ -570,6 +576,7 @@ const WorktreeCard = ({
             onStartEnvironment={onStartEnvironment}
             onStopEnvironment={onStopEnvironment}
             onViewLogs={onViewLogs}
+            connectionDisabled={connectionDisabled}
           />
         </Space>
       </div>
@@ -601,6 +608,7 @@ const WorktreeCard = ({
               <Button
                 type="primary"
                 icon={<PlusOutlined />}
+                disabled={connectionDisabled}
                 onClick={e => {
                   e.stopPropagation();
                   onCreateSession(worktree.worktree_id);

--- a/apps/agor-ui/src/contexts/ConnectionContext.tsx
+++ b/apps/agor-ui/src/contexts/ConnectionContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * ConnectionContext - Global connection state for disabling UI during disconnections
+ *
+ * Prevents queued actions from flooding the daemon when reconnecting
+ */
+interface ConnectionContextValue {
+  connected: boolean;
+  connecting: boolean;
+}
+
+const ConnectionContext = createContext<ConnectionContextValue>({
+  connected: false,
+  connecting: false,
+});
+
+export const ConnectionProvider = ConnectionContext.Provider;
+
+/**
+ * Hook to check if UI should be disabled due to disconnection
+ *
+ * Usage:
+ * ```tsx
+ * const disabled = useConnectionDisabled();
+ * <Button disabled={disabled} onClick={...}>Submit</Button>
+ * ```
+ */
+export function useConnectionDisabled(): boolean {
+  const { connected } = useContext(ConnectionContext);
+  return !connected;
+}
+
+/**
+ * Hook to get full connection state
+ */
+export function useConnectionState(): ConnectionContextValue {
+  return useContext(ConnectionContext);
+}

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -55,6 +55,10 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Track if we've done initial fetch - prevents refetch on reconnection
+  // WebSocket events keep data synchronized in real-time
+  const [hasInitiallyFetched, setHasInitiallyFetched] = useState(false);
+
   // Fetch all data
   const fetchData = useCallback(async () => {
     if (!client) {
@@ -78,17 +82,11 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
         mcpServersResult,
         sessionMcpResult,
       ] = await Promise.all([
-        client
-          .service('sessions')
-          .find({ query: { $limit: 1000, $sort: { updated_at: -1 } } }), // Fetch up to 1000 sessions, sorted by most recent
-        client
-          .service('tasks')
-          .find({ query: { $limit: 500 } }), // Fetch up to 500 tasks
+        client.service('sessions').find({ query: { $limit: 1000, $sort: { updated_at: -1 } } }), // Fetch up to 1000 sessions, sorted by most recent
+        client.service('tasks').find({ query: { $limit: 500 } }), // Fetch up to 500 tasks
         client.service('boards').find(),
         client.service('board-objects').find(),
-        client
-          .service('board-comments')
-          .find({ query: { $limit: 500 } }), // Fetch up to 500 comments
+        client.service('board-comments').find({ query: { $limit: 500 } }), // Fetch up to 500 comments
         client.service('repos').find(),
         client.service('worktrees').find(),
         client.service('users').find(),
@@ -158,19 +156,21 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       return;
     }
 
-    // Initial fetch
-    fetchData();
+    // Initial fetch (only once - WebSocket events keep us synced after that)
+    if (!hasInitiallyFetched) {
+      fetchData().then(() => setHasInitiallyFetched(true));
+    }
 
     // Subscribe to session events
     const sessionsService = client.service('sessions');
     const handleSessionCreated = (session: Session) => {
-      setSessions((prev) => [...prev, session]);
+      setSessions(prev => [...prev, session]);
     };
     const handleSessionPatched = (session: Session) => {
-      setSessions((prev) => prev.map((s) => (s.session_id === session.session_id ? session : s)));
+      setSessions(prev => prev.map(s => (s.session_id === session.session_id ? session : s)));
     };
     const handleSessionRemoved = (session: Session) => {
-      setSessions((prev) => prev.filter((s) => s.session_id !== session.session_id));
+      setSessions(prev => prev.filter(s => s.session_id !== session.session_id));
     };
 
     sessionsService.on('created', handleSessionCreated);
@@ -181,23 +181,23 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to task events
     const tasksService = client.service('tasks');
     const handleTaskCreated = (task: Task) => {
-      setTasks((prev) => ({
+      setTasks(prev => ({
         ...prev,
         [task.session_id]: [...(prev[task.session_id] || []), task],
       }));
     };
     const handleTaskPatched = (task: Task) => {
-      setTasks((prev) => ({
+      setTasks(prev => ({
         ...prev,
-        [task.session_id]: (prev[task.session_id] || []).map((t) =>
+        [task.session_id]: (prev[task.session_id] || []).map(t =>
           t.task_id === task.task_id ? task : t
         ),
       }));
     };
     const handleTaskRemoved = (task: Task) => {
-      setTasks((prev) => ({
+      setTasks(prev => ({
         ...prev,
-        [task.session_id]: (prev[task.session_id] || []).filter((t) => t.task_id !== task.task_id),
+        [task.session_id]: (prev[task.session_id] || []).filter(t => t.task_id !== task.task_id),
       }));
     };
 
@@ -209,13 +209,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to board events
     const boardsService = client.service('boards');
     const handleBoardCreated = (board: Board) => {
-      setBoards((prev) => [...prev, board]);
+      setBoards(prev => [...prev, board]);
     };
     const handleBoardPatched = (board: Board) => {
-      setBoards((prev) => prev.map((b) => (b.board_id === board.board_id ? board : b)));
+      setBoards(prev => prev.map(b => (b.board_id === board.board_id ? board : b)));
     };
     const handleBoardRemoved = (board: Board) => {
-      setBoards((prev) => prev.filter((b) => b.board_id !== board.board_id));
+      setBoards(prev => prev.filter(b => b.board_id !== board.board_id));
     };
 
     boardsService.on('created', handleBoardCreated);
@@ -226,15 +226,15 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to board object events
     const boardObjectsService = client.service('board-objects');
     const handleBoardObjectCreated = (boardObject: BoardEntityObject) => {
-      setBoardObjects((prev) => [...prev, boardObject]);
+      setBoardObjects(prev => [...prev, boardObject]);
     };
     const handleBoardObjectPatched = (boardObject: BoardEntityObject) => {
-      setBoardObjects((prev) =>
-        prev.map((bo) => (bo.object_id === boardObject.object_id ? boardObject : bo))
+      setBoardObjects(prev =>
+        prev.map(bo => (bo.object_id === boardObject.object_id ? boardObject : bo))
       );
     };
     const handleBoardObjectRemoved = (boardObject: BoardEntityObject) => {
-      setBoardObjects((prev) => prev.filter((bo) => bo.object_id !== boardObject.object_id));
+      setBoardObjects(prev => prev.filter(bo => bo.object_id !== boardObject.object_id));
     };
 
     boardObjectsService.on('created', handleBoardObjectCreated);
@@ -245,13 +245,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to repo events
     const reposService = client.service('repos');
     const handleRepoCreated = (repo: Repo) => {
-      setRepos((prev) => [...prev, repo]);
+      setRepos(prev => [...prev, repo]);
     };
     const handleRepoPatched = (repo: Repo) => {
-      setRepos((prev) => prev.map((r) => (r.repo_id === repo.repo_id ? repo : r)));
+      setRepos(prev => prev.map(r => (r.repo_id === repo.repo_id ? repo : r)));
     };
     const handleRepoRemoved = (repo: Repo) => {
-      setRepos((prev) => prev.filter((r) => r.repo_id !== repo.repo_id));
+      setRepos(prev => prev.filter(r => r.repo_id !== repo.repo_id));
     };
 
     reposService.on('created', handleRepoCreated);
@@ -262,15 +262,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to worktree events
     const worktreesService = client.service('worktrees');
     const handleWorktreeCreated = (worktree: Worktree) => {
-      setWorktrees((prev) => [...prev, worktree]);
+      setWorktrees(prev => [...prev, worktree]);
     };
     const handleWorktreePatched = (worktree: Worktree) => {
-      setWorktrees((prev) =>
-        prev.map((w) => (w.worktree_id === worktree.worktree_id ? worktree : w))
-      );
+      setWorktrees(prev => prev.map(w => (w.worktree_id === worktree.worktree_id ? worktree : w)));
     };
     const handleWorktreeRemoved = (worktree: Worktree) => {
-      setWorktrees((prev) => prev.filter((w) => w.worktree_id !== worktree.worktree_id));
+      setWorktrees(prev => prev.filter(w => w.worktree_id !== worktree.worktree_id));
     };
 
     worktreesService.on('created', handleWorktreeCreated);
@@ -281,13 +279,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to user events
     const usersService = client.service('users');
     const handleUserCreated = (user: User) => {
-      setUsers((prev) => [...prev, user]);
+      setUsers(prev => [...prev, user]);
     };
     const handleUserPatched = (user: User) => {
-      setUsers((prev) => prev.map((u) => (u.user_id === user.user_id ? user : u)));
+      setUsers(prev => prev.map(u => (u.user_id === user.user_id ? user : u)));
     };
     const handleUserRemoved = (user: User) => {
-      setUsers((prev) => prev.filter((u) => u.user_id !== user.user_id));
+      setUsers(prev => prev.filter(u => u.user_id !== user.user_id));
     };
 
     usersService.on('created', handleUserCreated);
@@ -298,15 +296,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to MCP server events
     const mcpServersService = client.service('mcp-servers');
     const handleMCPServerCreated = (server: MCPServer) => {
-      setMcpServers((prev) => [...prev, server]);
+      setMcpServers(prev => [...prev, server]);
     };
     const handleMCPServerPatched = (server: MCPServer) => {
-      setMcpServers((prev) =>
-        prev.map((s) => (s.mcp_server_id === server.mcp_server_id ? server : s))
-      );
+      setMcpServers(prev => prev.map(s => (s.mcp_server_id === server.mcp_server_id ? server : s)));
     };
     const handleMCPServerRemoved = (server: MCPServer) => {
-      setMcpServers((prev) => prev.filter((s) => s.mcp_server_id !== server.mcp_server_id));
+      setMcpServers(prev => prev.filter(s => s.mcp_server_id !== server.mcp_server_id));
     };
 
     mcpServersService.on('created', handleMCPServerCreated);
@@ -320,7 +316,7 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       session_id: string;
       mcp_server_id: string;
     }) => {
-      setSessionMcpServerIds((prev) => ({
+      setSessionMcpServerIds(prev => ({
         ...prev,
         [relationship.session_id]: [
           ...(prev[relationship.session_id] || []),
@@ -332,10 +328,10 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       session_id: string;
       mcp_server_id: string;
     }) => {
-      setSessionMcpServerIds((prev) => ({
+      setSessionMcpServerIds(prev => ({
         ...prev,
         [relationship.session_id]: (prev[relationship.session_id] || []).filter(
-          (id) => id !== relationship.mcp_server_id
+          id => id !== relationship.mcp_server_id
         ),
       }));
     };
@@ -346,13 +342,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to board comment events
     const commentsService = client.service('board-comments');
     const handleCommentCreated = (comment: BoardComment) => {
-      setComments((prev) => [...prev, comment]);
+      setComments(prev => [...prev, comment]);
     };
     const handleCommentPatched = (comment: BoardComment) => {
-      setComments((prev) => prev.map((c) => (c.comment_id === comment.comment_id ? comment : c)));
+      setComments(prev => prev.map(c => (c.comment_id === comment.comment_id ? comment : c)));
     };
     const handleCommentRemoved = (comment: BoardComment) => {
-      setComments((prev) => prev.filter((c) => c.comment_id !== comment.comment_id));
+      setComments(prev => prev.filter(c => c.comment_id !== comment.comment_id));
     };
 
     commentsService.on('created', handleCommentCreated);
@@ -410,7 +406,7 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       commentsService.removeListener('updated', handleCommentPatched);
       commentsService.removeListener('removed', handleCommentRemoved);
     };
-  }, [client, fetchData]);
+  }, [client, fetchData, hasInitiallyFetched]);
 
   return {
     sessions,


### PR DESCRIPTION
## Summary
Fixes #180 - Prevents UI from completely resetting during WebSocket reconnections, preserving user state (typed text, canvas position, open drawers) and preventing database overload from queued actions.

## Problem
When the WebSocket connection to the daemon was lost (network blip, daemon restart), the UI would:
1. **Completely unmount** showing a fullscreen loading spinner
2. **Lose all ephemeral state**: typed prompts, canvas zoom/pan, open drawers
3. **Queue up actions** that would fire simultaneously on reconnect, overwhelming SQLite with `SQLITE_BUSY` errors

## Solution

### 1. Track Initial Load State
- Added `hasLoadedOnce` state tracking in `App.tsx`
- Only show fullscreen loading/reconnecting screens on initial load
- During reconnections, keep UI mounted and show subtle indicator instead

### 2. Subtle Connection Status Indicator
- Created `ConnectionStatus` component shown in app header
- Three states: connected (green, auto-hides), reconnecting (yellow), disconnected (red)
- Non-intrusive, preserves user workflow

### 3. Optimize Data Fetching
- Modified `useAgorData` to only fetch data once on initial load
- Rely on WebSocket events for real-time updates after that
- Prevents redundant API calls on every reconnection

### 4. Infinite Browser Reconnection
- Browser: `reconnectionAttempts: Number.POSITIVE_INFINITY` (keep trying)
- CLI: `reconnectionAttempts: 2` (fail fast for better DX)
- Modified `useAgorClient` to distinguish initial connection failures from reconnection attempts

### 5. Global UI Disabling During Disconnection
- Created `ConnectionContext` to provide connection state globally
- Added `useConnectionDisabled()` hook for components
- Disabled all action buttons when disconnected:
  - Send Prompt, Fork, Spawn Subsession (SessionDrawer)
  - New Session, Archive/Delete (WorktreeCard)
  - Delete Session (SessionCard)
  - Create Worktree (NewSessionButton)
  - Start/Stop Environment (EnvironmentPill)
- Prevents actions from queuing and overwhelming database on reconnect

## Testing
Tested with Chrome DevTools network throttling:
1. ✅ Offline → Online: Auto-reconnects without UI reset
2. ✅ Typed text preserved during reconnection
3. ✅ Canvas position/zoom maintained
4. ✅ Open drawers stay open
5. ✅ Buttons disabled during disconnection
6. ✅ No SQLITE_BUSY errors on reconnection

## Files Changed
- `apps/agor-ui/src/App.tsx` - Initial load tracking, ConnectionProvider
- `apps/agor-ui/src/hooks/useAgorClient.ts` - Smart reconnection handling
- `apps/agor-ui/src/hooks/useAgorData.ts` - Prevent redundant fetches
- `apps/agor-ui/src/components/ConnectionStatus/` (NEW) - Subtle status indicator
- `apps/agor-ui/src/contexts/ConnectionContext.tsx` (NEW) - Global connection state
- `apps/agor-ui/src/components/{NewSessionButton,WorktreeCard,SessionCard,SessionDrawer,EnvironmentPill}/` - Disable buttons when disconnected
- `packages/core/src/api/index.ts` - Infinite reconnection for browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)