### PR TITLE
fix: resolve Ant Design deprecation warnings and remove debug logging

### DIFF
--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -80,7 +80,7 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
 
     return (
       <div key={field} style={{ marginBottom: token.marginLG }}>
-        <Space direction="vertical" size="small" style={{ width: '100%' }}>
+        <Space orientation="vertical" size="small" style={{ width: '100%' }}>
           <Space>
             <Text strong>{label}</Text>
             {description && <Text type="secondary">{description}</Text>}
@@ -138,7 +138,7 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
   };
 
   return (
-    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+    <Space orientation="vertical" size="large" style={{ width: '100%' }}>
       {KEY_CONFIGS.filter((config) => config.field in keyStatus).map((config) =>
         renderKeyField(config)
       )}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -366,7 +366,6 @@ export const App: React.FC<AppProps> = ({
   };
 
   const handleCreateSession = async (config: NewSessionConfig) => {
-    console.log('Creating session with config:', config, 'for board:', currentBoardId);
     const sessionId = await onCreateSession?.(config, currentBoardId);
     setNewSessionWorktreeId(null);
 
@@ -425,10 +424,6 @@ export const App: React.FC<AppProps> = ({
       if (!client) return;
 
       try {
-        console.log(
-          `📋 Permission decision: ${allow ? 'ALLOW' : 'DENY'} (${scope}) for task ${taskId}`
-        );
-
         // Call the permission decision endpoint
         await client.service(`sessions/${sessionId}/permission-decision`).create({
           requestId,
@@ -439,8 +434,6 @@ export const App: React.FC<AppProps> = ({
           scope,
           decidedBy: user?.user_id || 'anonymous',
         });
-
-        console.log(`✅ Permission decision sent successfully`);
       } catch (error) {
         console.error('❌ Failed to send permission decision:', error);
       }

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -207,7 +207,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
               {instanceLabel}
             </Tag>
           ))}
-        <Divider type="vertical" style={{ height: 32, margin: '0 8px' }} />
+        <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />
         {currentBoardId && boards.length > 0 && (
           <div style={{ minWidth: 200 }}>
             <BoardSwitcher
@@ -264,7 +264,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                 marginRight: 8,
               }}
             />
-            <Divider type="vertical" style={{ height: 32, margin: '0 8px' }} />
+            <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />
           </>
         )}
         {eventStreamEnabled && (

--- a/apps/agor-ui/src/components/LoginPage/ParticleBackground.tsx
+++ b/apps/agor-ui/src/components/LoginPage/ParticleBackground.tsx
@@ -18,13 +18,12 @@ export const ParticleBackground = memo(function ParticleBackground() {
     initParticlesEngine(async (engine) => {
       await loadSlim(engine);
     }).then(() => {
-      console.log('tsParticles initialized');
       setInit(true);
     });
   }, []);
 
-  const particlesLoaded = async (container?: Container): Promise<void> => {
-    console.log('Particles loaded:', container);
+  const particlesLoaded = async (_container?: Container): Promise<void> => {
+    // no-op
   };
 
   if (!init) {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -442,10 +442,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
     // Extract zone labels - memoized to only change when labels actually change
     const zoneLabels = useMemo(() => {
-      console.log('🔄 [SessionCanvas] Recalculating zoneLabels', {
-        hasBoard: !!board,
-        objectsCount: Object.keys(board?.objects || {}).length,
-      });
       if (!board?.objects) return {};
       const labels: Record<string, string> = {};
       Object.entries(board.objects).forEach(([id, obj]) => {
@@ -453,7 +449,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           labels[id] = obj.label;
         }
       });
-      console.log('✅ [SessionCanvas] zoneLabels calculated:', labels);
       return labels;
     }, [board]);
 
@@ -466,7 +461,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         const boardObject = boardObjectByWorktree.get(worktreeId);
 
         if (!boardObject || !boardObject.zone_id) {
-          console.warn('Worktree not pinned or board object not found');
           return;
         }
 
@@ -1438,9 +1432,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     },
                   };
                 } else {
-                  console.warn(
-                    `⚠️ Zone ${parentId} not found for comment ${comment_id}, using absolute position`
-                  );
                   commentData.position = { absolute: position };
                   // biome-ignore lint/suspicious/noExplicitAny: need null to clear DB field, not undefined
                   commentData.worktree_id = null as any;
@@ -1464,9 +1455,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     },
                   };
                 } else {
-                  console.warn(
-                    `⚠️ Worktree ${parentId} not found for comment ${comment_id}, using absolute position`
-                  );
                   commentData.position = { absolute: position };
                   // biome-ignore lint/suspicious/noExplicitAny: need null to clear DB field, not undefined
                   commentData.worktree_id = null as any;
@@ -1730,7 +1718,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               offset_y: position.y - worktreeNode.position.y,
             },
           };
