### PR TITLE
Fix ERR_STRING_TOO_LONG in agor daemon logs

### DIFF
--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -10,7 +10,9 @@
     "build": "tsup",
     "dev": "NODE_NO_WARNINGS=1 tsx bin/dev.ts",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@agor/core": "workspace:*",
@@ -27,7 +29,8 @@
     "oclif": "^4.22.81",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   },
   "oclif": {
     "bin": "agor",

--- a/apps/agor-cli/src/commands/daemon/logs.ts
+++ b/apps/agor-cli/src/commands/daemon/logs.ts
@@ -21,6 +21,7 @@ export default class DaemonLogs extends Command {
       char: 'n',
       description: 'Number of lines to display',
       default: 50,
+      min: 1,
     }),
   };
 

--- a/apps/agor-cli/src/lib/daemon-manager.test.ts
+++ b/apps/agor-cli/src/lib/daemon-manager.test.ts
@@ -33,6 +33,22 @@ describe('daemon-manager logs', () => {
     expect(readFileSpy).not.toHaveBeenCalled();
   });
 
+  it('returns empty string when lines is zero or negative', () => {
+    const logFile = getLogFilePath();
+    fs.writeFileSync(logFile, 'line-1\nline-2\n');
+
+    expect(readLogs(0)).toBe('');
+    expect(readLogs(-3)).toBe('');
+  });
+
+  it('falls back to default line count for non-finite line values', () => {
+    const logFile = getLogFilePath();
+    const allLines = Array.from({ length: 80 }, (_, i) => `line-${i + 1}`);
+    fs.writeFileSync(logFile, `${allLines.join('\n')}\n`);
+
+    expect(readLogs(Number.NaN)).toBe(allLines.slice(-50).join('\n'));
+  });
+
   it('handles very large log files without ERR_STRING_TOO_LONG', () => {
     const logFile = getLogFilePath();
     const fd = fs.openSync(logFile, 'w');

--- a/apps/agor-cli/src/lib/daemon-manager.test.ts
+++ b/apps/agor-cli/src/lib/daemon-manager.test.ts
@@ -51,6 +51,15 @@ describe('daemon-manager logs', () => {
     expect(readLogs(2)).toBe('tail-1\ntail-2');
   });
 
+  it('adds truncation notice when safety cap is hit before enough lines are found', () => {
+    const logFile = getLogFilePath();
+    const nineMbSingleLine = `${'x'.repeat(9 * 1024 * 1024)}\n`;
+    fs.writeFileSync(logFile, nineMbSingleLine);
+
+    const output = readLogs(2);
+    expect(output).toContain('[output truncated: scanned last 8MB of 9MB]');
+  });
+
   it('rotates oversized logs and keeps bounded history', () => {
     const logFile = getLogFilePath();
 
@@ -68,5 +77,14 @@ describe('daemon-manager logs', () => {
     expect(fs.readFileSync(`${logFile}.1`, 'utf-8')).toBe('third');
     expect(fs.readFileSync(`${logFile}.2`, 'utf-8')).toBe('second');
     expect(fs.existsSync(`${logFile}.3`)).toBe(false);
+  });
+
+  it('does not rotate when log size equals maxBytes threshold', () => {
+    const logFile = getLogFilePath();
+    fs.writeFileSync(logFile, '12345');
+    rotateDaemonLogIfNeeded(logFile, { maxBytes: 5, maxFiles: 2 });
+
+    expect(fs.existsSync(logFile)).toBe(true);
+    expect(fs.existsSync(`${logFile}.1`)).toBe(false);
   });
 });

--- a/apps/agor-cli/src/lib/daemon-manager.test.ts
+++ b/apps/agor-cli/src/lib/daemon-manager.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLogFilePath, readLogs, rotateDaemonLogIfNeeded } from './daemon-manager.js';
+
+describe('daemon-manager logs', () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-cli-logs-test-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(tempHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('returns "No logs found" when daemon log is missing', () => {
+    expect(readLogs(50)).toBe('No logs found');
+  });
+
+  it('returns the last requested lines without reading the whole file', () => {
+    const logFile = getLogFilePath();
+    const allLines = Array.from({ length: 5000 }, (_, i) => `line-${i + 1}`);
+    fs.writeFileSync(logFile, `${allLines.join('\n')}\n`);
+
+    const readFileSpy = vi.spyOn(fs, 'readFileSync');
+    const output = readLogs(3);
+
+    expect(output).toBe('line-4998\nline-4999\nline-5000');
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles very large log files without ERR_STRING_TOO_LONG', () => {
+    const logFile = getLogFilePath();
+    const fd = fs.openSync(logFile, 'w');
+    try {
+      const hugeBytes = 600 * 1024 * 1024;
+      const trailer = 'tail-1\ntail-2\n';
+      const trailerBytes = Buffer.byteLength(trailer, 'utf-8');
+
+      fs.ftruncateSync(fd, hugeBytes);
+      fs.writeSync(fd, trailer, hugeBytes - trailerBytes, 'utf-8');
+    } finally {
+      fs.closeSync(fd);
+    }
+
+    expect(() => readLogs(2)).not.toThrow();
+    expect(readLogs(2)).toBe('tail-1\ntail-2');
+  });
+
+  it('rotates oversized logs and keeps bounded history', () => {
+    const logFile = getLogFilePath();
+
+    fs.writeFileSync(logFile, 'first');
+    rotateDaemonLogIfNeeded(logFile, { maxBytes: 1, maxFiles: 2 });
+    expect(fs.readFileSync(`${logFile}.1`, 'utf-8')).toBe('first');
+
+    fs.writeFileSync(logFile, 'second');
+    rotateDaemonLogIfNeeded(logFile, { maxBytes: 1, maxFiles: 2 });
+    expect(fs.readFileSync(`${logFile}.1`, 'utf-8')).toBe('second');
+    expect(fs.readFileSync(`${logFile}.2`, 'utf-8')).toBe('first');
+
+    fs.writeFileSync(logFile, 'third');
+    rotateDaemonLogIfNeeded(logFile, { maxBytes: 1, maxFiles: 2 });
+    expect(fs.readFileSync(`${logFile}.1`, 'utf-8')).toBe('third');
+    expect(fs.readFileSync(`${logFile}.2`, 'utf-8')).toBe('second');
+    expect(fs.existsSync(`${logFile}.3`)).toBe(false);
+  });
+});

--- a/apps/agor-cli/src/lib/daemon-manager.ts
+++ b/apps/agor-cli/src/lib/daemon-manager.ts
@@ -10,6 +10,18 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+const DEFAULT_LOG_LINES = 50;
+const MIN_TAIL_READ_BYTES = 64 * 1024;
+const AVG_LOG_LINE_BYTES = 256;
+const MAX_TAIL_READ_BYTES = 8 * 1024 * 1024;
+const DEFAULT_ROTATE_MAX_BYTES = 50 * 1024 * 1024; // 50MB
+const DEFAULT_ROTATE_MAX_FILES = 5;
+
+export interface DaemonLogRotationOptions {
+  maxBytes?: number;
+  maxFiles?: number;
+}
+
 /**
  * Get Agor home directory (~/.agor)
  */
@@ -82,6 +94,13 @@ export function startDaemon(daemonPath: string): number {
 
   // Ensure log directory exists
   const logFile = getLogFilePath();
+
+  try {
+    rotateDaemonLogIfNeeded(logFile);
+  } catch (error) {
+    console.warn(`⚠ Failed to rotate daemon logs: ${(error as Error).message}`);
+  }
+
   const logStream = fs.openSync(logFile, 'a');
 
   // Spawn daemon in detached mode
@@ -166,19 +185,113 @@ export function stopDaemon(): boolean {
 /**
  * Get last N lines from log file
  *
+ * Reads from the end of the file with a bounded window to avoid loading
+ * arbitrarily large logs into memory.
+ *
  * @param lines - Number of lines to read (default: 50)
  * @returns Log content
  */
-export function readLogs(lines: number = 50): string {
+export function readLogs(lines: number = DEFAULT_LOG_LINES): string {
   const logFile = getLogFilePath();
 
   if (!fs.existsSync(logFile)) {
     return 'No logs found';
   }
 
-  const content = fs.readFileSync(logFile, 'utf-8');
-  const allLines = content.split('\n').filter((line) => line.trim() !== '');
-  const lastLines = allLines.slice(-lines);
+  const safeLines = sanitizeRequestedLineCount(lines);
+  if (safeLines <= 0) {
+    return '';
+  }
 
-  return lastLines.join('\n');
+  const fd = fs.openSync(logFile, 'r');
+  try {
+    const fileSize = fs.fstatSync(fd).size;
+    if (fileSize <= 0) {
+      return '';
+    }
+
+    const maxReadableBytes = Math.min(fileSize, MAX_TAIL_READ_BYTES);
+    let bytesToRead = Math.min(
+      maxReadableBytes,
+      Math.max(MIN_TAIL_READ_BYTES, safeLines * AVG_LOG_LINE_BYTES)
+    );
+
+    let lastLines: string[] = [];
+    while (bytesToRead <= maxReadableBytes) {
+      const tailBuffer = readTailBuffer(fd, fileSize, bytesToRead);
+      const tailContent = tailBuffer.toString('utf-8').replaceAll('\0', '').replace(/\r\n/g, '\n');
+      const allLines = tailContent.split('\n').filter((line) => line.trim() !== '');
+      lastLines = allLines.slice(-safeLines);
+
+      if (allLines.length >= safeLines || bytesToRead === maxReadableBytes) {
+        break;
+      }
+
+      bytesToRead = Math.min(maxReadableBytes, bytesToRead * 2);
+    }
+
+    return lastLines.join('\n');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Rotate daemon log file if it exceeds configured size.
+ * Retains N rotated files: daemon.log.1 ... daemon.log.N
+ */
+export function rotateDaemonLogIfNeeded(
+  logFile: string,
+  options: DaemonLogRotationOptions = {}
+): void {
+  if (!fs.existsSync(logFile)) {
+    return;
+  }
+
+  const maxBytes = Math.max(1, Math.floor(options.maxBytes ?? DEFAULT_ROTATE_MAX_BYTES));
+  const maxFiles = Math.max(1, Math.floor(options.maxFiles ?? DEFAULT_ROTATE_MAX_FILES));
+  const logSize = fs.statSync(logFile).size;
+
+  if (logSize < maxBytes) {
+    return;
+  }
+
+  const oldestLog = `${logFile}.${maxFiles}`;
+  if (fs.existsSync(oldestLog)) {
+    fs.unlinkSync(oldestLog);
+  }
+
+  for (let i = maxFiles - 1; i >= 1; i--) {
+    const src = `${logFile}.${i}`;
+    const dest = `${logFile}.${i + 1}`;
+
+    if (!fs.existsSync(src)) {
+      continue;
+    }
+
+    if (fs.existsSync(dest)) {
+      fs.unlinkSync(dest);
+    }
+    fs.renameSync(src, dest);
+  }
+
+  fs.renameSync(logFile, `${logFile}.1`);
+}
+
+function sanitizeRequestedLineCount(lines: number): number {
+  if (!Number.isFinite(lines)) {
+    return DEFAULT_LOG_LINES;
+  }
+
+  const parsed = Math.floor(lines);
+  return Math.max(0, parsed);
+}
+
+function readTailBuffer(fd: number, fileSize: number, bytesToRead: number): Buffer {
+  const readLength = Math.min(bytesToRead, fileSize);
+  const start = fileSize - readLength;
+  const buffer = Buffer.allocUnsafe(readLength);
+  const bytesRead = fs.readSync(fd, buffer, 0, readLength, start);
+
+  return bytesRead === readLength ? buffer : buffer.subarray(0, bytesRead);
 }

--- a/apps/agor-cli/src/lib/daemon-manager.ts
+++ b/apps/agor-cli/src/lib/daemon-manager.ts
@@ -217,11 +217,20 @@ export function readLogs(lines: number = DEFAULT_LOG_LINES): string {
     );
 
     let lastLines: string[] = [];
+    let truncatedByCap = false;
     while (bytesToRead <= maxReadableBytes) {
       const tailBuffer = readTailBuffer(fd, fileSize, bytesToRead);
       const tailContent = tailBuffer.toString('utf-8').replaceAll('\0', '').replace(/\r\n/g, '\n');
       const allLines = tailContent.split('\n').filter((line) => line.trim() !== '');
       lastLines = allLines.slice(-safeLines);
+
+      if (
+        bytesToRead === maxReadableBytes &&
+        fileSize > maxReadableBytes &&
+        allLines.length < safeLines
+      ) {
+        truncatedByCap = true;
+      }
 
       if (allLines.length >= safeLines || bytesToRead === maxReadableBytes) {
         break;
@@ -230,7 +239,13 @@ export function readLogs(lines: number = DEFAULT_LOG_LINES): string {
       bytesToRead = Math.min(maxReadableBytes, bytesToRead * 2);
     }
 
-    return lastLines.join('\n');
+    const logText = lastLines.join('\n');
+    if (!truncatedByCap) {
+      return logText;
+    }
+
+    const prefix = `[output truncated: scanned last ${formatBytes(maxReadableBytes)} of ${formatBytes(fileSize)}]`;
+    return logText.length > 0 ? `${prefix}\n${logText}` : prefix;
   } finally {
     fs.closeSync(fd);
   }
@@ -252,7 +267,7 @@ export function rotateDaemonLogIfNeeded(
   const maxFiles = Math.max(1, Math.floor(options.maxFiles ?? DEFAULT_ROTATE_MAX_FILES));
   const logSize = fs.statSync(logFile).size;
 
-  if (logSize < maxBytes) {
+  if (logSize <= maxBytes) {
     return;
   }
 
@@ -294,4 +309,14 @@ function readTailBuffer(fd: number, fileSize: number, bytesToRead: number): Buff
   const bytesRead = fs.readSync(fd, buffer, 0, readLength, start);
 
   return bytesRead === readLength ? buffer : buffer.subarray(0, bytesRead);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${Math.round((bytes / (1024 * 1024)) * 10) / 10}MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round((bytes / 1024) * 10) / 10}KB`;
+  }
+  return `${bytes}B`;
 }

--- a/apps/agor-cli/vitest.config.ts
+++ b/apps/agor-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@27.1.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/agor-daemon:
     dependencies:


### PR DESCRIPTION
## Summary
- replace full-file daemon log reads with bounded tail reads from end-of-file
- add safeguards for invalid line counts and capped read windows to avoid huge string allocation
- add size-based daemon log rotation on startup (50MB threshold, keep 5 files)
- add CLI tests covering missing logs, tail behavior, large sparse logs, and rotation retention

## Validation
- pnpm i
- pnpm check