### PR TITLE
fix(ui): fix chimes min value and default

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/AudioSettingsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AudioSettingsTab.tsx
@@ -25,6 +25,8 @@ import {
   DEFAULT_AUDIO_PREFERENCES,
   getAvailableChimes,
   getChimeDisplayName,
+  MIN_DURATION_MAX,
+  MIN_DURATION_MIN,
   previewChimeSound,
 } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
@@ -225,8 +227,8 @@ export const AudioSettingsTab: React.FC<AudioSettingsTabProps> = ({ user, form }
                 >
                   <Space.Compact style={{ width: '100%' }}>
                     <InputNumber
-                      min={0}
-                      max={60}
+                      min={MIN_DURATION_MIN}
+                      max={MIN_DURATION_MAX}
                       step={1}
                       style={{ width: '100%' }}
                       disabled={!form.getFieldValue('enabled')}

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -26,6 +26,7 @@ import {
   theme,
 } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
+import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { ApiKeyFields, type ApiKeyStatus } from '../ApiKeyFields';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
@@ -124,10 +125,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       // Initialize audio form with user's preferences
       const audioPrefs = userData.preferences?.audio;
       audioForm.setFieldsValue({
-        enabled: audioPrefs?.enabled ?? true,
-        chime: audioPrefs?.chime ?? 'bell',
-        volume: audioPrefs?.volume ?? 50,
-        minDurationSeconds: audioPrefs?.minDurationSeconds ?? 5,
+        enabled: audioPrefs?.enabled ?? DEFAULT_AUDIO_PREFERENCES.enabled,
+        chime: audioPrefs?.chime ?? DEFAULT_AUDIO_PREFERENCES.chime,
+        volume: audioPrefs?.volume ?? DEFAULT_AUDIO_PREFERENCES.volume,
+        minDurationSeconds:
+          audioPrefs?.minDurationSeconds ?? DEFAULT_AUDIO_PREFERENCES.minDurationSeconds,
       });
     },
     [form, claudeForm, codexForm, geminiForm, audioForm]

--- a/apps/agor-ui/src/utils/audio.ts
+++ b/apps/agor-ui/src/utils/audio.ts
@@ -47,6 +47,10 @@ function getChimeAssetPath(chime: ChimeSound | string): string | null {
   return relativePath;
 }
 
+/** Minimum duration bounds for the chimes setting (in seconds) */
+export const MIN_DURATION_MIN = 0;
+export const MIN_DURATION_MAX = 300;
+
 /**
  * Default audio preferences
  */
@@ -54,7 +58,7 @@ export const DEFAULT_AUDIO_PREFERENCES: AudioPreferences = {
   enabled: false,
   chime: 'gentle-chime',
   volume: 0.5,
-  minDurationSeconds: 5,
+  minDurationSeconds: 30,
 };
 
 /**


### PR DESCRIPTION
## Summary
- Change default `minDurationSeconds` from 5s to 30s for new users
- Increase max allowed value from 60s to 300s (5 minutes)
- Fix inconsistent fallback defaults in `UserSettingsModal` — was using wrong chime name (`'bell'` instead of `'gentle-chime'`), wrong volume scale (`50` instead of `0.5`), and wrong enabled state (`true` instead of `false`). Now references `DEFAULT_AUDIO_PREFERENCES` as single source of truth.

## Test plan
- [ ] Open user settings > Audio tab with no prior audio preferences set — verify defaults show correctly (disabled, gentle-chime, 50% volume, 30s min duration)
- [ ] Set min duration to 0 — verify chimes play for all task completions
- [ ] Set min duration to values between 0-300 — verify input accepts them
- [ ] Set min duration above 300 — verify input rejects it
- [ ] Existing users with saved preferences — verify their settings are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)