### PR TITLE
feat: centralize pagination limits to prevent data truncation

### DIFF
--- a/apps/agor-cli/src/commands/board/add-session.ts
+++ b/apps/agor-cli/src/commands/board/add-session.ts
@@ -6,6 +6,7 @@
  * associated with that worktree.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import type { Board, BoardEntityObject, Session, Worktree } from '@agor/core/types';
 import { Args } from '@oclif/core';
 import chalk from 'chalk';
@@ -36,8 +37,10 @@ export default class BoardAddSession extends BaseCommand {
     const client = await this.connectToDaemon();
 
     try {
-      // Find board by ID or slug (fetch all boards)
-      const boardsResult = await client.service('boards').find({ query: { $limit: -1 } });
+      // Find board by ID or slug
+      const boardsResult = await client
+        .service('boards')
+        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
       const boards = (Array.isArray(boardsResult) ? boardsResult : boardsResult.data) as Board[];
 
       const board = boards.find(
@@ -52,8 +55,10 @@ export default class BoardAddSession extends BaseCommand {
         this.error(`Board not found: ${args.boardId}`);
       }
 
-      // Find session by short or full ID (fetch all sessions)
-      const sessionsResult = await client.service('sessions').find({ query: { $limit: -1 } });
+      // Find session by short or full ID
+      const sessionsResult = await client
+        .service('sessions')
+        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
       const sessions = (
         Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data
       ) as Session[];
@@ -73,7 +78,9 @@ export default class BoardAddSession extends BaseCommand {
         this.error('Session has no worktree associated');
       }
 
-      const worktreesResult = await client.service('worktrees').find({ query: { $limit: -1 } });
+      const worktreesResult = await client
+        .service('worktrees')
+        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
       const worktrees = (
         Array.isArray(worktreesResult) ? worktreesResult : worktreesResult.data
       ) as Worktree[];

--- a/apps/agor-cli/src/commands/repo/list.ts
+++ b/apps/agor-cli/src/commands/repo/list.ts
@@ -4,6 +4,7 @@
  * Displays repositories in a beautiful table.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { formatShortId } from '@agor/core/db';
 import type { Repo } from '@agor/core/types';
 import { Flags } from '@oclif/core';
@@ -28,7 +29,7 @@ export default class RepoList extends BaseCommand {
     limit: Flags.integer({
       char: 'l',
       description: 'Maximum number of repos to show',
-      default: 50,
+      default: PAGINATION.CLI_DEFAULT_LIMIT,
     }),
   };
 

--- a/apps/agor-cli/src/commands/session/list.ts
+++ b/apps/agor-cli/src/commands/session/list.ts
@@ -4,6 +4,7 @@
  * Displays sessions in a beautiful table with filters.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { formatShortId } from '@agor/core/db';
 import type { Session } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
@@ -53,7 +54,7 @@ export default class SessionList extends BaseCommand {
     limit: Flags.integer({
       char: 'l',
       description: 'Maximum number of sessions to show',
-      default: 50,
+      default: PAGINATION.CLI_DEFAULT_LIMIT,
     }),
   };
 

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -11,6 +11,7 @@
  * - Mentions and notifications (Phase 4)
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { BoardCommentsRepository, type Database } from '@agor/core/db';
 import type { BoardComment, QueryParams } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
@@ -44,8 +45,8 @@ export class BoardCommentsService extends DrizzleService<
       id: 'comment_id',
       resourceType: 'BoardComment',
       paginate: {
-        default: 100,
-        max: 500,
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
     });
 
@@ -70,9 +71,9 @@ export class BoardCommentsService extends DrizzleService<
       created_by: filters.created_by,
     });
 
-    // Apply pagination if requested (default: 100)
-    const $limit = filters.$limit || 100;
-    const $skip = filters.$skip || 0;
+    // Apply pagination if requested
+    const $limit = filters.$limit ?? PAGINATION.DEFAULT_LIMIT;
+    const $skip = filters.$skip ?? 0;
     const paginated = allComments.slice($skip, $skip + $limit);
 
     // Return paginated result format expected by FeathersJS

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -5,6 +5,7 @@
  * Uses DrizzleService adapter with BoardRepository.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { BoardRepository, type Database } from '@agor/core/db';
 import type {
   AuthenticatedParams,
@@ -39,8 +40,8 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
       id: 'board_id',
       resourceType: 'Board',
       paginate: {
-        default: 50,
-        max: 100,
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
     });
 

