### PR TITLE
fix(ui): resolve React and Ant Design console warnings

### DIFF
--- a/apps/agor-ui/src/components/AgentSelectionCard/AgentSelectionCard.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionCard/AgentSelectionCard.tsx
@@ -27,7 +27,7 @@ export const AgentSelectionCard: React.FC<AgentSelectionCardProps> = ({
         body: { padding: 12 },
       }}
     >
-      <Space direction="vertical" style={{ width: '100%' }} size={4}>
+      <Space orientation="vertical" style={{ width: '100%' }} size={4}>
         <Space style={{ width: '100%', justifyContent: 'space-between' }} size={8}>
           <Space size={8}>
             <ToolIcon tool={agent.id} size={24} />

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -645,6 +645,8 @@ export const App: React.FC<AppProps> = ({
               }}
             >
               <Panel
+                id="comments-panel"
+                order={1}
                 ref={commentsPanelRef}
                 collapsible
                 defaultSize={commentsPanelCollapsed ? 0 : commentsPanelSize}
@@ -697,6 +699,8 @@ export const App: React.FC<AppProps> = ({
                 }}
               />
               <Panel
+                id="content-panel"
+                order={2}
                 defaultSize={commentsPanelCollapsed ? 100 : 100 - commentsPanelSize}
                 minSize={40}
               >
@@ -712,6 +716,8 @@ export const App: React.FC<AppProps> = ({
                   }}
                 >
                   <Panel
+                    id="canvas-panel"
+                    order={1}
                     defaultSize={selectedSessionId ? 100 - sessionPanelSize : 100}
                     minSize={20}
                   >
@@ -793,7 +799,13 @@ export const App: React.FC<AppProps> = ({
                             'var(--ant-color-border-secondary)';
                         }}
                       />
