### PR TITLE
fix: improve NewSessionButton positioning for better visual balance

### DIFF
--- a/apps/agor-ui/src/components/NewSessionButton/NewSessionButton.tsx
+++ b/apps/agor-ui/src/components/NewSessionButton/NewSessionButton.tsx
@@ -27,7 +27,7 @@ export const NewSessionButton: React.FC<NewSessionButtonProps> = ({ onClick, has
         style={{
           position: 'absolute',
           right: 24,
-          top: 80,
+          top: 24,
           width: 56,
           height: 56,
           boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',


### PR DESCRIPTION
## Summary
- Fixed the positioning of the "+" button for creating new worktrees to ensure equal spacing from both the navbar and right edge
- Changed `top` position from `80px` to `24px` to match the `right` margin of `24px`

## Changes
- **apps/agor-ui/src/components/NewSessionButton/NewSessionButton.tsx**
  - Updated button position from `top: 80` to `top: 24`
  - Maintains consistent 24px spacing from both navbar (top) and window edge (right)

## Visual Impact
The button now has symmetric spacing, creating a more balanced and visually appealing layout that follows consistent spacing principles.

## Test plan
- [x] Verified button appears at correct position
- [x] Checked spacing is equal from both edges (24px)
- [x] Ensured button functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)