### PR TITLE
feat: config-aware `agor daemon start` CLI command

### DIFF
--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@agor/core": "workspace:*",
+    "@agor/daemon": "workspace:*",
     "@oclif/core": "^4.8.2",
     "@oclif/plugin-help": "^6.2.37",
     "chalk": "^5.6.2",

--- a/apps/agor-cli/src/commands/daemon/start.ts
+++ b/apps/agor-cli/src/commands/daemon/start.ts
@@ -1,197 +1,96 @@
 /**
- * `agor daemon start` - Start daemon in background
+ * `agor daemon start` - Config-aware daemon startup for headless/k8s deployments.
+ *
+ * Reads config.yaml (including services: section), then boots the daemon
+ * in-process with the resolved config.
+ *
+ * Port/host are set via config.yaml (daemon.port / daemon.host) or env vars (PORT).
+ * Compose with sync: `agor daemon sync --config ... && agor daemon start --config ...`
  */
 
-import { isDaemonRunning } from '@agor/core/api';
-import { getDaemonUrl } from '@agor/core/config';
-import { checkMigrationStatus, createDatabase, getDatabaseUrl } from '@agor/core/db';
-import { extractDbFilePath } from '@agor/core/utils/path';
+import type { AgorConfig } from '@agor/core/config';
+import { loadConfig, loadConfigFromFile } from '@agor/core/config';
+import { validateAllowedTiers, validateServiceDependencies } from '@agor/core/types';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
-import { getDaemonPath, isAgorInitialized, isInstalledPackage } from '../../lib/context.js';
-import { startDaemon } from '../../lib/daemon-manager.js';
 
 export default class DaemonStart extends Command {
-  static description = 'Start daemon in background';
+  static description = 'Start daemon with config-aware boot (services, resources)';
 
   static examples = [
-    '<%= config.bin %> <%= command.id %>',
-    '<%= config.bin %> <%= command.id %> --foreground',
+    '<%= config.bin %> daemon start',
+    '<%= config.bin %> daemon start --config /etc/agor/config.yaml',
   ];
 
   static flags = {
-    foreground: Flags.boolean({
-      char: 'f',
-      description: 'Run daemon in foreground (synchronous)',
-      default: false,
+    config: Flags.string({
+      char: 'c',
+      description: 'Path to config file (default: ~/.agor/config.yaml)',
     }),
   };
 
   async run(): Promise<void> {
     const { flags } = await this.parse(DaemonStart);
 
-    // Check if running in production mode
-    if (!isInstalledPackage()) {
-      this.log(chalk.red('✗ Daemon lifecycle commands only work in production mode.'));
-      this.log('');
-      this.log(chalk.bold('In development, start the daemon with:'));
-      this.log(`  ${chalk.cyan('cd apps/agor-daemon && pnpm dev')}`);
-      this.log('');
-      this.exit(1);
-    }
+    // 1. Load config
+    const config = flags.config ? await this.loadConfigFromPath(flags.config) : await loadConfig();
 
-    // Check if Agor has been initialized
-    const initialized = await isAgorInitialized();
-    if (!initialized) {
-      this.log(chalk.red('✗ Agor is not initialized'));
-      this.log('');
-      this.log('Initialize Agor first with:');
-      this.log(`  ${chalk.cyan('agor init')}`);
-      this.log('');
-      this.exit(1);
-    }
-
-    // Get daemon binary path
-    const daemonPath = getDaemonPath();
-    if (!daemonPath) {
-      this.log(chalk.red('✗ Daemon binary not found'));
-      this.log('');
-      this.log('Your installation may be corrupted. Try reinstalling:');
-      this.log(`  ${chalk.cyan('npm install -g agor-live')}`);
-      this.log('');
-      this.exit(1);
-    }
-
-    // Check if daemon binary actually exists
-    const fs = await import('node:fs');
-    if (!fs.existsSync(daemonPath)) {
-      this.log(chalk.red('✗ Daemon binary not found'));
-      this.log('');
-      this.log(`Expected location: ${chalk.dim(daemonPath)}`);
-      this.log('');
-      this.log('Your installation may be corrupted. Try reinstalling:');
-      this.log(`  ${chalk.cyan('npm install -g agor-live')}`);
-      this.log('');
-      this.exit(1);
-    }
-
-    // Check for pending migrations before starting daemon
-    try {
-      const dbUrl = getDatabaseUrl();
-      const db = createDatabase({ url: dbUrl });
-      const migrationStatus = await checkMigrationStatus(db);
-
-      if (migrationStatus.hasPending) {
-        const dbFilePath = extractDbFilePath(dbUrl);
-
-        this.log(chalk.red('✗ Database migrations required'));
-        this.log('');
-        this.log(`Pending migrations (${migrationStatus.pending.length}):`);
-        for (const migration of migrationStatus.pending) {
-          this.log(`  ${chalk.yellow('•')} ${migration}`);
+    // 2. Validate services config early (fail fast before boot)
+    if (config.services) {
+      const tierViolations = validateAllowedTiers(config.services);
+      if (tierViolations.length > 0) {
+        this.log(chalk.red('Services configuration error:'));
+        for (const v of tierViolations) {
+          this.log(
+            chalk.red(`  '${v.group}' cannot be '${v.tier}' (allowed: ${v.allowed.join(', ')})`)
+          );
         }
-        this.log('');
-        this.log(chalk.bold('⚠️  IMPORTANT: Backup your database before running migrations!'));
-        this.log('');
-        this.log('Backup command:');
-        this.log(chalk.cyan(`  cp ${dbFilePath} ${dbFilePath}.backup-$(date +%s)`));
-        this.log('');
-        this.log('Then run migrations with:');
-        this.log(`  ${chalk.cyan('agor db migrate')}`);
-        this.log('');
         this.exit(1);
       }
-    } catch (error) {
-      // Rethrow if this is an exit error (so we don't continue starting daemon)
-      if (error && typeof error === 'object' && 'oclif' in error) {
-        throw error;
+
+      const depViolations = validateServiceDependencies(config.services);
+      if (depViolations.length > 0) {
+        this.log(chalk.yellow('Service dependency warnings (will be auto-promoted at boot):'));
+        for (const v of depViolations) {
+          this.log(
+            chalk.yellow(
+              `  '${v.service}' requires '${v.dependency}' to be at least '${v.requiredTier}'`
+            )
+          );
+        }
       }
-      // Otherwise log warning and continue (for actual migration check errors)
-      console.warn('Warning: Could not check migration status:', error);
     }
 
-    // Check if already running
-    const daemonUrl = await getDaemonUrl();
-    const running = await isDaemonRunning(daemonUrl);
+    // 3. Start daemon in-process
+    this.log(chalk.bold('Starting Agor daemon...'));
 
-    if (running) {
-      this.log(chalk.yellow('⚠ Daemon is already running'));
-      this.log('');
-      this.log('Check status with:');
-      this.log(`  ${chalk.cyan('agor daemon status')}`);
-      this.log('');
-      this.exit(0);
+    if (config.services) {
+      const nonDefault = Object.entries(config.services).filter(
+        ([, tier]) => tier !== undefined && tier !== 'on'
+      );
+      if (nonDefault.length > 0) {
+        this.log(chalk.dim(`  Services: ${nonDefault.map(([g, t]) => `${g}=${t}`).join(', ')}`));
+      }
     }
+
+    this.log('');
 
     try {
-      if (flags.foreground) {
-        // Foreground mode: run daemon inline (blocking)
-        this.log(chalk.green('Starting daemon in foreground mode...'));
-        this.log(chalk.dim(`URL: ${daemonUrl}`));
-        this.log(chalk.dim('Press Ctrl+C to stop'));
-        this.log('');
-
-        const { spawn } = await import('node:child_process');
-
-        // Start daemon as foreground process (inherits stdio)
-        const child = spawn('node', [daemonPath], {
-          stdio: 'inherit',
-          env: {
-            ...process.env,
-            NODE_ENV: 'production',
-          },
-        });
-
-        // Wait for child to exit
-        await new Promise<void>((resolve, reject) => {
-          child.on('exit', (code) => {
-            if (code === 0) {
-              resolve();
-            } else {
-              reject(new Error(`Daemon exited with code ${code}`));
-            }
-          });
-
-          child.on('error', reject);
-        });
-      } else {
-        // Background mode: start detached daemon
-        const pid = startDaemon(daemonPath);
-
-        this.log(chalk.green('✓ Daemon started successfully'));
-        this.log('');
-        this.log(`  PID: ${chalk.cyan(String(pid))}`);
-        this.log(`  URL: ${chalk.cyan(daemonUrl)}`);
-        this.log('');
-        this.log('View logs with:');
-        this.log(`  ${chalk.cyan('agor daemon logs')}`);
-        this.log('');
-
-        // Wait for daemon to fully boot (including migrations if fresh install)
-        // Try multiple times with exponential backoff
-        let isRunning = false;
-        const maxAttempts = 5;
-        for (let attempt = 0; attempt < maxAttempts; attempt++) {
-          const waitTime = 1000 * (attempt + 1); // 1s, 2s, 3s, 4s, 5s
-          await new Promise((resolve) => setTimeout(resolve, waitTime));
-
-          isRunning = await isDaemonRunning(daemonUrl);
-          if (isRunning) break;
-        }
-
-        if (!isRunning) {
-          this.log(chalk.yellow('⚠ Daemon started but not responding'));
-          this.log('');
-          this.log('Check logs for errors:');
-          this.log(`  ${chalk.cyan('agor daemon logs')}`);
-          this.log('');
-        }
-      }
+      const { startDaemon } = await import('@agor/daemon');
+      await startDaemon({ config });
     } catch (error) {
-      this.log(chalk.red('✗ Failed to start daemon'));
-      this.log('');
-      this.log(`Error: ${(error as Error).message}`);
-      this.log('');
+      this.log(chalk.red('Failed to start daemon:'));
+      this.log(chalk.red(`  ${error instanceof Error ? error.message : String(error)}`));
+      this.exit(1);
+    }
+  }
+
+  private async loadConfigFromPath(configPath: string): Promise<AgorConfig> {
+    try {
+      return await loadConfigFromFile(configPath);
+    } catch (error) {
+      this.log(chalk.red(`Failed to load config from ${configPath}:`));
+      this.log(chalk.red(`  ${error instanceof Error ? error.message : String(error)}`));
       this.exit(1);
     }
   }

--- a/apps/agor-cli/src/commands/daemon/start.ts
+++ b/apps/agor-cli/src/commands/daemon/start.ts
@@ -8,11 +8,13 @@
  * Compose with sync: `agor daemon sync --config ... && agor daemon start --config ...`
  */
 
+import { pathToFileURL } from 'node:url';
 import type { AgorConfig } from '@agor/core/config';
 import { loadConfig, loadConfigFromFile } from '@agor/core/config';
 import { validateAllowedTiers, validateServiceDependencies } from '@agor/core/types';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
+import { getDaemonModulePath, isInstalledPackage } from '../../lib/context.js';
 
 export default class DaemonStart extends Command {
   static description = 'Start daemon with config-aware boot (services, resources)';
@@ -76,7 +78,10 @@ export default class DaemonStart extends Command {
     this.log('');
 
     try {
-      const { startDaemon } = await import('@agor/daemon');
+      const daemonModule = isInstalledPackage()
+        ? await import(pathToFileURL(this.getBundledDaemonModulePath()).href)
+        : await import('@agor/daemon');
+      const { startDaemon } = daemonModule;
       await startDaemon({ config });
     } catch (error) {
       this.log(chalk.red('Failed to start daemon:'));
@@ -93,5 +98,14 @@ export default class DaemonStart extends Command {
       this.log(chalk.red(`  ${error instanceof Error ? error.message : String(error)}`));
       this.exit(1);
     }
+  }
+
+  private getBundledDaemonModulePath(): string {
+    const daemonModulePath = getDaemonModulePath();
+    if (!daemonModulePath) {
+      this.log(chalk.red('Failed to locate bundled daemon module'));
+      this.exit(1);
+    }
+    return daemonModulePath;
   }
 }

--- a/apps/agor-cli/src/lib/context.ts
+++ b/apps/agor-cli/src/lib/context.ts
@@ -54,13 +54,36 @@ export function getDaemonPath(): string | null {
   const cliDistIndex = dirname.indexOf(`${path.sep}dist${path.sep}cli`);
   if (cliDistIndex === -1) {
     // Fallback: couldn't find dist/cli, use relative path
-    return path.resolve(dirname, '../../daemon/index.js');
+    return path.resolve(dirname, '../../daemon/main.js');
   }
 
   // Get package root (everything before /dist/cli)
   const packageRoot = dirname.substring(0, cliDistIndex);
 
   // Construct daemon path from package root
+  return path.join(packageRoot, 'dist', 'daemon', 'main.js');
+}
+
+/**
+ * Get path to bundled daemon module (library entrypoint for startDaemon import)
+ *
+ * @returns path to daemon module, or null if in development
+ */
+export function getDaemonModulePath(): string | null {
+  if (!isInstalledPackage()) {
+    // Development mode: use workspace package import
+    return null;
+  }
+
+  const dirname =
+    typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+  const cliDistIndex = dirname.indexOf(`${path.sep}dist${path.sep}cli`);
+  if (cliDistIndex === -1) {
+    return path.resolve(dirname, '../../daemon/index.js');
+  }
+
+  const packageRoot = dirname.substring(0, cliDistIndex);
   return path.join(packageRoot, 'dist', 'daemon', 'index.js');
 }
 

--- a/apps/agor-cli/tsup.config.ts
+++ b/apps/agor-cli/tsup.config.ts
@@ -22,5 +22,5 @@ export default defineConfig({
   clean: true,
   splitting: false,
   outDir: 'dist',
-  external: [/^@agor\/core/],
+  external: [/^@agor\/core/, /^@agor\/daemon/],
 });

--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -4,11 +4,18 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsup",
-    "dev": "concurrently -k -n core,daemon -c cyan,green \"pnpm --filter @agor/core dev\" \"./node_modules/.bin/tsx watch --clear-screen=false --ignore 'node_modules/**' src/index.ts\"",
-    "dev:daemon-only": "tsx watch --clear-screen=false --ignore 'node_modules/**' src/index.ts",
-    "start": "node dist/index.js",
+    "dev": "concurrently -k -n core,daemon -c cyan,green \"pnpm --filter @agor/core dev\" \"./node_modules/.bin/tsx watch --clear-screen=false --ignore 'node_modules/**' src/main.ts\"",
+    "dev:daemon-only": "tsx watch --clear-screen=false --ignore 'node_modules/**' src/main.ts",
+    "start": "node dist/main.js",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -20,7 +20,8 @@ import { patchConsole } from '@agor/core/utils/logger';
 
 patchConsole();
 
-import { loadConfig } from '@agor/core/config';
+import type { AgorConfig } from '@agor/core/config';
+import { loadConfig, loadConfigFromFile } from '@agor/core/config';
 import { getDatabaseUrl } from '@agor/core/db';
 import {
   authenticate,
@@ -83,10 +84,26 @@ process.on('unhandledRejection', (reason: unknown, _promise: Promise<unknown>) =
 });
 
 // ============================================================================
-// Main
+// Public API for programmatic startup
 // ============================================================================
 
-async function main() {
+/**
+ * Options for programmatic daemon startup (used by `agor daemon start` CLI command).
+ */
+export interface DaemonStartOptions {
+  /** Pre-loaded config (skips loadConfig()) */
+  config?: AgorConfig;
+  /** Path to config file (alternative to pre-loaded config) */
+  configPath?: string;
+}
+
+/**
+ * Start the Agor daemon programmatically.
+ *
+ * Called by `agor daemon start` CLI command with a pre-loaded config,
+ * or from main.ts with no args for direct execution.
+ */
+export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // Initialize Handlebars helpers for template rendering
   registerHandlebarsHelpers();
   console.log('✅ Handlebars helpers registered');
@@ -95,8 +112,12 @@ async function main() {
   process.env.GIT_TERMINAL_PROMPT = '0';
   process.env.GIT_ASKPASS = 'echo';
 
-  // Load config
-  const config = await loadConfig();
+  // Load config: CLI-provided > configPath > default loadConfig()
+  const config: AgorConfig = options?.config
+    ? options.config
+    : options?.configPath
+      ? await loadConfigFromFile(options.configPath)
+      : await loadConfig();
 
   // Resolve service tier configuration (validate deps, auto-promote)
   const servicesConfig = resolveServicesConfig(config.services);
@@ -171,7 +192,8 @@ async function main() {
   // Ports, daemon URL, credentials
   // --------------------------------------------------------------------------
   const envPort = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : undefined;
-  const DAEMON_PORT = envPort || config.daemon?.port || 3030;
+  const DAEMON_PORT = envPort ?? config.daemon?.port ?? 3030;
+  const DAEMON_HOST = config.daemon?.host ?? 'localhost';
 
   const envUiPort = process.env.UI_PORT ? Number.parseInt(process.env.UI_PORT, 10) : undefined;
   const UI_PORT = envUiPort || config.ui?.port || 5173;
@@ -406,6 +428,7 @@ async function main() {
     db,
     config,
     DAEMON_PORT,
+    DAEMON_HOST,
     svcEnabled,
     safeService,
     getSocketServer: socketIOConfig.getSocketServer,
@@ -413,9 +436,3 @@ async function main() {
     terminalsService: services.terminalsService,
   });
 }
-
-// Start the daemon
-main().catch((error) => {
-  console.error('Failed to start daemon:', error);
-  process.exit(1);
-});

--- a/apps/agor-daemon/src/main.ts
+++ b/apps/agor-daemon/src/main.ts
@@ -1,0 +1,13 @@
+/**
+ * Daemon entrypoint — starts the server.
+ *
+ * index.ts is a pure library that exports startDaemon().
+ * This file calls it for direct execution (pnpm dev, node dist/main.js).
+ */
+
+import { startDaemon } from './index.js';
+
+startDaemon().catch((error) => {
+  console.error('Failed to start daemon:', error);
+  process.exit(1);
+});

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -24,6 +24,8 @@ export interface StartupContext {
   db: Database;
   config: AgorConfig;
   DAEMON_PORT: number;
+  /** Bind address (default: 'localhost', use '0.0.0.0' for containers) */
+  DAEMON_HOST: string;
   svcEnabled: (group: string) => boolean;
   /** Safe service getter — returns undefined if service is not registered */
   // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service return type varies by path
@@ -170,6 +172,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     db,
     config,
     DAEMON_PORT,
+    DAEMON_HOST,
     svcEnabled,
     safeService,
     getSocketServer,
@@ -186,14 +189,17 @@ export async function startup(ctx: StartupContext): Promise<void> {
   await ensureMasterSecret(config);
 
   // 4. Start server
-  const server = await app.listen(DAEMON_PORT);
+  const server = await app.listen(DAEMON_PORT, DAEMON_HOST);
 
-  console.log(`🚀 Agor daemon running at http://localhost:${DAEMON_PORT}`);
-  console.log(`   Health: http://localhost:${DAEMON_PORT}/health`);
+  const displayHost = DAEMON_HOST === '0.0.0.0' ? 'localhost' : DAEMON_HOST;
+  console.log(
+    `🚀 Agor daemon running at http://${displayHost}:${DAEMON_PORT} (bound to ${DAEMON_HOST})`
+  );
+  console.log(`   Health: http://${displayHost}:${DAEMON_PORT}/health`);
   console.log(
     `   Authentication: ${config.daemon?.allowAnonymous !== false ? '🔓 Anonymous (default)' : '🔐 Required'}`
   );
-  console.log(`   Login: POST http://localhost:${DAEMON_PORT}/authentication`);
+  console.log(`   Login: POST http://${displayHost}:${DAEMON_PORT}/authentication`);
   console.log(`   Services:`);
   console.log(`     - /sessions`);
   console.log(`     - /tasks`);

--- a/packages/agor-live/bin/agor-daemon.js
+++ b/packages/agor-live/bin/agor-daemon.js
@@ -20,7 +20,7 @@ const { fileURLToPath } = await import('node:url');
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Daemon is bundled in dist/daemon relative to bin/
-const daemonPath = path.resolve(dirname, '../dist/daemon/index.js');
+const daemonPath = path.resolve(dirname, '../dist/daemon/main.js');
 
 // Import and run the daemon
 await import(daemonPath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       '@agor/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@agor/daemon':
+        specifier: workspace:*
+        version: link:../agor-daemon
       '@oclif/core':
         specifier: ^4.8.2
         version: 4.8.2

--- a/scripts/sync-agor-live-deps.mjs
+++ b/scripts/sync-agor-live-deps.mjs
@@ -16,7 +16,9 @@ const sourceManifests = [
   'packages/executor/package.json',
 ];
 
-const skipDeps = new Set(['@agor/core']);
+// Internal workspace packages are bundled/copied into agor-live dist.
+// They are not publishable npm dependencies and should not be synced into dependencies.
+const skipDeps = new Set(['@agor/core', '@agor/daemon']);
 const mode = process.argv.includes('--check') ? 'check' : 'write';
 
 const readJson = (relPath) => JSON.parse(readFileSync(resolve(repoRoot, relPath), 'utf8'));


### PR DESCRIPTION
## Summary

- Export `startDaemon(options?)` from daemon `index.ts` as public API for programmatic startup
- Create `main.ts` as the executable entrypoint (clean library/entrypoint separation)
- Rewrite CLI `daemon start` command to load config and call `startDaemon({ config })`
- Add `--config <path>` flag for custom config file path
- Add `DAEMON_HOST` support (`config.daemon.host`, defaults to `localhost`)
- Validate services config early (fail-fast on invalid tiers before boot)

## Design decisions

- **Config is the source of truth** — port/host set via `config.yaml` or `PORT` env var, no CLI flags for those
- **Clean library/entrypoint split** — `index.ts` exports `startDaemon()` (pure library), `main.ts` calls it (executable). No env var hacks to prevent auto-start.
- **Compose with sync** — no `--sync` flag; use `agor daemon sync && agor daemon start`

## Test plan

- [ ] `pnpm --filter @agor/daemon build` succeeds
- [ ] `pnpm --filter @agor/cli build` succeeds
- [ ] `pnpm check` passes (typecheck + lint + build)
- [ ] `pnpm dev` from `apps/agor-daemon` still works (uses `main.ts`)
- [ ] Importing `@agor/daemon` gives access to `startDaemon` without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)