### PR TITLE
fix: support MCP OAuth servers that omit resource_metadata in WWW-Authenticate

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -1521,27 +1521,16 @@ async function main() {
           headers: allHeaders,
         });
 
-        // Check for OAuth 2.1 auto-discovery (RFC 9728)
-        // The WWW-Authenticate header should contain: Bearer resource_metadata="<url>"
-        const hasResourceMetadata = wwwAuthenticate?.includes('resource_metadata=');
-
-        // Determine resource metadata URL from header or .well-known discovery
+        // Resolve resource metadata URL: try header first, then .well-known discovery
         let metadataUrl: string | null = null;
-        if (probeResponse.status === 401 && hasResourceMetadata) {
-          const metadataMatch = wwwAuthenticate!.match(/resource_metadata="([^"]+)"/);
-          metadataUrl = metadataMatch ? metadataMatch[1] : null;
-        } else if (probeResponse.status === 401 && !hasResourceMetadata) {
-          // Fallback: try .well-known discovery (handles servers like Notion that
-          // return 401 without resource_metadata in WWW-Authenticate)
-          console.log(
-            '[OAuth Test] WWW-Authenticate lacks resource_metadata, trying .well-known discovery'
-          );
-          const { discoverResourceMetadataUrl } = await import(
+        if (probeResponse.status === 401) {
+          const { resolveResourceMetadataUrl } = await import(
             '@agor/core/tools/mcp/oauth-mcp-transport'
           );
-          metadataUrl = await discoverResourceMetadataUrl(data.mcp_url);
-          if (metadataUrl) {
-            console.log('[OAuth Test] Discovered resource metadata URL:', metadataUrl);
+          const resolved = await resolveResourceMetadataUrl(wwwAuthenticate, data.mcp_url);
+          if (resolved) {
+            metadataUrl = resolved.metadataUrl;
+            console.log(`[OAuth Test] Resolved metadata URL (${resolved.source}):`, metadataUrl);
           }
         }
 
@@ -1607,15 +1596,11 @@ async function main() {
                 }
               };
 
-              // If the header lacked resource_metadata, synthesize one with the discovered URL
-              const effectiveHeader = hasResourceMetadata
-                ? wwwAuthenticate!
-                : `Bearer resource_metadata="${metadataUrl}"`;
-
               const token = await performMCPOAuthFlow(
-                effectiveHeader,
+                wwwAuthenticate || '',
                 data.client_id, // Optional client_id
-                browserOpener // Custom opener emits event to client
+                browserOpener, // Custom opener emits event to client
+                metadataUrl // Pre-discovered metadata URL (fallback for servers lacking resource_metadata)
               );
               console.log('[OAuth Test] OAuth flow completed, token obtained');
 
@@ -1992,34 +1977,25 @@ async function main() {
         }
 
         const wwwAuthenticate = probeResponse.headers.get('www-authenticate') || '';
-        const hasResourceMetadata = wwwAuthenticate.includes('resource_metadata=');
 
-        // If the 401 lacks resource_metadata in WWW-Authenticate (e.g. Notion),
-        // try auto-discovering the metadata URL via .well-known endpoint
-        let discoveredMetadataUrl: string | undefined;
-        if (!hasResourceMetadata) {
-          console.log(
-            '[OAuth Start] WWW-Authenticate lacks resource_metadata, trying .well-known discovery'
-          );
-          const { discoverResourceMetadataUrl } = await import(
-            '@agor/core/tools/mcp/oauth-mcp-transport'
-          );
-          discoveredMetadataUrl = (await discoverResourceMetadataUrl(data.mcp_url)) ?? undefined;
-
-          if (!discoveredMetadataUrl) {
-            return {
-              success: false,
-              error:
-                'Server returned 401 but does not advertise OAuth metadata. ' +
-                'No resource_metadata in WWW-Authenticate header and no ' +
-                '.well-known/oauth-protected-resource endpoint found.',
-            };
-          }
-          console.log('[OAuth Start] Discovered metadata URL:', discoveredMetadataUrl);
+        // Resolve resource metadata URL: try header first, then .well-known discovery
+        const { resolveResourceMetadataUrl, startMCPOAuthFlow } = await import(
+          '@agor/core/tools/mcp/oauth-mcp-transport'
+        );
+        const resolved = await resolveResourceMetadataUrl(wwwAuthenticate, data.mcp_url);
+        if (!resolved) {
+          return {
+            success: false,
+            error:
+              'Server returned 401 but does not advertise OAuth metadata. ' +
+              'No resource_metadata in WWW-Authenticate header and no ' +
+              '.well-known/oauth-protected-resource endpoint found.',
+          };
         }
-
-        // Import the two-phase OAuth flow functions
-        const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
+        console.log(
+          `[OAuth Start] Resolved metadata URL (${resolved.source}):`,
+          resolved.metadataUrl
+        );
 
         // Start the flow - use browser-facing base URL for the OAuth redirect URI
         // getBaseUrl() resolves: AGOR_BASE_URL env → daemon.base_url config → localhost fallback
@@ -2032,7 +2008,7 @@ async function main() {
           tokenUrlOverride,
           clientSecret: clientSecretOverride,
           scope: scopeOverride,
-          resourceMetadataUrl: discoveredMetadataUrl,
+          resourceMetadataUrl: resolved.metadataUrl,
         });
 
         // Capture initiating socket ID for scoped notifications
@@ -2476,34 +2452,21 @@ async function main() {
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
 
             if (probeResponse.status === 401) {
-              const hasMetadataInHeader = wwwAuthenticate?.includes('resource_metadata=');
+              const { resolveResourceMetadataUrl, performMCPOAuthFlow } = await import(
+                '@agor/core/tools/mcp/oauth-mcp-transport'
+              );
+              const resolved = await resolveResourceMetadataUrl(wwwAuthenticate, mcpUrl);
 
-              // If resource_metadata not in header, try .well-known discovery
-              let discoveredMetadataUrl: string | undefined;
-              if (!hasMetadataInHeader) {
-                const { discoverResourceMetadataUrl } = await import(
-                  '@agor/core/tools/mcp/oauth-mcp-transport'
+              if (resolved) {
+                console.log(
+                  `[MCP Discovery] OAuth 2.1 detected (${resolved.source}), starting browser flow...`
                 );
-                discoveredMetadataUrl = (await discoverResourceMetadataUrl(mcpUrl)) ?? undefined;
-              }
-
-              if (hasMetadataInHeader || discoveredMetadataUrl) {
-                console.log('[MCP Discovery] OAuth 2.1 detected, starting browser flow...');
-
-                const { performMCPOAuthFlow } = await import(
-                  '@agor/core/tools/mcp/oauth-mcp-transport'
-                );
-
-                // For performMCPOAuthFlow, we need a valid WWW-Authenticate header.
-                // If the header lacked resource_metadata, synthesize one.
-                const effectiveHeader = hasMetadataInHeader
-                  ? wwwAuthenticate!
-                  : `Bearer resource_metadata="${discoveredMetadataUrl}"`;
 
                 const token = await performMCPOAuthFlow(
-                  effectiveHeader,
+                  wwwAuthenticate || '',
                   undefined,
-                  openOAuthBrowser
+                  openOAuthBrowser,
+                  resolved.metadataUrl
                 );
 
                 cacheOAuth21Token(mcpUrl, token, 3600);

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -1525,21 +1525,28 @@ async function main() {
         // The WWW-Authenticate header should contain: Bearer resource_metadata="<url>"
         const hasResourceMetadata = wwwAuthenticate?.includes('resource_metadata=');
 
+        // Determine resource metadata URL from header or .well-known discovery
+        let metadataUrl: string | null = null;
         if (probeResponse.status === 401 && hasResourceMetadata) {
-          console.log('[OAuth Test] OAuth 2.1 auto-discovery detected');
-
-          // Extract resource metadata URL from WWW-Authenticate header
           const metadataMatch = wwwAuthenticate!.match(/resource_metadata="([^"]+)"/);
-          const metadataUrl = metadataMatch ? metadataMatch[1] : null;
-
-          if (!metadataUrl) {
-            return {
-              success: false,
-              error: 'OAuth 2.1 detected but resource_metadata URL could not be parsed',
-              oauthType: 'oauth2.1',
-              wwwAuthenticate,
-            };
+          metadataUrl = metadataMatch ? metadataMatch[1] : null;
+        } else if (probeResponse.status === 401 && !hasResourceMetadata) {
+          // Fallback: try .well-known discovery (handles servers like Notion that
+          // return 401 without resource_metadata in WWW-Authenticate)
+          console.log(
+            '[OAuth Test] WWW-Authenticate lacks resource_metadata, trying .well-known discovery'
+          );
+          const { discoverResourceMetadataUrl } = await import(
+            '@agor/core/tools/mcp/oauth-mcp-transport'
+          );
+          metadataUrl = await discoverResourceMetadataUrl(data.mcp_url);
+          if (metadataUrl) {
+            console.log('[OAuth Test] Discovered resource metadata URL:', metadataUrl);
           }
+        }
+
+        if (probeResponse.status === 401 && metadataUrl) {
+          console.log('[OAuth Test] OAuth 2.1 auto-discovery detected');
 
           // If start_browser_flow is true, perform the full OAuth flow with browser
           if (data.start_browser_flow) {
@@ -1600,8 +1607,13 @@ async function main() {
                 }
               };
 
+              // If the header lacked resource_metadata, synthesize one with the discovered URL
+              const effectiveHeader = hasResourceMetadata
+                ? wwwAuthenticate!
+                : `Bearer resource_metadata="${metadataUrl}"`;
+
               const token = await performMCPOAuthFlow(
-                wwwAuthenticate!,
+                effectiveHeader,
                 data.client_id, // Optional client_id
                 browserOpener // Custom opener emits event to client
               );
@@ -1972,12 +1984,38 @@ async function main() {
           signal: AbortSignal.timeout(15_000),
         });
 
-        const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
-        if (probeResponse.status !== 401 || !wwwAuthenticate?.includes('resource_metadata=')) {
+        if (probeResponse.status !== 401) {
           return {
             success: false,
-            error: 'Server does not require OAuth 2.1 authentication',
+            error: 'Server did not return 401 — OAuth 2.1 authentication may not be required',
           };
+        }
+
+        const wwwAuthenticate = probeResponse.headers.get('www-authenticate') || '';
+        const hasResourceMetadata = wwwAuthenticate.includes('resource_metadata=');
+
+        // If the 401 lacks resource_metadata in WWW-Authenticate (e.g. Notion),
+        // try auto-discovering the metadata URL via .well-known endpoint
+        let discoveredMetadataUrl: string | undefined;
+        if (!hasResourceMetadata) {
+          console.log(
+            '[OAuth Start] WWW-Authenticate lacks resource_metadata, trying .well-known discovery'
+          );
+          const { discoverResourceMetadataUrl } = await import(
+            '@agor/core/tools/mcp/oauth-mcp-transport'
+          );
+          discoveredMetadataUrl = (await discoverResourceMetadataUrl(data.mcp_url)) ?? undefined;
+
+          if (!discoveredMetadataUrl) {
+            return {
+              success: false,
+              error:
+                'Server returned 401 but does not advertise OAuth metadata. ' +
+                'No resource_metadata in WWW-Authenticate header and no ' +
+                '.well-known/oauth-protected-resource endpoint found.',
+            };
+          }
+          console.log('[OAuth Start] Discovered metadata URL:', discoveredMetadataUrl);
         }
 
         // Import the two-phase OAuth flow functions
@@ -1994,6 +2032,7 @@ async function main() {
           tokenUrlOverride,
           clientSecret: clientSecretOverride,
           scope: scopeOverride,
+          resourceMetadataUrl: discoveredMetadataUrl,
         });
 
         // Capture initiating socket ID for scoped notifications
@@ -2436,21 +2475,44 @@ async function main() {
 
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
 
-            if (probeResponse.status === 401 && wwwAuthenticate?.includes('resource_metadata=')) {
-              console.log('[MCP Discovery] OAuth 2.1 detected, starting browser flow...');
+            if (probeResponse.status === 401) {
+              const hasMetadataInHeader = wwwAuthenticate?.includes('resource_metadata=');
 
-              const { performMCPOAuthFlow } = await import(
-                '@agor/core/tools/mcp/oauth-mcp-transport'
-              );
-
-              const token = await performMCPOAuthFlow(wwwAuthenticate, undefined, openOAuthBrowser);
-
-              cacheOAuth21Token(mcpUrl, token, 3600);
-              if (serverId) {
-                await saveOAuth21TokenToDB(mcpServerRepo, serverId, token, 3600);
+              // If resource_metadata not in header, try .well-known discovery
+              let discoveredMetadataUrl: string | undefined;
+              if (!hasMetadataInHeader) {
+                const { discoverResourceMetadataUrl } = await import(
+                  '@agor/core/tools/mcp/oauth-mcp-transport'
+                );
+                discoveredMetadataUrl = (await discoverResourceMetadataUrl(mcpUrl)) ?? undefined;
               }
 
-              return token;
+              if (hasMetadataInHeader || discoveredMetadataUrl) {
+                console.log('[MCP Discovery] OAuth 2.1 detected, starting browser flow...');
+
+                const { performMCPOAuthFlow } = await import(
+                  '@agor/core/tools/mcp/oauth-mcp-transport'
+                );
+
+                // For performMCPOAuthFlow, we need a valid WWW-Authenticate header.
+                // If the header lacked resource_metadata, synthesize one.
+                const effectiveHeader = hasMetadataInHeader
+                  ? wwwAuthenticate!
+                  : `Bearer resource_metadata="${discoveredMetadataUrl}"`;
+
+                const token = await performMCPOAuthFlow(
+                  effectiveHeader,
+                  undefined,
+                  openOAuthBrowser
+                );
+
+                cacheOAuth21Token(mcpUrl, token, 3600);
+                if (serverId) {
+                  await saveOAuth21TokenToDB(mcpServerRepo, serverId, token, 3600);
+                }
+
+                return token;
+              }
             }
 
             return undefined;

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for OAuth MCP transport helpers.
+ *
+ * Covers:
+ * - isOAuthRequired(): Bearer challenge detection
+ * - discoverResourceMetadataUrl(): .well-known fallback discovery
+ * - resolveResourceMetadataUrl(): header parse + .well-known fallback
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  discoverResourceMetadataUrl,
+  isOAuthRequired,
+  resolveResourceMetadataUrl,
+} from './oauth-mcp-transport';
+
+// ---------------------------------------------------------------------------
+// isOAuthRequired — pure function, no mocking
+// ---------------------------------------------------------------------------
+
+describe('isOAuthRequired', () => {
+  function makeHeaders(wwwAuth?: string): Headers {
+    const h = new Headers();
+    if (wwwAuth) h.set('www-authenticate', wwwAuth);
+    return h;
+  }
+
+  it('returns false for non-401 status', () => {
+    expect(isOAuthRequired(200, makeHeaders('Bearer realm="OAuth"'))).toBe(false);
+    expect(isOAuthRequired(403, makeHeaders('Bearer realm="OAuth"'))).toBe(false);
+  });
+
+  it('returns false for 401 without www-authenticate', () => {
+    expect(isOAuthRequired(401, makeHeaders())).toBe(false);
+  });
+
+  it('returns true for 401 with resource_metadata (RFC 9728)', () => {
+    const header =
+      'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"';
+    expect(isOAuthRequired(401, makeHeaders(header))).toBe(true);
+  });
+
+  it('returns true for 401 with plain Bearer challenge (Notion-style)', () => {
+    const header = 'Bearer realm="OAuth", error="invalid_token"';
+    expect(isOAuthRequired(401, makeHeaders(header))).toBe(true);
+  });
+
+  it('returns true for 401 with lowercase bearer', () => {
+    expect(isOAuthRequired(401, makeHeaders('bearer realm="test"'))).toBe(true);
+  });
+
+  it('returns false for 401 with non-Bearer scheme', () => {
+    expect(isOAuthRequired(401, makeHeaders('Basic realm="test"'))).toBe(false);
+    expect(isOAuthRequired(401, makeHeaders('Digest realm="test"'))).toBe(false);
+  });
+
+  it('does not match Bearer as a substring of another scheme', () => {
+    // "X-Bearer-Custom" should not match — we require word boundary
+    expect(isOAuthRequired(401, makeHeaders('X-Bearer-Custom realm="test"'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverResourceMetadataUrl — needs fetch mock
+// ---------------------------------------------------------------------------
+
+describe('discoverResourceMetadataUrl', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('discovers metadata at root .well-known when MCP URL has no path', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        resource: 'https://mcp.example.com',
+        authorization_servers: ['https://mcp.example.com'],
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await discoverResourceMetadataUrl('https://mcp.example.com');
+    expect(result).toBe('https://mcp.example.com/.well-known/oauth-protected-resource');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('tries path-aware URL first when MCP URL has a path', async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+      calls.push(url);
+      if (url.includes('/mcp')) {
+        return {
+          ok: true,
+          json: async () => ({
+            authorization_servers: ['https://example.com'],
+          }),
+        };
+      }
+      return { ok: false };
+    }) as unknown as typeof fetch;
+
+    const result = await discoverResourceMetadataUrl('https://example.com/mcp');
+    expect(result).toBe('https://example.com/.well-known/oauth-protected-resource/mcp');
+    // Path-aware was tried first
+    expect(calls[0]).toBe('https://example.com/.well-known/oauth-protected-resource/mcp');
+  });
+
+  it('falls back to root when path-aware returns 404', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return { ok: false };
+      return {
+        ok: true,
+        json: async () => ({
+          authorization_servers: ['https://example.com'],
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    const result = await discoverResourceMetadataUrl('https://example.com/mcp');
+    expect(result).toBe('https://example.com/.well-known/oauth-protected-resource');
+  });
+
+  it('returns null when no endpoint responds', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+
+    const result = await discoverResourceMetadataUrl('https://example.com/mcp');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when response lacks authorization_servers', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resource: 'https://example.com' }), // no authorization_servers
+    }) as unknown as typeof fetch;
+
+    const result = await discoverResourceMetadataUrl('https://example.com');
+    expect(result).toBeNull();
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+
+    const result = await discoverResourceMetadataUrl('https://example.com');
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveResourceMetadataUrl — header parse + .well-known fallback
+// ---------------------------------------------------------------------------
+
+describe('resolveResourceMetadataUrl', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns header source when resource_metadata is in WWW-Authenticate', async () => {
+    const header =
+      'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"';
+    const result = await resolveResourceMetadataUrl(header, 'https://example.com/mcp');
+
+    expect(result).toEqual({
+      metadataUrl: 'https://example.com/.well-known/oauth-protected-resource',
+      source: 'header',
+    });
+  });
+
+  it('falls back to well-known when header lacks resource_metadata (Notion-style)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        authorization_servers: ['https://mcp.notion.com'],
+      }),
+    }) as unknown as typeof fetch;
+
+    const header = 'Bearer realm="OAuth", error="invalid_token"';
+    const result = await resolveResourceMetadataUrl(header, 'https://mcp.notion.com/mcp');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('well-known');
+  });
+
+  it('falls back to well-known when header is null', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        authorization_servers: ['https://example.com'],
+      }),
+    }) as unknown as typeof fetch;
+
+    const result = await resolveResourceMetadataUrl(null, 'https://example.com/mcp');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('well-known');
+  });
+
+  it('returns null when both strategies fail', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+
+    const header = 'Bearer realm="OAuth"';
+    const result = await resolveResourceMetadataUrl(header, 'https://example.com/mcp');
+
+    expect(result).toBeNull();
+  });
+
+  it('does not call .well-known when header parse succeeds', async () => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    const header =
+      'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"';
+    await resolveResourceMetadataUrl(header, 'https://example.com/mcp');
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -103,6 +103,57 @@ function parseWWWAuthenticate(header: string): string | null {
 }
 
 /**
+ * Discover the OAuth Protected Resource Metadata URL for an MCP server.
+ *
+ * Many MCP servers (e.g. Notion) return a 401 with a plain Bearer challenge
+ * that does NOT include the `resource_metadata` parameter per RFC 9728.
+ * However, they DO serve the metadata at the well-known path.
+ *
+ * This function tries to discover it by probing:
+ *   1. {origin}/.well-known/oauth-protected-resource  (root-level)
+ *   2. {origin}/.well-known/oauth-protected-resource{path}  (path-aware per RFC)
+ *
+ * @param mcpUrl - The MCP server URL
+ * @returns The resource metadata URL if discoverable, null otherwise
+ */
+export async function discoverResourceMetadataUrl(mcpUrl: string): Promise<string | null> {
+  const url = new URL(mcpUrl);
+  const origin = url.origin;
+  const path = url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '');
+
+  const candidates: string[] = [`${origin}/.well-known/oauth-protected-resource`];
+
+  // Add path-aware URL if the MCP endpoint isn't at root
+  if (path) {
+    candidates.push(`${origin}/.well-known/oauth-protected-resource${path}`);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      console.log('[MCP OAuth] Trying resource metadata discovery:', candidate);
+      const response = await fetch(candidate, { signal: AbortSignal.timeout(10_000) });
+      if (response.ok) {
+        // Validate it looks like proper metadata
+        const data = (await response.json()) as Record<string, unknown>;
+        if (data.authorization_servers && Array.isArray(data.authorization_servers)) {
+          console.log('[MCP OAuth] ✓ Discovered resource metadata at:', candidate);
+          return candidate;
+        }
+      }
+    } catch (err) {
+      console.log(
+        '[MCP OAuth] Discovery failed for',
+        candidate,
+        ':',
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+  }
+
+  return null;
+}
+
+/**
  * Fetch Protected Resource Metadata (RFC 9728)
  */
 async function fetchResourceMetadata(metadataUrl: string): Promise<OAuthMetadata> {
@@ -666,10 +717,21 @@ export async function performMCPOAuthFlow(
 }
 
 /**
- * Check if HTTP response indicates OAuth is required
+ * Check if HTTP response indicates OAuth is required.
+ *
+ * Returns true if the response is a 401 with either:
+ * - A WWW-Authenticate header containing resource_metadata (RFC 9728 compliant)
+ * - A WWW-Authenticate header containing Bearer (many OAuth servers omit resource_metadata)
  */
 export function isOAuthRequired(status: number, headers: Headers): boolean {
-  return status === 401 && headers.get('www-authenticate')?.includes('resource_metadata=') === true;
+  if (status !== 401) return false;
+  const wwwAuth = headers.get('www-authenticate');
+  if (!wwwAuth) return false;
+  // Strict check: resource_metadata present
+  if (wwwAuth.includes('resource_metadata=')) return true;
+  // Permissive check: Bearer challenge present (may need .well-known discovery)
+  if (wwwAuth.toLowerCase().includes('bearer')) return true;
+  return false;
 }
 
 /**
@@ -818,15 +880,19 @@ export async function startMCPOAuthFlow(
     tokenUrlOverride?: string;
     clientSecret?: string;
     scope?: string;
+    /** Pre-discovered resource metadata URL (used when WWW-Authenticate lacks resource_metadata) */
+    resourceMetadataUrl?: string;
   }
 ): Promise<OAuthFlowContext> {
   console.log('[MCP OAuth] Starting two-phase OAuth 2.1 flow');
 
-  // Step 1: Parse WWW-Authenticate header
-  const metadataUrl = parseWWWAuthenticate(wwwAuthenticateHeader);
+  // Step 1: Parse WWW-Authenticate header, fall back to pre-discovered URL
+  const metadataUrl = parseWWWAuthenticate(wwwAuthenticateHeader) || options?.resourceMetadataUrl;
   if (!metadataUrl) {
     throw new Error(
-      'Invalid WWW-Authenticate header. Expected format: Bearer resource_metadata="<url>"'
+      'Could not determine OAuth resource metadata URL. ' +
+        'The WWW-Authenticate header does not contain resource_metadata, ' +
+        'and no pre-discovered metadata URL was provided.'
     );
   }
   console.log('[MCP OAuth] Resource metadata URL:', metadataUrl);

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -121,12 +121,13 @@ export async function discoverResourceMetadataUrl(mcpUrl: string): Promise<strin
   const origin = url.origin;
   const path = url.pathname === '/' ? '' : url.pathname.replace(/\/$/, '');
 
-  const candidates: string[] = [`${origin}/.well-known/oauth-protected-resource`];
-
-  // Add path-aware URL if the MCP endpoint isn't at root
+  // Path-aware first (more specific), then root fallback.
+  // Per RFC 9728, path-scoped resources should match their specific metadata endpoint.
+  const candidates: string[] = [];
   if (path) {
     candidates.push(`${origin}/.well-known/oauth-protected-resource${path}`);
   }
+  candidates.push(`${origin}/.well-known/oauth-protected-resource`);
 
   for (const candidate of candidates) {
     try {
@@ -148,6 +149,38 @@ export async function discoverResourceMetadataUrl(mcpUrl: string): Promise<strin
         err instanceof Error ? err.message : String(err)
       );
     }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the OAuth resource metadata URL for an MCP server.
+ *
+ * Combines two strategies:
+ *   1. Parse the `resource_metadata` parameter from the WWW-Authenticate header (RFC 9728)
+ *   2. Auto-discover via `.well-known/oauth-protected-resource` (fallback for servers like Notion)
+ *
+ * Returns the metadata URL and its source, or null if neither strategy succeeds.
+ * This is the single entry point that daemon endpoints should use instead of
+ * duplicating parse + fallback logic.
+ */
+export async function resolveResourceMetadataUrl(
+  wwwAuthenticateHeader: string | null,
+  mcpUrl: string
+): Promise<{ metadataUrl: string; source: 'header' | 'well-known' } | null> {
+  // Strategy 1: Parse from WWW-Authenticate header
+  if (wwwAuthenticateHeader) {
+    const parsed = parseWWWAuthenticate(wwwAuthenticateHeader);
+    if (parsed) {
+      return { metadataUrl: parsed, source: 'header' };
+    }
+  }
+
+  // Strategy 2: Auto-discover via .well-known endpoint
+  const discovered = await discoverResourceMetadataUrl(mcpUrl);
+  if (discovered) {
+    return { metadataUrl: discovered, source: 'well-known' };
   }
 
   return null;
@@ -538,14 +571,20 @@ export async function performMCPOAuthFlow(
    * The function should open the provided URL in a browser. It can be async.
    * Throwing an error will abort the OAuth flow.
    */
-  browserOpener?: (url: string) => void | Promise<void>
+  browserOpener?: (url: string) => void | Promise<void>,
+  /** Pre-discovered resource metadata URL (used when WWW-Authenticate lacks resource_metadata) */
+  resourceMetadataUrl?: string
 ): Promise<string> {
   console.log('[MCP OAuth] Starting OAuth 2.1 Authorization Code flow with PKCE');
 
-  // Step 1: Parse WWW-Authenticate header
-  const metadataUrl = parseWWWAuthenticate(wwwAuthenticateHeader);
+  // Step 1: Parse WWW-Authenticate header, fall back to pre-discovered URL
+  const metadataUrl = parseWWWAuthenticate(wwwAuthenticateHeader) || resourceMetadataUrl;
   if (!metadataUrl) {
-    throw new Error('WWW-Authenticate header missing resource_metadata parameter');
+    throw new Error(
+      'Could not determine OAuth resource metadata URL. ' +
+        'The WWW-Authenticate header does not contain resource_metadata, ' +
+        'and no pre-discovered metadata URL was provided.'
+    );
   }
 
   console.log('[MCP OAuth] Resource metadata URL:', metadataUrl);
@@ -727,10 +766,11 @@ export function isOAuthRequired(status: number, headers: Headers): boolean {
   if (status !== 401) return false;
   const wwwAuth = headers.get('www-authenticate');
   if (!wwwAuth) return false;
-  // Strict check: resource_metadata present
+  // Strict check: resource_metadata present (RFC 9728 compliant)
   if (wwwAuth.includes('resource_metadata=')) return true;
-  // Permissive check: Bearer challenge present (may need .well-known discovery)
-  if (wwwAuth.toLowerCase().includes('bearer')) return true;
+  // Permissive check: Bearer auth scheme at start of challenge (may need .well-known discovery).
+  // Uses word boundary to avoid matching e.g. "X-Bearer-Custom" schemes.
+  if (/^\s*Bearer\b/i.test(wwwAuth)) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

- Fixes Notion MCP OAuth integration (and other servers that don't include `resource_metadata` in WWW-Authenticate header)
- Adds `.well-known/oauth-protected-resource` auto-discovery fallback when the 401 response lacks RFC 9728 `resource_metadata` parameter
- Applies the fix to all three OAuth entry points: `oauth-start`, `test-oauth`, and `discover`
- Updates `isOAuthRequired()` to recognize plain Bearer challenges
- Updates `startMCPOAuthFlow()` to accept a pre-discovered metadata URL

## Problem

Notion's MCP server (`https://mcp.notion.com/mcp`) returns:
```
HTTP/2 401
www-authenticate: Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"
```

Agor expected (per RFC 9728):
```
www-authenticate: Bearer resource_metadata="https://..."
```

This caused Agor to reject the server with "Server does not require OAuth 2.1 authentication", even though Notion properly serves metadata at `/.well-known/oauth-protected-resource`.

## Test plan

- [ ] Configure Notion MCP server in Agor Settings with `auth.type = oauth`
- [ ] Click "Start OAuth Flow" — should now proceed instead of failing
- [ ] Complete OAuth in browser — token should be saved
- [ ] Verify existing OAuth servers (Slack, etc.) still work via the original `resource_metadata` header path
- [ ] Verify the discover endpoint handles both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)