### PR TITLE
Remove excessive streaming chunk logging

### DIFF
--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -140,7 +140,6 @@ export function createStreamingCallbacks(
       // Get final sequence number for this message
       const finalSequence = sequenceCounters.get(message_id) || 0;
 
-      console.log(`[${toolName}] Stream ended: ${message_id}, final seq: ${finalSequence}`);
       await broadcastEvent('streaming:end', {
         message_id,
         session_id: currentSessionId,


### PR DESCRIPTION
## Summary
Removed noisy console logs that were cluttering daemon output during streaming operations.

## Changes
- ❌ Removed streaming chunk tracking logs (onStreamChunk, onStreamEnd)
- ❌ Removed thinking chunk logs (thinking_delta, thinking_complete)
- ❌ Removed tool input streaming logs (input_json_delta)
- ❌ Removed tool lifecycle logs (tool start/complete)
- 🧹 Cleaned up unused state counters (toolInputChunkCount, thinkingChunkCount)

## Impact
- Streaming functionality and buffering (20 char minimum) still works correctly
- WebSocket events are still broadcast properly
- Much cleaner daemon logs - only essential messages now

## Before
```
[daemon] [Executor 0a59676a] [claude-code] Streaming chunk: 3c0b9c7c, length: 6
[daemon] [Executor 0a59676a] [claude-code] Streaming chunk: 3c0b9c7c, length: 8
[daemon] [Executor 0a59676a] [claude-code] Streaming chunk: 3c0b9c7c, length: 3
[daemon] [Executor d59d210c] 🧠 Thinking chunk:  me search for where...
[daemon] [Executor d59d210c] 🧠 Thinking chunk:  this console...
[daemon] [Executor 9051cf69] 🔧 Tool input chunk (240)
```

## After
Clean logs with only essential messages!

🤖 Generated with [Claude Code](https://claude.com/claude-code)