### PR TITLE
fix: prevent sdk_session_id corruption on multi-user sessions

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -669,9 +669,22 @@ export class ClaudeTool implements ITool {
 
     if (this.sessionsRepo) {
       try {
-        console.log(
-          `📝 About to update session with: ${JSON.stringify({ sdk_session_id: agentSessionId })}`
-        );
+        // Guard: only set sdk_session_id if not already set (immutable after first capture)
+        const existingSession = await this.sessionsRepo.findById(sessionId);
+        if (existingSession?.sdk_session_id) {
+          if (existingSession.sdk_session_id === agentSessionId) {
+            console.log(
+              `💾 Agent SDK session_id unchanged (already ${agentSessionId.substring(0, 8)})`
+            );
+          } else {
+            console.warn(
+              `⚠️  Agent SDK returned new session_id ${agentSessionId.substring(0, 8)} but session already has ${existingSession.sdk_session_id.substring(0, 8)} — keeping original (sdk_session_id is immutable)`
+            );
+          }
+          return;
+        }
+
+        console.log(`📝 Setting sdk_session_id for first time: ${agentSessionId.substring(0, 8)}`);
         const updated = await this.sessionsRepo.update(sessionId, {
           sdk_session_id: agentSessionId,
         });

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -177,13 +177,17 @@ export class ClaudePromptService {
 
         // Handle each event from processor
         for (const event of events) {
-          // Handle session ID capture
+          // Handle session ID capture (only set if not already set — sdk_session_id is immutable)
           if (event.type === 'session_id_captured') {
-            if (this.sessionsRepo) {
+            if (this.sessionsRepo && !existingSdkSessionId) {
               await this.sessionsRepo.update(sessionId, {
                 sdk_session_id: event.agentSessionId,
               });
               console.log(`💾 Stored Agent SDK session_id in database`);
+            } else if (existingSdkSessionId && existingSdkSessionId !== event.agentSessionId) {
+              console.warn(
+                `⚠️  SDK returned new session_id ${event.agentSessionId.substring(0, 8)} but session already has ${existingSdkSessionId.substring(0, 8)} — keeping original`
+              );
             }
             continue; // Don't yield this event upstream
           }

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -424,6 +424,16 @@ export class CodexTool implements ITool {
     console.log(`🔑 Captured Codex thread ID for Agor session ${sessionId}: ${threadId}`);
 
     if (this.sessionsRepo) {
+      // Guard: only set sdk_session_id if not already set (immutable after first capture)
+      const existingSession = await this.sessionsRepo.findById(sessionId);
+      if (existingSession?.sdk_session_id) {
+        if (existingSession.sdk_session_id !== threadId) {
+          console.warn(
+            `⚠️  Codex returned new thread_id ${threadId.substring(0, 8)} but session already has ${existingSession.sdk_session_id.substring(0, 8)} — keeping original`
+          );
+        }
+        return;
+      }
       await this.sessionsRepo.update(sessionId, { sdk_session_id: threadId });
       console.log(`💾 Stored Codex thread ID in Agor session`);
     }


### PR DESCRIPTION
## Summary
- Makes `sdk_session_id` immutable after first capture — prevents silent corruption when a different user prompts the same Agor session
- Guards all 3 SDK capture paths: Claude (`captureAgentSessionId`, `session_id_captured` event), Codex (`captureThreadId`)
- Logs a warning when the SDK returns a different session ID than what's stored

## Root Cause
When user B prompts a session originally created by user A:
1. The SDK runs under user B's unix context (`~/.claude/projects/`)
2. It can't find user A's conversation files → creates a new SDK session
3. The new session ID **overwrites** the original `sdk_session_id` in the database
4. User A's conversation becomes permanently unreachable
5. Subsequent prompts fail with `error_during_execution: No conversation found`

Discovered via session `4833816d` where elizabeth prompted a session created by max.

## Changes
- `claude-tool.ts`: `captureAgentSessionId()` now checks if `sdk_session_id` is already set before writing
- `prompt-service.ts`: `session_id_captured` event handler guards with `!existingSdkSessionId`
- `codex-tool.ts`: `captureThreadId()` now checks if `sdk_session_id` is already set

Intentional clearing (MCP config changes, stale session recovery) is preserved as-is.

## Test plan
- [ ] User A creates session, prompts it → `sdk_session_id` is set
- [ ] User B prompts same session → `sdk_session_id` is NOT overwritten, warning logged
- [ ] User A prompts again → resumes original conversation successfully
- [ ] New session (no `sdk_session_id`) → first capture works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)