### PR TITLE
fix: ensure worktree cards spawn in center of viewport

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -284,6 +284,16 @@ export const App: React.FC<AppProps> = ({
     }
   }, [boardById, currentBoardId, setCurrentBoardId]);
 
+  // Recalculate default position when board changes while modal is open
+  // This ensures worktrees spawn at the center of the new board's viewport
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentBoardId is intentionally included to trigger recalculation on board switch
+  useEffect(() => {
+    if (newWorktreeModalOpen) {
+      const center = sessionCanvasRef.current?.getViewportCenter();
+      setNewWorktreeDefaultPosition(center || null);
+    }
+  }, [currentBoardId, newWorktreeModalOpen]);
+
   // Update favicon based on session activity on current board
   useFaviconStatus(currentBoardId, sessionsByWorktree, mapToArray(boardObjectById));
 


### PR DESCRIPTION
## Summary

Fixes the issue where worktree cards were not consistently spawning in the center of the viewport when creating new worktrees.

## Problem

The backend was ready to accept a `position` parameter for placing worktrees on the board, but the frontend never calculated or passed the viewport center position when opening the `NewWorktreeModal`. This resulted in worktrees being placed at fallback stagger positions instead of the viewport center.

## Solution

- Added `SessionCanvas` ref to `App.tsx` to access the `getViewportCenter()` method
- Calculate viewport center position when opening `NewWorktreeModal` (both from header and from NewSessionButton)
- Pass `defaultPosition` prop through to `NewWorktreeModal`
- Updated `onCreateWorktree` handler type signature to accept `boardId` and `position` parameters
- Pass position through the full creation flow to the backend

## Technical Details

The `SessionCanvas` component already exposed a `getViewportCenter()` method via `useImperativeHandle` that correctly calculates the center of the visible canvas viewport accounting for zoom, pan, and all UI chrome (panels, headers, etc.). This fix completes the integration by:

1. Creating a ref to `SessionCanvas` in `App.tsx`
2. Calling `getViewportCenter()` whenever the worktree modal is opened
3. Storing the position in state and passing it to `NewWorktreeModal`
4. Passing the position all the way through to the backend

## Testing

- ✅ pnpm install
- ✅ pnpm check (typecheck, lint, build)
- ✅ All pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)