### PR TITLE
fix: persist TODO list after task completion

### DIFF
--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -620,8 +620,8 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                   </div>
                 )}
 
-                {/* Show sticky TODO (latest) above typing indicator when task is running */}
-                {task.status === TaskStatus.RUNNING && <StickyTodoRenderer messages={messages} />}
+                {/* Show sticky TODO (latest) - persists after task completion for reference */}
+                <StickyTodoRenderer messages={messages} />
 
                 {/* Show typing indicator whenever task is actively running */}
                 {task.status === TaskStatus.RUNNING && (


### PR DESCRIPTION
## Summary

Fixes the issue where the TODO list would disappear immediately after task completion. Now the TODO list persists in the UI as a visual reference of completed work.

## Changes

- Removed the `task.status === TaskStatus.RUNNING` conditional check from StickyTodoRenderer
- The TODO list now always renders when present in messages, regardless of task status
- Users can now reference completed TODOs after the task finishes

## Test Plan

- [x] Verify TODO list displays during task execution
- [x] Verify TODO list persists after task completion
- [x] Verify completed TODOs show with strike-through styling
- [x] Verify no performance issues with always-on rendering
- [x] Global typecheck passes
- [x] Global build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)