### PR TITLE
fix(client): restore standalone @agor-live/client packaging

### DIFF
--- a/packages/agor-live/build.sh
+++ b/packages/agor-live/build.sh
@@ -132,6 +132,7 @@ echo ""
 echo "📦 Building @agor-live/client..."
 cd "$CLIENT_DIR"
 pnpm build
+pnpm check:pack
 
 echo ""
 echo "🖥️  Building CLI..."

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,6 +24,7 @@
     "build": "tsup && node scripts/patch-dts.mjs",
     "check:pack": "node scripts/validate-pack-artifact.mjs",
     "dev": "tsup --watch",
+    "prepublishOnly": "pnpm build && pnpm check:pack",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,18 +22,21 @@
   ],
   "scripts": {
     "build": "tsup && node scripts/patch-dts.mjs",
+    "check:pack": "node scripts/validate-pack-artifact.mjs",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@agor/core": "workspace:*",
     "@feathersjs/authentication-client": "^5.0.41",
     "@feathersjs/feathers": "^5.0.41",
     "@feathersjs/rest-client": "^5.0.41",
     "@feathersjs/socketio-client": "^5.0.41",
+    "js-yaml": "^4.1.1",
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
+    "@agor/core": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.10.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/client/scripts/validate-pack-artifact.mjs
+++ b/packages/client/scripts/validate-pack-artifact.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, unlinkSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agor-client-pack-'));
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+function listFilesRecursive(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursive(fullPath));
+      continue;
+    }
+    files.push(fullPath);
+  }
+  return files;
+}
+
+let tarballName;
+
+try {
+  const packOutput = execSync('npm pack --json', { cwd: packageDir, encoding: 'utf8' });
+  const parsed = JSON.parse(packOutput);
+  tarballName = parsed?.[0]?.filename;
+  if (!tarballName) {
+    throw new Error('npm pack did not return a filename');
+  }
+  execSync(`tar -xzf ${JSON.stringify(tarballName)} -C ${JSON.stringify(tempDir)}`, {
+    cwd: packageDir,
+  });
+} catch (error) {
+  fail(
+    `Unable to create/extract npm pack artifact: ${error instanceof Error ? error.message : String(error)}`
+  );
+}
+
+const packedRoot = path.join(tempDir, 'package');
+const packedManifestPath = path.join(packedRoot, 'package.json');
+const packedManifest = JSON.parse(readFileSync(packedManifestPath, 'utf8'));
+
+const dependencySections = [
+  ['dependencies', packedManifest.dependencies ?? {}],
+  ['peerDependencies', packedManifest.peerDependencies ?? {}],
+  ['optionalDependencies', packedManifest.optionalDependencies ?? {}],
+];
+
+for (const [sectionName, deps] of dependencySections) {
+  for (const [name, version] of Object.entries(deps)) {
+    if (typeof version === 'string' && version.startsWith('workspace:')) {
+      fail(`Packed manifest contains workspace protocol in ${sectionName}: ${name}=${version}`);
+    }
+  }
+}
+
+if (packedManifest.dependencies && Object.hasOwn(packedManifest.dependencies, '@agor/core')) {
+  fail('Packed manifest must not contain @agor/core as a runtime dependency');
+}
+
+const packedFiles = listFilesRecursive(packedRoot);
+const runtimeFiles = packedFiles.filter((file) => file.endsWith('.js') || file.endsWith('.cjs'));
+const typeFiles = packedFiles.filter(
+  (file) => file.endsWith('.d.ts') || file.endsWith('.d.cts') || file.endsWith('.d.mts')
+);
+
+for (const file of runtimeFiles) {
+  const content = readFileSync(file, 'utf8');
+  if (content.includes('@agor/core')) {
+    fail(`Runtime artifact still references @agor/core: ${path.relative(packedRoot, file)}`);
+  }
+}
+
+for (const file of typeFiles) {
+  const content = readFileSync(file, 'utf8');
+  if (content.includes('@agor/core')) {
+    fail(`Type artifact still references @agor/core: ${path.relative(packedRoot, file)}`);
+  }
+}
+
+try {
+  if (tarballName) {
+    unlinkSync(path.join(packageDir, tarballName));
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+} catch {
+  // Best-effort cleanup only.
+}
+
+if (!process.exitCode) {
+  console.log('✅ npm pack artifact is standalone (no workspace deps or @agor/core references)');
+}

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,1 +1,70 @@
-export { getDaemonUrl, getDefaultConfig, loadConfigSync } from '@agor/core/config';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import type { AgorConfig } from '../../core/src/config/types';
+
+const DEFAULT_DAEMON_PORT = 3030;
+const DEFAULT_DAEMON_HOST = 'localhost';
+
+export function getDefaultConfig(): AgorConfig {
+  return {
+    defaults: {
+      board: 'main',
+      agent: 'claude-code',
+    },
+    display: {
+      tableStyle: 'unicode',
+      colorOutput: true,
+      shortIdLength: 8,
+    },
+    daemon: {
+      port: DEFAULT_DAEMON_PORT,
+      host: DEFAULT_DAEMON_HOST,
+      allowAnonymous: true,
+      requireAuth: false,
+      mcpEnabled: true,
+    },
+    ui: {
+      port: 5173,
+      host: 'localhost',
+    },
+    codex: {
+      home: '~/.agor/codex',
+    },
+    execution: {
+      session_token_expiration_ms: 86400000,
+      session_token_max_uses: 1,
+      sync_unix_passwords: true,
+    },
+  };
+}
+
+export function loadConfigSync(): AgorConfig {
+  const configPath = path.join(homedir(), '.agor', 'config.yaml');
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    const config = yaml.load(content) as AgorConfig;
+    return config || {};
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return getDefaultConfig();
+    }
+    throw new Error(
+      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+export async function getDaemonUrl(): Promise<string> {
+  if (process.env.DAEMON_URL) {
+    return process.env.DAEMON_URL;
+  }
+
+  const config = loadConfigSync();
+  const defaults = getDefaultConfig();
+  const envPort = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : undefined;
+  const port = envPort || config.daemon?.port || defaults.daemon?.port || DEFAULT_DAEMON_PORT;
+  const host = config.daemon?.host || defaults.daemon?.host || DEFAULT_DAEMON_HOST;
+  return `http://${host}:${port}`;
+}

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import type { AgorConfig } from '@agor/core/client';
 import yaml from 'js-yaml';
-import type { AgorConfig } from '../../core/src/config/types';
 
 const DEFAULT_DAEMON_PORT = 3030;
 const DEFAULT_DAEMON_HOST = 'localhost';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,13 +6,13 @@
  *   const client = createClient('http://localhost:3030');
  */
 
-import type { AgorClient as CoreAgorClient } from '../../core/src/api/index';
+import type { AgorClient as CoreAgorClient } from '@agor/core/client';
 import {
   createClient as createCoreClient,
   createRestClient as createCoreRestClient,
   getApiKeyFromEnv,
   isDaemonRunning,
-} from '../../core/src/api/index';
+} from '@agor/core/client';
 import {
   attachReactiveSessionApi,
   type ReactiveAgorClient,
@@ -41,7 +41,7 @@ export type {
   SessionsService,
   TasksService,
   WorktreesService,
-} from '../../core/src/api/index';
+} from '@agor/core/client';
 
 export type {
   ReactiveAgorClient,
@@ -57,12 +57,9 @@ export type {
   ToolExecutionState,
 };
 
-export * from '../../core/src/config/browser';
-export type { AgorConfig } from '../../core/src/config/types';
-export * from '../../core/src/templates/handlebars-helpers';
+export * from '@agor/core/client';
 // Re-export full browser-safe type/runtime surface for UI consumers.
-export * from '../../core/src/types/index';
-export { toShortId as formatShortId } from '../../core/src/types/index';
+export { toShortId as formatShortId } from '@agor/core/client';
 export * from './models';
 
 export function createClient(...args: Parameters<typeof createCoreClient>): ReactiveAgorClient {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,13 +6,13 @@
  *   const client = createClient('http://localhost:3030');
  */
 
-import type { AgorClient as CoreAgorClient } from '@agor/core/api';
+import type { AgorClient as CoreAgorClient } from '../../core/src/api/index';
 import {
   createClient as createCoreClient,
   createRestClient as createCoreRestClient,
   getApiKeyFromEnv,
   isDaemonRunning,
-} from '@agor/core/api';
+} from '../../core/src/api/index';
 import {
   attachReactiveSessionApi,
   type ReactiveAgorClient,
@@ -41,7 +41,7 @@ export type {
   SessionsService,
   TasksService,
   WorktreesService,
-} from '@agor/core/api';
+} from '../../core/src/api/index';
 
 export type {
   ReactiveAgorClient,
@@ -57,13 +57,13 @@ export type {
   ToolExecutionState,
 };
 
-export * from '@agor/core/config/browser';
-export type { AgorConfig } from '@agor/core/config/types';
-export * from '@agor/core/models';
-export * from '@agor/core/templates/handlebars-helpers';
+export * from '../../core/src/config/browser';
+export type { AgorConfig } from '../../core/src/config/types';
+export * from '../../core/src/templates/handlebars-helpers';
 // Re-export full browser-safe type/runtime surface for UI consumers.
-export * from '@agor/core/types';
-export { toShortId as formatShortId } from '@agor/core/types';
+export * from '../../core/src/types/index';
+export { toShortId as formatShortId } from '../../core/src/types/index';
+export * from './models';
 
 export function createClient(...args: Parameters<typeof createCoreClient>): ReactiveAgorClient {
   const client = createCoreClient(...args);

--- a/packages/client/src/models.ts
+++ b/packages/client/src/models.ts
@@ -1,9 +1,7 @@
-import type { GeminiModel, GeminiModelInfo } from '../../core/src/models/gemini-shared';
-import { GEMINI_MODELS } from '../../core/src/models/gemini-shared';
+import type { GeminiModel, GeminiModelInfo } from '@agor/core/models/browser';
+import { GEMINI_MODELS } from '@agor/core/models/browser';
 
-export * from '../../core/src/models/claude';
-export * from '../../core/src/models/codex';
-export * from '../../core/src/models/gemini-shared';
+export * from '@agor/core/models/browser';
 
 interface ModelCache {
   models: GeminiModelInfo[];

--- a/packages/client/src/models.ts
+++ b/packages/client/src/models.ts
@@ -1,0 +1,121 @@
+export * from '../../core/src/models/claude';
+export * from '../../core/src/models/codex';
+
+export type GeminiModel =
+  | 'gemini-3-flash'
+  | 'gemini-3-pro'
+  | 'gemini-2.5-pro'
+  | 'gemini-2.5-flash'
+  | 'gemini-2.5-flash-lite'
+  | 'gemini-2.0-flash'
+  | 'gemini-2.0-flash-lite'
+  | 'gemini-2.0-pro'
+  | 'gemini-2.0-flash-thinking-experimental';
+
+export const DEFAULT_GEMINI_MODEL: GeminiModel = 'gemini-2.0-flash';
+
+export const GEMINI_MODELS: Record<
+  GeminiModel,
+  {
+    name: string;
+    description: string;
+    inputPrice: string;
+    outputPrice: string;
+    useCase: string;
+  }
+> = {
+  'gemini-3-flash': {
+    name: 'Gemini 3 Flash',
+    description: 'Latest Flash model - fast responses with strong capabilities',
+    inputPrice: 'TBD',
+    outputPrice: 'TBD',
+    useCase: 'General coding tasks, fast iteration, great price-to-performance',
+  },
+  'gemini-3-pro': {
+    name: 'Gemini 3 Pro',
+    description: 'Latest and most intelligent model (requires Ultra subscription or waitlist)',
+    inputPrice: 'Premium',
+    outputPrice: 'Premium',
+    useCase: 'Most complex tasks, advanced reasoning, state-of-the-art performance',
+  },
+  'gemini-2.5-pro': {
+    name: 'Gemini 2.5 Pro',
+    description: 'Most capable 2.5 model for complex reasoning and multi-step tasks',
+    inputPrice: 'Higher',
+    outputPrice: 'Higher',
+    useCase: 'Complex refactoring, architecture decisions, advanced debugging',
+  },
+  'gemini-2.5-flash': {
+    name: 'Gemini 2.5 Flash',
+    description: 'Balanced performance and cost for most agentic coding tasks',
+    inputPrice: '$0.30',
+    outputPrice: '$2.50',
+    useCase: 'Feature development, bug fixes, code reviews, testing',
+  },
+  'gemini-2.5-flash-lite': {
+    name: 'Gemini 2.5 Flash-Lite',
+    description: 'Ultra-fast, low-cost model for simple tasks',
+    inputPrice: '$0.10',
+    outputPrice: '$0.40',
+    useCase: 'File search, summaries, simple edits, code formatting',
+  },
+  'gemini-2.0-flash': {
+    name: 'Gemini 2.0 Flash',
+    description: "Google's default model (Jan 2025) - next-gen features with superior speed",
+    inputPrice: '$0.15',
+    outputPrice: '$0.60',
+    useCase: 'General purpose coding, native tool use, 1M token context',
+  },
+  'gemini-2.0-flash-lite': {
+    name: 'Gemini 2.0 Flash-Lite',
+    description: 'Ultra-efficient for simple, high-frequency tasks',
+    inputPrice: '$0.075',
+    outputPrice: '$0.30',
+    useCase: 'Simple edits, quick queries, high-volume operations',
+  },
+  'gemini-2.0-pro': {
+    name: 'Gemini 2.0 Pro',
+    description: 'Advanced reasoning and complex problem solving',
+    inputPrice: '$1.25',
+    outputPrice: '$5.00',
+    useCase: 'Complex architecture, advanced algorithms, deep refactoring',
+  },
+  'gemini-2.0-flash-thinking-experimental': {
+    name: 'Gemini 2.0 Flash Thinking (Experimental)',
+    description: 'Shows detailed reasoning process when responding',
+    inputPrice: '$0.15',
+    outputPrice: '$0.60',
+    useCase: 'Learning, debugging reasoning, understanding AI decision-making',
+  },
+};
+
+const DEFAULT_GEMINI_CONTEXT_LIMIT = 1_048_576;
+
+export const GEMINI_CONTEXT_LIMITS: Record<string, number> = {
+  'gemini-3-flash': 1_048_576,
+  'gemini-3-pro': 1_048_576,
+  'gemini-2.5-pro': 1_048_576,
+  'gemini-2.5-flash': 1_048_576,
+  'gemini-2.5-flash-lite': 1_048_576,
+  'gemini-2.0-flash': 1_048_576,
+  'gemini-2.0-flash-lite': 1_048_576,
+  'gemini-2.0-pro': 1_048_576,
+  'gemini-2.0-flash-thinking-experimental': 1_048_576,
+};
+
+export function getGeminiContextWindowLimit(model?: string): number {
+  if (!model) return DEFAULT_GEMINI_CONTEXT_LIMIT;
+
+  const normalized = model.toLowerCase();
+  if (GEMINI_CONTEXT_LIMITS[normalized]) {
+    return GEMINI_CONTEXT_LIMITS[normalized];
+  }
+
+  for (const [key, limit] of Object.entries(GEMINI_CONTEXT_LIMITS)) {
+    if (normalized.startsWith(`${key}-`)) {
+      return limit;
+    }
+  }
+
+  return DEFAULT_GEMINI_CONTEXT_LIMIT;
+}

--- a/packages/client/src/models.ts
+++ b/packages/client/src/models.ts
@@ -1,121 +1,75 @@
+import type { GeminiModel, GeminiModelInfo } from '../../core/src/models/gemini-shared';
+import { GEMINI_MODELS } from '../../core/src/models/gemini-shared';
+
 export * from '../../core/src/models/claude';
 export * from '../../core/src/models/codex';
+export * from '../../core/src/models/gemini-shared';
 
-export type GeminiModel =
-  | 'gemini-3-flash'
-  | 'gemini-3-pro'
-  | 'gemini-2.5-pro'
-  | 'gemini-2.5-flash'
-  | 'gemini-2.5-flash-lite'
-  | 'gemini-2.0-flash'
-  | 'gemini-2.0-flash-lite'
-  | 'gemini-2.0-pro'
-  | 'gemini-2.0-flash-thinking-experimental';
+interface ModelCache {
+  models: GeminiModelInfo[];
+  expiresAt: number;
+}
 
-export const DEFAULT_GEMINI_MODEL: GeminiModel = 'gemini-2.0-flash';
+interface GeminiModelsListResponse {
+  models?: Array<{
+    name?: string;
+    displayName?: string;
+    description?: string;
+    supportedGenerationMethods?: string[];
+    inputTokenLimit?: number;
+    outputTokenLimit?: number;
+  }>;
+}
 
-export const GEMINI_MODELS: Record<
-  GeminiModel,
-  {
-    name: string;
-    description: string;
-    inputPrice: string;
-    outputPrice: string;
-    useCase: string;
+let modelCache: ModelCache | null = null;
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+
+export async function fetchGeminiModels(
+  apiKey?: string,
+  forceRefresh = false
+): Promise<GeminiModelInfo[]> {
+  if (!forceRefresh && modelCache && Date.now() < modelCache.expiresAt) {
+    return modelCache.models;
   }
-> = {
-  'gemini-3-flash': {
-    name: 'Gemini 3 Flash',
-    description: 'Latest Flash model - fast responses with strong capabilities',
-    inputPrice: 'TBD',
-    outputPrice: 'TBD',
-    useCase: 'General coding tasks, fast iteration, great price-to-performance',
-  },
-  'gemini-3-pro': {
-    name: 'Gemini 3 Pro',
-    description: 'Latest and most intelligent model (requires Ultra subscription or waitlist)',
-    inputPrice: 'Premium',
-    outputPrice: 'Premium',
-    useCase: 'Most complex tasks, advanced reasoning, state-of-the-art performance',
-  },
-  'gemini-2.5-pro': {
-    name: 'Gemini 2.5 Pro',
-    description: 'Most capable 2.5 model for complex reasoning and multi-step tasks',
-    inputPrice: 'Higher',
-    outputPrice: 'Higher',
-    useCase: 'Complex refactoring, architecture decisions, advanced debugging',
-  },
-  'gemini-2.5-flash': {
-    name: 'Gemini 2.5 Flash',
-    description: 'Balanced performance and cost for most agentic coding tasks',
-    inputPrice: '$0.30',
-    outputPrice: '$2.50',
-    useCase: 'Feature development, bug fixes, code reviews, testing',
-  },
-  'gemini-2.5-flash-lite': {
-    name: 'Gemini 2.5 Flash-Lite',
-    description: 'Ultra-fast, low-cost model for simple tasks',
-    inputPrice: '$0.10',
-    outputPrice: '$0.40',
-    useCase: 'File search, summaries, simple edits, code formatting',
-  },
-  'gemini-2.0-flash': {
-    name: 'Gemini 2.0 Flash',
-    description: "Google's default model (Jan 2025) - next-gen features with superior speed",
-    inputPrice: '$0.15',
-    outputPrice: '$0.60',
-    useCase: 'General purpose coding, native tool use, 1M token context',
-  },
-  'gemini-2.0-flash-lite': {
-    name: 'Gemini 2.0 Flash-Lite',
-    description: 'Ultra-efficient for simple, high-frequency tasks',
-    inputPrice: '$0.075',
-    outputPrice: '$0.30',
-    useCase: 'Simple edits, quick queries, high-volume operations',
-  },
-  'gemini-2.0-pro': {
-    name: 'Gemini 2.0 Pro',
-    description: 'Advanced reasoning and complex problem solving',
-    inputPrice: '$1.25',
-    outputPrice: '$5.00',
-    useCase: 'Complex architecture, advanced algorithms, deep refactoring',
-  },
-  'gemini-2.0-flash-thinking-experimental': {
-    name: 'Gemini 2.0 Flash Thinking (Experimental)',
-    description: 'Shows detailed reasoning process when responding',
-    inputPrice: '$0.15',
-    outputPrice: '$0.60',
-    useCase: 'Learning, debugging reasoning, understanding AI decision-making',
-  },
-};
-
-const DEFAULT_GEMINI_CONTEXT_LIMIT = 1_048_576;
-
-export const GEMINI_CONTEXT_LIMITS: Record<string, number> = {
-  'gemini-3-flash': 1_048_576,
-  'gemini-3-pro': 1_048_576,
-  'gemini-2.5-pro': 1_048_576,
-  'gemini-2.5-flash': 1_048_576,
-  'gemini-2.5-flash-lite': 1_048_576,
-  'gemini-2.0-flash': 1_048_576,
-  'gemini-2.0-flash-lite': 1_048_576,
-  'gemini-2.0-pro': 1_048_576,
-  'gemini-2.0-flash-thinking-experimental': 1_048_576,
-};
-
-export function getGeminiContextWindowLimit(model?: string): number {
-  if (!model) return DEFAULT_GEMINI_CONTEXT_LIMIT;
-
-  const normalized = model.toLowerCase();
-  if (GEMINI_CONTEXT_LIMITS[normalized]) {
-    return GEMINI_CONTEXT_LIMITS[normalized];
+  if (!apiKey) {
+    throw new Error('API key required for fetching Gemini models');
   }
 
-  for (const [key, limit] of Object.entries(GEMINI_CONTEXT_LIMITS)) {
-    if (normalized.startsWith(`${key}-`)) {
-      return limit;
-    }
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`
+  );
+  if (!response.ok) {
+    throw new Error(`Gemini model fetch failed: ${response.status} ${response.statusText}`);
   }
 
-  return DEFAULT_GEMINI_CONTEXT_LIMIT;
+  const payload = (await response.json()) as GeminiModelsListResponse;
+  const models: GeminiModelInfo[] = (payload.models ?? [])
+    .filter((model) => model.name && model.supportedGenerationMethods?.includes('generateContent'))
+    .map((model) => ({
+      name: model.name!.replace('models/', ''),
+      displayName: model.displayName || model.name!,
+      description: model.description,
+      supportedActions: model.supportedGenerationMethods ?? [],
+      inputTokenLimit: model.inputTokenLimit,
+      outputTokenLimit: model.outputTokenLimit,
+    }));
+
+  modelCache = {
+    models,
+    expiresAt: Date.now() + CACHE_TTL,
+  };
+  return models;
+}
+
+export async function getAvailableGeminiModels(apiKey?: string): Promise<string[]> {
+  try {
+    const dynamicModels = await fetchGeminiModels(apiKey);
+    return dynamicModels.map((model) => model.name);
+  } catch (_error) {
+    return Object.keys(GEMINI_MODELS) as GeminiModel[];
+  }
+}
+
+export function clearGeminiModelCache(): void {
+  modelCache = null;
 }

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -1,5 +1,9 @@
-import type { AgorClient, SessionPromptOptions, SessionPromptResult } from '@agor/core/api';
-import type { Message, Session, Task } from '@agor/core/types';
+import type {
+  AgorClient,
+  SessionPromptOptions,
+  SessionPromptResult,
+} from '../../core/src/api/index';
+import type { Message, Session, Task } from '../../core/src/types/index';
 
 export type TaskHydrationMode = 'none' | 'lazy' | 'eager';
 

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -1,9 +1,11 @@
 import type {
   AgorClient,
+  Message,
+  Session,
   SessionPromptOptions,
   SessionPromptResult,
-} from '../../core/src/api/index';
-import type { Message, Session, Task } from '../../core/src/types/index';
+  Task,
+} from '@agor/core/client';
 
 export type TaskHydrationMode = 'none' | 'lazy' | 'eager';
 

--- a/packages/client/tsup.config.ts
+++ b/packages/client/tsup.config.ts
@@ -11,8 +11,6 @@ export default defineConfig({
   splitting: false,
   // Keep FeathersJS + socket.io as runtime dependencies (not bundled)
   external: [
-    '@agor/core',
-    '@agor/core/*',
     '@feathersjs/authentication-client',
     '@feathersjs/feathers',
     '@feathersjs/rest-client',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -135,10 +135,25 @@
       "import": "./dist/callbacks/child-completion-template.js",
       "require": "./dist/callbacks/child-completion-template.cjs"
     },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js",
+      "require": "./dist/client/index.cjs"
+    },
     "./models": {
       "types": "./dist/models/index.d.ts",
       "import": "./dist/models/index.js",
       "require": "./dist/models/index.cjs"
+    },
+    "./models/browser": {
+      "types": "./dist/models/browser.d.ts",
+      "import": "./dist/models/browser.js",
+      "require": "./dist/models/browser.cjs"
+    },
+    "./models/gemini-shared": {
+      "types": "./dist/models/gemini-shared.d.ts",
+      "import": "./dist/models/gemini-shared.js",
+      "require": "./dist/models/gemini-shared.cjs"
     },
     "./sdk": {
       "types": "./dist/sdk/index.d.ts",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Client-safe @agor/core surface for browser/SDK consumers.
+ *
+ * This entrypoint must stay free of Node-only SDK/runtime imports.
+ */
+
+export type {
+  AgorClient,
+  AgorService,
+  BoardsService,
+  MessagesService,
+  ReposLocalService,
+  ReposService,
+  ServiceTypes,
+  SessionPromptOptions,
+  SessionPromptResult,
+  SessionsService,
+  TasksService,
+  WorktreesService,
+} from '../api/index.js';
+export {
+  createClient,
+  createRestClient,
+  getApiKeyFromEnv,
+  isDaemonRunning,
+} from '../api/index.js';
+
+export * from '../config/browser.js';
+export type { AgorConfig } from '../config/types.js';
+export * from '../templates/handlebars-helpers.js';
+export * from '../types/index.js';

--- a/packages/core/src/models/browser.ts
+++ b/packages/core/src/models/browser.ts
@@ -1,0 +1,7 @@
+/**
+ * Browser-safe model metadata exports.
+ */
+
+export * from './claude.js';
+export * from './codex.js';
+export * from './gemini-shared.js';

--- a/packages/core/src/models/gemini-shared.ts
+++ b/packages/core/src/models/gemini-shared.ts
@@ -1,0 +1,146 @@
+/**
+ * Browser-safe Gemini model metadata shared across packages.
+ */
+
+/**
+ * Available Gemini models (2025)
+ */
+export type GeminiModel =
+  | 'gemini-3-flash'
+  | 'gemini-3-pro'
+  | 'gemini-2.5-pro'
+  | 'gemini-2.5-flash'
+  | 'gemini-2.5-flash-lite'
+  | 'gemini-2.0-flash'
+  | 'gemini-2.0-flash-lite'
+  | 'gemini-2.0-pro'
+  | 'gemini-2.0-flash-thinking-experimental';
+
+/**
+ * Dynamic model information from Gemini API
+ */
+export interface GeminiModelInfo {
+  name: string;
+  displayName: string;
+  description?: string;
+  supportedActions: string[];
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
+}
+
+/**
+ * Default model for new Gemini sessions
+ */
+export const DEFAULT_GEMINI_MODEL: GeminiModel = 'gemini-2.0-flash';
+
+/**
+ * Model metadata for UI display
+ */
+export const GEMINI_MODELS: Record<
+  GeminiModel,
+  {
+    name: string;
+    description: string;
+    inputPrice: string;
+    outputPrice: string;
+    useCase: string;
+  }
+> = {
+  'gemini-3-flash': {
+    name: 'Gemini 3 Flash',
+    description: 'Latest Flash model - fast responses with strong capabilities',
+    inputPrice: 'TBD',
+    outputPrice: 'TBD',
+    useCase: 'General coding tasks, fast iteration, great price-to-performance',
+  },
+  'gemini-3-pro': {
+    name: 'Gemini 3 Pro',
+    description: 'Latest and most intelligent model (requires Ultra subscription or waitlist)',
+    inputPrice: 'Premium',
+    outputPrice: 'Premium',
+    useCase: 'Most complex tasks, advanced reasoning, state-of-the-art performance',
+  },
+  'gemini-2.5-pro': {
+    name: 'Gemini 2.5 Pro',
+    description: 'Most capable 2.5 model for complex reasoning and multi-step tasks',
+    inputPrice: 'Higher',
+    outputPrice: 'Higher',
+    useCase: 'Complex refactoring, architecture decisions, advanced debugging',
+  },
+  'gemini-2.5-flash': {
+    name: 'Gemini 2.5 Flash',
+    description: 'Balanced performance and cost for most agentic coding tasks',
+    inputPrice: '$0.30',
+    outputPrice: '$2.50',
+    useCase: 'Feature development, bug fixes, code reviews, testing',
+  },
+  'gemini-2.5-flash-lite': {
+    name: 'Gemini 2.5 Flash-Lite',
+    description: 'Ultra-fast, low-cost model for simple tasks',
+    inputPrice: '$0.10',
+    outputPrice: '$0.40',
+    useCase: 'File search, summaries, simple edits, code formatting',
+  },
+  'gemini-2.0-flash': {
+    name: 'Gemini 2.0 Flash',
+    description: "Google's default model (Jan 2025) - next-gen features with superior speed",
+    inputPrice: '$0.15',
+    outputPrice: '$0.60',
+    useCase: 'General purpose coding, native tool use, 1M token context',
+  },
+  'gemini-2.0-flash-lite': {
+    name: 'Gemini 2.0 Flash-Lite',
+    description: 'Ultra-efficient for simple, high-frequency tasks',
+    inputPrice: '$0.075',
+    outputPrice: '$0.30',
+    useCase: 'Simple edits, quick queries, high-volume operations',
+  },
+  'gemini-2.0-pro': {
+    name: 'Gemini 2.0 Pro',
+    description: 'Advanced reasoning and complex problem solving',
+    inputPrice: '$1.25',
+    outputPrice: '$5.00',
+    useCase: 'Complex architecture, advanced algorithms, deep refactoring',
+  },
+  'gemini-2.0-flash-thinking-experimental': {
+    name: 'Gemini 2.0 Flash Thinking (Experimental)',
+    description: 'Shows detailed reasoning process when responding',
+    inputPrice: '$0.15',
+    outputPrice: '$0.60',
+    useCase: 'Learning, debugging reasoning, understanding AI decision-making',
+  },
+};
+
+const DEFAULT_GEMINI_CONTEXT_LIMIT = 1_048_576;
+
+/**
+ * Context window limits for Gemini models.
+ */
+export const GEMINI_CONTEXT_LIMITS: Record<string, number> = {
+  'gemini-3-flash': 1_048_576,
+  'gemini-3-pro': 1_048_576,
+  'gemini-2.5-pro': 1_048_576,
+  'gemini-2.5-flash': 1_048_576,
+  'gemini-2.5-flash-lite': 1_048_576,
+  'gemini-2.0-flash': 1_048_576,
+  'gemini-2.0-flash-lite': 1_048_576,
+  'gemini-2.0-pro': 1_048_576,
+  'gemini-2.0-flash-thinking-experimental': 1_048_576,
+};
+
+export function getGeminiContextWindowLimit(model?: string): number {
+  if (!model) return DEFAULT_GEMINI_CONTEXT_LIMIT;
+
+  const normalized = model.toLowerCase();
+  if (GEMINI_CONTEXT_LIMITS[normalized]) {
+    return GEMINI_CONTEXT_LIMITS[normalized];
+  }
+
+  for (const [key, limit] of Object.entries(GEMINI_CONTEXT_LIMITS)) {
+    if (normalized.startsWith(`${key}-`)) {
+      return limit;
+    }
+  }
+
+  return DEFAULT_GEMINI_CONTEXT_LIMIT;
+}

--- a/packages/core/src/models/gemini.ts
+++ b/packages/core/src/models/gemini.ts
@@ -5,162 +5,20 @@
  */
 
 import { GoogleGenAI } from '@google/genai';
+import type { GeminiModel, GeminiModelInfo } from './gemini-shared.js';
+import { GEMINI_MODELS } from './gemini-shared.js';
 
-/**
- * Available Gemini models (2025)
- *
- * NOTE: This list is used as a fallback when dynamic model fetching fails.
- * Models are fetched dynamically from the Gemini API when possible.
- */
-export type GeminiModel =
-  | 'gemini-3-flash' // Latest Flash model (Dec 2025) - fast, capable, great value
-  | 'gemini-3-pro' // Latest and most intelligent (Nov 2025+, requires waitlist/Ultra subscription)
-  | 'gemini-2.5-pro' // Most capable 2.5 model, complex reasoning (SWE-bench: 63.8%)
-  | 'gemini-2.5-flash' // Balanced cost/capability, agentic tasks
-  | 'gemini-2.5-flash-lite' // High throughput, low cost, simple tasks
-  | 'gemini-2.0-flash' // Default model since Jan 30, 2025
-  | 'gemini-2.0-flash-lite' // Ultra-efficient for simple, high-frequency tasks
-  | 'gemini-2.0-pro' // Released Feb 5, 2025
-  | 'gemini-2.0-flash-thinking-experimental'; // Shows reasoning process
-
-/**
- * Default model for new Gemini sessions
- *
- * Using Flash 2.0 (Google's default since Jan 30, 2025) for best balance.
- * Users can upgrade to Flash 2.5, Pro 2.5, or Pro 3 for different needs.
- */
-export const DEFAULT_GEMINI_MODEL: GeminiModel = 'gemini-2.0-flash';
-
-/**
- * Model metadata for UI display
- */
-export const GEMINI_MODELS: Record<
-  GeminiModel,
-  {
-    name: string;
-    description: string;
-    inputPrice: string; // $ per 1M tokens
-    outputPrice: string; // $ per 1M tokens
-    useCase: string;
-  }
-> = {
-  'gemini-3-flash': {
-    name: 'Gemini 3 Flash',
-    description: 'Latest Flash model - fast responses with strong capabilities',
-    inputPrice: 'TBD',
-    outputPrice: 'TBD',
-    useCase: 'General coding tasks, fast iteration, great price-to-performance',
-  },
-  'gemini-3-pro': {
-    name: 'Gemini 3 Pro',
-    description: 'Latest and most intelligent model (requires Ultra subscription or waitlist)',
-    inputPrice: 'Premium',
-    outputPrice: 'Premium',
-    useCase: 'Most complex tasks, advanced reasoning, state-of-the-art performance',
-  },
-  'gemini-2.5-pro': {
-    name: 'Gemini 2.5 Pro',
-    description: 'Most capable 2.5 model for complex reasoning and multi-step tasks',
-    inputPrice: 'Higher',
-    outputPrice: 'Higher',
-    useCase: 'Complex refactoring, architecture decisions, advanced debugging',
-  },
-  'gemini-2.5-flash': {
-    name: 'Gemini 2.5 Flash',
-    description: 'Balanced performance and cost for most agentic coding tasks',
-    inputPrice: '$0.30',
-    outputPrice: '$2.50',
-    useCase: 'Feature development, bug fixes, code reviews, testing',
-  },
-  'gemini-2.5-flash-lite': {
-    name: 'Gemini 2.5 Flash-Lite',
-    description: 'Ultra-fast, low-cost model for simple tasks',
-    inputPrice: '$0.10',
-    outputPrice: '$0.40',
-    useCase: 'File search, summaries, simple edits, code formatting',
-  },
-  'gemini-2.0-flash': {
-    name: 'Gemini 2.0 Flash',
-    description: "Google's default model (Jan 2025) - next-gen features with superior speed",
-    inputPrice: '$0.15',
-    outputPrice: '$0.60',
-    useCase: 'General purpose coding, native tool use, 1M token context',
-  },
-  'gemini-2.0-flash-lite': {
-    name: 'Gemini 2.0 Flash-Lite',
-    description: 'Ultra-efficient for simple, high-frequency tasks',
-    inputPrice: '$0.075',
-    outputPrice: '$0.30',
-    useCase: 'Simple edits, quick queries, high-volume operations',
-  },
-  'gemini-2.0-pro': {
-    name: 'Gemini 2.0 Pro',
-    description: 'Advanced reasoning and complex problem solving',
-    inputPrice: '$1.25',
-    outputPrice: '$5.00',
-    useCase: 'Complex architecture, advanced algorithms, deep refactoring',
-  },
-  'gemini-2.0-flash-thinking-experimental': {
-    name: 'Gemini 2.0 Flash Thinking (Experimental)',
-    description: 'Shows detailed reasoning process when responding',
-    inputPrice: '$0.15',
-    outputPrice: '$0.60',
-    useCase: 'Learning, debugging reasoning, understanding AI decision-making',
-  },
-};
-
-const DEFAULT_GEMINI_CONTEXT_LIMIT = 1_048_576;
-
-/**
- * Context window limits for Gemini models.
- * All Gemini 2.0+ models support 1M input tokens + 65k output tokens.
- * Reference: https://ai.google.dev/gemini-api/docs/models/gemini
- */
-export const GEMINI_CONTEXT_LIMITS: Record<string, number> = {
-  'gemini-3-flash': 1_048_576,
-  'gemini-3-pro': 1_048_576,
-  'gemini-2.5-pro': 1_048_576,
-  'gemini-2.5-flash': 1_048_576,
-  'gemini-2.5-flash-lite': 1_048_576,
-  'gemini-2.0-flash': 1_048_576,
-  'gemini-2.0-flash-lite': 1_048_576,
-  'gemini-2.0-pro': 1_048_576,
-  'gemini-2.0-flash-thinking-experimental': 1_048_576,
-};
-
-export function getGeminiContextWindowLimit(model?: string): number {
-  if (!model) return DEFAULT_GEMINI_CONTEXT_LIMIT;
-
-  const normalized = model.toLowerCase();
-  if (GEMINI_CONTEXT_LIMITS[normalized]) {
-    return GEMINI_CONTEXT_LIMITS[normalized];
-  }
-
-  // Handle versioned models like "gemini-2.5-pro-001"
-  for (const [key, limit] of Object.entries(GEMINI_CONTEXT_LIMITS)) {
-    if (normalized.startsWith(`${key}-`)) {
-      return limit;
-    }
-  }
-
-  return DEFAULT_GEMINI_CONTEXT_LIMIT;
-}
+export type { GeminiModel, GeminiModelInfo } from './gemini-shared.js';
+export {
+  DEFAULT_GEMINI_MODEL,
+  GEMINI_CONTEXT_LIMITS,
+  GEMINI_MODELS,
+  getGeminiContextWindowLimit,
+} from './gemini-shared.js';
 
 // ============================================================
 // Dynamic Model Fetching (NEW)
 // ============================================================
-
-/**
- * Dynamic model information from Gemini API
- */
-export interface GeminiModelInfo {
-  name: string;
-  displayName: string;
-  description?: string;
-  supportedActions: string[];
-  inputTokenLimit?: number;
-  outputTokenLimit?: number;
-}
 
 /**
  * Cache for dynamically fetched models

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     'utils/logger': 'src/utils/logger.ts', // Console monkey-patch for log level filtering
     'seed/index': 'src/seed/index.ts', // Development database seeding
     'callbacks/child-completion-template': 'src/callbacks/child-completion-template.ts', // Parent session callback templates
+    'client/index': 'src/client/index.ts', // Client-safe core entrypoint for browser/SDK consumers
+    'models/browser': 'src/models/browser.ts', // Browser-safe model metadata only
+    'models/gemini-shared': 'src/models/gemini-shared.ts', // Shared Gemini metadata/constants
     'models/index': 'src/models/index.ts', // Model metadata (browser-safe)
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,9 +569,6 @@ importers:
 
   packages/client:
     dependencies:
-      '@agor/core':
-        specifier: workspace:*
-        version: link:../core
       '@feathersjs/authentication-client':
         specifier: ^5.0.41
         version: 5.0.41(typescript@5.9.3)
@@ -584,10 +581,19 @@ importers:
       '@feathersjs/socketio-client':
         specifier: ^5.0.41
         version: 5.0.41
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       socket.io-client:
         specifier: ^4.8.3
         version: 4.8.3
     devDependencies:
+      '@agor/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.0


### PR DESCRIPTION
## Summary

Adds end-to-end Playwright tests for the embedded dashboard flow - the complete path from an external host app through `@superset-ui/embedded-sdk` to dashboard rendering in an iframe with guest token authentication.

**What's included:**

- **Minimal embed test app** (`playwright/embedded-app/index.html`) - static HTML page that uses the SDK's `embedDashboard()`, served by a Node.js `http.createServer` in the test fixture. Zero new npm dependencies.
- **`chromium-embedded` Playwright project** - dedicated test matching for `tests/embedded/**/*.spec.ts`, isolated from the main E2E and auth test projects.
- **API helpers** (`helpers/api/embedded.ts`) - `apiEnableEmbedding()`, `getGuestToken()`, `getDashboardIdBySlug()` for programmatic test setup.
- **`EmbeddedPage` page object** - iframe interaction, token bridge via `page.exposeFunction()`, dashboard content assertions.
- **5 test cases:**
  - Dashboard renders in embedded iframe
  - `hideTitle` UI config propagates through the SDK
  - Native filters work in embedded mode
  - `allowed_domains` blocks unauthorized referrer origins (403)
  - Guest token enables data access and chart rendering

**Config changes:**
- `EMBEDDED_SUPERSET: True` in test feature flags
- CORS config for `http://localhost:9000` (test app origin)

**CI note:** The embedded SDK bundle needs to be built before Playwright runs. The workflow change (`.github/workflows/superset-e2e.yml`) to add `cd superset-embedded-sdk && npm ci && npm run build` is staged locally but could not be pushed due to PAT scope limitations. It needs to be added in a follow-up or via the GitHub UI.

## Architecture

```
Playwright test (Node.js)
  beforeAll: start http server on :9000, enable embedding via API
  exposeFunction(__fetchGuestToken) -> bridges token to browser
  page.goto(http://localhost:9000/?uuid=...&supersetDomain=...)
    index.html calls embedDashboard()
      SDK creates iframe to /embedded/<uuid>
        SDK sends guest token via MessageChannel
          Dashboard renders
```

## Test plan

- [ ] Run `npx playwright test tests/embedded/ --project=chromium-embedded` locally with Flask on :8081
- [ ] Verify all 5 tests pass against a Superset instance with `load_examples` data
- [ ] Add SDK build step to CI workflow (`.github/workflows/superset-e2e.yml`)
- [ ] Verify existing `chromium` and `chromium-unauth` projects are unaffected
- [ ] Run full E2E suite to check for regressions
