### PR TITLE
fix(gateway): ignore bot mentions inside code blocks in Slack messages

### DIFF
--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -84,6 +84,8 @@ function parseThreadId(threadId: string): { channel: string; thread_ts: string }
 function hasActiveMention(text: string, mentionPattern: RegExp): boolean {
   // Strip triple-backtick blocks first (```...```), then inline code (`...`)
   const stripped = text.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
+  // Reset lastIndex in case the pattern has global/sticky flags (defensive)
+  mentionPattern.lastIndex = 0;
   return mentionPattern.test(stripped);
 }
 
@@ -337,12 +339,18 @@ export class SlackConnector implements GatewayConnector {
       // - Skip 'app_mention' events where the mention is only inside code blocks
       //   (those are not "real" mentions and should be handled as plain messages)
       const isThreadReply = !!event.thread_ts;
-      // app_mention events often lack channel_type, so also infer from channel ID prefix
+      // Determine if this is a channel/group message for dedup purposes.
+      // app_mention events often lack channel_type, so infer from channel ID prefix.
+      // IMPORTANT: Only use prefix inference for app_mention events. For message events,
+      // rely on the explicit channel_type to avoid misclassifying MPIMs (which also
+      // use G* prefix) and accidentally dropping messages.
       const channelPrefix = (event.channel as string | undefined)?.charAt(0);
       const isChannelMessage =
         event.channel_type === 'channel' ||
         event.channel_type === 'group' ||
-        (!event.channel_type && (channelPrefix === 'C' || channelPrefix === 'G'));
+        (eventType === 'app_mention' &&
+          !event.channel_type &&
+          (channelPrefix === 'C' || channelPrefix === 'G'));
 
       // CRITICAL: Prevent duplicates in channels/groups when bot ID unavailable
       // Strategy depends on require_mention setting:


### PR DESCRIPTION
## Summary

- Adds `hasActiveMention()` helper that strips code blocks (triple-backtick and inline) before testing for `<@BOT_ID>` mention patterns
- Updates dedup logic to only skip `message` events for **active** mentions (outside code blocks), and skip `app_mention` events where the mention is **only** inside code blocks
- Updates mention requirement validation to use code-block-aware detection
- Fixes `isChannelMessage` detection to infer channel type from Slack channel ID prefix for `app_mention` events (which often lack `channel_type`)

**Root cause:** Slack's `event.text` contains `<@BOT_ID>` in both active mentions and code-block mentions. The dedup logic was suppressing `message` events containing code-block mentions (assuming `app_mention` would handle them), but `app_mention` events for code-block mentions would either also be processed (creating unwanted sessions) or not fire at all — leaving no handler for the message. This caused no session mapping to be created, so subsequent thread replies triggered the unwanted "[system] To start a conversation in this thread" spam.

## Test plan

- [ ] Send a message with `@bot` inside a code block — bot should NOT respond or create a session
- [ ] Send a message with an active @bot mention (blue/clickable) — bot should respond normally
- [ ] Reply in a thread where bot was never actively mentioned — should NOT get the system message
- [ ] Reply in a thread where bot WAS actively mentioned — should route to existing session
- [ ] Send a message with both a code-block mention and an active mention — should respond (active mention takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)