### PR TITLE
fix: handle stale git branches during worktree creation and cleanup on deletion

### DIFF
--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -24,7 +24,14 @@ import {
 import { type Database, RepoRepository, WorktreeRepository } from '@agor/core/db';
 import { autoAssignWorktreeUniqueId } from '@agor/core/environment/variable-resolver';
 import type { Application } from '@agor/core/feathers';
-import { getDefaultBranch, getRemoteUrl, getWorktreePath, isValidGitRepo } from '@agor/core/git';
+import {
+  getDefaultBranch,
+  getRemoteUrl,
+  getWorktreePath,
+  isValidGitRepo,
+  listWorktrees,
+  simpleGit,
+} from '@agor/core/git';
 import type {
   AuthenticatedParams,
   QueryParams,
@@ -337,6 +344,43 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     );
     if (existingWorktree) {
       throw new Error(`A worktree named '${data.name}' already exists in this repository`);
+    }
+
+    // Pre-flight check: detect stale or conflicting branches before creating DB record
+    // This gives the user immediate feedback instead of a silent fire-and-forget failure
+    if (data.createBranch && repo.local_path) {
+      try {
+        const git = simpleGit(repo.local_path);
+        const branches = await git.branch();
+        const branchName = data.ref || data.name;
+
+        if (branches.all.includes(branchName)) {
+          // Branch exists — check if it's in use by another worktree
+          const gitWorktrees = await listWorktrees(repo.local_path);
+          const branchInUse = gitWorktrees.some((wt: { ref?: string }) => wt.ref === branchName);
+
+          if (branchInUse) {
+            throw new Error(
+              `A branch named '${branchName}' already exists and is in use by another worktree. Please choose a different name.`
+            );
+          }
+
+          // Branch exists but is orphaned — the executor will clean it up automatically
+          console.log(
+            `⚠️  Branch '${branchName}' exists but is orphaned (stale). Executor will clean it up.`
+          );
+        }
+      } catch (error) {
+        // Re-throw user-facing errors (branch conflicts)
+        if (error instanceof Error && error.message.includes('already exists and is in use')) {
+          throw error;
+        }
+        // Log but don't block creation for other git errors (e.g., repo not accessible)
+        console.warn(
+          `⚠️  Pre-flight branch check failed (continuing anyway):`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
     }
 
     const worktreePath = getWorktreePath(repo.slug, data.name);

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -324,6 +324,9 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
                 worktreeId: worktree.worktree_id,
                 worktreePath: worktree.path,
                 deleteDbRecord: false, // Already deleted above
+                // Clean up the branch if it was created by Agor
+                branch: worktree.ref,
+                deleteBranch: worktree.new_branch,
               },
             },
             {
@@ -434,6 +437,9 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
                 worktreeId: worktree.worktree_id,
                 worktreePath: worktree.path,
                 deleteDbRecord: false, // Daemon handles DB deletion separately
+                // Clean up the branch if it was created by Agor
+                branch: worktree.ref,
+                deleteBranch: worktree.new_branch,
               },
             },
             {

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -425,7 +425,39 @@ export async function createWorktree(
     args.push(ref);
   }
 
-  await git.raw(['worktree', 'add', ...args]);
+  try {
+    await git.raw(['worktree', 'add', ...args]);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Handle stale branch from previously deleted worktree
+    if (createBranch && errorMessage.includes('already exists')) {
+      console.warn(
+        `⚠️  Branch '${ref}' already exists. Checking if it's orphaned (stale from a deleted worktree)...`
+      );
+
+      // Check if the branch is in use by another worktree
+      const worktrees = await listWorktrees(repoPath);
+      const branchInUse = worktrees.some((wt) => wt.ref === ref);
+
+      if (branchInUse) {
+        throw new Error(
+          `A branch named '${ref}' already exists and is in use by another worktree. ` +
+            `Please choose a different name.`
+        );
+      }
+
+      // Branch exists but is orphaned — delete it and retry
+      console.log(`🧹 Deleting orphaned branch '${ref}' and retrying worktree creation...`);
+      await git.raw(['branch', '-D', ref]);
+
+      // Retry the worktree creation
+      await git.raw(['worktree', 'add', ...args]);
+      console.log(`✅ Successfully created worktree after cleaning up stale branch '${ref}'`);
+    } else {
+      throw error;
+    }
+  }
 
   // Add worktree to safe.directory to prevent "dubious ownership" errors
   // This is needed when worktrees are owned by a different user (e.g., daemon user)
@@ -737,6 +769,30 @@ export async function deleteWorktreeDirectory(worktreePath: string): Promise<voi
   }
 
   await rm(resolvedWorktreePath, { recursive: true, force: true });
