### PR TITLE
fix(ui): sort repos alphabetically by name in dropdowns and lists

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -75,7 +75,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   onUpdate,
   onDelete,
 }) => {
-  const repos = mapToArray(repoById);
+  const repos = mapToArray(repoById).sort((a, b) => a.name.localeCompare(b.name));
   const [repoModalOpen, setRepoModalOpen] = useState(false);
   const [editingRepo, setEditingRepo] = useState<Repo | null>(null);
   const [repoMode, setRepoMode] = useState<'remote' | 'local'>('remote');

--- a/apps/agor-ui/src/components/WorktreeFormFields/WorktreeFormFields.tsx
+++ b/apps/agor-ui/src/components/WorktreeFormFields/WorktreeFormFields.tsx
@@ -78,10 +78,12 @@ export const WorktreeFormFields: React.FC<WorktreeFormFieldsProps> = ({
               .toLowerCase()
               .includes(input.toLowerCase())
           }
-          options={mapToArray(repoById).map((repo: Repo) => ({
-            value: repo.repo_id,
-            label: repo.name || repo.slug,
-          }))}
+          options={mapToArray(repoById)
+            .sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug))
+            .map((repo: Repo) => ({
+              value: repo.repo_id,
+              label: repo.name || repo.slug,
+            }))}
           onChange={onRepoChange}
         />
       </Form.Item>


### PR DESCRIPTION
## Summary
- Sort repos alphabetically by name in the worktree creation form dropdown
- Sort repos alphabetically by name in the Settings modal repos CRUD list

Improves usability by displaying repos in a predictable, alphabetical order.

## Test plan
- [ ] Open worktree creation modal and verify repos dropdown is sorted A-Z
- [ ] Open Settings > Repos tab and verify repo cards are sorted A-Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)