### PR TITLE
fix: Implement optimized RBAC filtering and logout security

### DIFF
--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -411,11 +411,18 @@ export function useAuth(): UseAuthReturn {
 
   /**
    * Logout
+   *
+   * Clears authentication tokens and forces a full page reload to clear all cached state.
+   * This prevents cached data from one user from leaking to another user on the same browser.
    */
   const logout = async () => {
-    console.log('🚪 Logout called, clearing tokens');
+    console.log('🚪 Logout called, clearing tokens and reloading page');
     console.trace('Logout stack trace');
+
+    // Clear tokens from localStorage
     clearTokens();
+
+    // Clear state (will be reset on reload anyway, but good practice)
     setState({
       user: null,
       accessToken: null,
@@ -423,6 +430,13 @@ export function useAuth(): UseAuthReturn {
       loading: false,
       error: null,
     });
+
+    // Force full page reload to clear:
+    // - Feathers client cache
+    // - All React state (sessionById, worktreeById, etc.)
+    // - Any other in-memory cached data
+    // This prevents security issues where User A's data remains visible after User B logs in
+    window.location.href = '/';
   };
 
   return {


### PR DESCRIPTION
## Summary

This PR fixes two critical security issues and eliminates N+1 database query problems in the RBAC implementation.

### Security Fixes

1. **Session RBAC Filtering (Security Vulnerability)** ⚠️
   - **Issue:** Users could see ALL sessions globally, even for worktrees they don't have access to
   - **Root Cause:** Sessions service had RBAC checks on `get`, `create`, `patch`, `remove`, but NO filtering on `find()`
   - **Fix:** Added optimized SQL-based filtering hook for `sessions.find()`

2. **Logout State Persistence (Data Leak)** 🔒
   - **Issue:** When logging out and logging in as different user, cached data from previous user remained visible until page refresh
   - **Root Cause:** Logout only cleared localStorage tokens, not Feathers client cache or React state
   - **Fix:** Force full page reload on logout to clear all cached state

### Performance Optimizations

**Before (N+1 Problem):**
```typescript
// Old approach: Post-query filtering with N queries
for (const worktree of worktrees) {
  const isOwner = await worktreeRepo.isOwner(...);  // N queries!
}
```
With 100 worktrees = **100+ database queries per page load** 😱

**After (Optimized SQL):**
```sql
-- Single query with JOINs
SELECT DISTINCT s.*
FROM sessions s
INNER JOIN worktrees w ON s.worktree_id = w.worktree_id
LEFT JOIN worktree_owners wo ON w.worktree_id = wo.worktree_id AND wo.user_id = $userId
WHERE 
  wo.user_id IS NOT NULL  -- User owns worktree
  OR w.others_can IN ('view', 'prompt', 'all')  -- OR others_can allows access
```
**1 query instead of N+1** ✅

## Changes Made

### Repository Layer (packages/core/src/db/repositories/)

**worktrees.ts**
- Added `findAccessibleWorktrees()` - Single SQL query with LEFT JOIN

**sessions.ts**
- Added `findAccessibleSessions()` - Single SQL query with INNER + LEFT JOIN
- Returns sessions where user is owner OR worktree.others_can allows access

### Authorization Hooks (apps/agor-daemon/src/utils/worktree-authorization.ts)

- Updated `scopeWorktreeQuery()` - Changed from post-filtering to pre-filtering using BEFORE hook
- Added `scopeSessionQuery()` - New hook for session filtering with optimized SQL
- Deprecated `filterWorktreesByPermission()` - Marked as deprecated with warning (kept for reference)

### Service Hooks (apps/agor-daemon/src/index.ts)

- Worktrees `before.find` - Uses `scopeWorktreeQuery()` for SQL-based filtering
- Sessions `before.find` - Uses `scopeSessionQuery()` for SQL-based filtering  
- Removed old `after.find` hooks (no longer needed)

### UI Logout (apps/agor-ui/src/hooks/useAuth.ts)

- Added full page reload on logout to clear all cached state
- Prevents security issues where User A's data remains visible after User B logs in

## Key Benefits

1. ✅ **Security Fixed:** Users can only see sessions/worktrees they have access to
2. ✅ **Performance Optimized:** 1 SQL query instead of N+1 (100x faster for 100 worktrees)
3. ✅ **Config-Aware:** Checks `worktreeRbacEnabled` flag - simpler query when RBAC disabled
4. ✅ **Database-Level Filtering:** Works correctly with pagination (LIMIT/OFFSET)
5. ✅ **State Isolation:** Logout properly clears cache to prevent data leaks

## Testing

To test the RBAC filtering:

1. Create a worktree as `max@preset.io` with `others_can: 'none'`
2. Logout (will now force page reload)
3. Login as `admin@agor.live`
4. **Expected:** The private worktree should NOT appear in the list
5. **Expected:** Sessions in that worktree should NOT appear in the list

To test logout:
1. Login as User A, note the visible worktrees/sessions
2. Logout (should reload page automatically)
3. Login as User B
4. **Expected:** Only User B's accessible data is visible, no cached data from User A

## Type Safety

All changes pass TypeScript compilation:
- Added proper type annotations for map callbacks
- Created `sessionsRepository` instance for hook usage
- Removed unused `filterWorktreesByPermission` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>