### PR TITLE
fix: handle non-standard OAuth token response formats (e.g. Slack)

### DIFF
--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -333,7 +333,31 @@ async function exchangeCodeForToken(
     throw new Error(`Token exchange failed (${response.status}): ${errorText}`);
   }
 
-  return (await response.json()) as OAuthTokenResponse;
+  // biome-ignore lint/suspicious/noExplicitAny: OAuth providers return varied response shapes
+  const json = (await response.json()) as any;
+  console.log(
+    '[MCP OAuth] Token response keys:',
+    Object.keys(json),
+    'has access_token:',
+    !!json.access_token
+  );
+
+  // Standard OAuth 2.0 response has access_token at top level.
+  // Some providers (e.g. Slack) nest user tokens under authed_user.access_token.
+  const accessToken = json.access_token || json.authed_user?.access_token;
+  if (!accessToken) {
+    throw new Error(
+      `Token exchange succeeded but no access_token found in response. Keys: ${Object.keys(json).join(', ')}`
+    );
+  }
+
+  return {
+    access_token: accessToken,
+    token_type: json.token_type || json.authed_user?.token_type || 'bearer',
+    expires_in: json.expires_in,
+    refresh_token: json.refresh_token,
+    scope: json.scope || json.authed_user?.scope,
+  } as OAuthTokenResponse;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Slack's `oauth.v2.access` returns user tokens nested under `authed_user.access_token` instead of the standard top-level `access_token` field
- This caused the token to be saved as `undefined` in the database (showing up as `default` in the SQL insert)
- Now checks both `access_token` and `authed_user.access_token`, and throws a clear error if neither is present
- Logs response keys for debugging future OAuth provider quirks

Follow-up to #822, #821, #820, #819.

## Test plan
- [ ] Complete Slack OAuth flow end-to-end
- [ ] Verify token is saved to `user_mcp_oauth_tokens` table
- [ ] Verify non-Slack OAuth providers still work (standard `access_token` response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)