### PR TITLE
fix: Leaderboard returns user info and reads from normalized token data

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.ts
+++ b/apps/agor-daemon/src/mcp/routes.ts
@@ -3099,8 +3099,8 @@ export function setupMCPRoutes(app: Application): void {
           if (args?.sortOrder) query.sortOrder = args.sortOrder;
 
           // Add pagination
-          if (args?.limit) query.$limit = args.limit;
-          if (args?.offset) query.$skip = args.offset;
+          if (args?.limit) query.limit = args.limit;
+          if (args?.offset) query.offset = args.offset;
 
           const leaderboard = await app.service('leaderboard').find({ query });
           mcpResponse = {


### PR DESCRIPTION
## Summary
- **Add user info to leaderboard**: When grouping by user, the `agor_analytics_leaderboard` MCP tool now returns `userName`, `userEmail`, and `userEmoji` alongside `userId` via a LEFT JOIN on the users table — no more separate `agor_users_list` calls needed
- **Fix token accounting showing 0**: The leaderboard query was reading from `raw_sdk_response.tokenUsage.input_tokens` which doesn't exist in the actual stored data. Changed to read from `normalized_sdk_response.tokenUsage.totalTokens` and `normalized_sdk_response.costUsd`, which the executor already computes consistently across all agent SDKs (Claude, Codex, Gemini)
- **Fix MCP pagination params**: The handler was mapping `limit` → `$limit` and `offset` → `$skip` (FeathersJS conventions), but LeaderboardService expects `limit`/`offset` directly

## Test plan
- [ ] Call `agor_analytics_leaderboard` with `groupBy: "user"` and verify `userName`, `userEmail`, `userEmoji` are present in results
- [ ] Verify `totalTokens` and `totalCost` are non-zero for users with completed tasks
- [ ] Verify pagination (`limit`/`offset` params) works correctly
- [ ] Verify grouping without user dimension (e.g. `groupBy: "worktree"`) still works and doesn't include user fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)