### PR TITLE
fix: support OAuth providers without RFC 8414 metadata discovery

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -1388,9 +1388,11 @@ async function main() {
 
         let probeResponse: Response;
         try {
+          // Use POST since MCP servers use JSON-RPC over POST — many reject GET with 405
           probeResponse = await fetch(data.mcp_url, {
-            method: 'GET',
-            headers: { Accept: 'application/json' },
+            method: 'POST',
+            headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
             signal: AbortSignal.timeout(15_000),
           });
         } catch (fetchError) {
@@ -1510,11 +1512,13 @@ async function main() {
               }
 
               const testResponse = await fetch(data.mcp_url, {
-                method: 'GET',
+                method: 'POST',
                 headers: {
                   Authorization: `Bearer ${token}`,
                   Accept: 'application/json',
+                  'Content-Type': 'application/json',
                 },
+                body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
                 signal: AbortSignal.timeout(15_000),
               });
 
@@ -1685,11 +1689,13 @@ async function main() {
 
             try {
               const mcpResponse = await fetch(data.mcp_url, {
-                method: 'GET',
+                method: 'POST',
                 headers: {
                   Authorization: `Bearer ${token}`,
                   Accept: 'application/json',
+                  'Content-Type': 'application/json',
                 },
+                body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
               });
               mcpStatus = mcpResponse.status;
               mcpStatusText = mcpResponse.statusText;
@@ -1826,6 +1832,8 @@ async function main() {
         let authorizationUrlOverride: string | undefined;
         let tokenUrlOverride: string | undefined;
         let clientSecretOverride: string | undefined;
+        let clientIdFromConfig: string | undefined;
+        let scopeOverride: string | undefined;
         if (data.mcp_server_id) {
           const mcpServerRepo = new MCPServerRepository(db);
           const server = await mcpServerRepo.findById(data.mcp_server_id);
@@ -1833,7 +1841,9 @@ async function main() {
             oauthMode = server.auth.oauth_mode || 'per_user';
             authorizationUrlOverride = server.auth.oauth_authorization_url;
             tokenUrlOverride = server.auth.oauth_token_url;
+            clientIdFromConfig = server.auth.oauth_client_id;
             clientSecretOverride = server.auth.oauth_client_secret;
+            scopeOverride = server.auth.oauth_scope;
             console.log('[OAuth Start] OAuth mode from server config:', oauthMode);
             if (authorizationUrlOverride) {
               console.log('[OAuth Start] Authorization URL override:', authorizationUrlOverride);
@@ -1841,13 +1851,18 @@ async function main() {
             if (tokenUrlOverride) {
               console.log('[OAuth Start] Token URL override:', tokenUrlOverride);
             }
+            if (scopeOverride) {
+              console.log('[OAuth Start] Scope override:', scopeOverride);
+            }
           }
         }
 
         // Probe the MCP URL to get WWW-Authenticate header
+        // Use POST since MCP servers use JSON-RPC over POST — many reject GET with 405
         const probeResponse = await fetch(data.mcp_url, {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
+          method: 'POST',
+          headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
           signal: AbortSignal.timeout(15_000),
         });
 
@@ -1866,10 +1881,13 @@ async function main() {
         // getBaseUrl() resolves: AGOR_BASE_URL env → daemon.base_url config → localhost fallback
         const baseUrl = await getBaseUrl();
         const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
-        const context = await startMCPOAuthFlow(wwwAuthenticate, data.client_id, redirectUri, {
+        // Use client_id from request (UI form) or fall back to saved server config
+        const effectiveClientId = data.client_id || clientIdFromConfig;
+        const context = await startMCPOAuthFlow(wwwAuthenticate, effectiveClientId, redirectUri, {
           authorizationUrlOverride,
           tokenUrlOverride,
           clientSecret: clientSecretOverride,
+          scope: scopeOverride,
         });
 
         // Capture initiating socket ID for scoped notifications

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -548,6 +548,7 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                     }
                     if (value !== 'oauth') {
                       form.setFieldsValue({
+                        oauth_authorization_url: undefined,
                         oauth_token_url: undefined,
                         oauth_client_id: undefined,
                         oauth_client_secret: undefined,
@@ -624,6 +625,14 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
 
               {authType === 'oauth' && (
                 <>
+                  <Form.Item
+                    label="Authorization URL"
+                    name="oauth_authorization_url"
+                    tooltip="OAuth authorization endpoint for browser-based login. Leave empty for auto-discovery (RFC 8414)."
+                  >
+                    <Input placeholder="https://auth.example.com/oauth/authorize" allowClear />
+                  </Form.Item>
+
                   <Form.Item
                     label="Token URL"
                     name="oauth_token_url"
@@ -1264,6 +1273,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       formValues.jwt_api_token = server.auth?.api_token;
       formValues.jwt_api_secret = server.auth?.api_secret;
     } else if (serverAuthType === 'oauth') {
+      formValues.oauth_authorization_url = server.auth?.oauth_authorization_url;
       formValues.oauth_token_url = server.auth?.oauth_token_url;
       formValues.oauth_client_id = server.auth?.oauth_client_id;
       formValues.oauth_client_secret = server.auth?.oauth_client_secret;

--- a/apps/agor-ui/src/components/SettingsModal/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/SettingsModal/mcp-oauth-utils.ts
@@ -14,6 +14,7 @@ export function isTemplateValue(value: string | undefined): boolean {
 }
 
 export interface OAuthConfig {
+  oauth_authorization_url?: string;
   oauth_token_url?: string;
   oauth_client_id?: string;
   oauth_client_secret?: string;
@@ -28,6 +29,11 @@ export interface OAuthConfig {
  */
 export function extractOAuthConfig(values: Record<string, unknown>): OAuthConfig {
   const config: OAuthConfig = {};
+
+  // Only include authorization URL if it's provided
+  if (values.oauth_authorization_url && typeof values.oauth_authorization_url === 'string') {
+    config.oauth_authorization_url = values.oauth_authorization_url;
+  }
 
   // Only include token URL if it's provided (can be template or real value)
   if (values.oauth_token_url && typeof values.oauth_token_url === 'string') {

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -723,7 +723,12 @@ export async function startMCPOAuthFlow(
   wwwAuthenticateHeader: string,
   clientId?: string,
   redirectUri?: string,
-  options?: { authorizationUrlOverride?: string; tokenUrlOverride?: string; clientSecret?: string }
+  options?: {
+    authorizationUrlOverride?: string;
+    tokenUrlOverride?: string;
+    clientSecret?: string;
+    scope?: string;
+  }
 ): Promise<OAuthFlowContext> {
   console.log('[MCP OAuth] Starting two-phase OAuth 2.1 flow');
 
@@ -752,8 +757,33 @@ export async function startMCPOAuthFlow(
   console.log('[MCP OAuth] Authorization server:', authServerUrl);
 
   // Step 3: Fetch Authorization Server Metadata (RFC 8414)
-  const authServerMetadata = await fetchAuthorizationServerMetadata(authServerUrl);
-  console.log('[MCP OAuth] Authorization server metadata:', authServerMetadata);
+  // Skip auto-discovery when both authorization URL and token URL overrides are provided.
+  // Many OAuth providers (e.g. custom internal services) don't implement RFC 8414
+  // (.well-known/oauth-authorization-server) or OIDC discovery.
+  const hasFullOverrides = options?.authorizationUrlOverride && options?.tokenUrlOverride;
+  let authServerMetadata: AuthorizationServerMetadata | null = null;
+
+  if (hasFullOverrides) {
+    console.log('[MCP OAuth] Skipping auth server metadata fetch — manual overrides provided:', {
+      authorization: options.authorizationUrlOverride,
+      token: options.tokenUrlOverride,
+    });
+  } else {
+    try {
+      authServerMetadata = await fetchAuthorizationServerMetadata(authServerUrl);
+      console.log('[MCP OAuth] Authorization server metadata:', authServerMetadata);
+    } catch (metadataError) {
+      // If we have at least partial overrides, we can continue without metadata
+      if (options?.authorizationUrlOverride || options?.tokenUrlOverride) {
+        console.log(
+          '[MCP OAuth] Auth server metadata fetch failed, but partial overrides available:',
+          metadataError instanceof Error ? metadataError.message : String(metadataError)
+        );
+      } else {
+        throw metadataError;
+      }
+    }
+  }
 
   // Step 4: Generate PKCE challenge
   const pkce = generatePKCE();
@@ -769,7 +799,7 @@ export async function startMCPOAuthFlow(
 
   if (!actualClientId) {
     // Check if server supports Dynamic Client Registration (RFC 7591)
-    if (authServerMetadata.registration_endpoint) {
+    if (authServerMetadata?.registration_endpoint) {
       console.log('[MCP OAuth] Server supports Dynamic Client Registration');
       const registration = await registerDynamicClient(
         authServerMetadata.registration_endpoint,
@@ -778,7 +808,7 @@ export async function startMCPOAuthFlow(
       );
       actualClientId = registration.client_id;
       clientSecret = registration.client_secret;
-    } else {
+    } else if (!hasFullOverrides) {
       // No DCR support and no client_id provided - try MCP-style endpoint
       const mcpRegisterEndpoint = `${authServerUrl}/register`;
       console.log('[MCP OAuth] Trying MCP-style registration endpoint:', mcpRegisterEndpoint);
@@ -798,6 +828,11 @@ export async function startMCPOAuthFlow(
             'Please provide a client_id in the MCP server configuration.'
         );
       }
+    } else {
+      throw new Error(
+        'OAuth client_id is required when using manual OAuth URL overrides.\n\n' +
+          'Please provide a client_id in the MCP server configuration.'
+      );
     }
   }
 
@@ -805,15 +840,27 @@ export async function startMCPOAuthFlow(
   const state = crypto.randomUUID();
 
   // Resolve token endpoint (use override if provided)
-  const tokenEndpoint = options?.tokenUrlOverride || authServerMetadata.token_endpoint;
+  const tokenEndpoint = options?.tokenUrlOverride || authServerMetadata?.token_endpoint;
+  if (!tokenEndpoint) {
+    throw new Error(
+      'No token endpoint available. Either provide oauth_token_url in the MCP server config, ' +
+        'or ensure the authorization server supports RFC 8414 metadata discovery.'
+    );
+  }
   console.log('[MCP OAuth] Using token endpoint:', tokenEndpoint);
   if (options?.tokenUrlOverride) {
-    console.log('[MCP OAuth] (overridden from:', authServerMetadata.token_endpoint, ')');
+    console.log('[MCP OAuth] (overridden from:', authServerMetadata?.token_endpoint, ')');
   }
 
   // Step 7: Build authorization URL (use override if provided)
   const authorizationEndpoint =
-    options?.authorizationUrlOverride || authServerMetadata.authorization_endpoint;
+    options?.authorizationUrlOverride || authServerMetadata?.authorization_endpoint;
+  if (!authorizationEndpoint) {
+    throw new Error(
+      'No authorization endpoint available. Either provide oauth_authorization_url in the MCP server config, ' +
+        'or ensure the authorization server supports RFC 8414 metadata discovery.'
+    );
+  }
   console.log('[MCP OAuth] Using authorization endpoint:', authorizationEndpoint);
   const authUrl = new URL(authorizationEndpoint);
   authUrl.searchParams.set('response_type', 'code');
@@ -823,8 +870,10 @@ export async function startMCPOAuthFlow(
   authUrl.searchParams.set('code_challenge_method', 'S256');
   authUrl.searchParams.set('state', state);
 
-  // Add scopes if available
-  if (resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0) {
+  // Add scopes: prefer explicit scope option, then auto-discovered scopes
+  if (options?.scope) {
+    authUrl.searchParams.set('scope', options.scope);
+  } else if (resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0) {
     authUrl.searchParams.set('scope', resourceMetadata.scopes_supported.join(' '));
   }
 


### PR DESCRIPTION
## Summary
- Fix "Failed to fetch authorization server metadata: 404" for OAuth providers that don't implement RFC 8414 (.well-known/oauth-authorization-server) or OIDC discovery
- Add **Authorization URL** form field to MCP server settings (was missing — only Token URL existed)
- When both Authorization URL and Token URL are manually configured, skip auto-discovery entirely
- Pass scope and client_id from saved server config to the OAuth flow
- Use POST for MCP server probing (JSON-RPC over POST, many MCP servers reject GET with 405)

## Motivation
BirdsAI (and many internal OAuth providers) don't implement RFC 8414 metadata discovery. The OAuth flow was calling `fetchAuthorizationServerMetadata()` unconditionally, which threw a 404 before the manual override logic could take effect.

## Test plan
- [ ] Configure an MCP server with OAuth auth type, providing Authorization URL and Token URL manually
- [ ] Click "Start OAuth Flow" — should skip .well-known discovery and use the manual URLs
- [ ] Verify the browser-based OAuth flow completes successfully
- [ ] Test that servers WITH RFC 8414 support still work via auto-discovery (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)