### PR TITLE
fix(codex): properly stop Codex sessions using AbortSignal

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -113,6 +113,7 @@ export class CodexTool implements ITool {
    * @param taskId - Optional task ID for linking messages
    * @param permissionMode - Permission mode for tool execution ('ask' | 'auto' | 'allow-all')
    * @param streamingCallbacks - Optional callbacks for real-time streaming (enables typewriter effect)
+   * @param abortController - Optional AbortController for cancellation support
    * @returns User message ID and array of assistant message IDs
    */
   async executePromptWithStreaming(
@@ -120,7 +121,8 @@ export class CodexTool implements ITool {
     prompt: string,
     taskId?: TaskID,
     permissionMode?: PermissionMode,
-    streamingCallbacks?: StreamingCallbacks
+    streamingCallbacks?: StreamingCallbacks,
+    abortController?: AbortController
   ): Promise<CodexExecutionResult> {
     if (!this.promptService || !this.messagesRepo) {
       throw new Error('CodexTool not initialized with repositories for live execution');
@@ -152,7 +154,8 @@ export class CodexTool implements ITool {
       sessionId,
       prompt,
       taskId,
-      permissionMode
+      permissionMode,
+      abortController
     )) {
       // Detect if execution was stopped early
       if (event.type === 'stopped') {


### PR DESCRIPTION
## Summary
- Fix Codex session stop functionality that was stuck in "stopping" state
- Pass `AbortController.signal` to Codex SDK's `runStreamed()` via `TurnOptions`
- Handle `AbortError` properly as a clean stop (same pattern as Claude Code)
- Keep existing flag-based stop as backup mechanism

## Problem
When stopping a Codex session while processing a prompt, it would stay in "stopping" state and never actually stop. The flag-based approach (`stopRequested` Map) only worked if the event loop wasn't blocked waiting for SDK events.

## Solution
The Codex SDK supports proper cancellation via `AbortSignal` in `TurnOptions.signal`. Now when `abortController.abort()` is called, the SDK throws `AbortError` which is caught and handled as a clean stop.

## Test plan
- [ ] Start a Codex session and send a prompt
- [ ] Click stop while the agent is processing
- [ ] Verify the session properly transitions to idle state (not stuck in "stopping")

🤖 Generated with [Claude Code](https://claude.com/claude-code)