### PR TITLE
fix: read database config from config.yaml, fix Handlebars import

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -383,9 +383,7 @@ interface RouteParams extends Params {
 }
 
 // Determine database URL using centralized logic from @agor/core/db
-// Priority:
-// 1. If AGOR_DB_DIALECT=postgresql, use DATABASE_URL (required for Postgres)
-// 2. Otherwise, use AGOR_DB_PATH or default SQLite path
+// Priority: env vars > config.yaml > defaults (see getDatabaseUrl for details)
 const DB_PATH = getDatabaseUrl();
 
 // Main async function

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -20,6 +20,7 @@ import {
   StopOutlined,
 } from '@ant-design/icons';
 import { App, Badge, Button, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import Handlebars from 'handlebars';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -45,6 +46,13 @@ import {
 import { ThinkingModeSelector } from '../ThinkingModeSelector';
 import { ToolIcon } from '../ToolIcon';
 import { SessionPanelContent } from './SessionPanelContent';
+
+// Register helper to check if value is defined (not undefined)
+// This allows us to distinguish between false and undefined in templates
+Handlebars.registerHelper('isDefined', (value: unknown) => value !== undefined);
+
+// Compile template once at module load (after helper registration)
+const compiledSpawnTemplate = Handlebars.compile(spawnSubsessionTemplate);
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
@@ -415,12 +423,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         config.includeOriginalPrompt !== undefined ||
         config.extraInstructions !== undefined;
 
-      const Handlebars = await import('handlebars');
-      Handlebars.registerHelper('isDefined', (value) => value !== undefined);
-
-      const compiledTemplate = Handlebars.compile(spawnSubsessionTemplate);
-
-      const metaPrompt = compiledTemplate({
+      const metaPrompt = compiledSpawnTemplate({
         userPrompt: config.prompt || '',
         hasConfig,
         agenticTool: config.agent,

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -12,6 +12,7 @@ import { drizzle as drizzleSQLite } from 'drizzle-orm/libsql';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { drizzle as drizzlePostgres } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
+import { loadConfigSync } from '../config/config-manager';
 import * as postgresSchema from './schema.postgres';
 
 // Import both schemas explicitly
@@ -285,21 +286,65 @@ export type Database =
 export const DEFAULT_DB_PATH = 'file:~/.agor/agor.db';
 
 /**
- * Resolve database URL from environment variables
+ * Resolve database URL from environment and config
  *
  * Priority:
- * 1. If AGOR_DB_DIALECT=postgresql, use DATABASE_URL (required for Postgres)
- * 2. Otherwise, use AGOR_DB_PATH or default SQLite path
+ * 1. AGOR_DB_DIALECT + DATABASE_URL/AGOR_DB_PATH environment variables
+ * 2. database.dialect + database.postgresql.url / database.sqlite.path from config.yaml
+ * 3. Default SQLite path (~/.agor/agor.db)
  *
  * This ensures consistent database URL resolution across CLI and daemon.
  *
  * @returns Database URL string
  */
 export function getDatabaseUrl(): string {
+  // Environment variables take highest priority
   if (process.env.AGOR_DB_DIALECT === 'postgresql') {
     return process.env.DATABASE_URL || 'postgresql://localhost:5432/agor';
   }
-  return expandPath(process.env.AGOR_DB_PATH || DEFAULT_DB_PATH);
+  if (process.env.AGOR_DB_PATH) {
+    return expandPath(process.env.AGOR_DB_PATH);
+  }
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL;
+  }
+
+  // Fall back to config.yaml
+  try {
+    const config = loadConfigSync();
+    const dbConfig = config.database;
+
+    if (dbConfig) {
+      const dialect = dbConfig.dialect || getDatabaseDialect();
+
+      if (dialect === 'postgresql') {
+        // Build URL from individual params or use url directly
+        if (dbConfig.postgresql?.url) {
+          return dbConfig.postgresql.url;
+        }
+        if (dbConfig.postgresql?.host) {
+          const pg = dbConfig.postgresql;
+          const user = pg.user || 'postgres';
+          const password = pg.password ? `:${pg.password}` : '';
+          const host = pg.host;
+          const port = pg.port || 5432;
+          const database = pg.database || 'agor';
+          return `postgresql://${user}${password}@${host}:${port}/${database}`;
+        }
+      }
+
+      if (dialect === 'sqlite' && dbConfig.sqlite?.path) {
+        const sqlitePath = dbConfig.sqlite.path;
+        // Ensure file: prefix for consistency
+        const prefixed = sqlitePath.startsWith('file:') ? sqlitePath : `file:${sqlitePath}`;
+        return expandPath(prefixed);
+      }
+    }
+  } catch {
+    // Config not available — fall through to default
+  }
+
+  return expandPath(DEFAULT_DB_PATH);
 }
 
 /**

--- a/packages/core/src/db/schema-factory.ts
+++ b/packages/core/src/db/schema-factory.ts
@@ -10,6 +10,8 @@
  * with factory patterns. See the comment in those files for details.
  */
 
+import { loadConfigSync } from '../config/config-manager';
+
 /**
  * Supported database dialects
  */
@@ -53,9 +55,10 @@ export function detectDialectFromUrl(url: string): DatabaseDialect | null {
  *
  * Priority:
  * 1. AGOR_DB_DIALECT environment variable
- * 2. Auto-detect from DATABASE_URL
- * 3. Database config from config file (future)
- * 4. Default to 'sqlite'
+ * 2. Auto-detect from DATABASE_URL environment variable
+ * 3. database.dialect from ~/.agor/config.yaml
+ * 4. Auto-detect from database.postgresql.url in config
+ * 5. Default to 'sqlite'
  */
 export function getDatabaseDialect(): DatabaseDialect {
   const envDialect = process.env.AGOR_DB_DIALECT;
@@ -63,7 +66,7 @@ export function getDatabaseDialect(): DatabaseDialect {
     return envDialect;
   }
 
-  // Auto-detect from DATABASE_URL
+  // Auto-detect from DATABASE_URL env var
   const databaseUrl = process.env.DATABASE_URL;
   if (databaseUrl) {
     const detected = detectDialectFromUrl(databaseUrl);
@@ -72,9 +75,20 @@ export function getDatabaseDialect(): DatabaseDialect {
     }
   }
 
-  // Future: Load from config file
-  // const config = loadConfigSync();
-  // return config.database?.dialect || 'sqlite';
+  // Load from config file
+  try {
+    const config = loadConfigSync();
+    if (config.database?.dialect === 'postgresql' || config.database?.dialect === 'sqlite') {
+      return config.database.dialect;
+    }
+    // If no explicit dialect but postgresql config exists with a URL, infer it
+    if (config.database?.postgresql?.url) {
+      const detected = detectDialectFromUrl(config.database.postgresql.url);
+      if (detected) return detected;
+    }
+  } catch {
+    // Config not available (e.g., during bundling or tests) — fall through
+  }
 
   return 'sqlite';
 }


### PR DESCRIPTION
## Summary

- **Database config.yaml support**: `getDatabaseDialect()` and `getDatabaseUrl()` now read `database.dialect`, `database.postgresql.url`, and `database.sqlite.path` from `~/.agor/config.yaml`. Environment variables still take priority. Supports building PostgreSQL URLs from individual `host`/`port`/`user`/`password` fields.
- **Handlebars fix**: Replace broken dynamic `await import('handlebars')` in SessionPanel with static import and module-level template compilation, matching the ForkSpawnModal pattern. Fixes `TypeError: Me.registerHelper is not a function` when spawning subsessions.

## Test plan

- [x] Configure `database.dialect: postgresql` + `database.postgresql.url` in config.yaml → daemon connects to PostgreSQL
- [x] Remove database config → daemon falls back to SQLite as before
- [x] Set `AGOR_DB_DIALECT=postgresql` env var → env var takes priority over config.yaml
- [ ] Spawn a subsession from the UI → no `registerHelper is not a function` error

Fixes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)