### PR TITLE
feat: support MCP servers with pre-registered OAuth clients (e.g. Figma)

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -242,7 +242,7 @@ async function persistOAuthToken(
   },
   logPrefix: string
 ): Promise<void> {
-  const expiresIn = tokenResponse.expires_in || 3600;
+  const expiresIn = tokenResponse.expires_in ?? 3600;
 
   // Cache the token at daemon level
   cacheOAuth21Token(cacheKey, tokenResponse.access_token, expiresIn);
@@ -1640,7 +1640,7 @@ async function main() {
                 metadataUrl // Pre-discovered metadata URL (fallback for servers lacking resource_metadata)
               );
               console.log('[OAuth Test] OAuth flow completed, token obtained');
-              const testExpiresIn = tokenResponse.expires_in || 3600;
+              const testExpiresIn = tokenResponse.expires_in ?? 3600;
 
               // Cache the token at daemon level for discover endpoint to use
               cacheOAuth21Token(data.mcp_url, tokenResponse.access_token, testExpiresIn);
@@ -2490,7 +2490,7 @@ async function main() {
                   openOAuthBrowser,
                   resolved.metadataUrl
                 );
-                const discoveryExpiresIn = tokenResponse.expires_in || 3600;
+                const discoveryExpiresIn = tokenResponse.expires_in ?? 3600;
 
                 cacheOAuth21Token(mcpUrl, tokenResponse.access_token, discoveryExpiresIn);
                 if (serverId) {

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -199,7 +199,8 @@ async function saveOAuth21TokenToDB(
   mcpServerRepo: MCPServerRepository,
   serverId: string,
   token: string,
-  expiresInSeconds: number
+  expiresInSeconds: number,
+  refreshToken?: string
 ): Promise<void> {
   const expiresAt = Date.now() + (expiresInSeconds - 60) * 1000; // 60s buffer
   const server = await mcpServerRepo.findById(serverId);
@@ -217,10 +218,11 @@ async function saveOAuth21TokenToDB(
       type: 'oauth',
       oauth_access_token: token,
       oauth_token_expires_at: expiresAt,
+      ...(refreshToken ? { oauth_refresh_token: refreshToken } : {}),
     },
   });
   console.log(
-    `[OAuth 2.1 DB] Token saved for server ${serverId}, expires at ${new Date(expiresAt).toISOString()}`
+    `[OAuth 2.1 DB] Token saved for server ${serverId}, expires at ${new Date(expiresAt).toISOString()}${refreshToken ? ', with refresh token' : ''}`
   );
 }
 
