### PR TITLE
fix: URI-encode PostgreSQL credentials, consolidate duplicate Handlebars template

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -51,16 +51,32 @@ import { SessionPanelContent } from './SessionPanelContent';
 // This allows us to distinguish between false and undefined in templates
 Handlebars.registerHelper('isDefined', (value: unknown) => value !== undefined);
 
-// Compile template once at module load (after helper registration)
-const compiledSpawnTemplate = Handlebars.compile(spawnSubsessionTemplate);
-
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
 
-// Compile the spawn subsession template once at module level
-const compiledSpawnSubsessionTemplate = compileTemplate<{ userPrompt: string }>(
-  spawnSubsessionTemplate
-);
+/** Context shape for the spawn subsession Handlebars template */
+interface SpawnTemplateContext {
+  userPrompt: string;
+  hasConfig?: boolean;
+  agenticTool?: string;
+  permissionMode?: PermissionMode;
+  modelConfig?: SpawnConfig['modelConfig'];
+  codexSandboxMode?: CodexSandboxMode;
+  codexApprovalPolicy?: CodexApprovalPolicy;
+  codexNetworkAccess?: boolean;
+  mcpServerIds?: string[];
+  hasCallbackConfig?: boolean;
+  callbackConfig?: {
+    enableCallback?: boolean;
+    includeLastMessage?: boolean;
+    includeOriginalPrompt?: boolean;
+  };
+  extraInstructions?: string;
+}
+
+// Compile the spawn subsession template once at module level (after helper registration)
+const compiledSpawnSubsessionTemplate =
+  compileTemplate<SpawnTemplateContext>(spawnSubsessionTemplate);
 
 export interface SessionPanelProps {
   client: AgorClient | null;
@@ -423,7 +439,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         config.includeOriginalPrompt !== undefined ||
         config.extraInstructions !== undefined;
 
-      const metaPrompt = compiledSpawnTemplate({
+      const metaPrompt = compiledSpawnSubsessionTemplate({
         userPrompt: config.prompt || '',
         hasConfig,
         agenticTool: config.agent,

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -324,8 +324,8 @@ export function getDatabaseUrl(): string {
         }
         if (dbConfig.postgresql?.host) {
           const pg = dbConfig.postgresql;
-          const user = pg.user || 'postgres';
-          const password = pg.password ? `:${pg.password}` : '';
+          const user = encodeURIComponent(pg.user || 'postgres');
+          const password = pg.password ? `:${encodeURIComponent(pg.password)}` : '';
           const host = pg.host;
           const port = pg.port || 5432;
           const database = pg.database || 'agor';


### PR DESCRIPTION
## Summary
- URI-encode `user` and `password` when building PostgreSQL connection URLs from individual config.yaml fields, preventing malformed URLs when credentials contain special characters (`@`, `:`, `/`, `%`)
- Remove duplicate compiled Handlebars template in SessionPanel — consolidate `compiledSpawnTemplate` and `compiledSpawnSubsessionTemplate` into a single module-level compiled template

## Context
Fast-follow cleanup for #649. Both issues were identified during code review and deferred to a separate PR.

## Test plan
- [x] `pnpm check` passes (typecheck + lint + build)
- [ ] Verify subsession spawn still works via SessionPanel (both simple and advanced config flows)
- [ ] Verify PostgreSQL config.yaml connection with special characters in password

🤖 Generated with [Claude Code](https://claude.com/claude-code)