### PR TITLE
fix(permissions): handle timeout race condition with UI feedback

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -96,7 +96,7 @@ import type {
   TaskID,
   User,
 } from '@agor/core/types';
-import { SessionStatus, TaskStatus } from '@agor/core/types';
+import { PermissionStatus, SessionStatus, TaskStatus } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 
 import { performOAuthDisconnect } from './services/oauth-disconnect.js';
@@ -659,6 +659,8 @@ async function main() {
       'task_stop', // Custom event for stopping tasks via WebSocket
       'task_stop_ack', // Executor acknowledges receipt of stop signal
       'task_stopped_complete', // Executor confirms task fully stopped
+      'permission:request', // Permission request broadcast to UI clients
+      'permission:timeout', // Permission request timed out notification
     ],
   });
 
@@ -3937,10 +3939,11 @@ async function main() {
 
   // Initialize PermissionService for UI-based permission prompts
   // Emits WebSocket events via sessions service for permission requests
+  const permissionTimeoutMs = config.execution?.permission_timeout_ms ?? 120_000;
   const permissionService = new PermissionService((event, data) => {
     // Emit events through sessions service for WebSocket broadcasting
     app.service('sessions').emit(event, data);
-  });
+  }, permissionTimeoutMs);
 
   // NOTE: Direct tool execution path disabled - all SDK execution now goes through executor
   // Tools moved to @agor/executor package for isolation
