### PR TITLE
feat: add required_user_env_vars config to block prompts with missing env vars

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -40,6 +40,7 @@ const DAEMON_VERSION = await loadDaemonVersion(import.meta.url);
 import {
   and,
   eq,
+  generateId,
   getDatabaseUrl,
   MCPServerRepository,
   MessagesRepository,
@@ -869,24 +870,27 @@ async function main() {
         const missingVars = requiredUserEnvVars.filter((v) => !executorEnv[v]);
         if (missingVars.length > 0) {
           const missingList = missingVars.map((v) => `\`${v}\``).join(', ');
-          await messagesService.create({
-            session_id: sessionId,
-            task_id: data.taskId,
+          const errorContent = [
+            `**Missing required environment variables:** ${missingList}`,
+            '',
+            'Your administrator requires these variables to be set before running prompts.',
+            '',
+            `**To fix:** Click your user avatar (top-right) → **Settings** → **Environment Variables**, then add values for: ${missingList}`,
+            '',
+            'This is a one-time setup — once configured, this message will not appear again.',
+          ].join('\n');
+          const systemMessage: Partial<Message> = {
+            message_id: generateId() as Message['message_id'],
+            session_id: sessionId as Message['session_id'],
+            task_id: data.taskId as Message['task_id'],
             type: 'system',
-            role: 'system',
-            content: [
-              `**Missing required environment variables:** ${missingList}`,
-              '',
-              'Your administrator requires these variables to be set before running prompts.',
-              '',
-              `**To fix:** Click your user avatar (top-right) → **Settings** → **Environment Variables**, then add values for: ${missingList}`,
-              '',
-              'This is a one-time setup — once configured, this message will not appear again.',
-            ].join('\n'),
+            role: 'system' as Message['role'],
+            content: errorContent,
             content_preview: `Missing required env vars: ${missingVars.join(', ')}`,
-            index: -1,
+            index: session.message_count,
             timestamp: new Date().toISOString(),
-          } as Partial<import('@agor/core/types').Message>);
+          };
+          await messagesService.create(systemMessage);
           throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
         }
       }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -266,7 +266,7 @@ export interface AgorExecutionSettings {
    * Required user environment variables.
    * When set, prompts are blocked if any listed var is missing from the user's resolved environment.
    * Users are directed to Settings → Environment Variables to configure them.
-   * Default: [] (no enforcement)
+   * Default: unset (no enforcement)
    *
    * @example Require git identity for proper commit attribution
    * ```yaml


### PR DESCRIPTION
## Summary
- Adds `execution.required_user_env_vars` config option to `~/.agor/config.yaml`
- When configured, validates user environment variables before spawning the executor
- Blocks prompts with a system message directing users to Settings → Environment Variables
- Useful for enforcing git identity (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`) to prevent commit misattribution across shared worktrees

## Context
Discovered that repo-level git config (e.g., `user.name = "Kamil Gabryjelski"` in the superset repo) causes all worktree commits to be attributed to whoever configured the repo. The fix is for users to set `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` env vars in their Agor user settings (these override any git config level). This config option ensures users don't forget to do so.

## Configuration
```yaml
# ~/.agor/config.yaml
execution:
  required_user_env_vars:
    - GIT_AUTHOR_NAME
    - GIT_AUTHOR_EMAIL
    - GIT_COMMITTER_NAME
    - GIT_COMMITTER_EMAIL
```

## Test plan
- [ ] Set `required_user_env_vars` in config, send a prompt without the vars set → system message appears, task fails, session returns to IDLE
- [ ] Set the required env vars in user settings, send another prompt → proceeds normally
- [ ] Remove `required_user_env_vars` from config → all prompts proceed without validation
- [ ] Empty array or omitted field → no enforcement (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)