### PR TITLE
fix: update broken Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Closes #123
 
 **Stuck? Confused? Need guidance?**
 
-- **[Discord](https://discord.gg/HZKWXfgc)** - Join our Discord community for support and discussion
+- **[Discord](https://discord.gg/Qh4TrFQZpd)** - Join our Discord community for support and discussion
 - **[GitHub Discussions](https://github.com/preset-io/agor/discussions)** - Ask questions, share ideas, get help
 - **[GitHub Issues](https://github.com/preset-io/agor/issues)** - Report bugs, request features
 - **Read the docs** - [CLAUDE.md](CLAUDE.md) and [context/](context/) have extensive documentation

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Highlights:
 
 ## Community
 
-- **[Discord](https://discord.gg/HZKWXfgc)** - Join our Discord community for support and discussion
+- **[Discord](https://discord.gg/Qh4TrFQZpd)** - Join our Discord community for support and discussion
 - **[GitHub Discussions](https://github.com/preset-io/agor/discussions)** - Ask questions, share ideas
 - **[GitHub Issues](https://github.com/preset-io/agor/issues)** - Report bugs, request features
 

--- a/apps/agor-docs/components/Hero.tsx
+++ b/apps/agor-docs/components/Hero.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { GifGallery } from './GifGallery';
 import styles from './Hero.module.css';
 import { ParticleBackground } from './ParticleBackground';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 
 interface HeroProps {
   title: string;
@@ -39,7 +40,7 @@ export function Hero({
               {ctaText}
             </Link>
             <Link
-              href="https://github.com/preset-io/agor"
+              href={GITHUB_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
               className={styles.secondaryButton}
@@ -47,7 +48,7 @@ export function Hero({
               View on GitHub →
             </Link>
             <Link
-              href="https://discord.gg/HZKWXfgc"
+              href={DISCORD_INVITE_URL}
               target="_blank"
               rel="noopener noreferrer"
               className={styles.secondaryButton}

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -1,0 +1,12 @@
+/**
+ * Centralized external links for agor-docs.
+ *
+ * Update DISCORD_INVITE_URL here when the invite link changes.
+ * NOTE: Markdown files (*.md, *.mdx) also reference this URL
+ * and must be updated separately via find-replace.
+ */
+
+export const DISCORD_INVITE_URL = 'https://discord.gg/Qh4TrFQZpd';
+export const GITHUB_REPO_URL = 'https://github.com/preset-io/agor';
+export const GITHUB_DISCUSSIONS_URL = 'https://github.com/preset-io/agor/discussions';
+export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -216,7 +216,7 @@ Questions? Reach out:
 
 - [GitHub Discussions](https://github.com/preset-io/agor/discussions)
 - [Email us](mailto:hello@agor.live)
-- [Join our Discord](https://discord.gg/agor) (coming soon)
+- [Join our Discord](https://discord.gg/Qh4TrFQZpd)
 
 ---
 

--- a/apps/agor-docs/pages/guide/development.mdx
+++ b/apps/agor-docs/pages/guide/development.mdx
@@ -394,7 +394,7 @@ Browse the **[roadmap issues](https://github.com/preset-io/agor/issues?q=is%3Ais
 
 ## Getting Help
 
-- **[Discord](https://discord.gg/HZKWXfgc)** - Join our Discord community for support and discussion
+- **[Discord](https://discord.gg/Qh4TrFQZpd)** - Join our Discord community for support and discussion
 - **[GitHub Discussions](https://github.com/preset-io/agor/discussions)** - Ask questions, share ideas
 - **[GitHub Issues](https://github.com/preset-io/agor/issues)** - Report bugs, request features
 

--- a/apps/agor-docs/pages/guide/getting-started.mdx
+++ b/apps/agor-docs/pages/guide/getting-started.mdx
@@ -295,7 +295,7 @@ agor daemon start
 
 ## Getting Help
 
-- **[Discord](https://discord.gg/HZKWXfgc)** - Join our Discord community for support and discussion
+- **[Discord](https://discord.gg/Qh4TrFQZpd)** - Join our Discord community for support and discussion
 - **[GitHub Discussions](https://github.com/preset-io/agor/discussions)** - Ask questions, share ideas
 - **[GitHub Issues](https://github.com/preset-io/agor/issues)** - Report bugs, request features
 

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import type { DocsThemeConfig } from 'nextra-theme-docs';
 import { useConfig } from 'nextra-theme-docs';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from './lib/links';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 const defaultSiteUrl = 'https://agor.live';
@@ -31,10 +32,10 @@ const config: DocsThemeConfig = {
     </span>
   ),
   project: {
-    link: 'https://github.com/preset-io/agor',
+    link: GITHUB_REPO_URL,
   },
   chat: {
-    link: 'https://discord.gg/HZKWXfgc',
+    link: DISCORD_INVITE_URL,
   },
   docsRepositoryBase: 'https://github.com/preset-io/agor/tree/main/apps/agor-docs',
 


### PR DESCRIPTION
## Summary
- Replace expired Discord invite link (`HZKWXfgc`) with new permanent link (`Qh4TrFQZpd`) across 7 files
- Centralize Discord/GitHub URLs in `apps/agor-docs/lib/links.ts` so `.tsx` files import from a single source of truth
- Also fixed the blog post `agor-cloud.mdx` which had a different broken link (`discord.gg/agor`) and removed the "(coming soon)" label

## Test plan
- [ ] Verify the new Discord link resolves: https://discord.gg/Qh4TrFQZpd
- [ ] Check the docs site navbar Discord icon links correctly
- [ ] Check the landing page "Join Discord" button links correctly

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)