### PR TITLE
fix: attach MCP servers to scheduled and spawned sessions

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -91,6 +91,7 @@ import type {
   Id,
   InputRequestContent,
   MCPServer,
+  MCPServerID,
   Message,
   MessageSource,
   Paginated,
@@ -2657,6 +2658,8 @@ async function main() {
   // Register session-mcp-servers as a top-level service for WebSocket events
   // This is needed for real-time updates when MCP servers are added/removed from sessions
   const sessionMCPServersService = createSessionMCPServersService(db);
+  // Cast to any: this service has a non-standard setServers method not in FeathersJS's service interface
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app.use('/session-mcp-servers', {
     async find(params?: {
       query?: { session_id?: string; mcp_server_id?: string; enabled?: boolean };
@@ -2692,7 +2695,17 @@ async function main() {
         added_at: new Date(row.added_at),
       }));
     },
-  });
+    async setServers(sessionId: SessionID, serverIds: MCPServerID[]) {
+      await sessionMCPServersService.setServers(sessionId, serverIds);
+      // Emit created events for real-time UI updates
+      for (const serverId of serverIds) {
+        app.service('session-mcp-servers').emit('created', {
+          session_id: sessionId,
+          mcp_server_id: serverId,
+        });
+      }
+    },
+  } as any);
 
   // Register users service (for authentication)
   const usersService = createUsersService(db);

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -25,12 +25,13 @@
 
 import type { Database } from '@agor/core/db';
 import { SessionRepository, UsersRepository, WorktreeRepository } from '@agor/core/db';
-import type { PermissionMode, Session, User, Worktree } from '@agor/core/types';
+import type { MCPServerID, PermissionMode, Session, User, Worktree } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import { getNextRunTime, getPrevRunTime } from '@agor/core/utils/cron';
 import Handlebars from 'handlebars';
 import type { Application } from '../declarations';
