### PR TITLE
feat: add JWT token authentication support for MCP servers

### DIFF
--- a/context/explorations/mcp-jwt-auth.md
+++ b/context/explorations/mcp-jwt-auth.md
@@ -1,0 +1,116 @@
+# MCP JWT Authentication
+
+Support for JWT token authentication when connecting to MCP servers over HTTP/SSE transport.
+
+## Overview
+
+Some MCP servers (like Preset's MCP server) require JWT authentication rather than static bearer tokens. This feature adds support for dynamically fetching JWT tokens from an authentication endpoint before connecting to the MCP server.
+
+## Authentication Flow
+
+```
+1. User configures MCP server with JWT auth:
+   - API URL: Token endpoint (e.g., https://api.preset.io/v1/auth/)
+   - API Token: Token name/identifier
+   - API Secret: Secret for authentication
+
+2. When connecting to MCP server:
+   a. POST to API URL with { name: api_token, secret: api_secret }
+   b. Receive { access_token: "..." } or { payload: { access_token: "..." } }
+   c. Use token via mcp-remote: npx mcp-remote <url> --header "Authorization: Bearer <token>"
+
+3. Tokens are cached for 15 minutes to avoid excessive API calls
+```
+
+## Configuration
+
+### UI Fields (Settings > MCP Servers)
+
+When transport is HTTP or SSE:
+
+- **Auth Type**: Select dropdown (none / bearer / jwt)
+- **Bearer Token**: For static token auth
+- **JWT Fields** (when auth type is JWT):
+  - API URL: The JWT token endpoint
+  - API Token: Token name for authentication
+  - API Secret: Secret for authentication
+
+### Database Schema
+
+Auth config stored in MCP server's JSON data blob:
+
+```typescript
+auth?: {
+  type: 'none' | 'bearer' | 'jwt';
+  token?: string;        // Bearer token
+  api_url?: string;      // JWT endpoint
+  api_token?: string;    // JWT token name
+  api_secret?: string;   // JWT secret
+  insecure?: boolean;    // Skip TLS verification
+}
+```
+
+## Implementation
+
+### Core Package
+
+- `packages/core/src/types/mcp.ts` - MCPAuth interface and types
+- `packages/core/src/tools/mcp/jwt-auth.ts` - Token fetching with caching
+- `packages/core/src/db/repositories/mcp-servers.ts` - Auth field persistence
+
+### Daemon
+
+- `apps/agor-daemon/src/index.ts` - Test JWT endpoint at `/mcp-servers/test-jwt`
+  - Proxies JWT token fetch to avoid browser CORS issues
+  - Optionally tests MCP server connection and returns tool count
+
+### UI
+
+- `apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx`
+  - Auth type dropdown
+  - Conditional JWT configuration fields
+  - Test Connection button
+
+## Test Connection Feature
+
+The Test Connection button:
+
+1. Validates JWT credentials by fetching a token
+2. If MCP URL is provided, attempts to connect via `mcp-remote --one-shot`
+3. Reports server name and tool count on success
+
+Response format:
+
+```typescript
+{
+  success: boolean;
+  tokenValid?: boolean;
+  serverName?: string;
+  toolCount?: number;
+  tools?: string[];      // First 10 tool names
+  mcpError?: string;     // If JWT valid but MCP connection failed
+  error?: string;        // If JWT fetch failed
+}
+```
+
+## Usage Example
+
+Adding Preset's MCP server:
+
+1. Settings > MCP Servers > New MCP Server
+2. Name: `preset-mcp`
+3. Transport: `HTTP` or `SSE`
+4. URL: `https://mcp.preset.io/mcp`
+5. Auth Type: `JWT`
+6. API URL: `https://api.preset.io/v1/auth/`
+7. API Token: `<your-token-name>`
+8. API Secret: `<your-secret>`
+9. Click "Test Connection" to verify
+10. Save
+
+## Security Considerations
+
+- JWT secrets stored in database (consider encryption at rest)
+- Tokens cached in memory only (not persisted)
+- Test endpoint proxies requests server-side to avoid CORS exposure
+- API secrets never sent to browser after initial form submission

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,6 +139,11 @@
       "types": "./dist/sdk/index.d.ts",
       "import": "./dist/sdk/index.js",
       "require": "./dist/sdk/index.cjs"
+    },
+    "./tools/mcp/jwt-auth": {
+      "types": "./dist/tools/mcp/jwt-auth.d.ts",
+      "import": "./dist/tools/mcp/jwt-auth.js",
+      "require": "./dist/tools/mcp/jwt-auth.cjs"
     }
   },
   "scripts": {

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -60,6 +60,7 @@ export class MCPServerRepository
       args: row.data.args,
       url: row.data.url,
       env: row.data.env,
+      auth: row.data.auth,
 
       // Scope foreign keys (nullable UUID strings - DB stores null, types expect undefined)
       owner_user_id: (row.owner_user_id as UserID | null) ?? undefined,
@@ -111,6 +112,7 @@ export class MCPServerRepository
         args: data.args,
         url: data.url,
         env: data.env,
+        auth: 'auth' in data ? data.auth : undefined,
         tools: 'tools' in data ? data.tools : undefined,
         resources: 'resources' in data ? data.resources : undefined,
         prompts: 'prompts' in data ? data.prompts : undefined,

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -645,6 +645,18 @@ export const mcpServers = pgTable(
         url?: string;
         env?: Record<string, string>;
 
+        // Authentication config (for HTTP/SSE transports)
+        auth?: {
+          type: 'none' | 'bearer' | 'jwt';
+          // Bearer token
+          token?: string;
+          // JWT config
+          api_url?: string;
+          api_token?: string;
+          api_secret?: string;
+          insecure?: boolean;
+        };
+
         // Discovered capabilities
         tools?: Array<{
           name: string;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -636,6 +636,18 @@ export const mcpServers = sqliteTable(
         url?: string;
         env?: Record<string, string>;
 
+        // Authentication config (for HTTP/SSE transports)
+        auth?: {
+          type: 'none' | 'bearer' | 'jwt';
+          // Bearer token
+          token?: string;
+          // JWT config
+          api_url?: string;
+          api_token?: string;
+          api_secret?: string;
+          insecure?: boolean;
+        };
+
         // Discovered capabilities
         tools?: Array<{
           name: string;

--- a/packages/core/src/tools/mcp/jwt-auth.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.ts
@@ -1,0 +1,173 @@
+/**
+ * JWT Authentication for MCP Servers
+ *
+ * Handles JWT token fetching and caching for MCP servers that require JWT authentication.
+ * Tokens are cached for 15 minutes to avoid excessive API calls.
+ */
+
+import type { MCPAuth } from '../../types/mcp';
+
+interface JWTConfig {
+  api_url: string;
+  api_token: string;
+  api_secret: string;
+  insecure?: boolean;
+}
+
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+// Cache tokens per unique credential set to avoid cross-tenant leakage
+const tokenCache = new Map<string, CachedToken>();
+
+// Token validity duration: 15 minutes (in milliseconds)
+const TOKEN_TTL_MS = 15 * 60 * 1000;
+
+function getCacheKey(config: JWTConfig): string {
+  return `${config.api_url}::${config.api_token}::${config.api_secret}`;
+}
+
+/**
+ * Fetch a JWT token from the authentication endpoint
+ *
+ * @param config - JWT configuration containing api_url, api_token, and api_secret
+ * @returns The access token string
+ * @throws Error if token fetch fails
+ */
+export async function fetchJWTToken(config: JWTConfig): Promise<string> {
+  const { api_url, api_token, api_secret } = config;
+  const cacheKey = getCacheKey(config);
+
+  // Check cache first
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.token;
+  }
+
+  // Fetch new token
+  const response = await fetch(api_url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: api_token,
+      secret: api_secret,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `JWT token fetch failed: ${response.status} ${response.statusText} - ${errorText}`
+    );
+  }
+
+  const data = (await response.json()) as {
+    access_token?: string;
+    payload?: { access_token?: string };
+  };
+
+  // Handle different response formats
+  const token = data.access_token || data.payload?.access_token;
+  if (!token) {
+    throw new Error('JWT response missing access_token field');
+  }
+
+  // Cache the token
+  tokenCache.set(cacheKey, {
+    token,
+    expiresAt: Date.now() + TOKEN_TTL_MS,
+  });
+
+  return token;
+}
+
+/**
+ * Clear cached token for a specific API URL
+ *
+ * @param api_url - The API URL to clear from cache
+ */
+export function clearJWTToken(api_url: string): void {
+  for (const key of tokenCache.keys()) {
+    if (key.startsWith(`${api_url}::`)) {
+      tokenCache.delete(key);
+    }
+  }
+}
+
+/**
+ * Clear all cached JWT tokens
+ */
+export function clearAllJWTTokens(): void {
+  tokenCache.clear();
+}
+
+/**
+ * Get MCP server connection args with JWT authentication
+ *
+ * For MCP servers using JWT auth, this returns the mcp-remote compatible
+ * command and args with the Bearer token header.
+ *
+ * @param serverUrl - The MCP server URL
+ * @param jwtConfig - JWT configuration
+ * @returns Object with command and args for spawning the MCP connection
+ */
+export async function getMCPRemoteArgsWithJWT(
+  serverUrl: string,
+  jwtConfig: JWTConfig
+): Promise<{ command: string; args: string[] }> {
+  const token = await fetchJWTToken(jwtConfig);
+
+  return {
+    command: 'npx',
+    args: ['mcp-remote', serverUrl, '--header', `Authorization: Bearer ${token}`],
+  };
+}
+
+/**
+ * Build Authorization headers for an MCP server based on its auth config.
+ *
+ * @param auth - MCP authentication configuration
+ * @returns Header map including Authorization when applicable
+ */
+export async function resolveMCPAuthHeaders(
+  auth?: MCPAuth
+): Promise<Record<string, string> | undefined> {
+  if (!auth || auth.type === 'none') {
+    return undefined;
+  }
+
+  if (auth.type === 'bearer') {
+    if (!auth.token) {
+      console.warn('MCP bearer authentication configured without a token');
+      return undefined;
+    }
+    return {
+      Authorization: `Bearer ${auth.token}`,
+    };
+  }
+
+  if (auth.type === 'jwt') {
+    const { api_url, api_token, api_secret } = auth;
+    if (!api_url || !api_token || !api_secret) {
+      console.warn('MCP JWT authentication missing api_url, api_token, or api_secret');
+      return undefined;
+    }
+
+    const token = await fetchJWTToken({
+      api_url,
+      api_token,
+      api_secret,
+      insecure: auth.insecure,
+    });
+
+    return {
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -34,6 +34,20 @@ export type MCPScope = 'global' | 'team' | 'repo' | 'session';
 export type MCPSource = 'user' | 'imported' | 'agor';
 
 /**
+ * MCP server authentication configuration
+ */
+export interface MCPAuth {
+  type: 'none' | 'bearer' | 'jwt';
+  // Bearer token
+  token?: string;
+  // JWT config
+  api_url?: string;
+  api_token?: string;
+  api_secret?: string;
+  insecure?: boolean;
+}
+
+/**
  * JSON Schema type for tool input schemas
  */
 export type JSONSchema = Record<string, unknown>;
@@ -108,6 +122,9 @@ export interface MCPServer {
   // Environment variables
   env?: Record<string, string>; // e.g., { "ALLOWED_PATHS": "/Users/me/projects" }
 
+  // Authentication (for HTTP/SSE transports)
+  auth?: MCPAuth;
+
   // Scope
   scope: MCPScope;
   owner_user_id?: UserID; // For 'global' scope
@@ -164,6 +181,7 @@ export interface CreateMCPServerInput {
   args?: string[];
   url?: string;
   env?: Record<string, string>;
+  auth?: MCPAuth;
   scope: MCPScope;
   owner_user_id?: UserID;
   team_id?: TeamID;
@@ -184,6 +202,7 @@ export interface UpdateMCPServerInput {
   args?: string[];
   url?: string;
   env?: Record<string, string>;
+  auth?: MCPAuth;
   scope?: MCPScope;
   enabled?: boolean;
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     'callbacks/child-completion-template': 'src/callbacks/child-completion-template.ts', // Parent session callback templates
     'models/index': 'src/models/index.ts', // Model metadata (browser-safe)
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
+    'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
   },
   format: ['cjs', 'esm'],
   dts: true,

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs/promises';
 import { validateDirectory } from '@agor/core';
 import { Claude } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
+import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 
 const { query } = Claude;
 type PermissionMode = Claude.PermissionMode;
@@ -582,6 +583,19 @@ export async function setupQuery(
           } else {
             // http and sse both use url
             serverConfig.url = server.url;
+          }
+
+          try {
+            const headers = await resolveMCPAuthHeaders(server.auth);
+            if (headers && server.transport !== 'stdio') {
+              serverConfig.headers = headers;
+              console.log(`     🔐 Added Authorization header for ${server.name}`);
+            }
+          } catch (error) {
+            console.warn(
+              `   ⚠️  Failed to resolve MCP auth headers for ${server.name}:`,
+              error instanceof Error ? error.message : String(error)
+            );
           }
 
           mcpConfig[server.name] = serverConfig;


### PR DESCRIPTION
## Summary
- Add JWT auth config to MCP server schema (`auth.type: 'jwt'` with `api_url`, `api_token`, `api_secret`)
- Implement token fetching with 15-minute caching in `jwt-auth.ts`
- Support mcp-remote with Bearer token header

## Test plan
- [ ] Configure MCP server with JWT auth in YAML config
- [ ] Verify token is fetched and cached
- [ ] Verify mcp-remote connects with Bearer header