### PR TITLE
perf: optimize attention glow effect on worktree cards

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -722,7 +722,7 @@ const WorktreeCardComponent = ({
         width: 500,
         cursor: 'default', // Override React Flow's drag cursor - only drag handles should show grab cursor
         transition: 'box-shadow 0.6s ease-in-out, border 0.6s ease-in-out',
-        willChange: needsAttention ? 'box-shadow' : 'auto',
+        willChange: needsAttention && !inPopover ? 'box-shadow' : 'auto',
         ...(needsAttention && !inPopover
           ? {
               boxShadow: attentionGlowShadow,

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -679,29 +679,23 @@ const WorktreeCardComponent = ({
     </div>
   );
 
-  // Use colorTextBase for glow - hex color that adapts to light/dark mode
-  // Fallback to detecting dark mode if colorTextBase is not available
   const isDarkMode = isDarkTheme(token);
-  const rawGlowColor = token.colorTextBase || (isDarkMode ? '#ffffff' : '#000000');
 
-  // Use Ant Design's Color class to normalize and convert to full hex format
-  // This handles shorthand hex (#fff -> #ffffff) and ensures we can append alpha values
-  let glowColor: string;
-  try {
-    const color = new AggregationColor(rawGlowColor);
-    // toHexString() always returns full 6 or 8 digit hex
-    glowColor = color.toHexString();
-  } catch {
-    // Fallback if color parsing fails
-    glowColor = isDarkMode ? '#ffffff' : '#000000';
-  }
+  // Memoize glow shadow string to avoid recomputing color normalization on every render
+  const attentionGlowShadow = useMemo(() => {
+    const rawGlowColor = token.colorTextBase || (isDarkMode ? '#ffffff' : '#000000');
 
-  const attentionGlowShadow = `
-    0 0 0 3px ${glowColor},
-    0 0 20px 4px ${glowColor}dd,
-    0 0 40px 8px ${glowColor}88,
-    0 0 60px 12px ${glowColor}44
-  `;
+    let glowColor: string;
+    try {
+      const color = new AggregationColor(rawGlowColor);
+      glowColor = color.toHexString();
+    } catch {
+      glowColor = isDarkMode ? '#ffffff' : '#000000';
+    }
+
+    // 2-layer glow: tight solid ring + soft halo (reduced from 4 layers for less paint work)
+    return `0 0 0 3px ${glowColor}, 0 0 24px 6px ${glowColor}99`;
+  }, [token.colorTextBase, isDarkMode]);
 
   // Ensure pin color is visible (adjust lightness if too pale)
   const visiblePinColor = useMemo(() => {
@@ -727,10 +721,10 @@ const WorktreeCardComponent = ({
       style={{
         width: 500,
         cursor: 'default', // Override React Flow's drag cursor - only drag handles should show grab cursor
-        transition: 'box-shadow 1s ease-in-out, border 1s ease-in-out',
+        transition: 'box-shadow 0.6s ease-in-out, border 0.6s ease-in-out',
+        willChange: needsAttention ? 'box-shadow' : 'auto',
         ...(needsAttention && !inPopover
           ? {
-              // Static multi-layer glow (no animation — avoids continuous GPU work)
               boxShadow: attentionGlowShadow,
               border: 'none',
             }

--- a/context/concepts/database-migrations.md
+++ b/context/concepts/database-migrations.md
@@ -39,4 +39,10 @@ Drizzle determines pending migrations by comparing each journal entry's `when` t
 
 When adding manual/backfill migrations to `meta/_journal.json`, always ensure the `when` value is **strictly greater** than all preceding entries. This applies to both `postgres` and `sqlite` journals independently.
 
+### Avoid CHECK constraints for enum-like columns
+
+Don't use `CHECK(col IN ('a', 'b', 'c'))` on SQLite columns. When a new value is added (like adding `'session'` to `others_can`), the CHECK constraint requires a full table recreation migration — SQLite can't alter constraints in place. This is error-prone and easy to forget when updating TypeScript enums.
+
+Instead, validate enum values at the application layer (Drizzle schema `enum` option, Zod, service hooks). The TypeScript types are the source of truth; the DB just stores text.
+
 _Detailed planning doc archived in `context/archives/database-migrations.md`._

--- a/packages/core/drizzle/sqlite/0034_add_session_to_others_can_check.sql
+++ b/packages/core/drizzle/sqlite/0034_add_session_to_others_can_check.sql
@@ -1,0 +1,53 @@
+-- Add 'session' to the others_can CHECK constraint
+-- PR #951 added the 'session' permission tier to TypeScript types but
+-- did not update the SQLite CHECK constraint from migration 0016.
+-- SQLite requires table recreation to modify CHECK constraints on existing columns.
+
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_worktrees` (
+	`worktree_id` text(36) PRIMARY KEY NOT NULL,
+	`repo_id` text(36) NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer,
+	`created_by` text NOT NULL DEFAULT 'anonymous',
+	`name` text NOT NULL,
+	`ref` text NOT NULL,
+	`ref_type` text,
+	`worktree_unique_id` integer NOT NULL,
+	`start_command` text,
+	`stop_command` text,
+	`nuke_command` text,
+	`health_check_url` text,
+	`app_url` text,
+	`logs_command` text,
+	`board_id` text(36),
+	`schedule_enabled` integer DEFAULT false NOT NULL,
+	`schedule_cron` text,
+	`schedule_last_triggered_at` integer,
+	`schedule_next_run_at` integer,
+	`needs_attention` integer DEFAULT true NOT NULL,
+	`archived` integer DEFAULT false NOT NULL,
+	`archived_at` integer,
+	`archived_by` text(36),
+	`filesystem_status` text,
+	`others_can` text DEFAULT 'view' CHECK(`others_can` IN ('none', 'view', 'session', 'prompt', 'all')),
+	`unix_group` text,
+	`others_fs_access` text DEFAULT 'read' CHECK(`others_fs_access` IN ('none', 'read', 'write')),
+	`data` text NOT NULL,
+	FOREIGN KEY (`repo_id`) REFERENCES `repos`(`repo_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`board_id`) REFERENCES `boards`(`board_id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+INSERT INTO `__new_worktrees` SELECT * FROM `worktrees`;--> statement-breakpoint
+DROP TABLE `worktrees`;--> statement-breakpoint
+ALTER TABLE `__new_worktrees` RENAME TO `worktrees`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+-- Recreate indexes
+CREATE INDEX IF NOT EXISTS `worktrees_repo_idx` ON `worktrees` (`repo_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_name_idx` ON `worktrees` (`name`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_ref_idx` ON `worktrees` (`ref`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_board_idx` ON `worktrees` (`board_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_created_idx` ON `worktrees` (`created_at`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_updated_idx` ON `worktrees` (`updated_at`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_repo_name_unique` ON `worktrees` (`repo_id`, `name`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_schedule_enabled_idx` ON `worktrees` (`schedule_enabled`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `worktrees_board_schedule_idx` ON `worktrees` (`board_id`, `schedule_enabled`);

--- a/packages/core/drizzle/sqlite/0034_add_session_to_others_can_check.sql
+++ b/packages/core/drizzle/sqlite/0034_add_session_to_others_can_check.sql
@@ -37,7 +37,26 @@ CREATE TABLE `__new_worktrees` (
 	FOREIGN KEY (`repo_id`) REFERENCES `repos`(`repo_id`) ON UPDATE no action ON DELETE cascade,
 	FOREIGN KEY (`board_id`) REFERENCES `boards`(`board_id`) ON UPDATE no action ON DELETE set null
 );--> statement-breakpoint
-INSERT INTO `__new_worktrees` SELECT * FROM `worktrees`;--> statement-breakpoint
+INSERT INTO `__new_worktrees` (
+	`worktree_id`, `repo_id`, `created_at`, `updated_at`, `created_by`,
+	`name`, `ref`, `ref_type`, `worktree_unique_id`,
+	`start_command`, `stop_command`, `nuke_command`,
+	`health_check_url`, `app_url`, `logs_command`,
+	`board_id`, `schedule_enabled`, `schedule_cron`,
+	`schedule_last_triggered_at`, `schedule_next_run_at`,
+	`needs_attention`, `archived`, `archived_at`, `archived_by`,
+	`filesystem_status`, `others_can`, `unix_group`, `others_fs_access`, `data`
+)
+SELECT
+	`worktree_id`, `repo_id`, `created_at`, `updated_at`, `created_by`,
+	`name`, `ref`, `ref_type`, `worktree_unique_id`,
+	`start_command`, `stop_command`, `nuke_command`,
+	`health_check_url`, `app_url`, `logs_command`,
+	`board_id`, `schedule_enabled`, `schedule_cron`,
+	`schedule_last_triggered_at`, `schedule_next_run_at`,
+	`needs_attention`, `archived`, `archived_at`, `archived_by`,
+	`filesystem_status`, `others_can`, `unix_group`, `others_fs_access`, `data`
+FROM `worktrees`;--> statement-breakpoint
 DROP TABLE `worktrees`;--> statement-breakpoint
 ALTER TABLE `__new_worktrees` RENAME TO `worktrees`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1775441036373,
       "tag": "0033_dapper_thing",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1775876000000,
+      "tag": "0034_add_session_to_others_can_check",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Optimized attention glow**: Reduced box-shadow from 4 layers to 2 (tight ring + soft halo). Memoized color computation. Added `will-change` hint. Shortened transition from 1s to 0.6s.
- **Fixed `others_can` CHECK constraint** (migration 0034): PR #951 added the `session` permission tier to TypeScript types but missed updating the SQLite CHECK constraint, causing `SQLITE_CONSTRAINT_CHECK` errors on worktree creation. Recreates the `worktrees` table with the corrected constraint.
- **Migration guide update**: Added guidance to avoid CHECK constraints on enum-like columns — validate at the app layer instead, since SQLite requires full table recreation to modify constraints.

## Commits
1. `perf: optimize attention glow effect on worktree cards`
2. `fix: add 'session' tier to others_can CHECK constraint (migration 0034)`
3. `docs: warn against CHECK constraints for enum columns in migration guide`

## Test plan
- [x] Verify glow appears on worktree cards that need attention
- [x] Verify glow disappears when opening a session from the worktree
- [ ] Verify glow looks good in both light and dark mode
- [ ] Verify pinned/agent border styles still work correctly
- [ ] Verify worktree creation succeeds (no more CHECK constraint error)
- [ ] Verify existing worktrees are preserved after migration 0034

🤖 Generated with [Claude Code](https://claude.com/claude-code)