### PR TITLE
fix: restart gateway listener on config change

### DIFF
--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -540,7 +540,12 @@ export class GatewayService {
       }
       console.log(`[gateway] Listener stopped for channel ${channelId.substring(0, 8)}`);
     } catch (error) {
-      console.error(`[gateway] Error stopping listener for ${channelId}:`, error);
+      // Old socket may still be alive — duplicate inbound messages are possible
+      // until the next daemon restart. See: listener lifecycle serialization (tech debt).
+      console.error(
+        `[gateway] Error stopping listener for ${channelId} (old socket may still be alive):`,
+        error
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Gateway channel config changes (e.g. toggling `enable_channels`) were silently ignored until daemon restart
- `startChannelListener()` had an early return if a listener already existed, so the old connector with stale config kept running
- Now `startListenerForChannel()` stops the existing listener before starting a new one, ensuring updated config is picked up immediately

## Context
Discovered while investigating Slack agents not responding after PR #838. PR #838's channel type resolution changes were correct — the actual issue was that Blake's gateway channel had `enableChannels: false`, and updating it in the UI didn't take effect because of this bug.

## Test plan
- [ ] Update a gateway channel's `enable_channels` setting in the UI
- [ ] Verify the listener restarts with new config (check logs for "Restarting listener for channel")
- [ ] Verify messages are processed according to the new config without daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)