### PR TITLE
Fix: Docker Compose permission errors on Linux (#248)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,56 @@
+# Agor Docker Development Environment Configuration
+# Copy this file to .env and customize for your setup
+
+# ============================================================================
+# Port Configuration
+# ============================================================================
+
+# Daemon API port (default: 3030)
+DAEMON_PORT=3030
+
+# UI development server port (default: 5173)
+UI_PORT=5173
+
+# CORS origin (default: * for dev, set specific origins in prod)
+# CORS_ORIGIN=http://localhost:5173
+
+# ============================================================================
+# Development Data Seeding
+# ============================================================================
+
+# Seed development fixtures on first startup (default: false)
+# Creates: Agor repo (https://github.com/preset-io/agor.git) + test-worktree
+SEED=false
+
+# ============================================================================
+# AI Agent API Keys (Optional)
+# ============================================================================
+
+# Anthropic Claude API key for Claude Code sessions
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI API key for Codex sessions
+# OPENAI_API_KEY=sk-...
+
+# Google Gemini API key for Gemini sessions
+# GEMINI_API_KEY=...
+
+# ============================================================================
+# Advanced: Host UID/GID Mapping (Linux Only)
+# ============================================================================
+
+# On Linux, you can optionally run the container as your host user to avoid
+# the automatic permission fix and ensure container-created files match your
+# host user ownership. Uncomment these lines and set to your UID/GID:
+#
+# Get your UID/GID with: id -u && id -g
+# UID=1000
+# GID=1000
+#
+# Then create docker-compose.override.yml with:
+#   services:
+#     agor-dev:
+#       user: "${UID:-1000}:${GID:-1000}"
+#
+# Note: On macOS/Windows, Docker Desktop handles UID mapping automatically.
+# This setting is unnecessary (and may cause issues) on those platforms.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
     volumes:
-      # Mount entire repo for hot-reload (but exclude node_modules)
+      # Mount entire repo for hot-reload (but exclude node_modules and build outputs)
       - .:/app
       # Exclude all node_modules directories (use container's versions)
       - /app/node_modules
@@ -39,6 +39,9 @@ services:
       - /app/apps/agor-cli/node_modules
       - /app/apps/agor-ui/node_modules
       - /app/packages/core/node_modules
+      # Exclude @agor/core build output (built fresh in container during entrypoint)
+      # This prevents empty/stale host dist from overwriting container's fresh build
+      - /app/packages/core/dist
       # Persist entire home directory (database, config, agent auth tokens, etc.)
       - agor-home:/home/agor
       # Mount SSH keys for git authentication (dev only)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,6 +3,11 @@ set -e
 
 echo "🚀 Starting Agor development environment..."
 
+# Fix permissions on bind-mounted source directory
+# (host-mounted files may have different ownership than container user)
+echo "🔧 Fixing source directory permissions..."
+sudo chown -R agor:agor /app
+
 # Dependencies are installed during Docker build and node_modules are excluded from volume mount
 # Just verify they exist, don't reinstall unless something is actually missing
 if [ ! -d "/app/node_modules" ]; then


### PR DESCRIPTION
Fixes two critical issues preventing `docker compose up` from working on fresh clones, particularly on Linux systems.

## Problems Fixed

1. **Permission mismatch on Linux**: Host files owned by different UID than container user (agor:1001), causing EACCES errors when tsup tries to write temporary bundled config files
2. **Empty dist directory**: `.dockerignore` excludes dist from image, then bind mount brings empty host dist into container, breaking module resolution

## Changes

### docker/docker-entrypoint.sh
- Add automatic permission fix on startup: `sudo chown -R agor:agor /app`
- Runs before building @agor/core to ensure write access for tsup

### docker-compose.yml
- Exclude `/app/packages/core/dist` from bind mount
- Prevents empty host dist from overwriting container's fresh build
- Ensures daemon can resolve @agor/core modules correctly

### docker/README.md
- Update "Volume Permission Issues" section with automatic fix explanation
- Add "Host UID/GID Mapping (Linux)" in Advanced Usage
- Document alternative UID override approach for Linux power users

### .env.example (new)
- Comprehensive environment variable documentation
- Port configuration, API keys, seeding options
- UID/GID override instructions for Linux users
- Platform-specific notes (macOS/Windows vs Linux)

## Testing

- ✅ Fresh build with `--no-cache` succeeds
- ✅ @agor/core builds without EACCES errors
- ✅ Daemon and UI start successfully
- ✅ No module resolution errors
- ✅ All pnpm checks pass (typecheck, lint, build)

## Platform Compatibility

- **Linux**: Both fixes required (permission + dist exclusion)
- **macOS/Windows**: Works with fixes (Docker Desktop handles UID mapping automatically)

Closes #248