-          console.log(`✓ Comment pinned to worktree ${worktreeId}`);
         } else if (zoneNode) {
           // Comment pinned to zone - use relative positioning
           const zoneId = zoneNode.id.replace('zone-', ''); // Extract zone object ID
@@ -1742,13 +1729,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               offset_y: position.y - zoneNode.position.y,
             },
           };
-          console.log(`✓ Comment pinned to zone ${zoneId}`);
         } else {
           // Free-floating comment - use absolute positioning
           commentData.position = {
             absolute: position,
           };
-          console.log('✓ Comment placed at absolute position');
         }
 
         await client.service('board-comments').create(commentData);
@@ -1835,10 +1820,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           },
           // biome-ignore lint/suspicious/noExplicitAny: Board patch with custom _action field
         } as any);
-
-        console.log(
-          `✓ ${markdownModal.objectId ? 'Updated' : 'Created'} markdown note ${objectId}`
-        );
       } catch (error) {
         console.error('Failed to save markdown note:', error);
         // Rollback optimistic update
@@ -2253,8 +2234,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     return;
                   }
 
-                  console.log('✅ Execute trigger:', triggerModal.trigger);
-
                   try {
                     const { sessionId, trigger } = triggerModal;
 
@@ -2307,7 +2286,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     try {
                       const template = Handlebars.compile(trigger.template);
                       renderedPrompt = template(context);
-                      console.log('📝 Rendered template:', renderedPrompt);
                     } catch (templateError) {
                       console.error('❌ Handlebars template error:', templateError);
                       // Fallback to raw template if template fails
@@ -2318,10 +2296,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     await client.service(`sessions/${sessionId}/prompt`).create({
                       prompt: renderedPrompt,
                     });
-
-                    console.log(
-                      `✨ Zone trigger executed for session ${sessionId.substring(0, 8)}: ${renderedPrompt.substring(0, 50)}...`
-                    );
                   } catch (error) {
                     console.error('❌ Failed to execute trigger:', error);
                   } finally {
@@ -2329,7 +2303,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   }
                 }}
                 onCancel={() => {
-                  console.log('⏭️  Trigger skipped by user');
                   setTriggerModal(null);
                 }}
                 okText="Yes, Execute"
@@ -2472,10 +2445,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               }
 
               try {
-                console.log(
-                  `✨ Executing ${action} for worktree ${worktreeTriggerModal.worktreeId.substring(0, 8)}`
-                );
-
                 let targetSessionId = sessionId;
 
                 // If creating new session, create it first
@@ -2498,14 +2467,12 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       : undefined,
                   });
                   targetSessionId = newSession.session_id;
-                  console.log(`✓ Created new session: ${targetSessionId.substring(0, 8)}`);
 
                   // Attach MCP servers if provided
                   if (mcpServerIds && mcpServerIds.length > 0) {
                     await client
                       .service(`sessions/${targetSessionId}/mcp-servers`)
                       .patch(null, { mcpServerIds });
-                    console.log(`✓ Attached ${mcpServerIds.length} MCP servers to session`);
                   }
                 }
 
@@ -2516,7 +2483,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       prompt: renderedTemplate,
                       permissionMode,
                     });
