### PR TITLE
feat(ui): show spinner on collapsed session groups when running

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -228,6 +228,18 @@ const WorktreeCardComponent = ({
     [sessions]
   );
 
+  // Check if any scheduled session is running (for collapse header spinner)
+  const hasRunningScheduledSession = useMemo(
+    () => scheduledSessions.some((s) => s.status === 'running' || s.status === 'stopping'),
+    [scheduledSessions]
+  );
+
+  // Check if any gateway session is running (for collapse header spinner)
+  const hasRunningGatewaySession = useMemo(
+    () => gatewaySessions.some((s) => s.status === 'running' || s.status === 'stopping'),
+    [gatewaySessions]
+  );
+
   // Check if worktree is still being created on filesystem
   const isCreating = worktree.filesystem_status === 'creating';
   const isFailed = worktree.filesystem_status === 'failed';
@@ -431,6 +443,7 @@ const WorktreeCardComponent = ({
           showZero
           style={{ backgroundColor: token.colorInfoBgHover }}
         />
+        {hasRunningScheduledSession && <Spin size="small" />}
       </Space>
     </div>
   );
@@ -501,6 +514,7 @@ const WorktreeCardComponent = ({
           showZero
           style={{ backgroundColor: token.colorSuccessBgHover }}
         />
+        {hasRunningGatewaySession && <Spin size="small" />}
       </Space>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a `<Spin size="small" />` indicator to the **Scheduled Runs** and **Gateway Sessions** collapse headers when any session in the group has status `running` or `stopping`
- Allows users to see at a glance that work is happening inside a collapsed group without needing to expand it
- Uses per-group `useMemo` hooks following the same pattern as the existing `hasRunningSession` check

## Test plan
- [ ] Verify spinner appears on "Scheduled Runs" header when a scheduled session is running
- [ ] Verify spinner appears on "Gateway Sessions" header when a gateway session is running
- [ ] Verify spinner disappears when no sessions in the group are running
- [ ] Verify spinner is visible in both collapsed and expanded states
- [ ] Verify no spinner shows when all sessions are idle/completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)