### PR TITLE
feat: sort board dropdown alphabetically by name

### DIFF
--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -47,7 +47,12 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
 
   // Build menu items
   const menuItems: MenuProps['items'] = useMemo(() => {
-    return boards.map((board) => {
+    // Sort boards alphabetically by name
+    const sortedBoards = [...boards].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+
+    return sortedBoards.map((board) => {
       const worktreeCount = worktreeCountByBoard.get(board.board_id) || 0;
       const isActive = board.board_id === currentBoardId;
 


### PR DESCRIPTION
## Summary
- Boards in the navigation dropdown are now sorted alphabetically by name for easier navigation
- Uses case-insensitive sorting with `localeCompare` for consistent ordering

## Test plan
- [ ] Open the board dropdown in the navigation
- [ ] Verify boards are displayed in alphabetical order
- [ ] Test with boards that have different cases in their names

🤖 Generated with [Claude Code](https://claude.com/claude-code)