### PR TITLE
fix: prevent duplicate worktree names within a repository

### DIFF
--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -32,6 +32,7 @@ import type {
   RepoEnvironmentConfig,
   RepoSlug,
   UserID,
+  UUID,
   Worktree,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
@@ -327,6 +328,16 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       local_path: repo.local_path,
       remote_url: repo.remote_url,
     });
+
+    // Check for duplicate worktree name in this repo (non-archived only)
+    const worktreeRepo = new WorktreeRepository(this.db);
+    const existingWorktree = await worktreeRepo.findActiveByRepoAndName(
+      repo.repo_id as UUID,
+      data.name
+    );
+    if (existingWorktree) {
+      throw new Error(`A worktree named '${data.name}' already exists in this repository`);
+    }
 
     const worktreePath = getWorktreePath(repo.slug, data.name);
 

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -297,6 +297,20 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
     return row ? this.rowToWorktree(row) : null;
   }
 
+  /**
+   * Find active (non-archived) worktree by repo_id and name
+   */
+  async findActiveByRepoAndName(repoId: UUID, name: string): Promise<Worktree | null> {
+    const row = await select(this.db)
+      .from(worktrees)
+      .where(
+        sql`${worktrees.repo_id} = ${repoId} AND ${worktrees.name} = ${name} AND ${worktrees.archived} = 0`
+      )
+      .one();
+
+    return row ? this.rowToWorktree(row) : null;
+  }
+
   // ===== RBAC: Ownership Management =====
 
   /**


### PR DESCRIPTION
## Summary
- Adds app-level validation in `ReposService.createWorktree()` to reject duplicate worktree names within the same repository
- Adds `findActiveByRepoAndName()` to `WorktreeRepository` that filters out archived worktrees
- Archived worktrees don't block name reuse — only active worktrees are checked

## Test plan
- [ ] Create worktree "test-feature" in a repo — should succeed
- [ ] Try to create another "test-feature" in the same repo — should fail with clear error message
- [ ] Create "test-feature" in a different repo — should succeed (names are repo-scoped)
- [ ] Archive a worktree, then create a new one with the same name — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)