### PR TITLE
API client quick wins: typed prompt helper, findAll, auth user typing, UUID input ergonomics

### DIFF
--- a/apps/agor-cli/src/commands/board/add-session.ts
+++ b/apps/agor-cli/src/commands/board/add-session.ts
@@ -38,10 +38,9 @@ export default class BoardAddSession extends BaseCommand {
 
     try {
       // Find board by ID or slug
-      const boardsResult = await client
+      const boards = (await client
         .service('boards')
-        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
-      const boards = (Array.isArray(boardsResult) ? boardsResult : boardsResult.data) as Board[];
+        .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })) as Board[];
 
       const board = boards.find(
         (b: Board) =>
@@ -56,12 +55,9 @@ export default class BoardAddSession extends BaseCommand {
       }
 
       // Find session by short or full ID
-      const sessionsResult = await client
+      const sessions = (await client
         .service('sessions')
-        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
-      const sessions = (
-        Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data
-      ) as Session[];
+        .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })) as Session[];
 
       const session = sessions.find(
         (s: Session) => s.session_id === args.sessionId || s.session_id.startsWith(args.sessionId)
@@ -78,12 +74,9 @@ export default class BoardAddSession extends BaseCommand {
         this.error('Session has no worktree associated');
       }
 
-      const worktreesResult = await client
+      const worktrees = (await client
         .service('worktrees')
-        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
-      const worktrees = (
-        Array.isArray(worktreesResult) ? worktreesResult : worktreesResult.data
-      ) as Worktree[];
+        .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })) as Worktree[];
 
       const worktree = worktrees.find((w: Worktree) => w.worktree_id === session.worktree_id);
 
@@ -93,15 +86,11 @@ export default class BoardAddSession extends BaseCommand {
       }
 
       // Check if worktree is already on the board
-      const boardObjectsResult = await client.service('board-objects').find({
+      const boardObjects = (await client.service('board-objects').findAll({
         query: {
           board_id: board.board_id,
         },
-      });
-
-      const boardObjects = (
-        Array.isArray(boardObjectsResult) ? boardObjectsResult : boardObjectsResult.data
-      ) as BoardEntityObject[];
+      })) as BoardEntityObject[];
 
       const existingObject = boardObjects.find(
         (bo: BoardEntityObject) => bo.worktree_id === worktree.worktree_id

--- a/apps/agor-cli/src/commands/board/list.ts
+++ b/apps/agor-cli/src/commands/board/list.ts
@@ -28,10 +28,9 @@ export default class BoardList extends BaseCommand {
 
     try {
       // Fetch all boards (high limit for accurate counts)
-      const result = await client
+      const allBoards = (await client
         .service('boards')
-        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
-      const allBoards = (Array.isArray(result) ? result : result.data) as Board[];
+        .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })) as Board[];
 
       if (allBoards.length === 0) {
         this.log(chalk.yellow('No boards found.'));
@@ -40,12 +39,9 @@ export default class BoardList extends BaseCommand {
       }
 
       // Fetch all board objects to count worktrees per board
-      const boardObjectsResult = await client
+      const boardObjects = (await client
         .service('board-objects')
-        .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } });
-      const boardObjects = (
-        Array.isArray(boardObjectsResult) ? boardObjectsResult : boardObjectsResult.data
-      ) as BoardEntityObject[];
+        .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })) as BoardEntityObject[];
 
       // Apply display limit
       const displayBoards = allBoards.slice(0, flags.limit);

