### PR TITLE
fix: agor init crashes when AGOR_DB_DIALECT=postgresql is set

### DIFF
--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -88,7 +88,7 @@ export default class Init extends Command {
       const { createDatabase, select, sessions, tasks, messages, repos } = await import(
         '@agor/core/db'
       );
-      const db = createDatabase({ url: `file:${dbPath}` });
+      const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
 
       // Count rows by selecting all and measuring length
       const sessionRows = await select(db).from(sessions).all();
@@ -345,7 +345,7 @@ export default class Init extends Command {
     // Initialize database
     this.log('');
     this.log('💾 Setting up database...');
-    const db = createDatabase({ url: `file:${dbPath}` });
+    const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
 
     await runMigrations(db);
     this.log(`${chalk.green('   ✓')} Created ${dbPath}`);
@@ -367,7 +367,7 @@ export default class Init extends Command {
 
       // Create default admin user with credentials displayed to user
       try {
-        const db = createDatabase({ url: `file:${dbPath}` });
+        const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
         const defaultEmail = 'admin@agor.live';
         const defaultPassword = 'admin';
 
@@ -527,7 +527,7 @@ export default class Init extends Command {
     ]);
 
     // Create admin user directly in database (no daemon required)
-    const db = createDatabase({ url: `file:${dbPath}` });
+    const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
 
     const _user = await createUser(db, {
       email,


### PR DESCRIPTION
## Summary
- Fixes #565: `agor init` crashes with `ECONNREFUSED 127.0.0.1:5432` when `AGOR_DB_DIALECT=postgresql` is set in the environment
- Adds explicit `dialect: 'sqlite'` to all four `createDatabase()` calls in `init.ts`, preventing the environment variable from routing the local SQLite file URL through the Postgres driver

## Test plan
- [ ] Set `AGOR_DB_DIALECT=postgresql` and `DATABASE_URL` to a Postgres URL, run `agor init --force` — should succeed with local SQLite
- [ ] Run `agor init` without any Postgres env vars — should still work as before
- [ ] Verify `agor daemon start` still respects `AGOR_DB_DIALECT=postgresql` for Postgres connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)