### PR TITLE
fix: correct Codex token accounting with proper normalization

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -131,11 +131,6 @@ async function calculateTaskContextWindow(
   tasksService: TasksServiceImpl,
   messagesService: MessagesServiceImpl
 ): Promise<number | undefined> {
-  if (session.agentic_tool !== 'claude-code') {
-    // For non-Claude Code tools, use simple calculation
-    return calculateContextWindowUsage(usage);
-  }
-
   try {
     // Fetch all tasks and messages for this session
     const allTasksResult = (await tasksService.find({
@@ -151,7 +146,10 @@ async function calculateTaskContextWindow(
       : allMessagesResult;
 
     // Calculate cumulative context window (input + output tokens)
-    return calculateCumulativeContextWindow(allTasks, allMessages);
+    // This represents the actual conversation size across all turns
+    // For all agents: Codex, Claude Code, Gemini, etc.
+    // Pass agenticTool so normalization can handle different token reporting formats
+    return calculateCumulativeContextWindow(allTasks, allMessages, session.agentic_tool);
   } catch (err) {
     console.warn(
       `⚠️  Failed to calculate cumulative context window for session ${session.session_id}:`,


### PR DESCRIPTION
## Problem
Codex token accounting was showing impossibly high values (e.g., 36M tokens for a 200K context window limit).

## Root Cause
OpenAI/Codex reports tokens differently than Claude:
- **Codex**: `input_tokens` INCLUDES cached tokens (`cache_read_tokens` is a subset)
- **Claude**: `input_tokens` EXCLUDES cached tokens (`cache_read_tokens` is additional)

We were treating them the same, effectively double-counting Codex's cached tokens.

## Solution
Implemented normalization on retrieval:
1. **Store raw SDK responses as-is** (preserves audit trail)
2. **Created `normalizeTokenUsage()` utility** that normalizes based on `agentic_tool`
3. **Applied normalization in three places**:
   - Backend context window calculation (`calculateCumulativeContextWindow`)
   - Leaderboard service SQL (CASE statement for Codex)
   - UI conversation footer (SessionDrawer token totals)

## Results
- ✅ Codex session now shows **508K tokens** (254% of 200K limit)
- ❌ Previously showed: **36.8M tokens** (18,413% of limit)
- ✅ Leaderboard accurate across all agents
- ✅ Context window pill shows correct percentages

## Architecture Benefits
- Raw data preserved (no transformation at ingestion)
- Single source of truth for interpretation logic
- Consistent calculations across all consumers
- Easy to extend for new tools

## Test Plan
- [x] Global typecheck passes
- [x] Global build succeeds
- [x] Verified token calculations for Codex sessions
- [x] Confirmed normalization doesn't affect Claude/Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)