### PR TITLE
Fix Zellij clipboard to work with browser instead of host machine

### DIFF
--- a/apps/agor-ui/package.json
+++ b/apps/agor-ui/package.json
@@ -25,6 +25,7 @@
     "@tsparticles/slim": "^3.9.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@webscopeio/react-textarea-autocomplete": "^4.9.2",
+    "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "ansi-to-react": "^6.1.6",

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -1,5 +1,6 @@
 import type { AgorClient } from '@agor/core/api';
 import type { User, UserID } from '@agor/core/types';
+import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal } from '@xterm/xterm';
 import { App, Modal } from 'antd';
@@ -186,6 +187,11 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
 
       terminal.open(terminalDivRef.current!);
       terminalRef.current = terminal;
+
+      // Load Clipboard addon for OSC 52 support
+      // This enables Zellij to copy to the browser clipboard via OSC 52 escape sequences
+      const clipboardAddon = new ClipboardAddon();
+      terminal.loadAddon(clipboardAddon);
 
       // Load Web Links addon for clickable URLs
       const webLinksAddon = new WebLinksAddon((_event, uri) => {

--- a/docker/zellij-config.kdl
+++ b/docker/zellij-config.kdl
@@ -8,12 +8,9 @@ pane_frames false
 // When enabled, mouse mode interferes with text selection and copy/paste in the browser
 mouse_mode false
 
-// Copy to clipboard on selection
-copy_on_select true
-
-// Clipboard management
-copy_command "pbcopy"  // macOS - will be ignored on Linux
-copy_clipboard "primary"
+// Disable Zellij's clipboard handling - let the browser handle copy/paste natively
+// This allows users to use standard browser shortcuts (Ctrl+C, Ctrl+V) without interference
+copy_on_select false
 
 // Scrollback buffer (10,000 lines)
 scroll_buffer_size 10000

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -53,6 +53,11 @@ export const AGOR_ZELLIJ_CONFIG = `// Agor Zellij Config
 // Hide startup banners for cleaner embedded terminal UX
 show_startup_tips false
 show_release_notes false
+
+// Clipboard configuration for web terminal (xterm.js)
+// Disable Zellij clipboard handling to allow native browser copy/paste
+mouse_mode false
+copy_on_select false
 `;
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@webscopeio/react-textarea-autocomplete':
         specifier: ^4.9.2
         version: 4.9.2(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@xterm/addon-clipboard':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@xterm/addon-web-links':
         specifier: ^0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
@@ -4147,6 +4150,9 @@ packages:
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
+
+  '@xterm/addon-clipboard@0.2.0':
+    resolution: {integrity: sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==}
 
   '@xterm/addon-web-links@0.11.0':
     resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
@@ -13324,6 +13330,10 @@ snapshots:
       textarea-caret: 3.0.2
 
   '@xmldom/xmldom@0.9.8': {}
+
+  '@xterm/addon-clipboard@0.2.0':
+    dependencies:
+      js-base64: 3.7.8
 
   '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the Zellij clipboard issue where copy operations showed "copied to clipboard" but actually copied to the host machine's clipboard instead of the browser's clipboard.

## Problem

When using Zellij through the Agor web interface, the clipboard wasn't working as expected:
- Selecting text and copying showed visual feedback from Zellij
- But the text was copied to the host machine's clipboard
- Browser clipboard remained empty, breaking normal web copy/paste workflows

## Solution

Instead of trying to make OSC 52 work with complex shell commands, we simply disable Zellij's clipboard handling and let the browser handle copy/paste natively.

**Changes:**
- Set `copy_on_select=false` in Zellij config templates
- Updated both Docker template (`docker/zellij-config.kdl`) and user creation config (`packages/core/src/unix/unix-integration-service.ts`)
- Added `@xterm/addon-clipboard` for paste support and OSC 52 compatibility
- Loaded ClipboardAddon in TerminalModal

## Benefits

✅ Native browser copy/paste shortcuts (Ctrl+C, Ctrl+V) work as expected
✅ No more copying to host machine clipboard  
✅ Still supports advanced use cases (vim, tmux) via OSC 52
✅ Simpler, more predictable behavior for web terminal users
✅ More intuitive for users familiar with web applications

## Testing

To test after merging:
1. For existing users, run the update script: `sudo /tmp/update-zellij-configs.sh`
2. Or manually copy the new config to `~/.config/zellij/config.kdl`
3. Restart Zellij sessions or run: `zellij action reload-config`
4. Select text in terminal and copy with Ctrl+C/Cmd+C
5. Verify it pastes into browser or other applications

New users will automatically get the fixed config on creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)