### PR TITLE
fix(ui): prevent crash when deleting zones with pinned sessions

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
@@ -62,9 +62,14 @@ export const DeleteZoneModal = ({
                     </div>
                   </div>
                 </Radio>
-                <Radio value={true}>
+                <Radio value={true} disabled>
                   <div>
-                    <div style={{ fontWeight: 500 }}>Delete pinned sessions too</div>
+                    <div style={{ fontWeight: 500 }}>
+                      Delete pinned sessions too{' '}
+                      <span style={{ fontSize: 11, color: token.colorTextTertiary }}>
+                        [coming soon]
+                      </span>
+                    </div>
                     <div style={{ fontSize: 12, color: token.colorTextSecondary }}>
                       Remove sessions from board entirely
                     </div>


### PR DESCRIPTION
## Summary

Fixed a critical race condition where deleting a zone with pinned sessions would cause the page to crash with a "zone not found" error.

## Problem

When deleting a zone with pinned sessions:

1. Zone was deleted from `board.objects` first
2. WebSocket broadcast sent updated board (without zone) to clients  
3. Worktrees still had `zone_id` pointing to the deleted zone
4. React Flow tried to render worktrees with `parentId` pointing to non-existent zone
5. **Page crashed** with console error: "Cannot unpin: zone not found"

## Solution

**Changed operation order** in `useBoardObjects.ts:75`:

- **Before**: Delete zone → then unpin worktrees ❌
- **After**: Unpin worktrees → then delete zone ✅

Now all worktrees are unpinned (`zone_id: null`) **before** the zone is deleted. When the WebSocket update arrives, worktrees no longer reference the deleted zone, preventing the crash.

## Additional Changes

Disabled the "Delete pinned sessions too" option (marked as `[coming soon]`) since implementing session deletion requires integration with the complex archive modal flow.

## Files Changed

- `apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts` - Fixed deletion order
- `apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx` - Disabled session deletion option

## Testing

- ✅ Typecheck passed
- ✅ Lint passed
- ✅ Build successful
- Manual testing: Zone deletion now works without crashes when sessions are pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)