### PR TITLE
fix: prevent race condition in Docker container startup

### DIFF
--- a/apps/agor-cli/src/base-command.ts
+++ b/apps/agor-cli/src/base-command.ts
@@ -138,6 +138,6 @@ export abstract class BaseCommand extends Command {
     client.io.close();
 
     // Give a brief moment for cleanup, then force exit
-    await new Promise<void>(resolve => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
   }
 }

--- a/apps/agor-cli/src/commands/board/list.ts
+++ b/apps/agor-cli/src/commands/board/list.ts
@@ -48,7 +48,7 @@ export default class BoardList extends BaseCommand {
 
       // Add rows
       for (const board of boards) {
-        const worktreeCount = boardObjects.filter(bo => bo.board_id === board.board_id).length;
+        const worktreeCount = boardObjects.filter((bo) => bo.board_id === board.board_id).length;
         table.push([
           board.board_id.substring(0, 8),
           `${board.icon || '📋'} ${board.name}`,

--- a/apps/agor-cli/src/commands/daemon/start.ts
+++ b/apps/agor-cli/src/commands/daemon/start.ts
@@ -144,7 +144,7 @@ export default class DaemonStart extends Command {
 
         // Wait for child to exit
         await new Promise<void>((resolve, reject) => {
-          child.on('exit', code => {
+          child.on('exit', (code) => {
             if (code === 0) {
               resolve();
             } else {
@@ -173,7 +173,7 @@ export default class DaemonStart extends Command {
         const maxAttempts = 5;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
           const waitTime = 1000 * (attempt + 1); // 1s, 2s, 3s, 4s, 5s
-          await new Promise(resolve => setTimeout(resolve, waitTime));
+          await new Promise((resolve) => setTimeout(resolve, waitTime));
 
           isRunning = await isDaemonRunning(daemonUrl);
           if (isRunning) break;

--- a/apps/agor-cli/src/commands/db/migrate.ts
+++ b/apps/agor-cli/src/commands/db/migrate.ts
@@ -25,10 +25,10 @@ export default class DbMigrate extends Command {
       const status = await checkMigrationStatus(db);
 
       if (!status.hasPending) {
-        this.log(chalk.green('✓') + ' Database is already up to date!');
+        this.log(`${chalk.green('✓')} Database is already up to date!`);
         this.log('');
         this.log(`Applied migrations (${status.applied.length}):`);
-        status.applied.forEach(tag => {
+        status.applied.forEach((tag) => {
           this.log(`  ${chalk.dim('•')} ${tag}`);
         });
         return;
@@ -37,7 +37,7 @@ export default class DbMigrate extends Command {
       // Show pending migrations
       this.log(chalk.yellow('⚠️  Found pending migrations:'));
       this.log('');
-      status.pending.forEach(tag => {
+      status.pending.forEach((tag) => {
         this.log(`  ${chalk.yellow('+')} ${tag}`);
       });
       this.log('');
@@ -53,7 +53,7 @@ export default class DbMigrate extends Command {
 
       // Wait for user confirmation (only in TTY mode)
       if (process.stdin.isTTY) {
-        await new Promise<void>(resolve => {
+        await new Promise<void>((resolve) => {
           process.stdin.once('data', () => resolve());
           process.stdin.setRawMode(true);
           process.stdin.resume();
@@ -64,7 +64,7 @@ export default class DbMigrate extends Command {
         process.stdin.pause();
       } else {
         // In non-TTY mode, wait for a newline
-        await new Promise<void>(resolve => {
+        await new Promise<void>((resolve) => {
           process.stdin.once('data', () => resolve());
           process.stdin.resume();
         });
@@ -83,7 +83,7 @@ export default class DbMigrate extends Command {
         this.log(chalk.red('✗ Migration verification failed!'));
         this.log('');
         this.log(`Still have ${afterStatus.pending.length} pending migration(s):`);
-        afterStatus.pending.forEach(tag => {
+        afterStatus.pending.forEach((tag) => {
           this.log(`  ${chalk.red('•')} ${tag}`);
         });
         this.log('');
@@ -104,7 +104,7 @@ export default class DbMigrate extends Command {
       }
 
       this.log('');
-      this.log(chalk.green('✓') + ' All migrations completed successfully!');
+      this.log(`${chalk.green('✓')} All migrations completed successfully!`);
       this.log('');
       this.log('You can now start the daemon with:');
       this.log(chalk.cyan('  agor daemon start'));

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -107,7 +107,7 @@ export default class Init extends Command {
   private async listDirs(path: string): Promise<string[]> {
     try {
       const entries = await readdir(path, { withFileTypes: true });
-      return entries.filter(e => e.isDirectory()).map(e => e.name);
+      return entries.filter((e) => e.isDirectory()).map((e) => e.name);
     } catch {
       return [];
     }
@@ -522,14 +522,14 @@ export default class Init extends Command {
     // Create admin user directly in database (no daemon required)
     const db = createDatabase({ url: `file:${dbPath}` });
 
-    const user = await createUser(db, {
+    const _user = await createUser(db, {
       email,
       password,
       name: username,
       role: 'admin',
     });
 
-    this.log(chalk.green('   ✓') + ` Admin user created (${chalk.gray(email)})`);
+    this.log(`${chalk.green('   ✓')} Admin user created (${chalk.gray(email)})`);
   }
 
   /**

--- a/apps/agor-cli/src/commands/mcp/add.ts
+++ b/apps/agor-cli/src/commands/mcp/add.ts
@@ -111,12 +111,12 @@ export default class McpAdd extends BaseCommand {
 
       // Add transport-specific config
       if (flags.command) data.command = flags.command;
-      if (flags.args) data.args = flags.args.split(',').map(arg => arg.trim());
+      if (flags.args) data.args = flags.args.split(',').map((arg) => arg.trim());
       if (flags.url) data.url = flags.url;
 
       // Add environment variables
       if (flags.env) {
-        const envPairs = flags.env.split(',').map(pair => pair.trim());
+        const envPairs = flags.env.split(',').map((pair) => pair.trim());
         const envObject: Record<string, string> = {};
         for (const pair of envPairs) {
           const [key, value] = pair.split('=');

--- a/apps/agor-cli/src/commands/mcp/show.ts
+++ b/apps/agor-cli/src/commands/mcp/show.ts
@@ -38,7 +38,7 @@ export default class McpShow extends BaseCommand {
           query: { $limit: 1 },
         });
         const servers = (Array.isArray(result) ? result : result.data) as MCPServer[];
-        server = servers.find(s => s.name === args.id) || null;
+        server = servers.find((s) => s.name === args.id) || null;
       }
 
       if (!server) {

--- a/apps/agor-cli/src/commands/session/load-claude.ts
+++ b/apps/agor-cli/src/commands/session/load-claude.ts
@@ -68,11 +68,11 @@ export default class SessionLoadClaude extends BaseCommand {
       // Filter to conversation messages
       const conversation = filterConversationMessages(claudeSession.messages);
       this.log(
-        `${chalk.green('✓')} Conversation: ${conversation.length} messages (${conversation.filter(m => m.type === 'user').length} user, ${conversation.filter(m => m.type === 'assistant').length} assistant)`
+        `${chalk.green('✓')} Conversation: ${conversation.length} messages (${conversation.filter((m) => m.type === 'user').length} user, ${conversation.filter((m) => m.type === 'assistant').length} assistant)`
       );
 
       // Extract first user message as description
-      const firstUserMessage = conversation.find(m => m.type === 'user');
+      const firstUserMessage = conversation.find((m) => m.type === 'user');
       const description = firstUserMessage?.message?.content
         ? typeof firstUserMessage.message.content === 'string'
           ? firstUserMessage.message.content.substring(0, 200)
@@ -201,7 +201,7 @@ export default class SessionLoadClaude extends BaseCommand {
       this.log(`${chalk.green('✓')} Created ${totalTasks} tasks`);
 
       // Update session with task IDs
-      const taskIds = createdTasks.map(t => t.task_id);
+      const taskIds = createdTasks.map((t) => t.task_id);
       await sessionsService.patch(created.session_id, {
         tasks: taskIds,
       });
@@ -240,7 +240,9 @@ export default class SessionLoadClaude extends BaseCommand {
         for (let i = 0; i < messageLinkUpdates.length; i += batchSize) {
           const batch = messageLinkUpdates.slice(i, i + batchSize);
           await Promise.all(
-            batch.map(update => messagesService.patch(update.messageId, { task_id: update.taskId }))
+            batch.map((update) =>
+              messagesService.patch(update.messageId, { task_id: update.taskId })
+            )
           );
           this.log(
             `${chalk.blue('●')} Linked ${Math.min(i + batchSize, messageLinkUpdates.length)}/${messageLinkUpdates.length} messages...`

--- a/apps/agor-cli/src/commands/user/delete.ts
+++ b/apps/agor-cli/src/commands/user/delete.ts
@@ -43,7 +43,7 @@ export default class UserDelete extends BaseCommand {
       const users = (Array.isArray(result) ? result : result.data) as User[];
 
       const user = users.find(
-        u => u.email === args.user || u.user_id === args.user || u.user_id.startsWith(args.user)
+        (u) => u.email === args.user || u.user_id === args.user || u.user_id.startsWith(args.user)
       );
 
       if (!user) {

--- a/apps/agor-cli/src/commands/user/update.ts
+++ b/apps/agor-cli/src/commands/user/update.ts
@@ -51,7 +51,7 @@ export default class UserUpdate extends BaseCommand {
       const users = (Array.isArray(result) ? result : result.data) as User[];
 
       const user = users.find(
-        u => u.email === args.user || u.user_id === args.user || u.user_id.startsWith(args.user)
+        (u) => u.email === args.user || u.user_id === args.user || u.user_id.startsWith(args.user)
       );
 
       if (!user) {

--- a/apps/agor-cli/src/commands/worktree/cd.ts
+++ b/apps/agor-cli/src/commands/worktree/cd.ts
@@ -79,12 +79,12 @@ export default class WorktreeCd extends BaseCommand {
           AGOR_WORKTREE_ID: worktree.worktree_id,
           AGOR_WORKTREE_NAME: worktree.name,
         },
-        onExit: code => {
+        onExit: (code) => {
           this.log('');
           this.log(`${chalk.dim('← Exited worktree shell')}`);
           process.exit(code || 0);
         },
-        onError: error => {
+        onError: (error) => {
           this.error(`Failed to spawn shell: ${error.message}`);
         },
       });

--- a/apps/agor-cli/src/commands/worktree/list.ts
+++ b/apps/agor-cli/src/commands/worktree/list.ts
@@ -86,10 +86,10 @@ export default class WorktreeList extends BaseCommand {
       // Filter by archive status
       let filteredWorktrees = allWorktrees;
       if (flags.archived) {
-        filteredWorktrees = allWorktrees.filter(w => w.archived);
+        filteredWorktrees = allWorktrees.filter((w) => w.archived);
       } else if (!flags.all) {
         // Default: show only active (not archived)
-        filteredWorktrees = allWorktrees.filter(w => !w.archived);
+        filteredWorktrees = allWorktrees.filter((w) => !w.archived);
       }
 
       if (filteredWorktrees.length === 0) {

--- a/apps/agor-cli/test-commands.mjs
+++ b/apps/agor-cli/test-commands.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
+import { execSync } from 'node:child_process';
 import chalk from 'chalk';
-import { execSync } from 'child_process';
 
 const tests = [
   { name: 'whoami', cmd: 'pnpm -w agor whoami' },
@@ -47,24 +47,24 @@ for (const test of tests) {
     });
     console.log(chalk.green('✓ PASS'));
     passed++;
-  } catch (error) {
+  } catch (_error) {
     console.log(chalk.red('✗ FAIL'));
     failed++;
   }
 
   // Small delay between commands
-  await new Promise(r => setTimeout(r, 200));
+  await new Promise((r) => setTimeout(r, 200));
 }
 
 // Check for hanging processes
 console.log('');
 console.log(chalk.cyan('Checking for hanging processes...'));
-await new Promise(r => setTimeout(r, 500));
+await new Promise((r) => setTimeout(r, 500));
 
 let hangingCount = 0;
 try {
   const result = execSync("pgrep -f 'tsx.*agor' | wc -l", { encoding: 'utf8' });
-  hangingCount = parseInt(result.trim());
+  hangingCount = parseInt(result.trim(), 10);
 } catch {
   hangingCount = 0;
 }

--- a/apps/agor-cli/tsup.config.ts
+++ b/apps/agor-cli/tsup.config.ts
@@ -9,7 +9,7 @@ const baseCommandFile = ['src/base-command.ts'];
 
 // Create entry points
 const entries = Object.fromEntries(
-  [...commandFiles, ...libFiles, ...hookFiles, ...baseCommandFile].map(file => [
+  [...commandFiles, ...libFiles, ...hookFiles, ...baseCommandFile].map((file) => [
     file.replace(/^src\//, '').replace(/\.ts$/, ''),
     file,
   ])

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -99,12 +99,8 @@ import type {
   User,
 } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
-import {
-  getContextWindowLimit,
-  getSessionContextUsage,
-} from '@agor/core/utils/context-window';
+import { getContextWindowLimit, getSessionContextUsage } from '@agor/core/utils/context-window';
 import { NotFoundError } from '@agor/core/utils/errors';
-import type { TokenUsage } from '@agor/core/utils/pricing';
 // Import Claude SDK's PermissionMode type for ClaudeTool method signatures
 // (Agor's PermissionMode is a superset of all tool permission modes)
 import type { PermissionMode as ClaudePermissionMode } from '@anthropic-ai/claude-agent-sdk';
@@ -320,7 +316,7 @@ async function main() {
         /^https?:\/\/localhost(:\d+)?$/,
       ];
 
-      const isAllowed = allowedPatterns.some(pattern => pattern.test(origin));
+      const isAllowed = allowedPatterns.some((pattern) => pattern.test(origin));
 
       if (isAllowed) {
         callback(null, true);
@@ -439,7 +435,7 @@ async function main() {
         maxHttpBufferSize: 1e6, // 1MB max message size
         transports: ['websocket', 'polling'], // Prefer WebSocket
       },
-      io => {
+      (io) => {
         // Store Socket.io server instance for shutdown
         socketServer = io;
 
@@ -503,7 +499,7 @@ async function main() {
         });
 
         // Configure Socket.io for cursor presence events
-        io.on('connection', socket => {
+        io.on('connection', (socket) => {
           activeConnections++;
           const user = (socket as FeathersSocket).feathers?.user;
           console.log(
@@ -554,7 +550,7 @@ async function main() {
           });
 
           // Track disconnections
-          socket.on('disconnect', reason => {
+          socket.on('disconnect', (reason) => {
             activeConnections--;
             console.log(
               `🔌 Socket.io disconnected: ${socket.id} (reason: ${reason}, remaining: ${activeConnections})`
@@ -562,7 +558,7 @@ async function main() {
           });
 
           // Handle socket errors
-          socket.on('error', error => {
+          socket.on('error', (error) => {
             console.error(`❌ Socket.io error on ${socket.id}:`, error);
           });
         });
@@ -672,7 +668,7 @@ async function main() {
     console.error('❌ Database migrations required!');
     console.error('');
     console.error(`   Found ${migrationStatus.pending.length} pending migration(s):`);
-    migrationStatus.pending.forEach(tag => {
+    migrationStatus.pending.forEach((tag) => {
       console.error(`     - ${tag}`);
     });
     console.error('');
@@ -779,7 +775,7 @@ async function main() {
       // Return all session-MCP relationships
       // This allows the UI to fetch all relationships in one call
       const rows = await db.select().from(sessionMcpServers).all();
-      return rows.map(row => ({
+      return rows.map((row) => ({
         session_id: row.session_id,
         mcp_server_id: row.mcp_server_id,
         enabled: Boolean(row.enabled),
@@ -904,7 +900,7 @@ async function main() {
         (validateQuery as any)(userQueryValidator),
       ],
       find: [
-        context => {
+        (context) => {
           const params = context.params as AuthenticatedParams;
 
           if (!params.provider) {
@@ -927,13 +923,13 @@ async function main() {
         },
       ],
       get: [
-        context => {
+        (context) => {
           ensureMinimumRole(context.params as AuthenticatedParams, 'member', 'view users');
           return context;
         },
       ],
       create: [
-        async context => {
+        async (context) => {
           const params = context.params as AuthenticatedParams;
 
           if (!params.provider) {
@@ -949,7 +945,7 @@ async function main() {
         },
       ],
       patch: [
-        context => {
+        (context) => {
           const params = context.params as AuthenticatedParams;
           const userId = context.id as string;
 
@@ -989,7 +985,7 @@ async function main() {
       ],
       create: [
         requireMinimumRole('member', 'create sessions'),
-        async context => {
+        async (context) => {
           // Inject user_id if authenticated, otherwise use 'anonymous'
           const user = (context.params as { user?: { user_id: string; email: string } }).user;
           const userId = user?.user_id || 'anonymous';
@@ -1003,7 +999,7 @@ async function main() {
           );
 
           if (Array.isArray(context.data)) {
-            context.data.forEach(item => {
+            context.data.forEach((item) => {
               if (!item.created_by) (item as Record<string, unknown>).created_by = userId;
             });
           } else if (context.data && !context.data.created_by) {
@@ -1040,7 +1036,7 @@ async function main() {
     },
     after: {
       create: [
-        async context => {
+        async (context) => {
           // Skip MCP setup if MCP server is disabled
           if (config.daemon?.mcpEnabled === false) {
             return context;
@@ -1098,7 +1094,7 @@ async function main() {
           return context;
         },
         // Create OpenCode session if agentic_tool is 'opencode'
-        async context => {
+        async (context) => {
           const session = context.result as Session;
 
           if (session.agentic_tool === 'opencode') {
@@ -1167,7 +1163,7 @@ async function main() {
       ],
       create: [
         requireMinimumRole('member', 'create tasks'),
-        async context => {
+        async (context) => {
           // Inject user_id if authenticated, otherwise use 'anonymous'
           const user = (context.params as { user?: { user_id: string; email: string } }).user;
           const userId = user?.user_id || 'anonymous';
@@ -1181,7 +1177,7 @@ async function main() {
           );
 
           if (Array.isArray(context.data)) {
-            context.data.forEach(item => {
+            context.data.forEach((item) => {
               if (!item.created_by) (item as Record<string, unknown>).created_by = userId;
             });
           } else if (context.data && !context.data.created_by) {
@@ -1204,14 +1200,14 @@ async function main() {
       ],
       create: [
         requireMinimumRole('member', 'create boards'),
-        async context => {
+        async (context) => {
           // Inject user_id if authenticated, otherwise use 'anonymous'
           const userId =
             (context.params as { user?: { user_id: string; email: string } }).user?.user_id ||
             'anonymous';
 
           if (Array.isArray(context.data)) {
-            context.data.forEach(item => {
+            context.data.forEach((item) => {
               if (!item.created_by) (item as Record<string, unknown>).created_by = userId;
             });
           } else if (context.data && !context.data.created_by) {
@@ -1222,7 +1218,7 @@ async function main() {
       ],
       patch: [
         requireMinimumRole('member', 'update boards'),
-        async context => {
+        async (context) => {
           // Handle atomic board object operations via _action parameter
           const contextData = context.data || {};
           const { _action, objectId, objectData, objects, deleteAssociatedSessions } =
@@ -1621,7 +1617,7 @@ async function main() {
 
   if (config.opencode?.enabled !== false) {
     // Check OpenCode server availability on startup (non-blocking)
-    opencodeTool.checkInstalled().then(isAvailable => {
+    opencodeTool.checkInstalled().then((isAvailable) => {
       if (!isAvailable) {
         console.warn('⚠️  OpenCode server not available at', openCodeServerUrl);
         console.warn('   Start OpenCode with: opencode serve --port 4096');
@@ -1822,7 +1818,7 @@ async function main() {
             chunk,
           });
         },
-        onStreamEnd: messageId => {
+        onStreamEnd: (messageId) => {
           console.debug(
             `📡 [${new Date().toISOString()}] Streaming end: ${messageId.substring(0, 8)}`
           );
@@ -1855,7 +1851,7 @@ async function main() {
             chunk,
           });
         },
-        onThinkingEnd: messageId => {
+        onThinkingEnd: (messageId) => {
           console.debug(
             `📡 [${new Date().toISOString()}] Thinking end: ${messageId.substring(0, 8)}`
           );
@@ -1942,7 +1938,7 @@ async function main() {
               task.task_id,
               useStreaming ? streamingCallbacks : undefined
             ) || Promise.reject(new Error('OpenCode executeTask not available'))
-          ).then(result => {
+          ).then((result) => {
             console.log('[Daemon] OpenCodeTool.executeTask completed:', result);
             return {
               userMessageId: `user-${task.task_id}` as import('@agor/core/types').MessageID,
@@ -1968,7 +1964,7 @@ async function main() {
         }
 
         executeMethod
-          .then(async result => {
+          .then(async (result) => {
             try {
               // PHASE 3: Mark task as completed and update message count
               // (Messages already created with task_id, no need to patch)
@@ -2013,13 +2009,12 @@ async function main() {
                 // Safe to mark as completed
 
                 // Store raw SDK response - single source of truth for token accounting
-                const rawSdkResponse: import('@agor/core/types').RawSdkResponse | undefined =
-                  result
-                    ? {
-                        tool: session.agentic_tool,
-                        ...result,
-                      } as import('@agor/core/types').RawSdkResponse
-                    : undefined;
+                const rawSdkResponse: import('@agor/core/types').RawSdkResponse | undefined = result
+                  ? ({
+                      tool: session.agentic_tool,
+                      ...result,
+                    } as import('@agor/core/types').RawSdkResponse)
+                  : undefined;
 
                 // Calculate tool_use_count from all messages in this task
                 let toolUseCount = 0;
@@ -2165,7 +2160,7 @@ async function main() {
               await safePatch(tasksService, task.task_id, { status: TaskStatus.FAILED }, 'Task');
             }
           })
-          .catch(async error => {
+          .catch(async (error) => {
             console.error(`❌ Error executing prompt for task ${task.task_id}:`, error);
 
             // Check if error might be due to stale/invalid Agent SDK resume session
@@ -2381,7 +2376,7 @@ async function main() {
       if (!sessionId) throw new Error('Session ID required');
       if (!data.prompt) throw new Error('Prompt required');
 
-      const session = await sessionsService.get(sessionId, params);
+      const _session = await sessionsService.get(sessionId, params);
 
       // Create queued message
       const messageRepo = new MessagesRepository(db);
@@ -2462,7 +2457,7 @@ async function main() {
         );
         return;
       }
-    } catch (error) {
+    } catch (_error) {
       console.log(
         `⚠️  Queued message ${nextMessage.message_id.substring(0, 8)} no longer exists, skipping`
       );
@@ -3144,9 +3139,9 @@ async function main() {
         // Disconnect all active clients first
         socketServer.disconnectSockets();
         // Give sockets a moment to disconnect
-        await new Promise<void>(resolve => setTimeout(resolve, 100));
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
         // Now close the server with a timeout
-        await new Promise<void>(resolve => {
+        await new Promise<void>((resolve) => {
           const timeout = setTimeout(() => {
             console.warn('⚠️  Server close timeout, forcing exit');
             resolve();
@@ -3161,7 +3156,7 @@ async function main() {
       } else {
         // Fallback: close HTTP server directly if Socket.io wasn't initialized
         await new Promise<void>((resolve, reject) => {
-          server.close(err => {
+          server.close((err) => {
             if (err) {
               console.error('❌ Error closing server:', err);
               reject(err);
@@ -3185,7 +3180,7 @@ async function main() {
 }
 
 // Start the daemon
-main().catch(error => {
+main().catch((error) => {
   console.error('Failed to start daemon:', error);
   process.exit(1);
 });

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -11,7 +11,7 @@ import type { SessionID } from '@agor/core/types';
 
 // Constants for file search
 const MAX_FILE_RESULTS = 10;
-const MAX_USER_RESULTS = 5;
+const _MAX_USER_RESULTS = 5;
 
 interface FileSearchQuery {
   sessionId: SessionID;

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -141,7 +141,9 @@ export class HealthMonitor {
         this.stopMonitoring(worktreeId);
         // Only log at debug level - this is normal cleanup, not an error
         if (process.env.DEBUG) {
-          console.log(`   Health monitoring stopped for deleted worktree ${worktreeId.substring(0, 8)}`);
+          console.log(
+            `   Health monitoring stopped for deleted worktree ${worktreeId.substring(0, 8)}`
+          );
         }
         return;
       }
@@ -178,7 +180,7 @@ export class HealthMonitor {
 
       // Start monitoring running or starting worktrees
       const activeWorktrees = worktrees.filter(
-        w =>
+        (w) =>
           w.environment_instance?.status === 'running' ||
           w.environment_instance?.status === 'starting'
       );

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -104,7 +104,7 @@ export class LeaderboardService {
     } = query;
 
     // Parse groupBy dimensions
-    const dimensions = groupBy.split(',').map(d => d.trim());
+    const dimensions = groupBy.split(',').map((d) => d.trim());
     const includeUser = dimensions.includes('user');
     const includeWorktree = dimensions.includes('worktree');
     const includeRepo = dimensions.includes('repo');
@@ -220,7 +220,7 @@ export class LeaderboardService {
     const total = countResult[0]?.count || 0;
 
     // Transform results to match our interface
-    const data: LeaderboardEntry[] = results.map(row => ({
+    const data: LeaderboardEntry[] = results.map((row) => ({
       ...(includeUser && { userId: row.userId as string }),
       ...(includeWorktree && {
         worktreeId: row.worktreeId as string,

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -25,9 +25,9 @@
 
 import type { Database } from '@agor/core/db';
 import { SessionRepository, WorktreeRepository } from '@agor/core/db';
-import type { PermissionMode, Session, Worktree, WorktreeScheduleConfig } from '@agor/core/types';
+import type { PermissionMode, Session, Worktree } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
-import { getNextRunTime, getPrevRunTime, roundToMinute } from '@agor/core/utils/cron';
+import { getNextRunTime, getPrevRunTime } from '@agor/core/utils/cron';
 import Handlebars from 'handlebars';
 import type { Application } from '../declarations';
 
@@ -74,13 +74,13 @@ export class SchedulerService {
     this.isRunning = true;
 
     // Run first tick immediately
-    this.tick().catch(error => {
+    this.tick().catch((error) => {
       console.error('❌ Scheduler tick failed:', error);
     });
 
     // Schedule recurring ticks
     this.intervalHandle = setInterval(() => {
-      this.tick().catch(error => {
+      this.tick().catch((error) => {
         console.error('❌ Scheduler tick failed:', error);
       });
     }, this.config.tickInterval);
@@ -150,7 +150,7 @@ export class SchedulerService {
     const allWorktrees = await this.worktreeRepo.findAll();
 
     // Filter to only enabled schedules
-    const enabledSchedules = allWorktrees.filter(wt => wt.schedule_enabled === true);
+    const enabledSchedules = allWorktrees.filter((wt) => wt.schedule_enabled === true);
 
     return enabledSchedules;
   }
@@ -231,8 +231,8 @@ export class SchedulerService {
     // 1. Check deduplication using repository
     // Use repository to check for existing sessions (bypasses auth)
     const allSessions = await this.sessionRepo.findAll();
-    const worktreeSessions = allSessions.filter(s => s.worktree_id === worktree.worktree_id);
-    const existingSession = worktreeSessions.find(s => s.scheduled_run_at === scheduledRunAt);
+    const worktreeSessions = allSessions.filter((s) => s.worktree_id === worktree.worktree_id);
+    const existingSession = worktreeSessions.find((s) => s.scheduled_run_at === scheduledRunAt);
 
     if (existingSession) {
       // Still update next_run_at to prevent repeated checks
@@ -244,7 +244,7 @@ export class SchedulerService {
     const renderedPrompt = this.renderPrompt(schedule.prompt_template, worktree);
 
     // 3. Get current run index (count of all scheduled sessions for this worktree)
-    const scheduledSessions = worktreeSessions.filter(s => s.scheduled_from_worktree === true);
+    const scheduledSessions = worktreeSessions.filter((s) => s.scheduled_from_worktree === true);
     const runIndex = scheduledSessions.length + 1;
 
     // 4. Create session with schedule metadata
@@ -395,8 +395,8 @@ export class SchedulerService {
     try {
       // Fetch all scheduled sessions for this worktree using repository
       const allSessions = await this.sessionRepo.findAll();
-      const worktreeSessions = allSessions.filter(s => s.worktree_id === worktree.worktree_id);
-      const scheduledSessions = worktreeSessions.filter(s => s.scheduled_from_worktree === true);
+      const worktreeSessions = allSessions.filter((s) => s.worktree_id === worktree.worktree_id);
+      const scheduledSessions = worktreeSessions.filter((s) => s.scheduled_from_worktree === true);
 
       // Sort by scheduled_run_at DESC (newest first)
       scheduledSessions.sort((a, b) => {

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -15,7 +15,7 @@
 import { execSync } from 'node:child_process';
 import os from 'node:os';
 import { resolveUserEnvironment } from '@agor/core/config';
-import { formatShortId, WorktreeRepository, type Database } from '@agor/core/db';
+import { type Database, WorktreeRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { UserID, WorktreeID } from '@agor/core/types';
 import type { IPty } from '@homebridge/node-pty-prebuilt-multiarch';
@@ -170,7 +170,7 @@ export class TerminalsService {
             'attach-session',
             '-t',
             tmuxSession,
-            '\;',
+            ';',
             'new-window',
             '-n',
             windowName,
@@ -222,7 +222,7 @@ export class TerminalsService {
     });
 
     // Handle PTY output - broadcast to WebSocket clients
-    ptyProcess.onData(data => {
+    ptyProcess.onData((data) => {
       this.app.service('terminals').emit('data', {
         terminalId,
         data,
@@ -262,7 +262,7 @@ export class TerminalsService {
    * List all terminal sessions
    */
   async find(): Promise<Array<{ terminalId: string; cwd: string; createdAt: Date }>> {
-    return Array.from(this.sessions.values()).map(session => ({
+    return Array.from(this.sessions.values()).map((session) => ({
       terminalId: session.terminalId,
       cwd: session.cwd,
       createdAt: session.createdAt,

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -76,7 +76,7 @@ export class UsersService {
       rows = await this.db.select().from(users).all();
     }
 
-    const results = rows.map(row => this.rowToUser(row, includePassword));
+    const results = rows.map((row) => this.rowToUser(row, includePassword));
 
     return {
       total: results.length,
@@ -162,7 +162,13 @@ export class UsersService {
       updates.onboarding_completed = data.onboarding_completed;
 
     // Update data blob
-    if (data.avatar || data.preferences || data.api_keys || data.env_vars || data.default_agentic_config) {
+    if (
+      data.avatar ||
+      data.preferences ||
+      data.api_keys ||
+      data.env_vars ||
+      data.default_agentic_config
+    ) {
       const current = await this.get(id);
       const currentRow = await this.db.select().from(users).where(eq(users.user_id, id)).get();
       const currentData = currentRow?.data as {
@@ -211,7 +217,7 @@ export class UsersService {
             // Validate and encrypt
             const errors = validateEnvVar(key, value);
             if (errors.length > 0) {
-              const message = errors.map(e => e.message).join('; ');
+              const message = errors.map((e) => e.message).join('; ');
               throw new Error(`Invalid environment variable: ${message}`);
             }
 
@@ -373,7 +379,7 @@ export class UsersService {
         : undefined,
       // Return env var status (boolean), NOT actual values
       env_vars: data.env_vars
-        ? Object.fromEntries(Object.keys(data.env_vars).map(key => [key, true]))
+        ? Object.fromEntries(Object.keys(data.env_vars).map((key) => [key, true]))
         : undefined,
       // Return default agentic config
       default_agentic_config: data.default_agentic_config,
@@ -438,7 +444,7 @@ class UsersServiceWithAuth extends UsersService {
           }
         : undefined,
       env_vars: data.env_vars
-        ? Object.fromEntries(Object.keys(data.env_vars).map(key => [key, true]))
+        ? Object.fromEntries(Object.keys(data.env_vars).map((key) => [key, true]))
         : undefined,
     };
   }

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -13,16 +13,7 @@ import { ENVIRONMENT } from '@agor/core/config';
 import { type Database, WorktreeRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { cleanWorktree, removeWorktree } from '@agor/core/git';
-import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
-import type {
-  BoardEntityObject,
-  BoardID,
-  QueryParams,
-  Repo,
-  UUID,
-  Worktree,
-  WorktreeID,
-} from '@agor/core/types';
+import type { BoardID, QueryParams, Repo, UUID, Worktree, WorktreeID } from '@agor/core/types';
 import { getNextRunTime, validateCron } from '@agor/core/utils/cron';
 import { DrizzleService } from '../adapters/drizzle';
 
@@ -227,7 +218,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
         .then(() => {
           console.log(`✅ Worktree removed from filesystem successfully`);
         })
-        .catch(error => {
+        .catch((error) => {
           console.error(
             `⚠️  Failed to remove worktree from filesystem:`,
             error instanceof Error ? error.message : String(error)
@@ -262,9 +253,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
 
     // Stop environment if running
     if (worktree.environment_instance?.status === 'running') {
-      console.log(
-        `⚠️  Stopping environment for worktree ${worktree.name} before ${metadataAction}`
-      );
+      console.log(`⚠️  Stopping environment for worktree ${worktree.name} before ${metadataAction}`);
       try {
         await this.stopEnvironment(id, params);
       } catch (error) {
@@ -584,7 +573,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
           stdio: 'inherit', // Show output directly in daemon logs
         });
 
-        childProcess.on('exit', code => {
+        childProcess.on('exit', (code) => {
           if (code === 0) {
             console.log(`✅ Start command completed successfully for ${worktree.name}`);
             resolve();
@@ -663,7 +652,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
             stdio: 'inherit',
           });
 
-          stopProcess.on('exit', code => {
+          stopProcess.on('exit', (code) => {
             if (code === 0) {
               resolve();
             } else {
@@ -735,7 +724,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       await this.stopEnvironment(id, params);
 
       // Wait a bit for processes to clean up
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 
     // Start
@@ -747,7 +736,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
    */
   async checkHealth(id: WorktreeID, params?: WorktreeParams): Promise<Worktree> {
     const worktree = await this.get(id, params);
-    const repo = (await this.app.service('repos').get(worktree.repo_id)) as Repo;
+    const _repo = (await this.app.service('repos').get(worktree.repo_id)) as Repo;
 
     // Only check health for 'running' or 'starting' status
     const currentStatus = worktree.environment_instance?.status;
@@ -934,7 +923,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
           stderr += data.toString();
         });
 
-        childProcess.on('exit', code => {
+        childProcess.on('exit', (code) => {
           clearTimeout(timeout);
           if (code === 0 || stdout.length > 0) {
             resolve({ stdout, stderr, truncated });
@@ -943,7 +932,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
           }
         });
 
-        childProcess.on('error', error => {
+        childProcess.on('error', (error) => {
           clearTimeout(timeout);
           reject(error);
         });
@@ -983,30 +972,6 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
         error: error instanceof Error ? error.message : 'Unknown error',
       };
     }
-  }
-
-  /**
-   * Build template context for Handlebars rendering
-   */
-  private buildTemplateContext(worktree: Worktree, repo: Repo) {
-    let customContext = {};
-    try {
-      customContext = worktree.custom_context || {};
-    } catch {
-      // Invalid custom context, use empty object
-    }
-
-    return {
-      worktree: {
-        unique_id: worktree.worktree_unique_id,
-        name: worktree.name,
-        path: worktree.path,
-      },
-      repo: {
-        slug: repo.slug,
-      },
-      custom: customContext,
-    };
   }
 }
 

--- a/apps/agor-daemon/tsup.config.ts
+++ b/apps/agor-daemon/tsup.config.ts
@@ -6,7 +6,7 @@ const srcFiles = glob.sync('src/**/*.ts', { ignore: ['**/*.test.ts', '**/*.spec.
 
 // Create entry points
 const entries = Object.fromEntries(
-  srcFiles.map(file => [file.replace(/^src\//, '').replace(/\.ts$/, ''), file])
+  srcFiles.map((file) => [file.replace(/^src\//, '').replace(/\.ts$/, ''), file])
 );
 
 export default defineConfig({

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -151,7 +151,7 @@ function AppContent() {
   // Get current user from users array (real-time updates via WebSocket)
   // This ensures we get the latest onboarding_completed status
   // Fall back to user from auth if users array hasn't loaded yet
-  const currentUser = user ? users.find(u => u.user_id === user.user_id) || user : null;
+  const currentUser = user ? users.find((u) => u.user_id === user.user_id) || user : null;
 
   // Memoize welcome modal stats to prevent unnecessary re-renders
   const welcomeStats = useMemo(
@@ -438,7 +438,7 @@ function AppContent() {
 
   // Update draft for a specific session
   const handleUpdateDraft = (sessionId: string, draft: string) => {
-    setPromptDrafts(prev => {
+    setPromptDrafts((prev) => {
       const next = new Map(prev);
       if (draft.trim()) {
         next.set(sessionId, draft);
@@ -451,7 +451,7 @@ function AppContent() {
 
   // Clear draft for a specific session
   const handleClearDraft = (sessionId: string) => {
-    setPromptDrafts(prev => {
+    setPromptDrafts((prev) => {
       const next = new Map(prev);
       next.delete(sessionId);
       return next;
@@ -824,10 +824,10 @@ function AppContent() {
       const currentIds = sessionMcpServerIds[sessionId] || [];
 
       // Find servers to add (in new list but not in current)
-      const toAdd = mcpServerIds.filter(id => !currentIds.includes(id));
+      const toAdd = mcpServerIds.filter((id) => !currentIds.includes(id));
 
       // Find servers to remove (in current list but not in new)
-      const toRemove = currentIds.filter(id => !mcpServerIds.includes(id));
+      const toRemove = currentIds.filter((id) => !mcpServerIds.includes(id));
 
       // Add new relationships
       for (const serverId of toAdd) {
@@ -870,7 +870,7 @@ function AppContent() {
   const handleResolveComment = async (commentId: string) => {
     if (!client) return;
     try {
-      const comment = comments.find(c => c.comment_id === commentId);
+      const comment = comments.find((c) => c.comment_id === commentId);
       await client.service('board-comments').patch(commentId, {
         resolved: !comment?.resolved,
       });
@@ -925,8 +925,8 @@ function AppContent() {
 
   // Generate repo reference options for dropdowns
   const allOptions = getRepoReferenceOptions(repos, worktrees);
-  const _worktreeOptions = allOptions.filter(opt => opt.type === 'managed-worktree');
-  const _repoOptions = allOptions.filter(opt => opt.type === 'managed');
+  const _worktreeOptions = allOptions.filter((opt) => opt.type === 'managed-worktree');
+  const _repoOptions = allOptions.filter((opt) => opt.type === 'managed');
 
   // Handle onboarding dismissal
   const handleDismissOnboarding = async () => {

--- a/apps/agor-ui/src/components/AdvancedSettingsForm/AdvancedSettingsForm.tsx
+++ b/apps/agor-ui/src/components/AdvancedSettingsForm/AdvancedSettingsForm.tsx
@@ -26,19 +26,17 @@ export const AdvancedSettingsForm: React.FC<AdvancedSettingsFormProps> = ({
   showHelpText = true,
 }) => {
   return (
-    <>
-      <Form.Item
-        name="custom_context"
-        label="Custom Context (JSON)"
-        help={
-          showHelpText
-            ? 'Add custom fields for use in zone trigger templates (e.g., {{ session.context.yourField }})'
-            : undefined
-        }
-        rules={[{ validator: validateJSON }]}
-      >
-        <JSONEditor placeholder='{"teamName": "Backend", "sprintNumber": 42}' rows={4} />
-      </Form.Item>
-    </>
+    <Form.Item
+      name="custom_context"
+      label="Custom Context (JSON)"
+      help={
+        showHelpText
+          ? 'Add custom fields for use in zone trigger templates (e.g., {{ session.context.yourField }})'
+          : undefined
+      }
+      rules={[{ validator: validateJSON }]}
+    >
+      <JSONEditor placeholder='{"teamName": "Backend", "sprintNumber": 42}' rows={4} />
+    </Form.Item>
   );
 };

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -42,7 +42,6 @@ import type React from 'react';
 import { useMemo, useState } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
 import { CollapsibleText } from '../CollapsibleText';
-import { MarkdownRenderer } from '../MarkdownRenderer';
 import { ToolUseRenderer } from '../ToolUseRenderer';
 
 interface ToolUseBlock {
@@ -166,7 +165,7 @@ export const AgentChain: React.FC<AgentChainProps> = ({ messages }) => {
       // Special handling: Tool result messages (user role with tool_result blocks)
       // Extract text content and show as thoughts
       if (message.role === 'user') {
-        const toolResults = message.content.filter(b => b.type === 'tool_result');
+        const toolResults = message.content.filter((b) => b.type === 'tool_result');
         if (toolResults.length > 0) {
           for (const block of toolResults) {
             const toolResult = block as unknown as ToolResultBlock;
@@ -176,8 +175,8 @@ export const AgentChain: React.FC<AgentChainProps> = ({ messages }) => {
               resultText = toolResult.content;
             } else if (Array.isArray(toolResult.content)) {
               resultText = toolResult.content
-                .filter(b => b.type === 'text')
-                .map(b => (b as unknown as { text: string }).text)
+                .filter((b) => b.type === 'text')
+                .map((b) => (b as unknown as { text: string }).text)
                 .join('\n');
             }
 
@@ -497,7 +496,7 @@ export const AgentChain: React.FC<AgentChainProps> = ({ messages }) => {
                   gap: 4,
                 }}
               >
-                {stats.filesAffected.map(file => (
+                {stats.filesAffected.map((file) => (
                   <div
                     key={file}
                     style={{
@@ -558,10 +557,10 @@ export const AgentChain: React.FC<AgentChainProps> = ({ messages }) => {
           cursor: 'pointer',
           transition: 'all 0.2s',
         }}
-        onMouseEnter={e => {
+        onMouseEnter={(e) => {
           e.currentTarget.style.borderColor = token.colorPrimaryBorder;
         }}
-        onMouseLeave={e => {
+        onMouseLeave={(e) => {
           e.currentTarget.style.borderColor = token.colorBorder;
         }}
       >

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -64,7 +64,7 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
           marginTop: 8,
         }}
       >
-        {agents.map(agent => (
+        {agents.map((agent) => (
           <AgentSelectionCard
             key={agent.id}
             agent={agent}

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -85,7 +85,9 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
           name="codexSandboxMode"
           label="Sandbox Mode"
           help={
-            showHelpText ? 'Controls where Codex can write files (workspace vs. full access)' : undefined
+            showHelpText
+              ? 'Controls where Codex can write files (workspace vs. full access)'
+              : undefined
           }
         >
           <Select
@@ -103,9 +105,7 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
           name="codexApprovalPolicy"
           label="Approval Policy"
           help={
-            showHelpText
-              ? 'Controls whether Codex must ask before executing commands'
-              : undefined
+            showHelpText ? 'Controls whether Codex must ask before executing commands' : undefined
           }
         >
           <Select

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -70,7 +70,7 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
     if (!value) return;
 
     await onSave(field, value);
-    setInputValues(prev => ({ ...prev, [field]: '' }));
+    setInputValues((prev) => ({ ...prev, [field]: '' }));
   };
 
   const renderKeyField = (config: KeyFieldConfig) => {
@@ -109,7 +109,7 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
               <Input.Password
                 placeholder={placeholder}
                 value={inputValues[field] || ''}
-                onChange={e => setInputValues(prev => ({ ...prev, [field]: e.target.value }))}
+                onChange={(e) => setInputValues((prev) => ({ ...prev, [field]: e.target.value }))}
                 onPressEnter={() => handleSave(field)}
                 style={{ flex: 1 }}
                 disabled={disabled}
@@ -138,7 +138,7 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
 
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
-      {KEY_CONFIGS.filter(config => config.field in keyStatus).map(config =>
+      {KEY_CONFIGS.filter((config) => config.field in keyStatus).map((config) =>
         renderKeyField(config)
       )}
     </Space>

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -21,7 +21,6 @@ import type { AgenticToolOption } from '../../types';
 import { AppHeader } from '../AppHeader';
 import { CommentsPanel } from '../CommentsPanel';
 import { EnvironmentLogsModal } from '../EnvironmentLogsModal';
-import type { ModelConfig } from '../ModelSelector';
 import { NewSessionButton } from '../NewSessionButton';
 import { type NewSessionConfig, NewSessionModal } from '../NewSessionModal';
 import { type NewWorktreeConfig, NewWorktreeModal } from '../NewWorktreeModal';
@@ -199,7 +198,7 @@ export const App: React.FC<AppProps> = ({
   // Initialize current board from localStorage or fallback to first board or initialBoardId
   const [currentBoardId, setCurrentBoardId] = useState(() => {
     const stored = localStorage.getItem('agor:currentBoardId');
-    if (stored && boards.some(b => b.board_id === stored)) {
+    if (stored && boards.some((b) => b.board_id === stored)) {
       return stored;
     }
     return initialBoardId || boards[0]?.board_id || '';
@@ -219,7 +218,7 @@ export const App: React.FC<AppProps> = ({
 
   // If the stored board no longer exists (e.g., deleted), fallback to first board
   useEffect(() => {
-    if (currentBoardId && !boards.some(b => b.board_id === currentBoardId)) {
+    if (currentBoardId && !boards.some((b) => b.board_id === currentBoardId)) {
       const fallback = boards[0]?.board_id || '';
       setCurrentBoardId(fallback);
     }
@@ -273,13 +272,13 @@ export const App: React.FC<AppProps> = ({
     setSelectedSessionId(sessionId);
 
     // Clear the ready_for_prompt flag when opening the conversation
-    const session = sessions.find(s => s.session_id === sessionId);
+    const session = sessions.find((s) => s.session_id === sessionId);
     if (session?.ready_for_prompt) {
       onUpdateSession?.(sessionId, { ready_for_prompt: false });
     }
 
     // Clear the worktree's needs_attention flag when user interacts with it
-    const worktree = worktrees.find(w => w.worktree_id === session?.worktree_id);
+    const worktree = worktrees.find((w) => w.worktree_id === session?.worktree_id);
     if (worktree?.needs_attention) {
       onUpdateWorktree?.(worktree.worktree_id, { needs_attention: false });
     }
@@ -287,7 +286,7 @@ export const App: React.FC<AppProps> = ({
 
   const handleSendPrompt = async (prompt: string, permissionMode?: PermissionMode) => {
     if (selectedSessionId) {
-      const session = sessions.find(s => s.session_id === selectedSessionId);
+      const session = sessions.find((s) => s.session_id === selectedSessionId);
       const agentName = session?.agentic_tool || 'agentic_tool';
 
       // Show loading state
@@ -349,41 +348,43 @@ export const App: React.FC<AppProps> = ({
     [client, user?.user_id]
   );
 
-  const selectedSession = sessions.find(s => s.session_id === selectedSessionId) || null;
+  const selectedSession = sessions.find((s) => s.session_id === selectedSessionId) || null;
   const selectedSessionWorktree = selectedSession
-    ? worktrees.find(w => w.worktree_id === selectedSession.worktree_id)
+    ? worktrees.find((w) => w.worktree_id === selectedSession.worktree_id)
     : null;
   const sessionSettingsSession = sessionSettingsId
-    ? sessions.find(s => s.session_id === sessionSettingsId)
+    ? sessions.find((s) => s.session_id === sessionSettingsId)
     : null;
   const _selectedSessionTasks = selectedSessionId ? tasks[selectedSessionId] || [] : [];
-  const currentBoard = boards.find(b => b.board_id === currentBoardId);
+  const currentBoard = boards.find((b) => b.board_id === currentBoardId);
 
   // Find worktree and repo for WorktreeModal
   const selectedWorktree = worktreeModalWorktreeId
-    ? worktrees.find(w => w.worktree_id === worktreeModalWorktreeId)
+    ? worktrees.find((w) => w.worktree_id === worktreeModalWorktreeId)
     : null;
   const selectedWorktreeRepo = selectedWorktree
-    ? repos.find(r => r.repo_id === selectedWorktree.repo_id)
+    ? repos.find((r) => r.repo_id === selectedWorktree.repo_id)
     : null;
   const worktreeSessions = selectedWorktree
-    ? sessions.filter(s => s.worktree_id === selectedWorktree.worktree_id)
+    ? sessions.filter((s) => s.worktree_id === selectedWorktree.worktree_id)
     : [];
 
   // Find worktree for NewSessionModal
   const newSessionWorktree = newSessionWorktreeId
-    ? worktrees.find(w => w.worktree_id === newSessionWorktreeId)
+    ? worktrees.find((w) => w.worktree_id === newSessionWorktreeId)
     : null;
 
   // Filter worktrees by current board (via board_objects)
   const boardWorktreeIds = boardObjects
-    .filter(bo => bo.board_id === currentBoard?.board_id)
-    .map(bo => bo.worktree_id);
+    .filter((bo) => bo.board_id === currentBoard?.board_id)
+    .map((bo) => bo.worktree_id);
 
-  const boardWorktrees = worktrees.filter(wt => boardWorktreeIds.includes(wt.worktree_id));
+  const boardWorktrees = worktrees.filter((wt) => boardWorktreeIds.includes(wt.worktree_id));
 
   // Filter sessions by current board's worktrees
-  const boardSessions = sessions.filter(session => boardWorktreeIds.includes(session.worktree_id));
+  const boardSessions = sessions.filter((session) =>
+    boardWorktreeIds.includes(session.worktree_id)
+  );
 
   // Track active users via cursor presence
   const { activeUsers } = usePresence({
@@ -402,7 +403,7 @@ export const App: React.FC<AppProps> = ({
           lastSeen: Date.now(),
           cursor: undefined, // Current user doesn't have a remote cursor
         },
-        ...activeUsers.filter(activeUser => activeUser.user.user_id !== user.user_id),
+        ...activeUsers.filter((activeUser) => activeUser.user.user_id !== user.user_id),
       ]
     : activeUsers;
 
@@ -428,22 +429,23 @@ export const App: React.FC<AppProps> = ({
         currentBoardName={currentBoard?.name}
         currentBoardIcon={currentBoard?.icon}
         unreadCommentsCount={
-          comments.filter(c => c.board_id === currentBoardId && !c.resolved && !c.parent_comment_id)
-            .length
+          comments.filter(
+            (c) => c.board_id === currentBoardId && !c.resolved && !c.parent_comment_id
+          ).length
         }
       />
       <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
         <CommentsPanel
           client={client}
           boardId={currentBoardId || ''}
-          comments={comments.filter(c => c.board_id === currentBoardId)}
+          comments={comments.filter((c) => c.board_id === currentBoardId)}
           users={users}
           currentUserId={user?.user_id || 'anonymous'}
           boardObjects={currentBoard?.objects}
           worktrees={boardWorktrees}
           collapsed={commentsPanelCollapsed}
           onToggleCollapse={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
-          onSendComment={content => onSendComment?.(currentBoardId || '', content)}
+          onSendComment={(content) => onSendComment?.(currentBoardId || '', content)}
           onReplyComment={onReplyComment}
           onResolveComment={onResolveComment}
           onToggleReaction={onToggleReaction}
@@ -473,13 +475,13 @@ export const App: React.FC<AppProps> = ({
             onForkSession={onForkSession}
             onSpawnSession={onSpawnSession}
             onUpdateSessionMcpServers={onUpdateSessionMcpServers}
-            onOpenSettings={sessionId => {
+            onOpenSettings={(sessionId) => {
               setSessionSettingsId(sessionId);
             }}
-            onCreateSessionForWorktree={worktreeId => {
+            onCreateSessionForWorktree={(worktreeId) => {
               setNewSessionWorktreeId(worktreeId);
             }}
-            onOpenWorktree={worktreeId => {
+            onOpenWorktree={(worktreeId) => {
               setWorktreeModalWorktreeId(worktreeId);
             }}
             onArchiveOrDeleteWorktree={onArchiveOrDeleteWorktree}
@@ -489,9 +491,9 @@ export const App: React.FC<AppProps> = ({
             onViewLogs={setLogsModalWorktreeId}
             onOpenCommentsPanel={() => setCommentsPanelCollapsed(false)}
             onCommentHover={setHoveredCommentId}
-            onCommentSelect={commentId => {
+            onCommentSelect={(commentId) => {
               // Toggle selection: if clicking same comment, deselect
-              setSelectedCommentId(prev => (prev === commentId ? null : commentId));
+              setSelectedCommentId((prev) => (prev === commentId ? null : commentId));
             }}
           />
           <NewSessionButton
@@ -537,10 +539,10 @@ export const App: React.FC<AppProps> = ({
         onFork={handleFork}
         onSubsession={handleSubsession}
         onPermissionDecision={handlePermissionDecision}
-        onOpenSettings={sessionId => {
+        onOpenSettings={(sessionId) => {
           setSessionSettingsId(sessionId);
         }}
-        onOpenWorktree={worktreeId => {
+        onOpenWorktree={(worktreeId) => {
           setWorktreeModalWorktreeId(worktreeId);
         }}
         onOpenTerminal={handleOpenTerminal}
@@ -568,7 +570,7 @@ export const App: React.FC<AppProps> = ({
         mcpServers={mcpServers}
         activeTab={effectiveSettingsTab}
         editUserId={settingsEditUserId}
-        onTabChange={newTab => {
+        onTabChange={(newTab) => {
           setSettingsActiveTab(newTab);
           setSettingsEditUserId(undefined); // Clear editUserId when switching tabs
           // Clear openSettingsTab when user manually changes tabs
@@ -655,7 +657,7 @@ export const App: React.FC<AppProps> = ({
         <EnvironmentLogsModal
           open={!!logsModalWorktreeId}
           onClose={() => setLogsModalWorktreeId(null)}
-          worktree={worktrees.find(w => w.worktree_id === logsModalWorktreeId)!}
+          worktree={worktrees.find((w) => w.worktree_id === logsModalWorktreeId)!}
           client={client}
         />
       )}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -122,10 +122,10 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                 borderRadius: token.borderRadius,
                 transition: 'background 0.2s',
               }}
-              onMouseEnter={e => {
+              onMouseEnter={(e) => {
                 e.currentTarget.style.background = token.colorBgTextHover;
               }}
-              onMouseLeave={e => {
+              onMouseLeave={(e) => {
                 e.currentTarget.style.background = 'transparent';
               }}
               onClick={onMenuClick}
@@ -156,7 +156,11 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       </Space>
 
       <Space>
-        <ConnectionStatus connected={connected} connecting={connecting} onRetry={onRetryConnection} />
+        <ConnectionStatus
+          connected={connected}
+          connecting={connecting}
+          onRetry={onRetryConnection}
+        />
         {activeUsers.length > 0 && (
           <>
             <Facepile

--- a/apps/agor-ui/src/components/ArchiveDeleteWorktreeModal/ArchiveDeleteWorktreeModal.tsx
+++ b/apps/agor-ui/src/components/ArchiveDeleteWorktreeModal/ArchiveDeleteWorktreeModal.tsx
@@ -73,7 +73,10 @@ export const ArchiveDeleteWorktreeModal: React.FC<ArchiveDeleteWorktreeModalProp
           <Text strong style={{ display: 'block', marginBottom: 8 }}>
             Filesystem
           </Text>
-          <Radio.Group value={filesystemAction} onChange={e => setFilesystemAction(e.target.value)}>
+          <Radio.Group
+            value={filesystemAction}
+            onChange={(e) => setFilesystemAction(e.target.value)}
+          >
             <Space direction="vertical">
               <Radio value="preserved">
                 <div>
@@ -108,7 +111,7 @@ export const ArchiveDeleteWorktreeModal: React.FC<ArchiveDeleteWorktreeModalProp
           <Text strong style={{ display: 'block', marginBottom: 8 }}>
             Metadata & Sessions
           </Text>
-          <Radio.Group value={metadataAction} onChange={e => setMetadataAction(e.target.value)}>
+          <Radio.Group value={metadataAction} onChange={(e) => setMetadataAction(e.target.value)}>
             <Space direction="vertical">
               <Radio value="archive">
                 <div>

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -15,7 +15,7 @@ const { TextArea } = Input;
 const { Text } = Typography;
 
 // Constants
-const MAX_FILE_RESULTS = 10;
+const _MAX_FILE_RESULTS = 10;
 const MAX_USER_RESULTS = 5;
 const DEBOUNCE_MS = 300;
 
@@ -177,12 +177,12 @@ export const AutocompleteTextarea = React.forwardRef<
         const lowercaseQuery = searchQuery.toLowerCase();
         return users
           .filter(
-            u =>
-              (u.name && u.name.toLowerCase().includes(lowercaseQuery)) ||
+            (u) =>
+              u.name?.toLowerCase().includes(lowercaseQuery) ||
               u.email.toLowerCase().includes(lowercaseQuery)
           )
           .slice(0, MAX_USER_RESULTS)
-          .map(u => ({
+          .map((u) => ({
             name: u.name || u.email,
             email: u.email,
             type: 'user' as const,
@@ -295,7 +295,7 @@ export const AutocompleteTextarea = React.forwardRef<
             if (isPopoverOpen) {
               e.preventDefault();
               e.stopPropagation();
-              setHighlightedIndex(prev =>
+              setHighlightedIndex((prev) =>
                 prev < autocompleteOptions.length - 1 ? prev + 1 : prev
               );
             }
@@ -305,7 +305,7 @@ export const AutocompleteTextarea = React.forwardRef<
             if (isPopoverOpen) {
               e.preventDefault();
               e.stopPropagation();
-              setHighlightedIndex(prev => (prev > 0 ? prev - 1 : -1));
+              setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : -1));
             }
             break;
 
@@ -321,7 +321,7 @@ export const AutocompleteTextarea = React.forwardRef<
                 }
               } else if (autocompleteOptions.length > 0) {
                 // If nothing highlighted, highlight first non-heading item
-                const firstItem = autocompleteOptions.find(item => !('heading' in item));
+                const firstItem = autocompleteOptions.find((item) => !('heading' in item));
                 if (firstItem) {
                   const idx = autocompleteOptions.indexOf(firstItem);
                   setHighlightedIndex(idx);
@@ -440,11 +440,11 @@ export const AutocompleteTextarea = React.forwardRef<
                   backgroundColor: isHighlighted ? token.colorPrimaryBg : 'transparent',
                   color: isHighlighted ? token.colorPrimary : token.colorText,
                 }}
-                onMouseEnter={e => {
+                onMouseEnter={(e) => {
                   setHighlightedIndex(idx);
                   e.currentTarget.style.backgroundColor = token.colorBgTextHover;
                 }}
-                onMouseLeave={e => {
+                onMouseLeave={(e) => {
                   setHighlightedIndex(-1);
                   e.currentTarget.style.backgroundColor = 'transparent';
                 }}
@@ -465,7 +465,7 @@ export const AutocompleteTextarea = React.forwardRef<
         overlayStyle={{ paddingTop: 4 }}
       >
         <TextArea
-          ref={node => {
+          ref={(node) => {
             let textarea: HTMLTextAreaElement | null = null;
             if (
               node &&

--- a/apps/agor-ui/src/components/AutocompleteTextarea/index.ts
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/index.ts
@@ -1,2 +1,2 @@
+export type {} from './AutocompleteTextarea';
 export { AutocompleteTextarea } from './AutocompleteTextarea';
-export type { } from './AutocompleteTextarea';

--- a/apps/agor-ui/src/components/CodexNetworkAccessToggle/index.ts
+++ b/apps/agor-ui/src/components/CodexNetworkAccessToggle/index.ts
@@ -1,2 +1,2 @@
-export { CodexNetworkAccessToggle } from './CodexNetworkAccessToggle';
 export type { CodexNetworkAccessToggleProps } from './CodexNetworkAccessToggle';
+export { CodexNetworkAccessToggle } from './CodexNetworkAccessToggle';

--- a/apps/agor-ui/src/components/CollapsibleText/index.ts
+++ b/apps/agor-ui/src/components/CollapsibleText/index.ts
@@ -1,2 +1,2 @@
-export { CollapsibleText } from './CollapsibleText';
 export type { CollapsibleTextProps } from './CollapsibleText';
+export { CollapsibleText } from './CollapsibleText';

--- a/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
+++ b/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
@@ -86,9 +86,9 @@ const ReactionDisplay: React.FC<{
 
         // Build tooltip content with list of users who reacted
         const reactedUsers = userIds
-          .map(userId => users.find(u => u.user_id === userId))
+          .map((userId) => users.find((u) => u.user_id === userId))
           .filter(Boolean)
-          .map(user => user!.name || user!.email.split('@')[0]);
+          .map((user) => user!.name || user!.email.split('@')[0]);
 
         const tooltipContent =
           reactedUsers.length > 0 ? reactedUsers.join(', ') : 'Anonymous users';
@@ -108,10 +108,10 @@ const ReactionDisplay: React.FC<{
                 color: token.colorText,
                 transition: 'background-color 0.2s ease',
               }}
-              onMouseEnter={e => {
+              onMouseEnter={(e) => {
                 e.currentTarget.style.backgroundColor = token.colorPrimaryBgHover;
               }}
-              onMouseLeave={e => {
+              onMouseLeave={(e) => {
                 e.currentTarget.style.backgroundColor = hasReacted
                   ? token.colorPrimaryBg
                   : 'transparent';
@@ -139,7 +139,7 @@ const EmojiPickerButton: React.FC<{
     <Popover
       content={
         <EmojiPicker
-          onEmojiClick={emojiData => {
+          onEmojiClick={(emojiData) => {
             onToggle(emojiData.emoji);
             setPickerOpen(false);
           }}
@@ -176,7 +176,7 @@ const ReplyItem: React.FC<{
 }> = ({ reply, users, currentUserId, onToggleReaction, onDelete }) => {
   const { token } = theme.useToken();
   const [replyHovered, setReplyHovered] = useState(false);
-  const replyUser = users.find(u => u.user_id === reply.created_by);
+  const replyUser = users.find((u) => u.user_id === reply.created_by);
   const isReplyCurrentUser = reply.created_by === currentUserId;
 
   return (
@@ -215,7 +215,7 @@ const ReplyItem: React.FC<{
                     reactions={reply.reactions || []}
                     currentUserId={currentUserId}
                     users={users}
-                    onToggle={emoji => onToggleReaction(reply.comment_id, emoji)}
+                    onToggle={(emoji) => onToggleReaction(reply.comment_id, emoji)}
                   />
                 </div>
               )}
@@ -238,7 +238,9 @@ const ReplyItem: React.FC<{
           >
             <Space size="small">
               {onToggleReaction && (
-                <EmojiPickerButton onToggle={emoji => onToggleReaction(reply.comment_id, emoji)} />
+                <EmojiPickerButton
+                  onToggle={(emoji) => onToggleReaction(reply.comment_id, emoji)}
+                />
               )}
               {onDelete && isReplyCurrentUser && (
                 <Button
@@ -288,7 +290,7 @@ const CommentThread: React.FC<{
   const { token } = theme.useToken();
   const [showReplyInput, setShowReplyInput] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const user = users.find(u => u.user_id === comment.created_by);
+  const user = users.find((u) => u.user_id === comment.created_by);
   const isCurrentUser = comment.created_by === currentUserId;
 
   return (
@@ -346,7 +348,7 @@ const CommentThread: React.FC<{
                     reactions={comment.reactions || []}
                     currentUserId={currentUserId}
                     users={users}
-                    onToggle={emoji => onToggleReaction(comment.comment_id, emoji)}
+                    onToggle={(emoji) => onToggleReaction(comment.comment_id, emoji)}
                   />
                 </div>
               )}
@@ -370,7 +372,7 @@ const CommentThread: React.FC<{
             <Space size="small">
               {onToggleReaction && (
                 <EmojiPickerButton
-                  onToggle={emoji => onToggleReaction(comment.comment_id, emoji)}
+                  onToggle={(emoji) => onToggleReaction(comment.comment_id, emoji)}
                 />
               )}
               {onReply && (
@@ -430,7 +432,7 @@ const CommentThread: React.FC<{
           >
             <List
               dataSource={replies}
-              renderItem={reply => (
+              renderItem={(reply) => (
                 <ReplyItem
                   reply={reply}
                   users={users}
@@ -449,7 +451,7 @@ const CommentThread: React.FC<{
             <Input.Search
               placeholder="Reply..."
               enterButton={<SendOutlined />}
-              onSearch={value => {
+              onSearch={(value) => {
                 if (value.trim()) {
                   onReply(comment.comment_id, value);
                   setShowReplyInput(false);
@@ -494,9 +496,9 @@ export const CommentsPanel: React.FC<CommentsPanelProps> = ({
   const commentRefs = React.useRef<Record<string, React.RefObject<HTMLDivElement>>>({});
 
   // Separate thread roots from replies
-  const threadRoots = useMemo(() => comments.filter(c => isThreadRoot(c)), [comments]);
+  const threadRoots = useMemo(() => comments.filter((c) => isThreadRoot(c)), [comments]);
 
-  const allReplies = useMemo(() => comments.filter(c => !isThreadRoot(c)), [comments]);
+  const allReplies = useMemo(() => comments.filter((c) => !isThreadRoot(c)), [comments]);
 
   // Group replies by parent
   const repliesByParent = useMemo(() => {
@@ -515,7 +517,7 @@ export const CommentsPanel: React.FC<CommentsPanelProps> = ({
   // Apply filters to thread roots only
   const filteredThreads = useMemo(() => {
     return threadRoots
-      .filter(thread => {
+      .filter((thread) => {
         if (filter === 'active' && thread.resolved) return false;
         return true;
       })
@@ -553,14 +555,14 @@ export const CommentsPanel: React.FC<CommentsPanelProps> = ({
           groupType = 'zone';
         } else if (parent_type === 'worktree') {
           groupKey = `worktree-${parent_id}`;
-          const worktree = worktrees.find(w => w.worktree_id === parent_id);
+          const worktree = worktrees.find((w) => w.worktree_id === parent_id);
           groupLabel = worktree ? worktree.name : 'Unknown Worktree';
           groupType = 'worktree';
         }
       } else if (thread.worktree_id) {
         // Check for FK-based worktree attachment
         groupKey = `worktree-${thread.worktree_id}`;
-        const worktree = worktrees.find(w => w.worktree_id === thread.worktree_id);
+        const worktree = worktrees.find((w) => w.worktree_id === thread.worktree_id);
         groupLabel = worktree ? worktree.name : 'Unknown Worktree';
         groupType = 'worktree';
       }
@@ -747,7 +749,7 @@ export const CommentsPanel: React.FC<CommentsPanelProps> = ({
               children: (
                 <List
                   dataSource={group.threads}
-                  renderItem={thread => {
+                  renderItem={(thread) => {
                     // Create or get ref for this thread
                     if (!commentRefs.current[thread.comment_id]) {
                       commentRefs.current[thread.comment_id] = React.createRef<HTMLDivElement>();
@@ -791,8 +793,8 @@ export const CommentsPanel: React.FC<CommentsPanelProps> = ({
           placeholder="Add a comment..."
           enterButton={<SendOutlined />}
           value={commentInputValue}
-          onChange={e => setCommentInputValue(e.target.value)}
-          onSearch={value => {
+          onChange={(e) => setCommentInputValue(e.target.value)}
+          onSearch={(value) => {
             if (value.trim()) {
               onSendComment(value);
               setCommentInputValue('');

--- a/apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
+++ b/apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
@@ -29,17 +29,17 @@ export const CompactionBlock: React.FC<CompactionBlockProps> = ({ messages, agen
   const { token } = theme.useToken();
 
   // Find start and complete messages
-  const startMessage = messages.find(m => {
+  const startMessage = messages.find((m) => {
     if (!Array.isArray(m.content)) return false;
     return m.content.some(
-      b => b.type === 'system_status' && 'status' in b && b.status === 'compacting'
+      (b) => b.type === 'system_status' && 'status' in b && b.status === 'compacting'
     );
   });
 
-  const completeMessage = messages.find(m => {
+  const completeMessage = messages.find((m) => {
     if (!Array.isArray(m.content)) return false;
     return m.content.some(
-      b => b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction'
+      (b) => b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction'
     );
   });
 
@@ -52,7 +52,7 @@ export const CompactionBlock: React.FC<CompactionBlockProps> = ({ messages, agen
   // If we have complete message, show completion state
   if (completeMessage && Array.isArray(completeMessage.content)) {
     const completeBlock = completeMessage.content.find(
-      b => b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction'
+      (b) => b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction'
     );
 
     if (completeBlock) {

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -18,7 +18,11 @@ export interface ConnectionStatusProps {
  *
  * Auto-hides after 3 seconds when connected to reduce visual clutter
  */
-export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({ connected, connecting, onRetry }) => {
+export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
+  connected,
+  connecting,
+  onRetry,
+}) => {
   const { token } = theme.useToken();
   const [showConnected, setShowConnected] = useState(false);
   const [justReconnected, setJustReconnected] = useState(false);

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -13,9 +13,9 @@
  */
 
 import type { AgorClient } from '@agor/core/api';
-import type { Message, PermissionScope, SessionID, User } from '@agor/core/types';
+import type { PermissionScope, SessionID, User } from '@agor/core/types';
 import { Alert, Spin, Typography, theme } from 'antd';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useStreamingMessages, useTasks } from '../../hooks';
 import { TaskBlock } from '../TaskBlock';
 
@@ -129,7 +129,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     }, [onScrollRef, scrollToBottom]);
 
     // Fetch tasks for this session
-    const currentUser = users.find(u => u.user_id === currentUserId) || null;
+    const currentUser = users.find((u) => u.user_id === currentUserId) || null;
     const {
       tasks,
       loading: tasksLoading,
@@ -154,7 +154,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     useEffect(() => {
       if (tasks.length > 0) {
         const lastTaskId = tasks[tasks.length - 1].task_id;
-        setExpandedTaskIds(prev => {
+        setExpandedTaskIds((prev) => {
           // If no tasks expanded or last task changed, expand the last task
           if (prev.size === 0 || !prev.has(lastTaskId)) {
             // Scroll to bottom after expansion is rendered
@@ -170,7 +170,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
 
     // Handle task expand/collapse
     const handleTaskExpandChange = useCallback((taskId: string, expanded: boolean) => {
-      setExpandedTaskIds(prev => {
+      setExpandedTaskIds((prev) => {
         const next = new Set(prev);
         if (expanded) {
           next.add(taskId);
@@ -242,7 +242,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
         }}
       >
         {/* Task-organized conversation */}
-        {tasks.map(task => (
+        {tasks.map((task) => (
           <TaskBlock
             key={task.task_id}
             task={task}
@@ -252,7 +252,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
             users={users}
             currentUserId={currentUserId}
             isExpanded={expandedTaskIds.has(task.task_id)}
-            onExpandChange={expanded => handleTaskExpandChange(task.task_id, expanded)}
+            onExpandChange={(expanded) => handleTaskExpandChange(task.task_id, expanded)}
             sessionId={sessionId}
             onPermissionDecision={onPermissionDecision}
             worktreeName={worktreeName}

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -90,7 +90,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
               <Input.Password
                 placeholder="Enter new value"
                 value={editingValue}
-                onChange={e => setEditingValue(e.target.value)}
+                onChange={(e) => setEditingValue(e.target.value)}
                 onPressEnter={() => handleUpdate(record.key)}
                 autoFocus
                 disabled={disabled}
@@ -186,7 +186,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
           <Input
             placeholder="Variable name (e.g., GITHUB_TOKEN)"
             value={newKey}
-            onChange={e => setNewKey(e.target.value)}
+            onChange={(e) => setNewKey(e.target.value)}
             onPressEnter={handleAdd}
             style={{ width: '30%' }}
             disabled={disabled}
@@ -194,7 +194,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
           <Input.Password
             placeholder="Value"
             value={newValue}
-            onChange={e => setNewValue(e.target.value)}
+            onChange={(e) => setNewValue(e.target.value)}
             onPressEnter={handleAdd}
             style={{ flex: 1 }}
             disabled={disabled}

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -45,7 +45,7 @@ export function EnvironmentPill({
         <Tag
           color="default"
           style={{ cursor: 'pointer', userSelect: 'none', opacity: 0.6 }}
-          onClick={e => {
+          onClick={(e) => {
             e.stopPropagation();
             onEdit?.();
           }}
@@ -180,7 +180,7 @@ export function EnvironmentPill({
               href={environmentUrl}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={e => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
@@ -232,7 +232,7 @@ export function EnvironmentPill({
                   type="text"
                   size="small"
                   icon={<PlayCircleOutlined />}
-                  onClick={event => {
+                  onClick={(event) => {
                     event.stopPropagation();
                     if (!startDisabled) {
                       onStartEnvironment(worktree.worktree_id);
@@ -264,7 +264,7 @@ export function EnvironmentPill({
                   type="text"
                   size="small"
                   icon={<StopOutlined />}
-                  onClick={event => {
+                  onClick={(event) => {
                     event.stopPropagation();
                     if (!stopDisabled) {
                       onStopEnvironment(worktree.worktree_id);
@@ -292,7 +292,7 @@ export function EnvironmentPill({
                   type="text"
                   size="small"
                   icon={<FileTextOutlined />}
-                  onClick={event => {
+                  onClick={(event) => {
                     event.stopPropagation();
                     if (repo.environment_config?.logs_command) {
                       onViewLogs(worktree.worktree_id);

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -44,7 +44,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   const { token } = theme.useToken();
 
   // Handle array of strings: filter empty, join with double newlines
-  const text = Array.isArray(content) ? content.filter(t => t.trim()).join('\n\n') : content;
+  const text = Array.isArray(content) ? content.filter((t) => t.trim()).join('\n\n') : content;
 
   // Detect dark mode from Ant Design token system
   const isDarkMode =

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -17,9 +17,9 @@ import {
   PermissionStatus,
   type User,
 } from '@agor/core/types';
-import { CheckCircleFilled, RobotOutlined } from '@ant-design/icons';
+import { RobotOutlined } from '@ant-design/icons';
 import { Bubble } from '@ant-design/x';
-import { Space, Spin, Tooltip, Typography, theme } from 'antd';
+import { Tooltip, Typography, theme } from 'antd';
 
 const { Text } = Typography;
 
@@ -96,9 +96,9 @@ function isTaskToolPrompt(message: Message): boolean {
   if (!Array.isArray(message.content)) return false;
 
   // Must have at least one text block (not tool_result)
-  const hasTextBlock = message.content.some(block => block.type === 'text');
+  const hasTextBlock = message.content.some((block) => block.type === 'text');
   const hasOnlyTextBlocks = message.content.every(
-    block => block.type === 'text' || block.type === 'thinking'
+    (block) => block.type === 'text' || block.type === 'thinking'
   );
 
   // If it has text blocks and NO tool_result blocks, it's likely a Task prompt
@@ -115,7 +115,7 @@ function isTaskToolResult(message: Message): boolean {
   // Check if contains tool_result block
   // Note: We can't easily determine if it's specifically a Task result here,
   // but groupMessagesIntoBlocks ensures only Task results reach this as non-chain messages
-  const hasToolResult = message.content.some(block => block.type === 'tool_result');
+  const hasToolResult = message.content.some((block) => block.type === 'tool_result');
 
   // User messages with tool_results that aren't in agent chains are likely Task results
   return hasToolResult;
@@ -159,7 +159,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
           }
           onDeny={
             canInteract && onPermissionDecision && sessionId && taskId
-              ? messageId => {
+              ? (messageId) => {
                   onPermissionDecision(
                     sessionId,
                     content.request_id,
@@ -199,7 +199,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
   const shouldUseTyping = isStreaming && hasContent;
 
   // Get current user's emoji
-  const currentUser = users.find(u => u.user_id === currentUserId);
+  const currentUser = users.find((u) => u.user_id === currentUserId);
   const userEmoji = currentUser?.emoji || '👤';
 
   // Skip rendering if message has no content
@@ -293,8 +293,8 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
               resultText = toolResult.content;
             } else if (Array.isArray(toolResult.content)) {
               resultText = toolResult.content
-                .filter(b => b.type === 'text')
-                .map(b => (b as unknown as { text: string }).text)
+                .filter((b) => b.type === 'text')
+                .map((b) => (b as unknown as { text: string }).text)
                 .join('\n');
             }
 
@@ -337,8 +337,8 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
   // Skip rendering if message has no meaningful content
   const hasThinking =
     thinkingBlocks.length > 0 || (streamingThinking && streamingThinking.length > 0);
-  const hasTextBefore = textBeforeTools.some(text => text.trim().length > 0);
-  const hasTextAfter = textAfterTools.some(text => text.trim().length > 0);
+  const hasTextBefore = textBeforeTools.some((text) => text.trim().length > 0);
+  const hasTextAfter = textAfterTools.some((text) => text.trim().length > 0);
   const hasTools = toolBlocks.length > 0;
 
   if (!hasThinking && !hasTextBefore && !hasTextAfter && !hasTools) {

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -95,7 +95,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   // Determine initial mode based on whether the value is in the aliases list
   // If no value provided, default to 'alias' mode (recommended)
-  const isValueInAliases = value?.model ? modelList.some(m => m.id === value.model) : true; // Default to true when no value (will use alias mode)
+  const isValueInAliases = value?.model ? modelList.some((m) => m.id === value.model) : true; // Default to true when no value (will use alias mode)
 
   const initialMode = value?.mode || (isValueInAliases ? 'alias' : 'exact');
   const [mode, setMode] = useState<'alias' | 'exact'>(initialMode);
@@ -133,7 +133,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   return (
     <Space direction="vertical" style={{ width: '100%' }}>
-      <Radio.Group value={mode} onChange={e => handleModeChange(e.target.value)}>
+      <Radio.Group value={mode} onChange={(e) => handleModeChange(e.target.value)}>
         <Space direction="vertical">
           <Radio value="alias">
             <Space>
@@ -150,7 +150,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 value={value?.model || modelList[0].id}
                 onChange={handleModelChange}
                 style={{ width: '100%', minWidth: 400 }}
-                options={modelList.map(m => ({
+                options={modelList.map((m) => ({
                   value: m.id,
                   label: m.id,
                 }))}
@@ -171,7 +171,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             <div style={{ marginLeft: 24, marginTop: 8 }}>
               <Input
                 value={value?.model}
-                onChange={e => handleModelChange(e.target.value)}
+                onChange={(e) => handleModelChange(e.target.value)}
                 placeholder={
                   effectiveTool === 'codex'
                     ? 'e.g., gpt-5-codex'

--- a/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.tsx
@@ -84,11 +84,11 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
     fetchProviders();
   }, []); // Only fetch once on mount
 
-  const selectedProvider = providers.find(p => p.id === value?.provider);
+  const selectedProvider = providers.find((p) => p.id === value?.provider);
   const availableModels = selectedProvider?.models || [];
 
   const handleProviderChange = (newProvider: string) => {
-    const provider = providers.find(p => p.id === newProvider);
+    const provider = providers.find((p) => p.id === newProvider);
     if (provider && provider.models.length > 0 && onChange) {
       // When provider changes, select first model
       onChange({
@@ -157,7 +157,7 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
           onChange={handleProviderChange}
           placeholder="Select provider"
         >
-          {providers.map(provider => (
+          {providers.map((provider) => (
             <Select.Option key={provider.id} value={provider.id}>
               <Space>
                 <span>{provider.name}</span>
@@ -184,7 +184,7 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
             showSearch
             optionFilterProp="children"
           >
-            {availableModels.map(model => (
+            {availableModels.map((model) => (
               <Select.Option key={model.id} value={model.id}>
                 {model.name}
               </Select.Option>

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -114,7 +114,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
   };
 
   const handleCreate = () => {
-    form.validateFields().then(values => {
+    form.validateFields().then((values) => {
       // Get user defaults for the selected agent (fallback if form fields weren't mounted)
       const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent as AgenticToolName];
 

--- a/apps/agor-ui/src/components/PermissionModeSelector/index.ts
+++ b/apps/agor-ui/src/components/PermissionModeSelector/index.ts
@@ -1,5 +1,5 @@
 export {
-  PermissionModeSelector,
-  CODEX_SANDBOX_MODES,
   CODEX_APPROVAL_POLICIES,
+  CODEX_SANDBOX_MODES,
+  PermissionModeSelector,
 } from './PermissionModeSelector';

--- a/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
+++ b/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
@@ -223,10 +223,7 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
                 type="primary"
                 icon={<CheckOutlined />}
                 onClick={() =>
-                  onApprove?.(
-                    message.message_id,
-                    remember ? rememberScope : PermissionScope.ONCE
-                  )
+                  onApprove?.(message.message_id, remember ? rememberScope : PermissionScope.ONCE)
                 }
                 style={{ backgroundColor: token.colorSuccess }}
               >

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -208,7 +208,7 @@ const ContextWindowPopoverContent: React.FC<{
       children: (
         <div style={{ fontSize: '0.9em' }}>
           {Object.entries(sdkResponse.modelUsage).map(([modelId, usage]) => {
-            const modelContextUsage = (usage.inputTokens || 0) + (usage.outputTokens || 0);
+            const _modelContextUsage = (usage.inputTokens || 0) + (usage.outputTokens || 0);
 
             return (
               <div key={modelId} style={{ marginBottom: 12 }}>

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -52,22 +52,15 @@ import { CommentNode, ZoneNode } from './canvas/BoardObjectNodes';
 import { CursorNode } from './canvas/CursorNode';
 import { MarkdownNode } from './canvas/MarkdownNode';
 import { useBoardObjects } from './canvas/useBoardObjects';
-import {
-  findIntersectingObjects,
-  findZoneAtPosition,
-  findZoneForNode,
-  type ZoneCollision,
-} from './canvas/utils/collisionDetection';
+import { findIntersectingObjects, findZoneAtPosition } from './canvas/utils/collisionDetection';
 import { getWorktreeParentInfo, getZoneParentInfo } from './canvas/utils/commentUtils';
 import {
   absoluteToRelative,
   calculateStoragePosition,
-  getDragAbsolutePosition,
   getNodeAbsolutePosition,
   type ParentInfo,
   relativeToAbsolute,
 } from './canvas/utils/coordinateTransforms';
-import { getAbsoluteNodePosition } from './canvas/utils/nodePositionUtils';
 import { ZoneTriggerModal } from './canvas/ZoneTriggerModal';
 
 const { Paragraph } = Typography;
@@ -324,7 +317,7 @@ const SessionCanvas = ({
   const isDraggingRef = useRef(false);
 
   // Helper: Check if a node intersects with a zone
-  const findIntersectingZone = useCallback(
+  const _findIntersectingZone = useCallback(
     (nodePosition: { x: number; y: number }, nodeWidth = 400, nodeHeight = 200) => {
       if (!board?.objects) return null;
 
@@ -410,7 +403,7 @@ const SessionCanvas = ({
 
       // Find the board_object for this worktree
       const boardObject = boardObjects.find(
-        bo => bo.worktree_id === worktreeId && bo.board_id === board.board_id
+        (bo) => bo.worktree_id === worktreeId && bo.board_id === board.board_id
       );
 
       if (!boardObject || !boardObject.zone_id) {
@@ -462,7 +455,7 @@ const SessionCanvas = ({
 
       // Find board object for this worktree (if positioned on this board)
       const boardObject = boardObjects.find(
-        bo => bo.worktree_id === worktree.worktree_id && bo.board_id === board?.board_id
+        (bo) => bo.worktree_id === worktree.worktree_id && bo.board_id === board?.board_id
       );
 
       // Use stored position from boardObject if available, otherwise auto-layout
@@ -483,10 +476,10 @@ const SessionCanvas = ({
           : undefined;
 
       // Get sessions for this worktree
-      const worktreeSessions = sessions.filter(s => s.worktree_id === worktree.worktree_id);
+      const worktreeSessions = sessions.filter((s) => s.worktree_id === worktree.worktree_id);
 
       // Get repo for this worktree
-      const repo = repos.find(r => r.repo_id === worktree.repo_id);
+      const repo = repos.find((r) => r.repo_id === worktree.repo_id);
       if (!repo) {
         console.error(`Repo not found for worktree ${worktree.worktree_id}`);
         continue;
@@ -614,7 +607,7 @@ const SessionCanvas = ({
 
     // Filter to only spatial comments on this board (absolute OR relative positioned) and not resolved
     const spatialComments = comments.filter(
-      c =>
+      (c) =>
         (c.position?.absolute || c.position?.relative) &&
         c.board_id === board?.board_id &&
         !c.resolved
@@ -633,7 +626,7 @@ const SessionCanvas = ({
 
     for (const comment of spatialComments) {
       // Find user who created the comment
-      const user = users.find(u => u.user_id === comment.created_by);
+      const user = users.find((u) => u.user_id === comment.created_by);
 
       // Determine position, parentId, parentLabel, and parentColor based on comment attachment
       let position: { x: number; y: number };
@@ -662,7 +655,7 @@ const SessionCanvas = ({
           }
         } else if (rel.parent_type === 'worktree') {
           // Parent is a worktree - validate worktree exists
-          const worktree = worktrees.find(w => w.worktree_id === rel.parent_id);
+          const worktree = worktrees.find((w) => w.worktree_id === rel.parent_id);
           if (worktree) {
             const info = getWorktreeParentInfo(rel.parent_id, worktrees);
             parentId = info.parentId;
@@ -722,15 +715,15 @@ const SessionCanvas = ({
   useEffect(() => {
     if (isDraggingRef.current) return;
 
-    setNodes(currentNodes => {
+    setNodes((currentNodes) => {
       // Separate existing nodes by type
-      const existingZones = currentNodes.filter(n => n.type === 'zone');
-      const existingCursors = currentNodes.filter(n => n.type === 'cursor');
-      const existingComments = currentNodes.filter(n => n.type === 'comment');
+      const existingZones = currentNodes.filter((n) => n.type === 'zone');
+      const existingCursors = currentNodes.filter((n) => n.type === 'cursor');
+      const existingComments = currentNodes.filter((n) => n.type === 'comment');
 
       // Update worktree nodes with preserved state
-      const updatedWorktrees = initialNodes.map(newNode => {
-        const existingNode = currentNodes.find(n => n.id === newNode.id);
+      const updatedWorktrees = initialNodes.map((newNode) => {
+        const existingNode = currentNodes.find((n) => n.id === newNode.id);
         const localPosition = localPositionsRef.current[newNode.id];
 
         // If we have a local position (user is dragging or just dragged), use it
@@ -741,7 +734,7 @@ const SessionCanvas = ({
           if (newNode.parentId) {
             // Parent could be a zone or another worktree
             const parentNode = [...initialNodes, ...existingZones].find(
-              n => n.id === newNode.parentId
+              (n) => n.id === newNode.parentId
             );
             if (parentNode) {
               incomingAbsolutePosition = relativeToAbsolute(newNode.position, parentNode.position);
@@ -765,7 +758,7 @@ const SessionCanvas = ({
           if (newNode.parentId) {
             // Parent could be a zone or another worktree
             const parentNode = [...initialNodes, ...existingZones].find(
-              n => n.id === newNode.parentId
+              (n) => n.id === newNode.parentId
             );
             if (parentNode) {
               positionToUse = absoluteToRelative(localPosition, parentNode.position);
@@ -787,11 +780,11 @@ const SessionCanvas = ({
   // Helper: Partition nodes by type
   const partitionNodesByType = useCallback((nodes: Node[]) => {
     return {
-      zones: nodes.filter(n => n.type === 'zone'),
-      markdown: nodes.filter(n => n.type === 'markdown'),
-      worktrees: nodes.filter(n => n.type === 'worktreeNode'),
-      comments: nodes.filter(n => n.type === 'comment'),
-      cursors: nodes.filter(n => n.type === 'cursor'),
+      zones: nodes.filter((n) => n.type === 'zone'),
+      markdown: nodes.filter((n) => n.type === 'markdown'),
+      worktrees: nodes.filter((n) => n.type === 'worktreeNode'),
+      comments: nodes.filter((n) => n.type === 'comment'),
+      cursors: nodes.filter((n) => n.type === 'cursor'),
     };
   }, []);
 
@@ -810,21 +803,21 @@ const SessionCanvas = ({
 
     const boardObjectNodes = getBoardObjectNodes();
 
-    setNodes(currentNodes => {
+    setNodes((currentNodes) => {
       const { worktrees, comments, cursors } = partitionNodesByType(currentNodes);
 
       // Separate zones and markdown from boardObjectNodes
       const zones = boardObjectNodes
-        .filter(n => n.type === 'zone' && !deletedObjectsRef.current.has(n.id))
-        .map(newZone => {
-          const existingZone = currentNodes.find(n => n.id === newZone.id);
+        .filter((n) => n.type === 'zone' && !deletedObjectsRef.current.has(n.id))
+        .map((newZone) => {
+          const existingZone = currentNodes.find((n) => n.id === newZone.id);
           return { ...newZone, selected: existingZone?.selected };
         });
 
       const markdown = boardObjectNodes
-        .filter(n => n.type === 'markdown' && !deletedObjectsRef.current.has(n.id))
-        .map(newMarkdown => {
-          const existingMarkdown = currentNodes.find(n => n.id === newMarkdown.id);
+        .filter((n) => n.type === 'markdown' && !deletedObjectsRef.current.has(n.id))
+        .map((newMarkdown) => {
+          const existingMarkdown = currentNodes.find((n) => n.id === newMarkdown.id);
           return { ...newMarkdown, selected: existingMarkdown?.selected };
         });
 
@@ -836,7 +829,7 @@ const SessionCanvas = ({
   useEffect(() => {
     if (isDraggingRef.current) return;
 
-    setNodes(currentNodes => {
+    setNodes((currentNodes) => {
       const { zones, markdown, worktrees, comments } = partitionNodesByType(currentNodes);
       return applyZOrder(zones, markdown, worktrees, comments, cursorNodes);
     });
@@ -846,11 +839,11 @@ const SessionCanvas = ({
   useEffect(() => {
     if (isDraggingRef.current) return;
 
-    setNodes(currentNodes => {
+    setNodes((currentNodes) => {
       const { zones, markdown, worktrees, cursors } = partitionNodesByType(currentNodes);
 
       // Apply local position overrides to comment nodes (to prevent flicker during drag)
-      const commentsWithLocalPositions = commentNodes.map(newNode => {
+      const commentsWithLocalPositions = commentNodes.map((newNode) => {
         const localPosition = localPositionsRef.current[newNode.id];
 
         if (localPosition) {
@@ -858,7 +851,7 @@ const SessionCanvas = ({
           // If node has parentId, position is relative to parent - must convert to absolute
           let incomingAbsolutePosition = newNode.position;
           if (newNode.parentId) {
-            const parentNode = [...worktrees, ...zones].find(n => n.id === newNode.parentId);
+            const parentNode = [...worktrees, ...zones].find((n) => n.id === newNode.parentId);
             if (parentNode) {
               incomingAbsolutePosition = relativeToAbsolute(newNode.position, parentNode.position);
             }
@@ -879,7 +872,7 @@ const SessionCanvas = ({
           // If node now has parentId, convert local absolute position to relative
           let positionToUse = localPosition;
           if (newNode.parentId) {
-            const parentNode = [...worktrees, ...zones].find(n => n.id === newNode.parentId);
+            const parentNode = [...worktrees, ...zones].find((n) => n.id === newNode.parentId);
             if (parentNode) {
               positionToUse = absoluteToRelative(localPosition, parentNode.position);
             }
@@ -908,7 +901,7 @@ const SessionCanvas = ({
       // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
       changes.forEach((change: any) => {
         if (change.type === 'dimensions' && change.dimensions) {
-          const node = nodes.find(n => n.id === change.id);
+          const node = nodes.find((n) => n.id === change.id);
           if (node?.type === 'zone') {
             // Check if dimensions actually changed (to avoid infinite loop from React Flow emitting unchanged dimensions)
             const currentWidth = node.style?.width;
@@ -1047,7 +1040,7 @@ const SessionCanvas = ({
           const currentNodes = nodes;
 
           for (const [nodeId, position] of Object.entries(updates)) {
-            const draggedNode = currentNodes.find(n => n.id === nodeId);
+            const draggedNode = currentNodes.find((n) => n.id === nodeId);
 
             if (draggedNode?.type === 'zone') {
               // Zone moved - update position via batchUpdateObjectPositions
@@ -1117,7 +1110,7 @@ const SessionCanvas = ({
                 : null;
 
               if (droppedZoneId) {
-                const zoneNode = currentNodes.find(n => n.id === droppedZoneId);
+                const zoneNode = currentNodes.find((n) => n.id === droppedZoneId);
                 if (zoneNode) {
                   // Use the zone's current React Flow position (always absolute for zones)
                   zonePosition = { x: zoneNode.position.x, y: zoneNode.position.y };
@@ -1126,7 +1119,7 @@ const SessionCanvas = ({
 
               // Check if worktree was already pinned to a zone before this drag
               const existingBoardObject = boardObjects.find(
-                bo => bo.worktree_id === nodeId && bo.board_id === board.board_id
+                (bo) => bo.worktree_id === nodeId && bo.board_id === board.board_id
               );
               const oldZoneId = existingBoardObject?.zone_id;
 
@@ -1164,7 +1157,7 @@ const SessionCanvas = ({
                     (async () => {
                       try {
                         // Find the worktree
-                        const worktree = worktrees.find(wt => wt.worktree_id === nodeId);
+                        const worktree = worktrees.find((wt) => wt.worktree_id === nodeId);
 
                         // Render template
                         const context = {
@@ -1227,7 +1220,7 @@ const SessionCanvas = ({
             for (const { worktree_id, position, zone_id } of worktreeUpdates) {
               // Find existing board_object or create new one
               const existingBoardObject = boardObjects.find(
-                bo => bo.worktree_id === worktree_id && bo.board_id === board.board_id
+                (bo) => bo.worktree_id === worktree_id && bo.board_id === board.board_id
               );
 
               if (existingBoardObject) {
@@ -1277,7 +1270,7 @@ const SessionCanvas = ({
 
             if (parentId && parentType === 'zone') {
               // Comment pinned to zone
-              const zoneNode = currentNodes.find(n => n.id === `zone-${parentId}`);
+              const zoneNode = currentNodes.find((n) => n.id === `zone-${parentId}`);
               if (zoneNode) {
                 const zoneAbsPos = getNodeAbsolutePosition(zoneNode, currentNodes);
                 const relativePos = calculateStoragePosition(position, {
@@ -1302,7 +1295,7 @@ const SessionCanvas = ({
               }
             } else if (parentId && parentType === 'worktree') {
               // Comment pinned to worktree
-              const worktreeNode = currentNodes.find(n => n.id === parentId);
+              const worktreeNode = currentNodes.find((n) => n.id === parentId);
               if (worktreeNode) {
                 const worktreeAbsPos = getNodeAbsolutePosition(worktreeNode, currentNodes);
                 const relativePos = calculateStoragePosition(position, {
@@ -1343,8 +1336,8 @@ const SessionCanvas = ({
 
             // Immediately update React Flow node to reflect new parentId
             // This prevents visual glitches while waiting for WebSocket sync
-            setNodes(prevNodes =>
-              prevNodes.map(n => {
+            setNodes((prevNodes) =>
+              prevNodes.map((n) => {
                 if (n.id === `comment-${comment_id}`) {
                   // Update parentId to match new parent (or undefined if free-floating)
                   const updates: Partial<Node> = { parentId: newReactFlowParentId };
@@ -1353,7 +1346,7 @@ const SessionCanvas = ({
                   if (newReactFlowParentId !== n.parentId) {
                     if (newReactFlowParentId) {
                       // Now has parent - convert to relative position
-                      const parent = prevNodes.find(p => p.id === newReactFlowParentId);
+                      const parent = prevNodes.find((p) => p.id === newReactFlowParentId);
                       if (parent) {
                         const parentAbsPos = getNodeAbsolutePosition(parent, prevNodes);
                         const relativePos = calculateStoragePosition(position, {
@@ -1454,7 +1447,7 @@ const SessionCanvas = ({
         const defaultBackgroundColor = '#d9d9d91a'; // 10% opacity
 
         // Optimistic update
-        setNodes(nodes => [
+        setNodes((nodes) => [
           ...nodes,
           {
             id: objectId,
@@ -1508,7 +1501,7 @@ const SessionCanvas = ({
             } as any)
             .catch((error: unknown) => {
               console.error('Failed to add zone:', error);
-              setNodes(nodes => nodes.filter(n => n.id !== objectId));
+              setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
             });
         }
       }
@@ -1627,10 +1620,10 @@ const SessionCanvas = ({
     const position = markdownModal.position;
 
     // Optimistic update
-    setNodes(nodes => {
+    setNodes((nodes) => {
       // If editing, update existing node
       if (markdownModal.objectId) {
-        return nodes.map(n =>
+        return nodes.map((n) =>
           n.id === objectId
             ? {
                 ...n,
@@ -1696,7 +1689,7 @@ const SessionCanvas = ({
       console.error('Failed to save markdown note:', error);
       // Rollback optimistic update
       if (!markdownModal.objectId) {
-        setNodes(nodes => nodes.filter(n => n.id !== objectId));
+        setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
       }
     }
 
@@ -1802,7 +1795,7 @@ const SessionCanvas = ({
           onNodeDragStop={handleNodeDragStop}
           onNodeClick={handleNodeClick}
           onPaneClick={handlePaneClick}
-          onInit={instance => {
+          onInit={(instance) => {
             reactFlowInstanceRef.current = instance;
           }}
           nodeTypes={nodeTypes}
@@ -1832,7 +1825,7 @@ const SessionCanvas = ({
           <Controls position="top-left" showInteractive={false}>
             {/* Custom toolbox buttons */}
             <ControlButton
-              onClick={e => {
+              onClick={(e) => {
                 e.stopPropagation();
                 setActiveTool('select');
               }}
@@ -1844,7 +1837,7 @@ const SessionCanvas = ({
               <SelectOutlined style={{ fontSize: '16px' }} />
             </ControlButton>
             <ControlButton
-              onClick={e => {
+              onClick={(e) => {
                 e.stopPropagation();
                 setActiveTool('zone');
               }}
@@ -1856,7 +1849,7 @@ const SessionCanvas = ({
               <BorderOutlined style={{ fontSize: '16px' }} />
             </ControlButton>
             <ControlButton
-              onClick={e => {
+              onClick={(e) => {
                 e.stopPropagation();
                 setActiveTool('comment');
               }}
@@ -1868,7 +1861,7 @@ const SessionCanvas = ({
               <CommentOutlined style={{ fontSize: '16px' }} />
             </ControlButton>
             <ControlButton
-              onClick={e => {
+              onClick={(e) => {
                 e.stopPropagation();
                 setActiveTool('markdown');
               }}
@@ -1880,7 +1873,7 @@ const SessionCanvas = ({
               <FileMarkdownOutlined style={{ fontSize: '16px' }} />
             </ControlButton>
             <ControlButton
-              onClick={e => {
+              onClick={(e) => {
                 e.stopPropagation();
                 setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
               }}
@@ -1895,7 +1888,7 @@ const SessionCanvas = ({
             </ControlButton>
           </Controls>
           <MiniMap
-            nodeColor={node => {
+            nodeColor={(node) => {
               // Handle cursor nodes (show as bright color)
               if (node.type === 'cursor') return token.colorWarning;
 
@@ -1945,8 +1938,8 @@ const SessionCanvas = ({
               <Input.TextArea
                 placeholder="Add a comment..."
                 value={commentInput}
-                onChange={e => setCommentInput(e.target.value)}
-                onPressEnter={e => {
+                onChange={(e) => setCommentInput(e.target.value)}
+                onPressEnter={(e) => {
                   if (!e.shiftKey) {
                     e.preventDefault();
                     handleCreateSpatialComment();
@@ -1996,13 +1989,13 @@ const SessionCanvas = ({
       {triggerModal &&
         (() => {
           // Pre-render the template for display in modal
-          const session = sessions.find(s => s.session_id === triggerModal.sessionId);
+          const session = sessions.find((s) => s.session_id === triggerModal.sessionId);
           let renderedPromptPreview = triggerModal.trigger.template;
 
           if (session) {
             try {
               // Lookup worktree data for this session
-              const worktree = worktrees.find(wt => wt.worktree_id === session.worktree_id);
+              const worktree = worktrees.find((wt) => wt.worktree_id === session.worktree_id);
 
               const context = {
                 session: {
@@ -2059,7 +2052,7 @@ const SessionCanvas = ({
                   const { sessionId, trigger } = triggerModal;
 
                   // Find the session to get its data for Handlebars context
-                  const session = sessions.find(s => s.session_id === sessionId);
+                  const session = sessions.find((s) => s.session_id === sessionId);
                   if (!session) {
                     console.error('❌ Session not found:', sessionId);
                     setTriggerModal(null);
@@ -2067,7 +2060,7 @@ const SessionCanvas = ({
                   }
 
                   // Lookup worktree data for this session
-                  const worktree = worktrees.find(wt => wt.worktree_id === session.worktree_id);
+                  const worktree = worktrees.find((wt) => wt.worktree_id === session.worktree_id);
 
                   // Build Handlebars context from session, board, and worktree data
                   const context = {
@@ -2207,7 +2200,7 @@ const SessionCanvas = ({
               <Typography.Text strong>Content (Markdown supported):</Typography.Text>
               <Input.TextArea
                 value={markdownContent}
-                onChange={e => setMarkdownContent(e.target.value)}
+                onChange={(e) => setMarkdownContent(e.target.value)}
                 placeholder={`# Title\n\n- Bullet point\n- Another point\n\n**Bold** and *italic*\n\n\`\`\`javascript\nconst code = "example";\n\`\`\``}
                 autoFocus
                 rows={20}
@@ -2246,7 +2239,7 @@ const SessionCanvas = ({
           open={true}
           onCancel={() => setWorktreeTriggerModal(null)}
           worktreeId={worktreeTriggerModal.worktreeId}
-          worktree={worktrees.find(wt => wt.worktree_id === worktreeTriggerModal.worktreeId)}
+          worktree={worktrees.find((wt) => wt.worktree_id === worktreeTriggerModal.worktreeId)}
           sessions={sessions}
           zoneName={worktreeTriggerModal.zoneName}
           trigger={worktreeTriggerModal.trigger}
@@ -2255,7 +2248,7 @@ const SessionCanvas = ({
           boardCustomContext={board?.custom_context}
           availableAgents={availableAgents}
           mcpServers={mcpServers}
-          currentUser={currentUserId ? users.find(u => u.user_id === currentUserId) : null}
+          currentUser={currentUserId ? users.find((u) => u.user_id === currentUserId) : null}
           onExecute={async ({
             sessionId,
             action,

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -69,7 +69,7 @@ const saveRecentColor = (color: string) => {
   try {
     const recent = getRecentColors();
     // Remove duplicate if exists
-    const filtered = recent.filter(c => c.toLowerCase() !== color.toLowerCase());
+    const filtered = recent.filter((c) => c.toLowerCase() !== color.toLowerCase());
     // Add to front, limit to 12 recent colors
     const updated = [color, ...filtered].slice(0, 12);
     localStorage.setItem(RECENT_COLORS_KEY, JSON.stringify(updated));
@@ -274,15 +274,15 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
         {/* Toolbar - ALWAYS rendered, visibility controlled by CSS only */}
         <div
           className="nodrag nopan"
-          onPointerDown={e => {
+          onPointerDown={(e) => {
             e.preventDefault();
             e.stopPropagation();
           }}
-          onPointerUp={e => {
+          onPointerUp={(e) => {
             e.preventDefault();
             e.stopPropagation();
           }}
-          onClick={e => {
+          onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
           }}
@@ -310,10 +310,10 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           {/* Border Color Picker */}
           <div
             className="nodrag nopan"
-            onPointerDown={e => {
+            onPointerDown={(e) => {
               e.stopPropagation();
             }}
-            onPointerUp={e => {
+            onPointerUp={(e) => {
               e.stopPropagation();
             }}
             style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
@@ -378,10 +378,10 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           {/* Background Color Picker */}
           <div
             className="nodrag nopan"
-            onPointerDown={e => {
+            onPointerDown={(e) => {
               e.stopPropagation();
             }}
-            onPointerUp={e => {
+            onPointerUp={(e) => {
               e.stopPropagation();
             }}
             style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
@@ -407,7 +407,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
                 {
                   label: 'Presets',
                   colors: colors.map(
-                    c =>
+                    (c) =>
                       `${c}${Math.round(ZONE_CONTENT_OPACITY * 255)
                         .toString(16)
                         .padStart(2, '0')}`
@@ -451,16 +451,16 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           {/* Lock/Unlock Button */}
           <button
             type="button"
-            onPointerDown={e => {
+            onPointerDown={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
-            onPointerUp={e => {
+            onPointerUp={(e) => {
               e.preventDefault();
               e.stopPropagation();
               handleToggleLock();
             }}
-            onClick={e => {
+            onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
@@ -495,16 +495,16 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           />
           <button
             type="button"
-            onPointerDown={e => {
+            onPointerDown={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
-            onPointerUp={e => {
+            onPointerUp={(e) => {
               e.preventDefault();
               e.stopPropagation();
               setConfigModalOpen(true);
             }}
-            onClick={e => {
+            onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
@@ -527,24 +527,24 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           </button>
           <button
             type="button"
-            onPointerDown={e => {
+            onPointerDown={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
-            onPointerUp={e => {
+            onPointerUp={(e) => {
               e.preventDefault();
               e.stopPropagation();
               setDeleteModalOpen(true);
             }}
-            onClick={e => {
+            onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
-            onMouseEnter={e => {
+            onMouseEnter={(e) => {
               e.currentTarget.style.color = token.colorError;
               e.currentTarget.style.borderColor = token.colorError;
             }}
-            onMouseLeave={e => {
+            onMouseLeave={(e) => {
               e.currentTarget.style.color = token.colorTextSecondary;
               e.currentTarget.style.borderColor = token.colorBorder;
             }}
@@ -578,7 +578,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
               ref={labelInputRef}
               type="text"
               value={label}
-              onChange={e => setLabel(e.target.value)}
+              onChange={(e) => setLabel(e.target.value)}
               onBlur={handleSaveLabel}
               onKeyDown={handleKeyDown}
               className="nodrag" // Prevent node drag when typing
@@ -633,7 +633,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
       <DeleteZoneModal
         open={deleteModalOpen}
         onCancel={() => setDeleteModalOpen(false)}
-        onConfirm={deleteAssociatedSessions => {
+        onConfirm={(deleteAssociatedSessions) => {
           setDeleteModalOpen(false);
           if (data.onDelete) {
             data.onDelete(data.objectId, deleteAssociatedSessions);

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/MarkdownNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/MarkdownNode.tsx
@@ -1,7 +1,6 @@
 import type { BoardObject } from '@agor/core/types';
 import { EditOutlined } from '@ant-design/icons';
 import { Button, Card, Typography, theme } from 'antd';
-import { useState } from 'react';
 import { MarkdownRenderer } from '../../MarkdownRenderer/MarkdownRenderer';
 
 interface MarkdownNodeData {
@@ -49,7 +48,7 @@ export const MarkdownNode = ({ data }: { data: MarkdownNodeData }) => {
             type="text"
             size="small"
             icon={<EditOutlined />}
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation();
               handleEdit();
             }}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -93,7 +93,7 @@ export const ZoneTriggerModal = ({
 
   // Filter sessions for this worktree
   const worktreeSessions = useMemo(() => {
-    return sessions.filter(s => s.worktree_id === worktreeId);
+    return sessions.filter((s) => s.worktree_id === worktreeId);
   }, [sessions, worktreeId]);
 
   // Smart default: Most recent active/completed session
@@ -101,7 +101,7 @@ export const ZoneTriggerModal = ({
     if (worktreeSessions.length === 0) return '';
 
     // Prioritize running sessions
-    const runningSessions = worktreeSessions.filter(s => s.status === 'running');
+    const runningSessions = worktreeSessions.filter((s) => s.status === 'running');
     if (runningSessions.length > 0) {
       // Most recently updated running session
       return runningSessions.sort(
@@ -121,7 +121,7 @@ export const ZoneTriggerModal = ({
 
   // Get the currently selected session (for pre-populating form on reuse)
   const selectedSession = useMemo(() => {
-    return worktreeSessions.find(s => s.session_id === selectedSessionId);
+    return worktreeSessions.find((s) => s.session_id === selectedSessionId);
   }, [selectedSessionId, worktreeSessions]);
 
   // Reset to defaults when modal opens
@@ -213,10 +213,11 @@ export const ZoneTriggerModal = ({
           mode === 'reuse_existing' && selectedSessionId
             ? {
                 description:
-                  worktreeSessions.find(s => s.session_id === selectedSessionId)?.description || '',
+                  worktreeSessions.find((s) => s.session_id === selectedSessionId)?.description ||
+                  '',
                 context:
-                  worktreeSessions.find(s => s.session_id === selectedSessionId)?.custom_context ||
-                  {},
+                  worktreeSessions.find((s) => s.session_id === selectedSessionId)
+                    ?.custom_context || {},
               }
             : {
                 description: '',
@@ -298,7 +299,7 @@ export const ZoneTriggerModal = ({
         <div>
           <Radio.Group
             value={mode}
-            onChange={e => setMode(e.target.value)}
+            onChange={(e) => setMode(e.target.value)}
             style={{ width: '100%' }}
           >
             <Space direction="vertical" size="middle" style={{ width: '100%' }}>
@@ -330,7 +331,7 @@ export const ZoneTriggerModal = ({
                 onChange={setSelectedSessionId}
                 style={{ width: '100%' }}
                 size="large"
-                options={worktreeSessions.map(session => ({
+                options={worktreeSessions.map((session) => ({
                   value: session.session_id,
                   label: (
                     <span>
@@ -348,7 +349,7 @@ export const ZoneTriggerModal = ({
               </Typography.Text>
               <Radio.Group
                 value={selectedAction}
-                onChange={e => setSelectedAction(e.target.value)}
+                onChange={(e) => setSelectedAction(e.target.value)}
                 style={{ width: '100%' }}
               >
                 <Space direction="vertical" style={{ width: '100%' }}>
@@ -365,10 +366,10 @@ export const ZoneTriggerModal = ({
         <Form
           form={form}
           layout="vertical"
-          onValuesChange={changedValues => {
+          onValuesChange={(changedValues) => {
             // Sync form changes to component state (only in create_new mode)
             if (mode === 'create_new') {
-              setSessionConfig(prev => ({ ...prev, ...changedValues }));
+              setSessionConfig((prev) => ({ ...prev, ...changedValues }));
             }
           }}
         >
@@ -435,7 +436,7 @@ export const ZoneTriggerModal = ({
           </Typography.Text>
           <Input.TextArea
             value={editableTemplate}
-            onChange={e => setEditableTemplate(e.target.value)}
+            onChange={(e) => setEditableTemplate(e.target.value)}
             rows={8}
             style={{
               fontFamily: 'monospace',

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -40,11 +40,11 @@ export const useBoardObjects = ({
   const _boardSessionIds = useMemo(() => {
     if (!board) return [];
     const boardWorktreeIds = new Set(
-      worktrees.filter(w => w.board_id === board.board_id).map(w => w.worktree_id)
+      worktrees.filter((w) => w.board_id === board.board_id).map((w) => w.worktree_id)
     );
     return sessions
-      .filter(s => s.worktree_id && boardWorktreeIds.has(s.worktree_id))
-      .map(s => s.session_id);
+      .filter((s) => s.worktree_id && boardWorktreeIds.has(s.worktree_id))
+      .map((s) => s.session_id);
   }, [board, worktrees, sessions]);
 
   /**
@@ -88,7 +88,7 @@ export const useBoardObjects = ({
       }
 
       // Optimistic removal of zone (just the zone node, worktrees remain but unpinned)
-      setNodes(nodes => nodes.filter(n => n.id !== objectId));
+      setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
 
       try {
         await client.service('boards').patch(board.board_id, {
@@ -172,7 +172,9 @@ export const useBoardObjects = ({
           for (const boardObj of boardObjects) {
             if (boardObj.zone_id === objectId) {
               // Count sessions in this worktree
-              const worktreeSessions = sessions.filter(s => s.worktree_id === boardObj.worktree_id);
+              const worktreeSessions = sessions.filter(
+                (s) => s.worktree_id === boardObj.worktree_id
+              );
               sessionCount += worktreeSessions.length;
             }
           }
@@ -236,7 +238,7 @@ export const useBoardObjects = ({
       const height = 600;
 
       // Optimistic update
-      setNodes(nodes => [
+      setNodes((nodes) => [
         ...nodes,
         {
           id: objectId,
@@ -278,7 +280,7 @@ export const useBoardObjects = ({
       } catch (error) {
         console.error('Failed to add zone node:', error);
         // Rollback
-        setNodes(nodes => nodes.filter(n => n.id !== objectId));
+        setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
       }
     },
     [client, setNodes, handleUpdateObject] // Removed board dependency
@@ -296,7 +298,7 @@ export const useBoardObjects = ({
       deletedObjectsRef.current.add(objectId);
 
       // Optimistic removal
-      setNodes(nodes => nodes.filter(n => n.id !== objectId));
+      setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
 
       try {
         await client.service('boards').patch(currentBoard.board_id, {

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/collisionDetection.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/collisionDetection.ts
@@ -41,7 +41,7 @@ export function findIntersectingObjects(
   allNodes: Node[]
 ): CollisionResult {
   // Find all zones/worktrees that contain the point
-  const intersectingNodes = allNodes.filter(node => {
+  const intersectingNodes = allNodes.filter((node) => {
     if (node.type !== 'zone' && node.type !== 'worktreeNode') return false;
 
     // Use measured dimensions (React Flow calculates from DOM)
@@ -70,8 +70,8 @@ export function findIntersectingObjects(
 
   // Priority: worktree > zone (worktrees are rendered on top)
   return {
-    worktreeNode: intersectingNodes.find(n => n.type === 'worktreeNode'),
-    zoneNode: intersectingNodes.find(n => n.type === 'zone'),
+    worktreeNode: intersectingNodes.find((n) => n.type === 'worktreeNode'),
+    zoneNode: intersectingNodes.find((n) => n.type === 'zone'),
   };
 }
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/coordinateTransforms.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/coordinateTransforms.ts
@@ -135,7 +135,7 @@ export function getDragAbsolutePosition(node: Node, allNodes: Node[]): Position 
 
   // If node has parent, position is relative - must convert
   if (node.parentId) {
-    const parent = allNodes.find(n => n.id === node.parentId);
+    const parent = allNodes.find((n) => n.id === node.parentId);
     if (parent) {
       const parentAbsPos = getNodeAbsolutePosition(parent, allNodes);
       return relativeToAbsolute(node.position, parentAbsPos);

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -109,7 +109,7 @@ const SessionCard = ({
             type="text"
             icon={<PlusCircleOutlined />}
             size="small"
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation();
               onSessionClick?.();
             }}
@@ -119,7 +119,7 @@ const SessionCard = ({
         </div>
       )}
 
-      {visibleTasks.map(task => (
+      {visibleTasks.map((task) => (
         <TaskListItem key={task.task_id} task={task} onClick={() => onTaskClick?.(task.task_id)} />
       ))}
     </div>
@@ -170,7 +170,7 @@ const SessionCard = ({
               <Tag
                 icon={<PushpinFilled />}
                 color="blue"
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onUnpin?.(session.session_id);
                 }}
@@ -194,7 +194,7 @@ const SessionCard = ({
                 type="text"
                 size="small"
                 icon={<ExpandOutlined />}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onSessionClick();
                 }}
@@ -206,7 +206,7 @@ const SessionCard = ({
                 type="text"
                 size="small"
                 icon={<SettingOutlined />}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onOpenSettings(session.session_id);
                 }}
@@ -219,7 +219,7 @@ const SessionCard = ({
                 size="small"
                 icon={<CloseOutlined />}
                 disabled={connectionDisabled}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   handleDelete();
                 }}

--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -29,7 +29,6 @@ import {
   Button,
   Divider,
   Drawer,
-  Input,
   Space,
   Spin,
   Tag,
@@ -187,7 +186,7 @@ const SessionDrawer = ({
   const [queuedMessages, setQueuedMessages] = React.useState<Message[]>([]);
 
   // Fetch tasks for this session to calculate token totals
-  const currentUser = users?.find(u => u.user_id === currentUserId) || null;
+  const currentUser = users?.find((u) => u.user_id === currentUserId) || null;
   const { tasks } = useTasks(client, session?.session_id || null, currentUser);
 
   // Fetch queued messages for this session
@@ -216,7 +215,7 @@ const SessionDrawer = ({
 
     const handleQueued = (message: Message) => {
       if (message.session_id === session.session_id) {
-        setQueuedMessages(prev => {
+        setQueuedMessages((prev) => {
           const updated = [...prev, message].sort(
             (a, b) => (a.queue_position ?? 0) - (b.queue_position ?? 0)
           );
@@ -231,8 +230,8 @@ const SessionDrawer = ({
       // Only process if it's a queued message for this session
       if (message.status === 'queued' && message.session_id === session.session_id) {
         console.log('[SessionDrawer] Removing queued message from UI:', message.message_id);
-        setQueuedMessages(prev => {
-          const filtered = prev.filter(m => m.message_id !== message.message_id);
+        setQueuedMessages((prev) => {
+          const filtered = prev.filter((m) => m.message_id !== message.message_id);
           console.log('[SessionDrawer] Queue after removal:', filtered);
           return filtered;
         });
@@ -413,7 +412,7 @@ const SessionDrawer = ({
 
         // Optimistically update the UI immediately (don't wait for WebSocket event)
         if (response.message) {
-          setQueuedMessages(prev => {
+          setQueuedMessages((prev) => {
             const updated = [...prev, response.message].sort(
               (a, b) => (a.queue_position ?? 0) - (b.queue_position ?? 0)
             );
@@ -562,7 +561,7 @@ const SessionDrawer = ({
   const isRunning = session.status === SessionStatus.RUNNING;
 
   // Get repo from worktree (worktree is passed from parent)
-  const repo = worktree ? repos.find(r => r.repo_id === worktree.repo_id) : null;
+  const repo = worktree ? repos.find((r) => r.repo_id === worktree.repo_id) : null;
 
   return (
     <Drawer
@@ -702,9 +701,9 @@ const SessionDrawer = ({
             {worktree?.pull_request_url && <PullRequestPill prUrl={worktree.pull_request_url} />}
             {/* MCP Servers */}
             {sessionMcpServerIds
-              .map(serverId => mcpServers.find(s => s.mcp_server_id === serverId))
+              .map((serverId) => mcpServers.find((s) => s.mcp_server_id === serverId))
               .filter(Boolean)
-              .map(server => (
+              .map((server) => (
                 <Tag key={server?.mcp_server_id} color="purple" icon={<ApiOutlined />}>
                   {server?.display_name || server?.name}
                 </Tag>
@@ -819,8 +818,8 @@ const SessionDrawer = ({
                         });
 
                         // Optimistically remove from UI
-                        setQueuedMessages(prev =>
-                          prev.filter(m => m.message_id !== msg.message_id)
+                        setQueuedMessages((prev) =>
+                          prev.filter((m) => m.message_id !== msg.message_id)
                         );
 
                         // Delete via messages service directly
@@ -892,7 +891,7 @@ const SessionDrawer = ({
             onChange={setInputValue}
             placeholder="Send a prompt, fork, or create a subsession... (type @ for autocomplete)"
             autoSize={{ minRows: 1, maxRows: 10 }}
-            onKeyPress={e => {
+            onKeyPress={(e) => {
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
                 // Allow sending/queueing when there's input (queues if running, sends if idle)

--- a/apps/agor-ui/src/components/SessionMetadataForm/SessionMetadataForm.tsx
+++ b/apps/agor-ui/src/components/SessionMetadataForm/SessionMetadataForm.tsx
@@ -34,17 +34,15 @@ export const SessionMetadataForm: React.FC<SessionMetadataFormProps> = ({
   titleLabel = 'Session Title',
 }) => {
   return (
-    <>
-      <Form.Item
-        name="title"
-        label={titleLabel}
-        rules={[{ required: titleRequired, message: 'Please enter a session title' }]}
-        help={
-          showHelpText && !titleRequired ? 'A short descriptive name for this session' : undefined
-        }
-      >
-        <Input placeholder="e.g., Auth System Implementation" />
-      </Form.Item>
-    </>
+    <Form.Item
+      name="title"
+      label={titleLabel}
+      rules={[{ required: titleRequired, message: 'Please enter a session title' }]}
+      help={
+        showHelpText && !titleRequired ? 'A short descriptive name for this session' : undefined
+      }
+    >
+      <Input placeholder="e.g., Auth System Implementation" />
+    </Form.Item>
   );
 };

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -1,9 +1,4 @@
-import type {
-  CodexApprovalPolicy,
-  CodexSandboxMode,
-  MCPServer,
-  Session,
-} from '@agor/core/types';
+import type { CodexApprovalPolicy, CodexSandboxMode, MCPServer, Session } from '@agor/core/types';
 import { DownOutlined } from '@ant-design/icons';
 import { Collapse, Form, Modal, Typography } from 'antd';
 import React from 'react';
@@ -99,7 +94,7 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
   ]);
 
   const handleOk = () => {
-    form.validateFields().then(values => {
+    form.validateFields().then((values) => {
       // Collect all updates
       const updates: Partial<Session> = {};
 
@@ -135,9 +130,7 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
           session.permission_config?.codex?.approvalPolicy ||
           'on-request';
         const networkAccess =
-          values.codexNetworkAccess ??
-          session.permission_config?.codex?.networkAccess ??
-          false;
+          values.codexNetworkAccess ?? session.permission_config?.codex?.networkAccess ?? false;
 
         updates.permission_config = {
           ...session.permission_config,

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -8,7 +8,7 @@ import { getDaemonUrl } from '../../config/daemon';
 
 // Lazy load particles
 const ParticleBackground = lazy(() =>
-  import('../LoginPage/ParticleBackground').then(module => ({
+  import('../LoginPage/ParticleBackground').then((module) => ({
     default: module.ParticleBackground,
   }))
 );
@@ -57,12 +57,12 @@ export const AboutTab: React.FC<AboutTabProps> = ({
 
     // Fetch health info
     fetch(`${daemonUrl}/health`)
-      .then(res => res.json())
-      .then(data => {
+      .then((res) => res.json())
+      .then((data) => {
         console.log('[AboutTab] Health info:', data);
         setHealthInfo(data);
       })
-      .catch(err => console.error('Failed to fetch health info:', err));
+      .catch((err) => console.error('Failed to fetch health info:', err));
   }, [daemonUrl, isAdmin]);
 
   return (

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -169,7 +169,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     if (!client) return;
 
     try {
-      setSavingKeys(prev => ({ ...prev, [field]: true }));
+      setSavingKeys((prev) => ({ ...prev, [field]: true }));
       setKeysError(null);
 
       await client.service('config').patch(null, {
@@ -178,13 +178,13 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
         },
       });
 
-      setKeyStatus(prev => ({ ...prev, [field]: true }));
+      setKeyStatus((prev) => ({ ...prev, [field]: true }));
     } catch (err) {
       console.error(`Failed to save ${field}:`, err);
       setKeysError(err instanceof Error ? err.message : `Failed to save ${field}`);
       throw err;
     } finally {
-      setSavingKeys(prev => ({ ...prev, [field]: false }));
+      setSavingKeys((prev) => ({ ...prev, [field]: false }));
     }
   };
 
@@ -193,7 +193,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     if (!client) return;
 
     try {
-      setSavingKeys(prev => ({ ...prev, [field]: true }));
+      setSavingKeys((prev) => ({ ...prev, [field]: true }));
       setKeysError(null);
 
       await client.service('config').patch(null, {
@@ -202,13 +202,13 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
         },
       });
 
-      setKeyStatus(prev => ({ ...prev, [field]: false }));
+      setKeyStatus((prev) => ({ ...prev, [field]: false }));
     } catch (err) {
       console.error(`Failed to clear ${field}:`, err);
       setKeysError(err instanceof Error ? err.message : `Failed to clear ${field}`);
       throw err;
     } finally {
-      setSavingKeys(prev => ({ ...prev, [field]: false }));
+      setSavingKeys((prev) => ({ ...prev, [field]: false }));
     }
   };
 
@@ -370,7 +370,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                         <Input
                           placeholder="http://localhost:4096"
                           value={opencodeServerUrl}
-                          onChange={e => setOpencodeServerUrl(e.target.value)}
+                          onChange={(e) => setOpencodeServerUrl(e.target.value)}
                           addonAfter={
                             <Tooltip title="Test connection to OpenCode server">
                               <Button

--- a/apps/agor-ui/src/components/SettingsModal/AudioSettingsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AudioSettingsTab.tsx
@@ -2,7 +2,7 @@
  * AudioSettingsTab - Configure task completion chime settings
  */
 
-import type { ChimeSound, UpdateUserInput, User } from '@agor/core/types';
+import type { User } from '@agor/core/types';
 import { PlayCircleOutlined, SoundOutlined } from '@ant-design/icons';
 import {
   Button,
@@ -46,7 +46,7 @@ export const AudioSettingsTab: React.FC<AudioSettingsTabProps> = ({ user, form }
     setIsPlaying(true);
     try {
       await previewChimeSound(chime, volume);
-    } catch (error) {
+    } catch (_error) {
       message.error('Failed to play preview. Check browser permissions.');
     } finally {
       // Reset after a short delay (chimes are ~1-2 seconds)
@@ -105,7 +105,7 @@ export const AudioSettingsTab: React.FC<AudioSettingsTabProps> = ({ user, form }
                       1: '100%',
                     }}
                     disabled={!form.getFieldValue('enabled')}
-                    tooltip={{ formatter: value => `${Math.round((value || 0) * 100)}%` }}
+                    tooltip={{ formatter: (value) => `${Math.round((value || 0) * 100)}%` }}
                   />
                 </Form.Item>
               )}
@@ -126,7 +126,7 @@ export const AudioSettingsTab: React.FC<AudioSettingsTabProps> = ({ user, form }
                         <Select
                           style={{ flex: 1 }}
                           disabled={!enabled}
-                          options={getAvailableChimes().map(chime => ({
+                          options={getAvailableChimes().map((chime) => ({
                             label: getChimeDisplayName(chime),
                             value: chime,
                           }))}

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -14,7 +14,6 @@ import {
   Table,
   Typography,
 } from 'antd';
-import type { Color } from 'antd/es/color-picker';
 import { useMemo, useState } from 'react';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { JSONEditor, validateJSON } from '../JSONEditor';
@@ -128,14 +127,14 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const boardSessionCounts = useMemo(() => {
     const counts = new Map<string, number>();
 
-    boards.forEach(board => {
+    boards.forEach((board) => {
       // Get worktrees for this board
-      const boardWorktrees = worktrees.filter(wt => wt.board_id === board.board_id);
-      const boardWorktreeIds = new Set(boardWorktrees.map(wt => wt.worktree_id));
+      const boardWorktrees = worktrees.filter((wt) => wt.board_id === board.board_id);
+      const boardWorktreeIds = new Set(boardWorktrees.map((wt) => wt.worktree_id));
 
       // Count sessions for these worktrees
       const sessionCount = sessions.filter(
-        session => session.worktree_id && boardWorktreeIds.has(session.worktree_id)
+        (session) => session.worktree_id && boardWorktreeIds.has(session.worktree_id)
       ).length;
 
       counts.set(board.board_id, sessionCount);
@@ -145,7 +144,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   }, [boards, sessions, worktrees]);
 
   const handleCreate = () => {
-    form.validateFields().then(values => {
+    form.validateFields().then((values) => {
       onCreate?.({
         name: values.name,
         icon: values.icon || '📋',
@@ -180,7 +179,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const handleUpdate = () => {
     if (!editingBoard) return;
 
-    form.validateFields().then(values => {
+    form.validateFields().then((values) => {
       onUpdate?.(editingBoard.board_id, {
         name: values.name,
         icon: values.icon,
@@ -317,7 +316,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
             <Space direction="vertical" style={{ width: '100%' }}>
               <Checkbox
                 checked={useCustomCSSCreate}
-                onChange={e => {
+                onChange={(e) => {
                   setUseCustomCSSCreate(e.target.checked);
                   if (e.target.checked) {
                     // Clear the color picker value when switching to custom CSS
@@ -340,7 +339,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
                     allowClear
                     showSearch
                     options={BACKGROUND_PRESETS}
-                    onChange={value => {
+                    onChange={(value) => {
                       if (value) {
                         form.setFieldsValue({ background_color: value });
                       }
@@ -415,7 +414,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
             <Space direction="vertical" style={{ width: '100%' }}>
               <Checkbox
                 checked={useCustomCSSEdit}
-                onChange={e => {
+                onChange={(e) => {
                   setUseCustomCSSEdit(e.target.checked);
                   if (e.target.checked) {
                     // Clear the color picker value when switching to custom CSS
@@ -438,7 +437,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
                     allowClear
                     showSearch
                     options={BACKGROUND_PRESETS}
-                    onChange={value => {
+                    onChange={(value) => {
                       if (value) {
                         form.setFieldsValue({ background_color: value });
                       }

--- a/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
@@ -7,7 +7,7 @@
 
 import type { AgenticToolName, DefaultAgenticConfig, MCPServer } from '@agor/core/types';
 import { getDefaultPermissionMode } from '@agor/core/types';
-import { Button, Form, Space, Tabs, Typography, message } from 'antd';
+import { Button, Form, message, Space, Tabs, Typography } from 'antd';
 import { useState } from 'react';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 
@@ -75,7 +75,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
   };
 
   const handleSave = async (tool: AgenticToolName) => {
-    setSaving(prev => ({ ...prev, [tool]: true }));
+    setSaving((prev) => ({ ...prev, [tool]: true }));
     try {
       const currentForm = getFormForTool(tool);
       const values = currentForm.getFieldsValue();
@@ -101,7 +101,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
       message.error('Failed to save settings');
       console.error('Error saving default agentic settings:', error);
     } finally {
-      setSaving(prev => ({ ...prev, [tool]: false }));
+      setSaving((prev) => ({ ...prev, [tool]: false }));
     }
   };
 
@@ -161,13 +161,22 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
 
       <Tabs
         activeKey={activeTab}
-        onChange={key => setActiveTab(key as AgenticToolName)}
+        onChange={(key) => setActiveTab(key as AgenticToolName)}
         items={tabItems.map(({ key, label, tool, form }) => ({
           key,
           label,
           children: (
-            <Form form={form} layout="vertical" initialValues={getInitialValues(tool)} style={{ paddingTop: 16 }}>
-              <AgenticToolConfigForm agenticTool={tool} mcpServers={mcpServers} showHelpText={false} />
+            <Form
+              form={form}
+              layout="vertical"
+              initialValues={getInitialValues(tool)}
+              style={{ paddingTop: 16 }}
+            >
+              <AgenticToolConfigForm
+                agenticTool={tool}
+                mcpServers={mcpServers}
+                showHelpText={false}
+              />
 
               <Space style={{ marginTop: 16 }}>
                 <Button onClick={() => handleClear(tool)}>Clear Defaults</Button>

--- a/apps/agor-ui/src/components/SettingsModal/OpenCodeTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/OpenCodeTab.tsx
@@ -12,7 +12,7 @@ import {
   InfoCircleOutlined,
   LoadingOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Form, Input, Space, Spin, Switch, message, theme, Tooltip } from 'antd';
+import { Alert, Button, Form, Input, message, Space, Spin, Switch, Tooltip, theme } from 'antd';
 import { useEffect, useState } from 'react';
 
 export interface OpenCodeTabProps {
@@ -262,7 +262,8 @@ export const OpenCodeTab: React.FC<OpenCodeTabProps> = ({ client }) => {
         <h4>About OpenCode</h4>
         <ul style={{ fontSize: 12, lineHeight: 1.8, color: token.colorTextSecondary }}>
           <li>
-            <strong>Multi-Provider Support:</strong> Access Claude, GPT-4, Gemini, and 70+ other models
+            <strong>Multi-Provider Support:</strong> Access Claude, GPT-4, Gemini, and 70+ other
+            models
           </li>
           <li>
             <strong>Privacy-First:</strong> All code and context stays local - no cloud storage

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -86,7 +86,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({ repos, onCreate, onUpdat
   };
 
   const handleSaveRepo = () => {
-    repoForm.validateFields().then(values => {
+    repoForm.validateFields().then((values) => {
       if (isEditing && editingRepo) {
         // Update existing repo
         onUpdate?.(editingRepo.repo_id, {
@@ -150,7 +150,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({ repos, onCreate, onUpdat
 
       {repos.length > 0 && (
         <Space direction="vertical" size={16} style={{ width: '100%' }}>
-          {repos.map(repo => (
+          {repos.map((repo) => (
             <Card
               key={repo.repo_id}
               size="small"

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -118,8 +118,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const handleWorktreeRowClick = (worktree: Worktree) => {
     // Snapshot the data when opening modal
     setSelectedWorktree(worktree);
-    setSelectedRepo(repos.find(r => r.repo_id === worktree.repo_id) || null);
-    setWorktreeSessions(sessions.filter(s => s.worktree_id === worktree.worktree_id));
+    setSelectedRepo(repos.find((r) => r.repo_id === worktree.repo_id) || null);
+    setWorktreeSessions(sessions.filter((s) => s.worktree_id === worktree.worktree_id));
     setWorktreeModalOpen(true);
   };
 

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -127,7 +127,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   // Auto-open edit modal if editUserId is provided
   useEffect(() => {
     if (editUserId) {
-      const userToEdit = users.find(u => u.user_id === editUserId);
+      const userToEdit = users.find((u) => u.user_id === editUserId);
       if (userToEdit) {
         handleEdit(userToEdit);
         setEditModalOpen(true);
@@ -163,7 +163,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   };
 
   const handleCreate = () => {
-    form.validateFields().then(values => {
+    form.validateFields().then((values) => {
       onCreate?.({
         email: values.email,
         password: values.password,
@@ -199,7 +199,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         setEditModalOpen(false);
         setEditingUser(null);
       })
-      .catch(err => {
+      .catch((err) => {
         console.error('Validation failed:', err);
       });
   };
@@ -209,7 +209,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     if (!editingUser) return;
 
     try {
-      setSavingApiKeys(prev => ({ ...prev, [field]: true }));
+      setSavingApiKeys((prev) => ({ ...prev, [field]: true }));
 
       // Update user via onUpdate callback
       await onUpdate?.(editingUser.user_id, {
@@ -219,12 +219,12 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       });
 
       // Update local state
-      setUserApiKeyStatus(prev => ({ ...prev, [field]: true }));
+      setUserApiKeyStatus((prev) => ({ ...prev, [field]: true }));
     } catch (err) {
       console.error(`Failed to save ${field}:`, err);
       throw err;
     } finally {
-      setSavingApiKeys(prev => ({ ...prev, [field]: false }));
+      setSavingApiKeys((prev) => ({ ...prev, [field]: false }));
     }
   };
 
@@ -233,7 +233,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     if (!editingUser) return;
 
     try {
-      setSavingApiKeys(prev => ({ ...prev, [field]: true }));
+      setSavingApiKeys((prev) => ({ ...prev, [field]: true }));
 
       // Update user via onUpdate callback
       await onUpdate?.(editingUser.user_id, {
@@ -243,12 +243,12 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       });
 
       // Update local state
-      setUserApiKeyStatus(prev => ({ ...prev, [field]: false }));
+      setUserApiKeyStatus((prev) => ({ ...prev, [field]: false }));
     } catch (err) {
       console.error(`Failed to clear ${field}:`, err);
       throw err;
     } finally {
-      setSavingApiKeys(prev => ({ ...prev, [field]: false }));
+      setSavingApiKeys((prev) => ({ ...prev, [field]: false }));
     }
   };
 
@@ -257,16 +257,16 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     if (!editingUser) return;
 
     try {
-      setSavingEnvVars(prev => ({ ...prev, [key]: true }));
+      setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
       await onUpdate?.(editingUser.user_id, {
         env_vars: { [key]: value },
       });
-      setUserEnvVars(prev => ({ ...prev, [key]: true }));
+      setUserEnvVars((prev) => ({ ...prev, [key]: true }));
     } catch (err) {
       console.error(`Failed to save ${key}:`, err);
       throw err;
     } finally {
-      setSavingEnvVars(prev => ({ ...prev, [key]: false }));
+      setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
     }
   };
 
@@ -275,11 +275,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     if (!editingUser) return;
 
     try {
-      setSavingEnvVars(prev => ({ ...prev, [key]: true }));
+      setSavingEnvVars((prev) => ({ ...prev, [key]: true }));
       await onUpdate?.(editingUser.user_id, {
         env_vars: { [key]: null },
       });
-      setUserEnvVars(prev => {
+      setUserEnvVars((prev) => {
         const updated = { ...prev };
         delete updated[key];
         return updated;
@@ -288,7 +288,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       console.error(`Failed to delete ${key}:`, err);
       throw err;
     } finally {
-      setSavingEnvVars(prev => ({ ...prev, [key]: false }));
+      setSavingEnvVars((prev) => ({ ...prev, [key]: false }));
     }
   };
 
@@ -306,7 +306,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     const currentForm = formMap[tool];
 
     try {
-      setSavingAgenticConfig(prev => ({ ...prev, [tool]: true }));
+      setSavingAgenticConfig((prev) => ({ ...prev, [tool]: true }));
 
       const values = currentForm.getFieldsValue();
 
@@ -336,7 +336,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       console.error(`Failed to save ${tool} config:`, err);
       throw err;
     } finally {
-      setSavingAgenticConfig(prev => ({ ...prev, [tool]: false }));
+      setSavingAgenticConfig((prev) => ({ ...prev, [tool]: false }));
     }
   };
 

--- a/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
@@ -88,7 +88,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
   const [selectedWorktree, setSelectedWorktree] = useState<Worktree | null>(null);
   const [hoveredArchiveButton, setHoveredArchiveButton] = useState<string | null>(null);
 
-  const reposById = useMemo(() => new Map(repos.map(repo => [repo.repo_id, repo])), [repos]);
+  const reposById = useMemo(() => new Map(repos.map((repo) => [repo.repo_id, repo])), [repos]);
 
   // Validate form fields to enable/disable Create button
   const validateForm = useCallback(() => {
@@ -109,10 +109,10 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       const lastBoardId = localStorage.getItem('agor:lastUsedBoardId');
 
       const defaultRepoId =
-        lastRepoId && repos.find(r => r.repo_id === lastRepoId) ? lastRepoId : repos[0].repo_id;
+        lastRepoId && repos.find((r) => r.repo_id === lastRepoId) ? lastRepoId : repos[0].repo_id;
 
       const defaultBoardId =
-        lastBoardId && boards.find(b => b.board_id === lastBoardId)
+        lastBoardId && boards.find((b) => b.board_id === lastBoardId)
           ? lastBoardId
           : boards.length > 0
             ? boards[0].board_id
@@ -122,7 +122,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       form.setFieldsValue({
         repoId: defaultRepoId,
         boardId: defaultBoardId,
-        sourceBranch: repos.find(r => r.repo_id === defaultRepoId)?.default_branch || 'main',
+        sourceBranch: repos.find((r) => r.repo_id === defaultRepoId)?.default_branch || 'main',
       });
 
       setSelectedRepoId(defaultRepoId);
@@ -199,14 +199,14 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
   // Get selected repo's default branch
   const getDefaultBranch = (): string => {
     if (!selectedRepoId) return 'main';
-    const repo = repos.find(r => r.repo_id === selectedRepoId);
+    const repo = repos.find((r) => r.repo_id === selectedRepoId);
     return repo?.default_branch || 'main';
   };
 
   // Update source branch when repo changes
   const handleRepoChange = (repoId: string) => {
     setSelectedRepoId(repoId);
-    const repo = repos.find(r => r.repo_id === repoId);
+    const repo = repos.find((r) => r.repo_id === repoId);
     const defaultBranch = repo?.default_branch || 'main';
     form.setFieldValue('sourceBranch', defaultBranch);
   };
@@ -277,7 +277,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       render: (_: unknown, record: Worktree) => {
         const status = record.environment_instance?.status;
         const healthStatus = record.environment_instance?.last_health_check?.status;
-        const repo = repos.find(r => r.repo_id === record.repo_id);
+        const repo = repos.find((r) => r.repo_id === record.repo_id);
         const hasEnvConfig = !!repo?.environment_config;
 
         const isRunningOrHealthy =
@@ -293,7 +293,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
                   size="small"
                   icon={<PlayCircleOutlined />}
                   disabled={isRunningOrHealthy}
-                  onClick={e => {
+                  onClick={(e) => {
                     e.stopPropagation();
                     onStartEnvironment?.(record.worktree_id);
                   }}
@@ -303,7 +303,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
                   type="text"
                   size="small"
                   icon={<PoweroffOutlined />}
-                  onClick={e => {
+                  onClick={(e) => {
                     e.stopPropagation();
                     onStopEnvironment?.(record.worktree_id);
                   }}
@@ -314,7 +314,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
                     type="text"
                     size="small"
                     icon={<GlobalOutlined />}
-                    onClick={e => {
+                    onClick={(e) => {
                       e.stopPropagation();
                       // Render the URL template with worktree context
                       const templateContext = {
@@ -366,7 +366,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       key: 'sessions',
       width: 100,
       render: (_: unknown, record: Worktree) => {
-        const sessionCount = sessions.filter(s => s.worktree_id === record.worktree_id).length;
+        const sessionCount = sessions.filter((s) => s.worktree_id === record.worktree_id).length;
         return (
           <Typography.Text type="secondary">
             {sessionCount} {sessionCount === 1 ? 'session' : 'sessions'}
@@ -415,7 +415,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
               }
               onMouseEnter={() => setHoveredArchiveButton(record.worktree_id)}
               onMouseLeave={() => setHoveredArchiveButton(null)}
-              onClick={e => {
+              onClick={(e) => {
                 e.stopPropagation();
                 if (record.archived) {
                   onUnarchive?.(record.worktree_id);
@@ -430,7 +430,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
             type="text"
             size="small"
             icon={<EditOutlined />}
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation();
               onRowClick?.(record);
             }}
@@ -440,7 +440,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
             size="small"
             icon={<DeleteOutlined />}
             danger
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation();
               setSelectedWorktree(record);
               setArchiveDeleteModalOpen(true);
@@ -460,9 +460,9 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
     // Filter by archive status
     let filtered = sorted;
     if (archiveFilter === 'active') {
-      filtered = sorted.filter(w => !w.archived);
+      filtered = sorted.filter((w) => !w.archived);
     } else if (archiveFilter === 'archived') {
-      filtered = sorted.filter(w => w.archived);
+      filtered = sorted.filter((w) => w.archived);
     }
 
     // Filter by search term
@@ -470,7 +470,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       return filtered;
     }
 
-    return filtered.filter(worktree => {
+    return filtered.filter((worktree) => {
       const repo = reposById.get(worktree.repo_id);
       const haystacks = [
         worktree.name,
@@ -481,7 +481,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
         repo?.slug,
       ];
 
-      return haystacks.some(value => {
+      return haystacks.some((value) => {
         if (value === undefined || value === null) {
           return false;
         }
@@ -506,12 +506,12 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
               allowClear
               placeholder="Search by name, repo, slug, path, or ID"
               value={searchTerm}
-              onChange={event => setSearchTerm(event.target.value)}
+              onChange={(event) => setSearchTerm(event.target.value)}
               style={{ maxWidth: token.sizeUnit * 40 }}
             />
             <Select
               value={archiveFilter}
-              onChange={value => setArchiveFilter(value)}
+              onChange={(value) => setArchiveFilter(value)}
               style={{ width: 120 }}
               options={[
                 { value: 'active', label: 'Active' },
@@ -585,7 +585,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
           rowKey="worktree_id"
           pagination={{ pageSize: 10 }}
           size="small"
-          onRow={record => ({
+          onRow={(record) => ({
             onClick: () => onRowClick?.(record),
             style: { cursor: onRowClick ? 'pointer' : 'default' },
           })}
@@ -621,9 +621,11 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
         <ArchiveDeleteWorktreeModal
           open={archiveDeleteModalOpen}
           worktree={selectedWorktree}
-          sessionCount={sessions.filter(s => s.worktree_id === selectedWorktree.worktree_id).length}
+          sessionCount={
+            sessions.filter((s) => s.worktree_id === selectedWorktree.worktree_id).length
+          }
           environmentRunning={selectedWorktree.environment_instance?.status === 'running'}
-          onConfirm={options => {
+          onConfirm={(options) => {
             handleArchiveOrDelete(selectedWorktree.worktree_id, options);
             setArchiveDeleteModalOpen(false);
             setSelectedWorktree(null);

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -29,7 +29,7 @@ import {
   UpOutlined,
 } from '@ant-design/icons';
 import { Bubble } from '@ant-design/x';
-import { Collapse, Flex, Space, Spin, Tag, Typography, theme } from 'antd';
+import { Collapse, Flex, Spin, Tag, Typography, theme } from 'antd';
 import React, { useMemo } from 'react';
 import { useStreamingMessages } from '../../hooks/useStreamingMessages';
 import { useTaskEvents } from '../../hooks/useTaskEvents';
@@ -95,7 +95,7 @@ function isAgentChainMessage(message: Message): boolean {
   // EXCEPTION: User messages with ONLY tool_result blocks are part of agent execution
   // (tool results are technically "user" role per Anthropic API, but they're automated responses)
   if (message.role === MessageRole.USER && Array.isArray(message.content)) {
-    const hasOnlyToolResults = message.content.every(block => block.type === 'tool_result');
+    const hasOnlyToolResults = message.content.every((block) => block.type === 'tool_result');
     if (hasOnlyToolResults) return true; // Part of agent chain, don't break it
   }
 
@@ -112,9 +112,9 @@ function isAgentChainMessage(message: Message): boolean {
 
   // Array content - check what types of blocks we have
   if (Array.isArray(message.content)) {
-    const hasTools = message.content.some(block => block.type === 'tool_use');
-    const hasThinking = message.content.some(block => block.type === 'thinking');
-    const hasText = message.content.some(block => block.type === 'text');
+    const hasTools = message.content.some((block) => block.type === 'tool_use');
+    const hasThinking = message.content.some((block) => block.type === 'thinking');
+    const hasText = message.content.some((block) => block.type === 'text');
 
     // SPECIAL: Task tools should display as regular agent messages, not in chain
     const hasOnlyTaskTool =
@@ -152,8 +152,8 @@ function isAgentChainMessage(message: Message): boolean {
  */
 function groupMessagesIntoBlocks(messages: Message[]): Block[] {
   // Separate top-level messages from nested (parent_tool_use_id)
-  const topLevel = messages.filter(m => !m.parent_tool_use_id);
-  const nested = messages.filter(m => m.parent_tool_use_id);
+  const topLevel = messages.filter((m) => !m.parent_tool_use_id);
+  const nested = messages.filter((m) => m.parent_tool_use_id);
 
   // Build compaction event map: task_id -> [start_message, complete_message?]
   // We aggregate compaction events that share the same task_id
@@ -161,7 +161,7 @@ function groupMessagesIntoBlocks(messages: Message[]): Block[] {
   for (const msg of topLevel) {
     if (msg.role === MessageRole.SYSTEM && Array.isArray(msg.content)) {
       const hasCompactionStatus = msg.content.some(
-        b =>
+        (b) =>
           (b.type === 'system_status' && 'status' in b && b.status === 'compacting') ||
           (b.type === 'system_complete' && 'systemType' in b && b.systemType === 'compaction')
       );
@@ -233,7 +233,7 @@ function groupMessagesIntoBlocks(messages: Message[]): Block[] {
       msg.role === MessageRole.USER &&
       Array.isArray(msg.content) &&
       msg.content.some(
-        block =>
+        (block) =>
           block.type === 'tool_result' &&
           taskToolIds.has((block as { tool_use_id?: string }).tool_use_id || '')
       );
@@ -260,7 +260,7 @@ function groupMessagesIntoBlocks(messages: Message[]): Block[] {
 
     // After processing the message, check if it has Task tool uses
     // If so, add nested operations + result as a regular agent-chain
-    const taskTools = msg.tool_uses?.filter(t => t.name === 'Task') || [];
+    const taskTools = msg.tool_uses?.filter((t) => t.name === 'Task') || [];
     for (const taskTool of taskTools) {
       const children = nestedByParent.get(taskTool.id) || [];
       const resultMsg = taskResultsByToolId.get(taskTool.id);
@@ -361,11 +361,11 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     const messages = useMemo(() => {
       // Filter streaming messages for this task
       const streamingForTask = Array.from(streamingMessages.values()).filter(
-        msg => msg.task_id === task.task_id
+        (msg) => msg.task_id === task.task_id
       );
 
       // Filter out DB messages that are already in streaming (avoid duplicates)
-      const dbOnlyMessages = taskMessages.filter(msg => !streamingMessages.has(msg.message_id));
+      const dbOnlyMessages = taskMessages.filter((msg) => !streamingMessages.has(msg.message_id));
 
       // Combine and sort by index
       return ([...dbOnlyMessages, ...streamingForTask] as Message[]).sort(
@@ -516,7 +516,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     return (
       <Collapse
         activeKey={isExpanded ? ['task-content'] : []}
-        onChange={keys => onExpandChange(keys.length > 0)}
+        onChange={(keys) => onExpandChange(keys.length > 0)}
         expandIcon={() => null}
         style={{ background: 'transparent', margin: `${token.sizeUnit * 3}px 0` }}
         items={[
@@ -562,7 +562,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         const content = block.message.content as PermissionRequestContent;
                         if (content.status === PermissionStatus.PENDING) {
                           // Check if this is the first pending permission request
-                          isFirstPending = !blocks.slice(0, blockIndex).some(b => {
+                          isFirstPending = !blocks.slice(0, blockIndex).some((b) => {
                             if (b.type === 'message' && b.message.type === 'permission_request') {
                               const c = b.message.content as PermissionRequestContent;
                               return c.status === PermissionStatus.PENDING;

--- a/apps/agor-ui/src/components/TaskBlock/TaskNestedBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskNestedBlock.tsx
@@ -77,9 +77,9 @@ export const TaskNestedBlock: React.FC<TaskNestedBlockProps> = ({
         return msg.content;
       }
       if (Array.isArray(msg.content)) {
-        const textBlocks = msg.content.filter(b => b.type === 'text');
+        const textBlocks = msg.content.filter((b) => b.type === 'text');
         if (textBlocks.length > 0) {
-          return textBlocks.map(b => (b as unknown as { text: string }).text).join('\n');
+          return textBlocks.map((b) => (b as unknown as { text: string }).text).join('\n');
         }
       }
     }

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -207,9 +207,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         <div>
           Terminal{sessionInfo.worktreeName ? ` - ${sessionInfo.worktreeName}` : ''}{' '}
           <span style={{ fontSize: '12px', fontWeight: 'normal', opacity: 0.6 }}>
-            {sessionInfo.tmuxSession
-              ? `(tmux: ${sessionInfo.tmuxSession})`
-              : '(ephemeral session)'}
+            {sessionInfo.tmuxSession ? `(tmux: ${sessionInfo.tmuxSession})` : '(ephemeral session)'}
           </span>
         </div>
       }

--- a/apps/agor-ui/src/components/ThinkingModeSelector/ThinkingModeSelector.tsx
+++ b/apps/agor-ui/src/components/ThinkingModeSelector/ThinkingModeSelector.tsx
@@ -54,7 +54,7 @@ export const ThinkingModeSelector: React.FC<ThinkingModeSelectorProps> = ({
         onChange={onChange}
         size={size}
         style={{ width: compact ? 90 : 200 }}
-        options={options.map(opt => ({
+        options={options.map((opt) => ({
           value: opt.value,
           label: (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
@@ -87,7 +87,7 @@ export const ToolUseRenderer: React.FC<ToolUseRendererProps> = ({ toolUse, toolR
     if (Array.isArray(toolResult.content)) {
       return toolResult.content
         .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
-        .map(block => block.text)
+        .map((block) => block.text)
         .join('\n\n');
     }
 

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/BashRenderer.stories.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/BashRenderer.stories.tsx
@@ -162,7 +162,9 @@ export const VeryLongOutput: Story = {
       command: 'find . -type f',
     },
     result: {
-      content: Array.from({ length: 50 }, (_, i) => `./src/components/Component${i}.tsx`).join('\n'),
+      content: Array.from({ length: 50 }, (_, i) => `./src/components/Component${i}.tsx`).join(
+        '\n'
+      ),
       is_error: false,
     },
   },

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/BashRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/BashRenderer.tsx
@@ -10,13 +10,13 @@
 import { theme } from 'antd';
 import type React from 'react';
 import { shouldUseAnsiRendering } from '../../../utils/ansi';
-import { CollapsibleAnsiText } from '../../CollapsibleText/CollapsibleAnsiText';
 import { CollapsibleText } from '../../CollapsibleText';
+import { CollapsibleAnsiText } from '../../CollapsibleText/CollapsibleAnsiText';
 import type { ToolRendererProps } from './index';
 
 export const BashRenderer: React.FC<ToolRendererProps> = ({ input, result }) => {
   const { token } = theme.useToken();
-  const command = input.command as string | undefined;
+  const _command = input.command as string | undefined;
   const isError = result?.is_error;
 
   // Extract text content from result
@@ -33,7 +33,7 @@ export const BashRenderer: React.FC<ToolRendererProps> = ({ input, result }) => 
           const b = block as { type: string; text?: string };
           return b.type === 'text';
         })
-        .map(block => block.text)
+        .map((block) => block.text)
         .join('\n\n');
     }
 
@@ -47,45 +47,42 @@ export const BashRenderer: React.FC<ToolRendererProps> = ({ input, result }) => 
   return (
     <div>
       {/* Output with collapsible code block */}
-      {result && (
-        <>
-          {useAnsi ? (
-            <CollapsibleAnsiText
-              style={{
-                fontSize: token.fontSizeSM,
-                margin: 0,
-                ...((!hasContent && {
-                  fontStyle: 'italic',
-                  color: token.colorTextTertiary,
-                }) as React.CSSProperties),
-                ...(isError && {
-                  color: token.colorError,
-                }),
-              }}
-            >
-              {hasContent ? resultText : '(no output)'}
-            </CollapsibleAnsiText>
-          ) : (
-            <CollapsibleText
-              code
-              preserveWhitespace
-              style={{
-                fontSize: token.fontSizeSM,
-                margin: 0,
-                ...((!hasContent && {
-                  fontStyle: 'italic',
-                  color: token.colorTextTertiary,
-                }) as React.CSSProperties),
-                ...(isError && {
-                  color: token.colorError,
-                }),
-              }}
-            >
-              {hasContent ? resultText : '(no output)'}
-            </CollapsibleText>
-          )}
-        </>
-      )}
+      {result &&
+        (useAnsi ? (
+          <CollapsibleAnsiText
+            style={{
+              fontSize: token.fontSizeSM,
+              margin: 0,
+              ...((!hasContent && {
+                fontStyle: 'italic',
+                color: token.colorTextTertiary,
+              }) as React.CSSProperties),
+              ...(isError && {
+                color: token.colorError,
+              }),
+            }}
+          >
+            {hasContent ? resultText : '(no output)'}
+          </CollapsibleAnsiText>
+        ) : (
+          <CollapsibleText
+            code
+            preserveWhitespace
+            style={{
+              fontSize: token.fontSizeSM,
+              margin: 0,
+              ...((!hasContent && {
+                fontStyle: 'italic',
+                color: token.colorTextTertiary,
+              }) as React.CSSProperties),
+              ...(isError && {
+                color: token.colorError,
+              }),
+            }}
+          >
+            {hasContent ? resultText : '(no output)'}
+          </CollapsibleText>
+        ))}
 
       {/* Tool input parameters (collapsible below result) */}
       {result && (

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EXAMPLE_CustomRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EXAMPLE_CustomRenderer.tsx
@@ -12,8 +12,8 @@
 
 import { theme } from 'antd';
 import type React from 'react';
-import { CollapsibleText } from '../../CollapsibleText';
 import { TEXT_TRUNCATION } from '../../../constants/ui';
+import { CollapsibleText } from '../../CollapsibleText';
 import type { ToolRendererProps } from './index';
 
 /**
@@ -39,7 +39,7 @@ export const ExampleCustomRenderer: React.FC<ToolRendererProps> = ({
     if (Array.isArray(result.content)) {
       return result.content
         .filter((block: any): block is { type: 'text'; text: string } => block.type === 'text')
-        .map(block => block.text)
+        .map((block) => block.text)
         .join('\n\n');
     }
 
@@ -78,9 +78,7 @@ export const ExampleCustomRenderer: React.FC<ToolRendererProps> = ({
             {resultText}
           </CollapsibleText>
         ) : (
-          <div style={{ fontStyle: 'italic', color: token.colorTextSecondary }}>
-            (no output)
-          </div>
+          <div style={{ fontStyle: 'italic', color: token.colorTextSecondary }}>(no output)</div>
         )}
       </div>
 

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
@@ -152,8 +152,8 @@ export const TodoListRenderer: React.FC<TodoListRendererProps> = ({ toolUseId, i
   }
 
   // Count statuses for summary
-  const completedCount = todos.filter(t => t.status === 'completed').length;
-  const inProgressCount = todos.filter(t => t.status === 'in_progress').length;
+  const completedCount = todos.filter((t) => t.status === 'completed').length;
+  const inProgressCount = todos.filter((t) => t.status === 'in_progress').length;
   const totalCount = todos.length;
 
   return (

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -138,13 +138,13 @@ const WorktreeCard = ({
 
   // Separate manual sessions from scheduled runs
   const manualSessions = useMemo(
-    () => sessions.filter(s => !s.scheduled_from_worktree),
+    () => sessions.filter((s) => !s.scheduled_from_worktree),
     [sessions]
   );
   const scheduledSessions = useMemo(
     () =>
       sessions
-        .filter(s => s.scheduled_from_worktree)
+        .filter((s) => s.scheduled_from_worktree)
         .sort((a, b) => (b.scheduled_run_at || 0) - (a.scheduled_run_at || 0)), // Most recent first
     [sessions]
   );
@@ -153,13 +153,13 @@ const WorktreeCard = ({
   const sessionTreeData = useMemo(() => buildSessionTree(manualSessions), [manualSessions]);
 
   // Check if any session is running
-  const hasRunningSession = useMemo(() => sessions.some(s => s.status === 'running'), [sessions]);
+  const hasRunningSession = useMemo(() => sessions.some((s) => s.status === 'running'), [sessions]);
 
   // Check if worktree needs attention (newly created OR has ready sessions)
   // Don't highlight if a session from this worktree is currently open in the drawer
   const needsAttention = useMemo(() => {
-    const hasReadySession = sessions.some(s => s.ready_for_prompt === true);
-    const hasOpenSession = sessions.some(s => s.session_id === selectedSessionId);
+    const hasReadySession = sessions.some((s) => s.ready_for_prompt === true);
+    const hasOpenSession = sessions.some((s) => s.session_id === selectedSessionId);
     const shouldHighlight = (worktree.needs_attention || hasReadySession) && !hasOpenSession;
 
     return shouldHighlight;
@@ -244,7 +244,7 @@ const WorktreeCard = ({
           boxShadow: session.ready_for_prompt ? `0 0 12px ${token.colorPrimary}30` : undefined,
         }}
         onClick={() => onSessionClick?.(session.session_id)}
-        onContextMenu={e => {
+        onContextMenu={(e) => {
           // Show fork/spawn menu on right-click if handlers exist
           if (onForkSession || onSpawnSession) {
             e.preventDefault();
@@ -302,7 +302,7 @@ const WorktreeCard = ({
     <Tree
       treeData={sessionTreeData}
       expandedKeys={expandedKeys}
-      onExpand={keys => setExpandedKeys(keys as React.Key[])}
+      onExpand={(keys) => setExpandedKeys(keys as React.Key[])}
       showLine
       showIcon={false}
       selectable={false}
@@ -338,7 +338,7 @@ const WorktreeCard = ({
             size="small"
             icon={<PlusOutlined />}
             disabled={connectionDisabled}
-            onClick={e => {
+            onClick={(e) => {
               e.stopPropagation();
               onCreateSession(worktree.worktree_id);
             }}
@@ -375,7 +375,7 @@ const WorktreeCard = ({
   // Scheduled runs content (flat list, no genealogy tree needed)
   const scheduledRunsContent = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {scheduledSessions.map(session => (
+      {scheduledSessions.map((session) => (
         <div
           key={session.session_id}
           style={{
@@ -511,7 +511,7 @@ const WorktreeCard = ({
             {isPinned && zoneName && (
               <Tag
                 icon={<PushpinFilled style={{ color: zoneColor }} />}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onUnpin?.(worktree.worktree_id);
                 }}
@@ -538,7 +538,7 @@ const WorktreeCard = ({
                 type="text"
                 size="small"
                 icon={<CodeOutlined />}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onOpenTerminal([`cd ${worktree.path}`], worktree.worktree_id);
                 }}
@@ -550,7 +550,7 @@ const WorktreeCard = ({
                 type="text"
                 size="small"
                 icon={<EditOutlined />}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onOpenSettings(worktree.worktree_id);
                 }}
@@ -563,7 +563,7 @@ const WorktreeCard = ({
                 size="small"
                 icon={<DeleteOutlined />}
                 disabled={connectionDisabled}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   setArchiveDeleteModalOpen(true);
                 }}
@@ -628,7 +628,7 @@ const WorktreeCard = ({
                 type="primary"
                 icon={<PlusOutlined />}
                 disabled={connectionDisabled}
-                onClick={e => {
+                onClick={(e) => {
                   e.stopPropagation();
                   onCreateSession(worktree.worktree_id);
                 }}
@@ -697,7 +697,7 @@ const WorktreeCard = ({
         worktree={worktree}
         sessionCount={sessions.length}
         environmentRunning={worktree.environment_instance?.status === 'running'}
-        onConfirm={options => {
+        onConfirm={(options) => {
           onArchiveOrDelete?.(worktree.worktree_id, options);
           setArchiveDeleteModalOpen(false);
         }}

--- a/apps/agor-ui/src/components/WorktreeListDrawer/WorktreeListDrawer.tsx
+++ b/apps/agor-ui/src/components/WorktreeListDrawer/WorktreeListDrawer.tsx
@@ -33,23 +33,23 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
 
   // Get current board
-  const currentBoard = boards.find(b => b.board_id === currentBoardId);
+  const currentBoard = boards.find((b) => b.board_id === currentBoardId);
 
   // Filter sessions by current board (worktree-centric model)
   const boardSessions = useMemo(() => {
     // Get worktrees for this board
-    const boardWorktrees = worktrees.filter(wt => wt.board_id === currentBoardId);
-    const boardWorktreeIds = new Set(boardWorktrees.map(wt => wt.worktree_id));
+    const boardWorktrees = worktrees.filter((wt) => wt.board_id === currentBoardId);
+    const boardWorktreeIds = new Set(boardWorktrees.map((wt) => wt.worktree_id));
 
     // Get sessions for these worktrees, sorted by last_updated desc
     return sessions
-      .filter(session => session.worktree_id && boardWorktreeIds.has(session.worktree_id))
+      .filter((session) => session.worktree_id && boardWorktreeIds.has(session.worktree_id))
       .sort((a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime());
   }, [sessions, worktrees, currentBoardId]);
 
   // Filter sessions by search query
   const filteredSessions = boardSessions.filter(
-    session =>
+    (session) =>
       session.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||
       session.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
       session.agentic_tool.toLowerCase().includes(searchQuery.toLowerCase())
@@ -70,7 +70,7 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
 
   // Get worktree name for session
   const getWorktreeName = (worktreeId: string) => {
-    return worktrees.find(wt => wt.worktree_id === worktreeId)?.name || 'Unknown';
+    return worktrees.find((wt) => wt.worktree_id === worktreeId)?.name || 'Unknown';
   };
 
   return (
@@ -98,7 +98,7 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
           style={{ width: '100%' }}
           value={currentBoardId}
           onChange={onBoardChange}
-          options={boards.map(board => ({
+          options={boards.map((board) => ({
             label: `${board.icon || '📋'} ${board.name}`,
             value: board.board_id,
           }))}
@@ -116,7 +116,7 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
           placeholder="Search sessions..."
           prefix={<SearchOutlined />}
           value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
+          onChange={(e) => setSearchQuery(e.target.value)}
           allowClear
         />
       </div>
@@ -126,17 +126,17 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
         <List
           dataSource={filteredSessions}
           locale={{ emptyText: 'No sessions in this board' }}
-          renderItem={session => (
+          renderItem={(session) => (
             <List.Item
               style={{
                 cursor: 'pointer',
                 padding: '12px 24px',
                 transition: 'background 0.2s',
               }}
-              onMouseEnter={e => {
+              onMouseEnter={(e) => {
                 e.currentTarget.style.background = token.colorBgTextHover;
               }}
-              onMouseLeave={e => {
+              onMouseLeave={(e) => {
                 e.currentTarget.style.background = 'transparent';
               }}
               onClick={() => {

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -675,7 +675,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   </Typography.Text>
                   <TextArea
                     value={upCommand}
-                    onChange={e => setUpCommand(e.target.value)}
+                    onChange={(e) => setUpCommand(e.target.value)}
                     placeholder="DAEMON_PORT={{add 3000 worktree.unique_id}} UI_PORT={{add 5000 worktree.unique_id}} docker compose -p {{worktree.name}} up -d"
                     rows={3}
                     style={{ fontFamily: 'monospace', fontSize: 11 }}
@@ -699,7 +699,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   </Typography.Text>
                   <TextArea
                     value={downCommand}
-                    onChange={e => setDownCommand(e.target.value)}
+                    onChange={(e) => setDownCommand(e.target.value)}
                     placeholder="docker compose -p {{worktree.name}} down"
                     rows={2}
                     style={{ fontFamily: 'monospace', fontSize: 11 }}
@@ -723,7 +723,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   </Typography.Text>
                   <Input
                     value={healthCheckUrlTemplate}
-                    onChange={e => setHealthCheckUrlTemplate(e.target.value)}
+                    onChange={(e) => setHealthCheckUrlTemplate(e.target.value)}
                     placeholder="http://localhost:{{add 9000 worktree.unique_id}}/health"
                     style={{ fontFamily: 'monospace', fontSize: 11 }}
                   />
@@ -739,7 +739,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   </Typography.Text>
                   <Input
                     value={appUrlTemplate}
-                    onChange={e => setAppUrlTemplate(e.target.value)}
+                    onChange={(e) => setAppUrlTemplate(e.target.value)}
                     placeholder="http://localhost:{{add 5000 worktree.unique_id}}"
                     style={{ fontFamily: 'monospace', fontSize: 11 }}
                   />
@@ -762,7 +762,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   </Typography.Text>
                   <TextArea
                     value={logsCommand}
-                    onChange={e => setLogsCommand(e.target.value)}
+                    onChange={(e) => setLogsCommand(e.target.value)}
                     placeholder="docker compose -p {{worktree.name}} logs --tail=100"
                     rows={2}
                     style={{ fontFamily: 'monospace', fontSize: 11 }}
@@ -918,7 +918,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                 <>
                   <TextArea
                     value={customContextJson}
-                    onChange={e => setCustomContextJson(e.target.value)}
+                    onChange={(e) => setCustomContextJson(e.target.value)}
                     placeholder='{\n  "feature_name": "authentication",\n  "extra_port": 3001\n}'
                     rows={6}
                     style={{ fontFamily: 'monospace', fontSize: 11 }}
@@ -1009,7 +1009,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                       </Typography.Text>
                       <Input
                         value={staticStartCommand}
-                        onChange={e => setStaticStartCommand(e.target.value)}
+                        onChange={(e) => setStaticStartCommand(e.target.value)}
                         placeholder="pnpm dev"
                         style={{ fontFamily: 'monospace', fontSize: 11 }}
                       />
@@ -1023,7 +1023,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                       </Typography.Text>
                       <Input
                         value={staticStopCommand}
-                        onChange={e => setStaticStopCommand(e.target.value)}
+                        onChange={(e) => setStaticStopCommand(e.target.value)}
                         placeholder="pkill -f 'pnpm dev'"
                         style={{ fontFamily: 'monospace', fontSize: 11 }}
                       />
@@ -1037,7 +1037,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                       </Typography.Text>
                       <Input
                         value={staticHealthCheckUrl}
-                        onChange={e => setStaticHealthCheckUrl(e.target.value)}
+                        onChange={(e) => setStaticHealthCheckUrl(e.target.value)}
                         placeholder="http://localhost:5173/health"
                         style={{ fontFamily: 'monospace', fontSize: 11 }}
                       />
@@ -1051,7 +1051,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                       </Typography.Text>
                       <Input
                         value={staticAppUrl}
-                        onChange={e => setStaticAppUrl(e.target.value)}
+                        onChange={(e) => setStaticAppUrl(e.target.value)}
                         placeholder="http://localhost:5173"
                         style={{ fontFamily: 'monospace', fontSize: 11 }}
                       />
@@ -1065,7 +1065,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                       </Typography.Text>
                       <Input
                         value={staticLogsCommand}
-                        onChange={e => setStaticLogsCommand(e.target.value)}
+                        onChange={(e) => setStaticLogsCommand(e.target.value)}
                         placeholder="docker logs agor-daemon"
                         style={{ fontFamily: 'monospace', fontSize: 11 }}
                       />

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
@@ -164,7 +164,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
                 onChange={setBoardId}
                 placeholder="Select board (optional)..."
                 allowClear
-                options={boards.map(board => ({
+                options={boards.map((board) => ({
                   value: board.board_id,
                   label: `${board.icon || '📋'} ${board.name}`,
                 }))}
@@ -174,7 +174,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
             <Form.Item label="Issue" labelCol={{ span: 6 }} wrapperCol={{ span: 18 }}>
               <Input
                 value={issueUrl}
-                onChange={e => setIssueUrl(e.target.value)}
+                onChange={(e) => setIssueUrl(e.target.value)}
                 placeholder="https://github.com/user/repo/issues/42"
                 prefix={<LinkOutlined />}
               />
@@ -183,7 +183,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
             <Form.Item label="Pull Request" labelCol={{ span: 6 }} wrapperCol={{ span: 18 }}>
               <Input
                 value={prUrl}
-                onChange={e => setPrUrl(e.target.value)}
+                onChange={(e) => setPrUrl(e.target.value)}
                 placeholder="https://github.com/user/repo/pull/43"
                 prefix={<LinkOutlined />}
               />
@@ -192,7 +192,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
             <Form.Item label="Notes" labelCol={{ span: 6 }} wrapperCol={{ span: 18 }}>
               <TextArea
                 value={notes}
-                onChange={e => setNotes(e.target.value)}
+                onChange={(e) => setNotes(e.target.value)}
                 placeholder="Freeform notes about this worktree..."
                 rows={4}
               />
@@ -228,7 +228,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
           worktree={worktree}
           sessionCount={sessions.length}
           environmentRunning={worktree.environment_instance?.status === 'running'}
-          onConfirm={options => {
+          onConfirm={(options) => {
             handleArchiveOrDelete(options);
             setArchiveDeleteModalOpen(false);
           }}

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -91,7 +91,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
     try {
       const description = cronstrue.toString(cronExpression, { verbose: true });
       setHumanReadable(description);
-    } catch (error) {
+    } catch (_error) {
       setHumanReadable('Invalid cron expression');
     }
   }, [cronExpression]);
@@ -210,7 +210,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
             <Form.Item label="Cron Expression" style={{ marginBottom: 0 }}>
               <Input
                 value={cronExpression}
-                onChange={e => setCronExpression(e.target.value)}
+                onChange={(e) => setCronExpression(e.target.value)}
                 placeholder="0 0 * * *"
                 prefix={<ClockCircleOutlined />}
               />
@@ -262,7 +262,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
             </Text>
             <TextArea
               value={promptTemplate}
-              onChange={e => setPromptTemplate(e.target.value)}
+              onChange={(e) => setPromptTemplate(e.target.value)}
               placeholder="Enter prompt template..."
               rows={6}
               style={{ fontFamily: 'monospace', fontSize: '13px' }}
@@ -283,7 +283,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
             <Space.Compact>
               <InputNumber
                 value={retention}
-                onChange={value => setRetention(value || 0)}
+                onChange={(value) => setRetention(value || 0)}
                 min={0}
                 max={100}
                 style={{ width: '150px' }}

--- a/apps/agor-ui/src/components/mobile/MobileNavTree.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileNavTree.tsx
@@ -39,7 +39,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
 
   // Count active comments per board (unresolved)
   const getActiveCommentCount = (boardId: string): number => {
-    return comments.filter(c => c.board_id === boardId && !c.resolved && !c.parent_comment_id)
+    return comments.filter((c) => c.board_id === boardId && !c.resolved && !c.parent_comment_id)
       .length;
   };
 
@@ -95,7 +95,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
       }}
     >
       <BoardCollapse
-        items={boards.map(board => {
+        items={boards.map((board) => {
           const boardWorktrees = worktreesByBoard[board.board_id] || [];
           const activeComments = getActiveCommentCount(board.board_id);
 
@@ -122,7 +122,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
                   <Button
                     type="text"
                     icon={<CommentOutlined style={{ fontSize: 18 }} />}
-                    onClick={e => handleCommentsClick(board.board_id, e)}
+                    onClick={(e) => handleCommentsClick(board.board_id, e)}
                     style={{
                       padding: '6px 10px',
                       height: 'auto',
@@ -140,7 +140,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
                   defaultActiveKey={[]}
                   ghost
                   expandIcon={({ isActive }) => <DownOutlined rotate={isActive ? 180 : 0} />}
-                  items={boardWorktrees.map(worktree => {
+                  items={boardWorktrees.map((worktree) => {
                     const worktreeSessions = sessionsByWorktree[worktree.worktree_id] || [];
 
                     return {
@@ -174,7 +174,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
                         ) : (
                           <List
                             dataSource={worktreeSessions}
-                            renderItem={session => (
+                            renderItem={(session) => (
                               <List.Item
                                 onClick={() => handleSessionClick(session.session_id)}
                                 style={{
@@ -182,11 +182,11 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
                                   padding: '6px 8px 6px 28px',
                                   borderRadius: 4,
                                 }}
-                                onMouseEnter={e => {
+                                onMouseEnter={(e) => {
                                   (e.currentTarget as HTMLElement).style.background =
                                     'rgba(255, 255, 255, 0.04)';
                                 }}
-                                onMouseLeave={e => {
+                                onMouseLeave={(e) => {
                                   (e.currentTarget as HTMLElement).style.background = 'transparent';
                                 }}
                               >

--- a/apps/agor-ui/src/components/mobile/MobilePromptInput.tsx
+++ b/apps/agor-ui/src/components/mobile/MobilePromptInput.tsx
@@ -48,7 +48,7 @@ export const MobilePromptInput: React.FC<MobilePromptInputProps> = ({
     >
       <Input.Search
         value={prompt}
-        onChange={e => setPrompt(e.target.value)}
+        onChange={(e) => setPrompt(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
         enterButton={<SendOutlined />}

--- a/apps/agor-ui/src/components/mobile/SessionPage.tsx
+++ b/apps/agor-ui/src/components/mobile/SessionPage.tsx
@@ -34,8 +34,8 @@ export const SessionPage: React.FC<SessionPageProps> = ({
 }) => {
   const { sessionId } = useParams<{ sessionId: string }>();
 
-  const session = sessions.find(s => s.session_id === sessionId);
-  const worktree = session ? worktrees.find(w => w.worktree_id === session.worktree_id) : null;
+  const session = sessions.find((s) => s.session_id === sessionId);
+  const worktree = session ? worktrees.find((w) => w.worktree_id === session.worktree_id) : null;
 
   if (!sessionId) {
     return (

--- a/apps/agor-ui/src/contexts/ThemeContext.tsx
+++ b/apps/agor-ui/src/contexts/ThemeContext.tsx
@@ -103,7 +103,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   // Update document background color and theme class when theme changes
   useEffect(() => {
-    const config = getCurrentThemeConfig();
+    const _config = getCurrentThemeConfig();
     const isDark =
       themeMode === 'dark' || (themeMode === 'custom' && customTheme?.algorithm === darkAlgorithm);
 

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -9,12 +9,7 @@ import type { AgorClient } from '@agor/core/api';
 import { createClient } from '@agor/core/api';
 import { useEffect, useRef, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
-import {
-  ACCESS_TOKEN_KEY,
-  getStoredRefreshToken,
-  REFRESH_TOKEN_KEY,
-  refreshAndStoreTokens,
-} from '../utils/tokenRefresh';
+import { getStoredRefreshToken, refreshAndStoreTokens } from '../utils/tokenRefresh';
 
 interface UseAgorClientResult {
   client: AgorClient | null;
@@ -95,7 +90,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                 setConnecting(false);
                 setError(null);
                 return;
-              } catch (accessTokenErr) {
+              } catch (_accessTokenErr) {
                 // Access token expired or invalid - try refresh token
                 console.log('Access token failed on reconnect, attempting refresh...');
 
@@ -150,7 +145,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
         }
       });
 
-      client.io.on('disconnect', reason => {
+      client.io.on('disconnect', (reason) => {
         if (mounted) {
           console.log('🔌 Disconnected from daemon:', reason);
           setConnected(false);
@@ -203,7 +198,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
             resolve();
           });
 
-          client.io.once('connect_error', err => {
+          client.io.once('connect_error', (err) => {
             clearTimeout(timeout);
             reject(err);
           });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -82,11 +82,17 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
         mcpServersResult,
         sessionMcpResult,
       ] = await Promise.all([
-        client.service('sessions').find({ query: { $limit: 1000, $sort: { updated_at: -1 } } }), // Fetch up to 1000 sessions, sorted by most recent
-        client.service('tasks').find({ query: { $limit: 500 } }), // Fetch up to 500 tasks
+        client
+          .service('sessions')
+          .find({ query: { $limit: 1000, $sort: { updated_at: -1 } } }), // Fetch up to 1000 sessions, sorted by most recent
+        client
+          .service('tasks')
+          .find({ query: { $limit: 500 } }), // Fetch up to 500 tasks
         client.service('boards').find(),
         client.service('board-objects').find(),
-        client.service('board-comments').find({ query: { $limit: 500 } }), // Fetch up to 500 comments
+        client
+          .service('board-comments')
+          .find({ query: { $limit: 500 } }), // Fetch up to 500 comments
         client.service('repos').find(),
         client.service('worktrees').find(),
         client.service('users').find(),
@@ -164,13 +170,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to session events
     const sessionsService = client.service('sessions');
     const handleSessionCreated = (session: Session) => {
-      setSessions(prev => [...prev, session]);
+      setSessions((prev) => [...prev, session]);
     };
     const handleSessionPatched = (session: Session) => {
-      setSessions(prev => prev.map(s => (s.session_id === session.session_id ? session : s)));
+      setSessions((prev) => prev.map((s) => (s.session_id === session.session_id ? session : s)));
     };
     const handleSessionRemoved = (session: Session) => {
-      setSessions(prev => prev.filter(s => s.session_id !== session.session_id));
+      setSessions((prev) => prev.filter((s) => s.session_id !== session.session_id));
     };
 
     sessionsService.on('created', handleSessionCreated);
@@ -181,23 +187,23 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to task events
     const tasksService = client.service('tasks');
     const handleTaskCreated = (task: Task) => {
-      setTasks(prev => ({
+      setTasks((prev) => ({
         ...prev,
         [task.session_id]: [...(prev[task.session_id] || []), task],
       }));
     };
     const handleTaskPatched = (task: Task) => {
-      setTasks(prev => ({
+      setTasks((prev) => ({
         ...prev,
-        [task.session_id]: (prev[task.session_id] || []).map(t =>
+        [task.session_id]: (prev[task.session_id] || []).map((t) =>
           t.task_id === task.task_id ? task : t
         ),
       }));
     };
     const handleTaskRemoved = (task: Task) => {
-      setTasks(prev => ({
+      setTasks((prev) => ({
         ...prev,
-        [task.session_id]: (prev[task.session_id] || []).filter(t => t.task_id !== task.task_id),
+        [task.session_id]: (prev[task.session_id] || []).filter((t) => t.task_id !== task.task_id),
       }));
     };
 
@@ -209,13 +215,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to board events
     const boardsService = client.service('boards');
     const handleBoardCreated = (board: Board) => {
-      setBoards(prev => [...prev, board]);
+      setBoards((prev) => [...prev, board]);
     };
     const handleBoardPatched = (board: Board) => {
-      setBoards(prev => prev.map(b => (b.board_id === board.board_id ? board : b)));
+      setBoards((prev) => prev.map((b) => (b.board_id === board.board_id ? board : b)));
     };
     const handleBoardRemoved = (board: Board) => {
-      setBoards(prev => prev.filter(b => b.board_id !== board.board_id));
+      setBoards((prev) => prev.filter((b) => b.board_id !== board.board_id));
     };
 
     boardsService.on('created', handleBoardCreated);
@@ -226,15 +232,15 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to board object events
     const boardObjectsService = client.service('board-objects');
     const handleBoardObjectCreated = (boardObject: BoardEntityObject) => {
-      setBoardObjects(prev => [...prev, boardObject]);
+      setBoardObjects((prev) => [...prev, boardObject]);
     };
     const handleBoardObjectPatched = (boardObject: BoardEntityObject) => {
-      setBoardObjects(prev =>
-        prev.map(bo => (bo.object_id === boardObject.object_id ? boardObject : bo))
+      setBoardObjects((prev) =>
+        prev.map((bo) => (bo.object_id === boardObject.object_id ? boardObject : bo))
       );
     };
     const handleBoardObjectRemoved = (boardObject: BoardEntityObject) => {
-      setBoardObjects(prev => prev.filter(bo => bo.object_id !== boardObject.object_id));
+      setBoardObjects((prev) => prev.filter((bo) => bo.object_id !== boardObject.object_id));
     };
 
     boardObjectsService.on('created', handleBoardObjectCreated);
@@ -245,13 +251,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to repo events
     const reposService = client.service('repos');
     const handleRepoCreated = (repo: Repo) => {
-      setRepos(prev => [...prev, repo]);
+      setRepos((prev) => [...prev, repo]);
     };
     const handleRepoPatched = (repo: Repo) => {
-      setRepos(prev => prev.map(r => (r.repo_id === repo.repo_id ? repo : r)));
+      setRepos((prev) => prev.map((r) => (r.repo_id === repo.repo_id ? repo : r)));
     };
     const handleRepoRemoved = (repo: Repo) => {
-      setRepos(prev => prev.filter(r => r.repo_id !== repo.repo_id));
+      setRepos((prev) => prev.filter((r) => r.repo_id !== repo.repo_id));
     };
 
     reposService.on('created', handleRepoCreated);
@@ -262,13 +268,15 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to worktree events
     const worktreesService = client.service('worktrees');
     const handleWorktreeCreated = (worktree: Worktree) => {
-      setWorktrees(prev => [...prev, worktree]);
+      setWorktrees((prev) => [...prev, worktree]);
     };
     const handleWorktreePatched = (worktree: Worktree) => {
-      setWorktrees(prev => prev.map(w => (w.worktree_id === worktree.worktree_id ? worktree : w)));
+      setWorktrees((prev) =>
+        prev.map((w) => (w.worktree_id === worktree.worktree_id ? worktree : w))
+      );
     };
     const handleWorktreeRemoved = (worktree: Worktree) => {
-      setWorktrees(prev => prev.filter(w => w.worktree_id !== worktree.worktree_id));
+      setWorktrees((prev) => prev.filter((w) => w.worktree_id !== worktree.worktree_id));
     };
 
     worktreesService.on('created', handleWorktreeCreated);
@@ -279,13 +287,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to user events
     const usersService = client.service('users');
     const handleUserCreated = (user: User) => {
-      setUsers(prev => [...prev, user]);
+      setUsers((prev) => [...prev, user]);
     };
     const handleUserPatched = (user: User) => {
-      setUsers(prev => prev.map(u => (u.user_id === user.user_id ? user : u)));
+      setUsers((prev) => prev.map((u) => (u.user_id === user.user_id ? user : u)));
     };
     const handleUserRemoved = (user: User) => {
-      setUsers(prev => prev.filter(u => u.user_id !== user.user_id));
+      setUsers((prev) => prev.filter((u) => u.user_id !== user.user_id));
     };
 
     usersService.on('created', handleUserCreated);
@@ -296,13 +304,15 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to MCP server events
     const mcpServersService = client.service('mcp-servers');
     const handleMCPServerCreated = (server: MCPServer) => {
-      setMcpServers(prev => [...prev, server]);
+      setMcpServers((prev) => [...prev, server]);
     };
     const handleMCPServerPatched = (server: MCPServer) => {
-      setMcpServers(prev => prev.map(s => (s.mcp_server_id === server.mcp_server_id ? server : s)));
+      setMcpServers((prev) =>
+        prev.map((s) => (s.mcp_server_id === server.mcp_server_id ? server : s))
+      );
     };
     const handleMCPServerRemoved = (server: MCPServer) => {
-      setMcpServers(prev => prev.filter(s => s.mcp_server_id !== server.mcp_server_id));
+      setMcpServers((prev) => prev.filter((s) => s.mcp_server_id !== server.mcp_server_id));
     };
 
     mcpServersService.on('created', handleMCPServerCreated);
@@ -316,7 +326,7 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       session_id: string;
       mcp_server_id: string;
     }) => {
-      setSessionMcpServerIds(prev => ({
+      setSessionMcpServerIds((prev) => ({
         ...prev,
         [relationship.session_id]: [
           ...(prev[relationship.session_id] || []),
@@ -328,10 +338,10 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       session_id: string;
       mcp_server_id: string;
     }) => {
-      setSessionMcpServerIds(prev => ({
+      setSessionMcpServerIds((prev) => ({
         ...prev,
         [relationship.session_id]: (prev[relationship.session_id] || []).filter(
-          id => id !== relationship.mcp_server_id
+          (id) => id !== relationship.mcp_server_id
         ),
       }));
     };
@@ -342,13 +352,13 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
     // Subscribe to board comment events
     const commentsService = client.service('board-comments');
     const handleCommentCreated = (comment: BoardComment) => {
-      setComments(prev => [...prev, comment]);
+      setComments((prev) => [...prev, comment]);
     };
     const handleCommentPatched = (comment: BoardComment) => {
-      setComments(prev => prev.map(c => (c.comment_id === comment.comment_id ? comment : c)));
+      setComments((prev) => prev.map((c) => (c.comment_id === comment.comment_id ? comment : c)));
     };
     const handleCommentRemoved = (comment: BoardComment) => {
-      setComments(prev => prev.filter(c => c.comment_id !== comment.comment_id));
+      setComments((prev) => prev.filter((c) => c.comment_id !== comment.comment_id));
     };
 
     commentsService.on('created', handleCommentCreated);

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -10,11 +10,9 @@ import type { User } from '@agor/core/types';
 import { useCallback, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
 import {
-  ACCESS_TOKEN_KEY,
   clearTokens,
   getStoredAccessToken,
   getStoredRefreshToken,
-  REFRESH_TOKEN_KEY,
   refreshAndStoreTokens,
   storeTokens,
 } from '../utils/tokenRefresh';
@@ -51,7 +49,7 @@ export function useAuth(): UseAuthReturn {
    */
   const reAuthenticate = useCallback(async (retryCount = 0) => {
     const MAX_RETRIES = 5;
-    setState(prev => ({ ...prev, loading: true, error: null }));
+    setState((prev) => ({ ...prev, loading: true, error: null }));
 
     // Move client outside try block so it's accessible in finally
     let client: ReturnType<typeof createClient> | null = null;
@@ -93,7 +91,7 @@ export function useAuth(): UseAuthReturn {
           resolve();
         });
 
-        client.io.once('connect_error', err => {
+        client.io.once('connect_error', (err) => {
           clearTimeout(timeout);
           reject(err);
         });
@@ -180,7 +178,7 @@ export function useAuth(): UseAuthReturn {
         console.log(
           `Connection failed (attempt ${retryCount + 1}/${MAX_RETRIES}), retrying in ${Math.round(delay)}ms...`
         );
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise((resolve) => setTimeout(resolve, delay));
         return reAuthenticate(retryCount + 1);
       }
 
@@ -295,7 +293,7 @@ export function useAuth(): UseAuthReturn {
             resolve();
           });
 
-          client.io.once('connect_error', err => {
+          client.io.once('connect_error', (err) => {
             clearTimeout(timeout);
             reject(err);
           });
@@ -303,7 +301,7 @@ export function useAuth(): UseAuthReturn {
 
         const refreshResult = await refreshAndStoreTokens(client, refreshToken);
 
-        setState(prev => ({
+        setState((prev) => ({
           ...prev,
           accessToken: refreshResult.accessToken,
           user: refreshResult.user,
@@ -338,7 +336,7 @@ export function useAuth(): UseAuthReturn {
    * Login with email and password
    */
   const login = async (email: string, password: string): Promise<boolean> => {
-    setState(prev => ({ ...prev, loading: true, error: null }));
+    setState((prev) => ({ ...prev, loading: true, error: null }));
 
     let client: ReturnType<typeof createClient> | null = null;
 
@@ -365,7 +363,7 @@ export function useAuth(): UseAuthReturn {
           resolve();
         });
 
-        client.io.once('connect_error', err => {
+        client.io.once('connect_error', (err) => {
           clearTimeout(timeout);
           reject(err);
         });
@@ -410,7 +408,7 @@ export function useAuth(): UseAuthReturn {
       console.error('❌ Login failed:', error);
       const errorMessage = error instanceof Error ? error.message : 'Login failed';
       console.error('❌ Error message:', errorMessage);
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         loading: false,
         error: errorMessage,

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -26,9 +26,7 @@ interface UseSessionActionsResult {
  * @param client - Agor client instance
  * @returns Session action functions and state
  */
-export function useSessionActions(
-  client: AgorClient | null
-): UseSessionActionsResult {
+export function useSessionActions(client: AgorClient | null): UseSessionActionsResult {
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/apps/agor-ui/src/hooks/useStreamingMessages.ts
+++ b/apps/agor-ui/src/hooks/useStreamingMessages.ts
@@ -96,7 +96,7 @@ export function useStreamingMessages(
 
       console.debug(`📡 Streaming start: ${data.message_id.substring(0, 8)}`);
 
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const newMap = new Map(prev);
         newMap.set(data.message_id, {
           message_id: data.message_id,
@@ -118,7 +118,7 @@ export function useStreamingMessages(
         return;
       }
 
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const message = prev.get(data.message_id);
         if (!message) {
           return prev;
@@ -144,7 +144,7 @@ export function useStreamingMessages(
 
       // Mark as ended but DON'T remove yet - wait for DB 'created' event
       // This prevents jitter where streaming message disappears before DB message appears
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const message = prev.get(data.message_id);
         if (!message) return prev;
 
@@ -159,7 +159,7 @@ export function useStreamingMessages(
       // Safety: Remove after 1 second if DB event doesn't arrive
       // This handles edge cases where 'created' event might be missed
       setTimeout(() => {
-        setStreamingMessages(prev => {
+        setStreamingMessages((prev) => {
           const newMap = new Map(prev);
           newMap.delete(data.message_id);
           return newMap;
@@ -175,7 +175,7 @@ export function useStreamingMessages(
       }
 
       // Mark as error but keep content
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const message = prev.get(data.message_id);
         if (!message) {
           return prev;
@@ -202,7 +202,7 @@ export function useStreamingMessages(
       );
 
       // Remove from streaming map now that it's in the DB
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const newMap = new Map(prev);
         newMap.delete(message.message_id);
         return newMap;
@@ -218,7 +218,7 @@ export function useStreamingMessages(
 
       console.debug(`🧠 Thinking start: ${data.message_id.substring(0, 8)}`);
 
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const newMap = new Map(prev);
         newMap.set(data.message_id, {
           message_id: data.message_id,
@@ -242,7 +242,7 @@ export function useStreamingMessages(
         return;
       }
 
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const message = prev.get(data.message_id);
         if (!message) {
           return prev;
@@ -267,7 +267,7 @@ export function useStreamingMessages(
 
       console.debug(`🧠 Thinking end: ${data.message_id.substring(0, 8)}`);
 
-      setStreamingMessages(prev => {
+      setStreamingMessages((prev) => {
         const message = prev.get(data.message_id);
         if (!message) return prev;
 

--- a/apps/agor-ui/src/hooks/useTaskMessages.ts
+++ b/apps/agor-ui/src/hooks/useTaskMessages.ts
@@ -79,9 +79,9 @@ export function useTaskMessages(
       if (message.task_id === taskId) {
         // Use flushSync to force immediate render (bypass React 18 automatic batching)
         flushSync(() => {
-          setMessages(prev => {
+          setMessages((prev) => {
             // Check if message already exists (avoid duplicates)
-            if (prev.some(m => m.message_id === message.message_id)) {
+            if (prev.some((m) => m.message_id === message.message_id)) {
               return prev;
             }
             // Insert in correct position based on index
@@ -96,13 +96,13 @@ export function useTaskMessages(
 
     const handleMessagePatched = (message: Message) => {
       if (message.task_id === taskId) {
-        setMessages(prev => prev.map(m => (m.message_id === message.message_id ? message : m)));
+        setMessages((prev) => prev.map((m) => (m.message_id === message.message_id ? message : m)));
       }
     };
 
     const handleMessageRemoved = (message: Message) => {
       if (message.task_id === taskId) {
-        setMessages(prev => prev.filter(m => m.message_id !== message.message_id));
+        setMessages((prev) => prev.filter((m) => m.message_id !== message.message_id));
       }
     };
 

--- a/apps/agor-ui/src/hooks/useTasks.ts
+++ b/apps/agor-ui/src/hooks/useTasks.ts
@@ -74,9 +74,9 @@ export function useTasks(
     const handleTaskCreated = (task: Task) => {
       // Only add if it belongs to this session
       if (task.session_id === sessionId) {
-        setTasks(prev => {
+        setTasks((prev) => {
           // Check if task already exists (avoid duplicates)
-          if (prev.some(t => t.task_id === task.task_id)) {
+          if (prev.some((t) => t.task_id === task.task_id)) {
             return prev;
           }
           // Insert in correct position based on created_at
@@ -90,9 +90,9 @@ export function useTasks(
 
     const handleTaskPatched = (task: Task) => {
       if (task.session_id === sessionId) {
-        setTasks(prev => {
+        setTasks((prev) => {
           // Find the previous task state to detect transitions
-          const oldTask = prev.find(t => t.task_id === task.task_id);
+          const oldTask = prev.find((t) => t.task_id === task.task_id);
           const wasRunning = oldTask?.status === TaskStatus.RUNNING;
           const isNowDone =
             task.status === TaskStatus.COMPLETED || task.status === TaskStatus.FAILED;
@@ -102,14 +102,14 @@ export function useTasks(
             playTaskCompletionChime(task, user?.preferences?.audio);
           }
 
-          return prev.map(t => (t.task_id === task.task_id ? task : t));
+          return prev.map((t) => (t.task_id === task.task_id ? task : t));
         });
       }
     };
 
     const handleTaskRemoved = (task: Task) => {
       if (task.session_id === sessionId) {
-        setTasks(prev => prev.filter(t => t.task_id !== task.task_id));
+        setTasks((prev) => prev.filter((t) => t.task_id !== task.task_id));
       }
     };
 

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -25,28 +25,28 @@
 }
 
 /* Headings - reduce excessive margins from Tailwind defaults */
-[data-streamdown="heading-1"],
-[data-streamdown="heading-2"],
-[data-streamdown="heading-3"],
-[data-streamdown="heading-4"],
-[data-streamdown="heading-5"],
-[data-streamdown="heading-6"] {
+[data-streamdown='heading-1'],
+[data-streamdown='heading-2'],
+[data-streamdown='heading-3'],
+[data-streamdown='heading-4'],
+[data-streamdown='heading-5'],
+[data-streamdown='heading-6'] {
   margin-top: 1em;
   margin-bottom: 0.5em;
 }
 
 /* Links - inherit primary color from Ant Design */
-[data-streamdown="link"] {
+[data-streamdown='link'] {
   color: var(--ant-color-primary);
   text-decoration: underline;
 }
 
-[data-streamdown="link"]:hover {
+[data-streamdown='link']:hover {
   color: var(--ant-color-primary-hover);
 }
 
 /* Code blocks - use Ant Design's neutral colors */
-[data-streamdown="inline-code"] {
+[data-streamdown='inline-code'] {
   background-color: rgba(0, 0, 0, 0.06);
   padding: 0.2em 0.4em;
   border-radius: 3px;
@@ -55,33 +55,33 @@
 
 /* Dark mode adjustments for inline code */
 @media (prefers-color-scheme: dark) {
-  [data-streamdown="inline-code"] {
+  [data-streamdown='inline-code'] {
     background-color: rgba(255, 255, 255, 0.08);
   }
 }
 
 /* Tables - match Ant Design table styling */
-[data-streamdown="table"] {
+[data-streamdown='table'] {
   border-color: var(--ant-color-border);
 }
 
-[data-streamdown="table-header"] {
+[data-streamdown='table-header'] {
   background-color: var(--ant-color-bg-container);
 }
 
-[data-streamdown="table-body"] {
+[data-streamdown='table-body'] {
   background-color: var(--ant-color-bg-layout);
 }
 
 /* Blockquotes - use Ant Design's text colors */
-[data-streamdown="blockquote"] {
+[data-streamdown='blockquote'] {
   border-left-color: var(--ant-color-border);
   color: var(--ant-color-text-secondary);
 }
 
 /* Lists - reduce spacing for better density */
-[data-streamdown="ordered-list"],
-[data-streamdown="unordered-list"] {
+[data-streamdown='ordered-list'],
+[data-streamdown='unordered-list'] {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
 }
@@ -94,11 +94,11 @@
 
 /* Copy/Download button styling - override Tailwind classes */
 [data-code-block-header] button,
-[data-streamdown="mermaid-block"] button,
-[data-streamdown="table-wrapper"] button,
-[data-streamdown="image-wrapper"] button {
+[data-streamdown='mermaid-block'] button,
+[data-streamdown='table-wrapper'] button,
+[data-streamdown='image-wrapper'] button {
   /* Override Tailwind text-muted-foreground */
-  color: var(--ant-color-text-secondary) !important;
+  color: var(--ant-color-text-secondary);
   background-color: transparent;
   border: 1px solid transparent;
   border-radius: 4px;
@@ -108,19 +108,19 @@
 }
 
 [data-code-block-header] button:hover:not(:disabled),
-[data-streamdown="mermaid-block"] button:hover:not(:disabled),
-[data-streamdown="table-wrapper"] button:hover:not(:disabled),
-[data-streamdown="image-wrapper"] button:hover:not(:disabled) {
+[data-streamdown='mermaid-block'] button:hover:not(:disabled),
+[data-streamdown='table-wrapper'] button:hover:not(:disabled),
+[data-streamdown='image-wrapper'] button:hover:not(:disabled) {
   /* Override Tailwind hover:text-foreground */
-  color: var(--ant-color-text) !important;
+  color: var(--ant-color-text);
   background-color: var(--ant-color-fill-quaternary);
   border-color: var(--ant-color-border);
 }
 
 [data-code-block-header] button:disabled,
-[data-streamdown="mermaid-block"] button:disabled,
-[data-streamdown="table-wrapper"] button:disabled,
-[data-streamdown="image-wrapper"] button:disabled {
+[data-streamdown='mermaid-block'] button:disabled,
+[data-streamdown='table-wrapper'] button:disabled,
+[data-streamdown='image-wrapper'] button:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }

--- a/apps/agor-ui/src/utils/clipboard.ts
+++ b/apps/agor-ui/src/utils/clipboard.ts
@@ -29,7 +29,7 @@ export async function copyToClipboard(
 
   try {
     // Try modern Clipboard API first (requires HTTPS)
-    if (navigator.clipboard && navigator.clipboard.writeText) {
+    if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text);
       if (showSuccess) {
         message.success(successMessage);

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,7 +16,7 @@ fi
 echo "🎣 Initializing git hooks..."
 pnpm husky install
 
-# Build @agor/core (required for CLI commands and daemon)
+# Build @agor/core once (required for CLI commands like init and user create-admin)
 echo "🔨 Building @agor/core..."
 pnpm --filter @agor/core build
 
@@ -40,9 +40,23 @@ if [ "$SEED" = "true" ]; then
   pnpm tsx scripts/seed.ts --skip-if-exists
 fi
 
-# Start daemon in background (use DAEMON_PORT env var or default to 3030)
+# Start @agor/core in watch mode (for hot-reload during development)
+# This will rebuild core, but daemon will wait for it via tsx watch on dist/
+echo "🔄 Starting @agor/core watch mode..."
+pnpm --filter @agor/core dev &
+CORE_PID=$!
+
+# Wait for watch build to complete (tsup --watch cleans dist/ first, then rebuilds)
+echo "⏳ Waiting for @agor/core watch build..."
+while [ ! -f "/app/packages/core/dist/index.js" ]; do
+  sleep 0.1
+done
+echo "✅ @agor/core build ready"
+
+# Start daemon in background (use dev:daemon-only to avoid duplicate core watch)
+# Core watch is already running above, daemon just runs tsx watch
 echo "🚀 Starting daemon on port ${DAEMON_PORT:-3030}..."
-PORT="${DAEMON_PORT:-3030}" pnpm --filter @agor/daemon dev &
+PORT="${DAEMON_PORT:-3030}" pnpm --filter @agor/daemon dev:daemon-only &
 DAEMON_PID=$!
 
 # Wait a bit for daemon to start
@@ -52,5 +66,6 @@ sleep 3
 echo "🎨 Starting UI on port ${UI_PORT:-5173}..."
 VITE_DAEMON_PORT="${DAEMON_PORT:-3030}" pnpm --filter agor-ui dev --host 0.0.0.0 --port "${UI_PORT:-5173}"
 
-# If UI exits, kill daemon too
+# If UI exits, kill both daemon and core watch
 kill $DAEMON_PID 2>/dev/null || true
+kill $CORE_PID 2>/dev/null || true

--- a/packages/core/src/config/agor-yml.test.ts
+++ b/packages/core/src/config/agor-yml.test.ts
@@ -7,7 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { RepoEnvironmentConfig } from '../types/worktree';
-import { type AgorYmlSchema, parseAgorYml, writeAgorYml } from './agor-yml';
+import { parseAgorYml, writeAgorYml } from './agor-yml';
 
 describe('parseAgorYml', () => {
   it('should parse valid .agor.yml with all fields', () => {

--- a/packages/core/src/config/env-locking.test.ts
+++ b/packages/core/src/config/env-locking.test.ts
@@ -23,7 +23,7 @@ describe('env-locking', () => {
   afterEach(() => {
     // Restore original environment
     Object.assign(process.env, originalEnv);
-    Object.keys(process.env).forEach(key => {
+    Object.keys(process.env).forEach((key) => {
       if (!(key in originalEnv)) {
         delete process.env[key];
       }
@@ -132,14 +132,14 @@ describe('env-locking', () => {
       const fn1 = async () => {
         executionOrder.push('start-user1');
         // Simulate some async work
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
         executionOrder.push('end-user1');
         expect(process.env.USER_ID).toBe('user-1-value');
       };
 
       const fn2 = async () => {
         executionOrder.push('start-user2');
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await new Promise((resolve) => setTimeout(resolve, 5));
         executionOrder.push('end-user2');
         expect(process.env.USER_ID).toBe('user-2-value');
       };
@@ -341,13 +341,13 @@ describe('env-locking', () => {
       const executionLog: string[] = [];
 
       vi.mocked(resolverModule.resolveUserEnvironment).mockImplementation(async () => {
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await new Promise((resolve) => setTimeout(resolve, 5));
         return {};
       });
 
       const fn1 = async () => {
         executionLog.push('fn1-start');
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
         executionLog.push('fn1-end');
       };
 
@@ -378,7 +378,7 @@ describe('env-locking', () => {
 
       const fn = async (userId: string) => {
         executionLog.push(`${userId}-start`);
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
         executionLog.push(`${userId}-end`);
       };
 

--- a/packages/core/src/config/repo-list.test.ts
+++ b/packages/core/src/config/repo-list.test.ts
@@ -232,8 +232,8 @@ describe('getRepoReferenceOptions', () => {
     const result = getRepoReferenceOptions(repos, worktrees);
 
     expect(result).toHaveLength(2);
-    expect(result.some(opt => opt.worktree === 'orphan-branch')).toBe(false);
-    expect(result.some(opt => opt.worktree === 'main')).toBe(true);
+    expect(result.some((opt) => opt.worktree === 'orphan-branch')).toBe(false);
+    expect(result.some((opt) => opt.worktree === 'main')).toBe(true);
   });
 
   it('should handle repos without worktrees', () => {
@@ -263,7 +263,7 @@ describe('getRepoReferenceOptions', () => {
     expect(result).toHaveLength(2);
     expect(result[0].type).toBe('managed');
     expect(result[1].type).toBe('managed');
-    expect(result.every(opt => opt.type === 'managed')).toBe(true);
+    expect(result.every((opt) => opt.type === 'managed')).toBe(true);
   });
 
   it('should use correct ID values for repo and worktree options', () => {
@@ -589,7 +589,7 @@ describe('getGroupedRepoReferenceOptions', () => {
 
     expect(result['preset-io/agor']).toHaveLength(2);
     expect(Object.keys(result)).toHaveLength(1);
-    expect(result['preset-io/agor'].some(opt => opt.worktree === 'orphan')).toBe(false);
+    expect(result['preset-io/agor'].some((opt) => opt.worktree === 'orphan')).toBe(false);
   });
 
   it('should handle repos without worktrees', () => {

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -21,11 +21,10 @@
 
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import bcryptjs from 'bcryptjs';
 import { eq, sql } from 'drizzle-orm';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 import type { Database } from './client';
-import { boards, users } from './schema';
+import { boards } from './schema';
 
 /**
  * Error thrown when migration fails
@@ -68,7 +67,7 @@ async function hasMigrationsTable(db: Database): Promise<boolean> {
  *
  * Safe to run multiple times (idempotent).
  */
-async function bootstrapMigrations(db: Database): Promise<void> {
+async function _bootstrapMigrations(db: Database): Promise<void> {
   try {
     console.log('🔧 Bootstrapping migration tracking...');
 
@@ -156,7 +155,7 @@ export async function checkMigrationStatus(
       // No migrations table = fresh database, all migrations pending
       return {
         hasPending: true,
-        pending: expectedMigrations.map(m => m.tag),
+        pending: expectedMigrations.map((m) => m.tag),
         applied: [],
       };
     }
@@ -180,19 +179,19 @@ export async function checkMigrationStatus(
       return {
         hasPending: false,
         pending: [],
-        applied: expectedMigrations.map(m => m.tag),
+        applied: expectedMigrations.map((m) => m.tag),
       };
     }
 
     // Find pending migrations (hash not in database, after normalization)
     const pending = expectedMigrations
-      .filter(m => !normalizedAppliedHashes.includes(m.hash))
-      .map(m => m.tag);
+      .filter((m) => !normalizedAppliedHashes.includes(m.hash))
+      .map((m) => m.tag);
 
     // Find applied migration tags (hash exists in database, after normalization)
     const appliedTags = expectedMigrations
-      .filter(m => normalizedAppliedHashes.includes(m.hash))
-      .map(m => m.tag);
+      .filter((m) => normalizedAppliedHashes.includes(m.hash))
+      .map((m) => m.tag);
 
     return {
       hasPending: pending.length > 0,

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -100,7 +100,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       throw new AmbiguousIdError(
         'Board',
         id,
-        results.map(r => formatShortId(r.board_id as UUID))
+        results.map((r) => formatShortId(r.board_id as UUID))
       );
     }
 
@@ -176,7 +176,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   async findAll(): Promise<Board[]> {
     try {
       const rows = await this.db.select().from(boards).all();
-      return rows.map(row => this.rowToBoard(row));
+      return rows.map((row) => this.rowToBoard(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all boards: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -73,9 +73,9 @@ export class MessagesRepository {
    * Bulk insert messages (optimized for session loading)
    */
   async createMany(messageList: Message[]): Promise<Message[]> {
-    const rows = messageList.map(m => this.messageToRow(m));
+    const rows = messageList.map((m) => this.messageToRow(m));
     const inserted = await this.db.insert(messages).values(rows).returning();
-    return inserted.map(r => this.rowToMessage(r));
+    return inserted.map((r) => this.rowToMessage(r));
   }
 
   /**
@@ -96,7 +96,7 @@ export class MessagesRepository {
    */
   async findAll(): Promise<Message[]> {
     const rows = await this.db.select().from(messages).orderBy(messages.index);
-    return rows.map(r => this.rowToMessage(r));
+    return rows.map((r) => this.rowToMessage(r));
   }
 
   /**
@@ -109,7 +109,7 @@ export class MessagesRepository {
       .where(eq(messages.session_id, sessionId))
       .orderBy(messages.index);
 
-    return rows.map(r => this.rowToMessage(r));
+    return rows.map((r) => this.rowToMessage(r));
   }
 
   /**
@@ -122,7 +122,7 @@ export class MessagesRepository {
       .where(eq(messages.task_id, taskId))
       .orderBy(messages.index);
 
-    return rows.map(r => this.rowToMessage(r));
+    return rows.map((r) => this.rowToMessage(r));
   }
 
   /**
@@ -142,8 +142,8 @@ export class MessagesRepository {
 
     // Filter by range in memory (simpler than complex SQL)
     return rows
-      .filter(r => r.index >= startIndex && r.index <= endIndex)
-      .map(r => this.rowToMessage(r));
+      .filter((r) => r.index >= startIndex && r.index <= endIndex)
+      .map((r) => this.rowToMessage(r));
   }
 
   /**
@@ -246,7 +246,7 @@ export class MessagesRepository {
       .where(and(eq(messages.session_id, sessionId), eq(messages.status, 'queued')))
       .orderBy(asc(messages.queue_position));
 
-    return rows.map(r => this.rowToMessage(r));
+    return rows.map((r) => this.rowToMessage(r));
   }
 
   /**

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -95,7 +95,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       throw new AmbiguousIdError(
         'Repo',
         id,
-        results.map(r => formatShortId(r.repo_id as UUID))
+        results.map((r) => formatShortId(r.repo_id as UUID))
       );
     }
 
@@ -167,7 +167,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
   async findAll(): Promise<Repo[]> {
     try {
       const rows = await this.db.select().from(repos).all();
-      return rows.map(row => this.rowToRepo(row));
+      return rows.map((row) => this.rowToRepo(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all repos: ${error instanceof Error ? error.message : String(error)}`,
@@ -196,7 +196,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       const fullId = await this.resolveId(id);
 
       // Use transaction to make read-merge-write atomic
-      return await this.db.transaction(async tx => {
+      return await this.db.transaction(async (tx) => {
         // STEP 1: Read current repo (within transaction)
         const currentRow = await tx.select().from(repos).where(eq(repos.repo_id, fullId)).get();
 
@@ -276,10 +276,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
    */
   async count(): Promise<number> {
     try {
-      const result = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(repos)
-        .get();
+      const result = await this.db.select({ count: sql<number>`count(*)` }).from(repos).get();
 
       return result?.count ?? 0;
     } catch (error) {

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -416,7 +416,7 @@ describe('SessionRepository.findAll', () => {
     const sessions = await repo.findAll();
 
     expect(sessions).toHaveLength(3);
-    expect(sessions.map(s => s.title).sort()).toEqual(['Session 1', 'Session 2', 'Session 3']);
+    expect(sessions.map((s) => s.title).sort()).toEqual(['Session 1', 'Session 2', 'Session 3']);
   });
 
   dbTest('should return fully populated session objects', async ({ db }) => {
@@ -464,7 +464,7 @@ describe('SessionRepository.findByStatus', () => {
     const idleSessions = await repo.findByStatus(SessionStatus.IDLE);
 
     expect(idleSessions).toHaveLength(2);
-    idleSessions.forEach(session => {
+    idleSessions.forEach((session) => {
       expect(session.status).toBe(SessionStatus.IDLE);
     });
   });
@@ -585,7 +585,7 @@ describe('SessionRepository.findChildren', () => {
     const children = await repo.findChildren(parent.session_id);
 
     expect(children).toHaveLength(2);
-    expect(children.map(c => c.session_id).sort()).toEqual(
+    expect(children.map((c) => c.session_id).sort()).toEqual(
       [child1.session_id, child2.session_id].sort()
     );
   });
@@ -869,7 +869,7 @@ describe('SessionRepository.update', () => {
     const data = createSessionData({ worktree_id: worktree.worktree_id });
     const created = await repo.create(data);
 
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     const updated = await repo.update(data.session_id!, { title: 'Updated' });
 
@@ -979,7 +979,7 @@ describe('SessionRepository.findRunning', () => {
     const running = await repo.findRunning();
 
     expect(running).toHaveLength(2);
-    running.forEach(session => {
+    running.forEach((session) => {
       expect(session.status).toBe(SessionStatus.RUNNING);
     });
   });
@@ -1091,7 +1091,7 @@ describe('SessionRepository edge cases', () => {
 
     const children = await repo.findChildren(root.session_id);
     expect(children).toHaveLength(2);
-    expect(children.map(c => c.session_id).sort()).toEqual(
+    expect(children.map((c) => c.session_id).sort()).toEqual(
       [child1.session_id, child2.session_id].sort()
     );
   });

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -41,13 +41,13 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       created_by: row.created_by,
       worktree_id: row.worktree_id as UUID,
       ...row.data,
-      tasks: row.data.tasks.map(id => id as UUID),
+      tasks: row.data.tasks.map((id) => id as UUID),
       genealogy: {
         parent_session_id: row.parent_session_id as UUID | undefined,
         forked_from_session_id: row.forked_from_session_id as UUID | undefined,
         fork_point_task_id: genealogyData.fork_point_task_id as UUID | undefined,
         spawn_point_task_id: genealogyData.spawn_point_task_id as UUID | undefined,
-        children: genealogyData.children.map(id => id as UUID),
+        children: genealogyData.children.map((id) => id as UUID),
       },
       permission_config: row.data.permission_config,
       scheduled_run_at: row.scheduled_run_at ?? undefined,
@@ -147,7 +147,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       throw new AmbiguousIdError(
         'Session',
         id,
-        results.map(r => formatShortId(r.session_id as UUID))
+        results.map((r) => formatShortId(r.session_id as UUID))
       );
     }
 
@@ -211,7 +211,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   async findAll(): Promise<Session[]> {
     try {
       const rows = await this.db.select().from(sessions).all();
-      return rows.map(row => this.rowToSession(row));
+      return rows.map((row) => this.rowToSession(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all sessions: ${error instanceof Error ? error.message : String(error)}`,
@@ -227,7 +227,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
     try {
       const rows = await this.db.select().from(sessions).where(eq(sessions.status, status)).all();
 
-      return rows.map(row => this.rowToSession(row));
+      return rows.map((row) => this.rowToSession(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find sessions by status: ${error instanceof Error ? error.message : String(error)}`,
@@ -249,7 +249,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         .where(eq(sessions.board_id, boardId))
         .all();
 
-      return rows.map(row => this.rowToSession(row));
+      return rows.map((row) => this.rowToSession(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find sessions by board: ${error instanceof Error ? error.message : String(error)}`,
@@ -277,7 +277,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         )
         .all();
 
-      return rows.map(row => this.rowToSession(row));
+      return rows.map((row) => this.rowToSession(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find child sessions: ${error instanceof Error ? error.message : String(error)}`,
@@ -345,7 +345,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
 
       // Use transaction to make read-merge-write atomic
       // This prevents race conditions where another update happens between read and write
-      return await this.db.transaction(async tx => {
+      return await this.db.transaction(async (tx) => {
         // STEP 1: Read current session (within transaction)
         const currentRow = await tx
           .select()
@@ -434,10 +434,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
    */
   async count(): Promise<number> {
     try {
-      const result = await this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(sessions)
-        .get();
+      const result = await this.db.select({ count: sql<number>`count(*)` }).from(sessions).get();
 
       return result?.count ?? 0;
     } catch (error) {

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -110,7 +110,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       throw new AmbiguousIdError(
         'Task',
         id,
-        results.map(r => formatShortId(r.task_id as UUID))
+        results.map((r) => formatShortId(r.task_id as UUID))
       );
     }
 
@@ -151,19 +151,21 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         return [];
       }
 
-      const inserts = taskList.map(task => this.taskToInsert(task));
+      const inserts = taskList.map((task) => this.taskToInsert(task));
 
       // Bulk insert all tasks
       await this.db.insert(tasks).values(inserts);
 
       // Retrieve all inserted tasks
-      const taskIds = inserts.map(t => t.task_id);
+      const taskIds = inserts.map((t) => t.task_id);
       const rows = await this.db
         .select()
         .from(tasks)
-        .where(sql`${tasks.task_id} IN ${sql.raw(`(${taskIds.map(id => `'${id}'`).join(',')})`)}`);
+        .where(
+          sql`${tasks.task_id} IN ${sql.raw(`(${taskIds.map((id) => `'${id}'`).join(',')})`)}`
+        );
 
-      return rows.map(row => this.rowToTask(row));
+      return rows.map((row) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to bulk create tasks: ${error instanceof Error ? error.message : String(error)}`,
@@ -197,7 +199,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   async findAll(): Promise<Task[]> {
     try {
       const rows = await this.db.select().from(tasks).all();
-      return rows.map(row => this.rowToTask(row));
+      return rows.map((row) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all tasks: ${error instanceof Error ? error.message : String(error)}`,
@@ -218,7 +220,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         .orderBy(tasks.created_at)
         .all();
 
-      return rows.map(row => this.rowToTask(row));
+      return rows.map((row) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find tasks by session: ${error instanceof Error ? error.message : String(error)}`,
@@ -238,7 +240,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         .where(eq(tasks.status, TaskStatus.RUNNING))
         .all();
 
-      return rows.map(row => this.rowToTask(row));
+      return rows.map((row) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find running tasks: ${error instanceof Error ? error.message : String(error)}`,
@@ -256,12 +258,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       const rows = await this.db
         .select()
         .from(tasks)
-        .where(
-          sql`${tasks.status} IN ('running', 'stopping', 'awaiting_permission')`
-        )
+        .where(sql`${tasks.status} IN ('running', 'stopping', 'awaiting_permission')`)
         .all();
 
-      return rows.map(row => this.rowToTask(row));
+      return rows.map((row) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find orphaned tasks: ${error instanceof Error ? error.message : String(error)}`,
@@ -277,7 +277,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     try {
       const rows = await this.db.select().from(tasks).where(eq(tasks.status, status)).all();
 
-      return rows.map(row => this.rowToTask(row));
+      return rows.map((row) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(
         `Failed to find tasks by status: ${error instanceof Error ? error.message : String(error)}`,
@@ -297,7 +297,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       const fullId = await this.resolveId(id);
 
       // Use transaction to make read-merge-write atomic
-      return await this.db.transaction(async tx => {
+      return await this.db.transaction(async (tx) => {
         // STEP 1: Read current task (within transaction)
         const currentRow = await tx.select().from(tasks).where(eq(tasks.task_id, fullId)).get();
 

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -139,7 +139,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
       throw new AmbiguousIdError(
         'Worktree',
         prefix,
-        matches.map(m => formatShortId(m.worktree_id as UUID))
+        matches.map((m) => formatShortId(m.worktree_id as UUID))
       );
     }
 
@@ -170,7 +170,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
       .from(worktrees)
       .where(conditions.length > 0 ? and(...conditions) : undefined);
 
-    return rows.map(row => this.rowToWorktree(row));
+    return rows.map((row) => this.rowToWorktree(row));
   }
 
   /**
@@ -187,7 +187,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
     }
 
     // Use transaction to make read-merge-write atomic
-    return await this.db.transaction(async tx => {
+    return await this.db.transaction(async (tx) => {
       // STEP 2: Re-read within transaction to ensure we have latest data
       const currentRow = await tx
         .select()

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -123,7 +123,7 @@ export const sessions = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     statusIdx: index('sessions_status_idx').on(table.status),
     agenticToolIdx: index('sessions_agentic_tool_idx').on(table.agentic_tool),
     boardIdx: index('sessions_board_idx').on(table.board_id),
@@ -188,7 +188,7 @@ export const tasks = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     sessionIdx: index('tasks_session_idx').on(table.session_id),
     statusIdx: index('tasks_status_idx').on(table.status),
     createdIdx: index('tasks_created_idx').on(table.created_at),
@@ -243,7 +243,7 @@ export const messages = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     // Indexes for efficient lookups
     sessionIdx: index('messages_session_id_idx').on(table.session_id),
     taskIdx: index('messages_task_id_idx').on(table.task_id),
@@ -281,7 +281,7 @@ export const boards = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     nameIdx: index('boards_name_idx').on(table.name),
     slugIdx: index('boards_slug_idx').on(table.slug),
   })
@@ -319,7 +319,7 @@ export const repos = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     slugIdx: index('repos_slug_idx').on(table.slug),
   })
 );
@@ -441,7 +441,7 @@ export const worktrees = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     repoIdx: index('worktrees_repo_idx').on(table.repo_id),
     nameIdx: index('worktrees_name_idx').on(table.name),
     refIdx: index('worktrees_ref_idx').on(table.ref),
@@ -551,7 +551,7 @@ export const users = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     emailIdx: index('users_email_idx').on(table.email),
   })
 );
@@ -631,7 +631,7 @@ export const mcpServers = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     nameIdx: index('mcp_servers_name_idx').on(table.name),
     scopeIdx: index('mcp_servers_scope_idx').on(table.scope),
     ownerIdx: index('mcp_servers_owner_idx').on(table.owner_user_id),
@@ -673,7 +673,7 @@ export const boardObjects = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     boardIdx: index('board_objects_board_idx').on(table.board_id),
     worktreeIdx: index('board_objects_worktree_idx').on(table.worktree_id),
   })
@@ -697,7 +697,7 @@ export const sessionMcpServers = sqliteTable(
     enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
     added_at: integer('added_at', { mode: 'timestamp_ms' }).notNull(),
   },
-  table => ({
+  (table) => ({
     // Composite primary key
     pk: index('session_mcp_servers_pk').on(table.session_id, table.mcp_server_id),
     // Indexes for queries
@@ -787,7 +787,7 @@ export const boardComments = sqliteTable(
       }>()
       .notNull(),
   },
-  table => ({
+  (table) => ({
     boardIdx: index('board_comments_board_idx').on(table.board_id),
     sessionIdx: index('board_comments_session_idx').on(table.session_id),
     taskIdx: index('board_comments_task_idx').on(table.task_id),

--- a/packages/core/src/db/scripts/test-integration.test.ts
+++ b/packages/core/src/db/scripts/test-integration.test.ts
@@ -275,11 +275,7 @@ describe('Session Repository Integration', () => {
 
     const repo = new SessionRepository(db);
 
-    const tools: Array<'claude-code' | 'codex' | 'gemini'> = [
-      'claude-code',
-      'codex',
-      'gemini',
-    ];
+    const tools: Array<'claude-code' | 'codex' | 'gemini'> = ['claude-code', 'codex', 'gemini'];
 
     for (const tool of tools) {
       const session = await repo.create({

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -129,11 +129,17 @@ export async function cloneRepo(options: CloneOptions): Promise<CloneResult> {
   // Inject token into URL for reliability (credential helper is also configured as backup)
   if (options.env?.GITHUB_TOKEN && cloneUrl.startsWith('https://github.com/')) {
     const token = options.env.GITHUB_TOKEN;
-    cloneUrl = cloneUrl.replace('https://github.com/', `https://x-access-token:${token}@github.com/`);
+    cloneUrl = cloneUrl.replace(
+      'https://github.com/',
+      `https://x-access-token:${token}@github.com/`
+    );
     console.debug('🔑 Injected GITHUB_TOKEN into URL');
   } else if (options.env?.GH_TOKEN && cloneUrl.startsWith('https://github.com/')) {
     const token = options.env.GH_TOKEN;
-    cloneUrl = cloneUrl.replace('https://github.com/', `https://x-access-token:${token}@github.com/`);
+    cloneUrl = cloneUrl.replace(
+      'https://github.com/',
+      `https://x-access-token:${token}@github.com/`
+    );
     console.debug('🔑 Injected GH_TOKEN into URL');
   }
 
@@ -274,7 +280,7 @@ export async function isClean(repoPath: string): Promise<boolean> {
 export async function getRemoteUrl(repoPath: string, remote: string = 'origin'): Promise<string> {
   const git = createGit(repoPath);
   const remotes = await git.getRemotes(true);
-  const remoteObj = remotes.find(r => r.name === remote);
+  const remoteObj = remotes.find((r) => r.name === remote);
   return remoteObj?.refs.fetch || '';
 }
 
@@ -484,7 +490,9 @@ export async function getRemoteBranches(
 ): Promise<string[]> {
   const git = createGit(repoPath);
   const branches = await git.branch(['-r']);
-  return branches.all.filter(b => b.startsWith(`${remote}/`)).map(b => b.replace(`${remote}/`, ''));
+  return branches.all
+    .filter((b) => b.startsWith(`${remote}/`))
+    .map((b) => b.replace(`${remote}/`, ''));
 }
 
 /**

--- a/packages/core/src/permissions/permission-service.test.ts
+++ b/packages/core/src/permissions/permission-service.test.ts
@@ -102,13 +102,13 @@ describe('PermissionService.emitRequest', () => {
     const sessionId = 'session-789' as SessionID;
     const tools = ['Bash', 'Write', 'Edit', 'Read', 'Glob'];
 
-    tools.forEach(toolName => {
+    tools.forEach((toolName) => {
       const request = createRequest({ toolName });
       service.emitRequest(sessionId, request);
     });
 
     expect(emitEvent).toHaveBeenCalledTimes(tools.length);
-    expect(emitEvent.mock.calls.map(c => (c[1] as PermissionRequest).toolName)).toEqual(tools);
+    expect(emitEvent.mock.calls.map((c) => (c[1] as PermissionRequest).toolName)).toEqual(tools);
   });
 
   it('should preserve all request fields', () => {

--- a/packages/core/src/seed/dev-fixtures.ts
+++ b/packages/core/src/seed/dev-fixtures.ts
@@ -59,7 +59,7 @@ export async function seedDevFixtures(options: SeedOptions = {}): Promise<SeedRe
 
     // Find the test-worktree
     const worktrees = await worktreeRepo.findAll({ repo_id: existing.repo_id });
-    const testWorktree = worktrees.find(w => w.name === 'test-worktree');
+    const testWorktree = worktrees.find((w) => w.name === 'test-worktree');
 
     return {
       repo_id: existing.repo_id,

--- a/packages/core/src/tools/base/tool.interface.ts
+++ b/packages/core/src/tools/base/tool.interface.ts
@@ -11,7 +11,7 @@
  * - Don't split into Client/Session unless runtime separation is clear
  */
 
-import type { Message, Session } from '../../types';
+import type { Message } from '../../types';
 import type { NormalizedSdkResponse, RawSdkResponse } from '../../types/sdk-response';
 import type {
   CreateSessionConfig,

--- a/packages/core/src/tools/claude/claude-tool.ts
+++ b/packages/core/src/tools/claude/claude-tool.ts
@@ -24,19 +24,17 @@ import {
   type Message,
   type MessageID,
   MessageRole,
-  type Session,
   type SessionID,
   type TaskID,
   TaskStatus,
 } from '../../types';
-import { calculateModelContextWindowUsage } from '../../utils/context-window';
-import type { TokenUsage } from '../../utils/pricing';
-import { calculateTokenCost } from '../../utils/pricing';
 import type {
   ClaudeCodeSdkResponse,
   NormalizedSdkResponse,
   RawSdkResponse,
 } from '../../types/sdk-response';
+import { calculateModelContextWindowUsage } from '../../utils/context-window';
+import type { TokenUsage } from '../../utils/pricing';
 import type { ImportOptions, ITool, SessionData, ToolCapabilities } from '../base';
 import { loadClaudeSession } from './import/load-session';
 import { transcriptsToMessages } from './import/message-converter';
@@ -49,7 +47,6 @@ import {
 } from './message-builder';
 import type { ProcessedEvent } from './message-processor';
 import { ClaudePromptService } from './prompt-service';
-import { safeCreateMessage } from './safe-message-service';
 
 /**
  * Service interface for creating messages via FeathersJS
@@ -315,7 +312,7 @@ export class ClaudeTool implements ITool {
 
         // Emit to streaming callbacks for message-level UI updates
         // Thinking blocks are part of assistant messages, but tracked separately
-        if (streamingCallbacks && streamingCallbacks.onThinkingChunk) {
+        if (streamingCallbacks?.onThinkingChunk) {
           // Start thinking stream if needed (separate from text stream)
           if (!currentThinkingMessageId) {
             currentThinkingMessageId = generateId() as MessageID;
@@ -339,7 +336,7 @@ export class ClaudeTool implements ITool {
 
       // Handle thinking complete
       if (event.type === 'thinking_complete') {
-        if (streamingCallbacks && streamingCallbacks.onThinkingEnd && currentThinkingMessageId) {
+        if (streamingCallbacks?.onThinkingEnd && currentThinkingMessageId) {
           streamingCallbacks.onThinkingEnd(currentThinkingMessageId);
           // Keep ID around for potential merging with text message later
           // Don't reset to null - we may need it for the complete message
@@ -930,7 +927,8 @@ export class ClaudeTool implements ITool {
       tokenUsage: {
         inputTokens: tokenUsage.input_tokens || 0,
         outputTokens: tokenUsage.output_tokens || 0,
-        totalTokens: tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
+        totalTokens:
+          tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
         cacheReadTokens: tokenUsage.cache_read_tokens || 0,
         cacheCreationTokens: tokenUsage.cache_creation_tokens || 0,
       },

--- a/packages/core/src/tools/claude/message-builder.ts
+++ b/packages/core/src/tools/claude/message-builder.ts
@@ -135,7 +135,7 @@ export async function createAssistantMessage(
   tokenUsage?: TokenUsage
 ): Promise<Message> {
   // Extract text content for preview
-  const textBlocks = content.filter(b => b.type === 'text').map(b => b.text || '');
+  const textBlocks = content.filter((b) => b.type === 'text').map((b) => b.text || '');
   const fullTextContent = textBlocks.join('');
   const contentPreview = fullTextContent.substring(0, 200);
 
@@ -181,13 +181,13 @@ function extractContentPreview(
   }>
 ): string {
   // For system_status blocks, return status-specific preview
-  const statusBlock = content.find(b => b.type === 'system_status');
+  const statusBlock = content.find((b) => b.type === 'system_status');
   if (statusBlock?.status === 'compacting') {
     return 'Compacting conversation context...';
   }
 
   // For text blocks, return text preview
-  const textBlocks = content.filter(b => b.type === 'text').map(b => b.text || '');
+  const textBlocks = content.filter((b) => b.type === 'text').map((b) => b.text || '');
   const fullTextContent = textBlocks.join('');
   return fullTextContent.substring(0, 200);
 }

--- a/packages/core/src/tools/claude/message-processor.ts
+++ b/packages/core/src/tools/claude/message-processor.ts
@@ -462,7 +462,7 @@ export class SDKMessageProcessor {
       const blockIndex = event.index;
 
       // Find the block that just completed
-      const completedBlock = this.state.contentBlockStack.find(b => b.index === blockIndex);
+      const completedBlock = this.state.contentBlockStack.find((b) => b.index === blockIndex);
 
       if (completedBlock?.type === 'tool_use') {
         console.debug(`🏁 Tool complete: ${completedBlock.toolName} (${completedBlock.toolUseId})`);
@@ -483,7 +483,7 @@ export class SDKMessageProcessor {
 
       // Remove from stack
       this.state.contentBlockStack = this.state.contentBlockStack.filter(
-        b => b.index !== blockIndex
+        (b) => b.index !== blockIndex
       );
     }
 
@@ -675,8 +675,8 @@ export class SDKMessageProcessor {
     }>
   ): Array<{ id: string; name: string; input: Record<string, unknown> }> {
     return contentBlocks
-      .filter(block => block.type === 'tool_use' && block.id && block.name && block.input)
-      .map(block => ({
+      .filter((block) => block.type === 'tool_use' && block.id && block.name && block.input)
+      .map((block) => ({
         id: block.id!,
         name: block.name!,
         input: block.input!,

--- a/packages/core/src/tools/claude/permissions/permission-hooks.ts
+++ b/packages/core/src/tools/claude/permissions/permission-hooks.ts
@@ -13,7 +13,6 @@ import type { Message, MessageID, SessionID, TaskID } from '../../../types';
 import { MessageRole, PermissionScope, PermissionStatus, TaskStatus } from '../../../types';
 import type { MessagesService, SessionsService, TasksService } from '../claude-tool';
 
-
 /**
  * Create canUseTool callback for permission handling
  *
@@ -68,7 +67,7 @@ export function createCanUseToolCallback(
 
       // STEP 2: Create lock for this permission check
       console.log(`🔒 [canUseTool] Requesting permission for ${toolName}...`);
-      const newLock = new Promise<void>(resolve => {
+      const newLock = new Promise<void>((resolve) => {
         releaseLock = resolve;
       });
       deps.permissionLocks.set(sessionId, newLock);
@@ -269,7 +268,9 @@ export function createCanUseToolCallback(
       if (releaseLock) {
         releaseLock();
         deps.permissionLocks.delete(sessionId);
-        console.log(`🔓 [canUseTool] Released permission lock for session ${sessionId.substring(0, 8)}`);
+        console.log(
+          `🔓 [canUseTool] Released permission lock for session ${sessionId.substring(0, 8)}`
+        );
       }
     }
   };

--- a/packages/core/src/tools/claude/prompt-service.ts
+++ b/packages/core/src/tools/claude/prompt-service.ts
@@ -186,7 +186,7 @@ export class ClaudePromptService {
         }
 
         // If we got an end event, break the outer loop
-        if (events.some(e => e.type === 'end')) {
+        if (events.some((e) => e.type === 'end')) {
           break;
         }
       }

--- a/packages/core/src/tools/claude/safe-message-service.ts
+++ b/packages/core/src/tools/claude/safe-message-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { isForeignKeyConstraintError } from '../../db/session-guard';
-import type { Message, SessionID } from '../../types';
+import type { Message } from '../../types';
 import type { MessagesService } from './claude-tool';
 
 /**

--- a/packages/core/src/tools/codex/codex-tool.ts
+++ b/packages/core/src/tools/codex/codex-tool.ts
@@ -19,20 +19,18 @@ import {
   type MessageID,
   MessageRole,
   type PermissionMode,
-  type Session,
   type SessionID,
   type TaskID,
 } from '../../types';
-import type { TokenUsage } from '../../utils/pricing';
-import { calculateTokenCost } from '../../utils/pricing';
 import type {
   CodexSdkResponse,
   NormalizedSdkResponse,
   RawSdkResponse,
 } from '../../types/sdk-response';
+import type { TokenUsage } from '../../utils/pricing';
 import type { ITool, StreamingCallbacks, ToolCapabilities } from '../base';
 import type { MessagesService, TasksService } from '../claude/claude-tool';
-import { DEFAULT_CODEX_MODEL, getCodexContextWindowLimit } from './models';
+import { DEFAULT_CODEX_MODEL } from './models';
 import { CodexPromptService } from './prompt-service';
 
 interface CodexExecutionResult {
@@ -62,7 +60,7 @@ export class CodexTool implements ITool {
     apiKey?: string,
     messagesService?: MessagesService,
     tasksService?: TasksService,
-    private db?: Database
+    db?: Database
   ) {
     this.messagesRepo = messagesRepo;
     this.sessionsRepo = sessionsRepo;
@@ -249,14 +247,14 @@ export class CodexTool implements ITool {
         // Filter out tool_use and tool_result blocks (already saved via tool_complete events)
         // But KEEP text blocks - these contain the response
         const textOnlyContent = event.content.filter(
-          block => block.type === 'text' // Only keep text blocks
+          (block) => block.type === 'text' // Only keep text blocks
         );
 
         // Only create message if there's text content (not just tools)
         if (textOnlyContent.length > 0) {
           // Extract full text for client-side streaming
           const _fullText = textOnlyContent
-            .map(block => (block as { text?: string }).text || '')
+            .map((block) => (block as { text?: string }).text || '')
             .join('');
 
           // Use existing message ID from streaming (if any) or generate new
@@ -359,7 +357,7 @@ export class CodexTool implements ITool {
     tokenUsage?: TokenUsage
   ): Promise<Message> {
     // Extract text content for preview
-    const textBlocks = content.filter(b => b.type === 'text').map(b => b.text || '');
+    const textBlocks = content.filter((b) => b.type === 'text').map((b) => b.text || '');
     const fullTextContent = textBlocks.join('');
     const contentPreview = fullTextContent.substring(0, 200);
 
@@ -430,8 +428,8 @@ export class CodexTool implements ITool {
     let capturedThreadId: string | undefined;
     let resolvedModel: string | undefined;
     let tokenUsage: TokenUsage | undefined;
-    let contextWindow: number | undefined;
-    let contextWindowLimit: number | undefined;
+    let _contextWindow: number | undefined;
+    let _contextWindowLimit: number | undefined;
 
     for await (const event of this.promptService.promptSessionStreaming(
       sessionId,
@@ -564,7 +562,8 @@ export class CodexTool implements ITool {
       tokenUsage: {
         inputTokens: tokenUsage.input_tokens || 0,
         outputTokens: tokenUsage.output_tokens || 0,
-        totalTokens: tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
+        totalTokens:
+          tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
         cacheReadTokens: 0, // Codex doesn't support caching
         cacheCreationTokens: 0, // Codex doesn't support caching
       },
@@ -574,5 +573,4 @@ export class CodexTool implements ITool {
       durationMs: codexResponse.durationMs,
     };
   }
-
 }

--- a/packages/core/src/tools/codex/prompt-service.ts
+++ b/packages/core/src/tools/codex/prompt-service.ts
@@ -13,7 +13,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { Codex, type Thread, type ThreadItem } from '@openai/codex-sdk';
-import { getCredential, resolveApiKey, resolveUserEnvironment } from '../../config';
+import { resolveApiKey, resolveUserEnvironment } from '../../config';
 import type { Database } from '../../db/client';
 import type { MessagesRepository } from '../../db/repositories/messages';
 import type { SessionMCPServerRepository } from '../../db/repositories/session-mcp-servers';
@@ -192,12 +192,12 @@ export class CodexPromptService {
 
     console.log(`📊 [Codex MCP] Found ${mcpServers.length} MCP server(s) for session`);
     if (mcpServers.length > 0) {
-      console.log(`   Servers: ${mcpServers.map(s => `${s.name} (${s.transport})`).join(', ')}`);
+      console.log(`   Servers: ${mcpServers.map((s) => `${s.name} (${s.transport})`).join(', ')}`);
     }
 
     // Filter MCP servers: Codex ONLY supports stdio transport (not HTTP/SSE)
-    const stdioServers = mcpServers.filter(s => s.transport === 'stdio');
-    const unsupportedServers = mcpServers.filter(s => s.transport !== 'stdio');
+    const stdioServers = mcpServers.filter((s) => s.transport === 'stdio');
+    const unsupportedServers = mcpServers.filter((s) => s.transport !== 'stdio');
 
     if (unsupportedServers.length > 0) {
       console.warn(
@@ -252,7 +252,7 @@ approval_policy = "${approvalPolicy}"
 ${networkAccessToml}${mcpServersToml}`;
 
     // Create hash to detect changes (include network access in hash)
-    const configHash = `${approvalPolicy}:${networkAccess}:${JSON.stringify(stdioServers.map(s => s.mcp_server_id))}`;
+    const configHash = `${approvalPolicy}:${networkAccess}:${JSON.stringify(stdioServers.map((s) => s.mcp_server_id))}`;
 
     // Skip if config hasn't changed (avoid unnecessary file I/O)
     if (this.lastMCPServersHash === configHash) {
@@ -284,7 +284,7 @@ ${networkAccessToml}${mcpServersToml}`;
     this.reinitializeCodex();
     if (stdioServers.length > 0) {
       console.log(
-        `✅ [Codex MCP] Configured ${stdioServers.length} STDIO MCP server(s): ${stdioServers.map(s => s.name).join(', ')}`
+        `✅ [Codex MCP] Configured ${stdioServers.length} STDIO MCP server(s): ${stdioServers.map((s) => s.name).join(', ')}`
       );
     }
 

--- a/packages/core/src/tools/gemini/conversation-converter.test.ts
+++ b/packages/core/src/tools/gemini/conversation-converter.test.ts
@@ -80,7 +80,7 @@ describe('convertConversationToHistory', () => {
       expect(history).toHaveLength(1);
       const firstMessage = history[0];
       expect(firstMessage).toBeDefined();
-      if (firstMessage && firstMessage.parts) {
+      if (firstMessage?.parts) {
         expect(firstMessage.parts).toHaveLength(2);
         expect(firstMessage.parts[0]).toEqual({ text: 'Text part' });
         expect(firstMessage.parts[1]).toHaveProperty('inlineData');
@@ -179,7 +179,7 @@ describe('convertConversationToHistory', () => {
 
       expect(history).toHaveLength(1);
       const msg = history[0];
-      if (msg && msg.parts) {
+      if (msg?.parts) {
         expect(msg.parts[0]).toEqual({ text: 'Valid message' });
       }
     });
@@ -224,7 +224,7 @@ describe('convertConversationToHistory', () => {
       // Should still include it since it has a 'text' property
       expect(history).toHaveLength(1);
       const msg = history[0];
-      if (msg && msg.parts) {
+      if (msg?.parts) {
         expect(msg.parts[0]).toEqual({ text: 123 });
       }
     });
@@ -244,7 +244,7 @@ describe('convertConversationToHistory', () => {
 
       expect(history).toHaveLength(1);
       const msg = history[0];
-      if (msg && msg.parts) {
+      if (msg?.parts) {
         expect(msg.parts[0]).toHaveProperty('text', 'Hello');
       }
     });
@@ -305,7 +305,7 @@ describe('convertConversationToHistory', () => {
       };
       const history = convertConversationToHistory(conversation);
 
-      expect(history.every(h => h.role === 'user')).toBe(true);
+      expect(history.every((h) => h.role === 'user')).toBe(true);
     });
 
     it('should always convert "gemini" type to "model" role', () => {
@@ -318,7 +318,7 @@ describe('convertConversationToHistory', () => {
       };
       const history = convertConversationToHistory(conversation);
 
-      expect(history.every(h => h.role === 'model')).toBe(true);
+      expect(history.every((h) => h.role === 'model')).toBe(true);
     });
   });
 
@@ -343,7 +343,7 @@ describe('convertConversationToHistory', () => {
 
       expect(history).toHaveLength(1);
       const msg = history[0];
-      if (msg && msg.parts) {
+      if (msg?.parts) {
         expect(msg.parts[0]).toHaveProperty('functionCall');
       }
     });
@@ -368,7 +368,7 @@ describe('convertConversationToHistory', () => {
 
       expect(history).toHaveLength(1);
       const msg = history[0];
-      if (msg && msg.parts) {
+      if (msg?.parts) {
         expect(msg.parts[0]).toHaveProperty('functionResponse');
       }
     });
@@ -390,7 +390,7 @@ describe('convertConversationToHistory', () => {
 
       expect(history).toHaveLength(1);
       const msg = history[0];
-      if (msg && msg.parts) {
+      if (msg?.parts) {
         expect(msg.parts).toHaveLength(3);
         expect(msg.parts[0]).toHaveProperty('text');
         expect(msg.parts[1]).toHaveProperty('inlineData');

--- a/packages/core/src/tools/gemini/gemini-tool.ts
+++ b/packages/core/src/tools/gemini/gemini-tool.ts
@@ -23,20 +23,18 @@ import {
   type MessageID,
   MessageRole,
   type PermissionMode,
-  type Session,
   type SessionID,
   type TaskID,
 } from '../../types';
-import type { ITool, StreamingCallbacks, ToolCapabilities } from '../base';
-import type { MessagesService, TasksService } from '../claude/claude-tool';
-import type { TokenUsage } from '../../utils/pricing';
-import { calculateTokenCost } from '../../utils/pricing';
 import type {
   GeminiSdkResponse,
   NormalizedSdkResponse,
   RawSdkResponse,
 } from '../../types/sdk-response';
-import { DEFAULT_GEMINI_MODEL, getGeminiContextWindowLimit } from './models';
+import type { TokenUsage } from '../../utils/pricing';
+import type { ITool, StreamingCallbacks, ToolCapabilities } from '../base';
+import type { MessagesService, TasksService } from '../claude/claude-tool';
+import { DEFAULT_GEMINI_MODEL } from './models';
 import { GeminiPromptService } from './prompt-service';
 
 interface GeminiExecutionResult {
@@ -64,7 +62,7 @@ export class GeminiTool implements ITool {
     mcpServerRepo?: MCPServerRepository,
     sessionMCPRepo?: SessionMCPServerRepository,
     mcpEnabled?: boolean,
-    private db?: Database
+    db?: Database
   ) {
     if (messagesRepo && sessionsRepo) {
       this.promptService = new GeminiPromptService(
@@ -353,8 +351,8 @@ export class GeminiTool implements ITool {
     const assistantMessageIds: MessageID[] = [];
     let resolvedModel: string | undefined;
     let tokenUsage: TokenUsage | undefined;
-    let contextWindow: number | undefined;
-    let contextWindowLimit: number | undefined;
+    let _contextWindow: number | undefined;
+    let _contextWindowLimit: number | undefined;
 
     for await (const event of this.promptService.promptSessionStreaming(
       sessionId,
@@ -482,7 +480,8 @@ export class GeminiTool implements ITool {
       tokenUsage: {
         inputTokens: tokenUsage.input_tokens || 0,
         outputTokens: tokenUsage.output_tokens || 0,
-        totalTokens: tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
+        totalTokens:
+          tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
         cacheReadTokens: tokenUsage.cache_read_tokens || 0,
         cacheCreationTokens: 0, // Not exposed in Gemini response yet
       },
@@ -491,5 +490,4 @@ export class GeminiTool implements ITool {
       model: geminiResponse.model,
     };
   }
-
 }

--- a/packages/core/src/tools/gemini/prompt-service.test.ts
+++ b/packages/core/src/tools/gemini/prompt-service.test.ts
@@ -1,4 +1,3 @@
-import { ApprovalMode, AuthType } from '@google/gemini-cli-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Database } from '../../db/client';
 import type { MCPServerRepository } from '../../db/repositories/mcp-servers';
@@ -6,7 +5,7 @@ import type { MessagesRepository } from '../../db/repositories/messages';
 import type { SessionMCPServerRepository } from '../../db/repositories/session-mcp-servers';
 import type { SessionRepository } from '../../db/repositories/sessions';
 import type { WorktreeRepository } from '../../db/repositories/worktrees';
-import type { PermissionMode, SessionID, TaskID } from '../../types';
+import type { SessionID } from '../../types';
 import { GeminiPromptService } from './prompt-service';
 
 describe('GeminiPromptService', () => {

--- a/packages/core/src/tools/gemini/prompt-service.ts
+++ b/packages/core/src/tools/gemini/prompt-service.ts
@@ -14,7 +14,6 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
-  ApprovalMode,
   AuthType,
   Config,
   executeToolCall,
@@ -23,7 +22,7 @@ import {
   MCPServerConfig,
   type ResumedSessionData,
 } from '@google/gemini-cli-core';
-import type { Content, Part } from '@google/genai';
+import type { Part } from '@google/genai';
 import { getDaemonUrl, resolveApiKey, resolveUserEnvironment } from '../../config';
 import type { Database } from '../../db/client';
 import type { MCPServerRepository } from '../../db/repositories/mcp-servers';
@@ -472,7 +471,7 @@ export class GeminiPromptService {
       // Find session file matching pattern: session-*-{sessionId-first8}.json
       const sessionIdShort = sessionId.slice(0, 8);
       const files = await fs.readdir(chatsDir);
-      const sessionFile = files.find(f => f.includes(sessionIdShort) && f.endsWith('.json'));
+      const sessionFile = files.find((f) => f.includes(sessionIdShort) && f.endsWith('.json'));
 
       if (!sessionFile) {
         console.debug(`No session file found for ${sessionId} (looking for *${sessionIdShort}*)`);

--- a/packages/core/src/tools/opencode/client.ts
+++ b/packages/core/src/tools/opencode/client.ts
@@ -274,7 +274,10 @@ export class OpenCodeClient {
       try {
         data = await response.json();
         // Log summary instead of full response to avoid log truncation
-        console.log('[OpenCode] Response received (keys):', data && typeof data === 'object' ? Object.keys(data) : typeof data);
+        console.log(
+          '[OpenCode] Response received (keys):',
+          data && typeof data === 'object' ? Object.keys(data) : typeof data
+        );
       } catch (parseError) {
         // If response body is empty or not JSON, return success message
         const text = await response.text();
@@ -308,12 +311,12 @@ export class OpenCodeClient {
 
           // Extract text parts
           const textParts = parts
-            .filter(part => part.type === 'text' && typeof part.text === 'string')
-            .map(part => part.text as string);
+            .filter((part) => part.type === 'text' && typeof part.text === 'string')
+            .map((part) => part.text as string);
           text = textParts.join('\n');
 
           // Extract metadata from step-finish part
-          const stepFinish = parts.find(part => part.type === 'step-finish');
+          const stepFinish = parts.find((part) => part.type === 'step-finish');
           if (stepFinish) {
             if (typeof stepFinish.cost === 'number') {
               metadata.cost = stepFinish.cost;

--- a/packages/core/src/tools/opencode/index.ts
+++ b/packages/core/src/tools/opencode/index.ts
@@ -5,12 +5,11 @@
  * Supports 75+ LLM providers with privacy-first architecture.
  */
 
-export { OpenCodeClient } from './client';
 export type {
   OpenCodeConfig,
   OpenCodeMessageEvent,
   OpenCodeSession,
 } from './client';
-
-export { OpenCodeTool } from './opencode-tool';
+export { OpenCodeClient } from './client';
 export type { OpenCodeConfig as OpenCodeToolConfig } from './opencode-tool';
+export { OpenCodeTool } from './opencode-tool';

--- a/packages/core/src/tools/opencode/opencode-tool.ts
+++ b/packages/core/src/tools/opencode/opencode-tool.ts
@@ -13,7 +13,7 @@
  */
 
 import { generateId } from '../../lib/ids';
-import type { Message, Session, SessionID, TaskID } from '../../types';
+import type { Message, SessionID, TaskID } from '../../types';
 import { MessageRole } from '../../types';
 import type {
   NormalizedSdkResponse,
@@ -246,14 +246,16 @@ export class OpenCodeTool implements ITool {
           },
         ],
         // Store OpenCode metadata
-        metadata: response.metadata ? {
-          opencode: {
-            messageId: response.metadata.messageId,
-            parentMessageId: response.metadata.parentMessageId,
-            cost: response.metadata.cost,
-            tokens: response.metadata.tokens,
-          },
-        } : undefined,
+        metadata: response.metadata
+          ? {
+              opencode: {
+                messageId: response.metadata.messageId,
+                parentMessageId: response.metadata.parentMessageId,
+                cost: response.metadata.cost,
+                tokens: response.metadata.tokens,
+              },
+            }
+          : undefined,
       });
 
       console.log('[OpenCodeTool] Message created:', message);
@@ -326,7 +328,7 @@ export class OpenCodeTool implements ITool {
     try {
       const sessions = await client.listSessions();
 
-      return sessions.map(session => ({
+      return sessions.map((session) => ({
         sessionId: session.id,
         toolType: 'opencode' as const,
         status: 'active' as const,
@@ -369,12 +371,12 @@ export class OpenCodeTool implements ITool {
       tokenUsage: {
         inputTokens: tokenUsage.input_tokens || 0,
         outputTokens: tokenUsage.output_tokens || 0,
-        totalTokens: tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
+        totalTokens:
+          tokenUsage.total_tokens || tokenUsage.input_tokens! + tokenUsage.output_tokens! || 0,
         cacheReadTokens: 0, // OpenCode caching TBD
         cacheCreationTokens: 0, // OpenCode caching TBD
       },
       model: opencodeResponse.model,
     };
   }
-
 }

--- a/packages/core/src/types/sdk-response.ts
+++ b/packages/core/src/types/sdk-response.ts
@@ -5,8 +5,8 @@
  * They are stored in tasks.raw_sdk_response for debugging and auditing.
  */
 
-import type { MessageID } from './id';
 import type { TokenUsage } from '../utils/pricing';
+import type { MessageID } from './id';
 
 // ============================================================================
 // Claude Code SDK Response (from Anthropic Claude Agent SDK)

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -1,10 +1,5 @@
+import type { CodexApprovalPolicy, CodexNetworkAccess, CodexSandboxMode } from './agentic-tool';
 import type { UserID } from './id';
-import type {
-  AgenticToolName,
-  CodexApprovalPolicy,
-  CodexNetworkAccess,
-  CodexSandboxMode,
-} from './agentic-tool';
 import type { PermissionMode } from './session';
 
 /**

--- a/packages/core/src/utils/context-window.ts
+++ b/packages/core/src/utils/context-window.ts
@@ -156,11 +156,7 @@ export function getSessionContextUsage(
     const task = tasks[i];
     const sdkResponse = task.raw_sdk_response;
     // Only Claude, Codex, and Gemini provide contextWindow (OpenCode doesn't)
-    if (
-      sdkResponse &&
-      'contextWindow' in sdkResponse &&
-      sdkResponse.contextWindow !== undefined
-    ) {
+    if (sdkResponse && 'contextWindow' in sdkResponse && sdkResponse.contextWindow !== undefined) {
       return sdkResponse.contextWindow;
     }
   }

--- a/packages/core/src/utils/cron.ts
+++ b/packages/core/src/utils/cron.ts
@@ -21,7 +21,7 @@ export function isValidCron(cronExpression: string): boolean {
       tz: 'UTC',
     });
     return true;
-  } catch (error) {
+  } catch (_error) {
     return false;
   }
 }

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -13,7 +13,10 @@
  * Base class for all Agor errors
  */
 export class AgorError extends Error {
-  constructor(message: string, public readonly code?: string) {
+  constructor(
+    message: string,
+    public readonly code?: string
+  ) {
     super(message);
     this.name = this.constructor.name;
     // Maintains proper stack trace for where our error was thrown (only available on V8)
@@ -50,7 +53,10 @@ export class AlreadyExistsError extends AgorError {
  * Thrown when validation fails
  */
 export class ValidationError extends AgorError {
-  constructor(message: string, public readonly field?: string) {
+  constructor(
+    message: string,
+    public readonly field?: string
+  ) {
     super(message, 'VALIDATION_ERROR');
   }
 }
@@ -103,7 +109,7 @@ export function formatUserError(error: unknown): string {
 
   // Remove sensitive details from error messages
   return message
-    .replace(/\/[\w\/]+\.ts:\d+/g, '[source]') // Remove file paths
+    .replace(/\/[\w/]+\.ts:\d+/g, '[source]') // Remove file paths
     .replace(/^Error: /, '') // Remove redundant "Error:" prefix
     .trim();
 }

--- a/packages/core/src/utils/path.test.ts
+++ b/packages/core/src/utils/path.test.ts
@@ -11,9 +11,7 @@ describe('expandPath', () => {
 
   it('expands file:~/ to file: + home directory', () => {
     expect(expandPath('file:~/foo')).toBe(`file:${join(homedir(), 'foo')}`);
-    expect(expandPath('file:~/.agor/agor.db')).toBe(
-      `file:${join(homedir(), '.agor', 'agor.db')}`
-    );
+    expect(expandPath('file:~/.agor/agor.db')).toBe(`file:${join(homedir(), '.agor', 'agor.db')}`);
   });
 
   it('returns absolute paths unchanged', () => {
@@ -44,9 +42,7 @@ describe('expandPath', () => {
 
 describe('extractDbFilePath', () => {
   it('extracts and expands file:~/ URLs', () => {
-    expect(extractDbFilePath('file:~/.agor/agor.db')).toBe(
-      join(homedir(), '.agor', 'agor.db')
-    );
+    expect(extractDbFilePath('file:~/.agor/agor.db')).toBe(join(homedir(), '.agor', 'agor.db'));
     expect(extractDbFilePath('file:~/foo/bar.db')).toBe(join(homedir(), 'foo', 'bar.db'));
   });
 

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,5 +1,4 @@
-import { copyFileSync, cpSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { cpSync } from 'node:fs';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Fixes the race condition during Docker container startup that caused transient `ENOENT` errors when the daemon tried to import from `@agor/core/dist` while it was being rebuilt.

## Problem

Previously, the daemon's `dev` script would start both `@agor/core` watch and the daemon via `concurrently`. The core watch would clean the `dist/` folder first, causing a race condition where the daemon tried to import from `dist/` during the rebuild window.

## Solution

1. **Start @agor/core watch mode explicitly** before starting the daemon
2. **Wait for dist/index.js to exist** using a while loop (prevents race condition)  
3. **Use dev:daemon-only script** to avoid duplicate core watch processes
4. **Cleanup both processes** on container exit

## Changes

- `docker/docker-entrypoint.sh`: Start core watch first, wait for build, then start daemon
- `apps/agor-daemon/src/services/scheduler.ts`: Fix TypeScript error (missing `db` property)
- Apply biome linting fixes across codebase

## Test Plan

```bash
docker compose -p test-fix down
docker compose -p test-fix up --build
```

Verify:
- No `ENOENT` errors during startup
- Daemon starts successfully after core build completes
- Hot reload works during development

🤖 Generated with [Claude Code](https://claude.com/claude-code)