+import type { SessionMCPServersService } from './session-mcp-servers';
 
 export interface SchedulerConfig {
   /** Tick interval in milliseconds (default: 30000 = 30s) */
@@ -363,6 +364,12 @@ export class SchedulerService {
       // AND pass user: creator so the executor's session token is generated for the correct user.
       // Without the user, the token defaults to 'anonymous' which doesn't exist in the database,
       // causing the executor to fail with "User not found: anonymous" error.
+      // Attach MCP servers BEFORE triggering prompt (executor reads them at launch)
+      if (schedule.mcp_server_ids?.length) {
+        const sessionMCPService = this.app.service('session-mcp-servers') as unknown as SessionMCPServersService;
+        await sessionMCPService.setServers(createdSession.session_id, schedule.mcp_server_ids as MCPServerID[]);
+      }
+
       const promptService = this.app.service('/sessions/:id/prompt');
       await promptService.create(
         {
@@ -376,8 +383,6 @@ export class SchedulerService {
           user: creator, // Pass creator user for session token generation
         } as import('@agor/core/types').AuthenticatedParams & { route: { id: string } }
       );
-
-      // TODO: Attach MCP servers if specified in schedule.mcp_server_ids
 
       // 7. Update schedule metadata
       await this.updateScheduleMetadata(worktree, scheduledRunAt, now);

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -8,9 +8,10 @@
 import { PAGINATION } from '@agor/core/config';
 import { type Database, SessionRepository, type SessionWithLastMessage } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Paginated, QueryParams, Session, TaskID } from '@agor/core/types';
+import type { MCPServerID, Paginated, QueryParams, Session, TaskID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
+import type { SessionMCPServersService } from './session-mcp-servers';
 
 /**
  * Session service params
@@ -241,7 +242,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       };
     }
 
-    // TODO: Handle MCP server attachment from data.mcpServerIds via session_mcp_servers junction table
+    const mcpServerIds = data.mcpServerIds;
 
     // Build callback configuration - only store explicit overrides
     // Leave fields undefined if not specified so parent's config applies
@@ -284,13 +285,18 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         model_config: modelConfig,
         callback_config: callbackConfig,
         // Don't copy sdk_session_id - spawn will get its own via forkSession:true
-        // TODO: Handle MCP server attachment via session_mcp_servers junction table
       },
       params
     );
 
     // Cast spawnedSession to Session to handle return type (create returns Session | Session[])
     const session = spawnedSession as Session;
+
+    // Attach MCP servers if specified in spawn config
+    if (mcpServerIds?.length) {
+      const sessionMCPService = this.app?.service('session-mcp-servers') as unknown as SessionMCPServersService;
+      await sessionMCPService.setServers(session.session_id, mcpServerIds as MCPServerID[]);
+    }
 
     // Update parent's children list
     const parentChildren = parent.genealogy?.children || [];

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -2,6 +2,7 @@ import type { AgorClient } from '@agor/core/api';
 import type { Repo, Session, SpawnConfig, User, Worktree } from '@agor/core/types';
 import { getAssistantConfig, isAssistant } from '@agor/core/types';
 import {
+  ApiOutlined,
   BranchesOutlined,
   ClockCircleOutlined,
   CodeOutlined,
@@ -32,6 +33,7 @@ import {
 import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useAppData } from '../../contexts/AppDataContext';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveDeleteWorktreeModal } from '../ArchiveDeleteWorktreeModal';
@@ -110,6 +112,7 @@ const WorktreeCardComponent = ({
 }: WorktreeCardProps) => {
   const { token } = theme.useToken();
   const connectionDisabled = useConnectionDisabled();
+  const { mcpServerById, sessionMcpServerIds } = useAppData();
 
   // Fork/Spawn modal state
   const [forkSpawnModal, setForkSpawnModal] = useState<{
@@ -454,7 +457,10 @@ const WorktreeCardComponent = ({
   // Scheduled runs content (flat list, no genealogy tree needed)
   const scheduledRunsContent = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {scheduledSessions.map((session) => (
+      {scheduledSessions.map((session) => {
+        const mcpIds = sessionMcpServerIds.get(session.session_id) || [];
+        const mcpServers = mcpIds.map((id) => mcpServerById.get(id)).filter(Boolean);
+        return (
         <div
           key={session.session_id}
           style={{
@@ -470,16 +476,40 @@ const WorktreeCardComponent = ({
         >
           <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
             <ToolIcon tool={session.agentic_tool} size={20} />
-            <Typography.Text
-              style={{
-                fontSize: 12,
-                flex: 1,
-                color: token.colorTextSecondary,
-                ...getSessionTitleStyles(2),
-              }}
-            >
-              {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-            </Typography.Text>
+            <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <Typography.Text
+                style={{
+                  fontSize: 12,
+                  color: token.colorTextSecondary,
+                  ...getSessionTitleStyles(2),
+                }}
+              >
+                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+              </Typography.Text>
+              {mcpServers.length > 0 && (
+                <Space size={4} wrap style={{ alignSelf: 'flex-start' }}>
+                  {mcpServers.map((server) => (
+                    <span
+                      key={server?.mcp_server_id}
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 4,
+                        fontSize: 11,
+                        color: token.colorPrimary,
+                        border: `1px solid ${token.colorPrimaryBorder}`,
+                        borderRadius: 4,
+                        padding: '0 6px',
+                        lineHeight: '18px',
+                      }}
+                    >
+                      <ApiOutlined style={{ fontSize: 10 }} />
+                      {server?.display_name || server?.name}
+                    </span>
+                  ))}
+                </Space>
+              )}
+            </div>
           </Space>
 
           {/* Status indicator */}
@@ -495,7 +525,8 @@ const WorktreeCardComponent = ({
             <TaskStatusIcon status={session.status} size={16} />
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 


### PR DESCRIPTION
## Summary

- Scheduled sessions (cron triggers) now have MCP servers attached at creation time via `scheduler.ts`
- Spawned sessions now have MCP servers attached when `mcpServerIds` is provided in the spawn config via `sessions.ts`
- Added `setServers` delegation to the `session-mcp-servers` service in `index.ts` so the method is callable via `app.service()`
- Emit `created` WebSocket events after `setServers` writes to DB, enabling real-time MCP tag updates in the UI without page reload
- WorktreeCard now shows MCP server tags inline on scheduled session cards

## Test plan

- [ ] Add MCP server IDs to a worktree schedule config
- [ ] Trigger a scheduled run (set cron to next minute)
- [ ] Verify session → MCP Servers tab shows the configured servers immediately after session creation (no page reload needed)
- [ ] Verify spawned sessions inherit MCP servers when `mcpServerIds` is passed in spawn config