### PR TITLE
feat: declarative daemon resources config and sync command

### DIFF
--- a/apps/agor-cli/src/commands/daemon/sync.ts
+++ b/apps/agor-cli/src/commands/daemon/sync.ts
@@ -30,6 +30,7 @@ import {
   UsersRepository,
   WorktreeRepository,
 } from '@agor/core/db';
+import { autoAssignWorktreeUniqueId } from '@agor/core/environment/variable-resolver';
 import { cloneRepo, createWorktree, getWorktreesDir } from '@agor/core/git';
 import type { User, UUID } from '@agor/core/types';
 import { Command, Flags } from '@oclif/core';
@@ -166,7 +167,7 @@ export default class DaemonSync extends Command {
       const existing = await repoRepo.findBySlug(repoCfg.slug);
       const repoPath = join(getReposDir(), repoCfg.slug);
       const fsExists = existsSync(repoPath);
-      const action = determineRepoAction(repoCfg, existing, fsExists);
+      const action = determineRepoAction(repoCfg, existing);
 
       if (action === 'create') {
         this.log(`  ${chalk.green('create')} repo ${chalk.cyan(repoCfg.slug)}`);
@@ -256,7 +257,7 @@ export default class DaemonSync extends Command {
           }
 
           const usedIds = await worktreeRepo.getAllUsedUniqueIds();
-          const nextId = usedIds.length > 0 ? Math.max(...usedIds) + 1 : 1;
+          const nextId = autoAssignWorktreeUniqueId(usedIds);
 
           await worktreeRepo.create({
             worktree_id: wtCfg.worktree_id as UUID,
@@ -324,7 +325,7 @@ export default class DaemonSync extends Command {
             );
           }
 
-          const hashedPassword = await hash(resolved.password, 10);
+          const hashedPassword = await hash(resolved.password, 12);
 
           await usersRepo.create({
             user_id: userCfg.user_id as UUID,

--- a/apps/agor-cli/src/commands/daemon/sync.ts
+++ b/apps/agor-cli/src/commands/daemon/sync.ts
@@ -8,17 +8,22 @@
 
 import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import type { ParsedRepoConfig, ParsedUserConfig, ParsedWorktreeConfig } from '@agor/core/config';
 import {
+  buildSlugToRepoIdMap,
   daemonResourcesConfigSchema,
+  determineRepoAction,
+  determineUserAction,
+  determineWorktreeAction,
   getReposDir,
   getWorktreePath,
   loadConfig,
-  resolveRepoSlugs,
+  loadConfigFromFile,
+  resolvePassword,
   validateResourceCrossReferences,
 } from '@agor/core/config';
 import {
   createDatabase,
-  generateId,
   getDatabaseUrl,
   hash,
   RepoRepository,
@@ -39,12 +44,20 @@ interface SyncCounts {
 export default class DaemonSync extends Command {
   static description = 'Sync resources from config.yml into database and filesystem';
 
-  static examples = ['<%= config.bin %> daemon sync', '<%= config.bin %> daemon sync --dry-run'];
+  static examples = [
+    '<%= config.bin %> daemon sync',
+    '<%= config.bin %> daemon sync --dry-run',
+    '<%= config.bin %> daemon sync --config /path/to/config.yml',
+  ];
 
   static flags = {
     'dry-run': Flags.boolean({
       description: 'Validate and report what would change without making changes',
       default: false,
+    }),
+    config: Flags.string({
+      char: 'c',
+      description: 'Path to config file (default: ~/.agor/config.yaml)',
     }),
   };
 
@@ -53,10 +66,10 @@ export default class DaemonSync extends Command {
     const dryRun = flags['dry-run'];
 
     // 1. Load and validate config
-    const config = await loadConfig();
+    const config = flags.config ? await this.loadConfigFromPath(flags.config) : await loadConfig();
 
     if (!config.resources) {
-      this.log(chalk.yellow('No resources section in config.yml — nothing to sync.'));
+      this.log(chalk.yellow('No resources section in config — nothing to sync.'));
       return;
     }
 
@@ -82,7 +95,7 @@ export default class DaemonSync extends Command {
       this.exit(1);
     }
 
-    this.log(chalk.bold('Syncing resources from config.yml...'));
+    this.log(chalk.bold('Syncing resources from config...'));
     if (dryRun) {
       this.log(chalk.yellow('(dry-run mode — no changes will be made)'));
     }
@@ -96,9 +109,6 @@ export default class DaemonSync extends Command {
     const worktreeRepo = new WorktreeRepository(db);
     const usersRepo = new UsersRepository(db);
 
-    // Resolve worktree.repo slugs to repo_ids
-    const _slugToRepoId = resolveRepoSlugs(resources);
-
     // 3. Sync repos
     const repoCounts = await this.syncRepos(resources.repos ?? [], repoRepo, dryRun);
 
@@ -106,7 +116,6 @@ export default class DaemonSync extends Command {
     const worktreeCounts = await this.syncWorktrees(
       resources.worktrees ?? [],
       resources.repos ?? [],
-      repoRepo,
       worktreeRepo,
       dryRun
     );
@@ -122,6 +131,18 @@ export default class DaemonSync extends Command {
     this.logCounts('Users', userCounts);
   }
 
+  private async loadConfigFromPath(
+    configPath: string
+  ): Promise<import('@agor/core/config').AgorConfig> {
+    try {
+      return await loadConfigFromFile(configPath);
+    } catch (error) {
+      this.log(chalk.red(`Failed to load config from ${configPath}:`));
+      this.log(chalk.red(`  ${error instanceof Error ? error.message : String(error)}`));
+      this.exit(1);
+    }
+  }
+
   private logCounts(label: string, counts: SyncCounts): void {
     const parts: string[] = [];
     if (counts.created > 0) parts.push(chalk.green(`${counts.created} created`));
@@ -135,14 +156,7 @@ export default class DaemonSync extends Command {
   // ---------------------------------------------------------------------------
 
   private async syncRepos(
-    repos: Array<{
-      repo_id: string;
-      slug: string;
-      remote_url?: string;
-      repo_type?: string;
-      default_branch?: string;
-      shallow?: boolean;
-    }>,
+    repos: ParsedRepoConfig[],
     repoRepo: RepoRepository,
     dryRun: boolean
   ): Promise<SyncCounts> {
@@ -150,67 +164,46 @@ export default class DaemonSync extends Command {
 
     for (const repoCfg of repos) {
       const existing = await repoRepo.findBySlug(repoCfg.slug);
+      const repoPath = join(getReposDir(), repoCfg.slug);
+      const fsExists = existsSync(repoPath);
+      const action = determineRepoAction(repoCfg, existing, fsExists);
 
-      if (existing) {
-        // Repo exists in DB — check if update needed
-        const needsUpdate =
-          (repoCfg.remote_url && existing.remote_url !== repoCfg.remote_url) ||
-          (repoCfg.default_branch && existing.default_branch !== repoCfg.default_branch);
-
-        if (needsUpdate) {
-          this.log(`  ${chalk.yellow('update')} repo ${chalk.cyan(repoCfg.slug)}`);
-          if (!dryRun) {
-            await repoRepo.update(existing.repo_id, {
-              remote_url: repoCfg.remote_url ?? existing.remote_url,
-              default_branch: repoCfg.default_branch ?? existing.default_branch,
-            });
-          }
-          counts.updated++;
-        } else {
-          counts.unchanged++;
-        }
-
-        // Check filesystem — re-clone if missing
-        const repoPath = join(getReposDir(), repoCfg.slug);
-        if (!existsSync(repoPath) && repoCfg.remote_url && !dryRun) {
-          this.log(
-            `  ${chalk.green('clone')} repo ${chalk.cyan(repoCfg.slug)} (filesystem missing)`
-          );
-          mkdirSync(join(getReposDir()), { recursive: true });
-          await cloneRepo({
-            url: repoCfg.remote_url,
-            targetDir: repoPath,
-          });
-        }
-      } else {
-        // Repo doesn't exist — create
+      if (action === 'create') {
         this.log(`  ${chalk.green('create')} repo ${chalk.cyan(repoCfg.slug)}`);
-
         if (!dryRun) {
-          const repoPath = join(getReposDir(), repoCfg.slug);
-
-          // Clone if remote
           if (repoCfg.remote_url) {
             mkdirSync(getReposDir(), { recursive: true });
-            await cloneRepo({
-              url: repoCfg.remote_url,
-              targetDir: repoPath,
-            });
+            await cloneRepo({ url: repoCfg.remote_url, targetDir: repoPath });
           }
-
-          // Register in DB
           await repoRepo.create({
             repo_id: repoCfg.repo_id as UUID,
             slug: repoCfg.slug,
             name: repoCfg.slug,
-            repo_type: (repoCfg.repo_type as 'remote' | 'local') ?? 'remote',
+            repo_type: repoCfg.repo_type ?? 'remote',
             remote_url: repoCfg.remote_url,
             default_branch: repoCfg.default_branch ?? 'main',
             local_path: repoPath,
           });
         }
-
         counts.created++;
+      } else if (action === 'update') {
+        this.log(`  ${chalk.yellow('update')} repo ${chalk.cyan(repoCfg.slug)}`);
+        if (!dryRun && existing) {
+          await repoRepo.update(existing.repo_id, {
+            remote_url: repoCfg.remote_url ?? existing.remote_url,
+            default_branch: repoCfg.default_branch ?? existing.default_branch,
+          });
+        }
+        counts.updated++;
+      } else {
+        counts.unchanged++;
+      }
+
+      // Re-clone if DB exists but filesystem is missing
+      if (existing && !fsExists && repoCfg.remote_url && !dryRun) {
+        this.log(`  ${chalk.green('clone')} repo ${chalk.cyan(repoCfg.slug)} (filesystem missing)`);
+        mkdirSync(getReposDir(), { recursive: true });
+        await cloneRepo({ url: repoCfg.remote_url, targetDir: repoPath });
       }
     }
 
@@ -222,74 +215,29 @@ export default class DaemonSync extends Command {
   // ---------------------------------------------------------------------------
 
   private async syncWorktrees(
-    worktrees: Array<{
-      worktree_id: string;
-      name: string;
-      ref: string;
-      ref_type?: 'branch' | 'tag';
-      others_can?: string;
-      mcp_server_ids?: string[];
-      repo: string;
-      readonly?: boolean;
-      agent?: Record<string, unknown>;
-    }>,
+    worktrees: ParsedWorktreeConfig[],
     repos: Array<{ repo_id: string; slug: string }>,
-    repoRepo: RepoRepository,
     worktreeRepo: WorktreeRepository,
     dryRun: boolean
   ): Promise<SyncCounts> {
     const counts: SyncCounts = { created: 0, updated: 0, unchanged: 0 };
-
-    // Build slug → repo_id map from declared repos
-    const slugToId = new Map<string, string>();
-    for (const repo of repos) {
-      slugToId.set(repo.slug, repo.repo_id);
-    }
+    const slugToId = buildSlugToRepoIdMap(repos);
 
     for (const wtCfg of worktrees) {
       const repoId = slugToId.get(wtCfg.repo);
       if (!repoId) {
-        // Should not happen after validation, but guard anyway
         this.log(chalk.red(`  skip worktree "${wtCfg.name}" — repo "${wtCfg.repo}" not found`));
         continue;
       }
 
       const existing = await worktreeRepo.findByRepoAndName(repoId as UUID, wtCfg.name);
+      const action = determineWorktreeAction(wtCfg, existing);
 
-      if (existing) {
-        // Worktree exists — check if update needed
-        const needsUpdate =
-          existing.ref !== wtCfg.ref ||
-          (wtCfg.others_can && existing.others_can !== wtCfg.others_can) ||
-          (wtCfg.mcp_server_ids &&
-            JSON.stringify(existing.mcp_server_ids) !== JSON.stringify(wtCfg.mcp_server_ids));
-
-        if (needsUpdate) {
-          this.log(
-            `  ${chalk.yellow('update')} worktree ${chalk.cyan(`${wtCfg.repo}/${wtCfg.name}`)}`
-          );
-          if (!dryRun) {
-            await worktreeRepo.update(existing.worktree_id, {
-              ref: wtCfg.ref,
-              ref_type: wtCfg.ref_type ?? existing.ref_type,
-              others_can:
-                (wtCfg.others_can as 'none' | 'view' | 'session' | 'prompt' | 'all') ??
-                existing.others_can,
-              mcp_server_ids: wtCfg.mcp_server_ids ?? existing.mcp_server_ids,
-            });
-          }
-          counts.updated++;
-        } else {
-          counts.unchanged++;
-        }
-      } else {
-        // Worktree doesn't exist — create
+      if (action === 'create') {
         this.log(
           `  ${chalk.green('create')} worktree ${chalk.cyan(`${wtCfg.repo}/${wtCfg.name}`)}`
         );
-
         if (!dryRun) {
-          // Create git worktree on disk
           const repoPath = join(getReposDir(), wtCfg.repo);
           const worktreePath = getWorktreePath(wtCfg.repo, wtCfg.name);
 
@@ -299,19 +247,17 @@ export default class DaemonSync extends Command {
               repoPath,
               worktreePath,
               wtCfg.ref,
-              false, // don't create branch
-              false, // don't pull latest
-              undefined, // no source branch
-              undefined, // no env
+              false,
+              false,
+              undefined,
+              undefined,
               wtCfg.ref_type
             );
           }
 
-          // Allocate unique ID
           const usedIds = await worktreeRepo.getAllUsedUniqueIds();
           const nextId = usedIds.length > 0 ? Math.max(...usedIds) + 1 : 1;
 
-          // Register in DB
           await worktreeRepo.create({
             worktree_id: wtCfg.worktree_id as UUID,
             repo_id: repoId as UUID,
@@ -327,8 +273,24 @@ export default class DaemonSync extends Command {
             last_used: new Date().toISOString(),
           });
         }
-
         counts.created++;
+      } else if (action === 'update') {
+        this.log(
+          `  ${chalk.yellow('update')} worktree ${chalk.cyan(`${wtCfg.repo}/${wtCfg.name}`)}`
+        );
+        if (!dryRun && existing) {
+          await worktreeRepo.update(existing.worktree_id, {
+            ref: wtCfg.ref,
+            ref_type: wtCfg.ref_type ?? existing.ref_type,
+            others_can:
+              (wtCfg.others_can as 'none' | 'view' | 'session' | 'prompt' | 'all') ??
+              existing.others_can,
+            mcp_server_ids: wtCfg.mcp_server_ids ?? existing.mcp_server_ids,
+          });
+        }
+        counts.updated++;
+      } else {
+        counts.unchanged++;
       }
     }
 
@@ -340,14 +302,7 @@ export default class DaemonSync extends Command {
   // ---------------------------------------------------------------------------
 
   private async syncUsers(
-    users: Array<{
-      user_id: string;
-      email: string;
-      name?: string;
-      role?: string;
-      unix_username?: string;
-      password?: string;
-    }>,
+    users: ParsedUserConfig[],
     usersRepo: UsersRepository,
     dryRun: boolean
   ): Promise<SyncCounts> {
@@ -355,60 +310,46 @@ export default class DaemonSync extends Command {
 
     for (const userCfg of users) {
       const existing = await usersRepo.findByEmail(userCfg.email);
+      const action = determineUserAction(userCfg, existing);
 
-      if (existing) {
-        // User exists — check if update needed
-        const needsUpdate =
-          (userCfg.name && existing.name !== userCfg.name) ||
-          (userCfg.role && existing.role !== userCfg.role) ||
-          (userCfg.unix_username && existing.unix_username !== userCfg.unix_username);
-
-        if (needsUpdate) {
-          this.log(`  ${chalk.yellow('update')} user ${chalk.cyan(userCfg.email)}`);
-          if (!dryRun) {
-            await usersRepo.update(existing.user_id, {
-              name: userCfg.name ?? existing.name,
-              role: (userCfg.role as 'superadmin' | 'admin' | 'member' | 'viewer') ?? existing.role,
-              unix_username: userCfg.unix_username ?? existing.unix_username,
-            });
-          }
-          counts.updated++;
-        } else {
-          counts.unchanged++;
-        }
-      } else {
-        // User doesn't exist — create
+      if (action === 'create') {
         this.log(`  ${chalk.green('create')} user ${chalk.cyan(userCfg.email)}`);
 
         if (!dryRun) {
-          // Resolve password
-          let password = '';
-          if (userCfg.password === 'generate') {
-            password = generateId(); // Random UUID as password
-          } else if (userCfg.password?.startsWith('env:')) {
-            const envVar = userCfg.password.slice(4);
-            password = process.env[envVar] ?? '';
-            if (!password) {
-              this.warn(`Environment variable ${envVar} not set for user ${userCfg.email}`);
-            }
-          } else if (userCfg.password) {
-            password = userCfg.password;
+          const resolved = resolvePassword(userCfg.password);
+
+          if (resolved.mustChange) {
+            this.log(
+              `    ${chalk.dim('generated temporary password for')} ${userCfg.email}: ${chalk.yellow(resolved.password)}`
+            );
           }
 
-          // Hash the password
-          const hashedPassword = password ? await hash(password, 10) : '';
+          const hashedPassword = await hash(resolved.password, 10);
 
           await usersRepo.create({
             user_id: userCfg.user_id as UUID,
             email: userCfg.email,
             name: userCfg.name,
-            role: (userCfg.role as 'superadmin' | 'admin' | 'member' | 'viewer') ?? 'member',
+            role: userCfg.role ?? 'member',
             unix_username: userCfg.unix_username,
             password: hashedPassword,
+            must_change_password: resolved.mustChange,
           } as Partial<User> & { password: string });
         }
 
         counts.created++;
+      } else if (action === 'update') {
+        this.log(`  ${chalk.yellow('update')} user ${chalk.cyan(userCfg.email)}`);
+        if (!dryRun && existing) {
+          await usersRepo.update(existing.user_id, {
+            name: userCfg.name ?? existing.name,
+            role: userCfg.role ?? existing.role,
+            unix_username: userCfg.unix_username ?? existing.unix_username,
+          });
+        }
+        counts.updated++;
+      } else {
+        counts.unchanged++;
       }
     }
 

--- a/apps/agor-cli/src/commands/daemon/sync.ts
+++ b/apps/agor-cli/src/commands/daemon/sync.ts
@@ -1,0 +1,417 @@
+/**
+ * `agor daemon sync` - Sync declared resources from config.yml into database and filesystem
+ *
+ * Reads the `resources:` section of config.yml and ensures all declared repos,
+ * worktrees, and users exist in the database and on disk. Idempotent — running
+ * twice with the same config produces no changes.
+ */
+
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  daemonResourcesConfigSchema,
+  getReposDir,
+  getWorktreePath,
+  loadConfig,
+  resolveRepoSlugs,
+  validateResourceCrossReferences,
+} from '@agor/core/config';
+import {
+  createDatabase,
+  generateId,
+  getDatabaseUrl,
+  hash,
+  RepoRepository,
+  UsersRepository,
+  WorktreeRepository,
+} from '@agor/core/db';
+import { cloneRepo, createWorktree, getWorktreesDir } from '@agor/core/git';
+import type { User, UUID } from '@agor/core/types';
+import { Command, Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+interface SyncCounts {
+  created: number;
+  updated: number;
+  unchanged: number;
+}
+
+export default class DaemonSync extends Command {
+  static description = 'Sync resources from config.yml into database and filesystem';
+
+  static examples = ['<%= config.bin %> daemon sync', '<%= config.bin %> daemon sync --dry-run'];
+
+  static flags = {
+    'dry-run': Flags.boolean({
+      description: 'Validate and report what would change without making changes',
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(DaemonSync);
+    const dryRun = flags['dry-run'];
+
+    // 1. Load and validate config
+    const config = await loadConfig();
+
+    if (!config.resources) {
+      this.log(chalk.yellow('No resources section in config.yml — nothing to sync.'));
+      return;
+    }
+
+    // Parse through Zod
+    const parseResult = daemonResourcesConfigSchema.safeParse(config.resources);
+    if (!parseResult.success) {
+      this.log(chalk.red('Config validation failed:'));
+      for (const issue of parseResult.error.issues) {
+        this.log(chalk.red(`  ${issue.path.join('.')}: ${issue.message}`));
+      }
+      this.exit(1);
+    }
+
+    const resources = parseResult.data;
+
+    // Cross-reference validation
+    const crossRefErrors = validateResourceCrossReferences(resources);
+    if (crossRefErrors.length > 0) {
+      this.log(chalk.red('Resource cross-reference errors:'));
+      for (const err of crossRefErrors) {
+        this.log(chalk.red(`  ${err.path}: ${err.message}`));
+      }
+      this.exit(1);
+    }
+
+    this.log(chalk.bold('Syncing resources from config.yml...'));
+    if (dryRun) {
+      this.log(chalk.yellow('(dry-run mode — no changes will be made)'));
+    }
+    this.log('');
+
+    // 2. Connect to database
+    const dbUrl = getDatabaseUrl();
+    const db = createDatabase({ url: dbUrl });
+
+    const repoRepo = new RepoRepository(db);
+    const worktreeRepo = new WorktreeRepository(db);
+    const usersRepo = new UsersRepository(db);
+
+    // Resolve worktree.repo slugs to repo_ids
+    const _slugToRepoId = resolveRepoSlugs(resources);
+
+    // 3. Sync repos
+    const repoCounts = await this.syncRepos(resources.repos ?? [], repoRepo, dryRun);
+
+    // 4. Sync worktrees (after repos, since they depend on repo_ids)
+    const worktreeCounts = await this.syncWorktrees(
+      resources.worktrees ?? [],
+      resources.repos ?? [],
+      repoRepo,
+      worktreeRepo,
+      dryRun
+    );
+
+    // 5. Sync users
+    const userCounts = await this.syncUsers(resources.users ?? [], usersRepo, dryRun);
+
+    // 6. Report
+    this.log('');
+    this.log(chalk.bold('Sync complete:'));
+    this.logCounts('Repos', repoCounts);
+    this.logCounts('Worktrees', worktreeCounts);
+    this.logCounts('Users', userCounts);
+  }
+
+  private logCounts(label: string, counts: SyncCounts): void {
+    const parts: string[] = [];
+    if (counts.created > 0) parts.push(chalk.green(`${counts.created} created`));
+    if (counts.updated > 0) parts.push(chalk.yellow(`${counts.updated} updated`));
+    if (counts.unchanged > 0) parts.push(chalk.dim(`${counts.unchanged} unchanged`));
+    this.log(`  ${label}: ${parts.length > 0 ? parts.join(', ') : chalk.dim('none declared')}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Repo sync
+  // ---------------------------------------------------------------------------
+
+  private async syncRepos(
+    repos: Array<{
+      repo_id: string;
+      slug: string;
+      remote_url?: string;
+      repo_type?: string;
+      default_branch?: string;
+      shallow?: boolean;
+    }>,
+    repoRepo: RepoRepository,
+    dryRun: boolean
+  ): Promise<SyncCounts> {
+    const counts: SyncCounts = { created: 0, updated: 0, unchanged: 0 };
+
+    for (const repoCfg of repos) {
+      const existing = await repoRepo.findBySlug(repoCfg.slug);
+
+      if (existing) {
+        // Repo exists in DB — check if update needed
+        const needsUpdate =
+          (repoCfg.remote_url && existing.remote_url !== repoCfg.remote_url) ||
+          (repoCfg.default_branch && existing.default_branch !== repoCfg.default_branch);
+
+        if (needsUpdate) {
+          this.log(`  ${chalk.yellow('update')} repo ${chalk.cyan(repoCfg.slug)}`);
+          if (!dryRun) {
+            await repoRepo.update(existing.repo_id, {
+              remote_url: repoCfg.remote_url ?? existing.remote_url,
+              default_branch: repoCfg.default_branch ?? existing.default_branch,
+            });
+          }
+          counts.updated++;
+        } else {
+          counts.unchanged++;
+        }
+
+        // Check filesystem — re-clone if missing
+        const repoPath = join(getReposDir(), repoCfg.slug);
+        if (!existsSync(repoPath) && repoCfg.remote_url && !dryRun) {
+          this.log(
+            `  ${chalk.green('clone')} repo ${chalk.cyan(repoCfg.slug)} (filesystem missing)`
+          );
+          mkdirSync(join(getReposDir()), { recursive: true });
+          await cloneRepo({
+            url: repoCfg.remote_url,
+            targetDir: repoPath,
+          });
+        }
+      } else {
+        // Repo doesn't exist — create
+        this.log(`  ${chalk.green('create')} repo ${chalk.cyan(repoCfg.slug)}`);
+
+        if (!dryRun) {
+          const repoPath = join(getReposDir(), repoCfg.slug);
+
+          // Clone if remote
+          if (repoCfg.remote_url) {
+            mkdirSync(getReposDir(), { recursive: true });
+            await cloneRepo({
+              url: repoCfg.remote_url,
+              targetDir: repoPath,
+            });
+          }
+
+          // Register in DB
+          await repoRepo.create({
+            repo_id: repoCfg.repo_id as UUID,
+            slug: repoCfg.slug,
+            name: repoCfg.slug,
+            repo_type: (repoCfg.repo_type as 'remote' | 'local') ?? 'remote',
+            remote_url: repoCfg.remote_url,
+            default_branch: repoCfg.default_branch ?? 'main',
+            local_path: repoPath,
+          });
+        }
+
+        counts.created++;
+      }
+    }
+
+    return counts;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Worktree sync
+  // ---------------------------------------------------------------------------
+
+  private async syncWorktrees(
+    worktrees: Array<{
+      worktree_id: string;
+      name: string;
+      ref: string;
+      ref_type?: 'branch' | 'tag';
+      others_can?: string;
+      mcp_server_ids?: string[];
+      repo: string;
+      readonly?: boolean;
+      agent?: Record<string, unknown>;
+    }>,
+    repos: Array<{ repo_id: string; slug: string }>,
+    repoRepo: RepoRepository,
+    worktreeRepo: WorktreeRepository,
+    dryRun: boolean
+  ): Promise<SyncCounts> {
+    const counts: SyncCounts = { created: 0, updated: 0, unchanged: 0 };
+
+    // Build slug → repo_id map from declared repos
+    const slugToId = new Map<string, string>();
+    for (const repo of repos) {
+      slugToId.set(repo.slug, repo.repo_id);
+    }
+
+    for (const wtCfg of worktrees) {
+      const repoId = slugToId.get(wtCfg.repo);
+      if (!repoId) {
+        // Should not happen after validation, but guard anyway
+        this.log(chalk.red(`  skip worktree "${wtCfg.name}" — repo "${wtCfg.repo}" not found`));
+        continue;
+      }
+
+      const existing = await worktreeRepo.findByRepoAndName(repoId as UUID, wtCfg.name);
+
+      if (existing) {
+        // Worktree exists — check if update needed
+        const needsUpdate =
+          existing.ref !== wtCfg.ref ||
+          (wtCfg.others_can && existing.others_can !== wtCfg.others_can) ||
+          (wtCfg.mcp_server_ids &&
+            JSON.stringify(existing.mcp_server_ids) !== JSON.stringify(wtCfg.mcp_server_ids));
+
+        if (needsUpdate) {
+          this.log(
+            `  ${chalk.yellow('update')} worktree ${chalk.cyan(`${wtCfg.repo}/${wtCfg.name}`)}`
+          );
+          if (!dryRun) {
+            await worktreeRepo.update(existing.worktree_id, {
+              ref: wtCfg.ref,
+              ref_type: wtCfg.ref_type ?? existing.ref_type,
+              others_can:
+                (wtCfg.others_can as 'none' | 'view' | 'session' | 'prompt' | 'all') ??
+                existing.others_can,
+              mcp_server_ids: wtCfg.mcp_server_ids ?? existing.mcp_server_ids,
+            });
+          }
+          counts.updated++;
+        } else {
+          counts.unchanged++;
+        }
+      } else {
+        // Worktree doesn't exist — create
+        this.log(
+          `  ${chalk.green('create')} worktree ${chalk.cyan(`${wtCfg.repo}/${wtCfg.name}`)}`
+        );
+
+        if (!dryRun) {
+          // Create git worktree on disk
+          const repoPath = join(getReposDir(), wtCfg.repo);
+          const worktreePath = getWorktreePath(wtCfg.repo, wtCfg.name);
+
+          if (!existsSync(worktreePath)) {
+            mkdirSync(join(getWorktreesDir(), wtCfg.repo), { recursive: true });
+            await createWorktree(
+              repoPath,
+              worktreePath,
+              wtCfg.ref,
+              false, // don't create branch
+              false, // don't pull latest
+              undefined, // no source branch
+              undefined, // no env
+              wtCfg.ref_type
+            );
+          }
+
+          // Allocate unique ID
+          const usedIds = await worktreeRepo.getAllUsedUniqueIds();
+          const nextId = usedIds.length > 0 ? Math.max(...usedIds) + 1 : 1;
+
+          // Register in DB
+          await worktreeRepo.create({
+            worktree_id: wtCfg.worktree_id as UUID,
+            repo_id: repoId as UUID,
+            name: wtCfg.name,
+            ref: wtCfg.ref,
+            ref_type: wtCfg.ref_type ?? 'branch',
+            path: worktreePath,
+            worktree_unique_id: nextId,
+            others_can:
+              (wtCfg.others_can as 'none' | 'view' | 'session' | 'prompt' | 'all') ?? 'session',
+            mcp_server_ids: wtCfg.mcp_server_ids,
+            new_branch: false,
+            last_used: new Date().toISOString(),
+          });
+        }
+
+        counts.created++;
+      }
+    }
+
+    return counts;
+  }
+
+  // ---------------------------------------------------------------------------
+  // User sync
+  // ---------------------------------------------------------------------------
+
+  private async syncUsers(
+    users: Array<{
+      user_id: string;
+      email: string;
+      name?: string;
+      role?: string;
+      unix_username?: string;
+      password?: string;
+    }>,
+    usersRepo: UsersRepository,
+    dryRun: boolean
+  ): Promise<SyncCounts> {
+    const counts: SyncCounts = { created: 0, updated: 0, unchanged: 0 };
+
+    for (const userCfg of users) {
+      const existing = await usersRepo.findByEmail(userCfg.email);
+
+      if (existing) {
+        // User exists — check if update needed
+        const needsUpdate =
+          (userCfg.name && existing.name !== userCfg.name) ||
+          (userCfg.role && existing.role !== userCfg.role) ||
+          (userCfg.unix_username && existing.unix_username !== userCfg.unix_username);
+
+        if (needsUpdate) {
+          this.log(`  ${chalk.yellow('update')} user ${chalk.cyan(userCfg.email)}`);
+          if (!dryRun) {
+            await usersRepo.update(existing.user_id, {
+              name: userCfg.name ?? existing.name,
+              role: (userCfg.role as 'superadmin' | 'admin' | 'member' | 'viewer') ?? existing.role,
+              unix_username: userCfg.unix_username ?? existing.unix_username,
+            });
+          }
+          counts.updated++;
+        } else {
+          counts.unchanged++;
+        }
+      } else {
+        // User doesn't exist — create
+        this.log(`  ${chalk.green('create')} user ${chalk.cyan(userCfg.email)}`);
+
+        if (!dryRun) {
+          // Resolve password
+          let password = '';
+          if (userCfg.password === 'generate') {
+            password = generateId(); // Random UUID as password
+          } else if (userCfg.password?.startsWith('env:')) {
+            const envVar = userCfg.password.slice(4);
+            password = process.env[envVar] ?? '';
+            if (!password) {
+              this.warn(`Environment variable ${envVar} not set for user ${userCfg.email}`);
+            }
+          } else if (userCfg.password) {
+            password = userCfg.password;
+          }
+
+          // Hash the password
+          const hashedPassword = password ? await hash(password, 10) : '';
+
+          await usersRepo.create({
+            user_id: userCfg.user_id as UUID,
+            email: userCfg.email,
+            name: userCfg.name,
+            role: (userCfg.role as 'superadmin' | 'admin' | 'member' | 'viewer') ?? 'member',
+            unix_username: userCfg.unix_username,
+            password: hashedPassword,
+          } as Partial<User> & { password: string });
+        }
+
+        counts.created++;
+      }
+    }
+
+    return counts;
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -226,7 +226,8 @@
     "simple-git": "^3.33.0",
     "slackify-markdown": "^5.0.0",
     "socket.io-client": "^4.8.3",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -82,6 +82,20 @@ export async function loadConfig(): Promise<AgorConfig> {
 }
 
 /**
+ * Load config from a specific file path.
+ *
+ * Unlike loadConfig(), this does NOT fall back to defaults if the file is missing.
+ * Throws on missing file or parse error.
+ */
+export async function loadConfigFromFile(filePath: string): Promise<AgorConfig> {
+  const content = await fs.readFile(filePath, 'utf-8');
+  const config = yaml.load(content) as AgorConfig;
+  const finalConfig = config || {};
+  validateConfig(finalConfig);
+  return finalConfig;
+}
+
+/**
  * Save config to ~/.agor/config.yaml
  */
 export async function saveConfig(config: AgorConfig): Promise<void> {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -15,4 +15,5 @@ export * from './key-resolver';
 export * from './repo-list';
 export * from './repo-reference';
 export * from './resource-schemas';
+export * from './resource-sync';
 export * from './types';

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -14,4 +14,5 @@ export * from './env-validation';
 export * from './key-resolver';
 export * from './repo-list';
 export * from './repo-reference';
+export * from './resource-schemas';
 export * from './types';

--- a/packages/core/src/config/repo-reference.ts
+++ b/packages/core/src/config/repo-reference.ts
@@ -107,12 +107,16 @@ export function extractSlugFromUrl(url: string): RepoSlug {
  * @param slug - Repository slug to validate
  * @returns True if valid
  */
+/**
+ * Regex for valid repo slugs (org/name format matching GitHub naming rules).
+ * Supports: alphanumeric, hyphens, underscores, dots. Safe for filesystem paths.
+ *
+ * Shared across repo-reference validation and config resource schemas.
+ */
+export const REPO_SLUG_PATTERN = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
 export function isValidSlug(slug: string): boolean {
-  // Must be org/name format with valid characters (matching GitHub's naming rules)
-  // - Supports: alphanumeric, hyphens, underscores, and dots
-  // - Safe for use in filesystem paths
-  const slugPattern = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
-  return slugPattern.test(slug);
+  return REPO_SLUG_PATTERN.test(slug);
 }
 
 /**

--- a/packages/core/src/config/resource-schemas.test.ts
+++ b/packages/core/src/config/resource-schemas.test.ts
@@ -72,9 +72,14 @@ describe('resourceRepoConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects invalid slug with uppercase', () => {
-    const result = resourceRepoConfigSchema.safeParse(validRepo({ slug: 'MyRepo' }));
+  it('rejects slug without org/name format', () => {
+    const result = resourceRepoConfigSchema.safeParse(validRepo({ slug: 'my-repo' }));
     expect(result.success).toBe(false);
+  });
+
+  it('accepts slug with uppercase, dots, and underscores', () => {
+    const result = resourceRepoConfigSchema.safeParse(validRepo({ slug: 'My_Org/my.repo' }));
+    expect(result.success).toBe(true);
   });
 
   it('defaults repo_type to remote', () => {
@@ -203,7 +208,7 @@ describe('validateResourceCrossReferences', () => {
 
   it('detects duplicate repo IDs', () => {
     const resources = daemonResourcesConfigSchema.parse({
-      repos: [validRepo(), validRepo({ slug: 'other-repo' })],
+      repos: [validRepo(), validRepo({ slug: 'other-org/other-repo' })],
     });
     const errors = validateResourceCrossReferences(resources);
     expect(errors).toHaveLength(1);

--- a/packages/core/src/config/resource-schemas.test.ts
+++ b/packages/core/src/config/resource-schemas.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for resource config Zod schemas and cross-reference validation
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  daemonResourcesConfigSchema,
+  resolveRepoSlugs,
+  resourceRepoConfigSchema,
+  resourceUserConfigSchema,
+  resourceWorktreeConfigSchema,
+  validateResourceCrossReferences,
+} from './resource-schemas';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_UUID = '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f';
+const VALID_UUID_2 = '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a70';
+const VALID_UUID_3 = '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a71';
+
+function validRepo(overrides: Record<string, unknown> = {}) {
+  return {
+    repo_id: VALID_UUID,
+    slug: 'my-org/my-repo',
+    remote_url: 'https://github.com/my-org/my-repo.git',
+    ...overrides,
+  };
+}
+
+function validWorktree(overrides: Record<string, unknown> = {}) {
+  return {
+    worktree_id: VALID_UUID_2,
+    name: 'main',
+    ref: 'main',
+    repo: 'my-org/my-repo',
+    ...overrides,
+  };
+}
+
+function validUser(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: VALID_UUID_3,
+    email: 'admin@example.com',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Repo schema
+// ---------------------------------------------------------------------------
+
+describe('resourceRepoConfigSchema', () => {
+  it('accepts valid repo config', () => {
+    const result = resourceRepoConfigSchema.safeParse(validRepo());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts repo with all optional fields', () => {
+    const result = resourceRepoConfigSchema.safeParse(
+      validRepo({
+        repo_type: 'local',
+        default_branch: 'develop',
+        shallow: true,
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid UUID', () => {
+    const result = resourceRepoConfigSchema.safeParse(validRepo({ repo_id: 'not-a-uuid' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid slug with uppercase', () => {
+    const result = resourceRepoConfigSchema.safeParse(validRepo({ slug: 'MyRepo' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults repo_type to remote', () => {
+    const result = resourceRepoConfigSchema.parse(validRepo());
+    expect(result.repo_type).toBe('remote');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worktree schema
+// ---------------------------------------------------------------------------
+
+describe('resourceWorktreeConfigSchema', () => {
+  it('accepts valid worktree config', () => {
+    const result = resourceWorktreeConfigSchema.safeParse(validWorktree());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts worktree with agent config', () => {
+    const result = resourceWorktreeConfigSchema.safeParse(
+      validWorktree({
+        agent: {
+          agentic_tool: 'claude-code',
+          permission_mode: 'bypassPermissions',
+          model: 'claude-sonnet-4-5-20250514',
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    const result = resourceWorktreeConfigSchema.safeParse(validWorktree({ name: '' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty ref', () => {
+    const result = resourceWorktreeConfigSchema.safeParse(validWorktree({ ref: '' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all permission levels', () => {
+    for (const level of ['none', 'view', 'session', 'prompt', 'all']) {
+      const result = resourceWorktreeConfigSchema.safeParse(validWorktree({ others_can: level }));
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User schema
+// ---------------------------------------------------------------------------
+
+describe('resourceUserConfigSchema', () => {
+  it('accepts valid user config', () => {
+    const result = resourceUserConfigSchema.safeParse(validUser());
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid email', () => {
+    const result = resourceUserConfigSchema.safeParse(validUser({ email: 'not-an-email' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults role to member', () => {
+    const result = resourceUserConfigSchema.parse(validUser());
+    expect(result.role).toBe('member');
+  });
+
+  it('accepts all valid roles', () => {
+    for (const role of ['superadmin', 'admin', 'member', 'viewer']) {
+      const result = resourceUserConfigSchema.safeParse(validUser({ role }));
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Top-level resources schema
+// ---------------------------------------------------------------------------
+
+describe('daemonResourcesConfigSchema', () => {
+  it('accepts empty resources', () => {
+    const result = daemonResourcesConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts full resources config', () => {
+    const result = daemonResourcesConfigSchema.safeParse({
+      repos: [validRepo()],
+      worktrees: [validWorktree()],
+      users: [validUser()],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-reference validation
+// ---------------------------------------------------------------------------
+
+describe('validateResourceCrossReferences', () => {
+  it('returns no errors for valid config', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo()],
+      worktrees: [validWorktree()],
+      users: [validUser()],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toEqual([]);
+  });
+
+  it('detects duplicate repo IDs', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo(), validRepo({ slug: 'other-repo' })],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Duplicate repo_id');
+  });
+
+  it('detects duplicate repo slugs', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo(), validRepo({ repo_id: VALID_UUID_2 })],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Duplicate repo slug');
+  });
+
+  it('detects worktree referencing unknown repo', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo()],
+      worktrees: [validWorktree({ repo: 'nonexistent/repo' })],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('unknown repo slug');
+  });
+
+  it('detects duplicate worktree IDs', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo()],
+      worktrees: [validWorktree(), validWorktree({ name: 'develop' })],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Duplicate worktree_id');
+  });
+
+  it('detects duplicate user IDs', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      users: [validUser(), validUser({ email: 'other@example.com' })],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Duplicate user_id');
+  });
+
+  it('detects duplicate user emails', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      users: [validUser(), validUser({ user_id: VALID_UUID })],
+    });
+    const errors = validateResourceCrossReferences(resources);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('Duplicate user email');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slug cross-reference resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveRepoSlugs', () => {
+  it('maps worktree IDs to repo IDs via slug', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo()],
+      worktrees: [validWorktree()],
+    });
+    const result = resolveRepoSlugs(resources);
+    expect(result.get(VALID_UUID_2)).toBe(VALID_UUID);
+  });
+
+  it('skips worktrees with unknown repo slug', () => {
+    const resources = daemonResourcesConfigSchema.parse({
+      repos: [validRepo()],
+      worktrees: [validWorktree({ repo: 'nonexistent/repo' })],
+    });
+    const result = resolveRepoSlugs(resources);
+    expect(result.size).toBe(0);
+  });
+
+  it('handles empty resources', () => {
+    const resources = daemonResourcesConfigSchema.parse({});
+    const result = resolveRepoSlugs(resources);
+    expect(result.size).toBe(0);
+  });
+});

--- a/packages/core/src/config/resource-schemas.test.ts
+++ b/packages/core/src/config/resource-schemas.test.ts
@@ -5,7 +5,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   daemonResourcesConfigSchema,
-  resolveRepoSlugs,
   resourceRepoConfigSchema,
   resourceUserConfigSchema,
   resourceWorktreeConfigSchema,
@@ -81,6 +80,20 @@ describe('resourceRepoConfigSchema', () => {
   it('defaults repo_type to remote', () => {
     const result = resourceRepoConfigSchema.parse(validRepo());
     expect(result.repo_type).toBe('remote');
+  });
+
+  it('rejects remote repo without remote_url', () => {
+    const result = resourceRepoConfigSchema.safeParse(
+      validRepo({ remote_url: undefined, repo_type: 'remote' })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts local repo without remote_url', () => {
+    const result = resourceRepoConfigSchema.safeParse(
+      validRepo({ remote_url: undefined, repo_type: 'local' })
+    );
+    expect(result.success).toBe(true);
   });
 });
 
@@ -242,35 +255,5 @@ describe('validateResourceCrossReferences', () => {
     const errors = validateResourceCrossReferences(resources);
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toContain('Duplicate user email');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Slug cross-reference resolution
-// ---------------------------------------------------------------------------
-
-describe('resolveRepoSlugs', () => {
-  it('maps worktree IDs to repo IDs via slug', () => {
-    const resources = daemonResourcesConfigSchema.parse({
-      repos: [validRepo()],
-      worktrees: [validWorktree()],
-    });
-    const result = resolveRepoSlugs(resources);
-    expect(result.get(VALID_UUID_2)).toBe(VALID_UUID);
-  });
-
-  it('skips worktrees with unknown repo slug', () => {
-    const resources = daemonResourcesConfigSchema.parse({
-      repos: [validRepo()],
-      worktrees: [validWorktree({ repo: 'nonexistent/repo' })],
-    });
-    const result = resolveRepoSlugs(resources);
-    expect(result.size).toBe(0);
-  });
-
-  it('handles empty resources', () => {
-    const resources = daemonResourcesConfigSchema.parse({});
-    const result = resolveRepoSlugs(resources);
-    expect(result.size).toBe(0);
   });
 });

--- a/packages/core/src/config/resource-schemas.ts
+++ b/packages/core/src/config/resource-schemas.ts
@@ -86,6 +86,15 @@ export const daemonResourcesConfigSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Inferred types (for consumers that don't import zod)
+// ---------------------------------------------------------------------------
+
+export type ParsedRepoConfig = z.infer<typeof resourceRepoConfigSchema>;
+export type ParsedWorktreeConfig = z.infer<typeof resourceWorktreeConfigSchema>;
+export type ParsedUserConfig = z.infer<typeof resourceUserConfigSchema>;
+export type ParsedResourcesConfig = z.infer<typeof daemonResourcesConfigSchema>;
+
+// ---------------------------------------------------------------------------
 // Cross-reference & uniqueness validation
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/config/resource-schemas.ts
+++ b/packages/core/src/config/resource-schemas.ts
@@ -37,14 +37,19 @@ export const enforcedAgentConfigSchema = z.object({
 // ResourceRepoConfig
 // ---------------------------------------------------------------------------
 
-export const resourceRepoConfigSchema = z.object({
-  repo_id: uuidSchema,
-  slug: slugSchema,
-  remote_url: z.string().optional(),
-  repo_type: z.enum(['remote', 'local']).default('remote'),
-  default_branch: z.string().optional(),
-  shallow: z.boolean().optional(),
-});
+export const resourceRepoConfigSchema = z
+  .object({
+    repo_id: uuidSchema,
+    slug: slugSchema,
+    remote_url: z.string().optional(),
+    repo_type: z.enum(['remote', 'local']).default('remote'),
+    default_branch: z.string().optional(),
+    shallow: z.boolean().optional(),
+  })
+  .refine((data) => data.repo_type !== 'remote' || data.remote_url, {
+    message: 'remote_url is required when repo_type is "remote"',
+    path: ['remote_url'],
+  });
 
 // ---------------------------------------------------------------------------
 // ResourceWorktreeConfig
@@ -188,26 +193,4 @@ export function validateResourceCrossReferences(
   }
 
   return errors;
-}
-
-/**
- * Resolve worktree.repo (slug) to the corresponding repo_id.
- * Returns a map of worktree_id → repo_id.
- */
-export function resolveRepoSlugs(
-  resources: z.infer<typeof daemonResourcesConfigSchema>
-): Map<string, string> {
-  const slugToId = new Map<string, string>();
-  for (const repo of resources.repos ?? []) {
-    slugToId.set(repo.slug, repo.repo_id);
-  }
-
-  const result = new Map<string, string>();
-  for (const wt of resources.worktrees ?? []) {
-    const repoId = slugToId.get(wt.repo);
-    if (repoId) {
-      result.set(wt.worktree_id, repoId);
-    }
-  }
-  return result;
 }

--- a/packages/core/src/config/resource-schemas.ts
+++ b/packages/core/src/config/resource-schemas.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { REPO_SLUG_PATTERN } from './repo-reference';
 
 // ---------------------------------------------------------------------------
 // Shared validators
@@ -14,12 +15,12 @@ const uuidSchema = z
   .string()
   .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, 'Must be a valid UUID');
 
-/** Lowercase alphanumeric with hyphens and slashes (for org/repo slugs) */
-const slugSchema = z
+/** Repo slug in org/name format — uses shared REPO_SLUG_PATTERN from repo-reference.ts */
+const repoSlugSchema = z
   .string()
   .regex(
-    /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/,
-    'Must be lowercase alphanumeric with hyphens (e.g., "my-repo" or "org/my-repo")'
+    REPO_SLUG_PATTERN,
+    'Must be org/name format with alphanumeric, hyphens, underscores, or dots (e.g., "my-org/my-repo")'
   );
 
 // ---------------------------------------------------------------------------
@@ -40,7 +41,7 @@ export const enforcedAgentConfigSchema = z.object({
 export const resourceRepoConfigSchema = z
   .object({
     repo_id: uuidSchema,
-    slug: slugSchema,
+    slug: repoSlugSchema,
     remote_url: z.string().optional(),
     repo_type: z.enum(['remote', 'local']).default('remote'),
     default_branch: z.string().optional(),
@@ -62,7 +63,7 @@ export const resourceWorktreeConfigSchema = z.object({
   ref_type: z.enum(['branch', 'tag']).optional(),
   others_can: z.enum(['none', 'view', 'session', 'prompt', 'all']).optional(),
   mcp_server_ids: z.array(z.string()).optional(),
-  repo: slugSchema,
+  repo: repoSlugSchema,
   readonly: z.boolean().optional(),
   agent: enforcedAgentConfigSchema.optional(),
 });

--- a/packages/core/src/config/resource-schemas.ts
+++ b/packages/core/src/config/resource-schemas.ts
@@ -1,0 +1,204 @@
+/**
+ * Zod validation schemas for the `resources:` section of config.yml.
+ *
+ * Validates structure, formats, and cross-references between declared resources.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Shared validators
+// ---------------------------------------------------------------------------
+
+const uuidSchema = z
+  .string()
+  .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, 'Must be a valid UUID');
+
+/** Lowercase alphanumeric with hyphens and slashes (for org/repo slugs) */
+const slugSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)*$/,
+    'Must be lowercase alphanumeric with hyphens (e.g., "my-repo" or "org/my-repo")'
+  );
+
+// ---------------------------------------------------------------------------
+// EnforcedAgentConfig
+// ---------------------------------------------------------------------------
+
+export const enforcedAgentConfigSchema = z.object({
+  agentic_tool: z.enum(['claude-code', 'codex', 'gemini', 'opencode', 'copilot']).optional(),
+  permission_mode: z.string().optional(),
+  model: z.string().optional(),
+  mcp_server_ids: z.array(z.string()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// ResourceRepoConfig
+// ---------------------------------------------------------------------------
+
+export const resourceRepoConfigSchema = z.object({
+  repo_id: uuidSchema,
+  slug: slugSchema,
+  remote_url: z.string().optional(),
+  repo_type: z.enum(['remote', 'local']).default('remote'),
+  default_branch: z.string().optional(),
+  shallow: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// ResourceWorktreeConfig
+// ---------------------------------------------------------------------------
+
+export const resourceWorktreeConfigSchema = z.object({
+  worktree_id: uuidSchema,
+  name: z.string().min(1, 'Worktree name is required'),
+  ref: z.string().min(1, 'Git ref is required'),
+  ref_type: z.enum(['branch', 'tag']).optional(),
+  others_can: z.enum(['none', 'view', 'session', 'prompt', 'all']).optional(),
+  mcp_server_ids: z.array(z.string()).optional(),
+  repo: slugSchema,
+  readonly: z.boolean().optional(),
+  agent: enforcedAgentConfigSchema.optional(),
+});
+
+// ---------------------------------------------------------------------------
+// ResourceUserConfig
+// ---------------------------------------------------------------------------
+
+export const resourceUserConfigSchema = z.object({
+  user_id: uuidSchema,
+  email: z.string().email('Must be a valid email address'),
+  name: z.string().optional(),
+  role: z.enum(['superadmin', 'admin', 'member', 'viewer']).default('member'),
+  unix_username: z.string().optional(),
+  password: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// DaemonResourcesConfig (top-level)
+// ---------------------------------------------------------------------------
+
+export const daemonResourcesConfigSchema = z.object({
+  repos: z.array(resourceRepoConfigSchema).optional(),
+  worktrees: z.array(resourceWorktreeConfigSchema).optional(),
+  users: z.array(resourceUserConfigSchema).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Cross-reference & uniqueness validation
+// ---------------------------------------------------------------------------
+
+export interface ResourceValidationError {
+  path: string;
+  message: string;
+}
+
+/**
+ * Validate cross-references and uniqueness constraints that Zod can't express:
+ * - No duplicate repo_id / worktree_id / user_id values
+ * - No duplicate repo slugs
+ * - worktree.repo references a declared repo slug
+ */
+export function validateResourceCrossReferences(
+  resources: z.infer<typeof daemonResourcesConfigSchema>
+): ResourceValidationError[] {
+  const errors: ResourceValidationError[] = [];
+  const repos = resources.repos ?? [];
+  const worktrees = resources.worktrees ?? [];
+  const users = resources.users ?? [];
+
+  // Collect repo slugs for cross-reference checking
+  const repoSlugs = new Set<string>();
+  const repoIds = new Set<string>();
+
+  for (let i = 0; i < repos.length; i++) {
+    const repo = repos[i];
+
+    if (repoIds.has(repo.repo_id)) {
+      errors.push({
+        path: `resources.repos[${i}].repo_id`,
+        message: `Duplicate repo_id: ${repo.repo_id}`,
+      });
+    }
+    repoIds.add(repo.repo_id);
+
+    if (repoSlugs.has(repo.slug)) {
+      errors.push({
+        path: `resources.repos[${i}].slug`,
+        message: `Duplicate repo slug: ${repo.slug}`,
+      });
+    }
+    repoSlugs.add(repo.slug);
+  }
+
+  // Check worktree uniqueness and repo cross-references
+  const worktreeIds = new Set<string>();
+
+  for (let i = 0; i < worktrees.length; i++) {
+    const wt = worktrees[i];
+
+    if (worktreeIds.has(wt.worktree_id)) {
+      errors.push({
+        path: `resources.worktrees[${i}].worktree_id`,
+        message: `Duplicate worktree_id: ${wt.worktree_id}`,
+      });
+    }
+    worktreeIds.add(wt.worktree_id);
+
+    if (!repoSlugs.has(wt.repo)) {
+      errors.push({
+        path: `resources.worktrees[${i}].repo`,
+        message: `Worktree references unknown repo slug: "${wt.repo}". Declared repos: [${[...repoSlugs].join(', ')}]`,
+      });
+    }
+  }
+
+  // Check user uniqueness
+  const userIds = new Set<string>();
+  const userEmails = new Set<string>();
+
+  for (let i = 0; i < users.length; i++) {
+    const user = users[i];
+
+    if (userIds.has(user.user_id)) {
+      errors.push({
+        path: `resources.users[${i}].user_id`,
+        message: `Duplicate user_id: ${user.user_id}`,
+      });
+    }
+    userIds.add(user.user_id);
+
+    if (userEmails.has(user.email)) {
+      errors.push({
+        path: `resources.users[${i}].email`,
+        message: `Duplicate user email: ${user.email}`,
+      });
+    }
+    userEmails.add(user.email);
+  }
+
+  return errors;
+}
+
+/**
+ * Resolve worktree.repo (slug) to the corresponding repo_id.
+ * Returns a map of worktree_id → repo_id.
+ */
+export function resolveRepoSlugs(
+  resources: z.infer<typeof daemonResourcesConfigSchema>
+): Map<string, string> {
+  const slugToId = new Map<string, string>();
+  for (const repo of resources.repos ?? []) {
+    slugToId.set(repo.slug, repo.repo_id);
+  }
+
+  const result = new Map<string, string>();
+  for (const wt of resources.worktrees ?? []) {
+    const repoId = slugToId.get(wt.repo);
+    if (repoId) {
+      result.set(wt.worktree_id, repoId);
+    }
+  }
+  return result;
+}

--- a/packages/core/src/config/resource-sync.test.ts
+++ b/packages/core/src/config/resource-sync.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for pure sync logic functions (resource-sync.ts)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildSlugToRepoIdMap,
+  determineRepoAction,
+  determineUserAction,
+  determineWorktreeAction,
+  resolvePassword,
+} from './resource-sync';
+
+// ---------------------------------------------------------------------------
+// determineRepoAction
+// ---------------------------------------------------------------------------
+
+describe('determineRepoAction', () => {
+  it('returns create when no existing repo', () => {
+    expect(determineRepoAction({ remote_url: 'https://example.com/repo' }, null, false)).toBe(
+      'create'
+    );
+  });
+
+  it('returns unchanged when existing matches config', () => {
+    const existing = { remote_url: 'https://example.com/repo', default_branch: 'main' };
+    const config = { remote_url: 'https://example.com/repo', default_branch: 'main' };
+    expect(determineRepoAction(config, existing, true)).toBe('unchanged');
+  });
+
+  it('returns update when remote_url differs', () => {
+    const existing = { remote_url: 'https://old.com/repo', default_branch: 'main' };
+    const config = { remote_url: 'https://new.com/repo' };
+    expect(determineRepoAction(config, existing, true)).toBe('update');
+  });
+
+  it('returns update when default_branch differs', () => {
+    const existing = { remote_url: 'https://example.com/repo', default_branch: 'main' };
+    const config = { default_branch: 'develop' };
+    expect(determineRepoAction(config, existing, true)).toBe('update');
+  });
+
+  it('returns unchanged when config fields are undefined', () => {
+    const existing = { remote_url: 'https://example.com/repo', default_branch: 'main' };
+    expect(determineRepoAction({}, existing, true)).toBe('unchanged');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// determineWorktreeAction
+// ---------------------------------------------------------------------------
+
+describe('determineWorktreeAction', () => {
+  it('returns create when no existing worktree', () => {
+    expect(determineWorktreeAction({ ref: 'main' }, null)).toBe('create');
+  });
+
+  it('returns unchanged when existing matches', () => {
+    const existing = { ref: 'main', others_can: 'session', mcp_server_ids: ['a'] };
+    const config = { ref: 'main', others_can: 'session', mcp_server_ids: ['a'] };
+    expect(determineWorktreeAction(config, existing)).toBe('unchanged');
+  });
+
+  it('returns update when ref differs', () => {
+    const existing = { ref: 'main' };
+    const config = { ref: 'develop' };
+    expect(determineWorktreeAction(config, existing)).toBe('update');
+  });
+
+  it('returns update when others_can differs', () => {
+    const existing = { ref: 'main', others_can: 'session' };
+    const config = { ref: 'main', others_can: 'all' };
+    expect(determineWorktreeAction(config, existing)).toBe('update');
+  });
+
+  it('returns update when mcp_server_ids differ', () => {
+    const existing = { ref: 'main', mcp_server_ids: ['a'] };
+    const config = { ref: 'main', mcp_server_ids: ['a', 'b'] };
+    expect(determineWorktreeAction(config, existing)).toBe('update');
+  });
+
+  it('returns unchanged when optional fields are undefined in config', () => {
+    const existing = { ref: 'main', others_can: 'session', mcp_server_ids: ['a'] };
+    const config = { ref: 'main' };
+    expect(determineWorktreeAction(config, existing)).toBe('unchanged');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// determineUserAction
+// ---------------------------------------------------------------------------
+
+describe('determineUserAction', () => {
+  it('returns create when no existing user', () => {
+    expect(determineUserAction({ name: 'Alice' }, null)).toBe('create');
+  });
+
+  it('returns unchanged when existing matches', () => {
+    const existing = { name: 'Alice', role: 'member', unix_username: 'alice' };
+    const config = { name: 'Alice', role: 'member', unix_username: 'alice' };
+    expect(determineUserAction(config, existing)).toBe('unchanged');
+  });
+
+  it('returns update when name differs', () => {
+    const existing = { name: 'Alice' };
+    const config = { name: 'Bob' };
+    expect(determineUserAction(config, existing)).toBe('update');
+  });
+
+  it('returns update when role differs', () => {
+    const existing = { name: 'Alice', role: 'member' };
+    const config = { name: 'Alice', role: 'admin' };
+    expect(determineUserAction(config, existing)).toBe('update');
+  });
+
+  it('returns update when unix_username differs', () => {
+    const existing = { name: 'Alice', unix_username: 'alice' };
+    const config = { name: 'Alice', unix_username: 'alice2' };
+    expect(determineUserAction(config, existing)).toBe('update');
+  });
+
+  it('returns unchanged when config fields are undefined', () => {
+    const existing = { name: 'Alice', role: 'admin', unix_username: 'alice' };
+    expect(determineUserAction({}, existing)).toBe('unchanged');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePassword
+// ---------------------------------------------------------------------------
+
+describe('resolvePassword', () => {
+  it('generates random password when undefined', () => {
+    const result = resolvePassword(undefined);
+    expect(result.mustChange).toBe(true);
+    expect(result.password).toHaveLength(32); // 16 bytes → 32 hex chars
+    expect(result.password).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('generates random password when empty string', () => {
+    const result = resolvePassword('');
+    expect(result.mustChange).toBe(true);
+    expect(result.password).toHaveLength(32);
+  });
+
+  it('returns literal password as-is', () => {
+    const result = resolvePassword('my-secret');
+    expect(result.password).toBe('my-secret');
+    expect(result.mustChange).toBe(false);
+  });
+
+  it('resolves Handlebars env template', () => {
+    const result = resolvePassword('{{env.MY_SECRET}}', { MY_SECRET: 'hunter2' });
+    expect(result.password).toBe('hunter2');
+    expect(result.mustChange).toBe(false);
+  });
+
+  it('resolves multiple Handlebars refs', () => {
+    const result = resolvePassword('{{env.USER}}-{{env.PASS}}', {
+      USER: 'admin',
+      PASS: 'secret',
+    });
+    expect(result.password).toBe('admin-secret');
+    expect(result.mustChange).toBe(false);
+  });
+
+  it('handles whitespace in Handlebars template', () => {
+    const result = resolvePassword('{{ env.MY_VAR }}', { MY_VAR: 'value' });
+    expect(result.password).toBe('value');
+    expect(result.mustChange).toBe(false);
+  });
+
+  it('throws on missing env var in Handlebars template', () => {
+    expect(() => resolvePassword('{{env.MISSING}}', {})).toThrow(
+      'Environment variable MISSING is not set'
+    );
+  });
+
+  it('throws on empty env var in Handlebars template', () => {
+    expect(() => resolvePassword('{{env.EMPTY}}', { EMPTY: '' })).toThrow(
+      'Environment variable EMPTY is not set'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSlugToRepoIdMap
+// ---------------------------------------------------------------------------
+
+describe('buildSlugToRepoIdMap', () => {
+  it('builds map from repos', () => {
+    const repos = [
+      { repo_id: 'id-1', slug: 'org/repo-a' },
+      { repo_id: 'id-2', slug: 'org/repo-b' },
+    ];
+    const map = buildSlugToRepoIdMap(repos);
+    expect(map.get('org/repo-a')).toBe('id-1');
+    expect(map.get('org/repo-b')).toBe('id-2');
+    expect(map.size).toBe(2);
+  });
+
+  it('returns empty map for empty input', () => {
+    expect(buildSlugToRepoIdMap([]).size).toBe(0);
+  });
+});

--- a/packages/core/src/config/resource-sync.test.ts
+++ b/packages/core/src/config/resource-sync.test.ts
@@ -17,32 +17,30 @@ import {
 
 describe('determineRepoAction', () => {
   it('returns create when no existing repo', () => {
-    expect(determineRepoAction({ remote_url: 'https://example.com/repo' }, null, false)).toBe(
-      'create'
-    );
+    expect(determineRepoAction({ remote_url: 'https://example.com/repo' }, null)).toBe('create');
   });
 
   it('returns unchanged when existing matches config', () => {
     const existing = { remote_url: 'https://example.com/repo', default_branch: 'main' };
     const config = { remote_url: 'https://example.com/repo', default_branch: 'main' };
-    expect(determineRepoAction(config, existing, true)).toBe('unchanged');
+    expect(determineRepoAction(config, existing)).toBe('unchanged');
   });
 
   it('returns update when remote_url differs', () => {
     const existing = { remote_url: 'https://old.com/repo', default_branch: 'main' };
     const config = { remote_url: 'https://new.com/repo' };
-    expect(determineRepoAction(config, existing, true)).toBe('update');
+    expect(determineRepoAction(config, existing)).toBe('update');
   });
 
   it('returns update when default_branch differs', () => {
     const existing = { remote_url: 'https://example.com/repo', default_branch: 'main' };
     const config = { default_branch: 'develop' };
-    expect(determineRepoAction(config, existing, true)).toBe('update');
+    expect(determineRepoAction(config, existing)).toBe('update');
   });
 
   it('returns unchanged when config fields are undefined', () => {
     const existing = { remote_url: 'https://example.com/repo', default_branch: 'main' };
-    expect(determineRepoAction({}, existing, true)).toBe('unchanged');
+    expect(determineRepoAction({}, existing)).toBe('unchanged');
   });
 });
 

--- a/packages/core/src/config/resource-sync.test.ts
+++ b/packages/core/src/config/resource-sync.test.ts
@@ -179,6 +179,24 @@ describe('resolvePassword', () => {
       'Environment variable EMPTY is not set'
     );
   });
+
+  it('throws on unrecognized template expression', () => {
+    expect(() => resolvePassword('{{typo}}', {})).toThrow(
+      'Unrecognized template expression {{typo}}'
+    );
+  });
+
+  it('throws on unknown namespace in template', () => {
+    expect(() => resolvePassword('{{secret.KEY}}', {})).toThrow(
+      'Unrecognized template expression {{secret.KEY}}'
+    );
+  });
+
+  it('throws when mixing valid and invalid templates', () => {
+    expect(() => resolvePassword('{{env.OK}}-{{bad}}', { OK: 'val' })).toThrow(
+      'Unrecognized template expression {{bad}}'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/config/resource-sync.ts
+++ b/packages/core/src/config/resource-sync.ts
@@ -22,8 +22,7 @@ export type UserAction = 'create' | 'update' | 'unchanged';
 
 export function determineRepoAction(
   config: { remote_url?: string; default_branch?: string },
-  existing: { remote_url?: string; default_branch?: string } | null,
-  _fsExists: boolean
+  existing: { remote_url?: string; default_branch?: string } | null
 ): RepoAction {
   if (!existing) return 'create';
 

--- a/packages/core/src/config/resource-sync.ts
+++ b/packages/core/src/config/resource-sync.ts
@@ -114,10 +114,10 @@ export function resolvePassword(
 /**
  * Resolve Handlebars-style `{{env.VAR_NAME}}` references in a string.
  *
- * @throws Error if any referenced env var is not set
+ * @throws Error if any referenced env var is not set or if unrecognized templates remain
  */
 function resolveHandlebarsEnv(template: string, env: Record<string, string | undefined>): string {
-  return template.replace(/\{\{\s*env\.(\w+)\s*\}\}/g, (_match, varName: string) => {
+  const resolved = template.replace(/\{\{\s*env\.(\w+)\s*\}\}/g, (_match, varName: string) => {
     const value = env[varName];
     if (value === undefined || value === '') {
       throw new Error(
@@ -126,6 +126,16 @@ function resolveHandlebarsEnv(template: string, env: Record<string, string | und
     }
     return value;
   });
+
+  // Error on any unresolved templates (e.g. {{typo}}, {{unknown.ref}})
+  const remaining = resolved.match(/\{\{[^}]*\}\}/);
+  if (remaining) {
+    throw new Error(
+      `Unrecognized template expression ${remaining[0]} in password template "${template}". Only {{env.VAR_NAME}} is supported.`
+    );
+  }
+
+  return resolved;
 }
 
 /**

--- a/packages/core/src/config/resource-sync.ts
+++ b/packages/core/src/config/resource-sync.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure sync logic for config resource declarations.
+ *
+ * These functions determine what actions to take without performing side effects.
+ * This makes them trivially unit-testable.
+ *
+ * Function signatures use structural types (not branded) so they accept both
+ * canonical types (Repo, Worktree, User) and Zod-parsed plain objects.
+ */
+
+// ---------------------------------------------------------------------------
+// Action types
+// ---------------------------------------------------------------------------
+
+export type RepoAction = 'create' | 'update' | 'unchanged';
+export type WorktreeAction = 'create' | 'update' | 'unchanged';
+export type UserAction = 'create' | 'update' | 'unchanged';
+
+// ---------------------------------------------------------------------------
+// Repo sync decisions
+// ---------------------------------------------------------------------------
+
+export function determineRepoAction(
+  config: { remote_url?: string; default_branch?: string },
+  existing: { remote_url?: string; default_branch?: string } | null,
+  _fsExists: boolean
+): RepoAction {
+  if (!existing) return 'create';
+
+  const needsUpdate =
+    (config.remote_url !== undefined && existing.remote_url !== config.remote_url) ||
+    (config.default_branch !== undefined && existing.default_branch !== config.default_branch);
+
+  return needsUpdate ? 'update' : 'unchanged';
+}
+
+// ---------------------------------------------------------------------------
+// Worktree sync decisions
+// ---------------------------------------------------------------------------
+
+export function determineWorktreeAction(
+  config: { ref: string; others_can?: string; mcp_server_ids?: string[] },
+  existing: { ref: string; others_can?: string; mcp_server_ids?: string[] } | null
+): WorktreeAction {
+  if (!existing) return 'create';
+
+  const needsUpdate =
+    existing.ref !== config.ref ||
+    (config.others_can !== undefined && existing.others_can !== config.others_can) ||
+    (config.mcp_server_ids !== undefined &&
+      JSON.stringify(existing.mcp_server_ids) !== JSON.stringify(config.mcp_server_ids));
+
+  return needsUpdate ? 'update' : 'unchanged';
+}
+
+// ---------------------------------------------------------------------------
+// User sync decisions
+// ---------------------------------------------------------------------------
+
+export function determineUserAction(
+  config: { name?: string; role?: string; unix_username?: string },
+  existing: { name?: string; role?: string; unix_username?: string } | null
+): UserAction {
+  if (!existing) return 'create';
+
+  const needsUpdate =
+    (config.name !== undefined && existing.name !== config.name) ||
+    (config.role !== undefined && existing.role !== config.role) ||
+    (config.unix_username !== undefined && existing.unix_username !== config.unix_username);
+
+  return needsUpdate ? 'update' : 'unchanged';
+}
+
+// ---------------------------------------------------------------------------
+// Password resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolvedPassword {
+  /** The cleartext password (before hashing) */
+  password: string;
+  /** Whether the user must change this password on first login */
+  mustChange: boolean;
+}
+
+/**
+ * Resolve a password config value to a cleartext password.
+ *
+ * Rules:
+ * - If omitted/undefined: generate a random temporary password, mustChange=true
+ * - If contains `{{`: treat as Handlebars template, resolve `{{env.VAR_NAME}}`
+ * - Otherwise: use as literal string
+ *
+ * @throws Error if a Handlebars template references a missing env var
+ */
+export function resolvePassword(
+  config: string | undefined,
+  env: Record<string, string | undefined> = process.env
+): ResolvedPassword {
+  // No password configured — generate a temporary one
+  if (config === undefined || config === '') {
+    const generated = generateRandomPassword();
+    return { password: generated, mustChange: true };
+  }
+
+  // Handlebars template — resolve {{env.VAR_NAME}}
+  if (config.includes('{{')) {
+    const resolved = resolveHandlebarsEnv(config, env);
+    return { password: resolved, mustChange: false };
+  }
+
+  // Literal string
+  return { password: config, mustChange: false };
+}
+
+/**
+ * Resolve Handlebars-style `{{env.VAR_NAME}}` references in a string.
+ *
+ * @throws Error if any referenced env var is not set
+ */
+function resolveHandlebarsEnv(template: string, env: Record<string, string | undefined>): string {
+  return template.replace(/\{\{\s*env\.(\w+)\s*\}\}/g, (_match, varName: string) => {
+    const value = env[varName];
+    if (value === undefined || value === '') {
+      throw new Error(
+        `Environment variable ${varName} is not set (referenced in password template "${template}")`
+      );
+    }
+    return value;
+  });
+}
+
+/**
+ * Generate a random password (32 hex chars).
+ */
+function generateRandomPassword(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Slug → repo_id resolution
+// ---------------------------------------------------------------------------
+
+export function buildSlugToRepoIdMap(
+  repos: Array<{ repo_id: string; slug: string }>
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const repo of repos) {
+    map.set(repo.slug, repo.repo_id);
+  }
+  return map;
+}

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2,6 +2,8 @@
  * Agor Configuration Types
  */
 
+import type { DaemonResourcesConfig } from '../types/config-resources';
+
 /**
  * Type for user-provided JSON data where structure is unknown or dynamic
  *
@@ -426,6 +428,9 @@ export interface AgorConfig {
 
   /** Onboarding settings (CLI init → UI wizard) */
   onboarding?: AgorOnboardingSettings;
+
+  /** Declarative resource definitions for headless/k8s deployments */
+  resources?: DaemonResourcesConfig;
 }
 
 /**

--- a/packages/core/src/types/config-resources.ts
+++ b/packages/core/src/types/config-resources.ts
@@ -44,7 +44,7 @@ export type ResourceWorktreeConfig = Pick<
 export type ResourceUserConfig = Pick<User, 'user_id' | 'email' | 'name' | 'role'> & {
   /** Unix username for process impersonation */
   unix_username?: string;
-  /** Password: 'generate' | 'env:VAR_NAME' | literal string */
+  /** Password: Handlebars template '{{env.VAR}}', literal string, or omit to auto-generate */
   password?: string;
 };
 

--- a/packages/core/src/types/config-resources.ts
+++ b/packages/core/src/types/config-resources.ts
@@ -17,7 +17,10 @@ export type ResourceRepoConfig = Pick<
   Repo,
   'repo_id' | 'slug' | 'remote_url' | 'repo_type' | 'default_branch'
 > & {
-  /** Shallow clone for faster boot (--depth=1) */
+  /**
+   * Shallow clone for faster boot (--depth=1)
+   * @todo Not yet applied during sync — parsed and validated but not wired into provisioning logic.
+   */
   shallow?: boolean;
 };
 
@@ -31,9 +34,15 @@ export type ResourceWorktreeConfig = Pick<
 > & {
   /** Repo slug reference — resolved to repo_id during sync */
   repo: string;
-  /** Mount filesystem read-only */
+  /**
+   * Mount filesystem read-only
+   * @todo Not yet applied during sync — parsed and validated but not wired into provisioning logic.
+   */
   readonly?: boolean;
-  /** Enforced agent settings for all sessions on this worktree */
+  /**
+   * Enforced agent settings for all sessions on this worktree
+   * @todo Not yet applied during sync — parsed and validated but not wired into provisioning logic.
+   */
   agent?: EnforcedAgentConfig;
 };
 

--- a/packages/core/src/types/config-resources.ts
+++ b/packages/core/src/types/config-resources.ts
@@ -1,0 +1,74 @@
+// src/types/config-resources.ts
+//
+// Serializable config types for the `resources:` section of config.yml.
+// Composed from existing canonical types using Pick<> — never disconnected.
+
+import type { AgenticToolName } from './agentic-tool';
+import type { Repo } from './repo';
+import type { PermissionMode } from './session';
+import type { User } from './user';
+import type { Worktree } from './worktree';
+
+// ---------------------------------------------------------------------------
+// Repo config: identity + clone info
+// ---------------------------------------------------------------------------
+
+export type ResourceRepoConfig = Pick<
+  Repo,
+  'repo_id' | 'slug' | 'remote_url' | 'repo_type' | 'default_branch'
+> & {
+  /** Shallow clone for faster boot (--depth=1) */
+  shallow?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Worktree config: identity + git ref + permissions
+// ---------------------------------------------------------------------------
+
+export type ResourceWorktreeConfig = Pick<
+  Worktree,
+  'worktree_id' | 'name' | 'ref' | 'ref_type' | 'others_can' | 'mcp_server_ids'
+> & {
+  /** Repo slug reference — resolved to repo_id during sync */
+  repo: string;
+  /** Mount filesystem read-only */
+  readonly?: boolean;
+  /** Enforced agent settings for all sessions on this worktree */
+  agent?: EnforcedAgentConfig;
+};
+
+// ---------------------------------------------------------------------------
+// User config: identity + role
+// ---------------------------------------------------------------------------
+
+export type ResourceUserConfig = Pick<User, 'user_id' | 'email' | 'name' | 'role'> & {
+  /** Unix username for process impersonation */
+  unix_username?: string;
+  /** Password: 'generate' | 'env:VAR_NAME' | literal string */
+  password?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Enforced agent config (composed from existing union types)
+// ---------------------------------------------------------------------------
+
+export interface EnforcedAgentConfig {
+  /** Which agentic coding tool to use */
+  agentic_tool?: AgenticToolName;
+  /** Permission/approval mode (enforced, not overridable) */
+  permission_mode?: PermissionMode;
+  /** Model identifier (e.g., 'claude-sonnet-4-5-20250514') */
+  model?: string;
+  /** MCP server IDs to attach to every session */
+  mcp_server_ids?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Top-level resources config
+// ---------------------------------------------------------------------------
+
+export interface DaemonResourcesConfig {
+  repos?: ResourceRepoConfig[];
+  worktrees?: ResourceWorktreeConfig[];
+  users?: ResourceUserConfig[];
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './artifact';
 export * from './board';
 export * from './board-comment';
 export * from './card';
+export * from './config-resources';
 export * from './context';
 export * from './feathers';
 export * from './file';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,9 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/bcryptjs':
         specifier: ^2.4.6


### PR DESCRIPTION
## Summary

- Add `resources:` section to `config.yaml` for declarative provisioning of repos, worktrees, and users
- Add `agor daemon sync` CLI command that reads config, validates with Zod schemas, and upserts resources
- Extract pure sync logic into testable functions (`determineRepoAction`, `determineWorktreeAction`, `determineUserAction`, `resolvePassword`)
- Password handling uses Handlebars templates (`{{env.VAR_NAME}}`), auto-generates with `must_change_password: true` when omitted
- Add `--config` flag for custom config file paths (headless/k8s deployments)
- 53 unit tests covering Zod schemas, cross-reference validation, and sync logic

### New files
- `packages/core/src/types/config-resources.ts` — Config types via `Pick<>` from canonical types
- `packages/core/src/config/resource-schemas.ts` — Zod validation schemas + cross-reference validation
- `packages/core/src/config/resource-sync.ts` — Pure sync decision functions
- `apps/agor-cli/src/commands/daemon/sync.ts` — CLI command

## Test plan

- [x] 26 schema tests pass (`resource-schemas.test.ts`)
- [x] 27 sync logic tests pass (`resource-sync.test.ts`)
- [x] `pnpm check` passes (typecheck + lint + build across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)