### PR TITLE
feat(ui): add user pill to event stream items

### DIFF
--- a/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
@@ -13,10 +13,12 @@ import {
   MessageOutlined,
   ThunderboltOutlined,
   ToolOutlined,
+  UserOutlined,
 } from '@ant-design/icons';
 import { Button, Popover, Tag, Typography, theme } from 'antd';
 import React from 'react';
 import type { SocketEvent } from '../../hooks/useEventStream';
+import { UserAvatar } from '../metadata/UserAvatar';
 import { EventStreamPill, SessionMetadataCard } from '../Pill';
 import WorktreeCard from '../WorktreeCard/WorktreeCard';
 
@@ -135,7 +137,7 @@ const EventItemComponent = ({
     return { entity: eventName };
   };
 
-  // Extract session_id and worktree_id from event data
+  // Extract session_id, worktree_id, and created_by from event data
   const sessionId =
     event.data && typeof event.data === 'object' && 'session_id' in event.data
       ? (event.data.session_id as string)
@@ -146,6 +148,11 @@ const EventItemComponent = ({
       ? (event.data.worktree_id as string)
       : undefined;
 
+  const createdBy =
+    event.data && typeof event.data === 'object' && 'created_by' in event.data
+      ? (event.data.created_by as string)
+      : undefined;
+
   // Lookup full objects from maps
   const session = sessionId ? sessionById.get(sessionId) : undefined;
   // Derive worktree from session if not directly in event data
@@ -153,6 +160,9 @@ const EventItemComponent = ({
   const worktree = derivedWorktreeId ? worktreeById.get(derivedWorktreeId) : undefined;
   const repo = worktree ? repos.find((r) => r.repo_id === worktree.repo_id) : undefined;
   const worktreeSessions = worktree ? sessionsByWorktree.get(worktree.worktree_id) || [] : [];
+
+  // Look up user if created_by is present
+  const user = createdBy ? userById.get(createdBy) : undefined;
 
   // Parse event name into entity and action
   const { entity, action } = parseEventName(event.eventName);
@@ -299,6 +309,13 @@ const EventItemComponent = ({
             />
           }
         />
+      )}
+
+      {/* User pill - shows who triggered this event */}
+      {user && (
+        <Tag icon={<UserOutlined />} color="magenta" style={{ margin: 0, fontSize: 11 }}>
+          <UserAvatar user={user} showName={true} size="small" />
+        </Tag>
       )}
 
       {event.data ? (


### PR DESCRIPTION
## Summary

Adds user attribution pill to EventStreamPanel events showing who triggered each action in multiplayer scenarios.

## Changes

- Added `UserOutlined` icon import from `@ant-design/icons`
- Imported `UserAvatar` component for user display
- Extracted `created_by` field from event data (similar to `session_id` and `worktree_id`)
- Added user lookup from `userById` map
- Added user pill display with magenta color tag
- Pill shows user emoji + name via `UserAvatar` component
- Includes tooltip with full user details (name, email, role)

## Visual Design

- **Position**: After worktree pill, before info button
- **Color**: Magenta (new color distinguishing it from other pills)
- **Icon**: `UserOutlined`
- **Content**: User emoji + name (compact format)
- **Tooltip**: Full user details via `UserAvatar`
- **Visibility**: Only shows when event has `created_by` field

## Testing

- ✅ `pnpm check` passed (typecheck + lint + build)
- ✅ Pre-commit hooks passed
- Component only renders when user data is available
- Works with existing event stream filtering

## Screenshots

The user pill appears on events that have `created_by` fields (sessions, tasks, board comments), providing better visibility into which user triggered each action in the multiplayer environment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)