### PR TITLE
fix: apply user defaults in MCP session creation and simplify API

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.ts
+++ b/apps/agor-daemon/src/mcp/routes.ts
@@ -1291,12 +1291,7 @@ export function setupMCPRoutes(app: Application): void {
             // Mode: subsession - spawn child session (reuse existing spawn logic)
             console.log(`🌱 MCP spawning subsession from ${args.sessionId.substring(0, 8)}`);
 
-            const spawnData: {
-              prompt: string;
-              title?: string;
-              agentic_tool?: AgenticToolName;
-              task_id?: string;
-            } = {
+            const spawnData: Partial<import('@agor/core/types').SpawnConfig> = {
               prompt: args.prompt,
             };
 
@@ -1305,7 +1300,7 @@ export function setupMCPRoutes(app: Application): void {
             }
 
             if (args.agenticTool) {
-              spawnData.agentic_tool = args.agenticTool as AgenticToolName;
+              spawnData.agent = args.agenticTool as AgenticToolName;
             }
 
             if (args.taskId) {


### PR DESCRIPTION
## Summary

This fixes a bug where user default agentic tool configuration was not properly applied when creating sessions through the MCP server.

## Bug Fixes

- **Fixed overly restrictive condition in `agor_sessions_create`**: The handler only applied `modelConfig` if a specific model was set (`userToolDefaults?.modelConfig?.model`). Now applies all modelConfig fields (thinkingMode, manualThinkingTokens, mode) when any are present in user defaults.
- **Applied same fix to zone trigger (always_new) session creation**.

## API Simplification

Based on feedback that permission modes and agentic tool configuration are **too complex for agents to manage via MCP**, I've removed these parameters from all MCP session creation tools:

### Removed Parameters:
- ✅ `permissionMode` - removed from `agor_sessions_create`, `agor_sessions_spawn`, `agor_sessions_prompt`, and `agor_sessions_update`
- ✅ `mcpServerIds` - removed from `agor_sessions_create` (always uses user defaults)
- ✅ `modelConfig`, `codexSandboxMode`, `codexApprovalPolicy`, `codexNetworkAccess` - removed from `agor_sessions_spawn`

### New Behavior:
All MCP-created sessions now **always** use:
1. User defaults from `default_agentic_config` (if configured)
2. System defaults (if no user defaults exist)
3. Parent session settings (for fork/spawn operations)

### Updated Descriptions:
- `agor_sessions_create`: "Session configuration (permissions, model, MCP servers) is automatically inherited from user defaults."
- `agor_sessions_spawn`: "Session configuration is inherited from parent (same agent) or user defaults (different agent)."
- `agor_sessions_prompt`: "Configuration is inherited from parent session or user defaults."
- `agor_sessions_update`: Removed permission mode updates entirely

This makes the MCP API much simpler and prevents agents from making poor decisions about configuration they don't fully understand.

## Testing

- ✅ `pnpm check` passes (typecheck + lint + build)
- No pre-commit hook failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)