### PR TITLE
chore: clean up verbose logging and fix frontend warnings

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -1327,12 +1327,16 @@ async function main() {
   // All services have requireAuth hooks, so only authenticated users can access them
   // This means any connection that successfully calls a service is authenticated
   app.publish((data, context) => {
-    console.log(`📡 [Publish] ${context.path} ${context.method}`, {
-      id: context.id,
-      hasData: !!data,
-      dataKeys: data ? Object.keys(data).join(',') : 'none',
-      channelCount: app.channel('everybody').length,
-    });
+    // Skip logging for internal events without path/method (e.g., repository-triggered events)
+    if (context.path && context.method) {
+      console.log(
+        `📡 [Publish] ${context.path} ${context.method}`,
+        context.id
+          ? `id: ${typeof context.id === 'string' ? context.id.substring(0, 8) : context.id}`
+          : '',
+        `channels: ${app.channel('everybody').length}`
+      );
+    }
     // Broadcast to all connected clients (they're all authenticated due to requireAuth)
     return app.channel('everybody');
   });

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -636,6 +636,7 @@ export const App: React.FC<AppProps> = ({
           />
           <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
             <PanelGroup
+              id="main-layout"
               direction="horizontal"
               style={{ flex: 1 }}
               onLayout={(sizes) => {
@@ -677,29 +678,33 @@ export const App: React.FC<AppProps> = ({
                   />
                 )}
               </Panel>
-              {!commentsPanelCollapsed && (
-                <PanelResizeHandle
-                  style={{
-                    width: '4px',
-                    background: 'var(--ant-color-border-secondary)',
-                    cursor: 'col-resize',
-                    transition: 'background 0.2s',
-                  }}
-                  onMouseEnter={(e) => {
+              <PanelResizeHandle
+                style={{
+                  width: commentsPanelCollapsed ? '0px' : '4px',
+                  background: 'var(--ant-color-border-secondary)',
+                  cursor: commentsPanelCollapsed ? 'default' : 'col-resize',
+                  transition: 'background 0.2s',
+                  pointerEvents: commentsPanelCollapsed ? 'none' : 'auto',
+                }}
+                onMouseEnter={(e) => {
+                  if (!commentsPanelCollapsed) {
                     (e.currentTarget as unknown as HTMLDivElement).style.background =
                       'var(--ant-color-primary)';
-                  }}
-                  onMouseLeave={(e) => {
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!commentsPanelCollapsed) {
                     (e.currentTarget as unknown as HTMLDivElement).style.background =
                       'var(--ant-color-border-secondary)';
-                  }}
-                />
-              )}
+                  }
+                }}
+              />
               <Panel
                 defaultSize={commentsPanelCollapsed ? 100 : 100 - commentsPanelSize}
                 minSize={40}
               >
                 <PanelGroup
+                  id="canvas-session"
                   direction="horizontal"
                   style={{ flex: 1 }}
                   onLayout={(sizes) => {

--- a/apps/agor-ui/src/components/BrandLogo/BrandLogo.tsx
+++ b/apps/agor-ui/src/components/BrandLogo/BrandLogo.tsx
@@ -45,8 +45,6 @@ export const BrandLogo: React.FC<BrandLogoProps> = ({ level = 3, style, classNam
     ...style,
   };
 
-  console.log('BrandLogo rendering with level:', level, 'fontSize:', LEVEL_SIZES[level]);
-
   return (
     <h1 className={className} style={gradientStyle}>
       agor

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -71,25 +71,29 @@ export const Facepile: React.FC<FacepileProps> = ({
               </div>
             }
           >
-            <AgorAvatar
-              style={{
-                cursor: canClick ? 'pointer' : 'default',
-              }}
-              onClick={() => {
-                if (canClick) {
-                  onUserClick(user.user_id, boardId, cursor);
-                }
-              }}
-            >
-              {user.emoji || '👤'}
-            </AgorAvatar>
+            <span>
+              <AgorAvatar
+                style={{
+                  cursor: canClick ? 'pointer' : 'default',
+                }}
+                onClick={() => {
+                  if (canClick) {
+                    onUserClick(user.user_id, boardId, cursor);
+                  }
+                }}
+              >
+                {user.emoji || '👤'}
+              </AgorAvatar>
+            </span>
           </Tooltip>
         );
       })}
 
       {overflowCount > 0 && (
         <Tooltip title={`+${overflowCount} more active users`}>
-          <AgorAvatar>+{overflowCount}</AgorAvatar>
+          <span>
+            <AgorAvatar>+{overflowCount}</AgorAvatar>
+          </span>
         </Tooltip>
       )}
     </div>

--- a/apps/agor-ui/src/components/GettingStartedPopover/GettingStartedPopover.tsx
+++ b/apps/agor-ui/src/components/GettingStartedPopover/GettingStartedPopover.tsx
@@ -221,9 +221,11 @@ export const GettingStartedPopover: React.FC<GettingStartedPopoverProps> = ({
       onOpenChange={setOpen}
       placement="bottomRight"
       overlayStyle={{ zIndex: 1050 }}
-      overlayInnerStyle={{
-        backgroundColor: 'rgba(0, 0, 0, 0.5)',
-        backdropFilter: 'blur(8px)',
+      styles={{
+        body: {
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          backdropFilter: 'blur(8px)',
+        },
       }}
     >
       {children}

--- a/apps/agor-ui/src/contexts/ThemeContext.tsx
+++ b/apps/agor-ui/src/contexts/ThemeContext.tsx
@@ -107,18 +107,14 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const isDark =
       themeMode === 'dark' || (themeMode === 'custom' && customTheme?.algorithm === darkAlgorithm);
 
-    console.log('Theme update:', { themeMode, isDark, customTheme: !!customTheme });
-
     // Set background color on document body
     document.body.style.backgroundColor = isDark ? '#141414' : '#f0f2f5';
 
     // Set 'dark' class for Tailwind dark mode (used by Streamdown)
     if (isDark) {
       document.documentElement.classList.add('dark');
-      console.log('Added dark class to html element');
     } else {
       document.documentElement.classList.remove('dark');
-      console.log('Removed dark class from html element');
     }
   }, [themeMode, customTheme, getCurrentThemeConfig]);
 

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -59,7 +59,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       setConnecting(true);
       setError(null);
 
-      console.log('🔌 useAgorClient: Creating new client (autoConnect: false)');
       // Create client (autoConnect: false, so we control connection timing)
       client = createClient(url, false);
       clientRef.current = client;
@@ -73,7 +72,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       // Setup socket event listeners BEFORE connecting
       client.io.on('connect', async () => {
         if (mounted) {
-          console.log('🔌 Connected to daemon');
           hasConnectedOnce = true; // Mark that we've successfully connected
 
           // Re-authenticate on reconnection (e.g., after daemon restart or network recovery)
@@ -85,7 +83,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                   strategy: 'jwt',
                   accessToken,
                 });
-                console.log('✓ Re-authenticated with stored token after reconnect');
                 setConnected(true);
                 setConnecting(false);
                 setError(null);
@@ -106,7 +103,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                       accessToken: refreshResult.accessToken,
                     });
 
-                    console.log('✓ Re-authenticated with refresh token after reconnect');
                     setConnected(true);
                     setConnecting(false);
                     setError(null);
@@ -124,7 +120,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
               await client.authenticate({
                 strategy: 'anonymous',
               });
-              console.log('✓ Re-authenticated anonymously after reconnect');
               setConnected(true);
               setConnecting(false);
               setError(null);
@@ -177,7 +172,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       });
 
       // Now manually connect the socket
-      console.log('🔌 useAgorClient: Manually connecting socket');
       client.io.connect();
 
       // Wait for connection before authenticating
@@ -253,12 +247,10 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
     return () => {
       mounted = false;
       if (client?.io) {
-        console.log('🔌 useAgorClient: Cleaning up socket connection...');
         // Remove all listeners to prevent memory leaks
         client.io.removeAllListeners();
         // Disconnect gracefully (close is more forceful than disconnect)
         client.io.close();
-        console.log('✅ useAgorClient: Socket closed');
       }
       // Clear global reference
       // biome-ignore lint/suspicious/noExplicitAny: Global window extension for HMR cleanup

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -70,7 +70,6 @@ export function useAuth(): UseAuthReturn {
       }
 
       // Create temporary client
-      console.log('🔌 useAuth: Creating temporary client for authentication');
       client = createClient(getDaemonUrl());
 
       // Connect the client first (since autoConnect is false)
@@ -208,7 +207,6 @@ export function useAuth(): UseAuthReturn {
     } finally {
       // CRITICAL: Always close the client connection to prevent leaks
       if (client?.io) {
-        console.log('🔌 useAuth: Closing temporary client connection');
         client.io.removeAllListeners();
         client.io.close();
       }
@@ -275,7 +273,6 @@ export function useAuth(): UseAuthReturn {
       let client: ReturnType<typeof createClient> | null = null;
 
       try {
-        console.log('🔌 useAuth.autoRefresh: Creating temporary client for token refresh');
         client = createClient(getDaemonUrl());
         client.io.connect();
 
@@ -322,7 +319,6 @@ export function useAuth(): UseAuthReturn {
       } finally {
         // CRITICAL: Always close the client connection to prevent leaks
         if (client?.io) {
-          console.log('🔌 useAuth.autoRefresh: Closing temporary client connection');
           client.io.removeAllListeners();
           client.io.close();
         }
@@ -342,7 +338,6 @@ export function useAuth(): UseAuthReturn {
 
     try {
       // Create temporary client for login
-      console.log('🔌 useAuth.login: Creating temporary client for login');
       client = createClient(getDaemonUrl());
 
       // Connect the client first (since autoConnect is false)
@@ -384,16 +379,7 @@ export function useAuth(): UseAuthReturn {
       });
 
       // Store both access and refresh tokens
-      console.log('💾 Saving tokens to localStorage...');
       storeTokens(result.accessToken, result.refreshToken);
-
-      // Verify tokens were saved
-      const savedAccessToken = getStoredAccessToken();
-      const savedRefreshToken = getStoredRefreshToken();
-      console.log('✓ Tokens stored in localStorage:', {
-        accessTokenSaved: !!savedAccessToken,
-        refreshTokenSaved: !!savedRefreshToken,
-      });
 
       setState({
         user: result.user,
@@ -417,7 +403,6 @@ export function useAuth(): UseAuthReturn {
     } finally {
       // CRITICAL: Always close the client connection to prevent leaks
       if (client?.io) {
-        console.log('🔌 useAuth.login: Closing temporary client connection');
         client.io.removeAllListeners();
         client.io.close();
       }

--- a/apps/agor-ui/src/utils/handlebars-helpers.ts
+++ b/apps/agor-ui/src/utils/handlebars-helpers.ts
@@ -17,5 +17,4 @@ export * from '@agor/core/templates/handlebars-helpers';
  */
 export function initializeHandlebarsHelpers(): void {
   registerHandlebarsHelpers();
-  console.log('✅ Handlebars helpers registered');
 }

--- a/context/explorations/file-upload.md
+++ b/context/explorations/file-upload.md
@@ -14,12 +14,14 @@ Allow users to upload files directly into a conversation, making them accessible
 **New backend endpoint:** `POST /sessions/:id/upload` with multer middleware
 
 **New UI components:**
+
 - Upload button next to prompt textarea
 - Drag-and-drop zone on textarea
 - Upload dialog with destination selection
 - Optional agent notification with custom message
 
 **Key features:**
+
 - Any file type accepted (multimodal-ready)
 - Files accessible via existing `@` autocomplete
 - Optional system message in conversation ("User uploaded file: ...")
@@ -32,17 +34,20 @@ Allow users to upload files directly into a conversation, making them accessible
 ### Why Build This?
 
 **1. Multimodal Workflows**
+
 - Share screenshots for UI feedback
 - Upload error logs for debugging
 - Provide reference documents for context
 - Share design mockups, diagrams, specs
 
 **2. Natural Interaction**
+
 - "Here's what I'm seeing" + screenshot is intuitive
 - Reduces friction vs. manual file placement + path typing
 - Drag-drop matches modern app expectations
 
 **3. Agent Accessibility**
+
 - Files land in worktree = agent can read them
 - `.agor/uploads/` is predictable, agent-friendly location
 - Works with existing `@` mention autocomplete
@@ -55,13 +60,14 @@ Allow users to upload files directly into a conversation, making them accessible
 
 **Primary destination:** `{worktree.path}/.agor/uploads/`
 
-| Location | Path | Use Case |
-|----------|------|----------|
+| Location           | Path                             | Use Case                           |
+| ------------------ | -------------------------------- | ---------------------------------- |
 | Worktree (default) | `{worktree.path}/.agor/uploads/` | Agent-accessible, can be committed |
-| Temp | `$TMPDIR/agor-uploads/` | Ephemeral, auto-cleanup |
-| Global | `~/.agor/uploads/` | Shared across sessions |
+| Temp               | `$TMPDIR/agor-uploads/`          | Ephemeral, auto-cleanup            |
+| Global             | `~/.agor/uploads/`               | Shared across sessions             |
 
 **Rationale for worktree default:**
+
 - Agent always has access (it's running in the worktree)
 - User can commit if desired (though `.agor/` typically gitignored)
 - Clear mental model: "files for this work"
@@ -95,6 +101,7 @@ Allow users to upload files directly into a conversation, making them accessible
 **2. Drag-and-drop** - Drop files anywhere on textarea
 
 Visual feedback on drag-over:
+
 ```
 +---------------------------------------------------------------+
 |  +---------------------------+                                |
@@ -311,6 +318,7 @@ interface UploadedFile {
 ```
 
 **Enables:**
+
 - "Uploaded files" panel in session/worktree UI
 - File browser with download/delete actions
 - Usage analytics
@@ -347,6 +355,7 @@ const handlePaste = (e: React.ClipboardEvent) => {
 ## Implementation Phases
 
 ### Phase 1: MVP
+
 - [ ] Add multer dependency
 - [ ] Create upload endpoint (worktree destination only)
 - [ ] Upload button component
@@ -354,17 +363,20 @@ const handlePaste = (e: React.ClipboardEvent) => {
 - [ ] Insert `@{filepath}` into textarea after upload
 
 ### Phase 2: Full Dialog
+
 - [ ] Destination selection (worktree/temp/global)
 - [ ] "Notify agent" checkbox + message textarea
 - [ ] Drag-and-drop on textarea
 
 ### Phase 3: Polish
+
 - [ ] Upload progress indicator
 - [ ] Multi-file upload UI
 - [ ] Clipboard paste support
 - [ ] System messages in conversation
 
 ### Phase 4: Optional Enhancements
+
 - [ ] Uploaded files metadata table
 - [ ] Files panel in session UI
 - [ ] Cleanup automation for temp files
@@ -374,10 +386,12 @@ const handlePaste = (e: React.ClipboardEvent) => {
 ## Dependencies
 
 **New packages:**
+
 - `multer` - Multipart form handling
 - `@types/multer` - TypeScript types
 
 **Estimated effort:**
+
 - Phase 1: 4-6 hours
 - Phase 2: 2-3 hours
 - Phase 3: 2-3 hours

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -341,9 +341,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       const statusInfo = updates.status
         ? ` (status: ${updates.status}, ready_for_prompt: ${updates.ready_for_prompt})`
         : '';
-      console.log(
-        `🔄 [SessionRepo] Starting transaction for session ${fullId.substring(0, 8)}${statusInfo}`
-      );
+      console.debug(`🔄 [SessionRepo] Updating session ${fullId.substring(0, 8)}${statusInfo}`);
 
       // Use transaction to make read-merge-write atomic
       // This prevents race conditions where another update happens between read and write

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -292,8 +292,8 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     try {
       const fullId = await this.resolveId(id);
 
-      console.log(
-        `🔄 [TaskRepo] Starting transaction for task ${fullId.substring(0, 8)}${updates.status ? ` (status: ${updates.status})` : ''}`
+      console.debug(
+        `🔄 [TaskRepo] Updating task ${fullId.substring(0, 8)}${updates.status ? ` (status: ${updates.status})` : ''}`
       );
 
       // Use transaction to make read-merge-write atomic
@@ -316,10 +316,6 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         const merged = deepMerge(current, updates);
         const insertData = this.taskToInsert(merged);
 
-        console.log(
-          `💾 [TaskRepo] Writing task ${fullId.substring(0, 8)} status: ${insertData.status}`
-        );
-
         // STEP 3: Write merged task (within same transaction)
         // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
         await update(tx as any, tasks)
@@ -334,8 +330,6 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         // Return merged task (no need to re-fetch, we have it in memory)
         return merged;
       });
-
-      console.log(`✅ [TaskRepo] Transaction committed for task ${fullId.substring(0, 8)}`);
       return result;
     } catch (error) {
       if (error instanceof RepositoryError) throw error;


### PR DESCRIPTION
## Summary
- Cleaned up verbose logging across backend and frontend
- Fixed React warnings in frontend components

## Backend Changes
- Fixed double publish logs with undefined path/method by adding guard condition
- Reduced repository transaction logs to `console.debug()` level (respects `LOG_LEVEL` env var)
- Now shows cleaner publish logs: `📡 [Publish] sessions patch id: 70ec46b1 channels: 0`

## Frontend Changes

### Log Removals (8 categories)
- Removed BrandLogo rendering logs
- Removed token storage confirmation logs (2 logs)
- Removed all client connection lifecycle logs (7 logs total from useAuth and useAgorClient)
- Removed Handlebars helper registration log
- Removed ThemeContext logs (3 logs for theme updates and dark class)

### Warning Fixes (3 fixes)
- Fixed deprecated `overlayInnerStyle` → `styles.body` in GettingStartedPopover
- Fixed findDOMNode deprecation by wrapping AgorAvatar in `<span>` in Facepile
- Added explicit IDs to PanelGroups and made resize handle always present (invisible when collapsed)

## Result
- Much cleaner console output for better developer experience
- All React warnings resolved
- Verbose logs can still be enabled with `LOG_LEVEL=debug` for debugging

## Test plan
- [x] pnpm install
- [x] pnpm check (typecheck + lint + build)
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)