### PR TITLE
fix: remove duplicate toast notification on schedule save

### DIFF
--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -121,7 +121,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
         schedule_cron: cronExpression,
         schedule: scheduleConfig,
       });
-      message.success('Schedule configuration saved');
+      // Note: onUpdate already shows a success toast, so we don't show another one here
     } catch (error) {
       message.error('Failed to save schedule configuration');
       console.error('Error saving schedule:', error);


### PR DESCRIPTION
## Summary
Fixes duplicate toast notification when saving worktree schedule settings.

## Problem
When saving worktree settings on the Schedule tab, two toast notifications appeared:
1. One properly styled toast: "Worktree updated successfully!" (from parent handler)
2. One unthemed toast: "Schedule configuration saved" (from ScheduleTab)

## Solution
Removed the duplicate toast from ScheduleTab since the parent `onUpdate` callback already displays a success notification. This follows the same pattern used in EnvironmentTab.

## Changes
- `apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx:124`: Removed `message.success('Schedule configuration saved')` and added a comment explaining why

## Test plan
- [x] Save schedule configuration in worktree settings
- [x] Verify only one toast appears: "Worktree updated successfully!"
- [x] Verify toast is properly styled
- [x] Run `pnpm check` to ensure no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)