### PR TITLE
feat: default zone trigger modal to reuse session when available

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -127,13 +127,14 @@ export const ZoneTriggerModal = ({
   // Reset to defaults when modal opens
   useEffect(() => {
     if (open) {
-      setMode('create_new');
+      // Default to 'reuse_existing' if sessions are available, otherwise 'create_new'
+      setMode(worktreeSessions.length > 0 ? 'reuse_existing' : 'create_new');
       setSelectedSessionId(smartDefaultSession);
       setSelectedAction('prompt');
       form.resetFields();
       setSessionConfig({}); // Clear session config state
     }
-  }, [open, smartDefaultSession, form]);
+  }, [open, smartDefaultSession, form, worktreeSessions.length]);
 
   // Pre-populate form AND state when creating new session
   // Priority: Most recent session > User defaults > System defaults


### PR DESCRIPTION
## Summary
Improved UX for zone trigger modal by defaulting to "Reuse a session" option when existing sessions are available in the worktree.

## Changes
- Modified `ZoneTriggerModal.tsx` to conditionally set the default mode based on session availability
- When `worktreeSessions.length > 0`, defaults to `'reuse_existing'` instead of `'create_new'`
- Added `worktreeSessions.length` to the effect dependency array for proper reactivity

## Benefits
- Faster workflow - users don't need to manually switch to reuse mode when sessions exist
- Prioritizes session reuse over creating new sessions, reducing session proliferation
- Falls back to "create new" when no sessions exist, maintaining sensible defaults

## Test Plan
- [x] Typecheck passed
- [x] Build passed
- [x] Lint-staged passed
- [ ] Manual testing: Drop worktree with existing sessions into zone trigger
- [ ] Manual testing: Drop worktree without sessions into zone trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)