### PR TITLE
fix(ui): remove noisy toast messages when sending prompts

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -502,22 +502,15 @@ function AppContent() {
     if (!client) return;
 
     try {
-      showLoading('Sending prompt...', { key: 'prompt' });
-
       await client.service(`sessions/${sessionId}/prompt`).create({
         prompt,
         permissionMode,
       });
 
-      showSuccess('Response received!', { key: 'prompt' });
-
       // Clear the draft after sending
       handleClearDraft(sessionId);
     } catch (error) {
-      showError(
-        `Failed to send prompt: ${error instanceof Error ? error.message : String(error)}`,
-        { key: 'prompt' }
-      );
+      showError(`Failed to send prompt: ${error instanceof Error ? error.message : String(error)}`);
       console.error('Prompt error:', error);
     }
   };


### PR DESCRIPTION
## Summary
- Remove "Sending prompt..." loading toast and "Response received!" success toast when sending prompts
- These toasts added visual noise without providing useful feedback since users already see the prompt being sent and response streaming in the conversation

## Test plan
- [x] Verify no toast appears when sending a prompt successfully
- [x] Verify error toast still appears on prompt failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)