### PR TITLE
fix: add FOR UPDATE lock to prevent lost updates in session patches

### DIFF
--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -107,6 +107,31 @@ export function jsonExtract(db: Database, column: SQL.Aliased | SQL | any, path:
 }
 
 /**
+ * Acquire a row-level lock within a transaction (PostgreSQL FOR UPDATE).
+ *
+ * On PostgreSQL, executes `SELECT 1 FROM <table> WHERE <pk> = <id> FOR UPDATE`
+ * so that concurrent transactions block until this one commits.
+ * On SQLite, this is a no-op — SQLite's transaction model provides implicit locking.
+ *
+ * @param tx - Transaction context (from db.transaction callback)
+ * @param db - Database instance (used for dialect detection only)
+ * @param table - The Drizzle table to lock
+ * @param where - WHERE clause identifying the row (e.g., eq(sessions.session_id, id))
+ */
+export async function lockRowForUpdate(
+  tx: Database,
+  db: Database,
+  table: SQLiteTable | PgTable,
+  where: SQL
+): Promise<void> {
+  if (isPostgresDatabase(db)) {
+    // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for raw SQL execution
+    await (tx as any).execute(sql`SELECT 1 FROM ${table} WHERE ${where} FOR UPDATE`);
+  }
+  // SQLite: no-op — implicit locking via transaction
+}
+
+/**
  * Raw SQL query result type
  */
 export type RawQueryResult = {

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -8,7 +8,7 @@ import type { Repo, UUID } from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
 import { formatShortId, generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, lockRowForUpdate, select, update } from '../database-wrapper';
 import { type RepoInsert, type RepoRow, repos } from '../schema';
 import {
   AmbiguousIdError,
@@ -209,6 +209,10 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
 
       // Use transaction to make read-merge-write atomic
       return await this.db.transaction(async (tx) => {
+        // Acquire row-level lock on PostgreSQL to prevent lost updates
+        // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
+        await lockRowForUpdate(tx as any, this.db, repos, eq(repos.repo_id, fullId));
+
         // STEP 1: Read current repo (within transaction)
         // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
         const currentRow = await select(tx as any)

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -11,7 +11,7 @@ import { getBaseUrl } from '../../config/config-manager';
 import { formatShortId, generateId } from '../../lib/ids';
 import { getSessionUrl } from '../../utils/url';
 import type { Database } from '../client';
-import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
+import { deleteFrom, insert, lockRowForUpdate, select, update } from '../database-wrapper';
 import {
   boards,
   type SessionInsert,
@@ -492,13 +492,8 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         // STEP 0: Acquire row-level lock on PostgreSQL to prevent lost updates.
         // Without FOR UPDATE, two concurrent patches can both read the same state,
         // then the last writer silently overwrites the first writer's changes.
-        // SQLite doesn't need this — its transaction model provides implicit locking.
-        if (isPostgresDatabase(this.db)) {
-          // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for raw SQL execution
-          await (tx as any).execute(
-            sql`SELECT 1 FROM sessions WHERE session_id = ${fullId} FOR UPDATE`
-          );
-        }
+        // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
+        await lockRowForUpdate(tx as any, this.db, sessions, eq(sessions.session_id, fullId));
 
         // STEP 1: Read current session with worktree and board JOINs (within transaction)
         // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -9,7 +9,7 @@ import { TaskStatus } from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
 import { formatShortId, generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, lockRowForUpdate, select, update } from '../database-wrapper';
 import { type TaskInsert, type TaskRow, tasks } from '../schema';
 import {
   AmbiguousIdError,
@@ -301,6 +301,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
 
       // Use transaction to make read-merge-write atomic
       const result = await this.db.transaction(async (tx) => {
+        // Acquire row-level lock on PostgreSQL to prevent lost updates
+        // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
+        await lockRowForUpdate(tx as any, this.db, tasks, eq(tasks.task_id, fullId));
+
         // STEP 1: Read current task (within transaction)
         // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
         const currentRow = await select(tx as any)

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -8,7 +8,7 @@ import type { AgenticToolName, SessionStatus, UUID, Worktree, WorktreeID } from 
 import { and, desc, eq, getTableColumns, inArray, isNotNull, isNull, like, or } from 'drizzle-orm';
 import { formatShortId, generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, lockRowForUpdate, select, update } from '../database-wrapper';
 import { type WorktreeInsert, type WorktreeRow, worktreeOwners, worktrees } from '../schema';
 import {
   AmbiguousIdError,
@@ -255,6 +255,15 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
 
     // Use transaction to make read-merge-write atomic
     return await this.db.transaction(async (tx) => {
+      // Acquire row-level lock on PostgreSQL to prevent lost updates
+      await lockRowForUpdate(
+        // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
+        tx as any,
+        this.db,
+        worktrees,
+        eq(worktrees.worktree_id, existing.worktree_id)
+      );
+
       // STEP 2: Re-read within transaction to ensure we have latest data
       // biome-ignore lint/suspicious/noExplicitAny: Transaction context requires type assertion for database wrapper functions
       const currentRow = await select(tx as any)


### PR DESCRIPTION
## Summary

- Adds `SELECT ... FOR UPDATE` row lock in `SessionRepository.update()` to prevent lost-update race conditions on PostgreSQL
- Two concurrent patches (e.g., executor saving `custom_context` while TasksService sets `ready_for_prompt=true`) could silently overwrite each other under READ COMMITTED isolation, causing 309+ sessions stuck in `idle` + `ready_for_prompt=false`
- Lock is PostgreSQL-only — SQLite's transaction model provides implicit locking, so no change needed there

## How it works

Before the read-merge-write cycle, a `SELECT 1 FROM sessions WHERE session_id = ? FOR UPDATE` acquires a row-level lock. The second concurrent transaction blocks until the first commits, then reads the updated data — eliminating the lost-update window.

## Test plan

- [ ] Verify daemon starts cleanly on SQLite (no FOR UPDATE attempted)
- [ ] Verify daemon starts cleanly on PostgreSQL
- [ ] Concurrent session patches no longer produce stale overwrites on PostgreSQL
- [ ] `pnpm check` passes (typecheck + lint + build) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)