### PR TITLE
fix: add git safe.directory configuration for autocomplete on Linux

### DIFF
--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -76,7 +76,7 @@ export class FilesService {
         // Handle "dubious ownership" error on Linux by adding to safe.directory
         if (error instanceof Error && error.message.includes('dubious ownership')) {
           console.log(`Adding ${worktree.path} to git safe.directory`);
-          await git.addConfig('safe.directory', worktree.path, false, 'global');
+          await git.addConfig('safe.directory', worktree.path, true, 'global');
           // Retry the ls-files command
           result = await git.raw(['ls-files', '-z']);
         } else {

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -429,7 +429,7 @@ export async function createWorktree(
   // but accessed by other users (e.g., in multi-user Linux environments)
   try {
     const worktreeGit = createGit(worktreePath, env);
-    await worktreeGit.addConfig('safe.directory', worktreePath, false, 'global');
+    await worktreeGit.addConfig('safe.directory', worktreePath, true, 'global');
     console.log(`✅ Added ${worktreePath} to git safe.directory`);
   } catch (error) {
     // Non-fatal - log warning and continue


### PR DESCRIPTION
## Summary
Fixes file autocomplete not working in multi-user Linux environments where worktrees are owned by a different user (e.g., daemon user).

## Problem
Git 2.35.2+ introduced "dubious ownership" security checks that prevent git operations in directories with different ownership. This caused autocomplete to fail because the files service uses `git ls-files` to search for files in the worktree.

**Symptoms:**
- Autocomplete shows users ✅ (no git required)
- Autocomplete does NOT show files ❌ (requires `git ls-files`)
- Only affects Linux multi-user environments
- Previously worked on macOS (different ownership model)

## Solution
Two-layer fix for comprehensive coverage:

1. **Proactive:** Configure safe.directory at worktree creation time
   - All new worktrees automatically configured
   - Added in `packages/core/src/git/index.ts`

2. **Reactive:** Runtime fallback in files service for existing worktrees
   - Catches "dubious ownership" errors
   - Auto-configures and retries on first use
   - Added in `apps/agor-daemon/src/services/files.ts`

This replaces the previous approach of using `*` wildcard (which doesn't actually work) with explicit per-worktree configuration.

## Test plan
- [x] TypeScript compilation successful
- [x] Linting passes
- [x] Manual test: `git ls-files` works after configuration
- [ ] Test autocomplete shows both users AND files in UI
- [ ] Verify new worktrees work immediately
- [ ] Verify existing worktrees auto-fix on first autocomplete attempt

## Files changed
- `packages/core/src/git/index.ts` - Add safe.directory config at worktree creation
- `apps/agor-daemon/src/services/files.ts` - Add runtime fallback for existing worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)