### PR TITLE
chore: bump agor-live to 0.15.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Releases
 
-## 0.15.0 (2026-03-06)
+## 0.14.1 (2026-03-06)
 
 ### Features
 - **Anthropic API passthrough** — add ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN passthrough to sessions for custom API endpoints

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.15.0",
+  "version": "0.14.1",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump `agor-live` package version from 0.14.0 to 0.15.0
- Add release notes to RELEASES.md covering changes since 0.14.0

## Changes since 0.14.0
- **feat:** ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN passthrough to sessions
- **fix:** Terminal not rendering on first open
- **fix:** Settings Assistants tab navigating to Boards instead of Assistants

🤖 Generated with [Claude Code](https://claude.com/claude-code)