--- a/apps/agor-daemon/src/services/mcp-servers.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.ts
@@ -5,6 +5,7 @@
  * Uses DrizzleService adapter with MCPServerRepository.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { type Database, MCPServerRepository } from '@agor/core/db';
 import type {
   CreateMCPServerInput,
@@ -46,8 +47,8 @@ export class MCPServersService extends DrizzleService<
       id: 'mcp_server_id',
       resourceType: 'McpServer',
       paginate: {
-        default: 50,
-        max: 100,
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
     });
 

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -5,6 +5,7 @@
  * Uses DrizzleService adapter with MessagesRepository.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { type Database, MessagesRepository } from '@agor/core/db';
 import type { Message, Paginated, QueryParams, SessionID, TaskID } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
@@ -31,8 +32,8 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
       id: 'message_id',
       resourceType: 'Message',
       paginate: {
-        default: 100,
-        max: 1000, // Allow larger page size for bulk message retrieval
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
       multi: ['create', 'remove'], // Allow bulk creates and removes
     });

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -11,6 +11,7 @@ import {
   extractSlugFromUrl,
   isValidGitUrl,
   isValidSlug,
+  PAGINATION,
   parseAgorYml,
   resolveUserEnvironment,
   writeAgorYml,
@@ -100,8 +101,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       id: 'repo_id',
       resourceType: 'Repo',
       paginate: {
-        default: 50,
-        max: 100,
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
     });
 

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -5,6 +5,7 @@
  * Uses DrizzleService adapter with SessionRepository.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { type Database, SessionRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Paginated, QueryParams, Session, TaskID } from '@agor/core/types';
@@ -33,8 +34,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       id: 'session_id',
       resourceType: 'Session',
       paginate: {
-        default: 50,
-        max: 1000, // Increased from 100 to allow fetching more sessions
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
       multi: ['patch', 'remove'], // Allow multi-patch and multi-remove
     });

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -9,6 +9,7 @@ import {
   type ChildCompletionContext,
   renderChildCompletionCallback,
 } from '@agor/core/callbacks/child-completion-template';
+import { PAGINATION } from '@agor/core/config';
 import { type Database, MessagesRepository, TaskRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Paginated, QueryParams, Session, Task } from '@agor/core/types';
@@ -37,8 +38,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       id: 'task_id',
       resourceType: 'Task',
       paginate: {
-        default: 100,
-        max: 500,
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
       multi: ['patch', 'remove'],
     });
@@ -58,7 +59,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
       // Apply pagination if enabled
       if (this.paginate) {
-        const limit = params.query.$limit ?? this.paginate.default ?? 100;
+        const limit = params.query.$limit ?? this.paginate.default ?? PAGINATION.DEFAULT_LIMIT;
         const skip = params.query.$skip ?? 0;
 
         return {
@@ -77,7 +78,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       const tasks = await this.taskRepo.findRunning();
 
       if (this.paginate) {
-        const limit = params.query.$limit ?? this.paginate.default ?? 100;
+        const limit = params.query.$limit ?? this.paginate.default ?? PAGINATION.DEFAULT_LIMIT;
         const skip = params.query.$skip ?? 0;
 
         return {

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -9,7 +9,7 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { createUserProcessEnvironment, ENVIRONMENT } from '@agor/core/config';
+import { createUserProcessEnvironment, ENVIRONMENT, PAGINATION } from '@agor/core/config';
 import { type Database, WorktreeRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { cleanWorktree, removeWorktree } from '@agor/core/git';
@@ -59,8 +59,8 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       id: 'worktree_id',
       resourceType: 'Worktree',
       paginate: {
-        default: 50,
-        max: 100,
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
       },
     });
 

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgorClient } from '@agor/core/api';
+import { PAGINATION } from '@agor/core/config/browser';
 import type {
   Board,
   BoardComment,
@@ -83,17 +84,15 @@ export function useAgorData(client: AgorClient | null): UseAgorDataResult {
       ] = await Promise.all([
         client
           .service('sessions')
-          .find({ query: { $limit: 1000, $sort: { updated_at: -1 } } }), // Fetch up to 1000 sessions, sorted by most recent
-        client.service('boards').find(),
-        client.service('board-objects').find(),
-        client
-          .service('board-comments')
-          .find({ query: { $limit: 500 } }), // Fetch up to 500 comments
-        client.service('repos').find(),
-        client.service('worktrees').find(),
-        client.service('users').find(),
-        client.service('mcp-servers').find(),
-        client.service('session-mcp-servers').find(),
+          .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT, $sort: { updated_at: -1 } } }),
+        client.service('boards').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('board-objects').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('board-comments').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('repos').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('worktrees').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('users').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('mcp-servers').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('session-mcp-servers').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
       ]);
 
       // Handle paginated vs array results

