### PR TITLE
fix(ui): restore board switcher in navbar

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -476,6 +476,10 @@ export const App: React.FC<AppProps> = ({
         }
         eventStreamEnabled={eventStreamEnabled}
         hasUserMentions={hasUserMentions}
+        boards={mapToArray(boardById)}
+        currentBoardId={currentBoardId}
+        onBoardChange={setCurrentBoardId}
+        worktreeById={worktreeById}
       />
       <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
         <CommentsPanel

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,4 +1,4 @@
-import type { ActiveUser, User } from '@agor/core/types';
+import type { ActiveUser, Board, User, Worktree } from '@agor/core/types';
 import {
   ApiOutlined,
   CommentOutlined,
@@ -11,6 +11,7 @@ import {
 import type { MenuProps } from 'antd';
 import { Badge, Button, Divider, Dropdown, Layout, Space, Tooltip, Typography, theme } from 'antd';
 import { useState } from 'react';
+import { BoardSwitcher } from '../BoardSwitcher';
 import { ConnectionStatus } from '../ConnectionStatus';
 import { Facepile } from '../Facepile';
 import { ThemeSwitcher } from '../ThemeSwitcher';
@@ -37,6 +38,10 @@ export interface AppHeaderProps {
   unreadCommentsCount?: number;
   eventStreamEnabled?: boolean;
   hasUserMentions?: boolean; // True if current user is mentioned in active comments
+  boards?: Board[];
+  currentBoardId?: string;
+  onBoardChange?: (boardId: string) => void;
+  worktreeById?: Map<string, Worktree>;
 }
 
 export const AppHeader: React.FC<AppHeaderProps> = ({
@@ -58,6 +63,10 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   unreadCommentsCount = 0,
   eventStreamEnabled = false,
   hasUserMentions = false,
+  boards = [],
+  currentBoardId,
+  onBoardChange,
+  worktreeById = new Map(),
 }) => {
   const { token } = theme.useToken();
   const userEmoji = user?.emoji || '👤';
@@ -126,31 +135,23 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           agor
         </Title>
         <Divider type="vertical" style={{ height: 32, margin: '0 8px' }} />
+        {currentBoardId && boards.length > 0 && (
+          <div style={{ minWidth: 200 }}>
+            <BoardSwitcher
+              boards={boards}
+              currentBoardId={currentBoardId}
+              onBoardChange={onBoardChange || (() => {})}
+              worktreeById={worktreeById}
+            />
+          </div>
+        )}
         {currentBoardName && (
-          <Tooltip title="Toggle board drawer" placement="bottom">
-            <Space
-              size={8}
-              align="center"
-              style={{
-                cursor: 'pointer',
-                padding: '4px 8px',
-                borderRadius: token.borderRadius,
-                transition: 'background 0.2s',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = token.colorBgTextHover;
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = 'transparent';
-              }}
+          <Tooltip title="Toggle session drawer" placement="bottom">
+            <Button
+              type="text"
+              icon={<MenuOutlined style={{ fontSize: token.fontSizeLG }} />}
               onClick={onMenuClick}
-            >
-              {currentBoardIcon && <span style={{ fontSize: 16 }}>{currentBoardIcon}</span>}
-              <Typography.Text style={{ color: token.colorTextSecondary, fontSize: 14 }}>
-                {currentBoardName}
-              </Typography.Text>
-              <MenuOutlined style={{ fontSize: token.fontSizeLG }} />
-            </Space>
+            />
           </Tooltip>
         )}
         {currentBoardName && (


### PR DESCRIPTION
## Summary
Restore BoardSwitcher component that was accidentally removed in #297.

The @ mention PR appears to have resolved a merge conflict incorrectly, removing the board switcher changes that were added in #299 (commit `513f88cc`).

## Changes
- Re-add BoardSwitcher import and component to AppHeader
- Add board switcher props (boards, currentBoardId, onBoardChange, worktreeById)
- Pass board switcher props from App to AppHeader  
- Update MenuOutlined tooltip from "board drawer" to "session drawer"

This restores the ability to switch between boards directly from the navbar dropdown, which shows board emojis and worktree count badges.

## Test plan
- [ ] Verify board switcher dropdown appears in navbar
- [ ] Test switching between boards via dropdown
- [ ] Verify worktree counts display correctly
- [ ] Confirm session drawer toggle works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)