### PR TITLE
fix: fully remove worktree directory on archive delete and recreate on unarchive

### DIFF
--- a/apps/agor-daemon/src/services/worktrees.test.ts
+++ b/apps/agor-daemon/src/services/worktrees.test.ts
@@ -15,12 +15,17 @@ function createServiceHarness() {
     patch: vi.fn(async () => ({})),
   };
 
+  const reposService = {
+    get: vi.fn(async () => ({ repo_id: 'repo-1', local_path: '/tmp/repo', unix_group: null })),
+  };
+
   const app = {
     service(path: string) {
       if (path === 'board-objects') return boardObjectsService;
       if (path === 'sessions') return sessionsService;
       if (path === 'boards') return { get: vi.fn(async () => ({ objects: {} })) };
       if (path === 'worktrees') return { find: vi.fn(async () => []) };
+      if (path === 'repos') return reposService;
       throw new Error(`Unknown service: ${path}`);
     },
   } as unknown as Application;
@@ -38,12 +43,14 @@ describe('WorktreesService.unarchive', () => {
     vi.spyOn(service, 'get').mockResolvedValue({
       worktree_id: worktreeId,
       name: 'WT 1',
+      path: '/tmp',
       archived: true,
       board_id: existingBoardId,
     } as never);
     const patchSpy = vi.spyOn(service, 'patch').mockResolvedValue({
       worktree_id: worktreeId,
       name: 'WT 1',
+      path: '/tmp',
       archived: false,
       board_id: existingBoardId,
     } as never);
@@ -85,12 +92,14 @@ describe('WorktreesService.unarchive', () => {
     vi.spyOn(service, 'get').mockResolvedValue({
       worktree_id: worktreeId,
       name: 'WT 2',
+      path: '/tmp',
       archived: true,
       board_id: boardId,
     } as never);
     vi.spyOn(service, 'patch').mockResolvedValue({
       worktree_id: worktreeId,
       name: 'WT 2',
+      path: '/tmp',
       archived: false,
       board_id: boardId,
     } as never);
@@ -111,12 +120,14 @@ describe('WorktreesService.unarchive', () => {
     vi.spyOn(service, 'get').mockResolvedValue({
       worktree_id: worktreeId,
       name: 'WT 3',
+      path: '/tmp',
       archived: true,
       board_id: oldBoardId,
     } as never);
     const patchSpy = vi.spyOn(service, 'patch').mockResolvedValue({
       worktree_id: worktreeId,
       name: 'WT 3',
+      path: '/tmp',
       archived: false,
       board_id: newBoardId,
     } as never);

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -637,10 +637,6 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       // Resolve Unix user for impersonation
       const asUser = await resolveGitImpersonationForWorktree(this.db, worktree);
 
-      // If the branch was deleted during archive (new_branch worktrees delete their branch),
-      // we need to recreate it from the base ref.
-      const branchWasDeleted = worktree.new_branch === true;
-
       try {
         const sessionToken = await appWithToken.sessionTokenService?.generateToken(
           'worktree-unarchive',
@@ -660,9 +656,13 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
                 worktreePath: worktree.path,
                 branch: worktree.ref,
                 refType: worktree.ref_type || 'branch',
-                // If branch was deleted during archive, recreate it from base_ref
-                createBranch: branchWasDeleted,
-                sourceBranch: branchWasDeleted ? worktree.base_ref : undefined,
+                // Always try to checkout the existing branch first.
+                // If the branch was deleted during archive, git worktree add will fail
+                // and the executor marks filesystem_status as 'failed'.
+                // We intentionally avoid createBranch:true here because createWorktree's
+                // orphan cleanup path would force-delete an existing branch, risking data loss.
+                createBranch: false,
+                sourceBranch: worktree.base_ref,
                 // Unix group isolation
                 initUnixGroup: rbacEnabled,
                 othersAccess: worktree.others_fs_access || 'read',

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -6,10 +6,11 @@
  */
 
 import type { ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { ENVIRONMENT, PAGINATION } from '@agor/core/config';
+import { ENVIRONMENT, isWorktreeRbacEnabled, PAGINATION } from '@agor/core/config';
 import { type Database, WorktreeRepository, type WorktreeWithZoneAndSessions } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -609,6 +610,75 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
     }
 
     const unarchivedWorktree = await this.patch(id, patchData, params);
+
+    // Recreate the git worktree on filesystem if the directory is missing
+    // (e.g., it was archived with filesystemAction: 'deleted')
+    if (!existsSync(worktree.path)) {
+      console.log(`📂 Worktree directory missing, spawning executor to recreate: ${worktree.path}`);
+
+      // Set filesystem_status to 'creating' while we rebuild
+      await this.patch(id, { filesystem_status: 'creating' }, { provider: undefined });
+
+      const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as
+        | UserID
+        | undefined;
+      const appWithToken = this.app as unknown as {
+        sessionTokenService?: import('../services/session-token-service').SessionTokenService;
+      };
+
+      // Look up repo to get local_path
+      const reposService = this.app.service('repos');
+      const repo = (await reposService.get(worktree.repo_id)) as Repo;
+
+      const rbacEnabled = isWorktreeRbacEnabled();
+      const { getDaemonUser } = await import('@agor/core/config');
+      const daemonUser = getDaemonUser();
+
+      // Resolve Unix user for impersonation
+      const asUser = await resolveGitImpersonationForWorktree(this.db, worktree);
+
+      try {
+        const sessionToken = await appWithToken.sessionTokenService?.generateToken(
+          'worktree-unarchive',
+          userId || 'anonymous'
+        );
+        if (sessionToken) {
+          spawnExecutor(
+            {
+              command: 'git.worktree.add',
+              sessionToken,
+              daemonUrl: getDaemonUrl(),
+              params: {
+                worktreeId: worktree.worktree_id,
+                repoId: repo.repo_id,
+                repoPath: repo.local_path,
+                worktreeName: worktree.name,
+                worktreePath: worktree.path,
+                branch: worktree.ref,
+                // Don't create a new branch — the branch already exists from before archival
+                createBranch: false,
+                // Unix group isolation
+                initUnixGroup: rbacEnabled,
+                othersAccess: worktree.others_fs_access || 'read',
+                daemonUser,
+                repoUnixGroup: repo.unix_group,
+              },
+            },
+            {
+              logPrefix: `[WorktreesService.unarchive ${worktree.name}]`,
+              asUser,
+            }
+          );
+        }
+      } catch (error) {
+        console.error(
+          `⚠️  Failed to spawn executor for worktree recreation:`,
+          error instanceof Error ? error.message : String(error)
+        );
+        // Mark as failed so the UI can show the error state
+        await this.patch(id, { filesystem_status: 'failed' }, { provider: undefined });
+      }
+    }
 
     // Ensure a board object exists when unarchiving to a board.
     // Older archived worktrees may have had their board object removed.

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -637,6 +637,10 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       // Resolve Unix user for impersonation
       const asUser = await resolveGitImpersonationForWorktree(this.db, worktree);
 
+      // If the branch was deleted during archive (new_branch worktrees delete their branch),
+      // we need to recreate it from the base ref.
+      const branchWasDeleted = worktree.new_branch === true;
+
       try {
         const sessionToken = await appWithToken.sessionTokenService?.generateToken(
           'worktree-unarchive',
@@ -655,8 +659,10 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
                 worktreeName: worktree.name,
                 worktreePath: worktree.path,
                 branch: worktree.ref,
-                // Don't create a new branch — the branch already exists from before archival
-                createBranch: false,
+                refType: worktree.ref_type || 'branch',
+                // If branch was deleted during archive, recreate it from base_ref
+                createBranch: branchWasDeleted,
+                sourceBranch: branchWasDeleted ? worktree.base_ref : undefined,
                 // Unix group isolation
                 initUnixGroup: rbacEnabled,
                 othersAccess: worktree.others_fs_access || 'read',
@@ -669,6 +675,9 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
               asUser,
             }
           );
+        } else {
+          console.error('⚠️  No session token service available for worktree recreation');
+          await this.patch(id, { filesystem_status: 'failed' }, { provider: undefined });
         }
       } catch (error) {
         console.error(

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -22,6 +22,7 @@ import {
   cloneRepo,
   createWorktree,
   deleteBranch,
+  deleteWorktreeDirectory,
   getReposDir,
   removeWorktree,
 } from '@agor/core/git';
@@ -648,10 +649,19 @@ export async function handleGitWorktreeRemove(
 
       console.log(`[git.worktree.remove] Repo path: ${repoPath}, Worktree name: ${worktreeName}`);
 
-      // Remove the worktree using git
+      // Remove the worktree using git (deregisters from .git/worktrees/)
       await removeWorktree(repoPath, worktreeName);
-      filesystemRemoved = true;
+      console.log(`[git.worktree.remove] Git worktree deregistered`);
 
+      // git worktree remove --force may leave residual files on disk.
+      // Fully delete the directory to reclaim all disk space.
+      if (existsSync(worktreePath)) {
+        console.log(`[git.worktree.remove] Directory still exists, removing residual files...`);
+        await deleteWorktreeDirectory(worktreePath);
+        console.log(`[git.worktree.remove] Directory fully removed`);
+      }
+
+      filesystemRemoved = true;
       console.log(`[git.worktree.remove] Worktree removed from filesystem`);
 
       // Delete the associated branch if requested
@@ -675,6 +685,15 @@ export async function handleGitWorktreeRemove(
           );
         }
       }
+    } else if (existsSync(worktreePath)) {
+      // No .git file but directory exists — orphaned directory from a previous partial removal.
+      // Clean it up completely.
+      console.log(
+        '[git.worktree.remove] No .git file but directory exists (orphaned), removing directory...'
+      );
+      await deleteWorktreeDirectory(worktreePath);
+      filesystemRemoved = true;
+      console.log('[git.worktree.remove] Orphaned directory removed');
     } else {
       console.log(
         '[git.worktree.remove] Worktree does not exist on filesystem, skipping git removal'


### PR DESCRIPTION
## Summary
- **Archive with `deleted`**: After `git worktree remove --force`, now also `rm -rf` the directory via `deleteWorktreeDirectory()` to fully reclaim disk space. Also handles orphaned directories (no `.git` file but directory still exists).
- **Unarchive**: When the worktree directory is missing (e.g., after a `deleted` archive), spawns the executor to run `git worktree add` to recreate it from the existing branch, including Unix group/ACL setup when RBAC is enabled.

## Test plan
- [ ] Archive a worktree with `filesystemAction: "deleted"` and verify the directory is completely removed from disk
- [ ] Unarchive a worktree that was archived with `deleted` and verify the directory is recreated with the correct branch checked out
- [ ] Verify Unix group/ACL setup is restored on unarchive when RBAC is enabled
- [ ] Verify `filesystem_status` transitions: `ready` → `deleted` (archive) → `creating` → `ready` (unarchive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)