### PR TITLE
fix(ui): handle JSON string todos input in TodoListRenderer

### DIFF
--- a/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
+++ b/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
@@ -15,13 +15,7 @@
 import type { Message } from '@agor/core/types';
 import { theme } from 'antd';
 import { useMemo } from 'react';
-import { TodoListRenderer } from '../ToolUseRenderer/renderers/TodoListRenderer';
-
-interface TodoItem {
-  content: string;
-  activeForm: string;
-  status: 'pending' | 'in_progress' | 'completed';
-}
+import { parseTodosInput, TodoListRenderer } from '../ToolUseRenderer/renderers/TodoListRenderer';
 
 interface StickyTodoRendererProps {
   /**
@@ -50,18 +44,8 @@ export function StickyTodoRenderer({ messages }: StickyTodoRendererProps) {
           if (block.type === 'tool_use' && block.name === 'TodoWrite') {
             // Found the latest TodoWrite - return its todos and exit immediately
             const input = block.input as Record<string, unknown> | undefined;
-            const raw = input?.todos;
-            // Handle both parsed arrays and JSON strings (tool input may be serialized)
-            if (Array.isArray(raw)) return raw as TodoItem[];
-            if (typeof raw === 'string') {
-              try {
-                const parsed = JSON.parse(raw);
-                if (Array.isArray(parsed)) return parsed as TodoItem[];
-              } catch {
-                // Invalid JSON
-              }
-            }
-            return null;
+            const todos = parseTodosInput(input?.todos);
+            return todos.length > 0 ? todos : null;
           }
         }
       }

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
@@ -12,7 +12,7 @@ import { CheckCircleFilled } from '@ant-design/icons';
 import { Spin, theme } from 'antd';
 import type React from 'react';
 
-interface TodoItem {
+export interface TodoItem {
   content: string;
   activeForm: string;
   status: 'pending' | 'in_progress' | 'completed';
@@ -20,6 +20,23 @@ interface TodoItem {
 
 interface TodoWriteInput {
   todos: TodoItem[];
+}
+
+/**
+ * Parse a todos value that may be either a TodoItem[] array or a JSON string.
+ * Tool input from message data may arrive serialized; this normalizes both forms.
+ */
+export function parseTodosInput(raw: unknown): TodoItem[] {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // Invalid JSON — fall through to empty
+    }
+  }
+  return [];
 }
 
 interface TodoListRendererProps {
@@ -144,21 +161,8 @@ const TodoItemRow: React.FC<{ todo: TodoItem; index: number }> = ({ todo, index 
 export const TodoListRenderer: React.FC<TodoListRendererProps> = ({ toolUseId, input }) => {
   const { token } = theme.useToken();
 
-  // Extract todos array - handle both parsed arrays and JSON strings
-  // (tool input from message data may arrive as a serialized JSON string)
-  const todos = (() => {
-    const raw = input?.todos;
-    if (Array.isArray(raw)) return raw;
-    if (typeof raw === 'string') {
-      try {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed)) return parsed;
-      } catch {
-        // Invalid JSON — fall through to empty
-      }
-    }
-    return [];
-  })();
+  // Extract todos array — handles both parsed arrays and JSON strings
+  const todos = parseTodosInput(input?.todos);
 
   if (todos.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

- Fix `TypeError: r.filter is not a function` crash in the UI caused by `TodoWrite` tool input arriving as a serialized JSON string instead of a parsed array
- Add defensive parsing in both `TodoListRenderer` and `StickyTodoRenderer` to handle both formats gracefully

## Root Cause

The `TodoWrite` tool's `input.todos` field can arrive as either:
- A parsed `TodoItem[]` array (expected)
- A JSON string like `'[{"content": "Fix failing CI test", "status": "in_progress"}]'` (actual)

Since strings are truthy, the `|| []` fallback didn't trigger. Strings have `.length` (so the empty check passed) but no `.filter()` method, causing the crash.

## Error

```
TypeError: r.filter is not a function
    at e4e (index-C43qDMvK.js:1355:2808)
```

## Files Changed

- `apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx` — Parse JSON string if `input.todos` is not an array
- `apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx` — Same defensive parsing when extracting todos from message data

## Test plan

- [x] `pnpm check` passes (typecheck, lint, build)
- [ ] Verify TodoWrite tool renders correctly with array input (normal case)
- [ ] Verify TodoWrite tool renders correctly when input.todos is a JSON string
- [ ] Verify StickyTodoRenderer works during active sessions with todo lists


🤖 Generated with [Claude Code](https://claude.com/claude-code)