### PR TITLE
docs: expand subtitle messaging to cover all 5 breakthroughs

### DIFF
--- a/context/explorations/simplified-messaging.md
+++ b/context/explorations/simplified-messaging.md
@@ -6,7 +6,7 @@
 > A visual, collaborative UX for Claude Code, Codex, Gemini CLI, and OpenCode
 
 **Subtitle:**
-> A visual platform to orchestrate AI coding agents. Great solo. Team-ready.
+> Organize work on spatial boards. Let supervisor agents coordinate the swarm. Automate with zones, extend with APIs. Solo-first, multiplayer-ready.
 
 ---
 
@@ -72,16 +72,42 @@ Why it works:
 
 ---
 
+## The 5 Breakthroughs
+
+The subtitle should touch on all 5 core differentiators:
+
+| # | Breakthrough | How We Cover It |
+|---|--------------|-----------------|
+| 1 | **Multi-agent** (Claude Code, Codex, Gemini CLI, OpenCode) | ✅ Tagline names all 4 tools directly |
+| 2 | **Spatial canvas** / spatial memory | ✅ "Organize work on spatial boards" |
+| 3 | **Multiplayer** | ✅ "multiplayer-ready" |
+| 4 | **Internal MCP** / supervisor agents / cross-agent coordination | ✅ "Let supervisor agents coordinate the swarm" |
+| 5 | **Platform** (API, TypeScript client, MCP, socket events) | ✅ "Automate with zones, extend with APIs" |
+
+---
+
 ## Subtitle Options Considered
 
-**Platform + orchestration:**
+**v1 - Platform + orchestration:**
 > A collaborative platform to run, visualize, and orchestrate AI coding sessions — CLI, visual client, and APIs included.
 
-**Solo-first, scale implied:**
+**v2 - Solo-first, scale implied:**
 > A visual platform to run and orchestrate AI coding agents. Bring your team when you're ready.
 
-**Minimal (winner):**
+**v3 - Minimal:**
 > A visual platform to orchestrate AI coding agents. Great solo. Team-ready.
+
+**v4 - Hit all 5 explicitly:**
+> Spatial boards that tap into visual memory. Agents that spawn and supervise other agents. A full platform: CLI, TypeScript client, MCP, real-time events. Great solo. Team-ready.
+
+**v5 - Lead with supervisor magic:**
+> Agents that can see the whole board and spawn other agents. Spatial zones with prompt automation. Built as a platform from day one — CLI, TypeScript client, and APIs included.
+
+**v6 - Poetic, less listy (winner):**
+> Organize work on spatial boards. Let supervisor agents coordinate the swarm. Automate with zones, extend with APIs. Solo-first, multiplayer-ready.
+
+**v7 - Punchy bullet style:**
+> Spatial boards. Supervisor agents. Zone automation. Full platform APIs. Great solo. Team-ready.
 
 ---
 


### PR DESCRIPTION
## Summary

- Updated subtitle to touch on all 5 Agor breakthroughs: spatial canvas, supervisor agents, zone automation, platform APIs, and multiplayer
- Added "The 5 Breakthroughs" framework documenting what the messaging needs to cover
- Documented iteration history (v1-v7) with rationale

**New subtitle:**
> Organize work on spatial boards. Let supervisor agents coordinate the swarm. Automate with zones, extend with APIs. Solo-first, multiplayer-ready.

## Test plan

- [x] Review messaging doc for clarity
- [ ] Consider updating README.md and landing page with new messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)