### PR TITLE
feat(ui): add scroll-to-top and scroll-to-bottom navigation buttons to conversation view

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -72,9 +72,9 @@ export interface ConversationViewProps {
   currentUserId?: string;
 
   /**
-   * Callback to expose scroll-to-bottom function to parent
+   * Callback to expose scroll functions to parent
    */
-  onScrollRef?: (scrollToBottom: () => void) => void;
+  onScrollRef?: (scrollToBottom: () => void, scrollToTop: () => void) => void;
 
   /**
    * Permission decision handler
@@ -160,12 +160,19 @@ export const ConversationView = React.memo<ConversationViewProps>(
       }
     }, []);
 
-    // Expose scroll function to parent
+    // Scroll to top function
+    const scrollToTop = useCallback(() => {
+      if (containerRef.current) {
+        containerRef.current.scrollTop = 0;
+      }
+    }, []);
+
+    // Expose scroll functions to parent
     useEffect(() => {
       if (onScrollRef) {
-        onScrollRef(scrollToBottom);
+        onScrollRef(scrollToBottom, scrollToTop);
       }
-    }, [onScrollRef, scrollToBottom]);
+    }, [onScrollRef, scrollToBottom, scrollToTop]);
 
     // Fetch tasks for this session
     const currentUser = currentUserId ? userById.get(currentUserId) || null : null;

--- a/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
+++ b/apps/agor-ui/src/components/SessionDrawer/SessionDrawer.tsx
@@ -24,6 +24,8 @@ import {
   SendOutlined,
   SettingOutlined,
   StopOutlined,
+  VerticalAlignBottomOutlined,
+  VerticalAlignTopOutlined,
 } from '@ant-design/icons';
 import {
   App,
@@ -181,6 +183,7 @@ const SessionDrawer = ({
     session?.model_config?.thinkingMode || 'auto'
   );
   const [scrollToBottom, setScrollToBottom] = React.useState<(() => void) | null>(null);
+  const [scrollToTop, setScrollToTop] = React.useState<(() => void) | null>(null);
   const [isStopping, setIsStopping] = React.useState(false);
   const [queuedMessages, setQueuedMessages] = React.useState<Message[]>([]);
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
@@ -707,10 +710,19 @@ const SessionDrawer = ({
         },
       }}
     >
-      {/* All pills in one line */}
-      {(worktree || sessionMcpServerIds.length > 0) && (
-        <div style={{ marginBottom: token.sizeUnit }}>
-          <Space size={8} wrap>
+      {/* Header row with pills and scroll navigation */}
+      <div
+        style={{
+          marginBottom: token.sizeUnit,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: token.sizeUnit * 2,
+        }}
+      >
+        {/* Pills section (only shown if there's content) */}
+        {(worktree || sessionMcpServerIds.length > 0) && (
+          <Space size={8} wrap style={{ flex: 1 }}>
             {/* Worktree Info */}
             {worktree && repo && (
               <RepoPill
@@ -749,8 +761,31 @@ const SessionDrawer = ({
                 </Tag>
               ))}
           </Space>
-        </div>
-      )}
+        )}
+        {/* Spacer if no pills */}
+        {!(worktree || sessionMcpServerIds.length > 0) && <div style={{ flex: 1 }} />}
+        {/* Scroll Navigation Buttons - always visible */}
+        <Space size={4}>
+          <Tooltip title="Scroll to top of conversation">
+            <Button
+              type="text"
+              size="small"
+              icon={<VerticalAlignTopOutlined />}
+              onClick={() => scrollToTop?.()}
+              disabled={!scrollToTop}
+            />
+          </Tooltip>
+          <Tooltip title="Scroll to bottom of conversation">
+            <Button
+              type="text"
+              size="small"
+              icon={<VerticalAlignBottomOutlined />}
+              onClick={() => scrollToBottom?.()}
+              disabled={!scrollToBottom}
+            />
+          </Tooltip>
+        </Space>
+      </div>
 
       {/* Concepts - TODO: Re-implement with contextFiles */}
       {/* {session.contextFiles && session.contextFiles.length > 0 && (
@@ -774,7 +809,10 @@ const SessionDrawer = ({
         sessionModel={session.model_config?.model}
         userById={userById}
         currentUserId={currentUserId}
-        onScrollRef={setScrollToBottom}
+        onScrollRef={(scrollBottom, scrollTop) => {
+          setScrollToBottom(() => scrollBottom);
+          setScrollToTop(() => scrollTop);
+        }}
         onPermissionDecision={onPermissionDecision}
         worktreeName={worktree?.name}
         scheduledFromWorktree={session.scheduled_from_worktree}


### PR DESCRIPTION
## Summary
- Add navigation buttons in the SessionDrawer header to quickly jump to the beginning or end of conversations
- Especially helpful for long conversations that span many tasks

## Changes
- Add `scrollToTop` function to ConversationView component
- Expose both `scrollToTop` and `scrollToBottom` via `onScrollRef` callback
- Add `VerticalAlignTopOutlined` and `VerticalAlignBottomOutlined` icon buttons to SessionDrawer header
- Position buttons on right side of header row (after Worktree/Environment pills)
- Style as small, unobtrusive text buttons with tooltips

## Test plan
- [x] Run `pnpm check` (typecheck + lint) - all passed
- [ ] Open a session with a long conversation
- [ ] Click the top button to scroll to the beginning
- [ ] Click the bottom button to scroll to the end
- [ ] Verify buttons are visible in header row
- [ ] Verify tooltips appear on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)