### PR TITLE
fix: vertically center Spin indicator in EnvironmentPill

### DIFF
--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -74,7 +74,12 @@ export function EnvironmentPill({
         return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: 12 }} />;
       case 'starting':
       case 'stopping':
-        return <Spin size="small" />;
+        return (
+          <Spin
+            size="small"
+            style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12 }}
+          />
+        );
       case 'healthy':
         return <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 12 }} />;
       case 'unhealthy':


### PR DESCRIPTION
## Summary
- Fixed Ant Design `<Spin />` loading indicator not vertically centered with "env" text in the EnvironmentPill toolbar
- Added `display: inline-flex`, `align-items: center`, and `fontSize: 12` to match other status icons

## Test plan
- [ ] Verify the spinner dots in the env pill are vertically centered with the "env" text when environment is starting/stopping
- [ ] Confirm other status icons (stopped, healthy, unhealthy, running, error) remain properly aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)