### PR TITLE
feat(auth): POST /authentication/impersonate endpoint

### DIFF
--- a/apps/agor-daemon/src/auth-jwt-integration.test.ts
+++ b/apps/agor-daemon/src/auth-jwt-integration.test.ts
@@ -22,16 +22,21 @@
  */
 
 import type { Database } from '@agor/core/db';
-import { createDatabaseAsync } from '@agor/core/db';
+import { createDatabaseAsync, generateId } from '@agor/core/db';
 import {
   AuthenticationService,
   authenticate,
+  BadRequest,
+  Forbidden,
   feathers,
   JWTStrategy,
   LocalStrategy,
+  NotAuthenticated,
+  NotFound,
 } from '@agor/core/feathers';
-import type { HookContext } from '@agor/core/types';
-import { ROLES } from '@agor/core/types';
+import type { AuthenticatedParams, HookContext, User } from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { requireMinimumRole } from './utils/authorization';
 
@@ -497,6 +502,349 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
       });
 
       await expect(app.service('/files').find({})).rejects.toThrow();
+    });
+  });
+});
+
+// =============================================================================
+// Impersonation Endpoint Tests
+// =============================================================================
+//
+// These tests exercise the full handler logic for POST /authentication/impersonate,
+// not just the hook layer. The handler contains inline guards (superadmin check,
+// recursive impersonation block, user lookup, expiry validation) that need direct
+// testing since they're security-critical.
+// =============================================================================
+
+describe('POST /authentication/impersonate - Handler Logic', () => {
+  const JWT_SECRET = 'test-impersonation-secret';
+  const MAX_EXPIRY_MS = 3_600_000;
+
+  // Mock target user
+  const targetUser: Pick<User, 'user_id' | 'email' | 'name' | 'emoji' | 'role'> = {
+    user_id: 'target-user-id' as User['user_id'],
+    email: 'target@example.com',
+    name: 'Target User',
+    emoji: '🎯',
+    role: ROLES.MEMBER,
+  };
+
+  // Mock usersService that returns targetUser or throws
+  const mockUsersService = {
+    async get(id: string) {
+      if (id === targetUser.user_id) return targetUser;
+      throw new Error('Not found');
+    },
+  };
+
+  /**
+   * Creates the impersonation handler matching production logic.
+   * This mirrors register-routes.ts but with injected dependencies for testing.
+   */
+  function createImpersonateHandler(usersService = mockUsersService, configuredMaxExpiry?: number) {
+    return async (
+      data: { user_id?: string; expiry_ms?: number },
+      params?: AuthenticatedParams & { authentication?: { payload?: Record<string, unknown> } }
+    ) => {
+      // 1. Caller must be authenticated
+      if (!params?.user || !params.user.user_id) {
+        throw new NotAuthenticated('Authentication required');
+      }
+
+      const caller = params.user;
+
+      // 2. Caller must have role: superadmin
+      if (!hasMinimumRole(caller.role, ROLES.SUPERADMIN)) {
+        throw new Forbidden('Superadmin role required for impersonation');
+      }
+
+      // 3. Block recursive impersonation
+      if (params.authentication?.payload?.is_impersonated === true) {
+        throw new Forbidden('Cannot impersonate from an already-impersonated token');
+      }
+
+      // 4. user_id must be provided
+      if (!data?.user_id) {
+        throw new BadRequest('user_id is required');
+      }
+
+      // 5. Validate expiry_ms
+      if (data.expiry_ms != null) {
+        if (typeof data.expiry_ms !== 'number' || !Number.isFinite(data.expiry_ms)) {
+          throw new BadRequest('expiry_ms must be a finite number');
+        }
+        if (data.expiry_ms <= 0) {
+          throw new BadRequest('expiry_ms must be a positive number');
+        }
+      }
+
+      // 6. Target user must exist
+      let resolvedUser: typeof targetUser;
+      try {
+        resolvedUser = await usersService.get(data.user_id);
+      } catch {
+        throw new NotFound(`User not found: ${data.user_id}`);
+      }
+
+      // 7. Compute expiry
+      const configMax = configuredMaxExpiry ?? MAX_EXPIRY_MS;
+      const maxExpiry = Math.min(configMax, MAX_EXPIRY_MS);
+      const requestedExpiry = data.expiry_ms ?? maxExpiry;
+      const expiryMs = Math.min(requestedExpiry, maxExpiry);
+
+      // 8. Generate token
+      const jti = generateId();
+
+      const accessToken = jwt.sign(
+        {
+          sub: resolvedUser.user_id,
+          type: 'access',
+          impersonated_by: caller.user_id,
+          is_impersonated: true,
+          jti,
+        },
+        JWT_SECRET,
+        {
+          expiresIn: Math.ceil(expiryMs / 1000),
+          issuer: 'agor',
+          audience: 'https://agor.dev',
+        }
+      );
+
+      return {
+        accessToken,
+        user: {
+          user_id: resolvedUser.user_id,
+          email: resolvedUser.email,
+          name: resolvedUser.name,
+          emoji: resolvedUser.emoji,
+          role: resolvedUser.role,
+        },
+      };
+    };
+  }
+
+  // Helper to build authenticated params
+  function superadminParams(
+    overrides?: Partial<
+      AuthenticatedParams & { authentication: { payload: Record<string, unknown> } }
+    >
+  ) {
+    return {
+      user: { user_id: 'superadmin-1', email: 'admin@example.com', role: ROLES.SUPERADMIN },
+      authenticated: true,
+      provider: 'rest',
+      ...overrides,
+    } as AuthenticatedParams & { authentication?: { payload?: Record<string, unknown> } };
+  }
+
+  // ── Guard tests ──────────────────────────────────────────────────────────
+
+  describe('Guard: authentication required', () => {
+    it('rejects when no user in params', async () => {
+      const handler = createImpersonateHandler();
+      await expect(handler({ user_id: targetUser.user_id }, {} as any)).rejects.toThrow(
+        NotAuthenticated
+      );
+    });
+
+    it('rejects when user_id is missing from params.user', async () => {
+      const handler = createImpersonateHandler();
+      await expect(handler({ user_id: targetUser.user_id }, { user: {} } as any)).rejects.toThrow(
+        NotAuthenticated
+      );
+    });
+  });
+
+  describe('Guard: superadmin role required', () => {
+    it('rejects member role', async () => {
+      const handler = createImpersonateHandler();
+      const params = superadminParams({
+        user: { user_id: 'member-1', email: 'm@example.com', role: ROLES.MEMBER },
+      } as any);
+      await expect(handler({ user_id: targetUser.user_id }, params)).rejects.toThrow(Forbidden);
+    });
+
+    it('rejects admin role', async () => {
+      const handler = createImpersonateHandler();
+      const params = superadminParams({
+        user: { user_id: 'admin-1', email: 'a@example.com', role: ROLES.ADMIN },
+      } as any);
+      await expect(handler({ user_id: targetUser.user_id }, params)).rejects.toThrow(Forbidden);
+    });
+
+    it('accepts superadmin role', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler({ user_id: targetUser.user_id }, superadminParams());
+      expect(result.accessToken).toBeDefined();
+    });
+  });
+
+  describe('Guard: recursive impersonation blocked', () => {
+    it('rejects when caller token is already impersonated', async () => {
+      const handler = createImpersonateHandler();
+      const params = superadminParams({
+        authentication: { payload: { is_impersonated: true } },
+      });
+      await expect(handler({ user_id: targetUser.user_id }, params)).rejects.toThrow(Forbidden);
+    });
+
+    it('allows when is_impersonated is false', async () => {
+      const handler = createImpersonateHandler();
+      const params = superadminParams({
+        authentication: { payload: { is_impersonated: false } },
+      });
+      const result = await handler({ user_id: targetUser.user_id }, params);
+      expect(result.accessToken).toBeDefined();
+    });
+
+    it('allows when no authentication payload present', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler({ user_id: targetUser.user_id }, superadminParams());
+      expect(result.accessToken).toBeDefined();
+    });
+  });
+
+  // ── Input validation tests ───────────────────────────────────────────────
+
+  describe('Input: user_id validation', () => {
+    it('rejects missing user_id', async () => {
+      const handler = createImpersonateHandler();
+      await expect(handler({}, superadminParams())).rejects.toThrow(BadRequest);
+    });
+
+    it('rejects empty string user_id', async () => {
+      const handler = createImpersonateHandler();
+      await expect(handler({ user_id: '' }, superadminParams())).rejects.toThrow(BadRequest);
+    });
+
+    it('returns 404 for nonexistent user', async () => {
+      const handler = createImpersonateHandler();
+      await expect(handler({ user_id: 'nonexistent-id' }, superadminParams())).rejects.toThrow(
+        NotFound
+      );
+    });
+  });
+
+  describe('Input: expiry_ms validation', () => {
+    it('rejects non-number expiry_ms', async () => {
+      const handler = createImpersonateHandler();
+      await expect(
+        handler({ user_id: targetUser.user_id, expiry_ms: 'abc' as any }, superadminParams())
+      ).rejects.toThrow(BadRequest);
+    });
+
+    it('rejects NaN expiry_ms', async () => {
+      const handler = createImpersonateHandler();
+      await expect(
+        handler({ user_id: targetUser.user_id, expiry_ms: Number.NaN }, superadminParams())
+      ).rejects.toThrow(BadRequest);
+    });
+
+    it('rejects Infinity expiry_ms', async () => {
+      const handler = createImpersonateHandler();
+      await expect(
+        handler(
+          { user_id: targetUser.user_id, expiry_ms: Number.POSITIVE_INFINITY },
+          superadminParams()
+        )
+      ).rejects.toThrow(BadRequest);
+    });
+
+    it('rejects zero expiry_ms', async () => {
+      const handler = createImpersonateHandler();
+      await expect(
+        handler({ user_id: targetUser.user_id, expiry_ms: 0 }, superadminParams())
+      ).rejects.toThrow(BadRequest);
+    });
+
+    it('rejects negative expiry_ms', async () => {
+      const handler = createImpersonateHandler();
+      await expect(
+        handler({ user_id: targetUser.user_id, expiry_ms: -1000 }, superadminParams())
+      ).rejects.toThrow(BadRequest);
+    });
+  });
+
+  // ── Expiry capping tests ─────────────────────────────────────────────────
+
+  describe('Expiry capping', () => {
+    it('defaults to 1h when no expiry_ms provided', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler({ user_id: targetUser.user_id }, superadminParams());
+      const decoded = jwt.verify(result.accessToken, JWT_SECRET) as jwt.JwtPayload;
+      // exp - iat should be ~3600 seconds (1h)
+      expect(decoded.exp! - decoded.iat!).toBe(3600);
+    });
+
+    it('caps expiry at 1h even when requesting more', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler(
+        { user_id: targetUser.user_id, expiry_ms: 7_200_000 }, // 2h
+        superadminParams()
+      );
+      const decoded = jwt.verify(result.accessToken, JWT_SECRET) as jwt.JwtPayload;
+      expect(decoded.exp! - decoded.iat!).toBe(3600);
+    });
+
+    it('allows shorter expiry', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler(
+        { user_id: targetUser.user_id, expiry_ms: 300_000 }, // 5 min
+        superadminParams()
+      );
+      const decoded = jwt.verify(result.accessToken, JWT_SECRET) as jwt.JwtPayload;
+      expect(decoded.exp! - decoded.iat!).toBe(300);
+    });
+
+    it('respects configured max when lower than hard cap', async () => {
+      const handler = createImpersonateHandler(mockUsersService, 600_000); // 10 min config
+      const result = await handler(
+        { user_id: targetUser.user_id, expiry_ms: 1_800_000 }, // 30 min request
+        superadminParams()
+      );
+      const decoded = jwt.verify(result.accessToken, JWT_SECRET) as jwt.JwtPayload;
+      expect(decoded.exp! - decoded.iat!).toBe(600); // capped at 10 min
+    });
+  });
+
+  // ── Token claims tests ───────────────────────────────────────────────────
+
+  describe('Token claims', () => {
+    it('includes impersonation claims in JWT', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler({ user_id: targetUser.user_id }, superadminParams());
+      const decoded = jwt.verify(result.accessToken, JWT_SECRET) as jwt.JwtPayload;
+
+      expect(decoded.sub).toBe(targetUser.user_id);
+      expect(decoded.type).toBe('access');
+      expect(decoded.impersonated_by).toBe('superadmin-1');
+      expect(decoded.is_impersonated).toBe(true);
+      expect(decoded.jti).toBeDefined();
+      expect(decoded.iss).toBe('agor');
+      expect(decoded.aud).toBe('https://agor.dev');
+    });
+
+    it('returns sanitized user object', async () => {
+      const handler = createImpersonateHandler();
+      const result = await handler({ user_id: targetUser.user_id }, superadminParams());
+
+      expect(result.user).toEqual({
+        user_id: targetUser.user_id,
+        email: targetUser.email,
+        name: targetUser.name,
+        emoji: targetUser.emoji,
+        role: targetUser.role,
+      });
+    });
+
+    it('generates unique jti per call', async () => {
+      const handler = createImpersonateHandler();
+      const result1 = await handler({ user_id: targetUser.user_id }, superadminParams());
+      const result2 = await handler({ user_id: targetUser.user_id }, superadminParams());
+      const decoded1 = jwt.verify(result1.accessToken, JWT_SECRET) as jwt.JwtPayload;
+      const decoded2 = jwt.verify(result2.accessToken, JWT_SECRET) as jwt.JwtPayload;
+      expect(decoded1.jti).not.toBe(decoded2.jti);
     });
   });
 });

