### PR TITLE
Resolve permission issues and startup hang by aligning container UID/GID

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,3 @@
+services:
+  agor-dev:
+    user: "${UID:-1000}:${GID:-1000}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,12 @@ services:
       context: .
       dockerfile: docker/Dockerfile
       target: development
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    # Ensure we run as the 'agor' user (defined in Dockerfile)
+    # This is critical for sudo access and permission handling in entrypoint
+    user: agor
     # No container_name - allows multiple instances via docker compose -p flag
     ports:
       # Expose daemon port (so browser can connect) - configurable via DAEMON_PORT

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,8 +65,14 @@ RUN npm install -g \
   @openai/codex@0.69.0 \
   opencode-ai@latest
 
-# Create non-root 'agor' user (main application user)
-RUN useradd -m -s /bin/bash agor && \
+# Arguments for matching host user UID/GID (default to 1000)
+ARG UID=1000
+ARG GID=1000
+
+# Rename existing 'node' user to 'agor' and switch UID/GID to match host
+# This is critical for bind mount permissions on Linux
+RUN usermod -l agor -d /home/agor -m -u ${UID} node && \
+    groupmod -n agor -g ${GID} node && \
     # Grant passwordless sudo for fixing volume permissions and executor spawning
     echo "agor ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agor && \
     chmod 0440 /etc/sudoers.d/agor && \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,8 +10,13 @@ echo "✅ Using pre-built dependencies from Docker image"
 # Fix permissions for build output directories only (not the entire /app tree!)
 # The bind mount (.:/app) is read-only for most files - we only need write access to dist/
 echo "🔧 Ensuring write access to build output directories..."
-sudo chown -R agor:agor /app/packages/*/dist /app/apps/*/dist 2>/dev/null || true
-echo "✅ Build directories writable"
+# Try to sudo chown if possible (non-interactive), but don't fail if not.
+if sudo -n true 2>/dev/null; then
+  sudo -n chown -R agor:agor /app/packages/*/dist /app/apps/*/dist 2>/dev/null || true
+  echo "✅ Build directories writable"
+else
+  echo "⚠️ sudo not available, skipping permission fix (this is expected if running as correct user)"
+fi
 
 # Skip husky in Docker (git hooks run on host, not in container)
 # Also avoids "fatal: not a git repository" error with worktrees where .git is a file, not a directory


### PR DESCRIPTION
when using `FROM node:20-slim AS base` we get a `node` user with UID 1000.
Then the Dockerfile creates a new user `agor` which has UID 1001.
When following the instructions for [Linux UID Mapping](https://github.com/preset-io/agor/blob/main/docker/README.md#host-uidgid-mapping-linux) there is a chance the UID will not match and `sudo` will not work inside the conainer - `sudo chown` will hang due to [fail](https://github.com/preset-io/agor/blob/5914487327ce25c07b8c92c9f00c6330963c43a4/docker/docker-entrypoint.sh#L13).

In order to fix this:
- Update Dockerfile to reuse existing 'node' user (UID 1000) as 'agor' instead of creating a new user. This ensures bind mount permissions match the host user.
- Add support for dynamic UID/GID via build arguments in Dockerfile and docker-compose.yml to match any host environment.
- Force user  in docker-compose.yml to ensure correct execution context.