@@ -1357,13 +1359,14 @@ async function main() {
 
       // Complete the flow
       const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
-      const token = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+      const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+      const expiresIn = tokenResponse.expires_in || 3600;
 
       // Remove from pending flows
       pendingOAuthFlows.delete(state);
 
       // Cache the token at daemon level
-      cacheOAuth21Token(pendingFlow.context.metadataUrl, token, 3600);
+      cacheOAuth21Token(pendingFlow.context.metadataUrl, tokenResponse.access_token, expiresIn);
 
       // Save to database based on OAuth mode
       if (pendingFlow.mcpServerId) {
@@ -1374,15 +1377,22 @@ async function main() {
           await userTokenRepo.saveToken(
             pendingFlow.userId as import('@agor/core/types').UserID,
             pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
-            token,
-            3600
+            tokenResponse.access_token,
+            expiresIn,
+            tokenResponse.refresh_token
           );
           console.log(
             `[OAuth Callback] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
           );
         } else {
           const mcpServerRepo = new MCPServerRepository(db);
-          await saveOAuth21TokenToDB(mcpServerRepo, pendingFlow.mcpServerId, token, 3600);
+          await saveOAuth21TokenToDB(
+            mcpServerRepo,
+            pendingFlow.mcpServerId,
+            tokenResponse.access_token,
+            expiresIn,
+            tokenResponse.refresh_token
+          );
           console.log(`[OAuth Callback] Shared token saved for server ${pendingFlow.mcpServerId}`);
         }
       }
@@ -2092,13 +2102,14 @@ async function main() {
         }
 
         // Complete the flow
-        const token = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+        const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+        const expiresIn = tokenResponse.expires_in || 3600;
 
         // Remove from pending flows
         pendingOAuthFlows.delete(state);
 
         // Cache the token at daemon level
-        cacheOAuth21Token(pendingFlow.context.metadataUrl, token, 3600);
+        cacheOAuth21Token(pendingFlow.context.metadataUrl, tokenResponse.access_token, expiresIn);
 
         // Save to database based on OAuth mode
         if (pendingFlow.mcpServerId) {
@@ -2110,8 +2121,9 @@ async function main() {
             await userTokenRepo.saveToken(
               pendingFlow.userId as import('@agor/core/types').UserID,
               pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
-              token,
-              3600 // 1 hour expiry
+              tokenResponse.access_token,
+              expiresIn,
+              tokenResponse.refresh_token
             );
             console.log(
               `[OAuth Complete] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
@@ -2119,7 +2131,13 @@ async function main() {
           } else {
             // Shared mode: save to MCP server's auth config
             const mcpServerRepo = new MCPServerRepository(db);
-            await saveOAuth21TokenToDB(mcpServerRepo, pendingFlow.mcpServerId, token, 3600);
+            await saveOAuth21TokenToDB(
+              mcpServerRepo,
+              pendingFlow.mcpServerId,
+              tokenResponse.access_token,
+              expiresIn,
+              tokenResponse.refresh_token
+            );
             console.log(
               `[OAuth Complete] Shared token saved for server ${pendingFlow.mcpServerId}`
             );

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -227,6 +227,57 @@ async function saveOAuth21TokenToDB(
 }
 
 /**
+ * Cache + persist an OAuth token after a successful flow completion.
+ * Shared by both the callback handler and the manual oauth-complete service.
+ */
+async function persistOAuthToken(
+  // biome-ignore lint/suspicious/noExplicitAny: db type is complex (Drizzle instance), callers always pass the correct value
+  db: any,
+  tokenResponse: { access_token: string; expires_in?: number; refresh_token?: string },
+  cacheKey: string,
+  pendingFlow: {
+    mcpServerId?: string;
+    userId?: string;
+    oauthMode?: 'per_user' | 'shared';
+  },
+  logPrefix: string
+): Promise<void> {
+  const expiresIn = tokenResponse.expires_in || 3600;
+
+  // Cache the token at daemon level
+  cacheOAuth21Token(cacheKey, tokenResponse.access_token, expiresIn);
+
+  // Save to database based on OAuth mode
+  if (pendingFlow.mcpServerId) {
+    const oauthMode = pendingFlow.oauthMode || 'per_user';
+
+    if (oauthMode === 'per_user' && pendingFlow.userId) {
+      const userTokenRepo = new UserMCPOAuthTokenRepository(db);
+      await userTokenRepo.saveToken(
+        pendingFlow.userId as import('@agor/core/types').UserID,
+        pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
+        tokenResponse.access_token,
+        expiresIn,
+        tokenResponse.refresh_token
+      );
+      console.log(
+        `[${logPrefix}] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
+      );
+    } else {
+      const mcpServerRepo = new MCPServerRepository(db);
+      await saveOAuth21TokenToDB(
+        mcpServerRepo,
+        pendingFlow.mcpServerId,
+        tokenResponse.access_token,
+        expiresIn,
+        tokenResponse.refresh_token
+      );
+      console.log(`[${logPrefix}] Shared token saved for server ${pendingFlow.mcpServerId}`);
+    }
+  }
+}
+
+/**
  * Get OAuth 2.1 token from in-memory cache
  */
 function getOAuth21Token(mcpUrl: string): string | undefined {
@@ -1360,42 +1411,18 @@ async function main() {
       // Complete the flow
       const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
       const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
-      const expiresIn = tokenResponse.expires_in || 3600;
 
       // Remove from pending flows
       pendingOAuthFlows.delete(state);
 
-      // Cache the token at daemon level
-      cacheOAuth21Token(pendingFlow.context.metadataUrl, tokenResponse.access_token, expiresIn);
-
-      // Save to database based on OAuth mode
-      if (pendingFlow.mcpServerId) {
-        const oauthMode = pendingFlow.oauthMode || 'per_user';
-
-        if (oauthMode === 'per_user' && pendingFlow.userId) {
-          const userTokenRepo = new UserMCPOAuthTokenRepository(db);
-          await userTokenRepo.saveToken(
-            pendingFlow.userId as import('@agor/core/types').UserID,
-            pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
-            tokenResponse.access_token,
-            expiresIn,
-            tokenResponse.refresh_token
-          );
-          console.log(
-            `[OAuth Callback] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
-          );
-        } else {
-          const mcpServerRepo = new MCPServerRepository(db);
-          await saveOAuth21TokenToDB(
-            mcpServerRepo,
-            pendingFlow.mcpServerId,
-            tokenResponse.access_token,
-            expiresIn,
-            tokenResponse.refresh_token
-          );
-          console.log(`[OAuth Callback] Shared token saved for server ${pendingFlow.mcpServerId}`);
-        }
-      }
+      // Cache + persist token
+      await persistOAuthToken(
+        db,
+        tokenResponse,
+        pendingFlow.context.metadataUrl,
+        pendingFlow,
+        'OAuth Callback'
+      );
 
       // Notify the initiating client that OAuth completed successfully
       if (app.io) {
@@ -1606,28 +1633,33 @@ async function main() {
                 }
               };
 
-              const token = await performMCPOAuthFlow(
+              const tokenResponse = await performMCPOAuthFlow(
                 wwwAuthenticate || '',
                 data.client_id, // Optional client_id
                 browserOpener, // Custom opener emits event to client
                 metadataUrl // Pre-discovered metadata URL (fallback for servers lacking resource_metadata)
               );
               console.log('[OAuth Test] OAuth flow completed, token obtained');
+              const testExpiresIn = tokenResponse.expires_in || 3600;
 
-              // Test the token against the MCP server
               // Cache the token at daemon level for discover endpoint to use
-              // Default to 1 hour if we don't have exact expiry (the transport caches with real expiry)
-              cacheOAuth21Token(data.mcp_url, token, 3600);
+              cacheOAuth21Token(data.mcp_url, tokenResponse.access_token, testExpiresIn);
 
               // Also save to database if we have a server ID (for cross-process access)
               if (data.mcp_server_id) {
-                await saveOAuth21TokenToDB(mcpServerRepo, data.mcp_server_id, token, 3600);
+                await saveOAuth21TokenToDB(
+                  mcpServerRepo,
+                  data.mcp_server_id,
+                  tokenResponse.access_token,
+                  testExpiresIn,
+                  tokenResponse.refresh_token
+                );
               }
 
               const testResponse = await fetch(data.mcp_url, {
                 method: 'POST',
                 headers: {
-                  Authorization: `Bearer ${token}`,
+                  Authorization: `Bearer ${tokenResponse.access_token}`,
                   Accept: 'application/json',
                   'Content-Type': 'application/json',
                 },
@@ -2103,46 +2135,18 @@ async function main() {
 
         // Complete the flow
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
-        const expiresIn = tokenResponse.expires_in || 3600;
 
         // Remove from pending flows
         pendingOAuthFlows.delete(state);
 
-        // Cache the token at daemon level
-        cacheOAuth21Token(pendingFlow.context.metadataUrl, tokenResponse.access_token, expiresIn);
-
-        // Save to database based on OAuth mode
-        if (pendingFlow.mcpServerId) {
-          const oauthMode = pendingFlow.oauthMode || 'per_user';
-
-          if (oauthMode === 'per_user' && pendingFlow.userId) {
-            // Per-user mode: save to user_mcp_oauth_tokens table
-            const userTokenRepo = new UserMCPOAuthTokenRepository(db);
-            await userTokenRepo.saveToken(
-              pendingFlow.userId as import('@agor/core/types').UserID,
-              pendingFlow.mcpServerId as import('@agor/core/types').MCPServerID,
-              tokenResponse.access_token,
-              expiresIn,
-              tokenResponse.refresh_token
-            );
-            console.log(
-              `[OAuth Complete] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
-            );
-          } else {
-            // Shared mode: save to MCP server's auth config
-            const mcpServerRepo = new MCPServerRepository(db);
-            await saveOAuth21TokenToDB(
-              mcpServerRepo,
-              pendingFlow.mcpServerId,
-              tokenResponse.access_token,
-              expiresIn,
-              tokenResponse.refresh_token
-            );
-            console.log(
-              `[OAuth Complete] Shared token saved for server ${pendingFlow.mcpServerId}`
-            );
-          }
-        }
+        // Cache + persist token
+        await persistOAuthToken(
+          db,
+          tokenResponse,
+          pendingFlow.context.metadataUrl,
+          pendingFlow,
+          'OAuth Complete'
+        );
 
         console.log('[OAuth Complete] Flow completed successfully');
 
@@ -2480,19 +2484,26 @@ async function main() {
                   `[MCP Discovery] OAuth 2.1 detected (${resolved.source}), starting browser flow...`
                 );
 
-                const token = await performMCPOAuthFlow(
+                const tokenResponse = await performMCPOAuthFlow(
                   wwwAuthenticate || '',
                   undefined,
                   openOAuthBrowser,
                   resolved.metadataUrl
                 );
+                const discoveryExpiresIn = tokenResponse.expires_in || 3600;
 
-                cacheOAuth21Token(mcpUrl, token, 3600);
+                cacheOAuth21Token(mcpUrl, tokenResponse.access_token, discoveryExpiresIn);
                 if (serverId) {
-                  await saveOAuth21TokenToDB(mcpServerRepo, serverId, token, 3600);
+                  await saveOAuth21TokenToDB(
+                    mcpServerRepo,
+                    serverId,
+                    tokenResponse.access_token,
+                    discoveryExpiresIn,
+                    tokenResponse.refresh_token
+                  );
                 }
 
-                return token;
+                return tokenResponse.access_token;
               }
             }
 

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -670,7 +670,7 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                       <ul style={{ margin: 0, paddingLeft: 20, fontSize: 12 }}>
                         <li>
                           <strong>Auto-discovery:</strong> OAuth 2.1 servers advertise their
-                          endpoints automatically via RFC 9728
+                          endpoints automatically
                         </li>
                         <li>
                           <strong>Pre-registered apps:</strong> Some servers (e.g. Figma, GitHub)

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -610,17 +610,23 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                   <Form.Item
                     label="Client ID"
                     name="oauth_client_id"
-                    tooltip="OAuth client ID. Supports templates like {{ user.env.OAUTH_CLIENT_ID }}"
+                    tooltip="Required for servers that don't support Dynamic Client Registration (e.g. Figma, GitHub). Register an OAuth app with the provider and paste the client ID here."
                   >
-                    <Input placeholder="{{ user.env.OAUTH_CLIENT_ID }}" allowClear />
+                    <Input
+                      placeholder="Enter client ID or {{ user.env.OAUTH_CLIENT_ID }}"
+                      allowClear
+                    />
                   </Form.Item>
 
                   <Form.Item
                     label="Client Secret"
                     name="oauth_client_secret"
-                    tooltip="OAuth client secret. Supports templates like {{ user.env.OAUTH_CLIENT_SECRET }}"
+                    tooltip="Required for servers that use confidential clients (e.g. Figma). The secret is sent via HTTP Basic Auth during token exchange."
                   >
-                    <Input.Password placeholder="{{ user.env.OAUTH_CLIENT_SECRET }}" allowClear />
+                    <Input.Password
+                      placeholder="Enter client secret or {{ user.env.OAUTH_CLIENT_SECRET }}"
+                      allowClear
+                    />
                   </Form.Item>
 
                   <Form.Item
@@ -659,15 +665,20 @@ const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                   </Form.Item>
 
                   <Alert
-                    message="OAuth 2.1 Auto-Discovery"
+                    message="OAuth Configuration"
                     description={
                       <ul style={{ margin: 0, paddingLeft: 20, fontSize: 12 }}>
                         <li>
-                          All fields are optional - OAuth 2.1 servers advertise their endpoints
+                          <strong>Auto-discovery:</strong> OAuth 2.1 servers advertise their
+                          endpoints automatically via RFC 9728
                         </li>
-                        <li>MCP server returns metadata URL in WWW-Authenticate header</li>
+                        <li>
+                          <strong>Pre-registered apps:</strong> Some servers (e.g. Figma, GitHub)
+                          require you to register an OAuth app in their developer portal and enter
+                          the Client ID and Client Secret here
+                        </li>
+                        <li>When Client ID is provided, Dynamic Client Registration is skipped</li>
                         <li>Browser opens automatically for user authentication (PKCE flow)</li>
-                        <li>Only fill Client ID/Secret for legacy Client Credentials flow</li>
                       </ul>
                     }
                     type="info"

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -120,12 +120,12 @@ export class UserMCPOAuthTokenRepository {
       const existing = await this.getToken(userId, serverId);
 
       if (existing) {
-        // Update existing token
+        // Update existing token — only overwrite refresh_token when a new one is provided
         await update(this.db, userMcpOauthTokens)
           .set({
             oauth_access_token: accessToken,
             oauth_token_expires_at: expiresAt,
-            oauth_refresh_token: refreshToken,
+            ...(refreshToken != null ? { oauth_refresh_token: refreshToken } : {}),
             updated_at: now,
           })
           .where(

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -8,6 +8,7 @@
 
 import crypto from 'node:crypto';
 import http from 'node:http';
+import type { OAuthTokenResponse } from './oauth-auth.js';
 
 export interface OAuthMetadata {
   authorization_servers: string[];
@@ -77,13 +78,8 @@ export interface DynamicClientRegistrationResponse {
   client_name?: string;
 }
 
-export interface OAuthTokenResponse {
-  access_token: string;
-  token_type: string;
-  expires_in?: number;
-  refresh_token?: string;
-  scope?: string;
-}
+// Re-export the canonical OAuthTokenResponse from oauth-auth to avoid duplication
+export type { OAuthTokenResponse } from './oauth-auth.js';
 
 /**
  * Generate PKCE code verifier and challenge
@@ -576,7 +572,7 @@ export async function performMCPOAuthFlow(
   browserOpener?: (url: string) => void | Promise<void>,
   /** Pre-discovered resource metadata URL (used when WWW-Authenticate lacks resource_metadata) */
   resourceMetadataUrl?: string
-): Promise<string> {
+): Promise<OAuthTokenResponse> {
   console.log('[MCP OAuth] Starting OAuth 2.1 Authorization Code flow with PKCE');
 
   // Step 1: Parse WWW-Authenticate header, fall back to pre-discovered URL
@@ -596,7 +592,7 @@ export async function performMCPOAuthFlow(
   if (cached && cached.expiresAt > Date.now()) {
     const ttlRemaining = Math.floor((cached.expiresAt - Date.now()) / 1000);
     console.log(`[MCP OAuth] Using cached token (valid for ${ttlRemaining}s)`);
-    return cached.token;
+    return { access_token: cached.token, token_type: 'bearer', expires_in: ttlRemaining };
   }
 
   if (cached) {
@@ -750,7 +746,7 @@ export async function performMCPOAuthFlow(
       `[MCP OAuth] Token cached for ${expiresInSeconds}s (${EXPIRY_BUFFER_SECONDS}s buffer)`
     );
 
-    return tokenResponse.access_token;
+    return tokenResponse;
   } finally {
     // Always close callback server, even on error
     callback.server.close();

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -732,7 +732,7 @@ export async function performMCPOAuthFlow(
     console.log('[MCP OAuth] Access token received successfully');
 
     // Step 10: Cache token
-    const expiresInSeconds = tokenResponse.expires_in || DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS;
+    const expiresInSeconds = tokenResponse.expires_in ?? DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS;
     const expiresAt = Date.now() + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
     const fetchedAt = Date.now();
 
@@ -1133,7 +1133,7 @@ export async function completeMCPOAuthFlow(
   console.log('[MCP OAuth] Access token received successfully');
 
   // Cache token
-  const expiresInSeconds = tokenResponse.expires_in || DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS;
+  const expiresInSeconds = tokenResponse.expires_in ?? DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS;
   const expiresAt = Date.now() + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
   const fetchedAt = Date.now();
 

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -259,8 +259,10 @@ async function registerDynamicClient(
     const errorText = await response.text();
     throw new Error(
       `Dynamic Client Registration failed (${response.status}): ${errorText}\n\n` +
-        'The MCP server may not support Dynamic Client Registration. ' +
-        'You may need to manually register an OAuth client and provide the client_id.'
+        'This MCP server does not support Dynamic Client Registration (RFC 7591). ' +
+        "You need to register an OAuth app in the provider's developer portal " +
+        '(e.g. figma.com/developers/apps for Figma) and enter the Client ID and ' +
+        'Client Secret in the MCP server configuration.'
     );
   }
 
@@ -669,8 +671,8 @@ export async function performMCPOAuthFlow(
           throw new Error(
             'OAuth client_id is required but the authorization server does not support ' +
               'Dynamic Client Registration.\n\n' +
-              'Please provide a client_id in the MCP server configuration, or contact the ' +
-              'server administrator to register an OAuth client.\n\n' +
+              "Register an OAuth app in the provider's developer portal and enter " +
+              'the Client ID (and Client Secret if required) in the MCP server configuration.\n\n' +
               `Server: ${authServerUrl}\n` +
               `Registration error: ${regError instanceof Error ? regError.message : String(regError)}`
           );
@@ -1030,7 +1032,8 @@ export async function startMCPOAuthFlow(
         throw new Error(
           'OAuth client_id is required but the authorization server does not support ' +
             'Dynamic Client Registration.\n\n' +
-            'Please provide a client_id in the MCP server configuration.'
+            "Register an OAuth app in the provider's developer portal and enter " +
+            'the Client ID (and Client Secret if required) in the MCP server configuration.'
         );
       }
     } else {
@@ -1109,7 +1112,7 @@ export async function completeMCPOAuthFlow(
   context: OAuthFlowContext,
   code: string,
   state: string
-): Promise<string> {
+): Promise<OAuthTokenResponse> {
   console.log('[MCP OAuth] Completing OAuth flow with authorization code');
   console.log('[MCP OAuth] Token endpoint:', context.tokenEndpoint);
   console.log('[MCP OAuth] Redirect URI:', context.redirectUri);
@@ -1148,7 +1151,7 @@ export async function completeMCPOAuthFlow(
     `[MCP OAuth] Token cached for ${expiresInSeconds}s (${EXPIRY_BUFFER_SECONDS}s buffer)`
   );
 
-  return tokenResponse.access_token;
+  return tokenResponse;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Improve UI guidance**: Updated the OAuth configuration Alert and field tooltips to explain when to provide pre-registered credentials (e.g. Figma, GitHub) vs relying on auto-discovery
- **Improve error messages**: DCR failure messages now specifically direct users to register an OAuth app in the provider's developer portal and enter credentials in the MCP server config
- **Return full token response** from `completeMCPOAuthFlow`: Previously only returned the `access_token` string, losing `refresh_token` and `expires_in`. Now returns the full `OAuthTokenResponse`
- **Store refresh tokens**: Both per-user and shared token storage now persist `refresh_token` from the OAuth provider
- **Use actual expiry**: Token storage uses the server-provided `expires_in` instead of a hardcoded 3600s

## Context

Figma's MCP server does NOT support Dynamic Client Registration (RFC 7591). It requires:
1. A registered OAuth app at figma.com/developers/apps
2. `client_id` and `client_secret` entered in Agor's MCP server configuration
3. Standard OAuth 2.0 Authorization Code flow with PKCE

The backend already supported pre-registered credentials (skips DCR when `client_id` is provided), but the UX didn't guide users toward this path, and the token response handling lost important metadata.

## Test plan

- [ ] Configure a Figma MCP server with client_id and client_secret from figma.com/developers/apps
- [ ] Verify "Start OAuth Flow" opens Figma auth page and successfully obtains token
- [ ] Verify refresh_token is stored in the database after OAuth completion
- [ ] Verify token expiry matches the provider's value (not hardcoded 3600s)
- [ ] Verify DCR still works for servers that support it (no regression)
- [ ] Verify improved error message when DCR fails without client_id configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)