### PR TITLE
feat: add user question / input request handling (#653)

### DIFF
--- a/apps/agor-cli/src/commands/session/list.ts
+++ b/apps/agor-cli/src/commands/session/list.ts
@@ -81,19 +81,21 @@ export default class SessionList extends BaseCommand {
    * Format status with color
    */
   private formatStatus(status: Session['status']): string {
-    const icons = {
+    const icons: Record<string, string> = {
       running: chalk.blue('●'),
       stopping: chalk.yellow('◐'),
       awaiting_permission: chalk.yellow('⏸'),
+      awaiting_input: chalk.yellow('❓'),
       completed: chalk.green('✓'),
       failed: chalk.red('✗'),
       idle: chalk.gray('○'),
     };
 
-    const labels = {
+    const labels: Record<string, string> = {
       running: chalk.blue('Running'),
       stopping: chalk.yellow('Stopping'),
       awaiting_permission: chalk.yellow('Awaiting Permission'),
+      awaiting_input: chalk.yellow('Awaiting Input'),
       completed: chalk.green('Done'),
       failed: chalk.red('Failed'),
       idle: chalk.gray('Idle'),

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -83,6 +83,7 @@ import type {
   Board,
   HookContext,
   Id,
+  InputRequestContent,
   MCPServer,
   Message,
   MessageSource,
@@ -973,6 +974,7 @@ async function main() {
       'thinking:chunk',
       'thinking:end',
       'permission_resolved', // Permission approval/denial notification for executors
+      'input_resolved', // Input request (AskUserQuestion) answer notification for executors
     ],
     docs: {
       description: 'Conversation messages within AI agent sessions',
@@ -5179,6 +5181,92 @@ async function main() {
     },
     {
       create: { role: 'member', action: 'respond to permission requests' },
+    },
+    requireAuth
+  );
+
+  // Input response endpoint (for AskUserQuestion answers)
+  registerAuthenticatedRoute(
+    app,
+    '/sessions/:id/input-response',
+    {
+      async create(
+        data: {
+          requestId: string;
+          taskId?: string;
+          answers: Record<string, string>;
+          annotations?: Record<string, { markdown?: string; notes?: string }>;
+          respondedBy: string;
+        },
+        params: RouteParams
+      ) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Session ID required');
+        if (!data.requestId) throw new Error('requestId required');
+        if (!data.answers || typeof data.answers !== 'object')
+          throw new Error('answers field required');
+
+        // Find the input request message
+        const messagesService = app.service('messages');
+        const messages = await messagesService.find({
+          query: {
+            session_id: id,
+            type: 'input_request',
+            $limit: 100,
+          },
+        });
+
+        const messageList = isPaginated(messages) ? messages.data : messages;
+        const inputMessage = messageList.find((msg: Message) => {
+          const content = msg.content as InputRequestContent;
+          return content?.request_id === data.requestId;
+        });
+
+        if (!inputMessage) {
+          throw new Error(`Input request ${data.requestId} not found`);
+        }
+
+        const inputContent = inputMessage.content as InputRequestContent;
+
+        // Resolve task_id with fallback
+        const resolvedTaskId = inputContent.task_id || inputMessage.task_id;
+
+        if (!resolvedTaskId) {
+          console.error(
+            `❌ [InputResponse] Cannot resolve input: task_id missing. requestId=${data.requestId}`
+          );
+          throw new Error(
+            'Cannot process input response: task_id is missing. This input request may be corrupted.'
+          );
+        }
+
+        // Update the message with the answer
+        await messagesService.patch(inputMessage.message_id, {
+          content: {
+            ...inputContent,
+            status: 'answered',
+            answers: data.answers,
+            annotations: data.annotations,
+            answered_by: data.respondedBy,
+            answered_at: new Date().toISOString(),
+          },
+        });
+
+        // Emit input_resolved event for Feathers/WebSocket executor architecture
+        app.service('messages').emit('input_resolved', {
+          requestId: data.requestId,
+          taskId: resolvedTaskId,
+          sessionId: id,
+          answers: data.answers,
+          annotations: data.annotations,
+          respondedBy: data.respondedBy,
+        });
+
+        return { success: true };
+      },
+    },
+    {
+      create: { role: 'member', action: 'respond to input requests' },
     },
     requireAuth
   );

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -451,6 +451,31 @@ export const App: React.FC<AppProps> = ({
     [client, user?.user_id]
   );
 
+  const handleInputResponse = useCallback(
+    async (
+      sessionId: string,
+      requestId: string,
+      taskId: string,
+      answers: Record<string, string>,
+      annotations?: Record<string, { markdown?: string; notes?: string }>
+    ) => {
+      if (!client) return;
+
+      try {
+        await client.service(`sessions/${sessionId}/input-response`).create({
+          requestId,
+          taskId,
+          answers,
+          annotations,
+          respondedBy: user?.user_id || 'anonymous',
+        });
+      } catch (error) {
+        console.error('❌ Failed to send input response:', error);
+      }
+    },
+    [client, user?.user_id]
+  );
+
   const selectedSession = selectedSessionId ? sessionById.get(selectedSessionId) || null : null;
   const selectedSessionWorktree = selectedSession
     ? worktreeById.get(selectedSession.worktree_id)
@@ -559,6 +584,7 @@ export const App: React.FC<AppProps> = ({
       onUpdateSession,
       onDeleteSession,
       onPermissionDecision: handlePermissionDecision,
+      onInputResponse: handleInputResponse,
       onStartEnvironment,
       onStopEnvironment,
       onNukeEnvironment,
@@ -574,6 +600,7 @@ export const App: React.FC<AppProps> = ({
       onUpdateSession,
       onDeleteSession,
       handlePermissionDecision,
+      handleInputResponse,
       onStartEnvironment,
       onStopEnvironment,
       onNukeEnvironment,

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -88,6 +88,17 @@ export interface ConversationViewProps {
   ) => void;
 
   /**
+   * Input response handler (AskUserQuestion answers)
+   */
+  onInputResponse?: (
+    sessionId: string,
+    requestId: string,
+    taskId: string,
+    answers: Record<string, string>,
+    annotations?: Record<string, { markdown?: string; notes?: string }>
+  ) => void;
+
+  /**
    * Worktree name for hiding redundant branch names
    */
   worktreeName?: string;
@@ -135,6 +146,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     currentUserId,
     onScrollRef,
     onPermissionDecision,
+    onInputResponse,
     worktreeName,
     scheduledFromWorktree,
     scheduledRunAt,
@@ -422,6 +434,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
             onExpandChange={expandHandlers.get(task.task_id)!}
             sessionId={sessionId}
             onPermissionDecision={onPermissionDecision}
+            onInputResponse={onInputResponse}
             worktreeName={worktreeName}
             scheduledFromWorktree={scheduledFromWorktree}
             scheduledRunAt={scheduledRunAt}

--- a/apps/agor-ui/src/components/InputRequestBlock/InputRequestBlock.tsx
+++ b/apps/agor-ui/src/components/InputRequestBlock/InputRequestBlock.tsx
@@ -1,0 +1,283 @@
+/**
+ * InputRequestBlock - Displays an AskUserQuestion input request
+ *
+ * Shows:
+ * - Questions with selectable options (radio for single, checkbox for multi)
+ * - "Other" free-text input for each question
+ * - Submit button to send all answers
+ * - Answered/timed-out states for resolved requests
+ */
+
+import { type InputRequestContent, InputRequestStatus, type Message } from '@agor/core/types';
+import { CheckOutlined, ClockCircleOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Button, Card, Checkbox, Input, Radio, Space, Typography, theme } from 'antd';
+import type React from 'react';
+import { useState } from 'react';
+
+const { Title } = Typography;
+
+interface InputRequestBlockProps {
+  message: Message;
+  content: InputRequestContent;
+  isActive: boolean;
+  onSubmit?: (
+    messageId: string,
+    answers: Record<string, string>,
+    annotations?: Record<string, { markdown?: string; notes?: string }>
+  ) => void;
+}
+
+export const InputRequestBlock: React.FC<InputRequestBlockProps> = ({
+  message,
+  content,
+  isActive,
+  onSubmit,
+}) => {
+  const { token } = theme.useToken();
+  const { questions, status, answers: existingAnswers, answered_at, answered_by } = content;
+
+  // Track selected answers per question (keyed by question text)
+  const [selectedAnswers, setSelectedAnswers] = useState<Record<string, string>>({});
+  const [otherText, setOtherText] = useState<Record<string, string>>({});
+  const [usingOther, setUsingOther] = useState<Record<string, boolean>>({});
+
+  const isAnswered = status === InputRequestStatus.ANSWERED;
+  const isTimedOut = status === InputRequestStatus.TIMED_OUT;
+
+  const getStateStyle = () => {
+    if (isActive) {
+      return {
+        background: 'rgba(22, 119, 255, 0.05)',
+        border: `1px solid ${token.colorPrimaryBorder}`,
+      };
+    }
+    if (isAnswered) {
+      return {
+        background: 'rgba(82, 196, 26, 0.03)',
+        border: `1px solid ${token.colorSuccessBorder}`,
+      };
+    }
+    if (isTimedOut) {
+      return {
+        background: 'rgba(0, 0, 0, 0.02)',
+        border: `1px solid ${token.colorBorder}`,
+        opacity: 0.7,
+      };
+    }
+    return {};
+  };
+
+  const getIcon = () => {
+    if (isActive)
+      return <QuestionCircleOutlined style={{ fontSize: 20, color: token.colorPrimary }} />;
+    if (isAnswered) return <CheckOutlined style={{ fontSize: 20, color: token.colorSuccess }} />;
+    if (isTimedOut)
+      return <ClockCircleOutlined style={{ fontSize: 20, color: token.colorTextDisabled }} />;
+    return null;
+  };
+
+  const getTitle = () => {
+    if (isActive) return 'Question from Agent';
+    if (isAnswered) return 'Question Answered';
+    if (isTimedOut) return 'Question Timed Out';
+    return 'Question';
+  };
+
+  const getSubtitle = () => {
+    if (isActive) return 'The agent needs your input to continue';
+    if (isAnswered && answered_at) {
+      const byText = answered_by ? ` by ${answered_by}` : '';
+      return `Answered${byText} ${new Date(answered_at).toLocaleString()}`;
+    }
+    if (isTimedOut) return 'This question timed out before receiving an answer';
+    return '';
+  };
+
+  const handleSubmit = () => {
+    if (!onSubmit) return;
+
+    const answers: Record<string, string> = {};
+    for (const q of questions) {
+      if (usingOther[q.question]) {
+        answers[q.question] = otherText[q.question] || '';
+      } else {
+        answers[q.question] = selectedAnswers[q.question] || '';
+      }
+    }
+
+    onSubmit(message.message_id, answers);
+  };
+
+  // Check if all questions have answers
+  const allAnswered = questions.every((q) => {
+    if (usingOther[q.question]) return (otherText[q.question] || '').trim().length > 0;
+    return (selectedAnswers[q.question] || '').length > 0;
+  });
+
+  return (
+    <Card
+      style={{
+        marginTop: token.sizeUnit * 2,
+        ...getStateStyle(),
+      }}
+      styles={{
+        body: {
+          padding: token.sizeUnit * 2,
+        },
+      }}
+    >
+      <Space direction="vertical" size={token.sizeUnit * 1.5} style={{ width: '100%' }}>
+        {/* Header */}
+        <Space size={token.sizeUnit}>
+          {getIcon()}
+          <div>
+            <Title level={5} style={{ margin: 0 }}>
+              {getTitle()}
+            </Title>
+            {getSubtitle() && (
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                {getSubtitle()}
+              </Typography.Text>
+            )}
+          </div>
+        </Space>
+
+        {/* Questions */}
+        {questions.map((q, qIdx) => (
+          <div
+            key={`q-${qIdx}-${q.question.substring(0, 20)}`}
+            style={{
+              padding: token.sizeUnit,
+              background: token.colorBgContainer,
+              borderRadius: token.borderRadius,
+            }}
+          >
+            {q.header && (
+              <Typography.Text
+                strong
+                style={{
+                  fontSize: 11,
+                  textTransform: 'uppercase',
+                  color: token.colorTextSecondary,
+                }}
+              >
+                {q.header}
+              </Typography.Text>
+            )}
+            <Typography.Paragraph style={{ margin: `${token.sizeUnit / 2}px 0` }}>
+              {q.question}
+            </Typography.Paragraph>
+
+            {/* Active: show interactive options */}
+            {isActive && !q.multiSelect && (
+              <Radio.Group
+                value={usingOther[q.question] ? '__other__' : selectedAnswers[q.question]}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  if (val === '__other__') {
+                    setUsingOther((prev) => ({ ...prev, [q.question]: true }));
+                  } else {
+                    setUsingOther((prev) => ({ ...prev, [q.question]: false }));
+                    setSelectedAnswers((prev) => ({ ...prev, [q.question]: val }));
+                  }
+                }}
+                style={{ width: '100%' }}
+              >
+                <Space direction="vertical" size={token.sizeUnit / 2} style={{ width: '100%' }}>
+                  {q.options.map((opt) => (
+                    <Radio key={opt.label} value={opt.label}>
+                      <span>
+                        <strong>{opt.label}</strong>
+                        {opt.description && (
+                          <Typography.Text type="secondary" style={{ marginLeft: 8, fontSize: 12 }}>
+                            — {opt.description}
+                          </Typography.Text>
+                        )}
+                      </span>
+                    </Radio>
+                  ))}
+                  <Radio value="__other__">
+                    <strong>Other</strong>
+                  </Radio>
+                  {usingOther[q.question] && (
+                    <Input.TextArea
+                      placeholder="Type your answer..."
+                      value={otherText[q.question] || ''}
+                      onChange={(e) =>
+                        setOtherText((prev) => ({ ...prev, [q.question]: e.target.value }))
+                      }
+                      autoSize={{ minRows: 1, maxRows: 4 }}
+                      style={{ marginLeft: 24 }}
+                    />
+                  )}
+                </Space>
+              </Radio.Group>
+            )}
+
+            {/* Active: multi-select */}
+            {isActive && q.multiSelect && (
+              <Checkbox.Group
+                value={(selectedAnswers[q.question] || '').split(',').filter(Boolean)}
+                onChange={(vals) => {
+                  setSelectedAnswers((prev) => ({
+                    ...prev,
+                    [q.question]: (vals as string[]).join(','),
+                  }));
+                }}
+                style={{ width: '100%' }}
+              >
+                <Space direction="vertical" size={token.sizeUnit / 2} style={{ width: '100%' }}>
+                  {q.options.map((opt) => (
+                    <Checkbox key={opt.label} value={opt.label}>
+                      <span>
+                        <strong>{opt.label}</strong>
+                        {opt.description && (
+                          <Typography.Text type="secondary" style={{ marginLeft: 8, fontSize: 12 }}>
+                            — {opt.description}
+                          </Typography.Text>
+                        )}
+                      </span>
+                    </Checkbox>
+                  ))}
+                </Space>
+              </Checkbox.Group>
+            )}
+
+            {/* Answered: show selected answer */}
+            {isAnswered && existingAnswers && (
+              <Typography.Text code style={{ fontSize: 13 }}>
+                {existingAnswers[q.question] || '(no answer)'}
+              </Typography.Text>
+            )}
+
+            {/* Timed out */}
+            {isTimedOut && (
+              <Typography.Text type="secondary" italic>
+                No answer received
+              </Typography.Text>
+            )}
+          </div>
+        ))}
+
+        {/* Timestamp */}
+        {isActive && message.timestamp && (
+          <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+            Asked at {new Date(message.timestamp).toLocaleString()}
+          </Typography.Text>
+        )}
+
+        {/* Submit button */}
+        {isActive && onSubmit && (
+          <Button
+            type="primary"
+            icon={<CheckOutlined />}
+            onClick={handleSubmit}
+            disabled={!allAnswered}
+          >
+            Submit Answer{questions.length > 1 ? 's' : ''}
+          </Button>
+        )}
+      </Space>
+    </Card>
+  );
+};

--- a/apps/agor-ui/src/components/InputRequestBlock/InputRequestBlock.tsx
+++ b/apps/agor-ui/src/components/InputRequestBlock/InputRequestBlock.tsx
@@ -217,11 +217,17 @@ export const InputRequestBlock: React.FC<InputRequestBlockProps> = ({
             {/* Active: multi-select */}
             {isActive && q.multiSelect && (
               <Checkbox.Group
-                value={(selectedAnswers[q.question] || '').split(',').filter(Boolean)}
+                value={(() => {
+                  try {
+                    return JSON.parse(selectedAnswers[q.question] || '[]');
+                  } catch {
+                    return [];
+                  }
+                })()}
                 onChange={(vals) => {
                   setSelectedAnswers((prev) => ({
                     ...prev,
-                    [q.question]: (vals as string[]).join(','),
+                    [q.question]: JSON.stringify(vals),
                   }));
                 }}
                 style={{ width: '100%' }}

--- a/apps/agor-ui/src/components/InputRequestBlock/index.ts
+++ b/apps/agor-ui/src/components/InputRequestBlock/index.ts
@@ -1,0 +1,1 @@
+export { InputRequestBlock } from './InputRequestBlock';

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -11,6 +11,8 @@
 
 import {
   type ContentBlock as CoreContentBlock,
+  type InputRequestContent,
+  InputRequestStatus,
   type Message,
   type PermissionRequestContent,
   PermissionScope,
@@ -26,6 +28,7 @@ import { formatTimestampWithRelative } from '../../utils/time';
 import { AgorAvatar } from '../AgorAvatar';
 import { CollapsibleMarkdown } from '../CollapsibleText/CollapsibleMarkdown';
 import { CopyableContent } from '../CopyableContent';
+import { InputRequestBlock } from '../InputRequestBlock';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { PermissionRequestBlock } from '../PermissionRequestBlock';
 import { ThinkingBlock } from '../ThinkingBlock';
@@ -76,6 +79,13 @@ interface MessageBlockProps {
     taskId: string,
     allow: boolean,
     scope: PermissionScope
+  ) => void;
+  onInputResponse?: (
+    sessionId: string,
+    requestId: string,
+    taskId: string,
+    answers: Record<string, string>,
+    annotations?: Record<string, { markdown?: string; notes?: string }>
   ) => void;
 }
 
@@ -130,6 +140,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
   isLatestMessage = false,
   allMessages = [],
   onPermissionDecision,
+  onInputResponse,
 }) => {
   const { token } = theme.useToken();
 
@@ -168,6 +179,29 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
               : undefined
           }
           isWaiting={isPending && !isFirstPendingPermission}
+        />
+      </div>
+    );
+  }
+
+  // Handle input request messages (AskUserQuestion)
+  if (message.type === 'input_request') {
+    const content = message.content as InputRequestContent;
+    const isPending = content.status === InputRequestStatus.PENDING;
+
+    return (
+      <div style={{ margin: `${token.sizeUnit * 1.5}px 0` }}>
+        <InputRequestBlock
+          message={message}
+          content={content}
+          isActive={isPending}
+          onSubmit={
+            isPending && onInputResponse && sessionId && taskId
+              ? (_messageId, answers, annotations) => {
+                  onInputResponse(sessionId, content.request_id, taskId, answers, annotations);
+                }
+              : undefined
+          }
         />
       </div>
     );

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -31,6 +31,7 @@ const ACTIVE_STATUSES: TimerStatus[] = [
   TaskStatus.RUNNING,
   TaskStatus.STOPPING,
   TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.AWAITING_INPUT,
 ];
 
 const statusConfig: Record<
@@ -50,6 +51,10 @@ const statusConfig: Record<
     color: PILL_COLORS.warning,
   },
   [TaskStatus.AWAITING_PERMISSION]: {
+    icon: <PauseCircleOutlined />,
+    color: PILL_COLORS.warning,
+  },
+  [TaskStatus.AWAITING_INPUT]: {
     icon: <PauseCircleOutlined />,
     color: PILL_COLORS.warning,
   },

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -8,6 +8,7 @@ import {
   CloseCircleOutlined,
   HourglassOutlined,
   PauseCircleOutlined,
+  QuestionCircleOutlined,
   StopOutlined,
 } from '@ant-design/icons';
 import { Tooltip, theme } from 'antd';
@@ -55,7 +56,7 @@ const statusConfig: Record<
     color: PILL_COLORS.warning,
   },
   [TaskStatus.AWAITING_INPUT]: {
-    icon: <PauseCircleOutlined />,
+    icon: <QuestionCircleOutlined />,
     color: PILL_COLORS.warning,
   },
   [TaskStatus.COMPLETED]: {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -249,7 +249,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       if (
         candidate.status === TaskStatus.RUNNING ||
         candidate.status === TaskStatus.STOPPING ||
-        candidate.status === TaskStatus.AWAITING_PERMISSION
+        candidate.status === TaskStatus.AWAITING_PERMISSION ||
+        candidate.status === TaskStatus.AWAITING_INPUT
       ) {
         return candidate;
       }

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -69,6 +69,7 @@ export const SessionPanelContent: React.FC<SessionPanelContentProps> = ({
     onStopEnvironment,
     onViewLogs,
     onPermissionDecision,
+    onInputResponse,
   } = useAppActions();
 
   // Get repo from worktree
@@ -161,6 +162,7 @@ export const SessionPanelContent: React.FC<SessionPanelContentProps> = ({
           setScrollToTop(() => scrollTop);
         }}
         onPermissionDecision={onPermissionDecision}
+        onInputResponse={onInputResponse}
         worktreeName={worktree?.name}
         scheduledFromWorktree={session.scheduled_from_worktree}
         scheduledRunAt={session.scheduled_run_at}

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -86,6 +86,13 @@ interface TaskBlockProps {
     allow: boolean,
     scope: PermissionScope
   ) => void;
+  onInputResponse?: (
+    sessionId: string,
+    requestId: string,
+    taskId: string,
+    answers: Record<string, string>,
+    annotations?: Record<string, { markdown?: string; notes?: string }>
+  ) => void;
   worktreeName?: string;
   scheduledFromWorktree?: boolean;
   scheduledRunAt?: number;
@@ -343,6 +350,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     onExpandChange,
     sessionId,
     onPermissionDecision,
+    onInputResponse,
     worktreeName,
     scheduledFromWorktree,
     scheduledRunAt,
@@ -585,6 +593,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           isTaskRunning={task.status === TaskStatus.RUNNING}
                           sessionId={sessionId}
                           onPermissionDecision={onPermissionDecision}
+                          onInputResponse={onInputResponse}
                           isFirstPendingPermission={isFirstPending}
                           isLatestMessage={isLatestMessage}
                           taskId={task.task_id}

--- a/apps/agor-ui/src/components/TaskStatusIcon.tsx
+++ b/apps/agor-ui/src/components/TaskStatusIcon.tsx
@@ -41,6 +41,8 @@ export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({ status, size = 1
       return <LoadingOutlined style={{ ...iconStyle, color: token.colorWarning }} />;
     case TaskStatus.AWAITING_PERMISSION:
     case 'awaiting_permission': // SessionStatus.AWAITING_PERMISSION
+    case TaskStatus.AWAITING_INPUT:
+    case 'awaiting_input': // SessionStatus.AWAITING_INPUT
       return <PauseCircleOutlined style={{ ...iconStyle, color: token.colorWarning }} />;
     case TaskStatus.FAILED:
     case 'failed': // SessionStatus.FAILED

--- a/apps/agor-ui/src/components/mobile/SessionPage.tsx
+++ b/apps/agor-ui/src/components/mobile/SessionPage.tsx
@@ -89,6 +89,28 @@ export const SessionPage: React.FC<SessionPageProps> = ({
     }
   };
 
+  const handleInputResponse = async (
+    _sessionId: string,
+    requestId: string,
+    taskId: string,
+    answers: Record<string, string>,
+    annotations?: Record<string, { markdown?: string; notes?: string }>
+  ) => {
+    if (!client) return;
+
+    try {
+      await client.service(`sessions/${_sessionId}/input-response`).create({
+        requestId,
+        taskId,
+        answers,
+        annotations,
+        respondedBy: currentUser?.user_id || 'anonymous',
+      });
+    } catch (error) {
+      console.error('Failed to send input response:', error);
+    }
+  };
+
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <MobileHeader
@@ -115,6 +137,7 @@ export const SessionPage: React.FC<SessionPageProps> = ({
           userById={userById}
           currentUserId={currentUser?.user_id}
           onPermissionDecision={handlePermissionDecision}
+          onInputResponse={handleInputResponse}
           scheduledFromWorktree={session.scheduled_from_worktree}
           scheduledRunAt={session.scheduled_run_at}
           genealogy={session.genealogy}

--- a/apps/agor-ui/src/components/mobile/SessionPage.tsx
+++ b/apps/agor-ui/src/components/mobile/SessionPage.tsx
@@ -1,8 +1,8 @@
 import type { AgorClient } from '@agor/core/api';
 import type { PermissionMode, Repo, Session, SessionID, User, Worktree } from '@agor/core/types';
-import { PermissionScope } from '@agor/core/types';
 import { Alert, Spin } from 'antd';
 import { useParams } from 'react-router-dom';
+import { useAppActions } from '../../contexts/AppActionsContext';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { ConversationView } from '../ConversationView';
 import { MobileHeader } from './MobileHeader';
@@ -34,6 +34,7 @@ export const SessionPage: React.FC<SessionPageProps> = ({
   onUpdateDraft,
 }) => {
   const { sessionId } = useParams<{ sessionId: string }>();
+  const { onPermissionDecision, onInputResponse } = useAppActions();
 
   const session = sessionId ? sessionById.get(sessionId) : undefined;
   const worktree = session?.worktree_id ? worktreeById.get(session.worktree_id) || null : null;
@@ -65,52 +66,6 @@ export const SessionPage: React.FC<SessionPageProps> = ({
     onSendPrompt?.(sessionId, prompt);
   };
 
-  const handlePermissionDecision = async (
-    _sessionId: string,
-    requestId: string,
-    taskId: string,
-    allow: boolean,
-    scope: PermissionScope
-  ) => {
-    if (!client) return;
-
-    try {
-      await client.service(`sessions/${_sessionId}/permission-decision`).create({
-        requestId,
-        taskId,
-        allow,
-        reason: allow ? 'Approved by user' : 'Denied by user',
-        remember: scope !== PermissionScope.ONCE,
-        scope,
-        decidedBy: currentUser?.user_id || 'anonymous',
-      });
-    } catch (error) {
-      console.error('Failed to send permission decision:', error);
-    }
-  };
-
-  const handleInputResponse = async (
-    _sessionId: string,
-    requestId: string,
-    taskId: string,
-    answers: Record<string, string>,
-    annotations?: Record<string, { markdown?: string; notes?: string }>
-  ) => {
-    if (!client) return;
-
-    try {
-      await client.service(`sessions/${_sessionId}/input-response`).create({
-        requestId,
-        taskId,
-        answers,
-        annotations,
-        respondedBy: currentUser?.user_id || 'anonymous',
-      });
-    } catch (error) {
-      console.error('Failed to send input response:', error);
-    }
-  };
-
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
       <MobileHeader
@@ -136,8 +91,8 @@ export const SessionPage: React.FC<SessionPageProps> = ({
           sessionModel={session.model_config?.model}
           userById={userById}
           currentUserId={currentUser?.user_id}
-          onPermissionDecision={handlePermissionDecision}
-          onInputResponse={handleInputResponse}
+          onPermissionDecision={onPermissionDecision}
+          onInputResponse={onInputResponse}
           scheduledFromWorktree={session.scheduled_from_worktree}
           scheduledRunAt={session.scheduled_run_at}
           genealogy={session.genealogy}

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -22,6 +22,13 @@ export interface AppActionsContextValue {
     allow: boolean,
     scope: PermissionScope
   ) => void;
+  onInputResponse?: (
+    sessionId: string,
+    requestId: string,
+    taskId: string,
+    answers: Record<string, string>,
+    annotations?: Record<string, { markdown?: string; notes?: string }>
+  ) => void;
 
   // Worktree/Environment actions
   onStartEnvironment?: (worktreeId: string) => void;

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -255,7 +255,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     try {
       const rows = await select(this.db)
         .from(tasks)
-        .where(sql`${tasks.status} IN ('running', 'stopping', 'awaiting_permission')`)
+        .where(
+          sql`${tasks.status} IN ('running', 'stopping', 'awaiting_permission', 'awaiting_input')`
+        )
         .all();
 
       return rows.map((row: TaskRow) => this.rowToTask(row));

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -61,7 +61,15 @@ export const sessions = pgTable(
 
     // Materialized for filtering/joins (cross-DB compatible)
     status: text('status', {
-      enum: ['idle', 'running', 'stopping', 'awaiting_permission', 'completed', 'failed'],
+      enum: [
+        'idle',
+        'running',
+        'stopping',
+        'awaiting_permission',
+        'awaiting_input',
+        'completed',
+        'failed',
+      ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
       enum: ['claude-code', 'codex', 'gemini', 'opencode'],
@@ -188,6 +196,7 @@ export const tasks = pgTable(
         'running',
         'stopping',
         'awaiting_permission',
+        'awaiting_input',
         'completed',
         'failed',
         'stopped',
@@ -257,7 +266,14 @@ export const messages = pgTable(
 
     // Materialized for queries
     type: text('type', {
-      enum: ['user', 'assistant', 'system', 'file-history-snapshot', 'permission_request'],
+      enum: [
+        'user',
+        'assistant',
+        'system',
+        'file-history-snapshot',
+        'permission_request',
+        'input_request',
+      ],
     }).notNull(),
     role: text('role', {
       enum: ['user', 'assistant', 'system'],

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -56,7 +56,15 @@ export const sessions = sqliteTable(
 
     // Materialized for filtering/joins (cross-DB compatible)
     status: text('status', {
-      enum: ['idle', 'running', 'stopping', 'awaiting_permission', 'completed', 'failed'],
+      enum: [
+        'idle',
+        'running',
+        'stopping',
+        'awaiting_permission',
+        'awaiting_input',
+        'completed',
+        'failed',
+      ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
       enum: ['claude-code', 'codex', 'gemini', 'opencode'],
@@ -183,6 +191,7 @@ export const tasks = sqliteTable(
         'running',
         'stopping',
         'awaiting_permission',
+        'awaiting_input',
         'completed',
         'failed',
         'stopped',
@@ -252,7 +261,14 @@ export const messages = sqliteTable(
 
     // Materialized for queries
     type: text('type', {
-      enum: ['user', 'assistant', 'system', 'file-history-snapshot', 'permission_request'],
+      enum: [
+        'user',
+        'assistant',
+        'system',
+        'file-history-snapshot',
+        'permission_request',
+        'input_request',
+      ],
     }).notNull(),
     role: text('role', {
       enum: ['user', 'assistant', 'system'],

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -37,7 +37,8 @@ export type MessageType =
   | 'assistant'
   | 'system'
   | 'file-history-snapshot'
-  | 'permission_request';
+  | 'permission_request'
+  | 'input_request';
 
 /**
  * Content block (for multi-modal messages)
@@ -101,6 +102,36 @@ export interface PermissionRequestContent {
 }
 
 /**
+ * Input request status
+ * Used when the agent asks the user a question via AskUserQuestion tool
+ */
+export enum InputRequestStatus {
+  PENDING = 'pending',
+  ANSWERED = 'answered',
+  TIMED_OUT = 'timed_out',
+}
+
+/**
+ * Input request content
+ * Used when type === 'input_request'
+ */
+export interface InputRequestContent {
+  request_id: string;
+  task_id?: TaskID;
+  questions: Array<{
+    question: string;
+    header: string;
+    options: Array<{ label: string; description: string; markdown?: string }>;
+    multiSelect: boolean;
+  }>;
+  status: InputRequestStatus;
+  answers?: Record<string, string>;
+  annotations?: Record<string, { markdown?: string; notes?: string }>;
+  answered_by?: string;
+  answered_at?: string;
+}
+
+/**
  * Message
  *
  * Represents a single turn in the conversation.
@@ -131,7 +162,7 @@ export interface Message {
   content_preview: string;
 
   /** Full message content (type depends on message type) */
-  content: string | ContentBlock[] | PermissionRequestContent;
+  content: string | ContentBlock[] | PermissionRequestContent | InputRequestContent;
 
   /** Tool uses in this message (for assistant messages) */
   tool_uses?: ToolUse[];

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -17,6 +17,7 @@ export const SessionStatus = {
   RUNNING: 'running',
   STOPPING: 'stopping', // Stop requested, waiting for task to stop
   AWAITING_PERMISSION: 'awaiting_permission',
+  AWAITING_INPUT: 'awaiting_input', // Waiting for user to answer AskUserQuestion
   COMPLETED: 'completed',
   FAILED: 'failed',
 } as const;

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -7,6 +7,7 @@ export const TaskStatus = {
   RUNNING: 'running',
   STOPPING: 'stopping', // Stop requested, waiting for SDK to halt
   AWAITING_PERMISSION: 'awaiting_permission',
+  AWAITING_INPUT: 'awaiting_input', // Waiting for user to answer AskUserQuestion
   COMPLETED: 'completed',
   FAILED: 'failed',
   STOPPED: 'stopped', // User-requested stop (distinct from failed)

--- a/packages/executor/src/handlers/sdk/claude.ts
+++ b/packages/executor/src/handlers/sdk/claude.ts
@@ -5,6 +5,8 @@
  */
 
 import type { MessageSource, PermissionMode, SessionID, TaskID } from '@agor/core/types';
+import { globalInputRequestManager } from '../../input-requests/input-request-manager.js';
+import { InputRequestService } from '../../input-requests/input-request-service.js';
 import { globalPermissionManager } from '../../permissions/permission-manager.js';
 import { PermissionService } from '../../permissions/permission-service.js';
 import { ClaudeTool } from '../../sdk-handlers/claude/claude-tool.js';
@@ -36,8 +38,15 @@ export async function executeClaudeCodeTask(params: {
     (client.service('sessions') as any).emit(event, data);
   });
 
-  // Register with global permission manager
+  // Create InputRequestService that emits via Feathers WebSocket
+  const inputRequestService = new InputRequestService(async (event, data) => {
+    // biome-ignore lint/suspicious/noExplicitAny: Feathers service types don't include emit method
+    (client.service('sessions') as any).emit(event, data);
+  });
+
+  // Register with global managers
   globalPermissionManager.register(sessionId, permissionService);
+  globalInputRequestManager.register(sessionId, inputRequestService);
 
   try {
     // Execute using base helper with Claude-specific factory
@@ -60,11 +69,13 @@ export async function executeClaudeCodeTask(params: {
           repos.repos,
           true, // mcpEnabled
           useNativeAuth, // Flag for Claude CLI OAuth (`claude login`)
-          repos.mcpOAuthNotifyService // Service for notifying UI about OAuth requirements
+          repos.mcpOAuthNotifyService, // Service for notifying UI about OAuth requirements
+          inputRequestService
         ),
     });
   } finally {
-    // Unregister from global permission manager
+    // Unregister from global managers
     globalPermissionManager.unregister(sessionId);
+    globalInputRequestManager.unregister(sessionId);
   }
 }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -15,6 +15,7 @@ import type {
   SessionID,
   TaskID,
 } from '@agor/core/types';
+import { globalInputRequestManager } from './input-requests/input-request-manager.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 
@@ -154,6 +155,32 @@ export class AgorExecutor {
             remember: data.remember,
             scope: data.scope as PermissionScope,
             decidedBy: data.decidedBy,
+          });
+        }
+      }
+    );
+
+    // Listen for input_resolved events (AskUserQuestion answers)
+    // biome-ignore lint/suspicious/noExplicitAny: Feathers types don't support custom events
+    (this.client.service('messages') as any).on(
+      'input_resolved',
+      (data: {
+        requestId: string;
+        taskId: string;
+        answers: Record<string, string>;
+        annotations?: Record<string, { markdown?: string; notes?: string }>;
+        respondedBy: string;
+      }) => {
+        console.log('[executor] Received input_resolved event:', data);
+
+        if (data.taskId === this.config.taskId) {
+          // Forward to global input request manager
+          globalInputRequestManager.resolveInput({
+            requestId: data.requestId,
+            taskId: data.taskId as TaskID,
+            answers: data.answers,
+            annotations: data.annotations,
+            respondedBy: data.respondedBy,
           });
         }
       }

--- a/packages/executor/src/input-requests/input-request-manager.ts
+++ b/packages/executor/src/input-requests/input-request-manager.ts
@@ -1,0 +1,47 @@
+/**
+ * Global Input Request Manager
+ *
+ * Maintains a registry of input request services across all active sessions.
+ * Routes input_resolved notifications from daemon to the correct session's InputRequestService.
+ */
+
+import type { InputRequestService, InputResponse } from './input-request-service.js';
+
+export class InputRequestManager {
+  private services = new Map<string, InputRequestService>();
+
+  /**
+   * Register an input request service for a session
+   */
+  register(sessionId: string, service: InputRequestService): void {
+    this.services.set(sessionId, service);
+    console.log(
+      `[InputRequestManager] Registered service for session ${sessionId.substring(0, 8)}`
+    );
+  }
+
+  /**
+   * Unregister an input request service
+   */
+  unregister(sessionId: string): void {
+    this.services.delete(sessionId);
+    console.log(
+      `[InputRequestManager] Unregistered service for session ${sessionId.substring(0, 8)}`
+    );
+  }
+
+  /**
+   * Route an input response to the correct service
+   * Called by IPC notification handler
+   */
+  resolveInput(response: InputResponse): void {
+    // Find the service by request ID (iterate through all services)
+    for (const [_sessionId, service] of this.services.entries()) {
+      // Try to resolve - the service will only resolve if it has this requestId
+      service.resolveInput(response);
+    }
+  }
+}
+
+// Global singleton instance
+export const globalInputRequestManager = new InputRequestManager();

--- a/packages/executor/src/input-requests/input-request-service.ts
+++ b/packages/executor/src/input-requests/input-request-service.ts
@@ -82,6 +82,18 @@ export class InputRequestService {
     signal: AbortSignal
   ): Promise<InputResponse> {
     return new Promise((resolve) => {
+      // Check if already aborted before setting up listeners
+      if (signal.aborted) {
+        console.log(`❓ [executor] Input request already aborted: ${requestId}`);
+        resolve({
+          requestId,
+          taskId,
+          answers: {},
+          respondedBy: 'system',
+        });
+        return;
+      }
+
       // Handle cancellation
       signal.addEventListener('abort', () => {
         const pending = this.pendingRequests.get(requestId);

--- a/packages/executor/src/input-requests/input-request-service.ts
+++ b/packages/executor/src/input-requests/input-request-service.ts
@@ -1,0 +1,162 @@
+/**
+ * Input Request Service (Executor Version)
+ *
+ * Handles async input requests from Claude Agent SDK's AskUserQuestion tool.
+ * Emits events via Feathers WebSocket to daemon for broadcasting to UI clients.
+ *
+ * ## Flow in Feathers/WebSocket Architecture:
+ *
+ * 1. canUseTool intercepts AskUserQuestion → InputRequestService.emitRequest()
+ * 2. Event sent via Feathers WebSocket to daemon → Daemon broadcasts to UI clients
+ * 3. Task/session updated via Feathers client (awaiting_input)
+ * 4. InputRequestService.waitForResponse() creates Promise that pauses SDK
+ * 5. UI answers → daemon receives answers → WebSocket notification to executor
+ * 6. Executor receives input_resolved event → calls InputRequestService.resolveInput()
+ * 7. Promise resolves → SDK resumes with answers via updatedInput
+ */
+
+import type { SessionID, TaskID } from '@agor/core/types';
+
+export interface InputRequest {
+  requestId: string;
+  sessionId: SessionID;
+  taskId: TaskID;
+  questions: Array<{
+    question: string;
+    header: string;
+    options: Array<{ label: string; description: string; markdown?: string }>;
+    multiSelect: boolean;
+  }>;
+  timestamp: string;
+}
+
+export interface InputResponse {
+  requestId: string;
+  taskId: TaskID;
+  answers: Record<string, string>;
+  annotations?: Record<string, { markdown?: string; notes?: string }>;
+  respondedBy: string;
+}
+
+/** Timeout for input requests: 5 minutes (users need time to read and answer) */
+const INPUT_REQUEST_TIMEOUT_MS = 300000;
+
+/**
+ * Executor version of InputRequestService
+ * Emits events via IPC to daemon instead of directly via WebSocket
+ */
+export class InputRequestService {
+  private pendingRequests = new Map<
+    string,
+    {
+      sessionId: SessionID;
+      resolve: (response: InputResponse) => void;
+      timeout: NodeJS.Timeout;
+    }
+  >();
+
+  /**
+   * @param emitEvent - Function to emit events via IPC to daemon
+   */
+  constructor(private emitEvent: (event: string, data: unknown) => Promise<void>) {}
+
+  /**
+   * Emit an input request event to daemon (which broadcasts via WebSocket)
+   */
+  async emitRequest(sessionId: SessionID, request: Omit<InputRequest, 'sessionId'>) {
+    const fullRequest: InputRequest = { ...request, sessionId };
+    await this.emitEvent('input:request', fullRequest);
+    console.log(
+      `❓ [executor] Input request emitted via IPC: ${request.questions.length} question(s) for task ${request.taskId}`
+    );
+  }
+
+  /**
+   * Wait for an input response from daemon
+   * Returns a Promise that pauses SDK execution until resolved
+   */
+  waitForResponse(
+    requestId: string,
+    taskId: TaskID,
+    sessionId: SessionID,
+    signal: AbortSignal
+  ): Promise<InputResponse> {
+    return new Promise((resolve) => {
+      // Handle cancellation
+      signal.addEventListener('abort', () => {
+        const pending = this.pendingRequests.get(requestId);
+        if (pending) {
+          clearTimeout(pending.timeout);
+          this.pendingRequests.delete(requestId);
+        }
+        console.log(`❓ [executor] Input request cancelled: ${requestId}`);
+        resolve({
+          requestId,
+          taskId,
+          answers: {},
+          respondedBy: 'system',
+        });
+      });
+
+      // Timeout after 5 minutes
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+        console.warn(`⚠️  [executor] Input request timeout: ${requestId}`);
+        resolve({
+          requestId,
+          taskId,
+          answers: {},
+          respondedBy: 'system',
+        });
+      }, INPUT_REQUEST_TIMEOUT_MS);
+
+      this.pendingRequests.set(requestId, { sessionId, resolve, timeout });
+      console.log(`❓ [executor] Waiting for input response: ${requestId}`);
+    });
+  }
+
+  /**
+   * Resolve a pending input request
+   * Called by IPC handler when daemon sends input_resolved notification
+   */
+  resolveInput(response: InputResponse) {
+    const pending = this.pendingRequests.get(response.requestId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      pending.resolve(response);
+      this.pendingRequests.delete(response.requestId);
+      console.log(
+        `❓ [executor] Input resolved: ${response.requestId} → answered by ${response.respondedBy}`
+      );
+    } else {
+      console.warn(`⚠️  [executor] No pending input request found for ${response.requestId}`);
+    }
+  }
+
+  /**
+   * Cancel all pending input requests for a session
+   */
+  cancelPendingRequests(sessionId: SessionID) {
+    let cancelledCount = 0;
+
+    for (const [requestId, pending] of this.pendingRequests.entries()) {
+      if (pending.sessionId === sessionId) {
+        clearTimeout(pending.timeout);
+        pending.resolve({
+          requestId,
+          taskId: '' as TaskID,
+          answers: {},
+          respondedBy: 'system',
+        });
+        this.pendingRequests.delete(requestId);
+        cancelledCount++;
+      }
+    }
+
+    if (cancelledCount > 0) {
+      console.log(
+        `❓ [executor] Cancelled ${cancelledCount} pending input request(s) for session ${sessionId.substring(0, 8)}`
+      );
+    }
+  }
+}

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -21,6 +21,7 @@ import type {
   SessionRepository,
   WorktreeRepository,
 } from '../../db/feathers-repositories.js';
+import type { InputRequestService } from '../../input-requests/input-request-service.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
 import type { NormalizedSdkResponse, RawSdkResponse } from '../../types/sdk-response.js';
 // Removed import of calculateModelContextWindowUsage - inlined instead
@@ -119,7 +120,8 @@ export class ClaudeTool implements ITool {
     mcpEnabled?: boolean,
     _useNativeAuth?: boolean, // Claude supports `claude login` OAuth, but no special handling needed in tool
     // biome-ignore lint/suspicious/noExplicitAny: Feathers service type
-    mcpOAuthNotifyService?: any // Service for notifying UI about OAuth requirements
+    mcpOAuthNotifyService?: any, // Service for notifying UI about OAuth requirements
+    inputRequestService?: InputRequestService
   ) {
     if (messagesRepo && sessionsRepo) {
       this.promptService = new ClaudePromptService(
@@ -135,7 +137,8 @@ export class ClaudeTool implements ITool {
         reposRepo,
         messagesService,
         mcpEnabled,
-        mcpOAuthNotifyService
+        mcpOAuthNotifyService,
+        inputRequestService
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -8,13 +8,20 @@
 
 import { generateId } from '@agor/core';
 import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
-import { MessageRole, PermissionScope, PermissionStatus, TaskStatus } from '@agor/core/types';
+import {
+  InputRequestStatus,
+  MessageRole,
+  PermissionScope,
+  PermissionStatus,
+  TaskStatus,
+} from '@agor/core/types';
 import type {
   MCPServerRepository,
   MessagesRepository,
   SessionMCPServerRepository,
   SessionRepository,
 } from '../../../db/feathers-repositories.js';
+import type { InputRequestService } from '../../../input-requests/input-request-service.js';
 import type { PermissionService } from '../../../permissions/permission-service.js';
 import type { MessagesService, SessionsService, TasksService } from '../claude-tool.js';
 
@@ -30,6 +37,7 @@ export function createCanUseToolCallback(
   taskId: TaskID,
   deps: {
     permissionService: PermissionService;
+    inputRequestService?: InputRequestService;
     tasksService: TasksService;
     sessionsRepo: SessionRepository;
     messagesRepo: MessagesRepository;
@@ -127,6 +135,158 @@ export function createCanUseToolCallback(
           `⚠️ [canUseTool] MCP tool "${toolName}" has invalid format, requiring manual approval`
         );
         // Fall through to normal permission flow for malformed tool names
+      }
+    }
+
+    // Intercept AskUserQuestion tool — route through InputRequestService
+    // instead of the normal permission flow
+    if (toolName === 'AskUserQuestion' && deps.inputRequestService) {
+      // Track lock release for AskUserQuestion flow
+      let releaseInputLock: (() => void) | undefined;
+
+      try {
+        // Wait for any pending permission/input check to finish
+        const existingLock = deps.permissionLocks.get(sessionId);
+        if (existingLock) {
+          await existingLock;
+        }
+
+        // Create lock for this input request
+        const newLock = new Promise<void>((resolve) => {
+          releaseInputLock = resolve;
+        });
+        deps.permissionLocks.set(sessionId, newLock);
+
+        const requestId = generateId();
+        const timestamp = new Date().toISOString();
+
+        // Extract questions from toolInput (matches AskUserQuestionInput schema)
+        const questions =
+          (toolInput.questions as Array<{
+            question: string;
+            header: string;
+            options: Array<{
+              label: string;
+              description: string;
+              markdown?: string;
+            }>;
+            multiSelect: boolean;
+          }>) || [];
+
+        // Get current message index
+        const existingMessages = await deps.messagesRepo.findBySessionId(sessionId);
+        const nextIndex = existingMessages.length;
+
+        // Create input_request message
+        const inputMessage: Message = {
+          message_id: generateId() as MessageID,
+          session_id: sessionId,
+          task_id: taskId,
+          type: 'input_request',
+          role: MessageRole.SYSTEM,
+          index: nextIndex,
+          timestamp,
+          content_preview: `Question: ${questions[0]?.question || 'User input requested'}`,
+          content: {
+            request_id: requestId,
+            task_id: taskId,
+            questions,
+            status: InputRequestStatus.PENDING,
+          },
+        };
+
+        if (deps.messagesService) {
+          await deps.messagesService.create(inputMessage);
+        }
+
+        // Update task/session status to awaiting_input
+        await deps.tasksService.patch(taskId, {
+          status: TaskStatus.AWAITING_INPUT,
+        });
+        if (deps.sessionsService) {
+          await deps.sessionsService.patch(sessionId, {
+            status: 'awaiting_input' as const,
+          });
+        }
+
+        // Emit WebSocket event for UI
+        deps.inputRequestService.emitRequest(sessionId, {
+          requestId,
+          taskId,
+          questions,
+          timestamp,
+        });
+
+        // Wait for UI response (Promise pauses SDK execution)
+        const response = await deps.inputRequestService.waitForResponse(
+          requestId,
+          taskId,
+          sessionId,
+          options.signal
+        );
+
+        // Determine if this was a timeout (empty answers from system)
+        const isTimeout =
+          response.respondedBy === 'system' && Object.keys(response.answers).length === 0;
+
+        // Update the input_request message with response
+        if (deps.messagesService) {
+          const baseContent =
+            typeof inputMessage.content === 'object' && !Array.isArray(inputMessage.content)
+              ? inputMessage.content
+              : {};
+
+          // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service has patch method but type definition is incomplete
+          await (deps.messagesService as any).patch(inputMessage.message_id, {
+            content: {
+              ...(baseContent as Record<string, unknown>),
+              status: isTimeout ? InputRequestStatus.TIMED_OUT : InputRequestStatus.ANSWERED,
+              answers: response.answers,
+              annotations: response.annotations,
+              answered_by: response.respondedBy,
+              answered_at: new Date().toISOString(),
+            },
+          });
+        }
+
+        // Restore task/session status to running
+        await deps.tasksService.patch(taskId, {
+          status: TaskStatus.RUNNING,
+        });
+        if (deps.sessionsService) {
+          await deps.sessionsService.patch(sessionId, {
+            status: 'running' as const,
+          });
+        }
+
+        if (isTimeout) {
+          // On timeout, deny the tool use (Claude will see the denial)
+          return {
+            behavior: 'deny' as const,
+            message: 'User input request timed out',
+          };
+        }
+
+        // Return answers via updatedInput so Claude receives them
+        return {
+          behavior: 'allow' as const,
+          updatedInput: {
+            ...toolInput,
+            answers: response.answers,
+            annotations: response.annotations,
+          },
+        };
+      } catch (error) {
+        console.error('[canUseTool] Error in AskUserQuestion flow:', error);
+        return {
+          behavior: 'deny' as const,
+          message: error instanceof Error ? error.message : 'Unknown error in input request flow',
+        };
+      } finally {
+        if (releaseInputLock) {
+          releaseInputLock();
+          deps.permissionLocks.delete(sessionId);
+        }
       }
     }
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -13,6 +13,7 @@ import type {
   SessionRepository,
   WorktreeRepository,
 } from '../../db/feathers-repositories.js';
+import type { InputRequestService } from '../../input-requests/input-request-service.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
 import type { SessionID, TaskID } from '../../types.js';
 import { MessageRole } from '../../types.js';
@@ -68,7 +69,8 @@ export class ClaudePromptService {
     private messagesService?: import('./claude-tool').MessagesService, // FeathersJS Messages service for creating permission requests
     private mcpEnabled?: boolean,
     // biome-ignore lint/suspicious/noExplicitAny: Feathers service type
-    private mcpOAuthNotifyService?: any // Service for notifying UI about OAuth requirements
+    private mcpOAuthNotifyService?: any, // Service for notifying UI about OAuth requirements
+    private inputRequestService?: InputRequestService
   ) {
     // No client initialization needed - Agent SDK is stateless
   }
@@ -110,6 +112,7 @@ export class ClaudePromptService {
         sessionMCPRepo: this.sessionMCPRepo,
         mcpServerRepo: this.mcpServerRepo,
         permissionService: this.permissionService,
+        inputRequestService: this.inputRequestService,
         tasksService: this.tasksService,
         mcpEnabled: this.mcpEnabled,
         sessionsService: this.sessionsService,
@@ -265,6 +268,7 @@ export class ClaudePromptService {
         sessionMCPRepo: this.sessionMCPRepo,
         mcpServerRepo: this.mcpServerRepo,
         permissionService: this.permissionService,
+        inputRequestService: this.inputRequestService,
         tasksService: this.tasksService,
         mcpEnabled: this.mcpEnabled,
         sessionsService: this.sessionsService,

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -24,6 +24,7 @@ import type {
   SessionRepository,
   WorktreeRepository,
 } from '../../db/feathers-repositories.js';
+import type { InputRequestService } from '../../input-requests/input-request-service.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
 import type { MCPServersConfig, SessionID, TaskID, UserID } from '../../types.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
@@ -104,6 +105,7 @@ export interface QuerySetupDeps {
   sessionMCPRepo?: SessionMCPServerRepository;
   mcpServerRepo?: MCPServerRepository;
   permissionService?: PermissionService;
+  inputRequestService?: InputRequestService;
   tasksService?: TasksService;
   sessionsService?: SessionsService;
   messagesService?: MessagesService;
@@ -333,6 +335,7 @@ export async function setupQuery(
   ) {
     queryOptions.canUseTool = createCanUseToolCallback(sessionId, taskId, {
       permissionService: deps.permissionService,
+      inputRequestService: deps.inputRequestService,
       tasksService: deps.tasksService!,
       sessionsRepo: deps.sessionsRepo,
       messagesRepo: deps.messagesRepo!,


### PR DESCRIPTION
## Summary

- Add full-stack support for Claude's `AskUserQuestion` tool, routing questions through Agor's custom UI instead of the CLI prompt
- Intercept `AskUserQuestion` in the existing `canUseTool` SDK callback, pause execution via Promise, render an interactive question UI, and return answers via `updatedInput`
- Mirror the existing permission request architecture (executor → daemon → UI → daemon → executor) for input requests

## Changes

### Core types (`packages/core`)
- Add `input_request` message type, `InputRequestStatus` enum, `InputRequestContent` interface
- Add `AWAITING_INPUT` to `TaskStatus` and `SessionStatus`
- Update DB schemas (SQLite + Postgres) and repository queries

### Executor (`packages/executor`)
- New `InputRequestService` + `InputRequestManager` (mirrors permission pattern)
- Intercept `AskUserQuestion` in `canUseTool` callback before normal permission flow
- Wire service through claude-tool → prompt-service → query-builder → permission-hooks
- Listen for `input_resolved` WebSocket events

### Daemon (`apps/agor-daemon`)
- Add `/sessions/:id/input-response` REST endpoint (mirrors permission-decision)
- Register `input_resolved` in messages service WebSocket events

### UI (`apps/agor-ui`)
- New `InputRequestBlock` component with radio/checkbox options and free-text "Other" input
- Wire `onInputResponse` through full component tree via `AppActionsContext`
- Recognize `awaiting_input` status in TaskStatusIcon, TimerPill, SessionPanel
- Support both desktop and mobile views (mobile uses shared context, no duplication)

## Test plan

- [ ] Start a session and trigger `AskUserQuestion` (e.g., prompt Claude to ask the user a question)
- [ ] Verify `input_request` message appears in the conversation UI with interactive options
- [ ] Submit an answer via the UI and verify Claude receives it and continues
- [ ] Let a question time out (5 min) and verify status changes to `timed_out`
- [ ] Test multi-select questions with options containing special characters (commas)
- [ ] Test stop/abort during an active input request
- [ ] Verify mobile view renders questions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)