### PR TITLE
fix: Properly fetch tags for new repos

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -370,6 +370,7 @@ function AppContent() {
         const newWorktree = await handleCreateWorktree(config.newWorktree.repoId, {
           name: config.newWorktree.name,
           ref: config.newWorktree.ref,
+          refType: config.newWorktree.refType,
           createBranch: config.newWorktree.createBranch,
           sourceBranch: config.newWorktree.sourceBranch,
           pullLatest: config.newWorktree.pullLatest,

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -93,6 +93,7 @@ export interface AppProps {
     data: {
       name: string;
       ref: string;
+      refType?: 'branch' | 'tag';
       createBranch: boolean;
       sourceBranch: string;
       pullLatest: boolean;
@@ -307,6 +308,7 @@ export const App: React.FC<AppProps> = ({
     const worktree = await onCreateWorktree?.(config.repoId, {
       name: config.name,
       ref: config.ref,
+      refType: config.refType,
       createBranch: config.createBranch,
       sourceBranch: config.sourceBranch,
       pullLatest: config.pullLatest,


### PR DESCRIPTION
When working on https://github.com/preset-io/agor/pull/294, I was using a repo that was already cloned through Agor. When testing with a new repo I noticed this wasn't working properly. This fix addresses the issue.