### PR TITLE
fix: sort Settings modal tables alphabetically by primary column

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -244,7 +244,11 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
     const term = searchTerm.trim().toLowerCase();
     const assistantWorktrees = Array.from(worktreeById.values())
       .filter((w) => !w.archived && isAssistant(w))
-      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+      .sort((a, b) => {
+        const nameA = getAssistantConfig(a)?.displayName ?? a.name;
+        const nameB = getAssistantConfig(b)?.displayName ?? b.name;
+        return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
+      });
 
     if (!term) return assistantWorktrees;
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -43,7 +43,7 @@ import {
 } from 'antd';
 import { useEffect, useState } from 'react';
 import { copyToClipboard } from '@/utils/clipboard';
-import { mapToArray } from '@/utils/mapHelpers';
+import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { AgentSelectionGrid } from '../AgentSelectionGrid';
@@ -840,7 +840,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     },
   ];
 
-  const channels = mapToArray(gatewayChannelById);
+  const channels = mapToSortedArray(gatewayChannelById, (a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
 
   return (
     <div>

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -27,7 +27,7 @@ import {
   Typography,
 } from 'antd';
 import { useEffect, useState } from 'react';
-import { mapToArray } from '@/utils/mapHelpers';
+import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { extractOAuthConfig, extractOAuthConfigForTesting } from './mcp-oauth-utils';
 
@@ -1493,7 +1493,9 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       </div>
 
       <Table
-        dataSource={mapToArray(mcpServerById)}
+        dataSource={mapToSortedArray(mcpServerById, (a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+        )}
         columns={columns}
         rowKey="mcp_server_id"
         pagination={{ pageSize: 10, showSizeChanger: true }}

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from 'antd';
 import { useState } from 'react';
-import { mapToArray } from '@/utils/mapHelpers';
+import { mapToSortedArray } from '@/utils/mapHelpers';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { UserSettingsModal } from './UserSettingsModal';
 
@@ -156,7 +156,9 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       </div>
 
       <Table
-        dataSource={mapToArray(userById)}
+        dataSource={mapToSortedArray(userById, (a, b) =>
+          a.email.localeCompare(b.email, undefined, { sensitivity: 'base' })
+        )}
         columns={columns}
         rowKey="user_id"
         pagination={false}


### PR DESCRIPTION
## Summary
- Sort **Assistants** table by display name (A-Z)
- Sort **Users** table by email (A-Z)
- Sort **MCP Servers** table by name (A-Z)
- Sort **Gateway Channels** table by name (A-Z)
- Boards and Repos tables were already sorted — no changes needed

All sorts use case-insensitive `localeCompare` with `sensitivity: 'base'`, consistent with the existing BoardsTable pattern.

## Test plan
- [ ] Open Settings modal, verify each table tab shows rows in alphabetical order
- [ ] Verify search/filter still works on Assistants tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)