### PR TITLE
feat(kubernetes): Isolated Worktree Pods for Kubernetes

### DIFF
--- a/apps/agor-cli/src/commands/worktree/shell.ts
+++ b/apps/agor-cli/src/commands/worktree/shell.ts
@@ -1,0 +1,149 @@
+/**
+ * `agor worktree shell <worktree-id>` - Open interactive shell in a worktree
+ *
+ * Connects to a shell pod via the daemon's WebSocket terminal proxy.
+ * Works for both local daemon mode and remote k8s pod mode.
+ *
+ * Requirements:
+ * - User must be logged in (agor login --url <daemon-url>)
+ * - Daemon must be running
+ */
+
+import { Args } from '@oclif/core';
+import chalk from 'chalk';
+import { BaseCommand } from '../../base-command';
+
+export default class WorktreeShell extends BaseCommand {
+  static description = 'Open interactive shell in a worktree';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> abc123',
+    '<%= config.bin %> <%= command.id %> 01933e4a-b2c1-7890-a456-789012345678',
+  ];
+
+  static args = {
+    worktreeId: Args.string({
+      description: 'Worktree ID (full UUID or short ID)',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(WorktreeShell);
+
+    // Connect to daemon (uses stored URL from login)
+    const client = await this.connectToDaemon();
+
+    this.log(chalk.dim(`Connected to daemon at ${this.daemonUrl}`));
+
+    try {
+      // Get worktree info
+      const worktreesService = client.service('worktrees');
+      let worktree;
+      try {
+        worktree = await worktreesService.get(args.worktreeId);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await this.cleanupClient(client);
+        this.error(`Worktree not found: ${args.worktreeId}\n${chalk.dim(`Error: ${errorMessage}`)}`);
+        return;
+      }
+
+      this.log(chalk.bold.cyan(`Opening shell in worktree: ${worktree.name}`));
+      this.log('');
+
+      // Create terminal session
+      const terminalsService = client.service('terminals');
+
+      let terminalResult: { terminalId: string; cwd: string };
+      try {
+        terminalResult = await terminalsService.create({
+          worktreeId: worktree.worktree_id,
+        }) as { terminalId: string; cwd: string };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await this.cleanupClient(client);
+        this.error(`Failed to create terminal: ${errorMessage}`);
+        return;
+      }
+
+      const { terminalId } = terminalResult;
+      this.log(chalk.dim(`Terminal session: ${terminalId}`));
+      this.log(chalk.dim('Press Ctrl+D to exit'));
+      this.log('');
+
+      // Set up raw mode for stdin
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true);
+      }
+      process.stdin.resume();
+
+      // Handle terminal output
+      terminalsService.on('data', (event: unknown) => {
+        const { terminalId: tid, data } = event as { terminalId: string; data: string };
+        if (tid === terminalId) {
+          process.stdout.write(data);
+        }
+      });
+
+      // Handle terminal exit
+      terminalsService.on('exit', async (event: unknown) => {
+        const { terminalId: tid, exitCode } = event as { terminalId: string; exitCode: number };
+        if (tid === terminalId) {
+          this.log('');
+          this.log(chalk.dim(`Shell exited with code ${exitCode}`));
+
+          // Restore terminal
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(false);
+          }
+
+          await this.cleanupClient(client);
+          process.exit(exitCode);
+        }
+      });
+
+      // Forward stdin to terminal
+      process.stdin.on('data', (data: Buffer) => {
+        terminalsService.patch(terminalId, { input: data.toString() }).catch((err: Error) => {
+          console.error('Failed to send input:', err.message);
+        });
+      });
+
+      // Handle Ctrl+C gracefully
+      process.on('SIGINT', async () => {
+        // Send Ctrl+C to terminal instead of exiting
+        terminalsService.patch(terminalId, { input: '\x03' }).catch(() => {});
+      });
+
+      // Handle terminal resize
+      const sendResize = () => {
+        const { columns, rows } = process.stdout;
+        if (columns && rows) {
+          terminalsService.patch(terminalId, {
+            resize: { cols: columns, rows }
+          }).catch(() => {});
+        }
+      };
+
+      // Send initial size
+      sendResize();
+
+      // Handle resize events
+      process.stdout.on('resize', sendResize);
+
+      // Keep process running
+      await new Promise(() => {});
+
+    } catch (error) {
+      // Restore terminal on error
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      await this.cleanupClient(client);
+      this.error(
+        `Shell connection failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}

--- a/apps/agor-cli/src/commands/worktree/ssh.ts
+++ b/apps/agor-cli/src/commands/worktree/ssh.ts
@@ -1,0 +1,364 @@
+/**
+ * `agor worktree ssh <worktree-id>` - SSH into a worktree shell pod
+ *
+ * Connects to a shell pod via SSH using auto-generated keys.
+ * Keys are stored in ~/.agor/ssh/agor-key and registered with the daemon on first use.
+ *
+ * Requirements:
+ * - User must be logged in
+ * - Daemon must be in pod mode (not daemon mode)
+ * - Shell pod must be started for the worktree
+ */
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { createRestClient, isDaemonRunning } from '@agor/core/api';
+import { Args, Flags } from '@oclif/core';
+import chalk from 'chalk';
+import { BaseCommand } from '../../base-command';
+import { loadToken } from '../../lib/auth';
+
+const SSH_DIR = join(homedir(), '.agor', 'ssh');
+const PRIVATE_KEY_PATH = join(SSH_DIR, 'agor-key');
+const PUBLIC_KEY_PATH = join(SSH_DIR, 'agor-key.pub');
+
+export default class WorktreeSsh extends BaseCommand {
+  static description = 'SSH into a worktree shell pod';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> abc123',
+    '<%= config.bin %> <%= command.id %> 01933e4a-b2c1-7890-a456-789012345678',
+    '<%= config.bin %> <%= command.id %> abc123 --port 2222',
+    '<%= config.bin %> <%= command.id %> abc123 --url https://agor.example.com',
+  ];
+
+  static flags = {
+    url: Flags.string({
+      char: 'u',
+      description: 'Daemon URL (overrides config)',
+      required: false,
+    }),
+    port: Flags.integer({
+      char: 'p',
+      description: 'SSH port to connect to (uses NodePort by default)',
+      required: false,
+    }),
+    host: Flags.string({
+      char: 'H',
+      description: 'SSH host to connect to (uses cluster node by default)',
+      required: false,
+    }),
+    'generate-key': Flags.boolean({
+      description: 'Force regenerate SSH key pair',
+      default: false,
+    }),
+  };
+
+  static args = {
+    worktreeId: Args.string({
+      description: 'Worktree ID (full UUID or short ID)',
+      required: true,
+    }),
+  };
+
+  /**
+   * Generate SSH key pair if it doesn't exist
+   */
+  private async ensureSshKey(forceRegenerate = false): Promise<{ publicKey: string; privateKeyPath: string }> {
+    // Create SSH directory if needed
+    if (!existsSync(SSH_DIR)) {
+      mkdirSync(SSH_DIR, { recursive: true, mode: 0o700 });
+    }
+
+    // Check if key already exists
+    if (!forceRegenerate && existsSync(PRIVATE_KEY_PATH) && existsSync(PUBLIC_KEY_PATH)) {
+      const publicKey = readFileSync(PUBLIC_KEY_PATH, 'utf-8').trim();
+      return { publicKey, privateKeyPath: PRIVATE_KEY_PATH };
+    }
+
+    // Generate new key pair using ssh-keygen
+    this.log(chalk.dim('Generating SSH key pair...'));
+
+    return new Promise((resolve, reject) => {
+      const keygenArgs = [
+        '-t', 'ed25519',
+        '-f', PRIVATE_KEY_PATH,
+        '-N', '', // No passphrase
+        '-C', 'agor-cli',
+      ];
+
+      const keygen = spawn('ssh-keygen', keygenArgs, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stderr = '';
+      keygen.stderr?.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      keygen.on('close', (code) => {
+        if (code !== 0) {
+          reject(new Error(`ssh-keygen failed with code ${code}: ${stderr}`));
+          return;
+        }
+
+        // Read the generated public key
+        const publicKey = readFileSync(PUBLIC_KEY_PATH, 'utf-8').trim();
+
+        this.log(chalk.green('  SSH key pair generated'));
+        this.log(chalk.dim(`  Private key: ${PRIVATE_KEY_PATH}`));
+        this.log(chalk.dim(`  Public key: ${PUBLIC_KEY_PATH}`));
+
+        resolve({ publicKey, privateKeyPath: PRIVATE_KEY_PATH });
+      });
+
+      keygen.on('error', (err) => {
+        reject(new Error(`Failed to run ssh-keygen: ${err.message}`));
+      });
+    });
+  }
+
+  /**
+   * Register public key with the daemon
+   */
+  private async registerSshKey(
+    client: Awaited<ReturnType<typeof this.connectToDaemon>>,
+    publicKey: string,
+    worktreeId: string
+  ): Promise<{
+    success: boolean;
+    message: string;
+    sshInfo?: { serviceName: string; nodePort: number | null };
+  }> {
+    // Use fetch to call the custom route directly since Feathers client doesn't support custom routes well
+    const response = await fetch(`${this.daemonUrl}/terminals/ssh/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // Get the access token from the authenticated client
+        'Authorization': `Bearer ${(await client.get('authentication'))?.accessToken}`,
+      },
+      body: JSON.stringify({ publicKey, worktreeId }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({ message: 'Unknown error' })) as { message?: string };
+      throw new Error(errorBody.message || `HTTP ${response.status}`);
+    }
+
+    return response.json() as Promise<{
+      success: boolean;
+      message: string;
+      sshInfo?: { serviceName: string; nodePort: number | null };
+    }>;
+  }
+
+  /**
+   * Get SSH connection info from daemon
+   */
+  private async getSshInfo(
+    client: Awaited<ReturnType<typeof this.connectToDaemon>>,
+    worktreeId: string
+  ): Promise<{
+    available: boolean;
+    serviceName?: string;
+    nodePort?: number | null;
+    message?: string;
+  }> {
+    const response = await fetch(`${this.daemonUrl}/terminals/ssh/${worktreeId}/info`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${(await client.get('authentication'))?.accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({ message: 'Unknown error' })) as { message?: string };
+      throw new Error(errorBody.message || `HTTP ${response.status}`);
+    }
+
+    return response.json() as Promise<{
+      available: boolean;
+      serviceName?: string;
+      nodePort?: number | null;
+      message?: string;
+    }>;
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(WorktreeSsh);
+
+    // Use custom URL if provided, otherwise use default from config
+    let client;
+    if (flags.url) {
+      // Custom URL provided - connect directly
+      this.daemonUrl = flags.url;
+      const running = await isDaemonRunning(flags.url);
+      if (!running) {
+        this.error(
+          chalk.red(`✗ Daemon not reachable at ${flags.url}`) +
+            '\n\n' +
+            chalk.dim('Check that the URL is correct and the daemon is running.')
+        );
+      }
+      client = await createRestClient(flags.url);
+
+      // Load stored token and authenticate
+      const storedAuth = await loadToken();
+      if (storedAuth) {
+        try {
+          await client.authenticate({
+            strategy: 'jwt',
+            accessToken: storedAuth.accessToken,
+          });
+        } catch {
+          this.error(
+            chalk.red('✗ Authentication failed') +
+              '\n\n' +
+              chalk.dim('Your session may have expired. Please login again:') +
+              '\n  ' +
+              chalk.cyan('agor login')
+          );
+        }
+      } else {
+        this.error(
+          chalk.red('✗ Not authenticated') +
+            '\n\n' +
+            chalk.dim('Please login first:') +
+            '\n  ' +
+            chalk.cyan('agor login')
+        );
+      }
+    } else {
+      // Use default daemon URL from config
+      client = await this.connectToDaemon();
+    }
+
+    // Show which daemon we're connected to
+    this.log(chalk.dim(`Connected to daemon at ${this.daemonUrl}`));
+
+    try {
+      // Ensure we have an SSH key
+      const { publicKey, privateKeyPath } = await this.ensureSshKey(flags['generate-key']);
+
+      // Get worktree info to get the user's unix_username
+      const worktreesService = client.service('worktrees');
+      let worktree;
+      try {
+        worktree = await worktreesService.get(args.worktreeId);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        await this.cleanupClient(client);
+        this.error(`Worktree not found: ${args.worktreeId}\n${chalk.dim(`Error: ${errorMessage}`)}`);
+        return; // TypeScript control flow - this.error() throws but TS doesn't know
+      }
+
+      this.log('');
+      this.log(chalk.bold.cyan(`Connecting to worktree: ${worktree.name}`));
+      this.log('');
+
+      // Register SSH key with daemon (idempotent - won't duplicate if already registered)
+      this.log(chalk.dim('Registering SSH key...'));
+      const registerResult = await this.registerSshKey(client, publicKey, args.worktreeId);
+
+      if (!registerResult.success) {
+        await this.cleanupClient(client);
+        this.error(registerResult.message);
+      }
+
+      this.log(chalk.green(`  ${registerResult.message}`));
+
+      // Get SSH connection info
+      let nodePort = flags.port;
+      let sshHost = flags.host;
+
+      if (!nodePort && registerResult.sshInfo?.nodePort) {
+        nodePort = registerResult.sshInfo.nodePort;
+      }
+
+      if (!nodePort) {
+        // Try to get SSH info from daemon
+        const sshInfo = await this.getSshInfo(client, args.worktreeId);
+        if (!sshInfo.available) {
+          await this.cleanupClient(client);
+          this.error(sshInfo.message || 'SSH not available for this worktree');
+        }
+        nodePort = sshInfo.nodePort || undefined;
+      }
+
+      if (!nodePort) {
+        await this.cleanupClient(client);
+        this.error('Could not determine SSH port. Please specify with --port');
+      }
+
+      // Default host is localhost (for local development/port-forward) or cluster node
+      if (!sshHost) {
+        // Try to detect if we're running inside the cluster or outside
+        // For now, default to localhost (assumes port-forward or NodePort access)
+        sshHost = 'localhost';
+      }
+
+      // Get the user's Unix username from their profile
+      const usersService = client.service('users');
+      const auth = await client.get('authentication');
+      const userId = auth?.user?.user_id;
+
+      if (!userId) {
+        await this.cleanupClient(client);
+        this.error('Could not determine user ID. Please ensure you are logged in.');
+      }
+
+      const user = await usersService.get(userId);
+      const unixUsername = user?.unix_username;
+
+      if (!unixUsername) {
+        await this.cleanupClient(client);
+        this.error('Your user account does not have a Unix username configured. Contact your administrator.');
+      }
+
+      this.log('');
+      this.log(chalk.bold('SSH Connection:'));
+      this.log(chalk.dim(`  User:     ${unixUsername}`));
+      this.log(chalk.dim(`  Host:     ${sshHost}`));
+      this.log(chalk.dim(`  Port:     ${nodePort}`));
+      this.log(chalk.dim(`  Key:      ${privateKeyPath}`));
+      this.log('');
+
+      // Close the Feathers client before spawning SSH
+      await this.cleanupClient(client);
+
+      // Spawn SSH with the connection details
+      this.log(chalk.cyan('Connecting via SSH...'));
+      this.log('');
+
+      const sshArgs = [
+        '-i', privateKeyPath,
+        '-p', nodePort.toString(),
+        '-o', 'StrictHostKeyChecking=no',
+        '-o', 'UserKnownHostsFile=/dev/null',
+        '-o', 'LogLevel=ERROR',
+        `${unixUsername}@${sshHost}`,
+      ];
+
+      const ssh = spawn('ssh', sshArgs, {
+        stdio: 'inherit', // Inherit stdin/stdout/stderr for interactive session
+      });
+
+      ssh.on('close', (code) => {
+        process.exit(code || 0);
+      });
+
+      ssh.on('error', (err) => {
+        this.error(`Failed to start SSH: ${err.message}`);
+      });
+
+    } catch (error) {
+      await this.cleanupClient(client);
+      this.error(
+        `SSH connection failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}

--- a/apps/agor-cli/src/lib/auth.ts
+++ b/apps/agor-cli/src/lib/auth.ts
@@ -20,6 +20,8 @@ export interface StoredAuth {
     role: string;
   };
   expiresAt: number;
+  /** Daemon URL used during login (if custom URL was specified) */
+  daemonUrl?: string;
 }
 
 /**

--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -39,6 +39,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.10.2",
+    "@types/ws": "^8.18.1",
     "concurrently": "^9.2.1",
     "glob": "^11.0.3",
     "tsup": "^8.3.5",

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -229,4 +229,12 @@ export interface WorktreesServiceImpl extends Service<Worktree, Partial<Worktree
     options?: { boardId?: import('@agor/core/types').BoardID },
     params?: FeathersParams
   ): Promise<Worktree>;
+  getBuildLogs(
+    id: WorktreeID,
+    params?: FeathersParams
+  ): Promise<{
+    logs: string;
+    exists: boolean;
+    path: string;
+  }>;
 }

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -3968,6 +3968,33 @@ async function main() {
     requireAuth
   );
 
+  // GET /worktrees/build-logs?worktree_id=xxx - Get build logs (start/stop/nuke output)
+  registerAuthenticatedRoute(
+    app,
+    '/worktrees/build-logs',
+    {
+      async find(params: Params) {
+        console.log('🔧 Build logs endpoint called');
+
+        // Extract worktree ID from query params
+        const id = params?.query?.worktree_id;
+
+        if (!id) {
+          console.error('❌ No worktree_id in query params');
+          throw new Error('worktree_id query parameter required');
+        }
+
+        console.log('✅ Found worktree ID:', id);
+        return worktreesService.getBuildLogs(id as import('@agor/core/types').WorktreeID, params);
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express
+    } as any,
+    {
+      find: { role: 'member', action: 'view worktree build logs' },
+    },
+    requireAuth
+  );
+
   // ===== RBAC: Worktree Owner Management =====
   // Now handled by the worktree-owners service (registered above)
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -633,6 +633,7 @@ export class TerminalsService {
     // Ensure shell pod exists (creates Podman pod first if needed)
     const podName = await this.podManager.ensureShellPod(
       data.worktreeId,
+      worktreeName,
       resolvedUserId,
       cwd,
       userUid,
@@ -1231,7 +1232,7 @@ export class TerminalsService {
   /**
    * Send input to terminal
    */
-  async patch(id: string, data: { input?: string; resize?: ResizeTerminalData }): Promise<void> {
+  async patch(id: string, data: { input?: string; resize?: ResizeTerminalData }): Promise<{ id: string }> {
     const session = this.sessions.get(id);
     if (!session) {
       throw new Error(`Terminal ${id} not found`);
@@ -1269,6 +1270,8 @@ export class TerminalsService {
         }
       }
     }
+
+    return { id };
   }
 
   /**
@@ -1433,6 +1436,7 @@ export class TerminalsService {
     try {
       podName = await this.podManager.ensureShellPod(
         worktreeId,
+        worktree.name,
         userId,
         worktree.path,
         userUid,

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -321,6 +321,20 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       }
     }
 
+    // Clean up Kubernetes ingress and app service (if in pod mode)
+    const podManager = this.getPodManager();
+    if (podManager) {
+      try {
+        await podManager.deleteWorktreeIngress(id);
+        console.log(`🗑️  Deleted ingress and app service for ${worktree.name}`);
+      } catch (error) {
+        console.warn(
+          `Failed to delete ingress/service:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
     // Perform filesystem action first (before DB changes)
     let filesRemoved = 0;
     if (filesystemAction === 'cleaned') {
@@ -969,6 +983,19 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       const managedProcess = this.processes.get(id);
       if (managedProcess) {
         this.processes.delete(id);
+      }
+
+      // Clean up Kubernetes ingress and app service (if in pod mode)
+      if (podManager) {
+        try {
+          await podManager.deleteWorktreeIngress(id);
+          console.log(`🗑️  Deleted ingress and app service for ${worktree.name}`);
+        } catch (error) {
+          console.warn(
+            `Failed to delete ingress/service:`,
+            error instanceof Error ? error.message : String(error)
+          );
+        }
       }
 
       // Update status to 'stopped' with clear nuke message

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -36,6 +36,7 @@ import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
 import { AppHeader } from '../AppHeader';
 import { CommentsPanel } from '../CommentsPanel';
+import { BuildLogsModal } from '../BuildLogsModal';
 import { EnvironmentLogsModal } from '../EnvironmentLogsModal';
 import { EventStreamPanel } from '../EventStreamPanel';
 import { NewSessionButton } from '../NewSessionButton';
@@ -239,6 +240,7 @@ export const App: React.FC<AppProps> = ({
   const [sessionSettingsId, setSessionSettingsId] = useState<string | null>(null);
   const [worktreeModalWorktreeId, setWorktreeModalWorktreeId] = useState<string | null>(null);
   const [logsModalWorktreeId, setLogsModalWorktreeId] = useState<string | null>(null);
+  const [buildLogsModalWorktreeId, setBuildLogsModalWorktreeId] = useState<string | null>(null);
   const [themeEditorOpen, setThemeEditorOpen] = useState(false);
 
   // Initialize event stream panel state from localStorage (collapsed by default)
@@ -533,6 +535,7 @@ export const App: React.FC<AppProps> = ({
       onStopEnvironment,
       onNukeEnvironment,
       onViewLogs: (worktreeId: string) => setLogsModalWorktreeId(worktreeId),
+      onViewBuildLogs: (worktreeId: string) => setBuildLogsModalWorktreeId(worktreeId),
       onOpenSettings: (sessionId: string) => setSessionSettingsId(sessionId),
       onOpenWorktree: (worktreeId: string) => setWorktreeModalWorktreeId(worktreeId),
       onOpenTerminal: handleOpenTerminal,
@@ -756,6 +759,7 @@ export const App: React.FC<AppProps> = ({
                         onStartEnvironment={onStartEnvironment}
                         onStopEnvironment={onStopEnvironment}
                         onViewLogs={setLogsModalWorktreeId}
+                        onViewBuildLogs={setBuildLogsModalWorktreeId}
                         onNukeEnvironment={onNukeEnvironment}
                         onOpenCommentsPanel={() => setCommentsPanelCollapsed(false)}
                         onCommentHover={setHoveredCommentId}
@@ -962,6 +966,14 @@ export const App: React.FC<AppProps> = ({
               open={!!logsModalWorktreeId}
               onClose={() => setLogsModalWorktreeId(null)}
               worktree={worktreeById.get(logsModalWorktreeId)!}
+              client={client}
+            />
+          )}
+          {buildLogsModalWorktreeId && (
+            <BuildLogsModal
+              open={!!buildLogsModalWorktreeId}
+              onClose={() => setBuildLogsModalWorktreeId(null)}
+              worktree={worktreeById.get(buildLogsModalWorktreeId)!}
               client={client}
             />
           )}

--- a/apps/agor-ui/src/components/BuildLogsModal/BuildLogsModal.tsx
+++ b/apps/agor-ui/src/components/BuildLogsModal/BuildLogsModal.tsx
@@ -1,0 +1,195 @@
+import type { AgorClient } from '@agor/core/api';
+import type { Worktree } from '@agor/core/types';
+import { ReloadOutlined } from '@ant-design/icons';
+import Ansi from 'ansi-to-react';
+import { Alert, Button, Checkbox, Modal, Space, Typography, theme } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const { Text } = Typography;
+
+interface BuildLogsModalProps {
+  open: boolean;
+  onClose: () => void;
+  worktree: Worktree;
+  client: AgorClient | null;
+}
+
+interface BuildLogsResponse {
+  logs: string;
+  exists: boolean;
+  path: string;
+}
+
+export const BuildLogsModal: React.FC<BuildLogsModalProps> = ({
+  open,
+  onClose,
+  worktree,
+  client,
+}) => {
+  const { token } = theme.useToken();
+  const [logs, setLogs] = useState<BuildLogsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const logsContainerRef = useRef<HTMLDivElement>(null);
+  const logsRef = useRef<BuildLogsResponse | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchLogs = useCallback(
+    async (autoScroll = true) => {
+      if (!client) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = (await client.service('worktrees/build-logs').find({
+          query: {
+            worktree_id: worktree.worktree_id,
+          },
+        })) as unknown as BuildLogsResponse;
+
+        // Only update and scroll if logs changed
+        const logsChanged = data.logs !== logsRef.current?.logs;
+        logsRef.current = data;
+        setLogs(data);
+
+        // Scroll to bottom after fetching (only if logs changed and autoScroll enabled)
+        if (autoScroll && logsChanged) {
+          setTimeout(() => {
+            logsContainerRef.current?.scrollTo({
+              top: logsContainerRef.current.scrollHeight,
+              behavior: 'smooth',
+            });
+          }, 100);
+        }
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch build logs');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [client, worktree.worktree_id]
+  );
+
+  // Fetch logs when modal opens
+  useEffect(() => {
+    if (open) {
+      fetchLogs();
+    } else {
+      setLogs(null);
+      setError(null);
+      logsRef.current = null;
+    }
+  }, [open, fetchLogs]);
+
+  // Auto-refresh interval
+  useEffect(() => {
+    // Clear any existing interval
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    // Set up new interval if auto-refresh is enabled and modal is open
+    if (autoRefresh && open) {
+      intervalRef.current = setInterval(() => {
+        fetchLogs(true);
+      }, 3000); // 3 seconds
+    }
+
+    // Cleanup on unmount
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [autoRefresh, open, fetchLogs]);
+
+  return (
+    <Modal
+      title={`Build Logs - ${worktree.name}`}
+      open={open}
+      onCancel={onClose}
+      width={900}
+      style={{ top: 20 }}
+      footer={[
+        <Checkbox
+          key="auto-refresh"
+          checked={autoRefresh}
+          onChange={(e) => setAutoRefresh(e.target.checked)}
+        >
+          Auto-refresh
+        </Checkbox>,
+        <Button key="refresh" icon={<ReloadOutlined />} onClick={() => fetchLogs()} loading={loading}>
+          Refresh
+        </Button>,
+        <Button key="close" onClick={onClose}>
+          Close
+        </Button>,
+      ]}
+    >
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        {/* Path info */}
+        {logs && (
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            Log file: {logs.path}
+          </Text>
+        )}
+
+        {/* Error state */}
+        {error && <Alert message="Error fetching build logs" description={error} type="error" showIcon />}
+
+        {/* No logs yet */}
+        {logs && !logs.exists && (
+          <Alert
+            message="No build logs yet"
+            description="Build logs will appear here after you start, stop, or nuke the environment."
+            type="info"
+            showIcon
+          />
+        )}
+
+        {/* Logs display */}
+        {logs && logs.exists && logs.logs && (
+          <div
+            ref={logsContainerRef}
+            style={{
+              backgroundColor: '#000',
+              border: `1px solid ${token.colorBorder}`,
+              borderRadius: token.borderRadius,
+              padding: 16,
+              height: '60vh',
+              overflowY: 'auto',
+              fontFamily: 'monospace',
+              fontSize: 12,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              color: '#fff',
+            }}
+          >
+            <Ansi>{logs.logs}</Ansi>
+          </div>
+        )}
+
+        {/* Loading state */}
+        {loading && !logs && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: 40,
+              color: token.colorTextSecondary,
+              height: '60vh',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            Loading build logs...
+          </div>
+        )}
+      </Space>
+    </Modal>
+  );
+};

--- a/apps/agor-ui/src/components/BuildLogsModal/index.ts
+++ b/apps/agor-ui/src/components/BuildLogsModal/index.ts
@@ -1,0 +1,1 @@
+export { BuildLogsModal } from './BuildLogsModal';

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircleOutlined,
   CloseCircleOutlined,
   EditOutlined,
+  ExportOutlined,
   FileTextOutlined,
   FireOutlined,
   GlobalOutlined,
@@ -38,8 +39,8 @@ export function EnvironmentPill({
   const hasConfig = !!repo.environment_config;
   const env = worktree.environment_instance;
 
-  // Get static app_url (user-editable, initialized from template)
-  const environmentUrl = worktree.app_url;
+  // Get environment URL - prefer runtime access_urls (from ingress), fall back to static app_url
+  const environmentUrl = env?.access_urls?.[0]?.url || worktree.app_url;
 
   // Case 1: No config at all - show grayed discovery pill
   if (!hasConfig) {
@@ -311,6 +312,35 @@ export function EnvironmentPill({
                 />
               </Tooltip>
             )}
+            {/* Open App button */}
+            <Tooltip
+              title={
+                !isRunning
+                  ? 'Start environment first'
+                  : !environmentUrl
+                    ? 'No app URL configured'
+                    : `Open ${environmentUrl}`
+              }
+            >
+              <Button
+                type="text"
+                size="small"
+                icon={<ExportOutlined />}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (isRunning && environmentUrl) {
+                    window.open(environmentUrl, '_blank', 'noopener,noreferrer');
+                  }
+                }}
+                disabled={!isRunning || !environmentUrl}
+                style={{
+                  height: 22,
+                  width: 22,
+                  minWidth: 22,
+                  padding: 0,
+                }}
+              />
+            </Tooltip>
             {onNukeEnvironment && worktree.nuke_command && (
               <Tooltip title="Nuke environment (destructive - removes all data and volumes)">
                 <Button

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -7,11 +7,12 @@ import {
   FileTextOutlined,
   FireOutlined,
   GlobalOutlined,
+  KeyOutlined,
   PlayCircleOutlined,
   StopOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Space, Spin, Tag, Tooltip, theme } from 'antd';
+import { Button, Space, Spin, Tag, Tooltip, message, theme } from 'antd';
 import { getEnvironmentState } from '../../utils/environmentState';
 
 interface EnvironmentPillProps {
@@ -333,6 +334,26 @@ export function EnvironmentPill({
                 />
               </Tooltip>
             )}
+            <Tooltip title="Copy SSH command">
+              <Button
+                type="text"
+                size="small"
+                icon={<KeyOutlined />}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  const shortId = worktree.worktree_id.substring(0, 8);
+                  const sshCommand = `agor worktree ssh ${shortId}`;
+                  navigator.clipboard.writeText(sshCommand);
+                  message.success('SSH command copied to clipboard');
+                }}
+                style={{
+                  height: 22,
+                  width: 22,
+                  minWidth: 22,
+                  padding: 0,
+                }}
+              />
+            </Tooltip>
             {onNukeEnvironment && worktree.nuke_command && (
               <Tooltip title="Nuke environment (destructive - removes all data and volumes)">
                 <Button

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -1,9 +1,9 @@
 import type { Repo, Worktree } from '@agor/core/types';
 import {
+  BuildOutlined,
   CheckCircleOutlined,
   CloseCircleOutlined,
   EditOutlined,
-  ExportOutlined,
   FileTextOutlined,
   FireOutlined,
   GlobalOutlined,
@@ -22,6 +22,7 @@ interface EnvironmentPillProps {
   onStopEnvironment?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onViewBuildLogs?: (worktreeId: string) => void;
   connectionDisabled?: boolean; // Disable actions when disconnected
 }
 
@@ -33,6 +34,7 @@ export function EnvironmentPill({
   onStopEnvironment,
   onNukeEnvironment,
   onViewLogs,
+  onViewBuildLogs,
   connectionDisabled = false,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
@@ -312,35 +314,25 @@ export function EnvironmentPill({
                 />
               </Tooltip>
             )}
-            {/* Open App button */}
-            <Tooltip
-              title={
-                !isRunning
-                  ? 'Start environment first'
-                  : !environmentUrl
-                    ? 'No app URL configured'
-                    : `Open ${environmentUrl}`
-              }
-            >
-              <Button
-                type="text"
-                size="small"
-                icon={<ExportOutlined />}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  if (isRunning && environmentUrl) {
-                    window.open(environmentUrl, '_blank', 'noopener,noreferrer');
-                  }
-                }}
-                disabled={!isRunning || !environmentUrl}
-                style={{
-                  height: 22,
-                  width: 22,
-                  minWidth: 22,
-                  padding: 0,
-                }}
-              />
-            </Tooltip>
+            {onViewBuildLogs && (
+              <Tooltip title="View build logs (start/stop output)">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<BuildOutlined />}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onViewBuildLogs(worktree.worktree_id);
+                  }}
+                  style={{
+                    height: 22,
+                    width: 22,
+                    minWidth: 22,
+                    padding: 0,
+                  }}
+                />
+              </Tooltip>
+            )}
             {onNukeEnvironment && worktree.nuke_command && (
               <Tooltip title="Nuke environment (destructive - removes all data and volumes)">
                 <Button

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -117,6 +117,7 @@ interface SessionCanvasProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onViewBuildLogs?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
   onOpenCommentsPanel?: () => void;
   onCommentHover?: (commentId: string | null) => void;
@@ -188,6 +189,7 @@ interface WorktreeNodeData {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onViewBuildLogs?: (worktreeId: string) => void;
   onUnpin?: (worktreeId: string) => void;
   compact?: boolean;
   isPinned?: boolean;
@@ -220,6 +222,7 @@ const WorktreeNode = ({ data }: { data: WorktreeNodeData }) => {
         onStartEnvironment={data.onStartEnvironment}
         onStopEnvironment={data.onStopEnvironment}
         onViewLogs={data.onViewLogs}
+        onViewBuildLogs={data.onViewBuildLogs}
         onUnpin={data.onUnpin}
         isPinned={data.isPinned}
         zoneName={data.zoneName}
@@ -274,6 +277,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onStartEnvironment,
       onStopEnvironment,
       onViewLogs,
+      onViewBuildLogs,
       onNukeEnvironment,
       onOpenCommentsPanel,
       onCommentHover,
@@ -580,6 +584,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onStartEnvironment,
             onStopEnvironment,
             onViewLogs,
+            onViewBuildLogs,
             onNukeEnvironment,
             onUnpin: handleUnpinWorktree,
             compact: false,
@@ -611,6 +616,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onStartEnvironment,
       onStopEnvironment,
       onViewLogs,
+      onViewBuildLogs,
       onNukeEnvironment,
       handleUnpinWorktree,
       zoneLabels,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -750,11 +750,11 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           </Space>
           <Space size={4}>
             {onOpenTerminal && worktree && (
-              <Tooltip title="Open terminal in worktree directory">
+              <Tooltip title="Open terminal">
                 <Button
                   type="text"
                   icon={<CodeOutlined />}
-                  onClick={() => onOpenTerminal([`cd ${worktree.path}`], worktree.worktree_id)}
+                  onClick={() => onOpenTerminal([], worktree.worktree_id)}
                 />
               </Tooltip>
             )}

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -540,9 +540,9 @@ const WorktreeCardComponent = ({
                 icon={<CodeOutlined />}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onOpenTerminal([`cd ${worktree.path}`], worktree.worktree_id);
+                  onOpenTerminal([], worktree.worktree_id);
                 }}
-                title="Open terminal in worktree directory"
+                title="Open terminal"
               />
             )}
             {onOpenSettings && (

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -71,6 +71,7 @@ interface WorktreeCardProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onViewBuildLogs?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
   onUnpin?: (worktreeId: string) => void;
   isPinned?: boolean;
@@ -99,6 +100,7 @@ const WorktreeCardComponent = ({
   onStartEnvironment,
   onStopEnvironment,
   onViewLogs,
+  onViewBuildLogs,
   onNukeEnvironment,
   onUnpin,
   isPinned = false,
@@ -593,6 +595,7 @@ const WorktreeCardComponent = ({
             onStartEnvironment={onStartEnvironment}
             onStopEnvironment={onStopEnvironment}
             onViewLogs={onViewLogs}
+            onViewBuildLogs={onViewBuildLogs}
             onNukeEnvironment={onNukeEnvironment}
             connectionDisabled={connectionDisabled}
           />

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -16,6 +16,7 @@ import {
   CopyOutlined,
   DownloadOutlined,
   EditOutlined,
+  ExportOutlined,
   FileTextOutlined,
   FireOutlined,
   LoadingOutlined,
@@ -680,6 +681,30 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   }
                 >
                   View Logs
+                </Button>
+
+                <Button
+                  size="small"
+                  icon={<ExportOutlined />}
+                  onClick={() => {
+                    const appUrl = worktree.environment_instance?.access_urls?.[0]?.url;
+                    if (appUrl) {
+                      window.open(appUrl, '_blank', 'noopener,noreferrer');
+                    }
+                  }}
+                  disabled={
+                    envStatus !== 'running' ||
+                    !worktree.environment_instance?.access_urls?.length
+                  }
+                  title={
+                    envStatus !== 'running'
+                      ? 'Start the environment first'
+                      : !worktree.environment_instance?.access_urls?.length
+                        ? 'No app URL configured'
+                        : `Open ${worktree.environment_instance?.access_urls?.[0]?.url}`
+                  }
+                >
+                  Open App
                 </Button>
               </div>
 

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
@@ -280,7 +280,6 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
           >
             Archive/Delete Worktree
           </Button>
-          {/* TODO: Add "Open in Terminal" button once terminal integration is ready */}
         </Space>
         <ArchiveDeleteWorktreeModal
           open={archiveDeleteModalOpen}

--- a/context/explorations/isolated-terminal-pods.md
+++ b/context/explorations/isolated-terminal-pods.md
@@ -1,0 +1,1101 @@
+# Isolated Terminal Pods
+
+**Status**: Exploration
+**Created**: 2024-12-07
+
+## Overview
+
+Enable terminals to run in dedicated Kubernetes pods instead of the daemon pod. Each worktree gets its own isolated pod with Podman, allowing users to run docker-compose stacks without affecting other users or worktrees.
+
+## Motivation
+
+**Current state**: Terminals (Zellij) run inside the daemon pod
+- All users share the same pod
+- Cannot run docker-compose (no container runtime)
+- Limited isolation between users
+
+**Problems**:
+1. No docker-compose support in Kubernetes deployment
+2. Users can interfere with each other
+3. Resource contention in daemon pod
+4. Security: shared filesystem access
+
+## Architecture
+
+### High-Level Design
+
+The architecture separates **shell pods** (isolated per user) from **Podman pods** (shared per worktree):
+
+```
+Worktree: feature-xyz
+│
+├── Shell Pod (user: jose)          ← Isolated terminal
+│   └── Zellij + DOCKER_HOST
+│
+├── Shell Pod (user: alice)         ← Isolated terminal
+│   └── Zellij + DOCKER_HOST
+│
+└── Podman Pod (worktree)           ← Shared containers
+    ├── podman socket :2375
+    ├── app container
+    ├── db container
+    └── redis container
+```
+
+**Key benefits:**
+- Users have isolated terminals (can't see each other's shell history, processes)
+- Shared docker-compose stack (both users see same running app)
+- One set of containers per worktree (resource efficient)
+- Users manage containers via `DOCKER_HOST` environment variable
+
+### Mermaid Diagram
+
+```mermaid
+flowchart TB
+    subgraph Client["Browser"]
+        UI[Agor UI]
+    end
+
+    subgraph K8s["Kubernetes Cluster"]
+        subgraph DaemonPod["Daemon Pod"]
+            API[API Server<br/>REST + WebSocket]
+            K8sClient[Kubernetes Client]
+            PodManager[Pod Manager]
+            GC[GC Loop<br/>idle timeout]
+        end
+
+        subgraph Worktree1["Worktree: feature-xyz"]
+            subgraph ShellPod1["Shell Pod (jose)"]
+                Zellij1[Zellij Terminal]
+                DH1[DOCKER_HOST=tcp://podman-xyz:2375]
+            end
+
+            subgraph ShellPod2["Shell Pod (alice)"]
+                Zellij2[Zellij Terminal]
+                DH2[DOCKER_HOST=tcp://podman-xyz:2375]
+            end
+
+            subgraph PodmanPod1["Podman Pod (shared)"]
+                PodmanSocket1[Podman Socket :2375]
+                subgraph Containers1["Containers"]
+                    App1[app:3000]
+                    DB1[postgres:5432]
+                    Redis1[redis:6379]
+                end
+            end
+
+            PodmanSvc1[Service: podman-xyz]
+        end
+
+        subgraph Worktree2["Worktree: bugfix-123"]
+            subgraph ShellPod3["Shell Pod (jose)"]
+                Zellij3[Zellij Terminal]
+                DH3[DOCKER_HOST=tcp://podman-123:2375]
+            end
+
+            subgraph PodmanPod2["Podman Pod (shared)"]
+                PodmanSocket2[Podman Socket :2375]
+                subgraph Containers2["Containers"]
+                    App2[app:3000]
+                end
+            end
+
+            PodmanSvc2[Service: podman-123]
+        end
+
+        subgraph Storage["Shared Storage (EFS)"]
+            Worktrees[(worktrees/)]
+            Repos[(repos/)]
+        end
+
+        K8sAPI[Kubernetes API]
+    end
+
+    UI <-->|WebSocket| API
+    API --> PodManager
+    PodManager -->|create/delete pods| K8sClient
+    K8sClient --> K8sAPI
+    K8sAPI -->|kubectl exec| ShellPod1
+    K8sAPI -->|kubectl exec| ShellPod2
+    K8sAPI -->|kubectl exec| ShellPod3
+    GC -->|list & delete idle| K8sClient
+
+    ShellPod1 -->|DOCKER_HOST| PodmanSvc1
+    ShellPod2 -->|DOCKER_HOST| PodmanSvc1
+    PodmanSvc1 --> PodmanPod1
+
+    ShellPod3 -->|DOCKER_HOST| PodmanSvc2
+    PodmanSvc2 --> PodmanPod2
+
+    ShellPod1 --> Worktrees
+    ShellPod2 --> Worktrees
+    ShellPod3 --> Worktrees
+    PodmanPod1 --> Worktrees
+    PodmanPod2 --> Worktrees
+    DaemonPod --> Repos
+```
+
+### Terminal Streaming Flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser UI
+    participant WS as Daemon WebSocket
+    participant PM as Pod Manager
+    participant K8s as Kubernetes API
+    participant Shell as Shell Pod (user)
+    participant Podman as Podman Pod (worktree)
+
+    UI->>WS: Open terminal for worktree W, user U
+    WS->>PM: ensureShellPod(worktree, user)
+    WS->>PM: ensurePodmanPod(worktree)
+
+    alt Shell Pod doesn't exist
+        PM->>K8s: createShellPod(user, worktree)
+        K8s-->>PM: Pod created
+    end
+
+    alt Podman Pod doesn't exist
+        PM->>K8s: createPodmanPod(worktree)
+        K8s-->>PM: Pod created
+        PM->>K8s: createService(podman-{worktree})
+        K8s-->>PM: Service created
+    end
+
+    PM->>K8s: waitForPods(Ready)
+    K8s-->>PM: Pods ready
+
+    PM-->>WS: shellPodName
+    WS->>K8s: exec(shellPod, "zellij attach")
+    K8s->>Shell: Start exec stream
+
+    loop Terminal Session
+        UI->>WS: stdin (keystrokes)
+        WS->>K8s: write to exec stdin
+        K8s->>Shell: stdin
+
+        Note over Shell,Podman: User runs: docker-compose up
+        Shell->>Podman: DOCKER_HOST → tcp://podman-svc:2375
+        Podman-->>Shell: Container output
+
+        Shell->>K8s: stdout
+        K8s->>WS: exec stdout
+        WS->>UI: terminal output
+    end
+
+    UI->>WS: Close terminal
+    WS->>PM: updateLastActivity(shellPod)
+    WS->>K8s: Close exec stream
+```
+
+### Pod Lifecycle
+
+```mermaid
+stateDiagram-v2
+    state "Shell Pods (per user)" as ShellState {
+        [*] --> NoShellPod
+        NoShellPod --> CreatingShell: User opens terminal
+        CreatingShell --> ShellRunning: Pod ready
+        ShellRunning --> ShellIdle: Terminal closed
+        ShellIdle --> ShellRunning: Terminal reopened
+        ShellIdle --> ShellDeleted: Idle timeout (30min)
+        ShellDeleted --> [*]
+    }
+
+    state "Podman Pod (per worktree)" as PodmanState {
+        [*] --> NoPodmanPod
+        NoPodmanPod --> CreatingPodman: First shell pod created
+        CreatingPodman --> PodmanRunning: Pod + Service ready
+        PodmanRunning --> PodmanRunning: Containers running
+        PodmanRunning --> PodmanIdle: All shell pods deleted
+        PodmanIdle --> PodmanRunning: New shell pod created
+        PodmanIdle --> PodmanDeleted: Idle timeout (1hr)
+        PodmanDeleted --> [*]
+    }
+
+    note right of ShellState
+        Each user gets their own
+        shell pod per worktree
+    end note
+
+    note right of PodmanState
+        Shared by all users
+        working on same worktree
+    end note
+```
+
+### Docker Compose via DOCKER_HOST
+
+```mermaid
+flowchart LR
+    subgraph ShellPodJose["Shell Pod (jose)"]
+        Terminal1[Zellij Terminal]
+        ENV1["DOCKER_HOST=tcp://podman-xyz:2375"]
+    end
+
+    subgraph ShellPodAlice["Shell Pod (alice)"]
+        Terminal2[Zellij Terminal]
+        ENV2["DOCKER_HOST=tcp://podman-xyz:2375"]
+    end
+
+    subgraph PodmanPod["Podman Pod (worktree-xyz)"]
+        Socket[Podman Socket<br/>:2375]
+
+        subgraph Containers["Shared Containers"]
+            direction TB
+            C1[frontend:3000]
+            C2[backend:8080]
+            C3[postgres:5432]
+            C4[redis:6379]
+        end
+    end
+
+    subgraph K8sService["Kubernetes Service"]
+        Svc[podman-xyz:2375]
+    end
+
+    subgraph EFS["EFS Storage"]
+        WT["/worktrees/repo/xyz"]
+        DC["docker-compose.yml"]
+    end
+
+    Terminal1 -->|"docker-compose up"| ENV1
+    Terminal2 -->|"docker ps"| ENV2
+    ENV1 --> Svc
+    ENV2 --> Svc
+    Svc --> Socket
+    Socket --> Containers
+
+    WT --> Terminal1
+    WT --> Terminal2
+    DC -.->|read by| Terminal1
+```
+
+### Components
+
+**1. Daemon Pod (existing)**
+- REST/WebSocket API
+- Orchestrates shell and Podman pod lifecycle
+- Proxies terminal streams via kubectl exec
+- Manages Kubernetes Services for Podman pods
+
+**2. Shell Pod (new, per user per worktree)**
+- One pod per user per worktree
+- Lightweight container with Zellij + docker CLI
+- Mounts shared EFS for worktrees/repos
+- `DOCKER_HOST` env var points to Podman pod's service
+- Isolated: users can't see each other's terminals
+
+**3. Podman Pod (new, per worktree)**
+- One pod per worktree (shared by all users)
+- Runs Podman with exposed socket (:2375)
+- Handles all docker-compose container management
+- Mounts shared EFS for worktrees
+- Kubernetes Service exposes the socket to shell pods
+
+**4. Shared Storage (EFS)**
+- `/worktrees` - All worktree directories
+- `/repos` - All cloned repositories
+- ReadWriteMany access mode
+
+## Configuration
+
+### Helm Values
+
+```yaml
+daemon:
+  config:
+    execution:
+      # Terminal execution mode
+      # - daemon: Run terminals in daemon pod (current behavior)
+      # - pod: Run terminals in isolated user pods
+      terminal_mode: pod
+
+      # User pod configuration (only used when terminal_mode: pod)
+      user_pod:
+        image: quay.io/podman/stable
+        # Idle timeout before pod is garbage collected
+        idle_timeout_minutes: 30
+        # Resource limits per user pod
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 2
+            memory: 4Gi
+        # Security context
+        privileged: true  # Required for Podman
+```
+
+### Per-Repo Override (.agor.yml)
+
+```yaml
+# .agor.yml
+environment:
+  # Override terminal mode for this repo
+  terminal_mode: pod  # or 'daemon'
+```
+
+## Pod Specifications
+
+### Shell Pod (per user per worktree)
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: agor-shell-{worktree_id_short}-{user_id_short}
+  namespace: agor
+  labels:
+    app.kubernetes.io/name: agor-shell-pod
+    app.kubernetes.io/component: terminal
+    agor.io/worktree-id: "{worktree_id}"
+    agor.io/user-id: "{user_id}"
+  annotations:
+    agor.io/created-at: "{timestamp}"
+    agor.io/last-activity: "{timestamp}"
+spec:
+  serviceAccountName: agor-shell-pod
+
+  containers:
+  - name: shell
+    image: agor/shell:latest  # Lightweight: zellij + docker CLI + git
+    command: ["sleep", "infinity"]
+    env:
+    - name: WORKTREE_PATH
+      value: "/worktrees/{repo_slug}/{worktree_name}"
+    - name: DOCKER_HOST
+      value: "tcp://podman-{worktree_id_short}.agor.svc:2375"
+    volumeMounts:
+    - name: worktrees
+      mountPath: /worktrees
+    - name: repos
+      mountPath: /repos
+    workingDir: "/worktrees/{repo_slug}/{worktree_name}"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
+
+  volumes:
+  - name: worktrees
+    persistentVolumeClaim:
+      claimName: agor-worktrees
+  - name: repos
+    persistentVolumeClaim:
+      claimName: agor-repos
+```
+
+### Podman Pod (per worktree, shared)
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: agor-podman-{worktree_id_short}
+  namespace: agor
+  labels:
+    app.kubernetes.io/name: agor-podman-pod
+    app.kubernetes.io/component: container-runtime
+    agor.io/worktree-id: "{worktree_id}"
+  annotations:
+    agor.io/created-at: "{timestamp}"
+    agor.io/last-activity: "{timestamp}"
+spec:
+  serviceAccountName: agor-podman-pod
+
+  containers:
+  - name: podman
+    image: quay.io/podman/stable
+    command:
+    - podman
+    - system
+    - service
+    - --time=0
+    - tcp://0.0.0.0:2375
+    securityContext:
+      privileged: true  # Required for nested containers
+    ports:
+    - containerPort: 2375
+      name: docker-api
+    env:
+    - name: WORKTREE_PATH
+      value: "/worktrees/{repo_slug}/{worktree_name}"
+    volumeMounts:
+    - name: worktrees
+      mountPath: /worktrees
+    - name: podman-storage
+      mountPath: /var/lib/containers
+    workingDir: "/worktrees/{repo_slug}/{worktree_name}"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 4
+        memory: 8Gi
+
+  volumes:
+  - name: worktrees
+    persistentVolumeClaim:
+      claimName: agor-worktrees
+  - name: podman-storage
+    emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podman-{worktree_id_short}
+  namespace: agor
+  labels:
+    agor.io/worktree-id: "{worktree_id}"
+spec:
+  selector:
+    app.kubernetes.io/name: agor-podman-pod
+    agor.io/worktree-id: "{worktree_id}"
+  ports:
+  - port: 2375
+    targetPort: 2375
+    name: docker-api
+```
+
+### Shell Pod Image (Dockerfile.shell)
+
+```dockerfile
+FROM debian:bookworm-slim
+
+# Install essentials
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    ca-certificates \
+    docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Zellij
+RUN curl -fsSL https://github.com/zellij-org/zellij/releases/latest/download/zellij-x86_64-unknown-linux-musl.tar.gz \
+    | tar -xz -C /usr/local/bin
+
+# Create agor user
+RUN useradd -m -s /bin/bash agor
+
+USER agor
+WORKDIR /home/agor
+
+CMD ["sleep", "infinity"]
+```
+
+## Terminal Streaming via kubectl exec
+
+### Flow
+
+```
+1. UI requests terminal for worktree W
+2. Daemon receives WebSocket connection
+3. Daemon checks: does pod exist for W?
+   - No: Create pod, wait for Ready
+   - Yes: Use existing pod
+4. Daemon creates exec stream:
+   kubectl exec -it agor-worktree-{id} -- zellij attach -c main
+5. Daemon pipes:
+   - UI WebSocket stdin → exec stdin
+   - exec stdout → UI WebSocket
+6. On disconnect: update last-activity timestamp
+```
+
+### Implementation (TypeScript)
+
+```typescript
+import * as k8s from '@kubernetes/client-node';
+
+class PodManager {
+  private kc: k8s.KubeConfig;
+  private k8sApi: k8s.CoreV1Api;
+  private exec: k8s.Exec;
+  private namespace = 'agor';
+
+  constructor() {
+    this.kc = new k8s.KubeConfig();
+    this.kc.loadFromCluster(); // In-cluster config
+    this.k8sApi = this.kc.makeApiClient(k8s.CoreV1Api);
+    this.exec = new k8s.Exec(this.kc);
+  }
+
+  /**
+   * Ensure shell pod exists for user + worktree
+   */
+  async ensureShellPod(worktree: Worktree, user: User): Promise<string> {
+    const worktreeShort = worktree.worktree_id.slice(0, 8);
+    const userShort = user.user_id.slice(0, 8);
+    const shellPodName = `agor-shell-${worktreeShort}-${userShort}`;
+
+    // Also ensure Podman pod exists (shared for worktree)
+    await this.ensurePodmanPod(worktree);
+
+    try {
+      const { body: pod } = await this.k8sApi.readNamespacedPod(shellPodName, this.namespace);
+      if (pod.status?.phase === 'Running') {
+        return shellPodName;
+      }
+      await this.waitForPod(shellPodName);
+      return shellPodName;
+    } catch (e: any) {
+      if (e.statusCode === 404) {
+        await this.createShellPod(worktree, user);
+        await this.waitForPod(shellPodName);
+        return shellPodName;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Ensure Podman pod exists for worktree (shared by all users)
+   */
+  async ensurePodmanPod(worktree: Worktree): Promise<string> {
+    const worktreeShort = worktree.worktree_id.slice(0, 8);
+    const podmanPodName = `agor-podman-${worktreeShort}`;
+    const serviceName = `podman-${worktreeShort}`;
+
+    try {
+      const { body: pod } = await this.k8sApi.readNamespacedPod(podmanPodName, this.namespace);
+      if (pod.status?.phase === 'Running') {
+        return podmanPodName;
+      }
+      await this.waitForPod(podmanPodName);
+      return podmanPodName;
+    } catch (e: any) {
+      if (e.statusCode === 404) {
+        // Create Podman pod
+        await this.createPodmanPod(worktree);
+        // Create Service to expose Podman socket
+        await this.createPodmanService(worktree);
+        await this.waitForPod(podmanPodName);
+        return podmanPodName;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Create shell pod for user
+   */
+  async createShellPod(worktree: Worktree, user: User): Promise<void> {
+    const worktreeShort = worktree.worktree_id.slice(0, 8);
+    const userShort = user.user_id.slice(0, 8);
+
+    const manifest: k8s.V1Pod = {
+      metadata: {
+        name: `agor-shell-${worktreeShort}-${userShort}`,
+        namespace: this.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'agor-shell-pod',
+          'app.kubernetes.io/component': 'terminal',
+          'agor.io/worktree-id': worktree.worktree_id,
+          'agor.io/user-id': user.user_id,
+        },
+        annotations: {
+          'agor.io/created-at': new Date().toISOString(),
+          'agor.io/last-activity': new Date().toISOString(),
+        },
+      },
+      spec: {
+        serviceAccountName: 'agor-shell-pod',
+        containers: [
+          {
+            name: 'shell',
+            image: 'agor/shell:latest',
+            command: ['sleep', 'infinity'],
+            env: [
+              { name: 'WORKTREE_PATH', value: worktree.path },
+              { name: 'DOCKER_HOST', value: `tcp://podman-${worktreeShort}.${this.namespace}.svc:2375` },
+            ],
+            workingDir: worktree.path,
+            volumeMounts: [
+              { name: 'worktrees', mountPath: '/worktrees' },
+              { name: 'repos', mountPath: '/repos' },
+            ],
+            resources: {
+              requests: { cpu: '50m', memory: '128Mi' },
+              limits: { cpu: '1', memory: '1Gi' },
+            },
+          },
+        ],
+        volumes: [
+          { name: 'worktrees', persistentVolumeClaim: { claimName: 'agor-worktrees' } },
+          { name: 'repos', persistentVolumeClaim: { claimName: 'agor-repos' } },
+        ],
+      },
+    };
+
+    await this.k8sApi.createNamespacedPod(this.namespace, manifest);
+  }
+
+  /**
+   * Create Podman pod for worktree
+   */
+  async createPodmanPod(worktree: Worktree): Promise<void> {
+    const worktreeShort = worktree.worktree_id.slice(0, 8);
+
+    const manifest: k8s.V1Pod = {
+      metadata: {
+        name: `agor-podman-${worktreeShort}`,
+        namespace: this.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'agor-podman-pod',
+          'app.kubernetes.io/component': 'container-runtime',
+          'agor.io/worktree-id': worktree.worktree_id,
+        },
+        annotations: {
+          'agor.io/created-at': new Date().toISOString(),
+          'agor.io/last-activity': new Date().toISOString(),
+        },
+      },
+      spec: {
+        serviceAccountName: 'agor-podman-pod',
+        containers: [
+          {
+            name: 'podman',
+            image: 'quay.io/podman/stable',
+            command: ['podman', 'system', 'service', '--time=0', 'tcp://0.0.0.0:2375'],
+            securityContext: { privileged: true },
+            ports: [{ containerPort: 2375, name: 'docker-api' }],
+            env: [{ name: 'WORKTREE_PATH', value: worktree.path }],
+            workingDir: worktree.path,
+            volumeMounts: [
+              { name: 'worktrees', mountPath: '/worktrees' },
+              { name: 'podman-storage', mountPath: '/var/lib/containers' },
+            ],
+            resources: {
+              requests: { cpu: '100m', memory: '256Mi' },
+              limits: { cpu: '4', memory: '8Gi' },
+            },
+          },
+        ],
+        volumes: [
+          { name: 'worktrees', persistentVolumeClaim: { claimName: 'agor-worktrees' } },
+          { name: 'podman-storage', emptyDir: {} },
+        ],
+      },
+    };
+
+    await this.k8sApi.createNamespacedPod(this.namespace, manifest);
+  }
+
+  /**
+   * Create Service for Podman pod
+   */
+  async createPodmanService(worktree: Worktree): Promise<void> {
+    const worktreeShort = worktree.worktree_id.slice(0, 8);
+
+    const manifest: k8s.V1Service = {
+      metadata: {
+        name: `podman-${worktreeShort}`,
+        namespace: this.namespace,
+        labels: { 'agor.io/worktree-id': worktree.worktree_id },
+      },
+      spec: {
+        selector: {
+          'app.kubernetes.io/name': 'agor-podman-pod',
+          'agor.io/worktree-id': worktree.worktree_id,
+        },
+        ports: [{ port: 2375, targetPort: 2375, name: 'docker-api' }],
+      },
+    };
+
+    await this.k8sApi.createNamespacedService(this.namespace, manifest);
+  }
+
+  /**
+   * Stream terminal session via kubectl exec
+   */
+  async execTerminal(
+    shellPodName: string,
+    onData: (data: string) => void,
+    onClose: () => void
+  ): Promise<{ write: (data: string) => void; close: () => void }> {
+    const ws = await this.exec.exec(
+      this.namespace,
+      shellPodName,
+      'shell',
+      ['zellij', 'attach', '-c', 'main'],
+      process.stdout,
+      process.stderr,
+      process.stdin,
+      true, // tty
+      (status) => {
+        console.log('Exec closed:', status);
+        onClose();
+      }
+    );
+
+    return {
+      write: (data: string) => ws.stdin.write(data),
+      close: () => ws.close(),
+    };
+  }
+
+  /**
+   * Update last activity timestamp
+   */
+  async updateLastActivity(podName: string): Promise<void> {
+    await this.k8sApi.patchNamespacedPod(
+      podName,
+      this.namespace,
+      { metadata: { annotations: { 'agor.io/last-activity': new Date().toISOString() } } },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { headers: { 'Content-Type': 'application/merge-patch+json' } }
+    );
+  }
+
+  /**
+   * Garbage collect idle shell pods
+   */
+  async gcIdleShellPods(idleTimeoutMinutes: number): Promise<void> {
+    const { body: pods } = await this.k8sApi.listNamespacedPod(
+      this.namespace,
+      undefined, undefined, undefined, undefined,
+      'app.kubernetes.io/component=terminal'
+    );
+
+    const now = Date.now();
+    for (const pod of pods.items) {
+      const lastActivity = pod.metadata?.annotations?.['agor.io/last-activity'];
+      if (lastActivity) {
+        const idleMs = now - new Date(lastActivity).getTime();
+        if (idleMs > idleTimeoutMinutes * 60 * 1000) {
+          console.log(`GC: Deleting idle shell pod ${pod.metadata?.name}`);
+          await this.k8sApi.deleteNamespacedPod(pod.metadata!.name!, this.namespace);
+        }
+      }
+    }
+  }
+
+  /**
+   * Garbage collect Podman pods with no active shell pods
+   */
+  async gcOrphanedPodmanPods(idleTimeoutMinutes: number): Promise<void> {
+    // Get all Podman pods
+    const { body: podmanPods } = await this.k8sApi.listNamespacedPod(
+      this.namespace,
+      undefined, undefined, undefined, undefined,
+      'app.kubernetes.io/component=container-runtime'
+    );
+
+    // Get all shell pods
+    const { body: shellPods } = await this.k8sApi.listNamespacedPod(
+      this.namespace,
+      undefined, undefined, undefined, undefined,
+      'app.kubernetes.io/component=terminal'
+    );
+
+    // Get worktree IDs with active shell pods
+    const activeWorktreeIds = new Set(
+      shellPods.items.map(p => p.metadata?.labels?.['agor.io/worktree-id']).filter(Boolean)
+    );
+
+    const now = Date.now();
+    for (const pod of podmanPods.items) {
+      const worktreeId = pod.metadata?.labels?.['agor.io/worktree-id'];
+      const lastActivity = pod.metadata?.annotations?.['agor.io/last-activity'];
+
+      // If no shell pods reference this worktree and it's idle, delete it
+      if (worktreeId && !activeWorktreeIds.has(worktreeId) && lastActivity) {
+        const idleMs = now - new Date(lastActivity).getTime();
+        if (idleMs > idleTimeoutMinutes * 60 * 1000) {
+          console.log(`GC: Deleting orphaned Podman pod ${pod.metadata?.name}`);
+          await this.k8sApi.deleteNamespacedPod(pod.metadata!.name!, this.namespace);
+          // Also delete the service
+          await this.k8sApi.deleteNamespacedService(`podman-${worktreeId.slice(0, 8)}`, this.namespace);
+        }
+      }
+    }
+  }
+
+  private async waitForPod(podName: string, timeoutMs = 60000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const { body: pod } = await this.k8sApi.readNamespacedPod(podName, this.namespace);
+      if (pod.status?.phase === 'Running') {
+        return;
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    throw new Error(`Timeout waiting for pod ${podName} to be ready`);
+  }
+}
+```
+
+## Lifecycle Management
+
+### Pod States
+
+```
+                    ┌─────────┐
+                    │ No Pod  │
+                    └────┬────┘
+                         │ First terminal opened
+                         ▼
+                    ┌─────────┐
+                    │ Creating│
+                    └────┬────┘
+                         │ Pod ready
+                         ▼
+┌────────────┐      ┌─────────┐
+│ GC (delete)│◀─────│ Running │◀────┐
+└────────────┘      └────┬────┘     │
+     ▲               │   │          │
+     │ Idle timeout  │   │ Terminal │
+     │               │   │ opened   │
+     │               ▼   │          │
+     │          ┌─────────┐         │
+     └──────────│  Idle   │─────────┘
+                └─────────┘
+```
+
+### Activity Tracking
+
+- Update `agor.io/last-activity` annotation on:
+  - Terminal opened
+  - Terminal input received
+  - Terminal closed (to reset timeout)
+- Daemon runs GC loop every 5 minutes
+- Pods with no activity > `idle_timeout_minutes` are deleted
+
+## Docker Compose Support
+
+### How Podman Handles docker-compose
+
+Podman is docker-compatible. Inside the user pod:
+
+```bash
+# User runs in their terminal
+cd /worktrees/preset-io/agor/my-feature
+docker-compose up -d
+
+# Podman intercepts and runs containers
+# Containers run INSIDE the user pod (nested)
+```
+
+### Port Forwarding
+
+For accessing services running in docker-compose:
+
+**Option A: kubectl port-forward (manual)**
+```bash
+kubectl port-forward pod/agor-worktree-abc123 8080:8080
+```
+
+**Option B: Service per pod (automatic)**
+- Create a Service when pod is created
+- Expose commonly used ports (80, 443, 3000, 5173, 8080)
+- Access via `{worktree-id}.agor.local`
+
+**Option C: Ingress per worktree**
+- Dynamic ingress creation
+- `{worktree-name}.{repo}.agor.local` routes to pod
+
+Recommendation: Start with Option A, add Option B/C later.
+
+## Kubernetes Workload Management
+
+### Approach: Direct K8s Client (Option A)
+
+The daemon manages Kubernetes resources directly using `@kubernetes/client-node`:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     Daemon Pod                          │
+│                                                         │
+│  ┌─────────────────┐    ┌─────────────────────────────┐│
+│  │ Terminal Service│    │ PodManager                  ││
+│  │                 │───▶│ ├── ensureShellPod()        ││
+│  │ WebSocket       │    │ ├── ensurePodmanPod()       ││
+│  │ connections     │    │ ├── createPodmanService()   ││
+│  └─────────────────┘    │ ├── gcIdleShellPods()       ││
+│                         │ └── gcOrphanedPodmanPods()  ││
+│                         └──────────────┬──────────────┘│
+│                                        │               │
+│  ┌─────────────────────────────────────▼──────────────┐│
+│  │ @kubernetes/client-node                            ││
+│  │ ├── CoreV1Api (pods, services)                     ││
+│  │ └── Exec (terminal streaming)                      ││
+│  └─────────────────────────────────────┬──────────────┘│
+│                                        │               │
+└────────────────────────────────────────┼───────────────┘
+                                         │ HTTPS
+                                         ▼
+                              ┌──────────────────────┐
+                              │ Kubernetes API       │
+                              │ (kubernetes.default) │
+                              └──────────────────────┘
+```
+
+### Why Option A (not Operator)
+
+| Aspect | Direct Client (Option A) | Operator (Option B) |
+|--------|-------------------------|---------------------|
+| Complexity | ✅ Simple | ❌ CRDs, reconciliation loops |
+| Deployment | ✅ Single pod | ❌ Extra operator pod |
+| Latency | ✅ Immediate | ⚠️ Reconciliation delay |
+| Error handling | ✅ Sync, in-process | ⚠️ Async, status fields |
+| K8s-native | ⚠️ Imperative | ✅ Declarative |
+
+For Agor's use case (on-demand pod creation for terminals), Option A is simpler and faster. An Operator would be overkill.
+
+### In-Cluster Authentication
+
+When running inside Kubernetes, the library auto-loads credentials:
+
+```typescript
+const kc = new k8s.KubeConfig();
+kc.loadFromCluster(); // Reads from /var/run/secrets/kubernetes.io/serviceaccount/
+
+// Token is auto-injected by K8s:
+// - /var/run/secrets/kubernetes.io/serviceaccount/token
+// - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+// - /var/run/secrets/kubernetes.io/serviceaccount/namespace
+```
+
+### Package Dependencies
+
+Add to `apps/agor-daemon/package.json`:
+
+```json
+{
+  "dependencies": {
+    "@kubernetes/client-node": "^0.20.0"
+  }
+}
+```
+
+## RBAC Requirements
+
+### Service Account for Daemon
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agor-daemon
+  namespace: agor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agor-daemon
+  namespace: agor
+rules:
+# Pod management (shell pods, Podman pods)
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch"]
+# Terminal streaming via exec
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+# Pod logs (for debugging)
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+# Service management (for Podman sockets)
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["create", "delete", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agor-daemon
+  namespace: agor
+subjects:
+- kind: ServiceAccount
+  name: agor-daemon
+  namespace: agor
+roleRef:
+  kind: Role
+  name: agor-daemon
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### Service Account for Shell Pods
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agor-shell-pod
+  namespace: agor
+# No RBAC needed - shell pods don't access K8s API
+# They just run terminals and use DOCKER_HOST
+```
+
+### Service Account for Podman Pods
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agor-podman-pod
+  namespace: agor
+# No RBAC needed - Podman pods just run containers
+# They expose socket but don't access K8s API
+```
+
+## Migration Path
+
+### Phase 1: Shell Pod Isolation
+- [ ] Add `terminal_mode` config flag
+- [ ] Build `agor/shell` Docker image (Zellij + docker CLI)
+- [ ] Implement PodManager class
+- [ ] Shell pod creation/deletion
+- [ ] kubectl exec streaming for terminals
+- [ ] GC loop for idle shell pods
+- [ ] EFS PVC setup for worktrees/repos
+
+### Phase 2: Podman Pod + DOCKER_HOST
+- [ ] Podman pod creation with socket exposed
+- [ ] Kubernetes Service for each Podman pod
+- [ ] Set DOCKER_HOST env var in shell pods
+- [ ] Test docker-compose commands from shell pod
+- [ ] GC for orphaned Podman pods (no shell pods)
+
+### Phase 3: Networking & Access
+- [ ] Port forwarding helper in UI (for accessing app ports)
+- [ ] Optional: Ingress per worktree for web access
+- [ ] Health checks for Podman pods
+
+### Phase 4: Polish
+- [ ] Pod startup optimization (pre-pull images on nodes)
+- [ ] Shell pod image caching
+- [ ] Metrics and monitoring (pod count, resource usage)
+- [ ] Pod logs accessible in UI
+- [ ] Handle pod eviction/restart gracefully
+
+## Open Questions
+
+1. **Privileged mode alternatives**: Can we use user namespaces instead of privileged for Podman?
+
+2. **Image caching**: Should we use a DaemonSet to pre-pull the Podman image on all nodes?
+
+3. **Resource quotas**: Should we enforce per-user resource limits across all their pods?
+
+4. **Persistent Podman storage**: Should `/var/lib/containers` be on EFS too (slower but containers persist)?
+
+5. **Multi-arch**: Need both amd64 and arm64 Podman images?
+
+## Related Docs
+
+- `context/concepts/worktrees.md` - Worktree data model
+- `context/explorations/unix-user-modes.md` - User isolation modes
+- Kubernetes Exec API: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#exec-options
+- Podman in Kubernetes: https://www.redhat.com/sysadmin/podman-inside-kubernetes
+

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,212 @@
+# Agor Helm Chart
+
+Deploy Agor to Kubernetes using Helm.
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.0+
+- Docker (for building images)
+- kubectl configured to access your cluster
+
+## Quick Start
+
+### 1. Build Docker Images
+
+```bash
+# From repository root
+cd /path/to/agor
+
+# Build daemon image
+docker build -t agor/daemon:dev -f helm/docker/Dockerfile.daemon .
+
+# Build UI image
+docker build -t agor/ui:dev -f helm/docker/Dockerfile.ui .
+
+# For minikube, load images into cluster
+minikube image load agor/daemon:dev
+minikube image load agor/ui:dev
+
+# For kind
+kind load docker-image agor/daemon:dev
+kind load docker-image agor/ui:dev
+```
+
+### 2. Install Chart
+
+```bash
+# Development (local cluster)
+helm install agor ./helm/agor -f helm/values-dev.yaml
+
+# Production
+helm install agor ./helm/agor -f helm/values-production.yaml
+
+# With custom values
+helm install agor ./helm/agor \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=agor.example.com
+```
+
+### 3. Access Agor
+
+With ingress enabled:
+```bash
+# Add to /etc/hosts (for local dev)
+echo "127.0.0.1 agor.local" | sudo tee -a /etc/hosts
+
+# If using minikube
+minikube tunnel
+```
+
+Without ingress (port-forward):
+```bash
+# UI
+kubectl port-forward svc/agor-ui 5173:80
+
+# API
+kubectl port-forward svc/agor-daemon 3030:3030
+
+# Open http://localhost:5173
+```
+
+## Configuration
+
+### Key Values
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `daemon.enabled` | Deploy daemon | `true` |
+| `daemon.image.repository` | Daemon image | `agor/daemon` |
+| `daemon.image.tag` | Daemon image tag | `latest` |
+| `daemon.persistence.enabled` | Enable persistent storage | `true` |
+| `daemon.persistence.data.size` | Database PVC size | `1Gi` |
+| `daemon.persistence.worktrees.size` | Worktrees PVC size | `10Gi` |
+| `ui.enabled` | Deploy UI | `true` |
+| `ui.image.repository` | UI image | `agor/ui` |
+| `ingress.enabled` | Enable ingress | `false` |
+| `ingress.className` | Ingress class | `""` |
+
+### Secrets
+
+Create a secret for API keys:
+
+```bash
+kubectl create secret generic agor-secrets \
+  --from-literal=anthropic-api-key=sk-ant-xxx
+```
+
+Reference in values:
+
+```yaml
+daemon:
+  extraEnv:
+    - name: ANTHROPIC_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: agor-secrets
+          key: anthropic-api-key
+```
+
+### Storage
+
+For production, use a proper storage class:
+
+```yaml
+global:
+  storageClass: "gp3"  # AWS EBS
+  # storageClass: "standard"  # GKE
+  # storageClass: "managed-premium"  # AKS
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                   Ingress                        │
+│                 (nginx/traefik)                  │
+└───────────────────┬─────────────────────────────┘
+                    │
+        ┌───────────┴───────────┐
+        │                       │
+        ▼                       ▼
+┌───────────────┐       ┌───────────────┐
+│   agor-ui     │       │  agor-daemon  │
+│   (nginx)     │       │  (node.js)    │
+│   Port 80     │       │   Port 3030   │
+└───────────────┘       └───────┬───────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │                       │
+                    ▼                       ▼
+            ┌─────────────┐         ┌─────────────┐
+            │  PVC: data  │         │PVC: worktrees│
+            │ (SQLite DB) │         │  (git repos) │
+            └─────────────┘         └─────────────┘
+```
+
+## Limitations
+
+When running in Kubernetes:
+
+1. **Terminal features**: Zellij-based terminals require special configuration
+2. **Unix user isolation**: Not supported in K8s (designed for single-host)
+3. **WebSocket**: Ensure ingress supports WebSocket upgrades
+
+## Development
+
+### Lint Chart
+
+```bash
+helm lint ./helm/agor
+```
+
+### Template Rendering
+
+```bash
+helm template agor ./helm/agor -f helm/values-dev.yaml
+```
+
+### Upgrade
+
+```bash
+helm upgrade agor ./helm/agor -f helm/values-dev.yaml
+```
+
+### Uninstall
+
+```bash
+helm uninstall agor
+
+# Also delete PVCs if needed
+kubectl delete pvc -l app.kubernetes.io/name=agor
+```
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+kubectl describe pod -l app.kubernetes.io/name=agor
+kubectl logs -l app.kubernetes.io/component=daemon
+```
+
+### Database issues
+
+```bash
+# Connect to daemon pod
+kubectl exec -it deploy/agor-daemon -- sh
+
+# Check database
+sqlite3 /data/agor.db ".tables"
+```
+
+### WebSocket connection issues
+
+Ensure ingress has WebSocket support:
+
+```yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+```

--- a/helm/agor/Chart.yaml
+++ b/helm/agor/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: agor
+description: Multiplayer canvas for orchestrating AI coding agents
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - agor
+  - ai
+  - coding
+  - agents
+  - claude
+  - multiplayer
+home: https://agor.live
+sources:
+  - https://github.com/preset-io/agor
+maintainers:
+  - name: Agor Team
+    url: https://agor.live

--- a/helm/agor/templates/NOTES.txt
+++ b/helm/agor/templates/NOTES.txt
@@ -1,0 +1,32 @@
+
+Agor has been deployed!
+
+{{- if .Values.ingress.enabled }}
+Access Agor at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+
+To access Agor, run:
+
+  # UI
+  kubectl port-forward svc/{{ include "agor.ui.fullname" . }} 5173:{{ .Values.ui.service.port }}
+
+  # Daemon API
+  kubectl port-forward svc/{{ include "agor.daemon.fullname" . }} 3030:{{ .Values.daemon.service.port }}
+
+Then open http://localhost:5173 in your browser.
+{{- end }}
+
+{{- if not .Values.daemon.persistence.enabled }}
+
+WARNING: Persistence is disabled! Data will be lost when pods restart.
+Enable persistence in production:
+
+  daemon:
+    persistence:
+      enabled: true
+{{- end }}
+
+For more information, visit https://agor.live

--- a/helm/agor/templates/_helpers.tpl
+++ b/helm/agor/templates/_helpers.tpl
@@ -1,0 +1,179 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "agor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agor.labels" -}}
+helm.sh/chart: {{ include "agor.chart" . }}
+{{ include "agor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Daemon labels
+*/}}
+{{- define "agor.daemon.labels" -}}
+{{ include "agor.labels" . }}
+app.kubernetes.io/component: daemon
+{{- end }}
+
+{{/*
+Daemon selector labels
+*/}}
+{{- define "agor.daemon.selectorLabels" -}}
+{{ include "agor.selectorLabels" . }}
+app.kubernetes.io/component: daemon
+{{- end }}
+
+{{/*
+UI labels
+*/}}
+{{- define "agor.ui.labels" -}}
+{{ include "agor.labels" . }}
+app.kubernetes.io/component: ui
+{{- end }}
+
+{{/*
+UI selector labels
+*/}}
+{{- define "agor.ui.selectorLabels" -}}
+{{ include "agor.selectorLabels" . }}
+app.kubernetes.io/component: ui
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "agor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agor.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Daemon fullname
+*/}}
+{{- define "agor.daemon.fullname" -}}
+{{- printf "%s-daemon" (include "agor.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+UI fullname
+*/}}
+{{- define "agor.ui.fullname" -}}
+{{- printf "%s-ui" (include "agor.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Image pull secrets
+*/}}
+{{- define "agor.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database URL based on database type
+*/}}
+{{- define "agor.databaseUrl" -}}
+{{- if eq .Values.database.type "sqlite" -}}
+file:/home/agor/.agor/agor.db
+{{- else if eq .Values.database.type "turso" -}}
+{{ .Values.database.turso.url }}
+{{- else if eq .Values.database.type "postgresql" -}}
+{{- with .Values.database.postgresql -}}
+postgresql://{{ .username }}:{{ .password }}@{{ .host }}:{{ default 5432 .port }}/{{ .database }}{{ if .sslMode }}?sslmode={{ .sslMode }}{{ end }}
+{{- end -}}
+{{- else -}}
+file:/home/agor/.agor/agor.db
+{{- end -}}
+{{- end }}
+
+{{/*
+Database environment variables
+Returns a list of env var specs for the database configuration
+*/}}
+{{- define "agor.databaseEnv" -}}
+{{- if eq .Values.database.type "sqlite" }}
+- name: DATABASE_URL
+  value: "file:/home/agor/.agor/agor.db"
+{{- else if eq .Values.database.type "turso" }}
+- name: DATABASE_URL
+  {{- if .Values.database.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.database.existingSecret }}
+      key: DATABASE_URL
+  {{- else }}
+  value: {{ .Values.database.turso.url | quote }}
+  {{- end }}
+{{- if or .Values.database.turso.authToken .Values.database.existingSecret }}
+- name: TURSO_AUTH_TOKEN
+  {{- if .Values.database.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.database.existingSecret }}
+      key: TURSO_AUTH_TOKEN
+  {{- else }}
+  value: {{ .Values.database.turso.authToken | quote }}
+  {{- end }}
+{{- end }}
+{{- else if eq .Values.database.type "postgresql" }}
+- name: DATABASE_URL
+  {{- if .Values.database.existingSecret }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.database.existingSecret }}
+      key: DATABASE_URL
+  {{- else }}
+  value: {{ include "agor.databaseUrl" . | quote }}
+  {{- end }}
+- name: AGOR_DB_DIALECT
+  value: "postgresql"
+{{- end }}
+{{- end }}

--- a/helm/agor/templates/configmap.yaml
+++ b/helm/agor/templates/configmap.yaml
@@ -7,3 +7,5 @@ metadata:
 data:
   config.yaml: |
     {{- toYaml .Values.daemon.config | nindent 4 }}
+    kubernetes:
+      namespace: {{ .Release.Namespace }}

--- a/helm/agor/templates/configmap.yaml
+++ b/helm/agor/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agor.fullname" . }}-config
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.daemon.config | nindent 4 }}

--- a/helm/agor/templates/deployment-daemon.yaml
+++ b/helm/agor/templates/deployment-daemon.yaml
@@ -75,6 +75,7 @@ spec:
               mountPath: /etc/agor/config.yaml
               subPath: config.yaml
               readOnly: true
+        {{- if not .Values.daemon.skipMigrations }}
         - name: init-db
           image: "{{ .Values.daemon.image.repository }}:{{ .Values.daemon.image.tag }}"
           imagePullPolicy: {{ .Values.daemon.image.pullPolicy }}
@@ -102,6 +103,7 @@ spec:
           volumeMounts:
             - name: home
               mountPath: /home
+        {{- end }}
         {{- if and .Values.daemon.config.daemon.requireAuth (not .Values.daemon.skipAdminBootstrap) }}
         - name: init-admin
           image: "{{ .Values.daemon.image.repository }}:{{ .Values.daemon.image.tag }}"

--- a/helm/agor/templates/deployment-daemon.yaml
+++ b/helm/agor/templates/deployment-daemon.yaml
@@ -1,0 +1,185 @@
+{{- if .Values.daemon.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agor.daemon.fullname" . }}
+  labels:
+    {{- include "agor.daemon.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.daemon.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "agor.daemon.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.daemon.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "agor.daemon.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "agor.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "agor.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- if .Values.daemon.homeSymlink }}
+        - name: init-home-symlink
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "=== Creating home symlink ==="
+              # Create symlink for path compatibility (e.g., /home/agorpg -> /home/agor)
+              ln -sfn /home/agor /home/{{ .Values.daemon.homeSymlink }}
+              echo "Created symlink /home/{{ .Values.daemon.homeSymlink }} -> /home/agor"
+              ls -la /home/
+          volumeMounts:
+            - name: home
+              mountPath: /home
+        {{- end }}
+        - name: init-config
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "=== Init config ==="
+              mkdir -p /home/agor/.agor
+              cp /etc/agor/config.yaml /home/agor/.agor/config.yaml
+              chown 1000:1000 /home/agor
+              chown 1000:1000 /home/agor/.agor
+              chown 1000:1000 /home/agor/.agor/config.yaml
+              echo "Config copied successfully"
+          volumeMounts:
+            - name: home
+              mountPath: /home
+            - name: config
+              mountPath: /etc/agor/config.yaml
+              subPath: config.yaml
+              readOnly: true
+        - name: init-db
+          image: "{{ .Values.daemon.image.repository }}:{{ .Values.daemon.image.tag }}"
+          imagePullPolicy: {{ .Values.daemon.image.pullPolicy }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          command:
+            - sh
+            - -c
+            - |
+              echo "=== Running database migrations ==="
+              node -e "
+                const { createDatabaseAsync, runMigrations } = require('@agor/core/db');
+                async function migrate() {
+                  const db = await createDatabaseAsync({ url: process.env.DATABASE_URL });
+                  await runMigrations(db);
+                  console.log('✅ Migrations complete');
+                }
+                migrate().catch(e => { console.error(e); process.exit(1); });
+              "
+          env:
+            {{- include "agor.databaseEnv" . | nindent 12 }}
+            - name: HOME
+              value: "/home/agor"
+          volumeMounts:
+            - name: home
+              mountPath: /home
+        {{- if and .Values.daemon.config.daemon.requireAuth (not .Values.daemon.skipAdminBootstrap) }}
+        - name: init-admin
+          image: "{{ .Values.daemon.image.repository }}:{{ .Values.daemon.image.tag }}"
+          imagePullPolicy: {{ .Values.daemon.image.pullPolicy }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          command:
+            - sh
+            - -c
+            - |
+              echo "=== Creating admin user (if not exists) ==="
+              agor user create-admin || true
+              echo "✅ Admin user ready"
+          env:
+            {{- include "agor.databaseEnv" . | nindent 12 }}
+            - name: HOME
+              value: "/home/agor"
+          volumeMounts:
+            - name: home
+              mountPath: /home
+        {{- end }}
+      containers:
+        - name: daemon
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.daemon.image.repository }}:{{ .Values.daemon.image.tag }}"
+          imagePullPolicy: {{ .Values.daemon.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.daemon.service.port }}
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.daemon.env.NODE_ENV | quote }}
+            - name: PORT
+              value: {{ .Values.daemon.env.PORT | quote }}
+            {{- include "agor.databaseEnv" . | nindent 12 }}
+            # Ensure HOME is set correctly for os.homedir()
+            - name: HOME
+              value: "/home/agor"
+            {{- range .Values.daemon.extraEnv }}
+            - name: {{ .name }}
+              {{- if .value }}
+              value: {{ .value | quote }}
+              {{- else if .valueFrom }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          volumeMounts:
+            # /home directory (includes symlinks created by init container)
+            - name: home
+              mountPath: /home
+            # Worktrees storage
+            - name: worktrees
+              mountPath: /worktrees
+          livenessProbe:
+            {{- toYaml .Values.daemon.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.daemon.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.daemon.resources | nindent 12 }}
+      volumes:
+        # Home directory (emptyDir for structure + symlinks, config is copied in)
+        - name: home
+          {{- if .Values.daemon.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "agor.daemon.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: worktrees
+          {{- if .Values.daemon.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "agor.daemon.fullname" . }}-worktrees
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "agor.fullname" . }}-config
+      {{- with .Values.daemon.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemon.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemon.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/agor/templates/deployment-daemon.yaml
+++ b/helm/agor/templates/deployment-daemon.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.daemon.forceRollout }}
+        rollout/timestamp: {{ now | quote }}
+        {{- end }}
         {{- with .Values.daemon.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -53,10 +56,21 @@ spec:
               chown 1000:1000 /home/agor
               chown 1000:1000 /home/agor/.agor
               chown 1000:1000 /home/agor/.agor/config.yaml
-              echo "Config copied successfully"
+
+              # Create symlinks to /data for worktrees and repos
+              echo "Creating symlinks to /data..."
+              mkdir -p /data/worktrees /data/repos
+              ln -sfn /data/worktrees /home/agor/.agor/worktrees
+              ln -sfn /data/repos /home/agor/.agor/repos
+              chown -h 1000:1000 /home/agor/.agor/worktrees /home/agor/.agor/repos
+
+              echo "Config and symlinks ready"
+              ls -la /home/agor/.agor/
           volumeMounts:
             - name: home
               mountPath: /home
+            - name: data
+              mountPath: /data
             - name: config
               mountPath: /etc/agor/config.yaml
               subPath: config.yaml

--- a/helm/agor/templates/deployment-daemon.yaml
+++ b/helm/agor/templates/deployment-daemon.yaml
@@ -142,9 +142,9 @@ spec:
             # /home directory (includes symlinks created by init container)
             - name: home
               mountPath: /home
-            # Worktrees storage
-            - name: worktrees
-              mountPath: /worktrees
+            # Data storage (worktrees + repos)
+            - name: data
+              mountPath: /data
           livenessProbe:
             {{- toYaml .Values.daemon.livenessProbe | nindent 12 }}
           readinessProbe:
@@ -152,18 +152,22 @@ spec:
           resources:
             {{- toYaml .Values.daemon.resources | nindent 12 }}
       volumes:
-        # Home directory (emptyDir for structure + symlinks, config is copied in)
+        # Home directory (~/.agor for SQLite db, config, etc)
         - name: home
           {{- if .Values.daemon.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "agor.daemon.fullname" . }}-data
+            claimName: {{ include "agor.daemon.fullname" . }}-home
           {{- else }}
           emptyDir: {}
           {{- end }}
-        - name: worktrees
-          {{- if .Values.daemon.persistence.enabled }}
+        # Data storage (EFS: worktrees + repos)
+        - name: data
+          {{- if .Values.daemon.persistence.data.existingClaim }}
           persistentVolumeClaim:
-            claimName: {{ include "agor.daemon.fullname" . }}-worktrees
+            claimName: {{ .Values.daemon.persistence.data.existingClaim }}
+          {{- else if .Values.daemon.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "agor.daemon.fullname" . }}-data
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm/agor/templates/deployment-ui.yaml
+++ b/helm/agor/templates/deployment-ui.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.ui.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agor.ui.fullname" . }}
+  labels:
+    {{- include "agor.ui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "agor.ui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.ui.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "agor.ui.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "agor.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "agor.serviceAccountName" . }}
+      # UI (nginx) needs to run without restrictive security context
+      containers:
+        - name: ui
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- if .Values.ui.env.VITE_DAEMON_URL }}
+            - name: VITE_DAEMON_URL
+              value: {{ .Values.ui.env.VITE_DAEMON_URL | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+      {{- with .Values.ui.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.ui.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/agor/templates/ingress.yaml
+++ b/helm/agor/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agor.fullname" . }}
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                {{- if eq .service "daemon" }}
+                name: {{ include "agor.daemon.fullname" $ }}
+                port:
+                  number: {{ $.Values.daemon.service.port }}
+                {{- else }}
+                name: {{ include "agor.ui.fullname" $ }}
+                port:
+                  number: {{ $.Values.ui.service.port }}
+                {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/agor/templates/ingress.yaml
+++ b/helm/agor/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "agor.fullname" . }}
+  name: {{ include "agor.ui.fullname" . }}
   labels:
     {{- include "agor.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/helm/agor/templates/pvc.yaml
+++ b/helm/agor/templates/pvc.yaml
@@ -1,5 +1,24 @@
 {{- if and .Values.daemon.enabled .Values.daemon.persistence.enabled }}
 ---
+# Home directory PVC (~/.agor for SQLite db, config)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agor.daemon.fullname" . }}-home
+  labels:
+    {{- include "agor.daemon.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.daemon.persistence.home.accessMode | default "ReadWriteOnce" }}
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.daemon.persistence.home.size | default "1Gi" }}
+{{- if not .Values.daemon.persistence.data.existingClaim }}
+---
+# Data PVC (worktrees + repos) - only create if not using existingClaim
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,27 +27,12 @@ metadata:
     {{- include "agor.daemon.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - {{ .Values.daemon.persistence.data.accessMode }}
+    - {{ .Values.daemon.persistence.data.accessMode | default "ReadWriteOnce" }}
   {{- if .Values.global.storageClass }}
   storageClassName: {{ .Values.global.storageClass }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.daemon.persistence.data.size }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "agor.daemon.fullname" . }}-worktrees
-  labels:
-    {{- include "agor.daemon.labels" . | nindent 4 }}
-spec:
-  accessModes:
-    - {{ .Values.daemon.persistence.worktrees.accessMode }}
-  {{- if .Values.global.storageClass }}
-  storageClassName: {{ .Values.global.storageClass }}
-  {{- end }}
-  resources:
-    requests:
-      storage: {{ .Values.daemon.persistence.worktrees.size }}
+      storage: {{ .Values.daemon.persistence.data.size | default "10Gi" }}
+{{- end }}
 {{- end }}

--- a/helm/agor/templates/pvc.yaml
+++ b/helm/agor/templates/pvc.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.daemon.enabled .Values.daemon.persistence.enabled }}
+{{- $storageClass := .Values.daemon.persistence.storageClass | default .Values.global.storageClass }}
+{{- if not .Values.daemon.persistence.home.existingClaim }}
 ---
 # Home directory PVC (~/.agor for SQLite db, config)
 apiVersion: v1
@@ -9,13 +11,14 @@ metadata:
     {{- include "agor.daemon.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - {{ .Values.daemon.persistence.home.accessMode | default "ReadWriteOnce" }}
-  {{- if .Values.global.storageClass }}
-  storageClassName: {{ .Values.global.storageClass }}
+    - {{ .Values.daemon.persistence.home.accessMode | default "ReadWriteMany" }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.daemon.persistence.home.size | default "1Gi" }}
+      storage: {{ .Values.daemon.persistence.home.size | default "5Gi" }}
+{{- end }}
 {{- if not .Values.daemon.persistence.data.existingClaim }}
 ---
 # Data PVC (worktrees + repos) - only create if not using existingClaim
@@ -27,12 +30,12 @@ metadata:
     {{- include "agor.daemon.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - {{ .Values.daemon.persistence.data.accessMode | default "ReadWriteOnce" }}
-  {{- if .Values.global.storageClass }}
-  storageClassName: {{ .Values.global.storageClass }}
+    - {{ .Values.daemon.persistence.data.accessMode | default "ReadWriteMany" }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.daemon.persistence.data.size | default "10Gi" }}
+      storage: {{ .Values.daemon.persistence.data.size | default "50Gi" }}
 {{- end }}
 {{- end }}

--- a/helm/agor/templates/pvc.yaml
+++ b/helm/agor/templates/pvc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.daemon.enabled .Values.daemon.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agor.daemon.fullname" . }}-data
+  labels:
+    {{- include "agor.daemon.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.daemon.persistence.data.accessMode }}
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.daemon.persistence.data.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agor.daemon.fullname" . }}-worktrees
+  labels:
+    {{- include "agor.daemon.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.daemon.persistence.worktrees.accessMode }}
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.daemon.persistence.worktrees.size }}
+{{- end }}

--- a/helm/agor/templates/rbac-pod-management.yaml
+++ b/helm/agor/templates/rbac-pod-management.yaml
@@ -8,10 +8,14 @@ metadata:
   labels:
     {{- include "agor.labels" . | nindent 4 }}
 rules:
-# Pod management (shell pods, Podman pods)
+# Deployment management (shell deployments, Podman deployments)
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch"]
+# Pod read access (for listing pods from deployments, exec)
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["create", "delete", "get", "list", "watch", "patch"]
+  verbs: ["get", "list", "watch"]
 # Terminal streaming via exec (get required for initial connection, create for exec)
 - apiGroups: [""]
   resources: ["pods/exec"]
@@ -20,10 +24,14 @@ rules:
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get"]
-# Service management (for Podman sockets)
+# Service management (for Podman sockets and app services)
 - apiGroups: [""]
   resources: ["services"]
-  verbs: ["create", "delete", "get", "list"]
+  verbs: ["create", "delete", "get", "list", "patch", "update"]
+# Ingress management (for app URLs)
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["create", "delete", "get", "list", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/agor/templates/rbac-pod-management.yaml
+++ b/helm/agor/templates/rbac-pod-management.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.daemon.userPods.enabled }}
+# RBAC for daemon to manage user pods (shell + podman)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agor.fullname" . }}-pod-manager
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+rules:
+# Pod management (shell pods, Podman pods)
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "delete", "get", "list", "watch", "patch"]
+# Terminal streaming via exec (get required for initial connection, create for exec)
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create", "get"]
+# Pod logs (for debugging)
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+# Service management (for Podman sockets)
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["create", "delete", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agor.fullname" . }}-pod-manager
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "agor.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "agor.fullname" . }}-pod-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# ServiceAccount for shell pods (no RBAC needed)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agor-shell-pod
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: shell-pod
+---
+# ServiceAccount for Podman pods (no RBAC needed)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agor-podman-pod
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+    app.kubernetes.io/component: podman-pod
+{{- end }}

--- a/helm/agor/templates/service-daemon.yaml
+++ b/helm/agor/templates/service-daemon.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.daemon.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agor.daemon.fullname" . }}
+  labels:
+    {{- include "agor.daemon.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.daemon.service.type }}
+  ports:
+    - port: {{ .Values.daemon.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agor.daemon.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/agor/templates/service-ui.yaml
+++ b/helm/agor/templates/service-ui.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agor.ui.fullname" . }}
+  labels:
+    {{- include "agor.ui.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - port: {{ .Values.ui.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agor.ui.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/agor/templates/serviceaccount.yaml
+++ b/helm/agor/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agor.serviceAccountName" . }}
+  labels:
+    {{- include "agor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/agor/values.yaml
+++ b/helm/agor/values.yaml
@@ -42,9 +42,9 @@ daemon:
   enabled: true
 
   image:
-    repository: agor/daemon
+    repository: public.ecr.aws/a5v0t1w0/agor/daemon
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   replicaCount: 1
 
@@ -101,7 +101,7 @@ daemon:
 
     # Shell pod configuration (one per user per worktree)
     shellPod:
-      image: agor/shell:latest
+      image: public.ecr.aws/a5v0t1w0/agor/shell:latest
       resources:
         requests:
           cpu: 50m
@@ -109,10 +109,20 @@ daemon:
         limits:
           cpu: "1"
           memory: 1Gi
+      # SSH sidecar container resources
+      sshdResources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
 
     # Podman pod configuration (one per worktree, shared by users)
     podmanPod:
-      image: quay.io/podman/stable
+      image: public.ecr.aws/a5v0t1w0/agor/podman:latest
+      # Init container image for setup tasks
+      initImage: busybox:1.36
       resources:
         requests:
           cpu: 100m
@@ -130,6 +140,15 @@ daemon:
     storage:
       dataPvc: agor-data
 
+    # Base domain for worktree app ingresses (e.g., "agor.local" -> "myapp.agor.local")
+    appBaseDomain: agor.local
+
+    # Ingress class name for worktree app ingresses
+    ingressClassName: traefik
+
+    # Traefik entrypoint name for SSH routing
+    sshEntryPoint: ssh
+
   # Skip auto-creating admin user on startup
   # Set to true when using external database with pre-seeded users
   skipAdminBootstrap: false
@@ -137,15 +156,18 @@ daemon:
   # Persistence for daemon storage
   persistence:
     enabled: true
+    # Storage class for PVCs (nfs recommended for user pods RWX support)
+    storageClass: nfs
     # Home directory (~/.agor for SQLite db, config)
     home:
-      size: 1Gi
-      accessMode: ReadWriteOnce
-    # Data storage (worktrees + repos) - use existingClaim for EFS
+      size: 5Gi
+      accessMode: ReadWriteMany
+      # existingClaim: agor-home-nfs
+    # Data storage (worktrees + repos)
     data:
-      size: 10Gi
-      accessMode: ReadWriteOnce
-      # existingClaim: agor-data  # Use pre-existing PVC (e.g., EFS)
+      size: 50Gi
+      accessMode: ReadWriteMany
+      # existingClaim: agor-data-nfs
 
   # Pod annotations
   podAnnotations: {}
@@ -180,9 +202,9 @@ ui:
   enabled: true
 
   image:
-    repository: agor/ui
+    repository: public.ecr.aws/a5v0t1w0/agor/ui
     tag: "latest"
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   replicaCount: 1
 

--- a/helm/agor/values.yaml
+++ b/helm/agor/values.yaml
@@ -1,0 +1,218 @@
+# Agor Helm Chart - Default Values
+# Override these in your own values file (e.g., values-production.yaml)
+
+# Global settings
+global:
+  # Image pull secrets for private registries
+  imagePullSecrets: []
+  # Storage class for persistent volumes (empty = default)
+  storageClass: ""
+
+# Database configuration
+# Supports: sqlite (local file), turso (libSQL cloud), postgresql
+database:
+  # Database type: sqlite, turso, postgresql
+  type: sqlite
+
+  # For sqlite: uses local file at /home/agor/.agor/agor.db (default)
+  # No additional configuration needed
+
+  # For turso (libSQL cloud):
+  # turso:
+  #   url: "libsql://your-db-name.turso.io"
+  #   authToken: ""  # Or use existingSecret
+
+  # For postgresql:
+  # postgresql:
+  #   host: postgres.default.svc.cluster.local
+  #   port: 5432
+  #   database: agor
+  #   username: agor
+  #   password: ""  # Or use existingSecret
+  #   sslMode: require  # disable, require, verify-ca, verify-full
+
+  # Use existing secret for credentials (recommended for production)
+  # Secret should contain keys based on database type:
+  #   - turso: TURSO_AUTH_TOKEN
+  #   - postgresql: DATABASE_URL or (PGUSER, PGPASSWORD, PGHOST, etc.)
+  existingSecret: ""
+
+# Daemon (Backend API)
+daemon:
+  enabled: true
+
+  image:
+    repository: agor/daemon
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  # Resource limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 3030
+
+  # Environment variables
+  env:
+    NODE_ENV: production
+    PORT: "3030"
+
+  # Extra environment variables (for secrets, etc.)
+  extraEnv: []
+  # - name: ANTHROPIC_API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: agor-secrets
+  #       key: anthropic-api-key
+
+  # Agor configuration (rendered to config.yaml)
+  config:
+    daemon:
+      port: 3030
+      allowAnonymous: false
+    execution:
+      worktree_rbac: false
+      unix_user_mode: simple
+
+  # Skip auto-creating admin user on startup
+  # Set to true when using external database with pre-seeded users
+  skipAdminBootstrap: false
+
+  # Persistence for SQLite database and worktrees
+  persistence:
+    enabled: true
+    # Database storage
+    data:
+      size: 1Gi
+      accessMode: ReadWriteOnce
+    # Git worktrees storage
+    worktrees:
+      size: 10Gi
+      accessMode: ReadWriteOnce
+
+  # Pod annotations
+  podAnnotations: {}
+
+  # Node selector
+  nodeSelector: {}
+
+  # Tolerations
+  tolerations: []
+
+  # Affinity
+  affinity: {}
+
+  # Liveness probe
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 30
+
+  # Readiness probe
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+# UI (Frontend)
+ui:
+  enabled: true
+
+  image:
+    repository: agor/ui
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  # Resource limits
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 80
+
+  # Environment variables passed at build time
+  env:
+    VITE_DAEMON_URL: ""  # Will be set via ingress hostname
+
+  # Pod annotations
+  podAnnotations: {}
+
+  # Node selector
+  nodeSelector: {}
+
+  # Tolerations
+  tolerations: []
+
+  # Affinity
+  affinity: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+
+  # UI hostname
+  hosts:
+    - host: agor.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: ui
+        # API routes proxied to daemon
+        - path: /api
+          pathType: Prefix
+          service: daemon
+        - path: /socket.io
+          pathType: Prefix
+          service: daemon
+
+  tls: []
+  # - secretName: agor-tls
+  #   hosts:
+  #     - agor.local
+
+# Service Account
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# Pod Security Context
+podSecurityContext:
+  fsGroup: 1000
+
+# Container Security Context
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+
+# Network Policy
+networkPolicy:
+  enabled: false

--- a/helm/agor/values.yaml
+++ b/helm/agor/values.yaml
@@ -83,22 +83,69 @@ daemon:
     execution:
       worktree_rbac: false
       unix_user_mode: simple
+      # Terminal execution mode:
+      # - daemon: Run terminals in daemon pod (default, simpler)
+      # - pod: Run terminals in isolated user pods (requires userPods config)
+      terminal_mode: daemon
+      # Unix UID range for user allocation (for consistent file ownership on EFS/NFS)
+      # UIDs are assigned from this range when Unix users are created
+      unix_uid_range:
+        min: 10000
+        max: 60000
+
+  # User Pods configuration (for terminal_mode: pod)
+  # Creates isolated pods per user+worktree for terminals
+  # with shared Podman pods per worktree for docker-compose
+  userPods:
+    enabled: false
+
+    # Shell pod configuration (one per user per worktree)
+    shellPod:
+      image: agor/shell:latest
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+
+    # Podman pod configuration (one per worktree, shared by users)
+    podmanPod:
+      image: quay.io/podman/stable
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: "4"
+          memory: 8Gi
+
+    # Idle timeout before pods are garbage collected (minutes)
+    idleTimeoutMinutes:
+      shell: 30    # Shell pods deleted after 30min of inactivity
+      podman: 60   # Podman pods deleted 60min after last shell pod
+
+    # Storage configuration (must be ReadWriteMany for user pods)
+    storage:
+      dataPvc: agor-data
 
   # Skip auto-creating admin user on startup
   # Set to true when using external database with pre-seeded users
   skipAdminBootstrap: false
 
-  # Persistence for SQLite database and worktrees
+  # Persistence for daemon storage
   persistence:
     enabled: true
-    # Database storage
-    data:
+    # Home directory (~/.agor for SQLite db, config)
+    home:
       size: 1Gi
       accessMode: ReadWriteOnce
-    # Git worktrees storage
-    worktrees:
+    # Data storage (worktrees + repos) - use existingClaim for EFS
+    data:
       size: 10Gi
       accessMode: ReadWriteOnce
+      # existingClaim: agor-data  # Use pre-existing PVC (e.g., EFS)
 
   # Pod annotations
   podAnnotations: {}

--- a/helm/build.sh
+++ b/helm/build.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Build and optionally deploy Agor to Kubernetes
+#
+# Usage:
+#   ./build.sh                    # Build images only
+#   ./build.sh --push             # Build and push to registry
+#   ./build.sh --deploy           # Build and deploy to local cluster
+#   ./build.sh --deploy minikube  # Build for minikube
+#   ./build.sh --deploy kind      # Build for kind
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Default values
+TAG="${TAG:-dev}"
+REGISTRY="${REGISTRY:-}"
+PUSH=false
+DEPLOY=false
+CLUSTER_TYPE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --push)
+            PUSH=true
+            shift
+            ;;
+        --deploy)
+            DEPLOY=true
+            if [[ -n "$2" && ! "$2" =~ ^-- ]]; then
+                CLUSTER_TYPE="$2"
+                shift
+            fi
+            shift
+            ;;
+        --tag)
+            TAG="$2"
+            shift 2
+            ;;
+        --registry)
+            REGISTRY="$2"
+            shift 2
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Set image names
+if [[ -n "$REGISTRY" ]]; then
+    DAEMON_IMAGE="${REGISTRY}/agor/daemon:${TAG}"
+    UI_IMAGE="${REGISTRY}/agor/ui:${TAG}"
+else
+    DAEMON_IMAGE="agor/daemon:${TAG}"
+    UI_IMAGE="agor/ui:${TAG}"
+fi
+
+echo -e "${CYAN}Building Agor Docker images${NC}"
+echo -e "  Daemon: ${DAEMON_IMAGE}"
+echo -e "  UI:     ${UI_IMAGE}"
+echo ""
+
+# Build daemon
+echo -e "${YELLOW}Building daemon image...${NC}"
+docker build \
+    -t "$DAEMON_IMAGE" \
+    -f "$SCRIPT_DIR/docker/Dockerfile.daemon" \
+    "$PROJECT_ROOT"
+echo -e "${GREEN}✓ Daemon image built${NC}"
+
+# Build UI
+echo -e "${YELLOW}Building UI image...${NC}"
+docker build \
+    -t "$UI_IMAGE" \
+    -f "$SCRIPT_DIR/docker/Dockerfile.ui" \
+    "$PROJECT_ROOT"
+echo -e "${GREEN}✓ UI image built${NC}"
+
+# Push if requested
+if $PUSH; then
+    echo -e "${YELLOW}Pushing images to registry...${NC}"
+    docker push "$DAEMON_IMAGE"
+    docker push "$UI_IMAGE"
+    echo -e "${GREEN}✓ Images pushed${NC}"
+fi
+
+# Deploy if requested
+if $DEPLOY; then
+    echo ""
+    echo -e "${CYAN}Deploying to Kubernetes${NC}"
+
+    # Load images for local clusters
+    case "$CLUSTER_TYPE" in
+        minikube)
+            echo -e "${YELLOW}Loading images into minikube...${NC}"
+            minikube image load "$DAEMON_IMAGE"
+            minikube image load "$UI_IMAGE"
+            ;;
+        kind)
+            echo -e "${YELLOW}Loading images into kind...${NC}"
+            kind load docker-image "$DAEMON_IMAGE"
+            kind load docker-image "$UI_IMAGE"
+            ;;
+    esac
+
+    # Install/upgrade helm chart
+    echo -e "${YELLOW}Installing Helm chart...${NC}"
+    helm upgrade --install agor "$SCRIPT_DIR/agor" \
+        -f "$SCRIPT_DIR/values-dev.yaml" \
+        --set daemon.image.tag="$TAG" \
+        --set ui.image.tag="$TAG"
+
+    echo -e "${GREEN}✓ Deployed!${NC}"
+    echo ""
+    echo -e "Access Agor:"
+    echo -e "  kubectl port-forward svc/agor-ui 5173:80"
+    echo -e "  Open http://localhost:5173"
+fi
+
+echo ""
+echo -e "${GREEN}Done!${NC}"

--- a/helm/build.sh
+++ b/helm/build.sh
@@ -61,14 +61,17 @@ done
 if [[ -n "$REGISTRY" ]]; then
     DAEMON_IMAGE="${REGISTRY}/agor/daemon:${TAG}"
     UI_IMAGE="${REGISTRY}/agor/ui:${TAG}"
+    SHELL_IMAGE="${REGISTRY}/agor/shell:${TAG}"
 else
     DAEMON_IMAGE="agor/daemon:${TAG}"
     UI_IMAGE="agor/ui:${TAG}"
+    SHELL_IMAGE="agor/shell:${TAG}"
 fi
 
 echo -e "${CYAN}Building Agor Docker images${NC}"
 echo -e "  Daemon: ${DAEMON_IMAGE}"
 echo -e "  UI:     ${UI_IMAGE}"
+echo -e "  Shell:  ${SHELL_IMAGE}"
 echo ""
 
 # Build daemon
@@ -87,11 +90,20 @@ docker build \
     "$PROJECT_ROOT"
 echo -e "${GREEN}✓ UI image built${NC}"
 
+# Build shell pod image (for terminal_mode: pod)
+echo -e "${YELLOW}Building shell pod image...${NC}"
+docker build \
+    -t "$SHELL_IMAGE" \
+    -f "$SCRIPT_DIR/docker/Dockerfile.shell" \
+    "$SCRIPT_DIR/docker"
+echo -e "${GREEN}✓ Shell image built${NC}"
+
 # Push if requested
 if $PUSH; then
     echo -e "${YELLOW}Pushing images to registry...${NC}"
     docker push "$DAEMON_IMAGE"
     docker push "$UI_IMAGE"
+    docker push "$SHELL_IMAGE"
     echo -e "${GREEN}✓ Images pushed${NC}"
 fi
 
@@ -106,11 +118,13 @@ if $DEPLOY; then
             echo -e "${YELLOW}Loading images into minikube...${NC}"
             minikube image load "$DAEMON_IMAGE"
             minikube image load "$UI_IMAGE"
+            minikube image load "$SHELL_IMAGE"
             ;;
         kind)
             echo -e "${YELLOW}Loading images into kind...${NC}"
             kind load docker-image "$DAEMON_IMAGE"
             kind load docker-image "$UI_IMAGE"
+            kind load docker-image "$SHELL_IMAGE"
             ;;
     esac
 

--- a/helm/docker-compose.yaml
+++ b/helm/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  daemon:
+    image: agor/daemon:dev
+    ports:
+      - "3030:3030"
+    volumes:
+      # Mount host ~/.agor to container's /home/agor/.agor
+      - ~/.agor:/home/agor/.agor
+    environment:
+      - NODE_ENV=production
+      - PORT=3030
+      - DATABASE_URL=file:/home/agor/.agor/agor.db
+
+  # UI (build first: docker build -t agor/ui:dev -f helm/docker/Dockerfile.ui .)
+  ui:
+    image: agor/ui:dev
+    ports:
+      - "5173:8080"
+    depends_on:
+      - daemon

--- a/helm/docker/Dockerfile.daemon
+++ b/helm/docker/Dockerfile.daemon
@@ -117,11 +117,9 @@ RUN chmod +x /app/executor/bin/agor-executor 2>/dev/null || true && \
     # Create symlink so daemon can find cli.js at expected path
     ln -sf /app/executor/dist/cli.js /app/executor/cli.js
 
-# Create agor home directory with symlinks to /data (mounted at runtime)
+# Create agor home directory (symlinks to /data created by init container at runtime)
 RUN mkdir -p /home/agor/.agor && \
-    ln -s /data/worktrees /home/agor/.agor/worktrees && \
-    ln -s /data/repos /home/agor/.agor/repos && \
-    chown -h agor:agor /home/agor/.agor /home/agor/.agor/worktrees /home/agor/.agor/repos
+    chown -R agor:agor /home/agor/.agor
 
 # Set environment
 ENV NODE_ENV=production

--- a/helm/docker/Dockerfile.daemon
+++ b/helm/docker/Dockerfile.daemon
@@ -65,8 +65,34 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Zellij from GitHub releases
+# Install Docker CLI (client only, no daemon) and Docker Compose plugin
+# Used to communicate with Podman pods via DOCKER_HOST
 ARG TARGETARCH
+RUN DOCKER_ARCH=$(case "${TARGETARCH}" in \
+        "amd64") echo "x86_64" ;; \
+        "arm64") echo "aarch64" ;; \
+        *) echo "x86_64" ;; \
+    esac) && \
+    # Install docker CLI
+    curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-24.0.7.tgz" \
+    | tar -xz --strip-components=1 -C /usr/local/bin docker/docker && \
+    chmod +x /usr/local/bin/docker && \
+    # Install docker-compose standalone (v2)
+    COMPOSE_ARCH=$(case "${TARGETARCH}" in \
+        "amd64") echo "x86_64" ;; \
+        "arm64") echo "aarch64" ;; \
+        *) echo "x86_64" ;; \
+    esac) && \
+    curl -fsSL "https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-linux-${COMPOSE_ARCH}" \
+    -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose && \
+    # Create docker cli plugins directory and symlink for "docker compose" command
+    mkdir -p /usr/local/lib/docker/cli-plugins && \
+    ln -s /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose && \
+    docker --version && \
+    docker-compose --version
+
+# Install Zellij from GitHub releases
 RUN ARCH=$(case "${TARGETARCH}" in \
         "amd64") echo "x86_64" ;; \
         "arm64") echo "aarch64" ;; \
@@ -75,6 +101,7 @@ RUN ARCH=$(case "${TARGETARCH}" in \
     curl -fsSL "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
     | tar -xz -C /usr/local/bin && \
     chmod +x /usr/local/bin/zellij
+
 
 # Create agor user with uid 1000 (replacing node user from base image)
 # Add passwordless sudo for Unix user management and impersonation

--- a/helm/docker/Dockerfile.daemon
+++ b/helm/docker/Dockerfile.daemon
@@ -1,0 +1,123 @@
+# Agor Daemon Dockerfile
+# Multi-stage build for smaller production image
+
+# ============================================
+# Stage 1: Build
+# ============================================
+FROM node:22-bookworm-slim AS builder
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy package files
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/core/package.json ./packages/core/
+COPY packages/executor/package.json ./packages/executor/
+COPY apps/agor-daemon/package.json ./apps/agor-daemon/
+COPY apps/agor-cli/package.json ./apps/agor-cli/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY packages/core ./packages/core
+COPY packages/executor ./packages/executor
+COPY apps/agor-daemon ./apps/agor-daemon
+COPY apps/agor-cli ./apps/agor-cli
+COPY turbo.json ./
+
+# Build all packages
+RUN pnpm --filter @agor/core build
+RUN pnpm --filter @agor/executor build
+RUN pnpm --filter @agor/cli build
+RUN pnpm --filter @agor/daemon build
+
+# Use pnpm deploy to create a standalone production bundle
+# This properly handles workspace dependencies
+RUN pnpm --filter @agor/daemon deploy --prod /prod/daemon
+
+# Also deploy CLI
+RUN pnpm --filter @agor/cli deploy --prod /prod/cli
+
+# Deploy executor
+RUN pnpm --filter @agor/executor deploy --prod /prod/executor
+
+# ============================================
+# Stage 2: Production
+# ============================================
+FROM node:22-bookworm-slim AS production
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    sudo \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Zellij from GitHub releases
+ARG TARGETARCH
+RUN ARCH=$(case "${TARGETARCH}" in \
+        "amd64") echo "x86_64" ;; \
+        "arm64") echo "aarch64" ;; \
+        *) echo "x86_64" ;; \
+    esac) && \
+    curl -fsSL "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/zellij
+
+# Create agor user with uid 1000 (replacing node user from base image)
+# Add passwordless sudo for Unix user management and impersonation
+RUN userdel -r node 2>/dev/null || true && \
+    groupadd -g 1000 agor && \
+    useradd -u 1000 -g 1000 -m agor && \
+    echo "agor ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agor && \
+    chmod 0440 /etc/sudoers.d/agor
+
+WORKDIR /app
+
+# Copy the deployed production bundle (includes all dependencies)
+COPY --from=builder --chown=agor:agor /prod/daemon ./
+
+# Copy CLI and create symlink
+COPY --from=builder --chown=agor:agor /prod/cli /opt/agor-cli
+RUN chmod +x /opt/agor-cli/bin/run.js && \
+    ln -s /opt/agor-cli/bin/run.js /usr/local/bin/agor && \
+    # Verify CLI is accessible (will fail build if broken)
+    node /opt/agor-cli/bin/run.js --version
+
+# Copy executor to expected location
+# Daemon expects cli.js at /app/executor/cli.js
+COPY --from=builder --chown=agor:agor /prod/executor /app/executor
+RUN chmod +x /app/executor/bin/agor-executor 2>/dev/null || true && \
+    # Create symlink so daemon can find cli.js at expected path
+    ln -sf /app/executor/dist/cli.js /app/executor/cli.js
+
+# Create agor home directory (where config and db will be mounted)
+RUN mkdir -p /home/agor/.agor && chown agor:agor /home/agor/.agor
+
+# Set environment
+ENV NODE_ENV=production
+ENV PORT=3030
+
+# Switch to non-root user
+USER agor
+
+EXPOSE 3030
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:3030/health || exit 1
+
+# Start daemon
+CMD ["node", "dist/index.js"]

--- a/helm/docker/Dockerfile.daemon
+++ b/helm/docker/Dockerfile.daemon
@@ -24,7 +24,6 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/core/package.json ./packages/core/
 COPY packages/executor/package.json ./packages/executor/
 COPY apps/agor-daemon/package.json ./apps/agor-daemon/
-COPY apps/agor-cli/package.json ./apps/agor-cli/
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
@@ -33,21 +32,16 @@ RUN pnpm install --frozen-lockfile
 COPY packages/core ./packages/core
 COPY packages/executor ./packages/executor
 COPY apps/agor-daemon ./apps/agor-daemon
-COPY apps/agor-cli ./apps/agor-cli
 COPY turbo.json ./
 
 # Build all packages
 RUN pnpm --filter @agor/core build
 RUN pnpm --filter @agor/executor build
-RUN pnpm --filter @agor/cli build
 RUN pnpm --filter @agor/daemon build
 
 # Use pnpm deploy to create a standalone production bundle
 # This properly handles workspace dependencies
 RUN pnpm --filter @agor/daemon deploy --prod /prod/daemon
-
-# Also deploy CLI
-RUN pnpm --filter @agor/cli deploy --prod /prod/cli
 
 # Deploy executor
 RUN pnpm --filter @agor/executor deploy --prod /prod/executor
@@ -115,13 +109,6 @@ WORKDIR /app
 
 # Copy the deployed production bundle (includes all dependencies)
 COPY --from=builder --chown=agor:agor /prod/daemon ./
-
-# Copy CLI and create symlink
-COPY --from=builder --chown=agor:agor /prod/cli /opt/agor-cli
-RUN chmod +x /opt/agor-cli/bin/run.js && \
-    ln -s /opt/agor-cli/bin/run.js /usr/local/bin/agor && \
-    # Verify CLI is accessible (will fail build if broken)
-    node /opt/agor-cli/bin/run.js --version
 
 # Copy executor to expected location
 # Daemon expects cli.js at /app/executor/cli.js

--- a/helm/docker/Dockerfile.daemon
+++ b/helm/docker/Dockerfile.daemon
@@ -103,8 +103,11 @@ RUN chmod +x /app/executor/bin/agor-executor 2>/dev/null || true && \
     # Create symlink so daemon can find cli.js at expected path
     ln -sf /app/executor/dist/cli.js /app/executor/cli.js
 
-# Create agor home directory (where config and db will be mounted)
-RUN mkdir -p /home/agor/.agor && chown agor:agor /home/agor/.agor
+# Create agor home directory with symlinks to /data (mounted at runtime)
+RUN mkdir -p /home/agor/.agor && \
+    ln -s /data/worktrees /home/agor/.agor/worktrees && \
+    ln -s /data/repos /home/agor/.agor/repos && \
+    chown -h agor:agor /home/agor/.agor /home/agor/.agor/worktrees /home/agor/.agor/repos
 
 # Set environment
 ENV NODE_ENV=production

--- a/helm/docker/Dockerfile.podman
+++ b/helm/docker/Dockerfile.podman
@@ -1,0 +1,22 @@
+# Agor Podman Pod Dockerfile
+# Podman with podman-compose for running user environments
+#
+# Based on official podman image, adds podman-compose
+
+FROM quay.io/podman/stable
+
+# Install podman-compose (Python-based docker-compose compatible tool)
+# The podman image is Fedora-based, use dnf
+RUN dnf install -y \
+    python3-pip \
+    git \
+    && dnf clean all && \
+    pip3 install podman-compose
+
+# Verify installation
+RUN podman --version && \
+    podman-compose --version
+
+# Default command: run podman system service
+# Creates socket at /run/podman/podman.sock and TCP on 2375
+CMD ["sh", "-c", "podman system service --time=0 unix:///run/podman/podman.sock & podman system service --time=0 tcp://0.0.0.0:2375"]

--- a/helm/docker/Dockerfile.shell
+++ b/helm/docker/Dockerfile.shell
@@ -1,124 +1,100 @@
 # Agor Shell Pod Dockerfile
-# Lightweight image for isolated terminal sessions
+# Minimal image for isolated terminal sessions
 #
 # Contains:
 # - Zellij (terminal multiplexer)
-# - Docker CLI (for DOCKER_HOST to Podman pod)
-# - Git (for version control)
-# - Common dev tools
+# - Docker CLI (standalone binary, connects to DOCKER_HOST)
+# - Claude Code (AI agent)
+# - Git, vi, basic tools
 
 FROM debian:bookworm-slim
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
-    # Docker CLI (uses DOCKER_HOST to connect to Podman pod)
-    docker.io \
+ARG TARGETARCH
+
+# Install minimal runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
     # Version control
     git \
-    # Networking tools
+    # Networking (for downloads and debugging)
     curl \
-    wget \
     ca-certificates \
-    # SSH server (for sshd sidecar container)
+    # SSH server (for sshd sidecar)
     openssh-server \
-    # Shell utilities
+    # Shell
     bash \
-    bash-completion \
-    less \
+    # Editor
     vim-tiny \
+    # Basic tools
     jq \
-    # Process management
     procps \
-    htop \
-    # Build essentials (for some docker-compose projects)
-    make \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    # Create sshd privilege separation directory
     && mkdir -p /run/sshd
 
-# Install Zellij from GitHub releases (optional - may fail in restricted networks)
-ARG TARGETARCH
+# Install Docker CLI only (standalone binary, ~50MB vs ~300MB for docker.io)
 RUN ARCH=$(case "${TARGETARCH}" in \
         "amd64") echo "x86_64" ;; \
         "arm64") echo "aarch64" ;; \
         *) echo "x86_64" ;; \
     esac) && \
-    (curl -fsSL --connect-timeout 30 "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
-    | tar -xz -C /usr/local/bin && \
-    chmod +x /usr/local/bin/zellij) || echo "Warning: Failed to install zellij (network issue?)"
+    curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-24.0.7.tgz" \
+    | tar -xz --strip-components=1 -C /usr/local/bin docker/docker && \
+    chmod +x /usr/local/bin/docker
 
-# Install docker-compose v2 (standalone, optional)
+# Install docker-compose v2 (standalone)
 RUN ARCH=$(case "${TARGETARCH}" in \
         "amd64") echo "x86_64" ;; \
         "arm64") echo "aarch64" ;; \
         *) echo "x86_64" ;; \
     esac) && \
-    (curl -fsSL --connect-timeout 30 "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
+    curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
     -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose) || echo "Warning: Failed to install docker-compose (network issue?)"
+    chmod +x /usr/local/bin/docker-compose
 
-# Install Node.js 22 LTS (required for Claude Code)
+# Install Zellij (terminal multiplexer)
+RUN ARCH=$(case "${TARGETARCH}" in \
+        "amd64") echo "x86_64" ;; \
+        "arm64") echo "aarch64" ;; \
+        *) echo "x86_64" ;; \
+    esac) && \
+    curl -fsSL "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/zellij
+
+# Install Node.js 22 LTS (required for Claude Code) - minimal install
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    npm cache clean --force
 
-# Install Claude Code globally
-RUN npm install -g @anthropic-ai/claude-code
+# Install Claude Code
+RUN npm install -g @anthropic-ai/claude-code && \
+    npm cache clean --force
 
-# Create agor user with uid 1000
+# Create default user (init container creates actual users)
 RUN groupadd -g 1000 agor && \
-    useradd -u 1000 -g 1000 -m -s /bin/bash agor
+    useradd -u 1000 -g 1000 -m -s /bin/bash agor && \
+    mkdir -p /home/agor/.agor /home/agor/.config/zellij
 
-# Note: Shell pods use dynamic users created by init container
-# Symlinks are created at runtime in /data/homes/<username>/.agor/
-RUN mkdir -p /home/agor/.agor
-
-# Setup home directory and config files
-RUN mkdir -p /home/agor/.config/zellij && \
-    # Default Zellij config (simple layout)
-    echo '// Agor shell pod Zellij config' > /home/agor/.config/zellij/config.kdl && \
-    echo 'default_shell "bash"' >> /home/agor/.config/zellij/config.kdl && \
-    echo 'pane_frames false' >> /home/agor/.config/zellij/config.kdl && \
-    echo 'theme "default"' >> /home/agor/.config/zellij/config.kdl && \
-    # Bash profile for nicer terminal experience
-    echo '# Agor shell pod bashrc' > /home/agor/.bashrc && \
-    echo "export PS1='\\[\\033[01;32m\\]\\u@agor\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\$ '" >> /home/agor/.bashrc && \
-    echo 'export EDITOR=vim' >> /home/agor/.bashrc && \
-    echo '' >> /home/agor/.bashrc && \
-    echo '# Docker aliases (works via DOCKER_HOST)' >> /home/agor/.bashrc && \
-    echo "alias d='docker'" >> /home/agor/.bashrc && \
-    echo "alias dc='docker-compose'" >> /home/agor/.bashrc && \
-    echo "alias dps='docker ps'" >> /home/agor/.bashrc && \
-    echo "alias dlogs='docker logs -f'" >> /home/agor/.bashrc && \
-    echo '' >> /home/agor/.bashrc && \
-    echo '# Git aliases' >> /home/agor/.bashrc && \
-    echo "alias gs='git status'" >> /home/agor/.bashrc && \
-    echo "alias gd='git diff'" >> /home/agor/.bashrc && \
-    echo "alias gl='git log --oneline -10'" >> /home/agor/.bashrc && \
-    echo '' >> /home/agor/.bashrc && \
-    echo '# Source bash completion' >> /home/agor/.bashrc && \
-    echo 'if [ -f /etc/bash_completion ]; then' >> /home/agor/.bashrc && \
-    echo '    . /etc/bash_completion' >> /home/agor/.bashrc && \
-    echo 'fi' >> /home/agor/.bashrc && \
-    echo '' >> /home/agor/.bashrc && \
-    echo '# Show DOCKER_HOST on login' >> /home/agor/.bashrc && \
-    echo 'if [ -n "$DOCKER_HOST" ]; then' >> /home/agor/.bashrc && \
-    echo '    echo "DOCKER_HOST: $DOCKER_HOST"' >> /home/agor/.bashrc && \
-    echo 'fi' >> /home/agor/.bashrc && \
-    echo '' >> /home/agor/.bashrc && \
-    echo 'cd "${WORKTREE_PATH:-$HOME}"' >> /home/agor/.bashrc && \
+# Minimal bashrc
+RUN echo 'export PS1="\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' > /home/agor/.bashrc && \
+    echo 'export EDITOR=vi' >> /home/agor/.bashrc && \
+    echo 'alias vi=vim.tiny' >> /home/agor/.bashrc && \
+    echo 'alias d=docker' >> /home/agor/.bashrc && \
+    echo 'alias dc=docker-compose' >> /home/agor/.bashrc && \
     chown -R agor:agor /home/agor
 
-# Set environment
+# Minimal Zellij config
+RUN echo 'default_shell "bash"' > /home/agor/.config/zellij/config.kdl && \
+    echo 'pane_frames false' >> /home/agor/.config/zellij/config.kdl && \
+    chown -R agor:agor /home/agor/.config
+
 ENV HOME=/home/agor
 ENV USER=agor
 ENV SHELL=/bin/bash
 
-# Switch to non-root user
 USER agor
 WORKDIR /home/agor
 
-# Default command (overridden by K8s)
 CMD ["sleep", "infinity"]

--- a/helm/docker/Dockerfile.shell
+++ b/helm/docker/Dockerfile.shell
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     wget \
     ca-certificates \
+    # SSH server (for sshd sidecar container)
+    openssh-server \
     # Shell utilities
     bash \
     bash-completion \
@@ -30,37 +32,39 @@ RUN apt-get update && apt-get install -y \
     htop \
     # Build essentials (for some docker-compose projects)
     make \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # Create sshd privilege separation directory
+    && mkdir -p /run/sshd
 
-# Install Zellij from GitHub releases
+# Install Zellij from GitHub releases (optional - may fail in restricted networks)
 ARG TARGETARCH
 RUN ARCH=$(case "${TARGETARCH}" in \
         "amd64") echo "x86_64" ;; \
         "arm64") echo "aarch64" ;; \
         *) echo "x86_64" ;; \
     esac) && \
-    curl -fsSL "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
+    (curl -fsSL --connect-timeout 30 "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
     | tar -xz -C /usr/local/bin && \
-    chmod +x /usr/local/bin/zellij
+    chmod +x /usr/local/bin/zellij) || echo "Warning: Failed to install zellij (network issue?)"
 
-# Install docker-compose v2 (standalone)
+# Install docker-compose v2 (standalone, optional)
 RUN ARCH=$(case "${TARGETARCH}" in \
         "amd64") echo "x86_64" ;; \
         "arm64") echo "aarch64" ;; \
         *) echo "x86_64" ;; \
     esac) && \
-    curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
+    (curl -fsSL --connect-timeout 30 "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
     -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose) || echo "Warning: Failed to install docker-compose (network issue?)"
 
 # Create agor user with uid 1000
 RUN groupadd -g 1000 agor && \
     useradd -u 1000 -g 1000 -m -s /bin/bash agor
 
-# Setup .agor directory with symlinks to /data (mounted at runtime)
-RUN mkdir -p /home/agor/.agor && \
-    ln -s /data/worktrees /home/agor/.agor/worktrees && \
-    ln -s /data/repos /home/agor/.agor/repos
+# Note: Shell pods use dynamic users created by init container
+# Symlinks are created at runtime in /data/homes/<username>/.agor/
+RUN mkdir -p /home/agor/.agor
 
 # Setup home directory and config files
 RUN mkdir -p /home/agor/.config/zellij && \

--- a/helm/docker/Dockerfile.shell
+++ b/helm/docker/Dockerfile.shell
@@ -58,6 +58,15 @@ RUN ARCH=$(case "${TARGETARCH}" in \
     -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose) || echo "Warning: Failed to install docker-compose (network issue?)"
 
+# Install Node.js 22 LTS (required for Claude Code)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+
 # Create agor user with uid 1000
 RUN groupadd -g 1000 agor && \
     useradd -u 1000 -g 1000 -m -s /bin/bash agor

--- a/helm/docker/Dockerfile.shell
+++ b/helm/docker/Dockerfile.shell
@@ -1,0 +1,111 @@
+# Agor Shell Pod Dockerfile
+# Lightweight image for isolated terminal sessions
+#
+# Contains:
+# - Zellij (terminal multiplexer)
+# - Docker CLI (for DOCKER_HOST to Podman pod)
+# - Git (for version control)
+# - Common dev tools
+
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    # Docker CLI (uses DOCKER_HOST to connect to Podman pod)
+    docker.io \
+    # Version control
+    git \
+    # Networking tools
+    curl \
+    wget \
+    ca-certificates \
+    # Shell utilities
+    bash \
+    bash-completion \
+    less \
+    vim-tiny \
+    jq \
+    # Process management
+    procps \
+    htop \
+    # Build essentials (for some docker-compose projects)
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Zellij from GitHub releases
+ARG TARGETARCH
+RUN ARCH=$(case "${TARGETARCH}" in \
+        "amd64") echo "x86_64" ;; \
+        "arm64") echo "aarch64" ;; \
+        *) echo "x86_64" ;; \
+    esac) && \
+    curl -fsSL "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${ARCH}-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /usr/local/bin && \
+    chmod +x /usr/local/bin/zellij
+
+# Install docker-compose v2 (standalone)
+RUN ARCH=$(case "${TARGETARCH}" in \
+        "amd64") echo "x86_64" ;; \
+        "arm64") echo "aarch64" ;; \
+        *) echo "x86_64" ;; \
+    esac) && \
+    curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
+    -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+# Create agor user with uid 1000
+RUN groupadd -g 1000 agor && \
+    useradd -u 1000 -g 1000 -m -s /bin/bash agor
+
+# Setup .agor directory with symlinks to /data (mounted at runtime)
+RUN mkdir -p /home/agor/.agor && \
+    ln -s /data/worktrees /home/agor/.agor/worktrees && \
+    ln -s /data/repos /home/agor/.agor/repos
+
+# Setup home directory and config files
+RUN mkdir -p /home/agor/.config/zellij && \
+    # Default Zellij config (simple layout)
+    echo '// Agor shell pod Zellij config' > /home/agor/.config/zellij/config.kdl && \
+    echo 'default_shell "bash"' >> /home/agor/.config/zellij/config.kdl && \
+    echo 'pane_frames false' >> /home/agor/.config/zellij/config.kdl && \
+    echo 'theme "default"' >> /home/agor/.config/zellij/config.kdl && \
+    # Bash profile for nicer terminal experience
+    echo '# Agor shell pod bashrc' > /home/agor/.bashrc && \
+    echo "export PS1='\\[\\033[01;32m\\]\\u@agor\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\$ '" >> /home/agor/.bashrc && \
+    echo 'export EDITOR=vim' >> /home/agor/.bashrc && \
+    echo '' >> /home/agor/.bashrc && \
+    echo '# Docker aliases (works via DOCKER_HOST)' >> /home/agor/.bashrc && \
+    echo "alias d='docker'" >> /home/agor/.bashrc && \
+    echo "alias dc='docker-compose'" >> /home/agor/.bashrc && \
+    echo "alias dps='docker ps'" >> /home/agor/.bashrc && \
+    echo "alias dlogs='docker logs -f'" >> /home/agor/.bashrc && \
+    echo '' >> /home/agor/.bashrc && \
+    echo '# Git aliases' >> /home/agor/.bashrc && \
+    echo "alias gs='git status'" >> /home/agor/.bashrc && \
+    echo "alias gd='git diff'" >> /home/agor/.bashrc && \
+    echo "alias gl='git log --oneline -10'" >> /home/agor/.bashrc && \
+    echo '' >> /home/agor/.bashrc && \
+    echo '# Source bash completion' >> /home/agor/.bashrc && \
+    echo 'if [ -f /etc/bash_completion ]; then' >> /home/agor/.bashrc && \
+    echo '    . /etc/bash_completion' >> /home/agor/.bashrc && \
+    echo 'fi' >> /home/agor/.bashrc && \
+    echo '' >> /home/agor/.bashrc && \
+    echo '# Show DOCKER_HOST on login' >> /home/agor/.bashrc && \
+    echo 'if [ -n "$DOCKER_HOST" ]; then' >> /home/agor/.bashrc && \
+    echo '    echo "DOCKER_HOST: $DOCKER_HOST"' >> /home/agor/.bashrc && \
+    echo 'fi' >> /home/agor/.bashrc && \
+    echo '' >> /home/agor/.bashrc && \
+    echo 'cd "${WORKTREE_PATH:-$HOME}"' >> /home/agor/.bashrc && \
+    chown -R agor:agor /home/agor
+
+# Set environment
+ENV HOME=/home/agor
+ENV USER=agor
+ENV SHELL=/bin/bash
+
+# Switch to non-root user
+USER agor
+WORKDIR /home/agor
+
+# Default command (overridden by K8s)
+CMD ["sleep", "infinity"]

--- a/helm/docker/Dockerfile.ui
+++ b/helm/docker/Dockerfile.ui
@@ -33,6 +33,8 @@ RUN pnpm --filter @agor/core build
 ARG VITE_DAEMON_URL=""
 ENV VITE_DAEMON_URL=$VITE_DAEMON_URL
 ENV NODE_ENV=docker
+# Limit Node.js memory to prevent OOM during build
+ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN pnpm --filter agor-ui build
 
 # ============================================

--- a/helm/docker/Dockerfile.ui
+++ b/helm/docker/Dockerfile.ui
@@ -1,0 +1,58 @@
+# Agor UI Dockerfile
+# Multi-stage build: Node for building, nginx for serving
+
+# ============================================
+# Stage 1: Build
+# ============================================
+FROM node:22-bookworm-slim AS builder
+
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy package files
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY packages/core/package.json ./packages/core/
+COPY apps/agor-ui/package.json ./apps/agor-ui/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY packages/core ./packages/core
+COPY apps/agor-ui ./apps/agor-ui
+COPY turbo.json ./
+
+# Build core first (UI depends on it for types)
+RUN pnpm --filter @agor/core build
+
+# Build UI
+# VITE_DAEMON_URL is configured at runtime via nginx
+# NODE_ENV=docker to avoid /ui/ base path (production uses /ui/ for embedding)
+ARG VITE_DAEMON_URL=""
+ENV VITE_DAEMON_URL=$VITE_DAEMON_URL
+ENV NODE_ENV=docker
+RUN pnpm --filter agor-ui build
+
+# ============================================
+# Stage 2: Production (nginx)
+# ============================================
+FROM nginx:alpine AS production
+
+# Remove default config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy nginx configuration
+COPY helm/docker/nginx.conf /etc/nginx/conf.d/agor.conf
+
+# Copy built assets
+COPY --from=builder /app/apps/agor-ui/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget -q --spider http://localhost:8080/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/helm/docker/nginx.conf
+++ b/helm/docker/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 1000;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA routing - serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "OK";
+        add_header Content-Type text/plain;
+    }
+}

--- a/helm/postgres/README.md
+++ b/helm/postgres/README.md
@@ -1,0 +1,46 @@
+# PostgreSQL for Agor
+
+Standalone PostgreSQL deployment. Designed to be easily replaced with RDS.
+
+## Quick Deploy
+
+```bash
+# 1. Create secret (not in git)
+kubectl create secret generic postgres-credentials \
+  -n agor \
+  --from-literal=username=agor \
+  --from-literal=password=YOUR_PASSWORD \
+  --from-literal=database-url=postgresql://agor:YOUR_PASSWORD@postgres:5432/agor
+
+# 2. Deploy
+kubectl apply -k helm/postgres/ -n agor
+```
+
+## Migrating to RDS
+
+When ready to switch to RDS:
+
+1. Stop the agor-daemon deployment
+2. Update `postgres-credentials` secret with RDS connection details:
+   ```bash
+   kubectl create secret generic postgres-credentials \
+     -n agor \
+     --from-literal=username=agor \
+     --from-literal=password=YOUR_RDS_PASSWORD \
+     --from-literal=database-url=postgresql://agor:PASSWORD@your-rds-endpoint.rds.amazonaws.com:5432/agor \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+3. Delete the local postgres deployment:
+   ```bash
+   kubectl delete -f helm/postgres/deployment.yaml -n agor
+   kubectl delete -f helm/postgres/service.yaml -n agor
+   ```
+4. Restart agor-daemon
+
+## Connection Details
+
+- **Host**: `postgres` (cluster internal) or RDS endpoint
+- **Port**: `5432`
+- **Database**: `agor`
+- **User**: from secret `postgres-credentials.username`
+- **Password**: from secret `postgres-credentials.password`

--- a/helm/postgres/deployment.yaml
+++ b/helm/postgres/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # Required for RWO PVC
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/component: database
+    spec:
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "chown -R 70:70 /var/lib/postgresql/data"]
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      containers:
+        - name: postgres
+          image: postgres:18-alpine
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: agor
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/18/docker
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - agor
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - agor
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: agor-pgdata

--- a/helm/postgres/kustomization.yaml
+++ b/helm/postgres/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: agor
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/helm/postgres/service.yaml
+++ b/helm/postgres/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    app.kubernetes.io/name: postgres

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -11,6 +11,9 @@ daemon:
   # Symlink for path compatibility with local dev (e.g., /home/agorpg -> /home/agor)
   homeSymlink: agorpg
 
+  # Force pod restart on every helm upgrade (picks up new images)
+  forceRollout: true
+
   image:
     repository: agor/daemon
     tag: dev
@@ -49,6 +52,15 @@ daemon:
             limits:
               cpu: "1"
               memory: 1Gi
+        podmanPod:
+          image: agor/podman:dev
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 3Gi
         storage:
           dataPvc: agor-data
 
@@ -64,6 +76,15 @@ daemon:
         limits:
           cpu: "1"
           memory: 1Gi
+    podmanPod:
+      image: agor/podman:dev
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          cpu: "4"
+          memory: 6Gi
     storage:
       dataPvc: agor-data
 
@@ -98,16 +119,13 @@ ui:
       cpu: 100m
       memory: 64Mi
 
-# Enable ingress for local development with nginx
+# Enable ingress for local development with Traefik (Colima default)
 ingress:
   enabled: true
-  className: nginx
+  className: traefik
   annotations:
-    # WebSocket support
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
-    nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
+    # WebSocket support for Traefik
+    traefik.ingress.kubernetes.io/router.middlewares: ""
   hosts:
     - host: agor.local
       paths:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -54,11 +54,11 @@ daemon:
               memory: 1Gi
           sshdResources:
             requests:
-              cpu: 10m
-              memory: 32Mi
+              cpu: 50m
+              memory: 256Mi
             limits:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 500m
+              memory: 512Mi
         podmanPod:
           image: public.ecr.aws/a5v0t1w0/agor/podman:dev
           initImage: busybox:1.36
@@ -89,11 +89,11 @@ daemon:
           memory: 1Gi
       sshdResources:
         requests:
-          cpu: 10m
-          memory: 32Mi
+          cpu: 50m
+          memory: 256Mi
         limits:
-          cpu: 100m
-          memory: 64Mi
+          cpu: 500m
+          memory: 512Mi
     podmanPod:
       image: public.ecr.aws/a5v0t1w0/agor/podman:dev
       initImage: busybox:1.36

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -1,12 +1,12 @@
 # Development values for Agor
 # Usage: helm install agor ./helm/agor -f helm/values-dev.yaml
 
-# Database: PostgreSQL (local docker container via host.docker.internal)
+# Database: PostgreSQL
 database:
   type: postgresql
-  existingSecret: agor-db-credentials-local
+  existingSecret: postgres-credentials
 
-# Use local images (built with docker build)
+# Use ECR images
 daemon:
   # Symlink for path compatibility with local dev (e.g., /home/agorpg -> /home/agor)
   homeSymlink: agorpg
@@ -15,9 +15,9 @@ daemon:
   forceRollout: true
 
   image:
-    repository: agor/daemon
+    repository: public.ecr.aws/a5v0t1w0/agor/daemon
     tag: dev
-    pullPolicy: Never  # Use local image
+    pullPolicy: Always
 
   # Smaller resources for dev
   resources:
@@ -44,7 +44,7 @@ daemon:
       user_pods:
         enabled: true
         shellPod:
-          image: agor/shell:dev
+          image: public.ecr.aws/a5v0t1w0/agor/shell:dev
           resources:
             requests:
               cpu: 50m
@@ -52,8 +52,16 @@ daemon:
             limits:
               cpu: "1"
               memory: 1Gi
+          sshdResources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
         podmanPod:
-          image: agor/podman:dev
+          image: public.ecr.aws/a5v0t1w0/agor/podman:dev
+          initImage: busybox:1.36
           resources:
             requests:
               cpu: 100m
@@ -62,13 +70,16 @@ daemon:
               cpu: "2"
               memory: 3Gi
         storage:
-          dataPvc: agor-data
+          dataPvc: agor-data-nfs
+        appBaseDomain: agor-k8s.sandbox.preset.zone
+        ingressClassName: traefik
+        sshEntryPoint: ssh
 
   # User Pods configuration (for terminal_mode: pod)
   userPods:
     enabled: true
     shellPod:
-      image: agor/shell:dev
+      image: public.ecr.aws/a5v0t1w0/agor/shell:dev
       resources:
         requests:
           cpu: 50m
@@ -76,8 +87,16 @@ daemon:
         limits:
           cpu: "1"
           memory: 1Gi
+      sshdResources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
     podmanPod:
-      image: agor/podman:dev
+      image: public.ecr.aws/a5v0t1w0/agor/podman:dev
+      initImage: busybox:1.36
       resources:
         requests:
           cpu: 100m
@@ -86,10 +105,16 @@ daemon:
           cpu: "4"
           memory: 6Gi
     storage:
-      dataPvc: agor-data
+      dataPvc: agor-data-nfs
+    appBaseDomain: agor-k8s.sandbox.preset.zone
+    ingressClassName: traefik
+    sshEntryPoint: ssh
 
   # Skip admin bootstrap - using external PostgreSQL
   skipAdminBootstrap: true
+
+  # Skip migrations on startup (run manually when schema changes)
+  skipMigrations: true
 
   # Extra environment variables
   extraEnv:
@@ -99,17 +124,20 @@ daemon:
           name: agor-github-token
           key: token
 
-  # Enable persistence with local PVC (simulating EFS)
+  # Enable persistence with NFS PVCs
   persistence:
     enabled: true
+    storageClass: nfs
+    home:
+      existingClaim: agor-home-nfs
     data:
-      existingClaim: agor-data
+      existingClaim: agor-data-nfs
 
 ui:
   image:
-    repository: agor/ui
+    repository: public.ecr.aws/a5v0t1w0/agor/ui
     tag: dev
-    pullPolicy: Never  # Use local image
+    pullPolicy: Always
 
   resources:
     requests:
@@ -119,7 +147,7 @@ ui:
       cpu: 100m
       memory: 64Mi
 
-# Enable ingress for local development with Traefik (Colima default)
+# Enable ingress
 ingress:
   enabled: true
   className: traefik
@@ -127,7 +155,8 @@ ingress:
     # WebSocket support for Traefik
     traefik.ingress.kubernetes.io/router.middlewares: ""
   hosts:
-    - host: agor.local
+    # Main domain
+    - host: agor-k8s.sandbox.preset.zone
       paths:
         - path: /
           pathType: Prefix
@@ -138,7 +167,6 @@ ingress:
         - path: /socket.io
           pathType: Prefix
           service: daemon
-        # All API service routes
         - path: /users
           pathType: Prefix
           service: daemon

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -1,0 +1,123 @@
+# Development values for Agor
+# Usage: helm install agor ./helm/agor -f helm/values-dev.yaml
+
+# Database: PostgreSQL
+database:
+  type: postgresql
+  existingSecret: agor-db-credentials
+
+# Use local images (built with docker build)
+daemon:
+  # Symlink for path compatibility with local dev (e.g., /home/agorpg -> /home/agor)
+  homeSymlink: agorpg
+
+  image:
+    repository: agor/daemon
+    tag: dev
+    pullPolicy: Never  # Use local image
+
+  # Smaller resources for dev
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # Dev configuration
+  config:
+    daemon:
+      port: 3030
+      requireAuth: true
+      allowAnonymous: false
+    execution:
+      worktree_rbac: false
+      unix_user_mode: opportunistic
+
+  # Skip admin bootstrap - using external PostgreSQL
+  skipAdminBootstrap: true
+
+  # Extra environment variables
+  extraEnv:
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: agor-github-token
+          key: token
+
+  # Disable persistence for quick iteration (use emptyDir)
+  persistence:
+    enabled: false
+
+ui:
+  image:
+    repository: agor/ui
+    tag: dev
+    pullPolicy: Never  # Use local image
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+# Enable ingress for local development with nginx
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    # WebSocket support
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
+  hosts:
+    - host: agor.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: ui
+        - path: /health
+          pathType: Prefix
+          service: daemon
+        - path: /socket.io
+          pathType: Prefix
+          service: daemon
+        # All API service routes
+        - path: /users
+          pathType: Prefix
+          service: daemon
+        - path: /sessions
+          pathType: Prefix
+          service: daemon
+        - path: /tasks
+          pathType: Prefix
+          service: daemon
+        - path: /messages
+          pathType: Prefix
+          service: daemon
+        - path: /worktrees
+          pathType: Prefix
+          service: daemon
+        - path: /repos
+          pathType: Prefix
+          service: daemon
+        - path: /boards
+          pathType: Prefix
+          service: daemon
+        - path: /board-objects
+          pathType: Prefix
+          service: daemon
+        - path: /terminals
+          pathType: Prefix
+          service: daemon
+        - path: /auth
+          pathType: Prefix
+          service: daemon
+
+# Disable security context for local dev (simpler)
+podSecurityContext: {}
+securityContext: {}

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -1,10 +1,10 @@
 # Development values for Agor
 # Usage: helm install agor ./helm/agor -f helm/values-dev.yaml
 
-# Database: PostgreSQL
+# Database: PostgreSQL (local docker container via host.docker.internal)
 database:
   type: postgresql
-  existingSecret: agor-db-credentials
+  existingSecret: agor-db-credentials-local
 
 # Use local images (built with docker build)
 daemon:
@@ -34,6 +34,38 @@ daemon:
     execution:
       worktree_rbac: false
       unix_user_mode: opportunistic
+      terminal_mode: pod  # Use isolated shell pods instead of daemon
+      unix_uid_range:
+        min: 10000
+        max: 60000
+      user_pods:
+        enabled: true
+        shellPod:
+          image: agor/shell:dev
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+        storage:
+          dataPvc: agor-data
+
+  # User Pods configuration (for terminal_mode: pod)
+  userPods:
+    enabled: true
+    shellPod:
+      image: agor/shell:dev
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+    storage:
+      dataPvc: agor-data
 
   # Skip admin bootstrap - using external PostgreSQL
   skipAdminBootstrap: true
@@ -46,9 +78,11 @@ daemon:
           name: agor-github-token
           key: token
 
-  # Disable persistence for quick iteration (use emptyDir)
+  # Enable persistence with local PVC (simulating EFS)
   persistence:
-    enabled: false
+    enabled: true
+    data:
+      existingClaim: agor-data
 
 ui:
   image:

--- a/helm/values-postgres.yaml
+++ b/helm/values-postgres.yaml
@@ -1,0 +1,106 @@
+# PostgreSQL configuration for Agor
+# Usage: helm install agor ./helm/agor -f helm/values-postgres.yaml
+
+# Database: PostgreSQL
+database:
+  type: postgresql
+  postgresql:
+    host: postgres.default.svc.cluster.local
+    port: 5432
+    database: agor
+    username: agor
+    password: changeme  # Use existingSecret in production!
+    sslMode: disable    # Use 'require' in production
+
+  # For production, use a secret instead:
+  # existingSecret: agor-db-credentials
+  # Secret should contain: DATABASE_URL
+
+# Daemon configuration
+daemon:
+  image:
+    repository: agor/daemon
+    tag: dev
+    pullPolicy: Never
+
+  config:
+    daemon:
+      port: 3030
+      requireAuth: true
+      allowAnonymous: false
+    execution:
+      worktree_rbac: false
+
+  # Skip admin bootstrap - manage users externally for shared DB
+  skipAdminBootstrap: true
+
+  # Disable data persistence (using external DB)
+  # Still need worktrees persistence for git repos
+  persistence:
+    enabled: true
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# UI configuration
+ui:
+  image:
+    repository: agor/ui
+    tag: dev
+    pullPolicy: Never
+
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: agor.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: ui
+        - path: /health
+          pathType: Prefix
+          service: daemon
+        - path: /socket.io
+          pathType: Prefix
+          service: daemon
+        - path: /users
+          pathType: Prefix
+          service: daemon
+        - path: /sessions
+          pathType: Prefix
+          service: daemon
+        - path: /tasks
+          pathType: Prefix
+          service: daemon
+        - path: /messages
+          pathType: Prefix
+          service: daemon
+        - path: /worktrees
+          pathType: Prefix
+          service: daemon
+        - path: /repos
+          pathType: Prefix
+          service: daemon
+        - path: /boards
+          pathType: Prefix
+          service: daemon
+        - path: /board-objects
+          pathType: Prefix
+          service: daemon
+        - path: /terminals
+          pathType: Prefix
+          service: daemon
+        - path: /auth
+          pathType: Prefix
+          service: daemon
+
+# Disable security context for simpler setup
+podSecurityContext: {}
+securityContext: {}

--- a/helm/values-turso.yaml
+++ b/helm/values-turso.yaml
@@ -1,0 +1,102 @@
+# Turso (libSQL cloud) configuration for Agor
+# Usage: helm install agor ./helm/agor -f helm/values-turso.yaml
+
+# Database: Turso (libSQL cloud)
+database:
+  type: turso
+  turso:
+    url: "libsql://your-db-name.turso.io"
+    authToken: ""  # Set via --set or use existingSecret
+
+  # For production, use a secret:
+  # existingSecret: agor-turso-credentials
+  # Secret should contain: DATABASE_URL, TURSO_AUTH_TOKEN
+
+# Daemon configuration
+daemon:
+  image:
+    repository: agor/daemon
+    tag: dev
+    pullPolicy: Never
+
+  config:
+    daemon:
+      port: 3030
+      requireAuth: true
+      allowAnonymous: false
+    execution:
+      worktree_rbac: false
+
+  # Skip admin bootstrap - manage users externally for shared DB
+  skipAdminBootstrap: true
+
+  # Disable data persistence (using cloud DB)
+  # Still need worktrees persistence for git repos
+  persistence:
+    enabled: true
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# UI configuration
+ui:
+  image:
+    repository: agor/ui
+    tag: dev
+    pullPolicy: Never
+
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: agor.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: ui
+        - path: /health
+          pathType: Prefix
+          service: daemon
+        - path: /socket.io
+          pathType: Prefix
+          service: daemon
+        - path: /users
+          pathType: Prefix
+          service: daemon
+        - path: /sessions
+          pathType: Prefix
+          service: daemon
+        - path: /tasks
+          pathType: Prefix
+          service: daemon
+        - path: /messages
+          pathType: Prefix
+          service: daemon
+        - path: /worktrees
+          pathType: Prefix
+          service: daemon
+        - path: /repos
+          pathType: Prefix
+          service: daemon
+        - path: /boards
+          pathType: Prefix
+          service: daemon
+        - path: /board-objects
+          pathType: Prefix
+          service: daemon
+        - path: /terminals
+          pathType: Prefix
+          service: daemon
+        - path: /auth
+          pathType: Prefix
+          service: daemon
+
+# Disable security context for simpler setup
+podSecurityContext: {}
+securityContext: {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -149,6 +149,11 @@
       "types": "./dist/unix/index.d.ts",
       "import": "./dist/unix/index.js",
       "require": "./dist/unix/index.cjs"
+    },
+    "./kubernetes": {
+      "types": "./dist/kubernetes/index.d.ts",
+      "import": "./dist/kubernetes/index.js",
+      "require": "./dist/kubernetes/index.cjs"
     }
   },
   "scripts": {
@@ -171,6 +176,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.55",
     "@feathersjs/authentication": "^5.0.37",
+    "@kubernetes/client-node": "^0.22.3",
     "@feathersjs/authentication-client": "^5.0.37",
     "@feathersjs/authentication-local": "^5.0.37",
     "@feathersjs/errors": "^5.0.37",

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -145,6 +145,43 @@ export interface AgorCodexSettings {
 }
 
 /**
+ * User Pods configuration for terminal_mode: pod
+ */
+export interface AgorUserPodsSettings {
+  /** Enable user pods (default: false) */
+  enabled?: boolean;
+
+  /** Shell pod configuration */
+  shellPod?: {
+    image?: string;
+    resources?: {
+      requests?: { cpu?: string; memory?: string };
+      limits?: { cpu?: string; memory?: string };
+    };
+  };
+
+  /** Podman pod configuration */
+  podmanPod?: {
+    image?: string;
+    resources?: {
+      requests?: { cpu?: string; memory?: string };
+      limits?: { cpu?: string; memory?: string };
+    };
+  };
+
+  /** Idle timeout in minutes */
+  idleTimeoutMinutes?: {
+    shell?: number;
+    podman?: number;
+  };
+
+  /** Storage PVC name */
+  storage?: {
+    dataPvc?: string;
+  };
+}
+
+/**
  * Execution settings
  */
 export interface AgorExecutionSettings {
@@ -165,6 +202,18 @@ export interface AgorExecutionSettings {
 
   /** Sync web passwords to Unix user passwords (default: true). When enabled, passwords are synced on user creation/update. */
   sync_unix_passwords?: boolean;
+
+  /** Terminal execution mode: daemon (run in daemon pod), pod (isolated user pods) */
+  terminal_mode?: 'daemon' | 'pod';
+
+  /** User pods configuration (for terminal_mode: pod) */
+  user_pods?: AgorUserPodsSettings;
+
+  /** Unix UID range for user allocation (default: 10000-60000) */
+  unix_uid_range?: {
+    min?: number;
+    max?: number;
+  };
 }
 
 /**

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -38,6 +38,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
       emoji: row.emoji ?? undefined,
       role: row.role,
       unix_username: row.unix_username ?? undefined,
+      unix_uid: row.unix_uid ?? undefined,
       onboarding_completed: row.onboarding_completed,
       avatar: row.data.avatar,
       preferences: row.data.preferences as User['preferences'],
@@ -83,6 +84,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
       emoji: user.emoji ?? null,
       role: user.role ?? 'member',
       unix_username: user.unix_username ?? null,
+      unix_uid: user.unix_uid ?? null,
       onboarding_completed: user.onboarding_completed ?? false,
       data: {
         avatar: user.avatar,

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -136,10 +136,11 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
     }
 
     // Short ID match (prefix) - just use the id directly as a prefix since it's already short
+    // Use LOWER() for case-insensitive matching (PostgreSQL LIKE is case-sensitive)
     const prefix = id.replace(/-/g, '').toLowerCase();
     const matches = await select(this.db)
       .from(worktrees)
-      .where(like(worktrees.worktree_id, `${prefix}%`))
+      .where(sql`LOWER(${worktrees.worktree_id}) LIKE ${prefix + '%'}`)
       .limit(2); // Fetch 2 to detect ambiguity
 
     if (matches.length === 0) return null;

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -572,6 +572,10 @@ export const users = pgTable(
     // Unix username for process impersonation (optional, app-enforced uniqueness)
     unix_username: text('unix_username'),
 
+    // Unix UID for container security context (consistent file ownership on EFS/NFS)
+    // Assigned from configurable range (default 10000-60000) when unix_username is set
+    unix_uid: integer('unix_uid'),
+
     // Onboarding state
     onboarding_completed: t.bool('onboarding_completed').notNull().default(false),
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -563,6 +563,10 @@ export const users = sqliteTable(
     // Unix username for process impersonation (optional, app-enforced uniqueness)
     unix_username: text('unix_username'),
 
+    // Unix UID for container security context (consistent file ownership on EFS/NFS)
+    // Assigned from configurable range (default 10000-60000) when unix_username is set
+    unix_uid: integer('unix_uid'),
+
     // Onboarding state
     onboarding_completed: t.bool('onboarding_completed').notNull().default(false),
 

--- a/packages/core/src/kubernetes/index.ts
+++ b/packages/core/src/kubernetes/index.ts
@@ -22,6 +22,7 @@ export {
   buildPodmanDeploymentManifest,
   buildPodmanServiceManifest,
   buildShellDeploymentManifest,
+  buildShellSshServiceManifest,
   type PodmanPodParams,
   type ShellPodParams,
 } from './pod-manifests.js';
@@ -39,6 +40,9 @@ export {
   getPodmanPodName,
   getPodmanServiceName,
   getShellPodName,
+  getShellSshHostname,
+  getShellSshIngressRouteName,
+  getShellSshServiceName,
   getUserShortId,
   getWorktreeShortId,
   // Labels and annotations

--- a/packages/core/src/kubernetes/index.ts
+++ b/packages/core/src/kubernetes/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Kubernetes Integration Module
+ *
+ * Provides isolated terminal pod management for Kubernetes deployments.
+ *
+ * @module kubernetes
+ */
+
+// Pod manager
+export {
+  getPodManager,
+  PodManager,
+  PodManagerError,
+  type PodManagerOptions,
+  resetPodManager,
+} from './pod-manager';
+
+// Pod manifest builders
+export {
+  buildPodmanPodManifest,
+  buildPodmanServiceManifest,
+  buildShellPodManifest,
+  type PodmanPodParams,
+  type ShellPodParams,
+} from './pod-manifests';
+// Types
+export {
+  DEFAULT_USER_POD_CONFIG,
+  getDockerHost,
+  getPodmanPodName,
+  getPodmanServiceName,
+  getShellPodName,
+  POD_ANNOTATIONS,
+  POD_LABEL_VALUES,
+  POD_LABELS,
+  type PodmanPodConfig,
+  type PodmanPodInfo,
+  SERVICE_ACCOUNTS,
+  type ShellPodConfig,
+  type ShellPodInfo,
+  type TerminalMode,
+  type UserPodConfig,
+} from './types';

--- a/packages/core/src/kubernetes/index.ts
+++ b/packages/core/src/kubernetes/index.ts
@@ -13,34 +13,44 @@ export {
   PodManagerError,
   type PodManagerOptions,
   resetPodManager,
-} from './pod-manager';
+} from './pod-manager.js';
 
 // Deployment manifest builders
 export {
+  buildAppIngressManifest,
+  buildAppServiceManifest,
   buildPodmanDeploymentManifest,
   buildPodmanServiceManifest,
   buildShellDeploymentManifest,
   type PodmanPodParams,
   type ShellPodParams,
-} from './pod-manifests';
+} from './pod-manifests.js';
 
-// Legacy Pod manifests (deprecated)
-export { buildPodmanPodManifest, buildShellPodManifest } from './pod-manifests';
-// Types
+// Template loader (for advanced use cases)
+export { clearTemplateCache } from './template-loader.js';
+
+// Types and naming utilities
 export {
   DEFAULT_USER_POD_CONFIG,
+  // Naming functions
+  getAppIngressName,
+  getAppServiceName,
   getDockerHost,
   getPodmanPodName,
   getPodmanServiceName,
   getShellPodName,
+  getUserShortId,
+  getWorktreeShortId,
+  // Labels and annotations
   POD_ANNOTATIONS,
   POD_LABEL_VALUES,
   POD_LABELS,
+  SERVICE_ACCOUNTS,
+  // Types
   type PodmanPodConfig,
   type PodmanPodInfo,
-  SERVICE_ACCOUNTS,
   type ShellPodConfig,
   type ShellPodInfo,
   type TerminalMode,
   type UserPodConfig,
-} from './types';
+} from './types.js';

--- a/packages/core/src/kubernetes/index.ts
+++ b/packages/core/src/kubernetes/index.ts
@@ -15,14 +15,17 @@ export {
   resetPodManager,
 } from './pod-manager';
 
-// Pod manifest builders
+// Deployment manifest builders
 export {
-  buildPodmanPodManifest,
+  buildPodmanDeploymentManifest,
   buildPodmanServiceManifest,
-  buildShellPodManifest,
+  buildShellDeploymentManifest,
   type PodmanPodParams,
   type ShellPodParams,
 } from './pod-manifests';
+
+// Legacy Pod manifests (deprecated)
+export { buildPodmanPodManifest, buildShellPodManifest } from './pod-manifests';
 // Types
 export {
   DEFAULT_USER_POD_CONFIG,

--- a/packages/core/src/kubernetes/pod-manager.ts
+++ b/packages/core/src/kubernetes/pod-manager.ts
@@ -116,11 +116,13 @@ export class PodManager {
    * Creates Podman deployment first if needed (shared for worktree)
    * Returns the actual pod name (not deployment name) for exec
    *
+   * @param worktreeName - Worktree name (used as pod hostname)
    * @param userUid - Unix UID for consistent file ownership on EFS/NFS
    * @param unixUsername - Unix username for /etc/passwd entry
    */
   async ensureShellPod(
     worktreeId: WorktreeID,
+    worktreeName: string,
     userId: UserID,
     worktreePath: string,
     userUid?: number,
@@ -154,7 +156,7 @@ export class PodManager {
       const e = error as { statusCode?: number };
       if (e.statusCode === 404) {
         // Create shell deployment
-        await this.createShellDeployment(worktreeId, userId, worktreePath, userUid, unixUsername);
+        await this.createShellDeployment(worktreeId, worktreeName, userId, worktreePath, userUid, unixUsername);
         await this.waitForDeployment(deploymentName);
       } else {
         throw new PodManagerError(
@@ -214,6 +216,7 @@ export class PodManager {
    */
   private async createShellDeployment(
     worktreeId: WorktreeID,
+    worktreeName: string,
     userId: UserID,
     worktreePath: string,
     userUid?: number,
@@ -221,6 +224,7 @@ export class PodManager {
   ): Promise<void> {
     const manifest = buildShellDeploymentManifest({
       worktreeId,
+      worktreeName,
       userId,
       worktreePath,
       config: this.config,

--- a/packages/core/src/kubernetes/pod-manager.ts
+++ b/packages/core/src/kubernetes/pod-manager.ts
@@ -1,0 +1,552 @@
+/**
+ * Kubernetes Pod Manager
+ *
+ * Manages shell pods and Podman pods for isolated terminal execution.
+ * Uses @kubernetes/client-node to interact with the Kubernetes API.
+ */
+
+import * as k8s from '@kubernetes/client-node';
+import type { UserID, WorktreeID } from '../types/id.js';
+import {
+  buildPodmanPodManifest,
+  buildPodmanServiceManifest,
+  buildShellPodManifest,
+} from './pod-manifests';
+import {
+  DEFAULT_USER_POD_CONFIG,
+  getPodmanPodName,
+  getPodmanServiceName,
+  getShellPodName,
+  POD_ANNOTATIONS,
+  POD_LABEL_VALUES,
+  POD_LABELS,
+  type PodmanPodInfo,
+  type ShellPodInfo,
+  type UserPodConfig,
+} from './types';
+
+/**
+ * Error thrown when a pod operation fails
+ */
+export class PodManagerError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: number,
+    public readonly podName?: string
+  ) {
+    super(message);
+    this.name = 'PodManagerError';
+  }
+}
+
+/**
+ * Options for creating PodManager
+ */
+export interface PodManagerOptions {
+  config?: Partial<UserPodConfig>;
+  kubeConfigPath?: string; // For testing outside cluster
+}
+
+/**
+ * Manages Kubernetes pods for isolated terminal execution
+ */
+export class PodManager {
+  private kc: k8s.KubeConfig;
+  private k8sApi: k8s.CoreV1Api;
+  private exec: k8s.Exec;
+  private config: UserPodConfig;
+  private initialized = false;
+
+  constructor(options: PodManagerOptions = {}) {
+    this.kc = new k8s.KubeConfig();
+    this.config = { ...DEFAULT_USER_POD_CONFIG, ...options.config };
+
+    // Load kubeconfig
+    if (options.kubeConfigPath) {
+      this.kc.loadFromFile(options.kubeConfigPath);
+    } else {
+      try {
+        this.kc.loadFromCluster();
+      } catch {
+        // Fallback to default config for local development
+        this.kc.loadFromDefault();
+      }
+    }
+
+    this.k8sApi = this.kc.makeApiClient(k8s.CoreV1Api);
+    this.exec = new k8s.Exec(this.kc);
+    this.initialized = true;
+  }
+
+  /**
+   * Check if PodManager is initialized and enabled
+   */
+  isEnabled(): boolean {
+    return this.initialized && this.config.enabled;
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): UserPodConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Update configuration
+   */
+  updateConfig(config: Partial<UserPodConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  /**
+   * Ensure shell pod exists for user + worktree
+   * Creates Podman pod first if needed (shared for worktree)
+   *
+   * @param userUid - Unix UID for consistent file ownership on EFS/NFS
+   * @param unixUsername - Unix username for /etc/passwd entry
+   */
+  async ensureShellPod(
+    worktreeId: WorktreeID,
+    userId: UserID,
+    worktreePath: string,
+    userUid?: number,
+    unixUsername?: string
+  ): Promise<string> {
+    const shellPodName = getShellPodName(worktreeId, userId);
+
+    // Ensure Podman pod exists first (shared for worktree)
+    await this.ensurePodmanPod(worktreeId, worktreePath);
+
+    try {
+      const { body: pod } = await this.k8sApi.readNamespacedPod(
+        shellPodName,
+        this.config.namespace
+      );
+
+      if (pod.status?.phase === 'Running') {
+        // Update last activity
+        await this.updateLastActivity(shellPodName);
+        return shellPodName;
+      }
+
+      // Pod exists but not running, wait for it
+      await this.waitForPod(shellPodName);
+      return shellPodName;
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number };
+      if (e.statusCode === 404) {
+        // Create shell pod
+        await this.createShellPod(worktreeId, userId, worktreePath, userUid, unixUsername);
+        await this.waitForPod(shellPodName);
+        return shellPodName;
+      }
+      throw new PodManagerError(
+        `Failed to get shell pod: ${error instanceof Error ? error.message : String(error)}`,
+        e.statusCode,
+        shellPodName
+      );
+    }
+  }
+
+  /**
+   * Ensure Podman pod exists for worktree (shared by all users)
+   */
+  async ensurePodmanPod(worktreeId: WorktreeID, worktreePath: string): Promise<string> {
+    const podmanPodName = getPodmanPodName(worktreeId);
+
+    try {
+      const { body: pod } = await this.k8sApi.readNamespacedPod(
+        podmanPodName,
+        this.config.namespace
+      );
+
+      if (pod.status?.phase === 'Running') {
+        return podmanPodName;
+      }
+
+      // Pod exists but not running, wait for it
+      await this.waitForPod(podmanPodName);
+      return podmanPodName;
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number };
+      if (e.statusCode === 404) {
+        // Create Podman pod and service
+        await this.createPodmanPod(worktreeId, worktreePath);
+        await this.createPodmanService(worktreeId);
+        await this.waitForPod(podmanPodName);
+        return podmanPodName;
+      }
+      throw new PodManagerError(
+        `Failed to get Podman pod: ${error instanceof Error ? error.message : String(error)}`,
+        e.statusCode,
+        podmanPodName
+      );
+    }
+  }
+
+  /**
+   * Create shell pod
+   */
+  private async createShellPod(
+    worktreeId: WorktreeID,
+    userId: UserID,
+    worktreePath: string,
+    userUid?: number,
+    unixUsername?: string
+  ): Promise<void> {
+    const manifest = buildShellPodManifest({
+      worktreeId,
+      userId,
+      worktreePath,
+      config: this.config,
+      userUid,
+      unixUsername,
+    });
+
+    console.log(
+      `[PodManager] Creating shell pod: ${manifest.metadata?.name} (UID: ${userUid ?? 'default'})`
+    );
+
+    try {
+      await this.k8sApi.createNamespacedPod(this.config.namespace, manifest);
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number; body?: { message?: string } };
+      throw new PodManagerError(
+        `Failed to create shell pod: ${e.body?.message || String(error)}`,
+        e.statusCode,
+        manifest.metadata?.name
+      );
+    }
+  }
+
+  /**
+   * Create Podman pod
+   */
+  private async createPodmanPod(worktreeId: WorktreeID, worktreePath: string): Promise<void> {
+    const manifest = buildPodmanPodManifest({
+      worktreeId,
+      worktreePath,
+      config: this.config,
+    });
+
+    console.log(`[PodManager] Creating Podman pod: ${manifest.metadata?.name}`);
+
+    try {
+      await this.k8sApi.createNamespacedPod(this.config.namespace, manifest);
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number; body?: { message?: string } };
+      throw new PodManagerError(
+        `Failed to create Podman pod: ${e.body?.message || String(error)}`,
+        e.statusCode,
+        manifest.metadata?.name
+      );
+    }
+  }
+
+  /**
+   * Create Podman service
+   */
+  private async createPodmanService(worktreeId: WorktreeID): Promise<void> {
+    const manifest = buildPodmanServiceManifest(worktreeId, this.config);
+    const serviceName = manifest.metadata?.name;
+
+    console.log(`[PodManager] Creating Podman service: ${serviceName}`);
+
+    try {
+      await this.k8sApi.createNamespacedService(this.config.namespace, manifest);
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number; body?: { message?: string } };
+      // Ignore if service already exists
+      if (e.statusCode !== 409) {
+        throw new PodManagerError(
+          `Failed to create Podman service: ${e.body?.message || String(error)}`,
+          e.statusCode
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete shell pod
+   */
+  async deleteShellPod(worktreeId: WorktreeID, userId: UserID): Promise<void> {
+    const podName = getShellPodName(worktreeId, userId);
+
+    console.log(`[PodManager] Deleting shell pod: ${podName}`);
+
+    try {
+      await this.k8sApi.deleteNamespacedPod(podName, this.config.namespace);
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number };
+      // Ignore if already deleted
+      if (e.statusCode !== 404) {
+        throw new PodManagerError(
+          `Failed to delete shell pod: ${error instanceof Error ? error.message : String(error)}`,
+          e.statusCode,
+          podName
+        );
+      }
+    }
+  }
+
+  /**
+   * Delete Podman pod and service
+   */
+  async deletePodmanPod(worktreeId: WorktreeID): Promise<void> {
+    const podName = getPodmanPodName(worktreeId);
+    const serviceName = getPodmanServiceName(worktreeId);
+
+    console.log(`[PodManager] Deleting Podman pod and service: ${podName}`);
+
+    try {
+      await this.k8sApi.deleteNamespacedPod(podName, this.config.namespace);
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number };
+      if (e.statusCode !== 404) {
+        console.error(`Failed to delete Podman pod ${podName}:`, error);
+      }
+    }
+
+    try {
+      await this.k8sApi.deleteNamespacedService(serviceName, this.config.namespace);
+    } catch (error: unknown) {
+      const e = error as { statusCode?: number };
+      if (e.statusCode !== 404) {
+        console.error(`Failed to delete Podman service ${serviceName}:`, error);
+      }
+    }
+  }
+
+  /**
+   * Update last activity annotation on pod
+   */
+  async updateLastActivity(podName: string): Promise<void> {
+    try {
+      await this.k8sApi.patchNamespacedPod(
+        podName,
+        this.config.namespace,
+        {
+          metadata: {
+            annotations: {
+              [POD_ANNOTATIONS.LAST_ACTIVITY]: new Date().toISOString(),
+            },
+          },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { headers: { 'Content-Type': 'application/merge-patch+json' } }
+      );
+    } catch (error) {
+      // Non-critical, just log
+      console.warn(`Failed to update last activity for ${podName}:`, error);
+    }
+  }
+
+  /**
+   * Wait for pod to be running
+   */
+  private async waitForPod(podName: string, timeoutMs = 60000): Promise<void> {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const { body: pod } = await this.k8sApi.readNamespacedPod(podName, this.config.namespace);
+
+        if (pod.status?.phase === 'Running') {
+          return;
+        }
+
+        if (pod.status?.phase === 'Failed' || pod.status?.phase === 'Succeeded') {
+          throw new PodManagerError(
+            `Pod ${podName} is in terminal state: ${pod.status.phase}`,
+            undefined,
+            podName
+          );
+        }
+      } catch (error: unknown) {
+        const e = error as { statusCode?: number };
+        if (e.statusCode !== 404) {
+          throw error;
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    throw new PodManagerError(`Timeout waiting for pod ${podName} to be ready`, undefined, podName);
+  }
+
+  /**
+   * List all shell pods
+   */
+  async listShellPods(): Promise<ShellPodInfo[]> {
+    const { body } = await this.k8sApi.listNamespacedPod(
+      this.config.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${POD_LABELS.COMPONENT}=${POD_LABEL_VALUES.TERMINAL}`
+    );
+
+    return body.items.map((pod) => ({
+      podName: pod.metadata?.name || '',
+      worktreeId: (pod.metadata?.labels?.[POD_LABELS.WORKTREE_ID] || '') as WorktreeID,
+      userId: (pod.metadata?.labels?.[POD_LABELS.USER_ID] || '') as UserID,
+      createdAt: pod.metadata?.annotations?.[POD_ANNOTATIONS.CREATED_AT] || '',
+      lastActivity: pod.metadata?.annotations?.[POD_ANNOTATIONS.LAST_ACTIVITY] || '',
+      status: (pod.status?.phase as ShellPodInfo['status']) || 'Unknown',
+    }));
+  }
+
+  /**
+   * List all Podman pods
+   */
+  async listPodmanPods(): Promise<PodmanPodInfo[]> {
+    const { body } = await this.k8sApi.listNamespacedPod(
+      this.config.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${POD_LABELS.COMPONENT}=${POD_LABEL_VALUES.CONTAINER_RUNTIME}`
+    );
+
+    return body.items.map((pod) => {
+      const worktreeId = (pod.metadata?.labels?.[POD_LABELS.WORKTREE_ID] || '') as WorktreeID;
+      return {
+        podName: pod.metadata?.name || '',
+        serviceName: getPodmanServiceName(worktreeId),
+        worktreeId,
+        createdAt: pod.metadata?.annotations?.[POD_ANNOTATIONS.CREATED_AT] || '',
+        lastActivity: pod.metadata?.annotations?.[POD_ANNOTATIONS.LAST_ACTIVITY] || '',
+        status: (pod.status?.phase as PodmanPodInfo['status']) || 'Unknown',
+      };
+    });
+  }
+
+  /**
+   * Garbage collect idle shell pods
+   */
+  async gcIdleShellPods(): Promise<number> {
+    const pods = await this.listShellPods();
+    const now = Date.now();
+    const timeoutMs = this.config.idleTimeoutMinutes.shell * 60 * 1000;
+    let deleted = 0;
+
+    for (const pod of pods) {
+      if (pod.lastActivity) {
+        const idleMs = now - new Date(pod.lastActivity).getTime();
+        if (idleMs > timeoutMs) {
+          console.log(
+            `[PodManager] GC: Deleting idle shell pod ${pod.podName} (idle ${Math.round(idleMs / 60000)}min)`
+          );
+          try {
+            await this.k8sApi.deleteNamespacedPod(pod.podName, this.config.namespace);
+            deleted++;
+          } catch (error) {
+            console.error(`Failed to delete shell pod ${pod.podName}:`, error);
+          }
+        }
+      }
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Garbage collect orphaned Podman pods (no active shell pods)
+   */
+  async gcOrphanedPodmanPods(): Promise<number> {
+    const shellPods = await this.listShellPods();
+    const podmanPods = await this.listPodmanPods();
+    const now = Date.now();
+    const timeoutMs = this.config.idleTimeoutMinutes.podman * 60 * 1000;
+
+    // Get worktree IDs with active shell pods
+    const activeWorktreeIds = new Set(
+      shellPods.filter((p) => p.status === 'Running').map((p) => p.worktreeId)
+    );
+
+    let deleted = 0;
+
+    for (const pod of podmanPods) {
+      // Skip if there are active shell pods for this worktree
+      if (activeWorktreeIds.has(pod.worktreeId)) {
+        continue;
+      }
+
+      // Check idle timeout
+      if (pod.lastActivity) {
+        const idleMs = now - new Date(pod.lastActivity).getTime();
+        if (idleMs > timeoutMs) {
+          console.log(
+            `[PodManager] GC: Deleting orphaned Podman pod ${pod.podName} (idle ${Math.round(idleMs / 60000)}min)`
+          );
+          await this.deletePodmanPod(pod.worktreeId);
+          deleted++;
+        }
+      }
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Run garbage collection for all pod types
+   */
+  async runGC(): Promise<{ shellPodsDeleted: number; podmanPodsDeleted: number }> {
+    const shellPodsDeleted = await this.gcIdleShellPods();
+    const podmanPodsDeleted = await this.gcOrphanedPodmanPods();
+
+    if (shellPodsDeleted > 0 || podmanPodsDeleted > 0) {
+      console.log(
+        `[PodManager] GC complete: ${shellPodsDeleted} shell pods, ${podmanPodsDeleted} Podman pods deleted`
+      );
+    }
+
+    return { shellPodsDeleted, podmanPodsDeleted };
+  }
+
+  /**
+   * Get exec instance for terminal streaming
+   */
+  getExec(): k8s.Exec {
+    return this.exec;
+  }
+
+  /**
+   * Get namespace
+   */
+  getNamespace(): string {
+    return this.config.namespace;
+  }
+}
+
+/**
+ * Singleton instance for daemon use
+ */
+let podManagerInstance: PodManager | null = null;
+
+/**
+ * Get or create PodManager instance
+ */
+export function getPodManager(options?: PodManagerOptions): PodManager {
+  if (!podManagerInstance) {
+    podManagerInstance = new PodManager(options);
+  } else if (options?.config) {
+    podManagerInstance.updateConfig(options.config);
+  }
+  return podManagerInstance;
+}
+
+/**
+ * Reset PodManager instance (for testing)
+ */
+export function resetPodManager(): void {
+  podManagerInstance = null;
+}

--- a/packages/core/src/kubernetes/pod-manager.ts
+++ b/packages/core/src/kubernetes/pod-manager.ts
@@ -739,6 +739,8 @@ export class PodManager {
             `[PodManager] GC: Deleting orphaned Podman pod ${pod.podName} (idle ${Math.round(idleMs / 60000)}min)`
           );
           await this.deletePodmanPod(pod.worktreeId);
+          // Also delete associated ingress and app service
+          await this.deleteWorktreeIngress(pod.worktreeId);
           deleted++;
         }
       }

--- a/packages/core/src/kubernetes/pod-manifests.ts
+++ b/packages/core/src/kubernetes/pod-manifests.ts
@@ -2,21 +2,27 @@
  * Kubernetes Deployment Manifest Builders
  *
  * Functions to build Deployment and Service manifests for isolated terminal pods.
+ * Uses YAML templates from the templates directory for maintainability.
  */
 
-import type { V1Deployment, V1Pod, V1Service } from '@kubernetes/client-node';
+import type { V1Deployment, V1Ingress, V1Service } from '@kubernetes/client-node';
 import type { UserID, WorktreeID } from '../types/id.js';
 import {
+  loadAppIngress,
+  loadAppService,
+  loadPodmanDeployment,
+  loadPodmanService,
+  loadShellDeployment,
+} from './template-loader.js';
+import {
+  getAppIngressName,
+  getAppServiceName,
   getDockerHost,
   getPodmanPodName,
   getPodmanServiceName,
   getShellPodName,
-  POD_ANNOTATIONS,
-  POD_LABEL_VALUES,
-  POD_LABELS,
-  SERVICE_ACCOUNTS,
   type UserPodConfig,
-} from './types';
+} from './types.js';
 
 export interface ShellPodParams {
   worktreeId: WorktreeID;
@@ -36,512 +42,106 @@ export interface PodmanPodParams {
 }
 
 /**
- * Build shell deployment manifest
+ * Build shell deployment manifest using YAML template
  */
 export function buildShellDeploymentManifest(params: ShellPodParams): V1Deployment {
   const { worktreeId, userId, worktreePath, config, userUid, unixUsername } = params;
-  const deploymentName = getShellPodName(worktreeId, userId);
-  const dockerHost = getDockerHost(worktreeId, config.namespace);
+
+  const runAsUser = userUid ?? 1000;
+  const runAsGroup = userUid ?? 1000;
+  const username = unixUsername ?? 'agor';
   const now = new Date().toISOString();
 
-  // Use user's UID if provided, otherwise fall back to default (1000)
-  const runAsUser = userUid ?? 1000;
-  const runAsGroup = userUid ?? 1000; // Use same value for group
-  const username = unixUsername ?? 'agor';
-
-  const labels = {
-    [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.SHELL_POD,
-    [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.TERMINAL,
-    [POD_LABELS.WORKTREE_ID]: worktreeId,
-    [POD_LABELS.USER_ID]: userId,
-    [POD_LABELS.UNIX_USERNAME]: username,
-    [POD_LABELS.UNIX_UID]: String(runAsUser),
-  };
-
-  return {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: deploymentName,
-      namespace: config.namespace,
-      labels,
-      annotations: {
-        [POD_ANNOTATIONS.CREATED_AT]: now,
-      },
-    },
-    spec: {
-      replicas: 1,
-      selector: {
-        matchLabels: {
-          [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.SHELL_POD,
-          [POD_LABELS.WORKTREE_ID]: worktreeId,
-          [POD_LABELS.USER_ID]: userId,
-        },
-      },
-      template: {
-        metadata: {
-          labels,
-          annotations: {
-            [POD_ANNOTATIONS.CREATED_AT]: now,
-            [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
-          },
-        },
-        spec: {
-          serviceAccountName: SERVICE_ACCOUNTS.SHELL_POD,
-          // fsGroup for volume permissions, but don't set runAsUser at pod level
-          // so init container can run as root
-          securityContext: {
-            fsGroup: runAsGroup,
-          },
-          initContainers: [
-            {
-              name: 'init-user',
-              image: 'busybox:1.36',
-              // Run as root to create passwd/group files and home directory
-              securityContext: {
-                runAsUser: 0,
-                runAsGroup: 0,
-              },
-              command: ['sh', '-c'],
-              args: [
-                `set -e
-# Create passwd with root and our user
-cat > /etc-override/passwd << 'PASSWD'
-root:x:0:0:root:/root:/bin/sh
-nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
-PASSWD
-echo "${username}:x:${runAsUser}:${runAsGroup}:${username}:/home/${username}:/bin/bash" >> /etc-override/passwd
-
-# Create group with root and our group
-cat > /etc-override/group << 'GROUP'
-root:x:0:
-nobody:x:65534:
-GROUP
-echo "${username}:x:${runAsGroup}:" >> /etc-override/group
-
-chmod 644 /etc-override/passwd /etc-override/group
-
-# Create persistent home directory in /data/homes/{username}
-mkdir -p /data/homes/${username}
-mkdir -p /data/homes/${username}/.agor
-chown -R ${runAsUser}:${runAsGroup} /data/homes/${username}
-
-# Create symlinks for worktrees/repos in user's .agor
-ln -sf /data/worktrees /data/homes/${username}/.agor/worktrees
-ln -sf /data/repos /data/homes/${username}/.agor/repos
-
-# Create symlink: /home/{username} -> /data/homes/{username}
-mkdir -p /home-override
-ln -sf /data/homes/${username} /home-override/${username}
-
-echo "Created user ${username} (UID ${runAsUser}) with home at /data/homes/${username}"`,
-              ],
-              volumeMounts: [
-                { name: 'etc-override', mountPath: '/etc-override' },
-                { name: 'home-override', mountPath: '/home-override' },
-                { name: 'data', mountPath: '/data' },
-              ],
-            },
-          ],
-          containers: [
-            {
-              name: 'shell',
-              image: config.shellPod.image,
-              command: ['sleep', 'infinity'],
-              securityContext: {
-                runAsUser,
-                runAsGroup,
-                runAsNonRoot: true,
-              },
-              env: [
-                { name: 'WORKTREE_PATH', value: worktreePath },
-                { name: 'DOCKER_HOST', value: dockerHost },
-                { name: 'HOME', value: `/home/${username}` },
-                { name: 'USER', value: username },
-                { name: 'LOGNAME', value: username },
-              ],
-              workingDir: worktreePath,
-              volumeMounts: [
-                { name: 'data', mountPath: '/data' },
-                { name: 'home-override', mountPath: '/home' },
-                { name: 'etc-override', mountPath: '/etc/passwd', subPath: 'passwd' },
-                { name: 'etc-override', mountPath: '/etc/group', subPath: 'group' },
-              ],
-              resources: {
-                requests: {
-                  cpu: config.shellPod.resources.requests.cpu,
-                  memory: config.shellPod.resources.requests.memory,
-                },
-                limits: {
-                  cpu: config.shellPod.resources.limits.cpu,
-                  memory: config.shellPod.resources.limits.memory,
-                },
-              },
-            },
-          ],
-          volumes: [
-            {
-              name: 'data',
-              persistentVolumeClaim: { claimName: config.storage.dataPvc },
-            },
-            {
-              name: 'home-override',
-              emptyDir: {},
-            },
-            {
-              name: 'etc-override',
-              emptyDir: {},
-            },
-          ],
-        },
-      },
-    },
-  };
+  return loadShellDeployment({
+    name: getShellPodName(worktreeId, userId),
+    namespace: config.namespace,
+    worktreeId,
+    userId,
+    username,
+    runAsUser,
+    runAsGroup,
+    worktreePath,
+    dockerHost: getDockerHost(worktreeId, config.namespace),
+    shellImage: config.shellPod.image,
+    dataPvc: config.storage.dataPvc,
+    requestsCpu: config.shellPod.resources.requests.cpu,
+    requestsMemory: config.shellPod.resources.requests.memory,
+    limitsCpu: config.shellPod.resources.limits.cpu,
+    limitsMemory: config.shellPod.resources.limits.memory,
+    createdAt: now,
+  });
 }
 
 /**
- * Build Podman deployment manifest
+ * Build Podman deployment manifest using YAML template
  */
 export function buildPodmanDeploymentManifest(params: PodmanPodParams): V1Deployment {
   const { worktreeId, worktreePath, config } = params;
-  const deploymentName = getPodmanPodName(worktreeId);
   const now = new Date().toISOString();
 
-  const labels = {
-    [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
-    [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.CONTAINER_RUNTIME,
-    [POD_LABELS.WORKTREE_ID]: worktreeId,
-  };
-
-  return {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: deploymentName,
-      namespace: config.namespace,
-      labels,
-      annotations: {
-        [POD_ANNOTATIONS.CREATED_AT]: now,
-      },
-    },
-    spec: {
-      replicas: 1,
-      selector: {
-        matchLabels: {
-          [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
-          [POD_LABELS.WORKTREE_ID]: worktreeId,
-        },
-      },
-      template: {
-        metadata: {
-          labels,
-          annotations: {
-            [POD_ANNOTATIONS.CREATED_AT]: now,
-            [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
-          },
-        },
-        spec: {
-          serviceAccountName: SERVICE_ACCOUNTS.PODMAN_POD,
-          initContainers: [
-            {
-              name: 'init-paths',
-              image: 'busybox:1.36',
-              command: ['sh', '-c'],
-              args: [
-                `set -e
-# Generate machine-id (32 hex chars)
-cat /proc/sys/kernel/random/uuid | tr -d "-" > /etc-override/machine-id
-chmod 444 /etc-override/machine-id
-
-# Create symlinks to match daemon paths
-mkdir -p /home/agor/.agor
-ln -sf /data/worktrees /home/agor/.agor/worktrees
-ln -sf /data/repos /home/agor/.agor/repos
-echo "Init complete"`,
-              ],
-              volumeMounts: [
-                { name: 'etc-override', mountPath: '/etc-override' },
-                { name: 'data', mountPath: '/data' },
-                { name: 'home', mountPath: '/home' },
-              ],
-            },
-          ],
-          containers: [
-            {
-              name: 'podman',
-              image: config.podmanPod.image,
-              command: ['podman', 'system', 'service', '--time=0', 'tcp://0.0.0.0:2375'],
-              securityContext: {
-                privileged: true, // Required for nested containers
-              },
-              ports: [{ containerPort: 2375, name: 'docker-api', protocol: 'TCP' }],
-              env: [{ name: 'WORKTREE_PATH', value: worktreePath }],
-              workingDir: worktreePath,
-              volumeMounts: [
-                { name: 'data', mountPath: '/data' },
-                { name: 'home', mountPath: '/home' },
-                { name: 'podman-storage', mountPath: '/var/lib/containers' },
-                { name: 'etc-override', mountPath: '/etc/machine-id', subPath: 'machine-id' },
-              ],
-              resources: {
-                requests: {
-                  cpu: config.podmanPod.resources.requests.cpu,
-                  memory: config.podmanPod.resources.requests.memory,
-                },
-                limits: {
-                  cpu: config.podmanPod.resources.limits.cpu,
-                  memory: config.podmanPod.resources.limits.memory,
-                },
-              },
-              // Readiness probe to ensure Podman is ready
-              readinessProbe: {
-                tcpSocket: { port: 2375 },
-                initialDelaySeconds: 2,
-                periodSeconds: 5,
-              },
-            },
-          ],
-          volumes: [
-            {
-              name: 'data',
-              persistentVolumeClaim: { claimName: config.storage.dataPvc },
-            },
-            {
-              name: 'home',
-              emptyDir: {},
-            },
-            {
-              name: 'podman-storage',
-              emptyDir: {},
-            },
-            {
-              name: 'etc-override',
-              emptyDir: {},
-            },
-          ],
-        },
-      },
-    },
-  };
+  return loadPodmanDeployment({
+    name: getPodmanPodName(worktreeId),
+    namespace: config.namespace,
+    worktreeId,
+    worktreePath,
+    podmanImage: config.podmanPod.image,
+    dataPvc: config.storage.dataPvc,
+    requestsCpu: config.podmanPod.resources.requests.cpu,
+    requestsMemory: config.podmanPod.resources.requests.memory,
+    limitsCpu: config.podmanPod.resources.limits.cpu,
+    limitsMemory: config.podmanPod.resources.limits.memory,
+    createdAt: now,
+  });
 }
 
 /**
- * Build Podman service manifest
+ * Build Podman service manifest using YAML template
  */
 export function buildPodmanServiceManifest(
   worktreeId: WorktreeID,
   config: UserPodConfig
 ): V1Service {
-  const serviceName = getPodmanServiceName(worktreeId);
-
-  return {
-    apiVersion: 'v1',
-    kind: 'Service',
-    metadata: {
-      name: serviceName,
-      namespace: config.namespace,
-      labels: {
-        [POD_LABELS.WORKTREE_ID]: worktreeId,
-      },
-    },
-    spec: {
-      selector: {
-        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
-        [POD_LABELS.WORKTREE_ID]: worktreeId,
-      },
-      ports: [{ port: 2375, targetPort: 2375, name: 'docker-api', protocol: 'TCP' }],
-    },
-  };
-}
-
-// ============================================
-// Legacy Pod manifests (kept for compatibility)
-// ============================================
-
-/**
- * Build shell pod manifest (legacy - use buildShellDeploymentManifest instead)
- * @deprecated Use buildShellDeploymentManifest for better lifecycle management
- */
-export function buildShellPodManifest(params: ShellPodParams): V1Pod {
-  const { worktreeId, userId, worktreePath, config, userUid, unixUsername } = params;
-  const podName = getShellPodName(worktreeId, userId);
-  const dockerHost = getDockerHost(worktreeId, config.namespace);
-  const now = new Date().toISOString();
-
-  const runAsUser = userUid ?? 1000;
-  const runAsGroup = userUid ?? 1000;
-  const username = unixUsername ?? 'agor';
-
-  return {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: {
-      name: podName,
-      namespace: config.namespace,
-      labels: {
-        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.SHELL_POD,
-        [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.TERMINAL,
-        [POD_LABELS.WORKTREE_ID]: worktreeId,
-        [POD_LABELS.USER_ID]: userId,
-        [POD_LABELS.UNIX_USERNAME]: username,
-        [POD_LABELS.UNIX_UID]: String(runAsUser),
-      },
-      annotations: {
-        [POD_ANNOTATIONS.CREATED_AT]: now,
-        [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
-      },
-    },
-    spec: {
-      serviceAccountName: SERVICE_ACCOUNTS.SHELL_POD,
-      restartPolicy: 'Never',
-      securityContext: {
-        fsGroup: runAsGroup,
-      },
-      initContainers: [
-        {
-          name: 'init-user',
-          image: 'busybox:1.36',
-          securityContext: {
-            runAsUser: 0,
-            runAsGroup: 0,
-          },
-          command: ['sh', '-c'],
-          args: [
-            `set -e
-cat > /etc-override/passwd << 'PASSWD'
-root:x:0:0:root:/root:/bin/sh
-nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
-PASSWD
-echo "${username}:x:${runAsUser}:${runAsGroup}:${username}:/home/agor:/bin/bash" >> /etc-override/passwd
-cat > /etc-override/group << 'GROUP'
-root:x:0:
-nobody:x:65534:
-GROUP
-echo "${username}:x:${runAsGroup}:" >> /etc-override/group
-chmod 644 /etc-override/passwd /etc-override/group`,
-          ],
-          volumeMounts: [{ name: 'etc-override', mountPath: '/etc-override' }],
-        },
-      ],
-      containers: [
-        {
-          name: 'shell',
-          image: config.shellPod.image,
-          command: ['sleep', 'infinity'],
-          securityContext: {
-            runAsUser,
-            runAsGroup,
-            runAsNonRoot: true,
-          },
-          env: [
-            { name: 'WORKTREE_PATH', value: worktreePath },
-            { name: 'DOCKER_HOST', value: dockerHost },
-            { name: 'HOME', value: '/home/agor' },
-            { name: 'USER', value: username },
-            { name: 'LOGNAME', value: username },
-          ],
-          workingDir: worktreePath,
-          volumeMounts: [
-            { name: 'data', mountPath: '/data' },
-            { name: 'etc-override', mountPath: '/etc/passwd', subPath: 'passwd' },
-            { name: 'etc-override', mountPath: '/etc/group', subPath: 'group' },
-          ],
-          resources: {
-            requests: {
-              cpu: config.shellPod.resources.requests.cpu,
-              memory: config.shellPod.resources.requests.memory,
-            },
-            limits: {
-              cpu: config.shellPod.resources.limits.cpu,
-              memory: config.shellPod.resources.limits.memory,
-            },
-          },
-        },
-      ],
-      volumes: [
-        {
-          name: 'data',
-          persistentVolumeClaim: { claimName: config.storage.dataPvc },
-        },
-        {
-          name: 'etc-override',
-          emptyDir: {},
-        },
-      ],
-    },
-  };
+  return loadPodmanService({
+    name: getPodmanServiceName(worktreeId),
+    namespace: config.namespace,
+    worktreeId,
+  });
 }
 
 /**
- * Build Podman pod manifest (legacy - use buildPodmanDeploymentManifest instead)
- * @deprecated Use buildPodmanDeploymentManifest for better lifecycle management
+ * Build app service manifest using YAML template
  */
-export function buildPodmanPodManifest(params: PodmanPodParams): V1Pod {
-  const { worktreeId, worktreePath, config } = params;
-  const podName = getPodmanPodName(worktreeId);
-  const now = new Date().toISOString();
+export function buildAppServiceManifest(
+  worktreeId: WorktreeID,
+  port: number,
+  config: UserPodConfig
+): V1Service {
+  return loadAppService({
+    name: getAppServiceName(worktreeId),
+    namespace: config.namespace,
+    worktreeId,
+    port,
+  });
+}
 
-  return {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: {
-      name: podName,
-      namespace: config.namespace,
-      labels: {
-        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
-        [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.CONTAINER_RUNTIME,
-        [POD_LABELS.WORKTREE_ID]: worktreeId,
-      },
-      annotations: {
-        [POD_ANNOTATIONS.CREATED_AT]: now,
-        [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
-      },
-    },
-    spec: {
-      serviceAccountName: SERVICE_ACCOUNTS.PODMAN_POD,
-      restartPolicy: 'Never',
-      containers: [
-        {
-          name: 'podman',
-          image: config.podmanPod.image,
-          command: ['podman', 'system', 'service', '--time=0', 'tcp://0.0.0.0:2375'],
-          securityContext: {
-            privileged: true,
-          },
-          ports: [{ containerPort: 2375, name: 'docker-api', protocol: 'TCP' }],
-          env: [{ name: 'WORKTREE_PATH', value: worktreePath }],
-          workingDir: worktreePath,
-          volumeMounts: [
-            { name: 'data', mountPath: '/data' },
-            { name: 'podman-storage', mountPath: '/var/lib/containers' },
-          ],
-          resources: {
-            requests: {
-              cpu: config.podmanPod.resources.requests.cpu,
-              memory: config.podmanPod.resources.requests.memory,
-            },
-            limits: {
-              cpu: config.podmanPod.resources.limits.cpu,
-              memory: config.podmanPod.resources.limits.memory,
-            },
-          },
-          readinessProbe: {
-            tcpSocket: { port: 2375 },
-            initialDelaySeconds: 2,
-            periodSeconds: 5,
-          },
-        },
-      ],
-      volumes: [
-        {
-          name: 'data',
-          persistentVolumeClaim: { claimName: config.storage.dataPvc },
-        },
-        {
-          name: 'podman-storage',
-          emptyDir: {},
-        },
-      ],
-    },
-  };
+/**
+ * Build app ingress manifest using YAML template
+ */
+export function buildAppIngressManifest(
+  worktreeId: WorktreeID,
+  worktreeName: string,
+  port: number,
+  config: UserPodConfig,
+  baseDomain: string = 'agor.local'
+): V1Ingress {
+  const hostname = `${worktreeName}.${baseDomain}`;
+
+  return loadAppIngress({
+    name: getAppIngressName(worktreeId),
+    namespace: config.namespace,
+    worktreeId,
+    hostname,
+    serviceName: getAppServiceName(worktreeId),
+    port,
+  });
 }

--- a/packages/core/src/kubernetes/pod-manifests.ts
+++ b/packages/core/src/kubernetes/pod-manifests.ts
@@ -23,6 +23,7 @@ import {
   getPodmanServiceName,
   getShellPodName,
   getShellSshServiceName,
+  getUserSecretName,
   type UserPodConfig,
 } from './types.js';
 
@@ -82,6 +83,7 @@ export function buildShellDeploymentManifest(params: ShellPodParams): V1Deployme
     sshdLimitsCpu: sshdResources.limits.cpu,
     sshdLimitsMemory: sshdResources.limits.memory,
     createdAt: now,
+    userSecretName: getUserSecretName(userId),
   });
 }
 

--- a/packages/core/src/kubernetes/pod-manifests.ts
+++ b/packages/core/src/kubernetes/pod-manifests.ts
@@ -1,10 +1,10 @@
 /**
- * Kubernetes Pod Manifest Builders
+ * Kubernetes Deployment Manifest Builders
  *
- * Functions to build Pod and Service manifests for isolated terminal pods.
+ * Functions to build Deployment and Service manifests for isolated terminal pods.
  */
 
-import type { V1Pod, V1Service } from '@kubernetes/client-node';
+import type { V1Deployment, V1Pod, V1Service } from '@kubernetes/client-node';
 import type { UserID, WorktreeID } from '../types/id.js';
 import {
   getDockerHost,
@@ -36,7 +36,331 @@ export interface PodmanPodParams {
 }
 
 /**
- * Build shell pod manifest
+ * Build shell deployment manifest
+ */
+export function buildShellDeploymentManifest(params: ShellPodParams): V1Deployment {
+  const { worktreeId, userId, worktreePath, config, userUid, unixUsername } = params;
+  const deploymentName = getShellPodName(worktreeId, userId);
+  const dockerHost = getDockerHost(worktreeId, config.namespace);
+  const now = new Date().toISOString();
+
+  // Use user's UID if provided, otherwise fall back to default (1000)
+  const runAsUser = userUid ?? 1000;
+  const runAsGroup = userUid ?? 1000; // Use same value for group
+  const username = unixUsername ?? 'agor';
+
+  const labels = {
+    [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.SHELL_POD,
+    [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.TERMINAL,
+    [POD_LABELS.WORKTREE_ID]: worktreeId,
+    [POD_LABELS.USER_ID]: userId,
+    [POD_LABELS.UNIX_USERNAME]: username,
+    [POD_LABELS.UNIX_UID]: String(runAsUser),
+  };
+
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: deploymentName,
+      namespace: config.namespace,
+      labels,
+      annotations: {
+        [POD_ANNOTATIONS.CREATED_AT]: now,
+      },
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.SHELL_POD,
+          [POD_LABELS.WORKTREE_ID]: worktreeId,
+          [POD_LABELS.USER_ID]: userId,
+        },
+      },
+      template: {
+        metadata: {
+          labels,
+          annotations: {
+            [POD_ANNOTATIONS.CREATED_AT]: now,
+            [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
+          },
+        },
+        spec: {
+          serviceAccountName: SERVICE_ACCOUNTS.SHELL_POD,
+          // fsGroup for volume permissions, but don't set runAsUser at pod level
+          // so init container can run as root
+          securityContext: {
+            fsGroup: runAsGroup,
+          },
+          initContainers: [
+            {
+              name: 'init-user',
+              image: 'busybox:1.36',
+              // Run as root to create passwd/group files and home directory
+              securityContext: {
+                runAsUser: 0,
+                runAsGroup: 0,
+              },
+              command: ['sh', '-c'],
+              args: [
+                `set -e
+# Create passwd with root and our user
+cat > /etc-override/passwd << 'PASSWD'
+root:x:0:0:root:/root:/bin/sh
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+PASSWD
+echo "${username}:x:${runAsUser}:${runAsGroup}:${username}:/home/${username}:/bin/bash" >> /etc-override/passwd
+
+# Create group with root and our group
+cat > /etc-override/group << 'GROUP'
+root:x:0:
+nobody:x:65534:
+GROUP
+echo "${username}:x:${runAsGroup}:" >> /etc-override/group
+
+chmod 644 /etc-override/passwd /etc-override/group
+
+# Create persistent home directory in /data/homes/{username}
+mkdir -p /data/homes/${username}
+mkdir -p /data/homes/${username}/.agor
+chown -R ${runAsUser}:${runAsGroup} /data/homes/${username}
+
+# Create symlinks for worktrees/repos in user's .agor
+ln -sf /data/worktrees /data/homes/${username}/.agor/worktrees
+ln -sf /data/repos /data/homes/${username}/.agor/repos
+
+# Create symlink: /home/{username} -> /data/homes/{username}
+mkdir -p /home-override
+ln -sf /data/homes/${username} /home-override/${username}
+
+echo "Created user ${username} (UID ${runAsUser}) with home at /data/homes/${username}"`,
+              ],
+              volumeMounts: [
+                { name: 'etc-override', mountPath: '/etc-override' },
+                { name: 'home-override', mountPath: '/home-override' },
+                { name: 'data', mountPath: '/data' },
+              ],
+            },
+          ],
+          containers: [
+            {
+              name: 'shell',
+              image: config.shellPod.image,
+              command: ['sleep', 'infinity'],
+              securityContext: {
+                runAsUser,
+                runAsGroup,
+                runAsNonRoot: true,
+              },
+              env: [
+                { name: 'WORKTREE_PATH', value: worktreePath },
+                { name: 'DOCKER_HOST', value: dockerHost },
+                { name: 'HOME', value: `/home/${username}` },
+                { name: 'USER', value: username },
+                { name: 'LOGNAME', value: username },
+              ],
+              workingDir: worktreePath,
+              volumeMounts: [
+                { name: 'data', mountPath: '/data' },
+                { name: 'home-override', mountPath: '/home' },
+                { name: 'etc-override', mountPath: '/etc/passwd', subPath: 'passwd' },
+                { name: 'etc-override', mountPath: '/etc/group', subPath: 'group' },
+              ],
+              resources: {
+                requests: {
+                  cpu: config.shellPod.resources.requests.cpu,
+                  memory: config.shellPod.resources.requests.memory,
+                },
+                limits: {
+                  cpu: config.shellPod.resources.limits.cpu,
+                  memory: config.shellPod.resources.limits.memory,
+                },
+              },
+            },
+          ],
+          volumes: [
+            {
+              name: 'data',
+              persistentVolumeClaim: { claimName: config.storage.dataPvc },
+            },
+            {
+              name: 'home-override',
+              emptyDir: {},
+            },
+            {
+              name: 'etc-override',
+              emptyDir: {},
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Build Podman deployment manifest
+ */
+export function buildPodmanDeploymentManifest(params: PodmanPodParams): V1Deployment {
+  const { worktreeId, worktreePath, config } = params;
+  const deploymentName = getPodmanPodName(worktreeId);
+  const now = new Date().toISOString();
+
+  const labels = {
+    [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
+    [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.CONTAINER_RUNTIME,
+    [POD_LABELS.WORKTREE_ID]: worktreeId,
+  };
+
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: deploymentName,
+      namespace: config.namespace,
+      labels,
+      annotations: {
+        [POD_ANNOTATIONS.CREATED_AT]: now,
+      },
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
+          [POD_LABELS.WORKTREE_ID]: worktreeId,
+        },
+      },
+      template: {
+        metadata: {
+          labels,
+          annotations: {
+            [POD_ANNOTATIONS.CREATED_AT]: now,
+            [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
+          },
+        },
+        spec: {
+          serviceAccountName: SERVICE_ACCOUNTS.PODMAN_POD,
+          initContainers: [
+            {
+              name: 'init-paths',
+              image: 'busybox:1.36',
+              command: ['sh', '-c'],
+              args: [
+                `set -e
+# Generate machine-id (32 hex chars)
+cat /proc/sys/kernel/random/uuid | tr -d "-" > /etc-override/machine-id
+chmod 444 /etc-override/machine-id
+
+# Create symlinks to match daemon paths
+mkdir -p /home/agor/.agor
+ln -sf /data/worktrees /home/agor/.agor/worktrees
+ln -sf /data/repos /home/agor/.agor/repos
+echo "Init complete"`,
+              ],
+              volumeMounts: [
+                { name: 'etc-override', mountPath: '/etc-override' },
+                { name: 'data', mountPath: '/data' },
+                { name: 'home', mountPath: '/home' },
+              ],
+            },
+          ],
+          containers: [
+            {
+              name: 'podman',
+              image: config.podmanPod.image,
+              command: ['podman', 'system', 'service', '--time=0', 'tcp://0.0.0.0:2375'],
+              securityContext: {
+                privileged: true, // Required for nested containers
+              },
+              ports: [{ containerPort: 2375, name: 'docker-api', protocol: 'TCP' }],
+              env: [{ name: 'WORKTREE_PATH', value: worktreePath }],
+              workingDir: worktreePath,
+              volumeMounts: [
+                { name: 'data', mountPath: '/data' },
+                { name: 'home', mountPath: '/home' },
+                { name: 'podman-storage', mountPath: '/var/lib/containers' },
+                { name: 'etc-override', mountPath: '/etc/machine-id', subPath: 'machine-id' },
+              ],
+              resources: {
+                requests: {
+                  cpu: config.podmanPod.resources.requests.cpu,
+                  memory: config.podmanPod.resources.requests.memory,
+                },
+                limits: {
+                  cpu: config.podmanPod.resources.limits.cpu,
+                  memory: config.podmanPod.resources.limits.memory,
+                },
+              },
+              // Readiness probe to ensure Podman is ready
+              readinessProbe: {
+                tcpSocket: { port: 2375 },
+                initialDelaySeconds: 2,
+                periodSeconds: 5,
+              },
+            },
+          ],
+          volumes: [
+            {
+              name: 'data',
+              persistentVolumeClaim: { claimName: config.storage.dataPvc },
+            },
+            {
+              name: 'home',
+              emptyDir: {},
+            },
+            {
+              name: 'podman-storage',
+              emptyDir: {},
+            },
+            {
+              name: 'etc-override',
+              emptyDir: {},
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Build Podman service manifest
+ */
+export function buildPodmanServiceManifest(
+  worktreeId: WorktreeID,
+  config: UserPodConfig
+): V1Service {
+  const serviceName = getPodmanServiceName(worktreeId);
+
+  return {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: serviceName,
+      namespace: config.namespace,
+      labels: {
+        [POD_LABELS.WORKTREE_ID]: worktreeId,
+      },
+    },
+    spec: {
+      selector: {
+        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
+        [POD_LABELS.WORKTREE_ID]: worktreeId,
+      },
+      ports: [{ port: 2375, targetPort: 2375, name: 'docker-api', protocol: 'TCP' }],
+    },
+  };
+}
+
+// ============================================
+// Legacy Pod manifests (kept for compatibility)
+// ============================================
+
+/**
+ * Build shell pod manifest (legacy - use buildShellDeploymentManifest instead)
+ * @deprecated Use buildShellDeploymentManifest for better lifecycle management
  */
 export function buildShellPodManifest(params: ShellPodParams): V1Pod {
   const { worktreeId, userId, worktreePath, config, userUid, unixUsername } = params;
@@ -44,9 +368,8 @@ export function buildShellPodManifest(params: ShellPodParams): V1Pod {
   const dockerHost = getDockerHost(worktreeId, config.namespace);
   const now = new Date().toISOString();
 
-  // Use user's UID if provided, otherwise fall back to default (1000)
   const runAsUser = userUid ?? 1000;
-  const runAsGroup = userUid ?? 1000; // Use same value for group
+  const runAsGroup = userUid ?? 1000;
   const username = unixUsername ?? 'agor';
 
   return {
@@ -71,8 +394,6 @@ export function buildShellPodManifest(params: ShellPodParams): V1Pod {
     spec: {
       serviceAccountName: SERVICE_ACCOUNTS.SHELL_POD,
       restartPolicy: 'Never',
-      // fsGroup for volume permissions, but don't set runAsUser at pod level
-      // so init container can run as root
       securityContext: {
         fsGroup: runAsGroup,
       },
@@ -80,7 +401,6 @@ export function buildShellPodManifest(params: ShellPodParams): V1Pod {
         {
           name: 'init-user',
           image: 'busybox:1.36',
-          // Run as root to create passwd/group files
           securityContext: {
             runAsUser: 0,
             runAsGroup: 0,
@@ -88,23 +408,17 @@ export function buildShellPodManifest(params: ShellPodParams): V1Pod {
           command: ['sh', '-c'],
           args: [
             `set -e
-# Create passwd with root and our user
 cat > /etc-override/passwd << 'PASSWD'
 root:x:0:0:root:/root:/bin/sh
 nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
 PASSWD
 echo "${username}:x:${runAsUser}:${runAsGroup}:${username}:/home/agor:/bin/bash" >> /etc-override/passwd
-
-# Create group with root and our group
 cat > /etc-override/group << 'GROUP'
 root:x:0:
 nobody:x:65534:
 GROUP
 echo "${username}:x:${runAsGroup}:" >> /etc-override/group
-
-chmod 644 /etc-override/passwd /etc-override/group
-echo "Created user ${username} with UID ${runAsUser}"
-cat /etc-override/passwd`,
+chmod 644 /etc-override/passwd /etc-override/group`,
           ],
           volumeMounts: [{ name: 'etc-override', mountPath: '/etc-override' }],
         },
@@ -159,7 +473,8 @@ cat /etc-override/passwd`,
 }
 
 /**
- * Build Podman pod manifest
+ * Build Podman pod manifest (legacy - use buildPodmanDeploymentManifest instead)
+ * @deprecated Use buildPodmanDeploymentManifest for better lifecycle management
  */
 export function buildPodmanPodManifest(params: PodmanPodParams): V1Pod {
   const { worktreeId, worktreePath, config } = params;
@@ -191,7 +506,7 @@ export function buildPodmanPodManifest(params: PodmanPodParams): V1Pod {
           image: config.podmanPod.image,
           command: ['podman', 'system', 'service', '--time=0', 'tcp://0.0.0.0:2375'],
           securityContext: {
-            privileged: true, // Required for nested containers
+            privileged: true,
           },
           ports: [{ containerPort: 2375, name: 'docker-api', protocol: 'TCP' }],
           env: [{ name: 'WORKTREE_PATH', value: worktreePath }],
@@ -210,7 +525,6 @@ export function buildPodmanPodManifest(params: PodmanPodParams): V1Pod {
               memory: config.podmanPod.resources.limits.memory,
             },
           },
-          // Readiness probe to ensure Podman is ready
           readinessProbe: {
             tcpSocket: { port: 2375 },
             initialDelaySeconds: 2,
@@ -228,35 +542,6 @@ export function buildPodmanPodManifest(params: PodmanPodParams): V1Pod {
           emptyDir: {},
         },
       ],
-    },
-  };
-}
-
-/**
- * Build Podman service manifest
- */
-export function buildPodmanServiceManifest(
-  worktreeId: WorktreeID,
-  config: UserPodConfig
-): V1Service {
-  const serviceName = getPodmanServiceName(worktreeId);
-
-  return {
-    apiVersion: 'v1',
-    kind: 'Service',
-    metadata: {
-      name: serviceName,
-      namespace: config.namespace,
-      labels: {
-        [POD_LABELS.WORKTREE_ID]: worktreeId,
-      },
-    },
-    spec: {
-      selector: {
-        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
-        [POD_LABELS.WORKTREE_ID]: worktreeId,
-      },
-      ports: [{ port: 2375, targetPort: 2375, name: 'docker-api', protocol: 'TCP' }],
     },
   };
 }

--- a/packages/core/src/kubernetes/pod-manifests.ts
+++ b/packages/core/src/kubernetes/pod-manifests.ts
@@ -1,0 +1,262 @@
+/**
+ * Kubernetes Pod Manifest Builders
+ *
+ * Functions to build Pod and Service manifests for isolated terminal pods.
+ */
+
+import type { V1Pod, V1Service } from '@kubernetes/client-node';
+import type { UserID, WorktreeID } from '../types/id.js';
+import {
+  getDockerHost,
+  getPodmanPodName,
+  getPodmanServiceName,
+  getShellPodName,
+  POD_ANNOTATIONS,
+  POD_LABEL_VALUES,
+  POD_LABELS,
+  SERVICE_ACCOUNTS,
+  type UserPodConfig,
+} from './types';
+
+export interface ShellPodParams {
+  worktreeId: WorktreeID;
+  userId: UserID;
+  worktreePath: string;
+  config: UserPodConfig;
+  /** Unix UID for consistent file ownership on EFS/NFS */
+  userUid?: number;
+  /** Unix username for /etc/passwd entry */
+  unixUsername?: string;
+}
+
+export interface PodmanPodParams {
+  worktreeId: WorktreeID;
+  worktreePath: string;
+  config: UserPodConfig;
+}
+
+/**
+ * Build shell pod manifest
+ */
+export function buildShellPodManifest(params: ShellPodParams): V1Pod {
+  const { worktreeId, userId, worktreePath, config, userUid, unixUsername } = params;
+  const podName = getShellPodName(worktreeId, userId);
+  const dockerHost = getDockerHost(worktreeId, config.namespace);
+  const now = new Date().toISOString();
+
+  // Use user's UID if provided, otherwise fall back to default (1000)
+  const runAsUser = userUid ?? 1000;
+  const runAsGroup = userUid ?? 1000; // Use same value for group
+  const username = unixUsername ?? 'agor';
+
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: podName,
+      namespace: config.namespace,
+      labels: {
+        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.SHELL_POD,
+        [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.TERMINAL,
+        [POD_LABELS.WORKTREE_ID]: worktreeId,
+        [POD_LABELS.USER_ID]: userId,
+        [POD_LABELS.UNIX_USERNAME]: username,
+        [POD_LABELS.UNIX_UID]: String(runAsUser),
+      },
+      annotations: {
+        [POD_ANNOTATIONS.CREATED_AT]: now,
+        [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
+      },
+    },
+    spec: {
+      serviceAccountName: SERVICE_ACCOUNTS.SHELL_POD,
+      restartPolicy: 'Never',
+      // fsGroup for volume permissions, but don't set runAsUser at pod level
+      // so init container can run as root
+      securityContext: {
+        fsGroup: runAsGroup,
+      },
+      initContainers: [
+        {
+          name: 'init-user',
+          image: 'busybox:1.36',
+          // Run as root to create passwd/group files
+          securityContext: {
+            runAsUser: 0,
+            runAsGroup: 0,
+          },
+          command: ['sh', '-c'],
+          args: [
+            `set -e
+# Create passwd with root and our user
+cat > /etc-override/passwd << 'PASSWD'
+root:x:0:0:root:/root:/bin/sh
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+PASSWD
+echo "${username}:x:${runAsUser}:${runAsGroup}:${username}:/home/agor:/bin/bash" >> /etc-override/passwd
+
+# Create group with root and our group
+cat > /etc-override/group << 'GROUP'
+root:x:0:
+nobody:x:65534:
+GROUP
+echo "${username}:x:${runAsGroup}:" >> /etc-override/group
+
+chmod 644 /etc-override/passwd /etc-override/group
+echo "Created user ${username} with UID ${runAsUser}"
+cat /etc-override/passwd`,
+          ],
+          volumeMounts: [{ name: 'etc-override', mountPath: '/etc-override' }],
+        },
+      ],
+      containers: [
+        {
+          name: 'shell',
+          image: config.shellPod.image,
+          command: ['sleep', 'infinity'],
+          securityContext: {
+            runAsUser,
+            runAsGroup,
+            runAsNonRoot: true,
+          },
+          env: [
+            { name: 'WORKTREE_PATH', value: worktreePath },
+            { name: 'DOCKER_HOST', value: dockerHost },
+            { name: 'HOME', value: '/home/agor' },
+            { name: 'USER', value: username },
+            { name: 'LOGNAME', value: username },
+          ],
+          workingDir: worktreePath,
+          volumeMounts: [
+            { name: 'data', mountPath: '/data' },
+            { name: 'etc-override', mountPath: '/etc/passwd', subPath: 'passwd' },
+            { name: 'etc-override', mountPath: '/etc/group', subPath: 'group' },
+          ],
+          resources: {
+            requests: {
+              cpu: config.shellPod.resources.requests.cpu,
+              memory: config.shellPod.resources.requests.memory,
+            },
+            limits: {
+              cpu: config.shellPod.resources.limits.cpu,
+              memory: config.shellPod.resources.limits.memory,
+            },
+          },
+        },
+      ],
+      volumes: [
+        {
+          name: 'data',
+          persistentVolumeClaim: { claimName: config.storage.dataPvc },
+        },
+        {
+          name: 'etc-override',
+          emptyDir: {},
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Build Podman pod manifest
+ */
+export function buildPodmanPodManifest(params: PodmanPodParams): V1Pod {
+  const { worktreeId, worktreePath, config } = params;
+  const podName = getPodmanPodName(worktreeId);
+  const now = new Date().toISOString();
+
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: podName,
+      namespace: config.namespace,
+      labels: {
+        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
+        [POD_LABELS.COMPONENT]: POD_LABEL_VALUES.CONTAINER_RUNTIME,
+        [POD_LABELS.WORKTREE_ID]: worktreeId,
+      },
+      annotations: {
+        [POD_ANNOTATIONS.CREATED_AT]: now,
+        [POD_ANNOTATIONS.LAST_ACTIVITY]: now,
+      },
+    },
+    spec: {
+      serviceAccountName: SERVICE_ACCOUNTS.PODMAN_POD,
+      restartPolicy: 'Never',
+      containers: [
+        {
+          name: 'podman',
+          image: config.podmanPod.image,
+          command: ['podman', 'system', 'service', '--time=0', 'tcp://0.0.0.0:2375'],
+          securityContext: {
+            privileged: true, // Required for nested containers
+          },
+          ports: [{ containerPort: 2375, name: 'docker-api', protocol: 'TCP' }],
+          env: [{ name: 'WORKTREE_PATH', value: worktreePath }],
+          workingDir: worktreePath,
+          volumeMounts: [
+            { name: 'data', mountPath: '/data' },
+            { name: 'podman-storage', mountPath: '/var/lib/containers' },
+          ],
+          resources: {
+            requests: {
+              cpu: config.podmanPod.resources.requests.cpu,
+              memory: config.podmanPod.resources.requests.memory,
+            },
+            limits: {
+              cpu: config.podmanPod.resources.limits.cpu,
+              memory: config.podmanPod.resources.limits.memory,
+            },
+          },
+          // Readiness probe to ensure Podman is ready
+          readinessProbe: {
+            tcpSocket: { port: 2375 },
+            initialDelaySeconds: 2,
+            periodSeconds: 5,
+          },
+        },
+      ],
+      volumes: [
+        {
+          name: 'data',
+          persistentVolumeClaim: { claimName: config.storage.dataPvc },
+        },
+        {
+          name: 'podman-storage',
+          emptyDir: {},
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Build Podman service manifest
+ */
+export function buildPodmanServiceManifest(
+  worktreeId: WorktreeID,
+  config: UserPodConfig
+): V1Service {
+  const serviceName = getPodmanServiceName(worktreeId);
+
+  return {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: serviceName,
+      namespace: config.namespace,
+      labels: {
+        [POD_LABELS.WORKTREE_ID]: worktreeId,
+      },
+    },
+    spec: {
+      selector: {
+        [POD_LABELS.APP_NAME]: POD_LABEL_VALUES.PODMAN_POD,
+        [POD_LABELS.WORKTREE_ID]: worktreeId,
+      },
+      ports: [{ port: 2375, targetPort: 2375, name: 'docker-api', protocol: 'TCP' }],
+    },
+  };
+}

--- a/packages/core/src/kubernetes/pod-manifests.ts
+++ b/packages/core/src/kubernetes/pod-manifests.ts
@@ -28,6 +28,7 @@ import {
 
 export interface ShellPodParams {
   worktreeId: WorktreeID;
+  worktreeName: string;
   userId: UserID;
   worktreePath: string;
   config: UserPodConfig;
@@ -47,7 +48,7 @@ export interface PodmanPodParams {
  * Build shell deployment manifest using YAML template
  */
 export function buildShellDeploymentManifest(params: ShellPodParams): V1Deployment {
-  const { worktreeId, userId, worktreePath, config, userUid, unixUsername } = params;
+  const { worktreeId, worktreeName, userId, worktreePath, config, userUid, unixUsername } = params;
 
   const runAsUser = userUid ?? 1000;
   const runAsGroup = userUid ?? 1000;
@@ -63,6 +64,7 @@ export function buildShellDeploymentManifest(params: ShellPodParams): V1Deployme
     name: getShellPodName(worktreeId, userId),
     namespace: config.namespace,
     worktreeId,
+    worktreeName,
     userId,
     username,
     runAsUser,

--- a/packages/core/src/kubernetes/template-loader.ts
+++ b/packages/core/src/kubernetes/template-loader.ts
@@ -76,6 +76,10 @@ export interface ShellDeploymentParams {
   requestsMemory: string;
   limitsCpu: string;
   limitsMemory: string;
+  sshdRequestsCpu: string;
+  sshdRequestsMemory: string;
+  sshdLimitsCpu: string;
+  sshdLimitsMemory: string;
   createdAt: string;
 }
 
@@ -89,6 +93,7 @@ export interface PodmanDeploymentParams {
   worktreeId: string;
   worktreePath: string;
   podmanImage: string;
+  initImage: string;
   dataPvc: string;
   requestsCpu: string;
   requestsMemory: string;
@@ -129,10 +134,64 @@ export interface AppIngressParams {
   hostname: string;
   serviceName: string;
   port: number;
+  ingressClassName: string;
 }
 
 export function loadAppIngress(params: AppIngressParams): V1Ingress {
   return renderTemplate<V1Ingress>('app-ingress', params);
+}
+
+export interface ShellSshServiceParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+  userId: string;
+}
+
+export function loadShellSshService(params: ShellSshServiceParams): V1Service {
+  return renderTemplate<V1Service>('shell-ssh-service', params);
+}
+
+/**
+ * Traefik IngressRouteTCP for SSH
+ * Note: This is a Traefik CRD, not a standard K8s resource
+ */
+export interface ShellSshIngressRouteParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+  userId: string;
+  hostname: string;
+  serviceName: string;
+  sshEntryPoint: string;
+}
+
+// IngressRouteTCP is a Traefik CRD - define minimal type
+export interface IngressRouteTCP {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    labels?: Record<string, string>;
+  };
+  spec: {
+    entryPoints: string[];
+    routes: Array<{
+      match: string;
+      services: Array<{
+        name: string;
+        port: number;
+      }>;
+    }>;
+    tls?: {
+      passthrough?: boolean;
+    };
+  };
+}
+
+export function loadShellSshIngressRoute(params: ShellSshIngressRouteParams): IngressRouteTCP {
+  return renderTemplate<IngressRouteTCP>('shell-ssh-ingressroute', params);
 }
 
 /**

--- a/packages/core/src/kubernetes/template-loader.ts
+++ b/packages/core/src/kubernetes/template-loader.ts
@@ -82,6 +82,8 @@ export interface ShellDeploymentParams {
   sshdLimitsCpu: string;
   sshdLimitsMemory: string;
   createdAt: string;
+  /** Kubernetes Secret name containing user's API keys (ANTHROPIC_API_KEY, etc.) */
+  userSecretName: string;
 }
 
 export function loadShellDeployment(params: ShellDeploymentParams): V1Deployment {

--- a/packages/core/src/kubernetes/template-loader.ts
+++ b/packages/core/src/kubernetes/template-loader.ts
@@ -1,0 +1,143 @@
+/**
+ * Kubernetes Template Loader
+ *
+ * Loads YAML templates from the templates directory and interpolates values.
+ * Uses a simple mustache-like syntax: {{variableName}}
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load as parseYaml } from 'js-yaml';
+import type { V1Deployment, V1Ingress, V1Service } from '@kubernetes/client-node';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = join(__dirname, 'templates');
+
+/**
+ * Template cache for performance
+ */
+const templateCache = new Map<string, string>();
+
+/**
+ * Load a template file (with caching)
+ */
+function loadTemplate(templateName: string): string {
+  if (templateCache.has(templateName)) {
+    return templateCache.get(templateName)!;
+  }
+
+  const templatePath = join(TEMPLATES_DIR, `${templateName}.yaml`);
+  const content = readFileSync(templatePath, 'utf-8');
+  templateCache.set(templateName, content);
+  return content;
+}
+
+/**
+ * Interpolate template variables using mustache-like syntax
+ * Supports: {{variableName}} - replaced with string value
+ */
+function interpolate(template: string, values: Record<string, string | number>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    if (key in values) {
+      return String(values[key]);
+    }
+    console.warn(`Template variable not found: ${key}`);
+    return match;
+  });
+}
+
+/**
+ * Load and render a template
+ */
+function renderTemplate<T>(templateName: string, values: object): T {
+  const template = loadTemplate(templateName);
+  const rendered = interpolate(template, values as Record<string, string | number>);
+  return parseYaml(rendered) as T;
+}
+
+// ============================================
+// Template-specific loaders with typed parameters
+// ============================================
+
+export interface ShellDeploymentParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+  userId: string;
+  username: string;
+  runAsUser: number;
+  runAsGroup: number;
+  worktreePath: string;
+  dockerHost: string;
+  shellImage: string;
+  dataPvc: string;
+  requestsCpu: string;
+  requestsMemory: string;
+  limitsCpu: string;
+  limitsMemory: string;
+  createdAt: string;
+}
+
+export function loadShellDeployment(params: ShellDeploymentParams): V1Deployment {
+  return renderTemplate<V1Deployment>('shell-deployment', params);
+}
+
+export interface PodmanDeploymentParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+  worktreePath: string;
+  podmanImage: string;
+  dataPvc: string;
+  requestsCpu: string;
+  requestsMemory: string;
+  limitsCpu: string;
+  limitsMemory: string;
+  createdAt: string;
+}
+
+export function loadPodmanDeployment(params: PodmanDeploymentParams): V1Deployment {
+  return renderTemplate<V1Deployment>('podman-deployment', params);
+}
+
+export interface PodmanServiceParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+}
+
+export function loadPodmanService(params: PodmanServiceParams): V1Service {
+  return renderTemplate<V1Service>('podman-service', params);
+}
+
+export interface AppServiceParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+  port: number;
+}
+
+export function loadAppService(params: AppServiceParams): V1Service {
+  return renderTemplate<V1Service>('app-service', params);
+}
+
+export interface AppIngressParams {
+  name: string;
+  namespace: string;
+  worktreeId: string;
+  hostname: string;
+  serviceName: string;
+  port: number;
+}
+
+export function loadAppIngress(params: AppIngressParams): V1Ingress {
+  return renderTemplate<V1Ingress>('app-ingress', params);
+}
+
+/**
+ * Clear template cache (for testing or hot reload)
+ */
+export function clearTemplateCache(): void {
+  templateCache.clear();
+}

--- a/packages/core/src/kubernetes/template-loader.ts
+++ b/packages/core/src/kubernetes/template-loader.ts
@@ -64,6 +64,7 @@ export interface ShellDeploymentParams {
   name: string;
   namespace: string;
   worktreeId: string;
+  worktreeName: string;
   userId: string;
   username: string;
   runAsUser: number;

--- a/packages/core/src/kubernetes/templates/app-ingress.yaml
+++ b/packages/core/src/kubernetes/templates/app-ingress.yaml
@@ -6,10 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: worktree-app
     agor.io/worktree-id: "{{worktreeId}}"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
 spec:
-  ingressClassName: traefik
+  ingressClassName: "{{ingressClassName}}"
   rules:
     - host: "{{hostname}}"
       http:

--- a/packages/core/src/kubernetes/templates/app-ingress.yaml
+++ b/packages/core/src/kubernetes/templates/app-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/component: worktree-app
+    agor.io/worktree-id: "{{worktreeId}}"
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: "{{hostname}}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "{{serviceName}}"
+                port:
+                  number: {{port}}

--- a/packages/core/src/kubernetes/templates/app-service.yaml
+++ b/packages/core/src/kubernetes/templates/app-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/component: worktree-app
+    agor.io/worktree-id: "{{worktreeId}}"
+spec:
+  selector:
+    app.kubernetes.io/name: agor-podman-pod
+    agor.io/worktree-id: "{{worktreeId}}"
+  ports:
+    - name: http
+      port: {{port}}
+      targetPort: {{port}}
+      protocol: TCP

--- a/packages/core/src/kubernetes/templates/podman-deployment.yaml
+++ b/packages/core/src/kubernetes/templates/podman-deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/name: agor-podman-pod
+    app.kubernetes.io/component: container-runtime
+    agor.io/worktree-id: "{{worktreeId}}"
+  annotations:
+    agor.io/created-at: "{{createdAt}}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agor-podman-pod
+      agor.io/worktree-id: "{{worktreeId}}"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agor-podman-pod
+        app.kubernetes.io/component: container-runtime
+        agor.io/worktree-id: "{{worktreeId}}"
+      annotations:
+        agor.io/created-at: "{{createdAt}}"
+        agor.io/last-activity: "{{createdAt}}"
+    spec:
+      serviceAccountName: agor-podman-pod
+      initContainers:
+        - name: init-paths
+          image: busybox:1.36
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              cat /proc/sys/kernel/random/uuid | tr -d "-" > /etc-override/machine-id
+              chmod 444 /etc-override/machine-id
+
+              mkdir -p /home/agor/.agor
+              ln -sf /data/worktrees /home/agor/.agor/worktrees
+              ln -sf /data/repos /home/agor/.agor/repos
+              echo "Init complete"
+          volumeMounts:
+            - name: etc-override
+              mountPath: /etc-override
+            - name: data
+              mountPath: /data
+            - name: home
+              mountPath: /home
+      containers:
+        - name: podman
+          image: "{{podmanImage}}"
+          command: ["podman", "system", "service", "--time=0", "tcp://0.0.0.0:2375"]
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 2375
+              name: docker-api
+              protocol: TCP
+          env:
+            - name: WORKTREE_PATH
+              value: "{{worktreePath}}"
+          workingDir: "{{worktreePath}}"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: home
+              mountPath: /home
+            - name: podman-storage
+              mountPath: /var/lib/containers
+            - name: etc-override
+              mountPath: /etc/machine-id
+              subPath: machine-id
+          resources:
+            requests:
+              cpu: "{{requestsCpu}}"
+              memory: "{{requestsMemory}}"
+            limits:
+              cpu: "{{limitsCpu}}"
+              memory: "{{limitsMemory}}"
+          readinessProbe:
+            tcpSocket:
+              port: 2375
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: "{{dataPvc}}"
+        - name: home
+          emptyDir: {}
+        - name: podman-storage
+          emptyDir: {}
+        - name: etc-override
+          emptyDir: {}

--- a/packages/core/src/kubernetes/templates/podman-deployment.yaml
+++ b/packages/core/src/kubernetes/templates/podman-deployment.yaml
@@ -28,28 +28,21 @@ spec:
       serviceAccountName: agor-podman-pod
       initContainers:
         - name: init-paths
-          image: busybox:1.36
+          image: "{{initImage}}"
           command: ["sh", "-c"]
           args:
             - |
               set -e
               cat /proc/sys/kernel/random/uuid | tr -d "-" > /etc-override/machine-id
               chmod 444 /etc-override/machine-id
-
-              mkdir -p /home/agor/.agor
-              ln -sf /data/worktrees /home/agor/.agor/worktrees
-              ln -sf /data/repos /home/agor/.agor/repos
               echo "Init complete"
           volumeMounts:
             - name: etc-override
               mountPath: /etc-override
-            - name: data
-              mountPath: /data
-            - name: home
-              mountPath: /home
       containers:
         - name: podman
           image: "{{podmanImage}}"
+          imagePullPolicy: Always
           command: ["podman", "system", "service", "--time=0", "tcp://0.0.0.0:2375"]
           securityContext:
             privileged: true
@@ -64,8 +57,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            - name: home
-              mountPath: /home
             - name: podman-storage
               mountPath: /var/lib/containers
             - name: etc-override
@@ -87,8 +78,6 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: "{{dataPvc}}"
-        - name: home
-          emptyDir: {}
         - name: podman-storage
           emptyDir: {}
         - name: etc-override

--- a/packages/core/src/kubernetes/templates/podman-service.yaml
+++ b/packages/core/src/kubernetes/templates/podman-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/component: container-runtime
+    agor.io/worktree-id: "{{worktreeId}}"
+spec:
+  selector:
+    app.kubernetes.io/name: agor-podman-pod
+    agor.io/worktree-id: "{{worktreeId}}"
+  ports:
+    - port: 2375
+      targetPort: 2375
+      name: docker-api
+      protocol: TCP

--- a/packages/core/src/kubernetes/templates/shell-deployment.yaml
+++ b/packages/core/src/kubernetes/templates/shell-deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/name: agor-shell-pod
+    app.kubernetes.io/component: terminal
+    agor.io/worktree-id: "{{worktreeId}}"
+    agor.io/user-id: "{{userId}}"
+    agor.io/unix-username: "{{username}}"
+    agor.io/unix-uid: "{{runAsUser}}"
+  annotations:
+    agor.io/created-at: "{{createdAt}}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agor-shell-pod
+      agor.io/worktree-id: "{{worktreeId}}"
+      agor.io/user-id: "{{userId}}"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agor-shell-pod
+        app.kubernetes.io/component: terminal
+        agor.io/worktree-id: "{{worktreeId}}"
+        agor.io/user-id: "{{userId}}"
+        agor.io/unix-username: "{{username}}"
+        agor.io/unix-uid: "{{runAsUser}}"
+      annotations:
+        agor.io/created-at: "{{createdAt}}"
+        agor.io/last-activity: "{{createdAt}}"
+    spec:
+      serviceAccountName: agor-shell-pod
+      securityContext:
+        fsGroup: {{runAsGroup}}
+      initContainers:
+        - name: init-user
+          image: busybox:1.36
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              cat > /etc-override/passwd << 'PASSWD'
+              root:x:0:0:root:/root:/bin/sh
+              nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+              PASSWD
+              echo "{{username}}:x:{{runAsUser}}:{{runAsGroup}}:{{username}}:/home/{{username}}:/bin/bash" >> /etc-override/passwd
+
+              cat > /etc-override/group << 'GROUP'
+              root:x:0:
+              nobody:x:65534:
+              GROUP
+              echo "{{username}}:x:{{runAsGroup}}:" >> /etc-override/group
+
+              chmod 644 /etc-override/passwd /etc-override/group
+
+              mkdir -p /data/homes/{{username}}
+              mkdir -p /data/homes/{{username}}/.agor
+              chown -R {{runAsUser}}:{{runAsGroup}} /data/homes/{{username}}
+
+              ln -sf /data/worktrees /data/homes/{{username}}/.agor/worktrees
+              ln -sf /data/repos /data/homes/{{username}}/.agor/repos
+
+              mkdir -p /home-override
+              ln -sf /data/homes/{{username}} /home-override/{{username}}
+
+              echo "Created user {{username}} (UID {{runAsUser}}) with home at /data/homes/{{username}}"
+          volumeMounts:
+            - name: etc-override
+              mountPath: /etc-override
+            - name: home-override
+              mountPath: /home-override
+            - name: data
+              mountPath: /data
+      containers:
+        - name: shell
+          image: "{{shellImage}}"
+          command: ["sleep", "infinity"]
+          securityContext:
+            runAsUser: {{runAsUser}}
+            runAsGroup: {{runAsGroup}}
+            runAsNonRoot: true
+          env:
+            - name: WORKTREE_PATH
+              value: "{{worktreePath}}"
+            - name: DOCKER_HOST
+              value: "{{dockerHost}}"
+            - name: HOME
+              value: "/home/{{username}}"
+            - name: USER
+              value: "{{username}}"
+            - name: LOGNAME
+              value: "{{username}}"
+          workingDir: "{{worktreePath}}"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: home-override
+              mountPath: /home
+            - name: etc-override
+              mountPath: /etc/passwd
+              subPath: passwd
+            - name: etc-override
+              mountPath: /etc/group
+              subPath: group
+          resources:
+            requests:
+              cpu: "{{requestsCpu}}"
+              memory: "{{requestsMemory}}"
+            limits:
+              cpu: "{{limitsCpu}}"
+              memory: "{{limitsMemory}}"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: "{{dataPvc}}"
+        - name: home-override
+          emptyDir: {}
+        - name: etc-override
+          emptyDir: {}

--- a/packages/core/src/kubernetes/templates/shell-deployment.yaml
+++ b/packages/core/src/kubernetes/templates/shell-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         agor.io/created-at: "{{createdAt}}"
         agor.io/last-activity: "{{createdAt}}"
     spec:
+      hostname: "{{worktreeName}}"
       serviceAccountName: agor-shell-pod
       securityContext:
         fsGroup: {{runAsGroup}}
@@ -142,7 +143,7 @@ spec:
               value: "{{username}}"
             - name: LOGNAME
               value: "{{username}}"
-          workingDir: "{{worktreePath}}"
+          workingDir: "/home/{{username}}"
           volumeMounts:
             - name: data
               mountPath: /data

--- a/packages/core/src/kubernetes/templates/shell-deployment.yaml
+++ b/packages/core/src/kubernetes/templates/shell-deployment.yaml
@@ -37,7 +37,8 @@ spec:
         fsGroup: {{runAsGroup}}
       initContainers:
         - name: init-user
-          image: busybox:1.36
+          image: "{{shellImage}}"
+          imagePullPolicy: Always
           securityContext:
             runAsUser: 0
             runAsGroup: 0
@@ -45,41 +46,86 @@ spec:
           args:
             - |
               set -e
+              # Create passwd/group files
               cat > /etc-override/passwd << 'PASSWD'
               root:x:0:0:root:/root:/bin/sh
               nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+              sshd:x:74:74:sshd:/var/empty/sshd:/sbin/nologin
               PASSWD
               echo "{{username}}:x:{{runAsUser}}:{{runAsGroup}}:{{username}}:/home/{{username}}:/bin/bash" >> /etc-override/passwd
 
               cat > /etc-override/group << 'GROUP'
               root:x:0:
               nobody:x:65534:
+              sshd:x:74:
               GROUP
               echo "{{username}}:x:{{runAsGroup}}:" >> /etc-override/group
 
               chmod 644 /etc-override/passwd /etc-override/group
 
+              # Create user home directory
               mkdir -p /data/homes/{{username}}
               mkdir -p /data/homes/{{username}}/.agor
+              mkdir -p /data/homes/{{username}}/.ssh
+              chmod 700 /data/homes/{{username}}/.ssh
+              touch /data/homes/{{username}}/.ssh/authorized_keys
+              chmod 600 /data/homes/{{username}}/.ssh/authorized_keys
               chown -R {{runAsUser}}:{{runAsGroup}} /data/homes/{{username}}
 
-              ln -sf /data/worktrees /data/homes/{{username}}/.agor/worktrees
-              ln -sf /data/repos /data/homes/{{username}}/.agor/repos
+              ln -sfn /data/worktrees /data/homes/{{username}}/.agor/worktrees
+              ln -sfn /data/repos /data/homes/{{username}}/.agor/repos
 
               mkdir -p /home-override
               ln -sf /data/homes/{{username}} /home-override/{{username}}
 
-              echo "Created user {{username}} (UID {{runAsUser}}) with home at /data/homes/{{username}}"
+              # Generate SSH host keys if they don't exist
+              mkdir -p /ssh-host-keys
+              if [ ! -f /data/ssh-host-keys/ssh_host_rsa_key ]; then
+                mkdir -p /data/ssh-host-keys
+                ssh-keygen -t rsa -b 4096 -f /data/ssh-host-keys/ssh_host_rsa_key -N "" -q
+                ssh-keygen -t ecdsa -b 521 -f /data/ssh-host-keys/ssh_host_ecdsa_key -N "" -q
+                ssh-keygen -t ed25519 -f /data/ssh-host-keys/ssh_host_ed25519_key -N "" -q
+                chmod 600 /data/ssh-host-keys/ssh_host_*_key
+                chmod 644 /data/ssh-host-keys/ssh_host_*_key.pub
+              fi
+              cp /data/ssh-host-keys/* /ssh-host-keys/
+              chmod 600 /ssh-host-keys/ssh_host_*_key
+              chmod 644 /ssh-host-keys/ssh_host_*_key.pub
+
+              # Create sshd_config
+              cat > /etc-override/sshd_config << 'SSHD_CONFIG'
+              Port 22
+              Protocol 2
+              HostKey /etc/ssh/ssh_host_rsa_key
+              HostKey /etc/ssh/ssh_host_ecdsa_key
+              HostKey /etc/ssh/ssh_host_ed25519_key
+              PermitRootLogin no
+              PubkeyAuthentication yes
+              PasswordAuthentication no
+              ChallengeResponseAuthentication no
+              UsePAM no
+              X11Forwarding no
+              PrintMotd no
+              AcceptEnv LANG LC_*
+              Subsystem sftp /usr/lib/openssh/sftp-server
+              AuthorizedKeysFile /home/%u/.ssh/authorized_keys
+              SSHD_CONFIG
+              chmod 644 /etc-override/sshd_config
+
+              echo "Created user {{username}} (UID {{runAsUser}}) with SSH support"
           volumeMounts:
             - name: etc-override
               mountPath: /etc-override
             - name: home-override
               mountPath: /home-override
+            - name: ssh-host-keys
+              mountPath: /ssh-host-keys
             - name: data
               mountPath: /data
       containers:
         - name: shell
           image: "{{shellImage}}"
+          imagePullPolicy: Always
           command: ["sleep", "infinity"]
           securityContext:
             runAsUser: {{runAsUser}}
@@ -115,6 +161,56 @@ spec:
             limits:
               cpu: "{{limitsCpu}}"
               memory: "{{limitsMemory}}"
+        - name: sshd
+          image: "{{shellImage}}"
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c", "mkdir -p /run/sshd && /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          ports:
+            - containerPort: 22
+              name: ssh
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: home-override
+              mountPath: /home
+            - name: etc-override
+              mountPath: /etc/passwd
+              subPath: passwd
+            - name: etc-override
+              mountPath: /etc/group
+              subPath: group
+            - name: etc-override
+              mountPath: /etc/ssh/sshd_config
+              subPath: sshd_config
+            - name: ssh-host-keys
+              mountPath: /etc/ssh/ssh_host_rsa_key
+              subPath: ssh_host_rsa_key
+            - name: ssh-host-keys
+              mountPath: /etc/ssh/ssh_host_rsa_key.pub
+              subPath: ssh_host_rsa_key.pub
+            - name: ssh-host-keys
+              mountPath: /etc/ssh/ssh_host_ecdsa_key
+              subPath: ssh_host_ecdsa_key
+            - name: ssh-host-keys
+              mountPath: /etc/ssh/ssh_host_ecdsa_key.pub
+              subPath: ssh_host_ecdsa_key.pub
+            - name: ssh-host-keys
+              mountPath: /etc/ssh/ssh_host_ed25519_key
+              subPath: ssh_host_ed25519_key
+            - name: ssh-host-keys
+              mountPath: /etc/ssh/ssh_host_ed25519_key.pub
+              subPath: ssh_host_ed25519_key.pub
+          resources:
+            requests:
+              cpu: "{{sshdRequestsCpu}}"
+              memory: "{{sshdRequestsMemory}}"
+            limits:
+              cpu: "{{sshdLimitsCpu}}"
+              memory: "{{sshdLimitsMemory}}"
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -122,4 +218,6 @@ spec:
         - name: home-override
           emptyDir: {}
         - name: etc-override
+          emptyDir: {}
+        - name: ssh-host-keys
           emptyDir: {}

--- a/packages/core/src/kubernetes/templates/shell-deployment.yaml
+++ b/packages/core/src/kubernetes/templates/shell-deployment.yaml
@@ -113,6 +113,45 @@ spec:
               SSHD_CONFIG
               chmod 644 /etc-override/sshd_config
 
+              # Create profile.d directory for SSH environment variables
+              mkdir -p /etc-override/profile.d
+              cat > /etc-override/profile.d/agor-env.sh << 'AGOR_ENV'
+              # Agor environment variables for shell/SSH sessions
+              # Clean: Only set essential vars + user API keys
+
+              # Unset Kubernetes-injected service discovery variables
+              unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT KUBERNETES_PORT
+              for var in $(env | grep -E '^(AGOR_|KUBERNETES_|.*_SERVICE_HOST|.*_SERVICE_PORT|.*_PORT_[0-9])' | cut -d= -f1); do
+                unset "$var" 2>/dev/null
+              done
+
+              # Set only the variables users need
+              export WORKTREE_PATH="{{worktreePath}}"
+              export DOCKER_HOST="{{dockerHost}}"
+
+              # Load user API keys from secret mount (each key is a file)
+              if [ -d /run/secrets/user-keys ]; then
+                for keyfile in /run/secrets/user-keys/*; do
+                  if [ -f "$keyfile" ]; then
+                    keyname=$(basename "$keyfile")
+                    export "$keyname"="$(cat "$keyfile")"
+                  fi
+                done
+              fi
+              AGOR_ENV
+              chmod 644 /etc-override/profile.d/agor-env.sh
+
+              # Add to user's bashrc to source profile.d scripts
+              cat >> /data/homes/{{username}}/.bashrc << 'BASHRC'
+              # Source Agor environment
+              if [ -d /etc/profile.d ]; then
+                for f in /etc/profile.d/agor-*.sh; do
+                  [ -r "$f" ] && . "$f"
+                done
+              fi
+              BASHRC
+              chown {{runAsUser}}:{{runAsGroup}} /data/homes/{{username}}/.bashrc
+
               echo "Created user {{username}} (UID {{runAsUser}}) with SSH support"
           volumeMounts:
             - name: etc-override
@@ -143,6 +182,10 @@ spec:
               value: "{{username}}"
             - name: LOGNAME
               value: "{{username}}"
+          envFrom:
+            - secretRef:
+                name: "{{userSecretName}}"
+                optional: true
           workingDir: "/home/{{username}}"
           volumeMounts:
             - name: data
@@ -155,6 +198,12 @@ spec:
             - name: etc-override
               mountPath: /etc/group
               subPath: group
+            - name: etc-override
+              mountPath: /etc/profile.d
+              subPath: profile.d
+            - name: user-keys
+              mountPath: /run/secrets/user-keys
+              readOnly: true
           resources:
             requests:
               cpu: "{{requestsCpu}}"
@@ -205,6 +254,12 @@ spec:
             - name: ssh-host-keys
               mountPath: /etc/ssh/ssh_host_ed25519_key.pub
               subPath: ssh_host_ed25519_key.pub
+            - name: etc-override
+              mountPath: /etc/profile.d
+              subPath: profile.d
+            - name: user-keys
+              mountPath: /run/secrets/user-keys
+              readOnly: true
           resources:
             requests:
               cpu: "{{sshdRequestsCpu}}"
@@ -222,3 +277,7 @@ spec:
           emptyDir: {}
         - name: ssh-host-keys
           emptyDir: {}
+        - name: user-keys
+          secret:
+            secretName: "{{userSecretName}}"
+            optional: true

--- a/packages/core/src/kubernetes/templates/shell-ssh-ingressroute.yaml
+++ b/packages/core/src/kubernetes/templates/shell-ssh-ingressroute.yaml
@@ -1,0 +1,30 @@
+# Traefik TCP IngressRoute for SSH
+# Note: Requires Traefik entrypoint for SSH (e.g., "ssh" on port 2222)
+# and TLS passthrough. Client must wrap SSH in TLS for SNI routing.
+#
+# Example client connection:
+#   ssh -o ProxyCommand="openssl s_client -quiet -connect %h:2222 -servername %h" user@{{hostname}}
+#
+# Or configure in ~/.ssh/config:
+#   Host *.ssh.agor.local
+#     ProxyCommand openssl s_client -quiet -connect %h:2222 -servername %h
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/name: agor-shell-ssh
+    app.kubernetes.io/component: ssh
+    agor.io/worktree-id: "{{worktreeId}}"
+    agor.io/user-id: "{{userId}}"
+spec:
+  entryPoints:
+    - {{sshEntryPoint}}
+  routes:
+    - match: HostSNI(`{{hostname}}`)
+      services:
+        - name: "{{serviceName}}"
+          port: 22
+  tls:
+    passthrough: true

--- a/packages/core/src/kubernetes/templates/shell-ssh-service.yaml
+++ b/packages/core/src/kubernetes/templates/shell-ssh-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{name}}"
+  namespace: "{{namespace}}"
+  labels:
+    app.kubernetes.io/name: agor-shell-ssh
+    app.kubernetes.io/component: ssh
+    agor.io/worktree-id: "{{worktreeId}}"
+    agor.io/user-id: "{{userId}}"
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: agor-shell-pod
+    agor.io/worktree-id: "{{worktreeId}}"
+    agor.io/user-id: "{{userId}}"
+  ports:
+    - port: 22
+      targetPort: 22
+      name: ssh
+      protocol: TCP

--- a/packages/core/src/kubernetes/types.ts
+++ b/packages/core/src/kubernetes/types.ts
@@ -261,3 +261,11 @@ export function getDockerHost(worktreeId: WorktreeID, namespace: string): string
   const serviceName = getPodmanServiceName(worktreeId);
   return `tcp://${serviceName}.${namespace}.svc:2375`;
 }
+
+/**
+ * Generate user secret name for API keys
+ * Format: agor-user-{userId}-keys
+ */
+export function getUserSecretName(userId: UserID): string {
+  return `agor-user-${getUserShortId(userId)}-keys`;
+}

--- a/packages/core/src/kubernetes/types.ts
+++ b/packages/core/src/kubernetes/types.ts
@@ -1,0 +1,176 @@
+/**
+ * Kubernetes Integration Types
+ *
+ * Types for isolated terminal pods feature.
+ */
+
+import type { UserID, WorktreeID } from '../types/id.js';
+
+/**
+ * Terminal execution mode
+ */
+export type TerminalMode = 'daemon' | 'pod';
+
+/**
+ * Shell pod configuration
+ */
+export interface ShellPodConfig {
+  image: string;
+  resources: {
+    requests: { cpu: string; memory: string };
+    limits: { cpu: string; memory: string };
+  };
+}
+
+/**
+ * Podman pod configuration
+ */
+export interface PodmanPodConfig {
+  image: string;
+  resources: {
+    requests: { cpu: string; memory: string };
+    limits: { cpu: string; memory: string };
+  };
+}
+
+/**
+ * User pod configuration (from Helm values)
+ */
+export interface UserPodConfig {
+  enabled: boolean;
+  namespace: string;
+  shellPod: ShellPodConfig;
+  podmanPod: PodmanPodConfig;
+  idleTimeoutMinutes: {
+    shell: number;
+    podman: number;
+  };
+  storage: {
+    /** Single PVC for all data (worktrees + repos as subdirectories) */
+    dataPvc: string;
+  };
+}
+
+/**
+ * Default user pod configuration
+ */
+export const DEFAULT_USER_POD_CONFIG: UserPodConfig = {
+  enabled: false,
+  namespace: 'agor',
+  shellPod: {
+    image: 'agor/shell:dev',
+    resources: {
+      requests: { cpu: '50m', memory: '128Mi' },
+      limits: { cpu: '1', memory: '1Gi' },
+    },
+  },
+  podmanPod: {
+    image: 'quay.io/podman/stable',
+    resources: {
+      requests: { cpu: '100m', memory: '256Mi' },
+      limits: { cpu: '4', memory: '8Gi' },
+    },
+  },
+  idleTimeoutMinutes: {
+    shell: 30,
+    podman: 60,
+  },
+  storage: {
+    dataPvc: 'agor-data',
+  },
+};
+
+/**
+ * Shell pod metadata
+ */
+export interface ShellPodInfo {
+  podName: string;
+  worktreeId: WorktreeID;
+  userId: UserID;
+  createdAt: string;
+  lastActivity: string;
+  status: 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Unknown';
+}
+
+/**
+ * Podman pod metadata
+ */
+export interface PodmanPodInfo {
+  podName: string;
+  serviceName: string;
+  worktreeId: WorktreeID;
+  createdAt: string;
+  lastActivity: string;
+  status: 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Unknown';
+}
+
+/**
+ * Pod labels used for querying
+ */
+export const POD_LABELS = {
+  APP_NAME: 'app.kubernetes.io/name',
+  COMPONENT: 'app.kubernetes.io/component',
+  WORKTREE_ID: 'agor.io/worktree-id',
+  USER_ID: 'agor.io/user-id',
+  UNIX_USERNAME: 'agor.io/unix-username',
+  UNIX_UID: 'agor.io/unix-uid',
+} as const;
+
+/**
+ * Pod label values
+ */
+export const POD_LABEL_VALUES = {
+  SHELL_POD: 'agor-shell-pod',
+  PODMAN_POD: 'agor-podman-pod',
+  TERMINAL: 'terminal',
+  CONTAINER_RUNTIME: 'container-runtime',
+} as const;
+
+/**
+ * Pod annotations
+ */
+export const POD_ANNOTATIONS = {
+  CREATED_AT: 'agor.io/created-at',
+  LAST_ACTIVITY: 'agor.io/last-activity',
+} as const;
+
+/**
+ * Service account names
+ */
+export const SERVICE_ACCOUNTS = {
+  SHELL_POD: 'agor-shell-pod',
+  PODMAN_POD: 'agor-podman-pod',
+} as const;
+
+/**
+ * Generate shell pod name
+ */
+export function getShellPodName(worktreeId: WorktreeID, userId: UserID): string {
+  const worktreeShort = worktreeId.slice(0, 8);
+  const userShort = userId.slice(0, 8);
+  return `agor-shell-${worktreeShort}-${userShort}`;
+}
+
+/**
+ * Generate podman pod name
+ */
+export function getPodmanPodName(worktreeId: WorktreeID): string {
+  const worktreeShort = worktreeId.slice(0, 8);
+  return `agor-podman-${worktreeShort}`;
+}
+
+/**
+ * Generate podman service name
+ */
+export function getPodmanServiceName(worktreeId: WorktreeID): string {
+  const worktreeShort = worktreeId.slice(0, 8);
+  return `podman-${worktreeShort}`;
+}
+
+/**
+ * Generate DOCKER_HOST value for a worktree
+ */
+export function getDockerHost(worktreeId: WorktreeID, namespace: string): string {
+  const serviceName = getPodmanServiceName(worktreeId);
+  return `tcp://${serviceName}.${namespace}.svc:2375`;
+}

--- a/packages/core/src/kubernetes/types.ts
+++ b/packages/core/src/kubernetes/types.ts
@@ -142,29 +142,72 @@ export const SERVICE_ACCOUNTS = {
   PODMAN_POD: 'agor-podman-pod',
 } as const;
 
+// ============================================
+// Resource Naming Convention
+// ============================================
+// All worktree-related Kubernetes resources follow the pattern:
+//   wt-{worktreeId}-{component}[-{extra}]
+//
+// Components:
+//   - shell-{userId}  : Shell deployment for terminal access
+//   - podman          : Podman deployment for container runtime
+//   - podman-svc      : Service for podman docker API
+//   - app-svc         : Service for worktree app port
+//   - ingress         : Ingress for external app access
+// ============================================
+
 /**
- * Generate shell pod name
+ * Get short worktree ID (first 8 chars)
  */
-export function getShellPodName(worktreeId: WorktreeID, userId: UserID): string {
-  const worktreeShort = worktreeId.slice(0, 8);
-  const userShort = userId.slice(0, 8);
-  return `agor-shell-${worktreeShort}-${userShort}`;
+export function getWorktreeShortId(worktreeId: WorktreeID): string {
+  return worktreeId.slice(0, 8);
 }
 
 /**
- * Generate podman pod name
+ * Get short user ID (first 8 chars)
+ */
+export function getUserShortId(userId: UserID): string {
+  return userId.slice(0, 8);
+}
+
+/**
+ * Generate shell deployment name
+ * Format: wt-{worktreeId}-shell-{userId}
+ */
+export function getShellPodName(worktreeId: WorktreeID, userId: UserID): string {
+  return `wt-${getWorktreeShortId(worktreeId)}-shell-${getUserShortId(userId)}`;
+}
+
+/**
+ * Generate podman deployment name
+ * Format: wt-{worktreeId}-podman
  */
 export function getPodmanPodName(worktreeId: WorktreeID): string {
-  const worktreeShort = worktreeId.slice(0, 8);
-  return `agor-podman-${worktreeShort}`;
+  return `wt-${getWorktreeShortId(worktreeId)}-podman`;
 }
 
 /**
  * Generate podman service name
+ * Format: wt-{worktreeId}-podman-svc
  */
 export function getPodmanServiceName(worktreeId: WorktreeID): string {
-  const worktreeShort = worktreeId.slice(0, 8);
-  return `podman-${worktreeShort}`;
+  return `wt-${getWorktreeShortId(worktreeId)}-podman-svc`;
+}
+
+/**
+ * Generate app service name
+ * Format: wt-{worktreeId}-app-svc
+ */
+export function getAppServiceName(worktreeId: WorktreeID): string {
+  return `wt-${getWorktreeShortId(worktreeId)}-app-svc`;
+}
+
+/**
+ * Generate app ingress name
+ * Format: wt-{worktreeId}-ingress
+ */
+export function getAppIngressName(worktreeId: WorktreeID): string {
+  return `wt-${getWorktreeShortId(worktreeId)}-ingress`;
 }
 
 /**

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -119,6 +119,8 @@ export interface User extends BaseUserFields {
   updated_at?: Date;
   // Unix username for process impersonation (optional, unique, admin-managed)
   unix_username?: string;
+  // Unix UID for container security context (consistent file ownership on EFS/NFS)
+  unix_uid?: number;
   // API key status (boolean only, never exposes actual keys)
   api_keys?: {
     ANTHROPIC_API_KEY?: boolean; // true = key is set, false/undefined = not set

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for worktree isolation
+    'kubernetes/index': 'src/kubernetes/index.ts', // Kubernetes pod management for isolated terminals
   },
   format: ['cjs', 'esm'],
   dts: true,
@@ -43,6 +44,7 @@ export default defineConfig({
     '@google/gemini-cli-core',
     '@google/genai',
     '@opencode-ai/sdk',
+    '@kubernetes/client-node',
     'node:fs',
     'node:fs/promises',
     'node:path',

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -59,5 +59,9 @@ export default defineConfig({
     // Copy template files to dist so they're available at runtime
     cpSync('src/templates/agor-system-prompt.md', 'dist/templates/agor-system-prompt.md');
     console.log('✅ Copied agor-system-prompt.md template to dist/');
+
+    // Copy kubernetes YAML templates to dist
+    cpSync('src/kubernetes/templates', 'dist/kubernetes/templates', { recursive: true });
+    console.log('✅ Copied kubernetes templates to dist/');
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -6109,6 +6112,7 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -12727,7 +12731,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
 
   '@types/cookiejar@2.1.5': {}
 
@@ -12868,7 +12872,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.7':
     dependencies:
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -12947,7 +12951,7 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
 
   '@types/nlcst@2.0.3':
     dependencies:
@@ -13000,11 +13004,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
 
   '@types/serve-static@1.15.10':
     dependencies:
@@ -13016,7 +13020,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
       form-data: 4.0.4
 
   '@types/tough-cookie@4.0.5': {}
@@ -14352,7 +14356,7 @@ snapshots:
   engine.io@6.6.4:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -17144,7 +17148,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.0
+      '@types/node': 22.19.0
       long: 5.3.2
 
   proxy-addr@2.0.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@kubernetes/client-node':
+        specifier: ^0.22.3
+        version: 0.22.3
       '@libsql/client':
         specifier: ^0.15.15
         version: 0.15.15
@@ -2008,6 +2011,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2043,8 +2050,23 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@kubernetes/client-node@0.22.3':
+    resolution: {integrity: sha512-dG8uah3+HDJLpJEESshLRZlAZ4PgDeV9mZXT0u1g7oy4KMRzdZ7n5g0JEIlL6QhK51/2ztcIqURAnjfjJt6Z+g==}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -3973,6 +3995,9 @@ packages:
       ajv:
         optional: true
 
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
@@ -4055,6 +4080,13 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
@@ -4082,6 +4114,12 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
@@ -4102,6 +4140,9 @@ packages:
   baseline-browser-mapping@2.8.25:
     resolution: {integrity: sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
@@ -4177,6 +4218,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
+
   byte-counter@0.1.0:
     resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
     engines: {node: '>=20'}
@@ -4217,6 +4262,9 @@ packages:
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4280,6 +4328,10 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chromatic@12.2.0:
     resolution: {integrity: sha512-GswmBW9ZptAoTns1BMyjbm55Z7EsIJnUvYKdQqXIBZIKbGErmpA+p4c0BYA+nzw5B0M+rb3Iqp1IaH8TFwIQew==}
@@ -4449,6 +4501,9 @@ packages:
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -4644,6 +4699,10 @@ packages:
 
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4917,6 +4976,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -5176,12 +5238,19 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -5279,6 +5348,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
@@ -5286,6 +5358,10 @@ packages:
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
 
   form-data@2.5.5:
     resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
@@ -5415,6 +5491,9 @@ packages:
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
   git-hooks-list@3.2.0:
     resolution: {integrity: sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==}
 
@@ -5506,6 +5585,15 @@ packages:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
+
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5626,6 +5714,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
 
   http2-wrapper@2.2.1:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
@@ -5802,6 +5894,9 @@ packages:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -5820,6 +5915,14 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5874,6 +5977,9 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
   jsdom@27.1.0:
     resolution: {integrity: sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -5882,6 +5988,10 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5901,8 +6011,17 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json2mq@0.2.0:
     resolution: {integrity: sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==}
@@ -5918,9 +6037,18 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonpath-plus@10.3.0:
+    resolution: {integrity: sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
 
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
@@ -6441,6 +6569,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
@@ -6619,6 +6751,12 @@ packages:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  oauth4webapi@3.8.3:
+    resolution: {integrity: sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6674,6 +6812,9 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openid-client@6.8.1:
+    resolution: {integrity: sha512-VoYT6enBo6Vj2j3Q5Ec0AezS+9YGzQo1f5Xc42lreMGlfP4ljiXPKVDvCADh+XHCV/bqPu/wWSiCVXbJKvrODw==}
 
   oxc-resolver@11.13.1:
     resolution: {integrity: sha512-/MS37pbsjfdujmuiM/qONFToT8zjDh78xOhVOPStG7fiZlE0b8od8XOfLhqovL0NnMR0ojumTUWF4LK/U15qDQ==}
@@ -6797,6 +6938,9 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -6925,6 +7069,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -6937,6 +7084,10 @@ packages:
 
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  qs@6.5.3:
+    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -7410,6 +7561,11 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -7479,6 +7635,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -7715,6 +7874,11 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -7737,6 +7901,10 @@ packages:
     peerDependenciesMeta:
       prettier:
         optional: true
+
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
 
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
@@ -7896,6 +8064,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
+    engines: {node: '>=18'}
+
   teeny-request@10.1.0:
     resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
     engines: {node: '>=18'}
@@ -7983,6 +8155,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
 
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
@@ -8093,6 +8269,9 @@ packages:
   turbo@2.6.0:
     resolution: {integrity: sha512-kC5VJqOXo50k0/0jnJDDjibLAXalqT9j7PQ56so0pN+81VR4Fwb2QgIE9dTzT3phqOTQuEXkPh3sCpnv5Isz2g==}
     hasBin: true
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   twoslash-protocol@0.2.12:
     resolution: {integrity: sha512-5qZLXVYfZ9ABdjqbvPc4RWMr7PrpPaaDSeaYY55vl/w1j6H6kzsWK/urAEIXlzYlyrFmyz1UbwIt+AA0ck+wbg==}
@@ -8225,6 +8404,9 @@ packages:
   upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
 
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
@@ -8246,6 +8428,11 @@ packages:
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@8.3.2:
@@ -8270,6 +8457,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8619,6 +8810,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
@@ -10641,6 +10836,10 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -10687,7 +10886,33 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
   '@keyv/serialize@1.1.1': {}
+
+  '@kubernetes/client-node@0.22.3':
+    dependencies:
+      byline: 5.0.0
+      isomorphic-ws: 5.0.0(ws@8.18.3)
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.3.0
+      request: 2.88.2
+      rfc4648: 1.5.4
+      stream-buffers: 3.0.3
+      tar: 7.5.2
+      tslib: 2.8.1
+      ws: 8.18.3
+    optionalDependencies:
+      openid-client: 6.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -13119,6 +13344,13 @@ snapshots:
     optionalDependencies:
       ajv: 8.17.1
 
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -13239,6 +13471,12 @@ snapshots:
 
   arrify@2.0.1: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
@@ -13263,6 +13501,10 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
+
   axe-core@4.11.0: {}
 
   bail@2.0.2: {}
@@ -13274,6 +13516,10 @@ snapshots:
   base64id@2.0.0: {}
 
   baseline-browser-mapping@2.8.25: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   bcryptjs@2.4.3: {}
 
@@ -13373,6 +13619,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  byline@5.0.0: {}
+
   byte-counter@0.1.0: {}
 
   bytes@3.1.2: {}
@@ -13423,6 +13671,8 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
       upper-case-first: 2.0.2
+
+  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -13503,6 +13753,8 @@ snapshots:
       readdirp: 4.1.2
 
   chownr@1.1.4: {}
+
+  chownr@3.0.0: {}
 
   chromatic@12.2.0: {}
 
@@ -13649,6 +13901,8 @@ snapshots:
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
+
+  core-util-is@1.0.2: {}
 
   cors@2.8.5:
     dependencies:
@@ -13876,6 +14130,10 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.21
 
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@6.0.0:
@@ -14032,6 +14290,11 @@ snapshots:
       stream-shift: 1.0.3
 
   eastasianwidth@0.2.0: {}
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -14438,6 +14701,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extsprintf@1.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -14447,6 +14712,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
@@ -14559,9 +14826,17 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forever-agent@0.6.1: {}
+
   form-data-encoder@2.1.4: {}
 
   form-data-encoder@4.1.0: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   form-data@2.5.5:
     dependencies:
@@ -14708,6 +14983,10 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
 
   git-hooks-list@3.2.0: {}
 
@@ -14880,6 +15159,13 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
+
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
 
   has-flag@4.0.0: {}
 
@@ -15122,6 +15408,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+
   http2-wrapper@2.2.1:
     dependencies:
       quick-lru: 5.1.1
@@ -15269,6 +15561,8 @@ snapshots:
 
   is-stream@4.0.1: {}
 
+  is-typedarray@1.0.0: {}
+
   is-unicode-supported@2.1.0: {}
 
   is-wsl@2.2.0:
@@ -15284,6 +15578,12 @@ snapshots:
       system-architecture: 0.1.0
 
   isexe@2.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
+  isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -15337,6 +15637,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbn@0.1.1: {}
+
   jsdom@27.1.0:
     dependencies:
       '@acemir/cssom': 0.9.20
@@ -15364,6 +15666,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsep@1.4.0: {}
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -15379,7 +15683,13 @@ snapshots:
       '@babel/runtime': 7.28.4
       ts-algebra: 2.0.0
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
+
+  json-stringify-safe@5.0.1: {}
 
   json2mq@0.2.0:
     dependencies:
@@ -15397,6 +15707,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonpath-plus@10.3.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
+
   jsonwebtoken@9.0.2:
     dependencies:
       jws: 3.2.2
@@ -15409,6 +15725,13 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.3
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
 
   jwa@1.4.2:
     dependencies:
@@ -16235,6 +16558,10 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
+
   mj-context-menu@0.6.1: {}
 
   mkdirp-classic@0.5.3: {}
@@ -16451,6 +16778,11 @@ snapshots:
 
   npm-to-yarn@3.0.1: {}
 
+  oauth-sign@0.9.0: {}
+
+  oauth4webapi@3.8.3:
+    optional: true
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -16534,6 +16866,12 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openid-client@6.8.1:
+    dependencies:
+      jose: 6.1.3
+      oauth4webapi: 3.8.3
+    optional: true
 
   oxc-resolver@11.13.1:
     optionalDependencies:
@@ -16676,6 +17014,8 @@ snapshots:
 
   pend@1.2.0: {}
 
+  performance-now@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -16812,6 +17152,10 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -16828,6 +17172,8 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.5.3: {}
 
   quansync@0.2.11: {}
 
@@ -17518,6 +17864,29 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -17601,6 +17970,8 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rfc4648@1.5.4: {}
 
   rfdc@1.4.1: {}
 
@@ -17967,6 +18338,18 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   stackback@0.0.2: {}
 
   statuses@2.0.1: {}
@@ -17998,6 +18381,8 @@ snapshots:
       - supports-color
       - utf-8-validate
       - vite
+
+  stream-buffers@3.0.3: {}
 
   stream-events@1.0.5:
     dependencies:
@@ -18169,6 +18554,14 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@7.5.2:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   teeny-request@10.1.0:
     dependencies:
       http-proxy-agent: 5.0.0
@@ -18247,6 +18640,11 @@ snapshots:
   toggle-selection@1.0.6: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
 
   tough-cookie@6.0.0:
     dependencies:
@@ -18352,6 +18750,8 @@ snapshots:
       turbo-linux-arm64: 2.6.0
       turbo-windows-64: 2.6.0
       turbo-windows-arm64: 2.6.0
+
+  tweetnacl@0.14.5: {}
 
   twoslash-protocol@0.2.12: {}
 
@@ -18499,6 +18899,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
   url-template@2.0.8: {}
 
   use-sync-external-store@1.6.0(react@18.3.1):
@@ -18512,6 +18916,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@13.0.0: {}
+
+  uuid@3.4.0: {}
 
   uuid@8.3.2: {}
 
@@ -18527,6 +18933,12 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   vfile-location@5.0.3:
     dependencies:
@@ -18935,6 +19347,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.1: {}
 


### PR DESCRIPTION
## Isolated Worktree Pods for Kubernetes

### Summary

This PR introduces Kubernetes-native terminal execution for Agor, enabling isolated shell environments per worktree with full container runtime support.

**Key additions:**
- Shell pods with per-user isolation and SSH access
- Podman sidecar for running containers within worktrees
- Helm chart for production Kubernetes deployments
- CLI commands: `agor worktree shell` and `agor worktree ssh`

### Why Isolated Pods?

**Before (daemon mode):**
- All terminals run as subprocesses of the daemon
- Shared filesystem namespace between users
- No container runtime available in worktrees
- Single point of failure - daemon crash kills all sessions

**After (pod mode):**
- Each worktree gets dedicated Kubernetes pods
- User isolation via Unix UID/GID mapping
- Per-worktree Podman container runtime (`DOCKER_HOST` auto-configured)
- Fault isolation - pod crashes don't affect other users
- Native SSH access for IDE remote development (VS Code, Cursor, JetBrains)

### Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                     Kubernetes Cluster                       │
├─────────────────────────────────────────────────────────────┤
│                                                              │
│  ┌──────────────┐     ┌──────────────────────────────────┐  │
│  │  agor-daemon │────▶│  Shell Pod (per user/worktree)   │  │
│  │              │     │  ├─ shell container (sleep inf)  │  │
│  │  - API       │     │  └─ sshd container (port 22)     │  │
│  │  - WebSocket │     └──────────────────────────────────┘  │
│  │  - Pod mgmt  │                                            │
│  └──────────────┘     ┌──────────────────────────────────┐  │
│                       │  Podman Pod (per worktree)        │  │
│                       │  └─ podman container (port 2375)  │  │
│                       └──────────────────────────────────┘  │
│                                                              │
│  ┌────────────────────────────────────────────────────────┐ │
│  │                  Shared NFS PVC                         │ │
│  │  /data/worktrees/  /data/repos/  /data/homes/          │ │
│  └────────────────────────────────────────────────────────┘ │
└─────────────────────────────────────────────────────────────┘
```

### Features

**Shell Pods:**
- Runs as user's Unix UID (mapped from Agor user)
- Zellij terminal multiplexer pre-installed
- Git, SSH, and development tools included
- Environment auto-configured: `WORKTREE_PATH`, `DOCKER_HOST`
- User API keys injected from Kubernetes secrets

**SSH Access:**
- Each shell pod runs an SSHD sidecar
- Public key authentication (keys managed via `agor worktree ssh --register-key`)
- Traefik IngressRoute for external SSH routing
- Compatible with VS Code Remote SSH, Cursor, JetBrains Gateway

**Podman Runtime:**
- Each worktree gets a dedicated Podman container
- Exposed as Docker API on internal service
- Enables `docker build`, `docker run` within worktrees
- Rootless container execution

**Idle Garbage Collection:**
- Shell pods: 30 min idle timeout (configurable)
- Podman pods: 60 min idle timeout (configurable)
- Activity tracking via last-activity annotations

### CLI Commands

```bash
# Open WebSocket terminal in worktree
agor worktree shell <worktree-id>

# SSH into worktree pod
agor worktree ssh <worktree-id>

# Register SSH public key
agor worktree ssh <worktree-id> --register-key ~/.ssh/id_ed25519.pub

# Supports short IDs
agor worktree shell af19e3dd
```

### Configuration

Terminal mode is configured in `~/.agor/config.yaml` or Helm values:

```yaml
execution:
  terminal_mode: pod  # 'daemon' or 'pod'
  user_pods:
    enabled: true
    shellPod:
      image: agor/shell:dev
      resources:
        limits:
          cpu: "1"
          memory: 1Gi
      sshdResources:
        limits:
          memory: 512Mi
    podmanPod:
      image: agor/podman:dev
      resources:
        limits:
          cpu: "4"
          memory: 6Gi
```

### Helm Deployment

```bash
# Build and push images
./helm/build.sh --push

# Deploy to Kubernetes
helm upgrade --install agor ./helm/agor -f helm/values-dev.yaml
```

### Test Plan

- [ ] Create worktree and verify shell pod creation
- [ ] Test `agor worktree shell` WebSocket terminal
- [ ] Register SSH key and test `agor worktree ssh`
- [ ] Run container builds via Podman (`docker build .`)
- [ ] Verify idle GC cleans up pods after timeout
- [ ] Test multi-user isolation (different UIDs)