### PR TITLE
fix(ui): update Claude models documentation link

### DIFF
--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -221,19 +221,21 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
               />
               <div style={{ marginTop: 8, fontSize: 12, color: 'rgba(255, 255, 255, 0.45)' }}>
                 Enter any model ID to pin to a specific version.{' '}
-                <Link
+                <a
                   href={
                     effectiveTool === 'codex'
                       ? 'https://platform.openai.com/docs/models'
                       : effectiveTool === 'gemini'
                         ? 'https://ai.google.dev/gemini-api/docs/models'
-                        : 'https://docs.anthropic.com/en/docs/about-claude/models' // claude-code (opencode handled earlier)
+                        : 'https://platform.claude.com/docs/en/about-claude/models' // claude-code (opencode handled earlier)
                   }
                   target="_blank"
-                  style={{ fontSize: 12 }}
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  style={{ fontSize: 12, color: '#1677ff' }}
                 >
                   View available models
-                </Link>
+                </a>
               </div>
             </div>
           )}


### PR DESCRIPTION
The old docs.anthropic.com URL was returning 404. Updated to the current platform.claude.com documentation URL.

Also switched from Typography.Link to native anchor tag for more reliable external link behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)