--- a/apps/agor-ui/src/hooks/useMessages.ts
+++ b/apps/agor-ui/src/hooks/useMessages.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AgorClient } from '@agor/core/api';
+import { PAGINATION } from '@agor/core/config/browser';
 import type { Message, SessionID } from '@agor/core/types';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -42,7 +43,7 @@ export function useMessages(
       const result = await client.service('messages').find({
         query: {
           session_id: sessionId,
-          $limit: 1000, // Fetch up to 1000 messages
+          $limit: PAGINATION.DEFAULT_LIMIT,
           $sort: {
             index: 1, // Sort by index ascending
           },

--- a/apps/agor-ui/src/hooks/useTaskMessages.ts
+++ b/apps/agor-ui/src/hooks/useTaskMessages.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgorClient } from '@agor/core/api';
+import { PAGINATION } from '@agor/core/config/browser';
 import type { Message, TaskID } from '@agor/core/types';
 import { useCallback, useEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
@@ -48,7 +49,7 @@ export function useTaskMessages(
       const result = await client.service('messages').find({
         query: {
           task_id: taskId,
-          $limit: 10000, // High limit to fetch all messages for this task
+          $limit: PAGINATION.DEFAULT_LIMIT,
           $sort: {
             index: 1, // Sort by index ascending
           },

--- a/apps/agor-ui/src/hooks/useTasks.ts
+++ b/apps/agor-ui/src/hooks/useTasks.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AgorClient } from '@agor/core/api';
+import { PAGINATION } from '@agor/core/config/browser';
 import { type SessionID, type Task, TaskStatus, type User } from '@agor/core/types';
 import { useCallback, useEffect, useState } from 'react';
 import { playTaskCompletionChime } from '../utils/audio';
@@ -51,7 +52,7 @@ export function useTasks(
       const result = await client.service('tasks').find({
         query: {
           session_id: sessionId,
-          $limit: 1000, // Fetch up to 1000 tasks
+          $limit: PAGINATION.DEFAULT_LIMIT,
           $sort: {
             created_at: 1, // Sort by creation time ascending
           },

--- a/packages/core/src/config/constants.ts
+++ b/packages/core/src/config/constants.ts
@@ -99,16 +99,29 @@ export const DATABASE = {
    * Batch size for bulk task inserts
    */
   TASK_BATCH_SIZE: 100,
+} as const;
+
+/**
+ * Pagination Constants
+ *
+ * High limits to avoid silent truncation of results.
+ * FeathersJS pagination defaults were causing data loss when collections grew.
+ */
+export const PAGINATION = {
+  /**
+   * Default limit for services/UI - high enough to fetch "all" in practice
+   */
+  DEFAULT_LIMIT: 10_000,
 
   /**
-   * Default pagination limit
+   * Maximum allowed limit - prevents accidental DoS from unbounded queries
    */
-  DEFAULT_PAGE_SIZE: 50,
+  MAX_LIMIT: 10_000,
 
   /**
-   * Maximum pagination limit
+   * Default limit for CLI list commands - reasonable for terminal display
    */
-  MAX_PAGE_SIZE: 100,
+  CLI_DEFAULT_LIMIT: 50,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Addresses issue where worktrees were disappearing on instances with ~100 worktrees due to FeathersJS default pagination limits silently truncating results
- Add centralized `PAGINATION` constant in `@agor/core/config` with `DEFAULT_LIMIT` (10k), `MAX_LIMIT` (10k), and `CLI_DEFAULT_LIMIT` (50)
- Update all daemon services to use centralized pagination constants
- Add explicit `$limit` to all UI data fetches in `useAgorData.ts`
- Fix `$limit: -1` bug in CLI commands (caused empty arrays due to `Math.min(-1, max) = -1`)
- Add `--limit` flag to `board list` and `worktree list` commands
- Standardize CLI list commands to use `CLI_DEFAULT_LIMIT` (50) for reasonable terminal output

## Test plan

- [ ] Verify worktrees no longer disappear on instances with >50 worktrees
- [ ] Test CLI `--limit` flags work correctly (`agor worktree list -l 10`)
- [ ] Confirm UI loads all data without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)