@@ -5131,6 +5134,16 @@ async function main() {
 
         // Type-safe access to permission content
         const permissionContent = permissionMessage.content as PermissionRequestContent;
+
+        // If already resolved (timed out, approved, or denied), return informative response
+        if (permissionContent.status !== PermissionStatus.PENDING) {
+          return {
+            success: false,
+            alreadyResolved: true,
+            status: permissionContent.status,
+            message: `Permission request already ${permissionContent.status}`,
+          };
+        }
 
         // Resolve task_id with fallback for backward compatibility:
         // 1. Try content.task_id (new messages)

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -205,7 +205,7 @@ export const App: React.FC<AppProps> = ({
   instanceLabel,
   instanceDescription,
 }) => {
-  const { showWarning } = useThemedMessage();
+  const { showWarning, showInfo } = useThemedMessage();
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionWorktreeId, setNewSessionWorktreeId] = useState<string | null>(null);
   const [newWorktreeModalOpen, setNewWorktreeModalOpen] = useState(false);
@@ -435,7 +435,7 @@ export const App: React.FC<AppProps> = ({
 
       try {
         // Call the permission decision endpoint
-        await client.service(`sessions/${sessionId}/permission-decision`).create({
+        const result = await client.service(`sessions/${sessionId}/permission-decision`).create({
           requestId,
           taskId,
           allow,
@@ -444,11 +444,27 @@ export const App: React.FC<AppProps> = ({
           scope,
           decidedBy: user?.user_id || 'anonymous',
         });
+
+        // Handle already-resolved permissions (e.g., timed out before user clicked)
+        const response = result as
+          | { success: true }
+          | { success: false; alreadyResolved: true; status: string; message: string };
+        if ('alreadyResolved' in response && response.alreadyResolved) {
+          const label =
+            response.status === 'timed_out'
+              ? 'timed out'
+              : response.status === 'approved'
+                ? 'been approved'
+                : response.status === 'denied'
+                  ? 'been denied'
+                  : 'been resolved';
+          showInfo(`This permission has already ${label}`);
+        }
       } catch (error) {
         console.error('❌ Failed to send permission decision:', error);
       }
     },
-    [client, user?.user_id]
+    [client, user?.user_id, showInfo]
   );
 
   const selectedSession = selectedSessionId ? sessionById.get(selectedSessionId) || null : null;

--- a/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
+++ b/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
@@ -14,7 +14,7 @@ import {
   PermissionScope,
   PermissionStatus,
 } from '@agor/core/types';
-import { CheckOutlined, CloseOutlined, LockOutlined } from '@ant-design/icons';
+import { CheckOutlined, ClockCircleOutlined, CloseOutlined, LockOutlined } from '@ant-design/icons';
 import { Button, Card, Descriptions, Radio, Select, Space, Typography, theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
@@ -45,9 +45,10 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
 
   const { tool_name, tool_input, status, approved_at } = content;
 
-  // Determine the state: active, approved, denied, or waiting
+  // Determine the state: active, approved, denied, timed out, or waiting
   const isApproved = status === PermissionStatus.APPROVED;
   const isDenied = status === PermissionStatus.DENIED;
+  const isTimedOut = status === PermissionStatus.TIMED_OUT;
 
   // State-based styling
   const getStateStyle = () => {
@@ -76,10 +77,19 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
         border: `1px solid ${token.colorErrorBorder}`,
       };
     }
+    if (isTimedOut) {
+      return {
+        background: 'rgba(0, 0, 0, 0.02)',
+        border: `1px solid ${token.colorBorder}`,
+        opacity: 0.75,
+      };
+    }
     return {};
   };
 
   const getIcon = () => {
+    if (isTimedOut)
+      return <ClockCircleOutlined style={{ fontSize: 20, color: token.colorTextDisabled }} />;
     if (isActive) return <LockOutlined style={{ fontSize: 20, color: token.colorWarning }} />;
     if (isApproved) return <CheckOutlined style={{ fontSize: 20, color: token.colorSuccess }} />;
     if (isDenied) return <CloseOutlined style={{ fontSize: 20, color: token.colorError }} />;
@@ -87,6 +97,7 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
   };
 
   const getTitle = () => {
+    if (isTimedOut) return 'Permission Timed Out';
     if (isWaiting) return 'Waiting for Previous Permission';
     if (isActive) return 'Permission Required';
     if (isApproved) return 'Permission Approved';
@@ -95,6 +106,7 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
   };
 
   const getSubtitle = () => {
+    if (isTimedOut) return 'The agent continued without this permission';
     if (isActive) return 'The agent needs your approval to continue';
     if (isApproved && approved_at) {
       return `Approved ${new Date(approved_at).toLocaleString()}`;

--- a/apps/agor-ui/src/hooks/useTaskMessages.ts
+++ b/apps/agor-ui/src/hooks/useTaskMessages.ts
@@ -7,7 +7,8 @@
 
 import type { AgorClient } from '@agor/core/api';
 import { PAGINATION } from '@agor/core/config/browser';
-import type { Message, TaskID } from '@agor/core/types';
+import type { Message, PermissionRequestContent, TaskID } from '@agor/core/types';
+import { PermissionStatus } from '@agor/core/types';
 import { useCallback, useEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
 
@@ -113,10 +114,32 @@ export function useTaskMessages(
       }
     };
 
+    // Listen for permission:timeout on sessions service as a fallback.
+    // The primary mechanism is message patching (executor patches the permission message
+    // with TIMED_OUT status, which arrives via handleMessagePatched above). This listener
+    // handles the case where the patch event is missed or arrives late.
+    const sessionsService = client.service('sessions');
+    const handlePermissionTimeout = (data: { requestId: string; taskId: string }) => {
+      if (data.taskId !== taskId) return;
+      setMessages((prev) =>
+        prev.map((m) => {
+          if (m.type !== 'permission_request') return m;
+          const content = m.content as PermissionRequestContent;
+          if (content.request_id !== data.requestId) return m;
+          if (content.status !== PermissionStatus.PENDING) return m;
+          return {
+            ...m,
+            content: { ...content, status: PermissionStatus.TIMED_OUT },
+          };
+        })
+      );
+    };
+
     messagesService.on('created', handleMessageCreated);
     messagesService.on('patched', handleMessagePatched);
     messagesService.on('updated', handleMessagePatched);
     messagesService.on('removed', handleMessageRemoved);
+    sessionsService.on('permission:timeout', handlePermissionTimeout);
 
     // Cleanup listeners
     return () => {
@@ -124,6 +147,7 @@ export function useTaskMessages(
       messagesService.removeListener('patched', handleMessagePatched);
       messagesService.removeListener('updated', handleMessagePatched);
       messagesService.removeListener('removed', handleMessageRemoved);
+      sessionsService.removeListener('permission:timeout', handlePermissionTimeout);
     };
   }, [client, taskId, enabled, fetchMessages]);
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -212,6 +212,9 @@ export interface AgorExecutionSettings {
   /** Sync web passwords to Unix user passwords (default: true). When enabled, passwords are synced on user creation/update. */
   sync_unix_passwords?: boolean;
 
+  /** Permission request timeout in ms (default: 120000 = 2 minutes). When a permission request is not resolved within this time, it is auto-denied. */
+  permission_timeout_ms?: number;
+
   /**
    * Executor command template for remote/containerized execution.
    *

--- a/packages/core/src/permissions/permission-service.test.ts
+++ b/packages/core/src/permissions/permission-service.test.ts
@@ -237,7 +237,7 @@ describe('PermissionService.waitForDecision', () => {
     expect(result.allow).toBe(false);
   });
 
-  it('should timeout after 60 seconds with deny decision', async () => {
+  it('should timeout after default 120 seconds with deny decision', async () => {
     const requestId = 'req-timeout';
     const taskId = 'task-timeout' as TaskID;
     const signal = new AbortController().signal;
@@ -249,14 +249,60 @@ describe('PermissionService.waitForDecision', () => {
       signal
     );
 
-    // Fast-forward 60 seconds
-    vi.advanceTimersByTime(60000);
+    // Fast-forward 120 seconds (new default)
+    vi.advanceTimersByTime(120000);
 
     const result = await waitPromise;
     expect(result.allow).toBe(false);
     expect(result.reason).toBe('Timeout');
     expect(result.decidedBy).toBe('system');
     expect(result.scope).toBe(PermissionScope.ONCE);
+  });
+
+  it('should emit permission:timeout event on timeout', async () => {
+    const requestId = 'req-timeout-event';
+    const taskId = 'task-timeout-event' as TaskID;
+    const sessionId = 'session-timeout-event' as SessionID;
+    const signal = new AbortController().signal;
+
+    const waitPromise = service.waitForDecision(requestId, taskId, sessionId, signal);
+
+    vi.advanceTimersByTime(120000);
+
+    await waitPromise;
+
+    // Verify permission:timeout event was emitted
+    expect(emitEvent).toHaveBeenCalledWith('permission:timeout', {
+      requestId,
+      sessionId,
+      taskId,
+    });
+  });
+
+  it('should use custom timeout value from constructor', async () => {
+    const customEmit = vi.fn();
+    const customService = new PermissionService(customEmit as any, 5000);
+    const requestId = 'req-custom-timeout';
+    const taskId = 'task-custom-timeout' as TaskID;
+    const signal = new AbortController().signal;
+
+    const waitPromise = customService.waitForDecision(
+      requestId,
+      taskId,
+      'session-test' as SessionID,
+      signal
+    );
+
+    // Should not timeout at 4 seconds
+    vi.advanceTimersByTime(4000);
+
+    // Resolve a check - the promise should still be pending
+    // Advance to 5 seconds to trigger timeout
+    vi.advanceTimersByTime(1000);
+
+    const result = await waitPromise;
+    expect(result.allow).toBe(false);
+    expect(result.reason).toBe('Timeout');
   });
 
   it('should handle abort signal', async () => {
@@ -297,7 +343,7 @@ describe('PermissionService.waitForDecision', () => {
     await waitPromise;
 
     // Verify timeout was cleared (advancing time should not trigger timeout)
-    vi.advanceTimersByTime(60000);
+    vi.advanceTimersByTime(120000);
 
     // No additional resolution should occur
     const decision = createDecision({ requestId, taskId });
@@ -412,7 +458,7 @@ describe('PermissionService.waitForDecision', () => {
       signal
     );
 
-    vi.advanceTimersByTime(60000);
+    vi.advanceTimersByTime(120000);
 
     const result = await waitPromise;
     expect(result.taskId).toBe(taskId);
@@ -490,7 +536,7 @@ describe('PermissionService.resolvePermission', () => {
     await waitPromise;
 
     // Timeout should not fire
-    vi.advanceTimersByTime(60000);
+    vi.advanceTimersByTime(120000);
     // Test passes if no additional resolution occurs
   });
 
@@ -711,7 +757,7 @@ describe('PermissionService edge cases', () => {
 
     // Since signal is already aborted, event listener won't fire
     // This will hit the timeout instead
-    vi.advanceTimersByTime(60000);
+    vi.advanceTimersByTime(120000);
 
     const result = await waitPromise;
     expect(result.allow).toBe(false);

--- a/packages/core/src/permissions/permission-service.ts
+++ b/packages/core/src/permissions/permission-service.ts
@@ -66,7 +66,10 @@ export class PermissionService {
     }
   >();
 
-  constructor(private emitEvent: (event: string, data: unknown) => void) {}
+  constructor(
+    private emitEvent: (event: string, data: unknown) => void,
+    private timeoutMs: number = 120_000
+  ) {}
 
   /**
    * Emit a permission request event to the UI
@@ -118,10 +121,14 @@ export class PermissionService {
         });
       });
 
-      // Timeout after 60 seconds (fail-safe)
+      // Timeout (fail-safe, configurable via constructor, default 2 minutes)
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(requestId);
         console.warn(`⚠️  Permission request timeout: ${requestId}`);
+
+        // Broadcast timeout to UI so it can update the permission block state
+        this.emitEvent('permission:timeout', { requestId, sessionId, taskId });
+
         resolve({
           requestId,
           taskId,
@@ -131,7 +138,7 @@ export class PermissionService {
           scope: PermissionScope.ONCE,
           decidedBy: 'system', // System-initiated timeout
         });
-      }, 60000);
+      }, this.timeoutMs);
 
       this.pendingRequests.set(requestId, { sessionId, resolve, timeout });
     });

--- a/packages/executor/src/handlers/sdk/claude.ts
+++ b/packages/executor/src/handlers/sdk/claude.ts
@@ -4,6 +4,7 @@
  * Executes prompts using Claude Code SDK with Feathers/WebSocket architecture
  */
 
+import { loadConfig } from '@agor/core/config';
 import type { MessageSource, PermissionMode, SessionID, TaskID } from '@agor/core/types';
 import { globalPermissionManager } from '../../permissions/permission-manager.js';
 import { PermissionService } from '../../permissions/permission-service.js';
@@ -29,12 +30,16 @@ export async function executeClaudeCodeTask(params: {
   // Import base executor helper
   const { executeToolTask } = await import('./base-executor.js');
 
+  // Load config for permission timeout setting
+  const config = await loadConfig();
+  const permissionTimeoutMs = config.execution?.permission_timeout_ms ?? 120_000;
+
   // Create PermissionService that emits via Feathers WebSocket
   const permissionService = new PermissionService(async (event, data) => {
     // Emit permission events directly via Feathers
     // biome-ignore lint/suspicious/noExplicitAny: Feathers service types don't include emit method
     (client.service('sessions') as any).emit(event, data);
-  });
+  }, permissionTimeoutMs);
 
   // Register with global permission manager
   globalPermissionManager.register(sessionId, permissionService);

--- a/packages/executor/src/permissions/permission-service.ts
+++ b/packages/executor/src/permissions/permission-service.ts
@@ -4,6 +4,13 @@
  * Handles async permission requests from Claude Agent SDK PreToolUse hooks.
  * Emits events via Feathers WebSocket to daemon for broadcasting to UI clients.
  *
+ * ## Why this is separate from packages/core/src/permissions/permission-service.ts
+ *
+ * The core version is used by the daemon for in-process tool execution (sync emitEvent).
+ * This executor version uses async emitEvent (events go over Feathers WebSocket to daemon).
+ * The two share the same logic but differ in their emitEvent signature (sync vs async),
+ * which makes them incompatible as a single class without adding unnecessary abstraction.
+ *
  * ## Flow in Feathers/WebSocket Architecture:
  *
  * 1. PreToolUse hook fires → PermissionService.emitRequest()
@@ -57,8 +64,12 @@ export class PermissionService {
 
   /**
    * @param emitEvent - Function to emit events via IPC to daemon
+   * @param timeoutMs - Permission request timeout in ms (default: 120000 = 2 minutes)
    */
-  constructor(private emitEvent: (event: string, data: unknown) => Promise<void>) {}
+  constructor(
+    private emitEvent: (event: string, data: unknown) => Promise<void>,
+    private timeoutMs: number = 120_000
+  ) {}
 
   /**
    * Emit a permission request event to daemon (which broadcasts via WebSocket)
@@ -101,10 +112,14 @@ export class PermissionService {
         });
       });
 
-      // Timeout after 60 seconds
+      // Timeout (configurable via constructor, default 2 minutes)
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(requestId);
         console.warn(`⚠️  [executor] Permission request timeout: ${requestId}`);
+
+        // Broadcast timeout to UI via daemon
+        this.emitEvent('permission:timeout', { requestId, sessionId, taskId });
+
         resolve({
           requestId,
           taskId,
@@ -114,7 +129,7 @@ export class PermissionService {
           scope: PermissionScope.ONCE,
           decidedBy: 'system',
         });
-      }, 60000);
+      }, this.timeoutMs);
 
       this.pendingRequests.set(requestId, { sessionId, resolve, timeout });
       console.log(`🛡️  [executor] Waiting for permission decision: ${requestId}`);


### PR DESCRIPTION
## Summary

Fixes #654

- Increase default permission timeout from 60s to 120s, configurable via `execution.permission_timeout_ms` in `config.yaml`
- Emit `permission:timeout` WebSocket event on timeout; UI listener in `useTaskMessages` updates the permission block to `TIMED_OUT` state as a fallback alongside the primary message-patch mechanism
- Add `TIMED_OUT` visual state in `PermissionRequestBlock` (grey styling, clock icon, "Permission Timed Out" title, "The agent continued without this permission" subtitle)
- Return informative `{ alreadyResolved: true, status }` response instead of throwing when user clicks approve/deny on an already-resolved permission; UI shows a notification
- Register `permission:request` and `permission:timeout` as custom events on the sessions service

Re-request button for timed-out permissions deferred to #655.

## Test plan

- [x] `pnpm -C packages/core test` — 36 permission service tests pass (3 new: timeout event emission, custom timeout value, updated default)
- [x] TypeScript compiles cleanly across all packages
- [x] Biome lint passes
- [ ] Manual: trigger a permission request, wait for timeout, verify UI shows "Permission Timed Out" state
- [ ] Manual: click approve/deny on a timed-out request, verify notification instead of error
- [ ] Manual: set `execution.permission_timeout_ms` in config.yaml, verify both services use it

🤖 Generated with [Claude Code](https://claude.com/claude-code)