### PR TITLE
feat: expose RBAC fields in worktree create/update MCP tools

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -131,6 +131,9 @@ export interface ReposServiceImpl extends Service<Repo, Partial<Repo>, FeathersP
       issue_url?: string;
       pull_request_url?: string;
       boardId?: string;
+      zoneId?: string;
+      others_can?: 'none' | 'view' | 'prompt' | 'all';
+      others_fs_access?: 'none' | 'read' | 'write';
     },
     params?: FeathersParams
   ): Promise<Worktree>;

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -1,3 +1,4 @@
+import { isWorktreeRbacEnabled } from '@agor/core/config';
 import { WorktreeRepository } from '@agor/core/db';
 import type {
   AgenticToolName,
@@ -283,18 +284,25 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       );
 
       // Add additional owners (creator is already added by reposService.createWorktree)
+      const ownerWarnings: string[] = [];
       if (args.ownerIds && args.ownerIds.length > 0) {
-        const worktreeOwnersService = ctx.app.service('worktrees/:id/owners');
-        for (const ownerId of args.ownerIds) {
-          try {
-            await worktreeOwnersService.create(
-              { user_id: ownerId },
-              { ...ctx.baseServiceParams, route: { id: worktree.worktree_id } }
-            );
-          } catch (error) {
-            console.warn(
-              `⚠️  Failed to add owner ${ownerId} to worktree ${worktree.worktree_id}: ${error instanceof Error ? error.message : String(error)}`
-            );
+        if (!isWorktreeRbacEnabled()) {
+          ownerWarnings.push(
+            'ownerIds ignored: worktree RBAC is not enabled. Enable worktree_rbac in config to manage owners.'
+          );
+        } else {
+          const worktreeOwnersService = ctx.app.service('worktrees/:id/owners');
+          for (const ownerId of args.ownerIds) {
+            try {
+              await worktreeOwnersService.create(
+                { user_id: ownerId },
+                { ...ctx.baseServiceParams, route: { id: worktree.worktree_id } }
+              );
+            } catch (error) {
+              ownerWarnings.push(
+                `Failed to add owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
           }
         }
       }
@@ -311,6 +319,10 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       } else {
         response.hint =
           'Use agor_worktrees_set_zone to pin this worktree to a specific zone and optionally trigger zone prompt templates.';
+      }
+
+      if (ownerWarnings.length > 0) {
+        response.ownerWarnings = ownerWarnings;
       }
 
       return textResult(response);
@@ -486,29 +498,39 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       // Handle owner additions/removals via the owners service (includes unix sync hooks)
       const ownerErrors: string[] = [];
       if (hasOwnerChanges) {
-        const worktreeOwnersService = ctx.app.service('worktrees/:id/owners');
-        const routeParams = { ...ctx.baseServiceParams, route: { id: resolvedWorktreeId } };
+        if (!isWorktreeRbacEnabled()) {
+          ownerErrors.push(
+            'Owner changes ignored: worktree RBAC is not enabled. Enable worktree_rbac in config to manage owners.'
+          );
+        } else {
+          const worktreeOwnersService = ctx.app.service('worktrees/:id/owners');
+          // Use full UUID from resolved worktree (not the potentially-short input ID)
+          const routeParams = {
+            ...ctx.baseServiceParams,
+            route: { id: worktree.worktree_id },
+          };
 
-        if (args.addOwnerIds) {
-          for (const ownerId of args.addOwnerIds) {
-            try {
-              await worktreeOwnersService.create({ user_id: ownerId }, routeParams);
-            } catch (error) {
-              ownerErrors.push(
-                `Failed to add owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
-              );
+          if (args.addOwnerIds) {
+            for (const ownerId of args.addOwnerIds) {
+              try {
+                await worktreeOwnersService.create({ user_id: ownerId }, routeParams);
+              } catch (error) {
+                ownerErrors.push(
+                  `Failed to add owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
+                );
+              }
             }
           }
-        }
 
-        if (args.removeOwnerIds) {
-          for (const ownerId of args.removeOwnerIds) {
-            try {
-              await worktreeOwnersService.remove(ownerId, routeParams);
-            } catch (error) {
-              ownerErrors.push(
-                `Failed to remove owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
-              );
+          if (args.removeOwnerIds) {
+            for (const ownerId of args.removeOwnerIds) {
+              try {
+                await worktreeOwnersService.remove(ownerId, routeParams);
+              } catch (error) {
+                ownerErrors.push(
+                  `Failed to remove owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
+                );
+              }
             }
           }
         }

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -161,6 +161,32 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
           .string()
           .optional()
           .describe('Pull request URL to associate with the worktree.'),
+        // RBAC fields (optional, sensible defaults, safe to ignore for single-user setups)
+        othersCan: z
+          .enum(['none', 'view', 'prompt', 'all'])
+          .optional()
+          .describe(
+            'App-layer permission for non-owner users. ' +
+              '"none" = no access, "view" = read-only, "prompt" = can send prompts to sessions, "all" = full access. ' +
+              'Default: "view". Always effective regardless of Unix isolation mode. Single-user setups can ignore this.'
+          ),
+        othersFsAccess: z
+          .enum(['none', 'read', 'write'])
+          .optional()
+          .describe(
+            'OS-level filesystem permission for non-owner users. ' +
+              '"none" = no filesystem access, "read" = read-only, "write" = read-write. ' +
+              'Default: "read". Only effective when Unix isolation (AGOR_UNIX_MODE) is configured. ' +
+              'Has no effect in simple mode. Single-user setups can ignore this.'
+          ),
+        ownerIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Additional user IDs to add as owners of this worktree. ' +
+              'The creating user is always added as owner automatically. ' +
+              'Owners have full access regardless of othersCan/othersFsAccess settings.'
+          ),
       }),
     },
     async (args) => {
@@ -234,6 +260,9 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       // Positioning is handled automatically by the repos service —
       // agents don't need to think about x/y coordinates.
 
+      const othersCan = args.othersCan as 'none' | 'view' | 'prompt' | 'all' | undefined;
+      const othersFsAccess = args.othersFsAccess as 'none' | 'read' | 'write' | undefined;
+
       const worktree = await reposService.createWorktree(
         repoId,
         {
@@ -247,9 +276,28 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
           ...(pullRequestUrl ? { pull_request_url: pullRequestUrl } : {}),
           ...(boardId ? { boardId } : {}),
           ...(zoneId ? { zoneId } : {}),
+          ...(othersCan ? { others_can: othersCan } : {}),
+          ...(othersFsAccess ? { others_fs_access: othersFsAccess } : {}),
         },
         ctx.baseServiceParams
       );
+
+      // Add additional owners (creator is already added by reposService.createWorktree)
+      if (args.ownerIds && args.ownerIds.length > 0) {
+        const worktreeOwnersService = ctx.app.service('worktrees/:id/owners');
+        for (const ownerId of args.ownerIds) {
+          try {
+            await worktreeOwnersService.create(
+              { user_id: ownerId },
+              { ...ctx.baseServiceParams, route: { id: worktree.worktree_id } }
+            );
+          } catch (error) {
+            console.warn(
+              `⚠️  Failed to add owner ${ownerId} to worktree ${worktree.worktree_id}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        }
+      }
 
       // Build response with appropriate notes
       const response: Record<string, unknown> = { ...worktree };
@@ -274,7 +322,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
     'agor_worktrees_update',
     {
       description:
-        'Update metadata for an existing worktree (issue/PR URLs, notes, board placement, custom context)',
+        'Update metadata for an existing worktree (issue/PR URLs, notes, board placement, custom context, RBAC permissions, owners)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
         worktreeId: z
@@ -320,6 +368,39 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
           .optional()
           .describe(
             'Default MCP server IDs for new sessions in this worktree. Sessions inherit these unless they explicitly specify their own. Pass null to clear.'
+          ),
+        // RBAC fields (optional, safe to ignore for single-user setups)
+        othersCan: z
+          .enum(['none', 'view', 'prompt', 'all'])
+          .optional()
+          .describe(
+            'App-layer permission for non-owner users. ' +
+              '"none" = no access, "view" = read-only, "prompt" = can send prompts to sessions, "all" = full access. ' +
+              'Always effective regardless of Unix isolation mode. Single-user setups can ignore this.'
+          ),
+        othersFsAccess: z
+          .enum(['none', 'read', 'write'])
+          .optional()
+          .describe(
+            'OS-level filesystem permission for non-owner users. ' +
+              '"none" = no filesystem access, "read" = read-only, "write" = read-write. ' +
+              'Only effective when Unix isolation (AGOR_UNIX_MODE) is configured. ' +
+              'Has no effect in simple mode. Single-user setups can ignore this.'
+          ),
+        addOwnerIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'User IDs to ADD as owners of this worktree. ' +
+              'Owners have full access regardless of othersCan/othersFsAccess settings. ' +
+              'Idempotent — adding an existing owner is a no-op.'
+          ),
+        removeOwnerIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'User IDs to REMOVE as owners of this worktree. ' +
+              'Idempotent — removing a non-owner is a no-op.'
           ),
       }),
     },
@@ -371,17 +452,73 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
         fieldsProvided++;
         updates.mcp_server_ids = args.mcpServerIds === null ? [] : args.mcpServerIds;
       }
+      if (args.othersCan !== undefined) {
+        fieldsProvided++;
+        updates.others_can = args.othersCan;
+      }
+      if (args.othersFsAccess !== undefined) {
+        fieldsProvided++;
+        updates.others_fs_access = args.othersFsAccess;
+      }
+      const hasOwnerChanges =
+        (args.addOwnerIds && args.addOwnerIds.length > 0) ||
+        (args.removeOwnerIds && args.removeOwnerIds.length > 0);
+      if (hasOwnerChanges) fieldsProvided++;
 
       if (fieldsProvided === 0) throw new Error('provide at least one field to update');
 
-      const worktree = await ctx.app
-        .service('worktrees')
-        .patch(
-          resolvedWorktreeId as string,
-          updates as unknown as Partial<Worktree>,
-          ctx.baseServiceParams
-        );
-      return textResult({ worktree, note: 'Worktree metadata updated successfully.' });
+      // Patch worktree fields (skip if only owner changes)
+      let worktree: Worktree;
+      if (Object.keys(updates).length > 0) {
+        worktree = (await ctx.app
+          .service('worktrees')
+          .patch(
+            resolvedWorktreeId as string,
+            updates as unknown as Partial<Worktree>,
+            ctx.baseServiceParams
+          )) as Worktree;
+      } else {
+        worktree = (await ctx.app
+          .service('worktrees')
+          .get(resolvedWorktreeId as string, ctx.baseServiceParams)) as Worktree;
+      }
+
+      // Handle owner additions/removals via the owners service (includes unix sync hooks)
+      const ownerErrors: string[] = [];
+      if (hasOwnerChanges) {
+        const worktreeOwnersService = ctx.app.service('worktrees/:id/owners');
+        const routeParams = { ...ctx.baseServiceParams, route: { id: resolvedWorktreeId } };
+
+        if (args.addOwnerIds) {
+          for (const ownerId of args.addOwnerIds) {
+            try {
+              await worktreeOwnersService.create({ user_id: ownerId }, routeParams);
+            } catch (error) {
+              ownerErrors.push(
+                `Failed to add owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+          }
+        }
+
+        if (args.removeOwnerIds) {
+          for (const ownerId of args.removeOwnerIds) {
+            try {
+              await worktreeOwnersService.remove(ownerId, routeParams);
+            } catch (error) {
+              ownerErrors.push(
+                `Failed to remove owner ${ownerId}: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+          }
+        }
+      }
+
+      return textResult({
+        worktree,
+        note: 'Worktree metadata updated successfully.',
+        ...(ownerErrors.length > 0 ? { ownerWarnings: ownerErrors } : {}),
+      });
     }
   );
 

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -342,6 +342,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       pull_request_url?: string;
       boardId?: string;
       zoneId?: string;
+      others_can?: 'none' | 'view' | 'prompt' | 'all';
+      others_fs_access?: 'none' | 'read' | 'write';
     },
     params?: RepoParams
   ): Promise<Worktree> {
@@ -513,6 +515,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         worktree_unique_id: worktreeUniqueId,
         filesystem_status: 'creating', // Will be set to 'ready' by executor
         // Environment templates will be rendered by executor after Unix group creation
+        // RBAC fields (optional, defaults handled by repository layer)
+        ...(data.others_can ? { others_can: data.others_can } : {}),
+        ...(data.others_fs_access ? { others_fs_access: data.others_fs_access } : {}),
         sessions: [],
         last_used: new Date().toISOString(),
         issue_url: data.issue_url,
@@ -674,7 +679,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             refType: data.refType,
             // Unix group isolation (only when RBAC is enabled)
             initUnixGroup: rbacEnabled,
-            othersAccess: worktree.others_fs_access || 'read', // Default to read access
+            othersAccess: data.others_fs_access || worktree.others_fs_access || 'read', // Default to read access
             daemonUser,
             repoUnixGroup: repo.unix_group,
             creatorUnixUsername, // Creator will be added to worktree group


### PR DESCRIPTION
## Summary
- Adds optional RBAC parameters (`othersCan`, `othersFsAccess`, `ownerIds`) to `agor_worktrees_create` MCP tool
- Adds optional RBAC parameters (`othersCan`, `othersFsAccess`, `addOwnerIds`, `removeOwnerIds`) to `agor_worktrees_update` MCP tool
- Wires through to service layer: permission fields via worktree patch, owner management via `worktrees/:id/owners` service (which has unix group sync hooks)

All fields are optional with sensible defaults. No schema, migration, or UI changes.

## Test plan
- [ ] Create a worktree via MCP with `othersCan: "prompt"` and verify the field persists in DB
- [ ] Create a worktree via MCP with `ownerIds` and verify owners appear in `worktree_owners` table
- [ ] Update a worktree via MCP with `addOwnerIds` / `removeOwnerIds` and verify junction table changes
- [ ] Update `othersFsAccess` via MCP and verify it persists
- [ ] Verify existing create/update calls without RBAC params still work (backward compatible)
- [ ] Verify owner errors are returned as warnings, not failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)