### PR TITLE
feat(ui): dynamic board tab titles

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -27,6 +27,7 @@ import {
 import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { AppDataProvider } from '../../contexts/AppDataContext';
+import { useBoardTitle } from '../../hooks/useBoardTitle';
 import { useEventStream } from '../../hooks/useEventStream';
 import { useFaviconStatus } from '../../hooks/useFaviconStatus';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
@@ -456,6 +457,9 @@ export const App: React.FC<AppProps> = ({
     : null;
   const sessionSettingsSession = sessionSettingsId ? sessionById.get(sessionSettingsId) : null;
   const currentBoard = boardById.get(currentBoardId);
+
+  // Update browser tab title based on current board
+  useBoardTitle(currentBoard);
 
   // Find worktree and repo for WorktreeModal
   const selectedWorktree = worktreeModalWorktreeId

--- a/apps/agor-ui/src/hooks/useBoardTitle.ts
+++ b/apps/agor-ui/src/hooks/useBoardTitle.ts
@@ -1,0 +1,27 @@
+/**
+ * React hook for updating the browser tab title based on the current board.
+ *
+ * When a board is selected, the tab title shows "{icon} {name}" (or just the name
+ * if no icon is set). Resets to "Agor" when no board is active or on unmount.
+ */
+
+import type { Board } from '@agor/core/types';
+import { useEffect } from 'react';
+
+const DEFAULT_TITLE = 'Agor';
+
+export function useBoardTitle(currentBoard: Board | undefined) {
+  useEffect(() => {
+    if (currentBoard?.icon && currentBoard?.name) {
+      document.title = `${currentBoard.icon} ${currentBoard.name}`;
+    } else if (currentBoard?.name) {
+      document.title = currentBoard.name;
+    } else {
+      document.title = DEFAULT_TITLE;
+    }
+
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [currentBoard?.icon, currentBoard?.name]);
+}


### PR DESCRIPTION
## Summary
- Add `useBoardTitle` hook that dynamically updates `document.title` when viewing a board
- Tab shows `{emoji} {name}` (e.g. "🦀 Agor Claw"), falling back to just the name if no emoji, or "Agor" if no board is active
- Resets title to "Agor" on unmount/navigation away from a board

## Test plan
- [ ] Open a board with emoji and name → tab shows "{emoji} {name}"
- [ ] Open a board without emoji → tab shows just the name
- [ ] Navigate away from a board → tab resets to "Agor"
- [ ] Switch between boards → tab title updates correctly
- [ ] Open multiple boards in different tabs → each shows correct title
- [ ] `pnpm check` passes (typecheck, lint, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)