### PR TITLE
feat: add agor_sessions_stop MCP tool

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -5832,7 +5832,11 @@ async function main() {
             },
             params
           );
-          return { success: true, reason: 'No active tasks found, session reset to idle' };
+          return {
+            success: true,
+            status: SessionStatus.IDLE,
+            reason: 'No active tasks found, session reset to idle',
+          };
         }
 
         // Pick the most recent task
@@ -5881,7 +5885,7 @@ async function main() {
           console.error(`❌ [Stop] Failed to patch session to IDLE:`, error);
         }
 
-        return { success: true };
+        return { success: true, status: SessionStatus.IDLE };
       },
     },
     {

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -5780,9 +5780,13 @@ async function main() {
     app,
     '/sessions/:id/stop',
     {
-      async create(_data: unknown, params: RouteParams) {
+      async create(data: unknown, params: RouteParams) {
         const id = params.route?.id;
         if (!id) throw new Error('Session ID required');
+        const stopReason =
+          data && typeof data === 'object' && 'reason' in data && typeof data.reason === 'string'
+            ? data.reason
+            : undefined;
 
         const session = await sessionsService.get(id, params);
 
@@ -5818,7 +5822,7 @@ async function main() {
         if (targetTasksArray.length === 0) {
           // No active tasks — just reset session to IDLE (it's stuck)
           console.warn(
-            `⚠️  [Stop] No active tasks for session ${id.substring(0, 8)}, resetting to IDLE`
+            `⚠️  [Stop] No active tasks for session ${id.substring(0, 8)}, resetting to IDLE${stopReason ? ` (reason: ${stopReason})` : ''}`
           );
           await app.service('sessions').patch(
             id,
@@ -5840,7 +5844,7 @@ async function main() {
         const latestTask = targetTasksArray[0];
 
         console.log(
-          `🛑 [Stop] Stopping task ${latestTask.task_id.substring(0, 8)} for session ${id.substring(0, 8)}`
+          `🛑 [Stop] Stopping task ${latestTask.task_id.substring(0, 8)} for session ${id.substring(0, 8)}${stopReason ? ` (reason: ${stopReason})` : ''}`
         );
 
         // Kill the executor process (SIGTERM → 3s → SIGKILL)

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1163,7 +1163,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           { ...ctx.baseServiceParams, route: { id: sessionId } }
         );
 
-      const stopResult = result as { success: boolean; reason?: string };
+      const stopResult = result as { success: boolean; status?: string; reason?: string };
 
       if (!stopResult.success) {
         return textResult({
@@ -1173,13 +1173,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         });
       }
 
-      // Fetch the updated session to return current state
-      const session = await ctx.app.service('sessions').get(sessionId, ctx.baseServiceParams);
-
       return textResult({
         success: true,
         sessionId,
-        status: session.status,
+        status: stopResult.status,
         ...(args.reason ? { reason: args.reason } : {}),
         note: stopResult.reason || 'Session stopped successfully.',
       });

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1174,9 +1174,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }
 
       // Fetch the updated session to return current state
-      const session = await ctx.app
-        .service('sessions')
-        .get(sessionId, ctx.baseServiceParams);
+      const session = await ctx.app.service('sessions').get(sessionId, ctx.baseServiceParams);
 
       return textResult({
         success: true,

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1135,4 +1135,56 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       });
     }
   );
+
+  // Tool 12: agor_sessions_stop
+  server.registerTool(
+    'agor_sessions_stop',
+    {
+      description:
+        'Stop a running session. Kills the executor process and sets the session to idle. Use this for emergency stops, timeout-based cancellation, or human-in-the-loop gates. Only works on sessions in active states (running, awaiting_permission, stopping).',
+      annotations: { destructiveHint: true },
+      inputSchema: z.object({
+        sessionId: z.string().describe('Session ID to stop (UUIDv7 or short ID)'),
+        reason: z
+          .string()
+          .optional()
+          .describe(
+            'Audit log reason for the stop (e.g. "timeout", "user requested", "safety gate")'
+          ),
+      }),
+    },
+    async (args) => {
+      const sessionId = await resolveSessionId(ctx, args.sessionId);
+
+      const result = await ctx.app
+        .service('/sessions/:id/stop')
+        .create(
+          { ...(args.reason ? { reason: args.reason } : {}) },
+          { ...ctx.baseServiceParams, route: { id: sessionId } }
+        );
+
+      const stopResult = result as { success: boolean; reason?: string };
+
+      if (!stopResult.success) {
+        return textResult({
+          success: false,
+          sessionId,
+          error: stopResult.reason || 'Failed to stop session',
+        });
+      }
+
+      // Fetch the updated session to return current state
+      const session = await ctx.app
+        .service('sessions')
+        .get(sessionId, ctx.baseServiceParams);
+
+      return textResult({
+        success: true,
+        sessionId,
+        status: session.status,
+        ...(args.reason ? { reason: args.reason } : {}),
+        note: stopResult.reason || 'Session stopped successfully.',
+      });
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- Adds `agor_sessions_stop` MCP tool enabling orchestrator agents to programmatically stop running child sessions
- Supports `sessionId` (UUIDv7 or short ID) and optional `reason` parameter for audit logging
- Calls the existing `/sessions/:id/stop` endpoint, respecting the same RBAC as the UI stop button
- Annotated with `destructiveHint: true` since stopping terminates execution
- Updated the stop endpoint to accept and log an optional `reason` field

## Test plan
- [ ] Verify `agor_sessions_stop` appears in MCP tool discovery (`agor_search_tools`)
- [ ] Stop a running session via MCP and confirm it transitions to idle
- [ ] Confirm short ID resolution works for the sessionId parameter
- [ ] Verify stopping an already-idle session returns a clear error
- [ ] Verify the `reason` parameter appears in daemon logs
- [ ] Confirm RBAC: non-owners cannot stop sessions they don't have access to

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)