### PR TITLE
fix(ci): prevent Dependabot PRs for agor-live meta-package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  # Root workspace (devDependencies only)
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
   # Apps
   - package-ecosystem: 'npm'
     directory: '/apps/agor-cli'
@@ -21,7 +27,7 @@ updates:
     schedule:
       interval: 'weekly'
 
-  # Packages (excluding agor-live meta-package)
+  # Packages
   - package-ecosystem: 'npm'
     directory: '/packages/core'
     schedule:
@@ -32,5 +38,12 @@ updates:
     schedule:
       interval: 'weekly'
 
-  # Note: packages/agor-live is intentionally excluded as it's a meta-package
-  # whose dependencies are derived from other packages in the monorepo
+  # packages/agor-live is a meta-package whose dependencies are synced from
+  # other monorepo packages (see scripts/sync-agor-live-deps.mjs). Explicitly
+  # listed here with a wildcard ignore to prevent Dependabot from opening PRs.
+  - package-ecosystem: 'npm'
+    directory: '/packages/agor-live'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '*'


### PR DESCRIPTION
## Summary

- Add explicit Dependabot entry for `packages/agor-live` with `ignore: dependency-name: '*'` to prevent auto-discovery and unwanted PRs. This meta-package has its deps synced from other monorepo packages via `scripts/sync-agor-live-deps.mjs`.
- Add root workspace `/` entry so Dependabot tracks root devDependencies (biome, husky, turbo, typescript, etc.).
- Replaces the comment-only "exclusion" that wasn't actually preventing Dependabot from creating PRs.

Closes the issue that led to PRs #687 and #688 (both already closed).

## Test plan

- [ ] Verify Dependabot no longer opens PRs for `packages/agor-live`
- [ ] Confirm Dependabot still creates PRs for all other listed directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)