### PR TITLE
fix(permissions): include task_id in permission request content for proper event routing

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -102,6 +102,7 @@ import type {
   Message,
   Paginated,
   Params,
+  PermissionRequestContent,
   Session,
   SessionID,
   Task,
@@ -3736,7 +3737,8 @@ async function main() {
 
         const messageList = isPaginated(messages) ? messages.data : messages;
         const permissionMessage = messageList.find((msg: Message) => {
-          const content = msg.content as unknown as Record<string, unknown>;
+          // Type-safe access to permission request content
+          const content = msg.content as PermissionRequestContent;
           return content?.request_id === data.requestId;
         });
 
@@ -3744,11 +3746,28 @@ async function main() {
           throw new Error(`Permission request ${data.requestId} not found`);
         }
 
+        // Type-safe access to permission content
+        const permissionContent = permissionMessage.content as PermissionRequestContent;
+
+        // Resolve task_id with fallback for backward compatibility:
+        // 1. Try content.task_id (new messages)
+        // 2. Fall back to message.task_id (legacy messages or if content was missing it)
+        const resolvedTaskId = permissionContent.task_id || permissionMessage.task_id;
+
+        if (!resolvedTaskId) {
+          console.error(
+            `❌ [Permission] Cannot resolve permission: task_id missing from both content and message. requestId=${data.requestId}`
+          );
+          throw new Error(
+            'Cannot process permission decision: task_id is missing. This permission request may be corrupted.'
+          );
+        }
+
         // Update the message to mark it as approved/denied
         // This triggers the messages.patch hook which notifies the executor via IPC (legacy mode)
         await messagesService.patch(permissionMessage.message_id, {
           content: {
-            ...(permissionMessage.content as object),
+            ...permissionContent,
             status: data.allow ? 'approved' : 'denied',
             scope: data.scope,
             approved_by: data.decidedBy,
@@ -3761,12 +3780,11 @@ async function main() {
 
         // Emit permission_resolved event for Feathers/WebSocket executor architecture
         // IMPORTANT: Use camelCase property names to match executor's expectations
-        const content = permissionMessage.content as unknown as Record<string, unknown>;
         app.service('messages').emit('permission_resolved', {
-          requestId: data.requestId, // camelCase
-          taskId: content.task_id as string, // camelCase
-          sessionId: id, // camelCase (for consistency, though not used by executor)
-          allow: data.allow, // Correct property name (not "approved")
+          requestId: data.requestId,
+          taskId: resolvedTaskId, // Use resolved task_id with fallback for backward compat
+          sessionId: id,
+          allow: data.allow,
           reason: data.reason,
           remember: data.remember,
           scope: data.scope,

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -82,6 +82,7 @@ export enum PermissionStatus {
  */
 export interface PermissionRequestContent {
   request_id: string;
+  task_id?: TaskID; // Required for daemon to route permission_resolved event back to executor (optional for backward compat with legacy messages)
   tool_name: string;
   tool_input: Record<string, unknown>;
   tool_use_id?: string;

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -175,6 +175,7 @@ export function createCanUseToolCallback(
         content_preview: `Permission required: ${toolName}`,
         content: {
           request_id: requestId,
+          task_id: taskId, // Required for daemon to route permission_resolved event back to executor
           tool_name: toolName,
           tool_input: toolInput,
           tool_use_id: undefined,


### PR DESCRIPTION
## Summary

- Fixed permission approval flow where executor never received UI decisions, causing 60s timeout and auto-denial
- Added `task_id` to `PermissionRequestContent` interface and message content object
- Added type-safe access to permission content in daemon to prevent similar issues via TypeScript

## Problem

When a user approved a permission request in the UI:
1. The `permission_resolved` event was emitted with `taskId: undefined`
2. Executor's check `data.taskId === this.config.taskId` always failed
3. After 60-second timeout, permission was auto-denied

## Root Cause

The `task_id` was only set on the message object, not in the `content` object. The daemon extracted `content.task_id` which was `undefined`.

## Test plan

- [ ] Trigger a permission request in a session
- [ ] Approve the permission in the UI
- [ ] Verify agent immediately receives the decision (no 60s timeout)
- [ ] Verify denied permissions also work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)