### PR TITLE
Fix: Dismiss password change modal after successful password update

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -106,6 +106,7 @@ function AppContent() {
     accessToken,
     login,
     logout,
+    reAuthenticate,
   } = useAuth();
 
   // Call ALL hooks unconditionally BEFORE any conditional returns
@@ -554,6 +555,9 @@ function AppContent() {
     // This will auto-clear must_change_password flag on the backend
     await client.service('users').patch(userId, { password: newPassword } as Partial<User>);
     showSuccess('Password changed successfully!');
+    // Re-authenticate to refresh user state with must_change_password: false
+    // This will dismiss the modal and allow the user to continue
+    await reAuthenticate();
   };
 
   // Handle board CRUD


### PR DESCRIPTION
## Summary

Fixes the UX bug where the password change modal doesn't dismiss after successfully changing the password, requiring users to manually log out and log back in.

## Root Cause

When `must_change_password` is true, the `useAgorData` hook is **disabled** to prevent unnecessary data fetching before password change. This means WebSocket subscriptions are never set up, so the frontend never receives the `patched` user event with `must_change_password: false` after the password is changed on the backend.

## Solution

Call `reAuthenticate()` after successfully changing the password to fetch the updated user object from the backend. This refreshes the user state with `must_change_password: false`, which causes the modal to automatically dismiss and allows the user to continue using the app.

## Changes

- Added `reAuthenticate` to the destructured `useAuth()` hook return value
- Updated `handleForcePasswordChange` to call `reAuthenticate()` after successful password change

## Testing

1. Create a user with `must_change_password: true`
2. Log in as that user
3. Change the password in the modal
4. Verify the modal dismisses automatically
5. Verify the user can continue using the app without manual logout

## Before

- ❌ Modal stays open after password change
- ❌ User must manually log out and log back in

## After

- ✅ Modal dismisses automatically after password change
- ✅ User can continue using the app immediately