### PR TITLE
fix: allow retry stop requests when session stuck in STOPPING state

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -4207,8 +4207,8 @@ async function main() {
 
         targetTasksArray = [...runningTasks, ...awaitingTasks];
 
-        // If this is a retry, also check for STOPPING tasks
-        if (isRetry) {
+        // If this is a retry, also check for STOPPING tasks, but only as fallback
+        if (isRetry && targetTasksArray.length === 0) {
           const stoppingResult = await tasksService.find({
             query: {
               session_id: id,
@@ -4220,7 +4220,7 @@ async function main() {
           const stoppingTasks = isPaginated(stoppingFindResult)
             ? stoppingFindResult.data
             : stoppingFindResult;
-          targetTasksArray = [...targetTasksArray, ...stoppingTasks];
+          targetTasksArray = stoppingTasks;
         }
 
         if (targetTasksArray.length === 0) {
@@ -4230,10 +4230,18 @@ async function main() {
           };
         }
 
-        const latestTask = targetTasksArray[targetTasksArray.length - 1];
+        // Sort tasks by most recent activity (started_at or created_at) to ensure deterministic selection
+        targetTasksArray.sort((a, b) => {
+          const timeA = new Date(a.started_at || a.created_at).getTime();
+          const timeB = new Date(b.started_at || b.created_at).getTime();
+          return timeB - timeA; // Most recent first
+        });
+
+        const latestTask = targetTasksArray[0];
 
         // PHASE 1: Atomically update task AND session to STOPPING
-        // Skip this phase for retries since status is already STOPPING
+        // Skip task/session transition for retries, but re-assert ready_for_prompt
+        let didTransitionToStopping = false;
         if (!isRetry) {
           try {
             // Update task status to STOPPING
@@ -4250,11 +4258,25 @@ async function main() {
               },
               params
             );
+            didTransitionToStopping = true;
           } catch (error) {
             return {
               success: false,
               reason: `Failed to update status: ${error instanceof Error ? error.message : 'Unknown error'}`,
             };
+          }
+        } else {
+          // For retries, re-assert ready_for_prompt to ensure consistency
+          try {
+            await app.service('sessions').patch(
+              id,
+              {
+                ready_for_prompt: false,
+              },
+              params
+            );
+          } catch (error) {
+            console.warn(`⚠️  [Daemon] Failed to re-assert ready_for_prompt on retry:`, error);
           }
         }
 
@@ -4269,7 +4291,8 @@ async function main() {
         );
 
         // PHASE 3: Handle failed stop (revert to RUNNING)
-        if (!result.success) {
+        // Only revert if WE transitioned to STOPPING (not on retries of already-STOPPING sessions)
+        if (!result.success && didTransitionToStopping) {
           try {
             await tasksService.patch(latestTask.task_id, {
               status: TaskStatus.RUNNING,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -136,6 +136,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
   const [uploadModalOpen, setUploadModalOpen] = React.useState(false);
   const [droppedFiles, setDroppedFiles] = React.useState<File[]>([]);
+  const [stopRequestInFlight, setStopRequestInFlight] = React.useState(false);
 
   const currentUser = currentUserId ? userById.get(currentUserId) || null : null;
   const { tasks } = useTasks(client, session?.session_id || null, currentUser, open);
@@ -353,18 +354,21 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   };
 
   const handleStop = async () => {
-    if (!session || !client) return;
+    if (!session || !client || stopRequestInFlight) return;
 
+    // Show feedback immediately if this is a retry
+    if (isStopping) {
+      message.info('Retrying stop request...');
+    }
+
+    setStopRequestInFlight(true);
     try {
       await client.service(`sessions/${session.session_id}/stop`).create({});
-
-      // If this is a retry (session already stopping), show feedback
-      if (isStopping) {
-        message.info('Retrying stop request...');
-      }
     } catch (error) {
       console.error('Failed to stop execution:', error);
       message.error('Failed to stop execution. You can try again.');
+    } finally {
+      setStopRequestInFlight(false);
     }
   };
 
@@ -649,19 +653,21 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             <Space.Compact>
               <Tooltip
                 title={
-                  isStopping
-                    ? 'Stopping... (Click again to retry if stuck)'
-                    : isRunning
-                      ? 'Stop Execution'
-                      : 'No active execution'
+                  stopRequestInFlight
+                    ? 'Sending stop request...'
+                    : isStopping
+                      ? 'Stopping... (Click again to retry if stuck)'
+                      : isRunning
+                        ? 'Stop Execution'
+                        : 'No active execution'
                 }
               >
                 <Button
                   danger
                   icon={<StopOutlined />}
                   onClick={handleStop}
-                  disabled={!isRunning}
-                  loading={isStopping}
+                  disabled={!isRunning || stopRequestInFlight}
+                  loading={isStopping && !stopRequestInFlight}
                 />
               </Tooltip>
               <Tooltip title="Advanced Spawn Options">


### PR DESCRIPTION
## Problem

When stopping a Claude Code session from the UI, the session doesn't always actually stop. Once stuck in the `STOPPING` state, users had no way to retry - the stop button was disabled and the API rejected further stop requests.

This resulted in frustrating "OMG it didn't stop again, what do I do!?" moments.

## Root Cause

The stop endpoint explicitly rejected requests for sessions not in `RUNNING` or `AWAITING_PERMISSION` state:

```typescript
if (
  session.status !== SessionStatus.RUNNING &&
  session.status !== SessionStatus.AWAITING_PERMISSION
) {
  return {
    success: false,
    reason: `Session is not running (status: ${session.status})`,
  };
}
```

Once in `STOPPING` state, users were blocked at both the API and UI level.

## Solution

Allow users to retry stop requests when sessions are stuck in the `STOPPING` state:

### Backend Changes (apps/agor-daemon/src/index.ts)

- Allow stop requests for sessions in `STOPPING` state
- Detect retry attempts with `isRetry` flag
- Include `STOPPING` tasks in query for retry attempts
- Skip redundant state transitions when retrying (already in STOPPING)
- Add logging for retry attempts

### UI Changes (apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx)

- Enable stop button while session is `STOPPING` (remove `isStopping` guard)
- Update tooltip to "Stopping... (Click again to retry if stuck)"
- Show "Retrying stop request..." message when clicking during STOPPING
- Improve error handling with user-friendly retry message

## Key Features

✅ **Non-breaking**: Normal stop flow works exactly as before
✅ **User-friendly**: Clear visual feedback that retry is possible  
✅ **Defensive**: Maintains all existing safety nets and timeouts from `handleStopWithAck`
✅ **Simple**: Minimal code changes, leverages existing robust stop handler

## User Experience

**Before**: Session stuck in STOPPING → user frustrated, no recourse

**After**: Session stuck in STOPPING → user can click stop again to retry → session eventually stops or gets force-stopped by safety nets

The stop button now shows a loading spinner while stopping, but remains clickable. The tooltip explicitly tells users they can "Click again to retry if stuck", making the retry capability discoverable.

## Testing

- [x] Build passes (`pnpm check`)
- [x] Type checking passes
- [x] Linting passes
- [ ] Manual testing: Normal stop flow
- [ ] Manual testing: Retry when stuck
- [ ] Manual testing: Multiple rapid retries

## Related Work

This builds on previous stopping reliability improvements:
- 7dd05d88: AbortController for reliable Claude SDK stopping
- eeb84522: AbortController for Codex SDK stopping  
- 59144873: Prevent stop signals from affecting subsequent tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)