### PR TITLE
fix(core): use JSON_SCHEMA for YAML board import to parse numbers correctly

### DIFF
--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -570,12 +570,15 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
 
   /**
    * Parse YAML string into a validated BoardExportBlob without creating a board
-   * Uses FAILSAFE_SCHEMA to prevent code execution via malicious YAML tags
+   * Uses JSON_SCHEMA to prevent code execution via malicious YAML tags
+   * while still correctly parsing numbers, booleans, and null
    */
   parseYamlToBlob(yamlContent: string): BoardExportBlob {
     try {
-      // Use FAILSAFE_SCHEMA to prevent RCE via !!js/function or other code-executing tags
-      const blob = yaml.load(yamlContent, { schema: yaml.FAILSAFE_SCHEMA }) as BoardExportBlob;
+      // Use JSON_SCHEMA to prevent RCE via !!js/function or other code-executing tags
+      // while still parsing numbers, booleans, and null correctly
+      // (FAILSAFE_SCHEMA parses everything as strings, breaking numeric validations)
+      const blob = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA }) as BoardExportBlob;
       this.validateBoardBlob(blob);
       return blob;
     } catch (error) {


### PR DESCRIPTION
## Summary

- Fixed board import failing with "missing position/dimensions" error when importing YAML files
- Root cause: `FAILSAFE_SCHEMA` was parsing all YAML values as strings, so zone coordinates like `x: 100` became `"100"` instead of `100`
- Changed to `JSON_SCHEMA` which still prevents RCE via malicious YAML tags (like `!!js/function`) but correctly parses numbers, booleans, and null

## Test plan

- [ ] Import a board YAML file with zones that have numeric x/y/width/height values
- [ ] Verify the import succeeds without "missing position/dimensions" error
- [ ] Verify zones appear correctly on the board

🤖 Generated with [Claude Code](https://claude.com/claude-code)