### PR TITLE
Fix EventStreamPanel layout with wrapping pills and wider panel

### DIFF
--- a/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
@@ -196,6 +196,7 @@ const EventItemComponent = ({
         borderBottom: `1px solid ${token.colorBorderSecondary}`,
         background: token.colorBgContainer,
         display: 'flex',
+        flexWrap: 'wrap',
         alignItems: 'center',
         gap: 8,
         fontSize: 12,

--- a/apps/agor-ui/src/components/EventStreamPanel/EventStreamPanel.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventStreamPanel.tsx
@@ -43,7 +43,7 @@ export const EventStreamPanel: React.FC<EventStreamPanelProps> = ({
   onToggleCollapse,
   events,
   onClear,
-  width = 600,
+  width = 700,
   worktreeById,
   sessionById,
   sessionsByWorktree,


### PR DESCRIPTION
## Summary

- Increased EventStreamPanel width from 600px to 700px for more horizontal space
- Added `flexWrap: 'wrap'` to EventItem container so pills wrap to the next line instead of being cut off

## Test plan

- [ ] Open the Event Stream panel in the UI
- [ ] Verify the panel is wider (700px instead of 600px)
- [ ] Create events with multiple pills (session, worktree, user)
- [ ] Verify pills wrap to the next line when they overflow instead of being cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)