### PR TITLE
Fix Codex edit_files diff to use per-invocation pre/post snapshots

### DIFF
--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -3,7 +3,12 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { enrichContentBlocks, enrichToolResults, registerToolUses } from './diff-enrichment.js';
+import {
+  enrichContentBlocks,
+  enrichToolResults,
+  registerToolInvocationStart,
+  registerToolUses,
+} from './diff-enrichment.js';
 
 interface TestContentBlock {
   type: string;
@@ -205,6 +210,74 @@ describe('diff enrichment', () => {
     expect(toolResult.diff?.files?.[0]?.kind).toBe('add');
     const lines = toolResult.diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
     expect(lines.some((line) => line.includes('+export const added = true;'))).toBe(true);
+  });
+
+  it('uses invocation snapshots so add then remove across calls both render correctly', () => {
+    const repoDir = createTempGitRepo();
+    const srcDir = path.join(repoDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(repoDir, 'README.md'), '# test\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const relPath = 'src/toggle.ts';
+    const absPath = path.join(repoDir, relPath);
+
+    // Invocation 1: add file
+    registerToolInvocationStart(
+      'tool-codex-edit-files-toggle-add',
+      'edit_files',
+      { changes: [{ path: relPath, kind: 'add' }] },
+      { workingDirectory: repoDir }
+    );
+    fs.writeFileSync(absPath, 'export const mode = "on";\n', 'utf-8');
+    const addBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-toggle-add',
+        name: 'edit_files',
+        input: { changes: [{ path: relPath, kind: 'add' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-toggle-add',
+        content: '[completed]',
+      },
+    ];
+    enrichContentBlocks(addBlocks, { workingDirectory: repoDir });
+
+    expect(addBlocks[1].diff?.files).toHaveLength(1);
+    expect(addBlocks[1].diff?.files?.[0]?.kind).toBe('add');
+    const addLines = addBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(addLines.some((line) => line.includes('+export const mode = "on";'))).toBe(true);
+
+    // Invocation 2: delete same file (after add already happened)
+    registerToolInvocationStart(
+      'tool-codex-edit-files-toggle-delete',
+      'edit_files',
+      { changes: [{ path: relPath, kind: 'delete' }] },
+      { workingDirectory: repoDir }
+    );
+    fs.rmSync(absPath);
+    const deleteBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-toggle-delete',
+        name: 'edit_files',
+        input: { changes: [{ path: relPath, kind: 'delete' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-toggle-delete',
+        content: '[completed]',
+      },
+    ];
+    enrichContentBlocks(deleteBlocks, { workingDirectory: repoDir });
+
+    expect(deleteBlocks[1].diff?.files).toHaveLength(1);
+    expect(deleteBlocks[1].diff?.files?.[0]?.kind).toBe('delete');
+    const deleteLines = deleteBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(deleteLines.some((line) => line.includes('-export const mode = "on";'))).toBe(true);
   });
 
   it('skips unsafe relative paths when resolving git HEAD content', () => {

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  clearToolInvocationState,
   enrichContentBlocks,
   enrichToolResults,
   registerToolInvocationStart,
@@ -278,6 +279,122 @@ describe('diff enrichment', () => {
     expect(deleteBlocks[1].diff?.files?.[0]?.kind).toBe('delete');
     const deleteLines = deleteBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
     expect(deleteLines.some((line) => line.includes('-export const mode = "on";'))).toBe(true);
+  });
+
+  it('isolates snapshot lookups by scope when tool_use IDs collide', () => {
+    const sharedToolUseId = 'tool-collision-id';
+
+    const repoA = createTempGitRepo();
+    const fileA = path.join(repoA, 'collision-a.ts');
+    fs.writeFileSync(fileA, 'const value = "a-head";\n', 'utf-8');
+    execSync('git add .', { cwd: repoA, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoA, stdio: 'ignore' });
+    fs.writeFileSync(fileA, 'const value = "a-pre";\n', 'utf-8');
+    registerToolInvocationStart(
+      sharedToolUseId,
+      'edit_files',
+      { changes: [{ path: 'collision-a.ts', kind: 'update' }] },
+      { workingDirectory: repoA, snapshotScope: 'scope-a' }
+    );
+    fs.writeFileSync(fileA, 'const value = "a-post";\n', 'utf-8');
+
+    const repoB = createTempGitRepo();
+    const fileB = path.join(repoB, 'collision-b.ts');
+    fs.writeFileSync(fileB, 'const value = "b-head";\n', 'utf-8');
+    execSync('git add .', { cwd: repoB, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoB, stdio: 'ignore' });
+    fs.writeFileSync(fileB, 'const value = "b-pre";\n', 'utf-8');
+    registerToolInvocationStart(
+      sharedToolUseId,
+      'edit_files',
+      { changes: [{ path: 'collision-b.ts', kind: 'update' }] },
+      { workingDirectory: repoB, snapshotScope: 'scope-b' }
+    );
+    fs.writeFileSync(fileB, 'const value = "b-post";\n', 'utf-8');
+
+    const blocksA: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: sharedToolUseId,
+        name: 'edit_files',
+        input: { changes: [{ path: 'collision-a.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: sharedToolUseId,
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocksA, { workingDirectory: repoA, snapshotScope: 'scope-a' });
+
+    const linesA = blocksA[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(linesA.some((line) => line.includes('-const value = "a-pre";'))).toBe(true);
+    expect(linesA.some((line) => line.includes('+const value = "a-post";'))).toBe(true);
+    expect(linesA.some((line) => line.includes('b-pre'))).toBe(false);
+
+    const blocksB: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: sharedToolUseId,
+        name: 'edit_files',
+        input: { changes: [{ path: 'collision-b.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: sharedToolUseId,
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocksB, { workingDirectory: repoB, snapshotScope: 'scope-b' });
+
+    const linesB = blocksB[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(linesB.some((line) => line.includes('-const value = "b-pre";'))).toBe(true);
+    expect(linesB.some((line) => line.includes('+const value = "b-post";'))).toBe(true);
+    expect(linesB.some((line) => line.includes('a-pre'))).toBe(false);
+  });
+
+  it('falls back to git HEAD diff after explicit snapshot cleanup', () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'cleanup.ts');
+
+    fs.writeFileSync(filePath, 'const value = "head";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    // Diverge from HEAD before registering snapshot so snapshot and HEAD differ.
+    fs.writeFileSync(filePath, 'const value = "pre";\n', 'utf-8');
+    registerToolInvocationStart(
+      'tool-codex-edit-files-cleanup',
+      'edit_files',
+      { changes: [{ path: 'cleanup.ts', kind: 'update' }] },
+      { workingDirectory: repoDir, snapshotScope: 'scope-cleanup' }
+    );
+
+    fs.writeFileSync(filePath, 'const value = "post";\n', 'utf-8');
+    clearToolInvocationState('tool-codex-edit-files-cleanup', { snapshotScope: 'scope-cleanup' });
+
+    const blocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-cleanup',
+        name: 'edit_files',
+        input: { changes: [{ path: 'cleanup.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-cleanup',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocks, { workingDirectory: repoDir, snapshotScope: 'scope-cleanup' });
+
+    const lines = blocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-const value = "head";'))).toBe(true);
+    expect(lines.some((line) => line.includes('+const value = "post";'))).toBe(true);
+    expect(lines.some((line) => line.includes('-const value = "pre";'))).toBe(false);
   });
 
   it('skips unsafe relative paths when resolving git HEAD content', () => {

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -39,6 +39,7 @@ interface ToolUseInfo {
 
 export interface DiffEnrichmentContext {
   workingDirectory?: string;
+  snapshotScope?: string;
 }
 
 export interface FileChangeSpec {
@@ -52,6 +53,11 @@ interface EditFilesSnapshot {
   absolutePath: string;
   beforeExists: boolean;
   beforeContent?: string;
+}
+
+interface PendingSnapshotEntry {
+  snapshots: EditFilesSnapshot[];
+  createdAt: number;
 }
 
 interface ContentBlock {
@@ -138,7 +144,8 @@ function resolveRepoRelativePath(gitRoot: string, absolutePath: string): string 
  * Entries are deleted after consumption to avoid unbounded growth.
  */
 const pendingToolUses = new Map<string, ToolUseInfo>();
-const pendingEditFilesSnapshots = new Map<string, EditFilesSnapshot[]>();
+const pendingEditFilesSnapshots = new Map<string, PendingSnapshotEntry>();
+const MAX_PENDING_EDIT_FILES_SNAPSHOTS = 400;
 
 /**
  * Register tool uses from an assistant message for later enrichment lookup.
@@ -215,15 +222,24 @@ export function registerToolInvocationStart(
     }
 
     if (snapshots.length > 0) {
-      pendingEditFilesSnapshots.set(toolUseId, snapshots);
+      pendingEditFilesSnapshots.set(getSnapshotKey(toolUseId, context), {
+        snapshots,
+        createdAt: Date.now(),
+      });
     }
 
-    if (pendingEditFilesSnapshots.size > 400) {
-      pendingEditFilesSnapshots.clear();
-    }
+    pruneOldestEditFilesSnapshots();
   } catch {
     // Best effort — swallow any errors
   }
+}
+
+/**
+ * Clear pending per-invocation snapshot state for a specific tool use.
+ * Used on terminal paths (stop/abort/error) to prevent stale cache buildup.
+ */
+export function clearToolInvocationState(toolUseId: string, context?: DiffEnrichmentContext): void {
+  pendingEditFilesSnapshots.delete(getSnapshotKey(toolUseId, context));
 }
 
 /**
@@ -443,10 +459,13 @@ function enrichEditFilesResult(
   if (!changes || changes.length === 0) return;
   const workingDirectory = context?.workingDirectory;
 
-  const snapshots = toolUseId ? pendingEditFilesSnapshots.get(toolUseId) : undefined;
+  const snapshotEntry = toolUseId
+    ? pendingEditFilesSnapshots.get(getSnapshotKey(toolUseId, context))
+    : undefined;
   if (toolUseId) {
-    pendingEditFilesSnapshots.delete(toolUseId);
+    pendingEditFilesSnapshots.delete(getSnapshotKey(toolUseId, context));
   }
+  const snapshots = snapshotEntry?.snapshots;
 
   if (snapshots?.length) {
     const snapshotDiffs = enrichFromEditFilesSnapshots(snapshots);
@@ -568,6 +587,24 @@ function normalizeChangeKind(kind: string | undefined): 'add' | 'update' | 'dele
     return kind;
   }
   return 'update';
+}
+
+function getSnapshotKey(toolUseId: string, context?: DiffEnrichmentContext): string {
+  return `${context?.snapshotScope ?? 'global'}:${toolUseId}`;
+}
+
+function pruneOldestEditFilesSnapshots(): void {
+  if (pendingEditFilesSnapshots.size <= MAX_PENDING_EDIT_FILES_SNAPSHOTS) return;
+
+  const overflowCount = pendingEditFilesSnapshots.size - MAX_PENDING_EDIT_FILES_SNAPSHOTS;
+  const oldestKeys = [...pendingEditFilesSnapshots.entries()]
+    .sort((a, b) => a[1].createdAt - b[1].createdAt)
+    .slice(0, overflowCount)
+    .map(([key]) => key);
+
+  for (const key of oldestKeys) {
+    pendingEditFilesSnapshots.delete(key);
+  }
 }
 
 function enrichFromEditFilesSnapshots(snapshots: EditFilesSnapshot[]): FileDiff[] {

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -41,6 +41,19 @@ export interface DiffEnrichmentContext {
   workingDirectory?: string;
 }
 
+export interface FileChangeSpec {
+  path: string;
+  kind?: string;
+}
+
+interface EditFilesSnapshot {
+  path: string;
+  kind: 'add' | 'update' | 'delete';
+  absolutePath: string;
+  beforeExists: boolean;
+  beforeContent?: string;
+}
+
 interface ContentBlock {
   type: string;
   id?: string;
@@ -125,6 +138,7 @@ function resolveRepoRelativePath(gitRoot: string, absolutePath: string): string 
  * Entries are deleted after consumption to avoid unbounded growth.
  */
 const pendingToolUses = new Map<string, ToolUseInfo>();
+const pendingEditFilesSnapshots = new Map<string, EditFilesSnapshot[]>();
 
 /**
  * Register tool uses from an assistant message for later enrichment lookup.
@@ -135,6 +149,80 @@ export function registerToolUses(
 ): void {
   for (const tu of toolUses) {
     pendingToolUses.set(tu.id, { name: tu.name, input: tu.input });
+  }
+}
+
+/**
+ * Register a pre-edit snapshot for tools that need true pre/post diffs.
+ * Currently used for Codex edit_files at tool-start time so completion does not
+ * rely on git HEAD state.
+ */
+export function registerToolInvocationStart(
+  toolUseId: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  context?: DiffEnrichmentContext
+): void {
+  try {
+    if (toolName.toLowerCase() !== 'edit_files') return;
+
+    const changes = toolInput.changes as FileChangeSpec[] | undefined;
+    if (!changes || changes.length === 0) return;
+
+    const workingDirectory = context?.workingDirectory;
+    let gitRoot: string;
+    try {
+      gitRoot = execSync('git rev-parse --show-toplevel', {
+        encoding: 'utf-8',
+        timeout: 5000,
+        ...(workingDirectory ? { cwd: workingDirectory } : {}),
+      }).trim();
+    } catch {
+      return;
+    }
+
+    const snapshots: EditFilesSnapshot[] = [];
+    for (const change of changes) {
+      if (!change?.path) continue;
+
+      const kind = normalizeChangeKind(change.kind);
+      const absolutePath = path.isAbsolute(change.path)
+        ? change.path
+        : path.resolve(workingDirectory || gitRoot, change.path);
+
+      // Only snapshot files inside the repo.
+      if (!resolveRepoRelativePath(gitRoot, absolutePath)) continue;
+
+      let beforeExists = false;
+      let beforeContent: string | undefined;
+      try {
+        const stat = fs.statSync(absolutePath);
+        if (stat.size <= MAX_FILE_SIZE_BYTES) {
+          beforeContent = fs.readFileSync(absolutePath, 'utf-8');
+        }
+        beforeExists = true;
+      } catch {
+        beforeExists = false;
+      }
+
+      snapshots.push({
+        path: change.path,
+        kind,
+        absolutePath,
+        beforeExists,
+        beforeContent,
+      });
+    }
+
+    if (snapshots.length > 0) {
+      pendingEditFilesSnapshots.set(toolUseId, snapshots);
+    }
+
+    if (pendingEditFilesSnapshots.size > 400) {
+      pendingEditFilesSnapshots.clear();
+    }
+  } catch {
+    // Best effort — swallow any errors
   }
 }
 
@@ -158,7 +246,7 @@ export function enrichToolResults(contentBlocks: ContentBlock[]): void {
     // Consume the entry — we no longer need it
     pendingToolUses.delete(toolUseId);
 
-    enrichBlock(block, toolUse.name, toolUse.input);
+    enrichBlock(block, toolUse.name, toolUse.input, undefined, toolUseId);
   }
 
   // GC: clear any stale entries older than expected
@@ -202,7 +290,7 @@ export function enrichContentBlocks(
     const toolUse = localToolUses.get(toolUseId);
     if (!toolUse) continue;
 
-    enrichBlock(block, toolUse.name, toolUse.input, context);
+    enrichBlock(block, toolUse.name, toolUse.input, context, toolUseId);
   }
 }
 
@@ -218,7 +306,8 @@ function enrichBlock(
   block: ContentBlock,
   toolName: string,
   toolInput: Record<string, unknown>,
-  context?: DiffEnrichmentContext
+  context?: DiffEnrichmentContext,
+  toolUseId?: string
 ): void {
   try {
     // Normalize tool names across SDKs (Claude: "Edit", Codex: "edit", etc.)
@@ -228,7 +317,7 @@ function enrichBlock(
     } else if (normalized === 'write') {
       enrichWriteResult(block, toolInput);
     } else if (normalized === 'edit_files') {
-      enrichEditFilesResult(block, toolInput, context);
+      enrichEditFilesResult(block, toolInput, context, toolUseId);
     }
   } catch {
     // Best effort — swallow any errors
@@ -347,11 +436,28 @@ function enrichWriteResult(block: ContentBlock, input: Record<string, unknown>):
 function enrichEditFilesResult(
   block: ContentBlock,
   input: Record<string, unknown>,
-  context?: DiffEnrichmentContext
+  context?: DiffEnrichmentContext,
+  toolUseId?: string
 ): void {
-  const changes = input.changes as Array<{ path: string; kind: string }> | undefined;
+  const changes = input.changes as FileChangeSpec[] | undefined;
   if (!changes || changes.length === 0) return;
   const workingDirectory = context?.workingDirectory;
+
+  const snapshots = toolUseId ? pendingEditFilesSnapshots.get(toolUseId) : undefined;
+  if (toolUseId) {
+    pendingEditFilesSnapshots.delete(toolUseId);
+  }
+
+  if (snapshots?.length) {
+    const snapshotDiffs = enrichFromEditFilesSnapshots(snapshots);
+    if (snapshotDiffs.length > 0) {
+      block.diff = {
+        structuredPatch: snapshotDiffs[0].structuredPatch,
+        files: snapshotDiffs,
+      };
+      return;
+    }
+  }
 
   // Find git root once for relative path resolution
   let gitRoot: string;
@@ -370,7 +476,7 @@ function enrichEditFilesResult(
   for (const change of changes) {
     if (!change.path) continue;
 
-    const kind = (change.kind || 'update') as 'add' | 'update' | 'delete';
+    const kind = normalizeChangeKind(change.kind);
     const filePath = change.path;
     const resolvedPath = path.isAbsolute(filePath)
       ? filePath
@@ -455,4 +561,72 @@ function gitShowHeadFile(gitRoot: string, relativePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+function normalizeChangeKind(kind: string | undefined): 'add' | 'update' | 'delete' {
+  if (kind === 'add' || kind === 'delete' || kind === 'update') {
+    return kind;
+  }
+  return 'update';
+}
+
+function enrichFromEditFilesSnapshots(snapshots: EditFilesSnapshot[]): FileDiff[] {
+  const fileDiffs: FileDiff[] = [];
+
+  for (const snapshot of snapshots) {
+    try {
+      let afterExists = false;
+      let afterContent = '';
+
+      try {
+        const stat = fs.statSync(snapshot.absolutePath);
+        if (stat.size <= MAX_FILE_SIZE_BYTES) {
+          afterContent = fs.readFileSync(snapshot.absolutePath, 'utf-8');
+        }
+        afterExists = true;
+      } catch {
+        afterExists = false;
+      }
+
+      const beforeContent = snapshot.beforeExists ? (snapshot.beforeContent ?? '') : '';
+      const beforeForDiff = snapshot.beforeExists ? beforeContent : '';
+      const afterForDiff = afterExists ? afterContent : '';
+      if (!snapshot.beforeExists && !afterExists) continue;
+      if (beforeForDiff === afterForDiff) continue;
+
+      let resultKind: 'add' | 'update' | 'delete' = snapshot.kind;
+      if (!snapshot.beforeExists && afterExists) {
+        resultKind = 'add';
+      } else if (snapshot.beforeExists && !afterExists) {
+        resultKind = 'delete';
+      } else {
+        resultKind = 'update';
+      }
+
+      const patch = structuredPatch(
+        snapshot.path,
+        snapshot.path,
+        beforeForDiff,
+        afterForDiff,
+        '',
+        '',
+        {
+          context: resultKind === 'add' ? 0 : CONTEXT_LINES,
+        }
+      );
+
+      if (patch.hunks.length > 0) {
+        fileDiffs.push({
+          path: snapshot.path,
+          kind: resultKind,
+          structuredPatch: patch.hunks,
+        });
+      }
+    } catch {
+      // Best effort — skip files that fail
+    }
+  }
+
+  // Keep fallback path in calling method if this yields no diffs.
+  return fileDiffs;
 }

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -29,7 +29,7 @@ import {
   type SessionID,
   type TaskID,
 } from '../../types.js';
-import { enrichContentBlocks } from '../base/diff-enrichment.js';
+import { enrichContentBlocks, registerToolInvocationStart } from '../base/diff-enrichment.js';
 import type { ITool, StreamingCallbacks, ToolCapabilities } from '../base/index.js';
 import type {
   MessagesService,
@@ -222,6 +222,13 @@ export class CodexTool implements ITool {
 
       // Handle tool execution start (live UI indicator)
       if (event.type === 'tool_start') {
+        registerToolInvocationStart(
+          event.toolUse.id,
+          event.toolUse.name,
+          event.toolUse.input,
+          workingDirectory ? { workingDirectory } : undefined
+        );
+
         if (taskId) {
           await this.emitTaskEvent('tool:start', {
             task_id: taskId,

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -29,7 +29,11 @@ import {
   type SessionID,
   type TaskID,
 } from '../../types.js';
-import { enrichContentBlocks, registerToolInvocationStart } from '../base/diff-enrichment.js';
+import {
+  clearToolInvocationState,
+  enrichContentBlocks,
+  registerToolInvocationStart,
+} from '../base/diff-enrichment.js';
 import type { ITool, StreamingCallbacks, ToolCapabilities } from '../base/index.js';
 import type {
   MessagesService,
@@ -189,6 +193,8 @@ export class CodexTool implements ITool {
     let wasStopped = false;
     let workingDirectory: string | undefined;
     const pendingToolMessageIds = new Map<string, MessageID>();
+    const pendingSnapshotToolIds = new Set<string>();
+    const snapshotContext = { snapshotScope: sessionId };
 
     if (this.sessionsRepo && this.worktreesRepo) {
       const session = await this.sessionsRepo.findById(sessionId);
@@ -209,6 +215,10 @@ export class CodexTool implements ITool {
       if (event.type === 'stopped') {
         wasStopped = true;
         console.log(`🛑 Codex execution was stopped for session ${sessionId}`);
+        for (const toolUseId of pendingSnapshotToolIds) {
+          clearToolInvocationState(toolUseId, snapshotContext);
+        }
+        pendingSnapshotToolIds.clear();
         continue; // Skip processing this event
       }
       // Capture resolved model from partial/complete events
@@ -222,12 +232,11 @@ export class CodexTool implements ITool {
 
       // Handle tool execution start (live UI indicator)
       if (event.type === 'tool_start') {
-        registerToolInvocationStart(
-          event.toolUse.id,
-          event.toolUse.name,
-          event.toolUse.input,
-          workingDirectory ? { workingDirectory } : undefined
-        );
+        registerToolInvocationStart(event.toolUse.id, event.toolUse.name, event.toolUse.input, {
+          ...(workingDirectory ? { workingDirectory } : {}),
+          ...snapshotContext,
+        });
+        pendingSnapshotToolIds.add(event.toolUse.id);
 
         if (taskId) {
           await this.emitTaskEvent('tool:start', {
@@ -371,7 +380,12 @@ export class CodexTool implements ITool {
         ];
 
         // Best-effort diff enrichment for Edit/Write tool results
-        enrichContentBlocks(toolContent, { workingDirectory });
+        enrichContentBlocks(toolContent, {
+          ...(workingDirectory ? { workingDirectory } : {}),
+          ...snapshotContext,
+        });
+        clearToolInvocationState(event.toolUse.id, snapshotContext);
+        pendingSnapshotToolIds.delete(event.toolUse.id);
 
         const existingToolMessageId = pendingToolMessageIds.get(event.toolUse.id);
         if (existingToolMessageId) {


### PR DESCRIPTION
## Summary
- add shared diff-enrichment snapshot registration for tool start events
- wire Codex tool_start to register edit_files pre-state
- consume snapshots on tool_complete to compute true per-invocation diffs before fallback to HEAD-based diffing
- add regression test for add-then-remove across separate tool invocations

## Why
Codex edit_files diff rendering could miss remove operations when a file was added and then removed in separate invocations, because enrichment compared current state to git HEAD instead of operation pre/post state.

## Validation
- pnpm -C packages/executor test src/sdk-handlers/base/diff-enrichment.test.ts
- pnpm -C packages/executor typecheck
