### PR TITLE
fix(executor): apply query filters in permission request lookup

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -4637,7 +4637,6 @@ async function main() {
           query: {
             session_id: id,
             type: 'permission_request',
-            $limit: 100, // Get recent permission requests
           },
         });
 
@@ -4649,7 +4648,9 @@ async function main() {
         });
 
         if (!permissionMessage) {
-          throw new Error(`Permission request ${data.requestId} not found`);
+          throw new Error(
+            `Permission request ${data.requestId} not found (found ${messageList.length} permission_request messages in session ${id})`
+          );
         }
 
         // Type-safe access to permission content

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -42,12 +42,32 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
   }
 
   /**
+   * Apply non-operator query fields (type, role, etc.) as filters on a message array.
+   * Called in shortcut paths (session_id, task_id) which bypass the ORM's query handling.
+   */
+  private applyQueryFilters(msgs: Message[], query: Record<string, unknown>): Message[] {
+    let filtered = msgs;
+    for (const [key, value] of Object.entries(query)) {
+      if (key.startsWith('$')) continue; // Skip $limit, $skip, $sort
+      if (key === 'session_id') continue; // Already used for repo lookup
+      if (key === 'task_id') continue; // Already used for repo lookup
+      filtered = filtered.filter(
+        (msg) => (msg as unknown as Record<string, unknown>)[key] === value
+      );
+    }
+    return filtered;
+  }
+
+  /**
    * Override find to support task-based and session-based filtering
    */
   async find(params?: MessageParams): Promise<Message[] | Paginated<Message>> {
     // If filtering by task_id, use repository method
     if (params?.query?.task_id) {
-      const messages = await this.messagesRepo.findByTaskId(params.query.task_id);
+      let messages = await this.messagesRepo.findByTaskId(params.query.task_id);
+
+      // Apply additional query filters (type, role, etc.)
+      messages = this.applyQueryFilters(messages, params.query);
 
       // Apply pagination if enabled
       if (this.paginate) {
@@ -67,7 +87,10 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
 
     // If filtering by session_id, use repository method
     if (params?.query?.session_id) {
-      const messages = await this.messagesRepo.findBySessionId(params.query.session_id);
+      let messages = await this.messagesRepo.findBySessionId(params.query.session_id);
+
+      // Apply additional query filters (type, role, etc.)
+      messages = this.applyQueryFilters(messages, params.query);
 
       // Apply pagination if enabled
       if (this.paginate) {

--- a/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
+++ b/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
@@ -14,7 +14,7 @@ import {
   PermissionScope,
   PermissionStatus,
 } from '@agor/core/types';
-import { CheckOutlined, CloseOutlined, LockOutlined } from '@ant-design/icons';
+import { CheckOutlined, ClockCircleOutlined, CloseOutlined, LockOutlined } from '@ant-design/icons';
 import { Button, Card, Descriptions, Radio, Select, Space, Typography, theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
@@ -45,9 +45,10 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
 
   const { tool_name, tool_input, status, approved_at } = content;
 
-  // Determine the state: active, approved, denied, or waiting
+  // Determine the state: active, approved, denied, timed out, or waiting
   const isApproved = status === PermissionStatus.APPROVED;
   const isDenied = status === PermissionStatus.DENIED;
+  const isTimedOut = status === PermissionStatus.TIMED_OUT;
 
   // State-based styling
   const getStateStyle = () => {
@@ -76,6 +77,13 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
         border: `1px solid ${token.colorErrorBorder}`,
       };
     }
+    if (isTimedOut) {
+      return {
+        background: 'rgba(0, 0, 0, 0.02)',
+        border: `1px solid ${token.colorBorder}`,
+        opacity: 0.8,
+      };
+    }
     return {};
   };
 
@@ -83,6 +91,8 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
     if (isActive) return <LockOutlined style={{ fontSize: 20, color: token.colorWarning }} />;
     if (isApproved) return <CheckOutlined style={{ fontSize: 20, color: token.colorSuccess }} />;
     if (isDenied) return <CloseOutlined style={{ fontSize: 20, color: token.colorError }} />;
+    if (isTimedOut)
+      return <ClockCircleOutlined style={{ fontSize: 20, color: token.colorTextSecondary }} />;
     return null;
   };
 
@@ -91,6 +101,7 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
     if (isActive) return 'Permission Required';
     if (isApproved) return 'Permission Approved';
     if (isDenied) return 'Permission Denied';
+    if (isTimedOut) return 'Permission Request Timed Out';
     return 'Permission Request';
   };
 
@@ -101,6 +112,9 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
     }
     if (isDenied && approved_at) {
       return `Denied ${new Date(approved_at).toLocaleString()}`;
+    }
+    if (isTimedOut && approved_at) {
+      return `Timed out ${new Date(approved_at).toLocaleString()}`;
     }
     return '';
   };


### PR DESCRIPTION
## Summary

- **Messages service query filter bypass fixed**: The `findBySessionId` and `findByTaskId` shortcut paths in `MessagesService` were ignoring additional query parameters like `type`, so queries like `{ session_id, type: 'permission_request' }` returned all messages instead of just permission requests. Added `applyQueryFilters()` to apply non-operator fields on these paths.
- **Improved permission request error diagnostics**: The error when a permission request isn't found now includes the count of permission_request messages found and the session ID. Also removed the unnecessary `$limit: 100` that could mask results.
- **Added timed-out state to permission UI**: `PermissionRequestBlock` now renders `TIMED_OUT` status with a clock icon, muted styling, and timestamp.

Follows up on #638.

## Test plan

- [x] Verify permission request lookup succeeds when filtering by `type: 'permission_request'` via session_id query path
- [x] Verify timed-out permission requests render with clock icon and "Permission Request Timed Out" label
- [x] Verify approved/denied permission states still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)