### PR TITLE
fix: atomically update session state when task status changes

### DIFF
--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -97,29 +97,68 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
   /**
    * Override patch to detect task completion and:
-   * 1. Set ready_for_prompt flag
-   * 2. Queue callback to parent session (if exists)
+   * 1. Atomically update session status to IDLE when task reaches terminal state
+   * 2. Set ready_for_prompt flag
+   * 3. Queue callback to parent session (if exists)
    */
   async patch(id: string, data: Partial<Task>, params?: TaskParams): Promise<Task | Task[]> {
     const result = await super.patch(id, data, params);
 
-    // If task is being marked as completed or failed (terminal status)
-    if (data.status === TaskStatus.COMPLETED || data.status === TaskStatus.FAILED) {
+    // If task is being marked as completed, failed, or stopped (terminal status)
+    if (
+      data.status === TaskStatus.COMPLETED ||
+      data.status === TaskStatus.FAILED ||
+      data.status === TaskStatus.STOPPED
+    ) {
       // Handle both single task and array of tasks
       const tasks = Array.isArray(result) ? result : [result];
 
       for (const task of tasks) {
         if (task.session_id && this.app) {
           try {
+            // ATOMICALLY update session status to IDLE and set ready_for_prompt
+            // This ensures WebSocket events are emitted immediately via FeathersJS service layer
+            await this.app.service('sessions').patch(task.session_id, {
+              status: 'idle',
+              ready_for_prompt: true,
+            });
+
+            console.log(
+              `✅ [TasksService] Session ${task.session_id.substring(0, 8)} status updated to IDLE (task ${task.task_id.substring(0, 8)} ${data.status})`
+            );
+
             // Check if session has parent and queue callback
-            // NOTE: Don't patch ready_for_prompt here - it's set atomically with status=IDLE in index.ts
-            // to avoid race condition between partial patches
             const session = await this.app.service('sessions').get(task.session_id);
             if (session.genealogy?.parent_session_id) {
               await this.queueParentCallback(task, session, params);
             }
           } catch (error) {
             console.error('❌ [TasksService] Failed to process task completion:', error);
+          }
+        }
+      }
+    }
+
+    // If task is being marked as running, atomically update session status to RUNNING
+    if (data.status === TaskStatus.RUNNING) {
+      // Handle both single task and array of tasks
+      const tasks = Array.isArray(result) ? result : [result];
+
+      for (const task of tasks) {
+        if (task.session_id && this.app) {
+          try {
+            // ATOMICALLY update session status to RUNNING
+            // This ensures WebSocket events are emitted immediately via FeathersJS service layer
+            await this.app.service('sessions').patch(task.session_id, {
+              status: 'running',
+              ready_for_prompt: false,
+            });
+
+            console.log(
+              `✅ [TasksService] Session ${task.session_id.substring(0, 8)} status updated to RUNNING (task ${task.task_id.substring(0, 8)})`
+            );
+          } catch (error) {
+            console.error('❌ [TasksService] Failed to update session status to RUNNING:', error);
           }
         }
       }


### PR DESCRIPTION
## Summary

After merging PRs #330 and #319, the new executor process architecture had a gap where session state updates were delayed. This PR fixes the issue by making session state updates atomic with task status changes.

## Problem

The executor refactoring had a timing issue:
- Tasks would complete and update their status via FeathersJS service ✅
- But session status only changed when the executor **process exited** ❌  
- This created a gap where tasks showed as complete but sessions still showed as "running"
- WebSocket events weren't firing immediately for session state changes

## Solution

Made session state updates **atomic** with task state changes by updating the `TasksService.patch()` hook:

### 1. TasksService.patch() - Atomic session state updates

```typescript
// When task → RUNNING: session → RUNNING + ready_for_prompt: false
// When task → COMPLETED/FAILED/STOPPED: session → IDLE + ready_for_prompt: true
await this.app.service('sessions').patch(task.session_id, {
  status: 'idle',
  ready_for_prompt: true,
});
```

Uses `app.service('sessions').patch()` to ensure WebSocket events fire immediately.

### 2. Executor exit handler - Now a safety net

- Only updates session to IDLE if still in RUNNING state
- Prevents duplicate updates and race conditions  
- Logs whether it updated or skipped

### 3. Prompt endpoint - Added clarifying comments

Explains why manual session→RUNNING update is still needed:
- Task is **created** with RUNNING status (not patched)
- TasksService.patch() hook only fires on **updates**, not creates

## Files Changed

- `apps/agor-daemon/src/services/tasks.ts` - Added atomic session state updates in patch hook
- `apps/agor-daemon/src/index.ts` - Updated executor exit handler to be a safety net

## Result

✅ Session state now updates **immediately** when task status changes  
✅ WebSocket events fire in **real-time**  
✅ UI state synchronization issue **fixed**  

## Test Plan

- [ ] Start a session and execute a prompt
- [ ] Verify session status changes to "running" immediately
- [ ] Wait for task to complete
- [ ] Verify session status changes to "idle" immediately (not after executor exits)
- [ ] Check that WebSocket events fire for session state changes
- [ ] Test with spawned child sessions (callback system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)