### PR TITLE
fix: prevent user settings modal from reopening after save

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -610,6 +610,7 @@ export const App: React.FC<AppProps> = ({
         mcpServers={mcpServers}
         activeTab={effectiveSettingsTab}
         editUserId={settingsEditUserId}
+        onClearEditUserId={() => setSettingsEditUserId(undefined)}
         onTabChange={(newTab) => {
           setSettingsActiveTab(newTab);
           setSettingsEditUserId(undefined); // Clear editUserId when switching tabs

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -10,6 +10,7 @@ import {
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Badge, Button, Divider, Dropdown, Layout, Space, Tooltip, Typography, theme } from 'antd';
+import { useState } from 'react';
 import { ConnectionStatus } from '../ConnectionStatus';
 import { Facepile } from '../Facepile';
 import { ThemeSwitcher } from '../ThemeSwitcher';
@@ -58,6 +59,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 }) => {
   const { token } = theme.useToken();
   const userEmoji = user?.emoji || '👤';
+  const [userDropdownOpen, setUserDropdownOpen] = useState(false);
 
   const userMenuItems: MenuProps['items'] = [
     {
@@ -80,13 +82,19 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
       key: 'user-settings',
       label: 'User Settings',
       icon: <UserOutlined />,
-      onClick: onUserSettingsClick,
+      onClick: () => {
+        setUserDropdownOpen(false);
+        onUserSettingsClick?.();
+      },
     },
     {
       key: 'logout',
       label: 'Logout',
       icon: <LogoutOutlined />,
-      onClick: onLogout,
+      onClick: () => {
+        setUserDropdownOpen(false);
+        onLogout?.();
+      },
     },
   ];
 
@@ -205,7 +213,13 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             onClick={onSettingsClick}
           />
         </Tooltip>
-        <Dropdown menu={{ items: userMenuItems }} placement="bottomRight" trigger={['click']}>
+        <Dropdown
+          menu={{ items: userMenuItems }}
+          placement="bottomRight"
+          trigger={['click']}
+          open={userDropdownOpen}
+          onOpenChange={setUserDropdownOpen}
+        >
           <Tooltip title={user?.name || 'User menu'} placement="bottom">
             <Button type="text" icon={<UserOutlined style={{ fontSize: token.fontSizeLG }} />} />
           </Tooltip>

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -39,6 +39,7 @@ export interface SettingsModalProps {
   activeTab?: string; // Control which tab is shown when modal opens
   onTabChange?: (tabKey: string) => void;
   editUserId?: string; // Auto-open edit modal for this user (for "User Settings" shortcut)
+  onClearEditUserId?: () => void; // Callback to clear editUserId
   onCreateBoard?: (board: Partial<Board>) => void;
   onUpdateBoard?: (boardId: string, updates: Partial<Board>) => void;
   onDeleteBoard?: (boardId: string) => void;
@@ -91,6 +92,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   activeTab = 'boards',
   onTabChange,
   editUserId,
+  onClearEditUserId,
   onCreateBoard,
   onUpdateBoard,
   onDeleteBoard,
@@ -228,6 +230,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                 onUpdate={onUpdateUser}
                 onDelete={onDeleteUser}
                 editUserId={editUserId}
+                onClearEditUserId={onClearEditUserId}
               />
             ),
           },

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -38,6 +38,7 @@ interface UsersTableProps {
   onUpdate?: (userId: string, updates: UpdateUserInput) => void;
   onDelete?: (userId: string) => void;
   editUserId?: string; // Auto-open edit modal for this user
+  onClearEditUserId?: () => void; // Callback to clear editUserId in parent
 }
 
 export const UsersTable: React.FC<UsersTableProps> = ({
@@ -47,6 +48,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   onUpdate,
   onDelete,
   editUserId,
+  onClearEditUserId,
 }) => {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -206,6 +208,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         form.resetFields();
         setEditModalOpen(false);
         setEditingUser(null);
+        onClearEditUserId?.(); // Clear editUserId in parent to prevent reopening
       })
       .catch((err) => {
         console.error('Validation failed:', err);
@@ -340,6 +343,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       // Close modal after successful save
       setEditModalOpen(false);
       setEditingUser(null);
+      onClearEditUserId?.(); // Clear editUserId in parent to prevent reopening
     } catch (err) {
       console.error(`Failed to save ${tool} config:`, err);
       throw err;
@@ -383,11 +387,13 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         // API Keys tab - nothing to save (keys save individually)
         setEditModalOpen(false);
         setEditingUser(null);
+        onClearEditUserId?.(); // Clear editUserId in parent to prevent reopening
         break;
       case 'env-vars':
         // Env Vars tab - nothing to save (vars save individually)
         setEditModalOpen(false);
         setEditingUser(null);
+        onClearEditUserId?.(); // Clear editUserId in parent to prevent reopening
         break;
       case 'audio':
         await handleAudioSave();
@@ -421,6 +427,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
 
       setEditModalOpen(false);
       setEditingUser(null);
+      onClearEditUserId?.(); // Clear editUserId in parent to prevent reopening
     } catch (error) {
       console.error('Failed to save audio settings:', error);
     }
@@ -596,6 +603,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
           setEditModalOpen(false);
           setEditingUser(null);
           setActiveTab('general');
+          onClearEditUserId?.(); // Clear editUserId in parent to prevent reopening
         }}
         okText="Save"
         cancelText="Close"


### PR DESCRIPTION
## Summary

Fixed an issue where the User Settings modal would reopen immediately after saving changes. The bug was caused by the user dropdown menu remaining open after clicking "User Settings", which would trigger the modal to reopen on the next interaction.

## Changes

### AppHeader Component
- Added controlled state (`userDropdownOpen`) for the user dropdown menu
- Explicitly close dropdown when "User Settings" or "Logout" menu items are clicked
- Added `open` and `onOpenChange` props to the Dropdown component

### State Management Chain
- Added `onClearEditUserId` callback prop through App → SettingsModal → UsersTable
- Clear `editUserId` state when:
  - Modal closes (via Cancel or X button)
  - User data is saved successfully
  - Switching between tabs
  - After agentic config saves

## Technical Details

Both fixes work together to provide a complete solution:
1. **Dropdown control** (UI layer): Ensures dropdown closes immediately on menu item click
2. **State cleanup** (data layer): Prevents auto-reopen logic by clearing the `editUserId` trigger

## Test Plan

- [x] Open User Settings from navbar dropdown
- [x] Make changes and click Save
- [x] Verify modal closes and does not reopen
- [x] Verify ESC key still closes modal
- [x] Verify pnpm check passes (typecheck + lint + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)