### PR TITLE
feat(session): disambiguate Agor and Claude SDK session IDs in context

### DIFF
--- a/packages/core/src/templates/agor-system-prompt.md
+++ b/packages/core/src/templates/agor-system-prompt.md
@@ -11,9 +11,12 @@ Agor is a collaborative workspace where multiple AI agents can work together on 
 {{#if session}}
 **Session Information:**
 
-- Session ID: `{{session.session_id}}`
+- Agor Session ID: `{{session.session_id}}`
+{{#if session.sdk_session_id}}
+- Claude SDK Session ID: `{{session.sdk_session_id}}`
+{{/if}}
 - Agent Type: {{session.agentic_tool}}
-  {{/if}}
+{{/if}}
 
 {{#if worktree}}
 **Worktree:**

--- a/packages/core/src/templates/session-context.ts
+++ b/packages/core/src/templates/session-context.ts
@@ -63,6 +63,7 @@ export async function buildSessionContext(
   if (session) {
     context.session = {
       session_id: session.session_id,
+      sdk_session_id: session.sdk_session_id, // Claude SDK session ID (for conversation continuity)
       agentic_tool: session.agentic_tool,
       permission_config: session.permission_config || {},
       created_at: session.created_at,

--- a/packages/executor/src/sdk-handlers/claude/session-context.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/session-context.test.ts
@@ -25,7 +25,7 @@ describe('generateSessionContext', () => {
     const context = generateSessionContext(sessionId);
 
     expect(context).toContain('abcd1234');
-    expect(context).toContain(`(short: \`abcd1234\`)`);
+    expect(context).toContain('short: `abcd1234`');
   });
 
   it('should include markdown formatting', () => {
@@ -35,6 +35,25 @@ describe('generateSessionContext', () => {
     expect(context).toContain('---'); // separator
     expect(context).toContain('**'); // bold
     expect(context).toContain('`'); // code blocks
+  });
+
+  it('should include SDK session ID when provided', () => {
+    const sessionId = '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f' as SessionID;
+    const sdkSessionId = 'sdk-abc123-def456';
+    const context = generateSessionContext(sessionId, sdkSessionId);
+
+    expect(context).toContain(sessionId); // Agor session ID
+    expect(context).toContain(sdkSessionId); // SDK session ID
+    expect(context).toContain('Agor Session ID');
+    expect(context).toContain('Claude SDK Session ID');
+  });
+
+  it('should not include SDK session ID line when not provided', () => {
+    const sessionId = '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f' as SessionID;
+    const context = generateSessionContext(sessionId);
+
+    expect(context).toContain(sessionId);
+    expect(context).not.toContain('Claude SDK Session ID');
   });
 });
 


### PR DESCRIPTION
## Summary

- Show both Agor Session ID and Claude SDK Session ID in the CLAUDE.md session context
- This helps agents distinguish between Agor's internal tracking ID and Claude CLI's conversation continuity ID
- Updated both Handlebars template system (`agor-system-prompt.md`) and direct CLAUDE.md append functions

## Changes

- `packages/core/src/templates/session-context.ts` - Added `sdk_session_id` to template context
- `packages/core/src/templates/agor-system-prompt.md` - Updated template with conditional SDK ID display
- `packages/executor/src/sdk-handlers/claude/session-context.ts` - Added optional `sdkSessionId` parameter
- `packages/executor/src/sdk-handlers/claude/session-context.test.ts` - Added tests for SDK session ID handling

## Test plan

- [x] pnpm install passes
- [x] pnpm check (typecheck + lint) passes
- [x] New tests verify SDK session ID is included when provided and excluded when not

🤖 Generated with [Claude Code](https://claude.com/claude-code)