### PR TITLE
fix: fork session now uses modal with title field

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -4938,7 +4938,10 @@ async function main() {
     app,
     '/sessions/:id/fork',
     {
-      async create(data: { prompt: string; task_id?: string; title?: string }, params: RouteParams) {
+      async create(
+        data: { prompt: string; task_id?: string; title?: string },
+        params: RouteParams
+      ) {
         const id = params.route?.id;
         if (!id) throw new Error('Session ID required');
         console.log(`🔀 Forking session: ${id.substring(0, 8)}`);

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -4938,7 +4938,7 @@ async function main() {
     app,
     '/sessions/:id/fork',
     {
-      async create(data: { prompt: string; task_id?: string }, params: RouteParams) {
+      async create(data: { prompt: string; task_id?: string; title?: string }, params: RouteParams) {
         const id = params.route?.id;
         if (!id) throw new Error('Session ID required');
         console.log(`🔀 Forking session: ${id.substring(0, 8)}`);

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -167,7 +167,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    */
   async fork(
     id: string,
-    data: { prompt: string; task_id?: string },
+    data: { prompt: string; task_id?: string; title?: string },
     params?: SessionParams
   ): Promise<Session> {
     const parent = await this.get(id, params);
@@ -176,7 +176,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       {
         agentic_tool: parent.agentic_tool,
         status: SessionStatus.IDLE,
-        title: data.prompt.substring(0, 100), // First 100 chars as title
+        title: data.title || data.prompt.substring(0, 100), // Use explicit title or first 100 chars of prompt
         description: data.prompt,
         worktree_id: parent.worktree_id,
         created_by: parent.created_by, // Inherit parent's creator for proper attribution

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -659,8 +659,8 @@ function AppContent() {
   };
 
   // Handle fork session
-  const handleForkSession = async (sessionId: string, prompt: string) => {
-    const session = await forkSession(sessionId as SessionID, prompt);
+  const handleForkSession = async (sessionId: string, prompt: string, title?: string) => {
+    const session = await forkSession(sessionId as SessionID, prompt, title);
     if (session) {
       showSuccess('Session forked successfully!');
       // Clear the draft after forking

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -9,7 +9,7 @@ import type { AgorClient } from '@agor/core/api';
 import type { AgenticToolName, MCPServer, Session, SpawnConfig, User } from '@agor/core/types';
 import { getDefaultPermissionMode } from '@agor/core/types';
 import { DownOutlined } from '@ant-design/icons';
-import { Checkbox, Collapse, Form, Modal, Radio, Typography } from 'antd';
+import { Checkbox, Collapse, Form, Input, Modal, Radio, Typography } from 'antd';
 import { useEffect, useState } from 'react';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
@@ -96,7 +96,8 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
       setLoading(true);
 
       if (action === 'fork') {
-        await onConfirm(prompt);
+        const title = values.title?.trim();
+        await onConfirm({ prompt, title: title || undefined });
       } else {
         // Build spawn config based on preset
         const spawnConfig: Partial<SpawnConfig> = { prompt };
@@ -144,7 +145,7 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
   const actionLabel = action === 'fork' ? 'Fork' : 'Spawn';
   const actionDescription =
     action === 'fork'
-      ? 'Create a sibling session to explore an alternative approach'
+      ? 'Create a forked session to explore an alternative approach'
       : 'Create a child session to work on a focused subsession';
 
   return (
@@ -171,6 +172,17 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
       </div>
 
       <Form form={form} layout="vertical">
+        {/* Title (fork only) */}
+        {action === 'fork' && (
+          <Form.Item
+            name="title"
+            label="Title"
+            rules={[{ required: true, message: 'Please enter a title' }]}
+          >
+            <Input placeholder="e.g., Try alternative authentication approach" />
+          </Form.Item>
+        )}
+
         {/* Prompt */}
         <Form.Item
           name="prompt"

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -439,9 +439,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const handleForkModalConfirm = async (promptOrConfig: string | Partial<SpawnConfig>) => {
     if (!session) return;
-    // Fork always receives a string prompt (not a config object)
     const prompt = typeof promptOrConfig === 'string' ? promptOrConfig : promptOrConfig.prompt || '';
-    await onFork?.(session.session_id, prompt);
+    const title =
+      typeof promptOrConfig === 'object' ? promptOrConfig.title : undefined;
+    await onFork?.(session.session_id, prompt, title);
     setForkModalOpen(false);
   };
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -34,6 +34,7 @@ import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessi
 import { compileTemplate } from '../../utils/templates';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { FileUpload, FileUploadButton } from '../FileUpload';
+import { ForkSpawnModal } from '../ForkSpawnModal';
 import { MCPServerPill } from '../MCPServerPill';
 import { CreatedByTag } from '../metadata';
 import { PermissionModeSelector } from '../PermissionModeSelector';
@@ -191,6 +192,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [scrollToBottom, setScrollToBottom] = React.useState<(() => void) | null>(null);
   const [scrollToTop, setScrollToTop] = React.useState<(() => void) | null>(null);
   const [queuedMessages, setQueuedMessages] = React.useState<Message[]>([]);
+  const [forkModalOpen, setForkModalOpen] = React.useState(false);
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
   const [uploadModalOpen, setUploadModalOpen] = React.useState(false);
   const [droppedFiles, setDroppedFiles] = React.useState<File[]>([]);
@@ -432,9 +434,15 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const handleFork = () => {
     if (!session) return;
-    onFork?.(session.session_id, inputValue.trim());
-    setInputValue('');
-    deleteDraft(session.session_id);
+    setForkModalOpen(true);
+  };
+
+  const handleForkModalConfirm = async (promptOrConfig: string | Partial<SpawnConfig>) => {
+    if (!session) return;
+    // Fork always receives a string prompt (not a config object)
+    const prompt = typeof promptOrConfig === 'string' ? promptOrConfig : promptOrConfig.prompt || '';
+    await onFork?.(session.session_id, prompt);
+    setForkModalOpen(false);
   };
 
   const handleSpawnModalConfirm = async (config: string | Partial<SpawnConfig>) => {
@@ -933,6 +941,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             }}
           />
         )}
+
+        {/* Fork session modal */}
+        <ForkSpawnModal
+          open={forkModalOpen}
+          action="fork"
+          session={session}
+          currentUser={currentUser}
+          mcpServerById={mcpServerById}
+          initialPrompt={inputValue}
+          onConfirm={handleForkModalConfirm}
+          onCancel={() => setForkModalOpen(false)}
+          client={client}
+          userById={userById}
+        />
       </div>
     </div>
   );

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -439,9 +439,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const handleForkModalConfirm = async (promptOrConfig: string | Partial<SpawnConfig>) => {
     if (!session) return;
-    const prompt = typeof promptOrConfig === 'string' ? promptOrConfig : promptOrConfig.prompt || '';
-    const title =
-      typeof promptOrConfig === 'object' ? promptOrConfig.title : undefined;
+    const prompt =
+      typeof promptOrConfig === 'string' ? promptOrConfig : promptOrConfig.prompt || '';
+    const title = typeof promptOrConfig === 'object' ? promptOrConfig.title : undefined;
     await onFork?.(session.session_id, prompt, title);
     setForkModalOpen(false);
   };

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -12,7 +12,7 @@ import type { WorktreeModalTab } from '../components/WorktreeModal/WorktreeModal
 export interface AppActionsContextValue {
   // Session actions
   onSendPrompt?: (sessionId: string, prompt: string, permissionMode?: PermissionMode) => void;
-  onFork?: (sessionId: string, prompt: string) => Promise<void>;
+  onFork?: (sessionId: string, prompt: string, title?: string) => Promise<void>;
   onSubsession?: (sessionId: string, config: string | Partial<SpawnConfig>) => Promise<void>;
   onUpdateSession?: (sessionId: string, updates: Partial<Session>) => void;
   onDeleteSession?: (sessionId: string) => void;

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -96,7 +96,11 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
     }
   };
 
-  const forkSession = async (sessionId: SessionID, prompt: string, title?: string): Promise<Session | null> => {
+  const forkSession = async (
+    sessionId: SessionID,
+    prompt: string,
+    title?: string
+  ): Promise<Session | null> => {
     if (!client) {
       setError('Client not connected');
       return null;

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -22,7 +22,7 @@ interface UseSessionActionsResult {
   deleteSession: (sessionId: SessionID) => Promise<boolean>;
   archiveSession: (sessionId: SessionID) => Promise<Session | null>;
   unarchiveSession: (sessionId: SessionID) => Promise<Session | null>;
-  forkSession: (sessionId: SessionID, prompt: string) => Promise<Session | null>;
+  forkSession: (sessionId: SessionID, prompt: string, title?: string) => Promise<Session | null>;
   spawnSession: (sessionId: SessionID, config: Partial<SpawnConfig>) => Promise<Session | null>;
   creating: boolean;
   error: string | null;
@@ -96,7 +96,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
     }
   };
 
-  const forkSession = async (sessionId: SessionID, prompt: string): Promise<Session | null> => {
+  const forkSession = async (sessionId: SessionID, prompt: string, title?: string): Promise<Session | null> => {
     if (!client) {
       setError('Client not connected');
       return null;
@@ -109,6 +109,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       // Call custom fork endpoint via FeathersJS client
       const forkedSession = (await client.service(`sessions/${sessionId}/fork`).create({
         prompt,
+        ...(title ? { title } : {}),
       })) as Session;
 
       // Send the prompt to the forked session to actually execute it


### PR DESCRIPTION
## Summary

Fixes the issue where forked sessions were created with empty titles. The fork functionality now uses a modal dialog (like spawn does) to collect both a title and prompt from users before creating the fork.

## Changes

### 1. Fork now uses modal dialog (555b5eff)
- Changed fork button to open `ForkSpawnModal` instead of directly using input value
- Ensures users always provide a prompt when forking
- Consistent UX with spawn workflow

### 2. Added dedicated title field (b813acb9)
- Added required **Title** input field to fork modal
- Title is separate from the prompt (matches "Create New Session" UX)
- Title flows through entire chain: UI → hooks → backend
- Backend uses explicit title or falls back to first 100 chars of prompt
- Updated description text: "Create a **forked** session" (was "sibling session")

## Screenshots

**Before:** Fork button directly used input value (could be empty)
Forked sessions created without title, and empty content.
<img width="1916" height="1032" alt="image" src="https://github.com/user-attachments/assets/818fd2f2-0a82-4113-9ce5-8ea1b83e6df4" />


**After:** Modal with dedicated title and prompt fields
<img width="1919" height="1066" alt="image" src="https://github.com/user-attachments/assets/2da6defc-a42f-4a4e-b6ef-a1b5745b0521" />

## Benefits

- ✅ Forked sessions always have meaningful titles
- ✅ Consistent UX between fork and spawn
- ✅ Built-in validation prevents empty prompts
- ✅ Clear separation between title (display name) and prompt (agent task)

## Files Changed

- `apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx` - Added title field
- `apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx` - Use modal for fork
- `apps/agor-ui/src/hooks/useSessionActions.ts` - Pass title to backend
- `apps/agor-ui/src/contexts/AppActionsContext.tsx` - Add title parameter
- `apps/agor-ui/src/App.tsx` - Thread title through handler
- `apps/agor-daemon/src/index.ts` - Accept title in fork endpoint
- `apps/agor-daemon/src/services/sessions.ts` - Use title if provided

## Test Plan

- [x] Fork modal opens when clicking fork button
- [x] Title field is required
- [x] Prompt field is required
- [x] Forked session created with correct title
- [x] Forked session receives prompt and begins execution
- [x] Modal description shows "forked session" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)