### PR TITLE
fix(gateway): silently drop thread replies in non-Agor threads

### DIFF
--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -166,7 +166,9 @@ export class GatewayService {
     // in threads that have nothing to do with Agor. Sending a visible rejection would
     // cause the bot to spam every active thread in the channel.
     if (!existingMapping && data.metadata?.requires_mapping_verification) {
-      console.log(
+      // Use debug level — this fires for every non-Agor thread reply in monitored
+      // channels and would create excessive log noise at info level.
+      console.debug(
         `[gateway] IGNORED: Thread reply without mention in unmapped thread: channel=${channel.id.substring(0, 8)}, thread=${data.thread_id}`
       );
       return {


### PR DESCRIPTION
## Summary

- **Root cause:** When `allow_thread_replies_without_mention` is enabled (default: true), the Slack connector forwards ALL thread replies to the gateway — even in threads where Agor was never mentioned. The gateway correctly rejects these unmapped threads, but was sending a visible `[system] To start a conversation in this thread, please @mention me in your message.` rejection into the thread.
- **Fix:** Remove the `sendDebugMessage` call from the unmapped-thread rejection path. These are normal messages in threads that have nothing to do with Agor — the rejection should be silent (log-only), not a user-facing message posted to Slack.
- **Impact:** Eliminates bot spam in every non-Agor thread in monitored channels.

## Test plan

- [ ] Send a message in a Slack thread where Agor was NEVER mentioned → No response from bot
- [ ] Send a message in a thread where Agor WAS previously mentioned → Bot responds normally
- [ ] @mention Agor in a new thread → Bot creates session and responds
- [ ] Send a thread reply WITH @Agor mention → Bot responds
- [ ] Verify server logs show `[gateway] IGNORED:` (not `REJECTED:`) for non-Agor threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)