### PR TITLE
fix: exclude cache_read_tokens from first task context window

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -182,11 +182,7 @@ async function calculateTaskContextWindow(
 
     // A) First task in session
     if (session.tasks.length === 0) {
-      return (
-        (currentTaskUsage.cache_read_tokens || 0) +
-        (currentTaskUsage.cache_creation_tokens || 0) +
-        currentTaskTokens
-      );
+      return (currentTaskUsage.cache_creation_tokens || 0) + currentTaskTokens;
     }
 
     // Get previous task


### PR DESCRIPTION
## Summary

Fixes the token window accounting to exclude `cache_read_tokens` from the first task in a session.

## Problem

On the first task of a session, there's no previous conversation history that could be cached yet. Including `cache_read_tokens` in the context window calculation for the first task was incorrect and led to inflated context window usage.

## Solution

Removed `cache_read_tokens` from the first task context window calculation in `calculateTaskContextWindow()`. The first task now only includes:
- `cache_creation_tokens` - Content being written to cache for future use
- `currentTaskTokens` (input + output) - The actual fresh tokens for this task

This aligns the first task calculation with the compaction reset logic (which also excludes `cache_read_tokens`).

## Changes

**Before:**
```typescript
// A) First task in session
if (session.tasks.length === 0) {
  return (
    (currentTaskUsage.cache_read_tokens || 0) +
    (currentTaskUsage.cache_creation_tokens || 0) +
    currentTaskTokens
  );
}
```

**After:**
```typescript
// A) First task in session
if (session.tasks.length === 0) {
  return (currentTaskUsage.cache_creation_tokens || 0) + currentTaskTokens;
}
```

## Testing

- ✅ Global typecheck passes
- ✅ Global build succeeds
- ✅ Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)