### PR TITLE
fix: surface API key decryption failures to users

### DIFF
--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -86,6 +86,7 @@ export class ConfigService {
     apiKey: string | null;
     source: 'user' | 'config' | 'env' | 'native';
     useNativeAuth: boolean;
+    decryptionFailed?: boolean;
   }> {
     const { taskId, keyName } = data;
 
@@ -114,6 +115,7 @@ export class ConfigService {
       apiKey: result.apiKey ?? null,
       source: result.source === 'none' ? 'native' : result.source,
       useNativeAuth: result.useNativeAuth,
+      ...(result.decryptionFailed && { decryptionFailed: true }),
     };
   }
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -289,6 +289,15 @@ export async function executeToolTask(params: {
   // Resolve API key with proper precedence (user → config → env → native auth)
   const resolution = await resolveApiKeyForTask(apiKeyEnvVar as ApiKeyName, client, taskId);
 
+  // Fail fast if stored key can't be decrypted (e.g. master secret changed)
+  if (resolution.decryptionFailed) {
+    throw new Error(
+      `API key "${apiKeyEnvVar}" could not be decrypted. ` +
+        `The stored key may have been encrypted with a different master secret. ` +
+        `Please re-enter your API key in Settings > API Keys.`
+    );
+  }
+
   // Log resolution result
   if (resolution.apiKey) {
     console.log(`[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`);


### PR DESCRIPTION
## Summary

Fixes #579 — API key decryption failures are now surfaced to users instead of being silently swallowed.

When `AGOR_MASTER_SECRET` changes (container rebuild, config reset, etc.), previously-encrypted API keys become permanently unreadable. Before this fix:
- Decryption errors were silently caught
- The system fell through to other key sources or native auth
- Users saw keys as "Set" in the UI while sessions failed with cryptic 401 errors
- The only diagnosis path required reading daemon logs

### Changes

- **`packages/core/src/types/user.ts`** — Extend `api_keys` and `env_vars` status types to support `'decryption_failed'` tri-state
- **`packages/core/src/config/key-resolver.ts`** — Add `decryptionFailed` flag to `KeyResolutionResult`; stop silent fallthrough to config/env on decryption errors
- **`apps/agor-daemon/src/services/users.ts`** — Add `getKeyStatus()` helper that trial-decrypts keys; update `rowToUser()` to return accurate decryptability status; throw descriptive error from `getApiKey()` instead of silent `undefined`
- **`packages/executor/src/handlers/sdk/base-executor.ts`** — Fail tasks immediately with clear user-facing error message on decryption failure
- **`apps/agor-ui/src/components/ApiKeyFields.tsx`** — Add warning tag, alert banner, and "Re-enter Key" input for broken keys
- **`apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx`** — Pass through `'decryption_failed'` status from server response
- **`apps/agor-daemon/src/index.ts`** — Add non-blocking startup health check that warns about undecryptable keys with affected user emails

## Test plan

- [ ] Save an API key, then change `AGOR_MASTER_SECRET` and restart daemon — verify startup log shows warning about undecryptable keys
- [ ] Open Settings > API Keys — verify affected keys show "Decryption Failed" warning tag with alert banner and "Re-enter Key" input
- [ ] Try to run a session with a broken key — verify task fails with clear error message instead of cryptic 401
- [ ] Re-enter the key via the UI — verify it works normally again (shows "Set" tag)
- [ ] Verify keys that ARE decryptable still show "Set" as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)