### PR TITLE
feat(config): add instanceLabel and instanceDescription config options

### DIFF
--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -53,6 +53,10 @@ export default class Init extends Command {
       description: 'Set daemon config values even if .agor already exists (for Docker/deployment)',
       default: false,
     }),
+    'instance-label': Flags.string({
+      description: 'Instance label for deployment identification (e.g., "staging", "prod-us-east")',
+      required: false,
+    }),
   };
 
   private async pathExists(path: string): Promise<boolean> {
@@ -665,6 +669,7 @@ export default class Init extends Command {
   private async setDaemonConfig(flags: {
     'daemon-port'?: number;
     'daemon-host'?: string;
+    'instance-label'?: string;
   }): Promise<void> {
     // Get daemon port from flag or environment variable
     const daemonPort = flags['daemon-port'] || process.env.DAEMON_PORT;
@@ -677,6 +682,13 @@ export default class Init extends Command {
     const daemonHost = flags['daemon-host'] || 'localhost';
     await setConfigValue('daemon.host', daemonHost);
     this.log(`${chalk.green('   ✓')} Set daemon.host = ${daemonHost}`);
+
+    // Get instance label from flag or environment variable
+    const instanceLabel = flags['instance-label'] || process.env.INSTANCE_LABEL;
+    if (instanceLabel) {
+      await setConfigValue('daemon.instanceLabel', instanceLabel);
+      this.log(`${chalk.green('   ✓')} Set daemon.instanceLabel = ${instanceLabel}`);
+    }
 
     // Enable authentication for Docker/deployment environments
     await setConfigValue('daemon.requireAuth', true);

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -267,6 +267,12 @@ async function main() {
   const envUiPort = process.env.UI_PORT ? Number.parseInt(process.env.UI_PORT, 10) : undefined;
   const UI_PORT = envUiPort || config.ui?.port || 5173;
 
+  // Handle INSTANCE_LABEL env var override (for Docker deployments)
+  if (process.env.INSTANCE_LABEL) {
+    config.daemon = config.daemon || {};
+    config.daemon.instanceLabel = process.env.INSTANCE_LABEL;
+  }
+
   // Initialize Anthropic API key (extracted to setup/credentials.ts)
   // Side effect: sets process.env.ANTHROPIC_API_KEY if found in config
   initializeAnthropicApiKey(config, process.env.ANTHROPIC_API_KEY);

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -31,6 +31,7 @@ import {
   useAuth,
   useAuthConfig,
   useBoardActions,
+  useInstanceConfig,
   useSessionActions,
 } from './hooks';
 import { StreamdownDemoPage } from './pages/StreamdownDemoPage';
@@ -93,6 +94,9 @@ function AppContent() {
     loading: authConfigLoading,
     error: authConfigError,
   } = useAuthConfig();
+
+  // Fetch instance configuration (label, description)
+  const { config: instanceConfig } = useInstanceConfig();
 
   // Authentication
   const {
@@ -1082,6 +1086,8 @@ function AppContent() {
                 onDeleteComment={handleDeleteComment}
                 onLogout={logout}
                 onRetryConnection={retryConnection}
+                instanceLabel={instanceConfig?.instanceLabel}
+                instanceDescription={instanceConfig?.instanceDescription}
               />
             </>
           }
@@ -1151,6 +1157,8 @@ function AppContent() {
                 onDeleteComment={handleDeleteComment}
                 onLogout={logout}
                 onRetryConnection={retryConnection}
+                instanceLabel={instanceConfig?.instanceLabel}
+                instanceDescription={instanceConfig?.instanceDescription}
               />
             </>
           }
@@ -1220,6 +1228,8 @@ function AppContent() {
                 onDeleteComment={handleDeleteComment}
                 onLogout={logout}
                 onRetryConnection={retryConnection}
+                instanceLabel={instanceConfig?.instanceLabel}
+                instanceDescription={instanceConfig?.instanceDescription}
               />
             </>
           }

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -129,6 +129,10 @@ export interface AppProps {
   onDeleteComment?: (commentId: string) => void;
   onLogout?: () => void;
   onRetryConnection?: () => void;
+  /** Instance label for deployment identification (displayed as a Tag in navbar) */
+  instanceLabel?: string;
+  /** Instance description (markdown) shown in popover around the instance label */
+  instanceDescription?: string;
 }
 
 export const App: React.FC<AppProps> = ({
@@ -188,6 +192,8 @@ export const App: React.FC<AppProps> = ({
   onDeleteComment,
   onLogout,
   onRetryConnection,
+  instanceLabel,
+  instanceDescription,
 }) => {
   const { showWarning } = useThemedMessage();
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
@@ -638,6 +644,8 @@ export const App: React.FC<AppProps> = ({
                 // This would require exposing a method on SessionCanvasRef
               }
             }}
+            instanceLabel={instanceLabel}
+            instanceDescription={instanceDescription}
           />
           <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
             <PanelGroup

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -10,13 +10,25 @@ import {
   UserOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Badge, Button, Divider, Dropdown, Layout, Space, Tooltip, theme } from 'antd';
+import {
+  Badge,
+  Button,
+  Divider,
+  Dropdown,
+  Layout,
+  Popover,
+  Space,
+  Tag,
+  Tooltip,
+  theme,
+} from 'antd';
 import { useState } from 'react';
 import { BoardSwitcher } from '../BoardSwitcher';
 import { BrandLogo } from '../BrandLogo';
 import { ConnectionStatus } from '../ConnectionStatus';
 import { Facepile } from '../Facepile';
 import { GettingStartedPopover } from '../GettingStartedPopover';
+import { MarkdownRenderer } from '../MarkdownRenderer';
 import { ThemeSwitcher } from '../ThemeSwitcher';
 
 const { Header } = Layout;
@@ -57,6 +69,10 @@ export interface AppHeaderProps {
     boardId?: BoardID,
     cursorPosition?: { x: number; y: number }
   ) => void; // Navigate to user's board
+  /** Instance label for deployment identification (displayed as a Tag) */
+  instanceLabel?: string;
+  /** Instance description (markdown) shown in popover around the instance label */
+  instanceDescription?: string;
 }
 
 export const AppHeader: React.FC<AppHeaderProps> = ({
@@ -91,6 +107,8 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   onOpenNewWorktree,
   boardById,
   onUserClick,
+  instanceLabel,
+  instanceDescription,
 }) => {
   const { token } = theme.useToken();
   const userEmoji = user?.emoji || '👤';
@@ -168,6 +186,27 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           }}
         />
         <BrandLogo level={3} style={{ marginTop: -6 }} />
+        {instanceLabel &&
+          (instanceDescription ? (
+            <Popover
+              content={
+                <div style={{ maxWidth: 400 }}>
+                  <MarkdownRenderer content={instanceDescription} />
+                </div>
+              }
+              title={instanceLabel}
+              trigger="hover"
+              placement="bottomLeft"
+            >
+              <Tag color="blue" style={{ cursor: 'help', marginLeft: 8 }}>
+                {instanceLabel}
+              </Tag>
+            </Popover>
+          ) : (
+            <Tag color="blue" style={{ marginLeft: 8 }}>
+              {instanceLabel}
+            </Tag>
+          ))}
         <Divider type="vertical" style={{ height: 32, margin: '0 8px' }} />
         {currentBoardId && boards.length > 0 && (
           <div style={{ minWidth: 200 }}>

--- a/apps/agor-ui/src/hooks/index.ts
+++ b/apps/agor-ui/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from './useAgorData';
 export * from './useAuth';
 export * from './useAuthConfig';
 export * from './useBoardActions';
+export * from './useInstanceConfig';
 export * from './useLocalStorage';
 export * from './useMessages';
 export * from './useSessionActions';

--- a/apps/agor-ui/src/hooks/useInstanceConfig.ts
+++ b/apps/agor-ui/src/hooks/useInstanceConfig.ts
@@ -1,0 +1,47 @@
+/**
+ * useInstanceConfig - Fetch instance configuration (label, description)
+ *
+ * Retrieves instance identification settings from daemon config.
+ * Used to display the instance label in the navbar.
+ */
+
+import { useEffect, useState } from 'react';
+import { getDaemonUrl } from '../config/daemon';
+
+interface InstanceConfig {
+  instanceLabel?: string;
+  instanceDescription?: string;
+}
+
+export function useInstanceConfig() {
+  const [config, setConfig] = useState<InstanceConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    async function fetchInstanceConfig() {
+      try {
+        const response = await fetch(`${getDaemonUrl()}/config/daemon`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch instance config: ${response.statusText}`);
+        }
+
+        const daemonConfig = await response.json();
+        setConfig({
+          instanceLabel: daemonConfig?.instanceLabel,
+          instanceDescription: daemonConfig?.instanceDescription,
+        });
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setConfig(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchInstanceConfig();
+  }, []);
+
+  return { config, loading, error };
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,9 @@ services:
       - AGOR_USE_EXECUTOR=${AGOR_USE_EXECUTOR:-false}
       - AGOR_EXECUTOR_USERNAME=${AGOR_EXECUTOR_USERNAME:-agor_executor}
 
+      # Instance identification (optional - displayed in UI navbar)
+      - INSTANCE_LABEL=${INSTANCE_LABEL:-}
+
     depends_on:
       postgres:
         condition: service_healthy

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -64,6 +64,14 @@ export interface AgorDaemonSettings {
    * Required when Unix isolation is enabled (worktree_rbac or unix_user_mode).
    * In dev mode without isolation, falls back to current process user. */
   unix_user?: string;
+
+  /** Instance label for deployment identification (e.g., "staging", "prod-us-east").
+   * Displayed as a Tag in the UI navbar when set. */
+  instanceLabel?: string;
+
+  /** Instance description (markdown supported).
+   * Displayed as a popover around the instance label Tag. */
+  instanceDescription?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add optional instance identification settings that display in the UI navbar:

- **`daemon.instanceLabel`** - displayed as a blue Tag next to the logo
- **`daemon.instanceDescription`** - markdown content shown in a popover when hovering over the label

## Configuration Options

**Config file** (`~/.agor/config.yaml`):
```yaml
daemon:
  instanceLabel: "staging-us-east"
  instanceDescription: |
    ## Staging Environment
    
    This instance is for **testing purposes only**.
```

**CLI flag**:
```bash
agor init --instance-label "my-pretty-instance"
```

**Environment variable** (for Docker deployments):
```bash
INSTANCE_LABEL="production" docker-compose up
```

## Files Changed

- `packages/core/src/config/types.ts` - Added type definitions
- `apps/agor-daemon/src/index.ts` - Handle `INSTANCE_LABEL` env var
- `apps/agor-cli/src/commands/init.ts` - Added `--instance-label` flag
- `docker-compose.yml` - Added `INSTANCE_LABEL` env var passthrough
- `apps/agor-ui/src/hooks/useInstanceConfig.ts` - New hook to fetch config
- `apps/agor-ui/src/components/AppHeader/AppHeader.tsx` - Display Tag with Popover

## Test plan

- [ ] Set `daemon.instanceLabel` in config.yaml and verify Tag appears in navbar
- [ ] Set `daemon.instanceDescription` and verify Popover shows on hover
- [ ] Test `agor init --instance-label "test"` writes to config
- [ ] Test `INSTANCE_LABEL=foo docker-compose up` passes value to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)