### PR TITLE
fix: correct migration 0012 timestamp to enable scheduler task execution

### DIFF
--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -89,7 +89,7 @@
     {
       "idx": 12,
       "version": "7",
-      "when": 1738806595000,
+      "when": 1770276001000,
       "tag": "0012_fix_session_timestamp_overflow",
       "breakpoints": true
     }


### PR DESCRIPTION
## Problem
The scheduler was failing to create scheduled sessions because migration `0012_fix_session_timestamp_overflow` was never being applied. The migration journal had an incorrect timestamp that caused Drizzle to skip the migration.

## Root Cause
Migration 0012's timestamp (`1738806595000` = Feb 6, 2025) was **BEFORE** migration 0011's timestamp (`1770276000000` = Feb 5, 2026). This caused Drizzle's migration system to think 0012 had already been applied.

As a result, the `sessions.scheduled_run_at` column remained as `integer` type instead of `bigint`, causing PostgreSQL integer overflow errors when the scheduler tried to insert sessions with large timestamp values (JavaScript millisecond timestamps ~1.7 trillion).

## Solution
Update migration 0012 timestamp from `1738806595000` to `1770276001000` (1 second after 0011) to restore proper chronological ordering.

**Timeline:**
- 0011: `1770276000000` (2026-02-05T07:20:00.000Z)
- 0012: `1770276001000` (2026-02-05T07:20:01.000Z) ✅

## Impact
- Migration 0012 will now run on next daemon restart
- `sessions.scheduled_run_at` will be converted to `bigint`
- Scheduler will be able to create sessions successfully
- No data loss (ALTER COLUMN TYPE is safe operation)

## Testing
- ✅ `pnpm check` passes (typecheck + lint + build)
- ✅ Pre-commit hooks pass
- Migration will be verified on next daemon restart

## Files Changed
- `packages/core/drizzle/postgres/meta/_journal.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)