### PR TITLE
fix(ui): fix terminal not rendering on first open

### DIFF
--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -83,6 +83,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
   const terminalDivRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [modalReady, setModalReady] = useState(false);
   const [sessionInfo, setSessionInfo] = useState<{
     zellijSession?: string;
     zellijReused?: boolean;
@@ -93,7 +94,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
   const isAdmin = user?.role === 'admin' || user?.role === 'owner';
 
   useEffect(() => {
-    if (!open || !terminalDivRef.current || !client) return;
+    if (!open || !modalReady || !terminalDivRef.current || !client) return;
 
     // Skip terminal setup for non-admin users
     if (!isAdmin) return;
@@ -304,7 +305,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       setIsConnected(false);
       setSessionInfo({});
     };
-  }, [open, client, initialCommands, isAdmin, worktreeId, user?.user_id]);
+  }, [open, modalReady, client, initialCommands, isAdmin, worktreeId, user?.user_id]);
 
   const handleClose = () => {
     if (isConnected) {
@@ -329,6 +330,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       title={`Terminal${sessionInfo.worktreeName ? ` - ${sessionInfo.worktreeName}` : ''}`}
       open={open}
       onCancel={handleClose}
+      afterOpenChange={setModalReady}
       footer={null}
       width="auto"
       styles={{


### PR DESCRIPTION
## Summary
- Fix xterm.js terminal rendering as a tiny black square on first open
- Root cause: `terminal.open(container)` was called before the Ant Design Modal animation completed, so the container had zero dimensions
- Solution: Use Modal's `afterOpenChange` callback to defer terminal initialization until the container is fully visible and sized

## Changes
- Added `modalReady` state that tracks when the Modal animation completes
- Added `afterOpenChange={setModalReady}` to the Modal component
- Terminal setup effect now waits for both `open` and `modalReady` to be true

## Test plan
- [ ] Open terminal from a worktree card — should render correctly on first open
- [ ] Close and reopen — should still work
- [ ] Full page refresh, then open terminal — should render correctly (previously broken)
- [ ] Verify terminal input/output works after fix
- [ ] Verify terminal reconnection to existing Zellij session works

🤖 Generated with [Claude Code](https://claude.com/claude-code)