### PR TITLE
fix: correct Codex context-window computation

### DIFF
--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -24,6 +24,7 @@ import {
 import { Collapse, Popover, Tooltip, theme } from 'antd';
 import type React from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
+import { getContextWindowPercentage } from '../../utils/contextWindow';
 import { Tag } from '../Tag';
 
 /**
@@ -410,7 +411,7 @@ export const ContextWindowPill: React.FC<ContextWindowPillProps> = ({
   style,
 }) => {
   // Handle division by zero - if no limit, show as unknown percentage
-  const percentage = limit > 0 ? Math.round((used / limit) * 100) : 0;
+  const percentage = limit > 0 ? Math.round(getContextWindowPercentage(used, limit)) : 0;
   const hasLimit = limit > 0;
 
   // Color-code based on usage: green (<50%), yellow (50-80%), red (>80%)

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -195,6 +195,11 @@ interface ContextWindowPillProps extends BasePillProps {
       costUsd?: number;
       primaryModel?: string;
       durationMs?: number;
+      contextUsageSnapshot?: {
+        totalTokens: number;
+        maxTokens: number;
+        percentage: number;
+      };
     };
   };
 }
@@ -220,34 +225,22 @@ const ContextWindowPopoverContent: React.FC<{
   const normalized = taskMetadata?.normalized_sdk_response;
 
   // Add authoritative context usage from SDK's getContextUsage() if available
-  const rawContextUsage =
-    sdkResponse &&
-    typeof sdkResponse === 'object' &&
-    sdkResponse !== null &&
-    'rawContextUsage' in sdkResponse &&
-    sdkResponse.rawContextUsage &&
-    typeof sdkResponse.rawContextUsage === 'object'
-      ? (sdkResponse.rawContextUsage as {
-          totalTokens: number;
-          maxTokens: number;
-          percentage: number;
-        })
-      : null;
+  const contextUsageSnapshot = normalized?.contextUsageSnapshot ?? null;
 
-  if (rawContextUsage) {
+  if (contextUsageSnapshot) {
     advancedItems.push({
       key: 'sdk-context-usage',
       label: 'Context Window (SDK)',
       children: (
         <div style={{ fontSize: '0.9em', color: token.colorTextSecondary }}>
           <div>
-            Used: <strong>{rawContextUsage.totalTokens.toLocaleString()}</strong> tokens
+            Used: <strong>{contextUsageSnapshot.totalTokens.toLocaleString()}</strong> tokens
           </div>
           <div>
-            Limit: <strong>{rawContextUsage.maxTokens.toLocaleString()}</strong> tokens
+            Limit: <strong>{contextUsageSnapshot.maxTokens.toLocaleString()}</strong> tokens
           </div>
           <div>
-            Percentage: <strong>{rawContextUsage.percentage}%</strong>
+            Percentage: <strong>{contextUsageSnapshot.percentage}%</strong>
           </div>
           <div style={{ fontSize: '0.85em', color: token.colorTextTertiary, marginTop: 4 }}>
             Authoritative snapshot from SDK getContextUsage()

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -515,6 +515,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                   duration_ms: task.duration_ms,
                   agentic_tool,
                   raw_sdk_response: task.raw_sdk_response,
+                  normalized_sdk_response: normalized ?? undefined,
                 }}
               />
             )}

--- a/apps/agor-ui/src/utils/contextWindow.test.ts
+++ b/apps/agor-ui/src/utils/contextWindow.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getContextWindowGradient, getContextWindowPercentage } from './contextWindow';
+
+describe('contextWindow utils', () => {
+  it('clamps percentage to 100 when usage exceeds limit', () => {
+    expect(getContextWindowPercentage(600_000, 100_000)).toBe(100);
+  });
+
+  it('clamps percentage to 0 for invalid values', () => {
+    expect(getContextWindowPercentage(Number.NaN, 100_000)).toBe(0);
+    expect(getContextWindowPercentage(1_000, 0)).toBe(0);
+  });
+
+  it('builds a bounded gradient for over-limit usage', () => {
+    const gradient = getContextWindowGradient(600_000, 100_000);
+    expect(gradient).toBe(
+      'linear-gradient(to right, rgba(255, 77, 79, 0.12) 100%, transparent 100%)'
+    );
+  });
+});

--- a/apps/agor-ui/src/utils/contextWindow.ts
+++ b/apps/agor-ui/src/utils/contextWindow.ts
@@ -20,6 +20,11 @@ export function getContextWindowColor(percentage: number): string {
   return 'rgba(255, 77, 79, 0.12)'; // Red
 }
 
+function clampPercentage(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
 /**
  * Create a horizontal gradient background for context window progress
  *
@@ -33,7 +38,7 @@ export function getContextWindowGradient(
 ): string | undefined {
   if (!used || !limit) return undefined;
 
-  const percentage = (used / limit) * 100;
+  const percentage = clampPercentage((used / limit) * 100);
   const color = getContextWindowColor(percentage);
 
   return `linear-gradient(to right, ${color} ${percentage}%, transparent ${percentage}%)`;
@@ -51,5 +56,5 @@ export function getContextWindowPercentage(
   limit: number | undefined
 ): number {
   if (!used || !limit) return 0;
-  return (used / limit) * 100;
+  return clampPercentage((used / limit) * 100);
 }

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -79,6 +79,13 @@ export interface Task {
     };
     contextWindowLimit?: number; // Model's max context window (e.g., 200k for Claude)
     costUsd?: number; // Estimated cost in USD (if pricing available)
+    primaryModel?: string; // Resolved model used for the task
+    durationMs?: number; // Total execution duration from SDK, when available
+    contextUsageSnapshot?: {
+      totalTokens: number;
+      maxTokens: number;
+      percentage: number;
+    }; // Authoritative SDK context snapshot when available
   };
 
   // Computed context window - cumulative token usage for this session

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -11,10 +11,10 @@ describe('estimateCodexContextWindowFromRunningTotals', () => {
       },
     });
 
-    expect(result).toBe(15_120);
+    expect(result).toBe(15_360);
   });
 
-  it('uses input-token delta for running totals and does not add output tokens', () => {
+  it('uses input-token delta for running totals and adds output tokens', () => {
     const result = estimateCodexContextWindowFromRunningTotals(
       {
         type: 'turn.completed',
@@ -32,7 +32,7 @@ describe('estimateCodexContextWindowFromRunningTotals', () => {
       }
     );
 
-    expect(result).toBe(15_300);
+    expect(result).toBe(16_100);
   });
 
   it('falls back to current snapshot when running totals reset', () => {
@@ -53,7 +53,7 @@ describe('estimateCodexContextWindowFromRunningTotals', () => {
       }
     );
 
-    expect(result).toBe(9_800);
+    expect(result).toBe(10_050);
   });
 
   it('returns undefined for invalid current payloads', () => {

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { estimateCodexContextWindowFromRunningTotals } from './base-executor.js';
+
+describe('estimateCodexContextWindowFromRunningTotals', () => {
+  it('uses current snapshot when there is no previous task', () => {
+    const result = estimateCodexContextWindowFromRunningTotals({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 15_120,
+        output_tokens: 240,
+      },
+    });
+
+    expect(result).toBe(15_120);
+  });
+
+  it('uses input-token delta for running totals and does not add output tokens', () => {
+    const result = estimateCodexContextWindowFromRunningTotals(
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 30_900,
+          output_tokens: 800,
+        },
+      },
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 15_600,
+          output_tokens: 700,
+        },
+      }
+    );
+
+    expect(result).toBe(15_300);
+  });
+
+  it('falls back to current snapshot when running totals reset', () => {
+    const result = estimateCodexContextWindowFromRunningTotals(
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 9_800,
+          output_tokens: 250,
+        },
+      },
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 120_000,
+          output_tokens: 400,
+        },
+      }
+    );
+
+    expect(result).toBe(9_800);
+  });
+
+  it('returns undefined for invalid current payloads', () => {
+    expect(estimateCodexContextWindowFromRunningTotals(undefined)).toBeUndefined();
+    expect(
+      estimateCodexContextWindowFromRunningTotals({ usage: { output_tokens: 123 } })
+    ).toBeUndefined();
+  });
+});

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -20,6 +20,7 @@ import type {
 import { MessageRole } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
+import { extractCodexContextWindowUsage } from '../../sdk-handlers/codex/usage.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 
@@ -288,6 +289,33 @@ function extractCodexTurnCounts(
   };
 }
 
+export function estimateCodexContextWindowFromRunningTotals(
+  currentRawSdkResponse: unknown,
+  previousRawSdkResponse?: unknown
+): number | undefined {
+  const current = extractCodexTurnCounts(currentRawSdkResponse);
+  if (!current) {
+    return undefined;
+  }
+
+  const currentSnapshot = extractCodexContextWindowUsage(currentRawSdkResponse);
+  if (!currentSnapshot || currentSnapshot <= 0) {
+    return undefined;
+  }
+
+  const previous = extractCodexTurnCounts(previousRawSdkResponse);
+  if (!previous) {
+    return currentSnapshot;
+  }
+
+  if (current.inputTokens < previous.inputTokens) {
+    // Running total reset (e.g., compaction/new session counter).
+    return currentSnapshot;
+  }
+
+  return Math.max(0, current.inputTokens - previous.inputTokens);
+}
+
 async function computeCodexDeltaWindowEstimate(
   client: AgorClient,
   sessionId: SessionID,
@@ -302,7 +330,8 @@ async function computeCodexDeltaWindowEstimate(
   const existingTasks = await client.service('tasks').find({
     query: {
       session_id: sessionId,
-      $limit: 200,
+      $sort: { created_at: -1 },
+      $limit: 100,
     },
   });
 
@@ -323,26 +352,14 @@ async function computeCodexDeltaWindowEstimate(
       return bCreated - aCreated;
     });
 
-  let previousInputTokens: number | undefined;
+  let previousRawSdkResponse: unknown;
   for (const task of previousTasks) {
-    const previous = extractCodexTurnCounts(task.raw_sdk_response);
-    if (previous) {
-      previousInputTokens = previous.inputTokens;
+    if (extractCodexTurnCounts(task.raw_sdk_response)) {
+      previousRawSdkResponse = task.raw_sdk_response;
       break;
     }
   }
-
-  if (previousInputTokens === undefined) {
-    return current.inputTokens + current.outputTokens;
-  }
-
-  if (current.inputTokens < previousInputTokens) {
-    // Counter reset/compaction: treat current turn as new baseline.
-    return current.inputTokens + current.outputTokens;
-  }
-
-  const deltaInput = current.inputTokens - previousInputTokens;
-  return deltaInput + current.outputTokens;
+  return estimateCodexContextWindowFromRunningTotals(currentRawSdkResponse, previousRawSdkResponse);
 }
 
 /**

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -57,8 +57,6 @@ export interface BaseTool {
       maxTokens: number;
       percentage: number;
     };
-    /** Optional debug payload from SDK stream (e.g. last item.completed item for Codex) */
-    lastItemRawPayload?: unknown;
   }>;
 
   // Optional stopTask method for tools that support interruption
