### PR TITLE
chore: update demo video link to newer unscripted demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
   </table>
 </div>
 
-**[→ Watch unscripted demo on YouTube](https://www.youtube.com/watch?v=qiYHw20zjzE)** (13 minutes)
+**[→ Watch unscripted demo on YouTube](https://www.youtube.com/watch?v=3in0qh7ZH0g)** (13 minutes)
 
 ---
 

--- a/apps/agor-docs/pages/blog/announcement.mdx
+++ b/apps/agor-docs/pages/blog/announcement.mdx
@@ -35,7 +35,7 @@ Agor flips that into a multiplayer canvas. See all the work at once. Fork withou
 <div style={{ margin: '2rem 0', maxWidth: '100%' }}>
   <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0 }}>
     <iframe
-      src="https://www.youtube.com/embed/qiYHw20zjzE"
+      src="https://www.youtube.com/embed/3in0qh7ZH0g"
       style={{
         position: 'absolute',
         top: 0,

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -28,7 +28,7 @@ import { GifGallery } from '../../components';
 
 <GifGallery />
 
-**▶️ [Watch 13-minute walkthrough on YouTube](https://www.youtube.com/watch?v=qiYHw20zjzE)** — Unscripted demo showing Agor's core features
+**▶️ [Watch 13-minute walkthrough on YouTube](https://www.youtube.com/watch?v=3in0qh7ZH0g)** — Unscripted demo showing Agor's core features
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace old YouTube demo video (`qiYHw20zjzE`) with new unscripted demo (`3in0qh7ZH0g`) across 3 files
- Preserves URL formats: `watch` links in README.md and guide, `embed` link in blog announcement

## Test plan
- [ ] Verify YouTube links resolve correctly in README.md, blog announcement, and guide page

🤖 Generated with [Claude Code](https://claude.com/claude-code)