### PR TITLE
fix(unix): apply worktree directory permissions when creating groups

### DIFF
--- a/apps/agor-cli/src/commands/admin/sync-unix.ts
+++ b/apps/agor-cli/src/commands/admin/sync-unix.ts
@@ -576,21 +576,33 @@ export default class SyncUnix extends Command {
           this.log(chalk.cyan(`Found ${worktreesWithGroup.length} worktree(s) with unix_group\n`));
 
           for (const wt of worktreesWithGroup) {
-            const worktree = wt as {
+            // Extract path from the data JSON blob (it's not a top-level column)
+            const rawWorktree = wt as {
               worktree_id: string;
               name: string;
               unix_group: string;
-              path: string;
               others_fs_access: 'none' | 'read' | 'write' | null;
+              data: { path?: string } | null;
             };
 
-            this.log(chalk.bold(`📁 ${worktree.name}`));
-            this.log(chalk.gray(`   worktree_id: ${worktree.worktree_id.substring(0, 8)}`));
-            this.log(chalk.gray(`   unix_group: ${worktree.unix_group}`));
-            this.log(chalk.gray(`   path: ${worktree.path}`));
+            const worktreePath = rawWorktree.data?.path;
+
+            // Skip worktrees without a path
+            if (!worktreePath) {
+              this.log(chalk.yellow(`📁 ${rawWorktree.name}`));
+              this.log(chalk.gray(`   worktree_id: ${rawWorktree.worktree_id.substring(0, 8)}`));
+              this.log(chalk.gray(`   unix_group: ${rawWorktree.unix_group}`));
+              this.log(chalk.red(`   ⚠ No path found in worktree data, skipping\n`));
+              continue;
+            }
+
+            this.log(chalk.bold(`📁 ${rawWorktree.name}`));
+            this.log(chalk.gray(`   worktree_id: ${rawWorktree.worktree_id.substring(0, 8)}`));
+            this.log(chalk.gray(`   unix_group: ${rawWorktree.unix_group}`));
+            this.log(chalk.gray(`   path: ${worktreePath}`));
 
             // Calculate permission mode based on others_fs_access
-            const othersAccess = worktree.others_fs_access || 'read';
+            const othersAccess = rawWorktree.others_fs_access || 'read';
             const permissionMode = getWorktreePermissionMode(othersAccess);
 
             this.log(chalk.gray(`   others_fs_access: ${othersAccess} → mode: ${permissionMode}`));
@@ -598,17 +610,17 @@ export default class SyncUnix extends Command {
             if (dryRun) {
               this.log(
                 chalk.gray(
-                  `   [dry-run] Would run: chgrp -R ${worktree.unix_group} "${worktree.path}"`
+                  `   [dry-run] Would run: chgrp -R ${rawWorktree.unix_group} "${worktreePath}"`
                 )
               );
               this.log(
-                chalk.gray(`   [dry-run] Would run: chmod -R ${permissionMode} "${worktree.path}"`)
+                chalk.gray(`   [dry-run] Would run: chmod -R ${permissionMode} "${worktreePath}"`)
               );
               this.log('');
             } else {
               try {
                 // Use the same command structure as UnixGroupCommands.setDirectoryGroup
-                const cmd = `sh -c 'chgrp -R ${worktree.unix_group} "${worktree.path}" && chmod -R ${permissionMode} "${worktree.path}"'`;
+                const cmd = `sh -c 'chgrp -R ${rawWorktree.unix_group} "${worktreePath}" && chmod -R ${permissionMode} "${worktreePath}"'`;
                 execSync(cmd, { stdio: 'pipe' });
 
                 worktreesRepaired++;

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -686,21 +686,14 @@ export class UnixIntegrationService {
   async syncWorktree(worktreeId: WorktreeID): Promise<void> {
     console.log(`[UnixIntegration] Full sync for worktree ${worktreeId.substring(0, 8)}`);
 
-    // Ensure group exists
+    // Ensure group exists and permissions are set
+    // Note: createWorktreeGroup() handles setting directory permissions internally
     await this.createWorktreeGroup(worktreeId);
-
-    // Get worktree for path
-    const worktree = await this.worktreeRepo.findById(worktreeId);
 
     // Add all owners to group and create symlinks
     const ownerIds = await this.worktreeRepo.getOwners(worktreeId);
     for (const ownerId of ownerIds) {
       await this.addUserToWorktreeGroup(worktreeId, ownerId);
-    }
-
-    // Set permissions if path is available
-    if (worktree?.path) {
-      await this.setWorktreePermissions(worktreeId, worktree.path);
     }
   }
 


### PR DESCRIPTION
## Summary

- Call `setWorktreePermissions()` from `createWorktreeGroup()` after group creation to apply correct directory ownership and permissions
- Add `--repair-worktree-perms` flag to `agor admin sync-unix` command for fixing existing worktrees with broken permissions
- Respects `others_fs_access` setting: `none`=2750, `read`=2755 (default), `write`=2777

## Context

The Unix isolation system was creating worktree groups (`agor_wt_*`) but failing to apply group ownership and permissions to the actual worktree directories. This caused permission denied errors when users in the worktree group tried to edit files.

The fix uses the already-existing `setWorktreePermissions()` method - it just wasn't being called after group creation.

## Test plan

- [ ] Enable RBAC: `agor config set execution.worktree_rbac true`
- [ ] Create a new worktree and verify directory permissions match `others_fs_access` setting
- [ ] Run `sudo agor admin sync-unix --repair-worktree-perms --dry-run` to preview repairs
- [ ] Run `sudo agor admin sync-unix --repair-worktree-perms` to apply repairs
- [ ] Verify group members can create/edit files in repaired worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)