### PR TITLE
feat: replace hamburger menu icon with list icon for sessions drawer

### DIFF
--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -3,10 +3,10 @@ import {
   ApiOutlined,
   CommentOutlined,
   LogoutOutlined,
-  MenuOutlined,
   QuestionCircleOutlined,
   SettingOutlined,
   SoundOutlined,
+  UnorderedListOutlined,
   UserOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
@@ -185,7 +185,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           <Tooltip title="Toggle session drawer" placement="bottom">
             <Button
               type="text"
-              icon={<MenuOutlined style={{ fontSize: token.fontSizeLG }} />}
+              icon={<UnorderedListOutlined style={{ fontSize: token.fontSizeLG }} />}
               onClick={onMenuClick}
             />
           </Tooltip>

--- a/apps/agor-ui/src/components/mobile/MobileHeader.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileHeader.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@agor/core/types';
-import { MenuOutlined } from '@ant-design/icons';
+import { UnorderedListOutlined } from '@ant-design/icons';
 import { Button, Layout, Space, Typography, theme } from 'antd';
 
 const { Header } = Layout;
@@ -78,7 +78,7 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({
         {showMenu && (
           <Button
             type="text"
-            icon={<MenuOutlined style={{ fontSize: token.fontSizeLG }} />}
+            icon={<UnorderedListOutlined style={{ fontSize: token.fontSizeLG }} />}
             onClick={onMenuClick}
           />
         )}


### PR DESCRIPTION
## Summary
- Replaced `MenuOutlined` with `UnorderedListOutlined` in both desktop and mobile headers
- Better represents the sessions list content in the drawer
- More intuitive for users - clearly indicates it opens a list

## Changes
- **AppHeader.tsx**: Updated desktop header icon from hamburger to list
- **MobileHeader.tsx**: Updated mobile header icon from hamburger to list

## Why?
The hamburger menu icon (`≡`) is typically used for generic navigation menus. Since this button specifically opens a sessions list, the list icon (`☰`) more accurately represents its purpose and makes the UI more semantic.

## Test plan
- [x] Run `pnpm install`
- [x] Run `pnpm check` - all typecheck, lint, and build tests passed
- [ ] Visual verification in browser
- [ ] Test on mobile view

🤖 Generated with [Claude Code](https://claude.com/claude-code)