-                      <Panel defaultSize={sessionPanelSize} minSize={25} maxSize={75}>
+                      <Panel
+                        id="session-panel"
+                        order={2}
+                        defaultSize={sessionPanelSize}
+                        minSize={25}
+                        maxSize={75}
+                      >
                         {selectedSessionId ? (
                           <SessionPanel
                             client={client}

--- a/apps/agor-ui/src/components/ArchiveDeleteWorktreeModal/ArchiveDeleteWorktreeModal.tsx
+++ b/apps/agor-ui/src/components/ArchiveDeleteWorktreeModal/ArchiveDeleteWorktreeModal.tsx
@@ -48,7 +48,7 @@ export const ArchiveDeleteWorktreeModal: React.FC<ArchiveDeleteWorktreeModalProp
       cancelText="Cancel"
       width={600}
     >
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         {/* Worktree Info */}
         <div>
           <Text strong>Worktree: </Text>
@@ -77,7 +77,7 @@ export const ArchiveDeleteWorktreeModal: React.FC<ArchiveDeleteWorktreeModalProp
             value={filesystemAction}
             onChange={(e) => setFilesystemAction(e.target.value)}
           >
-            <Space direction="vertical">
+            <Space orientation="vertical">
               <Radio value="preserved">
                 <div>
                   <div>Leave untouched</div>
@@ -112,7 +112,7 @@ export const ArchiveDeleteWorktreeModal: React.FC<ArchiveDeleteWorktreeModalProp
             Metadata & Sessions
           </Text>
           <Radio.Group value={metadataAction} onChange={(e) => setMetadataAction(e.target.value)}>
-            <Space direction="vertical">
+            <Space orientation="vertical">
               <Radio value="archive">
                 <div>
                   <div>Archive (recommended)</div>
@@ -138,7 +138,7 @@ export const ArchiveDeleteWorktreeModal: React.FC<ArchiveDeleteWorktreeModalProp
           <Alert
             message="Warning"
             description={
-              <Space direction="vertical" size="small" style={{ width: '100%' }}>
+              <Space orientation="vertical" size="small" style={{ width: '100%' }}>
                 <Text>
                   • All {sessionCount} session(s), messages, and history will be permanently deleted
                 </Text>

--- a/apps/agor-ui/src/components/CodexNetworkAccessToggle/CodexNetworkAccessToggle.tsx
+++ b/apps/agor-ui/src/components/CodexNetworkAccessToggle/CodexNetworkAccessToggle.tsx
@@ -25,7 +25,7 @@ export const CodexNetworkAccessToggle: React.FC<CodexNetworkAccessToggleProps> =
   const isEnabled = typeof checked === 'boolean' ? checked : !!value;
 
   return (
-    <Space direction="vertical" style={{ width: '100%' }}>
+    <Space orientation="vertical" style={{ width: '100%' }}>
       <Space>
         <Switch
           checked={isEnabled}

--- a/apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
+++ b/apps/agor-ui/src/components/CompactionBlock/CompactionBlock.tsx
@@ -77,7 +77,7 @@ export const CompactionBlock: React.FC<CompactionBlockProps> = ({ messages, agen
             placement="start"
             avatar={avatar}
             content={
-              <Space direction="vertical" size="small" style={{ width: '100%' }}>
+              <Space orientation="vertical" size="small" style={{ width: '100%' }}>
                 <Space>
                   <CheckCircleFilled style={{ color: token.colorSuccess, fontSize: 14 }} />
                   <Text type="secondary">Context compacted successfully</Text>

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -155,7 +155,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   }));
 
   return (
-    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+    <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
       <Text type="secondary">
         Environment variables are encrypted at rest and available to all agent operations
         (subprocesses, terminal sessions, environment commands). Common variables: GITHUB_TOKEN,
@@ -181,7 +181,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
       />
 
       {/* Add New Variable Form */}
-      <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="small" style={{ width: '100%' }}>
         <Text strong>Add New Variable</Text>
         <Space.Compact style={{ width: '100%' }}>
           <Input

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -151,7 +151,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
         </Button>,
       ]}
     >
-      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
         {/* Timestamp and truncation warning */}
         {logs && !logs.error && (
           <div>

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -175,7 +175,7 @@ export function EnvironmentPill({
       <Space
         size={0}
         style={{ width: '100%', display: 'inline-flex', alignItems: 'center' }}
-        direction="horizontal"
+        orientation="horizontal"
       >
         {/* Left section - clickable to open URL (when running) */}
         {env?.status === 'running' && environmentUrl ? (

--- a/apps/agor-ui/src/components/EventStreamPanel/EventStreamPanel.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventStreamPanel.tsx
@@ -315,7 +315,7 @@ export const EventStreamPanel: React.FC<EventStreamPanelProps> = ({
           </Checkbox>
         </Space>
 
-        <Space direction="horizontal" size="small" style={{ width: '100%', marginTop: 12 }} wrap>
+        <Space orientation="horizontal" size="small" style={{ width: '100%', marginTop: 12 }} wrap>
           <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 200 }}>
             <Text type="secondary" style={{ marginBottom: 4, fontSize: 11 }}>
               Event Types:

--- a/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
+++ b/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
@@ -2,7 +2,7 @@ import { PaperClipOutlined, UploadOutlined } from '@ant-design/icons';
 import { App, Button, Checkbox, Input, Modal, Radio, Space, Typography, Upload } from 'antd';
 import type { RcFile, UploadFile } from 'antd/es/upload/interface';
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { ACCESS_TOKEN_KEY } from '../../utils/tokenRefresh';
 
 const { TextArea } = Input;
@@ -163,7 +163,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
       cancelText="Cancel"
       width={600}
     >
-      <Space direction="vertical" style={{ width: '100%' }} size="large">
+      <Space orientation="vertical" style={{ width: '100%' }} size="large">
         {/* File selector */}
         <Upload
           multiple
@@ -194,9 +194,9 @@ export const FileUpload: React.FC<FileUploadProps> = ({
             onChange={(e) => setDestination(e.target.value)}
             style={{ marginTop: 8, display: 'block' }}
           >
-            <Space direction="vertical">
+            <Space orientation="vertical">
               <Radio value="worktree">
-                <Space direction="vertical" size={0}>
+                <Space orientation="vertical" size={0}>
                   <Text>Worktree (.agor/uploads/)</Text>
                   <Text type="secondary" style={{ fontSize: '12px' }}>
                     Default - Agent-accessible, can be committed
@@ -204,7 +204,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
                 </Space>
               </Radio>
               <Radio value="temp">
-                <Space direction="vertical" size={0}>
+                <Space orientation="vertical" size={0}>
                   <Text>Temp folder</Text>
                   <Text type="secondary" style={{ fontSize: '12px' }}>
                     Ephemeral, auto-cleanup
@@ -212,7 +212,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
                 </Space>
               </Radio>
               <Radio value="global">
-                <Space direction="vertical" size={0}>
+                <Space orientation="vertical" size={0}>
                   <Text>Global (~/.agor/uploads/)</Text>
                   <Text type="secondary" style={{ fontSize: '12px' }}>
                     Shared across sessions
@@ -257,19 +257,18 @@ export interface FileUploadButtonProps {
   size?: 'small' | 'middle' | 'large';
 }
 
-export const FileUploadButton: React.FC<FileUploadButtonProps> = ({
-  onClick,
-  disabled,
-  size = 'middle',
-}) => {
-  return (
-    <Button
-      icon={<PaperClipOutlined />}
-      onClick={onClick}
-      disabled={disabled}
-      size={size}
-      type="text"
-      title="Upload files"
-    />
-  );
-};
+export const FileUploadButton = forwardRef<HTMLButtonElement, FileUploadButtonProps>(
+  ({ onClick, disabled, size = 'middle' }, ref) => {
+    return (
+      <Button
+        ref={ref}
+        icon={<PaperClipOutlined />}
+        onClick={onClick}
+        disabled={disabled}
+        size={size}
+        type="text"
+        title="Upload files"
+      />
+    );
+  }
+);

--- a/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.tsx
+++ b/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.tsx
@@ -67,7 +67,7 @@ export function ForcePasswordChangeModal({
       onCancel={onLogout}
       confirmLoading={loading}
       closable={false}
-      maskClosable={false}
+      mask={{ closable: false }}
       keyboard={false}
       width={400}
     >

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -86,7 +86,7 @@ export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
         variant="borderless"
       >
         {/* Header */}
-        <Space direction="vertical" size="large" style={{ width: '100%', marginBottom: 24 }}>
+        <Space orientation="vertical" size="large" style={{ width: '100%', marginBottom: 24 }}>
           <div style={{ textAlign: 'center' }}>
             <img
               src={`${import.meta.env.BASE_URL}favicon.png`}
@@ -117,7 +117,7 @@ export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
             type="error"
             message="Login Failed"
             description={
-              <Space direction="vertical" size="small" style={{ width: '100%' }}>
+              <Space orientation="vertical" size="small" style={{ width: '100%' }}>
                 <div>{error}</div>
                 <div
                   style={{
@@ -176,7 +176,7 @@ export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
 
         {/* Footer */}
         <div style={{ textAlign: 'center', marginTop: 24 }}>
-          <Space direction="vertical" size={4}>
+          <Space orientation="vertical" size={4}>
             <Text type="secondary" style={{ fontSize: 12 }}>
               New user? <code>agor user create-admin</code>
             </Text>

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -130,9 +130,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   };
 
   return (
-    <Space direction="vertical" style={{ width: '100%' }}>
+    <Space orientation="vertical" style={{ width: '100%' }}>
       <Radio.Group value={mode} onChange={(e) => handleModeChange(e.target.value)}>
-        <Space direction="vertical">
+        <Space orientation="vertical">
           <Radio value="alias">
             <Space>
               Use model alias (recommended)

--- a/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/OpenCodeModelSelector.tsx
@@ -150,7 +150,7 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
   }
 
   return (
-    <Space direction="vertical" style={{ width: '100%' }}>
+    <Space orientation="vertical" style={{ width: '100%' }}>
       {/* Provider Dropdown */}
       <div>
         <Text strong style={{ display: 'block', marginBottom: 8 }}>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -697,7 +697,7 @@ export function OnboardingWizard({
       </Paragraph>
 
       <Space
-        direction="vertical"
+        orientation="vertical"
         size="middle"
         style={{ width: '100%', maxWidth: 400, margin: '0 auto' }}
       >
@@ -1233,7 +1233,7 @@ export function OnboardingWizard({
     <Modal
       open={open}
       closable={false}
-      maskClosable={false}
+      mask={{ closable: false }}
       keyboard={false}
       footer={footer}
       width={640}

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -290,7 +290,7 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
   // Full mode: render as Radio group with descriptions
   return (
     <Radio.Group value={effectiveValue} onChange={(e) => onChange?.(e.target.value)}>
-      <Space direction="vertical" style={{ width: '100%' }}>
+      <Space orientation="vertical" style={{ width: '100%' }}>
         {modes.map(({ mode, label, description, icon, color }) => (
           <Radio key={mode} value={mode}>
             <Space>

--- a/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
+++ b/apps/agor-ui/src/components/PermissionRequestBlock/PermissionRequestBlock.tsx
@@ -117,7 +117,7 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
         },
       }}
     >
-      <Space direction="vertical" size={token.sizeUnit * 1.5} style={{ width: '100%' }}>
+      <Space orientation="vertical" size={token.sizeUnit * 1.5} style={{ width: '100%' }}>
         {/* Header */}
         <Space size={token.sizeUnit}>
           {getIcon()}
@@ -191,14 +191,14 @@ export const PermissionRequestBlock: React.FC<PermissionRequestBlockProps> = ({
 
         {/* Action Buttons - show only when active */}
         {isActive && onApprove && onDeny && (
-          <Space direction="vertical" size={token.sizeUnit} style={{ width: '100%' }}>
+          <Space orientation="vertical" size={token.sizeUnit} style={{ width: '100%' }}>
             {/* Radio group for remember choice */}
             <Radio.Group
               value={remember}
               onChange={(e) => setRemember(e.target.value)}
               style={{ width: '100%' }}
             >
-              <Space direction="vertical" size={token.sizeUnit / 2} style={{ width: '100%' }}>
+              <Space orientation="vertical" size={token.sizeUnit / 2} style={{ width: '100%' }}>
                 <Radio value={false}>Allow once</Radio>
                 <Space size={token.sizeUnit / 2} style={{ width: '100%', alignItems: 'center' }}>
                   <Radio value={true}>Remember for this</Radio>

--- a/apps/agor-ui/src/components/Pill/Pill.stories.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.stories.tsx
@@ -31,7 +31,7 @@ type Story = StoryObj;
 
 export const AllPills: Story = {
   render: () => (
-    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+    <Space orientation="vertical" size="large" style={{ width: '100%' }}>
       <div>
         <h3>Metadata Pills</h3>
         <Space wrap>
@@ -178,7 +178,7 @@ export const Timer: Story = {
 
 export const Genealogy: Story = {
   render: () => (
-    <Space direction="vertical">
+    <Space orientation="vertical">
       <Space>
         <ForkPill fromSessionId="0199b850-d329-7893-bc1c-197cbf4f4a7f" />
         <ForkPill
@@ -211,7 +211,7 @@ export const Features: Story = {
 
 export const EventStream: Story = {
   render: () => (
-    <Space direction="vertical" size="large">
+    <Space orientation="vertical" size="large">
       <div>
         <h3>EventStreamPill - Basic (no popover)</h3>
         <Space wrap>
@@ -320,7 +320,7 @@ export const EventStream: Story = {
 
 export const SessionMetadata: Story = {
   render: () => (
-    <Space direction="vertical" size="large">
+    <Space orientation="vertical" size="large">
       <div>
         <h3>Running Session (Forked)</h3>
         <SessionMetadataCard

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2006,103 +2006,120 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             >
               {/* Zoom controls */}
               <Tooltip title="Zoom In" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    reactFlowInstanceRef.current?.zoomIn();
-                  }}
-                >
-                  <PlusOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reactFlowInstanceRef.current?.zoomIn();
+                    }}
+                  >
+                    <PlusOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               <Tooltip title="Zoom Out" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    reactFlowInstanceRef.current?.zoomOut();
-                  }}
-                >
-                  <MinusOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reactFlowInstanceRef.current?.zoomOut();
+                    }}
+                  >
+                    <MinusOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               <Tooltip title="Fit View" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    reactFlowInstanceRef.current?.fitView();
-                  }}
-                >
-                  <ZoomInOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reactFlowInstanceRef.current?.fitView();
+                    }}
+                  >
+                    <ZoomInOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               {/* Custom toolbox buttons */}
               <Tooltip title="Select" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setActiveTool('select');
-                  }}
-                  style={{
-                    borderLeft: activeTool === 'select' ? '3px solid #1677ff' : 'none',
-                  }}
-                >
-                  <SelectOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setActiveTool('select');
+                    }}
+                    style={{
+                      borderLeft: activeTool === 'select' ? '3px solid #1677ff' : 'none',
+                    }}
+                  >
+                    <SelectOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               <Tooltip title="Add Zone" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setActiveTool('zone');
-                  }}
-                  style={{
-                    borderLeft: activeTool === 'zone' ? '3px solid #1677ff' : 'none',
-                  }}
-                >
-                  <BorderOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setActiveTool('zone');
+                    }}
+                    style={{
+                      borderLeft: activeTool === 'zone' ? '3px solid #1677ff' : 'none',
+                    }}
+                  >
+                    <BorderOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               <Tooltip title="Add Comment" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setActiveTool('comment');
-                  }}
-                  style={{
-                    borderLeft: activeTool === 'comment' ? '3px solid #1677ff' : 'none',
-                  }}
-                >
-                  <CommentOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setActiveTool('comment');
+                    }}
+                    style={{
+                      borderLeft: activeTool === 'comment' ? '3px solid #1677ff' : 'none',
+                    }}
+                  >
+                    <CommentOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               <Tooltip title="Add Markdown Note" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setActiveTool('markdown');
-                  }}
-                  style={{
-                    borderLeft: activeTool === 'markdown' ? '3px solid #1677ff' : 'none',
-                  }}
-                >
-                  <FileMarkdownOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setActiveTool('markdown');
+                    }}
+                    style={{
+                      borderLeft: activeTool === 'markdown' ? '3px solid #1677ff' : 'none',
+                    }}
+                  >
+                    <FileMarkdownOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
               <Tooltip title="Eraser - Click to toggle" placement="right" mouseEnterDelay={0.3}>
-                <ControlButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
-                  }}
-                  style={{
-                    borderLeft: activeTool === 'eraser' ? `3px solid ${token.colorError}` : 'none',
-                    color: activeTool === 'eraser' ? token.colorError : 'inherit',
-                    backgroundColor:
-                      activeTool === 'eraser' ? `${token.colorError}15` : 'transparent',
-                  }}
-                >
-                  <DeleteOutlined style={{ fontSize: '16px' }} />
-                </ControlButton>
+                <span>
+                  <ControlButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
+                    }}
+                    style={{
+                      borderLeft:
+                        activeTool === 'eraser' ? `3px solid ${token.colorError}` : 'none',
+                      color: activeTool === 'eraser' ? token.colorError : 'inherit',
+                      backgroundColor:
+                        activeTool === 'eraser' ? `${token.colorError}15` : 'transparent',
+                    }}
+                  >
+                    <DeleteOutlined style={{ fontSize: '16px' }} />
+                  </ControlButton>
+                </span>
               </Tooltip>
             </Controls>
             <MiniMap

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -296,7 +296,7 @@ export const ZoneTriggerModal = ({
       cancelText="Cancel"
       width={700}
     >
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         {/* Primary Choice: Create New or Reuse */}
         <div>
           <Radio.Group
@@ -304,7 +304,7 @@ export const ZoneTriggerModal = ({
             onChange={(e) => setMode(e.target.value)}
             style={{ width: '100%' }}
           >
-            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
               <Radio value="create_new">Create a new session</Radio>
               <Radio value="reuse_existing" disabled={worktreeSessions.length === 0}>
                 Reuse a session
@@ -357,7 +357,7 @@ export const ZoneTriggerModal = ({
                 onChange={(e) => setSelectedAction(e.target.value)}
                 style={{ width: '100%' }}
               >
-                <Space direction="vertical" style={{ width: '100%' }}>
+                <Space orientation="vertical" style={{ width: '100%' }}>
                   <Radio value="prompt">Prompt - Send message to selected session</Radio>
                   <Radio value="fork">Fork - Fork selected session and send message</Radio>
                   <Radio value="spawn">Spawn - Spawn child session and send message</Radio>
@@ -409,7 +409,7 @@ export const ZoneTriggerModal = ({
                   </Typography.Text>
                 ),
                 children: (
-                  <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+                  <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
                     {mode === 'reuse_existing' && (
                       <Alert
                         message="Showing current configuration. These settings are for reference."

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -560,7 +560,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         />
       )}
       <Space
-        direction="vertical"
+        orientation="vertical"
         style={{ width: '100%', position: 'relative', zIndex: 1 }}
         size={8}
       >

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -197,7 +197,7 @@ export const SessionPanelContent: React.FC<SessionPanelContentProps> = ({
           >
             Queued Messages ({queuedMessages.length})
           </Typography.Text>
-          <Space direction="vertical" size={8} style={{ width: '100%' }}>
+          <Space orientation="vertical" size={8} style={{ width: '100%' }}>
             {queuedMessages.map((msg, idx) => (
               <div
                 key={msg.message_id}

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -89,7 +89,7 @@ export const AboutTab: React.FC<AboutTabProps> = ({
 
       {/* Content */}
       <div style={{ position: 'relative', zIndex: 1 }}>
-        <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Space orientation="vertical" size="large" style={{ width: '100%' }}>
           {/* Connection Info */}
           <Card
             title="Connection Info"

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -347,7 +347,7 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
   return (
     <div>
       <Space
-        direction="vertical"
+        orientation="vertical"
         size={token.sizeUnit * 2}
         style={{ marginBottom: token.sizeUnit * 2, width: '100%' }}
       >

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -467,7 +467,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
           </Form.Item>
 
           <Form.Item label="Background">
-            <Space direction="vertical" style={{ width: '100%' }}>
+            <Space orientation="vertical" style={{ width: '100%' }}>
               <Checkbox
                 checked={useCustomCSSCreate}
                 onChange={(e) => {
@@ -566,7 +566,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
           </Form.Item>
 
           <Form.Item label="Background">
-            <Space direction="vertical" style={{ width: '100%' }}>
+            <Space orientation="vertical" style={{ width: '100%' }}>
               <Checkbox
                 checked={useCustomCSSEdit}
                 onChange={(e) => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -501,7 +501,7 @@ const ChannelFormFields: React.FC<{
                 />
               ),
               children: (
-                <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+                <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
                   <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                     Configure which agent and settings to use for sessions created from this
                     channel.
@@ -1001,7 +1001,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             <Alert
               message="Channel Key"
               description={
-                <Space direction="vertical" style={{ width: '100%' }}>
+                <Space orientation="vertical" style={{ width: '100%' }}>
                   <Input.Search
                     value={createdChannelKey}
                     readOnly

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -726,7 +726,7 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           {/* Test Connection - only for HTTP/SSE transport */}
           {transport !== 'stdio' && (
             <div style={{ borderTop: '1px solid #303030', marginTop: 16, paddingTop: 16 }}>
-              <Space direction="vertical" style={{ width: '100%' }}>
+              <Space orientation="vertical" style={{ width: '100%' }}>
                 <Button
                   type="default"
                   icon={<ApiOutlined />}
@@ -882,7 +882,7 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           </Button>,
         ]}
       >
-        <Space direction="vertical" style={{ width: '100%' }}>
+        <Space orientation="vertical" style={{ width: '100%' }}>
           <Typography.Paragraph>
             After signing in to the OAuth provider, you will be redirected to a page that may show
             an error (like "This site can't be reached"). This is expected.

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -241,7 +241,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
       )}
 
       {repos.length > 0 && (
-        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        <Space orientation="vertical" size={16} style={{ width: '100%' }}>
           {repos.map((repo: Repo) => {
             const isLocal = repo.repo_type === 'local';
             const tagColor = isLocal ? 'green' : 'blue';
@@ -279,7 +279,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                 }
               >
                 {/* Repo metadata */}
-                <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                <Space orientation="vertical" size={8} style={{ width: '100%' }}>
                   <div>
                     <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                       Slug:{' '}
@@ -421,7 +421,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
         footer={null}
       >
         {repoToDelete && (
-          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <Space orientation="vertical" size={16} style={{ width: '100%' }}>
             <Typography.Text>
               How would you like to delete{' '}
               <Typography.Text strong>"{repoToDelete.name}"</Typography.Text>?
@@ -430,7 +430,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
             {repoToDelete.repo_type === 'local' ? (
               // For local repos, only show database removal option
               <Card style={{ marginBottom: 8 }} styles={{ body: { padding: 16 } }}>
-                <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                <Space orientation="vertical" size={8} style={{ width: '100%' }}>
                   <Typography.Text strong>Remove from Agor</Typography.Text>
                   <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                     Remove this repository from Agor's database only. Your local files at{' '}
@@ -450,7 +450,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
               // For remote repos, show both options
               <>
                 <Card style={{ marginBottom: 8 }} styles={{ body: { padding: 16 } }}>
-                  <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                  <Space orientation="vertical" size={8} style={{ width: '100%' }}>
                     <Typography.Text strong>Remove from Agor (Keep Files)</Typography.Text>
                     <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                       Remove from database only. Repository and worktree directories in{' '}
@@ -465,7 +465,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                 </Card>
 
                 <Card styles={{ body: { padding: 16 } }}>
-                  <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                  <Space orientation="vertical" size={8} style={{ width: '100%' }}>
                     <Typography.Text strong>Delete Completely (Remove Files)</Typography.Text>
                     <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                       ⚠️ Remove from database AND delete all filesystem directories (repository +

--- a/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
@@ -375,7 +375,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
   return (
     <div>
       <Space
-        direction="vertical"
+        orientation="vertical"
         size={token.sizeUnit * 2}
         style={{ marginBottom: token.sizeUnit * 2, width: '100%' }}
       >

--- a/apps/agor-ui/src/components/StreamdownDemo/StreamdownDemo.tsx
+++ b/apps/agor-ui/src/components/StreamdownDemo/StreamdownDemo.tsx
@@ -195,7 +195,7 @@ Check out the [Streamdown documentation](https://streamdown.ai) for more details
 export const StreamdownDemo: React.FC = () => {
   return (
     <div style={{ padding: '24px', maxWidth: '1200px', margin: '0 auto' }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         <Title level={2}>Streamdown Feature Showcase</Title>
 
         <Card>

--- a/apps/agor-ui/src/components/TaskBlock/TaskNestedBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskNestedBlock.tsx
@@ -89,7 +89,7 @@ export const TaskNestedBlock: React.FC<TaskNestedBlockProps> = ({
 
   const header = (
     <div style={{ width: '100%' }}>
-      <Space direction="vertical" size={token.sizeXS} style={{ width: '100%' }}>
+      <Space orientation="vertical" size={token.sizeXS} style={{ width: '100%' }}>
         {/* Header line */}
         <Space size="small" style={{ width: '100%', justifyContent: 'space-between' }}>
           <Space size="small">

--- a/apps/agor-ui/src/components/ToolExecutingIndicator/ToolExecutingIndicator.tsx
+++ b/apps/agor-ui/src/components/ToolExecutingIndicator/ToolExecutingIndicator.tsx
@@ -29,7 +29,7 @@ const ToolExecutingIndicator = ({ toolsExecuting }: ToolExecutingIndicatorProps)
   }
 
   return (
-    <Space direction="vertical" size={4} style={{ width: '100%' }}>
+    <Space orientation="vertical" size={4} style={{ width: '100%' }}>
       {toolsExecuting.map((tool) => (
         <Tag
           key={tool.toolUseId}

--- a/apps/agor-ui/src/components/WorktreeFormFields/WorktreeFormFields.tsx
+++ b/apps/agor-ui/src/components/WorktreeFormFields/WorktreeFormFields.tsx
@@ -180,7 +180,7 @@ export const WorktreeFormFields: React.FC<WorktreeFormFieldsProps> = ({
       )}
 
       {showUrlFields && (
-        <Space direction="vertical" style={{ width: '100%' }}>
+        <Space orientation="vertical" style={{ width: '100%' }}>
           <Form.Item
             name={`${fieldPrefix}issue_url`}
             label="Issue URL (optional)"

--- a/apps/agor-ui/src/components/WorktreeModal/WorktreeModal.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/WorktreeModal.tsx
@@ -170,7 +170,7 @@ export const WorktreeModal: React.FC<WorktreeModalProps> = ({
       onCancel={onClose}
       footer={null}
       width={900}
-      maskClosable={false}
+      mask={{ closable: false }}
       styles={{
         body: { padding: 0, maxHeight: '80vh', overflowY: 'auto' },
       }}

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/AssistantTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/AssistantTab.tsx
@@ -50,7 +50,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({ worktree, onUpdate, 
 
   return (
     <div style={{ width: '100%', maxHeight: '70vh', overflowY: 'auto' }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         <Space>
           <RobotOutlined style={{ fontSize: 20 }} />
           <Typography.Text strong style={{ fontSize: 16 }}>

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -575,7 +575,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
 
   return (
     <div style={{ width: '100%', maxHeight: '70vh', overflowY: 'auto' }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         <Alert
           message={
             <span>
@@ -596,7 +596,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
         {/* ========== ENVIRONMENT CONTROLS (Top) ========== */}
         {hasEnvironmentConfig && (
           <Card size="small">
-            <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
               {/* Status and Control Buttons - Single Row */}
               <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                 {/* Spinner (only when running) */}
@@ -743,7 +743,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
             </Space>
           }
         >
-          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
             {isEditingTemplate ? (
               <>
                 {/* Up Command */}
@@ -882,7 +882,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                 </div>
               </>
             ) : (
-              <Space direction="vertical" size={4} style={{ width: '100%' }}>
+              <Space orientation="vertical" size={4} style={{ width: '100%' }}>
                 <TemplateField label="Up Command" value={upCommand} />
                 <TemplateField label="Down Command" value={downCommand} />
                 <TemplateField label="Nuke Command" value={nukeCommand} />
@@ -956,7 +956,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
           }
           size="small"
         >
-          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
             {/* Built-in Variables (Read-only) */}
             <div>
               <Typography.Text strong style={{ fontSize: 13, display: 'block', marginBottom: 8 }}>
@@ -1105,7 +1105,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
               </Typography.Text>
               {isEditingUrls ? (
                 <>
-                  <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                  <Space orientation="vertical" size={8} style={{ width: '100%' }}>
                     <div>
                       <Typography.Text
                         strong

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/FilesTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/FilesTab.tsx
@@ -153,7 +153,7 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ worktree, client }) => {
 
   return (
     <div style={{ width: '100%', maxHeight: '70vh', overflowY: 'auto' }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         {isTruncated && (
           <Alert
             type="warning"

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/GeneralTab.tsx
@@ -147,7 +147,7 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
 
   return (
     <div style={{ width: '100%', maxHeight: '70vh', overflowY: 'auto' }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         {/* Basic Information */}
         <Descriptions column={1} bordered size="small">
           <Descriptions.Item label="Name">

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -146,10 +146,10 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
 
   return (
     <div style={{ padding: '24px' }}>
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="large" style={{ width: '100%' }}>
         {/* Enable/Disable Schedule */}
         <Card size="small">
-          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="small" style={{ width: '100%' }}>
             <Space>
               <Switch
                 checked={scheduleEnabled}
@@ -172,7 +172,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
 
         {/* Cron Expression */}
         <Card size="small" title="Schedule Frequency">
-          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
             <div>
               <Text type="secondary" style={{ fontSize: '12px' }}>
                 Configure when to create new sessions
@@ -220,7 +220,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
 
         {/* Agent Selection */}
         <Card size="small" title="Agent Selection">
-          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="small" style={{ width: '100%' }}>
             <Text type="secondary" style={{ fontSize: '12px' }}>
               Choose which coding agent will run the scheduled sessions
             </Text>
@@ -256,7 +256,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
 
         {/* Prompt Template */}
         <Card size="small" title="Prompt Template">
-          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="small" style={{ width: '100%' }}>
             <Text type="secondary" style={{ fontSize: '12px' }}>
               Use Handlebars syntax for dynamic values. Available variables: worktree, board
             </Text>
@@ -276,7 +276,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
 
         {/* Retention Policy */}
         <Card size="small" title="Retention Policy">
-          <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          <Space orientation="vertical" size="small" style={{ width: '100%' }}>
             <Text type="secondary" style={{ fontSize: '12px' }}>
               Number of scheduled sessions to keep (0 = keep all)
             </Text>

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/SessionsTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/SessionsTab.tsx
@@ -203,7 +203,7 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({ sessions, client, onSess
 
   return (
     <div style={{ width: '100%', maxHeight: '70vh', overflowY: 'auto' }}>
-      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
         {/* Toolbar: search + archive toggle */}
         <div
           style={{


### PR DESCRIPTION
## Summary
- Replace deprecated `maskClosable` with `mask={{ closable }}` on all 3 Modal usages
- Replace deprecated `direction` with `orientation` on all ~60 Space component usages across 40 files
- Add `forwardRef` to `FileUploadButton` so Ant Design Tooltip can attach refs
- Wrap `ControlButton` (react-flow) in `<span>` tags inside Tooltips for ref forwarding
- Add stable `id` and `order` props to all `Panel` components in the main layout to fix dynamic panel warnings

## Test plan
- [x] `pnpm check` passes (typecheck + lint + build)
- [ ] Verify no React/Ant Design warnings in browser console
- [ ] Verify Tooltip positioning still works on canvas toolbar buttons
- [ ] Verify panel resizing behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)