### PR TITLE
fix: resolve short ID prefixes consistently across all MCP tools

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -5210,7 +5210,7 @@ async function main() {
         console.log(`   Streaming: ${data.stream !== false}`);
         console.log(`   Message source: ${data.messageSource || 'not specified'}`);
 
-        const id = params.route?.id;
+        let id = params.route?.id;
         if (!id) throw new Error('Session ID required');
         if (!data.prompt) throw new Error('Prompt required');
 
@@ -5230,6 +5230,8 @@ async function main() {
 
         // Get session to find current message count
         let session = await sessionsService.get(id, params);
+        // Resolve short ID prefix to full UUID for all downstream operations
+        id = session.session_id;
 
         // Auto-unarchive on prompt: if someone prompts an archived session, they want it back
         if (session.archived) {

--- a/apps/agor-daemon/src/mcp/resolve-ids.ts
+++ b/apps/agor-daemon/src/mcp/resolve-ids.ts
@@ -1,0 +1,71 @@
+/**
+ * Short ID Resolution Utilities for MCP Tools
+ *
+ * Resolves short ID prefixes (e.g. "5bb05f13") to full UUIDs by looking up
+ * the entity via the service layer. Each resolver calls service.get() which
+ * triggers the repository's resolveId() — handling exact match, prefix match,
+ * ambiguity errors, and not-found errors consistently.
+ *
+ * Usage: call at the top of MCP tool handlers before using IDs in service
+ * calls, route params, or FK values.
+ *
+ * All functions accept IdInput (short prefix or full UUID) and return the
+ * canonical full UUID.
+ */
+
+import type {
+  ArtifactID,
+  BoardID,
+  IdInput,
+  RepoID,
+  SessionID,
+  TaskID,
+  UserID,
+  WorktreeID,
+} from '@agor/core/types';
+import type { McpContext } from './server.js';
+
+export async function resolveSessionId(ctx: McpContext, id: IdInput): Promise<SessionID> {
+  const entity = await ctx.app.service('sessions').get(id, ctx.baseServiceParams);
+  return entity.session_id;
+}
+
+export async function resolveWorktreeId(ctx: McpContext, id: IdInput): Promise<WorktreeID> {
+  const entity = await ctx.app.service('worktrees').get(id, ctx.baseServiceParams);
+  return entity.worktree_id;
+}
+
+export async function resolveBoardId(ctx: McpContext, id: IdInput): Promise<BoardID> {
+  const entity = await ctx.app.service('boards').get(id, ctx.baseServiceParams);
+  return entity.board_id;
+}
+
+export async function resolveRepoId(ctx: McpContext, id: IdInput): Promise<RepoID> {
+  const entity = await ctx.app.service('repos').get(id, ctx.baseServiceParams);
+  return entity.repo_id;
+}
+
+export async function resolveCardId(ctx: McpContext, id: IdInput): Promise<string> {
+  const entity = await ctx.app.service('cards').get(id, ctx.baseServiceParams);
+  return entity.card_id;
+}
+
+export async function resolveTaskId(ctx: McpContext, id: IdInput): Promise<TaskID> {
+  const entity = await ctx.app.service('tasks').get(id, ctx.baseServiceParams);
+  return entity.task_id;
+}
+
+export async function resolveUserId(ctx: McpContext, id: IdInput): Promise<UserID> {
+  const entity = await ctx.app.service('users').get(id, ctx.baseServiceParams);
+  return entity.user_id;
+}
+
+export async function resolveMcpServerId(ctx: McpContext, id: IdInput): Promise<string> {
+  const entity = await ctx.app.service('mcp-servers').get(id, ctx.baseServiceParams);
+  return entity.mcp_server_id;
+}
+
+export async function resolveArtifactId(ctx: McpContext, id: IdInput): Promise<ArtifactID> {
+  const entity = await ctx.app.service('artifacts').get(id, ctx.baseServiceParams);
+  return entity.artifact_id;
+}

--- a/apps/agor-daemon/src/mcp/tools/analytics.ts
+++ b/apps/agor-daemon/src/mcp/tools/analytics.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { resolveRepoId, resolveUserId, resolveWorktreeId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -51,9 +52,9 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
     },
     async (args) => {
       const query: Record<string, unknown> = {};
-      if (args.userId) query.userId = args.userId;
-      if (args.worktreeId) query.worktreeId = args.worktreeId;
-      if (args.repoId) query.repoId = args.repoId;
+      if (args.userId) query.userId = await resolveUserId(ctx, args.userId);
+      if (args.worktreeId) query.worktreeId = await resolveWorktreeId(ctx, args.worktreeId);
+      if (args.repoId) query.repoId = await resolveRepoId(ctx, args.repoId);
       if (args.startDate) query.startDate = args.startDate;
       if (args.endDate) query.endDate = args.endDate;
       if (args.groupBy) query.groupBy = args.groupBy;

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -9,6 +9,7 @@ import { NotFoundError } from '@agor/core/utils/errors';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ArtifactsService } from '../../services/artifacts.js';
+import { resolveArtifactId, resolveBoardId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -109,12 +110,16 @@ When in doubt, leave unset — the hosted bundler supports the widest range of p
     },
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const resolvedBoardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
+      const resolvedArtifactId = coerceString(args.artifactId)
+        ? await resolveArtifactId(ctx, coerceString(args.artifactId)!)
+        : undefined;
       const artifact = await service.publish(
         {
           folderPath: coerceString(args.folderPath)!,
-          board_id: coerceString(args.boardId)!,
+          board_id: resolvedBoardId,
           name: coerceString(args.name)!,
-          artifact_id: coerceString(args.artifactId),
+          artifact_id: resolvedArtifactId,
           template: args.template,
           public: args.public,
           use_local_bundler: args.useLocalBundler,
@@ -254,7 +259,8 @@ When in doubt, leave unset — the hosted bundler supports the widest range of p
     },
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
-      const boardId = coerceString(args.boardId);
+      const boardIdRaw = coerceString(args.boardId);
+      const boardId = boardIdRaw ? await resolveBoardId(ctx, boardIdRaw) : undefined;
       const limit = typeof args.limit === 'number' ? args.limit : 50;
 
       let artifactsList: unknown[];

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -3,6 +3,7 @@ import type { Card, ZoneBoardObject } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { CardsService } from '../../services/cards.js';
+import { resolveBoardId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -27,7 +28,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const boardId = coerceString(args.boardId)!;
+      const boardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
       const title = coerceString(args.title)!;
       const board = await ctx.app.service('boards').get(boardId, ctx.baseServiceParams);
       let zoneData: ZoneBoardObject | undefined;
@@ -103,7 +104,8 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
-      const boardId = coerceString(args.boardId);
+      const boardIdRaw = coerceString(args.boardId);
+      const boardId = boardIdRaw ? await resolveBoardId(ctx, boardIdRaw) : undefined;
       const cardTypeId = coerceString(args.cardTypeId);
       const zoneId = coerceString(args.zoneId);
       const search = coerceString(args.search);

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -3,7 +3,7 @@ import type { Card, ZoneBoardObject } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { CardsService } from '../../services/cards.js';
-import { resolveBoardId } from '../resolve-ids.js';
+import { resolveBoardId, resolveCardId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -258,8 +258,9 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      const cardId = await resolveCardId(ctx, args.cardId);
       const zoneId = args.zoneId === null ? null : (coerceString(args.zoneId) ?? null);
-      const card = await ctx.app.service('cards').get(args.cardId, ctx.baseServiceParams);
+      const card = await ctx.app.service('cards').get(cardId, ctx.baseServiceParams);
       let zoneData: ZoneBoardObject | undefined;
       if (zoneId) {
         const board = await ctx.app.service('boards').get(card.board_id, ctx.baseServiceParams);
@@ -269,7 +270,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         zoneData = zone;
       }
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
-      const boardObject = await cardsService.moveToZone(args.cardId as never, zoneId, zoneData);
+      const boardObject = await cardsService.moveToZone(cardId as never, zoneId, zoneData);
       ctx.app.service('board-objects').emit('patched', boardObject);
       return textResult(boardObject);
     }
@@ -288,9 +289,10 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      const cardId = await resolveCardId(ctx, args.cardId);
       const boardObjectRepo = new BoardObjectRepository(ctx.db);
-      const boardObj = await boardObjectRepo.findByCardId(args.cardId as never);
-      if (!boardObj) throw new Error(`Card ${args.cardId} has no board placement`);
+      const boardObj = await boardObjectRepo.findByCardId(cardId as never);
+      if (!boardObj) throw new Error(`Card ${cardId} has no board placement`);
       const boardObjectsService = ctx.app.service(
         'board-objects'
       ) as unknown as import('../../services/board-objects.js').BoardObjectsService;
@@ -328,7 +330,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const boardId = coerceString(args.boardId)!;
+      const boardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
       const cardsArr = args.cards;
       if (!Array.isArray(cardsArr) || cardsArr.length === 0)
         throw new Error('non-empty cards array is required');
@@ -445,8 +447,9 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       const results = [];
 
       for (const m of moves) {
-        const cardId = coerceString(m.cardId);
-        if (!cardId) continue;
+        const cardIdRaw = coerceString(m.cardId);
+        if (!cardIdRaw) continue;
+        const cardId = await resolveCardId(ctx, cardIdRaw);
         const zoneId = m.zoneId === null ? null : (coerceString(m.zoneId) ?? null);
         let zoneData: ZoneBoardObject | undefined;
         if (zoneId) {

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, messages as messagesTable, or, select, sql } from '
 import type { ContentBlock } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { resolveSessionId, resolveTaskId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -49,13 +50,16 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const sessionId = coerceString(args.sessionId);
-      const taskId = coerceString(args.taskId);
+      const sessionIdRaw = coerceString(args.sessionId);
+      const taskIdRaw = coerceString(args.taskId);
       const search = coerceString(args.search);
 
-      if (!sessionId && !taskId && !search) {
+      if (!sessionIdRaw && !taskIdRaw && !search) {
         throw new Error('at least one of sessionId, taskId, or search is required');
       }
+
+      const sessionId = sessionIdRaw ? await resolveSessionId(ctx, sessionIdRaw) : undefined;
+      const taskId = taskIdRaw ? await resolveTaskId(ctx, taskIdRaw) : undefined;
 
       const includeToolCalls = args.includeToolCalls === true;
       const contentMode = args.contentMode === 'full' ? 'full' : 'preview';

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import type { SessionsServiceImpl } from '../../declarations.js';
 import type { SessionParams } from '../../services/sessions.js';
 import { ensureCanPromptSession } from '../../utils/worktree-authorization.js';
+import { resolveBoardId, resolveSessionId, resolveWorktreeId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -58,8 +59,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       const requestedLimit = args.limit;
       if (!args.sessionType && requestedLimit) query.$limit = requestedLimit;
       if (args.status) query.status = args.status;
-      if (args.boardId) query.board_id = args.boardId;
-      if (args.worktreeId) query.worktree_id = args.worktreeId;
+      if (args.boardId) query.board_id = await resolveBoardId(ctx, args.boardId);
+      if (args.worktreeId) query.worktree_id = await resolveWorktreeId(ctx, args.worktreeId);
       if (args.archived === true) {
         query.archived = true;
       } else if (!args.includeArchived) {
@@ -476,13 +477,14 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const mode = args.mode;
+      const sessionId = await resolveSessionId(ctx, args.sessionId);
 
       if (mode === 'continue') {
         const promptResponse = await ctx.app
           .service('/sessions/:id/prompt')
           .create(
             { prompt: args.prompt, stream: true },
-            { ...ctx.baseServiceParams, route: { id: args.sessionId } }
+            { ...ctx.baseServiceParams, route: { id: sessionId } }
           );
 
         if (promptResponse.queued) {
@@ -505,7 +507,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
         const forkedSession = await (
           ctx.app.service('sessions') as unknown as SessionsServiceImpl
-        ).fork(args.sessionId, forkData, ctx.baseServiceParams);
+        ).fork(sessionId, forkData, ctx.baseServiceParams);
 
         if (args.title) {
           await ctx.app
@@ -543,7 +545,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
         const childSession = await (
           ctx.app.service('sessions') as unknown as SessionsServiceImpl
-        ).spawn(args.sessionId, spawnData, ctx.baseServiceParams);
+        ).spawn(sessionId, spawnData, ctx.baseServiceParams);
 
         const promptResponse = await ctx.app.service('/sessions/:id/prompt').create(
           {
@@ -708,7 +710,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }
 
       const sessionData: Record<string, unknown> = {
-        worktree_id: args.worktreeId,
+        worktree_id: worktree.worktree_id,
         agentic_tool: agenticTool,
         status: 'idle',
         title: args.title,
@@ -974,8 +976,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // Build service query for non-archived sessions
       const query: Record<string, unknown> = { archived: false };
       if (args.status) query.status = args.status;
-      if (args.boardId) query.board_id = args.boardId;
-      if (args.worktreeId) query.worktree_id = args.worktreeId;
+      if (args.boardId) query.board_id = await resolveBoardId(ctx, args.boardId);
+      if (args.worktreeId) query.worktree_id = await resolveWorktreeId(ctx, args.worktreeId);
 
       // Fetch all matching sessions (paginate through all results)
       const allSessions: Session[] = [];

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -12,7 +12,12 @@ import { z } from 'zod';
 import type { SessionsServiceImpl } from '../../declarations.js';
 import type { SessionParams } from '../../services/sessions.js';
 import { ensureCanPromptSession } from '../../utils/worktree-authorization.js';
-import { resolveBoardId, resolveSessionId, resolveWorktreeId } from '../resolve-ids.js';
+import {
+  resolveBoardId,
+  resolveMcpServerId,
+  resolveSessionId,
+  resolveWorktreeId,
+} from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -674,9 +679,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       // MCP server inheritance: explicit param > worktree config > user defaults
       // An explicit empty array means "no MCPs" — does NOT fall through to worktree/user defaults.
+      // Resolve short IDs when from user input; worktree/user defaults are already full UUIDs.
       const mcpServerIds =
         args.mcpServerIds !== undefined
-          ? args.mcpServerIds
+          ? await Promise.all(args.mcpServerIds.map((id) => resolveMcpServerId(ctx, id)))
           : worktree.mcp_server_ids && worktree.mcp_server_ids.length > 0
             ? worktree.mcp_server_ids
             : userToolDefaults?.mcpServerIds || [];

--- a/apps/agor-daemon/src/mcp/tools/tasks.ts
+++ b/apps/agor-daemon/src/mcp/tools/tasks.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { resolveSessionId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -17,7 +18,7 @@ export function registerTaskTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const query: Record<string, unknown> = {};
-      if (args.sessionId) query.session_id = args.sessionId;
+      if (args.sessionId) query.session_id = await resolveSessionId(ctx, args.sessionId);
       if (args.limit) query.$limit = args.limit;
       const tasks = await ctx.app.service('tasks').find({ query, ...ctx.baseServiceParams });
       return textResult(tasks);

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -17,6 +17,7 @@ import type { ReposServiceImpl, WorktreesServiceImpl } from '../../declarations.
 import type { WorktreeParams } from '../../services/worktrees.js';
 import {
   resolveBoardId,
+  resolveMcpServerId,
   resolveRepoId,
   resolveSessionId,
   resolveWorktreeId,
@@ -471,7 +472,10 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }
       if (args.mcpServerIds !== undefined) {
         fieldsProvided++;
-        updates.mcp_server_ids = args.mcpServerIds === null ? [] : args.mcpServerIds;
+        updates.mcp_server_ids =
+          args.mcpServerIds === null
+            ? []
+            : await Promise.all(args.mcpServerIds.map((id) => resolveMcpServerId(ctx, id)));
       }
       if (args.othersCan !== undefined) {
         fieldsProvided++;

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -15,6 +15,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ReposServiceImpl, WorktreesServiceImpl } from '../../declarations.js';
 import type { WorktreeParams } from '../../services/worktrees.js';
+import {
+  resolveBoardId,
+  resolveRepoId,
+  resolveSessionId,
+  resolveWorktreeId,
+} from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -71,7 +77,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
     },
     async (args) => {
       const query: Record<string, unknown> = {};
-      if (args.repoId) query.repo_id = args.repoId;
+      if (args.repoId) query.repo_id = await resolveRepoId(ctx, args.repoId);
       if (args.limit) query.$limit = args.limit;
       if (args.archived === true) {
         query.archived = true;
@@ -191,10 +197,10 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }),
     },
     async (args) => {
-      const repoId = coerceString(args.repoId)!;
+      const repoId = await resolveRepoId(ctx, coerceString(args.repoId)!);
       let worktreeName = coerceString(args.worktreeName)!;
       const originalName = worktreeName;
-      const boardId = coerceString(args.boardId)!;
+      const boardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
       const zoneId = coerceString(args.zoneId);
       const autoSuffix = typeof args.autoSuffix === 'boolean' ? args.autoSuffix : true;
 
@@ -417,8 +423,10 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }),
     },
     async (args) => {
-      let resolvedWorktreeId = coerceString(args.worktreeId);
-      if (!resolvedWorktreeId) {
+      let resolvedWorktreeId: string;
+      if (coerceString(args.worktreeId)) {
+        resolvedWorktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
+      } else {
         const currentSession = await ctx.app.service('sessions').get(ctx.sessionId);
         const sessionWorktreeId = currentSession.worktree_id;
         if (!sessionWorktreeId)
@@ -454,7 +462,8 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }
       if (args.boardId !== undefined) {
         fieldsProvided++;
-        updates.board_id = args.boardId === null ? null : coerceString(args.boardId);
+        const boardIdStr = args.boardId === null ? null : coerceString(args.boardId);
+        updates.board_id = boardIdStr ? await resolveBoardId(ctx, boardIdStr) : null;
       }
       if (args.customContext !== undefined) {
         fieldsProvided++;
@@ -568,9 +577,11 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }),
     },
     async (args) => {
-      const worktreeId = coerceString(args.worktreeId)!;
+      const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
       const zoneId = coerceString(args.zoneId)!;
-      const targetSessionId = coerceString(args.targetSessionId);
+      const targetSessionId = coerceString(args.targetSessionId)
+        ? await resolveSessionId(ctx, coerceString(args.targetSessionId)!)
+        : undefined;
       const triggerTemplate = args.triggerTemplate === true;
 
       console.log(`📍 MCP pinning worktree ${worktreeId.substring(0, 8)} to zone ${zoneId}`);
@@ -911,7 +922,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }),
     },
     async (args) => {
-      const worktreeId = coerceString(args.worktreeId)!;
+      const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
       const filesystemAction =
         (args.filesystemAction as 'preserved' | 'cleaned' | 'deleted') || 'cleaned';
       const worktreesService = ctx.app.service('worktrees') as unknown as WorktreesServiceImpl;
@@ -940,8 +951,9 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }),
     },
     async (args) => {
-      const worktreeId = coerceString(args.worktreeId)!;
-      const boardId = coerceString(args.boardId);
+      const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
+      const boardIdStr = coerceString(args.boardId);
+      const boardId = boardIdStr ? await resolveBoardId(ctx, boardIdStr) : undefined;
       const worktreesService = ctx.app.service('worktrees') as unknown as WorktreesServiceImpl;
       const result = await worktreesService.unarchive(
         worktreeId as WorktreeID,
@@ -974,7 +986,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }),
     },
     async (args) => {
-      const worktreeId = coerceString(args.worktreeId)!;
+      const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
       const filesystemAction = (args.filesystemAction as 'preserved' | 'deleted') || 'deleted';
       const worktreesService = ctx.app.service('worktrees') as unknown as WorktreesServiceImpl;
       await worktreesService.archiveOrDelete(
@@ -1004,7 +1016,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
     },
     async (args) => {
       const query: Record<string, unknown> = { archived: false, $limit: args.limit || 200 };
-      if (args.repoId) query.repo_id = args.repoId;
+      if (args.repoId) query.repo_id = await resolveRepoId(ctx, args.repoId);
 
       const result = await ctx.app.service('worktrees').find({ query, ...ctx.baseServiceParams });
 

--- a/packages/core/src/types/id.ts
+++ b/packages/core/src/types/id.ts
@@ -54,6 +54,19 @@ export type ShortID = string;
  */
 export type IDPrefix = string;
 
+/**
+ * Unresolved ID input — either a full UUID or a short ID prefix.
+ *
+ * Used at API entry points (MCP tools, REST routes) where callers may pass
+ * either form. Must be resolved to a full UUID before use as a foreign key
+ * or in database queries.
+ *
+ * @example
+ * const input: IdInput = "01933e4a";                                // short prefix
+ * const input: IdInput = "01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f";  // full UUID
+ */
+export type IdInput = string;
+
 // ============================================================================
 // Entity-Specific ID Types
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Add `resolve-ids.ts` utility** — typed resolver functions for each entity (session, worktree, board, repo, card, task, user, artifact, mcp-server) that resolve short ID prefixes to full UUIDs via the service layer
- **Add `IdInput` type** — represents "short ID or full UUID" at API entry points, exported from `@agor/core/types`
- **Fix prompt service** — after `sessionsService.get(id)` resolves the short ID, the resolved `session.session_id` is now used for all downstream operations (task creation, queue operations, streaming events)
- **Fix all MCP tool handlers** — every tool that accepts an ID parameter now resolves it before using it in service calls, query filters, FK values, or route params

### Tools fixed

| Tool | Issue fixed |
|------|------------|
| `agor_sessions_list` | `boardId`, `worktreeId` query filters |
| `agor_sessions_prompt` | `sessionId` in route params (continue/fork/subsession modes) |
| `agor_sessions_create` | `worktreeId` FK in session create |
| `agor_sessions_bulk_archive` | `boardId`, `worktreeId` query filters |
| `agor_worktrees_list` | `repoId` query filter |
| `agor_worktrees_create` | `repoId`, `boardId` params |
| `agor_worktrees_update` | `worktreeId`, `boardId` params |
| `agor_worktrees_set_zone` | `worktreeId`, `targetSessionId` params |
| `agor_worktrees_archive/unarchive/delete` | `worktreeId`, `boardId` params |
| `agor_assistants_list` | `repoId` query filter |
| `agor_cards_create` | `boardId` FK |
| `agor_cards_list` | `boardId` query filter |
| `agor_artifacts_publish` | `boardId`, `artifactId` FKs |
| `agor_artifacts_list` | `boardId` query filter |
| `agor_analytics_leaderboard` | `userId`, `worktreeId`, `repoId` query filters |
| `agor_tasks_list` | `sessionId` query filter |
| `agor_messages_list` | `sessionId`, `taskId` query filters |

## Test plan

- [ ] Verify `agor_sessions_prompt` works with a short session ID prefix (the originally reported bug)
- [ ] Verify `agor_sessions_list` with short `boardId` filter returns correct results
- [ ] Verify `agor_worktrees_create` with short `repoId` and `boardId` creates worktree with correct FK values
- [ ] Verify ambiguous short IDs return clear error messages
- [ ] Verify full UUIDs continue to work without extra overhead (repository resolveId returns immediately for 36-char UUIDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)