### PR TITLE
fix(ui): fix modal padding and border-radius after antd v6 upgrade

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -317,6 +317,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           padding: 0,
           overflow: 'hidden',
         },
+        container: {
+          padding: 0,
+          borderRadius: 8,
+          overflow: 'hidden',
+        },
         header: {
           display: 'none',
         },

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -694,6 +694,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           padding: 0,
           overflow: 'hidden',
         },
+        container: {
+          padding: 0,
+          borderRadius: 8,
+          overflow: 'hidden',
+        },
         header: {
           display: 'none',
         },


### PR DESCRIPTION
## Summary

- Fix Settings Modal and User Settings Modal padding/styling issues after Ant Design v6 upgrade
- In antd v6, Modal introduced a new `container` semantic style key that applies `contentPadding` to `.ant-modal-container`
- Added `container: { padding: 0, borderRadius: 8, overflow: 'hidden' }` to both modals to restore the custom left-menu layout appearance

## Test plan

- [ ] Open Settings Modal - verify no extra padding/frame around content
- [ ] Open User Settings Modal - verify no extra padding/frame around content
- [ ] Verify both modals have rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)