### PR TITLE
chore: bump Codex to GPT-5.4 and SDK to 0.118.0

### DIFF
--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -113,7 +113,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (newMode === 'alias') {
         defaultModel = modelList[0].id;
       } else if (effectiveTool === 'codex') {
-        defaultModel = 'gpt-5.4-codex';
+        defaultModel = 'gpt-5.4';
       } else if (effectiveTool === 'gemini') {
         defaultModel = 'gemini-2.5-flash';
       } else if (effectiveTool === 'copilot') {
@@ -181,7 +181,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 onChange={(e) => handleModelChange(e.target.value)}
                 placeholder={
                   effectiveTool === 'codex'
-                    ? 'e.g., gpt-5.4-codex'
+                    ? 'e.g., gpt-5.4'
                     : effectiveTool === 'gemini'
                       ? 'e.g., gemini-2.5-pro'
                       : effectiveTool === 'copilot'

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import {
   AVAILABLE_CLAUDE_MODEL_ALIASES,
   CODEX_MODEL_METADATA,
+  DEFAULT_CODEX_MODEL,
   GEMINI_MODELS,
   type GeminiModel,
 } from '@agor/core/models';
@@ -113,7 +114,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (newMode === 'alias') {
         defaultModel = modelList[0].id;
       } else if (effectiveTool === 'codex') {
-        defaultModel = 'gpt-5.4';
+        defaultModel = DEFAULT_CODEX_MODEL;
       } else if (effectiveTool === 'gemini') {
         defaultModel = 'gemini-2.5-flash';
       } else if (effectiveTool === 'copilot') {
@@ -181,7 +182,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 onChange={(e) => handleModelChange(e.target.value)}
                 placeholder={
                   effectiveTool === 'codex'
-                    ? 'e.g., gpt-5.4'
+                    ? `e.g., ${DEFAULT_CODEX_MODEL}`
                     : effectiveTool === 'gemini'
                       ? 'e.g., gemini-2.5-pro'
                       : effectiveTool === 'copilot'

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -113,7 +113,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       if (newMode === 'alias') {
         defaultModel = modelList[0].id;
       } else if (effectiveTool === 'codex') {
-        defaultModel = 'gpt-5.3-codex';
+        defaultModel = 'gpt-5.4-codex';
       } else if (effectiveTool === 'gemini') {
         defaultModel = 'gemini-2.5-flash';
       } else if (effectiveTool === 'copilot') {
@@ -181,7 +181,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 onChange={(e) => handleModelChange(e.target.value)}
                 placeholder={
                   effectiveTool === 'codex'
-                    ? 'e.g., gpt-5.3-codex'
+                    ? 'e.g., gpt-5.4-codex'
                     : effectiveTool === 'gemini'
                       ? 'e.g., gemini-2.5-pro'
                       : effectiveTool === 'copilot'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ RUN npm install -g \
   pnpm@9.15.1 \
   @anthropic-ai/claude-code@2.1.87 \
   @google/gemini-cli@0.31.0 \
-  @openai/codex@0.116.0 \
+  @openai/codex@0.118.0 \
   opencode-ai@1.2.15
 
 # Arguments for matching host user UID/GID (default to 1000)

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -68,7 +68,7 @@
     "@oclif/plugin-help": "^6.2.37",
     "@octokit/auth-app": "^7.1.5",
     "@octokit/rest": "^22.0.0",
-    "@openai/codex-sdk": "^0.116.0",
+    "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.2.15",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -212,7 +212,7 @@
     "@libsql/client": "^0.15.15",
     "@octokit/auth-app": "^7.1.5",
     "@octokit/rest": "^22.0.0",
-    "@openai/codex-sdk": "^0.116.0",
+    "@openai/codex-sdk": "^0.118.0",
     "@opencode-ai/sdk": "^1.2.15",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.14.1",

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -5,7 +5,7 @@
  */
 
 /** Default Codex model */
-export const DEFAULT_CODEX_MODEL = 'gpt-5.4-codex';
+export const DEFAULT_CODEX_MODEL = 'gpt-5.4';
 
 /** Codex Mini model (GPT-5-Codex-Mini for cost-effective usage) */
 export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
@@ -20,14 +20,22 @@ export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
  */
 const _CODEX_MODEL_METADATA = {
   // GPT-5.4 models (newest)
-  'gpt-5.4-codex': {
-    name: 'GPT-5.4 Codex (Recommended)',
-    description: 'Most capable agentic coding model - latest release',
+  'gpt-5.4': {
+    name: 'GPT-5.4 (Recommended)',
+    description: 'Most capable model - unified coding, reasoning, and computer use',
+  },
+  'gpt-5.4-mini': {
+    name: 'GPT-5.4 Mini',
+    description: 'Smaller, faster GPT-5.4 variant',
   },
   // GPT-5.3 models
   'gpt-5.3-codex': {
     name: 'GPT-5.3 Codex',
     description: 'Strong agentic coding model - stronger reasoning, 25% faster',
+  },
+  'gpt-5.3-codex-spark': {
+    name: 'GPT-5.3 Codex Spark',
+    description: 'Real-time coding model, 1000+ tokens/sec (Pro users)',
   },
   // GPT-5.2 models
   'gpt-5.2-codex': {
@@ -105,9 +113,11 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
   // GPT-5.4 models
-  'gpt-5.4-codex': 400_000,
+  'gpt-5.4': 400_000,
+  'gpt-5.4-mini': 200_000,
   // GPT-5.3 models
   'gpt-5.3-codex': 400_000,
+  'gpt-5.3-codex-spark': 400_000,
   // GPT-5.2 models (400k context, 128k max output)
   'gpt-5.2-codex': 400_000,
   'gpt-5.2': 400_000,

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -5,7 +5,7 @@
  */
 
 /** Default Codex model */
-export const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';
+export const DEFAULT_CODEX_MODEL = 'gpt-5.4-codex';
 
 /** Codex Mini model (GPT-5-Codex-Mini for cost-effective usage) */
 export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
@@ -19,10 +19,15 @@ export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
  * Uses `as const satisfies` to preserve literal key types for CodexModel.
  */
 const _CODEX_MODEL_METADATA = {
-  // GPT-5.3 models (newest)
+  // GPT-5.4 models (newest)
+  'gpt-5.4-codex': {
+    name: 'GPT-5.4 Codex (Recommended)',
+    description: 'Most capable agentic coding model - latest release',
+  },
+  // GPT-5.3 models
   'gpt-5.3-codex': {
-    name: 'GPT-5.3 Codex (Recommended)',
-    description: 'Most capable agentic coding model - stronger reasoning, 25% faster',
+    name: 'GPT-5.3 Codex',
+    description: 'Strong agentic coding model - stronger reasoning, 25% faster',
   },
   // GPT-5.2 models
   'gpt-5.2-codex': {
@@ -99,6 +104,8 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
  * Values mirror OpenAI's public docs (Dec 2025) and fall back to 200k if unknown.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
+  // GPT-5.4 models
+  'gpt-5.4-codex': 400_000,
   // GPT-5.3 models
   'gpt-5.3-codex': 400_000,
   // GPT-5.2 models (400k context, 128k max output)

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -113,11 +113,11 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
   // GPT-5.4 models
-  'gpt-5.4': 400_000,
-  'gpt-5.4-mini': 200_000,
+  'gpt-5.4': 1_050_000,
+  'gpt-5.4-mini': 400_000,
   // GPT-5.3 models
   'gpt-5.3-codex': 400_000,
-  'gpt-5.3-codex-spark': 400_000,
+  'gpt-5.3-codex-spark': 128_000,
   // GPT-5.2 models (400k context, 128k max output)
   'gpt-5.2-codex': 400_000,
   'gpt-5.2': 400_000,

--- a/packages/executor/src/sdk-handlers/codex/models.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/models.test.ts
@@ -6,6 +6,10 @@ describe('getCodexContextWindowLimit', () => {
 
   it('returns expected limits for known Codex-compatible models', () => {
     const cases: Array<{ model: string; expected: number }> = [
+      { model: 'gpt-5.4', expected: 1_050_000 },
+      { model: 'gpt-5.4-mini', expected: 400_000 },
+      { model: 'gpt-5.3-codex', expected: 400_000 },
+      { model: 'gpt-5.3-codex-spark', expected: 128_000 },
       { model: 'gpt-5.1-codex', expected: defaultLimit },
       { model: 'gpt-5.1-codex-mini', expected: defaultLimit },
       { model: 'gpt-5.1', expected: defaultLimit },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: ^22.0.0
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.116.0
-        version: 0.116.0
+        specifier: ^0.118.0
+        version: 0.118.0
       '@opencode-ai/sdk':
         specifier: ^1.2.15
         version: 1.2.15
@@ -643,8 +643,8 @@ importers:
         specifier: ^22.0.0
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.116.0
-        version: 0.116.0
+        specifier: ^0.118.0
+        version: 0.118.0
       '@opencode-ai/sdk':
         specifier: ^1.2.15
         version: 1.2.15
@@ -2762,47 +2762,47 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
-  '@openai/codex-sdk@0.116.0':
-    resolution: {integrity: sha512-qrn1Pu5G1GJ9w4m/Lk3L3466ulMGG9SfyR0LPAaXdisuQI1rqgoUOuoZ4byX7cCzn0x1g2+WPc0apZgjMEK04Q==}
+  '@openai/codex-sdk@0.118.0':
+    resolution: {integrity: sha512-cMisxx4CGQL44yv2USqdgcPhxPOhv227+CJiF9snn2X7nL+6wary4g38OknornjlrPob7LyzdIFB7dXqjkXKxg==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.116.0':
-    resolution: {integrity: sha512-K6q9P2ZmpnzGmpS6Ybjvsdtvu8AbJx3f/Z4KmjH1u85StSS9TWMSQB8z0PPObKMejbtiIkHwhGyEIHi4iBYjig==}
+  '@openai/codex@0.118.0':
+    resolution: {integrity: sha512-oJhNOsP/Vu7DBUhodpP15z60cCZv3sKORqUn1+pepleqSTmc0zXJZSjz6fQOLzny9Ra6sRcvprFFKmQ3Q6+E6w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.116.0-darwin-arm64':
-    resolution: {integrity: sha512-WkdL083p8uMeASpg8bwV0DPGgzkm48LjN3MyU2m/YukujbiLnknAmG29O2q2rFCLm0oLSDIGUK8EnXA4ZcAF9Q==}
+  '@openai/codex@0.118.0-darwin-arm64':
+    resolution: {integrity: sha512-sxq7Q2q9YiJN1wNrzvFRCC5oQKXPVUvu9Ejg6SI/CvyyI9YdtyLTO633wQJALGB7XQfT+3tyM5nNBivnSzLA3Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.116.0-darwin-x64':
-    resolution: {integrity: sha512-Ax8uTwYSNIwGrzcNRcn0jJQhZzNcKGDbbn00Emde7gGOemjSLhRALjUaKjckAaW5xWnNqHTGdtzzPB4phNlDYg==}
+  '@openai/codex@0.118.0-darwin-x64':
+    resolution: {integrity: sha512-iIvrqzsh1iJmVfqyYwLZBiuh0MkN1Suqniz9hBfmRmE6txMWhRVfigb9SMBiOkfCW1C4sjBwLCsCSzg11rvppQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.116.0-linux-arm64':
-    resolution: {integrity: sha512-X7cL8rBSGDB+RSZc2FoKiqcMVeLPMmo06bkss/en4lLQsV1XG2DZI56WuXg92IOX3SjYl6Av/eOWgsb1t3UeLQ==}
+  '@openai/codex@0.118.0-linux-arm64':
+    resolution: {integrity: sha512-YKWmIqLBu9mmBhN3JHQNkLzk0BtAtV6LBPvhnL5eeHkNrChvA6PKrhsjy0O7wvRkiByZY/1dD14qVdAUfxcbiA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.116.0-linux-x64':
-    resolution: {integrity: sha512-S9InOgJT3tj6uQp55NqrCA1k5tklwFaH00JdC2ElbRmxchm7ard4WxHSJZX9TiY8enj4cQoLIC04NFTUCO+/PQ==}
+  '@openai/codex@0.118.0-linux-x64':
+    resolution: {integrity: sha512-vzU2d/gwAmZbf/DnwVzfQiNN3Ri04XpaZiJkHElIvGoqFbdrxRQFYTtslGDISYIO3o+POADZcFZIfamFsZj9yQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.116.0-win32-arm64':
-    resolution: {integrity: sha512-kX2oAUzkgZX9OsYpd4omv9IGf+9VWj4Vy3UtIAnQKBu1DTSzmTJmXDuDn87mkyUciSZadm2QbeqQQzm2NC0NYw==}
+  '@openai/codex@0.118.0-win32-arm64':
+    resolution: {integrity: sha512-AU7GPVFqd0Ml3P2OXfy6K6TONcxfCZLUh1zjYkkoPGWJ4A3BVMkOmMP9CAdSiQsnU/RQfdV/9IGqo1xwUQDdjA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.116.0-win32-x64':
-    resolution: {integrity: sha512-6sBIMOoA9FNuxQvCCnK0P548Wqrlk3I9SMdtOCUg2zYzYU7jOF2mWS1VpRQ6R+Jvo2x50dxeJZ+W37dBmXfprw==}
+  '@openai/codex@0.118.0-win32-x64':
+    resolution: {integrity: sha512-9vKW1ANQxIUsLpiY0VsOM+1avZjqxDZgqgxKABJHWRlLMuaSykwXexf8Hqq+BnYFfmn0d6MjxTuE1UtVvg9caw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -11875,35 +11875,35 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
-  '@openai/codex-sdk@0.116.0':
+  '@openai/codex-sdk@0.118.0':
     dependencies:
-      '@openai/codex': 0.116.0
+      '@openai/codex': 0.118.0
 
-  '@openai/codex@0.116.0':
+  '@openai/codex@0.118.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.116.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.116.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.116.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.116.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.116.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.116.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.118.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.118.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.118.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.118.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.118.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.118.0-win32-x64'
 
-  '@openai/codex@0.116.0-darwin-arm64':
+  '@openai/codex@0.118.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.116.0-darwin-x64':
+  '@openai/codex@0.118.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.116.0-linux-arm64':
+  '@openai/codex@0.118.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.116.0-linux-x64':
+  '@openai/codex@0.118.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.116.0-win32-arm64':
+  '@openai/codex@0.118.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.116.0-win32-x64':
+  '@openai/codex@0.118.0-win32-x64':
     optional: true
 
   '@opencode-ai/sdk@1.2.15': {}


### PR DESCRIPTION
## Summary

- **Default model**: `gpt-5.3-codex` → `gpt-5.4` (unified model, no separate `-codex` suffix)
- **New models added**: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`
- **SDK/CLI bumped**: `@openai/codex` 0.116.0 → 0.118.0 (Docker + package.json deps)
- **UI updated**: default model and placeholder in ModelSelector

## Test plan

- [ ] Verify `gpt-5.4` appears as default in model dropdown
- [ ] Verify `gpt-5.4-mini` and `gpt-5.3-codex-spark` appear in dropdown
- [ ] Test creating a Codex session with `gpt-5.4`
- [ ] Verify Docker build with updated CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)