### PR TITLE
fix(ui): prevent CSS breakage when closing the session panel

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -930,7 +930,7 @@ export const App: React.FC<AppProps> = ({
                     collapsible
                     collapsedSize={0}
                     defaultSize={selectedSessionId ? sessionPanelSize : 0}
-                    minSize={0}
+                    minSize={selectedSessionId || !eventStreamPanelCollapsed ? 15 : 0}
                     maxSize={75}
                     onExpand={() => {
                       // Restore saved size when panel expands
@@ -968,9 +968,11 @@ export const App: React.FC<AppProps> = ({
                           onNukeEnvironment,
                         }}
                       />
-                    ) : (
-                      // Panel is collapsed — render the last session hidden to keep
-                      // antd component CSS registered (prevents style GC).
+                    ) : null}
+                    {/* Hidden keep-alive: always render SessionPanel when no active
+                        session is selected. This prevents antd CSS-in-JS from GC'ing
+                        component styles that only exist in the panel tree. */}
+                    {!selectedSessionId && panelSession && (
                       <SessionPanel
                         client={null}
                         session={panelSession}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -273,6 +273,12 @@ export const App: React.FC<AppProps> = ({
 
   // Ref for programmatically controlling the comments panel
   const commentsPanelRef = useRef<ImperativePanelHandle>(null);
+  const sessionPanelRef = useRef<ImperativePanelHandle>(null);
+
+  // Track the last-opened session so we can keep the SessionPanel mounted
+  // (hidden) after closing, preventing antd CSS-in-JS from garbage collecting
+  // component styles that are only used inside the panel tree.
+  const [panelSessionId, setPanelSessionId] = useState<string | null>(null);
 
   // Session panel size persistence (percentage of available width)
   const [sessionPanelSize, setSessionPanelSize] = useLocalStorage<number>(
@@ -347,6 +353,7 @@ export const App: React.FC<AppProps> = ({
     },
     onSessionChange: (sessionId) => {
       setSelectedSessionId(sessionId);
+      if (sessionId) setPanelSessionId(sessionId);
     },
   });
 
@@ -392,6 +399,20 @@ export const App: React.FC<AppProps> = ({
     enabled: !eventStreamPanelCollapsed,
   });
 
+  // Imperatively collapse / expand the session panel.
+  // The Panel is always mounted (to prevent antd CSS GC), but its size is
+  // controlled programmatically based on whether content is active.
+  useEffect(() => {
+    const panel = sessionPanelRef.current;
+    if (!panel) return;
+    const shouldBeOpen = !!selectedSessionId || !eventStreamPanelCollapsed;
+    if (shouldBeOpen && panel.isCollapsed()) {
+      panel.expand();
+    } else if (!shouldBeOpen && !panel.isCollapsed()) {
+      panel.collapse();
+    }
+  }, [selectedSessionId, eventStreamPanelCollapsed]);
+
   const handleOpenTerminal = useCallback((commands: string[] = [], worktreeId?: string) => {
     setTerminalCommands(commands);
     setTerminalWorktreeId(worktreeId);
@@ -411,6 +432,7 @@ export const App: React.FC<AppProps> = ({
     // If session was created successfully, open the drawer to show it
     if (sessionId) {
       setSelectedSessionId(sessionId);
+      setPanelSessionId(sessionId);
     }
   };
 
@@ -456,6 +478,7 @@ export const App: React.FC<AppProps> = ({
 
   const handleSessionClick = (sessionId: string) => {
     setSelectedSessionId(sessionId);
+    setPanelSessionId(sessionId);
 
     const session = sessionById.get(sessionId);
 
@@ -535,6 +558,17 @@ export const App: React.FC<AppProps> = ({
   const selectedSessionWorktree = selectedSession
     ? worktreeById.get(selectedSession.worktree_id)
     : null;
+
+  // Derive the "panel session" — the session to render in the panel.
+  // Uses selected session when panel is active, falls back to last-opened
+  // session to keep the component tree mounted (preventing antd CSS GC).
+  const panelSession = selectedSessionId
+    ? selectedSession
+    : panelSessionId
+      ? sessionById.get(panelSessionId) || null
+      : null;
+  const panelSessionWorktree = panelSession ? worktreeById.get(panelSession.worktree_id) : null;
+
   const sessionSettingsSession = sessionSettingsId ? sessionById.get(sessionSettingsId) : null;
   const currentBoard = boardById.get(currentBoardId);
 
@@ -800,7 +834,7 @@ export const App: React.FC<AppProps> = ({
                   style={{ flex: 1 }}
                   onLayout={(sizes) => {
                     // Save right panel size when user resizes (only when panel is open)
-                    if (selectedSessionId && sizes.length === 2) {
+                    if (selectedSessionId && sizes.length === 2 && sizes[1] > 0) {
                       setSessionPanelSize(sizes[1]);
                     }
                   }}
@@ -867,69 +901,87 @@ export const App: React.FC<AppProps> = ({
                       />
                     </div>
                   </Panel>
-                  {(selectedSessionId || !eventStreamPanelCollapsed) && (
-                    <>
-                      <PanelResizeHandle
-                        style={{
-                          width: '4px',
-                          background: 'var(--ant-color-border-secondary)',
-                          cursor: 'col-resize',
-                          transition: 'background 0.2s',
-                        }}
-                        onMouseEnter={(e) => {
-                          (e.currentTarget as unknown as HTMLDivElement).style.background =
-                            'var(--ant-color-primary)';
-                        }}
-                        onMouseLeave={(e) => {
-                          (e.currentTarget as unknown as HTMLDivElement).style.background =
-                            'var(--ant-color-border-secondary)';
+                  {/* Always render the session/event-stream panel to prevent antd
+                      CSS-in-JS from garbage-collecting component styles when the
+                      panel content unmounts. The Panel collapses to 0 when hidden. */}
+                  <PanelResizeHandle
+                    style={{
+                      width: selectedSessionId || !eventStreamPanelCollapsed ? '4px' : '0px',
+                      background: 'var(--ant-color-border-secondary)',
+                      cursor:
+                        selectedSessionId || !eventStreamPanelCollapsed ? 'col-resize' : 'default',
+                      transition: 'background 0.2s, width 0.15s',
+                    }}
+                    onMouseEnter={(e) => {
+                      if (selectedSessionId || !eventStreamPanelCollapsed) {
+                        (e.currentTarget as unknown as HTMLDivElement).style.background =
+                          'var(--ant-color-primary)';
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      (e.currentTarget as unknown as HTMLDivElement).style.background =
+                        'var(--ant-color-border-secondary)';
+                    }}
+                  />
+                  <Panel
+                    ref={sessionPanelRef}
+                    id="session-panel"
+                    order={2}
+                    collapsible
+                    collapsedSize={0}
+                    defaultSize={selectedSessionId ? sessionPanelSize : 0}
+                    minSize={0}
+                    maxSize={75}
+                    onExpand={() => {
+                      // Restore saved size when panel expands
+                      sessionPanelRef.current?.resize(sessionPanelSize);
+                    }}
+                  >
+                    {selectedSessionId ? (
+                      <SessionPanel
+                        client={client}
+                        session={selectedSession}
+                        worktree={selectedSessionWorktree}
+                        currentUserId={user?.user_id}
+                        sessionMcpServerIds={
+                          selectedSessionId ? sessionMcpServerIds.get(selectedSessionId) || [] : []
+                        }
+                        open={!!selectedSessionId}
+                        onClose={() => {
+                          setSelectedSessionId(null);
                         }}
                       />
-                      <Panel
-                        id="session-panel"
-                        order={2}
-                        defaultSize={sessionPanelSize}
-                        minSize={25}
-                        maxSize={75}
-                      >
-                        {selectedSessionId ? (
-                          <SessionPanel
-                            client={client}
-                            session={selectedSession}
-                            worktree={selectedSessionWorktree}
-                            currentUserId={user?.user_id}
-                            sessionMcpServerIds={
-                              selectedSessionId
-                                ? sessionMcpServerIds.get(selectedSessionId) || []
-                                : []
-                            }
-                            open={!!selectedSessionId}
-                            onClose={() => {
-                              setSelectedSessionId(null);
-                            }}
-                          />
-                        ) : (
-                          <EventStreamPanel
-                            collapsed={false}
-                            onToggleCollapse={() => setEventStreamPanelCollapsed(true)}
-                            events={events}
-                            onClear={clearEvents}
-                            currentUserId={user?.user_id}
-                            selectedSessionId={selectedSessionId}
-                            currentBoard={currentBoard}
-                            client={client}
-                            worktreeActions={{
-                              onSessionClick: setSelectedSessionId,
-                              onCreateSession: (worktreeId) => setNewSessionWorktreeId(worktreeId),
-                              onOpenSettings: (worktreeId) =>
-                                setWorktreeModalWorktreeId(worktreeId),
-                              onNukeEnvironment,
-                            }}
-                          />
-                        )}
-                      </Panel>
-                    </>
-                  )}
+                    ) : !eventStreamPanelCollapsed ? (
+                      <EventStreamPanel
+                        collapsed={false}
+                        onToggleCollapse={() => setEventStreamPanelCollapsed(true)}
+                        events={events}
+                        onClear={clearEvents}
+                        currentUserId={user?.user_id}
+                        selectedSessionId={selectedSessionId}
+                        currentBoard={currentBoard}
+                        client={client}
+                        worktreeActions={{
+                          onSessionClick: handleSessionClick,
+                          onCreateSession: (worktreeId) => setNewSessionWorktreeId(worktreeId),
+                          onOpenSettings: (worktreeId) => setWorktreeModalWorktreeId(worktreeId),
+                          onNukeEnvironment,
+                        }}
+                      />
+                    ) : (
+                      // Panel is collapsed — render the last session hidden to keep
+                      // antd component CSS registered (prevents style GC).
+                      <SessionPanel
+                        client={null}
+                        session={panelSession}
+                        worktree={panelSessionWorktree}
+                        currentUserId={user?.user_id}
+                        sessionMcpServerIds={[]}
+                        open={false}
+                        onClose={() => {}}
+                      />
+                    )}
+                  </Panel>
                 </PanelGroup>
               </Panel>
             </PanelGroup>
@@ -1038,7 +1090,7 @@ export const App: React.FC<AppProps> = ({
               setWorktreeModalWorktreeId(null);
               openSettings();
             }}
-            onSessionClick={setSelectedSessionId}
+            onSessionClick={handleSessionClick}
           />
           <WorktreeListDrawer
             open={listDrawerOpen}
@@ -1048,7 +1100,7 @@ export const App: React.FC<AppProps> = ({
             onBoardChange={setCurrentBoardId}
             sessionsByWorktree={sessionsByWorktree}
             worktreeById={worktreeById}
-            onSessionClick={setSelectedSessionId}
+            onSessionClick={handleSessionClick}
           />
           <TerminalModal
             open={terminalOpen}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -559,6 +559,21 @@ export const App: React.FC<AppProps> = ({
     ? worktreeById.get(selectedSession.worktree_id)
     : null;
 
+  // If a session disappears from the active store (e.g. archived/deleted),
+  // clear stale selection so the right panel can recover cleanly.
+  useEffect(() => {
+    if (selectedSessionId && !selectedSession) {
+      setSelectedSessionId(null);
+    }
+  }, [selectedSessionId, selectedSession]);
+
+  // Keep the keep-alive pointer valid; clear it if that session no longer exists.
+  useEffect(() => {
+    if (panelSessionId && !sessionById.has(panelSessionId)) {
+      setPanelSessionId(null);
+    }
+  }, [panelSessionId, sessionById]);
+
   // Derive the "panel session" — the session to render in the panel.
   // Uses selected session when panel is active, falls back to last-opened
   // session to keep the component tree mounted (preventing antd CSS GC).

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -363,7 +363,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   }, [open, scrollToBottom, session]);
 
-  // Early return if no session
+  // When there's no session, render nothing (panel is collapsed to zero).
+  // When open=false, we still render the component tree (hidden) so that
+  // antd's CSS-in-JS doesn't garbage-collect component styles.
   if (!session) {
     return null;
   }
@@ -568,8 +570,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         return 'default';
     }
   };
-
-  if (!open) return null;
 
   // Footer controls
   const footerControls = (
@@ -824,7 +824,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       style={{
         width: '100%',
         height: '100%',
-        display: 'flex',
+        display: open ? 'flex' : 'none',
         flexDirection: 'column',
         background: token.colorBgElevated,
         borderLeft: `1px solid ${token.colorBorder}`,


### PR DESCRIPTION
## Summary

- **Root cause**: antd v5's `@ant-design/cssinjs` garbage-collects component CSS when the last instance of a component type unmounts. The SessionPanel renders antd components (`Alert`, `Form`, `Checkbox`, `Radio`, `Select`, `Flex`, `Descriptions`, `Upload`) not used elsewhere on the board — when the panel unmounted, their CSS was permanently removed.
- **Fix**: Keep the session `Panel` always mounted using `react-resizable-panels`' collapsible API (`collapsedSize=0`). When both the session and event stream panels are closed, a hidden `SessionPanel` renders with the last-viewed session data, keeping antd component CSS registered.
- SessionPanel now uses `display: none` instead of `return null` when closed, preserving the component tree.

## Test plan

- [ ] Open a board and click a worktree card to open the session panel
- [ ] Close the session panel — verify CSS/theming on the board remains intact
- [ ] Re-open the session panel — verify it works normally
- [ ] Toggle event stream panel on/off — verify no CSS breakage
- [ ] Switch between boards — verify panel state is handled correctly
- [ ] Resize the session panel, close it, reopen — verify saved size is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)