### PR TITLE
fix: preserve session permission mode when spawning executor

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -792,6 +792,12 @@ async function main() {
 
     // Build spawn command with optional Unix user impersonation
     const executorUnixUser = config.execution?.executor_unix_user;
+
+    // Determine permission mode: explicit override > session config > 'default'
+    // This ensures session settings (like bypassPermissions) are preserved unless explicitly overridden
+    const effectivePermissionMode =
+      data.permissionMode || session.permission_config?.mode || 'default';
+
     const nodeArgs = [
       executorPath,
       '--session-token',
@@ -805,7 +811,7 @@ async function main() {
       '--tool',
       session.agentic_tool,
       '--permission-mode',
-      data.permissionMode || 'default',
+      effectivePermissionMode,
       '--daemon-url',
       daemonUrl,
     ];


### PR DESCRIPTION
## Summary
Fixes an issue where queued messages (and all prompt executions) didn't respect the session's configured permission mode, such as `bypassPermissions`.

## Problem
When the executor was spawned, it defaulted to `'default'` permission mode when no explicit override was provided, completely ignoring the session's `permission_config.mode` setting. This affected:
- ✅ Direct prompt executions
- ✅ Queued messages
- ✅ Callback-triggered prompts
- ✅ All other executor spawns

## Solution
Changed the executor spawn logic to use this precedence:
1. Explicit `permissionMode` override (from prompt endpoint)
2. Session's configured `permission_config.mode`
3. `'default'` as final fallback

## Changes
- `apps/agor-daemon/src/index.ts:796-798` - Added fallback logic to respect session's permission mode

## Testing
- [x] `pnpm check` passes (typecheck, lint, build)
- [x] Pre-commit hooks pass

## Impact
- Session permission settings like `bypassPermissions` now work correctly for all prompt executions
- Explicit overrides via the prompt endpoint continue to work as expected
- No breaking changes - this fixes the intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)