### PR TITLE
feat(ui): replace ReactFlow tooltips with Ant Design tooltips

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -22,9 +22,12 @@ import {
   CommentOutlined,
   DeleteOutlined,
   FileMarkdownOutlined,
+  MinusOutlined,
+  PlusOutlined,
   SelectOutlined,
+  ZoomInOutlined,
 } from '@ant-design/icons';
-import { Button, Input, Modal, Popover, Slider, Typography, theme } from 'antd';
+import { Button, Input, Modal, Popover, Slider, Tooltip, Typography, theme } from 'antd';
 import Handlebars from 'handlebars';
 import {
   forwardRef,
@@ -1939,71 +1942,112 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             style={{ background: 'transparent' }}
           >
             {!canvasBackground && <Background />}
-            <Controls position="top-left" showInteractive={false}>
+            <Controls
+              position="top-left"
+              showZoom={false}
+              showFitView={false}
+              showInteractive={false}
+            >
+              {/* Zoom controls */}
+              <Tooltip title="Zoom In" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    reactFlowInstanceRef.current?.zoomIn();
+                  }}
+                >
+                  <PlusOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
+              <Tooltip title="Zoom Out" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    reactFlowInstanceRef.current?.zoomOut();
+                  }}
+                >
+                  <MinusOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
+              <Tooltip title="Fit View" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    reactFlowInstanceRef.current?.fitView();
+                  }}
+                >
+                  <ZoomInOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
               {/* Custom toolbox buttons */}
-              <ControlButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveTool('select');
-                }}
-                title="Select"
-                style={{
-                  borderLeft: activeTool === 'select' ? '3px solid #1677ff' : 'none',
-                }}
-              >
-                <SelectOutlined style={{ fontSize: '16px' }} />
-              </ControlButton>
-              <ControlButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveTool('zone');
-                }}
-                title="Add Zone"
-                style={{
-                  borderLeft: activeTool === 'zone' ? '3px solid #1677ff' : 'none',
-                }}
-              >
-                <BorderOutlined style={{ fontSize: '16px' }} />
-              </ControlButton>
-              <ControlButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveTool('comment');
-                }}
-                title="Add Comment"
-                style={{
-                  borderLeft: activeTool === 'comment' ? '3px solid #1677ff' : 'none',
-                }}
-              >
-                <CommentOutlined style={{ fontSize: '16px' }} />
-              </ControlButton>
-              <ControlButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveTool('markdown');
-                }}
-                title="Add Markdown Note"
-                style={{
-                  borderLeft: activeTool === 'markdown' ? '3px solid #1677ff' : 'none',
-                }}
-              >
-                <FileMarkdownOutlined style={{ fontSize: '16px' }} />
-              </ControlButton>
-              <ControlButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
-                }}
-                title="Eraser - Click to toggle"
-                style={{
-                  borderLeft: activeTool === 'eraser' ? `3px solid ${token.colorError}` : 'none',
-                  color: activeTool === 'eraser' ? token.colorError : 'inherit',
-                  backgroundColor:
-                    activeTool === 'eraser' ? `${token.colorError}15` : 'transparent',
-                }}
-              >
-                <DeleteOutlined style={{ fontSize: '16px' }} />
-              </ControlButton>
+              <Tooltip title="Select" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveTool('select');
+                  }}
+                  style={{
+                    borderLeft: activeTool === 'select' ? '3px solid #1677ff' : 'none',
+                  }}
+                >
+                  <SelectOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
+              <Tooltip title="Add Zone" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveTool('zone');
+                  }}
+                  style={{
+                    borderLeft: activeTool === 'zone' ? '3px solid #1677ff' : 'none',
+                  }}
+                >
+                  <BorderOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
+              <Tooltip title="Add Comment" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveTool('comment');
+                  }}
+                  style={{
+                    borderLeft: activeTool === 'comment' ? '3px solid #1677ff' : 'none',
+                  }}
+                >
+                  <CommentOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
+              <Tooltip title="Add Markdown Note" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveTool('markdown');
+                  }}
+                  style={{
+                    borderLeft: activeTool === 'markdown' ? '3px solid #1677ff' : 'none',
+                  }}
+                >
+                  <FileMarkdownOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
+              <Tooltip title="Eraser - Click to toggle" placement="right" mouseEnterDelay={0.3}>
+                <ControlButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
+                  }}
+                  style={{
+                    borderLeft: activeTool === 'eraser' ? `3px solid ${token.colorError}` : 'none',
+                    color: activeTool === 'eraser' ? token.colorError : 'inherit',
+                    backgroundColor:
+                      activeTool === 'eraser' ? `${token.colorError}15` : 'transparent',
+                  }}
+                >
+                  <DeleteOutlined style={{ fontSize: '16px' }} />
+                </ControlButton>
+              </Tooltip>
             </Controls>
             <MiniMap
               nodeColor={(node) => {


### PR DESCRIPTION
## Summary

Replace slow-appearing browser-native tooltips with fast, styled Ant Design tooltips for all board toolbox buttons.

## Changes

- ✅ Added Tooltip component import from antd
- ✅ Added custom zoom controls (Zoom In, Zoom Out, Fit View) with Ant Design tooltips
- ✅ Wrapped all existing tool buttons (Select, Zone, Comment, Markdown, Eraser) with Tooltips
- ✅ Set mouseEnterDelay to 300ms for faster appearance
- ✅ Hid default ReactFlow zoom/fitView buttons (showZoom=false, showFitView=false)
- ✅ Used placement="right" for optimal positioning

## Benefits

- **Faster appearance**: Tooltips now appear in 300ms instead of 1000ms+ (browser default)
- **Consistent styling**: Tooltips match Agor's dark mode theme
- **Better UX**: Smooth fade animations and consistent behavior
- **All buttons covered**: All 8 toolbox buttons now have uniform tooltip behavior

## Testing

- [x] Ran `pnpm install`
- [x] Ran `pnpm check` (typecheck, lint, build)
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)