### PR TITLE
fix: detect SDK error_during_execution and mark task as failed

### DIFF
--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -43,6 +43,10 @@ export interface BaseTool {
       cache_creation_tokens?: number;
     };
     wasStopped?: boolean;
+    /** Whether the SDK returned an error result (e.g., error_during_execution) */
+    hadError?: boolean;
+    /** Error details from SDK when hadError is true */
+    errorDetails?: string[];
     /** Raw SDK response for token accounting - stored and normalized */
     rawSdkResponse?: unknown;
   }>;
@@ -365,9 +369,20 @@ export async function executeToolTask(params: {
     // Capture git SHA at task end
     const shaAtEnd = await captureGitStateAtTaskEnd(client, sessionId);
 
+    // Determine task status based on SDK result
+    // - wasStopped: user explicitly stopped the task
+    // - hadError: SDK returned an error subtype (e.g., error_during_execution)
+    const taskStatus = result.wasStopped ? 'stopped' : result.hadError ? 'failed' : 'completed';
+
+    if (result.hadError) {
+      console.error(
+        `[${toolName}] SDK returned error result for session ${sessionId.substring(0, 8)}, marking task as failed${result.errorDetails?.length ? `: ${result.errorDetails.join('; ')}` : ''}`
+      );
+    }
+
     // Build patch data
     const patchData: Partial<Task> = {
-      status: result.wasStopped ? 'stopped' : 'completed',
+      status: taskStatus,
       completed_at: new Date().toISOString(),
     };
 

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -229,6 +229,9 @@ export class ClaudeTool implements ITool {
     modelUsage?: unknown;
     rawSdkResponse?: import('@agor/core/sdk').SDKResultMessage;
     wasStopped?: boolean;
+    hadError?: boolean;
+    /** Error details from SDK when hadError is true (e.g., errors array from error_during_execution) */
+    errorDetails?: string[];
   }> {
     if (!this.promptService || !this.messagesRepo) {
       throw new Error('ClaudeTool not initialized with repositories for live execution');
@@ -292,6 +295,8 @@ export class ClaudeTool implements ITool {
     let modelUsage: unknown | undefined;
     let rawSdkResponse: import('@agor/core/sdk').SDKResultMessage | undefined;
     let wasStopped = false;
+    let hadError = false;
+    let errorDetails: string[] | undefined;
 
     // Map our permission mode to Claude SDK's permission mode
     const mappedPermissionMode = permissionMode
@@ -449,6 +454,44 @@ export class ClaudeTool implements ITool {
       // Capture raw SDK response for token accounting
       if (event.type === 'result') {
         rawSdkResponse = event.raw_sdk_message;
+        // Detect error results from SDK (e.g., error_during_execution)
+        if (rawSdkResponse && 'subtype' in rawSdkResponse) {
+          const sdkResult = rawSdkResponse as {
+            subtype?: string;
+            errors?: string[];
+            is_error?: boolean;
+          };
+          if (sdkResult.subtype && sdkResult.subtype !== 'success') {
+            hadError = true;
+            errorDetails = sdkResult.errors;
+            console.error(
+              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, errors=${JSON.stringify(sdkResult.errors)}`
+            );
+
+            // Create a system message with the error details so it's visible in the conversation UI
+            if (this.messagesService && sdkResult.errors?.length) {
+              const errorText = sdkResult.errors.join('\n');
+              const errorMessageId = generateId() as MessageID;
+              await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
+                await createSystemMessage(
+                  sessionId,
+                  errorMessageId,
+                  [
+                    {
+                      type: 'text',
+                      text: `Agent SDK error (${sdkResult.subtype}): ${errorText}`,
+                    },
+                  ],
+                  taskId,
+                  nextIndex++,
+                  resolvedModel,
+                  this.messagesService!
+                );
+                return true;
+              });
+            }
+          }
+        }
       }
 
       // Capture metadata from result events (SDK may not type this properly)
@@ -610,6 +653,8 @@ export class ClaudeTool implements ITool {
       modelUsage,
       rawSdkResponse,
       wasStopped,
+      hadError,
+      errorDetails,
     };
   }
 
@@ -673,6 +718,9 @@ export class ClaudeTool implements ITool {
     modelUsage?: unknown;
     rawSdkResponse?: import('@agor/core/sdk').SDKResultMessage;
     wasStopped?: boolean;
+    hadError?: boolean;
+    /** Error details from SDK when hadError is true (e.g., errors array from error_during_execution) */
+    errorDetails?: string[];
   }> {
     if (!this.promptService || !this.messagesRepo) {
       throw new Error('ClaudeTool not initialized with repositories for live execution');
@@ -707,6 +755,8 @@ export class ClaudeTool implements ITool {
     let modelUsage: unknown | undefined;
     let rawSdkResponse: import('@agor/core/sdk').SDKResultMessage | undefined;
     let wasStopped = false;
+    let hadError = false;
+    let errorDetails: string[] | undefined;
 
     // Map our permission mode to Claude SDK's permission mode
     const mappedPermissionMode = permissionMode
@@ -740,6 +790,44 @@ export class ClaudeTool implements ITool {
       // Capture raw SDK response for token accounting
       if (event.type === 'result') {
         rawSdkResponse = event.raw_sdk_message;
+        // Detect error results from SDK (e.g., error_during_execution)
+        if (rawSdkResponse && 'subtype' in rawSdkResponse) {
+          const sdkResult = rawSdkResponse as {
+            subtype?: string;
+            errors?: string[];
+            is_error?: boolean;
+          };
+          if (sdkResult.subtype && sdkResult.subtype !== 'success') {
+            hadError = true;
+            errorDetails = sdkResult.errors;
+            console.error(
+              `[claude-code] SDK result indicates error: subtype=${sdkResult.subtype}, errors=${JSON.stringify(sdkResult.errors)}`
+            );
+
+            // Create a system message with the error details so it's visible in the conversation UI
+            if (this.messagesService && sdkResult.errors?.length) {
+              const errorText = sdkResult.errors.join('\n');
+              const errorMessageId = generateId() as MessageID;
+              await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
+                await createSystemMessage(
+                  sessionId,
+                  errorMessageId,
+                  [
+                    {
+                      type: 'text',
+                      text: `Agent SDK error (${sdkResult.subtype}): ${errorText}`,
+                    },
+                  ],
+                  taskId,
+                  nextIndex++,
+                  resolvedModel,
+                  this.messagesService!
+                );
+                return true;
+              });
+            }
+          }
+        }
       }
 
       // Capture metadata from result events (SDK may not type this properly)
@@ -827,6 +915,8 @@ export class ClaudeTool implements ITool {
       modelUsage,
       rawSdkResponse,
       wasStopped,
+      hadError,
+      errorDetails,
     };
   }
 


### PR DESCRIPTION
## Summary
- Detects when Claude Agent SDK returns non-success result subtypes (e.g., `error_during_execution`) — previously these were silently marked as `completed` with 0 tokens/0 messages, leaving sessions stuck
- Extracts the `errors[]` array from the SDK result and creates a system message in the conversation so the error is visible in the UI
- Marks the task as `failed` instead of `completed`, allowing existing hooks to return the session to `idle`/`ready_for_prompt`

## Context
Observed in session `4833816d` where the SDK returned:
```json
"subtype": "error_during_execution",
"errors": ["No conversation found with session ID: 6f70f84f-..."]
```
The task was incorrectly marked completed and the session got stuck.

## Test plan
- [ ] Trigger an `error_during_execution` scenario (e.g., stale sdk_session_id) and verify the task is marked `failed`
- [ ] Verify error system message appears in conversation UI
- [ ] Verify session returns to `idle` with `ready_for_prompt: true`
- [ ] Verify normal successful executions still marked `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)