### PR TITLE
fix(ui,executor): fix favicon base path and stop task ID mismatch

### DIFF
--- a/apps/agor-ui/index.html
+++ b/apps/agor-ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/png" href="favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agor</title>
     <style>

--- a/apps/agor-ui/src/hooks/useFaviconStatus.ts
+++ b/apps/agor-ui/src/hooks/useFaviconStatus.ts
@@ -18,7 +18,7 @@ export function useFaviconStatus(
   sessionsByWorktree: Map<string, Session[]>,
   boardObjects: BoardEntityObject[]
 ) {
-  const [baseFaviconUrl] = useState('/favicon.png');
+  const [baseFaviconUrl] = useState(`${import.meta.env.BASE_URL}favicon.png`);
   const { token } = theme.useToken();
 
   useEffect(() => {

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -98,7 +98,8 @@ export class AgorExecutor {
       }) => {
         console.log('[executor] Received task_stop event:', data);
 
-        if (data.session_id === this.config.sessionId && data.task_id === this.config.taskId) {
+        // Only check session_id - task_id may differ if session continued with new messages
+        if (data.session_id === this.config.sessionId) {
           // IMMEDIATELY send acknowledgment (before stopping)
           try {
             // biome-ignore lint/suspicious/noExplicitAny: Feathers types don't support custom events


### PR DESCRIPTION
## Summary
- Fix favicon.png to use relative path in index.html for Vite base handling
- Fix useFaviconStatus hook to use `import.meta.env.BASE_URL`
- Fix executor stop handler to only check `session_id` (not `task_id`) since task IDs change when session continues with new messages
- Remove debug logging from stop button implementation
- Replace `$in` operator with separate queries in daemon stop endpoint (Feathers schema validation doesn't support `$in`)

## Root Cause
The stop button wasn't working reliably because:
1. Executor checked both `session_id` AND `task_id` when receiving stop events
2. When a session continues with new prompts, new tasks are created
3. The executor's stored `taskId` was from session startup, so it ignored stop events for newer tasks

## Test plan
- [ ] Start a session and send multiple messages
- [ ] Hit stop button mid-execution
- [ ] Verify executor receives stop signal and aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)