### PR TITLE
feat(codex): add GPT-5.2 model support and bump SDK to 0.71.0

### DIFF
--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -22,32 +22,48 @@ export interface ModelSelectorProps {
 
 // Codex model options
 const CODEX_MODEL_OPTIONS = [
-  // GPT-5 models (current default)
+  // GPT-5.2 models (latest, recommended)
   {
-    id: 'gpt-5-codex',
-    label: 'GPT-5 Codex (Default)',
-    description: 'Optimized for software engineering',
+    id: 'gpt-5.2',
+    label: 'GPT-5.2 (Recommended)',
+    description: 'Best for complex tasks - 400k context, thinking mode',
   },
   {
-    id: 'gpt-5-codex-mini',
-    label: 'GPT-5 Codex Mini',
-    description: 'Faster, lighter model',
+    id: 'gpt-5.2-pro',
+    label: 'GPT-5.2 Pro',
+    description: 'Highest accuracy, xhigh reasoning for difficult problems',
   },
-  // GPT-5.1 models (latest - requires updated Codex CLI)
+  {
+    id: 'gpt-5.2-instant',
+    label: 'GPT-5.2 Instant',
+    description: 'Faster model for writing and information seeking',
+  },
+  // GPT-5.1 models
+  {
+    id: 'gpt-5.1-codex-max',
+    label: 'GPT-5.1 Codex Max',
+    description: 'Optimized for long-horizon agentic coding',
+  },
   {
     id: 'gpt-5.1-codex',
     label: 'GPT-5.1 Codex',
-    description: 'Latest model optimized for agentic coding tasks',
+    description: 'Optimized for agentic coding tasks',
   },
   {
     id: 'gpt-5.1-codex-mini',
     label: 'GPT-5.1 Codex Mini',
     description: 'Cost-effective variant with 4x more usage',
   },
+  // GPT-5 models (legacy)
   {
-    id: 'gpt-5.1',
-    label: 'GPT-5.1',
-    description: 'General-purpose model great for coding',
+    id: 'gpt-5-codex',
+    label: 'GPT-5 Codex',
+    description: 'Legacy model for software engineering',
+  },
+  {
+    id: 'gpt-5-codex-mini',
+    label: 'GPT-5 Codex Mini',
+    description: 'Legacy faster, lighter model',
   },
   // GPT-4o models
   { id: 'gpt-4o', label: 'GPT-4o', description: 'General purpose model' },
@@ -130,7 +146,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (newMode === 'alias') {
         defaultModel = modelList[0].id;
       } else if (effectiveTool === 'codex') {
-        defaultModel = 'gpt-5-codex';
+        defaultModel = 'gpt-5.2';
       } else if (effectiveTool === 'gemini') {
         defaultModel = 'gemini-2.5-flash';
       } else {
@@ -196,7 +212,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 onChange={(e) => handleModelChange(e.target.value)}
                 placeholder={
                   effectiveTool === 'codex'
-                    ? 'e.g., gpt-5-codex'
+                    ? 'e.g., gpt-5.2'
                     : effectiveTool === 'gemini'
                       ? 'e.g., gemini-2.5-pro'
                       : 'e.g., claude-opus-4-20250514' // claude-code (opencode handled earlier)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN npm install -g \
   pnpm@9.15.1 \
   @anthropic-ai/claude-code@2.0.55 \
   @google/gemini-cli@0.18.4 \
-  @openai/codex@0.63.0 \
+  @openai/codex@0.69.0 \
   opencode-ai@latest
 
 # Create non-root 'agor' user (main application user)

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -65,7 +65,7 @@
     "@modelcontextprotocol/sdk": "^1.24.0",
     "@oclif/core": "^4.6.0",
     "@oclif/plugin-help": "^6.2.18",
-    "@openai/codex-sdk": "^0.63.0",
+    "@openai/codex-sdk": "^0.71.0",
     "@opencode-ai/sdk": "^1.0.122",
     "bcryptjs": "^2.4.3",
     "chalk": "^5.6.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -185,7 +185,7 @@
     "@google/genai": "^1.26.0",
     "@iarna/toml": "^2.2.5",
     "@libsql/client": "^0.15.15",
-    "@openai/codex-sdk": "^0.63.0",
+    "@openai/codex-sdk": "^0.71.0",
     "@opencode-ai/sdk": "^1.0.122",
     "bcryptjs": "^2.4.3",
     "cron-parser": "^5.4.0",

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -12,7 +12,11 @@ export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
 
 /** Model aliases for Codex */
 export const CODEX_MODELS = {
-  // GPT-5.1 models (latest, recommended)
+  // GPT-5.2 models (latest, recommended)
+  'gpt-5.2': 'gpt-5.2', // GPT-5.2 Thinking - best for complex tasks (400k context)
+  'gpt-5.2-pro': 'gpt-5.2-pro', // GPT-5.2 Pro - highest accuracy, xhigh reasoning
+  'gpt-5.2-instant': 'gpt-5.2-instant', // GPT-5.2 Instant - faster for writing/info seeking
+  // GPT-5.1 models
   'gpt-5.1-codex-max': 'gpt-5.1-codex-max', // Optimized for long-horizon agentic coding
   'gpt-5.1-codex': 'gpt-5.1-codex',
   'gpt-5.1-codex-mini': 'gpt-5.1-codex-mini',
@@ -30,9 +34,13 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
 
 /**
  * Approximate context window limits for Codex-compatible OpenAI models.
- * Values mirror OpenAI's public docs (Nov 2025) and fall back to 200k if unknown.
+ * Values mirror OpenAI's public docs (Dec 2025) and fall back to 200k if unknown.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
+  // GPT-5.2 models (400k context, 128k max output)
+  'gpt-5.2': 400_000,
+  'gpt-5.2-pro': 400_000,
+  'gpt-5.2-instant': 400_000,
   // GPT-5.1 models
   'gpt-5.1-codex-max': 200_000,
   'gpt-5.1-codex': 200_000,

--- a/packages/executor/src/sdk-handlers/codex/models.ts
+++ b/packages/executor/src/sdk-handlers/codex/models.ts
@@ -12,7 +12,12 @@ export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
 
 /** Model aliases for Codex */
 export const CODEX_MODELS = {
-  // GPT-5.1 models (latest, recommended)
+  // GPT-5.2 models (latest, recommended)
+  'gpt-5.2': 'gpt-5.2', // GPT-5.2 Thinking - best for complex tasks (400k context)
+  'gpt-5.2-pro': 'gpt-5.2-pro', // GPT-5.2 Pro - highest accuracy, xhigh reasoning
+  'gpt-5.2-instant': 'gpt-5.2-instant', // GPT-5.2 Instant - faster for writing/info seeking
+  // GPT-5.1 models
+  'gpt-5.1-codex-max': 'gpt-5.1-codex-max', // Optimized for long-horizon agentic coding
   'gpt-5.1-codex': 'gpt-5.1-codex',
   'gpt-5.1-codex-mini': 'gpt-5.1-codex-mini',
   'gpt-5.1': 'gpt-5.1',
@@ -29,10 +34,15 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
 
 /**
  * Approximate context window limits for Codex-compatible OpenAI models.
- * Values mirror OpenAI's public docs (Nov 2025) and fall back to 200k if unknown.
+ * Values mirror OpenAI's public docs (Dec 2025) and fall back to 200k if unknown.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
+  // GPT-5.2 models (400k context, 128k max output)
+  'gpt-5.2': 400_000,
+  'gpt-5.2-pro': 400_000,
+  'gpt-5.2-instant': 400_000,
   // GPT-5.1 models
+  'gpt-5.1-codex-max': 200_000,
   'gpt-5.1-codex': 200_000,
   'gpt-5.1-codex-mini': 200_000,
   'gpt-5.1': 200_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,8 +422,8 @@ importers:
         specifier: ^6.2.18
         version: 6.2.35
       '@openai/codex-sdk':
-        specifier: ^0.63.0
-        version: 0.63.0
+        specifier: ^0.71.0
+        version: 0.71.0
       '@opencode-ai/sdk':
         specifier: ^1.0.122
         version: 1.0.125
@@ -551,8 +551,8 @@ importers:
         specifier: ^0.15.15
         version: 0.15.15
       '@openai/codex-sdk':
-        specifier: ^0.63.0
-        version: 0.63.0
+        specifier: ^0.71.0
+        version: 0.71.0
       '@opencode-ai/sdk':
         specifier: ^1.0.122
         version: 1.0.125
@@ -2364,6 +2364,10 @@ packages:
 
   '@openai/codex-sdk@0.63.0':
     resolution: {integrity: sha512-5ZJpytgGG0xxfloJUvPWxsVMVeROXG1t1q03aejTgWLubTcgGFRx9zNBdZE/OvJ7NGtUBbhQkfkzaFp1kIA2Cg==}
+    engines: {node: '>=18'}
+
+  '@openai/codex-sdk@0.71.0':
+    resolution: {integrity: sha512-4PkZL1+1WAKfNOeYYMPXSGCrnTLbJEHh3vu2/cmiJLv1/YFmc2YVCj9TWt+qR2++q+GsBIrIhzb5xdWQZZecPQ==}
     engines: {node: '>=18'}
 
   '@opencode-ai/sdk@1.0.125':
@@ -6089,7 +6093,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -11139,6 +11142,8 @@ snapshots:
       - supports-color
 
   '@openai/codex-sdk@0.63.0': {}
+
+  '@openai/codex-sdk@0.71.0': {}
 
   '@opencode-ai/sdk@1.0.125': {}
 


### PR DESCRIPTION
## Summary

- Add GPT-5.2 models (`gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-instant`) with 400k context window
- Bump `@openai/codex` CLI from 0.63.0 to 0.69.0 in Dockerfile  
- Bump `@openai/codex-sdk` from ^0.63.0 to ^0.71.0 in packages
- Update UI ModelSelector with GPT-5.2 as recommended default
- Add missing `gpt-5.1-codex-max` model to executor

## Test plan

- [ ] Verify Codex sessions can be created with new GPT-5.2 models
- [ ] Verify UI ModelSelector shows GPT-5.2 options correctly
- [ ] Verify context window limits are correct (400k for GPT-5.2)
- [ ] Docker build succeeds with new CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)