### PR TITLE
fix(ui): copy full message content in queued messages

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -223,8 +223,7 @@ export const SessionPanelContent: React.FC<SessionPanelContentProps> = ({
                     size="small"
                     icon={<CopyOutlined />}
                     onClick={() => {
-                      const textToCopy =
-                        msg.content_preview || (typeof msg.content === 'string' ? msg.content : '');
+                      const textToCopy = typeof msg.content === 'string' ? msg.content : '';
                       navigator.clipboard.writeText(textToCopy);
                       message.success('Message copied to clipboard');
                     }}


### PR DESCRIPTION
## Summary

Fixed copy-to-clipboard button in queued messages drawer to copy the full message content instead of the truncated preview text.

## Changes

- Updated copy button handler in `SessionPanelContent.tsx` to copy `msg.content` directly instead of `msg.content_preview`
- Display still shows truncated preview for visual clarity, but clipboard gets the full content

## Test Plan

1. Queue multiple messages in a session
2. View queued messages above the prompt text area
3. Click copy button on a long queued message
4. Verify clipboard contains full message content, not truncated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)