### PR TITLE
fix: proper TypeScript declarations for @agor/core subpath exports

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     index: 'src/index.ts',
     'types/index': 'src/types/index.ts',
     'db/index': 'src/db/index.ts',
+    'db/session-guard': 'src/db/session-guard.ts', // Defensive programming for deleted sessions
     'git/index': 'src/git/index.ts',
     'api/index': 'src/api/index.ts',
     'claude/index': 'src/claude/index.ts',

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

- Add missing `db/session-guard` tsup entry point so the declared `package.json` export actually produces JS and `.d.ts` files (was declared in exports but never built)
- Add `typecheck` script to `@agor/executor` so it's included in the turbo `pnpm typecheck` pipeline (was previously excluded, meaning type errors in executor were not caught by CI)

## Details

**Audit results** (all 32 subpath exports verified):
- `package.json` exports: All have proper `types` conditions before `import`/`require`
- `tsup.config.ts` entries: Now match 1:1 with `package.json` exports (previously `db/session-guard` was missing)
- `.d.ts` generation: Confirmed all 32 exports produce matching `.d.ts` files after build
- `moduleResolution`: All consuming packages use `"bundler"` (correct for `exports` field support)
- `tsconfig.json`: Core has `declaration: true` and `declarationMap: true`

**Fixed subpath export:**
- `@agor/core/db/session-guard` — was declared in `package.json` exports but had no tsup entry, so no JS/DTS files were built for it

**Pipeline improvement:**
- `@agor/executor` now runs `tsc --noEmit` as part of `pnpm typecheck` (6 packages typechecked instead of 5)

## Test plan

- [x] `pnpm check` passes (typecheck + lint + build)
- [x] All 32 `@agor/core` subpath exports have matching `.d.ts` files in `dist/`
- [x] `@agor/executor` typecheck passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)