-                    console.log(`✓ Sent prompt to session ${targetSessionId.substring(0, 8)}`);
                     break;
                   }
                   case 'fork': {
@@ -2527,9 +2493,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       prompt: renderedTemplate,
                       permissionMode,
                     });
-                    console.log(
-                      `✓ Forked session and sent prompt to ${forkedSession.session_id.substring(0, 8)}`
-                    );
                     break;
                   }
                   case 'spawn': {
@@ -2540,14 +2503,9 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       prompt: renderedTemplate,
                       permissionMode,
                     });
-                    console.log(
-                      `✓ Spawned child session and sent prompt to ${spawnedSession.session_id.substring(0, 8)}`
-                    );
                     break;
                   }
                 }
-
-                console.log('✅ Zone trigger executed successfully');
               } catch (error) {
                 console.error('❌ Failed to execute zone trigger:', error);
               } finally {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -826,7 +826,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             }}
             initialFiles={droppedFiles}
             onUploadComplete={(files) => {
-              console.log('Files uploaded:', files);
               message.success(`Uploaded ${files.length} file(s)`);
             }}
             onInsertMention={(filepath) => {

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -55,9 +55,6 @@ export const AboutTab: React.FC<AboutTabProps> = ({
   const [healthInfo, setHealthInfo] = useState<HealthInfo | null>(null);
 
   useEffect(() => {
-    console.log('[AboutTab] isAdmin:', isAdmin);
-    console.log('[AboutTab] connected:', connected);
-
     // Determine which detection method was used
     if ((window as WindowWithAgorConfig).AGOR_DAEMON_URL) {
       setDetectionMethod('Runtime injection (window.AGOR_DAEMON_URL)');
@@ -75,15 +72,13 @@ export const AboutTab: React.FC<AboutTabProps> = ({
         .service('health')
         .find()
         .then((data) => {
-          console.log('[AboutTab] Health info:', data);
           // Health endpoint returns a single object, not paginated
           const healthData = data as HealthInfo;
-          console.log('[AboutTab] Database info:', healthData.database);
           setHealthInfo(healthData);
         })
         .catch((err) => console.error('Failed to fetch health info:', err));
     }
-  }, [client, isAdmin, connected]);
+  }, [client]);
 
   return (
     <div style={{ position: 'relative', minHeight: 500, padding: '24px 0' }}>

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -38,7 +38,7 @@ const ApiKeyTabContent: React.FC<{
   return (
     <div style={{ paddingTop: token.paddingMD }}>
       <Alert
-        message={
+        title={
           <span>
             This is the <strong>global API key</strong> for all users. Per-user keys can be set in
             the Users tab.{' '}
@@ -58,7 +58,7 @@ const ApiKeyTabContent: React.FC<{
 
       {keysError && (
         <Alert
-          message={keysError}
+          title={keysError}
           type="error"
           icon={<WarningOutlined />}
           showIcon
@@ -401,7 +401,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
               <div style={{ paddingTop: token.paddingMD }}>
                 {/* OpenCode Info */}
                 <Alert
-                  message="OpenCode.ai Integration"
+                  title="OpenCode.ai Integration"
                   description={
                     <div>
                       <p style={{ marginBottom: token.marginXS }}>
@@ -471,7 +471,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                       {/* Connection Status */}
                       {opencodeConnected !== null && (
                         <Alert
-                          message={
+                          title={
                             opencodeConnected ? (
                               <Space>
                                 <CheckCircleOutlined style={{ color: token.colorSuccess }} />
@@ -493,7 +493,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                       {/* Setup Instructions (shown if not connected) */}
                       {opencodeConnected === false && (
                         <Alert
-                          message="Server Not Running"
+                          title="Server Not Running"
                           description={
                             <div>
                               <p style={{ marginBottom: token.marginXS }}>
@@ -533,7 +533,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                       {/* Success Status */}
                       {opencodeConnected === true && (
                         <Alert
-                          message="Ready to use!"
+                          title="Ready to use!"
                           description="You can now create sessions with OpenCode as the agentic tool."
                           type="success"
                           showIcon

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -298,9 +298,6 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           debugInfo?: unknown;
         };
 
-        // Log full response for debugging
-        console.log('[OAuth Test Response]', data);
-
         if (data.success) {
           if (data.requiresBrowserFlow) {
             // OAuth 2.1 detected but needs browser authentication
@@ -322,21 +319,11 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             }
             showSuccess(message);
           }
-
-          if (data.debugInfo) {
-            console.log('[OAuth Debug]', data.debugInfo);
-          }
         } else {
           // Show detailed error with hints
           let errorMsg = data.error || 'OAuth authentication failed';
           if (data.hint) {
             errorMsg += `\n\nHint: ${data.hint}`;
-          }
-          if (data.wwwAuthenticate) {
-            console.log('[OAuth] WWW-Authenticate header:', data.wwwAuthenticate);
-          }
-          if (data.responseHeaders) {
-            console.log('[OAuth] Response headers:', data.responseHeaders);
           }
           showError(errorMsg);
         }
@@ -880,9 +867,6 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     if (editingServer && mcpServerById.has(editingServer.mcp_server_id)) {
       const updatedServer = mcpServerById.get(editingServer.mcp_server_id);
       if (updatedServer && updatedServer !== editingServer) {
-        console.log('[MCP] Server updated via WebSocket, refreshing edit modal', {
-          serverId: String(editingServer.mcp_server_id).substring(0, 8),
-        });
         setEditingServer(updatedServer);
       }
     }
@@ -1079,11 +1063,6 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   };
 
   const handleEdit = async (server: MCPServer) => {
-    console.log('[MCP] handleEdit called with server:', {
-      name: server.name,
-      mcp_server_id: String(server.mcp_server_id).substring(0, 8),
-    });
-
     setEditingServer(server);
     setTestResult(null); // Reset test result when opening edit modal
     const serverAuthType = (server.auth?.type as 'none' | 'bearer' | 'jwt' | 'oauth') || 'none';
@@ -1131,9 +1110,6 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     form.setFieldsValue(formValues);
 
     setEditModalOpen(true);
-    console.log('[MCP] Edit modal opened for server:', server.name, {
-      transport: server.transport,
-    });
   };
 
   const handleUpdate = async () => {

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -60,9 +60,8 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         form.resetFields();
         setCreateModalOpen(false);
       })
-      .catch((error) => {
+      .catch(() => {
         // Form validation failed - Ant Design will show field errors automatically
-        console.log('Form validation failed:', error);
       });
   };
 

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -149,7 +149,6 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         cols: 160,
         linkHandler: {
           activate: (_event, uri) => {
-            console.debug('[Terminal] Opening link', uri);
             window.open(uri, '_blank', 'noopener,noreferrer');
           },
           hover: () => {
@@ -195,7 +194,6 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
 
       // Load Web Links addon for clickable URLs
       const webLinksAddon = new WebLinksAddon((_event, uri) => {
-        console.log('[Terminal] Link clicked:', uri);
         window.open(uri, '_blank', 'noopener,noreferrer');
       });
       terminal.loadAddon(webLinksAddon);
@@ -280,8 +278,6 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
             });
           }
         }
-
-        console.log(`[Terminal] Connected to executor terminal via channel: ${result.channel}`);
       } catch (error) {
         console.error('[Terminal] Failed to create terminal:', error);
         if (terminalRef.current) {

--- a/apps/agor-ui/src/components/WorktreeListDrawer/WorktreeListDrawer.tsx
+++ b/apps/agor-ui/src/components/WorktreeListDrawer/WorktreeListDrawer.tsx
@@ -81,7 +81,7 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
     <Drawer
       title={null}
       placement="left"
-      width={400}
+      size={400}
       open={open}
       onClose={onClose}
       styles={{
@@ -138,7 +138,7 @@ export const WorktreeListDrawer: React.FC<WorktreeListDrawerProps> = ({
                   </Space>
                 }
                 description={
-                  <Space direction="vertical" size={2} style={{ width: '100%' }}>
+                  <Space orientation="vertical" size={2} style={{ width: '100%' }}>
                     <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                       {session.agentic_tool} • {session.tasks.length}{' '}
                       {session.tasks.length === 1 ? 'task' : 'tasks'}

--- a/apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx
@@ -73,7 +73,6 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
       } catch (error: any) {
         // If service doesn't exist (404 or method not found), RBAC is disabled
         if (error?.code === 404 || error?.message?.includes('not found')) {
-          console.log('[OwnersSection] RBAC disabled - worktree-owners service not found');
           setRbacEnabled(false);
         } else {
           console.error('Failed to load data:', error);

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -188,13 +188,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
 
     const handleWorktreeUpdate = (data: unknown) => {
       const updatedWorktree = data as Worktree;
-      console.log(
-        '🔄 WebSocket worktree update:',
-        updatedWorktree.worktree_id.substring(0, 8),
-        updatedWorktree.environment_instance
-      );
       if (updatedWorktree.worktree_id === worktree.worktree_id) {
-        console.log('✅ Updating UI state for worktree:', worktree.name);
         setEnvStatus(updatedWorktree.environment_instance?.status || 'stopped');
         setLastHealthCheck(updatedWorktree.environment_instance?.last_health_check);
         setProcessInfo(updatedWorktree.environment_instance?.process);
@@ -203,7 +197,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
 
     client.service('worktrees').on('patched', handleWorktreeUpdate);
     return () => client.service('worktrees').removeListener('patched', handleWorktreeUpdate);
-  }, [client, worktree.worktree_id, worktree.name]);
+  }, [client, worktree.worktree_id]);
 
   // Environment control handlers
   const handleStart = async () => {

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
@@ -94,7 +94,6 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
         setOwners(ownersResponse as User[]);
       } catch (_error) {
         // If RBAC is disabled or service not found, allow all edits
-        console.log('Could not load owners, allowing edits');
         setOwners([]);
       } finally {
         setLoadingOwners(false);

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -89,8 +89,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                 return;
               } catch (_accessTokenErr) {
                 // Access token expired or invalid - try refresh token
-                console.log('Access token failed on reconnect, attempting refresh...');
-
                 // Check if we have a refresh token in localStorage
                 const refreshToken = getStoredRefreshToken();
                 if (refreshToken) {
@@ -142,12 +140,10 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
 
       client.io.on('disconnect', (reason) => {
         if (mounted) {
-          console.log('🔌 Disconnected from daemon:', reason);
           setConnected(false);
 
           // Auto-reconnect if disconnect was due to server restart (not intentional client disconnect)
           if (reason === 'io server disconnect' || reason === 'transport close') {
-            console.log('🔄 Daemon restarted, attempting to reconnect...');
             // Socket.io will auto-reconnect, we just need to re-authenticate when it does
           }
         }
@@ -163,7 +159,6 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
             setConnected(false);
           } else {
             // During reconnection, keep connecting=true so UI shows reconnecting indicator
-            console.log('🔄 Reconnection attempt failed, will retry...');
             setConnecting(true);
             setConnected(false);
             // Don't set error - socket.io will keep trying
@@ -269,11 +264,8 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
     const client = clientRef.current;
     if (!client?.io) return;
 
-    console.log('🔄 Manual reconnection requested');
-
     // If already connected, disconnect first
     if (client.io.connected) {
-      console.log('🔌 Disconnecting before retry...');
       client.io.disconnect();
     }
 

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -183,12 +183,6 @@ export function useAgorData(
       // Build MCP server Map for efficient lookups
       const mcpServersMap = new Map<string, MCPServer>();
       for (const mcpServer of mcpServersList) {
-        console.log('[useAgorData] Loading MCP server:', {
-          name: mcpServer.name,
-          mcp_server_id: mcpServer.mcp_server_id.substring(0, 8),
-          tools: mcpServer.tools,
-          toolCount: mcpServer.tools?.length || 0,
-        });
         mcpServersMap.set(mcpServer.mcp_server_id, mcpServer);
       }
       setMcpServerById(mcpServersMap);
@@ -245,12 +239,6 @@ export function useAgorData(
       });
     };
     const handleSessionPatched = (session: Session) => {
-      console.log(`🔄 [useAgorData] Session patched:`, {
-        session_id: session.session_id.substring(0, 8),
-        status: session.status,
-        ready_for_prompt: session.ready_for_prompt,
-      });
-
       // Track old worktree_id for migration detection
       let oldWorktreeId: string | null = null;
 
@@ -295,44 +283,22 @@ export function useAgorData(
           const newSessions = prev.get(newWorktreeId) || [];
           next.set(newWorktreeId, [...newSessions, session]);
 
-          console.log(
-            `🔄 [useAgorData] sessionsByWorktree updated (MIGRATED) for worktree ${newWorktreeId.substring(0, 8)}`
-          );
           return next;
         }
 
         // Session not found in this worktree and didn't migrate (shouldn't happen, but be safe)
         if (index === -1) {
-          console.log(
-            `⚠️ [useAgorData] Session ${session.session_id.substring(0, 8)} not found in worktree ${newWorktreeId.substring(0, 8)}, skipping sessionsByWorktree update`
-          );
           return prev;
         }
 
         // Check if session actually changed (reference equality is sufficient for socket updates)
         if (worktreeSessions[index] === session) {
-          console.log(
-            `🔄 [useAgorData] Session ${session.session_id.substring(0, 8)} reference unchanged, skipping sessionsByWorktree update`
-          );
           return prev;
         }
 
         // Create new array with updated session (in-place update)
         const updatedSessions = [...worktreeSessions];
         updatedSessions[index] = session;
-
-        const oldArrayRef = worktreeSessions;
-        const newArrayRef = updatedSessions;
-        console.log(
-          `🔄 [useAgorData] sessionsByWorktree updated for worktree ${newWorktreeId.substring(0, 8)}`,
-          {
-            arrayRefChanged: oldArrayRef !== newArrayRef,
-            oldLength: oldArrayRef.length,
-            newLength: newArrayRef.length,
-            sessionIndex: index,
-            sessionStatus: session.status,
-          }
-        );
 
         // Only create new Map with updated worktree entry
         const next = new Map(prev);
@@ -379,18 +345,11 @@ export function useAgorData(
       });
     };
     const handleBoardPatched = (board: Board) => {
-      console.log('🔄 [useAgorData] Board patched:', {
-        board_id: board.board_id.substring(0, 8),
-        objectsCount: Object.keys(board.objects || {}).length,
-        objects: board.objects,
-      });
       setBoardById((prev) => {
         const existing = prev.get(board.board_id);
         if (existing === board) {
-          console.log('⚠️ [useAgorData] Board reference unchanged, skipping update');
           return prev; // Same reference, no change
         }
-        console.log('✅ [useAgorData] Updating boardById Map with new board');
         const next = new Map(prev);
         next.set(board.board_id, board);
         return next;
@@ -553,12 +512,6 @@ export function useAgorData(
       });
     };
     const handleMCPServerPatched = (server: MCPServer) => {
-      console.log('[useAgorData] MCP server patched:', {
-        name: server.name,
-        mcp_server_id: server.mcp_server_id.substring(0, 8),
-        tools: server.tools,
-        toolCount: server.tools?.length || 0,
-      });
       setMcpServerById((prev) => {
         const existing = prev.get(server.mcp_server_id);
         if (existing === server) return prev; // Same reference, no change

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -51,8 +51,6 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
         throw new Error('Worktree ID is required');
       }
 
-      console.log(`Creating session with worktree_id: ${config.worktree_id}`);
-
       // Create session with worktree_id
       const agenticTool = config.agent as AgenticToolName;
       const permissionMode: PermissionMode =

--- a/apps/agor-ui/src/hooks/useStreamingMessages.ts
+++ b/apps/agor-ui/src/hooks/useStreamingMessages.ts
@@ -98,8 +98,6 @@ export function useStreamingMessages(
         return;
       }
 
-      console.debug(`📡 Streaming start: ${data.message_id.substring(0, 8)}`);
-
       setStreamingMessages((prev) => {
         const newMap = new Map(prev);
         newMap.set(data.message_id, {
@@ -143,8 +141,6 @@ export function useStreamingMessages(
       if (sessionId && data.session_id !== sessionId) {
         return;
       }
-
-      console.debug(`📡 Streaming end: ${data.message_id.substring(0, 8)}`);
 
       // Mark as ended but DON'T remove yet - wait for DB 'created' event
       // This prevents jitter where streaming message disappears before DB message appears
@@ -201,10 +197,6 @@ export function useStreamingMessages(
         return;
       }
 
-      console.debug(
-        `📡 Message created in DB: ${message.message_id.substring(0, 8)} - removing from streaming buffer`
-      );
-
       // Remove from streaming map now that it's in the DB
       setStreamingMessages((prev) => {
         const newMap = new Map(prev);
@@ -219,8 +211,6 @@ export function useStreamingMessages(
       if (sessionId && data.session_id !== sessionId) {
         return;
       }
-
-      console.debug(`🧠 Thinking start: ${data.message_id.substring(0, 8)}`);
 
       setStreamingMessages((prev) => {
         const newMap = new Map(prev);
@@ -268,8 +258,6 @@ export function useStreamingMessages(
       if (sessionId && data.session_id !== sessionId) {
         return;
       }
-
-      console.debug(`🧠 Thinking end: ${data.message_id.substring(0, 8)}`);
 
       setStreamingMessages((prev) => {
         const message = prev.get(data.message_id);

--- a/apps/agor-ui/src/hooks/useTaskEvents.ts
+++ b/apps/agor-ui/src/hooks/useTaskEvents.ts
@@ -55,8 +55,6 @@ export function useTaskEvents(
         return;
       }
 
-      console.debug(`🔧 Tool start: ${data.tool_name} (${data.tool_use_id.substring(0, 8)})`);
-
       setToolsExecuting((prev) => {
         // Avoid duplicates
         if (prev.some((t) => t.toolUseId === data.tool_use_id)) {
@@ -80,8 +78,6 @@ export function useTaskEvents(
       if (data.task_id !== taskId) {
         return;
       }
-
-      console.debug(`✅ Tool complete: ${data.tool_use_id.substring(0, 8)}`);
 
       setToolsExecuting((prev) => {
         // Mark as complete

--- a/apps/agor-ui/src/main.tsx
+++ b/apps/agor-ui/src/main.tsx
@@ -11,7 +11,6 @@ installClipboardPolyfill();
 // Cleanup WebSocket connections on Vite HMR
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
-    console.log('🔌 HMR: Cleaning up WebSocket connections...');
     // Close all open socket.io connections
     // biome-ignore lint/suspicious/noExplicitAny: Global window extension for HMR cleanup
     if (typeof window !== 'undefined' && (window as any).__agorClient) {
@@ -20,7 +19,6 @@ if (import.meta.hot) {
       if (client?.io) {
         client.io.removeAllListeners();
         client.io.close();
-        console.log('✅ HMR: Closed existing WebSocket connection');
       }
       // biome-ignore lint/suspicious/noExplicitAny: Global window extension for HMR cleanup
       delete (window as any).__agorClient;


### PR DESCRIPTION
## Summary
- Fix 4 types of Ant Design prop deprecation warnings (`Divider type→orientation`, `Drawer width→size`, `Alert message→title`, `Space direction→orientation`)
- Remove ~95 debug/junk `console.log`/`console.debug` statements from the UI codebase while preserving all `console.error` statements for real error handling
- Fix lint issues caused by removal (unused variables, extra blank lines, stale useEffect deps)

## Test plan
- [ ] Verify no Ant Design deprecation warnings appear in browser console
- [ ] Verify no debug logging noise in browser console during normal usage
- [ ] Verify error logging still works (e.g., network errors, failed uploads)
- [ ] Verify UI components render correctly (Alert, Divider, Drawer, Space, Upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)