### PR TITLE
fix: context window accounting and compaction UI

### DIFF
--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -252,6 +252,11 @@ export const AgentChain: React.FC<AgentChainProps> = ({ messages }) => {
     return items;
   }, [messages]);
 
+  // Early return if no items (prevents empty bordered boxes)
+  if (chainItems.length === 0) {
+    return null;
+  }
+
   // Calculate stats
   const stats = useMemo(() => {
     let thoughtCount = 0;

--- a/apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
+++ b/apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
@@ -1,0 +1,124 @@
+/**
+ * CompactionBlock - Renders compaction events (start + optional complete)
+ *
+ * Handles aggregation of compaction system messages:
+ * - system_status (compacting) → Shows spinner
+ * - system_complete (compaction) → Shows completion with metadata
+ *
+ * Receives an array of messages (sorted chronologically):
+ * - [start] → Spinner (in progress)
+ * - [start, complete] → Completion UI with metadata
+ */
+
+import type { Message } from '@agor/core/types';
+import { CheckCircleFilled, RobotOutlined } from '@ant-design/icons';
+import { Bubble } from '@ant-design/x';
+import { Space, Spin, Typography, theme } from 'antd';
+import type React from 'react';
+import { AgorAvatar } from '../AgorAvatar';
+import { ToolIcon } from '../ToolIcon';
+
+const { Text } = Typography;
+
+interface CompactionBlockProps {
+  messages: Message[]; // Array of system messages (start, complete)
+  agentic_tool?: string;
+}
+
+export const CompactionBlock: React.FC<CompactionBlockProps> = ({ messages, agentic_tool }) => {
+  const { token } = theme.useToken();
+
+  // Find start and complete messages
+  const startMessage = messages.find(m => {
+    if (!Array.isArray(m.content)) return false;
+    return m.content.some(
+      b => b.type === 'system_status' && 'status' in b && b.status === 'compacting'
+    );
+  });
+
+  const completeMessage = messages.find(m => {
+    if (!Array.isArray(m.content)) return false;
+    return m.content.some(
+      b => b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction'
+    );
+  });
+
+  const avatar = agentic_tool ? (
+    <ToolIcon tool={agentic_tool} size={32} />
+  ) : (
+    <AgorAvatar icon={<RobotOutlined />} style={{ backgroundColor: token.colorBgContainer }} />
+  );
+
+  // If we have complete message, show completion state
+  if (completeMessage && Array.isArray(completeMessage.content)) {
+    const completeBlock = completeMessage.content.find(
+      b => b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction'
+    );
+
+    if (completeBlock) {
+      // Extract metadata from complete block
+      const trigger = ('trigger' in completeBlock ? completeBlock.trigger : undefined) as
+        | string
+        | undefined;
+      const preTokens = ('pre_tokens' in completeBlock ? completeBlock.pre_tokens : undefined) as
+        | number
+        | undefined;
+
+      // Calculate duration from start and complete timestamps
+      const duration =
+        startMessage && completeMessage
+          ? new Date(completeMessage.timestamp).getTime() -
+            new Date(startMessage.timestamp).getTime()
+          : null;
+
+      return (
+        <div style={{ margin: `${token.sizeUnit}px 0` }}>
+          <Bubble
+            placement="start"
+            avatar={avatar}
+            content={
+              <Space direction="vertical" size="small" style={{ width: '100%' }}>
+                <Space>
+                  <CheckCircleFilled style={{ color: token.colorSuccess, fontSize: 14 }} />
+                  <Text type="secondary">Context compacted successfully</Text>
+                </Space>
+                {/* Show metadata if available */}
+                {(trigger || preTokens || duration) && (
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: token.colorTextTertiary,
+                      paddingLeft: 22,
+                    }}
+                  >
+                    {trigger && <div>Trigger: {trigger}</div>}
+                    {preTokens && <div>Pre-compaction tokens: {preTokens.toLocaleString()}</div>}
+                    {duration && <div>Duration: {(duration / 1000).toFixed(2)}s</div>}
+                  </div>
+                )}
+              </Space>
+            }
+            variant="outlined"
+          />
+        </div>
+      );
+    }
+  }
+
+  // Otherwise, show in-progress state (spinner)
+  return (
+    <div style={{ margin: `${token.sizeUnit}px 0` }}>
+      <Bubble
+        placement="start"
+        avatar={avatar}
+        content={
+          <Space>
+            <Spin size="small" />
+            <Text type="secondary">Compacting conversation context...</Text>
+          </Space>
+        }
+        variant="outlined"
+      />
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/CompactionBlock/index.ts
+++ b/apps/agor-ui/src/components/CompactionBlock/index.ts
@@ -1,0 +1,1 @@
+export { CompactionBlock } from './CompactionBlock';


### PR DESCRIPTION
## Summary

Fixes critical context window accounting bugs and improves compaction event visualization.

## Context Window Accounting Fixes

**Problem**: Context window was undershooting actual usage by 20-40K tokens, causing compaction to trigger too early (at 19% instead of expected 75-80%).

**Root causes**:
1. **Multi-model token summing**: When multiple models are used (e.g., Sonnet + Haiku for tools/thinking), we were taking MAX instead of SUM
2. **Missing baseline context**: System prompt (~20K) + CLAUDE.md + MCP tools (~3-7K) = ~23-27K tokens not accounted for

**Changes**:
- `packages/core/src/tools/claude/claude-tool.ts`: Fixed multi-model token accounting (SUM not MAX)
- `packages/core/src/utils/context-window.ts`: Added baseline context accounting
  - Fresh session: Add `cache_read + cache_creation` on first message
  - Post-compaction: Add `cache_creation` only (cache_read becomes unreliable, observed 248K-1.9M)
- Added detailed inline comments documenting token breakdown

## Compaction Event Aggregation

**Problem**: Compaction showed as 2 separate UI bubbles (start + complete) instead of one transitioning element.

**Solution**: Implemented aggregation pattern (similar to TODO handling but for system events).

**Changes**:
- `apps/agor-ui/src/components/CompactionBlock/` (NEW): Dedicated component for compaction
  - Receives array of messages (start + optional complete)
  - Shows spinner during compaction, metadata on complete (trigger, pre-tokens, duration)
- `apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx`: 
  - Added `compaction` block type alongside `message` and `agent-chain`
  - Group messages by `task_id`, insert at correct position by first message index
- `apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx`: Removed duplicate handling

## Streaming Fixes

**Problem**: Compaction complete spinner kept spinning forever.

**Root cause**: System messages weren't emitting `streaming:end` events.

**Fix**: Added `streaming:start` and `streaming:end` calls for all system messages in claude-tool.ts

## Bug Fixes

**Problem**: Empty bordered boxes appearing in UI when tool streaming starts.

**Fix**: Added early return in `AgentChain` when `chainItems.length === 0`

## Testing

- Experienced compaction event in this very session (159K pre-tokens, 2min 12sec duration)
- Verified metadata display (trigger: auto, pre-tokens, duration all shown correctly)
- All type checks and builds passing

## Files Changed

```
M apps/agor-ui/src/components/AgentChain/AgentChain.tsx
M apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
M apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
A apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
A apps/agor-ui/src/components/CompactionBlock/index.ts
M packages/core/src/tools/claude/claude-tool.ts
M packages/core/src/utils/context-window.ts
```