### PR TITLE
Style tmux integration with Agor teal theme

### DIFF
--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -109,7 +109,7 @@ export class TerminalsService {
     this.hasTmux = isTmuxAvailable();
 
     if (this.hasTmux) {
-      console.log('✅ tmux detected - persistent terminal sessions enabled');
+      console.log('\x1b[36m✅ tmux detected\x1b[0m - persistent terminal sessions enabled');
     } else {
       console.log('ℹ️  tmux not found - using ephemeral terminal sessions');
     }
@@ -163,7 +163,9 @@ export class TerminalsService {
           // Window exists - attach and select it
           shellArgs = ['attach-session', '-t', `${tmuxSession}:${windowIndex}`];
           tmuxReused = true;
-          console.log(`🔗 Reusing tmux window: ${tmuxSession}:${windowIndex} (${windowName})`);
+          console.log(
+            `\x1b[36m🔗 Reusing tmux window:\x1b[0m ${tmuxSession}:${windowIndex} (${windowName})`
+          );
         } else {
           // Window doesn't exist - attach and create new window
           shellArgs = [
@@ -178,13 +180,32 @@ export class TerminalsService {
             cwd,
           ];
           tmuxReused = false;
-          console.log(`🪟 Creating new window in tmux session: ${tmuxSession} (${windowName})`);
+          console.log(
+            `\x1b[36m🪟 Creating new window in tmux session:\x1b[0m ${tmuxSession} (${windowName})`
+          );
         }
       } else {
-        // Session doesn't exist - create it with first window
-        shellArgs = ['new-session', '-s', tmuxSession, '-n', windowName, '-c', cwd];
+        // Session doesn't exist - create it with first window and set theme inline
+        // Use semicolon to chain commands: create session THEN set theme
+        shellArgs = [
+          'new-session',
+          '-s',
+          tmuxSession,
+          '-n',
+          windowName,
+          '-c',
+          cwd,
+          ';',
+          'set-option',
+          '-t',
+          tmuxSession,
+          'status-style',
+          'bg=#2e9a92,fg=#000000',
+        ];
         tmuxReused = false;
-        console.log(`🚀 Creating tmux session: ${tmuxSession} with window (${windowName})`);
+        console.log(
+          `\x1b[36m🚀 Creating tmux session:\x1b[0m ${tmuxSession} with window (${windowName}) + teal theme`
+        );
       }
     } else {
       // Fallback to regular shell

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -48,6 +48,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
     // Create terminal instance and connect to backend
     const setupTerminal = async () => {
       // Create xterm instance with larger size to fit modal
+      // Custom theme with Agor teal (#2e9a92) for cyan
       const terminal = new Terminal({
         fontSize: 14,
         fontFamily: 'Menlo, Monaco, "Courier New", monospace',
@@ -55,6 +56,13 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         scrollback: 1000,
         rows: 40,
         cols: 160,
+        theme: {
+          background: '#000000',
+          foreground: '#ffffff',
+          cursor: '#ffffff',
+          cyan: '#2e9a92', // Agor teal - used for ANSI color code 36
+          brightCyan: '#3db5ab', // Lighter teal for bright cyan - used for ANSI code 96
+        },
       });
 
       terminal.open(terminalDivRef.current!);
@@ -91,28 +99,6 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
           worktreeName: result.worktreeName,
         });
         terminal.clear();
-
-        // Display welcome message with context
-        if (result.tmuxSession) {
-          if (result.tmuxReused) {
-            terminal.writeln(
-              `🔗 Reconnected to tmux window for ${result.worktreeName || 'worktree'}`
-            );
-            terminal.writeln(`📂 Current directory preserved from last session`);
-          } else {
-            terminal.writeln(`🪟 Created new tmux window for ${result.worktreeName || 'worktree'}`);
-            terminal.writeln(`📂 Working directory: ${result.cwd}`);
-          }
-          terminal.writeln(
-            `💡 Tip: Switch worktrees with Ctrl+B w | Session: "${result.tmuxSession}"`
-          );
-        } else {
-          terminal.writeln(`✅ Connected! Working directory: ${result.cwd}`);
-          if (worktreeId) {
-            terminal.writeln('ℹ️  Install tmux for persistent sessions');
-          }
-        }
-        terminal.writeln('');
 
         // Execute initial commands if provided
         if (initialCommands.length > 0) {


### PR DESCRIPTION
## Summary

- Set tmux status bar to Agor teal (#2e9a92) with black text for better brand consistency
- Apply theme automatically when creating new tmux sessions
- Add teal color to console logs for tmux operations
- Configure xterm.js theme for cyan color consistency (future-proofing)

## Changes

**Backend (`apps/agor-daemon/src/services/terminals.ts`):**
- Chain tmux theme configuration with session creation using semicolon command separator
- Set status bar background to `#2e9a92` (Agor teal) and foreground to `#000000` (black)
- Add ANSI cyan color codes to tmux-related console logs

**Frontend (`apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx`):**
- Configure xterm.js theme to use Agor teal for cyan color codes
- Remove deprecated welcome messages (tmux output was overwriting them anyway)

## Visual Impact

**Before:**
- Green tmux status bar (default tmux color)

**After:**
- Teal tmux status bar matching Agor's brand color (#2e9a92)
- Black text on teal for better contrast

## Testing

To test:
1. Open a terminal in Agor
2. Verify the tmux status bar at the bottom is teal instead of green
3. Check console logs show teal-colored tmux operation messages

For existing sessions, manually apply theme with:
\`\`\`bash
tmux set-option -t agor status-style "bg=#2e9a92,fg=#000000"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)