### PR TITLE
fix(ui): fix Settings Assistants tab navigating to Boards

### DIFF
--- a/apps/agor-ui/src/hooks/useSettingsRoute.ts
+++ b/apps/agor-ui/src/hooks/useSettingsRoute.ts
@@ -8,7 +8,7 @@ export type SettingsSection =
   | 'boards'
   | 'repos'
   | 'worktrees'
-  | 'agents'
+  | 'assistants'
   | 'mcp'
   | 'agentic-tools'
   | 'gateway'
@@ -66,7 +66,7 @@ export function useSettingsRoute() {
       'boards',
       'repos',
       'worktrees',
-      'agents',
+      'assistants',
       'mcp',
       'agentic-tools',
       'gateway',


### PR DESCRIPTION
## Summary
- The Settings modal "Assistants" tab was navigating to the Boards view instead of showing the Assistants panel
- Root cause: `useSettingsRoute.ts` used `'agents'` as the valid section key, but the menu item and switch statement both used `'assistants'` — causing the route validator to reject the section and fall back to `'boards'`
- Fixed by aligning the route key to `'assistants'` in both the `SettingsSection` type and `validSections` array

## Test plan
- [ ] Open Settings modal
- [ ] Click "Assistants" tab — should show the Assistants panel (not Boards)
- [ ] Verify URL changes to `/settings/assistants/`
- [ ] Verify other tabs still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)