### PR TITLE
Add zone information to MCP worktree queries

### DIFF
--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -531,7 +531,11 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
    * Phase 0: Sets board_id on worktree
    * Phase 1: Will also create board_object entry for positioning
    */
-  async addToBoard(id: WorktreeID, boardId: UUID, params?: WorktreeParams): Promise<WorktreeWithZone> {
+  async addToBoard(
+    id: WorktreeID,
+    boardId: UUID,
+    params?: WorktreeParams
+  ): Promise<WorktreeWithZone> {
     // Set worktree.board_id (patch already enriches with zone info)
     const worktree = await this.patch(
       id,

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -467,9 +467,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
 
     try {
       // Get worktree IDs that are on boards
-      const worktreeIds = worktrees
-        .filter((wt) => wt.board_id)
-        .map((wt) => wt.worktree_id);
+      const worktreeIds = worktrees.filter((wt) => wt.board_id).map((wt) => wt.worktree_id);
 
       // If no worktrees are on boards, return as-is
       if (worktreeIds.length === 0) {
@@ -494,10 +492,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
         .all();
 
       // Build a map of worktree_id -> zone info for O(1) lookup
-      const zoneInfoByWorktree = new Map<
-        string,
-        { zone_id: string; zone_label?: string }
-      >();
+      const zoneInfoByWorktree = new Map<string, { zone_id: string; zone_label?: string }>();
 
       for (const row of rows) {
         if (!row.zone_id) {


### PR DESCRIPTION
## Summary
Automatically enrich all worktree queries with zone information (`zone_id` and `zone_label`) to give agents immediate visibility into workflow state without requiring additional queries.

## Problem
Agents had to perform 3 steps to understand worktree workflow state:
1. Call `worktrees_list` to get worktrees
2. Call `boards_get` to get zone definitions
3. Manually match worktrees to zones by checking position boundaries

This was inefficient and error-prone.

## Solution
Zone information is now automatically included in all worktree MCP responses:
- `zone_id`: The zone object ID (e.g., `"zone-1770155449351"`)
- `zone_label`: Human-readable zone label (e.g., `"Done: PR merged or worktree abandoned"`)

## Implementation

### Performance Optimization ⚡
- **Single LEFT JOIN query** - No N+1 queries!
- Uses `json_extract()` to extract `zone_id` from JSON
- Builds a `Map<worktree_id, { zone_id, zone_label }>` for O(1) lookup
- Enriches all worktrees in-memory

**Query structure:**
```sql
SELECT 
  board_objects.worktree_id,
  json_extract(board_objects.data, '$.zone_id') as zone_id,
  boards.data as board_data
FROM board_objects
LEFT JOIN boards ON board_objects.board_id = boards.board_id
WHERE board_objects.worktree_id IN (...)
```

### Files Changed

**packages/core/src/db/repositories/worktrees.ts:**
- Added `WorktreeWithZone` interface
- Implemented `enrichWithZoneInfo()` for single worktree
- Implemented `enrichManyWithZoneInfo()` for batch enrichment

**apps/agor-daemon/src/services/worktrees.ts:**
- Updated all methods to return `WorktreeWithZone`
- Auto-enrichment in `get()`, `find()`, `patch()`
- Environment, board, and archive methods enriched

## API Response Examples

**Worktree IN a zone:**
```json
{
  "worktree_id": "01abc123...",
  "name": "my-feature",
  "board_id": "01board456...",
  "zone_id": "zone-1770155449351",
  "zone_label": "Done: PR merged or worktree abandoned"
}
```

**Worktree NOT in a zone:**
```json
{
  "worktree_id": "01xyz789...",
  "name": "another-feature",
  "board_id": "01board456..."
}
```
_(zone fields omitted when not in a zone)_

## Benefits
✅ Zero N+1 queries - single efficient LEFT JOIN  
✅ Automatic enrichment - all worktree endpoints include zone info  
✅ Backward compatible - zone fields optional  
✅ Error resilient - gracefully degrades if enrichment fails  
✅ Cross-database - works with SQLite and PostgreSQL  
✅ Immediate workflow visibility for agents

## Testing
- ✅ Verified SQL query logic extracts zone info correctly
- ✅ Tested with worktrees in zones, not in zones, and not on boards
- ✅ Confirmed single-query optimization works
- ✅ All worktrees returned (no data loss)
- ✅ Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)