### PR TITLE
fix: use browser-facing base URL for MCP OAuth redirect URI

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -15,6 +15,7 @@ patchConsole();
 
 import {
   createUserProcessEnvironment,
+  getBaseUrl,
   isUnixImpersonationEnabled,
   loadConfig,
   type UnknownJson,
@@ -1722,8 +1723,10 @@ async function main() {
         // Import the two-phase OAuth flow functions
         const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
 
-        // Start the flow - use daemon's public URL as redirect URI
-        const redirectUri = new URL('/mcp-servers/oauth-callback', daemonUrl).toString();
+        // Start the flow - use browser-facing base URL for the OAuth redirect URI
+        // getBaseUrl() resolves: AGOR_BASE_URL env → daemon.base_url config → localhost fallback
+        const baseUrl = await getBaseUrl();
+        const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
         const context = await startMCPOAuthFlow(wwwAuthenticate, data.client_id, redirectUri);
 
         // Capture initiating socket ID for scoped notifications


### PR DESCRIPTION
## Summary

- The OAuth redirect URI was constructed using `daemonUrl` (from `config.daemon.public_url`), which is the internal executor→daemon URL, not the browser-facing URL
- This caused the OAuth callback to redirect to `http://localhost:3031/mcp-servers/oauth-callback` instead of the public Agor URL
- Fixed by using `getBaseUrl()` which resolves: `AGOR_BASE_URL` env → `daemon.base_url` config → localhost fallback

## Note: Reverse proxy configuration

After deploying this fix, if you see a **401 on `GET /mcp-servers/oauth-callback`**, your reverse proxy (nginx/ingress) needs to allowlist this path for unauthenticated access. The endpoint itself has no auth middleware — the 401 comes from the proxy layer.

## Test plan

- [ ] Deploy and trigger MCP OAuth flow from the UI config modal
- [ ] Verify the redirect URI points to the public Agor URL (not localhost)
- [ ] Verify the OAuth callback completes successfully
- [ ] Verify agent-triggered OAuth flow also uses the correct redirect URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)