### PR TITLE
feat: add session ID popover and message timestamps

### DIFF
--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -489,6 +489,108 @@ interface SessionIdPillProps extends BasePillProps {
   showCopy?: boolean;
 }
 
+/**
+ * Session ID Popover Content Component
+ * Displays both Agor session ID and agentic tool session ID with copy buttons
+ */
+const SessionIdPopoverContent: React.FC<{
+  sessionId: string;
+  sdkSessionId?: string;
+  agenticTool?: string;
+}> = ({ sessionId, sdkSessionId, agenticTool }) => {
+  const { token } = theme.useToken();
+
+  const handleCopyAgor = () => {
+    copyToClipboard(sessionId, {
+      showSuccess: true,
+      successMessage: 'Agor session ID copied to clipboard',
+    });
+  };
+
+  const handleCopySdk = () => {
+    if (sdkSessionId) {
+      copyToClipboard(sdkSessionId, {
+        showSuccess: true,
+        successMessage: `${agenticTool || 'SDK'} session ID copied to clipboard`,
+      });
+    }
+  };
+
+  return (
+    <div style={{ width: 400, maxWidth: '90vw' }}>
+      {/* Agor Session ID */}
+      <div style={{ marginBottom: sdkSessionId ? 16 : 0 }}>
+        <div style={{ fontWeight: 600, fontSize: '0.95em', marginBottom: 8 }}>Agor Session ID</div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: 8,
+            background: token.colorBgContainer,
+            borderRadius: token.borderRadius,
+            border: `1px solid ${token.colorBorder}`,
+          }}
+        >
+          <div style={{ flex: 1, fontFamily: token.fontFamilyCode, fontSize: '0.9em' }}>
+            <div style={{ color: token.colorTextSecondary, fontSize: '0.85em', marginBottom: 2 }}>
+              {sessionId.substring(0, 8)}
+            </div>
+            <div style={{ wordBreak: 'break-all', fontSize: '0.75em', opacity: 0.7 }}>
+              {sessionId}
+            </div>
+          </div>
+          <Tag
+            icon={<CopyOutlined />}
+            color={PILL_COLORS.session}
+            style={{ cursor: 'pointer', margin: 0 }}
+            onClick={handleCopyAgor}
+          >
+            Copy
+          </Tag>
+        </div>
+      </div>
+
+      {/* SDK Session ID (if available) */}
+      {sdkSessionId && (
+        <div>
+          <div style={{ fontWeight: 600, fontSize: '0.95em', marginBottom: 8 }}>
+            {agenticTool || 'SDK'} Session ID
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: 8,
+              background: token.colorBgContainer,
+              borderRadius: token.borderRadius,
+              border: `1px solid ${token.colorBorder}`,
+            }}
+          >
+            <div style={{ flex: 1, fontFamily: token.fontFamilyCode, fontSize: '0.9em' }}>
+              <div style={{ color: token.colorTextSecondary, fontSize: '0.85em', marginBottom: 2 }}>
+                {sdkSessionId.substring(0, 8)}
+              </div>
+              <div style={{ wordBreak: 'break-all', fontSize: '0.75em', opacity: 0.7 }}>
+                {sdkSessionId}
+              </div>
+            </div>
+            <Tag
+              icon={<CopyOutlined />}
+              color={PILL_COLORS.session}
+              style={{ cursor: 'pointer', margin: 0 }}
+              onClick={handleCopySdk}
+            >
+              Copy
+            </Tag>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const SessionIdPill: React.FC<SessionIdPillProps> = ({
   sessionId,
   sdkSessionId,
@@ -502,39 +604,36 @@ export const SessionIdPill: React.FC<SessionIdPillProps> = ({
   const displayId = sdkSessionId || sessionId;
   const shortId = displayId.substring(0, 8);
 
-  // Generate tooltip based on what we're showing
-  const tooltipTitle = sdkSessionId
-    ? `${agenticTool || 'SDK'} session ID: ${displayId}`
-    : `Agor session ID: ${displayId}`;
+  const pill = (
+    <Tag
+      icon={showCopy ? <CopyOutlined /> : <CodeOutlined />}
+      color={PILL_COLORS.session}
+      style={{ cursor: showCopy ? 'pointer' : 'default', ...style }}
+    >
+      <span style={{ fontFamily: token.fontFamilyCode }}>{shortId}</span>
+    </Tag>
+  );
 
-  const handleCopy = () => {
-    copyToClipboard(displayId, {
-      showSuccess: true,
-      successMessage: `${sdkSessionId ? 'SDK' : 'Agor'} Session ID copied to clipboard`,
-    });
-  };
-
-  if (showCopy) {
-    return (
-      <Tooltip title={tooltipTitle}>
-        <Tag
-          icon={<CopyOutlined />}
-          color={PILL_COLORS.session}
-          style={{ cursor: 'pointer', ...style }}
-          onClick={handleCopy}
-        >
-          <span style={{ fontFamily: token.fontFamilyCode }}>{shortId}</span>
-        </Tag>
-      </Tooltip>
-    );
+  if (!showCopy) {
+    return pill;
   }
 
   return (
-    <Tooltip title={tooltipTitle}>
-      <Tag icon={<CodeOutlined />} color={PILL_COLORS.session} style={style}>
-        <span style={{ fontFamily: token.fontFamilyCode }}>{shortId}</span>
-      </Tag>
-    </Tooltip>
+    <Popover
+      content={
+        <SessionIdPopoverContent
+          sessionId={sessionId}
+          sdkSessionId={sdkSessionId}
+          agenticTool={agenticTool}
+        />
+      }
+      title={null}
+      trigger="hover"
+      placement="top"
+      mouseEnterDelay={0.3}
+    >
+      {pill}
+    </Popover>
   );
 };
 

--- a/apps/agor-ui/src/utils/time.ts
+++ b/apps/agor-ui/src/utils/time.ts
@@ -1,0 +1,66 @@
+/**
+ * Time formatting utilities for consistent timestamp display across the app
+ */
+
+/**
+ * Format a timestamp as human-relative time (e.g., "2h ago")
+ */
+export function formatRelativeTime(timestamp: string | Date): string {
+  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) {
+    return 'just now';
+  }
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  if (diffHour < 24) {
+    return `${diffHour}h ago`;
+  }
+  if (diffDay < 7) {
+    return `${diffDay}d ago`;
+  }
+  if (diffDay < 30) {
+    const weeks = Math.floor(diffDay / 7);
+    return `${weeks}w ago`;
+  }
+  if (diffDay < 365) {
+    const months = Math.floor(diffDay / 30);
+    return `${months}mo ago`;
+  }
+
+  const years = Math.floor(diffDay / 365);
+  return `${years}y ago`;
+}
+
+/**
+ * Format a timestamp as absolute time in ISO-ish format (local timezone)
+ * Format: "2025-01-12 15:45:30"
+ */
+export function formatAbsoluteTime(timestamp: string | Date): string {
+  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}
+
+/**
+ * Format a timestamp for tooltips: "2h ago (Jan 12, 2025, 3:45 PM)"
+ */
+export function formatTimestampWithRelative(timestamp: string | Date): string {
+  const relative = formatRelativeTime(timestamp);
+  const absolute = formatAbsoluteTime(timestamp);
+  return `${relative} (${absolute})`;
+}


### PR DESCRIPTION
## Summary

Enhances session identification and message context visibility:

- **Session ID Pill with Popover**: Hover over the session pill to see both Agor and SDK session IDs with individual copy buttons
- **Message Timestamps**: Hover over message avatars to see when messages were sent (relative + absolute time)
- **Time Utilities**: New reusable time formatting functions for consistent timestamp display

## Changes

### Enhanced SessionIdPill (`apps/agor-ui/src/components/Pill/Pill.tsx`)
- Added popover that displays both Agor and SDK session IDs
- Each ID shows short version (e.g., `22bf7211`) with full UUID
- Individual copy-to-clipboard buttons for each ID
- Clean layout with monospace font and proper spacing

### Message Timestamps (`apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx`)
- Added timestamp tooltips to all message bubbles
- Tooltips appear when hovering over message avatars
- Format: `"2h ago (2025-01-12 15:45:30)"` (relative + ISO format)
- Computed fresh on each hover for accurate relative times
- Uses Ant Design's `fresh` prop to avoid stale timestamps

### Time Utilities (`apps/agor-ui/src/utils/time.ts`)
- `formatRelativeTime()`: Converts timestamps to human-readable format ("2h ago", "5m ago", etc.)
- `formatAbsoluteTime()`: ISO-ish format in local timezone (YYYY-MM-DD HH:MM:SS)
- `formatTimestampWithRelative()`: Combined format for tooltips

## UI/UX Details

**Session Pill:**
- Hover delay of 300ms to avoid accidental triggers
- Only shows SDK section if SDK session ID exists
- Consistent styling with other pills

**Timestamps:**
- Non-intrusive tooltips on avatar hover
- Provides both context (how long ago) and precision (exact time)
- Updates dynamically when hovering (no background timers needed)

## Test Plan

- [x] Hover over session pill in conversation footer → see popover with both IDs
- [x] Click copy buttons → verify IDs copied to clipboard
- [x] Hover over message avatars → see timestamp tooltips
- [x] Wait a few minutes and hover again → verify relative time updates
- [x] Check user messages and assistant messages → tooltips work for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)