### PR TITLE
fix(ui): use single-line ellipsis truncation for task prompt in header

### DIFF
--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -420,18 +420,11 @@ export const TaskBlock = React.memo<TaskBlockProps>(
 
         {/* Right column: Content */}
         <Flex vertical flex={1} style={{ minWidth: 0 }}>
-          <Flex
-            align="center"
-            wrap
-            gap={token.sizeUnit / 2}
-            style={{ marginBottom: token.sizeUnit }}
-          >
-            <Typography.Text>
-              {typeof task.description === 'string'
-                ? task.description || 'User Prompt'
-                : 'User Prompt'}
-            </Typography.Text>
-          </Flex>
+          <Typography.Text ellipsis style={{ marginBottom: token.sizeUnit }}>
+            {typeof task.description === 'string'
+              ? task.description || 'User Prompt'
+              : 'User Prompt'}
+          </Typography.Text>
 
           {/* Task metadata */}
           <Flex wrap gap={token.sizeUnit}>

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -1,9 +1,19 @@
-/* Global styles for Agor UI */
-
 /* Import Inter font from Bunny Fonts CDN (privacy-friendly, GDPR compliant) */
 /* Weights: 400 (regular), 500 (medium), 600 (semibold) */
 /* Total size: ~75KB for Latin subset, cached across sites */
 @import url("https://fonts.bunny.net/css?family=inter:400,500,600&display=swap");
+
+/* Global styles for Agor UI */
+
+/* Fix Ant Design Collapse header title overflow for ellipsis truncation */
+.ant-collapse-header {
+  overflow: hidden;
+}
+
+.ant-collapse-header .ant-collapse-title {
+  overflow: hidden;
+  min-width: 0;
+}
 
 /* Blinking cursor animation for streaming messages */
 @keyframes blink {


### PR DESCRIPTION
## Summary

- Task headers now display the prompt on a single line with `...` truncation
- Previously showed a fixed character count which led to poor space usage in the compact header area
- Full prompt is visible by expanding the collapsible section

## Test plan

- [ ] Verify task headers show single-line truncated prompts with ellipsis
- [ ] Verify long prompts truncate properly without overflowing
- [ ] Verify expanding the task still shows full messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)