### PR TITLE
chore: bump agor-live to 0.13.0

### DIFF
--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps `agor-live` package version from 0.12.3 to 0.13.0

## Test plan
- [ ] Verify version in `packages/agor-live/package.json`
- [ ] Publish to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)