### PR TITLE
fix(ui): prevent expensive re-renders on prompt input keystrokes

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -89,7 +89,7 @@ export interface PromptInputHandle {
 }
 
 interface PromptInputProps {
-  sessionId: string;
+  sessionId: SessionID;
   getDraft: (id: string) => string;
   saveDraft: (id: string, value: string) => void;
   deleteDraft: (id: string) => void;
@@ -103,7 +103,6 @@ interface PromptInputProps {
   placeholder?: string;
   autoSize?: { minRows?: number; maxRows?: number };
   client: AgorClient | null;
-  sessionId_autocomplete: SessionID | null;
   userById: Map<string, User>;
   onFilesDrop?: (files: File[]) => void;
   slashCommands?: string[];
@@ -123,7 +122,6 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
       placeholder,
       autoSize,
       client,
-      sessionId_autocomplete,
       userById,
       onFilesDrop,
       slashCommands,
@@ -184,6 +182,17 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
       return () => clearTimeout(timer);
     }, [value, sessionId, saveDraft]);
 
+    // Flush draft on unmount so in-flight debounced writes aren't lost.
+    // Uses refs to capture the latest values without adding deps that would
+    // cause the effect to re-run (we only want the cleanup to fire on unmount).
+    const saveDraftRef = React.useRef(saveDraft);
+    saveDraftRef.current = saveDraft;
+    const sessionIdRef = React.useRef(sessionId);
+    sessionIdRef.current = sessionId;
+    React.useEffect(() => {
+      return () => saveDraftRef.current(sessionIdRef.current, valueRef.current);
+    }, []);
+
     const handleKeyPress = React.useCallback(
       (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (e.key === 'Enter' && !e.shiftKey) {
@@ -204,7 +213,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
         autoSize={autoSize}
         onKeyPress={handleKeyPress}
         client={client}
-        sessionId={sessionId_autocomplete}
+        sessionId={sessionId}
         userById={userById}
         onFilesDrop={onFilesDrop}
         slashCommands={slashCommands}
@@ -764,7 +773,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           }
           autoSize={{ minRows: 1, maxRows: 10 }}
           client={client}
-          sessionId_autocomplete={session?.session_id || null}
           userById={userById}
           onFilesDrop={(files) => {
             // Store dropped files and open modal

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -5,7 +5,9 @@ import type {
   Message,
   PermissionMode,
   Session,
+  SessionID,
   SpawnConfig,
+  User,
   Worktree,
 } from '@agor-live/client';
 import { AGENTIC_TOOL_CAPABILITIES, SessionStatus, TaskStatus } from '@agor-live/client';
@@ -73,6 +75,148 @@ interface SpawnTemplateContext {
 // Compile the spawn subsession template once at module level (after helper registration)
 const compiledSpawnSubsessionTemplate =
   compileTemplate<SpawnTemplateContext>(spawnSubsessionTemplate);
+
+// ---------------------------------------------------------------------------
+// PromptInput — thin wrapper around AutocompleteTextarea that keeps the typed
+// text in *local* state so that keystrokes never trigger a parent re-render.
+// The parent reads/clears the value imperatively via a ref.
+// ---------------------------------------------------------------------------
+
+export interface PromptInputHandle {
+  getValue: () => string;
+  clear: () => void;
+  insertText: (text: string) => void;
+}
+
+interface PromptInputProps {
+  sessionId: string;
+  getDraft: (id: string) => string;
+  saveDraft: (id: string, value: string) => void;
+  deleteDraft: (id: string) => void;
+  /** Fires only on empty↔non-empty transitions, not every keystroke */
+  onHasInputChange: (hasInput: boolean) => void;
+  /** Kept in sync so memoized children can read the latest value */
+  inputValueRef: React.MutableRefObject<string>;
+  /** Called on Enter (without Shift) when there is non-empty text */
+  onSubmit: () => void;
+  // Forwarded to AutocompleteTextarea
+  placeholder?: string;
+  autoSize?: { minRows?: number; maxRows?: number };
+  client: AgorClient | null;
+  sessionId_autocomplete: SessionID | null;
+  userById: Map<string, User>;
+  onFilesDrop?: (files: File[]) => void;
+  slashCommands?: string[];
+  skills?: string[];
+}
+
+const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
+  (
+    {
+      sessionId,
+      getDraft,
+      saveDraft,
+      deleteDraft,
+      onHasInputChange,
+      inputValueRef,
+      onSubmit,
+      placeholder,
+      autoSize,
+      client,
+      sessionId_autocomplete,
+      userById,
+      onFilesDrop,
+      slashCommands,
+      skills,
+    },
+    ref
+  ) => {
+    const [value, setValue] = React.useState(() => getDraft(sessionId));
+    const valueRef = React.useRef(value);
+
+    // Keep refs in sync (zero-cost, no re-render)
+    valueRef.current = value;
+    inputValueRef.current = value;
+
+    // Track empty↔non-empty transitions → notify parent (minimal re-renders)
+    const prevHasInput = React.useRef(!!value.trim());
+    React.useEffect(() => {
+      const has = !!value.trim();
+      if (has !== prevHasInput.current) {
+        prevHasInput.current = has;
+        onHasInputChange(has);
+      }
+    }, [value, onHasInputChange]);
+
+    // Imperative methods for the parent
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        getValue: () => valueRef.current,
+        clear: () => {
+          setValue('');
+          deleteDraft(sessionId);
+        },
+        insertText: (text: string) => {
+          setValue((prev) => {
+            const trimmed = prev.trim();
+            const separator = trimmed ? ' ' : '';
+            return `${trimmed}${separator}${text}`;
+          });
+        },
+      }),
+      [sessionId, deleteDraft]
+    );
+
+    // Session switch: save old draft, load new one
+    const prevSessionId = React.useRef(sessionId);
+    React.useEffect(() => {
+      if (prevSessionId.current !== sessionId) {
+        saveDraft(prevSessionId.current, valueRef.current);
+        setValue(getDraft(sessionId));
+        prevSessionId.current = sessionId;
+      }
+    }, [sessionId, saveDraft, getDraft]);
+
+    // Debounced draft persistence (300ms)
+    React.useEffect(() => {
+      const timer = setTimeout(() => saveDraft(sessionId, value), 300);
+      return () => clearTimeout(timer);
+    }, [value, sessionId, saveDraft]);
+
+    const handleKeyPress = React.useCallback(
+      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          if (valueRef.current.trim()) {
+            onSubmit();
+          }
+        }
+      },
+      [onSubmit]
+    );
+
+    return (
+      <AutocompleteTextarea
+        value={value}
+        onChange={setValue}
+        placeholder={placeholder}
+        autoSize={autoSize}
+        onKeyPress={handleKeyPress}
+        client={client}
+        sessionId={sessionId_autocomplete}
+        userById={userById}
+        onFilesDrop={onFilesDrop}
+        slashCommands={slashCommands}
+        skills={skills}
+      />
+    );
+  }
+);
+
+PromptInput.displayName = 'PromptInput';
+
+// ---------------------------------------------------------------------------
 
 export interface SessionPanelProps {
   client: AgorClient | null;
@@ -152,40 +296,13 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   }, []);
 