--- a/apps/agor-cli/src/commands/mcp/list.ts
+++ b/apps/agor-cli/src/commands/mcp/list.ts
@@ -46,8 +46,7 @@ export default class McpList extends BaseCommand {
       if (flags.enabled) query.enabled = true;
 
       // Fetch MCP servers
-      const result = await client.service('mcp-servers').find({ query });
-      const servers = (Array.isArray(result) ? result : result.data) as MCPServer[];
+      const servers = (await client.service('mcp-servers').findAll({ query })) as MCPServer[];
 
       if (servers.length === 0) {
         this.log(chalk.yellow('No MCP servers found.'));

--- a/apps/agor-cli/src/commands/mcp/remove.ts
+++ b/apps/agor-cli/src/commands/mcp/remove.ts
@@ -40,10 +40,9 @@ export default class McpRemove extends BaseCommand {
 
       // If it looks like a name (not a UUID), try to find by name
       if (!args.id.match(/^[0-9a-f]{8}/i)) {
-        const result = await client.service('mcp-servers').find({
+        const servers = await client.service('mcp-servers').findAll({
           query: { $limit: 100 },
         });
-        const servers = Array.isArray(result) ? result : result.data;
         const server = servers.find((s: { name: string }) => s.name === args.id);
 
         if (!server) {

--- a/apps/agor-cli/src/commands/mcp/show.ts
+++ b/apps/agor-cli/src/commands/mcp/show.ts
@@ -34,10 +34,9 @@ export default class McpShow extends BaseCommand {
         server = (await client.service('mcp-servers').get(args.id)) as MCPServer;
       } catch {
         // If not found by ID, try to find by name
-        const result = await client.service('mcp-servers').find({
+        const servers = (await client.service('mcp-servers').findAll({
           query: { $limit: 1 },
-        });
-        const servers = (Array.isArray(result) ? result : result.data) as MCPServer[];
+        })) as MCPServer[];
         server = servers.find((s) => s.name === args.id) || null;
       }
 

--- a/apps/agor-cli/src/commands/repo/rm.ts
+++ b/apps/agor-cli/src/commands/repo/rm.ts
@@ -52,8 +52,7 @@ export default class RepoRm extends BaseCommand {
         repo = await reposService.get(args.id);
       } catch {
         // Try as slug
-        const result = await reposService.find({ query: { slug: args.id } });
-        const repos = Array.isArray(result) ? result : result.data;
+        const repos = await reposService.findAll({ query: { slug: args.id } });
 
         if (repos.length > 0) {
           repo = repos[0];

--- a/apps/agor-cli/src/commands/session/load-claude.ts
+++ b/apps/agor-cli/src/commands/session/load-claude.ts
@@ -88,8 +88,7 @@ export default class SessionLoadClaude extends BaseCommand {
       // Try to find existing repo by path
       let repo: { repo_id: UUID; slug: string } | null = null;
       try {
-        const allRepos = await reposService.find({ query: { $limit: 1000 } });
-        const reposList = Array.isArray(allRepos) ? allRepos : allRepos.data;
+        const reposList = await reposService.findAll({ query: { $limit: 1000 } });
         repo = reposList.find((r: Repo) => r.local_path === absoluteProjectDir) || null;
       } catch {
         // Ignore errors

--- a/apps/agor-cli/src/commands/user/delete.ts
+++ b/apps/agor-cli/src/commands/user/delete.ts
@@ -39,8 +39,7 @@ export default class UserDelete extends BaseCommand {
     try {
       // Find user by email or ID
       const usersService = client.service('users');
-      const result = await usersService.find();
-      const users = (Array.isArray(result) ? result : result.data) as User[];
+      const users = (await usersService.findAll()) as User[];
 
       const user = users.find(
         (u) => u.email === args.user || u.user_id === args.user || u.user_id.startsWith(args.user)

--- a/apps/agor-cli/src/commands/user/update.ts
+++ b/apps/agor-cli/src/commands/user/update.ts
@@ -56,8 +56,7 @@ export default class UserUpdate extends BaseCommand {
     try {
       // Find user by email or ID
       const usersService = client.service('users');
-      const result = await usersService.find();
-      const users = (Array.isArray(result) ? result : result.data) as User[];
+      const users = (await usersService.findAll()) as User[];
 
       const user = users.find(
         (u) => u.email === args.user || u.user_id === args.user || u.user_id.startsWith(args.user)

--- a/apps/agor-cli/src/commands/worktree/add.ts
+++ b/apps/agor-cli/src/commands/worktree/add.ts
@@ -72,15 +72,12 @@ export default class WorktreeAdd extends BaseCommand {
 
       // Check if worktree already exists (query worktrees table)
       const worktreesService = client.service('worktrees');
-      const existingWorktrees = await worktreesService.find({
+      const worktreesList = (await worktreesService.findAll({
         query: {
           repo_id: repo.repo_id,
           name: args.name,
         },
-      });
-      const worktreesList = (
-        Array.isArray(existingWorktrees) ? existingWorktrees : existingWorktrees.data
-      ) as Worktree[];
+      })) as Worktree[];
       if (worktreesList.length > 0) {
         this.error(`Worktree '${args.name}' already exists at ${worktreesList[0].path}`);
       }

--- a/apps/agor-cli/src/commands/worktree/archive.ts
+++ b/apps/agor-cli/src/commands/worktree/archive.ts
@@ -67,10 +67,9 @@ export default class WorktreeArchive extends BaseCommand {
       // Query sessions service for count
       const sessionsService = client.service('sessions');
       try {
-        const sessionsResult = await sessionsService.find({
+        const allSessions = await sessionsService.findAll({
           query: { worktree_id: worktree.worktree_id, $limit: 10000 },
         });
-        const allSessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
 
         if (allSessions.length > 0) {
           this.log(

--- a/apps/agor-cli/src/commands/worktree/list.ts
+++ b/apps/agor-cli/src/commands/worktree/list.ts
@@ -76,20 +76,14 @@ export default class WorktreeList extends BaseCommand {
 
       if (flags['repo-id']) {
         // Filter by repo ID
-        const worktreesResult = await worktreesService.find({
+        allWorktrees = (await worktreesService.findAll({
           query: { repo_id: flags['repo-id'], $limit: PAGINATION.DEFAULT_LIMIT },
-        });
-        allWorktrees = (
-          Array.isArray(worktreesResult) ? worktreesResult : worktreesResult.data
-        ) as Worktree[];
+        })) as Worktree[];
       } else {
         // Show all worktrees
-        const worktreesResult = await worktreesService.find({
+        allWorktrees = (await worktreesService.findAll({
           query: { $limit: PAGINATION.DEFAULT_LIMIT },
-        });
-        allWorktrees = (
-          Array.isArray(worktreesResult) ? worktreesResult : worktreesResult.data
-        ) as Worktree[];
+        })) as Worktree[];
       }
 
       // Filter by archive status
@@ -145,10 +139,9 @@ export default class WorktreeList extends BaseCommand {
 
       try {
         // Fetch all sessions (use high limit to get all for accurate counts)
-        const sessionsResult = await sessionsService.find({
+        const allSessions = await sessionsService.findAll({
           query: { $limit: PAGINATION.DEFAULT_LIMIT },
         });
-        const allSessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
 
         // Count sessions per worktree
         for (const session of allSessions) {

--- a/apps/agor-cli/src/commands/worktree/rm.ts
+++ b/apps/agor-cli/src/commands/worktree/rm.ts
@@ -54,10 +54,9 @@ export default class WorktreeRemove extends BaseCommand {
       // Query sessions service for count
       const sessionsService = client.service('sessions');
       try {
-        const sessionsResult = await sessionsService.find({
+        const allSessions = await sessionsService.findAll({
           query: { worktree_id: worktree.worktree_id, $limit: 10000 },
         });
-        const allSessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
 
         if (allSessions.length > 0) {
           this.log(

--- a/apps/agor-cli/src/commands/worktree/show.ts
+++ b/apps/agor-cli/src/commands/worktree/show.ts
@@ -103,10 +103,9 @@ export default class WorktreeShow extends BaseCommand {
       this.log(chalk.bold('Sessions:'));
       const sessionsService = client.service('sessions');
       try {
-        const sessionsResult = await sessionsService.find({
+        const allSessions = await sessionsService.findAll({
           query: { worktree_id: worktree.worktree_id, $limit: 10000 },
         });
-        const allSessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
 
         if (allSessions.length > 0) {
           this.log(`  ${chalk.cyan(allSessions.length.toString())} session(s)`);

--- a/apps/agor-cli/src/commands/worktree/unarchive.ts
+++ b/apps/agor-cli/src/commands/worktree/unarchive.ts
@@ -61,7 +61,7 @@ export default class WorktreeUnarchive extends BaseCommand {
       // Query sessions service for count
       const sessionsService = client.service('sessions');
       try {
-        const sessionsResult = await sessionsService.find({
+        const allSessions = await sessionsService.findAll({
           query: {
             worktree_id: worktree.worktree_id,
             archived: true,
@@ -69,7 +69,6 @@ export default class WorktreeUnarchive extends BaseCommand {
             $limit: 10000,
           },
         });
-        const allSessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
 
         if (allSessions.length > 0) {
           this.log(

--- a/apps/agor-docs/pages/api-reference/index.mdx
+++ b/apps/agor-docs/pages/api-reference/index.mdx
@@ -133,6 +133,97 @@ All services follow standard REST patterns:
 - `PATCH /service/:id` - Update item (partial)
 - `DELETE /service/:id` - Delete item
 
+## Session Prompt Endpoint
+
+Use `POST /sessions/:id/prompt` to send a prompt to an existing session.
+
+```bash
+curl -X POST http://localhost:3030/sessions/<session-id>/prompt \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-token>" \
+  -d '{
+    "prompt": "Review the latest auth changes for security issues",
+    "permissionMode": "auto",
+    "stream": true
+  }'
+```
+
+Possible response shapes:
+
+```json
+{
+  "success": true,
+  "taskId": "0195d3c0-82df-7a75-b9b3-83f58de12345",
+  "status": "running",
+  "streaming": true
+}
+```
+
+```json
+{
+  "success": true,
+  "queued": true,
+  "message": {
+    "message_id": "0195d3c0-82df-7a75-b9b3-83f58de67890",
+    "status": "queued"
+  },
+  "queue_position": 2
+}
+```
+
+## Message Content Shape
+
+Message `content` supports both plain text and structured blocks:
+
+- `string`
+- `ContentBlock[]`
+
+String content example:
+
+```json
+{
+  "role": "assistant",
+  "content": "Implemented the fix and added tests."
+}
+```
+
+Structured content example:
+
+```json
+{
+  "role": "assistant",
+  "content": [
+    { "type": "text", "text": "Implemented the fix." },
+    { "type": "thinking", "thinking": "Checking edge cases before final response." }
+  ]
+}
+```
+
+## Browser Client Quick Start
+
+```ts
+import { createClient } from '@agor/core/api';
+
+const client = createClient('http://localhost:3030', true);
+
+await client.authenticate({
+  strategy: 'jwt',
+  accessToken: '<your-token>',
+});
+
+const sessions = await client.service('sessions').findAll({
+  query: { $limit: 20 },
+});
+
+const promptResult = await client.sessions.prompt(
+  sessions[0].session_id,
+  'Summarize current progress and next steps',
+  { stream: true }
+);
+
+console.log(promptResult);
+```
+
 ## WebSocket Events
 
 Real-time updates via Socket.IO:

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -573,8 +573,7 @@ function AppContent() {
     if (!client) return;
 
     try {
-      await client.service(`sessions/${sessionId}/prompt`).create({
-        prompt,
+      await client.sessions.prompt(sessionId, prompt, {
         permissionMode,
         messageSource: 'agor',
       });

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -44,6 +44,7 @@ import { Tag } from '../Tag';
 import {
   ALWAYS_EXPANDED_TOOLS,
   deriveToolStatus,
+  IMPLICIT_RESULT_TOOLS,
   renderToolStatusIcon,
   ToolBlock,
 } from '../ToolBlock';
@@ -456,13 +457,14 @@ export const AgentChain = React.memo<AgentChainProps>(
       const isError = toolResult?.is_error;
       const displayName = resolveDisplayName(toolUse);
       const isAlwaysExpanded = ALWAYS_EXPANDED_TOOLS.has(toolUse.name);
+      const hasImplicitResult = IMPLICIT_RESULT_TOOLS.has(toolUse.name);
 
       // Derive status and icon via shared helper.
       // A tool is potentially still running when no subsequent tool in
       // this chain has a result AND this is the active (latest) chain.
       const isPotentiallyRunning = index > lastResultToolIndex && isLatest !== false;
       const status = deriveToolStatus({
-        hasResult: !!toolResult,
+        hasResult: !!toolResult || hasImplicitResult,
         isError: !!isError,
         isPotentiallyRunning,
         isTaskRunning,

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -325,13 +325,11 @@ export const AutocompleteTextarea = React.forwardRef<
         setIsLoading(true);
 
         try {
-          const result = await client.service('files').find({
+          const result = await client.service('files').findAll({
             query: { sessionId, search: searchQuery },
           });
 
-          setFileResults(
-            Array.isArray(result) ? (result as FileResult[]) : (result?.data as FileResult[]) || []
-          );
+          setFileResults(result as FileResult[]);
         } catch (error) {
           console.error('File search error:', error);
           setFileResults([]);

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -37,6 +37,7 @@ import { ThinkingBlock } from '../ThinkingBlock';
 import {
   ALWAYS_EXPANDED_TOOLS,
   deriveToolStatus,
+  IMPLICIT_RESULT_TOOLS,
   renderToolStatusIcon,
   ToolBlock,
 } from '../ToolBlock';
@@ -662,6 +663,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
             return toolBlocks.map(({ toolUse, toolResult }, toolIndex) => {
               const displayName = getToolDisplayName(toolUse.name, toolUse.input);
               const isAlwaysExpanded = ALWAYS_EXPANDED_TOOLS.has(toolUse.name);
+              const hasImplicitResult = IMPLICIT_RESULT_TOOLS.has(toolUse.name);
 
               // A tool is potentially still running when no subsequent tool in
               // this message has a result AND this is the latest message.
@@ -670,7 +672,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
               const isPotentiallyRunning = toolIndex > lastResultIndex && isLatestMessage;
 
               const status = deriveToolStatus({
-                hasResult: !!toolResult,
+                hasResult: !!toolResult || hasImplicitResult,
                 isError: !!toolResult?.is_error,
                 isPotentiallyRunning,
                 isTaskRunning,

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1610,8 +1610,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                           });
 
                           // Send prompt to new session
-                          await client.service(`sessions/${newSession.session_id}/prompt`).create({
-                            prompt: renderedPrompt,
+                          await client.sessions.prompt(newSession.session_id, renderedPrompt, {
                             messageSource: 'agor',
                           });
                         } catch (error) {
@@ -2562,8 +2561,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     }
 
                     // Send rendered prompt to session
-                    await client.service(`sessions/${sessionId}/prompt`).create({
-                      prompt: renderedPrompt,
+                    await client.sessions.prompt(sessionId, renderedPrompt, {
                       messageSource: 'agor',
                     });
                   } catch (error) {
@@ -2751,8 +2749,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 // Execute action
                 switch (action) {
                   case 'prompt': {
-                    await client.service(`sessions/${targetSessionId}/prompt`).create({
-                      prompt: renderedTemplate,
+                    await client.sessions.prompt(targetSessionId, renderedTemplate, {
                       permissionMode,
                       messageSource: 'agor',
                     });
@@ -2762,8 +2759,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     const forkedSession = (await client
                       .service(`sessions/${targetSessionId}/fork`)
                       .create({})) as Session;
-                    await client.service(`sessions/${forkedSession.session_id}/prompt`).create({
-                      prompt: renderedTemplate,
+                    await client.sessions.prompt(forkedSession.session_id, renderedTemplate, {
                       permissionMode,
                       messageSource: 'agor',
                     });
@@ -2773,8 +2769,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                     const spawnedSession = (await client
                       .service(`sessions/${targetSessionId}/spawn`)
                       .create({})) as Session;
-                    await client.service(`sessions/${spawnedSession.session_id}/prompt`).create({
-                      prompt: renderedTemplate,
+                    await client.sessions.prompt(spawnedSession.session_id, renderedTemplate, {
                       permissionMode,
                       messageSource: 'agor',
                     });

--- a/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
@@ -40,9 +40,8 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
     if (!client) return;
     setLoading(true);
     try {
-      const result = await client.service('api/v1/user/api-keys').find({});
-      // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service returns vary
-      setKeys(Array.isArray(result) ? result : (result as any).data || []);
+      const result = await client.service('api/v1/user/api-keys').findAll({});
+      setKeys(result as ApiKeyEntry[]);
     } catch (err) {
       console.error('Failed to fetch API keys:', err);
     } finally {

--- a/apps/agor-ui/src/components/ToolBlock/index.ts
+++ b/apps/agor-ui/src/components/ToolBlock/index.ts
@@ -2,6 +2,7 @@ export { ToolBlock, type ToolBlockProps } from './ToolBlock';
 export {
   ALWAYS_EXPANDED_TOOLS,
   deriveToolStatus,
+  IMPLICIT_RESULT_TOOLS,
   renderToolStatusIcon,
   type ToolStatus,
 } from './toolStatus';

--- a/apps/agor-ui/src/components/ToolBlock/toolStatus.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/toolStatus.tsx
@@ -14,6 +14,12 @@ export type ToolStatus = 'success' | 'error' | 'pending' | 'stale';
 /** Tools whose content is always shown expanded by default */
 export const ALWAYS_EXPANDED_TOOLS = new Set(['Edit', 'Write', 'edit', 'write', 'edit_files']);
 
+/**
+ * Tools whose invocation payload itself represents terminal state, even without
+ * a dedicated tool_result block.
+ */
+export const IMPLICIT_RESULT_TOOLS = new Set(['TodoWrite']);
+
 interface ToolStatusInput {
   /** Whether a tool result exists */
   hasResult: boolean;

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
@@ -1,7 +1,7 @@
 /**
  * TodoListRenderer - Custom renderer for TodoWrite tool
  *
- * Displays Claude Code's todo list with:
+ * Displays agent todo lists with:
  * - Visual checkboxes (✓ completed, □ in-progress, ○ pending)
  * - Status-aware coloring
  * - Clean, minimal design

--- a/apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx
@@ -66,8 +66,7 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
         setSelectedOwnerIds(ownersData.map((o) => o.user_id));
 
         // Load all users
-        const usersResponse = await client.service('users').find({});
-        const users = Array.isArray(usersResponse) ? usersResponse : usersResponse.data || [];
+        const users = await client.service('users').findAll({});
         setAllUsers(users);
         setRbacEnabled(true); // If we got here, RBAC is enabled
         // biome-ignore lint/suspicious/noExplicitAny: Error type from API client is not strongly typed

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/FilesTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/FilesTab.tsx
@@ -43,11 +43,9 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ worktree, client }) => {
         setLoading(true);
         setError(null);
 
-        const result = await client.service('file').find({
+        const data = await client.service('file').findAll({
           query: { worktree_id: worktree.worktree_id },
         });
-        const data = Array.isArray(result) ? result : result.data;
-
         setFiles(data as FileListItem[]);
       } catch (err) {
         console.error('Failed to fetch files:', err);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -97,64 +97,43 @@ export function useAgorData(
       // Fetch sessions, boards, board-objects, comments, repos, worktrees, users, mcp servers, session-mcp relationships in parallel
       // Tasks are fetched just-in-time via useTasks hook to avoid unnecessary global subscriptions
       const [
-        sessionsResult,
-        boardsResult,
-        boardObjectsResult,
-        commentsResult,
-        cardsResult,
-        cardTypesResult,
-        reposResult,
-        worktreesResult,
-        usersResult,
-        mcpServersResult,
-        sessionMcpResult,
-        gatewayChannelsResult,
-        artifactsResult,
+        sessionsList,
+        boardsList,
+        boardObjectsList,
+        commentsList,
+        cardsList,
+        cardTypesList,
+        reposList,
+        worktreesList,
+        usersList,
+        mcpServersList,
+        sessionMcpList,
+        gatewayChannelsList,
+        artifactsList,
         oauthStatusResult,
       ] = await Promise.all([
         client
           .service('sessions')
-          .find({ query: { $limit: PAGINATION.DEFAULT_LIMIT, $sort: { updated_at: -1 } } }),
-        client.service('boards').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('board-objects').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('board-comments').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('cards').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('card-types').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('repos').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('worktrees').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('users').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('mcp-servers').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('session-mcp-servers').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('gateway-channels').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-        client.service('artifacts').find({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+          .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT, $sort: { updated_at: -1 } } }),
+        client.service('boards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('board-objects').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('board-comments').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('cards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('card-types').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('repos').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('worktrees').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('users').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('mcp-servers').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client
+          .service('session-mcp-servers')
+          .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('gateway-channels').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+        client.service('artifacts').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
         client
           .service('mcp-servers/oauth-status')
           .find()
           .catch(() => ({ authenticated_server_ids: [] })),
       ]);
-
-      // Handle paginated vs array results
-      const sessionsList = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
-      const boardsList = Array.isArray(boardsResult) ? boardsResult : boardsResult.data;
-      const boardObjectsList = Array.isArray(boardObjectsResult)
-        ? boardObjectsResult
-        : boardObjectsResult.data;
-      const commentsList = Array.isArray(commentsResult) ? commentsResult : commentsResult.data;
-      const cardsList = Array.isArray(cardsResult) ? cardsResult : cardsResult.data;
-      const cardTypesList = Array.isArray(cardTypesResult) ? cardTypesResult : cardTypesResult.data;
-      const reposList = Array.isArray(reposResult) ? reposResult : reposResult.data;
-      const worktreesList = Array.isArray(worktreesResult) ? worktreesResult : worktreesResult.data;
-      const usersList = Array.isArray(usersResult) ? usersResult : usersResult.data;
-      const mcpServersList = Array.isArray(mcpServersResult)
-        ? mcpServersResult
-        : mcpServersResult.data;
-      const sessionMcpList = Array.isArray(sessionMcpResult)
-        ? sessionMcpResult
-        : sessionMcpResult.data;
-      const gatewayChannelsList = Array.isArray(gatewayChannelsResult)
-        ? gatewayChannelsResult
-        : gatewayChannelsResult.data;
-      const artifactsList = Array.isArray(artifactsResult) ? artifactsResult : artifactsResult.data;
 
       // Build session Maps for efficient lookups
       const sessionsById = new Map<string, Session>();

--- a/apps/agor-ui/src/hooks/useMessages.ts
+++ b/apps/agor-ui/src/hooks/useMessages.ts
@@ -40,7 +40,7 @@ export function useMessages(
       setLoading(true);
       setError(null);
 
-      const result = await client.service('messages').find({
+      const messagesList = await client.service('messages').findAll({
         query: {
           session_id: sessionId,
           $limit: PAGINATION.DEFAULT_LIMIT,
@@ -49,8 +49,6 @@ export function useMessages(
           },
         },
       });
-
-      const messagesList = Array.isArray(result) ? result : result.data;
       setMessages(messagesList);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch messages');

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -115,8 +115,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       // Send the prompt to the forked session to actually execute it
       // Skip if prompt is empty (allows forking without initial prompt)
       if (prompt.trim()) {
-        await client.service(`sessions/${forkedSession.session_id}/prompt`).create({
-          prompt,
+        await client.sessions.prompt(forkedSession.session_id, prompt, {
           messageSource: 'agor',
         });
       }
@@ -154,8 +153,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
 
       // Send the prompt to the forked session
       if (prompt.trim()) {
-        await client.service(`sessions/${forkedSession.session_id}/prompt`).create({
-          prompt,
+        await client.sessions.prompt(forkedSession.session_id, prompt, {
           messageSource: 'agor',
         });
       }
@@ -190,10 +188,11 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
         .create(config)) as Session;
 
       // Send the prompt to the spawned session to actually execute it
-      await client.service(`sessions/${spawnedSession.session_id}/prompt`).create({
-        prompt: config.prompt,
-        messageSource: 'agor',
-      });
+      if (config.prompt?.trim()) {
+        await client.sessions.prompt(spawnedSession.session_id, config.prompt, {
+          messageSource: 'agor',
+        });
+      }
 
       return spawnedSession;
     } catch (err) {

--- a/apps/agor-ui/src/hooks/useTaskMessages.ts
+++ b/apps/agor-ui/src/hooks/useTaskMessages.ts
@@ -46,7 +46,7 @@ export function useTaskMessages(
       setLoading(true);
       setError(null);
 
-      const result = await client.service('messages').find({
+      const messagesList = await client.service('messages').findAll({
         query: {
           task_id: taskId,
           $limit: PAGINATION.DEFAULT_LIMIT,
@@ -55,8 +55,6 @@ export function useTaskMessages(
           },
         },
       });
-
-      const messagesList = Array.isArray(result) ? result : result.data;
       setMessages(messagesList);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch messages');

--- a/apps/agor-ui/src/hooks/useTasks.ts
+++ b/apps/agor-ui/src/hooks/useTasks.ts
@@ -49,7 +49,7 @@ export function useTasks(
       setLoading(true);
       setError(null);
 
-      const result = await client.service('tasks').find({
+      const tasksList = await client.service('tasks').findAll({
         query: {
           session_id: sessionId,
           $limit: PAGINATION.DEFAULT_LIMIT,
@@ -58,8 +58,6 @@ export function useTasks(
           },
         },
       });
-
-      const tasksList = Array.isArray(result) ? result : result.data;
       setTasks(tasksList);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch tasks');

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -5,11 +5,13 @@
  * Does NOT test FeathersJS internals, Socket.io, or HTTP libraries.
  */
 
+import type { AuthenticationResult, Session } from '@agor/core/types';
 import authClient from '@feathersjs/authentication-client';
 import type { Socket } from 'socket.io-client';
 import io from 'socket.io-client';
 import { beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
-import { createClient, isDaemonRunning } from './index';
+import type { AgorService, UpdatePayload } from './index';
+import { createClient, isDaemonRunning, normalizeFindResult } from './index';
 
 // Mock socket.io-client
 vi.mock('socket.io-client', () => ({
@@ -18,12 +20,37 @@ vi.mock('socket.io-client', () => ({
 
 // Mock @feathersjs/feathers
 vi.mock('@feathersjs/feathers', () => ({
-  feathers: vi.fn(() => ({
-    configure: vi.fn(function (this: any, plugin: any) {
-      plugin.call(this);
-      return this;
-    }),
-  })),
+  feathers: vi.fn(() => {
+    const services = new Map<string, any>();
+
+    const createService = () => ({
+      find: vi.fn(),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      patch: vi.fn(),
+      remove: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      removeListener: vi.fn(),
+      emit: vi.fn(),
+      methods: vi.fn(),
+    });
+
+    return {
+      configure: vi.fn(function (this: any, plugin: any) {
+        plugin.call(this);
+        return this;
+      }),
+      service: vi.fn((path: string) => {
+        const existing = services.get(path);
+        if (existing) return existing;
+        const created = createService();
+        services.set(path, created);
+        return created;
+      }),
+    };
+  }),
 }));
 
 // Mock @feathersjs/socketio-client
@@ -137,7 +164,7 @@ describe('createClient', () => {
         expect.objectContaining({
           reconnection: true,
           reconnectionDelay: 1000,
-          reconnectionDelayMax: 2000,
+          reconnectionDelayMax: 5000,
           reconnectionAttempts: 2,
         })
       );
@@ -149,7 +176,7 @@ describe('createClient', () => {
       expect(ioMock).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          timeout: 2000,
+          timeout: 20000,
         })
       );
     });
@@ -411,6 +438,114 @@ describe('createClient', () => {
         expect.objectContaining({ autoConnect: false })
       );
     });
+  });
+
+  describe('service helpers', () => {
+    it('should normalize paginated find results via findAll()', async () => {
+      const client = createClient();
+      const sessionsService = client.service('sessions');
+
+      const findMock = sessionsService.find as unknown as MockedFunction<any>;
+      findMock.mockResolvedValue({
+        total: 2,
+        limit: 10,
+        skip: 0,
+        data: [{ session_id: 's1' }, { session_id: 's2' }],
+      });
+
+      const results = await sessionsService.findAll();
+
+      expect(results).toEqual([{ session_id: 's1' }, { session_id: 's2' }]);
+      expect(findMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return array find results unchanged via findAll()', async () => {
+      const client = createClient();
+      const sessionsService = client.service('sessions');
+
+      const findMock = sessionsService.find as unknown as MockedFunction<any>;
+      findMock.mockResolvedValue([{ session_id: 's1' }]);
+
+      const results = await sessionsService.findAll();
+
+      expect(results).toEqual([{ session_id: 's1' }]);
+      expect(findMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should expose sessions.prompt helper that calls /sessions/:id/prompt route', async () => {
+      const client = createClient();
+      const routeService = client.service('sessions/session-123/prompt');
+      const createMock = routeService.create as unknown as MockedFunction<any>;
+
+      createMock.mockResolvedValue({
+        success: true,
+        taskId: 'task-123',
+        status: 'running',
+        streaming: true,
+      });
+
+      const result = await client.sessions.prompt('session-123', 'Fix failing tests', {
+        permissionMode: 'auto',
+        stream: true,
+      });
+
+      expect(createMock).toHaveBeenCalledWith(
+        {
+          prompt: 'Fix failing tests',
+          permissionMode: 'auto',
+          stream: true,
+        },
+        undefined
+      );
+      expect(result).toEqual({
+        success: true,
+        taskId: 'task-123',
+        status: 'running',
+        streaming: true,
+      });
+    });
+  });
+});
+
+describe('normalizeFindResult', () => {
+  it('returns paginated data array', () => {
+    const result = normalizeFindResult({
+      total: 1,
+      limit: 10,
+      skip: 0,
+      data: [{ id: 1 }],
+    });
+
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it('returns plain array result unchanged', () => {
+    const result = normalizeFindResult([{ id: 1 }]);
+    expect(result).toEqual([{ id: 1 }]);
+  });
+});
+
+describe('type-level API ergonomics', () => {
+  it('accepts plain string IDs for create/patch/update payloads', () => {
+    type SessionCreateInput = Parameters<AgorService<Session>['create']>[0];
+    type SessionPatchInput = Exclude<Parameters<AgorService<Session>['patch']>[1], null>;
+    type SessionIdUpdateInput = UpdatePayload<Session>['session_id'];
+
+    const createPayload: SessionCreateInput = {
+      worktree_id: '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f',
+    };
+    const patchPayload: SessionPatchInput = { worktree_id: '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f' };
+    const updateId: SessionIdUpdateInput = '01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f';
+
+    expect(createPayload.worktree_id).toBeDefined();
+    expect(patchPayload.worktree_id).toBeDefined();
+    expect(typeof updateId).toBe('string');
+  });
+
+  it('uses concrete user typing for AuthenticationResult.user', () => {
+    type AuthUser = NonNullable<AuthenticationResult['user']>;
+    const getEmail = (user: AuthUser): string => user.email;
+    expect(typeof getEmail).toBe('function');
   });
 });
 

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -472,6 +472,37 @@ describe('createClient', () => {
       expect(findMock).toHaveBeenCalledTimes(1);
     });
 
+    it('should auto-paginate and return all rows via findAll()', async () => {
+      const client = createClient();
+      const sessionsService = client.service('sessions');
+
+      const findMock = sessionsService.find as unknown as MockedFunction<any>;
+      findMock
+        .mockResolvedValueOnce({
+          total: 3,
+          limit: 2,
+          skip: 0,
+          data: [{ session_id: 's1' }, { session_id: 's2' }],
+        })
+        .mockResolvedValueOnce({
+          total: 3,
+          limit: 2,
+          skip: 2,
+          data: [{ session_id: 's3' }],
+        });
+
+      const results = await sessionsService.findAll();
+
+      expect(results).toEqual([{ session_id: 's1' }, { session_id: 's2' }, { session_id: 's3' }]);
+      expect(findMock).toHaveBeenCalledTimes(2);
+      expect(findMock).toHaveBeenNthCalledWith(2, {
+        query: {
+          $skip: 2,
+          $limit: 2,
+        },
+      });
+    });
+
     it('should expose sessions.prompt helper that calls /sessions/:id/prompt route', async () => {
       const client = createClient();
       const routeService = client.service('sessions/session-123/prompt');

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -15,10 +15,12 @@ import type {
   ContextFileListItem,
   MCPServer,
   Message,
+  PermissionMode,
   Repo,
   Session,
   Task,
   User,
+  UUID,
   Worktree,
 } from '@agor/core/types';
 import authentication from '@feathersjs/authentication-client';
@@ -38,6 +40,67 @@ const DEFAULT_DAEMON_URL = `http://${DAEMON.DEFAULT_HOST}:${DAEMON.DEFAULT_PORT}
  * Using a symbol avoids clashing with existing service properties.
  */
 const BOARDS_SERVICE_EXTENDED = Symbol('agor.boardsServiceExtended');
+const SERVICE_FIND_ALL_EXTENDED = Symbol('agor.serviceFindAllExtended');
+const CLIENT_SERVICE_FACTORY_EXTENDED = Symbol('agor.clientServiceFactoryExtended');
+const CLIENT_SESSIONS_HELPERS_EXTENDED = Symbol('agor.clientSessionsHelpersExtended');
+
+/**
+ * Client-side input type helper:
+ * keeps strongly typed output models branded, while accepting plain strings
+ * for branded UUID fields in create/update/patch payloads.
+ */
+export type ClientInput<T> = T extends UUID
+  ? string
+  : T extends string & { readonly __brand: string }
+    ? string
+    : T extends readonly (infer U)[]
+      ? ClientInput<U>[]
+      : T extends (...args: unknown[]) => unknown
+        ? T
+        : T extends object
+          ? { [K in keyof T]: ClientInput<T[K]> }
+          : T;
+
+export type CreatePayload<T> = Partial<ClientInput<T>>;
+export type UpdatePayload<T> = ClientInput<T>;
+export type PatchPayload<T> = Partial<ClientInput<T>> | null;
+export type FindResult<T> = Paginated<T> | T[];
+
+export interface SessionPromptRequest {
+  prompt: string;
+  permissionMode?: PermissionMode;
+  stream?: boolean;
+  messageSource?: 'gateway' | 'agor';
+}
+
+export interface QueuedSessionPromptResult {
+  success: true;
+  queued: true;
+  message: Message;
+  queue_position: number;
+}
+
+export interface RunningSessionPromptResult {
+  success: true;
+  taskId: string;
+  status: string;
+  streaming: boolean;
+  queued?: false;
+}
+
+export type SessionPromptResult = QueuedSessionPromptResult | RunningSessionPromptResult;
+
+export interface SessionPromptOptions extends Omit<SessionPromptRequest, 'prompt'> {
+  params?: Params;
+}
+
+export interface SessionsClientHelpers {
+  prompt(
+    sessionId: string,
+    prompt: string,
+    options?: SessionPromptOptions
+  ): Promise<SessionPromptResult>;
+}
 
 /**
  * Service interfaces for type safety
@@ -60,13 +123,19 @@ export interface ServiceTypes {
 /**
  * Feathers service with find method properly typed and event emitter methods
  */
-export interface AgorService<T> {
+export interface AgorService<
+  T,
+  TCreate = CreatePayload<T>,
+  TUpdate = UpdatePayload<T>,
+  TPatch = PatchPayload<T>,
+> {
   // CRUD methods
-  find(params?: Params): Promise<Paginated<T> | T[]>;
+  find(params?: Params): Promise<FindResult<T>>;
+  findAll(params?: Params): Promise<T[]>;
   get(id: string, params?: Params): Promise<T>;
-  create(data: Partial<T>, params?: Params): Promise<T>;
-  update(id: string, data: T, params?: Params): Promise<T>;
-  patch(id: string | null, data: Partial<T> | null, params?: Params): Promise<T>;
+  create(data: TCreate, params?: Params): Promise<T>;
+  update(id: string, data: TUpdate, params?: Params): Promise<T>;
+  patch(id: string | null, data: TPatch, params?: Params): Promise<T>;
   remove(id: string, params?: Params): Promise<T>;
 
   // Event emitter methods (for real-time updates)
@@ -300,6 +369,7 @@ export interface WorktreesService extends AgorService<Worktree> {
  */
 export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   io: Socket;
+  sessions: SessionsClientHelpers;
 
   // Typed service overloads for services with custom methods
   service(path: 'sessions'): SessionsService;
@@ -451,6 +521,69 @@ function extendBoardsService(client: AgorClient): void {
   boardsService[BOARDS_SERVICE_EXTENDED] = true;
 }
 
+export function normalizeFindResult<T>(result: FindResult<T>): T[] {
+  return Array.isArray(result) ? result : result.data;
+}
+
+function extendFindAllOnService(service: AgorService<unknown>): void {
+  const findAllService = service as AgorService<unknown> & {
+    [SERVICE_FIND_ALL_EXTENDED]?: boolean;
+  };
+
+  if (findAllService[SERVICE_FIND_ALL_EXTENDED]) {
+    return;
+  }
+
+  findAllService.findAll = async (params?: Params) => {
+    const result = await service.find(params);
+    return normalizeFindResult(result);
+  };
+
+  findAllService[SERVICE_FIND_ALL_EXTENDED] = true;
+}
+
+function extendServiceFactory(client: AgorClient): void {
+  const augmentedClient = client as AgorClient & {
+    [CLIENT_SERVICE_FACTORY_EXTENDED]?: boolean;
+  };
+
+  if (augmentedClient[CLIENT_SERVICE_FACTORY_EXTENDED]) {
+    return;
+  }
+
+  const rawService = client.service.bind(client) as (path: string) => AgorService<unknown>;
+
+  augmentedClient.service = ((path: string) => {
+    const service = rawService(path);
+    extendFindAllOnService(service);
+    return service;
+  }) as AgorClient['service'];
+
+  augmentedClient[CLIENT_SERVICE_FACTORY_EXTENDED] = true;
+}
+
+function extendSessionsHelpers(client: AgorClient): void {
+  const augmentedClient = client as AgorClient & {
+    [CLIENT_SESSIONS_HELPERS_EXTENDED]?: boolean;
+  };
+
+  if (augmentedClient[CLIENT_SESSIONS_HELPERS_EXTENDED]) {
+    return;
+  }
+
+  client.sessions = {
+    prompt: async (sessionId: string, prompt: string, options?: SessionPromptOptions) => {
+      const { params, ...requestOptions } = options ?? {};
+      const response = await client
+        .service(`sessions/${sessionId}/prompt`)
+        .create({ prompt, ...requestOptions } as SessionPromptRequest, params);
+      return response as SessionPromptResult;
+    },
+  };
+
+  augmentedClient[CLIENT_SESSIONS_HELPERS_EXTENDED] = true;
+}
+
 /**
  * Create Feathers client connected to agor-daemon
  *
@@ -511,7 +644,9 @@ export async function createRestClient(
     io: { opts: {} },
   } as unknown as Socket;
 
+  extendServiceFactory(client);
   extendBoardsService(client);
+  extendSessionsHelpers(client);
 
   return client;
 }
@@ -584,7 +719,9 @@ export function createClient(
   client.configure(authentication({ storage }));
   client.io = socket;
 
+  extendServiceFactory(client);
   extendBoardsService(client);
+  extendSessionsHelpers(client);
 
   return client;
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -525,6 +525,15 @@ export function normalizeFindResult<T>(result: FindResult<T>): T[] {
   return Array.isArray(result) ? result : result.data;
 }
 
+function isPaginatedResult<T>(result: FindResult<T>): result is Paginated<T> {
+  return (
+    !Array.isArray(result) &&
+    typeof result === 'object' &&
+    result !== null &&
+    Array.isArray((result as Paginated<T>).data)
+  );
+}
+
 function extendFindAllOnService(service: AgorService<unknown>): void {
   const findAllService = service as AgorService<unknown> & {
     [SERVICE_FIND_ALL_EXTENDED]?: boolean;
@@ -535,8 +544,52 @@ function extendFindAllOnService(service: AgorService<unknown>): void {
   }
 
   findAllService.findAll = async (params?: Params) => {
-    const result = await service.find(params);
-    return normalizeFindResult(result);
+    const firstResult = await service.find(params);
+    if (!isPaginatedResult(firstResult)) {
+      return firstResult;
+    }
+
+    const allData = [...firstResult.data];
+    let total = firstResult.total;
+    let nextSkip = firstResult.skip + firstResult.data.length;
+    const pageLimit =
+      typeof firstResult.limit === 'number' && firstResult.limit > 0
+        ? firstResult.limit
+        : firstResult.data.length;
+
+    if (!Number.isFinite(total) || pageLimit <= 0) {
+      return allData;
+    }
+
+    const baseQuery =
+      params?.query && typeof params.query === 'object' ? { ...params.query } : undefined;
+
+    while (allData.length < total) {
+      const nextParams: Params = {
+        ...(params ?? {}),
+        query: {
+          ...(baseQuery ?? {}),
+          $skip: nextSkip,
+          $limit: pageLimit,
+        },
+      };
+
+      const nextResult = await service.find(nextParams);
+      if (!isPaginatedResult(nextResult)) {
+        allData.push(...nextResult);
+        break;
+      }
+
+      if (nextResult.data.length === 0) {
+        break;
+      }
+
+      allData.push(...nextResult.data);
+      nextSkip = nextResult.skip + nextResult.data.length;
+      total = nextResult.total;
+    }
+
+    return allData;
   };
 
   findAllService[SERVICE_FIND_ALL_EXTENDED] = true;

--- a/packages/core/src/types/feathers.ts
+++ b/packages/core/src/types/feathers.ts
@@ -310,8 +310,16 @@ export interface AuthenticationResult {
     /** Decoded JWT payload */
     payload?: Record<string, unknown>;
   };
-  /** Authenticated user (if available) */
-  user?: AuthenticatedUser;
+  /**
+   * Authenticated user (if available)
+   *
+   * Uses a concrete user shape instead of `unknown` to improve client ergonomics.
+   * Includes the guaranteed auth fields plus optional full user fields.
+   */
+  user?: AuthenticatedUser & {
+    name?: string;
+    emoji?: string;
+  };
   /** Additional fields from strategy */
   [key: string]: unknown;
 }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -9,6 +9,13 @@ import { CodexPromptService } from './prompt-service.js';
 
 // Track how many Codex instances were created (module-level state)
 let mockInstanceCount = 0;
+let mockStreamEvents: Array<Record<string, unknown>> = [];
+
+async function* streamMockEvents() {
+  for (const event of mockStreamEvents) {
+    yield event;
+  }
+}
 
 // Mock @agor/core/sdk to avoid spawning real Codex CLI processes
 vi.mock('@agor/core/sdk', () => {
@@ -25,7 +32,7 @@ vi.mock('@agor/core/sdk', () => {
       return {
         id: 'mock-thread-id',
         run: vi.fn(),
-        runStreamed: vi.fn().mockResolvedValue({ events: [] }),
+        runStreamed: vi.fn().mockResolvedValue({ events: streamMockEvents() }),
       };
     }
 
@@ -33,7 +40,7 @@ vi.mock('@agor/core/sdk', () => {
       return {
         id: threadId,
         run: vi.fn(),
-        runStreamed: vi.fn().mockResolvedValue({ events: [] }),
+        runStreamed: vi.fn().mockResolvedValue({ events: streamMockEvents() }),
       };
     }
   }
@@ -61,6 +68,7 @@ const mockDb = {} as any;
 describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
   beforeEach(() => {
     mockInstanceCount = 0;
+    mockStreamEvents = [];
     vi.clearAllMocks();
   });
 
@@ -226,5 +234,75 @@ describe('CodexPromptService - Todo normalization', () => {
     );
 
     expect(toolUse).toBeNull();
+  });
+
+  it('emits only one TodoWrite tool_complete when both item.updated and item.completed fire', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    // Avoid filesystem/config setup noise in this focused stream test
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
+    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-1',
+      worktree_id: 'worktree-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockWorktreesRepo.findById.mockResolvedValue({
+      worktree_id: 'worktree-1',
+      path: process.cwd(),
+    });
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'item.updated',
+        item: {
+          id: 'todo-1',
+          type: 'todo_list',
+          items: [{ text: 'Review API client changes', completed: false }],
+        },
+      },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'todo-1',
+          type: 'todo_list',
+          items: [{ text: 'Review API client changes', completed: false }],
+        },
+      },
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 10,
+          cached_input_tokens: 0,
+          output_tokens: 20,
+        },
+      },
+    ];
+
+    const emitted: Array<{ type: string; toolUse?: { name?: string } }> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'review')) {
+      emitted.push(event as { type: string; toolUse?: { name?: string } });
+    }
+
+    const todoCompletions = emitted.filter(
+      (event) => event.type === 'tool_complete' && event.toolUse?.name === 'TodoWrite'
+    );
+    expect(todoCompletions).toHaveLength(1);
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -10,9 +10,9 @@ import { CodexPromptService } from './prompt-service.js';
 // Track how many Codex instances were created (module-level state)
 let mockInstanceCount = 0;
 
-// Mock @openai/codex-sdk to avoid spawning real processes
-vi.mock('@openai/codex-sdk', () => {
-  class MockCodex {
+// Mock @agor/core/sdk to avoid spawning real Codex CLI processes
+vi.mock('@agor/core/sdk', () => {
+  class MockCodexClient {
     apiKey: string;
     instanceId: number;
 
@@ -39,7 +39,9 @@ vi.mock('@openai/codex-sdk', () => {
   }
 
   return {
-    Codex: MockCodex,
+    Codex: {
+      Codex: MockCodexClient,
+    },
   };
 });
 
@@ -150,5 +152,79 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     // Call with actual key - should create new instance
     serviceWithPrivate.refreshClient('new-key');
     expect(mockInstanceCount).toBe(countAfterInit + 1);
+  });
+});
+
+describe('CodexPromptService - Todo normalization', () => {
+  it('maps codex todo_list to TodoWrite-compatible payload with inferred in_progress', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'todo-1',
+        type: 'todo_list',
+        items: [
+          { text: 'Completed step', completed: true },
+          { text: 'Current step', completed: false },
+          { text: 'Next step', completed: false },
+        ],
+      },
+      'completed'
+    );
+
+    expect(toolUse).toEqual({
+      id: 'todo-1',
+      name: 'TodoWrite',
+      input: {
+        todos: [
+          {
+            content: 'Completed step',
+            activeForm: 'Completed step',
+            status: 'completed',
+          },
+          {
+            content: 'Current step',
+            activeForm: 'Current step',
+            status: 'in_progress',
+          },
+          {
+            content: 'Next step',
+            activeForm: 'Next step',
+            status: 'pending',
+          },
+        ],
+      },
+    });
+  });
+
+  it('returns null for empty todo_list', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'todo-empty',
+        type: 'todo_list',
+        items: [],
+      },
+      'completed'
+    );
+
+    expect(toolUse).toBeNull();
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -498,6 +498,35 @@ export class CodexPromptService {
   }
 
   /**
+   * Convert Codex todo_list items to TodoWrite-compatible payload.
+   * Codex only provides completed:boolean, so we infer a single in_progress
+   * item as the first remaining incomplete step for better UI parity.
+   */
+  private codexTodosToTodoWriteInput(
+    items: Array<{ text: string; completed: boolean }>
+  ): Record<string, unknown> | null {
+    if (!Array.isArray(items) || items.length === 0) {
+      return null;
+    }
+
+    const firstIncompleteIndex = items.findIndex((todo) => !todo.completed);
+
+    return {
+      todos: items.map((todo, index) => ({
+        content: todo.text,
+        activeForm: todo.text,
+        status: todo.completed
+          ? 'completed'
+          : firstIncompleteIndex === -1
+            ? 'pending'
+            : index === firstIncompleteIndex
+              ? 'in_progress'
+              : 'pending',
+      })),
+    };
+  }
+
+  /**
    * Convert Codex item to ToolUse format
    * Maps different Codex item types to Agor tool use schema
    */
@@ -554,9 +583,15 @@ export class CodexPromptService {
       case 'reasoning':
         // Don't emit tool use for reasoning (it's internal)
         return null;
-      case 'todo_list':
-        // Don't emit tool use for todo list (it's internal)
-        return null;
+      case 'todo_list': {
+        const todoInput = this.codexTodosToTodoWriteInput(item.items);
+        if (!todoInput) return null;
+        return {
+          id: item.id,
+          name: 'TodoWrite',
+          input: todoInput,
+        };
+      }
       case 'agent_message':
         // Don't emit tool use for text messages
         return null;
@@ -831,10 +866,19 @@ export class CodexPromptService {
             break;
 
           case 'item.updated':
-            // NOTE: Based on official OpenAI sample, item.updated is only emitted for todo_list items
-            // agent_message, reasoning, command_execution, file_change only emit item.started/item.completed
-            // We could handle todo_list progress here if needed in the future
-            // For now, we ignore item.updated since we don't track todo lists
+            // Codex emits item.updated for todo_list progress updates.
+            // Normalize these into TodoWrite-style tool events so the UI can
+            // reuse the same sticky todo rendering as Claude Code.
+            if (event.item) {
+              const toolUseUpdate = this.itemToToolUse(event.item, 'completed');
+              if (toolUseUpdate?.name === 'TodoWrite') {
+                yield {
+                  type: 'tool_complete',
+                  toolUse: toolUseUpdate,
+                  threadId: thread.id || undefined,
+                };
+              }
+            }
             break;
 
           case 'item.completed':

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -827,6 +827,7 @@ export class CodexPromptService {
       let threadId = session.sdk_session_id || '';
       const resolvedModel: string | undefined = session.model_config?.model || undefined;
       let allToolUses: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
+      let todoIdsEmittedViaUpdate = new Set<string>();
 
       let eventCount = 0;
 
@@ -849,6 +850,7 @@ export class CodexPromptService {
         switch (event.type) {
           case 'turn.started':
             allToolUses = []; // Reset tool uses for new turn
+            todoIdsEmittedViaUpdate = new Set<string>();
             break;
 
           case 'item.started':
@@ -872,6 +874,7 @@ export class CodexPromptService {
             if (event.item) {
               const toolUseUpdate = this.itemToToolUse(event.item, 'completed');
               if (toolUseUpdate?.name === 'TodoWrite') {
+                todoIdsEmittedViaUpdate.add(toolUseUpdate.id);
                 yield {
                   type: 'tool_complete',
                   toolUse: toolUseUpdate,
@@ -887,6 +890,10 @@ export class CodexPromptService {
               // Emit tool_complete for tool items
               const toolUseComplete = this.itemToToolUse(event.item, 'completed');
               if (toolUseComplete) {
+                const isDuplicateTodoCompletion =
+                  event.item.type === 'todo_list' &&
+                  todoIdsEmittedViaUpdate.has(toolUseComplete.id);
+
                 // Add to allToolUses for backward compatibility (tool_uses field)
                 allToolUses.push({
                   id: toolUseComplete.id,
@@ -921,11 +928,13 @@ export class CodexPromptService {
                   });
                 }
 
-                yield {
-                  type: 'tool_complete',
-                  toolUse: toolUseComplete,
-                  threadId: thread.id || undefined,
-                };
+                if (!isDuplicateTodoCompletion) {
+                  yield {
+                    type: 'tool_complete',
+                    toolUse: toolUseComplete,
+                    threadId: thread.id || undefined,
+                  };
+                }
               }
 
               // Emit intermediate text messages immediately (instead of batching to turn end)


### PR DESCRIPTION
## Summary
- allow plain `string` values for branded UUID fields on client create/update/patch inputs while preserving branded IDs in server/output types
- add typed `client.sessions.prompt(sessionId, prompt, options?)` wrapper for `POST /sessions/:id/prompt`
- add `findAll()` and result-normalization helper so callers can consistently receive `T[]` instead of handling `Paginated<T> | T[]`
- type `AuthenticationResult.user` to concrete user shape (no longer `unknown`)
- update API docs with prompt route usage, `message.content` as `string | ContentBlock[]`, and browser getting-started snippet
- migrate frontend and CLI call sites to use the new client helpers where applicable

## Testing
- `pnpm check`
- `pnpm --filter @agor/core test -- src/api/index.test.ts`
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter agor-ui typecheck`
- `pnpm exec biome check apps/agor-ui/src/App.tsx apps/agor-ui/src/hooks/useSessionActions.ts apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx apps/agor-ui/src/hooks/useMessages.ts apps/agor-ui/src/hooks/useTasks.ts apps/agor-ui/src/hooks/useTaskMessages.ts apps/agor-ui/src/hooks/useAgorData.ts apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx apps/agor-ui/src/components/WorktreeModal/tabs/FilesTab.tsx apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx apps/agor-cli/src/commands/board/add-session.ts apps/agor-cli/src/commands/board/list.ts apps/agor-cli/src/commands/mcp/list.ts apps/agor-cli/src/commands/mcp/remove.ts apps/agor-cli/src/commands/mcp/show.ts apps/agor-cli/src/commands/repo/rm.ts apps/agor-cli/src/commands/session/load-claude.ts apps/agor-cli/src/commands/user/delete.ts apps/agor-cli/src/commands/user/update.ts apps/agor-cli/src/commands/worktree/add.ts apps/agor-cli/src/commands/worktree/archive.ts apps/agor-cli/src/commands/worktree/list.ts apps/agor-cli/src/commands/worktree/rm.ts apps/agor-cli/src/commands/worktree/show.ts apps/agor-cli/src/commands/worktree/unarchive.ts packages/core/src/api/index.ts packages/core/src/api/index.test.ts packages/core/src/types/feathers.ts`

## Follow-up
- consider normalizing `*_id` naming ergonomics by introducing typed aliases/helpers (`sessionId`, `worktreeId`) at client boundaries without changing wire format
