### PR TITLE
fix(ui): sort boards alphabetically in Settings CRUD view

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -25,7 +25,7 @@ import {
   Typography,
 } from 'antd';
 import { useMemo, useState } from 'react';
-import { mapToArray } from '@/utils/mapHelpers';
+import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { JSONEditor, validateJSON } from '../JSONEditor';
@@ -424,7 +424,9 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
       </div>
 
       <Table
-        dataSource={mapToArray(boardById)}
+        dataSource={mapToSortedArray(boardById, (a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+        )}
         columns={columns}
         rowKey="board_id"
         pagination={false}


### PR DESCRIPTION
## Summary
- Sort boards alphabetically by name in the Settings/CRUD view
- Use case-insensitive locale comparison for proper sorting

## Test plan
- [ ] Open Settings modal
- [ ] Navigate to Boards tab
- [ ] Verify boards are listed in alphabetical order by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)