### PR TITLE
fix: handle double-serialized arguments in agor_execute_tool

### DIFF
--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { coerceJsonRecord } from './server.js';
+
+describe('coerceJsonRecord', () => {
+  it('passes through a plain object unchanged', () => {
+    const obj = { boardId: '123', name: 'test' };
+    expect(coerceJsonRecord(obj)).toBe(obj);
+  });
+
+  it('passes through undefined unchanged', () => {
+    expect(coerceJsonRecord(undefined)).toBeUndefined();
+  });
+
+  it('passes through null unchanged', () => {
+    expect(coerceJsonRecord(null)).toBeNull();
+  });
+
+  it('passes through a number unchanged', () => {
+    expect(coerceJsonRecord(42)).toBe(42);
+  });
+
+  it('parses a JSON-stringified object back to an object', () => {
+    const input = JSON.stringify({ boardId: '123', name: 'test' });
+    expect(coerceJsonRecord(input)).toEqual({ boardId: '123', name: 'test' });
+  });
+
+  it('parses a complex stringified object with markdown content', () => {
+    const obj = {
+      worktreeId: 'abc-123',
+      initialPrompt:
+        '# Hello\n\nSome **markdown** with `backticks` and\n\n```ts\nconst x = 1;\n```',
+    };
+    expect(coerceJsonRecord(JSON.stringify(obj))).toEqual(obj);
+  });
+
+  it('returns "null" string parsed as null (Zod rejects downstream)', () => {
+    expect(coerceJsonRecord('null')).toBeNull();
+  });
+
+  it('returns "[]" string parsed as array (Zod rejects downstream)', () => {
+    expect(coerceJsonRecord('[]')).toEqual([]);
+  });
+
+  it('returns "42" string parsed as number (Zod rejects downstream)', () => {
+    expect(coerceJsonRecord('42')).toBe(42);
+  });
+
+  it('returns empty string unchanged (not valid JSON)', () => {
+    expect(coerceJsonRecord('')).toBe('');
+  });
+
+  it('returns malformed JSON string unchanged', () => {
+    expect(coerceJsonRecord('{bad json')).toBe('{bad json');
+  });
+
+  it('returns non-JSON string unchanged', () => {
+    expect(coerceJsonRecord('hello world')).toBe('hello world');
+  });
+});

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -62,6 +62,22 @@ export function coerceString(value: unknown): string | undefined {
 }
 
 /**
+ * Helper: coerce a possibly-stringified JSON value to a Record, or return as-is.
+ *
+ * Some MCP clients double-serialize nested objects as JSON strings (especially
+ * with large or complex content). This helper transparently parses those back.
+ * Returns the original value unchanged if it's not a string or not valid JSON.
+ */
+export function coerceJsonRecord(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
  * Helper: format a value as MCP text content response.
  */
 export function textResult(data: unknown) {

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { textResult } from '../server.js';
+import { coerceJsonRecord, textResult } from '../server.js';
 import { ToolRegistry } from '../tool-registry.js';
 
 /**
@@ -36,17 +36,8 @@ function resolveToolArgs(
 ): Record<string, unknown> {
   // Defense-in-depth: coerce stringified arguments even if Zod preprocess
   // already handled it (e.g. if the SDK bypasses schema validation).
-  let rawArgs = proxyArgs.arguments;
-  if (typeof rawArgs === 'string') {
-    try {
-      rawArgs = JSON.parse(rawArgs);
-    } catch {
-      throw new Error(
-        `Invalid arguments for tool ${toolName}: arguments is a string but not valid JSON`
-      );
-    }
-  }
-  let toolArgs: Record<string, unknown> = (rawArgs as Record<string, unknown>) ?? {};
+  let toolArgs: Record<string, unknown> =
+    (coerceJsonRecord(proxyArgs.arguments) as Record<string, unknown>) ?? {};
 
   if (Object.keys(toolArgs).length === 0) {
     // No nested arguments — check for flattened params at top level
@@ -158,20 +149,9 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
           tool_name: z.string().describe('The tool name to execute (e.g. "agor_worktrees_list")'),
           arguments: z
             .preprocess(
-              (val) => {
-                // Some MCP clients (e.g. Claude Code) double-serialize nested
-                // objects as JSON strings when content is large or contains
-                // special characters (markdown, backticks, multi-paragraph text).
-                // Coerce back to an object before validation.
-                if (typeof val === 'string') {
-                  try {
-                    return JSON.parse(val);
-                  } catch {
-                    return val; // let Zod reject the raw string
-                  }
-                }
-                return val;
-              },
+              // Some MCP clients double-serialize nested objects as JSON strings.
+              // Coerce back to an object before Zod validates against z.record().
+              coerceJsonRecord,
               z.record(z.string(), z.unknown())
             )
             .optional()

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -34,7 +34,19 @@ function resolveToolArgs(
   tool: RegisteredTool,
   toolName: string
 ): Record<string, unknown> {
-  let toolArgs: Record<string, unknown> = (proxyArgs.arguments as Record<string, unknown>) ?? {};
+  // Defense-in-depth: coerce stringified arguments even if Zod preprocess
+  // already handled it (e.g. if the SDK bypasses schema validation).
+  let rawArgs = proxyArgs.arguments;
+  if (typeof rawArgs === 'string') {
+    try {
+      rawArgs = JSON.parse(rawArgs);
+    } catch {
+      throw new Error(
+        `Invalid arguments for tool ${toolName}: arguments is a string but not valid JSON`
+      );
+    }
+  }
+  let toolArgs: Record<string, unknown> = (rawArgs as Record<string, unknown>) ?? {};
 
   if (Object.keys(toolArgs).length === 0) {
     // No nested arguments — check for flattened params at top level
@@ -145,7 +157,23 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
         .object({
           tool_name: z.string().describe('The tool name to execute (e.g. "agor_worktrees_list")'),
           arguments: z
-            .record(z.string(), z.unknown())
+            .preprocess(
+              (val) => {
+                // Some MCP clients (e.g. Claude Code) double-serialize nested
+                // objects as JSON strings when content is large or contains
+                // special characters (markdown, backticks, multi-paragraph text).
+                // Coerce back to an object before validation.
+                if (typeof val === 'string') {
+                  try {
+                    return JSON.parse(val);
+                  } catch {
+                    return val; // let Zod reject the raw string
+                  }
+                }
+                return val;
+              },
+              z.record(z.string(), z.unknown())
+            )
             .optional()
             .describe('Arguments to pass to the tool, matching its input schema'),
         })


### PR DESCRIPTION
## Summary

- Fix intermittent `"Invalid arguments for tool agor_execute_tool: expected record, received string"` errors when MCP clients (e.g. Claude Code) double-serialize the `arguments` object as a JSON string instead of a structured object
- Two layers of defense: `z.preprocess` on the Zod schema for SDK-level validation, and `JSON.parse` coercion in `resolveToolArgs` as defense-in-depth
- Invalid JSON or non-object values are still properly rejected after coercion

## Test plan

- [ ] Verify normal `agor_execute_tool` calls with object arguments still work
- [ ] Test with stringified arguments (e.g. `arguments: '{"boardId":"..."}'`) — should be coerced and succeed
- [ ] Test with invalid string arguments (e.g. `arguments: "not json"`) — should still fail with clear error
- [ ] Test with large `initialPrompt` containing markdown/backticks — the original failure case

🤖 Generated with [Claude Code](https://claude.com/claude-code)