-  const [inputValue, setInputValue] = React.useState(() => {
-    return session ? getDraft(session.session_id) : '';
-  });
-
-  // Mirror inputValue into a ref so memoized children and event handlers
-  // can read the current value without subscribing to state changes.
-  const inputValueRef = React.useRef(inputValue);
-  inputValueRef.current = inputValue;
-
-  const prevSessionIdRef = React.useRef(session?.session_id);
-
-  // Handle session switches — use ref to read current inputValue
-  // so this effect doesn't re-run on every keystroke.
-  React.useEffect(() => {
-    if (!session) return;
-
-    if (prevSessionIdRef.current !== session.session_id) {
-      if (prevSessionIdRef.current) {
-        saveDraft(prevSessionIdRef.current, inputValueRef.current);
-      }
-
-      setInputValue(getDraft(session.session_id));
-      prevSessionIdRef.current = session.session_id;
-    }
-  }, [session, saveDraft, getDraft]);
-
-  // Save draft on change — debounced to avoid localStorage writes on every keystroke
-  React.useEffect(() => {
-    if (!session) return;
-    const timer = setTimeout(() => {
-      saveDraft(session.session_id, inputValue);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [session, inputValue, saveDraft]);
+  // Input value lives entirely inside PromptInput (local state).
+  // The parent reads it imperatively via promptRef / inputValueRef — no
+  // parent re-renders on keystrokes.
+  const promptRef = React.useRef<PromptInputHandle>(null);
+  const inputValueRef = React.useRef(session ? getDraft(session.session_id) : '');
+  const [hasInput, setHasInput] = React.useState(() => !!inputValueRef.current.trim());
+  const handleHasInputChange = React.useCallback((v: boolean) => setHasInput(v), []);
 
   const getDefaultPermissionMode = React.useCallback((agent?: string): PermissionMode => {
     return agent === 'codex' ? 'auto' : 'acceptEdits';
@@ -397,9 +514,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const isStopping = session.status === SessionStatus.STOPPING;
 
   const handleSendPrompt = async () => {
-    if (!inputValue.trim() || connectionDisabled) return;
+    const value = promptRef.current?.getValue() ?? '';
+    if (!value.trim() || connectionDisabled) return;
 
-    const promptToSend = inputValue.trim();
+    const promptToSend = value.trim();
 
     try {
       if (isRunning && client) {
@@ -418,11 +536,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         }
 
         message.success(`Message queued at position ${response.message.queue_position}`);
-        setInputValue('');
-        deleteDraft(session.session_id);
+        promptRef.current?.clear();
       } else {
-        setInputValue('');
-        deleteDraft(session.session_id);
+        promptRef.current?.clear();
         onSendPrompt?.(session.session_id, promptToSend, permissionMode);
       }
     } catch (error) {
@@ -453,16 +569,16 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const handleFork = () => {
     if (!session) return;
-    onFork?.(session.session_id, inputValue.trim());
-    setInputValue('');
-    deleteDraft(session.session_id);
+    const value = promptRef.current?.getValue() ?? '';
+    onFork?.(session.session_id, value.trim());
+    promptRef.current?.clear();
   };
 
   const handleBtwSend = async () => {
-    if (!inputValue.trim() || connectionDisabled) return;
-    const promptToSend = inputValue.trim();
-    setInputValue('');
-    deleteDraft(session.session_id);
+    const value = promptRef.current?.getValue() ?? '';
+    if (!value.trim() || connectionDisabled) return;
+    const promptToSend = value.trim();
+    promptRef.current?.clear();
     await onBtwFork?.(session.session_id, promptToSend);
   };
 
@@ -512,7 +628,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
 
     setSpawnModalOpen(false);
-    setInputValue('');
+    promptRef.current?.clear();
   };
 
   const handlePermissionModeChange = (newMode: PermissionMode) => {
@@ -632,25 +748,23 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             banner
           />
         )}
-        <AutocompleteTextarea
-          value={inputValue}
-          onChange={setInputValue}
+        <PromptInput
+          ref={promptRef}
+          sessionId={session.session_id}
+          getDraft={getDraft}
+          saveDraft={saveDraft}
+          deleteDraft={deleteDraft}
+          onHasInputChange={handleHasInputChange}
+          inputValueRef={inputValueRef}
+          onSubmit={handleSendPrompt}
           placeholder={
             isRunning
               ? 'Session is working... Type here to queue, or use "btw" for a side question'
               : 'Send a prompt, fork, or use "btw" for a side question... (type @ for autocomplete)'
           }
           autoSize={{ minRows: 1, maxRows: 10 }}
-          onKeyPress={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              if (inputValue.trim() && !connectionDisabled) {
-                handleSendPrompt();
-              }
-            }
-          }}
           client={client}
-          sessionId={session?.session_id || null}
+          sessionId_autocomplete={session?.session_id || null}
           userById={userById}
           onFilesDrop={(files) => {
             // Store dropped files and open modal
@@ -817,7 +931,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                   type="primary"
                   icon={<SendOutlined />}
                   onClick={handleSendPrompt}
-                  disabled={connectionDisabled || !inputValue.trim()}
+                  disabled={connectionDisabled || !hasInput}
                 />
               </Tooltip>
             </Space.Compact>
@@ -964,11 +1078,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             }}
             onInsertMention={(filepath) => {
               // Insert @filepath mention into the textarea
-              setInputValue((prev) => {
-                const trimmed = prev.trim();
-                const separator = trimmed ? ' ' : '';
-                return `${trimmed}${separator}@${filepath}`;
-              });
+              promptRef.current?.insertText(`@${filepath}`);
             }}
           />
         )}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -156,27 +156,35 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     return session ? getDraft(session.session_id) : '';
   });
 
