### PR TITLE
feat(ide): add VS Code and code-server integration with user SSH config

### DIFF
--- a/apps/agor-cli/src/commands/user/create.ts
+++ b/apps/agor-cli/src/commands/user/create.ts
@@ -2,7 +2,7 @@
  * `agor user create` - Create a new user
  */
 
-import type { CreateUserInput, UserRole } from '@agor/core/types';
+import type { CreateUserInput, User, UserRole } from '@agor/core/types';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
@@ -108,7 +108,8 @@ export default class UserCreate extends BaseCommand {
         role: flags.role as UserRole,
         must_change_password: flags['force-password-change'],
       };
-      const user = await client.service('users').create(userData);
+      // Cast to Partial<User> to satisfy service typing
+      const user = await client.service('users').create(userData as Partial<User>);
 
       this.log(`${chalk.green('✓')} User created successfully`);
       this.log('');

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -19,6 +19,7 @@ import type {
   Repo,
   Session,
   Task,
+  VSCodeOpenResult,
   Worktree,
   WorktreeID,
 } from '@agor/core/types';
@@ -207,6 +208,12 @@ export interface WorktreesServiceImpl extends Service<Worktree, Partial<Worktree
   restartEnvironment(id: WorktreeID, params?: FeathersParams): Promise<Worktree>;
   nukeEnvironment(id: WorktreeID, params?: FeathersParams): Promise<Worktree>;
   checkHealth(id: WorktreeID, params?: FeathersParams): Promise<Worktree>;
