### PR TITLE
fix(ui): truncate long URLs in issue/PR pills and use conditional icons

### DIFF
--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -919,7 +919,7 @@ export const RepoPill: React.FC<RepoPillProps> = ({
  * Extract a concise display label from a URL.
  * GitHub: org/repo#123, Shortcut: story/12345, Jira/Linear: ticket ID, etc.
  */
-function getUrlDisplayLabel(url: string): string {
+export function getUrlDisplayLabel(url: string): string {
   try {
     const parsed = new URL(url);
     const pathParts = parsed.pathname.split('/').filter(Boolean);
@@ -952,7 +952,7 @@ function getUrlDisplayLabel(url: string): string {
   }
 }
 
-function isGitHubUrl(url: string): boolean {
+export function isGitHubUrl(url: string): boolean {
   try {
     const { hostname } = new URL(url);
     return hostname === 'github.com' || hostname.endsWith('.github.com');

--- a/apps/agor-ui/src/components/Pill/url-helpers.test.ts
+++ b/apps/agor-ui/src/components/Pill/url-helpers.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { getUrlDisplayLabel, isGitHubUrl } from './Pill';
+
+describe('getUrlDisplayLabel', () => {
+  describe('GitHub URLs', () => {
+    it('extracts org/repo#number for issues', () => {
+      expect(getUrlDisplayLabel('https://github.com/preset-io/agor/issues/714')).toBe(
+        'preset-io/agor#714'
+      );
+    });
+
+    it('extracts org/repo#number for pull requests', () => {
+      expect(getUrlDisplayLabel('https://github.com/preset-io/agor/pull/42')).toBe(
+        'preset-io/agor#42'
+      );
+    });
+
+    it('falls back to last segment for short GitHub URLs', () => {
+      expect(getUrlDisplayLabel('https://github.com/preset-io/agor')).toBe('agor');
+    });
+  });
+
+  describe('Shortcut URLs', () => {
+    it('extracts type/id from standard story URLs', () => {
+      expect(
+        getUrlDisplayLabel(
+          'https://app.shortcut.com/preset/story/12345/some-very-long-story-title-that-goes-on-forever'
+        )
+      ).toBe('story/12345');
+    });
+
+    it('extracts type/id from epic URLs', () => {
+      expect(getUrlDisplayLabel('https://app.shortcut.com/myorg/epic/99/epic-title')).toBe(
+        'epic/99'
+      );
+    });
+  });
+
+  describe('Linear URLs', () => {
+    it('extracts issue ID (not the slug) from issue URLs', () => {
+      expect(
+        getUrlDisplayLabel('https://linear.app/myteam/issue/TEAM-123/some-long-issue-title')
+      ).toBe('TEAM-123');
+    });
+
+    it('extracts issue ID without slug', () => {
+      expect(getUrlDisplayLabel('https://linear.app/myteam/issue/ENG-456')).toBe('ENG-456');
+    });
+
+    it('falls back to last segment for non-issue Linear URLs', () => {
+      expect(getUrlDisplayLabel('https://linear.app/myteam/project/abc')).toBe('abc');
+    });
+  });
+
+  describe('Jira / Atlassian URLs', () => {
+    it('extracts ticket ID from browse URLs', () => {
+      expect(getUrlDisplayLabel('https://myorg.atlassian.net/browse/PROJ-123')).toBe('PROJ-123');
+    });
+
+    it('handles Jira server URLs', () => {
+      expect(getUrlDisplayLabel('https://jira.mycompany.com/browse/TICKET-99')).toBe('TICKET-99');
+    });
+  });
+
+  describe('unknown / generic URLs', () => {
+    it('returns last path segment for unknown services', () => {
+      expect(getUrlDisplayLabel('https://example.com/project/tasks/42')).toBe('42');
+    });
+
+    it('returns hostname when path is empty', () => {
+      expect(getUrlDisplayLabel('https://example.com')).toBe('example.com');
+    });
+
+    it('returns hostname when path is just a slash', () => {
+      expect(getUrlDisplayLabel('https://example.com/')).toBe('example.com');
+    });
+  });
+
+  describe('malformed / edge-case URLs', () => {
+    it('falls back to last segment of non-URL string', () => {
+      expect(getUrlDisplayLabel('not-a-url/but/has/segments')).toBe('segments');
+    });
+
+    it('returns ? for empty string', () => {
+      expect(getUrlDisplayLabel('')).toBe('?');
+    });
+  });
+});
+
+describe('isGitHubUrl', () => {
+  it('returns true for github.com', () => {
+    expect(isGitHubUrl('https://github.com/org/repo')).toBe(true);
+  });
+
+  it('returns true for GitHub Enterprise subdomains', () => {
+    expect(isGitHubUrl('https://code.github.com/org/repo')).toBe(true);
+  });
+
+  it('returns false for github.com lookalikes', () => {
+    expect(isGitHubUrl('https://github.com.evil.com/phish')).toBe(false);
+  });
+
+  it('returns false for non-GitHub URLs', () => {
+    expect(isGitHubUrl('https://linear.app/team/issue/X-1')).toBe(false);
+  });
+
+  it('returns false for malformed URLs', () => {
+    expect(isGitHubUrl('not-a-url')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isGitHubUrl('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add text-overflow ellipsis with max-width (160px text, 220px tag) to prevent layout overflow from long URLs (e.g. Shortcut story URLs with long slugs)
- Show GitHub icon only for `github.com` URLs; use generic `LinkOutlined` for issues and `BranchesOutlined` for PRs on other services (Shortcut, Jira, Linear, etc.)
- Extract smart display labels per service: GitHub (`org/repo#123`), Shortcut (`story/12345`), Jira/Linear (ticket ID), generic (last path segment)
- Add tooltip showing full URL on hover for discoverability

## Test plan
- [ ] Verify GitHub issue/PR URLs still show GitHub icon and `org/repo#123` format
- [ ] Verify Shortcut URLs show generic icon and `story/12345` format
- [ ] Verify long URLs truncate with ellipsis instead of overflowing the card
- [ ] Verify full URL appears in tooltip on hover
- [ ] Verify clicking the pill still opens the URL in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)