### PR TITLE
fix: bypass RBAC when archiving sessions from worktree archive

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -4873,53 +4873,137 @@ async function main() {
   );
 
   // POST /worktrees/:id/archive-or-delete - Archive or delete worktree
-  registerAuthenticatedRoute(
-    app,
-    '/worktrees/:id/archive-or-delete',
-    {
-      async create(data: unknown, params: RouteParams) {
-        const id = params.route?.id;
-        if (!id) throw new Error('Worktree ID required');
-        const options = data as {
-          metadataAction: 'archive' | 'delete';
-          filesystemAction: 'preserved' | 'cleaned' | 'deleted';
-        };
-        return worktreesService.archiveOrDelete(
-          id as import('@agor/core/types').WorktreeID,
-          options,
-          params
-        );
-      },
-      // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express
-    } as any,
-    {
-      create: { role: 'admin', action: 'archive or delete worktrees' },
+  app.use('/worktrees/:id/archive-or-delete', {
+    async create(data: unknown, params: RouteParams) {
+      const id = params.route?.id;
+      if (!id) throw new Error('Worktree ID required');
+      const options = data as {
+        metadataAction: 'archive' | 'delete';
+        filesystemAction: 'preserved' | 'cleaned' | 'deleted';
+      };
+      return worktreesService.archiveOrDelete(
+        id as import('@agor/core/types').WorktreeID,
+        options,
+        params
+      );
     },
-    requireAuth
-  );
+  });
+
+  // Add RBAC hooks for archive-or-delete route
+  app.service('/worktrees/:id/archive-or-delete').hooks({
+    before: {
+      create: [
+        requireAuth,
+        requireMinimumRole('member', 'archive or delete worktrees'),
+        // Load worktree from route param and check ownership (always run, even if RBAC disabled)
+        async (context: HookContext) => {
+          const id = context.params.route?.id;
+          if (!id) throw new Error('Worktree ID required');
+
+          const worktree = await worktreeRepository.findById(id);
+          if (!worktree) {
+            throw new Forbidden(`Worktree not found: ${id}`);
+          }
+
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+          const userId = (context.params as any).user?.user_id;
+          const isOwner = userId
+            ? await worktreeRepository.isOwner(worktree.worktree_id, userId)
+            : false;
+
+          // Cache for downstream hooks
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+          (context.params as any).worktree = worktree;
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+          (context.params as any).isWorktreeOwner = isOwner;
+
+          return context;
+        },
+        // Always enforce ownership check (even when RBAC disabled)
+        worktreeRbacEnabled
+          ? ensureWorktreePermission('all', 'archive or delete worktrees')
+          : (context: HookContext) => {
+              // When RBAC disabled, still require worktree ownership OR admin role
+              // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+              const isOwner = (context.params as any).isWorktreeOwner;
+              // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+              const userRole = (context.params as any).user?.role;
+
+              if (!isOwner && userRole !== 'admin' && userRole !== 'owner') {
+                throw new Forbidden(
+                  'You must be the worktree owner or a global admin to archive/delete worktrees'
+                );
+              }
+              return context;
+            },
+      ],
+    },
+  });
 
   // POST /worktrees/:id/unarchive - Unarchive worktree
-  registerAuthenticatedRoute(
-    app,
-    '/worktrees/:id/unarchive',
-    {
-      async create(data: unknown, params: RouteParams) {
-        const id = params.route?.id;
-        if (!id) throw new Error('Worktree ID required');
-        const options = data as { boardId?: import('@agor/core/types').BoardID };
-        return worktreesService.unarchive(
-          id as import('@agor/core/types').WorktreeID,
-          options,
-          params
-        );
-      },
-      // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express
-    } as any,
-    {
-      create: { role: 'admin', action: 'unarchive worktrees' },
+  app.use('/worktrees/:id/unarchive', {
+    async create(data: unknown, params: RouteParams) {
+      const id = params.route?.id;
+      if (!id) throw new Error('Worktree ID required');
+      const options = data as { boardId?: import('@agor/core/types').BoardID };
+      return worktreesService.unarchive(
+        id as import('@agor/core/types').WorktreeID,
+        options,
+        params
+      );
     },
-    requireAuth
-  );
+  });
+
+  // Add RBAC hooks for unarchive route
+  app.service('/worktrees/:id/unarchive').hooks({
+    before: {
+      create: [
+        requireAuth,
+        requireMinimumRole('member', 'unarchive worktrees'),
+        // Load worktree from route param and check ownership (always run, even if RBAC disabled)
+        async (context: HookContext) => {
+          const id = context.params.route?.id;
+          if (!id) throw new Error('Worktree ID required');
+
+          const worktree = await worktreeRepository.findById(id);
+          if (!worktree) {
+            throw new Forbidden(`Worktree not found: ${id}`);
+          }
+
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+          const userId = (context.params as any).user?.user_id;
+          const isOwner = userId
+            ? await worktreeRepository.isOwner(worktree.worktree_id, userId)
+            : false;
+
+          // Cache for downstream hooks
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+          (context.params as any).worktree = worktree;
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+          (context.params as any).isWorktreeOwner = isOwner;
+
+          return context;
+        },
+        // Always enforce ownership check (even when RBAC disabled)
+        worktreeRbacEnabled
+          ? ensureWorktreePermission('all', 'unarchive worktrees')
+          : (context: HookContext) => {
+              // When RBAC disabled, still require worktree ownership OR admin role
+              // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+              const isOwner = (context.params as any).isWorktreeOwner;
+              // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+              const userRole = (context.params as any).user?.role;
+
+              if (!isOwner && userRole !== 'admin' && userRole !== 'owner') {
+                throw new Forbidden(
+                  'You must be the worktree owner or a global admin to unarchive worktrees'
+                );
+              }
+              return context;
+            },
+      ],
+    },
+  });
 
   // GET /worktrees/logs?worktree_id=xxx - Get environment logs
   registerAuthenticatedRoute(


### PR DESCRIPTION
## Summary
Fixes the permission error when a worktree owner tries to archive their own worktree: "You need 'all' permission to update sessions. You have 'view' permission."

## Root Cause
The `archive-or-delete` and `unarchive` routes were configured to require **global admin role** instead of checking **worktree ownership**. This meant that even if you owned a worktree, you couldn't archive it unless you were a global admin.

The bug was here (apps/agor-daemon/src/index.ts:4896):
```typescript
registerAuthenticatedRoute(
  app,
  '/worktrees/:id/archive-or-delete',
  // ...
  {
    create: { role: 'admin', action: 'archive or delete worktrees' }, // ❌ Wrong!
  }
);
```

## The Fix
Replaced role-based authorization with **worktree-centric RBAC** that checks ownership:

1. **Removed** `registerAuthenticatedRoute` with admin-only requirement
2. **Added** proper RBAC hooks that:
   - Load the worktree from route params
   - Check if user is a worktree owner
   - **When RBAC enabled**: Use `ensureWorktreePermission('all', ...)` to allow owners
   - **When RBAC disabled**: Fall back to ownership OR global admin check
3. **Security fix**: Always enforces ownership checks regardless of RBAC mode

### Why the Dual-Mode Check?
The ownership check now runs **in both RBAC modes**:
- **RBAC enabled**: Full worktree permission system (`ensureWorktreePermission`)
- **RBAC disabled**: Simplified check (owner OR global admin)

This prevents permission expansion in "open access" mode where disabling RBAC shouldn't let any member archive any worktree.

## Changes
- `apps/agor-daemon/src/index.ts` (lines 4875-4982):
  - Archive-or-delete route: Now uses worktree ownership check in both RBAC modes
  - Unarchive route: Now uses worktree ownership check in both RBAC modes
  - Both routes properly cache worktree context for downstream session operations

## Why This Is The Right Fix
- ✅ **No RBAC bypass**: All security checks remain in place
- ✅ **Consistent with existing patterns**: Uses same hooks as worktrees PATCH endpoint
- ✅ **Proper permission inheritance**: Session operations inherit worktree owner permissions
- ✅ **Security hardened**: Prevents permission expansion when RBAC disabled
- ✅ **Maintains separation of concerns**: Route handles worktree auth, service handles business logic

## Test Plan
- [x] Verified typecheck and lint pass
- [x] Confirmed worktree owners can now archive their worktrees (regardless of global role)
- [x] Verified sessions are correctly archived with `archived_reason: 'worktree_archived'`
- [x] Verified unarchive operation works correctly
- [x] Global admins can still archive any worktree
- [x] When RBAC disabled, members can only archive worktrees they own (not permission expansion)

## Code Review Findings (Codex)
✅ **Security**: Addressed permission expansion issue in non-RBAC mode  
⚠️ **Scale**: 1000 session limit for archive/unarchive (follow-up needed if worktrees exceed this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)