### PR TITLE
fix(ui): center loading spinner in conversation view

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -294,7 +294,15 @@ export const ConversationView = React.memo<ConversationViewProps>(
 
     if (loading && tasks.length === 0) {
       return (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: '2rem' }}>
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '2rem',
+          }}
+        >
           <Spin />
         </div>
       );


### PR DESCRIPTION
## Summary
Fixed an issue where the conversation footer would render directly under the loading spinner instead of staying at the bottom of the drawer.

## Changes
- Added `flex: 1` to the loading state container to fill available vertical space
- Added `alignItems: center` to vertically center the spinner
- This ensures the footer stays anchored at the bottom while the spinner displays in the center of the conversation area

## Test plan
- [x] Open a session drawer with a loading conversation
- [x] Verify the spinner appears centered in the conversation area
- [x] Verify the footer remains at the bottom of the drawer
- [x] Run `pnpm check` to verify no type/lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)