### PR TITLE
fix(daemon): trigger parent queue processing after callback queued

### DIFF
--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -180,22 +180,34 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
             // CRITICAL FIX: After queuing callback to parent, trigger parent's queue processing
             // if parent is idle. This ensures callbacks don't sit in the queue forever.
-            // biome-ignore lint/suspicious/noExplicitAny: Service type casting required for custom method access
-            const sessionsService = this.app.service('sessions') as any;
-            if (sessionsService.triggerQueueProcessing) {
-              // Get parent session to check if it's idle
-              const parentSession = await this.app
-                .service('sessions')
-                .get(session.genealogy.parent_session_id);
-              if (parentSession.status === 'idle' && parentSession.ready_for_prompt) {
-                console.log(
-                  `🔄 [TasksService] Triggering parent queue processing for ${parentSession.session_id.substring(0, 8)} (callback queued)`
-                );
-                await sessionsService.triggerQueueProcessing(
-                  session.genealogy.parent_session_id,
-                  params
-                );
+            // IMPORTANT: Isolated in try/catch so parent failures don't break child queue processing
+            try {
+              // biome-ignore lint/suspicious/noExplicitAny: Service type casting required for custom method access
+              const sessionsService = this.app.service('sessions') as any;
+              if (sessionsService.triggerQueueProcessing) {
+                // Get parent session to check if it's idle
+                // NOTE: Don't pass params here - we fetch parent without child's auth context
+                const parentSession = await this.app
+                  .service('sessions')
+                  .get(session.genealogy.parent_session_id);
+                if (parentSession.status === 'idle' && parentSession.ready_for_prompt) {
+                  console.log(
+                    `🔄 [TasksService] Triggering parent queue processing for ${parentSession.session_id.substring(0, 8)} (callback queued)`
+                  );
+                  // Pass empty params to avoid leaking child's auth context to parent
+                  // The queue processor will reconstruct parent auth from queued message metadata
+                  await sessionsService.triggerQueueProcessing(
+                    session.genealogy.parent_session_id,
+                    {}
+                  );
+                }
               }
+            } catch (error) {
+              // Don't throw - parent issues shouldn't break child queue processing
+              console.warn(
+                `⚠️  [TasksService] Failed to trigger parent queue processing (parent may be deleted):`,
+                error
+              );
             }
           }
 


### PR DESCRIPTION
## Summary

Fixes the callback queue mechanism where parent sessions weren't processing queued callbacks from child sessions.

## Problem

When a child session completes and queues a callback to its parent:
1. Child task completes → child session becomes `idle` + `ready_for_prompt: true`
2. Callback is queued to the **parent session**
3. Child session's queue is processed
4. **Parent session's queue is NEVER processed** ❌

The parent session doesn't have its status changed (it was already idle), so the `after.patch` hook that triggers queue processing never fires for the parent. The callback just sits in the parent's queue forever.

## Solution

After queuing the callback to the parent (tasks.ts:179), check if the parent is idle and ready. If so, immediately trigger the parent's queue processing via `triggerQueueProcessing()`.

## Changes

- `apps/agor-daemon/src/services/tasks.ts`: Added parent queue processing trigger after callback is queued (lines 181-199)

## Testing

- ✅ Type checking passed
- ✅ Linting passed
- ✅ Build successful

## Impact

Ensures that subsession callbacks are processed immediately when the parent is idle, fixing the race condition where callbacks would queue but never execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)