+  getVSCodeTarget(id: WorktreeID, params?: FeathersParams): Promise<VSCodeOpenResult>;
+  executeVSCodeLocally(id: WorktreeID, params?: FeathersParams): Promise<string>;
+  getCodeServerTarget(
+    id: WorktreeID,
+    params?: FeathersParams
+  ): Promise<import('@agor/core/types').CodeServerOpenResult>;
   getLogs(
     id: WorktreeID,
     params?: FeathersParams

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -357,6 +357,7 @@ async function main() {
 
   // Create Feathers app
   const app = feathersExpress(feathers());
+  app.set('agorConfig', config);
 
   // Configure CORS based on deployment environment (extracted to setup/cors.ts)
   const { origin: corsOrigin } = buildCorsConfig({
@@ -4208,6 +4209,57 @@ async function main() {
     } as any,
     {
       find: { role: 'member', action: 'check worktree health' },
+    },
+    requireAuth
+  );
+
+  // POST /worktrees-open-vscode - Generate VS Code deep link (socket/HTTP friendly)
+  registerAuthenticatedRoute(
+    app,
+    '/worktrees-open-vscode',
+    {
+      async create(data: { worktreeId?: string; executeLocally?: boolean }, params: RouteParams) {
+        if (!data?.worktreeId) {
+          throw new Error('worktreeId is required');
+        }
+
+        if (data.executeLocally) {
+          const result = await worktreesService.executeVSCodeLocally(
+            data.worktreeId as import('@agor/core/types').WorktreeID,
+            params
+          );
+          return { success: true, message: result };
+        }
+
+        return worktreesService.getVSCodeTarget(
+          data.worktreeId as import('@agor/core/types').WorktreeID,
+          params
+        );
+      },
+    },
+    {
+      create: { role: 'member', action: 'open worktrees in VS Code' },
+    },
+    requireAuth
+  );
+
+  // POST /worktrees-open-codeserver - Generate code-server URL (socket/HTTP friendly)
+  registerAuthenticatedRoute(
+    app,
+    '/worktrees-open-codeserver',
+    {
+      async create(data: { worktreeId?: string }, params: RouteParams) {
+        if (!data?.worktreeId) {
+          throw new Error('worktreeId is required');
+        }
+        return worktreesService.getCodeServerTarget(
+          data.worktreeId as import('@agor/core/types').WorktreeID,
+          params
+        );
+      },
+    },
+    {
+      create: { role: 'member', action: 'open worktrees in code-server' },
     },
     requireAuth
   );

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -180,6 +180,46 @@ export class ConfigService {
       }
     }
 
+    // Allow updating IDE configuration (VS Code / code-server)
+    if (data.ide) {
+      if (!config.ide) {
+        config.ide = {};
+      }
+
+      if (data.ide.vscode) {
+        if (!config.ide.vscode) {
+          config.ide.vscode = {};
+        }
+        const { enabled, preferred_mode, remote } = data.ide.vscode;
+
+        if (enabled !== undefined) {
+          config.ide.vscode.enabled = enabled;
+        }
+        if (preferred_mode !== undefined) {
+          config.ide.vscode.preferred_mode = preferred_mode;
+        }
+        if (remote) {
+          config.ide.vscode.remote = config.ide.vscode.remote || {};
+          if (remote.host !== undefined) config.ide.vscode.remote.host = remote.host;
+          if (remote.port !== undefined) config.ide.vscode.remote.port = remote.port;
+          if (remote.user !== undefined) config.ide.vscode.remote.user = remote.user;
+          if (remote.target !== undefined) config.ide.vscode.remote.target = remote.target;
+        }
+      }
+
+      if (data.ide.code_server) {
+        if (!config.ide.code_server) {
+          config.ide.code_server = {};
+        }
+        if (data.ide.code_server.enabled !== undefined) {
+          config.ide.code_server.enabled = data.ide.code_server.enabled;
+        }
+        if (data.ide.code_server.url_template !== undefined) {
+          config.ide.code_server.url_template = data.ide.code_server.url_template;
+        }
+      }
+    }
+
     await saveConfig(config);
     console.log('[Config Service] Config saved successfully');
 

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -5,6 +5,10 @@
  * Only active when authentication is enabled via config.
  */
 
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { generateId } from '@agor/core';
 import { getEnvVarBlockReason, isEnvVarAllowed, validateEnvVar } from '@agor/core/config';
 import {
@@ -33,6 +37,13 @@ interface CreateUserData {
   role?: 'owner' | 'admin' | 'member' | 'viewer';
   unix_username?: string;
   must_change_password?: boolean;
+  ssh_config?: {
+    host?: string;
+    port?: number;
+    user?: string;
+    target?: string;
+    public_key?: string | null;
+  };
 }
 
 /**
@@ -58,6 +69,14 @@ interface UpdateUserData {
   env_vars?: Record<string, string | null>; // { "GITHUB_TOKEN": "ghp_...", "NPM_TOKEN": null }
   // Default agentic tool configurations
   default_agentic_config?: import('@agor/core/types').DefaultAgenticConfig;
+  // User-level SSH config (public key + host/user/port/target)
+  ssh_config?: {
+    host?: string;
+    port?: number;
+    user?: string;
+    target?: string;
+    public_key?: string | null;
+  };
 }
 
 /**
@@ -184,7 +203,8 @@ export class UsersService {
       data.preferences ||
       data.api_keys ||
       data.env_vars ||
-      data.default_agentic_config
+      data.default_agentic_config ||
+      data.ssh_config
     ) {
       const current = await this.get(id);
       const currentRow = await select(this.db).from(users).where(eq(users.user_id, id)).one();
@@ -194,6 +214,7 @@ export class UsersService {
         api_keys?: Record<string, string>;
         env_vars?: Record<string, string>;
         default_agentic_config?: import('@agor/core/types').DefaultAgenticConfig;
+        ssh_config?: import('@agor/core/types').UserSSHConfig;
       };
 
       // Handle API keys (encrypt before storage)
@@ -249,13 +270,94 @@ export class UsersService {
         }
       }
 
-      updates.data = {
+      // Handle SSH config (user-level, public key stored as-is)
+      let nextSshConfig = currentData?.ssh_config
+        ? { ...currentData.ssh_config }
+        : ({} as import('@agor/core/types').UserSSHConfig);
+      let sshConfigTouched = false;
+
+      if (data.ssh_config) {
+        const incoming = data.ssh_config;
+
+        if (incoming.host !== undefined) {
+          nextSshConfig.host = incoming.host || undefined;
+          sshConfigTouched = true;
+        }
+        if (incoming.port !== undefined) {
+          nextSshConfig.port = incoming.port ?? undefined;
+          sshConfigTouched = true;
+        }
+        if (incoming.user !== undefined) {
+          nextSshConfig.user = incoming.user || undefined;
+          sshConfigTouched = true;
+        }
+        if (incoming.target !== undefined) {
+          nextSshConfig.target = incoming.target || undefined;
+          sshConfigTouched = true;
+        }
+
+        if (incoming.public_key !== undefined) {
+          sshConfigTouched = true;
+          const marker = `agor-${id}`;
+          const sshUser = incoming.user ?? nextSshConfig.user;
+
+          if (!incoming.public_key || incoming.public_key.trim().length === 0) {
+            // Clear public key
+            delete nextSshConfig.public_key;
+            delete nextSshConfig.public_key_fingerprint;
+            const syncResult = await this.syncAuthorizedKey({
+              sshUser,
+              publicKey: null,
+              marker,
+            });
+            const clearedPath = syncResult.path ?? nextSshConfig.authorized_keys_path;
+            nextSshConfig.authorized_keys_path = clearedPath;
+            if (!syncResult.success && syncResult.error) {
+              nextSshConfig.last_authorized_keys_error = syncResult.error;
+            } else {
+              delete nextSshConfig.last_authorized_keys_error;
+            }
+          } else {
+            const trimmedKey = incoming.public_key.trim();
+            const fingerprint = this.computeSshFingerprint(trimmedKey);
+            nextSshConfig.public_key = trimmedKey;
+            nextSshConfig.public_key_fingerprint = fingerprint;
+
+            const syncResult = await this.syncAuthorizedKey({
+              sshUser,
+              publicKey: trimmedKey,
+              marker,
+            });
+            const updatedPath = syncResult.path ?? nextSshConfig.authorized_keys_path;
+            nextSshConfig.authorized_keys_path = updatedPath;
+            if (!syncResult.success && syncResult.error) {
+              nextSshConfig.last_authorized_keys_error = syncResult.error;
+            } else {
+              delete nextSshConfig.last_authorized_keys_error;
+            }
+          }
+        }
+
+        if (sshConfigTouched) {
+          nextSshConfig.updated_at = new Date();
+        }
+      }
+
+      // Remove ssh_config if completely empty to keep data lean
+      const hasSshConfig =
+        Object.values({ ...nextSshConfig }).filter((v) => v !== undefined).length > 0;
+
+      const mergedData = {
+        ...(currentData || {}),
         avatar: data.avatar ?? current.avatar,
         preferences: data.preferences ?? current.preferences,
         api_keys: Object.keys(encryptedKeys).length > 0 ? encryptedKeys : undefined,
         env_vars: Object.keys(encryptedEnvVars).length > 0 ? encryptedEnvVars : undefined,
         default_agentic_config: data.default_agentic_config ?? current.default_agentic_config,
+        ssh_config: hasSshConfig ? nextSshConfig : undefined,
       };
+
+      updates.data = mergedData;
     }
 
     const row = await update(this.db, users)
@@ -357,6 +459,79 @@ export class UsersService {
   }
 
   /**
+   * Compute SSH public key fingerprint (SHA256)
+   */
+  private computeSshFingerprint(publicKey: string): string {
+    const parts = publicKey.trim().split(/\s+/);
+    if (parts.length < 2) {
+      throw new Error('Invalid SSH public key format');
+    }
+    const keyData = parts[1];
+    const decoded = Buffer.from(keyData, 'base64');
+    const digest = createHash('sha256').update(decoded).digest('base64');
+    return `SHA256:${digest}`;
+  }
+
+  /**
+   * Resolve authorized_keys path for a given SSH user
+   */
+  private resolveAuthorizedKeysPath(sshUser?: string): string | null {
+    if (!sshUser || sshUser.trim().length === 0) return null;
+    const username = sshUser.trim();
+    const current = os.userInfo().username;
+
+    let home: string;
+    if (username === current) {
+      home = os.homedir();
+    } else if (process.platform === 'darwin') {
+      home = path.join('/Users', username);
+    } else {
+      home = path.join('/home', username);
+    }
+
+    return path.join(home, '.ssh', 'authorized_keys');
+  }
+
+  /**
+   * Add/replace/remove a public key in authorized_keys for a given SSH user.
+   * Uses a marker to ensure idempotency.
+   */
+  private async syncAuthorizedKey(options: {
+    sshUser?: string;
+    publicKey: string | null;
+    marker: string;
+  }): Promise<{ success: boolean; path?: string; error?: string }> {
+    const authPath = this.resolveAuthorizedKeysPath(options.sshUser);
+    if (!authPath) {
+      return { success: false, error: 'Missing SSH user, cannot write authorized_keys' };
+    }
+
+    try {
+      await fs.mkdir(path.dirname(authPath), { recursive: true });
+      const existing = await fs.readFile(authPath, 'utf-8').catch(() => '');
+      const lines = existing.split(/\r?\n/).filter((line) => line.trim().length > 0);
+
+      // Remove previous entries with the same marker
+      const filtered = lines.filter((line) => !line.includes(options.marker));
+
+      if (options.publicKey) {
+        const keyLine = `${options.publicKey.trim().replace(/\s+/g, ' ')} ${options.marker}`;
+        filtered.push(keyLine);
+      }
+
+      const output = filtered.join('\n').trimEnd() + (filtered.length ? '\n' : '');
+      await fs.writeFile(authPath, output, { mode: 0o600 });
+      return { success: true, path: authPath };
+    } catch (err) {
+      return {
+        success: false,
+        path: authPath,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
    * Convert database row to User type
    *
    * @param row - Database row
@@ -372,6 +547,7 @@ export class UsersService {
       api_keys?: Record<string, string>; // Encrypted keys
       env_vars?: Record<string, string>; // Encrypted env vars
       default_agentic_config?: import('@agor/core/types').DefaultAgenticConfig;
+      ssh_config?: import('@agor/core/types').UserSSHConfig;
     };
 
     const user: User & { password?: string } = {
@@ -401,6 +577,14 @@ export class UsersService {
         : undefined,
       // Return default agentic config
       default_agentic_config: data.default_agentic_config,
+      ssh_config: data.ssh_config
+        ? {
+            ...data.ssh_config,
+            updated_at: data.ssh_config.updated_at
+              ? new Date(data.ssh_config.updated_at)
+              : undefined,
+          }
+        : undefined,
     };
 
     // Include password for authentication (FeathersJS LocalStrategy needs this)

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -9,20 +9,33 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { createUserProcessEnvironment, ENVIRONMENT, PAGINATION } from '@agor/core/config';
+import {
+  type AgorConfig,
+  type AgorIDESSHSettings,
+  type AgorIDEVSCodeSettings,
+  createUserProcessEnvironment,
+  ENVIRONMENT,
+  PAGINATION,
+} from '@agor/core/config';
 import { type Database, WorktreeRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   BoardID,
+  CodeServerOpenResult,
   QueryParams,
   Repo,
+  User,
   UserID,
+  UserSSHConfig,
   UUID,
+  VSCodeOpenMode,
+  VSCodeOpenResult,
   Worktree,
   WorktreeID,
 } from '@agor/core/types';
 import { getNextRunTime, validateCron } from '@agor/core/utils/cron';
+import Handlebars from 'handlebars';
 import { DrizzleService } from '../adapters/drizzle';
 import { getDaemonUrl, spawnExecutor } from '../utils/spawn-executor.js';
 
@@ -54,6 +67,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
   private worktreeRepo: WorktreeRepository;
   private db: Database;
   private app: Application;
+  private config: AgorConfig;
   private processes = new Map<WorktreeID, ManagedProcess>();
   // Cache board-objects service reference (lazy-loaded to avoid circular deps)
   private boardObjectsService?: {
@@ -62,7 +76,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
     remove: (id: string) => Promise<unknown>;
   };
 
-  constructor(db: Database, app: Application) {
+  constructor(db: Database, app: Application, config: AgorConfig) {
     const worktreeRepo = new WorktreeRepository(db);
     super(worktreeRepo, {
       id: 'worktree_id',
@@ -76,6 +90,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
     this.worktreeRepo = worktreeRepo;
     this.db = db;
     this.app = app;
+    this.config = config;
   }
 
   /**
@@ -956,7 +971,6 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
    */
   async checkHealth(id: WorktreeID, params?: WorktreeParams): Promise<Worktree> {
     const worktree = await this.get(id, params);
-    const _repo = (await this.app.service('repos').get(worktree.repo_id, params)) as Repo;
 
     // Only check health for 'running' or 'starting' status
     const currentStatus = worktree.environment_instance?.status;
@@ -1071,6 +1085,249 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
           },
         },
         params
+      );
+    }
+  }
+
+  /**
+   * Custom method: Generate VS Code deep link for this worktree
+   */
+  async getVSCodeTarget(id: WorktreeID, params?: WorktreeParams): Promise<VSCodeOpenResult> {
+    const worktree = await this.get(id, params);
+    const vscodeConfig = this.config.ide?.vscode;
+    const currentUserId = (params as WorktreeParams & { user?: { user_id?: UserID } })?.user
+      ?.user_id;
+    const userSshConfig = currentUserId
+      ? await this.getUserSshConfig(currentUserId).catch(() => undefined)
+      : undefined;
+
+    if (vscodeConfig?.enabled === false) {
+      return {
+        enabled: false,
+        reason: 'VS Code integration disabled via ide.vscode.enabled=false',
+      };
+    }
+
+    const modeOrder = this.getVSCodeModeOrder(vscodeConfig);
+    let fallbackReason: string | undefined;
+
+    for (const mode of modeOrder) {
+      if (mode === 'remote-ssh') {
+        const effectiveRemote = this.mergeRemoteConfig(vscodeConfig?.remote, userSshConfig);
+        const remoteResult = this.buildRemoteVSCodeResult(effectiveRemote, worktree.path);
+        if (remoteResult) return remoteResult;
+        if (effectiveRemote) {
+          const missingFields: string[] = [];
+          if (!effectiveRemote.host)
+            missingFields.push('SSH host (user settings or ide.vscode.remote.host)');
+          if (!effectiveRemote.user)
+            missingFields.push('SSH user (user settings or ide.vscode.remote.user)');
+          if (missingFields.length > 0) {
+            fallbackReason = `Remote SSH configuration incomplete (${missingFields.join(', ')})`;
+          }
+        }
+      } else if (mode === 'local') {
+        return this.buildLocalVSCodeResult(worktree.path, fallbackReason);
+      }
+    }
+
+    // Final fallback: local open
+    return this.buildLocalVSCodeResult(worktree.path, fallbackReason);
+  }
+
+  /**
+   * Preferred VS Code mode ordering
+   */
+  private getVSCodeModeOrder(config?: AgorIDEVSCodeSettings): VSCodeOpenMode[] {
+    const baseOrder: VSCodeOpenMode[] = ['remote-ssh', 'local'];
+    const preferred = config?.preferred_mode;
+    if (!preferred) {
+      return baseOrder;
+    }
+    return [preferred, ...baseOrder.filter((mode) => mode !== preferred)];
+  }
+
+  /**
+   * Merge global remote config with user-level SSH config (user overrides)
+   */
+  private mergeRemoteConfig(
+    globalRemote: AgorIDESSHSettings | undefined,
+    userSsh?: UserSSHConfig
+  ): AgorIDESSHSettings | undefined {
+    const userOverrides =
+      userSsh?.host !== undefined ||
+      userSsh?.port !== undefined ||
+      userSsh?.user !== undefined ||
+      userSsh?.target !== undefined;
+
+    const merged: AgorIDESSHSettings = {
+      host: userSsh?.host ?? globalRemote?.host,
+      port: userSsh?.port ?? globalRemote?.port,
+      user: userSsh?.user ?? globalRemote?.user,
+      target: userOverrides ? userSsh?.target || undefined : globalRemote?.target,
+    };
+
+    const hasValue =
+      merged.host !== undefined ||
+      merged.port !== undefined ||
+      merged.user !== undefined ||
+      merged.target !== undefined;
+    return hasValue ? merged : undefined;
+  }
+
+  /**
+   * Fetch user-level SSH configuration (if available)
+   */
+  private async getUserSshConfig(userId: UserID): Promise<UserSSHConfig | undefined> {
+    try {
+      const usersService = this.app.service('users') as unknown as {
+        get: (id: UserID, params?: WorktreeParams) => Promise<User>;
+      };
+      const user = await usersService.get(userId, { provider: undefined } as WorktreeParams);
+      return user?.ssh_config;
+    } catch (error) {
+      console.warn(`[WorktreesService] Failed to load user SSH config for ${userId}:`, error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Encode filesystem path for vscode:// URIs
+   */
+  private getPathSuffix(path: string): string {
+    const normalized = path.replace(/\\/g, '/');
+    const segments = normalized.split('/').filter((segment) => segment.length > 0);
+    if (segments.length === 0) {
+      return '/';
+    }
+    return `/${segments.map((segment) => encodeURIComponent(segment)).join('/')}`;
+  }
+
+  /**
+   * Build vscode://vscode-remote/tunnel URI when VS Code Tunnel configured
+   */
+  /**
+   * Build vscode://file URI for local fallback
+   */
+  private buildLocalVSCodeResult(path: string, reason?: string): VSCodeOpenResult {
+    const pathSuffix = this.getPathSuffix(path);
+    return {
+      enabled: true,
+      mode: 'local',
+      uri: `vscode://file${pathSuffix}`,
+      reason,
+    };
+  }
+
+  /**
+   * Build vscode://vscode-remote URI for Remote SSH (if configured)
+   */
+  private buildRemoteVSCodeResult(
+    remote: AgorIDESSHSettings | undefined,
+    path: string
+  ): VSCodeOpenResult | null {
+    if (!remote || !remote.host || !remote.user) {
+      return null;
+    }
+
+    const host = remote.host;
+    const user = remote.user;
+    const port = remote.port ?? 22;
+    const pathSuffix = this.getPathSuffix(path);
+    const targetLabel =
+      remote.target && remote.target.trim().length > 0
+        ? remote.target.trim()
+        : `${user}@${host}${port !== 22 ? `:${port}` : ''}`;
+
+    const uri = `vscode://vscode-remote/ssh-remote+${targetLabel}${pathSuffix}`;
+    const sshCommand = port === 22 ? `ssh ${user}@${host}` : `ssh -p ${port} ${user}@${host}`;
+
+    return {
+      enabled: true,
+      mode: 'remote-ssh',
+      uri,
+      sshCommand,
+      targetLabel,
+    };
+  }
+
+  /**
+   * Custom method: Generate code-server (web) URL for this worktree
+   */
+  async getCodeServerTarget(
+    id: WorktreeID,
+    params?: WorktreeParams
+  ): Promise<CodeServerOpenResult> {
+    const worktree = await this.get(id, params);
+    const codeServerConfig = this.config.ide?.code_server;
+
+    if (codeServerConfig?.enabled === false) {
+      return {
+        enabled: false,
+        reason: 'code-server integration disabled (ide.code_server.enabled=false)',
+      };
+    }
+
+    const template = codeServerConfig?.url_template?.trim();
+    if (!template) {
+      return {
+        enabled: false,
+        reason: 'ide.code_server.url_template not configured',
+      };
+    }
+
+    const repo = (await this.app.service('repos').get(worktree.repo_id, params)) as Repo;
+
+    try {
+      const compiled = Handlebars.compile(template, { noEscape: true });
+      const url = compiled({ worktree, repo });
+      if (!url || typeof url !== 'string') {
+        return {
+          enabled: false,
+          reason: 'code-server URL template did not produce a valid string',
+        };
+      }
+      return { enabled: true, url };
+    } catch (error) {
+      const reason =
+        error instanceof Error
+          ? error.message
+          : 'code-server URL template rendering failed (unknown error)';
+      return { enabled: false, reason };
+    }
+  }
+
+  /**
+   * Execute VS Code locally on the daemon machine
+   * Opens the worktree directory using the 'code' CLI command
+   */
+  async executeVSCodeLocally(id: WorktreeID, params?: WorktreeParams): Promise<string> {
+    const worktree = await this.get(id, params);
+
+    try {
+      console.log(`📝 Opening worktree ${worktree.name} in VS Code locally: ${worktree.path}`);
+
+      // Execute the 'code' command with the worktree path
+      const command = `code "${worktree.path}"`;
+
+      // Execute synchronously without waiting for output
+      // This will trigger VS Code to open in the background
+      const { exec } = await import('node:child_process');
+      exec(command, (error, stdout, stderr) => {
+        if (error) {
+          console.error(`Failed to execute code command for ${worktree.name}:`, error);
+          throw error;
+        }
+        if (stderr) {
+          console.warn(`code command stderr for ${worktree.name}:`, stderr);
+        }
+      });
+
+      return `Executed 'code ${worktree.path}' command on daemon machine`;
+    } catch (error) {
+      console.error(`Failed to open VS Code locally for ${worktree.name}:`, error);
+      throw new Error(
+        `Failed to open VS Code locally: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
@@ -1203,5 +1460,6 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
  * Service factory function
  */
 export function createWorktreesService(db: Database, app: Application): WorktreesService {
-  return new WorktreesService(db, app);
+  const config = app.get('agorConfig') as AgorConfig | undefined;
+  return new WorktreesService(db, app, config || {});
 }

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -86,7 +86,7 @@ function DeviceRouter() {
 function AppContent() {
   const { token } = theme.useToken();
   const { getCurrentThemeConfig } = useTheme();
-  const { showSuccess, showError, showLoading, destroy } = useThemedMessage();
+  const { showSuccess, showError, showLoading, showWarning, destroy } = useThemedMessage();
 
   // Fetch daemon auth and instance configuration
   const {
@@ -802,6 +802,109 @@ function AppContent() {
     }
   };
 
+  const handleOpenVSCode = async (worktreeId: string) => {
+    if (!client) return;
+    const key = `open-vscode-${worktreeId}`;
+    try {
+      showLoading('Preparing VS Code connection...', { key });
+      const result = await client.service('worktrees-open-vscode').create({ worktreeId });
+
+      if (!result || !result.enabled) {
+        const reason = result?.reason || 'VS Code integration is not configured';
+        showError(reason, { key });
+        return;
+      }
+
+      // Local development: execute code command directly
+      if (result.mode === 'local') {
+        try {
+          // Execute code command via backend to open worktree directory
+          await client.service('worktrees-open-vscode').create({
+            worktreeId,
+            executeLocally: true,
+          });
+          showSuccess('Executed code command locally to open worktree', { key });
+          return;
+        } catch (error) {
+          console.error('Failed to execute code command:', error);
+          // If execution fails, continue to try browser URI
+        }
+      }
+
+      // Non-local mode: use browser URI
+      if (!result.uri) {
+        const reason = result?.reason || 'VS Code URI is not available';
+        showError(reason, { key });
+        return;
+      }
+
+      const openLink = (uri: string) => {
+        if (typeof document === 'undefined') return;
+        const anchor = document.createElement('a');
+        anchor.href = uri;
+        anchor.style.display = 'none';
+        anchor.rel = 'noreferrer';
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+      };
+
+      const uriWithNewWindow = result.uri
+        ? `${result.uri}${result.uri.includes('?') ? '&' : '?'}windowId=agor-${Date.now()}`
+        : undefined;
+
+      if (uriWithNewWindow) {
+        openLink(uriWithNewWindow);
+      }
+
+      const successMessage =
+        result.mode === 'remote-ssh'
+          ? 'VS Code Remote SSH triggered'
+          : 'VS Code opening worktree locally';
+      showSuccess(successMessage, { key });
+
+      if (result.reason) {
+        showWarning(result.reason);
+      }
+    } catch (error) {
+      showError(
+        `Failed to open VS Code: ${error instanceof Error ? error.message : String(error)}`,
+        {
+          key,
+        }
+      );
+    }
+  };
+
+  const handleOpenCodeServer = async (worktreeId: string) => {
+    if (!client) return;
+    const key = `open-codeserver-${worktreeId}`;
+    try {
+      showLoading('Preparing code-server link...', { key });
+      const result = await client.service('worktrees-open-codeserver').create({ worktreeId });
+
+      if (!result || !result.enabled || !result.url) {
+        const reason = result?.reason || 'code-server integration is not configured';
+        showError(reason, { key });
+        return;
+      }
+
+      window.open(result.url, '_blank', 'noopener');
+      showSuccess('Opened code-server in browser', { key });
+
+      if (result.reason) {
+        showWarning(result.reason);
+      }
+    } catch (error) {
+      showError(
+        `Failed to open code-server: ${error instanceof Error ? error.message : String(error)}`,
+        {
+          key,
+        }
+      );
+    }
+  };
+
   // Handle MCP server CRUD
   const handleCreateMCPServer = async (data: CreateMCPServerInput) => {
     if (!client) return;
@@ -1054,6 +1157,8 @@ function AppContent() {
                 onUnarchiveWorktree={handleUnarchiveWorktree}
                 onUpdateWorktree={handleUpdateWorktree}
                 onCreateWorktree={handleCreateWorktree}
+                onOpenVSCode={handleOpenVSCode}
+                onOpenCodeServer={handleOpenCodeServer}
                 onStartEnvironment={handleStartEnvironment}
                 onStopEnvironment={handleStopEnvironment}
                 onNukeEnvironment={handleNukeEnvironment}
@@ -1125,6 +1230,8 @@ function AppContent() {
                 onUnarchiveWorktree={handleUnarchiveWorktree}
                 onUpdateWorktree={handleUpdateWorktree}
                 onCreateWorktree={handleCreateWorktree}
+                onOpenVSCode={handleOpenVSCode}
+                onOpenCodeServer={handleOpenCodeServer}
                 onStartEnvironment={handleStartEnvironment}
                 onStopEnvironment={handleStopEnvironment}
                 onNukeEnvironment={handleNukeEnvironment}
@@ -1196,6 +1303,8 @@ function AppContent() {
                 onUnarchiveWorktree={handleUnarchiveWorktree}
                 onUpdateWorktree={handleUpdateWorktree}
                 onCreateWorktree={handleCreateWorktree}
+                onOpenVSCode={handleOpenVSCode}
+                onOpenCodeServer={handleOpenCodeServer}
                 onStartEnvironment={handleStartEnvironment}
                 onStopEnvironment={handleStopEnvironment}
                 onNukeEnvironment={handleNukeEnvironment}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -112,6 +112,8 @@ export interface AppProps {
       pull_request_url?: string;
     }
   ) => Promise<Worktree | null>;
+  onOpenVSCode?: (worktreeId: string) => void;
+  onOpenCodeServer?: (worktreeId: string) => void;
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
@@ -175,6 +177,8 @@ export const App: React.FC<AppProps> = ({
   onUnarchiveWorktree,
   onUpdateWorktree,
   onCreateWorktree,
+  onOpenVSCode,
+  onOpenCodeServer,
   onStartEnvironment,
   onStopEnvironment,
   onNukeEnvironment,
@@ -553,6 +557,8 @@ export const App: React.FC<AppProps> = ({
       onOpenSettings: (sessionId: string) => setSessionSettingsId(sessionId),
       onOpenWorktree: (worktreeId: string) => setWorktreeModalWorktreeId(worktreeId),
       onOpenTerminal: handleOpenTerminal,
+      onOpenVSCode,
+      onOpenCodeServer,
     }),
     [
       onSendPrompt,
@@ -564,6 +570,8 @@ export const App: React.FC<AppProps> = ({
       onStartEnvironment,
       onStopEnvironment,
       onNukeEnvironment,
+      onOpenVSCode,
+      onOpenCodeServer,
       handleOpenTerminal,
     ]
   );
@@ -766,6 +774,8 @@ export const App: React.FC<AppProps> = ({
                         }}
                         onArchiveOrDeleteWorktree={onArchiveOrDeleteWorktree}
                         onOpenTerminal={handleOpenTerminal}
+                        onOpenVSCode={onOpenVSCode}
+                        onOpenCodeServer={onOpenCodeServer}
                         onStartEnvironment={onStartEnvironment}
                         onStopEnvironment={onStopEnvironment}
                         onViewLogs={setLogsModalWorktreeId}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -114,6 +114,8 @@ interface SessionCanvasProps {
     }
   ) => void;
   onOpenTerminal?: (commands: string[], worktreeId?: string) => void;
+  onOpenVSCode?: (worktreeId: string) => void;
+  onOpenCodeServer?: (worktreeId: string) => void;
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
@@ -185,6 +187,8 @@ interface WorktreeNodeData {
   ) => void;
   onOpenSettings?: (worktreeId: string) => void;
   onOpenTerminal?: (commands: string[], worktreeId?: string) => void;
+  onOpenVSCode?: (worktreeId: string) => void;
+  onOpenCodeServer?: (worktreeId: string) => void;
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
@@ -217,6 +221,8 @@ const WorktreeNode = ({ data }: { data: WorktreeNodeData }) => {
         onArchiveOrDelete={data.onArchiveOrDelete}
         onOpenSettings={data.onOpenSettings}
         onOpenTerminal={data.onOpenTerminal}
+        onOpenVSCode={data.onOpenVSCode}
+        onOpenCodeServer={data.onOpenCodeServer}
         onStartEnvironment={data.onStartEnvironment}
         onStopEnvironment={data.onStopEnvironment}
         onViewLogs={data.onViewLogs}
@@ -271,6 +277,8 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onOpenWorktree,
       onArchiveOrDeleteWorktree,
       onOpenTerminal,
+      onOpenVSCode,
+      onOpenCodeServer,
       onStartEnvironment,
       onStopEnvironment,
       onViewLogs,
@@ -577,6 +585,8 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onArchiveOrDelete: onArchiveOrDeleteWorktree,
             onOpenSettings: onOpenWorktree,
             onOpenTerminal,
+            onOpenVSCode,
+            onOpenCodeServer,
             onStartEnvironment,
             onStopEnvironment,
             onViewLogs,
@@ -608,6 +618,8 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onArchiveOrDeleteWorktree,
       onOpenWorktree,
       onOpenTerminal,
+      onOpenVSCode,
+      onOpenCodeServer,
       onStartEnvironment,
       onStopEnvironment,
       onViewLogs,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -15,6 +15,7 @@ import {
   CodeOutlined,
   DeleteOutlined,
   ForkOutlined,
+  GlobalOutlined,
   SendOutlined,
   SettingOutlined,
   StopOutlined,
@@ -44,6 +45,7 @@ import {
 } from '../Pill';
 import { ThinkingModeSelector } from '../ThinkingModeSelector';
 import { ToolIcon } from '../ToolIcon';
+import { VSCodeIcon } from '../VSCodeIcon';
 import { SessionPanelContent } from './SessionPanelContent';
 
 // Re-export PermissionMode from SDK for convenience
@@ -88,6 +90,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     onUpdateSession,
     onDeleteSession: onDelete,
     onOpenTerminal,
+    onOpenVSCode,
+    onOpenCodeServer,
   } = useAppActions();
 
   // Per-session draft storage
@@ -755,6 +759,24 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                   type="text"
                   icon={<CodeOutlined />}
                   onClick={() => onOpenTerminal([`cd ${worktree.path}`], worktree.worktree_id)}
+                />
+              </Tooltip>
+            )}
+            {onOpenVSCode && worktree && (
+              <Tooltip title="Open in VS Code">
+                <Button
+                  type="text"
+                  icon={<VSCodeIcon offsetY={1} />}
+                  onClick={() => onOpenVSCode(worktree.worktree_id)}
+                />
+              </Tooltip>
+            )}
+            {onOpenCodeServer && worktree && (
+              <Tooltip title="Open code-server in browser">
+                <Button
+                  type="text"
+                  icon={<GlobalOutlined />}
+                  onClick={() => onOpenCodeServer(worktree.worktree_id)}
                 />
               </Tooltip>
             )}

--- a/apps/agor-ui/src/components/SettingsModal/IDETab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/IDETab.tsx
@@ -1,0 +1,211 @@
+import type { AgorClient } from '@agor/core/api';
+import type { VSCodeOpenMode } from '@agor/core/types';
+import { Alert, Button, Form, Input, Select, Space, Switch, Typography, theme } from 'antd';
+import { useEffect, useState } from 'react';
+import { useThemedMessage } from '../../utils/message';
+
+const DEFAULT_CODE_SERVER_TEMPLATE =
+  'https://codeserver.example.com/?folder={{encodeURIComponent worktree.path}}';
+
+export interface IDETabProps {
+  client: AgorClient | null;
+}
+
+export const IDETab: React.FC<IDETabProps> = ({ client }) => {
+  const { token } = theme.useToken();
+  const { showSuccess, showError } = useThemedMessage();
+  const [loading, setLoading] = useState(true);
+
+  const [vscodeEnabled, setVscodeEnabled] = useState(true);
+  const [preferredMode, setPreferredMode] = useState<VSCodeOpenMode>('remote-ssh');
+  const [remoteHost, setRemoteHost] = useState('');
+  const [remotePort, setRemotePort] = useState<string>('');
+  const [remoteUser, setRemoteUser] = useState('');
+  const [remoteTarget, setRemoteTarget] = useState('');
+
+  const [codeServerEnabled, setCodeServerEnabled] = useState(false);
+  const [codeServerTemplate, setCodeServerTemplate] = useState(DEFAULT_CODE_SERVER_TEMPLATE);
+
+  useEffect(() => {
+    if (!client) return;
+
+    const loadConfig = async () => {
+      try {
+        setLoading(true);
+        const ideConfig = (await client.service('config').get('ide')) as {
+          vscode?: {
+            enabled?: boolean;
+            preferred_mode?: VSCodeOpenMode;
+            remote?: { host?: string; port?: number; user?: string; target?: string };
+          };
+          code_server?: { enabled?: boolean; url_template?: string };
+        };
+
+        if (ideConfig?.vscode) {
+          setVscodeEnabled(ideConfig.vscode.enabled !== false);
+          setPreferredMode(ideConfig.vscode.preferred_mode || 'remote-ssh');
+          setRemoteHost(ideConfig.vscode.remote?.host || '');
+          setRemotePort(
+            ideConfig.vscode.remote?.port !== undefined ? String(ideConfig.vscode.remote.port) : ''
+          );
+          setRemoteUser(ideConfig.vscode.remote?.user || '');
+          setRemoteTarget(ideConfig.vscode.remote?.target || '');
+        }
+
+        if (ideConfig?.code_server) {
+          setCodeServerEnabled(ideConfig.code_server.enabled === true);
+          setCodeServerTemplate(ideConfig.code_server.url_template || DEFAULT_CODE_SERVER_TEMPLATE);
+        }
+      } catch (err) {
+        console.error('Failed to load IDE config', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadConfig();
+  }, [client]);
+
+  const handleSave = async () => {
+    if (!client) return;
+
+    try {
+      const portNumber =
+        remotePort && !Number.isNaN(Number(remotePort)) ? Number(remotePort) : undefined;
+
+      await client.service('config').patch(null, {
+        ide: {
+          vscode: {
+            enabled: vscodeEnabled,
+            preferred_mode: preferredMode,
+            remote: {
+              host: remoteHost || undefined,
+              port: portNumber,
+              user: remoteUser || undefined,
+              target: remoteTarget || undefined,
+            },
+          },
+          code_server: {
+            enabled: codeServerEnabled,
+            url_template: codeServerTemplate || undefined,
+          },
+        },
+      });
+
+      showSuccess('IDE configuration saved');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save IDE configuration';
+      showError(message);
+      console.error('Failed to save IDE config', err);
+    }
+  };
+
+  return (
+    <div style={{ padding: token.paddingMD }}>
+      <Alert
+        type="info"
+        showIcon
+        message="VS Code Opening Methods"
+        description={
+          <div>
+            <p style={{ marginBottom: token.marginXS }}>
+              Supports <strong>Remote SSH</strong> and local <code>vscode://file</code> methods.
+            </p>
+            <p style={{ marginBottom: 0 }}>
+              Remote SSH is preferred by default; falls back to local method if configuration is
+              missing.
+            </p>
+          </div>
+        }
+        style={{ marginBottom: token.marginLG }}
+      />
+
+      <Form layout="vertical" disabled={loading}>
+        <Form.Item label="Enable VS Code Open Button">
+          <Space>
+            <Switch
+              checked={vscodeEnabled}
+              onChange={setVscodeEnabled}
+              checkedChildren="Enabled"
+              unCheckedChildren="Disabled"
+            />
+            <span style={{ color: token.colorTextSecondary, fontSize: 12 }}>
+              Button will be hidden when disabled
+            </span>
+          </Space>
+        </Form.Item>
+
+        <Form.Item label="Preferred Connection Mode">
+          <Select<VSCodeOpenMode>
+            value={preferredMode}
+            onChange={setPreferredMode}
+            options={[
+              { label: 'Remote SSH', value: 'remote-ssh' },
+              { label: 'Local (vscode://file)', value: 'local' },
+            ]}
+            style={{ width: 240 }}
+          />
+        </Form.Item>
+
+        <Typography.Title level={5} style={{ marginTop: token.marginLG }}>
+          Remote SSH
+        </Typography.Title>
+        <Form.Item label="Host">
+          <Input
+            placeholder="example.com"
+            value={remoteHost}
+            onChange={(e) => setRemoteHost(e.target.value)}
+          />
+        </Form.Item>
+        <Form.Item label="Port">
+          <Input
+            placeholder="22"
+            value={remotePort}
+            onChange={(e) => setRemotePort(e.target.value)}
+          />
+        </Form.Item>
+        <Form.Item label="User">
+          <Input
+            placeholder="dev"
+            value={remoteUser}
+            onChange={(e) => setRemoteUser(e.target.value)}
+          />
+        </Form.Item>
+        <Form.Item
+          label="SSH Target (optional)"
+          extra="If using a Host alias from ~/.ssh/config, enter that alias; otherwise leave blank to auto-generate user@host"
+        >
+          <Input
+            placeholder="my-ssh-alias"
+            value={remoteTarget}
+            onChange={(e) => setRemoteTarget(e.target.value)}
+          />
+        </Form.Item>
+
+        <Typography.Title level={5} style={{ marginTop: token.marginLG }}>
+          code-server (Browser-based)
+        </Typography.Title>
+        <Form.Item label="Enable code-server Button">
+          <Switch checked={codeServerEnabled} onChange={setCodeServerEnabled} />
+        </Form.Item>
+        <Form.Item
+          label="URL Template"
+          extra="Use Handlebars variables: worktree, repo; paths are encoded with encodeURIComponent by default"
+        >
+          <Input.TextArea
+            autoSize={{ minRows: 2, maxRows: 4 }}
+            placeholder={DEFAULT_CODE_SERVER_TEMPLATE}
+            value={codeServerTemplate}
+            onChange={(e) => setCodeServerTemplate(e.target.value)}
+          />
+        </Form.Item>
+
+        <Space style={{ marginTop: token.marginLG }}>
+          <Button type="primary" onClick={handleSave} disabled={loading}>
+            Save
+          </Button>
+        </Space>
+      </Form>
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -30,6 +30,7 @@ import type { WorktreeUpdate } from '../WorktreeModal/tabs/GeneralTab';
 import { AboutTab } from './AboutTab';
 import { AgenticToolsSection } from './AgenticToolsSection';
 import { BoardsTable } from './BoardsTable';
+import { IDETab } from './IDETab';
 import { MCPServersTable } from './MCPServersTable';
 import { ReposTable } from './ReposTable';
 import { UsersTable } from './UsersTable';
@@ -194,6 +195,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           icon: <ApiOutlined />,
         },
         {
+          key: 'ide',
+          label: 'IDE / VS Code',
+          icon: <InfoCircleOutlined />,
+        },
+        {
           key: 'agentic-tools',
           label: 'Agentic Tools',
           icon: <RobotOutlined />,
@@ -276,6 +282,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             onDelete={onDeleteMCPServer}
           />
         );
+      case 'ide':
+        return <IDETab client={client} />;
       case 'agentic-tools':
         return <AgenticToolsSection client={client} />;
       case 'users':

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -60,6 +60,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [geminiForm] = Form.useForm();
   const [opencodeForm] = Form.useForm();
   const [audioForm] = Form.useForm();
+  const [sshForm] = Form.useForm();
 
   // API key management state
   const [userApiKeyStatus, setUserApiKeyStatus] = useState<ApiKeyStatus>({
@@ -129,8 +130,16 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         volume: audioPrefs?.volume ?? 50,
         minDurationSeconds: audioPrefs?.minDurationSeconds ?? 5,
       });
+
+      sshForm.setFieldsValue({
+        sshHost: userData.ssh_config?.host,
+        sshPort: userData.ssh_config?.port,
+        sshUser: userData.ssh_config?.user,
+        sshTarget: userData.ssh_config?.target,
+        sshPublicKey: userData.ssh_config?.public_key,
+      });
     },
-    [form, claudeForm, codexForm, geminiForm, audioForm]
+    [form, claudeForm, codexForm, geminiForm, audioForm, sshForm]
   );
 
   // Initialize when modal opens with user data
@@ -172,6 +181,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     claudeForm.resetFields();
     codexForm.resetFields();
     geminiForm.resetFields();
+    sshForm.resetFields();
     setActiveTab('general');
     onClose();
   };

--- a/apps/agor-ui/src/components/VSCodeIcon/VSCodeIcon.tsx
+++ b/apps/agor-ui/src/components/VSCodeIcon/VSCodeIcon.tsx
@@ -1,0 +1,53 @@
+/**
+ * VSCodeIcon Component
+ *
+ * Displays the VSCode logo as an SVG icon
+ */
+
+import Icon from '@ant-design/icons';
+import type React from 'react';
+
+export interface VSCodeIconProps {
+  /** Optional size in px; if omitted, inherits from parent */
+  size?: number;
+  /** Additional CSS class (applied to the wrapper span.anticon) */
+  className?: string;
+  /** Optional vertical offset in px (rarely needed) */
+  offsetY?: number;
+}
+
+export const VSCodeIcon: React.FC<VSCodeIconProps> = ({ size, className = '', offsetY = 0 }) => {
+  const VSCodeSvg: React.FC = () => (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 128 128"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      focusable="false"
+      aria-hidden="true"
+      style={{ transform: offsetY ? `translateY(${offsetY}px)` : undefined }}
+    >
+      <path
+        fill="#0065A9"
+        d="M123.471 13.82 97.097 1.12A7.973 7.973 0 0 0 88 2.668L1.662 81.387a5.333 5.333 0 0 0 .006 7.887l7.052 6.411a5.333 5.333 0 0 0 6.811.303l103.971-78.875c3.488-2.646 8.498-.158 8.498 4.22v-.306a8.001 8.001 0 0 0-4.529-7.208Z"
+      />
+      <path
+        fill="#007ACC"
+        d="m123.471 114.181-26.374 12.698A7.973 7.973 0 0 1 88 125.333L1.662 46.613a5.333 5.333 0 0 1 .006-7.887l7.052-6.411a5.333 5.333 0 0 1 6.811-.303l103.971 78.874c3.488 2.647 8.498.159 8.498-4.219v.306a8.001 8.001 0 0 1-4.529 7.208Z"
+      />
+      <path
+        fill="#1F9CF0"
+        d="M97.098 126.882A7.977 7.977 0 0 1 88 125.333c2.952 2.952 8 .861 8-3.314V5.98c0-4.175-5.048-6.266-8-3.313a7.977 7.977 0 0 1 9.098-1.549L123.467 13.8A8 8 0 0 1 128 21.01v85.982a8 8 0 0 1-4.533 7.21l-26.369 12.681Z"
+      />
+    </svg>
+  );
+
+  return (
+    <Icon
+      component={VSCodeSvg}
+      className={className}
+      style={size ? { fontSize: size } : undefined}
+    />
+  );
+};

--- a/apps/agor-ui/src/components/VSCodeIcon/index.ts
+++ b/apps/agor-ui/src/components/VSCodeIcon/index.ts
@@ -1,0 +1,1 @@
+export { VSCodeIcon } from './VSCodeIcon';

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -8,6 +8,7 @@ import {
   DragOutlined,
   EditOutlined,
   ForkOutlined,
+  GlobalOutlined,
   PlusOutlined,
   PushpinFilled,
   SubnodeOutlined,
@@ -26,6 +27,7 @@ import { CreatedByTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
 import { TaskStatusIcon } from '../TaskStatusIcon';
 import { ToolIcon } from '../ToolIcon';
+import { VSCodeIcon } from '../VSCodeIcon';
 import { buildSessionTree, type SessionTreeNode } from './buildSessionTree';
 
 const _WORKTREE_CARD_MAX_WIDTH = 600;
@@ -68,6 +70,8 @@ interface WorktreeCardProps {
   ) => void;
   onOpenSettings?: (worktreeId: string) => void;
   onOpenTerminal?: (commands: string[], worktreeId?: string) => void;
+  onOpenVSCode?: (worktreeId: string) => void;
+  onOpenCodeServer?: (worktreeId: string) => void;
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
@@ -96,6 +100,8 @@ const WorktreeCardComponent = ({
   onArchiveOrDelete,
   onOpenSettings,
   onOpenTerminal,
+  onOpenVSCode,
+  onOpenCodeServer,
   onStartEnvironment,
   onStopEnvironment,
   onViewLogs,
@@ -551,6 +557,32 @@ const WorktreeCardComponent = ({
                   onOpenTerminal([`cd ${worktree.path}`], worktree.worktree_id);
                 }}
                 title="Open terminal in worktree directory"
+              />
+            )}
+            {onOpenVSCode && (
+              <Button
+                type="text"
+                size="small"
+                icon={<VSCodeIcon offsetY={0} />}
+                disabled={connectionDisabled}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenVSCode(worktree.worktree_id);
+                }}
+                title="Open in VS Code"
+              />
+            )}
+            {onOpenCodeServer && (
+              <Button
+                type="text"
+                size="small"
+                icon={<GlobalOutlined />}
+                disabled={connectionDisabled}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenCodeServer(worktree.worktree_id);
+                }}
+                title="Open in code-server (browser)"
               />
             )}
             {onOpenSettings && (

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -33,6 +33,8 @@ export interface AppActionsContextValue {
   onOpenSettings?: (sessionId: string) => void;
   onOpenWorktree?: (worktreeId: string) => void;
   onOpenTerminal?: (commands: string[], worktreeId?: string) => void;
+  onOpenVSCode?: (worktreeId: string) => void;
+  onOpenCodeServer?: (worktreeId: string) => void;
 }
 
 const AppActionsContext = createContext<AppActionsContextValue | undefined>(undefined);

--- a/apps/agor-ui/src/hooks/useSettingsRoute.ts
+++ b/apps/agor-ui/src/hooks/useSettingsRoute.ts
@@ -9,6 +9,7 @@ export type SettingsSection =
   | 'repos'
   | 'worktrees'
   | 'mcp'
+  | 'ide'
   | 'agentic-tools'
   | 'users'
   | 'about';
@@ -65,6 +66,7 @@ export function useSettingsRoute() {
       'repos',
       'worktrees',
       'mcp',
+      'ide',
       'agentic-tools',
       'users',
       'about',

--- a/context/concepts/vscode-open.md
+++ b/context/concepts/vscode-open.md
@@ -1,0 +1,130 @@
+# Worktree "Open in VS Code" Feature
+
+**Last updated: 2025-12-06 (Added: code-server browser support & connection mode configuration; distinction between global and user-level SSH configuration)**
+
+## Goals & Requirements
+
+- Provide "Open in VS Code" button in Worktree cards and Session panels.
+- Single click opens the corresponding Worktree directory in VS Code.
+- Supports three modes: Remote SSH, VS Code Tunnel, and Local.
+- Default priority is Remote SSH (to avoid tunnel relay latency); falls back automatically based on priority if configuration is missing.
+- Falls back to local `vscode://file` Deep Link if remote information is not configured.
+- Added browser-based `code-server` entry point with URL template generation.
+
+## Configuration Quick Reference
+
+- Global configuration (shared by all users): `ide.vscode`, `ide.code_server` under `~/.agor/config.yaml`.
+- User-level SSH configuration (per-user host/user/port/target and public key): Set via **User Settings → SSH / VS Code** in the frontend, stored in user profile (not config.yaml), and automatically written to the target user's `authorized_keys`.
+- Configuration priority: User-level SSH > Global `ide.vscode.remote` > Tunnel > Local.
+
+## Backend Implementation
+
+1. **Configuration Entry** (`~/.agor/config.yaml`)
+
+```yaml
+ide:
+  vscode:
+    enabled: true            # Default true, can be disabled to hide the button
+    preferred_mode: remote-ssh  # Default priority Remote SSH, options: tunnel / remote-ssh / local
+    remote:
+      host: my-server.com    # Remote SSH Host (required, otherwise falls back to local mode)
+      port: 22               # Optional, default 22
+      user: dev              # SSH user (required, otherwise falls back to local mode)
+      target: agor-dev       # Optional, corresponds to Host alias in ~/.ssh/config; auto-generates user@host[:port] if not set
+    tunnel:                  # Optional, only attempted if configured
+      name: agor-prod-tunnel
+      displayName: "Prod Tunnel"
+  code_server:
+    enabled: false           # Default disabled, shows "Open in code-server (browser)" button when enabled
+    url_template: "https://codeserver.example.com/?folder={{encodeURIComponent worktree.path}}"
+```
+
+2. `apps/agor-daemon/src/services/worktrees.ts`
+
+   - Added `getVSCodeTarget(worktreeId)`. Returns `VSCodeOpenResult` based on configuration.
+   - **Priority order (configurable): preferred_mode → other modes.**
+     - `preferred_mode: remote-ssh` (default): Prioritizes generating `vscode://vscode-remote/ssh-remote+<target>/<path>`.
+     - If Tunnel is configured and `preferred_mode` is set to `tunnel`, generates `vscode://vscode-remote/tunnel+<name>/<path>` (following remote authority specification, frontend appends `windowId` to ensure new window).
+     - Falls back to `vscode://file/<path>` if above conditions are not met, with `reason` in the result indicating local mode.
+   - Added `getCodeServerTarget(worktreeId)`: Renders browser code-server link using `ide.code_server.url_template`.
+
+3. `apps/agor-daemon/src/index.ts`
+
+   - Exposes `/worktrees-open-vscode` custom service, method: `POST { worktreeId } → VSCodeOpenResult`.
+   - Exposes `/worktrees-open-codeserver` custom service, method: `POST { worktreeId } → CodeServerOpenResult`.
+   - Uses unified routing (not `:id`) to ensure both Socket client and REST can call.
+   - Access control: `member` and above can trigger.
+
+## Frontend Interaction
+
+1. `App.tsx`
+
+   - `handleOpenVSCode(worktreeId)` calls the above service and creates a hidden `<a>` tag to trigger deep link based on returned `uri`.
+   - Displays toast based on `mode`, e.g., "VS Code Remote SSH triggered" for `remote-ssh`, "VS Code is opening worktree locally" for `local`.
+   - Always appends unique `windowId` to ensure VS Code opens in a new window without overwriting the current project.
+   - Added `handleOpenCodeServer(worktreeId)` to call `/worktrees-open-codeserver` and open the generated URL in browser.
+
+2. Button Locations
+
+   - Worktree card header (drag/terminal button area) adds "VS Code" and "code-server" buttons.
+   - SessionPanel top-right adds VS Code / code-server entry points.
+   - Settings > IDE / VS Code tab allows configuring `preferred_mode`, SSH/Tunnel info, and code-server URL template.
+
+3. Fallback Notice
+
+   - If the result is `local` with a `reason`, UI displays a warning indicating fallback to local mode due to missing configuration.
+
+## Usage Flow
+
+1. Global (shared by all users): Configure `~/.agor/config.yaml` on the machine running the daemon  
+   - VS Code Tunnel:
+     ```yaml
+     ide:
+       vscode:
+         tunnel:
+           name: agor-prod-tunnel
+           displayName: "Prod Tunnel"
+     ```
+   - Remote SSH (global default, can be overridden by user-level):
+     ```yaml
+     ide:
+       vscode:
+         remote:
+           host: my-server.com
+           port: 22
+           user: dev
+           target: agor-dev
+     ```
+   - Browser code-server:
+     ```yaml
+     ide:
+       code_server:
+         enabled: true
+         url_template: "https://codeserver.example.com/?folder={{encodeURIComponent worktree.path}}"
+     ```
+   - Other: `preferred_mode` (tunnel/remote-ssh/local), `enabled` toggle also under `ide.vscode`.
+2. User-level (individual SSH per user): Fill in host/port/user/target and public key (.pub) in **User Settings → SSH / VS Code**. After saving:
+   - Overrides current user's SSH configuration (higher priority than global).
+   - Automatically writes to target account's `authorized_keys` (shows error in UI if permission denied).
+3. Restart daemon (or wait for watch hot-reload to take effect).
+4. Click "Open in VS Code" in UI, browser calls `vscode://...` with unique `windowId`, VS Code always opens in new window.
+5. If code-server is enabled, click "Open in code-server (browser)" to open template-rendered link in new tab (template context: `worktree`, `repo`, with `encodeURIComponent` available).
+
+## Common Issues
+
+| Symptom | Possible Cause | Resolution |
+| --- | --- | --- |
+| Shows "VS Code integration not configured" | `ide.vscode.enabled` is false or service returns `enabled=false` | Enable in config.yaml |
+| Auto-falls back to local mode (shows reason) | `tunnel.name` missing and `remote.host/user` not configured | Fill in Tunnel name or Remote SSH info |
+| Deep Link doesn't launch VS Code | Browser blocks `vscode://` protocol or VS Code not installed locally | Check browser popup/local installation |
+| Tunnel too slow | Default changed to prioritize Remote SSH, set preferred_mode to remote-ssh/local in Settings>IDE |  |
+| Need browser-based access | Enable `ide.code_server.enabled=true` and fill in URL template | Settings>IDE Tab |
+
+## Related Code
+
+- `packages/core/src/config/types.ts`
+- `apps/agor-daemon/src/services/worktrees.ts`
+- `apps/agor-daemon/src/index.ts`
+- `apps/agor-ui/src/App.tsx`
+- `apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx`
+- `apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx`

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -8,6 +8,7 @@ import type {
   AuthenticationResult,
   Board,
   BoardExportBlob,
+  CodeServerOpenResult,
   ContextFileDetail,
   ContextFileListItem,
   MCPServer,
@@ -16,6 +17,7 @@ import type {
   Session,
   Task,
   User,
+  VSCodeOpenResult,
   Worktree,
 } from '@agor/core/types';
 import authentication from '@feathersjs/authentication-client';
@@ -46,6 +48,8 @@ export interface ServiceTypes {
   repos: Repo;
   'repos/local': Repo;
   worktrees: Worktree;
+  'worktrees-open-vscode': VSCodeOpenResult;
+  'worktrees-open-codeserver': import('../types/ide').CodeServerOpenResult;
   users: User;
   'mcp-servers': MCPServer;
   context: ContextFileListItem | ContextFileDetail; // GET /context returns list, GET /context/:path returns detail
@@ -257,6 +261,16 @@ export interface WorktreesService extends AgorService<Worktree> {
   checkHealth(id: string, params?: Params): Promise<Worktree>;
 
   /**
+   * Generate VS Code target (tunnel / SSH / local)
+   */
+  getVSCodeTarget(id: string, params?: Params): Promise<VSCodeOpenResult>;
+
+  /**
+   * Generate code-server URL for browser-based IDE
+   */
+  getCodeServerTarget(id: string, params?: Params): Promise<CodeServerOpenResult>;
+
+  /**
    * Archive or delete a worktree with filesystem cleanup options
    */
   archiveOrDelete(
@@ -272,6 +286,20 @@ export interface WorktreesService extends AgorService<Worktree> {
    * Unarchive a worktree
    */
   unarchive(id: string, options?: { boardId?: string }, params?: Params): Promise<Worktree>;
+}
+
+/**
+ * Service for opening VS Code with a worktree
+ */
+export interface WorktreesOpenVSCodeService {
+  create(data: { worktreeId: string }, params?: Params): Promise<VSCodeOpenResult>;
+}
+
+/**
+ * Service for opening code-server with a worktree
+ */
+export interface WorktreesOpenCodeServerService {
+  create(data: { worktreeId: string }, params?: Params): Promise<CodeServerOpenResult>;
 }
 
 /**
@@ -292,6 +320,10 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   // Bulk operation endpoints
   service(path: 'messages/bulk'): MessagesService;
   service(path: 'tasks/bulk'): TasksService;
+
+  // IDE integration endpoints
+  service(path: 'worktrees-open-vscode'): WorktreesOpenVSCodeService;
+  service(path: 'worktrees-open-codeserver'): WorktreesOpenCodeServerService;
 
   // Standard services (CRUD only)
   service(path: 'users'): AgorService<User>;

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -110,6 +110,16 @@ export function getDefaultConfig(): AgorConfig {
       session_token_max_uses: 1, // Single-use tokens
       sync_unix_passwords: true, // Default: sync passwords to Unix
     },
+    ide: {
+      vscode: {
+        enabled: true,
+        preferred_mode: 'remote-ssh',
+      },
+      code_server: {
+        enabled: false,
+        url_template: undefined,
+      },
+    },
   };
 }
 
@@ -184,6 +194,22 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
     ui: { ...defaults.ui, ...config.ui },
     codex: { ...defaults.codex, ...config.codex },
     execution: { ...defaults.execution, ...config.execution },
+    ide: {
+      ...defaults.ide,
+      ...config.ide,
+      vscode: {
+        ...defaults.ide?.vscode,
+        ...config.ide?.vscode,
+        remote: {
+          ...defaults.ide?.vscode?.remote,
+          ...config.ide?.vscode?.remote,
+        },
+      },
+      code_server: {
+        ...defaults.ide?.code_server,
+        ...config.ide?.code_server,
+      },
+    },
     paths: { ...defaults.paths, ...config.paths },
   };
 
@@ -212,25 +238,26 @@ export async function setConfigValue(key: string, value: string | boolean | numb
   const parts = key.split('.');
 
   if (parts.length === 1) {
-    // Top-level key - not supported (all config is nested)
     throw new Error(
       `Top-level config keys not supported. Use format: section.key (e.g., defaults.${parts[0]})`
     );
   }
 
-  // Nested key (e.g., "credentials.ANTHROPIC_API_KEY")
-  const section = parts[0];
-
-  if (!(config as UnknownJson)[section]) {
-    (config as UnknownJson)[section] = {};
+  let target: UnknownJson = config;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const segment = parts[i];
+    if (
+      !target ||
+      typeof target !== 'object' ||
+      target[segment] === null ||
+      typeof target[segment] !== 'object'
+    ) {
+      target[segment] = {};
+    }
+    target = target[segment];
   }
 
-  // Only support one level of nesting
-  if (parts.length === 2) {
-    (config as UnknownJson)[section][parts[1]] = value;
-  } else {
-    throw new Error(`Nested keys beyond one level not supported: ${key}`);
-  }
+  target[parts[parts.length - 1]] = value;
 
   await saveConfig(config);
 }
@@ -245,17 +272,32 @@ export async function unsetConfigValue(key: string): Promise<void> {
   const parts = key.split('.');
 
   if (parts.length === 1) {
-    // Top-level key - not supported
     throw new Error(`Top-level config keys not supported. Use format: section.key`);
   }
 
-  if (parts.length === 2) {
-    const section = parts[0];
-    const subKey = parts[1];
-
-    if ((config as UnknownJson)[section] && subKey in (config as UnknownJson)[section]) {
-      delete (config as UnknownJson)[section][subKey];
+  let cursor: UnknownJson = config;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const segment = parts[i];
+    if (
+      !cursor ||
+      typeof cursor !== 'object' ||
+      cursor[segment] === null ||
+      typeof cursor[segment] !== 'object'
+    ) {
+      cursor = null;
+      break;
     }
+
+    if (i === parts.length - 2) {
+      const container = cursor[segment];
+      const lastKey = parts[parts.length - 1];
+      if (container && typeof container === 'object' && lastKey in container) {
+        delete container[lastKey];
+      }
+      break;
+    }
+
+    cursor = cursor[segment];
   }
 
   await saveConfig(config);

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2,6 +2,8 @@
  * Agor Configuration Types
  */
 
+import type { VSCodeOpenMode } from '../types/ide';
+
 /**
  * Type for user-provided JSON data where structure is unknown or dynamic
  *
@@ -209,6 +211,68 @@ export interface AgorPathSettings {
 }
 
 /**
+ * Remote SSH configuration for VS Code integration
+ */
+export interface AgorIDESSHSettings {
+  /** Hostname or IP address reachable from the developer's machine */
+  host?: string;
+
+  /** SSH port (default: 22) */
+  port?: number;
+
+  /** SSH username to connect with */
+  user?: string;
+
+  /**
+   * Optional Remote SSH target label (defaults to `${user}@${host}`)
+   *
+   * This value is used in the vscode:// deep link (ssh-remote+target).
+   * Configure it to match the entry inside ~/.ssh/config if using an alias.
+   */
+  target?: string;
+}
+
+/**
+ * code-server integration settings
+ */
+export interface AgorIDECodeServerSettings {
+  /** Enable or disable code-server integration (default: false) */
+  enabled?: boolean;
+
+  /**
+   * URL template used to open the workspace in code-server.
+   * Handlebars context: { worktree, repo }
+   * Example: "https://codeserver.example.com/?folder={{encodeURIComponent worktree.path}}"
+   */
+  url_template?: string;
+}
+
+/**
+ * VS Code integration settings
+ */
+export interface AgorIDEVSCodeSettings {
+  /** Enable or disable VS Code integration (default: true) */
+  enabled?: boolean;
+
+  /** Preferred connection mode when multiple are configured */
+  preferred_mode?: VSCodeOpenMode;
+
+  /** Remote SSH configuration for vscode:// links */
+  remote?: AgorIDESSHSettings;
+}
+
+/**
+ * IDE integration settings
+ */
+export interface AgorIDESettings {
+  /** VS Code specific configuration */
+  vscode?: AgorIDEVSCodeSettings;
+
+  /** code-server (web) integration */
+  code_server?: AgorIDECodeServerSettings;
+}
+
+/**
  * Supported credential keys (enum for type safety)
  */
 export enum CredentialKey {
@@ -259,6 +323,9 @@ export interface AgorConfig {
   /** Execution isolation settings */
   execution?: AgorExecutionSettings;
 
+  /** IDE/Editor integration settings */
+  ide?: AgorIDESettings;
+
   /** Path configuration (data_home for repos/worktrees separation) */
   paths?: AgorPathSettings;
 
@@ -278,5 +345,9 @@ export type ConfigKey =
   | `opencode.${keyof AgorOpenCodeSettings}`
   | `codex.${keyof AgorCodexSettings}`
   | `execution.${keyof AgorExecutionSettings}`
+  | `ide.${keyof AgorIDESettings}`
+  | `ide.vscode.${keyof AgorIDEVSCodeSettings}`
+  | `ide.vscode.remote.${keyof AgorIDESSHSettings}`
+  | `ide.code_server.${keyof AgorIDECodeServerSettings}`
   | `paths.${keyof AgorPathSettings}`
   | `credentials.${keyof AgorCredentials}`;

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -57,6 +57,14 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
           ) as Record<string, boolean>)
         : undefined,
       default_agentic_config: row.data.default_agentic_config as User['default_agentic_config'],
+      ssh_config: row.data.ssh_config
+        ? {
+            ...row.data.ssh_config,
+            updated_at: row.data.ssh_config.updated_at
+              ? new Date(row.data.ssh_config.updated_at)
+              : undefined,
+          }
+        : undefined,
     };
   }
 
@@ -92,6 +100,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
         api_keys: user.api_keys_raw,
         env_vars: undefined, // Not implemented yet
         default_agentic_config: user.default_agentic_config,
+        ssh_config: user.ssh_config,
       },
     };
   }

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -641,6 +641,8 @@ export const users = pgTable(
             serverUrl?: string;
           };
         };
+        // User-level SSH config (public key + host/user/port/target)
+        ssh_config?: import('@agor/core/types').UserSSHConfig;
       }>()
       .notNull(),
   },

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -632,6 +632,8 @@ export const users = sqliteTable(
             serverUrl?: string;
           };
         };
+        // User-level SSH config (public key + host/user/port/target)
+        ssh_config?: import('@agor/core/types').UserSSHConfig;
       }>()
       .notNull(),
   },

--- a/packages/core/src/templates/handlebars-helpers.ts
+++ b/packages/core/src/templates/handlebars-helpers.ts
@@ -125,6 +125,14 @@ export function registerHandlebarsHelpers(): void {
       .join(replace);
   });
 
+  /**
+   * Encode URI component
+   * Usage: {{encodeURIComponent worktree.path}}
+   */
+  Handlebars.registerHelper('encodeURIComponent', (value: unknown): string => {
+    return encodeURIComponent(String(value ?? ''));
+  });
+
   // ===== Conditional Helpers =====
 
   /**

--- a/packages/core/src/types/ide.ts
+++ b/packages/core/src/types/ide.ts
@@ -1,0 +1,41 @@
+// src/types/ide.ts
+
+/**
+ * VS Code integration modes
+ *
+ * - remote-ssh: Use Remote - SSH via vscode://vscode-remote/ssh-remote+
+ * - local: Use vscode://file to open a local path directly
+ */
+export type VSCodeOpenMode = 'remote-ssh' | 'local';
+
+/**
+ * Result returned by /worktrees/:id/vscode endpoint
+ */
+export interface VSCodeOpenResult {
+  /** Whether IDE integration is enabled */
+  enabled: boolean;
+
+  /** Mode that will be used to open VS Code */
+  mode?: VSCodeOpenMode;
+
+  /** vscode:// URI to open */
+  uri?: string;
+
+  /** Optional user-facing reason when `enabled` is false or URI is unavailable */
+  reason?: string;
+
+  /** Remote SSH target label (helpful for tooltips) */
+  targetLabel?: string;
+
+  /** Suggested SSH command for reference */
+  sshCommand?: string;
+}
+
+/**
+ * Result returned by /worktrees-open-codeserver endpoint
+ */
+export interface CodeServerOpenResult {
+  enabled: boolean;
+  url?: string;
+  reason?: string;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -8,6 +8,7 @@ export * from './context';
 export * from './feathers';
 export * from './file';
 export * from './id';
+export * from './ide';
 export * from './mcp';
 export * from './message';
 export * from './presence';

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -108,6 +108,21 @@ export interface BaseUserFields {
 }
 
 /**
+ * User-level SSH / VS Code connection configuration
+ */
+export interface UserSSHConfig {
+  host?: string;
+  port?: number;
+  user?: string;
+  target?: string;
+  public_key?: string | null;
+  public_key_fingerprint?: string;
+  authorized_keys_path?: string;
+  last_authorized_keys_error?: string;
+  updated_at?: Date;
+}
+
+/**
  * User type - Authentication and authorization
  */
 export interface User extends BaseUserFields {
@@ -131,6 +146,8 @@ export interface User extends BaseUserFields {
   env_vars?: Record<string, boolean>; // { "GITHUB_TOKEN": true, "NPM_TOKEN": false }
   // Default agentic tool configuration (prepopulates session creation forms)
   default_agentic_config?: DefaultAgenticConfig;
+  // User-level SSH / VS Code configuration
+  ssh_config?: UserSSHConfig;
 }
 
 /**
@@ -142,6 +159,14 @@ export interface CreateUserInput extends Partial<BaseUserFields> {
   unix_username?: string;
   /** Force user to change password on first login (admin-only) */
   must_change_password?: boolean;
+  ssh_config?: {
+    host?: string;
+    port?: number;
+    user?: string;
+    target?: string;
+    /** Provide .pub content; set null/empty to clear */
+    public_key?: string | null;
+  };
 }
 
 /**
@@ -165,4 +190,13 @@ export interface UpdateUserInput extends Partial<BaseUserFields> {
   env_vars?: Record<string, string | null>; // { "GITHUB_TOKEN": "ghp_...", "NPM_TOKEN": null }
   // Default agentic tool configuration
   default_agentic_config?: DefaultAgenticConfig;
+  // SSH config for update
+  ssh_config?: {
+    host?: string;
+    port?: number;
+    user?: string;
+    target?: string;
+    /** Provide .pub content; set null/empty to clear */
+    public_key?: string | null;
+  };
 }


### PR DESCRIPTION
## Summary

- Add VS Code Remote SSH deep link support with user-level SSH configuration
- Add code-server browser integration with URL templates
- Add SSH public key management with authorized_keys sync
- Fix SSH config merge logic and path encoding issues
- Translate Chinese text to English in UI and backend

## Changes

- New IDE settings tab in Settings modal
- VS Code and code-server buttons on WorktreeCard and SessionPanel
- User-level SSH configuration with public key management
- Automatic authorized_keys sync for SSH public keys
- Documentation in `context/concepts/vscode-open.md`