### PR TITLE
fix(ui): wire onNukeEnvironment callback through component hierarchy

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -756,6 +756,7 @@ export const App: React.FC<AppProps> = ({
                         onStartEnvironment={onStartEnvironment}
                         onStopEnvironment={onStopEnvironment}
                         onViewLogs={setLogsModalWorktreeId}
+                        onNukeEnvironment={onNukeEnvironment}
                         onOpenCommentsPanel={() => setCommentsPanelCollapsed(false)}
                         onCommentHover={setHoveredCommentId}
                         onCommentSelect={(commentId) => {
@@ -827,6 +828,7 @@ export const App: React.FC<AppProps> = ({
                               onCreateSession: (worktreeId) => setNewSessionWorktreeId(worktreeId),
                               onOpenSettings: (worktreeId) =>
                                 setWorktreeModalWorktreeId(worktreeId),
+                              onNukeEnvironment,
                             }}
                           />
                         )}

--- a/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
@@ -34,6 +34,7 @@ export interface WorktreeActions {
   onStopEnvironment?: (worktreeId: string) => void;
   onOpenSettings?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onNukeEnvironment?: (worktreeId: string) => void;
 }
 
 export interface EventItemProps {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -117,6 +117,7 @@ interface SessionCanvasProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onNukeEnvironment?: (worktreeId: string) => void;
   onOpenCommentsPanel?: () => void;
   onCommentHover?: (commentId: string | null) => void;
   onCommentSelect?: (commentId: string | null) => void;
@@ -273,6 +274,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onStartEnvironment,
       onStopEnvironment,
       onViewLogs,
+      onNukeEnvironment,
       onOpenCommentsPanel,
       onCommentHover,
       onCommentSelect,
@@ -578,6 +580,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onStartEnvironment,
             onStopEnvironment,
             onViewLogs,
+            onNukeEnvironment,
             onUnpin: handleUnpinWorktree,
             compact: false,
             isPinned: !!dbZoneId,
@@ -608,6 +611,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onStartEnvironment,
       onStopEnvironment,
       onViewLogs,
+      onNukeEnvironment,
       handleUnpinWorktree,
       zoneLabels,
       userById,

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -71,6 +71,7 @@ interface WorktreeCardProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onNukeEnvironment?: (worktreeId: string) => void;
   onUnpin?: (worktreeId: string) => void;
   isPinned?: boolean;
   zoneName?: string;
@@ -98,6 +99,7 @@ const WorktreeCardComponent = ({
   onStartEnvironment,
   onStopEnvironment,
   onViewLogs,
+  onNukeEnvironment,
   onUnpin,
   isPinned = false,
   zoneName,
@@ -591,6 +593,7 @@ const WorktreeCardComponent = ({
             onStartEnvironment={onStartEnvironment}
             onStopEnvironment={onStopEnvironment}
             onViewLogs={onViewLogs}
+            onNukeEnvironment={onNukeEnvironment}
             connectionDisabled={connectionDisabled}
           />
         </Space>


### PR DESCRIPTION
## Summary

Fixed the missing nuke button in the Environment Pill by wiring the `onNukeEnvironment` callback through the component hierarchy.

## Problem

The nuke button in `EnvironmentPill` was not appearing even though:
- The `nuke_command` was properly configured in worktrees
- The button component code existed with the correct `FireOutlined` icon
- The conditional rendering logic was correct

## Root Cause

The `onNukeEnvironment` callback prop was never being passed down through the component hierarchy:
- `App.tsx` → `SessionCanvas` → `WorktreeCard` → `EnvironmentPill`

## Changes

- **WorktreeCard.tsx**: Added `onNukeEnvironment` to props interface and passed it to `EnvironmentPill`
- **SessionCanvas.tsx**: Added `onNukeEnvironment` to props interface, worktree node data, and dependency array
- **EventItem.tsx**: Added `onNukeEnvironment` to `WorktreeActions` interface
- **App.tsx**: Wired `onNukeEnvironment` to both `SessionCanvas` and `EventStreamPanel`

## Testing

- ✅ All type checks pass
- ✅ All linting checks pass  
- ✅ All builds successful

## Screenshots

The nuke button (🔥) should now appear in the Environment Pill when a worktree has a `nuke_command` configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)