### PR TITLE
feat: add ripgrep to all Docker images

### DIFF
--- a/.devcontainer/dev/Dockerfile
+++ b/.devcontainer/dev/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     less \
     tree \
+    ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Zellij (terminal multiplexer)

--- a/.devcontainer/playground/Dockerfile
+++ b/.devcontainer/playground/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     less \
     tree \
+    ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Zellij (terminal multiplexer)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
   tree \
   openssh-server \
   acl \
+  ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
 # Configure SSH server for multi-user testing (used in postgres profile)


### PR DESCRIPTION
## Summary
- Add `ripgrep` (`rg`) to the `apt-get install` step in all three Dockerfiles
- **`docker/Dockerfile`** — base image used for dev and prod worktree environments
- **`.devcontainer/dev/Dockerfile`** — VS Code devcontainer for development
- **`.devcontainer/playground/Dockerfile`** — VS Code devcontainer for playground

## Why
AI coding agents (Claude Code, Codex, Gemini CLI, etc.) rely heavily on `rg` for fast code search. Without it, agents fall back to slower alternatives or error out.

## Test plan
- [ ] `docker build --target development -t agor:dev -f docker/Dockerfile .` succeeds
- [ ] `docker run agor:dev rg --version` outputs ripgrep version

🤖 Generated with [Claude Code](https://claude.com/claude-code)