+}
+
+/**
+ * Delete a local git branch
+ *
+ * Uses -D (force delete) to handle branches that haven't been merged.
+ * Silently succeeds if the branch doesn't exist.
+ *
+ * @param repoPath - Path to the repository
+ * @param branchName - Branch name to delete
+ * @returns true if branch was deleted, false if it didn't exist
+ */
+export async function deleteBranch(repoPath: string, branchName: string): Promise<boolean> {
+  const git = createGit(repoPath);
+  try {
+    await git.raw(['branch', '-D', branchName]);
+    return true;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes('not found')) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -21,6 +21,7 @@ import {
   cleanWorktree,
   cloneRepo,
   createWorktree,
+  deleteBranch,
   getReposDir,
   removeWorktree,
 } from '@agor/core/git';
@@ -541,11 +542,17 @@ export async function handleGitWorktreeAdd(
       }
     }
 
+    // Provide user-friendly error messages for common failures
+    let userMessage = errorMessage;
+    if (errorMessage.includes('already exists') && errorMessage.includes('branch')) {
+      userMessage = `A branch named '${payload.params.branch || payload.params.worktreeName}' already exists and is in use by another worktree. Please choose a different name.`;
+    }
+
     return {
       success: false,
       error: {
         code: 'GIT_WORKTREE_ADD_FAILED',
-        message: errorMessage,
+        message: userMessage,
         details: {
           worktreeId,
           repoId: payload.params.repoId,
@@ -641,6 +648,28 @@ export async function handleGitWorktreeRemove(
       filesystemRemoved = true;
 
       console.log(`[git.worktree.remove] Worktree removed from filesystem`);
+
+      // Delete the associated branch if requested
+      if (payload.params.deleteBranch && payload.params.branch) {
+        const branchToDelete = payload.params.branch;
+        try {
+          console.log(`[git.worktree.remove] Deleting branch '${branchToDelete}'...`);
+          const deleted = await deleteBranch(repoPath, branchToDelete);
+          if (deleted) {
+            console.log(`[git.worktree.remove] Branch '${branchToDelete}' deleted`);
+          } else {
+            console.log(
+              `[git.worktree.remove] Branch '${branchToDelete}' not found (already deleted)`
+            );
+          }
+        } catch (branchError) {
+          // Log but don't fail the overall operation
+          console.warn(
+            `[git.worktree.remove] Failed to delete branch '${branchToDelete}':`,
+            branchError instanceof Error ? branchError.message : String(branchError)
+          );
+        }
+      }
     } else {
       console.log(
         '[git.worktree.remove] Worktree does not exist on filesystem, skipping git removal'

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -292,6 +292,12 @@ export const GitWorktreeRemovePayloadSchema = BasePayloadSchema.extend({
 
     /** Delete DB record after removal (default: true) */
     deleteDbRecord: z.boolean().optional().default(true),
+
+    /** Branch name to delete after worktree removal */
+    branch: z.string().optional(),
+
+    /** Whether to delete the branch after worktree removal (default: false) */
+    deleteBranch: z.boolean().optional().default(false),
   }),
 });
 


### PR DESCRIPTION
## Summary
- **Pre-flight branch conflict check**: Detects stale/conflicting branches in the daemon *before* creating the DB record, giving the API immediate error feedback instead of a silent fire-and-forget failure
- **Auto-recovery for orphaned branches**: When `git worktree add -b` fails because a branch already exists but isn't used by any worktree, automatically deletes the stale branch and retries
- **Branch cleanup on deletion**: When a worktree is permanently deleted, also deletes the associated git branch if it was created by Agor (`new_branch=true`)
- **Better error messages**: User-friendly errors for branch conflicts instead of raw git output

## Root Cause
When a worktree was deleted, the cleanup flow removed the worktree directory but left the git branch behind. Recreating a worktree with the same name then failed with `fatal: a branch named 'xxx' already exists`.

## Defense in Depth
1. **Layer 1 (daemon)**: Pre-flight check catches conflicts before DB record creation → immediate API error
2. **Layer 2 (core git)**: Auto-recovery deletes orphaned branches and retries → handles edge cases
3. **Layer 3 (executor)**: Branch cleanup on deletion prevents stale branches from accumulating

## Test plan
- [ ] Create a worktree with `createBranch=true`, delete it, recreate with the same name → should succeed (auto-cleanup)
- [ ] Create two worktrees, try to create a third with the same branch as an existing one → should fail with clear error
- [ ] Delete a worktree that was created with `new_branch=true` → branch should be cleaned up
- [ ] Delete a worktree that was NOT created by Agor → branch should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)