### PR TITLE
chore: bump agor-live to 0.14.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,23 @@
 # Releases
 
+## 0.14.2 (2026-03-13)
+
+### Features
+- **Messages MCP tool** — add `agor_messages_list` for browsing and searching session transcripts
+- **AskUserQuestion support** — full-stack implementation of interactive agent questions
+
+### Fixes
+- Prevent `sdk_session_id` from being overwritten after first capture
+- Detect SDK `error_during_execution` and mark task as failed
+- Copy-to-clipboard falls back to `execCommand` when Clipboard API throws
+- **Security**: prevent daemon env vars from leaking to agent sessions
+- Clean up stale zone references when deleting zones
+- Capture and surface actual error output when environment start fails
+- Make zone prompt template and trigger behavior optional
+
+### Chores
+- Remove Jenkinsfile and package-lock.json
+
 ## 0.14.1 (2026-03-06)
 
 ### Features

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump `agor-live` package version from 0.14.1 to 0.14.2
- Update RELEASES.md with changes since last release (messages MCP tool, AskUserQuestion support, security fixes, and more)

## Test plan
- [ ] Verify package.json version is 0.14.2
- [ ] Verify RELEASES.md entry is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)