### PR TITLE
fix: register OAuth callback route before FeathersJS mcp-servers service

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -1194,6 +1194,107 @@ async function main() {
   // Register repos service (accesses worktrees via app.service('worktrees'))
   app.use('/repos', createReposService(db, app));
 
+  // GET endpoint to receive OAuth callback redirects from the authorization server.
+  // MUST be registered BEFORE the /mcp-servers FeathersJS service below, otherwise
+  // FeathersJS interprets GET /mcp-servers/oauth-callback as mcp-servers.get('oauth-callback')
+  // and applies auth hooks, returning 401 to the unauthenticated browser redirect.
+  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS overloads app.get(); cast to Express to use route handler
+  (app as any as express.Application).get('/mcp-servers/oauth-callback', (async (
+    req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction
+  ) => {
+    // Security headers for the static HTML response
+    res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'");
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    try {
+      const code = req.query.code as string | undefined;
+      const state = req.query.state as string | undefined;
+      const error = req.query.error as string | undefined;
+
+      if (error) {
+        const errorDescription = (req.query.error_description as string) || error;
+        console.error('[OAuth Callback] Authorization error:', errorDescription);
+        res.status(400).send(oauthResultPage(false, `Authorization failed: ${errorDescription}`));
+        return;
+      }
+
+      if (!code || !state) {
+        res.status(400).send(oauthResultPage(false, 'Missing code or state parameter'));
+        return;
+      }
+
+      console.log('[OAuth Callback] Received callback, state:', state);
+
+      // Find the pending flow
+      const pendingFlow = pendingOAuthFlows.get(state);
+      if (!pendingFlow) {
+        res
+          .status(400)
+          .send(
+            oauthResultPage(false, 'OAuth flow expired or not found. Please start the flow again.')
+          );
+        return;
+      }
+
+      // Complete the flow
+      const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
+      const token = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+
+      // Remove from pending flows
+      pendingOAuthFlows.delete(state);
+
+      // Cache the token at daemon level
+      cacheOAuth21Token(pendingFlow.context.metadataUrl, token, 3600);
+
+      // Save to database based on OAuth mode
+      if (pendingFlow.mcpServerId) {
+        const oauthMode = pendingFlow.oauthMode || 'per_user';
+
+        if (oauthMode === 'per_user' && pendingFlow.userId) {
+          const userTokenRepo = new UserMCPOAuthTokenRepository(db);
+          await userTokenRepo.saveToken(
+            pendingFlow.userId as import('@agor/core/types').UserID,
+            pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
+            token,
+            3600
+          );
+          console.log(
+            `[OAuth Callback] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
+          );
+        } else {
+          const mcpServerRepo = new MCPServerRepository(db);
+          await saveOAuth21TokenToDB(mcpServerRepo, pendingFlow.mcpServerId, token, 3600);
+          console.log(`[OAuth Callback] Shared token saved for server ${pendingFlow.mcpServerId}`);
+        }
+      }
+
+      // Notify the initiating client that OAuth completed successfully
+      if (app.io) {
+        if (pendingFlow.socketId) {
+          app.io.to(pendingFlow.socketId).emit('oauth:completed', { state, success: true });
+        } else {
+          app.io.emit('oauth:completed', { state, success: true });
+        }
+      }
+
+      console.log('[OAuth Callback] Flow completed successfully');
+      res.send(oauthResultPage(true, 'OAuth authentication successful! You can close this tab.'));
+    } catch (err) {
+      console.error('[OAuth Callback] Error:', err);
+      res
+        .status(500)
+        .send(
+          oauthResultPage(
+            false,
+            `Authentication failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+    }
+  }) as express.RequestHandler);
+
   app.use('/mcp-servers', createMCPServersService(db));
 
   // JWT test endpoint for MCP servers (server-side to avoid CORS)
@@ -1881,108 +1982,6 @@ async function main() {
   app.service('mcp-servers/oauth-complete').hooks({
     before: { create: [requireAuth] },
   });
-
-  // GET endpoint to receive OAuth callback redirects from the authorization server
-  // The browser is redirected here after the user completes OAuth authorization
-  // IMPORTANT: Use app.get() instead of app.use() so this is a plain Express route,
-  // not a FeathersJS service. FeathersJS would apply auth hooks to app.use() services,
-  // but this endpoint must be unauthenticated (browser redirect from OAuth provider).
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS overloads app.get(); cast to Express to use route handler
-  (app as any as express.Application).get('/mcp-servers/oauth-callback', (async (
-    req: express.Request,
-    res: express.Response,
-    _next: express.NextFunction
-  ) => {
-    // Security headers for the static HTML response
-    res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'");
-    res.setHeader('X-Content-Type-Options', 'nosniff');
-    res.setHeader('X-Frame-Options', 'DENY');
-    res.setHeader('Referrer-Policy', 'no-referrer');
-    try {
-      const code = req.query.code as string | undefined;
-      const state = req.query.state as string | undefined;
-      const error = req.query.error as string | undefined;
-
-      if (error) {
-        const errorDescription = (req.query.error_description as string) || error;
-        console.error('[OAuth Callback] Authorization error:', errorDescription);
-        res.status(400).send(oauthResultPage(false, `Authorization failed: ${errorDescription}`));
-        return;
-      }
-
-      if (!code || !state) {
-        res.status(400).send(oauthResultPage(false, 'Missing code or state parameter'));
-        return;
-      }
-
-      console.log('[OAuth Callback] Received callback, state:', state);
-
-      // Find the pending flow
-      const pendingFlow = pendingOAuthFlows.get(state);
-      if (!pendingFlow) {
-        res
-          .status(400)
-          .send(
-            oauthResultPage(false, 'OAuth flow expired or not found. Please start the flow again.')
-          );
-        return;
-      }
-
-      // Complete the flow
-      const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
-      const token = await completeMCPOAuthFlow(pendingFlow.context, code, state);
-
-      // Remove from pending flows
-      pendingOAuthFlows.delete(state);
-
-      // Cache the token at daemon level
-      cacheOAuth21Token(pendingFlow.context.metadataUrl, token, 3600);
-
-      // Save to database based on OAuth mode
-      if (pendingFlow.mcpServerId) {
-        const oauthMode = pendingFlow.oauthMode || 'per_user';
-
-        if (oauthMode === 'per_user' && pendingFlow.userId) {
-          const userTokenRepo = new UserMCPOAuthTokenRepository(db);
-          await userTokenRepo.saveToken(
-            pendingFlow.userId as import('@agor/core/types').UserID,
-            pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
-            token,
-            3600
-          );
-          console.log(
-            `[OAuth Callback] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
-          );
-        } else {
-          const mcpServerRepo = new MCPServerRepository(db);
-          await saveOAuth21TokenToDB(mcpServerRepo, pendingFlow.mcpServerId, token, 3600);
-          console.log(`[OAuth Callback] Shared token saved for server ${pendingFlow.mcpServerId}`);
-        }
-      }
-
-      // Notify the initiating client that OAuth completed successfully
-      if (app.io) {
-        if (pendingFlow.socketId) {
-          app.io.to(pendingFlow.socketId).emit('oauth:completed', { state, success: true });
-        } else {
-          app.io.emit('oauth:completed', { state, success: true });
-        }
-      }
-
-      console.log('[OAuth Callback] Flow completed successfully');
-      res.send(oauthResultPage(true, 'OAuth authentication successful! You can close this tab.'));
-    } catch (err) {
-      console.error('[OAuth Callback] Error:', err);
-      res
-        .status(500)
-        .send(
-          oauthResultPage(
-            false,
-            `Authentication failed: ${err instanceof Error ? err.message : String(err)}`
-          )
-        );
-    }
-  }) as express.RequestHandler);
 
   // Notify UI that OAuth authentication is needed for MCP servers
   // Called by executor when MCP servers require authentication


### PR DESCRIPTION
## Summary
- Follow-up to #820 which changed `app.use()` to `app.get()` but still got 401
- **Root cause**: FeathersJS interprets `GET /mcp-servers/oauth-callback` as `mcp-servers.get('oauth-callback')`, routing it to the `mcp-servers` service which has auth hooks — regardless of whether an Express route is also registered
- **Fix**: Move the Express `app.get()` registration **before** `app.use('/mcp-servers', ...)` so Express handles the route before FeathersJS's service router can intercept it

## Test plan
- [ ] Start OAuth flow for Slack MCP server
- [ ] Verify the callback redirect no longer returns 401
- [ ] Verify token exchange completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)