### PR TITLE
fix(ui): prevent duplicate queued prompts in conversation panel

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -366,9 +366,11 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
     const handleQueued = (msg: Message) => {
       if (msg.session_id === session.session_id) {
-        setQueuedMessages((prev) =>
-          [...prev, msg].sort((a, b) => (a.queue_position ?? 0) - (b.queue_position ?? 0))
-        );
+        setQueuedMessages((prev) => {
+          // Deduplicate: optimistic update from enqueue may have already added this message
+          if (prev.some((m) => m.message_id === msg.message_id)) return prev;
+          return [...prev, msg].sort((a, b) => (a.queue_position ?? 0) - (b.queue_position ?? 0));
+        });
       }
     };
 
@@ -537,11 +539,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           })) as { success: boolean; message: Message; queue_position: number };
 
         if (response.message) {
-          setQueuedMessages((prev) =>
-            [...prev, response.message].sort(
+          setQueuedMessages((prev) => {
+            if (prev.some((m) => m.message_id === response.message.message_id)) return prev;
+            return [...prev, response.message].sort(
               (a, b) => (a.queue_position ?? 0) - (b.queue_position ?? 0)
-            )
-          );
+            );
+          });
         }
 
         message.success(`Message queued at position ${response.message.queue_position}`);


### PR DESCRIPTION
## Summary
- Fix duplicate queued prompts appearing in the conversation panel when enqueuing while a session is busy
- Root cause: both the optimistic update (after API response) and the WebSocket `queued` event handler were adding the same message to state
- Added deduplication check (by `message_id`) in both `handleQueued` and the optimistic update path so whichever fires second is a no-op

## Test plan
- [ ] Open a session panel while a session is running
- [ ] Enqueue a prompt — verify exactly one queued message appears (not two)
- [ ] Delete the queued message — verify it disappears cleanly
- [ ] Enqueue multiple prompts — verify each appears once, in correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)