### PR TITLE
fix: pass refType parameter through executor for tag worktree creation

### DIFF
--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -465,6 +465,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             branch: data.ref,
             sourceBranch: data.sourceBranch,
             createBranch: data.createBranch,
+            refType: data.refType,
             // Unix group isolation (only when RBAC is enabled)
             initUnixGroup: rbacEnabled,
             othersAccess: worktree.others_fs_access || 'read', // Default to read access

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -399,10 +399,11 @@ export async function handleGitWorktreeAdd(
     const branch = payload.params.branch || worktreeName;
     const createBranch = payload.params.createBranch ?? false;
     const sourceBranch = payload.params.sourceBranch;
+    const refType = payload.params.refType;
 
     console.log(`[git.worktree.add] Creating worktree at ${worktreePath}...`);
     console.log(
-      `[git.worktree.add] Repo: ${repoPath}, Branch: ${branch}, CreateBranch: ${createBranch}`
+      `[git.worktree.add] Repo: ${repoPath}, Branch: ${branch}, CreateBranch: ${createBranch}, RefType: ${refType || 'branch'}`
     );
 
     // Create the git worktree on filesystem
@@ -413,7 +414,8 @@ export async function handleGitWorktreeAdd(
       createBranch,
       true, // pullLatest
       sourceBranch,
-      env
+      env,
+      refType
     );
 
     console.log(`[git.worktree.add] Worktree created at ${worktreePath}`);

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -239,6 +239,9 @@ export const GitWorktreeAddPayloadSchema = BasePayloadSchema.extend({
     /** Create new branch */
     createBranch: z.boolean().optional(),
 
+    /** Type of ref (branch or tag) */
+    refType: z.enum(['branch', 'tag']).optional(),
+
     /** Initialize Unix group for worktree isolation (default: false, requires RBAC enabled) */
     initUnixGroup: z.boolean().optional().default(false),
 


### PR DESCRIPTION
Fixes worktree creation from tags by ensuring refType parameter is passed through the executor chain.

When creating a worktree from a tag, the refType parameter was not being passed to the executor, causing tag fetching to fail. This resulted in worktrees failing to create from tags while branch-based worktrees worked correctly.

**Changes:**
- Add refType field to GitWorktreeAddPayload schema
- Extract and pass refType in handleGitWorktreeAdd to createWorktree  
- Pass refType from repos service to executor payload

This ensures that when refType is 'tag', the git operations correctly fetch tags with --tags flag and handle the ref appropriately.

Fixes tag worktree creation functionality from previous PRs #294 and #333