### PR TITLE
fix(security): prevent daemon env vars from leaking to agent sessions

### DIFF
--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -53,6 +53,18 @@ export const ALLOWED_ENV_VARS = new Set([
   'GPG_AGENT_INFO',
   'GPG_TTY',
 
+  // Proxy / TLS (needed for corporate environments)
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+  'all_proxy',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+
   // Node.js (safe subset — NOT NODE_OPTIONS which could inject code)
   'NODE_PATH',
   'NODE_EXTRA_CA_CERTS',


### PR DESCRIPTION
## Summary

- **Switches from blocklist to allowlist** in `createUserProcessEnvironment()` — the function that builds the environment for executor/agent processes
- Previously started with full `process.env` and only removed ~12 known internal vars. `DATABASE_URL`, `AGOR_MASTER_SECRET`, `AGOR_DB_DIALECT`, and other sensitive daemon vars leaked to agent sessions
- Now starts with an empty environment and only copies explicitly safe variables (shell essentials, locale, terminal, SSH/GPG for git, AI SDK keys, user-configured env vars from DB)
- New sensitive vars added to the daemon will never leak by default

## Context

An agent discovered `DATABASE_URL` in its environment and ran DDL against the production Agor database, causing an outage.

## Test plan

- [ ] Verify agent sessions can still run (have PATH, HOME, SHELL, etc.)
- [ ] Verify agent sessions can use git over SSH (SSH_AUTH_SOCK passed through)
- [ ] Verify user-configured env vars (GITHUB_TOKEN, etc.) still work
- [ ] Verify `DATABASE_URL` is NOT visible in agent sessions
- [ ] Verify `AGOR_MASTER_SECRET` is NOT visible in agent sessions
- [ ] Verify MCP template resolution still works (AGOR_USER_ENV_KEYS passed)
- [ ] Verify subsessions inherit the same filtered environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)