### PR TITLE
fix: update Dockerfile workspaces path for consistency

### DIFF
--- a/.devcontainer/dev/Dockerfile
+++ b/.devcontainer/dev/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest |
 # and agor-live from npm for quick start
 RUN npm install -g pnpm@latest agor-live@latest @anthropic-ai/claude-code@latest @google/gemini-cli@latest @openai/codex@latest
 
-WORKDIR /workspace
+WORKDIR /workspaces
 
 # Note: Source code is available in /workspaces/agor for development
 # To develop on Agor itself: cd /workspaces/agor && pnpm install && pnpm build

--- a/.devcontainer/playground/Dockerfile
+++ b/.devcontainer/playground/Dockerfile
@@ -28,14 +28,14 @@ COPY packages/agor-live/package.json /tmp/agor-live-package.json
 # Install agor-live (rebuilds when package.json changes)
 RUN npm install -g agor-live@latest
 
-WORKDIR /workspace
+WORKDIR /workspaces
 
 # Create non-root 'agor' user for development
 RUN useradd -m -s /bin/bash agor && \
     # Grant sudoers access without password (needed for some development tasks)
     echo "agor ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/agor && \
     # Ensure agor owns the workspace
-    chown -R agor:agor /workspace
+    chown -R agor:agor /workspaces
 
 # Set agor as the default user
 USER agor


### PR DESCRIPTION
It should be /workspaces that refers to integrating Dev Containers with the development environment, especially in the context of platforms such as Visual Studio Code and GitHub Codespaces or DevPods.