### PR TITLE
fix(scheduler): populate unix_username for scheduled sessions

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -5531,6 +5531,7 @@ async function main() {
     tickInterval: 30000, // 30 seconds
     gracePeriod: 120000, // 2 minutes
     debug: process.env.NODE_ENV !== 'production',
+    unixUserMode: config.execution?.unix_user_mode ?? 'simple',
   });
   schedulerService.start();
   console.log(`🔄 Scheduler started (tick interval: 30s)`);


### PR DESCRIPTION
## Summary

Fixes scheduled session execution failures in strict Unix user mode by properly populating the `unix_username` field during session creation.

## The Problem

Scheduled heartbeat sessions were being created but NOT executing:
- Sessions showed `ready_for_prompt=true` with 0 messages
- Executor spawn failed with error: `Strict Unix user mode requires unix_username to be set`
- `sessionUnixUser: null` in executor logs
- Started happening around 17:00 UTC Feb 6
- Affected sessions: 06c7f377, 0a55aa78, 25cbf1c6

## Root Cause

The scheduler creates sessions via internal service calls (`provider: undefined`), which causes the `setSessionUnixUsername` hook to skip execution:

```typescript
// Skip for internal calls
if (!context.params.provider) {
  console.log('[setSessionUnixUsername] Skipping - no provider (internal call)');
  return context;
}
```

Result: scheduled sessions had `unix_username=null`, causing executor spawn failures in strict mode.

## Solution

The scheduler now explicitly looks up the worktree creator's `unix_username` and sets it on the session payload before creation:

```typescript
// Look up creator's unix_username for session execution context
const creator = await this.userRepo.findById(worktree.created_by);
const unixUsername = creator?.unix_username || null;

const session: Partial<Session> = {
  // ...
  created_by: worktree.created_by,
  unix_username: unixUsername, // Set unix_username for strict mode execution
  // ...
};
```

## Changes

- ✅ Import `UserRepository` in scheduler service
- ✅ Look up worktree creator's `unix_username` before session creation
- ✅ Set `unix_username` field in scheduled session payload
- ✅ Update step numbering in JSDoc comments

## Testing

Manual testing:
- Scheduled sessions should now execute properly in strict Unix mode
- Executor logs should show proper `sessionUnixUser` value
- Sessions should progress beyond IDLE status

## Cleanup Plan

The 3 orphaned sessions (06c7f377, 0a55aa78, 25cbf1c6) can be safely deleted - they have no messages and were stuck in IDLE status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)