--- a/apps/agor-daemon/src/auth-jwt-integration.test.ts
+++ b/apps/agor-daemon/src/auth-jwt-integration.test.ts
@@ -57,7 +57,27 @@ describe('JWT Authentication Integration - Production Auth Hooks', () => {
     // Create Feathers app with authentication configured like production
     app = feathers();
 
-    // Configure authentication with JWT (matching index.ts production setup)
+    // Authentication config must be set before registering strategies
+    // (LocalStrategy requires usernameField to be configured)
+    app.set('authentication', {
+      secret: 'test-jwt-secret',
+      entity: 'user',
+      entityId: 'user_id',
+      service: 'users',
+      authStrategies: ['jwt'],
+      jwtOptions: {
+        header: { typ: 'access' },
+        audience: 'https://agor.dev',
+        issuer: 'agor',
+        algorithm: 'HS256',
+        expiresIn: '7d',
+      },
+      local: {
+        usernameField: 'email',
+        passwordField: 'password',
+      },
+    });
+
     const authService = new AuthenticationService(app);
     authService.register('jwt', new JWTStrategy());
     authService.register('local', new LocalStrategy());
@@ -88,8 +108,8 @@ describe('JWT Authentication Integration - Production Auth Hooks', () => {
       },
     });
 
-    // Should reject unauthenticated request
-    await expect(app.service('/test-protected').find({})).rejects.toThrow();
+    // Should reject unauthenticated request (provider: 'rest' simulates external call)
+    await expect(app.service('/test-protected').find({ provider: 'rest' })).rejects.toThrow();
   });
 
   it('should accept requests with valid user in params', async () => {
@@ -136,6 +156,7 @@ describe('JWT Authentication Integration - Production Auth Hooks', () => {
       app.service('/test-admin').create({}, {
         user: { user_id: 'user-1', email: 'test@example.com', role: ROLES.MEMBER },
         authenticated: true,
+        provider: 'rest',
       } as any)
     ).rejects.toThrow();
 
@@ -143,6 +164,7 @@ describe('JWT Authentication Integration - Production Auth Hooks', () => {
     const result = await app.service('/test-admin').create({}, {
       user: { user_id: 'admin-1', email: 'admin@example.com', role: ROLES.ADMIN },
       authenticated: true,
+      provider: 'rest',
     } as any);
 
     expect(result.success).toBe(true);
@@ -162,6 +184,25 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
   beforeAll(async () => {
     // Create Feathers app with authentication (matching production setup)
     app = feathers();
+
+    app.set('authentication', {
+      secret: 'test-jwt-secret',
+      entity: 'user',
+      entityId: 'user_id',
+      service: 'users',
+      authStrategies: ['jwt'],
+      jwtOptions: {
+        header: { typ: 'access' },
+        audience: 'https://agor.dev',
+        issuer: 'agor',
+        algorithm: 'HS256',
+        expiresIn: '7d',
+      },
+      local: {
+        usernameField: 'email',
+        passwordField: 'password',
+      },
+    });
 
     const authService = new AuthenticationService(app);
     authService.register('jwt', new JWTStrategy());
@@ -187,8 +228,10 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      // Should reject without user
-      await expect(app.service('/sessions/:id/spawn').create({})).rejects.toThrow();
+      // Should reject without user (provider: 'rest' simulates external call)
+      await expect(
+        app.service('/sessions/:id/spawn').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('POST /sessions/:id/spawn accepts authenticated requests', async () => {
@@ -227,7 +270,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/sessions/:id/fork').create({})).rejects.toThrow();
+      await expect(
+        app.service('/sessions/:id/fork').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('POST /sessions/:id/stop rejects unauthenticated requests', async () => {
@@ -244,7 +289,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/sessions/:id/stop').create({})).rejects.toThrow();
+      await expect(
+        app.service('/sessions/:id/stop').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('GET /sessions/:id/mcp-servers rejects unauthenticated requests', async () => {
@@ -261,7 +308,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/sessions/:id/mcp-servers').find({})).rejects.toThrow();
+      await expect(
+        app.service('/sessions/:id/mcp-servers').find({ provider: 'rest' })
+      ).rejects.toThrow();
     });
   });
 
@@ -280,7 +329,7 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/tasks/bulk').create([])).rejects.toThrow();
+      await expect(app.service('/tasks/bulk').create([], { provider: 'rest' })).rejects.toThrow();
     });
 
     it('POST /tasks/:id/complete rejects unauthenticated requests', async () => {
@@ -297,7 +346,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/tasks/:id/complete').create({})).rejects.toThrow();
+      await expect(
+        app.service('/tasks/:id/complete').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('POST /tasks/:id/fail rejects unauthenticated requests', async () => {
@@ -314,7 +365,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/tasks/:id/fail').create({})).rejects.toThrow();
+      await expect(
+        app.service('/tasks/:id/fail').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
   });
 
@@ -333,7 +386,7 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/repos/local').create({})).rejects.toThrow();
+      await expect(app.service('/repos/local').create({}, { provider: 'rest' })).rejects.toThrow();
     });
 
     it('POST /repos/:id/worktrees rejects unauthenticated requests', async () => {
@@ -350,7 +403,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/repos/:id/worktrees').create({})).rejects.toThrow();
+      await expect(
+        app.service('/repos/:id/worktrees').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('DELETE /repos/:id/worktrees/:name rejects unauthenticated requests', async () => {
@@ -367,7 +422,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/repos/:id/worktrees/:name').remove('id')).rejects.toThrow();
+      await expect(
+        app.service('/repos/:id/worktrees/:name').remove('id', { provider: 'rest' })
+      ).rejects.toThrow();
     });
   });
 
@@ -386,7 +443,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/board-comments/:id/toggle-reaction').create({})).rejects.toThrow();
+      await expect(
+        app.service('/board-comments/:id/toggle-reaction').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('POST /boards/:id/sessions rejects unauthenticated requests', async () => {
@@ -403,7 +462,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/boards/:id/sessions').create({})).rejects.toThrow();
+      await expect(
+        app.service('/boards/:id/sessions').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
   });
 
@@ -423,13 +484,16 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
       });
 
       // Reject unauthenticated
-      await expect(app.service('/worktrees/:id/start').create({})).rejects.toThrow();
+      await expect(
+        app.service('/worktrees/:id/start').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
 
       // Reject non-admin (member role)
       await expect(
         app.service('/worktrees/:id/start').create({}, {
           user: { user_id: 'user-1', email: 'test@example.com', role: ROLES.MEMBER },
           authenticated: true,
+          provider: 'rest',
         } as any)
       ).rejects.toThrow();
     });
@@ -448,7 +512,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/worktrees/:id/stop').create({})).rejects.toThrow();
+      await expect(
+        app.service('/worktrees/:id/stop').create({}, { provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('GET /worktrees/:id/health rejects unauthenticated requests', async () => {
@@ -465,7 +531,9 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/worktrees/:id/health').find({})).rejects.toThrow();
+      await expect(
+        app.service('/worktrees/:id/health').find({ provider: 'rest' })
+      ).rejects.toThrow();
     });
 
     it('GET /worktrees/logs rejects unauthenticated requests', async () => {
@@ -482,7 +550,7 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/worktrees/logs').find({})).rejects.toThrow();
+      await expect(app.service('/worktrees/logs').find({ provider: 'rest' })).rejects.toThrow();
     });
   });
 
@@ -501,7 +569,7 @@ describe('JWT Authentication Integration - Protected Endpoints', () => {
         },
       });
 
-      await expect(app.service('/files').find({})).rejects.toThrow();
+      await expect(app.service('/files').find({ provider: 'rest' })).rejects.toThrow();
     });
   });
 });

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -9,6 +9,7 @@
 import { type AgorConfig, loadConfig } from '@agor/core/config';
 import {
   type Database,
+  generateId,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -25,6 +26,8 @@ import {
   errorHandler,
   Forbidden,
   LocalStrategy,
+  NotAuthenticated,
+  NotFound,
 } from '@agor/core/feathers';
 import { type PermissionDecision, PermissionService } from '@agor/core/permissions';
 import type {
@@ -429,6 +432,104 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     description: 'Token refresh endpoint - obtain a new access token using a refresh token',
     security: [],
   };
+
+  // ============================================================================
+  // Impersonation endpoint
+  // ============================================================================
+
+  const MAX_IMPERSONATION_EXPIRY_MS = 3_600_000; // 1 hour hard cap
+
+  app.use('/authentication/impersonate', {
+    async create(data: { user_id?: string; expiry_ms?: number }, params?: Params) {
+      // 1. Caller must be authenticated
+      const authParams = params as AuthenticatedParams;
+      if (!authParams?.user || !authParams.user.user_id) {
+        throw new NotAuthenticated('Authentication required');
+      }
+
+      const caller = authParams.user;
+
+      // 2. Caller must have role: superadmin
+      if (!hasMinimumRole(caller.role, ROLES.SUPERADMIN)) {
+        throw new Forbidden('Superadmin role required for impersonation');
+      }
+
+      // 3. Caller token must NOT be an impersonated token (block recursive impersonation)
+      // biome-ignore lint/suspicious/noExplicitAny: JWT payload has dynamic fields
+      const authPayload = (authParams as any).authentication?.payload;
+      if (authPayload?.is_impersonated === true) {
+        throw new Forbidden('Cannot impersonate from an already-impersonated token');
+      }
+
+      // 4. user_id must be provided
+      if (!data?.user_id) {
+        throw new BadRequest('user_id is required');
+      }
+
+      // 5. Target user must exist
+      const usersRepo = new UsersRepository(db);
+      const targetUser = await usersRepo.findById(data.user_id);
+      if (!targetUser) {
+        throw new NotFound(`User not found: ${data.user_id}`);
+      }
+
+      // 6. Compute expiry (default 1h, capped at 1h)
+      const configuredMax =
+        config.daemon?.impersonation_token_expiry_ms ?? MAX_IMPERSONATION_EXPIRY_MS;
+      const maxExpiry = Math.min(configuredMax, MAX_IMPERSONATION_EXPIRY_MS);
+      const requestedExpiry = data.expiry_ms ?? maxExpiry;
+      const expiryMs = Math.min(Math.max(requestedExpiry, 1), maxExpiry);
+
+      // 7. Generate token
+      const jti = generateId();
+      const expiresAt = new Date(Date.now() + expiryMs);
+
+      const accessToken = jwt.sign(
+        {
+          sub: targetUser.user_id,
+          type: 'access',
+          impersonated_by: caller.user_id,
+          is_impersonated: true,
+          jti,
+        },
+        jwtSecret,
+        {
+          expiresIn: Math.ceil(expiryMs / 1000),
+          issuer: 'agor',
+          audience: 'https://agor.dev',
+        }
+      );
+
+      // 8. Audit log
+      console.log(
+        `[auth] impersonation issued: caller=${caller.user_id} target=${targetUser.user_id} jti=${jti} exp=${expiresAt.toISOString()}`
+      );
+
+      return {
+        accessToken,
+        user: {
+          user_id: targetUser.user_id,
+          email: targetUser.email,
+          name: targetUser.name,
+          emoji: targetUser.emoji,
+          role: targetUser.role,
+        },
+      };
+    },
+  });
+
+  // Apply auth hooks to impersonation endpoint
+  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
+  const impersonateService = app.service('authentication/impersonate') as any;
+  impersonateService.docs = {
+    description:
+      'Impersonation endpoint - superadmins can issue short-lived tokens scoped to any user',
+  };
+  impersonateService.hooks({
+    before: {
+      create: [requireAuth],
+    },
+  });
 
   // ============================================================================
   // Initialize repositories and permission service

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -466,21 +466,32 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         throw new BadRequest('user_id is required');
       }
 
-      // 5. Target user must exist
-      const usersRepo = new UsersRepository(db);
-      const targetUser = await usersRepo.findById(data.user_id);
-      if (!targetUser) {
+      // 5. Validate expiry_ms if provided
+      if (data.expiry_ms != null) {
+        if (typeof data.expiry_ms !== 'number' || !Number.isFinite(data.expiry_ms)) {
+          throw new BadRequest('expiry_ms must be a finite number');
+        }
+        if (data.expiry_ms <= 0) {
+          throw new BadRequest('expiry_ms must be a positive number');
+        }
+      }
+
+      // 6. Target user must exist (uses usersService for consistency with refresh endpoint)
+      let targetUser: User;
+      try {
+        targetUser = await usersService.get(data.user_id as import('@agor/core/types').UUID);
+      } catch {
         throw new NotFound(`User not found: ${data.user_id}`);
       }
 
-      // 6. Compute expiry (default 1h, capped at 1h)
+      // 8. Compute expiry (default 1h, capped at 1h)
       const configuredMax =
         config.daemon?.impersonation_token_expiry_ms ?? MAX_IMPERSONATION_EXPIRY_MS;
       const maxExpiry = Math.min(configuredMax, MAX_IMPERSONATION_EXPIRY_MS);
       const requestedExpiry = data.expiry_ms ?? maxExpiry;
-      const expiryMs = Math.min(Math.max(requestedExpiry, 1), maxExpiry);
+      const expiryMs = Math.min(requestedExpiry, maxExpiry);
 
-      // 7. Generate token
+      // 9. Generate token
       const jti = generateId();
       const expiresAt = new Date(Date.now() + expiryMs);
 
@@ -500,7 +511,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
       );
 
-      // 8. Audit log
+      // 10. Audit log
       console.log(
         `[auth] impersonation issued: caller=${caller.user_id} target=${targetUser.user_id} jti=${jti} exp=${expiresAt.toISOString()}`
       );

--- a/apps/agor-daemon/vitest.config.ts
+++ b/apps/agor-daemon/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     environment: 'node',
     testTimeout: 10000,
     include: ['src/**/*.test.{ts,tsx}'],
-    exclude: [...configDefaults.exclude, 'src/auth-jwt-integration.test.ts', 'test/**'],
+    exclude: [...configDefaults.exclude, 'test/**'],
   },
 });

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -112,6 +112,9 @@ export interface AgorDaemonSettings {
    * Displayed as a popover around the instance label Tag. */
   instanceDescription?: string;
 
+  /** Maximum expiry for impersonation tokens in ms (default: 3600000 = 1 hour, capped at 1 hour) */
+  impersonation_token_expiry_ms?: number;
+
   /** Allow CORS from Sandpack/CodeSandbox bundler origins (default: true).
    * Enables artifacts on the hosted bundler to call the Agor API. */
   cors_allow_sandpack?: boolean;

--- a/packages/core/src/feathers/index.ts
+++ b/packages/core/src/feathers/index.ts
@@ -20,7 +20,7 @@ export {
 export { default as authClient } from '@feathersjs/authentication-client';
 export { LocalStrategy } from '@feathersjs/authentication-local';
 // Errors
-export { BadRequest, Forbidden, NotAuthenticated } from '@feathersjs/errors';
+export { BadRequest, Forbidden, NotAuthenticated, NotFound } from '@feathersjs/errors';
 export type { Application as ExpressApplication } from '@feathersjs/express';
 // Express Integration
 export { default as feathersExpress, errorHandler, rest } from '@feathersjs/express';


### PR DESCRIPTION
## Summary

- Adds `POST /authentication/impersonate` endpoint for superadmin user impersonation
- Issues stateless JWTs with `impersonated_by` and `is_impersonated` claims, max 1h expiry
- Guards: requireAuth → superadmin role check → recursive impersonation block → user existence check
- Adds `impersonation_token_expiry_ms` config option to `daemon` settings
- Exports `NotFound` from `@agor/core/feathers` for proper HTTP 404 responses

## Motivation

Needed for Preset chatbot integration — allows a service account with superadmin role to act on behalf of any user.

## Test plan

- [ ] Verify superadmin can POST `/authentication/impersonate` with `{ user_id }` and receives a valid JWT
- [ ] Verify non-superadmin gets 403
- [ ] Verify impersonated tokens cannot be used to impersonate again (recursive block)
- [ ] Verify missing/invalid `user_id` returns 400/404
- [ ] Verify `expiry_ms` is capped at 1 hour
- [ ] Verify audit log line is emitted on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)