### PR TITLE
feat: make AgentChain header single-line and more dense

### DIFF
--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -560,33 +560,33 @@ export const AgentChain: React.FC<AgentChainProps> = ({ messages }) => {
           e.currentTarget.style.borderColor = token.colorBorder;
         }}
       >
-        <Space direction="vertical" size={token.sizeUnit} style={{ width: '100%' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: token.sizeUnit }}>
-            {/* Expand/collapse icon */}
-            {expanded ? (
-              <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-            ) : (
-              <RightOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-            )}
+        <div
+          style={{ display: 'flex', alignItems: 'center', gap: token.sizeUnit, flexWrap: 'wrap' }}
+        >
+          {/* Expand/collapse icon */}
+          {expanded ? (
+            <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+          ) : (
+            <RightOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+          )}
 
-            {/* Status icon */}
-            {hasErrors ? (
-              <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
-            ) : (
-              <CheckCircleOutlined style={{ color: token.colorTextSecondary, fontSize: 16 }} />
-            )}
+          {/* Status icon */}
+          {hasErrors ? (
+            <CloseCircleOutlined style={{ color: token.colorError, fontSize: 16 }} />
+          ) : (
+            <CheckCircleOutlined style={{ color: token.colorTextSecondary, fontSize: 16 }} />
+          )}
 
-            {/* Summary text */}
-            <Typography.Text strong>
-              <BulbOutlined /> {stats.thoughtCount > 0 && `${stats.thoughtCount} thoughts`}
-              {stats.thoughtCount > 0 && stats.toolCount > 0 && ', '}
-              {stats.toolCount > 0 && `${stats.toolCount} tools`}
-            </Typography.Text>
-          </div>
+          {/* Summary text */}
+          <Typography.Text strong>
+            <BulbOutlined /> {stats.thoughtCount > 0 && `${stats.thoughtCount} thoughts`}
+            {stats.thoughtCount > 0 && stats.toolCount > 0 && ', '}
+            {stats.toolCount > 0 && `${stats.toolCount} tools`}
+          </Typography.Text>
 
           {/* Only show details when collapsed */}
           {!expanded && summaryDescription}
-        </Space>
+        </div>
       </div>
 
       {/* Expanded chain */}


### PR DESCRIPTION
## Summary
Consolidated the AgentChain collapsible header from a two-row layout into a single flex row with wrapping for a more compact, dense UI.

## Changes
- Removed `Space` component with `direction="vertical"`
- Combined expand icon, status icon, summary text, and tool pills into one horizontal row
- Added `flexWrap: 'wrap'` for natural overflow handling when content is too long
- Maintains readability while significantly reducing vertical space

## UI Impact
**Before:** Two separate lines (header text + pills on separate row)
**After:** Single line with all elements flowing horizontally, wrapping if needed

## Test plan
- [x] Typecheck passes
- [x] Build completes successfully
- [x] Pre-commit hooks pass
- [ ] Manual UI testing in running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)