### PR TITLE
feat(docs): apply brand gradient text to hero, navbar, and main page

### DIFF
--- a/apps/agor-docs/components/Hero.module.css
+++ b/apps/agor-docs/components/Hero.module.css
@@ -47,10 +47,13 @@
   line-height: 1.1;
   margin-top: 0;
   margin-bottom: 2rem;
-  background: linear-gradient(135deg, #2e9a92 0%, #3db4aa 100%);
+  background: linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .heroSubtitle {

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -11,7 +11,7 @@ description: Complete guide to agor - next-gen agent orchestration for AI coding
   />
 </div>
 
-# agor
+# <span className="gradient-text">agor</span>
 
 **Think Figma, but for AI coding assistants.**
 

--- a/apps/agor-docs/pages/styles.css
+++ b/apps/agor-docs/pages/styles.css
@@ -4,6 +4,16 @@
   --agor-teal: #2e9a92;
   --agor-teal-light: #3db4aa;
   --agor-teal-dark: #236e68;
+  --agor-gradient: linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%);
+}
+
+/* Gradient text utility class for brand consistency */
+.gradient-text {
+  background: var(--agor-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  font-weight: 700;
 }
 
 /* Custom link color for brand consistency */

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -17,7 +17,17 @@ const config: DocsThemeConfig = {
         style={{ height: '42px', width: '42px', borderRadius: '50%' }}
         suppressHydrationWarning
       />
-      <strong style={{ fontSize: '18px' }}>agor</strong>
+      <strong
+        style={{
+          fontSize: '18px',
+          background: 'linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          backgroundClip: 'text',
+        }}
+      >
+        agor
+      </strong>
     </span>
   ),
   project: {


### PR DESCRIPTION
## Summary

Applied consistent brand gradient (teal → cyan → aqua) across the agor-docs website for a cohesive brand identity.

## Changes

- **Hero page title**: Updated gradient from 2-color to 3-color brand gradient with `fit-content` width for better visibility
- **Navbar logo**: Applied gradient to "agor" text matching the main app's `BrandLogo` component
- **Main documentation page**: Applied gradient to the main "agor" heading
- **Global styles**: Added `--agor-gradient` CSS variable and `.gradient-text` utility class for consistent reuse

## Brand Gradient

```css
linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%)
```

This creates a beautiful transition from brand teal → bright cyan → light aqua.

## Testing

- ✅ Gradient visible on hero page
- ✅ Gradient visible in navbar
- ✅ Gradient visible on main documentation page
- ✅ Typecheck passed
- ✅ Lint passed
- ✅ Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)