@@ -262,6 +260,91 @@ async function captureGitStateAtTaskEnd(
   }
 }
 
+function extractCodexTurnCounts(
+  rawSdkResponse: unknown
+): { inputTokens: number; outputTokens: number } | undefined {
+  if (!rawSdkResponse || typeof rawSdkResponse !== 'object' || Array.isArray(rawSdkResponse)) {
+    return undefined;
+  }
+
+  const raw = rawSdkResponse as Record<string, unknown>;
+  const usage =
+    raw.usage && typeof raw.usage === 'object' && !Array.isArray(raw.usage)
+      ? (raw.usage as Record<string, unknown>)
+      : raw;
+
+  const inputTokens = usage.input_tokens;
+  const outputTokens = usage.output_tokens;
+  if (typeof inputTokens !== 'number' || !Number.isFinite(inputTokens) || inputTokens < 0) {
+    return undefined;
+  }
+
+  return {
+    inputTokens,
+    outputTokens:
+      typeof outputTokens === 'number' && Number.isFinite(outputTokens) && outputTokens >= 0
+        ? outputTokens
+        : 0,
+  };
+}
+
+async function computeCodexDeltaWindowEstimate(
+  client: AgorClient,
+  sessionId: SessionID,
+  currentTaskId: TaskID,
+  currentRawSdkResponse: unknown
+): Promise<number | undefined> {
+  const current = extractCodexTurnCounts(currentRawSdkResponse);
+  if (!current) {
+    return undefined;
+  }
+
+  const existingTasks = await client.service('tasks').find({
+    query: {
+      session_id: sessionId,
+      $limit: 200,
+    },
+  });
+
+  const taskRows: Task[] = Array.isArray(existingTasks)
+    ? (existingTasks as Task[])
+    : existingTasks &&
+        typeof existingTasks === 'object' &&
+        'data' in existingTasks &&
+        Array.isArray((existingTasks as { data?: unknown }).data)
+      ? (((existingTasks as { data?: Task[] }).data ?? []) as Task[])
+      : [];
+
+  const previousTasks = taskRows
+    .filter((task) => task.task_id !== currentTaskId)
+    .sort((a, b) => {
+      const aCreated = new Date(String(a.created_at ?? 0)).getTime();
+      const bCreated = new Date(String(b.created_at ?? 0)).getTime();
+      return bCreated - aCreated;
+    });
+
+  let previousInputTokens: number | undefined;
+  for (const task of previousTasks) {
+    const previous = extractCodexTurnCounts(task.raw_sdk_response);
+    if (previous) {
+      previousInputTokens = previous.inputTokens;
+      break;
+    }
+  }
+
+  if (previousInputTokens === undefined) {
+    return current.inputTokens + current.outputTokens;
+  }
+
+  if (current.inputTokens < previousInputTokens) {
+    // Counter reset/compaction: treat current turn as new baseline.
+    return current.inputTokens + current.outputTokens;
+  }
+
+  const deltaInput = current.inputTokens - previousInputTokens;
+  return deltaInput + current.outputTokens;
+}
+
 /**
  * Resolve API key with proper precedence:
  * 1. Per-user encrypted keys (from database) - HIGHEST
@@ -421,21 +504,7 @@ export async function executeToolTask(params: {
     // Add SDK response data for token accounting
     // Store both raw (for debugging) and normalized (for UI/analytics)
     if (result.rawSdkResponse) {
-      // Debug assist (temporary): surface the final item.completed payload in the
-      // Raw SDK panel by attaching it to raw_sdk_response.
-      if (
-        result.lastItemRawPayload !== undefined &&
-        result.rawSdkResponse &&
-        typeof result.rawSdkResponse === 'object' &&
-        !Array.isArray(result.rawSdkResponse)
-      ) {
-        patchData.raw_sdk_response = {
-          ...(result.rawSdkResponse as Record<string, unknown>),
-          last_item_raw_payload: result.lastItemRawPayload,
-        };
-      } else {
-        patchData.raw_sdk_response = result.rawSdkResponse;
-      }
+      patchData.raw_sdk_response = result.rawSdkResponse;
       // Normalize using tool-specific normalizer (toolName maps to agentic tool type)
       const normalized = normalizeRawSdkResponse(toolName, result.rawSdkResponse);
       if (normalized) {
@@ -476,20 +545,41 @@ export async function executeToolTask(params: {
           percentage: result.rawContextUsage.percentage,
         };
       }
-    } else if (tool.computeContextWindow) {
-      try {
-        const contextWindow = await tool.computeContextWindow(
-          sessionId,
-          taskId,
-          result.rawSdkResponse
-        );
-        if (contextWindow > 0) {
-          patchData.computed_context_window = contextWindow;
-          console.log(`[${toolName}] Computed context window: ${contextWindow} tokens`);
+    } else {
+      if (toolName === 'codex' && result.rawSdkResponse) {
+        try {
+          const estimatedWindow = await computeCodexDeltaWindowEstimate(
+            client,
+            sessionId,
+            taskId,
+            result.rawSdkResponse
+          );
+          if (estimatedWindow && estimatedWindow > 0) {
+            patchData.computed_context_window = estimatedWindow;
+            console.log(
+              `[${toolName}] Estimated context window from cumulative input delta: ${estimatedWindow} tokens`
+            );
+          }
+        } catch (error) {
+          console.warn(`[${toolName}] Failed to estimate delta-based context window:`, error);
         }
-      } catch (error) {
-        console.error(`[${toolName}] Failed to compute context window:`, error);
-        // Continue without context window - not critical
+      }
+
+      if (patchData.computed_context_window === undefined && tool.computeContextWindow) {
+        try {
+          const contextWindow = await tool.computeContextWindow(
+            sessionId,
+            taskId,
+            result.rawSdkResponse
+          );
+          if (contextWindow > 0) {
+            patchData.computed_context_window = contextWindow;
+            console.log(`[${toolName}] Computed context window: ${contextWindow} tokens`);
+          }
+        } catch (error) {
+          console.error(`[${toolName}] Failed to compute context window:`, error);
+          // Continue without context window - not critical
+        }
       }
     }
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -20,7 +20,7 @@ import type {
 import { MessageRole } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
-import { extractCodexContextWindowUsage } from '../../sdk-handlers/codex/usage.js';
+import { computeCodexContextWindowFromPreviousTask } from '../../sdk-handlers/codex/context-window-fallback.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 
@@ -261,107 +261,6 @@ async function captureGitStateAtTaskEnd(
   }
 }
 
-function extractCodexTurnCounts(
-  rawSdkResponse: unknown
-): { inputTokens: number; outputTokens: number } | undefined {
-  if (!rawSdkResponse || typeof rawSdkResponse !== 'object' || Array.isArray(rawSdkResponse)) {
-    return undefined;
-  }
-
-  const raw = rawSdkResponse as Record<string, unknown>;
-  const usage =
-    raw.usage && typeof raw.usage === 'object' && !Array.isArray(raw.usage)
-      ? (raw.usage as Record<string, unknown>)
-      : raw;
-
-  const inputTokens = usage.input_tokens;
-  const outputTokens = usage.output_tokens;
-  if (typeof inputTokens !== 'number' || !Number.isFinite(inputTokens) || inputTokens < 0) {
-    return undefined;
-  }
-
-  return {
-    inputTokens,
-    outputTokens:
-      typeof outputTokens === 'number' && Number.isFinite(outputTokens) && outputTokens >= 0
-        ? outputTokens
-        : 0,
-  };
-}
-
-export function estimateCodexContextWindowFromRunningTotals(
-  currentRawSdkResponse: unknown,
-  previousRawSdkResponse?: unknown
-): number | undefined {
-  const current = extractCodexTurnCounts(currentRawSdkResponse);
-  if (!current) {
-    return undefined;
-  }
-
-  const currentSnapshot = extractCodexContextWindowUsage(currentRawSdkResponse);
-  if (!currentSnapshot || currentSnapshot <= 0) {
-    return undefined;
-  }
-
-  const previous = extractCodexTurnCounts(previousRawSdkResponse);
-  if (!previous) {
-    return currentSnapshot + current.outputTokens;
-  }
-
-  if (current.inputTokens < previous.inputTokens) {
-    // Running total reset (e.g., compaction/new session counter).
-    return currentSnapshot + current.outputTokens;
-  }
-
-  return Math.max(0, current.inputTokens - previous.inputTokens) + current.outputTokens;
-}
-
-async function computeCodexDeltaWindowEstimate(
-  client: AgorClient,
-  sessionId: SessionID,
-  currentTaskId: TaskID,
-  currentRawSdkResponse: unknown
-): Promise<number | undefined> {
-  const current = extractCodexTurnCounts(currentRawSdkResponse);
-  if (!current) {
-    return undefined;
-  }
-
-  const existingTasks = await client.service('tasks').find({
-    query: {
-      session_id: sessionId,
-      $sort: { created_at: -1 },
-      $limit: 100,
-    },
-  });
-
-  const taskRows: Task[] = Array.isArray(existingTasks)
-    ? (existingTasks as Task[])
-    : existingTasks &&
-        typeof existingTasks === 'object' &&
-        'data' in existingTasks &&
-        Array.isArray((existingTasks as { data?: unknown }).data)
-      ? (((existingTasks as { data?: Task[] }).data ?? []) as Task[])
-      : [];
-
-  const previousTasks = taskRows
-    .filter((task) => task.task_id !== currentTaskId)
-    .sort((a, b) => {
-      const aCreated = new Date(String(a.created_at ?? 0)).getTime();
-      const bCreated = new Date(String(b.created_at ?? 0)).getTime();
-      return bCreated - aCreated;
-    });
-
-  let previousRawSdkResponse: unknown;
-  for (const task of previousTasks) {
-    if (extractCodexTurnCounts(task.raw_sdk_response)) {
-      previousRawSdkResponse = task.raw_sdk_response;
-      break;
-    }
-  }
-  return estimateCodexContextWindowFromRunningTotals(currentRawSdkResponse, previousRawSdkResponse);
-}
-
 /**
  * Resolve API key with proper precedence:
  * 1. Per-user encrypted keys (from database) - HIGHEST
@@ -565,20 +464,20 @@ export async function executeToolTask(params: {
     } else {
       if (toolName === 'codex' && result.rawSdkResponse) {
         try {
-          const estimatedWindow = await computeCodexDeltaWindowEstimate(
+          const inferredWindow = await computeCodexContextWindowFromPreviousTask(
             client,
             sessionId,
             taskId,
             result.rawSdkResponse
           );
-          if (estimatedWindow && estimatedWindow > 0) {
-            patchData.computed_context_window = estimatedWindow;
+          if (inferredWindow && inferredWindow > 0) {
+            patchData.computed_context_window = inferredWindow;
             console.log(
-              `[${toolName}] Estimated context window from cumulative input delta: ${estimatedWindow} tokens`
+              `[${toolName}] Inferred context window from previous-task running totals: ${inferredWindow} tokens`
             );
           }
         } catch (error) {
-          console.warn(`[${toolName}] Failed to estimate delta-based context window:`, error);
+          console.warn(`[${toolName}] Failed to infer context window from previous task:`, error);
         }
       }
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -436,23 +436,14 @@ export async function executeToolTask(params: {
       }
     }
 
-    // Use SDK's authoritative context usage when available (Claude Code),
-    // fall back to tool-specific computation for other tools (Codex, Gemini).
+    // Use SDK's authoritative context usage when available,
+    // fall back to tool-specific computation otherwise.
     // Handled independently of rawSdkResponse since the two data sources are separate.
     if (result.rawContextUsage && result.rawContextUsage.totalTokens > 0) {
       patchData.computed_context_window = result.rawContextUsage.totalTokens;
       console.log(
         `[${toolName}] SDK context usage: ${result.rawContextUsage.totalTokens}/${result.rawContextUsage.maxTokens} tokens (${result.rawContextUsage.percentage}%)`
       );
-
-      // Store rawContextUsage in the raw_sdk_response for debugging
-      if (patchData.raw_sdk_response && typeof patchData.raw_sdk_response === 'object') {
-        (patchData.raw_sdk_response as Record<string, unknown>).rawContextUsage = {
-          totalTokens: result.rawContextUsage.totalTokens,
-          maxTokens: result.rawContextUsage.maxTokens,
-          percentage: result.rawContextUsage.percentage,
-        };
-      }
 
       // Override contextWindowLimit in normalized response with the authoritative
       // maxTokens from getContextUsage() so the UI computes percentage correctly
@@ -461,8 +452,13 @@ export async function executeToolTask(params: {
         typeof patchData.normalized_sdk_response === 'object' &&
         result.rawContextUsage.maxTokens > 0
       ) {
-        (patchData.normalized_sdk_response as Record<string, unknown>).contextWindowLimit =
-          result.rawContextUsage.maxTokens;
+        const normalizedResponse = patchData.normalized_sdk_response as Record<string, unknown>;
+        normalizedResponse.contextWindowLimit = result.rawContextUsage.maxTokens;
+        normalizedResponse.contextUsageSnapshot = {
+          totalTokens: result.rawContextUsage.totalTokens,
+          maxTokens: result.rawContextUsage.maxTokens,
+          percentage: result.rawContextUsage.percentage,
+        };
       }
     } else if (tool.computeContextWindow) {
       try {

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -305,15 +305,15 @@ export function estimateCodexContextWindowFromRunningTotals(
 
   const previous = extractCodexTurnCounts(previousRawSdkResponse);
   if (!previous) {
-    return currentSnapshot;
+    return currentSnapshot + current.outputTokens;
   }
 
   if (current.inputTokens < previous.inputTokens) {
     // Running total reset (e.g., compaction/new session counter).
-    return currentSnapshot;
+    return currentSnapshot + current.outputTokens;
   }
 
-  return Math.max(0, current.inputTokens - previous.inputTokens);
+  return Math.max(0, current.inputTokens - previous.inputTokens) + current.outputTokens;
 }
 
 async function computeCodexDeltaWindowEstimate(

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -57,6 +57,8 @@ export interface BaseTool {
       maxTokens: number;
       percentage: number;
     };
+    /** Optional debug payload from SDK stream (e.g. last item.completed item for Codex) */
+    lastItemRawPayload?: unknown;
   }>;
 
   // Optional stopTask method for tools that support interruption
