### PR TITLE
chore: configure Dependabot to ignore agor-live meta-package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Apps
+  - package-ecosystem: "npm"
+    directory: "/apps/agor-cli"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/agor-daemon"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/agor-docs"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/agor-ui"
+    schedule:
+      interval: "weekly"
+
+  # Packages (excluding agor-live meta-package)
+  - package-ecosystem: "npm"
+    directory: "/packages/core"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/executor"
+    schedule:
+      interval: "weekly"
+
+  # Note: packages/agor-live is intentionally excluded as it's a meta-package
+  # whose dependencies are derived from other packages in the monorepo


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuration to enable Dependabot for the monorepo
- Explicitly includes all apps and packages **except** `packages/agor-live/`
- `agor-live` is a meta-package whose dependencies are derived from other packages, so Dependabot should not independently update them

## Coverage

**Apps (included):**
- `apps/agor-cli`
- `apps/agor-daemon`
- `apps/agor-docs`
- `apps/agor-ui`

**Packages (included):**
- `packages/core`
- `packages/executor`

**Packages (excluded):**
- `packages/agor-live` - Meta-package, dependencies managed elsewhere

## Test plan

- [ ] Verify Dependabot recognizes the configuration in GitHub UI
- [ ] Confirm no PRs are created for `packages/agor-live/`
- [ ] Confirm PRs are created for other packages/apps when dependencies are outdated

🤖 Generated with [Claude Code](https://claude.com/claude-code)