### PR TITLE
feat(ui): move board switcher to navbar, separate drawer toggle

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -464,6 +464,10 @@ export const App: React.FC<AppProps> = ({
           ).length
         }
         eventStreamEnabled={eventStreamEnabled}
+        boards={mapToArray(boardById)}
+        currentBoardId={currentBoardId}
+        onBoardChange={setCurrentBoardId}
+        worktreeById={worktreeById}
       />
       <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
         <CommentsPanel

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,4 +1,4 @@
-import type { ActiveUser, User } from '@agor/core/types';
+import type { ActiveUser, Board, User, Worktree } from '@agor/core/types';
 import {
   ApiOutlined,
   CommentOutlined,
@@ -11,6 +11,7 @@ import {
 import type { MenuProps } from 'antd';
 import { Badge, Button, Divider, Dropdown, Layout, Space, Tooltip, Typography, theme } from 'antd';
 import { useState } from 'react';
+import { BoardSwitcher } from '../BoardSwitcher';
 import { ConnectionStatus } from '../ConnectionStatus';
 import { Facepile } from '../Facepile';
 import { ThemeSwitcher } from '../ThemeSwitcher';
@@ -36,6 +37,10 @@ export interface AppHeaderProps {
   currentBoardIcon?: string;
   unreadCommentsCount?: number;
   eventStreamEnabled?: boolean;
+  boards?: Board[];
+  currentBoardId?: string;
+  onBoardChange?: (boardId: string) => void;
+  worktreeById?: Map<string, Worktree>;
 }
 
 export const AppHeader: React.FC<AppHeaderProps> = ({
@@ -56,6 +61,10 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   currentBoardIcon,
   unreadCommentsCount = 0,
   eventStreamEnabled = false,
+  boards = [],
+  currentBoardId,
+  onBoardChange,
+  worktreeById = new Map(),
 }) => {
   const { token } = theme.useToken();
   const userEmoji = user?.emoji || '👤';
@@ -124,31 +133,23 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           agor
         </Title>
         <Divider type="vertical" style={{ height: 32, margin: '0 8px' }} />
+        {currentBoardId && boards.length > 0 && (
+          <div style={{ minWidth: 200 }}>
+            <BoardSwitcher
+              boards={boards}
+              currentBoardId={currentBoardId}
+              onBoardChange={onBoardChange || (() => {})}
+              worktreeById={worktreeById}
+            />
+          </div>
+        )}
         {currentBoardName && (
-          <Tooltip title="Toggle board drawer" placement="bottom">
-            <Space
-              size={8}
-              align="center"
-              style={{
-                cursor: 'pointer',
-                padding: '4px 8px',
-                borderRadius: token.borderRadius,
-                transition: 'background 0.2s',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = token.colorBgTextHover;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = 'transparent';
-              }}
+          <Tooltip title="Toggle session drawer" placement="bottom">
+            <Button
+              type="text"
+              icon={<MenuOutlined style={{ fontSize: token.fontSizeLG }} />}
               onClick={onMenuClick}
-            >
-              {currentBoardIcon && <span style={{ fontSize: 16 }}>{currentBoardIcon}</span>}
-              <Typography.Text style={{ color: token.colorTextSecondary, fontSize: 14 }}>
-                {currentBoardName}
-              </Typography.Text>
-              <MenuOutlined style={{ fontSize: token.fontSizeLG }} />
-            </Space>
+            />
           </Tooltip>
         )}
         {currentBoardName && (

--- a/apps/agor-ui/src/components/WorktreeListDrawer/WorktreeListDrawer.tsx
+++ b/apps/agor-ui/src/components/WorktreeListDrawer/WorktreeListDrawer.tsx
@@ -3,10 +3,8 @@ import { SearchOutlined } from '@ant-design/icons';
 import { Badge, Drawer, Input, List, Space, Typography, theme } from 'antd';
 import type React from 'react';
 import { useMemo, useState } from 'react';
-import { BoardSwitcher } from '../BoardSwitcher';
 import { ToolIcon } from '../ToolIcon';
 
-const { Title } = Typography;
 const { useToken } = theme;
 
 interface WorktreeListDrawerProps {
@@ -89,24 +87,6 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
         body: { padding: 0 },
       }}
     >
-      {/* Board Switcher Header */}
-      <div
-        style={{
-          padding: '16px 24px',
-          borderBottom: `1px solid ${token.colorBorder}`,
-        }}
-      >
-        <Title level={5} style={{ marginBottom: 8 }}>
-          Board
-        </Title>
-        <BoardSwitcher
-          boards={boards}
-          currentBoardId={currentBoardId}
-          onBoardChange={onBoardChange}
-          worktreeById={worktreeById}
-        />
-      </div>
-
       {/* Search Bar */}
       <div
         style={{


### PR DESCRIPTION
## Summary

Move the BoardSwitcher component from the session drawer to the main navbar for direct, always-visible board switching.

## Changes

### NavBar (AppHeader)
- **Added BoardSwitcher** - Dropdown menu with board emoji and worktree count badges
- **Separate drawer toggle** - New MenuOutlined button specifically for opening session drawer
- **Two distinct actions**: 
  1. Board switcher dropdown (board selection)
  2. Session drawer toggle (session navigation)

### Session Drawer (WorktreeListDrawer)  
- **Removed BoardSwitcher** - No longer shows board selector
- **Sessions-only focus** - Drawer now exclusively for session navigation
- Cleaner, simpler UI focused on one purpose

### Benefits
- ✅ **Faster board switching** - Direct access from navbar, no drawer needed
- ✅ **Clearer UX** - Separate controls for board selection vs session navigation  
- ✅ **Always visible** - Board switcher accessible at all times
- ✅ **Better visual hierarchy** - Board shown prominently with emoji and worktree counts

## Screenshots

_Board switcher in navbar with separate session drawer toggle button_

## Test Plan

- [x] Open UI and verify board switcher appears in navbar
- [x] Click board switcher to see dropdown with all boards
- [x] Verify boards show emoji and worktree count badges
- [x] Click a different board to switch
- [x] Verify MenuOutlined button toggles session drawer
- [x] Verify session drawer no longer has board selector
- [x] Lint passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)