### PR TITLE
fix: session state timing and Gemini tool execution bugs

### DIFF
--- a/packages/core/src/templates/agor-system-prompt.md
+++ b/packages/core/src/templates/agor-system-prompt.md
@@ -12,9 +12,6 @@ Agor is a collaborative workspace where multiple AI agents can work together on 
 **Session Information:**
 - Session ID: `{{session.session_id}}`
 - Agent Type: {{session.agentic_tool}}
-{{#if session.permission_config.mode}}
-- Permission Mode: {{session.permission_config.mode}}
-{{/if}}
 {{/if}}
 
 {{#if worktree}}


### PR DESCRIPTION
## Summary

This PR fixes multiple critical bugs discovered during debugging:

### 1. Session Status Timing Bug ⏱️
- **Problem**: Sessions were being set to IDLE immediately after spawning the executor, before the task actually started running
- **Root cause**: `executeTask()` returns immediately after spawning the executor process (it doesn't wait), but the code was calling `session.patch(status: IDLE)` right after
- **Fix**: Removed premature session->IDLE updates in the prompt handler
- **Result**: Session now correctly stays RUNNING until the task completes, and TasksService.patch() hook automatically manages the transition to IDLE

### 2. Gemini Circular Reference Bug 🔄
- **Problem**: Gemini crashed with "Converting circular structure to JSON" error when using tools (like reading files)
- **Root cause**: Tool responses containing circular references (common with file system operations) couldn't be serialized
- **Fix**: Added sanitization in `gemini/prompt-service.ts` to detect circular references and fall back to string conversion
- **Result**: Gemini can now successfully execute file operations and other tools without crashing

### 3. System Prompt Cleanup 🧹
- **Problem**: The Agor system prompt template was showing `permission_config.mode` to agents
- **Issue**: This is a mutable property that confused agents about session settings
- **Fix**: Removed `permission_config.mode` from the Handleb ars template
- **Result**: Agents only see immutable session properties (ID, agent type)

### 4. Debug Logging 🐛
- Added WebSocket publish event logging for debugging
- Added sessionsByWorktree Map update logging in UI

## Test Plan

- [x] Test session status updates correctly when creating tasks
- [x] Test Gemini can read files without crashing
- [x] Verify sessions stay RUNNING during task execution
- [x] Verify sessions transition to IDLE after task completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)