### PR TITLE
fix: align Husky pre-commit with CI enforcement

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,8 @@
 echo "🔍 Running typecheck..."
 pnpm typecheck
 
-echo "✨ Running lint-staged..."
-pnpm exec lint-staged
+echo "✨ Running lint..."
+pnpm lint
+
+echo "🏗️  Running build..."
+pnpm turbo run build --filter='!@agor/docs'


### PR DESCRIPTION
## Summary

- Updated `.husky/pre-commit` to run the exact same checks as CI
- Replaced `lint-staged` with full `pnpm lint` 
- Added `pnpm turbo run build --filter='!@agor/docs'` step

## Motivation

Kept getting bit by CI having different check rules than pre-commit. This ensures that if pre-commit passes, CI will pass too.

## Changes

**Before:**
1. `pnpm typecheck`
2. `pnpm exec lint-staged` (only lints staged files with biome ci)

**After (now matches CI):**
1. `pnpm typecheck` 
2. `pnpm lint` (full biome check on entire codebase)
3. `pnpm turbo run build --filter='!@agor/docs'` (build all packages except docs)

## Impact

- No more CI surprises - if pre-commit passes, CI will pass
- Catches build errors before pushing
- Full lint coverage instead of just staged files
- Pre-commit will take longer but provides stronger guarantees

🤖 Generated with [Claude Code](https://claude.com/claude-code)