### PR TITLE
fix: permission approve fails on sessions with >100 messages

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -5108,13 +5108,14 @@ async function main() {
         if (!data.requestId) throw new Error('requestId required');
         if (typeof data.allow !== 'boolean') throw new Error('allow field required');
 
-        // Find the permission request message
+        // Find the permission request message by querying only permission_request type messages.
+        // No $limit override — the type filter at DB level ensures we only fetch
+        // permission_request messages, not all session messages.
         const messagesService = app.service('messages');
         const messages = await messagesService.find({
           query: {
             session_id: id,
             type: 'permission_request',
-            $limit: 100, // Get recent permission requests
           },
         });
 

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -67,7 +67,10 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
 
     // If filtering by session_id, use repository method
     if (params?.query?.session_id) {
-      const messages = await this.messagesRepo.findBySessionId(params.query.session_id);
+      // Use type-filtered query when type is specified (e.g., 'permission_request')
+      const messages = params.query.type
+        ? await this.messagesRepo.findBySessionIdAndType(params.query.session_id, params.query.type)
+        : await this.messagesRepo.findBySessionId(params.query.session_id);
 
       // Apply pagination if enabled
       if (this.paginate) {

--- a/apps/agor-docs/components/Hero.tsx
+++ b/apps/agor-docs/components/Hero.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { GifGallery } from './GifGallery';
 import styles from './Hero.module.css';
 import { ParticleBackground } from './ParticleBackground';
-import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 
 interface HeroProps {
   title: string;


### PR DESCRIPTION
## Summary

Fixes #669

- **Root cause:** The `permission-decision` endpoint queried all session messages via `MessagesService.find()`, which ignored the `type: 'permission_request'` filter. It then paginated to the first 100 oldest messages. Permission requests (always the newest message) fell outside this window in sessions with >100 messages.
- Add `findBySessionIdAndType()` to `MessagesRepository` for SQL-level type filtering
- Update `MessagesService.find()` to honor the `type` query parameter when `session_id` is present
- Remove hard-coded `$limit: 100` from the permission-decision endpoint (no longer needed since only permission_request messages are fetched)
- Clean up redundant dynamic `drizzle-orm` imports in the repository

## Test plan

- [ ] Create a session with >100 messages, trigger a permission request, click Approve — should succeed
- [ ] Verify permission approval still works on sessions with <100 messages (regression check)
- [ ] Verify invalid request_id still returns proper error


🤖 Generated with [Claude Code](https://claude.com/claude-code)