### PR TITLE
fix(db): use dialect-agnostic boolean for archived column queries

### DIFF
--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -5,18 +5,7 @@
  */
 
 import type { AgenticToolName, SessionStatus, UUID, Worktree, WorktreeID } from '@agor/core/types';
-import {
-  and,
-  desc,
-  eq,
-  getTableColumns,
-  inArray,
-  isNotNull,
-  isNull,
-  like,
-  or,
-  sql,
-} from 'drizzle-orm';
+import { and, desc, eq, getTableColumns, inArray, isNotNull, isNull, like, or } from 'drizzle-orm';
 import { formatShortId, generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
@@ -291,7 +280,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
   async findByRepoAndName(repoId: UUID, name: string): Promise<Worktree | null> {
     const row = await select(this.db)
       .from(worktrees)
-      .where(sql`${worktrees.repo_id} = ${repoId} AND ${worktrees.name} = ${name}`)
+      .where(and(eq(worktrees.repo_id, repoId), eq(worktrees.name, name)))
       .one();
 
     return row ? this.rowToWorktree(row) : null;
@@ -304,7 +293,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
     const row = await select(this.db)
       .from(worktrees)
       .where(
-        sql`${worktrees.repo_id} = ${repoId} AND ${worktrees.name} = ${name} AND ${worktrees.archived} = 0`
+        and(eq(worktrees.repo_id, repoId), eq(worktrees.name, name), eq(worktrees.archived, false))
       )
       .one();
 


### PR DESCRIPTION
## Summary

- Worktree creation via MCP was failing on Postgres due to SQLite-specific boolean syntax
- The `findActiveByRepoAndName` method used raw SQL with `archived = 0`, which fails on Postgres (requires `archived = false`)
- Replaced raw SQL templates with Drizzle ORM's `and()` and `eq()` operators, which handle dialect differences automatically
- Also updated `findByRepoAndName` to use Drizzle operators for consistency
- Removed unused `sql` import

## Test plan

- [ ] Verify worktree creation works via MCP on both SQLite and Postgres
- [ ] Test uniqueness check that runs before insert (`findActiveByRepoAndName`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)