### PR TITLE
debug: add OAuth scope computation logging to trace mcp:connect issue

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -2045,6 +2045,12 @@ async function main() {
         const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
         // Use client_id from request (UI form) or fall back to saved server config
         const effectiveClientId = data.client_id || clientIdFromConfig;
+        console.log('[OAuth Start] client_id debug:', {
+          'data.client_id': data.client_id,
+          clientIdFromConfig,
+          effectiveClientId,
+          scopeOverride,
+        });
         const context = await startMCPOAuthFlow(wwwAuthenticate, effectiveClientId, redirectUri, {
           authorizationUrlOverride,
           tokenUrlOverride,

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -632,12 +632,21 @@ export async function performMCPOAuthFlow(
 
     // Compute scopes early — needed for both DCR registration and auth URL.
     // Skip auto-populating from resource metadata when client_id is pre-registered.
+    console.log('[MCP OAuth performFlow] Scope computation inputs:', {
+      clientId,
+      actualClientId,
+      hasResourceScopes: !!(
+        resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0
+      ),
+      resourceScopes: resourceMetadata.scopes_supported,
+    });
     const scopeString =
       !actualClientId &&
       resourceMetadata.scopes_supported &&
       resourceMetadata.scopes_supported.length > 0
         ? resourceMetadata.scopes_supported.join(' ')
         : undefined;
+    console.log('[MCP OAuth performFlow] Computed scopeString:', scopeString);
 
     if (!actualClientId) {
       // Check if server supports Dynamic Client Registration (RFC 7591)
@@ -995,11 +1004,21 @@ export async function startMCPOAuthFlow(
   // from resource metadata — the resource server may advertise scopes (like "mcp:connect")
   // that the authorization server doesn't recognize. Pre-registered apps have scopes
   // configured during app registration, so omitting them lets the auth server use defaults.
+  console.log('[MCP OAuth] Scope computation inputs:', {
+    hasOptionsScope: !!options?.scope,
+    optionsScope: options?.scope,
+    clientId,
+    hasResourceScopes: !!(
+      resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0
+    ),
+    resourceScopes: resourceMetadata.scopes_supported,
+  });
   const scopeString = options?.scope
     ? options.scope
     : !clientId && resourceMetadata.scopes_supported && resourceMetadata.scopes_supported.length > 0
       ? resourceMetadata.scopes_supported.join(' ')
       : undefined;
+  console.log('[MCP OAuth] Computed scopeString:', scopeString);
 
   // Step 6: Get or register client_id
   let actualClientId = clientId;


### PR DESCRIPTION
## Summary
- Adds diagnostic logging at all three OAuth flow entry points to trace why "Invalid scope: mcp:connect" persists
- Logs `client_id`, scope computation inputs, and computed `scopeString` to identify the source of the unwanted scope
- Temporary debug commit to diagnose the issue

## Test plan
- [ ] Deploy and trigger Figma OAuth flow
- [ ] Check daemon logs for `[MCP OAuth] Scope computation inputs:` and `[MCP OAuth] Computed scopeString:`
- [ ] Verify whether `scope=mcp:connect` appears in the authorization URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)