### PR TITLE
fix: populate unix_username and created_by for MCP session creation

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.ts
+++ b/apps/agor-daemon/src/mcp/routes.ts
@@ -1300,6 +1300,9 @@ export function setupMCPRoutes(app: Application): void {
 
           console.log(`✨ MCP creating new session in worktree ${args.worktreeId.substring(0, 8)}`);
 
+          // Fetch user data to get unix_username
+          const user = await app.service('users').get(context.userId, baseServiceParams);
+
           // Get worktree to extract repo context
           const worktree = await app.service('worktrees').get(args.worktreeId, baseServiceParams);
 
@@ -1322,6 +1325,8 @@ export function setupMCPRoutes(app: Application): void {
             status: 'idle',
             title: args.title,
             description: args.description,
+            created_by: context.userId,
+            unix_username: user.unix_username,
             permission_config: {
               mode: permissionMode,
               allowedTools: [],

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -63,6 +63,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         title: data.prompt.substring(0, 100), // First 100 chars as title
         description: data.prompt,
         worktree_id: parent.worktree_id,
+        created_by: parent.created_by, // Inherit parent's creator for proper attribution
         unix_username: parent.unix_username, // Inherit parent's unix_username for consistent execution context
         git_state: { ...parent.git_state },
         genealogy: {
@@ -228,6 +229,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         title: data.title || data.prompt.substring(0, 100), // Use provided title or first 100 chars
         description: finalPrompt, // Use final prompt with extra instructions if provided
         worktree_id: parent.worktree_id,
+        created_by: parent.created_by, // Inherit parent's creator for proper attribution
         unix_username: parent.unix_username, // Inherit parent's unix_username for consistent execution context
         git_state: { ...parent.git_state },
         genealogy: {


### PR DESCRIPTION
## Summary
Fixes the "Strict Unix user mode requires unix_username to be set" error when creating sessions via MCP.

## Changes
- **MCP routes**: Fetch user record and populate `unix_username` and `created_by` fields when creating sessions
- **Fork/spawn methods**: Inherit `created_by` from parent for proper attribution throughout genealogy tree
- **Git safe.directory**: Fix configuration to use `*` instead of ineffective wildcard pattern

## Technical Details

### MCP Session Creation
The MCP `agor_sessions_create` tool now:
1. Fetches the authenticated user from the database
2. Extracts their `unix_username` 
3. Stamps both `created_by` and `unix_username` on the new session

This ensures sessions created via MCP can execute in strict Unix user mode.

### Git Safe Directory Wildcard
Git **does not support wildcard patterns** like `/path/*/*` in `safe.directory` config. The only wildcard git supports is a literal `*` which trusts ALL directories globally.

Using `*` is acceptable in Agor's security model because:
- Each user is isolated to their own Unix account
- Unix user isolation provides the actual security boundary
- The `safe.directory` check is just git's ownership validation

This prevents the need to add individual worktree paths for every new worktree created.

## Test Plan
- [x] Create session via MCP with strict Unix user mode enabled
- [x] Verify `unix_username` is populated
- [x] Verify no "dubious ownership" errors with git operations
- [x] Confirm fork/spawn inherit `created_by` properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)