### PR TITLE
feat(ui): add copy-to-clipboard for message bubbles

### DIFF
--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -23,7 +23,7 @@ import { Tooltip, theme } from 'antd';
 
 import type React from 'react';
 import { useState } from 'react';
-import { copyToClipboard } from '../../utils/clipboard';
+import { useCopyToClipboard } from '../../utils/clipboard';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { AgorAvatar } from '../AgorAvatar';
 import { CollapsibleMarkdown } from '../CollapsibleText/CollapsibleMarkdown';
@@ -90,17 +90,12 @@ interface BubbleContentWithCopyProps {
 
 const BubbleContentWithCopy: React.FC<BubbleContentWithCopyProps> = ({ textContent, children }) => {
   const [isHovered, setIsHovered] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [copied, copy] = useCopyToClipboard();
   const { token } = theme.useToken();
 
-  const handleCopy = async (e: React.MouseEvent) => {
+  const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
-    const success = await copyToClipboard(textContent, { showSuccess: false });
-
-    if (success) {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+    copy(textContent);
   };
 
   return (


### PR DESCRIPTION
## Summary
- Add hover-triggered copy icon in the top-right corner of each message bubble
- Allow users to copy raw markdown content to clipboard with visual feedback
- Supports both user and agent messages

## Implementation
- Created `extractRawMessageContent()` utility to extract raw markdown from messages
- Built `BubbleContentWithCopy` wrapper component for message content
- Copy icon positioned inside bubble at top-right with proper spacing (`-token.sizeUnit * 2`)
- Visual feedback with color changes and success state (green)
- Silent clipboard operation (no toast notifications)
- Extracts text and thinking blocks, skips tool_use/tool_result blocks

## Test Plan
- [ ] Hover over message bubbles in conversation view
- [ ] Click copy icon and verify content is copied to clipboard
- [ ] Check that icon appears in correct position (top-right inside bubble)
- [ ] Verify visual feedback (color change on hover, green on success)
- [ ] Test with both user and agent messages
- [ ] Test with messages containing thinking blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)