### PR TITLE
fix(sudoers): add /usr/bin/test to allowed commands

### DIFF
--- a/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
@@ -121,6 +121,11 @@ agor ALL=(ALL) NOPASSWD: /usr/sbin/gpasswd *
 agor ALL=(ALL) NOPASSWD: /usr/bin/chown * /home/*/agor/*
 agor ALL=(ALL) NOPASSWD: /usr/bin/chmod * /home/*/agor/*
 # ... and more (see full file for complete scoped rules)
+
+# Query commands (read-only, safe)
+agor ALL=(ALL) NOPASSWD: /usr/bin/id *
+agor ALL=(ALL) NOPASSWD: /usr/bin/getent *
+agor ALL=(ALL) NOPASSWD: /usr/bin/test *
 ```
 
 </details>

--- a/docker/sudoers/agor-daemon.sudoers
+++ b/docker/sudoers/agor-daemon.sudoers
@@ -126,6 +126,7 @@ agor ALL=(ALL) NOPASSWD: /usr/bin/id *
 agor ALL=(ALL) NOPASSWD: /usr/bin/getent *
 agor ALL=(ALL) NOPASSWD: /usr/bin/readlink *
 agor ALL=(ALL) NOPASSWD: /usr/bin/find *
+agor ALL=(ALL) NOPASSWD: /usr/bin/test *
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add `/usr/bin/test` to the sudoers allowlist for query commands
- Update docs quick reference to include query commands section

The Unix integration service uses `test -e` to check if files exist before creating them (e.g., zellij config in `prepareUserHome()`). Without sudo access to `test`, this fails with "sudo: a password is required" on RBAC-enabled instances.

## Test plan

- [ ] Deploy to RBAC-enabled instance
- [ ] Run `sudo visudo -c -f docker/sudoers/agor-daemon.sudoers` to validate syntax
- [ ] Create a worktree and verify no "password required" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)