### PR TITLE
fix: capture and surface error output when environment start fails

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.ts
+++ b/apps/agor-daemon/src/mcp/routes.ts
@@ -2604,6 +2604,11 @@ export function setupMCPRoutes(app: Application, db: Database): void {
               ],
             };
           } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            const commandOutput =
+              error instanceof Error
+                ? (error as Error & { commandOutput?: string }).commandOutput
+                : undefined;
             mcpResponse = {
               content: [
                 {
@@ -2611,7 +2616,8 @@ export function setupMCPRoutes(app: Application, db: Database): void {
                   text: JSON.stringify(
                     {
                       success: false,
-                      error: error instanceof Error ? error.message : 'Unknown error',
+                      error: errorMessage,
+                      ...(commandOutput ? { output: commandOutput } : {}),
                     },
                     null,
                     2

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -705,6 +705,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
 
     // Set status to 'starting' and record start timestamp
     // Merge with existing process fields (e.g. pid from a failed stop) rather than replacing
+    // Clear last_error from previous attempts
     await this.updateEnvironment(
       id,
       {
@@ -714,6 +715,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
           started_at: new Date().toISOString(),
         },
         last_health_check: undefined,
+        last_error: undefined,
       },
       params
     );
@@ -736,13 +738,34 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       await mkdir(dirname(logPath), { recursive: true });
 
       // Execute command and wait for it to complete
-      // The command should start services and return (e.g., docker-compose up -d)
+      // Use stdio: 'pipe' to capture output for error reporting
       const childProcess = await spawnEnvironmentCommand({
         command,
         worktree,
         db: this.db,
         commandType: 'start',
+        stdio: 'pipe',
       });
+
+      // Collect stdout/stderr for error reporting (last ~100 lines)
+      const outputChunks: string[] = [];
+      const MAX_OUTPUT_LINES = 100;
+
+      const collectOutput = (stream: NodeJS.ReadableStream | null, prefix?: string) => {
+        if (!stream) return;
+        stream.on('data', (chunk: Buffer) => {
+          const text = chunk.toString();
+          // Also forward to daemon console so logs aren't lost
+          if (prefix) {
+            process.stderr.write(text);
+          } else {
+            process.stdout.write(text);
+          }
+          outputChunks.push(text);
+        });
+      };
+      collectOutput(childProcess.stdout);
+      collectOutput(childProcess.stderr, 'stderr');
 
       await new Promise<void>((resolve, reject) => {
         childProcess.on('exit', (code: number | null) => {
@@ -750,7 +773,19 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
             console.log(`✅ Start command completed successfully for ${worktree.name}`);
             resolve();
           } else {
-            reject(new Error(`Start command exited with code ${code}`));
+            // Combine collected output and truncate to last ~100 lines
+            const fullOutput = outputChunks.join('');
+            const lines = fullOutput.split('\n');
+            const truncated =
+              lines.length > MAX_OUTPUT_LINES
+                ? `... (truncated ${lines.length - MAX_OUTPUT_LINES} lines)\n${lines.slice(-MAX_OUTPUT_LINES).join('\n')}`
+                : fullOutput;
+            const output = truncated.trim();
+            const err = new Error(`Start command exited with code ${code}`) as Error & {
+              commandOutput?: string;
+            };
+            err.commandOutput = output || undefined;
+            reject(err);
           }
         });
 
@@ -775,7 +810,13 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
         params
       );
     } catch (error) {
-      // Update status to 'error'
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const commandOutput =
+        error instanceof Error
+          ? (error as Error & { commandOutput?: string }).commandOutput
+          : undefined;
+
+      // Store short message in last_health_check, full output in last_error
       await this.updateEnvironment(
         id,
         {
@@ -783,8 +824,9 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
           last_health_check: {
             timestamp: new Date().toISOString(),
             status: 'unhealthy',
-            message: error instanceof Error ? error.message : 'Unknown error',
+            message: errorMessage,
           },
+          last_error: commandOutput || errorMessage,
         },
         params
       );

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -149,6 +149,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     worktree.environment_instance?.last_health_check
   );
   const [processInfo, setProcessInfo] = useState(worktree.environment_instance?.process);
+  const [lastError, setLastError] = useState(worktree.environment_instance?.last_error);
   const [logsModalOpen, setLogsModalOpen] = useState(false);
 
   // Track previous worktree reference to detect actual prop changes (not just editing flag changes)
@@ -160,6 +161,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     setEnvStatus(worktree.environment_instance?.status || 'stopped');
     setLastHealthCheck(worktree.environment_instance?.last_health_check);
     setProcessInfo(worktree.environment_instance?.process);
+    setLastError(worktree.environment_instance?.last_error);
 
     // Check if worktree prop actually changed (not just editing flags)
     const worktreeChanged = prevWorktreeRef.current !== worktree;
@@ -192,6 +194,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
         setEnvStatus(updatedWorktree.environment_instance?.status || 'stopped');
         setLastHealthCheck(updatedWorktree.environment_instance?.last_health_check);
         setProcessInfo(updatedWorktree.environment_instance?.process);
+        setLastError(updatedWorktree.environment_instance?.last_error);
       }
     };
 
@@ -679,10 +682,25 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
               </div>
 
               {/* Error State */}
-              {envStatus === 'error' && lastHealthCheck?.message && (
+              {envStatus === 'error' && (lastHealthCheck?.message || lastError) && (
                 <Alert
-                  message="Environment Error"
-                  description={lastHealthCheck.message}
+                  message={lastHealthCheck?.message || 'Environment Error'}
+                  description={
+                    lastError ? (
+                      <pre
+                        style={{
+                          maxHeight: 200,
+                          overflow: 'auto',
+                          margin: 0,
+                          fontSize: 11,
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-word',
+                        }}
+                      >
+                        {lastError}
+                      </pre>
+                    ) : undefined
+                  }
                   type="error"
                   showIcon
                   style={{ fontSize: 11 }}

--- a/packages/core/src/types/worktree.ts
+++ b/packages/core/src/types/worktree.ts
@@ -494,6 +494,14 @@ export interface WorktreeEnvironmentInstance {
    * Captured from stdout/stderr of environment process.
    */
   logs?: string[];
+
+  /**
+   * Last error output from a failed command (start/stop/nuke)
+   *
+   * Captures the last ~100 lines of stdout/stderr when a command exits non-zero.
+   * Cleared on the next successful start.
+   */
+  last_error?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Captures stdout/stderr from failed environment start commands (last ~100 lines)
- Stores error output as `last_error` on `WorktreeEnvironmentInstance` for persistence
- Displays error output in a scrollable code block in the Environment tab error Alert
- MCP `agor_environment_start` endpoint now returns command output in error responses
- Error is cleared on next start attempt

## Details
Previously, when a start command failed, users only saw a generic "Start command exited with code 1" message. The actual error output (e.g., docker-compose errors, missing dependencies, port conflicts) was lost to the daemon's stdout.

Now:
- `last_health_check.message` = short summary (e.g., "Start command exited with code 1")
- `last_error` = full captured output (truncated to last ~100 lines)
- Output is forwarded to daemon console so existing log flows aren't disrupted

## Test plan
- [ ] Start an environment with a broken start command (e.g., `exit 1` or invalid docker-compose)
- [ ] Verify the Environment tab shows the actual error output in a scrollable block
- [ ] Verify the toast notification shows the short error message
- [ ] Verify `agor_environment_start` MCP tool returns the `output` field on failure
- [ ] Start the environment successfully and verify `last_error` is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)