### PR TITLE
fix: ensure repo and worktree creators are added to Unix groups

### DIFF
--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -206,7 +206,8 @@ export async function handleGitClone(
             repoId,
             cloneResult.path,
             client,
-            payload.params.daemonUser
+            payload.params.daemonUser,
+            payload.params.creatorUnixUsername
           );
           console.log(`[git.clone] Unix group initialized: ${unixGroup}`);
         } catch (error) {
@@ -432,7 +433,8 @@ export async function handleGitWorktreeAdd(
           othersAccess,
           client,
           payload.params.daemonUser,
-          payload.params.creatorUnixUsername
+          payload.params.creatorUnixUsername,
+          payload.params.repoUnixGroup
         );
         console.log(`[git.worktree.add] Unix group initialized: ${unixGroup}`);
 

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -187,6 +187,9 @@ export const GitClonePayloadSchema = BasePayloadSchema.extend({
 
     /** Daemon Unix user to add to the repo group (for daemon access) */
     daemonUser: z.string().optional(),
+
+    /** Creator's Unix username to add to the repo group (for owner access) */
+    creatorUnixUsername: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

Fixes a bug where repo and worktree creators weren't being properly added to Unix groups, preventing them from accessing the repo's `.git/` directory.

## Changes

### Repo Creation (`git.clone`)
- Added `creatorUnixUsername` to `GitClonePayload` params
- Updated `initializeRepoGroup()` to accept and add creator to repo group
- Daemon fetches creator's `unix_username` and passes to executor

### Worktree Creation (`git.worktree.add`)
- Updated `initializeWorktreeGroup()` to accept `repoUnixGroup` param
- Creator now added to **both** worktree group AND repo group
- Ensures creator can access worktree directory and run git commands

### Owner Assignment (already working)
- When owners are added via the worktree-owners API
- Already handled via `unix.sync-worktree` executor command
- Adds owners to both worktree and repo groups

## Problem

When user `evan` created `/home/agorpg/.agor/repos/maintiner/`, the repo group `agor_rp_f93f0fbd` was created, but `evan` wasn't added to it. This caused permission denied errors when trying to access the `.git/` directory.

## Test Plan

1. Create a new repo as a user with `unix_username` set
2. Verify the user is in the repo group: `id -nG <username> | grep agor_rp_`
3. Create a worktree on that repo
4. Verify the user is in both worktree and repo groups
5. Verify git commands work without permission errors

## Files Changed

- `packages/executor/src/payload-types.ts` - Added `creatorUnixUsername` field
- `packages/executor/src/commands/unix.ts` - Updated group initialization functions
- `packages/executor/src/commands/git.ts` - Passed creator/repo group params
- `apps/agor-daemon/src/services/repos.ts` - Fetch and pass creator username

🤖 Generated with [Claude Code](https://claude.com/claude-code)