### PR TITLE
fix: resolve Slack channel type via cache + conversations.info API

### DIFF
--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -227,8 +227,14 @@ export class SlackConnector implements GatewayConnector {
 
     // 2. Check cache (populated from message events or prior API calls)
     const now = Date.now();
+
+    // Evict expired entries to prevent unbounded growth
+    for (const [key, entry] of this.channelTypeCache) {
+      if (entry.expiresAt <= now) this.channelTypeCache.delete(key);
+    }
+
     const cached = this.channelTypeCache.get(channelId);
-    if (cached && cached.expiresAt > now) {
+    if (cached) {
       return cached.type;
     }
 
@@ -263,25 +269,28 @@ export class SlackConnector implements GatewayConnector {
       // Fall through to prefix inference
     }
 
-    // 4. Last resort: prefix inference (unreliable but better than nothing)
+    // 4. Last resort: prefix inference for unambiguous prefixes only.
+    // IMPORTANT: C-prefix is NOT used — private channels can have C-prefix,
+    // and misclassifying them as public would recreate the original bug (#826).
+    // G → group and D → DM are reliable inferences.
     const prefix = channelId.charAt(0);
     let inferredType: string | undefined;
-    if (prefix === 'C') {
-      inferredType = 'channel';
-    } else if (prefix === 'G') {
+    if (prefix === 'G') {
       inferredType = 'group';
     } else if (prefix === 'D') {
       inferredType = 'im';
     }
     if (inferredType) {
-      console.warn(
-        `[slack] Using unreliable prefix inference for channel ${channelId} → ${inferredType}`
-      );
-      // Short TTL for prefix-inferred types — they may be wrong
+      console.warn(`[slack] Using prefix inference for channel ${channelId} → ${inferredType}`);
+      // Short TTL for prefix-inferred types
       this.channelTypeCache.set(channelId, {
         type: inferredType,
         expiresAt: now + SlackConnector.CHANNEL_CACHE_ERROR_TTL_MS,
       });
+    } else {
+      console.warn(
+        `[slack] Cannot determine channel type for ${channelId} (API failed, prefix ambiguous)`
+      );
     }
     return inferredType;
   }


### PR DESCRIPTION
## Summary

- **Adds channel type cache** to the Slack connector, populated from `message` events (which include reliable `channel_type`) and `conversations.info` API calls
- **Fixes misclassification of private channels** with `C`-prefix IDs that were incorrectly inferred as public channels, causing messages to be silently dropped when `enable_channels: false`
- **Fixes metadata bug** where callback passed raw `event.channel_type` (often `undefined` for `app_mention`) instead of the resolved value

## Details

`app_mention` events don't include `channel_type`. The old code inferred type from channel ID prefix (`C` → public, `G` → private), but Slack private channels can have a `C` prefix. With `enable_groups: true, enable_channels: false, require_mention: true`, this caused:

1. `message` event (correct `channel_type: group`) skipped by dedup (defers to `app_mention`)
2. `app_mention` event (missing `channel_type`) inferred as public via prefix → dropped

Resolution order for `resolveChannelType()`:
1. Explicit `channel_type` from event (trusted, cached for later)
2. In-memory cache hit (30min TTL)
3. `conversations.info` API call (cached on success)
4. Channel ID prefix inference (last resort, 1min TTL)

Closes #826

## Test plan

- [ ] Deploy to staging with `enable_groups: true, enable_channels: false, require_mention: true`
- [ ] Mention bot in a private channel with `C`-prefix ID → should be processed (not dropped)
- [ ] Verify `message` events populate the cache (check `conversations.info resolved` log)
- [ ] Verify `app_mention` events use cached type (no extra API call after first message)
- [ ] Verify public channel messages are still dropped when `enable_channels: false`
- [ ] Verify DMs still work regardless of config

🤖 Generated with [Claude Code](https://claude.com/claude-code)