+  // Mirror inputValue into a ref so memoized children and event handlers
+  // can read the current value without subscribing to state changes.
+  const inputValueRef = React.useRef(inputValue);
+  inputValueRef.current = inputValue;
+
   const prevSessionIdRef = React.useRef(session?.session_id);
 
-  // Handle session switches
+  // Handle session switches — use ref to read current inputValue
+  // so this effect doesn't re-run on every keystroke.
   React.useEffect(() => {
     if (!session) return;
 
     if (prevSessionIdRef.current !== session.session_id) {
       if (prevSessionIdRef.current) {
-        saveDraft(prevSessionIdRef.current, inputValue);
+        saveDraft(prevSessionIdRef.current, inputValueRef.current);
       }
 
       setInputValue(getDraft(session.session_id));
       prevSessionIdRef.current = session.session_id;
     }
-  }, [session, inputValue, saveDraft, getDraft]);
+  }, [session, saveDraft, getDraft]);
 
-  // Save draft on every change (so board switches don't lose it)
+  // Save draft on change — debounced to avoid localStorage writes on every keystroke
   React.useEffect(() => {
-    if (session) {
+    if (!session) return;
+    const timer = setTimeout(() => {
       saveDraft(session.session_id, inputValue);
-    }
+    }, 300);
+    return () => clearTimeout(timer);
   }, [session, inputValue, saveDraft]);
 
   const getDefaultPermissionMode = React.useCallback((agent?: string): PermissionMode => {
@@ -923,7 +931,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           worktree={worktree}
           currentUserId={currentUserId}
           sessionMcpServerIds={sessionMcpServerIds}
-          footerControls={footerControls}
           scrollToBottom={scrollToBottom}
           scrollToTop={scrollToTop}
           setScrollToBottom={setScrollToBottom}
@@ -933,9 +940,13 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           spawnModalOpen={spawnModalOpen}
           setSpawnModalOpen={setSpawnModalOpen}
           onSpawnModalConfirm={handleSpawnModalConfirm}
-          inputValue={inputValue}
+          inputValueRef={inputValueRef}
           isOpen={open}
         />
+
+        {/* Footer Controls — rendered outside SessionPanelContent so that
+            keystroke-driven re-renders don't propagate to ConversationView */}
+        {footerControls}
 
         {/* File upload modal */}
         {session && (

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -7,7 +7,7 @@ import {
   VerticalAlignTopOutlined,
 } from '@ant-design/icons';
 import { App, Button, Divider, Space, Tooltip, Typography, theme } from 'antd';
-import type React from 'react';
+import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppData } from '../../contexts/AppDataContext';
 import { copyToClipboard } from '../../utils/clipboard';
@@ -24,7 +24,6 @@ export interface SessionPanelContentProps {
   worktree?: Worktree | null;
   currentUserId?: string;
   sessionMcpServerIds?: string[];
-  footerControls: React.ReactNode;
   scrollToBottom: (() => void) | null;
   scrollToTop: (() => void) | null;
   setScrollToBottom: (fn: (() => void) | null) => void;
@@ -34,258 +33,262 @@ export interface SessionPanelContentProps {
   spawnModalOpen: boolean;
   setSpawnModalOpen: (open: boolean) => void;
   onSpawnModalConfirm: (config: string | Partial<SpawnConfig>) => Promise<void>;
-  inputValue: string;
+  inputValueRef: React.RefObject<string>;
   isOpen: boolean;
 }
 
-export const SessionPanelContent: React.FC<SessionPanelContentProps> = ({
-  client,
-  session,
-  worktree = null,
-  currentUserId,
-  sessionMcpServerIds = [],
-  footerControls,
-  scrollToBottom,
-  scrollToTop,
-  setScrollToBottom,
-  setScrollToTop,
-  queuedMessages,
-  setQueuedMessages,
-  spawnModalOpen,
-  setSpawnModalOpen,
-  onSpawnModalConfirm,
-  inputValue,
-  isOpen,
-}) => {
-  const { token } = theme.useToken();
-  const { message } = App.useApp();
+export const SessionPanelContent = React.memo<SessionPanelContentProps>(
+  ({
+    client,
+    session,
+    worktree = null,
+    currentUserId,
+    sessionMcpServerIds = [],
+    scrollToBottom,
+    scrollToTop,
+    setScrollToBottom,
+    setScrollToTop,
+    queuedMessages,
+    setQueuedMessages,
+    spawnModalOpen,
+    setSpawnModalOpen,
+    onSpawnModalConfirm,
+    inputValueRef,
+    isOpen,
+  }) => {
+    const { token } = theme.useToken();
+    const { message } = App.useApp();
 
-  // Get data from context
-  const { userById, repoById, mcpServerById, userAuthenticatedMcpServerIds } = useAppData();
+    // Get data from context
+    const { userById, repoById, mcpServerById, userAuthenticatedMcpServerIds } = useAppData();
 
-  // Get actions from context
-  const {
-    onOpenWorktree,
-    onStartEnvironment,
-    onStopEnvironment,
-    onNukeEnvironment,
-    onViewLogs,
-    onPermissionDecision,
-    onInputResponse,
-  } = useAppActions();
+    // Get actions from context
+    const {
+      onOpenWorktree,
+      onStartEnvironment,
+      onStopEnvironment,
+      onNukeEnvironment,
+      onViewLogs,
+      onPermissionDecision,
+      onInputResponse,
+    } = useAppActions();
 
-  // Get repo from worktree
-  const repo = worktree ? repoById.get(worktree.repo_id) || null : null;
+    // Get repo from worktree
+    const repo = worktree ? repoById.get(worktree.repo_id) || null : null;
 
-  return (
-    <>
-      {/* Header row with pills and scroll navigation */}
-      <div
-        style={{
-          marginBottom: token.sizeUnit,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: token.sizeUnit * 2,
-        }}
-      >
-        {/* Pills section (only shown if there's content) */}
-        {(worktree || sessionMcpServerIds.length > 0) && (
-          <Space size={8} wrap style={{ flex: 1 }}>
-            {/* Unified Worktree Pill */}
-            {worktree && repo && (
-              <WorktreeHeaderPill
-                repo={repo}
-                worktree={worktree}
-                onOpenWorktree={onOpenWorktree}
-                onStartEnvironment={onStartEnvironment}
-                onStopEnvironment={onStopEnvironment}
-                onNukeEnvironment={onNukeEnvironment}
-                onViewLogs={onViewLogs}
-              />
-            )}
-            {/* Issue and PR Pills */}
-            {worktree?.issue_url && <IssuePill issueUrl={worktree.issue_url} />}
-            {worktree?.pull_request_url && <PullRequestPill prUrl={worktree.pull_request_url} />}
-            {/* MCP Servers */}
-            {sessionMcpServerIds
-              .map((serverId) => mcpServerById.get(serverId))
-              .filter(Boolean)
-              .map((server) => (
-                <MCPServerPill
-                  key={server!.mcp_server_id}
-                  server={server!}
-                  needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
-                  client={client}
-                />
-              ))}
-          </Space>
-        )}
-        {/* Spacer if no pills */}
-        {!(worktree || sessionMcpServerIds.length > 0) && <div style={{ flex: 1 }} />}
-        {/* Scroll Navigation Buttons - always visible */}
-        <Space size={4}>
-          <Tooltip title="Scroll to top of conversation">
-            <Button
-              type="text"
-              size="small"
-              icon={<VerticalAlignTopOutlined />}
-              onClick={() => scrollToTop?.()}
-              disabled={!scrollToTop}
-            />
-          </Tooltip>
-          <Tooltip title="Scroll to bottom of conversation">
-            <Button
-              type="text"
-              size="small"
-              icon={<VerticalAlignBottomOutlined />}
-              onClick={() => scrollToBottom?.()}
-              disabled={!scrollToBottom}
-            />
-          </Tooltip>
-        </Space>
-      </div>
+    // Stable callback for ConversationView's onScrollRef to prevent breaking React.memo
+    const handleScrollRef = React.useCallback(
+      (scrollBottom: () => void, scrollTop: () => void) => {
+        setScrollToBottom(() => scrollBottom);
+        setScrollToTop(() => scrollTop);
+      },
+      [setScrollToBottom, setScrollToTop]
+    );
 
-      <Divider style={{ margin: `${token.sizeUnit * 2}px 0` }} />
-
-      {/* Task-Centric Conversation View - Scrollable */}
-      <ConversationView
-        client={client}
-        sessionId={session.session_id}
-        agentic_tool={session.agentic_tool}
-        sessionModel={session.model_config?.model}
-        userById={userById}
-        currentUserId={currentUserId}
-        onScrollRef={(scrollBottom, scrollTop) => {
-          setScrollToBottom(() => scrollBottom);
-          setScrollToTop(() => scrollTop);
-        }}
-        onPermissionDecision={onPermissionDecision}
-        onInputResponse={onInputResponse}
-        worktreeName={worktree?.name}
-        scheduledFromWorktree={session.scheduled_from_worktree}
-        scheduledRunAt={session.scheduled_run_at}
-        isActive={isOpen}
-        genealogy={session.genealogy}
-        assistantEmoji={
-          worktree && isAssistant(worktree) ? getAssistantConfig(worktree)?.emoji : undefined
-        }
-      />
-
-      {/* Queued Messages Drawer - Above Footer */}
-      {queuedMessages.length > 0 && (
+    return (
+      <>
+        {/* Header row with pills and scroll navigation */}
         <div
           style={{
-            flexShrink: 0,
-            background: token.colorBgElevated,
-            borderTop: `1px solid ${token.colorBorderSecondary}`,
-            borderTopLeftRadius: token.borderRadiusLG,
-            borderTopRightRadius: token.borderRadiusLG,
-            padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
-            marginLeft: -token.sizeUnit * 6 + token.sizeUnit * 2,
-            marginRight: -token.sizeUnit * 6 + token.sizeUnit * 2,
-            marginTop: token.sizeUnit * 2,
-            boxShadow: `0 -2px 8px ${token.colorBgMask}`,
+            marginBottom: token.sizeUnit,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: token.sizeUnit * 2,
           }}
         >
-          <Typography.Text
-            type="secondary"
-            style={{
-              fontSize: token.fontSizeSM,
-              display: 'block',
-              marginBottom: token.sizeUnit * 2,
-              fontWeight: 500,
-              textTransform: 'uppercase',
-              letterSpacing: '0.5px',
-            }}
-          >
-            Queued Messages ({queuedMessages.length})
-          </Typography.Text>
-          <Space orientation="vertical" size={8} style={{ width: '100%' }}>
-            {queuedMessages.map((msg, idx) => (
-              <div
-                key={msg.message_id}
-                style={{
-                  background: token.colorBgContainer,
-                  padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 3}px`,
-                  borderRadius: token.borderRadius,
-                  border: `1px solid ${token.colorBorder}`,
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  gap: token.sizeUnit * 2,
-                }}
-              >
-                <Typography.Text ellipsis style={{ flex: 1 }}>
-                  <span style={{ color: token.colorTextSecondary, marginRight: token.sizeUnit }}>
-                    {idx + 1}.
-                  </span>
-                  {msg.content_preview || (typeof msg.content === 'string' ? msg.content : '')}
-                </Typography.Text>
-                <Space size={4}>
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<CopyOutlined />}
-                    onClick={async () => {
-                      const textToCopy = typeof msg.content === 'string' ? msg.content : '';
-                      await copyToClipboard(textToCopy);
-                      message.success('Message copied to clipboard');
-                    }}
+          {/* Pills section (only shown if there's content) */}
+          {(worktree || sessionMcpServerIds.length > 0) && (
+            <Space size={8} wrap style={{ flex: 1 }}>
+              {/* Unified Worktree Pill */}
+              {worktree && repo && (
+                <WorktreeHeaderPill
+                  repo={repo}
+                  worktree={worktree}
+                  onOpenWorktree={onOpenWorktree}
+                  onStartEnvironment={onStartEnvironment}
+                  onStopEnvironment={onStopEnvironment}
+                  onNukeEnvironment={onNukeEnvironment}
+                  onViewLogs={onViewLogs}
+                />
+              )}
+              {/* Issue and PR Pills */}
+              {worktree?.issue_url && <IssuePill issueUrl={worktree.issue_url} />}
+              {worktree?.pull_request_url && <PullRequestPill prUrl={worktree.pull_request_url} />}
+              {/* MCP Servers */}
+              {sessionMcpServerIds
+                .map((serverId) => mcpServerById.get(serverId))
+                .filter(Boolean)
+                .map((server) => (
+                  <MCPServerPill
+                    key={server!.mcp_server_id}
+                    server={server!}
+                    needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
+                    client={client}
                   />
-                  <Button
-                    type="text"
-                    size="small"
-                    danger
-                    icon={<DeleteOutlined />}
-                    onClick={async () => {
-                      if (!client) return;
-
-                      try {
-                        // Optimistically remove from UI
-                        setQueuedMessages((prev) =>
-                          prev.filter((m) => m.message_id !== msg.message_id)
-                        );
-
-                        // Delete via messages service directly
-                        await client.service('messages').remove(msg.message_id);
-                      } catch (error) {
-                        message.error(
-                          `Failed to remove queued message: ${error instanceof Error ? error.message : String(error)}`
-                        );
-
-                        // Re-fetch queue to restore accurate state
-                        const response = await client
-                          .service(`sessions/${session.session_id}/messages/queue`)
-                          .find();
-                        const data = (response as { data: Message[] }).data || [];
-                        setQueuedMessages(data);
-                      }
-                    }}
-                  />
-                </Space>
-              </div>
-            ))}
+                ))}
+            </Space>
+          )}
+          {/* Spacer if no pills */}
+          {!(worktree || sessionMcpServerIds.length > 0) && <div style={{ flex: 1 }} />}
+          {/* Scroll Navigation Buttons - always visible */}
+          <Space size={4}>
+            <Tooltip title="Scroll to top of conversation">
+              <Button
+                type="text"
+                size="small"
+                icon={<VerticalAlignTopOutlined />}
+                onClick={() => scrollToTop?.()}
+                disabled={!scrollToTop}
+              />
+            </Tooltip>
+            <Tooltip title="Scroll to bottom of conversation">
+              <Button
+                type="text"
+                size="small"
+                icon={<VerticalAlignBottomOutlined />}
+                onClick={() => scrollToBottom?.()}
+                disabled={!scrollToBottom}
+              />
+            </Tooltip>
           </Space>
         </div>
-      )}
 
-      {/* Footer Controls (passed from parent) */}
-      {footerControls}
+        <Divider style={{ margin: `${token.sizeUnit * 2}px 0` }} />
 
-      {/* Advanced Spawn Modal */}
-      <ForkSpawnModal
-        open={spawnModalOpen}
-        action="spawn"
-        session={session}
-        currentUser={currentUserId ? userById.get(currentUserId) || null : null}
-        mcpServerById={mcpServerById}
-        initialPrompt={inputValue}
-        onConfirm={onSpawnModalConfirm}
-        onCancel={() => setSpawnModalOpen(false)}
-        client={client}
-        userById={userById}
-      />
-    </>
-  );
-};
+        {/* Task-Centric Conversation View - Scrollable */}
+        <ConversationView
+          client={client}
+          sessionId={session.session_id}
+          agentic_tool={session.agentic_tool}
+          sessionModel={session.model_config?.model}
+          userById={userById}
+          currentUserId={currentUserId}
+          onScrollRef={handleScrollRef}
+          onPermissionDecision={onPermissionDecision}
+          onInputResponse={onInputResponse}
+          worktreeName={worktree?.name}
+          scheduledFromWorktree={session.scheduled_from_worktree}
+          scheduledRunAt={session.scheduled_run_at}
+          isActive={isOpen}
+          genealogy={session.genealogy}
+          assistantEmoji={
+            worktree && isAssistant(worktree) ? getAssistantConfig(worktree)?.emoji : undefined
+          }
+        />
+
+        {/* Queued Messages Drawer - Above Footer */}
+        {queuedMessages.length > 0 && (
+          <div
+            style={{
+              flexShrink: 0,
+              background: token.colorBgElevated,
+              borderTop: `1px solid ${token.colorBorderSecondary}`,
+              borderTopLeftRadius: token.borderRadiusLG,
+              borderTopRightRadius: token.borderRadiusLG,
+              padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
+              marginLeft: -token.sizeUnit * 6 + token.sizeUnit * 2,
+              marginRight: -token.sizeUnit * 6 + token.sizeUnit * 2,
+              marginTop: token.sizeUnit * 2,
+              boxShadow: `0 -2px 8px ${token.colorBgMask}`,
+            }}
+          >
+            <Typography.Text
+              type="secondary"
+              style={{
+                fontSize: token.fontSizeSM,
+                display: 'block',
+                marginBottom: token.sizeUnit * 2,
+                fontWeight: 500,
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+              }}
+            >
+              Queued Messages ({queuedMessages.length})
+            </Typography.Text>
+            <Space orientation="vertical" size={8} style={{ width: '100%' }}>
+              {queuedMessages.map((msg, idx) => (
+                <div
+                  key={msg.message_id}
+                  style={{
+                    background: token.colorBgContainer,
+                    padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 3}px`,
+                    borderRadius: token.borderRadius,
+                    border: `1px solid ${token.colorBorder}`,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: token.sizeUnit * 2,
+                  }}
+                >
+                  <Typography.Text ellipsis style={{ flex: 1 }}>
+                    <span style={{ color: token.colorTextSecondary, marginRight: token.sizeUnit }}>
+                      {idx + 1}.
+                    </span>
+                    {msg.content_preview || (typeof msg.content === 'string' ? msg.content : '')}
+                  </Typography.Text>
+                  <Space size={4}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<CopyOutlined />}
+                      onClick={async () => {
+                        const textToCopy = typeof msg.content === 'string' ? msg.content : '';
+                        await copyToClipboard(textToCopy);
+                        message.success('Message copied to clipboard');
+                      }}
+                    />
+                    <Button
+                      type="text"
+                      size="small"
+                      danger
+                      icon={<DeleteOutlined />}
+                      onClick={async () => {
+                        if (!client) return;
+
+                        try {
+                          // Optimistically remove from UI
+                          setQueuedMessages((prev) =>
+                            prev.filter((m) => m.message_id !== msg.message_id)
+                          );
+
+                          // Delete via messages service directly
+                          await client.service('messages').remove(msg.message_id);
+                        } catch (error) {
+                          message.error(
+                            `Failed to remove queued message: ${error instanceof Error ? error.message : String(error)}`
+                          );
+
+                          // Re-fetch queue to restore accurate state
+                          const response = await client
+                            .service(`sessions/${session.session_id}/messages/queue`)
+                            .find();
+                          const data = (response as { data: Message[] }).data || [];
+                          setQueuedMessages(data);
+                        }
+                      }}
+                    />
+                  </Space>
+                </div>
+              ))}
+            </Space>
+          </div>
+        )}
+
+        {/* Advanced Spawn Modal */}
+        <ForkSpawnModal
+          open={spawnModalOpen}
+          action="spawn"
+          session={session}
+          currentUser={currentUserId ? userById.get(currentUserId) || null : null}
+          mcpServerById={mcpServerById}
+          initialPrompt={inputValueRef.current ?? ''}
+          onConfirm={onSpawnModalConfirm}
+          onCancel={() => setSpawnModalOpen(false)}
+          client={client}
+          userById={userById}
+        />
+      </>
+    );
+  }
+);


### PR DESCRIPTION
## Summary

- **Isolate conversation view from keystroke re-renders**: Moved footer controls (textarea + toolbar) out of `SessionPanelContent` and wrapped `SessionPanelContent` with `React.memo`. This prevents `ConversationView` (the heavy message list) from re-rendering on every keystroke.
- **Stabilize `onScrollRef` callback**: Replaced the inline arrow function passed to `ConversationView.onScrollRef` with a `useCallback`-memoized version, so `ConversationView`'s own `React.memo` actually works.
- **Debounce draft persistence**: Changed the draft save effect from firing synchronously on every keystroke to a 300ms debounced timeout, reducing localStorage write frequency.
- **Fix session-switch effect**: Removed `inputValue` from the session-switch `useEffect` dependency array (reads from ref instead), preventing it from re-running on every keystroke.

### Root cause

`inputValue` state lived in `SessionPanel`, which rendered both the textarea and (via `SessionPanelContent`) the entire conversation view. Every keystroke triggered `setInputValue` → full `SessionPanel` re-render → `SessionPanelContent` re-render → `ConversationView` re-render (despite its `React.memo`, defeated by a new inline `onScrollRef` callback each render).

### What changed

| File | Change |
|------|--------|
| `SessionPanel.tsx` | Added `inputValueRef` mirror, debounced draft save, moved `footerControls` rendering outside `SessionPanelContent` |
| `SessionPanelContent.tsx` | Wrapped with `React.memo`, replaced `footerControls`/`inputValue` props with `inputValueRef`, memoized `handleScrollRef` |

## Test plan

- [ ] Type in the prompt textarea — should feel instant with no lag
- [ ] Send a prompt — input clears correctly
- [ ] Switch sessions — draft loads/saves correctly
- [ ] Fork/Btw/Spawn actions still read the current input value
- [ ] Queued messages still display and can be deleted
- [ ] File upload → insert mention still works
- [ ] Scroll to top/bottom buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)