### PR TITLE
Improve Codex event visibility and tool telemetry parity

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -485,6 +485,28 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
+  registerAuthenticatedRoute(
+    app,
+    '/tasks/streaming',
+    {
+      async create(
+        data: {
+          event: 'tool:start' | 'tool:complete' | 'thinking:chunk';
+          data: Record<string, unknown>;
+        },
+        params: RouteParams
+      ) {
+        const _ = params;
+        app.service('tasks').emit(data.event, data.data);
+        return { success: true };
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'broadcast task streaming events' },
+    },
+    requireAuth
+  );
+
   // ============================================================================
   // Sessions custom routes (fork, spawn, genealogy, prompt, stop, queue)
   // ============================================================================

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -150,7 +150,9 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     createExecuteHandler(ctx, sessionsService, sessionTokenService)
   );
 
-  app.use('/tasks', createTasksService(db, app));
+  app.use('/tasks', createTasksService(db, app), {
+    events: ['tool:start', 'tool:complete', 'thinking:chunk'],
+  });
   if (svcEnabled('leaderboard')) {
     app.use('/leaderboard', createLeaderboardService(db));
   }

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -39,6 +39,7 @@ import { Popover, Space, Typography, theme } from 'antd';
 import React, { useMemo, useState } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
+import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
 import { CollapsibleText } from '../CollapsibleText';
 import { Tag } from '../Tag';
 import {
@@ -185,16 +186,7 @@ export const AgentChain = React.memo<AgentChainProps>(
           if (toolResults.length > 0) {
             for (const block of toolResults) {
               const toolResult = block as unknown as ToolResultBlock;
-              let resultText = '';
-
-              if (typeof toolResult.content === 'string') {
-                resultText = toolResult.content;
-              } else if (Array.isArray(toolResult.content)) {
-                resultText = toolResult.content
-                  .filter((b) => b.type === 'text')
-                  .map((b) => (b as unknown as { text: string }).text)
-                  .join('\n');
-              }
+              const resultText = toolResultToDisplayText(toolResult.content);
 
               if (resultText.trim()) {
                 items.push({

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -122,6 +122,7 @@ function getToolDescription(toolUse: ToolUseBlock): string | undefined {
       return input.pattern ? String(input.pattern) : undefined;
     case 'ToolSearch':
     case 'WebSearch':
+    case 'web_search':
       return input.query ? String(input.query) : undefined;
     case 'WebFetch':
       return input.url ? String(input.url) : undefined;

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -27,6 +27,7 @@ import { Tooltip, theme } from 'antd';
 import type React from 'react';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
+import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
 import { AgorAvatar } from '../AgorAvatar';
 import { CollapsibleMarkdown } from '../CollapsibleText/CollapsibleMarkdown';
 import { CopyableContent } from '../CopyableContent';
@@ -488,15 +489,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
           // Special handling: If this is a Task tool result (user message rendered as agent),
           // extract text content and display it
           if (isTaskResult) {
-            let resultText = '';
-            if (typeof toolResult.content === 'string') {
-              resultText = toolResult.content;
-            } else if (Array.isArray(toolResult.content)) {
-              resultText = toolResult.content
-                .filter((b) => b.type === 'text')
-                .map((b) => (b as unknown as { text: string }).text)
-                .join('\n');
-            }
+            const resultText = toolResultToDisplayText(toolResult.content);
 
             if (resultText.trim()) {
               textBeforeTools.push(resultText);

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -37,7 +37,6 @@ import { Bubble } from '@ant-design/x';
 import { Collapse, Flex, Spin, Typography, theme } from 'antd';
 import React, { useMemo } from 'react';
 import type { StreamingMessage } from '../../hooks/useStreamingMessages';
-import { useTaskEvents } from '../../hooks/useTaskEvents';
 import { useTaskMessages } from '../../hooks/useTaskMessages';
 import { getContextWindowGradient } from '../../utils/contextWindow';
 import { AgentChain } from '../AgentChain';
@@ -59,7 +58,6 @@ import { RateLimitBlock } from '../RateLimitBlock';
 import { StickyTodoRenderer } from '../StickyTodoRenderer';
 import { Tag } from '../Tag';
 import { TaskStatusIcon } from '../TaskStatusIcon';
-import ToolExecutingIndicator from '../ToolExecutingIndicator';
 import { ToolIcon } from '../ToolIcon';
 
 const { Paragraph } = Typography;
@@ -373,9 +371,6 @@ export const TaskBlock = React.memo<TaskBlockProps>(
   }) => {
     const { token } = theme.useToken();
 
-    // Track real-time tool executions for this task
-    const { toolsExecuting } = useTaskEvents(client, task.task_id);
-
     // Fetch messages for this task (only when expanded)
     const { messages: taskMessages, loading: messagesLoading } = useTaskMessages(
       client,
@@ -679,13 +674,6 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                     }
                     return null;
                   })}
-
-                {/* Show tool execution indicators when tools are running */}
-                {toolsExecuting.length > 0 && (
-                  <div style={{ margin: `${token.sizeUnit * 1.5}px 0` }}>
-                    <ToolExecutingIndicator toolsExecuting={toolsExecuting} />
-                  </div>
-                )}
 
                 {/* Show sticky TODO (latest) above typing indicator when task is running */}
                 {task.status === TaskStatus.RUNNING && <StickyTodoRenderer messages={messages} />}

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -675,8 +675,8 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                     return null;
                   })}
 
-                {/* Show sticky TODO (latest) above typing indicator when task is running */}
-                {task.status === TaskStatus.RUNNING && <StickyTodoRenderer messages={messages} />}
+                {/* Keep latest TODO visible even after completion (Claude parity). */}
+                <StickyTodoRenderer messages={messages} />
 
                 {/* Show typing indicator whenever task is actively running */}
                 {task.status === TaskStatus.RUNNING && (

--- a/apps/agor-ui/src/components/ToolExecutingIndicator/ToolExecutingIndicator.tsx
+++ b/apps/agor-ui/src/components/ToolExecutingIndicator/ToolExecutingIndicator.tsx
@@ -5,7 +5,7 @@
  * Displays a list of currently executing tools with visual feedback.
  */
 
-import { CheckCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { LoadingOutlined } from '@ant-design/icons';
 import { Space, Typography } from 'antd';
 import type { ToolExecution } from '../../hooks/useTaskEvents';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
@@ -21,8 +21,7 @@ interface ToolExecutingIndicatorProps {
  * Shows a list of tools that are currently executing or recently completed.
  * Each tool is displayed with:
  * - Tool name
- * - Execution status (executing = spinner, complete = checkmark)
- * - Color coding (blue = executing, green = complete)
+ * - Execution status (spinner while running)
  */
 const ToolExecutingIndicator = ({ toolsExecuting }: ToolExecutingIndicatorProps) => {
   if (toolsExecuting.length === 0) {
@@ -34,13 +33,13 @@ const ToolExecutingIndicator = ({ toolsExecuting }: ToolExecutingIndicatorProps)
       {toolsExecuting.map((tool) => (
         <Tag
           key={tool.toolUseId}
-          icon={tool.status === 'executing' ? <LoadingOutlined spin /> : <CheckCircleOutlined />}
-          color={tool.status === 'executing' ? 'processing' : 'success'}
+          icon={<LoadingOutlined spin />}
+          color="processing"
           style={{ margin: 0 }}
         >
           <Typography.Text style={{ fontSize: 12 }}>
             {getToolDisplayName(tool.toolName)}
-            {tool.status === 'executing' ? ' executing...' : ' complete'}
+            {' executing...'}
           </Typography.Text>
         </Tag>
       ))}

--- a/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
@@ -17,6 +17,7 @@ import type { ContentBlock as CoreContentBlock, DiffEnrichment } from '@agor/cor
 import { theme } from 'antd';
 import type React from 'react';
 import { shouldUseAnsiRendering } from '../../utils/ansi';
+import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
 import { CollapsibleText } from '../CollapsibleText';
 import { CollapsibleAnsiText } from '../CollapsibleText/CollapsibleAnsiText';
 import { ThemedSyntaxHighlighter } from '../ThemedSyntaxHighlighter';
@@ -112,24 +113,7 @@ export const ToolUseRenderer: React.FC<ToolUseRendererProps> = ({ toolUse, toolR
   // Extract text content from tool result
   const getResultText = (): string => {
     if (!toolResult) return '';
-
-    if (typeof toolResult.content === 'string') {
-      return toolResult.content;
-    }
-
-    if (Array.isArray(toolResult.content)) {
-      const textBlocks = toolResult.content
-        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
-        .map((block) => block.text)
-        .join('\n\n');
-      if (textBlocks.trim().length > 0) {
-        return textBlocks;
-      }
-      // Fall back to JSON when result blocks are non-text (e.g., structured MCP payloads).
-      return JSON.stringify(toolResult.content, null, 2);
-    }
-
-    return '';
+    return toolResultToDisplayText(toolResult.content);
   };
 
   const resultText = getResultText();

--- a/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/ToolUseRenderer.tsx
@@ -118,10 +118,15 @@ export const ToolUseRenderer: React.FC<ToolUseRendererProps> = ({ toolUse, toolR
     }
 
     if (Array.isArray(toolResult.content)) {
-      return toolResult.content
+      const textBlocks = toolResult.content
         .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
         .map((block) => block.text)
         .join('\n\n');
+      if (textBlocks.trim().length > 0) {
+        return textBlocks;
+      }
+      // Fall back to JSON when result blocks are non-text (e.g., structured MCP payloads).
+      return JSON.stringify(toolResult.content, null, 2);
     }
 
     return '';

--- a/apps/agor-ui/src/hooks/useTaskEvents.ts
+++ b/apps/agor-ui/src/hooks/useTaskEvents.ts
@@ -13,7 +13,7 @@ import type { useAgorClient } from './useAgorClient';
 export interface ToolExecution {
   toolUseId: string;
   toolName: string;
-  status: 'executing' | 'complete';
+  status: 'executing';
 }
 
 interface ToolStartEvent {
@@ -67,7 +67,7 @@ export function useTaskEvents(
           {
             toolUseId: data.tool_use_id,
             toolName: data.tool_name,
-            status: 'executing',
+            status: 'executing' as const,
           },
         ];
       });
@@ -80,19 +80,8 @@ export function useTaskEvents(
         return;
       }
 
-      setToolsExecuting((prev) => {
-        // Mark as complete
-        const updated = prev.map((tool) =>
-          tool.toolUseId === data.tool_use_id ? { ...tool, status: 'complete' as const } : tool
-        );
-
-        return updated;
-      });
-
-      // Remove from list after 2 seconds (gives time for visual feedback)
-      setTimeout(() => {
-        setToolsExecuting((prev) => prev.filter((t) => t.toolUseId !== data.tool_use_id));
-      }, 2000);
+      // Remove immediately on completion. The tool row itself already shows completion state.
+      setToolsExecuting((prev) => prev.filter((t) => t.toolUseId !== data.tool_use_id));
     };
 
     // Register event listeners

--- a/apps/agor-ui/src/utils/toolResultToDisplayText.ts
+++ b/apps/agor-ui/src/utils/toolResultToDisplayText.ts
@@ -1,0 +1,26 @@
+function isTextBlock(block: unknown): block is { type: 'text'; text: string } {
+  if (!block || typeof block !== 'object') return false;
+  const record = block as Record<string, unknown>;
+  return record.type === 'text' && typeof record.text === 'string';
+}
+
+export function toolResultToDisplayText(content: string | unknown[]): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    const textBlocks = content
+      .filter(isTextBlock)
+      .map((block) => block.text)
+      .join('\n\n');
+    if (textBlocks.trim().length > 0) {
+      return textBlocks;
+    }
+
+    // Preserve visibility for non-text payloads (e.g., MCP structured blocks).
+    return JSON.stringify(content, null, 2);
+  }
+
+  return '';
+}

--- a/packages/agor-live/build.sh
+++ b/packages/agor-live/build.sh
@@ -301,7 +301,7 @@ if [[ "$PUBLISH" == true ]]; then
     echo "🚀 Publishing packages..."
     echo ""
     echo "── Publishing agor-live@$NEW_VERSION ──"
-    cd "$SCRIPT_DIR" && npm publish
+    cd "$SCRIPT_DIR" && npm login && npm publish
     echo ""
     echo "── Publishing @agor-live/client@$NEW_VERSION ──"
     cd "$CLIENT_DIR" && npm publish --access public

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -315,6 +315,7 @@ export function createFeathersBackedRepositories(client: AgorClient) {
     // SDK handlers can use these services directly with proper typing
     messagesService: client.service('messages'),
     tasksService: client.service('tasks'),
+    tasksStreamingService: client.service('/tasks/streaming'),
     sessionsService: client.service('sessions'),
   };
 }

--- a/packages/executor/src/handlers/sdk/claude.ts
+++ b/packages/executor/src/handlers/sdk/claude.ts
@@ -67,6 +67,7 @@ export async function executeClaudeCodeTask(params: {
           repos.mcpServers,
           permissionService,
           repos.tasksService,
+          repos.tasksStreamingService,
           repos.sessionsService,
           repos.worktrees,
           repos.repos,

--- a/packages/executor/src/handlers/sdk/codex.ts
+++ b/packages/executor/src/handlers/sdk/codex.ts
@@ -40,6 +40,7 @@ export async function executeCodexTask(params: {
         apiKey,
         repos.messagesService,
         repos.tasksService,
+        repos.tasksStreamingService,
         useNativeAuth, // Flag for native auth (if applicable)
         repos.mcpServers, // MCPServerRepository for global MCP server resolution
         repos.users

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -91,6 +91,49 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('+const value = "new";'))).toBe(true);
   });
 
+  it('enriches absolute edit_files paths when tool path and git root use different symlink prefixes', () => {
+    const repoDir = createTempGitRepo();
+    const aliasParent = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-diff-enrichment-alias-'));
+    tempDirs.push(aliasParent);
+    const aliasRepo = path.join(aliasParent, 'repo-link');
+    fs.symlinkSync(repoDir, aliasRepo, 'dir');
+
+    const srcDir = path.join(repoDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const realFilePath = path.join(srcDir, 'example.ts');
+    const aliasFilePath = path.join(aliasRepo, 'src', 'example.ts');
+
+    fs.writeFileSync(realFilePath, 'const value = "old";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+    fs.writeFileSync(aliasFilePath, 'const value = "new";\n', 'utf-8');
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-symlink-path-1',
+        name: 'edit_files',
+        input: {
+          changes: [{ path: aliasFilePath, kind: 'update' }],
+        },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-symlink-path-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    const toolResult = contentBlocks[1];
+    expect(toolResult.diff?.files).toHaveLength(1);
+    expect(toolResult.diff?.files?.[0]?.kind).toBe('update');
+    const lines = toolResult.diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-const value = "old";'))).toBe(true);
+    expect(lines.some((line) => line.includes('+const value = "new";'))).toBe(true);
+  });
+
   it('enriches Codex edit_files delete operations with relative paths', () => {
     const repoDir = createTempGitRepo();
     const srcDir = path.join(repoDir, 'src');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -52,6 +52,67 @@ interface ContentBlock {
   [key: string]: unknown;
 }
 
+function isSafeRepoRelativePath(relativePath: string): boolean {
+  const normalized = path.posix.normalize(relativePath.split(path.sep).join('/'));
+  return !(
+    !normalized ||
+    normalized.startsWith('/') ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('\0') ||
+    normalized.includes('\n') ||
+    normalized.includes('\r')
+  );
+}
+
+function tryRealpath(p: string): string | null {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a path to a git-repo-relative path, tolerating symlink prefix drift.
+ *
+ * In production we may receive absolute tool paths under a symlinked mount
+ * while git reports a canonical root under a different prefix. This helper
+ * tries lexical and canonicalized candidates and returns a safe repo-relative path.
+ */
+function resolveRepoRelativePath(gitRoot: string, absolutePath: string): string | null {
+  const lexicalRelative = path.relative(gitRoot, absolutePath);
+  if (isSafeRepoRelativePath(lexicalRelative)) {
+    return lexicalRelative;
+  }
+
+  const gitRootReal = tryRealpath(gitRoot);
+  if (!gitRootReal) return null;
+
+  const candidates = new Set<string>();
+  candidates.add(absolutePath);
+
+  const absoluteReal = tryRealpath(absolutePath);
+  if (absoluteReal) {
+    candidates.add(absoluteReal);
+  } else {
+    // File may not exist (e.g., delete). Resolve through parent directory.
+    const parentReal = tryRealpath(path.dirname(absolutePath));
+    if (parentReal) {
+      candidates.add(path.join(parentReal, path.basename(absolutePath)));
+    }
+  }
+
+  for (const candidate of candidates) {
+    const relativePath = path.relative(gitRootReal, candidate);
+    if (isSafeRepoRelativePath(relativePath)) {
+      return relativePath;
+    }
+  }
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Pattern 1: Split messages (Claude)
 // ---------------------------------------------------------------------------
@@ -329,7 +390,8 @@ function enrichEditFilesResult(
         }
       } else if (kind === 'delete') {
         // Deleted file — get old content from git
-        const relativePath = path.relative(gitRoot, resolvedPath);
+        const relativePath = resolveRepoRelativePath(gitRoot, resolvedPath);
+        if (!relativePath) continue;
         const oldContent = gitShowHeadFile(gitRoot, relativePath);
         if (oldContent === null) continue;
         const patch = structuredPatch(filePath, filePath, oldContent, '', '', '', {
@@ -343,7 +405,8 @@ function enrichEditFilesResult(
         const stat = fs.statSync(resolvedPath);
         if (stat.size > MAX_FILE_SIZE_BYTES) continue;
         const currentContent = fs.readFileSync(resolvedPath, 'utf-8');
-        const relativePath = path.relative(gitRoot, resolvedPath);
+        const relativePath = resolveRepoRelativePath(gitRoot, resolvedPath);
+        if (!relativePath) continue;
         const oldContent = gitShowHeadFile(gitRoot, relativePath);
         if (oldContent === null) {
           // File may be new (not in HEAD) — treat as addition
@@ -379,15 +442,7 @@ function enrichEditFilesResult(
 function gitShowHeadFile(gitRoot: string, relativePath: string): string | null {
   // Ensure the ref path is safe and uses git's forward-slash separator.
   const normalized = path.posix.normalize(relativePath.split(path.sep).join('/'));
-  if (
-    !normalized ||
-    normalized.startsWith('/') ||
-    normalized === '..' ||
-    normalized.startsWith('../') ||
-    normalized.includes('\0') ||
-    normalized.includes('\n') ||
-    normalized.includes('\r')
-  ) {
+  if (!isSafeRepoRelativePath(normalized)) {
     return null;
   }
 

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -132,6 +132,13 @@ export interface TasksService {
   emit(event: string, data: unknown): void;
 }
 
+export interface TasksStreamingService {
+  create(data: {
+    event: 'tool:start' | 'tool:complete' | 'thinking:chunk';
+    data: Record<string, unknown>;
+  }): Promise<unknown>;
+}
+
 /**
  * Service interface for updating sessions via FeathersJS
  * This ensures WebSocket events are emitted when sessions are updated (e.g., permission config)
@@ -156,6 +163,7 @@ export class ClaudeTool implements ITool {
     mcpServerRepo?: MCPServerRepository,
     permissionService?: PermissionService,
     private tasksService?: TasksService,
+    private tasksStreamingService?: TasksStreamingService,
     sessionsService?: SessionsService,
     worktreesRepo?: WorktreeRepository,
     reposRepo?: RepoRepository,
@@ -205,6 +213,19 @@ export class ClaudeTool implements ITool {
     } catch {
       return false;
     }
+  }
+
+  private async emitTaskEvent(
+    event: 'tool:start' | 'tool:complete' | 'thinking:chunk',
+    data: Record<string, unknown>
+  ): Promise<void> {
+    if (this.tasksStreamingService) {
+      await this.tasksStreamingService.create({ event, data });
+      return;
+    }
+
+    // Fallback for environments that don't expose /tasks/streaming.
+    this.tasksService?.emit(event, data);
   }
 
   async importSession(sessionId: string, options?: ImportOptions): Promise<SessionData> {
@@ -399,8 +420,8 @@ export class ClaudeTool implements ITool {
 
       // Handle tool execution start
       if (event.type === 'tool_start') {
-        if (this.tasksService && taskId) {
-          this.tasksService.emit('tool:start', {
+        if (taskId) {
+          await this.emitTaskEvent('tool:start', {
             task_id: taskId,
             session_id: sessionId,
             tool_use_id: event.toolUseId,
@@ -411,8 +432,8 @@ export class ClaudeTool implements ITool {
 
       // Handle tool execution complete
       if (event.type === 'tool_complete') {
-        if (this.tasksService && taskId) {
-          this.tasksService.emit('tool:complete', {
+        if (taskId) {
+          await this.emitTaskEvent('tool:complete', {
             task_id: taskId,
             session_id: sessionId,
             tool_use_id: event.toolUseId,
@@ -484,8 +505,8 @@ export class ClaudeTool implements ITool {
       // Handle thinking partial (streaming)
       if (event.type === 'thinking_partial') {
         // Emit to tasks service for task-level tracking
-        if (this.tasksService && taskId) {
-          this.tasksService.emit('thinking:chunk', {
+        if (taskId) {
+          await this.emitTaskEvent('thinking:chunk', {
             task_id: taskId,
             session_id: sessionId,
             chunk: event.thinkingChunk,

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -199,6 +199,18 @@ export class CodexTool implements ITool {
         }
       }
 
+      // Handle tool execution start (live UI indicator)
+      if (event.type === 'tool_start') {
+        if (this.tasksService && taskId) {
+          this.tasksService.emit('tool:start', {
+            task_id: taskId,
+            session_id: sessionId,
+            tool_use_id: event.toolUse.id,
+            tool_name: event.toolUse.name,
+          });
+        }
+      }
+
       if (event.type === 'complete' && event.usage) {
         tokenUsage = event.usage;
       }
@@ -270,6 +282,21 @@ export class CodexTool implements ITool {
       }
       // Handle tool completion (create message immediately for live updates)
       else if (event.type === 'tool_complete') {
+        if (this.tasksService && taskId) {
+          this.tasksService.emit('tool:complete', {
+            task_id: taskId,
+            session_id: sessionId,
+            tool_use_id: event.toolUse.id,
+          });
+        }
+
+        const toolResultContent =
+          event.toolUse.output !== undefined
+            ? event.toolUse.output
+            : event.toolUse.status
+              ? `[${event.toolUse.status}]`
+              : '';
+
         // Create a message for this tool use immediately
         const toolMessageId = generateId() as MessageID;
         const toolContent = [
@@ -284,7 +311,7 @@ export class CodexTool implements ITool {
                 {
                   type: 'tool_result',
                   tool_use_id: event.toolUse.id,
-                  content: event.toolUse.output || `[${event.toolUse.status}]`,
+                  content: toolResultContent,
                   is_error: event.toolUse.status === 'failed' || event.toolUse.status === 'error',
                 },
               ]
@@ -320,16 +347,21 @@ export class CodexTool implements ITool {
       // Handle complete message (save to database)
       else if (event.type === 'complete' && event.content) {
         const usageForMessage = event.usage ?? tokenUsage;
-        // Filter out tool_use and tool_result blocks (already saved via tool_complete events)
-        // But KEEP text blocks - these contain the response
-        const textOnlyContent = event.content.filter(
-          (block) => block.type === 'text' // Only keep text blocks
+        // Filter out tool_use and tool_result blocks (already saved via tool_complete events),
+        // but keep text + thinking blocks so Codex reasoning is visible in the UI.
+        const nonToolContent = event.content.filter(
+          (block) => block.type === 'text' || block.type === 'thinking'
         );
 
-        // Only create message if there's text content (not just tools)
-        if (textOnlyContent.length > 0) {
+        // Only create message if there's non-tool content (not just tools)
+        if (nonToolContent.length > 0) {
           // Extract full text for streaming callback
-          const fullText = textOnlyContent
+          const fullText = nonToolContent
+            .filter((block) => block.type === 'text')
+            .map((block) => (block as { text?: string }).text || '')
+            .join('');
+          const fullThinking = nonToolContent
+            .filter((block) => block.type === 'thinking')
             .map((block) => (block as { text?: string }).text || '')
             .join('');
 
@@ -370,11 +402,29 @@ export class CodexTool implements ITool {
             }
           }
 
-          // Create complete message in DB (text only, tools already saved)
+          // Codex reasoning is not token-streamed by SDK. Emit a synthetic single
+          // thinking chunk so users see reasoning activity in real time.
+          if (streamingCallbacks && fullThinking && !fullText) {
+            try {
+              if (streamingCallbacks.onThinkingStart) {
+                await streamingCallbacks.onThinkingStart(assistantMessageId, {});
+              }
+              if (streamingCallbacks.onThinkingChunk) {
+                await streamingCallbacks.onThinkingChunk(assistantMessageId, fullThinking);
+              }
+              if (streamingCallbacks.onThinkingEnd) {
+                await streamingCallbacks.onThinkingEnd(assistantMessageId);
+              }
+            } catch (err) {
+              console.error(`[Codex] Thinking callback failed for ${assistantMessageId}:`, err);
+            }
+          }
+
+          // Create complete message in DB (non-tool content only, tools already saved)
           await this.createAssistantMessage(
             sessionId,
             assistantMessageId,
-            textOnlyContent,
+            nonToolContent,
             undefined, // No tool uses in this message (already saved separately)
             taskId,
             nextIndex++,
@@ -482,10 +532,14 @@ export class CodexTool implements ITool {
     resolvedModel?: string,
     tokenUsage?: TokenUsage
   ): Promise<Message> {
-    // Extract text content for preview
+    // Extract preview text (prefer normal text, then thinking text)
     const textBlocks = content.filter((b) => b.type === 'text').map((b) => b.text || '');
     const fullTextContent = textBlocks.join('');
-    const contentPreview = fullTextContent.substring(0, 200);
+    const fallbackThinking = content
+      .filter((b) => b.type === 'thinking')
+      .map((b) => b.text || '')
+      .join('');
+    const contentPreview = (fullTextContent || fallbackThinking).substring(0, 200);
 
     const message: Message = {
       message_id: messageId,

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -188,6 +188,7 @@ export class CodexTool implements ITool {
     let streamStarted = false; // tracks whether onStreamStart succeeded (for safe onStreamEnd)
     let wasStopped = false;
     let workingDirectory: string | undefined;
+    const pendingToolMessageIds = new Map<string, MessageID>();
 
     if (this.sessionsRepo && this.worktreesRepo) {
       const session = await this.sessionsRepo.findById(sessionId);
@@ -229,6 +230,33 @@ export class CodexTool implements ITool {
             tool_name: event.toolUse.name,
           });
         }
+
+        // Create tool row immediately so UI shows "running" state.
+        const toolMessageId = generateId() as MessageID;
+        await this.createAssistantMessage(
+          sessionId,
+          toolMessageId,
+          [
+            {
+              type: 'tool_use',
+              id: event.toolUse.id,
+              name: event.toolUse.name,
+              input: event.toolUse.input,
+            },
+          ],
+          [
+            {
+              id: event.toolUse.id,
+              name: event.toolUse.name,
+              input: event.toolUse.input,
+            },
+          ],
+          taskId,
+          nextIndex++,
+          resolvedModel
+        );
+        assistantMessageIds.push(toolMessageId);
+        pendingToolMessageIds.set(event.toolUse.id, toolMessageId);
       }
 
       if (event.type === 'complete' && event.usage) {
@@ -316,9 +344,6 @@ export class CodexTool implements ITool {
             : event.toolUse.status
               ? `[${event.toolUse.status}]`
               : '';
-
-        // Create a message for this tool use immediately
-        const toolMessageId = generateId() as MessageID;
         const toolContent = [
           {
             type: 'tool_use',
@@ -341,28 +366,40 @@ export class CodexTool implements ITool {
         // Best-effort diff enrichment for Edit/Write tool results
         enrichContentBlocks(toolContent, { workingDirectory });
 
-        await this.createAssistantMessage(
-          sessionId,
-          toolMessageId,
-          toolContent as Array<{
-            type: string;
-            text?: string;
-            id?: string;
-            name?: string;
-            input?: Record<string, unknown>;
-          }>,
-          [
-            {
-              id: event.toolUse.id,
-              name: event.toolUse.name,
-              input: event.toolUse.input,
-            },
-          ],
-          taskId,
-          nextIndex++,
-          resolvedModel
-        );
-        assistantMessageIds.push(toolMessageId);
+        const existingToolMessageId = pendingToolMessageIds.get(event.toolUse.id);
+        if (existingToolMessageId) {
+          await this.messagesService?.patch(existingToolMessageId, {
+            content: toolContent as Message['content'],
+            content_preview:
+              typeof toolResultContent === 'string' ? toolResultContent.substring(0, 200) : '',
+          });
+          pendingToolMessageIds.delete(event.toolUse.id);
+        } else {
+          // Fallback path if start event wasn't observed.
+          const toolMessageId = generateId() as MessageID;
+          await this.createAssistantMessage(
+            sessionId,
+            toolMessageId,
+            toolContent as Array<{
+              type: string;
+              text?: string;
+              id?: string;
+              name?: string;
+              input?: Record<string, unknown>;
+            }>,
+            [
+              {
+                id: event.toolUse.id,
+                name: event.toolUse.name,
+                input: event.toolUse.input,
+              },
+            ],
+            taskId,
+            nextIndex++,
+            resolvedModel
+          );
+          assistantMessageIds.push(toolMessageId);
+        }
       }
       // Handle complete message (save to database)
       else if (event.type === 'complete' && event.content) {

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -31,7 +31,11 @@ import {
 } from '../../types.js';
 import { enrichContentBlocks } from '../base/diff-enrichment.js';
 import type { ITool, StreamingCallbacks, ToolCapabilities } from '../base/index.js';
-import type { MessagesService, TasksService } from '../claude/claude-tool.js';
+import type {
+  MessagesService,
+  TasksService,
+  TasksStreamingService,
+} from '../claude/claude-tool.js';
 import { DEFAULT_CODEX_MODEL } from './models.js';
 import { CodexPromptService } from './prompt-service.js';
 
@@ -56,6 +60,7 @@ export class CodexTool implements ITool {
   private worktreesRepo?: WorktreeRepository;
   private messagesService?: MessagesService;
   private tasksService?: TasksService;
+  private tasksStreamingService?: TasksStreamingService;
 
   constructor(
     messagesRepo?: MessagesRepository,
@@ -66,6 +71,7 @@ export class CodexTool implements ITool {
     apiKey?: string,
     messagesService?: MessagesService,
     tasksService?: TasksService,
+    tasksStreamingService?: TasksStreamingService,
     _useNativeAuth?: boolean, // Codex doesn't have OAuth fallback, but accept for interface consistency
     mcpServerRepo?: MCPServerRepository,
     usersRepo?: UsersRepository
@@ -75,6 +81,7 @@ export class CodexTool implements ITool {
     this.worktreesRepo = worktreesRepo;
     this.messagesService = messagesService;
     this.tasksService = tasksService;
+    this.tasksStreamingService = tasksStreamingService;
 
     if (messagesRepo && sessionsRepo) {
       this.promptService = new CodexPromptService(
@@ -110,6 +117,19 @@ export class CodexTool implements ITool {
     } catch {
       return false;
     }
+  }
+
+  private async emitTaskEvent(
+    event: 'tool:start' | 'tool:complete' | 'thinking:chunk',
+    data: Record<string, unknown>
+  ): Promise<void> {
+    if (this.tasksStreamingService) {
+      await this.tasksStreamingService.create({ event, data });
+      return;
+    }
+
+    // Fallback for environments that don't expose /tasks/streaming.
+    this.tasksService?.emit(event, data);
   }
 
   /**
@@ -201,8 +221,8 @@ export class CodexTool implements ITool {
 
       // Handle tool execution start (live UI indicator)
       if (event.type === 'tool_start') {
-        if (this.tasksService && taskId) {
-          this.tasksService.emit('tool:start', {
+        if (taskId) {
+          await this.emitTaskEvent('tool:start', {
             task_id: taskId,
             session_id: sessionId,
             tool_use_id: event.toolUse.id,
@@ -282,8 +302,8 @@ export class CodexTool implements ITool {
       }
       // Handle tool completion (create message immediately for live updates)
       else if (event.type === 'tool_complete') {
-        if (this.tasksService && taskId) {
-          this.tasksService.emit('tool:complete', {
+        if (taskId) {
+          await this.emitTaskEvent('tool:complete', {
             task_id: taskId,
             session_id: sessionId,
             tool_use_id: event.toolUse.id,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -379,6 +379,42 @@ describe('CodexPromptService - tool payload mapping', () => {
     });
   });
 
+  it('falls back to structured_content when MCP content blocks are empty', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'mcp-structured-only',
+        type: 'mcp_tool_call',
+        server: 'agor',
+        tool: 'agor_execute_tool',
+        arguments: { tool_name: 'agor_sessions_get_current' },
+        result: {
+          content: [],
+          structured_content: { session_id: 'abc123', status: 'running' },
+        },
+        status: 'completed',
+      },
+      'completed'
+    );
+
+    expect(toolUse).toEqual({
+      id: 'mcp-structured-only',
+      name: 'agor.agor_execute_tool',
+      input: { tool_name: 'agor_sessions_get_current' },
+      output: JSON.stringify({ session_id: 'abc123', status: 'running' }, null, 2),
+      status: 'completed',
+    });
+  });
+
   it('marks web_search as completed to avoid stale UI status', () => {
     const service = new CodexPromptService(
       mockMessagesRepo,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -306,3 +306,145 @@ describe('CodexPromptService - Todo normalization', () => {
     expect(todoCompletions).toHaveLength(1);
   });
 });
+
+describe('CodexPromptService - tool payload mapping', () => {
+  it('preserves MCP result content on completion', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'mcp-1',
+        type: 'mcp_tool_call',
+        server: 'agor',
+        tool: 'agor_execute_tool',
+        arguments: { tool_name: 'agor_worktrees_list' },
+        result: {
+          content: [{ type: 'text', text: 'ok' }],
+          structured_content: { success: true },
+        },
+        status: 'completed',
+      },
+      'completed'
+    );
+
+    expect(toolUse).toEqual({
+      id: 'mcp-1',
+      name: 'agor.agor_execute_tool',
+      input: { tool_name: 'agor_worktrees_list' },
+      output: [{ type: 'text', text: 'ok' }],
+      status: 'completed',
+    });
+  });
+
+  it('preserves MCP error message on failure', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'mcp-2',
+        type: 'mcp_tool_call',
+        server: 'agor',
+        tool: 'agor_execute_tool',
+        arguments: {},
+        error: {
+          message: 'permission denied',
+        },
+        status: 'failed',
+      },
+      'completed'
+    );
+
+    expect(toolUse).toEqual({
+      id: 'mcp-2',
+      name: 'agor.agor_execute_tool',
+      input: {},
+      output: 'permission denied',
+      status: 'failed',
+    });
+  });
+
+  it('marks web_search as completed to avoid stale UI status', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'search-1',
+        type: 'web_search',
+        query: 'openai codex sdk',
+      },
+      'completed'
+    );
+
+    expect(toolUse).toEqual({
+      id: 'search-1',
+      name: 'web_search',
+      input: { query: 'openai codex sdk' },
+      status: 'completed',
+    });
+  });
+
+  it('propagates top-level stream error events (message field) as failures', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
+    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-1',
+      worktree_id: 'worktree-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockWorktreesRepo.findById.mockResolvedValue({
+      worktree_id: 'worktree-1',
+      path: process.cwd(),
+    });
+
+    mockStreamEvents = [{ type: 'error', message: 'stream exploded' }];
+
+    await expect(
+      (async () => {
+        for await (const _event of service.promptSessionStreaming('session-1' as any, 'review')) {
+          // no-op
+        }
+      })()
+    ).rejects.toThrow('Codex stream error: stream exploded');
+  });
+});

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -86,7 +86,7 @@ export type CodexStreamEvent =
         id: string;
         name: string;
         input: Record<string, unknown>;
-        output?: string;
+        output?: string | Array<Record<string, unknown>>;
         status?: string;
       };
       threadId?: string;
@@ -537,7 +537,7 @@ export class CodexPromptService {
     id: string;
     name: string;
     input: Record<string, unknown>;
-    output?: string;
+    output?: string | Array<Record<string, unknown>>;
     status?: string;
   } | null {
     switch (item.type) {
@@ -562,7 +562,17 @@ export class CodexPromptService {
             status: item.status,
           }),
         };
-      case 'mcp_tool_call':
+      case 'mcp_tool_call': {
+        // Preserve MCP result/error payloads so the UI can render meaningful output.
+        // This matches Claude's "start/end + payload" visibility model.
+        let mcpOutput: string | Array<Record<string, unknown>> | undefined;
+        if (status === 'completed') {
+          if (item.result?.content && Array.isArray(item.result.content)) {
+            mcpOutput = item.result.content as Array<Record<string, unknown>>;
+          } else if (item.error?.message) {
+            mcpOutput = item.error.message;
+          }
+        }
         return {
           id: item.id,
           name: `${item.server}.${item.tool}`,
@@ -570,15 +580,23 @@ export class CodexPromptService {
             item.arguments && typeof item.arguments === 'object' && !Array.isArray(item.arguments)
               ? (item.arguments as Record<string, unknown>)
               : {},
+          ...(mcpOutput !== undefined && {
+            output: mcpOutput,
+          }),
           ...(status === 'completed' && {
             status: item.status,
           }),
         };
+      }
       case 'web_search':
         return {
           id: item.id,
           name: 'web_search',
           input: { query: item.query },
+          ...(status === 'completed' && {
+            // Emit a terminal marker so web_search doesn't remain stale in UI.
+            status: 'completed',
+          }),
         };
       case 'reasoning':
         // Don't emit tool use for reasoning (it's internal)
@@ -821,7 +839,7 @@ export class CodexPromptService {
         name?: string;
         input?: Record<string, unknown>;
         tool_use_id?: string;
-        content?: string;
+        content?: string | Array<Record<string, unknown>>;
         is_error?: boolean;
       }> = [];
       let threadId = session.sdk_session_id || '';
@@ -951,6 +969,32 @@ export class CodexPromptService {
                   // No usage data for intermediate messages - only final turn.completed has it
                 };
               }
+
+              // Surface reasoning as thinking blocks (non-streaming) so Codex reuses
+              // the same ThinkingBlock UI used by Claude/OpenCode.
+              if ('text' in event.item && event.item.type === 'reasoning') {
+                const thinkingContent = [{ type: 'thinking', text: event.item.text as string }];
+                yield {
+                  type: 'complete',
+                  content: thinkingContent,
+                  threadId: thread.id || '',
+                  resolvedModel: resolvedModel || DEFAULT_CODEX_MODEL,
+                };
+              }
+
+              // Surface non-fatal item-level errors as assistant text so users can see
+              // what happened instead of dropping them silently.
+              if ('message' in event.item && event.item.type === 'error') {
+                const errorContent = [
+                  { type: 'text', text: `[Codex item error] ${event.item.message}` },
+                ];
+                yield {
+                  type: 'complete',
+                  content: errorContent,
+                  threadId: thread.id || '',
+                  resolvedModel: resolvedModel || DEFAULT_CODEX_MODEL,
+                };
+              }
             }
             break;
 
@@ -1001,13 +1045,15 @@ export class CodexPromptService {
           }
 
           case 'error':
-            // SDK retry errors (e.g., 401 retries before turn.failed)
-            // Log once at warn level instead of silently ignoring
-            console.warn(
-              `⚠️  [Codex] SDK error event for session ${sessionId.substring(0, 8)} (event ${eventCount}):`,
-              (event as { error?: unknown }).error || 'unknown'
+            // Fatal stream-level error from Codex SDK.
+            // Surface this as a task failure so users see it in the conversation.
+            throw new Error(
+              `Codex stream error: ${
+                (event as { message?: unknown; error?: unknown }).message ||
+                (event as { message?: unknown; error?: unknown }).error ||
+                'unknown'
+              }`
             );
-            break;
 
           default:
             // Ignore other event types silently

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -567,8 +567,10 @@ export class CodexPromptService {
         // This matches Claude's "start/end + payload" visibility model.
         let mcpOutput: string | Array<Record<string, unknown>> | undefined;
         if (status === 'completed') {
-          if (item.result?.content && Array.isArray(item.result.content)) {
+          if (Array.isArray(item.result?.content) && item.result.content.length > 0) {
             mcpOutput = item.result.content as Array<Record<string, unknown>>;
+          } else if (item.result?.structured_content !== undefined) {
+            mcpOutput = JSON.stringify(item.result.structured_content, null, 2);
           } else if (item.error?.message) {
             mcpOutput = item.error.message;
           }


### PR DESCRIPTION
## Summary
- improve Codex execution visibility while a task is running
- forward Codex tool lifecycle events to task event stream (`tool:start` / `tool:complete`)
- preserve MCP/web_search completion payloads and statuses for clearer tool blocks
- surface Codex reasoning as thinking blocks (with synthetic thinking stream events)
- surface Codex stream/item errors more explicitly
- bump `agor-live` and `@agor-live/client` patch versions to `0.16.3`
- update `packages/agor-live/build.sh` publish flow to chain `npm login` before `npm publish`

## Validation
- `pnpm i`
- `pnpm check`
