### PR TITLE
fix: use OAuth 2.0 discovery before OIDC for MCP servers

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -1455,10 +1455,12 @@ async function main() {
               registration_endpoint?: string;
             } | null = null;
 
-            // Try OIDC discovery first, then OAuth 2.0 discovery
+            // Try OAuth 2.0 discovery first (RFC 8414), then OIDC discovery.
+            // This order matters: OIDC endpoints (e.g. Slack's /openid/connect/authorize)
+            // don't support regular API scopes — only the OAuth 2.0 endpoint does.
             for (const wellKnownPath of [
-              '/.well-known/openid-configuration',
               '/.well-known/oauth-authorization-server',
+              '/.well-known/openid-configuration',
             ]) {
               try {
                 const authMetaResponse = await fetch(`${authServerUrl}${wellKnownPath}`);
@@ -1702,14 +1704,19 @@ async function main() {
         const userId = params?.user?.user_id;
         console.log('[OAuth Start] User ID:', userId);
 
-        // Get OAuth mode from MCP server config if server ID is provided
+        // Get OAuth config from MCP server if server ID is provided
         let oauthMode: 'per_user' | 'shared' | undefined;
+        let authorizationUrlOverride: string | undefined;
         if (data.mcp_server_id) {
           const mcpServerRepo = new MCPServerRepository(db);
           const server = await mcpServerRepo.findById(data.mcp_server_id);
           if (server?.auth?.type === 'oauth') {
             oauthMode = server.auth.oauth_mode || 'per_user';
+            authorizationUrlOverride = server.auth.oauth_authorization_url;
             console.log('[OAuth Start] OAuth mode from server config:', oauthMode);
+            if (authorizationUrlOverride) {
+              console.log('[OAuth Start] Authorization URL override:', authorizationUrlOverride);
+            }
           }
         }
 
@@ -1735,7 +1742,9 @@ async function main() {
         // getBaseUrl() resolves: AGOR_BASE_URL env → daemon.base_url config → localhost fallback
         const baseUrl = await getBaseUrl();
         const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
-        const context = await startMCPOAuthFlow(wwwAuthenticate, data.client_id, redirectUri);
+        const context = await startMCPOAuthFlow(wwwAuthenticate, data.client_id, redirectUri, {
+          authorizationUrlOverride,
+        });
 
         // Capture initiating socket ID for scoped notifications
         const connection = params?.connection as { id?: string } | undefined;

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -171,13 +171,15 @@ async function registerDynamicClient(
 async function fetchAuthorizationServerMetadata(
   authServerUrl: string
 ): Promise<AuthorizationServerMetadata> {
-  // Try OIDC discovery first
-  let metadataUrl = `${authServerUrl}/.well-known/openid-configuration`;
+  // Try OAuth 2.0 discovery first (RFC 8414), then fall back to OIDC discovery.
+  // This order matters: OIDC endpoints (e.g. Slack's /openid/connect/authorize) don't
+  // support regular API scopes — only the OAuth 2.0 endpoint does.
+  let metadataUrl = `${authServerUrl}/.well-known/oauth-authorization-server`;
   let response = await fetch(metadataUrl, { signal: AbortSignal.timeout(15_000) });
 
-  // Fall back to OAuth 2.0 discovery
+  // Fall back to OIDC discovery
   if (!response.ok) {
-    metadataUrl = `${authServerUrl}/.well-known/oauth-authorization-server`;
+    metadataUrl = `${authServerUrl}/.well-known/openid-configuration`;
     response = await fetch(metadataUrl, { signal: AbortSignal.timeout(15_000) });
   }
 
@@ -665,12 +667,15 @@ export interface OAuthFlowContext {
  * @param wwwAuthenticateHeader - The WWW-Authenticate header from 401 response
  * @param clientId - OAuth client ID (optional, will use DCR if not provided)
  * @param redirectUri - Custom redirect URI (optional, defaults to a placeholder)
+ * @param options - Additional options
+ * @param options.authorizationUrlOverride - Override the auto-discovered authorization endpoint URL
  * @returns Authorization URL and flow context
  */
 export async function startMCPOAuthFlow(
   wwwAuthenticateHeader: string,
   clientId?: string,
-  redirectUri?: string
+  redirectUri?: string,
+  options?: { authorizationUrlOverride?: string }
 ): Promise<OAuthFlowContext> {
   console.log('[MCP OAuth] Starting two-phase OAuth 2.1 flow');
 
@@ -751,8 +756,11 @@ export async function startMCPOAuthFlow(
   // Generate state for CSRF protection
   const state = crypto.randomUUID();
 
-  // Step 7: Build authorization URL
-  const authUrl = new URL(authServerMetadata.authorization_endpoint);
+  // Step 7: Build authorization URL (use override if provided)
+  const authorizationEndpoint =
+    options?.authorizationUrlOverride || authServerMetadata.authorization_endpoint;
+  console.log('[MCP OAuth] Using authorization endpoint:', authorizationEndpoint);
+  const authUrl = new URL(authorizationEndpoint);
   authUrl.searchParams.set('response_type', 'code');
   authUrl.searchParams.set('client_id', actualClientId);
   authUrl.searchParams.set('redirect_uri', actualRedirectUri);

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -42,6 +42,7 @@ export interface MCPAuth {
   api_token?: string;
   api_secret?: string;
   // OAuth 2.0 config
+  oauth_authorization_url?: string; // Override auto-discovered authorization endpoint
   oauth_token_url?: string;
   oauth_client_id?: string;
   oauth_client_secret?: string;


### PR DESCRIPTION
## Summary
- **Reversed OAuth discovery order**: try `.well-known/oauth-authorization-server` (RFC 8414) before `.well-known/openid-configuration`. Slack's OIDC endpoint returns `/openid/connect/authorize` which doesn't support regular API scopes like `search:read.public` — only the OAuth 2.0 endpoint (`/oauth/v2/authorize`) does.
- **Added `oauth_authorization_url` override** to `MCPAuth` interface as an escape hatch for providers where auto-discovery returns the wrong authorization endpoint.
- **Wired override through the OAuth flow**: the `/mcp-servers/oauth-start` endpoint reads the override from server config and passes it to `startMCPOAuthFlow`.

## Test plan
- [ ] Configure Slack MCP server with OAuth and verify it uses `/oauth/v2/authorize` (not `/openid/connect/authorize`)
- [ ] Verify scopes like `search:read.public` are accepted by the authorization endpoint
- [ ] Test OAuth flow with a non-Slack MCP server to ensure OIDC fallback still works
- [ ] Test `oauth_authorization_url` override by setting it manually in MCP server config

🤖 Generated with [Claude Code](https://claude.com/claude-code)