### PR TITLE
fix: refresh updated_at on session updates to prevent stale SDK disconnects

### DIFF
--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -518,13 +518,20 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         // Pass all columns via insertData (matches worktree repo pattern).
         // Previously used an explicit column allowlist that silently dropped
         // columns like archived/archived_reason, causing data to revert on reload.
+        // Always refresh updated_at to current time on every update — sessionToInsert()
+        // preserves the old timestamp from the merged session, but updates must advance it.
+        // Without this, the staleness check in query-builder.ts (hoursSinceUpdate > 24)
+        // would erroneously clear sdk_session_id and disconnect agents from their history.
+        insertData.updated_at = new Date();
+
         // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
         await update(tx as any, sessions)
           .set(insertData)
           .where(eq(sessions.session_id, fullId))
           .run();
 
-        // Return merged session (no need to re-fetch, we have it in memory)
+        // Return merged session with refreshed timestamp
+        merged.last_updated = insertData.updated_at.toISOString();
         return merged;
       });
 


### PR DESCRIPTION
## Summary

- **Hotfix** — agents were disconnected from their session history, acting as if each prompt was the first in a new session
- PR #787 changed `SessionRepository.update()` from an explicit column allowlist to `.set(insertData)`, but `sessionToInsert()` preserves the old `updated_at` timestamp from the merged session instead of advancing it to `new Date()`
- This caused the staleness check in `query-builder.ts` (`hoursSinceUpdate > 24`) to fire for any session idle >24h, skipping the SDK resume and starting agents fresh each time
- 13 stale-session events observed in production affecting active sessions (`05bc7624`, `5c09e572`)
- `sdk_session_id` values were protected from DB deletion by `deepMerge` ignoring `undefined`, but the resume path was still skipped

## Fix

Force `insertData.updated_at = new Date()` before the DB write, restoring the original auto-refresh behavior. Also sync the returned `merged.last_updated` so callers see the correct timestamp.

## Test plan

- [x] Deployed hotfix to production — confirmed sessions resumed correctly and agents reconnected to their history
- [x] Typecheck passes across all packages
- [x] Lint passes
- [ ] Verify no new "appears stale" warnings in daemon.log after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)