@@ -419,7 +421,21 @@ export async function executeToolTask(params: {
     // Add SDK response data for token accounting
     // Store both raw (for debugging) and normalized (for UI/analytics)
     if (result.rawSdkResponse) {
-      patchData.raw_sdk_response = result.rawSdkResponse;
+      // Debug assist (temporary): surface the final item.completed payload in the
+      // Raw SDK panel by attaching it to raw_sdk_response.
+      if (
+        result.lastItemRawPayload !== undefined &&
+        result.rawSdkResponse &&
+        typeof result.rawSdkResponse === 'object' &&
+        !Array.isArray(result.rawSdkResponse)
+      ) {
+        patchData.raw_sdk_response = {
+          ...(result.rawSdkResponse as Record<string, unknown>),
+          last_item_raw_payload: result.lastItemRawPayload,
+        };
+      } else {
+        patchData.raw_sdk_response = result.rawSdkResponse;
+      }
       // Normalize using tool-specific normalizer (toolName maps to agentic tool type)
       const normalized = normalizeRawSdkResponse(toolName, result.rawSdkResponse);
       if (normalized) {

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -42,6 +42,7 @@ import type {
 } from '../claude/claude-tool.js';
 import { DEFAULT_CODEX_MODEL } from './models.js';
 import { CodexPromptService } from './prompt-service.js';
+import { extractCodexContextWindowUsage } from './usage.js';
 
 interface CodexExecutionResult {
   userMessageId: MessageID;
@@ -51,6 +52,11 @@ interface CodexExecutionResult {
   contextWindowLimit?: number;
   model?: string;
   rawSdkResponse?: unknown; // Raw SDK event from Codex
+  rawContextUsage?: {
+    totalTokens: number;
+    maxTokens: number;
+    percentage: number;
+  };
   wasStopped?: boolean; // True if execution was stopped early via stopTask()
 }
 
@@ -186,6 +192,13 @@ export class CodexTool implements ITool {
     let resolvedModel: string | undefined;
     let currentMessageId: MessageID | null = null;
     let tokenUsage: TokenUsage | undefined;
+    let rawContextUsage:
+      | {
+          totalTokens: number;
+          maxTokens: number;
+          percentage: number;
+        }
+      | undefined;
     let _streamStartTime = Date.now();
     let _firstTokenTime: number | null = null;
     let rawSdkResponse: unknown;
@@ -277,6 +290,10 @@ export class CodexTool implements ITool {
 
       if (event.type === 'complete' && event.usage) {
         tokenUsage = event.usage;
+      }
+
+      if (event.type === 'complete' && event.rawContextUsage) {
+        rawContextUsage = event.rawContextUsage;
       }
 
       // Capture raw SDK response for token accounting
@@ -530,6 +547,7 @@ export class CodexTool implements ITool {
       contextWindowLimit: undefined,
       model: resolvedModel || DEFAULT_CODEX_MODEL,
       rawSdkResponse,
+      rawContextUsage,
       wasStopped,
     };
   }
@@ -696,6 +714,13 @@ export class CodexTool implements ITool {
     let _contextWindow: number | undefined;
     let _contextWindowLimit: number | undefined;
     let rawSdkResponse: unknown;
+    let rawContextUsage:
+      | {
+          totalTokens: number;
+          maxTokens: number;
+          percentage: number;
+        }
+      | undefined;
     let wasStopped = false;
 
     for await (const event of this.promptService.promptSessionStreaming(
@@ -722,6 +747,10 @@ export class CodexTool implements ITool {
 
       if (event.type === 'complete' && event.usage) {
         tokenUsage = event.usage;
+      }
+
+      if (event.type === 'complete' && event.rawContextUsage) {
+        rawContextUsage = event.rawContextUsage;
       }
 
       // Capture raw SDK response for token accounting
@@ -771,6 +800,7 @@ export class CodexTool implements ITool {
       contextWindowLimit: undefined,
       model: resolvedModel || DEFAULT_CODEX_MODEL,
       rawSdkResponse,
+      rawContextUsage,
       wasStopped,
     };
   }
@@ -831,33 +861,39 @@ export class CodexTool implements ITool {
   }
 
   /**
-   * Compute cumulative context window usage for a Codex session
+   * Compute context window usage for a Codex session
    *
-   * For Codex, the SDK already provides cumulative token counts in each task's response.
-   * The inputTokens field includes the full conversation history up to that point.
-   * We just need to extract and return the contextWindow from the current task's SDK response.
+   * Codex SDK usage is reported per turn (not cumulative across tasks).
+   * For context occupancy, use input-side tokens only:
+   * - usage.input_tokens
+   * - usage.cached_input_tokens
+   *
+   * Output tokens are excluded because they are generated during the turn and
+   * are not prompt-side context occupancy.
    *
    * @param sessionId - Session ID to compute context for
    * @param currentTaskId - Optional current task ID (not used for Codex, kept for interface consistency)
    * @param currentRawSdkResponse - Optional raw SDK response from current task (if available in memory)
-   * @returns Promise resolving to computed context window usage in tokens
+   * @returns Promise resolving to context usage in tokens
    */
   async computeContextWindow(
     sessionId: string,
     _currentTaskId?: string,
     currentRawSdkResponse?: unknown
   ): Promise<number> {
-    // Codex SDK provides cumulative tokens in each turn.completed event
-    // Simply extract input_tokens + output_tokens from the raw response
     if (currentRawSdkResponse) {
-      const response = currentRawSdkResponse as import('../../types/sdk-response').CodexSdkResponse;
-      const inputTokens = response.usage?.input_tokens || 0;
-      const outputTokens = response.usage?.output_tokens || 0;
-      const cumulativeTokens = inputTokens + outputTokens;
-      console.log(
-        `✅ Computed context window for Codex session ${sessionId}: ${cumulativeTokens} tokens (from current task)`
+      const contextWindow = extractCodexContextWindowUsage(currentRawSdkResponse);
+      if (contextWindow !== undefined) {
+        console.log(
+          `✅ Computed context window for Codex session ${sessionId}: ${contextWindow} tokens`
+        );
+        return contextWindow;
+      }
+
+      console.warn(
+        `⚠️  Could not extract Codex context window usage from rawSdkResponse for session ${sessionId}, returning 0`
       );
-      return cumulativeTokens;
+      return 0;
     }
 
     // IMPORTANT: Do NOT query database when currentRawSdkResponse is not provided

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -57,7 +57,6 @@ interface CodexExecutionResult {
     maxTokens: number;
     percentage: number;
   };
-  lastItemRawPayload?: unknown;
   wasStopped?: boolean; // True if execution was stopped early via stopTask()
 }
 
@@ -200,7 +199,6 @@ export class CodexTool implements ITool {
           percentage: number;
         }
       | undefined;
-    let lastItemRawPayload: unknown;
     let _streamStartTime = Date.now();
     let _firstTokenTime: number | null = null;
     let rawSdkResponse: unknown;
@@ -296,9 +294,6 @@ export class CodexTool implements ITool {
 
       if (event.type === 'complete' && event.rawContextUsage) {
         rawContextUsage = event.rawContextUsage;
-      }
-      if (event.type === 'complete' && event.lastItemRawPayload !== undefined) {
-        lastItemRawPayload = event.lastItemRawPayload;
       }
 
       // Capture raw SDK response for token accounting
@@ -553,7 +548,6 @@ export class CodexTool implements ITool {
       model: resolvedModel || DEFAULT_CODEX_MODEL,
       rawSdkResponse,
       rawContextUsage,
-      lastItemRawPayload,
       wasStopped,
     };
   }
@@ -727,7 +721,6 @@ export class CodexTool implements ITool {
           percentage: number;
         }
       | undefined;
-    let lastItemRawPayload: unknown;
     let wasStopped = false;
 
     for await (const event of this.promptService.promptSessionStreaming(
@@ -758,9 +751,6 @@ export class CodexTool implements ITool {
 
       if (event.type === 'complete' && event.rawContextUsage) {
         rawContextUsage = event.rawContextUsage;
-      }
-      if (event.type === 'complete' && event.lastItemRawPayload !== undefined) {
-        lastItemRawPayload = event.lastItemRawPayload;
       }
 
       // Capture raw SDK response for token accounting
@@ -811,7 +801,6 @@ export class CodexTool implements ITool {
       model: resolvedModel || DEFAULT_CODEX_MODEL,
       rawSdkResponse,
       rawContextUsage,
-      lastItemRawPayload,
       wasStopped,
     };
   }

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -57,6 +57,7 @@ interface CodexExecutionResult {
     maxTokens: number;
     percentage: number;
   };
+  lastItemRawPayload?: unknown;
   wasStopped?: boolean; // True if execution was stopped early via stopTask()
 }
 
@@ -199,6 +200,7 @@ export class CodexTool implements ITool {
           percentage: number;
         }
       | undefined;
+    let lastItemRawPayload: unknown;
     let _streamStartTime = Date.now();
     let _firstTokenTime: number | null = null;
     let rawSdkResponse: unknown;
@@ -294,6 +296,9 @@ export class CodexTool implements ITool {
 
       if (event.type === 'complete' && event.rawContextUsage) {
         rawContextUsage = event.rawContextUsage;
+      }
+      if (event.type === 'complete' && event.lastItemRawPayload !== undefined) {
+        lastItemRawPayload = event.lastItemRawPayload;
       }
 
       // Capture raw SDK response for token accounting
@@ -548,6 +553,7 @@ export class CodexTool implements ITool {
       model: resolvedModel || DEFAULT_CODEX_MODEL,
       rawSdkResponse,
       rawContextUsage,
+      lastItemRawPayload,
       wasStopped,
     };
   }
@@ -721,6 +727,7 @@ export class CodexTool implements ITool {
           percentage: number;
         }
       | undefined;
+    let lastItemRawPayload: unknown;
     let wasStopped = false;
 
     for await (const event of this.promptService.promptSessionStreaming(
@@ -751,6 +758,9 @@ export class CodexTool implements ITool {
 
       if (event.type === 'complete' && event.rawContextUsage) {
         rawContextUsage = event.rawContextUsage;
+      }
+      if (event.type === 'complete' && event.lastItemRawPayload !== undefined) {
+        lastItemRawPayload = event.lastItemRawPayload;
       }
 
       // Capture raw SDK response for token accounting
@@ -801,6 +811,7 @@ export class CodexTool implements ITool {
       model: resolvedModel || DEFAULT_CODEX_MODEL,
       rawSdkResponse,
       rawContextUsage,
+      lastItemRawPayload,
       wasStopped,
     };
   }

--- a/packages/executor/src/sdk-handlers/codex/context-window-fallback.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/context-window-fallback.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { estimateCodexContextWindowFromRunningTotals } from './base-executor.js';
+import { inferCodexContextWindowFromRunningTotals } from './context-window-fallback.js';
 
-describe('estimateCodexContextWindowFromRunningTotals', () => {
+describe('inferCodexContextWindowFromRunningTotals', () => {
   it('uses current snapshot when there is no previous task', () => {
-    const result = estimateCodexContextWindowFromRunningTotals({
+    const result = inferCodexContextWindowFromRunningTotals({
       type: 'turn.completed',
       usage: {
         input_tokens: 15_120,
@@ -15,7 +15,7 @@ describe('estimateCodexContextWindowFromRunningTotals', () => {
   });
 
   it('uses input-token delta for running totals and adds output tokens', () => {
-    const result = estimateCodexContextWindowFromRunningTotals(
+    const result = inferCodexContextWindowFromRunningTotals(
       {
         type: 'turn.completed',
         usage: {
@@ -36,7 +36,7 @@ describe('estimateCodexContextWindowFromRunningTotals', () => {
   });
 
   it('falls back to current snapshot when running totals reset', () => {
-    const result = estimateCodexContextWindowFromRunningTotals(
+    const result = inferCodexContextWindowFromRunningTotals(
       {
         type: 'turn.completed',
         usage: {
@@ -57,9 +57,9 @@ describe('estimateCodexContextWindowFromRunningTotals', () => {
   });
 
   it('returns undefined for invalid current payloads', () => {
-    expect(estimateCodexContextWindowFromRunningTotals(undefined)).toBeUndefined();
+    expect(inferCodexContextWindowFromRunningTotals(undefined)).toBeUndefined();
     expect(
-      estimateCodexContextWindowFromRunningTotals({ usage: { output_tokens: 123 } })
+      inferCodexContextWindowFromRunningTotals({ usage: { output_tokens: 123 } })
     ).toBeUndefined();
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/context-window-fallback.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/context-window-fallback.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { inferCodexContextWindowFromRunningTotals } from './context-window-fallback.js';
+import type { AgorClient } from '../../services/feathers-client.js';
+import {
+  computeCodexContextWindowFromPreviousTask,
+  inferCodexContextWindowFromRunningTotals,
+} from './context-window-fallback.js';
 
 describe('inferCodexContextWindowFromRunningTotals', () => {
   it('uses current snapshot when there is no previous task', () => {
@@ -61,5 +65,41 @@ describe('inferCodexContextWindowFromRunningTotals', () => {
     expect(
       inferCodexContextWindowFromRunningTotals({ usage: { output_tokens: 123 } })
     ).toBeUndefined();
+  });
+});
+
+describe('computeCodexContextWindowFromPreviousTask', () => {
+  it('queries latest tasks without $ne filter and uses previous task row', async () => {
+    const find = async ({ query }: { query: Record<string, unknown> }) => {
+      expect(query.$limit).toBe(2);
+      expect(query.$sort).toEqual({ created_at: -1 });
+      expect('task_id' in query).toBe(false);
+
+      return {
+        data: [
+          {
+            task_id: 'current-task',
+            raw_sdk_response: { usage: { input_tokens: 30_000, output_tokens: 10 } },
+          },
+          {
+            task_id: 'previous-task',
+            raw_sdk_response: { usage: { input_tokens: 15_000, output_tokens: 50 } },
+          },
+        ],
+      };
+    };
+
+    const client = {
+      service: () => ({ find }),
+    } as unknown as AgorClient;
+
+    const result = await computeCodexContextWindowFromPreviousTask(
+      client,
+      'session' as any,
+      'current-task' as any,
+      { usage: { input_tokens: 30_000, output_tokens: 200 } }
+    );
+
+    expect(result).toBe(15_200);
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/context-window-fallback.ts
+++ b/packages/executor/src/sdk-handlers/codex/context-window-fallback.ts
@@ -1,0 +1,102 @@
+import type { SessionID, TaskID } from '@agor/core/types';
+import type { AgorClient } from '../../services/feathers-client.js';
+import { extractCodexContextWindowUsage } from './usage.js';
+
+type CodexTurnCounts = { inputTokens: number; outputTokens: number };
+
+function extractCodexTurnCounts(rawSdkResponse: unknown): CodexTurnCounts | undefined {
+  if (!rawSdkResponse || typeof rawSdkResponse !== 'object' || Array.isArray(rawSdkResponse)) {
+    return undefined;
+  }
+
+  const raw = rawSdkResponse as Record<string, unknown>;
+  const usage =
+    raw.usage && typeof raw.usage === 'object' && !Array.isArray(raw.usage)
+      ? (raw.usage as Record<string, unknown>)
+      : raw;
+
+  const inputTokens = usage.input_tokens;
+  const outputTokens = usage.output_tokens;
+  if (typeof inputTokens !== 'number' || !Number.isFinite(inputTokens) || inputTokens < 0) {
+    return undefined;
+  }
+
+  return {
+    inputTokens,
+    outputTokens:
+      typeof outputTokens === 'number' && Number.isFinite(outputTokens) && outputTokens >= 0
+        ? outputTokens
+        : 0,
+  };
+}
+
+/**
+ * Infer Codex context-window usage from running totals in turn.completed usage payloads.
+ *
+ * This tracks context occupancy at task end:
+ * - Base inferred input occupancy (delta or current snapshot on reset)
+ * - Plus current output tokens (new assistant content that is now in transcript)
+ */
+export function inferCodexContextWindowFromRunningTotals(
+  currentRawSdkResponse: unknown,
+  previousRawSdkResponse?: unknown
+): number | undefined {
+  const current = extractCodexTurnCounts(currentRawSdkResponse);
+  if (!current) {
+    return undefined;
+  }
+
+  const currentInputSnapshot = extractCodexContextWindowUsage(currentRawSdkResponse);
+  if (!currentInputSnapshot || currentInputSnapshot <= 0) {
+    return undefined;
+  }
+
+  const previous = extractCodexTurnCounts(previousRawSdkResponse);
+  if (!previous) {
+    return currentInputSnapshot + current.outputTokens;
+  }
+
+  if (current.inputTokens < previous.inputTokens) {
+    // Counter reset/compaction: current snapshot becomes the new baseline.
+    return currentInputSnapshot + current.outputTokens;
+  }
+
+  return Math.max(0, current.inputTokens - previous.inputTokens) + current.outputTokens;
+}
+
+function firstTaskFromFindResult(tasks: unknown): { raw_sdk_response?: unknown } | undefined {
+  if (Array.isArray(tasks)) {
+    return tasks[0] as { raw_sdk_response?: unknown } | undefined;
+  }
+
+  if (
+    tasks &&
+    typeof tasks === 'object' &&
+    'data' in tasks &&
+    Array.isArray((tasks as { data?: unknown }).data)
+  ) {
+    return ((tasks as { data?: Array<{ raw_sdk_response?: unknown }> }).data ?? [])[0];
+  }
+
+  return undefined;
+}
+
+export async function computeCodexContextWindowFromPreviousTask(
+  client: AgorClient,
+  sessionId: SessionID,
+  currentTaskId: TaskID,
+  currentRawSdkResponse: unknown
+): Promise<number | undefined> {
+  const previousTask = await client.service('tasks').find({
+    query: {
+      session_id: sessionId,
+      task_id: { $ne: currentTaskId },
+      $sort: { created_at: -1 },
+      $limit: 1,
+    },
+  });
+
+  const previousRawSdkResponse = firstTaskFromFindResult(previousTask)?.raw_sdk_response;
+
+  return inferCodexContextWindowFromRunningTotals(currentRawSdkResponse, previousRawSdkResponse);
+}

--- a/packages/executor/src/sdk-handlers/codex/context-window-fallback.ts
+++ b/packages/executor/src/sdk-handlers/codex/context-window-fallback.ts
@@ -64,9 +64,11 @@ export function inferCodexContextWindowFromRunningTotals(
   return Math.max(0, current.inputTokens - previous.inputTokens) + current.outputTokens;
 }
 
-function firstTaskFromFindResult(tasks: unknown): { raw_sdk_response?: unknown } | undefined {
+type TaskRow = { task_id?: string; raw_sdk_response?: unknown };
+
+function taskRowsFromFindResult(tasks: unknown): TaskRow[] {
   if (Array.isArray(tasks)) {
-    return tasks[0] as { raw_sdk_response?: unknown } | undefined;
+    return tasks as TaskRow[];
   }
 
   if (
@@ -75,10 +77,10 @@ function firstTaskFromFindResult(tasks: unknown): { raw_sdk_response?: unknown }
     'data' in tasks &&
     Array.isArray((tasks as { data?: unknown }).data)
   ) {
-    return ((tasks as { data?: Array<{ raw_sdk_response?: unknown }> }).data ?? [])[0];
+    return (tasks as { data?: TaskRow[] }).data ?? [];
   }
 
-  return undefined;
+  return [];
 }
 
 export async function computeCodexContextWindowFromPreviousTask(
@@ -90,13 +92,14 @@ export async function computeCodexContextWindowFromPreviousTask(
   const previousTask = await client.service('tasks').find({
     query: {
       session_id: sessionId,
-      task_id: { $ne: currentTaskId },
       $sort: { created_at: -1 },
-      $limit: 1,
+      $limit: 2,
     },
   });
 
-  const previousRawSdkResponse = firstTaskFromFindResult(previousTask)?.raw_sdk_response;
+  const taskRows = taskRowsFromFindResult(previousTask);
+  const previousTaskRow = taskRows.find((task) => task.task_id !== currentTaskId);
+  const previousRawSdkResponse = previousTaskRow?.raw_sdk_response;
 
   return inferCodexContextWindowFromRunningTotals(currentRawSdkResponse, previousRawSdkResponse);
 }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -308,6 +308,77 @@ describe('CodexPromptService - Todo normalization', () => {
 });
 
 describe('CodexPromptService - tool payload mapping', () => {
+  it('captures token_count context snapshot and forwards it on turn completion', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
+    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-ctx',
+      worktree_id: 'worktree-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockWorktreesRepo.findById.mockResolvedValue({
+      worktree_id: 'worktree-1',
+      path: process.cwd(),
+    });
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              total_tokens: 210000,
+            },
+            last_token_usage: {
+              total_tokens: 12000,
+            },
+            model_context_window: 272000,
+          },
+        },
+      },
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 1000,
+          cached_input_tokens: 500,
+          output_tokens: 300,
+        },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-ctx' as any, 'review')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const completeEvent = emitted.find((event) => event.type === 'complete');
+    expect(completeEvent).toBeTruthy();
+    expect(completeEvent?.rawContextUsage).toEqual({
+      totalTokens: 210000,
+      maxTokens: 272000,
+      percentage: 77,
+    });
+  });
+
   it('preserves MCP result content on completion', () => {
     const service = new CodexPromptService(
       mockMessagesRepo,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -308,67 +308,6 @@ describe('CodexPromptService - Todo normalization', () => {
 });
 
 describe('CodexPromptService - tool payload mapping', () => {
-  it('forwards last item.completed payload on turn completion for debugging', async () => {
-    const service = new CodexPromptService(
-      mockMessagesRepo,
-      mockSessionsRepo,
-      mockSessionMCPServerRepo,
-      mockWorktreesRepo,
-      undefined,
-      'test-api-key',
-      mockDb
-    );
-
-    const serviceWithPrivates = service as any;
-    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
-    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
-    serviceWithPrivates.refreshClient = vi.fn();
-
-    mockSessionsRepo.findById.mockResolvedValue({
-      session_id: 'session-last-item',
-      worktree_id: 'worktree-1',
-      created_at: new Date().toISOString(),
-      sdk_session_id: null,
-      permission_config: { codex: {} },
-      model_config: {},
-      mcp_token: 'test-token',
-    });
-    mockWorktreesRepo.findById.mockResolvedValue({
-      worktree_id: 'worktree-1',
-      path: process.cwd(),
-    });
-
-    const lastItem = {
-      id: 'agent-msg-1',
-      type: 'agent_message',
-      text: 'final assistant text',
-    };
-
-    mockStreamEvents = [
-      { type: 'turn.started' },
-      { type: 'item.completed', item: lastItem },
-      {
-        type: 'turn.completed',
-        usage: {
-          input_tokens: 100,
-          cached_input_tokens: 0,
-          output_tokens: 20,
-        },
-      },
-    ];
-
-    const emitted: Array<Record<string, unknown>> = [];
-    for await (const event of service.promptSessionStreaming('session-last-item' as any, 'hello')) {
-      emitted.push(event as Record<string, unknown>);
-    }
-
-    const completeEvent = emitted.find(
-      (event) => event.type === 'complete' && event.rawSdkEvent !== undefined
-    );
-    expect(completeEvent).toBeTruthy();
-    expect(completeEvent?.lastItemRawPayload).toEqual(lastItem);
-  });
-
   it('captures token_count context snapshot and forwards it on turn completion', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -308,6 +308,67 @@ describe('CodexPromptService - Todo normalization', () => {
 });
 
 describe('CodexPromptService - tool payload mapping', () => {
+  it('forwards last item.completed payload on turn completion for debugging', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
+    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-last-item',
+      worktree_id: 'worktree-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockWorktreesRepo.findById.mockResolvedValue({
+      worktree_id: 'worktree-1',
+      path: process.cwd(),
+    });
+
+    const lastItem = {
+      id: 'agent-msg-1',
+      type: 'agent_message',
+      text: 'final assistant text',
+    };
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      { type: 'item.completed', item: lastItem },
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 0,
+          output_tokens: 20,
+        },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-last-item' as any, 'hello')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const completeEvent = emitted.find(
+      (event) => event.type === 'complete' && event.rawSdkEvent !== undefined
+    );
+    expect(completeEvent).toBeTruthy();
+    expect(completeEvent?.lastItemRawPayload).toEqual(lastItem);
+  });
+
   it('captures token_count context snapshot and forwards it on turn completion', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -31,7 +31,7 @@ import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID } from '../../types.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { DEFAULT_CODEX_MODEL } from './models.js';
-import { extractCodexTokenUsage } from './usage.js';
+import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
 
 export interface CodexPromptResult {
   /** Complete assistant response from Codex */
@@ -113,6 +113,11 @@ export type CodexStreamEvent =
       resolvedModel?: string;
       usage?: TokenUsage;
       rawSdkEvent?: import('../../types/sdk-response').CodexSdkResponse; // The actual turn.completed event from Codex SDK
+      rawContextUsage?: {
+        totalTokens: number;
+        maxTokens: number;
+        percentage: number;
+      };
     };
 
 export class CodexPromptService {
@@ -848,6 +853,13 @@ export class CodexPromptService {
       const resolvedModel: string | undefined = session.model_config?.model || undefined;
       let allToolUses: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
       let todoIdsEmittedViaUpdate = new Set<string>();
+      let latestContextUsage:
+        | {
+            totalTokens: number;
+            maxTokens: number;
+            percentage: number;
+          }
+        | undefined;
 
       let eventCount = 0;
 
@@ -867,10 +879,21 @@ export class CodexPromptService {
           break;
         }
 
+        if ((event as { type?: string }).type === 'event_msg') {
+          // Codex emits token_count as generic event_msg payloads.
+          // Capture the latest snapshot so turn.completed can return context usage.
+          const contextSnapshot = extractCodexContextSnapshotFromEvent(event);
+          if (contextSnapshot) {
+            latestContextUsage = contextSnapshot;
+          }
+          continue;
+        }
+
         switch (event.type) {
           case 'turn.started':
             allToolUses = []; // Reset tool uses for new turn
             todoIdsEmittedViaUpdate = new Set<string>();
+            latestContextUsage = undefined;
             break;
 
           case 'item.started':
@@ -1014,6 +1037,7 @@ export class CodexPromptService {
               resolvedModel: resolvedModel || DEFAULT_CODEX_MODEL,
               usage: mappedUsage,
               rawSdkEvent: event, // Pass through the actual SDK event (UNMUTATED)
+              rawContextUsage: latestContextUsage,
             };
 
             // Exit the event loop after turn completion

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -118,7 +118,6 @@ export type CodexStreamEvent =
         maxTokens: number;
         percentage: number;
       };
-      lastItemRawPayload?: unknown;
     };
 
 export class CodexPromptService {
@@ -861,7 +860,6 @@ export class CodexPromptService {
             percentage: number;
           }
         | undefined;
-      let lastCompletedItemRawPayload: unknown;
 
       let eventCount = 0;
 
@@ -896,7 +894,6 @@ export class CodexPromptService {
             allToolUses = []; // Reset tool uses for new turn
             todoIdsEmittedViaUpdate = new Set<string>();
             latestContextUsage = undefined;
-            lastCompletedItemRawPayload = undefined;
             break;
 
           case 'item.started':
@@ -931,9 +928,6 @@ export class CodexPromptService {
             break;
 
           case 'item.completed':
-            // Keep the latest raw item payload for debugging on turn completion.
-            // This is intentionally raw and unmodified.
-            lastCompletedItemRawPayload = event.item;
             // Collect completed items and emit tool_complete events
             if (event.item) {
               // Emit tool_complete for tool items
@@ -1044,7 +1038,6 @@ export class CodexPromptService {
               usage: mappedUsage,
               rawSdkEvent: event, // Pass through the actual SDK event (UNMUTATED)
               rawContextUsage: latestContextUsage,
-              lastItemRawPayload: lastCompletedItemRawPayload,
             };
 
             // Exit the event loop after turn completion

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -118,6 +118,7 @@ export type CodexStreamEvent =
         maxTokens: number;
         percentage: number;
       };
+      lastItemRawPayload?: unknown;
     };
 
 export class CodexPromptService {
@@ -860,6 +861,7 @@ export class CodexPromptService {
             percentage: number;
           }
         | undefined;
+      let lastCompletedItemRawPayload: unknown;
 
       let eventCount = 0;
 
@@ -894,6 +896,7 @@ export class CodexPromptService {
             allToolUses = []; // Reset tool uses for new turn
             todoIdsEmittedViaUpdate = new Set<string>();
             latestContextUsage = undefined;
+            lastCompletedItemRawPayload = undefined;
             break;
 
           case 'item.started':
@@ -928,6 +931,9 @@ export class CodexPromptService {
             break;
 
           case 'item.completed':
+            // Keep the latest raw item payload for debugging on turn completion.
+            // This is intentionally raw and unmodified.
+            lastCompletedItemRawPayload = event.item;
             // Collect completed items and emit tool_complete events
             if (event.item) {
               // Emit tool_complete for tool items
@@ -1038,6 +1044,7 @@ export class CodexPromptService {
               usage: mappedUsage,
               rawSdkEvent: event, // Pass through the actual SDK event (UNMUTATED)
               rawContextUsage: latestContextUsage,
+              lastItemRawPayload: lastCompletedItemRawPayload,
             };
 
             // Exit the event loop after turn completion

--- a/packages/executor/src/sdk-handlers/codex/usage.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.test.ts
@@ -54,7 +54,7 @@ describe('extractCodexTokenUsage', () => {
 });
 
 describe('extractCodexContextWindowUsage', () => {
-  it('uses input + cached input tokens for turn-level context usage', () => {
+  it('uses input tokens directly (cached tokens are already included)', () => {
     const result = extractCodexContextWindowUsage({
       type: 'turn.completed',
       usage: {
@@ -64,7 +64,7 @@ describe('extractCodexContextWindowUsage', () => {
       },
     });
 
-    expect(result).toBe(50_000);
+    expect(result).toBe(42_000);
   });
 
   it('supports direct usage payloads and camelCase keys', () => {
@@ -74,10 +74,35 @@ describe('extractCodexContextWindowUsage', () => {
       outputTokens: 900,
     });
 
-    expect(result).toBe(12_000);
+    expect(result).toBe(10_000);
   });
 
-  it('falls back to total tokens when input fields are unavailable (legacy)', () => {
+  it('matches observed Codex payloads without double-counting cache', () => {
+    const result = extractCodexContextWindowUsage({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 30_918,
+        cached_input_tokens: 15_488,
+        output_tokens: 184,
+      },
+    });
+
+    expect(result).toBe(30_918);
+  });
+
+  it('falls back to total - output when input is unavailable', () => {
+    const result = extractCodexContextWindowUsage({
+      type: 'turn.completed',
+      usage: {
+        total_tokens: 65_432,
+        output_tokens: 1_432,
+      },
+    });
+
+    expect(result).toBe(64_000);
+  });
+
+  it('falls back to total tokens when only total is available (legacy)', () => {
     const result = extractCodexContextWindowUsage({
       type: 'turn.completed',
       usage: {

--- a/packages/executor/src/sdk-handlers/codex/usage.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractCodexTokenUsage } from './usage.js';
+import {
+  extractCodexContextSnapshotFromEvent,
+  extractCodexContextWindowUsage,
+  extractCodexTokenUsage,
+} from './usage.js';
 
 describe('extractCodexTokenUsage', () => {
   it('returns undefined for non-object payloads', () => {
@@ -46,5 +50,106 @@ describe('extractCodexTokenUsage', () => {
       cache_read_tokens: 25,
       total_tokens: 150,
     });
+  });
+});
+
+describe('extractCodexContextWindowUsage', () => {
+  it('uses input + cached input tokens for turn-level context usage', () => {
+    const result = extractCodexContextWindowUsage({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 42_000,
+        cached_input_tokens: 8_000,
+        output_tokens: 1_500,
+      },
+    });
+
+    expect(result).toBe(50_000);
+  });
+
+  it('supports direct usage payloads and camelCase keys', () => {
+    const result = extractCodexContextWindowUsage({
+      inputTokens: 10_000,
+      cachedInputTokens: 2_000,
+      outputTokens: 900,
+    });
+
+    expect(result).toBe(12_000);
+  });
+
+  it('falls back to total tokens when input fields are unavailable (legacy)', () => {
+    const result = extractCodexContextWindowUsage({
+      type: 'turn.completed',
+      usage: {
+        total_tokens: 65_432,
+      },
+    });
+
+    expect(result).toBe(65_432);
+  });
+
+  it('returns undefined for invalid payloads', () => {
+    expect(extractCodexContextWindowUsage(undefined)).toBeUndefined();
+    expect(extractCodexContextWindowUsage(null)).toBeUndefined();
+    expect(extractCodexContextWindowUsage('bad')).toBeUndefined();
+    expect(extractCodexContextWindowUsage({ usage: { output_tokens: 123 } })).toBeUndefined();
+  });
+});
+
+describe('extractCodexContextSnapshotFromEvent', () => {
+  it('extracts total usage + model context window from token_count event_msg', () => {
+    const result = extractCodexContextSnapshotFromEvent({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: {
+            total_tokens: 210_000,
+          },
+          last_token_usage: {
+            total_tokens: 12_000,
+          },
+          model_context_window: 272_000,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      totalTokens: 210_000,
+      maxTokens: 272_000,
+      percentage: 77,
+    });
+  });
+
+  it('clamps percentage to 100 for over-limit totals', () => {
+    const result = extractCodexContextSnapshotFromEvent({
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: {
+            total_tokens: 1_000_000,
+          },
+          model_context_window: 272_000,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      totalTokens: 1_000_000,
+      maxTokens: 272_000,
+      percentage: 100,
+    });
+  });
+
+  it('returns undefined for non-token_count or malformed events', () => {
+    expect(extractCodexContextSnapshotFromEvent(undefined)).toBeUndefined();
+    expect(extractCodexContextSnapshotFromEvent({ type: 'turn.completed' })).toBeUndefined();
+    expect(
+      extractCodexContextSnapshotFromEvent({
+        type: 'event_msg',
+        payload: { type: 'other' },
+      })
+    ).toBeUndefined();
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/usage.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.ts
@@ -72,7 +72,7 @@ export function extractCodexTokenUsage(raw: unknown): TokenUsage | undefined {
  * 1) input_tokens / prompt_tokens (preferred)
  * 2) total_tokens - output_tokens (when both are available)
  * 3) total_tokens (legacy fallback when only total is available)
- * 3) undefined (no usable data)
+ * 4) undefined (no usable data)
  */
 export function extractCodexContextWindowUsage(raw: unknown): number | undefined {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {

--- a/packages/executor/src/sdk-handlers/codex/usage.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.ts
@@ -4,6 +4,11 @@ function normalizeNumber(value: unknown): number | undefined {
   return typeof value === 'number' ? value : undefined;
 }
 
+function sanitizeTokenCount(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  return Math.max(0, value);
+}
+
 /**
  * Normalize Codex SDK usage payload into Agor's TokenUsage shape.
  *
@@ -53,4 +58,113 @@ export function extractCodexTokenUsage(raw: unknown): TokenUsage | undefined {
   }
 
   return usage;
+}
+
+/**
+ * Extract context-window usage from a Codex turn payload.
+ *
+ * Source semantics from @openai/codex-sdk:
+ * - `usage.input_tokens` and `usage.cached_input_tokens` are input-side tokens used DURING the turn.
+ * - `usage.output_tokens` are completion tokens and should not count toward context-window occupancy.
+ *
+ * Returns the best available approximation for current context occupancy:
+ * 1) input + cached_input (preferred)
+ * 2) total_tokens (legacy fallback when input fields are missing)
+ * 3) undefined (no usable data)
+ */
+export function extractCodexContextWindowUsage(raw: unknown): number | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const payload = raw as Record<string, unknown>;
+  const usage =
+    payload.usage && typeof payload.usage === 'object' && !Array.isArray(payload.usage)
+      ? (payload.usage as Record<string, unknown>)
+      : payload;
+
+  const inputTokens = sanitizeTokenCount(
+    normalizeNumber(usage.input_tokens ?? usage.inputTokens ?? usage.prompt_tokens)
+  );
+  const cachedInputTokens = sanitizeTokenCount(
+    normalizeNumber(usage.cached_input_tokens ?? usage.cachedInputTokens ?? usage.cache_read_tokens)
+  );
+
+  if (inputTokens !== undefined || cachedInputTokens !== undefined) {
+    return (inputTokens || 0) + (cachedInputTokens || 0);
+  }
+
+  const fallbackTotal = sanitizeTokenCount(
+    normalizeNumber(usage.total_tokens ?? usage.totalTokens)
+  );
+  return fallbackTotal;
+}
+
+/**
+ * Extract an authoritative context snapshot from Codex `event_msg` token_count payloads.
+ *
+ * Expected shape (from Codex CLI protocol):
+ * {
+ *   type: "event_msg",
+ *   payload: {
+ *     type: "token_count",
+ *     info: {
+ *       total_token_usage: { total_tokens: number, ... },
+ *       model_context_window: number
+ *     }
+ *   }
+ * }
+ */
+export function extractCodexContextSnapshotFromEvent(
+  raw: unknown
+): { totalTokens: number; maxTokens: number; percentage: number } | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const event = raw as Record<string, unknown>;
+  if (event.type !== 'event_msg') {
+    return undefined;
+  }
+
+  const payload =
+    event.payload && typeof event.payload === 'object' && !Array.isArray(event.payload)
+      ? (event.payload as Record<string, unknown>)
+      : undefined;
+  if (!payload || payload.type !== 'token_count') {
+    return undefined;
+  }
+
+  const info =
+    payload.info && typeof payload.info === 'object' && !Array.isArray(payload.info)
+      ? (payload.info as Record<string, unknown>)
+      : undefined;
+  if (!info) {
+    return undefined;
+  }
+
+  const totalUsage =
+    info.total_token_usage &&
+    typeof info.total_token_usage === 'object' &&
+    !Array.isArray(info.total_token_usage)
+      ? (info.total_token_usage as Record<string, unknown>)
+      : undefined;
+
+  const totalTokens = sanitizeTokenCount(
+    normalizeNumber(totalUsage?.total_tokens ?? totalUsage?.totalTokens)
+  );
+  const maxTokens = sanitizeTokenCount(
+    normalizeNumber(info.model_context_window ?? info.modelContextWindow)
+  );
+
+  if (totalTokens === undefined || maxTokens === undefined || maxTokens <= 0) {
+    return undefined;
+  }
+
+  const percentage = Math.max(0, Math.min(100, Math.round((totalTokens / maxTokens) * 100)));
+  return {
+    totalTokens,
+    maxTokens,
+    percentage,
+  };
 }

--- a/packages/executor/src/sdk-handlers/codex/usage.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.ts
@@ -63,13 +63,15 @@ export function extractCodexTokenUsage(raw: unknown): TokenUsage | undefined {
 /**
  * Extract context-window usage from a Codex turn payload.
  *
- * Source semantics from @openai/codex-sdk:
- * - `usage.input_tokens` and `usage.cached_input_tokens` are input-side tokens used DURING the turn.
- * - `usage.output_tokens` are completion tokens and should not count toward context-window occupancy.
+ * Source semantics from OpenAI usage schema:
+ * - `input_tokens` already includes cached input tokens.
+ * - `cached_input_tokens` is a subset detail, not an additive field.
+ * - `output_tokens` are completion tokens and should not count toward context-window occupancy.
  *
  * Returns the best available approximation for current context occupancy:
- * 1) input + cached_input (preferred)
- * 2) total_tokens (legacy fallback when input fields are missing)
+ * 1) input_tokens / prompt_tokens (preferred)
+ * 2) total_tokens - output_tokens (when both are available)
+ * 3) total_tokens (legacy fallback when only total is available)
  * 3) undefined (no usable data)
  */
 export function extractCodexContextWindowUsage(raw: unknown): number | undefined {
@@ -86,18 +88,23 @@ export function extractCodexContextWindowUsage(raw: unknown): number | undefined
   const inputTokens = sanitizeTokenCount(
     normalizeNumber(usage.input_tokens ?? usage.inputTokens ?? usage.prompt_tokens)
   );
-  const cachedInputTokens = sanitizeTokenCount(
-    normalizeNumber(usage.cached_input_tokens ?? usage.cachedInputTokens ?? usage.cache_read_tokens)
-  );
 
-  if (inputTokens !== undefined || cachedInputTokens !== undefined) {
-    return (inputTokens || 0) + (cachedInputTokens || 0);
+  if (inputTokens !== undefined) {
+    return inputTokens;
   }
 
-  const fallbackTotal = sanitizeTokenCount(
+  const fallbackTotalTokens = sanitizeTokenCount(
     normalizeNumber(usage.total_tokens ?? usage.totalTokens)
   );
-  return fallbackTotal;
+  const outputTokens = sanitizeTokenCount(
+    normalizeNumber(usage.output_tokens ?? usage.outputTokens ?? usage.completion_tokens)
+  );
+
+  if (fallbackTotalTokens !== undefined && outputTokens !== undefined) {
+    return Math.max(0, fallbackTotalTokens - outputTokens);
+  }
+
+  return fallbackTotalTokens;
 }
 
 /**


### PR DESCRIPTION
## Summary
- compute Codex context-window usage from `event_msg` `token_count` snapshot (`total_token_usage.total_tokens` / `model_context_window`) instead of summing ambiguous turn usage fields
- preserve `raw_sdk_response` as raw (no mutation); store derived values in `normalized_sdk_response.contextUsageSnapshot`
- wire snapshot through Codex prompt stream/tool -> base executor for `computed_context_window`
- clamp UI context usage display to 0-100 to prevent impossible percentages from bad/missing data

## Root cause
- previous computation relied on fields in `turn.completed.usage` that can represent cumulative lifecycle usage and are not safe to aggregate for per-turn context occupancy
- this caused overcounting and impossible context percentages (e.g. >100%)

## Tests
- added Codex usage tests for snapshot extraction and percent computation with cumulative total semantics
- added prompt-service test to verify `rawContextUsage` capture on completion
- added UI util test for percent clamping behavior
- `pnpm check` passes

## Backward compatibility
- existing history remains readable; when snapshot data is missing we fall back to prior computation path and UI clamps invalid percentages
