### PR TITLE
Fix Codex edit_files diff mapping to show true before/after

### DIFF
--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EditFilesRenderer } from './EditFilesRenderer';
+
+describe('EditFilesRenderer', () => {
+  it('renders structured diff output for Codex edit_files when diff enrichment is present', () => {
+    render(
+      <EditFilesRenderer
+        toolUseId="tool-edit-files-1"
+        input={{
+          changes: [{ path: 'src/example.ts', kind: 'update' }],
+        }}
+        result={{
+          content: '[completed]',
+          diff: {
+            structuredPatch: [
+              {
+                oldStart: 1,
+                oldLines: 1,
+                newStart: 1,
+                newLines: 1,
+                lines: ['-const value = "old";', '+const value = "new";'],
+              },
+            ],
+            files: [
+              {
+                path: 'src/example.ts',
+                kind: 'update',
+                structuredPatch: [
+                  {
+                    oldStart: 1,
+                    oldLines: 1,
+                    newStart: 1,
+                    newLines: 1,
+                    lines: ['-const value = "old";', '+const value = "new";'],
+                  },
+                ],
+              },
+            ],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Update')).toBeInTheDocument();
+    expect(screen.getByText('src/example.ts')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'const value = "old";')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'const value = "new";')
+    ).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.getByText('-1')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditRenderer.test.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditRenderer.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EditRenderer } from './EditRenderer';
+
+describe('EditRenderer', () => {
+  it('renders Claude-style old/new input as an inline update diff', () => {
+    render(
+      <EditRenderer
+        toolUseId="tool-edit-1"
+        input={{
+          file_path: 'src/claude.ts',
+          old_string: 'hello',
+          new_string: 'world',
+        }}
+        result={{
+          content: 'ok',
+        }}
+      />
+    );
+
+    expect(screen.getByText('Update')).toBeInTheDocument();
+    expect(screen.getByText('src/claude.ts')).toBeInTheDocument();
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.getByText('world')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/vitest.config.ts
+++ b/apps/agor-ui/vitest.config.ts
@@ -1,8 +1,14 @@
+import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -127,6 +127,76 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('-const removed = true;'))).toBe(true);
   });
 
+  it('enriches Codex edit_files add operations with relative paths', () => {
+    const repoDir = createTempGitRepo();
+    const srcDir = path.join(repoDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+
+    fs.writeFileSync(path.join(repoDir, 'README.md'), '# test\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const newFilePath = path.join(srcDir, 'added.ts');
+    fs.writeFileSync(newFilePath, 'export const added = true;\n', 'utf-8');
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-add-1',
+        name: 'edit_files',
+        input: {
+          changes: [{ path: 'src/added.ts', kind: 'add' }],
+        },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-add-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    const toolResult = contentBlocks[1];
+    expect(toolResult.diff?.files).toHaveLength(1);
+    expect(toolResult.diff?.files?.[0]?.kind).toBe('add');
+    const lines = toolResult.diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('+export const added = true;'))).toBe(true);
+  });
+
+  it('skips unsafe relative paths when resolving git HEAD content', () => {
+    const repoDir = createTempGitRepo();
+    const srcDir = path.join(repoDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const filePath = path.join(srcDir, 'safe.ts');
+
+    fs.writeFileSync(filePath, 'const value = 1;\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+    fs.writeFileSync(filePath, 'const value = 2;\n', 'utf-8');
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-unsafe-1',
+        name: 'edit_files',
+        input: {
+          changes: [{ path: '../outside.ts', kind: 'update' }],
+        },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-unsafe-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    // Path resolves outside repo and should be ignored without enriching diff.
+    expect(contentBlocks[1].diff).toBeUndefined();
+  });
+
   it('preserves Claude split-message Edit enrichment behavior', () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'claude-edit.txt');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -71,7 +71,6 @@ describe('diff enrichment', () => {
         name: 'edit_files',
         input: {
           changes: [{ path: 'src/example.ts', kind: 'update' }],
-          working_directory: repoDir,
         },
       },
       {
@@ -81,7 +80,7 @@ describe('diff enrichment', () => {
       },
     ];
 
-    enrichContentBlocks(contentBlocks);
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
 
     const toolResult = contentBlocks[1];
     expect(toolResult.diff?.files).toHaveLength(1);
@@ -90,6 +89,42 @@ describe('diff enrichment', () => {
     const lines = toolResult.diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
     expect(lines.some((line) => line.includes('-const value = "old";'))).toBe(true);
     expect(lines.some((line) => line.includes('+const value = "new";'))).toBe(true);
+  });
+
+  it('enriches Codex edit_files delete operations with relative paths', () => {
+    const repoDir = createTempGitRepo();
+    const srcDir = path.join(repoDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const filePath = path.join(srcDir, 'delete-me.ts');
+
+    fs.writeFileSync(filePath, 'const removed = true;\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+    fs.rmSync(filePath);
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-delete-1',
+        name: 'edit_files',
+        input: {
+          changes: [{ path: 'src/delete-me.ts', kind: 'delete' }],
+        },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-delete-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    const toolResult = contentBlocks[1];
+    expect(toolResult.diff?.files).toHaveLength(1);
+    expect(toolResult.diff?.files?.[0]?.kind).toBe('delete');
+    const lines = toolResult.diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-const removed = true;'))).toBe(true);
   });
 
   it('preserves Claude split-message Edit enrichment behavior', () => {

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -1,0 +1,128 @@
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { enrichContentBlocks, enrichToolResults, registerToolUses } from './diff-enrichment.js';
+
+interface TestContentBlock {
+  type: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+  diff?: {
+    structuredPatch: Array<{
+      oldStart: number;
+      oldLines: number;
+      newStart: number;
+      newLines: number;
+      lines: string[];
+    }>;
+    files?: Array<{
+      path: string;
+      kind: 'add' | 'update' | 'delete';
+      structuredPatch: Array<{
+        oldStart: number;
+        oldLines: number;
+        newStart: number;
+        newLines: number;
+        lines: string[];
+      }>;
+    }>;
+  };
+}
+
+const tempDirs: string[] = [];
+
+function createTempGitRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-diff-enrichment-'));
+  tempDirs.push(dir);
+  execSync('git init', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.email "test@example.com"', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.name "Test User"', { cwd: dir, stdio: 'ignore' });
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('diff enrichment', () => {
+  it('enriches Codex edit_files updates with relative paths as true updates', () => {
+    const repoDir = createTempGitRepo();
+    const srcDir = path.join(repoDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const filePath = path.join(srcDir, 'example.ts');
+
+    fs.writeFileSync(filePath, 'const value = "old";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+    fs.writeFileSync(filePath, 'const value = "new";\n', 'utf-8');
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-1',
+        name: 'edit_files',
+        input: {
+          changes: [{ path: 'src/example.ts', kind: 'update' }],
+          working_directory: repoDir,
+        },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks);
+
+    const toolResult = contentBlocks[1];
+    expect(toolResult.diff?.files).toHaveLength(1);
+    expect(toolResult.diff?.files?.[0]?.path).toBe('src/example.ts');
+    expect(toolResult.diff?.files?.[0]?.kind).toBe('update');
+    const lines = toolResult.diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-const value = "old";'))).toBe(true);
+    expect(lines.some((line) => line.includes('+const value = "new";'))).toBe(true);
+  });
+
+  it('preserves Claude split-message Edit enrichment behavior', () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'claude-edit.txt');
+
+    // File is already in post-edit state when tool_result is enriched.
+    fs.writeFileSync(filePath, 'bar\n', 'utf-8');
+
+    registerToolUses([
+      {
+        id: 'tool-claude-edit-1',
+        name: 'Edit',
+        input: {
+          file_path: filePath,
+          old_string: 'foo\n',
+          new_string: 'bar\n',
+        },
+      },
+    ]);
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-claude-edit-1',
+        content: 'success',
+      },
+    ];
+
+    enrichToolResults(contentBlocks);
+
+    const lines = contentBlocks[0].diff?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-foo'))).toBe(true);
+    expect(lines.some((line) => line.includes('+bar'))).toBe(true);
+  });
+});

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -278,6 +278,8 @@ function enrichWriteResult(block: ContentBlock, input: Record<string, unknown>):
 function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknown>): void {
   const changes = input.changes as Array<{ path: string; kind: string }> | undefined;
   if (!changes || changes.length === 0) return;
+  const workingDirectory =
+    typeof input.working_directory === 'string' ? input.working_directory : undefined;
 
   // Find git root once for relative path resolution
   let gitRoot: string;
@@ -285,6 +287,7 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
     gitRoot = execSync('git rev-parse --show-toplevel', {
       encoding: 'utf-8',
       timeout: 5000,
+      ...(workingDirectory ? { cwd: workingDirectory } : {}),
     }).trim();
   } catch {
     return; // Not in a git repo or git unavailable
@@ -297,13 +300,16 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
 
     const kind = (change.kind || 'update') as 'add' | 'update' | 'delete';
     const filePath = change.path;
+    const resolvedPath = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(workingDirectory || gitRoot, filePath);
 
     try {
       if (kind === 'add') {
         // New file — all additions
-        const stat = fs.statSync(filePath);
+        const stat = fs.statSync(resolvedPath);
         if (stat.size > MAX_FILE_SIZE_BYTES) continue;
-        const content = fs.readFileSync(filePath, 'utf-8');
+        const content = fs.readFileSync(resolvedPath, 'utf-8');
         const patch = structuredPatch(filePath, filePath, '', content, '', '', {
           context: 0,
         });
@@ -312,10 +318,11 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
         }
       } else if (kind === 'delete') {
         // Deleted file — get old content from git
-        const relativePath = path.relative(gitRoot, filePath);
+        const relativePath = path.relative(gitRoot, resolvedPath);
         const oldContent = execSync(`git show HEAD:${relativePath}`, {
           encoding: 'utf-8',
           timeout: 5000,
+          cwd: gitRoot,
         });
         const patch = structuredPatch(filePath, filePath, oldContent, '', '', '', {
           context: CONTEXT_LINES,
@@ -325,15 +332,16 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
         }
       } else {
         // Update — diff git HEAD vs current file
-        const stat = fs.statSync(filePath);
+        const stat = fs.statSync(resolvedPath);
         if (stat.size > MAX_FILE_SIZE_BYTES) continue;
-        const currentContent = fs.readFileSync(filePath, 'utf-8');
-        const relativePath = path.relative(gitRoot, filePath);
+        const currentContent = fs.readFileSync(resolvedPath, 'utf-8');
+        const relativePath = path.relative(gitRoot, resolvedPath);
         let oldContent: string;
         try {
           oldContent = execSync(`git show HEAD:${relativePath}`, {
             encoding: 'utf-8',
             timeout: 5000,
+            cwd: gitRoot,
           });
         } catch {
           // File may be new (not in HEAD) — treat as addition

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -18,7 +18,7 @@
  *    to enrich adjacent tool_result blocks in one pass.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { FileDiff, StructuredPatchHunk } from '@agor/core/types';
@@ -35,6 +35,10 @@ const CONTEXT_LINES = 3;
 interface ToolUseInfo {
   name: string;
   input: Record<string, unknown>;
+}
+
+export interface DiffEnrichmentContext {
+  workingDirectory?: string;
 }
 
 interface ContentBlock {
@@ -113,7 +117,10 @@ export function enrichToolResults(contentBlocks: ContentBlock[]): void {
  * Used by Codex, OpenCode, and Gemini handlers.
  * Mutates content blocks in-place. Best-effort.
  */
-export function enrichContentBlocks(contentBlocks: ContentBlock[]): void {
+export function enrichContentBlocks(
+  contentBlocks: ContentBlock[],
+  context?: DiffEnrichmentContext
+): void {
   // Build local map from tool_use blocks in this array
   const localToolUses = new Map<string, ToolUseInfo>();
   for (const block of contentBlocks) {
@@ -134,7 +141,7 @@ export function enrichContentBlocks(contentBlocks: ContentBlock[]): void {
     const toolUse = localToolUses.get(toolUseId);
     if (!toolUse) continue;
 
-    enrichBlock(block, toolUse.name, toolUse.input);
+    enrichBlock(block, toolUse.name, toolUse.input, context);
   }
 }
 
@@ -149,7 +156,8 @@ export function enrichContentBlocks(contentBlocks: ContentBlock[]): void {
 function enrichBlock(
   block: ContentBlock,
   toolName: string,
-  toolInput: Record<string, unknown>
+  toolInput: Record<string, unknown>,
+  context?: DiffEnrichmentContext
 ): void {
   try {
     // Normalize tool names across SDKs (Claude: "Edit", Codex: "edit", etc.)
@@ -159,7 +167,7 @@ function enrichBlock(
     } else if (normalized === 'write') {
       enrichWriteResult(block, toolInput);
     } else if (normalized === 'edit_files') {
-      enrichEditFilesResult(block, toolInput);
+      enrichEditFilesResult(block, toolInput, context);
     }
   } catch {
     // Best effort — swallow any errors
@@ -275,11 +283,14 @@ function enrichWriteResult(block: ContentBlock, input: Record<string, unknown>):
  * No old/new content is provided — we reconstruct diffs by comparing
  * the current file (post-edit) against git HEAD.
  */
-function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknown>): void {
+function enrichEditFilesResult(
+  block: ContentBlock,
+  input: Record<string, unknown>,
+  context?: DiffEnrichmentContext
+): void {
   const changes = input.changes as Array<{ path: string; kind: string }> | undefined;
   if (!changes || changes.length === 0) return;
-  const workingDirectory =
-    typeof input.working_directory === 'string' ? input.working_directory : undefined;
+  const workingDirectory = context?.workingDirectory;
 
   // Find git root once for relative path resolution
   let gitRoot: string;
@@ -319,11 +330,8 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
       } else if (kind === 'delete') {
         // Deleted file — get old content from git
         const relativePath = path.relative(gitRoot, resolvedPath);
-        const oldContent = execSync(`git show HEAD:${relativePath}`, {
-          encoding: 'utf-8',
-          timeout: 5000,
-          cwd: gitRoot,
-        });
+        const oldContent = gitShowHeadFile(gitRoot, relativePath);
+        if (oldContent === null) continue;
         const patch = structuredPatch(filePath, filePath, oldContent, '', '', '', {
           context: CONTEXT_LINES,
         });
@@ -336,14 +344,8 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
         if (stat.size > MAX_FILE_SIZE_BYTES) continue;
         const currentContent = fs.readFileSync(resolvedPath, 'utf-8');
         const relativePath = path.relative(gitRoot, resolvedPath);
-        let oldContent: string;
-        try {
-          oldContent = execSync(`git show HEAD:${relativePath}`, {
-            encoding: 'utf-8',
-            timeout: 5000,
-            cwd: gitRoot,
-          });
-        } catch {
+        const oldContent = gitShowHeadFile(gitRoot, relativePath);
+        if (oldContent === null) {
           // File may be new (not in HEAD) — treat as addition
           const patch = structuredPatch(filePath, filePath, '', currentContent, '', '', {
             context: 0,
@@ -371,5 +373,31 @@ function enrichEditFilesResult(block: ContentBlock, input: Record<string, unknow
       structuredPatch: fileDiffs[0].structuredPatch,
       files: fileDiffs,
     };
+  }
+}
+
+function gitShowHeadFile(gitRoot: string, relativePath: string): string | null {
+  // Ensure the ref path is safe and uses git's forward-slash separator.
+  const normalized = path.posix.normalize(relativePath.split(path.sep).join('/'));
+  if (
+    !normalized ||
+    normalized.startsWith('/') ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('\0') ||
+    normalized.includes('\n') ||
+    normalized.includes('\r')
+  ) {
+    return null;
+  }
+
+  try {
+    return execFileSync('git', ['show', `HEAD:${normalized}`], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      cwd: gitRoot,
+    });
+  } catch {
+    return null;
   }
 }

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -53,6 +53,7 @@ export class CodexTool implements ITool {
   private promptService?: CodexPromptService;
   private messagesRepo?: MessagesRepository;
   private sessionsRepo?: SessionRepository;
+  private worktreesRepo?: WorktreeRepository;
   private messagesService?: MessagesService;
   private tasksService?: TasksService;
 
@@ -71,6 +72,7 @@ export class CodexTool implements ITool {
   ) {
     this.messagesRepo = messagesRepo;
     this.sessionsRepo = sessionsRepo;
+    this.worktreesRepo = worktreesRepo;
     this.messagesService = messagesService;
     this.tasksService = tasksService;
 
@@ -165,6 +167,15 @@ export class CodexTool implements ITool {
     let rawSdkResponse: unknown;
     let streamStarted = false; // tracks whether onStreamStart succeeded (for safe onStreamEnd)
     let wasStopped = false;
+    let workingDirectory: string | undefined;
+
+    if (this.sessionsRepo && this.worktreesRepo) {
+      const session = await this.sessionsRepo.findById(sessionId);
+      if (session) {
+        const worktree = await this.worktreesRepo.findById(session.worktree_id);
+        workingDirectory = worktree?.path;
+      }
+    }
 
     for await (const event of this.promptService.promptSessionStreaming(
       sessionId,
@@ -281,7 +292,7 @@ export class CodexTool implements ITool {
         ];
 
         // Best-effort diff enrichment for Edit/Write tool results
-        enrichContentBlocks(toolContent);
+        enrichContentBlocks(toolContent, { workingDirectory });
 
         await this.createAssistantMessage(
           sessionId,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -503,7 +503,8 @@ export class CodexPromptService {
    */
   private itemToToolUse(
     item: ThreadItem,
-    status: 'started' | 'completed'
+    status: 'started' | 'completed',
+    workingDirectory?: string
   ): {
     id: string;
     name: string;
@@ -528,6 +529,7 @@ export class CodexPromptService {
           name: 'edit_files',
           input: {
             changes: item.changes || [],
+            ...(workingDirectory ? { working_directory: workingDirectory } : {}),
           },
           ...(status === 'completed' && {
             status: item.status,
@@ -819,7 +821,7 @@ export class CodexPromptService {
           case 'item.started':
             // Emit tool_start events for tool items
             if (event.item) {
-              const toolUseStart = this.itemToToolUse(event.item, 'started');
+              const toolUseStart = this.itemToToolUse(event.item, 'started', worktree.path);
               if (toolUseStart) {
                 yield {
                   type: 'tool_start',
@@ -841,7 +843,7 @@ export class CodexPromptService {
             // Collect completed items and emit tool_complete events
             if (event.item) {
               // Emit tool_complete for tool items
-              const toolUseComplete = this.itemToToolUse(event.item, 'completed');
+              const toolUseComplete = this.itemToToolUse(event.item, 'completed', worktree.path);
               if (toolUseComplete) {
                 // Add to allToolUses for backward compatibility (tool_uses field)
                 allToolUses.push({

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -503,8 +503,7 @@ export class CodexPromptService {
    */
   private itemToToolUse(
     item: ThreadItem,
-    status: 'started' | 'completed',
-    workingDirectory?: string
+    status: 'started' | 'completed'
   ): {
     id: string;
     name: string;
@@ -529,7 +528,6 @@ export class CodexPromptService {
           name: 'edit_files',
           input: {
             changes: item.changes || [],
-            ...(workingDirectory ? { working_directory: workingDirectory } : {}),
           },
           ...(status === 'completed' && {
             status: item.status,
@@ -821,7 +819,7 @@ export class CodexPromptService {
           case 'item.started':
             // Emit tool_start events for tool items
             if (event.item) {
-              const toolUseStart = this.itemToToolUse(event.item, 'started', worktree.path);
+              const toolUseStart = this.itemToToolUse(event.item, 'started');
               if (toolUseStart) {
                 yield {
                   type: 'tool_start',
@@ -843,7 +841,7 @@ export class CodexPromptService {
             // Collect completed items and emit tool_complete events
             if (event.item) {
               // Emit tool_complete for tool items
-              const toolUseComplete = this.itemToToolUse(event.item, 'completed', worktree.path);
+              const toolUseComplete = this.itemToToolUse(event.item, 'completed');
               if (toolUseComplete) {
                 // Add to allToolUses for backward compatibility (tool_uses field)
                 allToolUses.push({


### PR DESCRIPTION
## Summary
- fix Codex `edit_files` diff enrichment to resolve relative paths correctly against the worktree
- pass worktree directory through Codex tool mapping so shared diff enrichment can compute real update diffs
- keep existing Claude diff behavior unchanged
- add regression tests for Codex edit_files + Claude edit diff enrichment
- add UI renderer tests for Codex EditFilesRenderer and Claude EditRenderer

## Validation
- `pnpm check` (pre-commit typecheck/lint passes; full build path still reports existing executor/core resolution issues in this worktree)
- `pnpm -C packages/executor test -- src/sdk-handlers/base/diff-enrichment.test.ts`
- `pnpm -C apps/agor-ui test -- src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx src/components/ToolUseRenderer/renderers/EditRenderer.test.tsx`
- `pnpm -C apps/agor-ui typecheck`
