### PR TITLE
feat: add manual reconnection via clickable disconnected tag

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -97,6 +97,7 @@ function AppContent() {
     connected,
     connecting,
     error: connectionError,
+    retryConnection,
   } = useAgorClient({
     accessToken: authenticated ? accessToken : null,
     allowAnonymous: authConfig?.allowAnonymous ?? false,
@@ -1089,6 +1090,7 @@ function AppContent() {
                 onToggleReaction={handleToggleReaction}
                 onDeleteComment={handleDeleteComment}
                 onLogout={logout}
+                onRetryConnection={retryConnection}
               />
             </>
           }

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -105,6 +105,7 @@ export interface AppProps {
   onToggleReaction?: (commentId: string, emoji: string) => void;
   onDeleteComment?: (commentId: string) => void;
   onLogout?: () => void;
+  onRetryConnection?: () => void;
 }
 
 export const App: React.FC<AppProps> = ({
@@ -141,6 +142,7 @@ export const App: React.FC<AppProps> = ({
   onUpdateRepo,
   onDeleteRepo,
   onArchiveOrDeleteWorktree,
+  onUnarchiveWorktree,
   onUpdateWorktree,
   onCreateWorktree,
   onStartEnvironment,
@@ -158,6 +160,7 @@ export const App: React.FC<AppProps> = ({
   onToggleReaction,
   onDeleteComment,
   onLogout,
+  onRetryConnection,
 }) => {
   const [newSessionWorktreeId, setNewSessionWorktreeId] = useState<string | null>(null);
   const [newWorktreeModalOpen, setNewWorktreeModalOpen] = useState(false);
@@ -420,6 +423,7 @@ export const App: React.FC<AppProps> = ({
         }}
         onThemeEditorClick={() => setThemeEditorOpen(true)}
         onLogout={onLogout}
+        onRetryConnection={onRetryConnection}
         currentBoardName={currentBoard?.name}
         currentBoardIcon={currentBoard?.icon}
         unreadCommentsCount={

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -28,6 +28,7 @@ export interface AppHeaderProps {
   onUserSettingsClick?: () => void;
   onThemeEditorClick?: () => void;
   onLogout?: () => void;
+  onRetryConnection?: () => void;
   currentBoardName?: string;
   currentBoardIcon?: string;
   unreadCommentsCount?: number;
@@ -45,6 +46,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   onUserSettingsClick,
   onThemeEditorClick,
   onLogout,
+  onRetryConnection,
   currentBoardName,
   currentBoardIcon,
   unreadCommentsCount = 0,
@@ -154,7 +156,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       </Space>
 
       <Space>
-        <ConnectionStatus connected={connected} connecting={connecting} />
+        <ConnectionStatus connected={connected} connecting={connecting} onRetry={onRetryConnection} />
         {activeUsers.length > 0 && (
           <>
             <Facepile

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 export interface ConnectionStatusProps {
   connected: boolean;
   connecting: boolean;
+  onRetry?: () => void;
 }
 
 /**
@@ -13,11 +14,11 @@ export interface ConnectionStatusProps {
  * States:
  * - Connected: Green checkmark (only shown briefly after reconnect)
  * - Reconnecting: Yellow spinner (shown during reconnection)
- * - Disconnected: Red warning (shown when connection lost)
+ * - Disconnected: Red warning (shown when connection lost, click to retry)
  *
  * Auto-hides after 3 seconds when connected to reduce visual clutter
  */
-export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({ connected, connecting }) => {
+export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({ connected, connecting, onRetry }) => {
   const { token } = theme.useToken();
   const [showConnected, setShowConnected] = useState(false);
   const [justReconnected, setJustReconnected] = useState(false);
@@ -49,10 +50,11 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({ connected, c
   // Disconnected state
   if (!connected && !connecting) {
     return (
-      <Tooltip title="Connection lost. Waiting for daemon..." placement="bottom">
+      <Tooltip title="Connection lost. Click to retry connection..." placement="bottom">
         <Tag
           icon={<WarningOutlined />}
           color="error"
+          onClick={onRetry}
           style={{
             margin: 0,
             display: 'flex',

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -15,6 +15,7 @@ interface UseAgorClientResult {
   connected: boolean;
   connecting: boolean;
   error: string | null;
+  retryConnection: () => void;
 }
 
 interface UseAgorClientOptions {
@@ -226,10 +227,33 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
     };
   }, [url, accessToken, allowAnonymous]);
 
+  /**
+   * Manually retry connection
+   * Useful when auto-reconnect fails or user wants to force reconnect
+   */
+  const retryConnection = () => {
+    const client = clientRef.current;
+    if (!client?.io) return;
+
+    console.log('🔄 Manual reconnection requested');
+
+    // If already connected, disconnect first
+    if (client.io.connected) {
+      console.log('🔌 Disconnecting before retry...');
+      client.io.disconnect();
+    }
+
+    // Trigger reconnection
+    setConnecting(true);
+    setError(null);
+    client.io.connect();
+  };
+
   return {
     client: clientRef.current,
     connected,
     connecting,
     error,
+    retryConnection,
   };
 }


### PR DESCRIPTION
## Summary
Adds ability to manually retry connection when WebSocket disconnects by clicking the "Disconnected" tag in the navbar.

## Problem
When the daemon connection was lost, the UI would show a "Disconnected" tag but users had no way to manually trigger a reconnection attempt. Auto-reconnection would eventually work, but users had to wait or do a full page refresh.

## Solution
Made the "Disconnected" tag clickable with a manual retry function:
- Click the red "Disconnected" tag to trigger reconnection
- Immediately transitions to yellow "Reconnecting" state
- Uses existing Socket.io reconnection and re-authentication logic
- On success, briefly shows green "Connected" then hides

## Changes
- **ConnectionStatus**: Add `onRetry` callback prop and wire to `onClick` handler
- **useAgorClient**: Add `retryConnection()` function that forces socket reconnect
- **AppHeader**: Pass through `onRetryConnection` prop
- **App components**: Wire `retryConnection` from hook through to header

## Bonus Fix
- Fixed missing `onUnarchiveWorktree` destructuring in App component

## Testing
- Manually tested by stopping/starting daemon
- Verified state transitions: Disconnected → Reconnecting → Connected
- Tested manual click triggers immediate reconnection attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)