### PR TITLE
fix: don't pass resource metadata scopes for pre-registered OAuth clients

### DIFF
--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -630,9 +630,12 @@ export async function performMCPOAuthFlow(
     let actualClientId = clientId;
     let clientSecret: string | undefined;
 
-    // Compute scopes early — needed for both DCR registration and auth URL
+    // Compute scopes early — needed for both DCR registration and auth URL.
+    // Skip auto-populating from resource metadata when client_id is pre-registered.
     const scopeString =
-      resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0
+      !actualClientId &&
+      resourceMetadata.scopes_supported &&
+      resourceMetadata.scopes_supported.length > 0
         ? resourceMetadata.scopes_supported.join(' ')
         : undefined;
 
@@ -987,10 +990,14 @@ export async function startMCPOAuthFlow(
   // so we use a known URI pattern that the user will copy from
   const actualRedirectUri = redirectUri || 'http://127.0.0.1:0/oauth/callback';
 
-  // Compute scopes early — needed for both DCR registration and auth URL
+  // Compute scopes early — needed for both DCR registration and auth URL.
+  // When a client_id is pre-registered (e.g. Figma, GitHub), don't auto-populate scopes
+  // from resource metadata — the resource server may advertise scopes (like "mcp:connect")
+  // that the authorization server doesn't recognize. Pre-registered apps have scopes
+  // configured during app registration, so omitting them lets the auth server use defaults.
   const scopeString = options?.scope
     ? options.scope
-    : resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0
+    : !clientId && resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0
       ? resourceMetadata.scopes_supported.join(' ')
       : undefined;
 


### PR DESCRIPTION
## Summary
- When a pre-registered `client_id` is provided, skip auto-populating scopes from RFC 9728 resource metadata (`scopes_supported`)
- Fixes "Invalid scope: mcp:connect" error with Figma's OAuth server, which advertises `mcp:connect` in resource metadata but doesn't accept it as a valid scope on the authorization endpoint
- Pre-registered OAuth apps have their scopes configured during app registration, so resource metadata scopes should not override them

## Test plan
- [ ] Configure Figma MCP server with pre-registered client_id/secret and no explicit scope
- [ ] Verify OAuth flow completes without "Invalid scope" error
- [ ] Verify MCP servers without pre-registered clients still auto-detect scopes from resource metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)