### PR TITLE
feat: add auto-refresh and improved layout to environment logs viewer

### DIFF
--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -32,10 +32,11 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
   const [loading, setLoading] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
   const logsContainerRef = useRef<HTMLDivElement>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const logsRef = useRef<LogsResponse | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchLogs = useCallback(
-    async (shouldAutoScroll = false) => {
+    async (shouldAutoScroll = false, isManualRefresh = false) => {
       if (!client) return;
 
       // Check if user is scrolled to bottom before fetching
@@ -44,7 +45,11 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
         container &&
         Math.abs(container.scrollHeight - container.scrollTop - container.clientHeight) < 10;
 
-      setLoading(true);
+      // Only show loading spinner for manual refreshes
+      if (isManualRefresh) {
+        setLoading(true);
+      }
+
       try {
         // Call the custom logs endpoint using Feathers client with query params
         const data = (await client.service('worktrees/logs').find({
@@ -53,32 +58,39 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
           },
         })) as unknown as LogsResponse;
         setLogs(data);
+        logsRef.current = data;
 
-        // Auto-scroll to bottom if shouldAutoScroll is true AND user was already at bottom
-        if (shouldAutoScroll && (isAtBottom || !logs)) {
+        // Auto-scroll to bottom if shouldAutoScroll is true AND (user was already at bottom OR first load)
+        const hadLogs = !!logsRef.current;
+        if (shouldAutoScroll && (isAtBottom || !hadLogs)) {
           setTimeout(() => {
             container?.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
           }, 100);
         }
       } catch (error: unknown) {
-        setLogs({
+        const errorData = {
           logs: '',
           timestamp: new Date().toISOString(),
           error: error instanceof Error ? error.message : 'Failed to fetch logs',
-        });
+        };
+        setLogs(errorData);
+        logsRef.current = errorData;
       } finally {
-        setLoading(false);
+        if (isManualRefresh) {
+          setLoading(false);
+        }
       }
     },
-    [client, worktree.worktree_id, logs]
+    [client, worktree.worktree_id]
   );
 
   // Fetch logs when modal opens
   useEffect(() => {
     if (open) {
-      fetchLogs();
+      fetchLogs(true, true); // Auto-scroll on initial load, show loading spinner
     } else {
       setLogs(null); // Clear logs when modal closes
+      logsRef.current = null;
     }
   }, [open, fetchLogs]);
 
@@ -129,7 +141,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
         <Button
           key="refresh"
           icon={<ReloadOutlined />}
-          onClick={() => fetchLogs()}
+          onClick={() => fetchLogs(false, true)}
           loading={loading}
         >
           Refresh


### PR DESCRIPTION
## Summary

- Added auto-refresh checkbox (checked by default) that polls logs every 3 seconds
- Set fixed height to 80vh for consistent layout from load
- Implemented smart auto-scroll that only scrolls when user is already at bottom (prevents interrupting users reading older logs)
- Increased modal width to 900px for better readability
- Improved loading state with centered content

## Test plan

- [x] Open environment logs modal
- [x] Verify auto-refresh is enabled by default and polls every 3 seconds
- [x] Verify logs container has fixed 80vh height with scroll
- [x] Verify auto-scroll only happens when user is at bottom
- [x] Verify checkbox can be toggled to disable/enable auto-refresh
- [x] Verify manual refresh button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)