### PR TITLE
fix: pinned worktree cards now properly show zone border color

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -437,8 +437,8 @@ const SessionCanvas = ({
       const zoneName = dbZoneId ? zoneLabels[dbZoneId] || 'Unknown Zone' : undefined;
       const zoneObj = zoneId && board?.objects?.[zoneId] ? board.objects[zoneId] : undefined;
       const zoneColor =
-        zoneObj && 'borderColor' in zoneObj
-          ? zoneObj.borderColor || zoneObj.color // Backwards compat
+        zoneObj && zoneObj.type === 'zone'
+          ? zoneObj.borderColor || zoneObj.color // Backwards compat: borderColor first, then fall back to deprecated color
           : undefined;
 
       // Get sessions for this worktree


### PR DESCRIPTION
## Summary
Fixed zone color extraction logic for pinned worktree cards. After decoupling `backgroundColor` from `borderColor` in zones, the type guard used to extract zone colors was incorrect.

## Changes
- Updated `SessionCanvas.tsx` to properly check `zoneObj.type === 'zone'` instead of using `'borderColor' in zoneObj`
- The previous type guard would always return true for optional properties, even when undefined
- Now correctly extracts `borderColor` with fallback to deprecated `color` field

## Test plan
- [x] Global typecheck passes
- [x] Global build passes
- [x] Lint-staged checks pass
- [ ] Manual testing: pin a worktree to a zone and verify border color matches zone's border color
- [ ] Manual testing: verify pin icon and tag use zone's border color

## Impact
- Pinned worktree cards now correctly display their zone's border color on the card border
- Pin icon and tag properly use the zone's border color
- Maintains backwards compatibility with zones using the deprecated 'color' field

🤖 Generated with [Claude Code](https://claude.com/claude-code)