### PR TITLE
feat(admin): harden sync-unix for box migration

### DIFF
--- a/apps/agor-cli/src/commands/admin/sync-unix.ts
+++ b/apps/agor-cli/src/commands/admin/sync-unix.ts
@@ -7,9 +7,14 @@
  * Default behavior (no flags needed):
  * - Creates missing Unix users for users with unix_username set
  * - Creates missing worktree groups (agor_wt_*) and repo groups (agor_rp_*)
+ * - Backfills unix_group on worktrees that don't have one
  * - Sets filesystem permissions on worktrees and .git directories
+ * - Creates missing worktree directories for non-archived worktrees
  * - Adds users to their worktree and repo groups
+ * - Prunes stale group memberships (users no longer owning a worktree)
  * - Ensures agor_users group exists and contains all managed users
+ * - Applies daemon user ACLs on worktree directories
+ * - Syncs user symlinks (creates missing, removes broken)
  *
  * Cleanup (opt-in, destructive):
  * - --cleanup: Deletes stale users and groups not in database
@@ -37,8 +42,11 @@ import {
   AGOR_USERS_GROUP,
   generateRepoGroupName,
   generateWorktreeGroupName,
+  getUserWorktreesDir,
   getWorktreePermissionMode,
+  getWorktreeSymlinkPath,
   REPO_GIT_PERMISSION_MODE,
+  SymlinkCommands,
   UnixGroupCommands,
   UnixUserCommands,
 } from '@agor/core/unix';
@@ -303,6 +311,76 @@ export default class SyncUnix extends Command {
     }
   }
 
+  /**
+   * Get members of a Unix group from the system
+   */
+  private getGroupMembers(groupName: string): string[] {
+    try {
+      const output = execSync(UnixGroupCommands.listGroupMembers(groupName), {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+      return output.trim().split(',').filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Remove user from a group
+   */
+  private removeUserFromGroup(username: string, groupName: string, dryRun: boolean): boolean {
+    const cmd = UnixGroupCommands.removeUserFromGroup(username, groupName);
+    if (dryRun) {
+      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
+      return true;
+    }
+    try {
+      execSync(cmd, { stdio: 'inherit' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check if a worktree directory should be created/synced based on archive state.
+   *
+   * Returns:
+   * - 'sync': Directory exists, apply permissions
+   * - 'create': Directory missing, non-archived — create it
+   * - 'skip': Skip this worktree (archived+deleted, creating, failed, etc.)
+   */
+  private getWorktreeDirectoryAction(
+    dirExists: boolean,
+    archived: boolean,
+    filesystemStatus: string | null | undefined
+  ): 'sync' | 'create' | 'skip' {
+    // Creating or failed worktrees — not ready, skip
+    if (filesystemStatus === 'creating' || filesystemStatus === 'failed') {
+      return 'skip';
+    }
+
+    // Archived + deleted — directory was intentionally removed
+    if (archived && filesystemStatus === 'deleted') {
+      return 'skip';
+    }
+
+    // Directory exists — always sync permissions regardless of archive state
+    if (dirExists) {
+      return 'sync';
+    }
+
+    // Directory missing + not archived — create it
+    if (!archived) {
+      return 'create';
+    }
+
+    // Directory missing + archived (preserved or cleaned) — skip
+    // The directory was expected to exist but doesn't — log info but don't create
+    return 'skip';
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(SyncUnix);
     const dryRun = flags['dry-run'];
@@ -322,8 +400,15 @@ export default class SyncUnix extends Command {
     let usersDeleted = 0;
     let cleanupErrors = 0;
     let worktreesSynced = 0;
+    let worktreesBackfilled = 0; // Worktrees that needed unix_group set in DB
+    let worktreeDirsCreated = 0; // Worktree directories created on disk
+    let worktreesSkipped = 0; // Worktrees skipped (archived/deleted, missing path, etc.)
     let reposBackfilled = 0; // Repos that needed unix_group set in DB
     let reposPermSynced = 0; // Repos that had .git permissions synced
+    let membershipsRemoved = 0; // Stale group memberships pruned
+    let daemonAclsApplied = 0; // Daemon user ACLs applied
+    let symlinksCreated = 0; // User symlinks created
+    let symlinksCleaned = 0; // Broken symlinks removed
     let syncErrors = 0;
 
     try {
@@ -832,13 +917,118 @@ export default class SyncUnix extends Command {
       } // end if (validUsers.length > 0)
 
       // ========================================
+      // Worktree Group Backfill Phase
+      // Ensures all worktrees have unix_group set in the database
+      // ========================================
+
+      this.log(chalk.cyan.bold('\n━━━ Sync Worktree Groups ━━━\n'));
+
+      let allWorktreesForBackfill = await select(db).from(worktrees).all();
+      const worktreesWithoutGroup = allWorktreesForBackfill.filter(
+        (wt: { unix_group: string | null; archived: boolean; filesystem_status: string | null }) =>
+          wt.unix_group === null && !(wt.archived && wt.filesystem_status === 'deleted')
+      );
+
+      if (worktreesWithoutGroup.length === 0) {
+        this.log(chalk.green('   ✓ All worktrees have unix_group set\n'));
+      } else {
+        this.log(
+          chalk.cyan(
+            `Found ${worktreesWithoutGroup.length} worktree(s) without unix_group (of ${allWorktreesForBackfill.length} total)\n`
+          )
+        );
+
+        for (const wt of worktreesWithoutGroup) {
+          const rawWt = wt as {
+            worktree_id: string;
+            name: string;
+            repo_id: string;
+            data: { path?: string } | null;
+          };
+
+          const wtGroup = generateWorktreeGroupName(rawWt.worktree_id as WorktreeID);
+
+          this.log(chalk.bold(`📁 ${rawWt.name}`));
+          this.log(chalk.gray(`   worktree_id: ${rawWt.worktree_id.substring(0, 8)}`));
+          this.log(chalk.gray(`   generated group: ${wtGroup}`));
+
+          // Create the Unix group if it doesn't exist
+          const groupExistsOnSystem = this.groupExists(wtGroup);
+
+          if (groupExistsOnSystem) {
+            this.log(chalk.green(`   ✓ Unix group already exists`));
+          } else {
+            this.log(chalk.yellow(`   → Creating Unix group ${wtGroup}...`));
+            if (this.createGroup(wtGroup, dryRun)) {
+              groupsCreated++;
+              this.log(chalk.green(`   ✓ Created Unix group ${wtGroup}`));
+            } else {
+              syncErrors++;
+              this.log(chalk.red(`   ✗ Failed to create Unix group ${wtGroup}`));
+              this.log('');
+              continue;
+            }
+          }
+
+          // Add daemon user to worktree group
+          if (daemonUser) {
+            const daemonInGroup = dryRun ? false : this.isUserInGroup(daemonUser, wtGroup);
+            if (!daemonInGroup) {
+              this.log(chalk.yellow(`   → Adding daemon user ${daemonUser} to ${wtGroup}...`));
+              if (this.addUserToGroup(daemonUser, wtGroup, dryRun)) {
+                daemonMembershipsAdded++;
+                this.log(chalk.green(`   ✓ Added daemon user to ${wtGroup}`));
+              } else {
+                this.log(chalk.red(`   ✗ Failed to add daemon user to ${wtGroup}`));
+              }
+            } else if (verbose) {
+              this.log(chalk.gray(`   ✓ Daemon user already in ${wtGroup}`));
+            }
+          }
+
+          // Update the database to set unix_group
+          if (dryRun) {
+            this.log(
+              chalk.gray(
+                `   [dry-run] Would update database: SET unix_group = '${wtGroup}' WHERE worktree_id = '${rawWt.worktree_id}'`
+              )
+            );
+          } else {
+            try {
+              await update(db, worktrees)
+                .set({ unix_group: wtGroup })
+                .where(eq(worktrees.worktree_id, rawWt.worktree_id))
+                .run();
+              this.log(chalk.green(`   ✓ Updated database with unix_group`));
+            } catch (error) {
+              syncErrors++;
+              this.log(chalk.red(`   ✗ Failed to update database: ${error}`));
+              this.log('');
+              continue;
+            }
+          }
+
+          worktreesBackfilled++;
+          this.log('');
+        }
+
+        this.log(chalk.bold('Worktree Group Backfill Summary:'));
+        this.log(`  Worktrees backfilled: ${worktreesBackfilled}${dryRun ? ' (dry-run)' : ''}`);
+        this.log('');
+
+        // Refresh for the permission sync phase
+        allWorktreesForBackfill = await select(db).from(worktrees).all();
+      }
+
+      // ========================================
       // Worktree Permission Sync Phase
+      // Archive-aware: handles missing directories, skips archived+deleted
       // ========================================
 
       this.log(chalk.cyan.bold('\n━━━ Sync Worktree Permissions ━━━\n'));
 
-      // Get all worktrees with unix_group set
-      const allWorktreesForSync = await select(db).from(worktrees).all();
+      // Get all worktrees with unix_group set (including newly backfilled)
+      const allWorktreesForSync = allWorktreesForBackfill;
       const worktreesWithGroup = allWorktreesForSync.filter(
         (wt: { unix_group: string | null }) => wt.unix_group !== null
       );
@@ -849,23 +1039,49 @@ export default class SyncUnix extends Command {
         this.log(chalk.cyan(`Found ${worktreesWithGroup.length} worktree(s) with unix_group\n`));
 
         for (const wt of worktreesWithGroup) {
-          // Extract path from the data JSON blob (it's not a top-level column)
           const rawWorktree = wt as {
             worktree_id: string;
             name: string;
             unix_group: string;
+            archived: boolean;
+            filesystem_status: string | null;
             others_fs_access: 'none' | 'read' | 'write' | null;
             data: { path?: string } | null;
           };
 
           const worktreePath = rawWorktree.data?.path;
 
-          // Skip worktrees without a path
+          // Skip worktrees without a path in the data blob
           if (!worktreePath) {
-            this.log(chalk.yellow(`📁 ${rawWorktree.name}`));
-            this.log(chalk.gray(`   worktree_id: ${rawWorktree.worktree_id.substring(0, 8)}`));
-            this.log(chalk.gray(`   unix_group: ${rawWorktree.unix_group}`));
-            this.log(chalk.red(`   ⚠ No path found in worktree data, skipping\n`));
+            if (verbose) {
+              this.log(chalk.gray(`   ⚠ ${rawWorktree.name}: no path in data, skipping`));
+            }
+            worktreesSkipped++;
+            continue;
+          }
+
+          const dirExists = existsSync(worktreePath);
+          const action = this.getWorktreeDirectoryAction(
+            dirExists,
+            rawWorktree.archived,
+            rawWorktree.filesystem_status
+          );
+
+          if (action === 'skip') {
+            if (verbose) {
+              const reason =
+                rawWorktree.filesystem_status === 'deleted'
+                  ? 'archived+deleted'
+                  : rawWorktree.filesystem_status === 'creating'
+                    ? 'still creating'
+                    : rawWorktree.filesystem_status === 'failed'
+                      ? 'creation failed'
+                      : rawWorktree.archived && !dirExists
+                        ? `archived (${rawWorktree.filesystem_status || 'unknown'}), dir missing`
+                        : 'unknown';
+              this.log(chalk.gray(`   ⊘ ${rawWorktree.name}: ${reason}, skipping`));
+            }
+            worktreesSkipped++;
             continue;
           }
 
@@ -873,6 +1089,30 @@ export default class SyncUnix extends Command {
           this.log(chalk.gray(`   worktree_id: ${rawWorktree.worktree_id.substring(0, 8)}`));
           this.log(chalk.gray(`   unix_group: ${rawWorktree.unix_group}`));
           this.log(chalk.gray(`   path: ${worktreePath}`));
+          if (rawWorktree.archived) {
+            this.log(
+              chalk.gray(`   archived: yes (fs: ${rawWorktree.filesystem_status || 'preserved'})`)
+            );
+          }
+
+          // Create missing directory for non-archived worktrees
+          if (action === 'create') {
+            this.log(chalk.yellow(`   → Directory missing, creating...`));
+            if (dryRun) {
+              this.log(chalk.gray(`   [dry-run] Would run: mkdir -p "${worktreePath}"`));
+            } else {
+              try {
+                execSync(`sudo -n mkdir -p "${worktreePath}"`, { stdio: 'pipe' });
+                worktreeDirsCreated++;
+                this.log(chalk.green(`   ✓ Created directory`));
+              } catch (error) {
+                syncErrors++;
+                this.log(chalk.red(`   ✗ Failed to create directory: ${error}`));
+                this.log('');
+                continue;
+              }
+            }
+          }
 
           // Calculate permission mode based on others_fs_access
           const othersAccess = rawWorktree.others_fs_access || 'read';
@@ -883,16 +1123,11 @@ export default class SyncUnix extends Command {
           if (dryRun) {
             this.log(
               chalk.gray(
-                `   [dry-run] Would run: chgrp -R ${rawWorktree.unix_group} "${worktreePath}"`
+                `   [dry-run] Would set group ${rawWorktree.unix_group} with mode ${permissionMode}`
               )
             );
-            this.log(
-              chalk.gray(`   [dry-run] Would run: chmod -R ${permissionMode} "${worktreePath}"`)
-            );
-            this.log('');
           } else {
             try {
-              // Run each command separately (no sh -c wrapper for security)
               for (const cmd of UnixGroupCommands.setDirectoryGroup(
                 worktreePath,
                 rawWorktree.unix_group,
@@ -902,17 +1137,42 @@ export default class SyncUnix extends Command {
               }
 
               worktreesSynced++;
-              this.log(chalk.green(`   ✓ Applied permissions (${permissionMode})\n`));
+              this.log(chalk.green(`   ✓ Applied permissions (${permissionMode})`));
             } catch (error) {
               syncErrors++;
-              this.log(chalk.red(`   ✗ Failed: ${error}\n`));
+              this.log(chalk.red(`   ✗ Failed to set permissions: ${error}`));
             }
           }
+
+          // Apply daemon user ACL so the running daemon can access without restart
+          if (daemonUser && (dirExists || action === 'create')) {
+            if (dryRun) {
+              this.log(chalk.gray(`   [dry-run] Would set daemon user ACL for ${daemonUser}`));
+            } else {
+              try {
+                for (const cmd of UnixGroupCommands.setUserAcl(worktreePath, daemonUser)) {
+                  execSync(cmd, { stdio: 'pipe' });
+                }
+                daemonAclsApplied++;
+                if (verbose) {
+                  this.log(chalk.green(`   ✓ Applied daemon ACL for ${daemonUser}`));
+                }
+              } catch (error) {
+                syncErrors++;
+                this.log(chalk.red(`   ✗ Failed to set daemon ACL: ${error}`));
+              }
+            }
+          }
+
+          this.log('');
         }
 
         // Summary for worktree sync
         this.log(chalk.bold('Worktree Sync Summary:'));
         this.log(`  Worktrees synced: ${worktreesSynced}${dryRun ? ' (dry-run)' : ''}`);
+        this.log(`  Directories created: ${worktreeDirsCreated}${dryRun ? ' (dry-run)' : ''}`);
+        this.log(`  Daemon ACLs applied: ${daemonAclsApplied}${dryRun ? ' (dry-run)' : ''}`);
+        this.log(`  Skipped: ${worktreesSkipped}`);
         if (syncErrors > 0) {
           this.log(chalk.red(`  Errors: ${syncErrors}`));
         }
@@ -960,6 +1220,16 @@ export default class SyncUnix extends Command {
           }
 
           const gitPath = `${repoPath}/.git`;
+
+          // Skip if .git directory doesn't exist on disk
+          if (!existsSync(gitPath)) {
+            if (verbose) {
+              this.log(
+                chalk.gray(`   ⊘ ${rawRepo.slug}: .git path missing (${gitPath}), skipping`)
+              );
+            }
+            continue;
+          }
 
           this.log(chalk.bold(`📁 ${rawRepo.slug}`));
           this.log(chalk.gray(`   repo_id: ${rawRepo.repo_id.substring(0, 8)}`));
@@ -1026,6 +1296,238 @@ export default class SyncUnix extends Command {
           this.log(chalk.red(`  Errors: ${syncErrors}`));
         }
         this.log('');
+      }
+
+      // ========================================
+      // Membership Pruning Phase
+      // Removes users from worktree groups they no longer own
+      // ========================================
+
+      this.log(chalk.cyan.bold('\n━━━ Prune Stale Group Memberships ━━━\n'));
+
+      {
+        // Build a map of worktree group → expected members (owners + daemon)
+        const allWtForPrune = await select(db).from(worktrees).all();
+        const allOwnerRows = await select(db).from(worktreeOwners).all();
+
+        // Map worktree_id → unix_group
+        const wtGroupMap = new Map<string, string>();
+        for (const wt of allWtForPrune) {
+          const raw = wt as { worktree_id: string; unix_group: string | null };
+          if (raw.unix_group) {
+            wtGroupMap.set(raw.worktree_id, raw.unix_group);
+          }
+        }
+
+        // Map unix_group → set of expected user_ids
+        const groupToOwnerIds = new Map<string, Set<string>>();
+        for (const row of allOwnerRows) {
+          const raw = row as { worktree_id: string; user_id: string };
+          const group = wtGroupMap.get(raw.worktree_id);
+          if (group) {
+            const owners = groupToOwnerIds.get(group) || new Set();
+            owners.add(raw.user_id);
+            groupToOwnerIds.set(group, owners);
+          }
+        }
+
+        // Map user_id → unix_username for all users with unix_username
+        const allUsersForPrune = (await select(db).from(users).all()) as UserWithUnix[];
+        const userIdToUnixName = new Map<string, string>();
+        const unixNameToUserId = new Map<string, string>();
+        for (const u of allUsersForPrune) {
+          if (u.unix_username) {
+            userIdToUnixName.set(u.user_id, u.unix_username);
+            unixNameToUserId.set(u.unix_username, u.user_id);
+          }
+        }
+
+        let pruneChecked = 0;
+        for (const [group, ownerIds] of groupToOwnerIds.entries()) {
+          if (!this.groupExists(group)) continue;
+          pruneChecked++;
+
+          // Get expected unix_usernames for this group
+          const expectedUsernames = new Set<string>();
+          for (const ownerId of ownerIds) {
+            const uname = userIdToUnixName.get(ownerId);
+            if (uname) expectedUsernames.add(uname);
+          }
+          // Daemon user is always expected
+          if (daemonUser) expectedUsernames.add(daemonUser);
+
+          // Get actual members from OS
+          const actualMembers = this.getGroupMembers(group);
+
+          for (const member of actualMembers) {
+            if (expectedUsernames.has(member)) continue;
+            // Skip the daemon user (safety)
+            if (daemonUser && member === daemonUser) continue;
+            // Skip non-agor users (manually added system users)
+            if (!member.startsWith('agor_') && member !== daemonUser) continue;
+
+            this.log(chalk.yellow(`   → Removing ${member} from ${group} (no longer owner)`));
+            if (this.removeUserFromGroup(member, group, dryRun)) {
+              membershipsRemoved++;
+              this.log(chalk.green(`   ✓ Removed ${member} from ${group}`));
+            } else {
+              syncErrors++;
+              this.log(chalk.red(`   ✗ Failed to remove ${member} from ${group}`));
+            }
+          }
+        }
+
+        if (membershipsRemoved === 0) {
+          this.log(
+            chalk.green(`   ✓ No stale memberships found (checked ${pruneChecked} groups)\n`)
+          );
+        } else {
+          this.log('');
+          this.log(chalk.bold('Membership Pruning Summary:'));
+          this.log(`  Memberships removed: ${membershipsRemoved}${dryRun ? ' (dry-run)' : ''}`);
+          this.log('');
+        }
+      }
+
+      // ========================================
+      // Symlink Sync Phase
+      // Creates missing symlinks, removes broken ones
+      // ========================================
+
+      if (validUsers.length > 0) {
+        this.log(chalk.cyan.bold('\n━━━ Sync User Symlinks ━━━\n'));
+
+        // Build worktree ownership data for symlink creation
+        const allWtForSymlinks = await select(db).from(worktrees).all();
+        const allOwnershipsForSymlinks = await select(db).from(worktreeOwners).all();
+
+        // Map worktree_id → worktree info
+        const wtInfoMap = new Map<
+          string,
+          {
+            name: string;
+            path: string | undefined;
+            archived: boolean;
+            filesystem_status: string | null;
+          }
+        >();
+        for (const wt of allWtForSymlinks) {
+          const raw = wt as {
+            worktree_id: string;
+            name: string;
+            archived: boolean;
+            filesystem_status: string | null;
+            data: { path?: string } | null;
+          };
+          wtInfoMap.set(raw.worktree_id, {
+            name: raw.name,
+            path: raw.data?.path,
+            archived: raw.archived,
+            filesystem_status: raw.filesystem_status,
+          });
+        }
+
+        // Map user_id → list of worktree_ids they own
+        const userToWorktrees = new Map<string, string[]>();
+        for (const row of allOwnershipsForSymlinks) {
+          const raw = row as { user_id: string; worktree_id: string };
+          const existing = userToWorktrees.get(raw.user_id) || [];
+          existing.push(raw.worktree_id);
+          userToWorktrees.set(raw.user_id, existing);
+        }
+
+        for (const user of validUsers) {
+          const worktreesDir = getUserWorktreesDir(user.unix_username);
+
+          if (verbose) {
+            this.log(chalk.gray(`   ${user.unix_username}: checking symlinks...`));
+          }
+
+          // Ensure ~/agor/worktrees/ directory exists
+          if (!existsSync(worktreesDir)) {
+            if (dryRun) {
+              this.log(chalk.gray(`   [dry-run] Would create ${worktreesDir}`));
+            } else {
+              try {
+                for (const cmd of UnixUserCommands.setupWorktreesDir(user.unix_username)) {
+                  execSync(cmd, { stdio: 'pipe' });
+                }
+              } catch {
+                // May already exist or user home may not exist yet
+                if (verbose) {
+                  this.log(chalk.gray(`   ⚠ Could not create ${worktreesDir}`));
+                }
+                continue;
+              }
+            }
+          }
+
+          // Clean up broken symlinks
+          if (!dryRun && existsSync(worktreesDir)) {
+            try {
+              execSync(SymlinkCommands.removeBrokenSymlinks(worktreesDir), { stdio: 'pipe' });
+              symlinksCleaned++; // Count users cleaned, not individual symlinks
+            } catch {
+              // Non-fatal
+            }
+          }
+
+          // Create symlinks for owned worktrees where directory exists
+          const ownedWtIds = userToWorktrees.get(user.user_id) || [];
+          for (const wtId of ownedWtIds) {
+            const wtInfo = wtInfoMap.get(wtId);
+            if (!wtInfo?.path) continue;
+
+            // Skip archived+deleted worktrees
+            if (wtInfo.archived && wtInfo.filesystem_status === 'deleted') continue;
+
+            // Skip if target directory doesn't exist
+            if (!existsSync(wtInfo.path)) continue;
+
+            const symlinkPath = getWorktreeSymlinkPath(user.unix_username, wtInfo.name);
+
+            // Skip if symlink already exists and points to the right target
+            if (existsSync(symlinkPath)) continue;
+
+            if (dryRun) {
+              this.log(
+                chalk.gray(`   [dry-run] Would create symlink: ${wtInfo.name} → ${wtInfo.path}`)
+              );
+              symlinksCreated++;
+            } else {
+              try {
+                for (const cmd of SymlinkCommands.createSymlinkWithOwnership(
+                  wtInfo.path,
+                  symlinkPath,
+                  user.unix_username
+                )) {
+                  execSync(`sudo -n ${cmd}`, { stdio: 'pipe' });
+                }
+                symlinksCreated++;
+                if (verbose) {
+                  this.log(
+                    chalk.green(`   ✓ ${user.unix_username}: ${wtInfo.name} → ${wtInfo.path}`)
+                  );
+                }
+              } catch {
+                if (verbose) {
+                  this.log(chalk.red(`   ✗ Failed to create symlink for ${wtInfo.name}`));
+                }
+                syncErrors++;
+              }
+            }
+          }
+        }
+
+        if (symlinksCreated > 0 || symlinksCleaned > 0) {
+          this.log('');
+          this.log(chalk.bold('Symlink Sync Summary:'));
+          this.log(`  Symlinks created: ${symlinksCreated}${dryRun ? ' (dry-run)' : ''}`);
+          this.log(`  Users cleaned: ${symlinksCleaned}${dryRun ? ' (dry-run)' : ''}`);
+          this.log('');
+        } else {
+          this.log(chalk.green('   ✓ All symlinks up to date\n'));
+        }
       }
 
       // ========================================
@@ -1179,6 +1681,7 @@ export default class SyncUnix extends Command {
       this.log(`  Users created:     ${usersCreated}${dryRunSuffix}`);
       this.log(`  Groups created:    ${groupsCreated}${dryRunSuffix}`);
       this.log(`  Memberships added: ${groupsAdded}${dryRunSuffix}`);
+      this.log(`  Memberships removed: ${membershipsRemoved}${dryRunSuffix}`);
       if (daemonUser) {
         this.log(`  Daemon memberships: ${daemonMembershipsAdded}${dryRunSuffix}`);
       }
@@ -1186,10 +1689,22 @@ export default class SyncUnix extends Command {
       // Worktree/Repo sync stats
       this.log('');
       this.log(chalk.bold('Filesystem Sync:'));
+      this.log(`  WT groups backfilled: ${worktreesBackfilled}${dryRunSuffix}`);
       this.log(`  Worktrees synced:  ${worktreesSynced}${dryRunSuffix}`);
+      this.log(`  Dirs created:      ${worktreeDirsCreated}${dryRunSuffix}`);
+      this.log(`  Skipped:           ${worktreesSkipped}`);
+      this.log(`  Daemon ACLs:       ${daemonAclsApplied}${dryRunSuffix}`);
       this.log(`  Repos backfilled:  ${reposBackfilled}${dryRunSuffix}`);
       this.log(`  Repo perms synced: ${reposPermSynced}${dryRunSuffix}`);
+
+      // Symlink stats
+      this.log('');
+      this.log(chalk.bold('Symlinks:'));
+      this.log(`  Created:           ${symlinksCreated}${dryRunSuffix}`);
+      this.log(`  Users cleaned:     ${symlinksCleaned}${dryRunSuffix}`);
+
       if (syncErrors > 0) {
+        this.log('');
         this.log(chalk.red(`  Sync errors:       ${syncErrors}`));
       }
 
@@ -1217,11 +1732,17 @@ export default class SyncUnix extends Command {
         groupsAdded > 0 ||
         groupsCreated > 0 ||
         daemonMembershipsAdded > 0 ||
+        membershipsRemoved > 0 ||
         usersDeleted > 0 ||
         groupsDeleted > 0 ||
         worktreesSynced > 0 ||
+        worktreesBackfilled > 0 ||
+        worktreeDirsCreated > 0 ||
+        daemonAclsApplied > 0 ||
         reposBackfilled > 0 ||
-        reposPermSynced > 0;
+        reposPermSynced > 0 ||
+        symlinksCreated > 0 ||
+        symlinksCleaned > 0;
       if (dryRun && hasChanges) {
         this.log(chalk.yellow('\nRun without --dry-run to apply changes'));
       }

--- a/apps/agor-cli/src/commands/admin/sync-unix.ts
+++ b/apps/agor-cli/src/commands/admin/sync-unix.ts
@@ -40,15 +40,25 @@ import {
 } from '@agor/core/db';
 import {
   AGOR_USERS_GROUP,
+  createAdminExecutor,
   generateRepoGroupName,
   generateWorktreeGroupName,
+  getGroupMembers,
+  getUserGroups,
   getUserWorktreesDir,
+  getWorktreeDirectoryAction,
   getWorktreePermissionMode,
   getWorktreeSymlinkPath,
+  groupExists,
+  isUserInGroup,
+  listAgorUsers,
+  listRepoGroups,
+  listWorktreeGroups,
   REPO_GIT_PERMISSION_MODE,
   SymlinkCommands,
   UnixGroupCommands,
   UnixUserCommands,
+  unixUserExists,
 } from '@agor/core/unix';
 import type { RepoID, WorktreeID } from '@agor-live/client';
 import { Command, Flags } from '@oclif/core';
@@ -118,269 +128,6 @@ export default class SyncUnix extends Command {
     }),
   };
 
-  /**
-   * Check if a Unix user exists on the system
-   */
-  private userExists(username: string): boolean {
-    try {
-      execSync(UnixUserCommands.userExists(username), { stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Get groups a Unix user belongs to
-   */
-  private getUserGroups(username: string): string[] {
-    try {
-      const output = execSync(UnixUserCommands.getUserGroups(username), {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-      return output.trim().split(/\s+/).filter(Boolean);
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * Check if a Unix group exists
-   */
-  private groupExists(groupName: string): boolean {
-    try {
-      execSync(UnixGroupCommands.groupExists(groupName), { stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Check if a Unix user is in a group
-   */
-  private isUserInGroup(username: string, groupName: string): boolean {
-    try {
-      execSync(UnixGroupCommands.isUserInGroup(username, groupName), { stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Create a Unix user (assumes running as root via sudo)
-   */
-  private createUser(username: string, dryRun: boolean): boolean {
-    const cmd = UnixUserCommands.createUser(username);
-    if (dryRun) {
-      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
-      return true;
-    }
-    try {
-      execSync(cmd, { stdio: 'inherit' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Add user to a group (assumes running as root via sudo)
-   */
-  private addUserToGroup(username: string, groupName: string, dryRun: boolean): boolean {
-    const cmd = UnixGroupCommands.addUserToGroup(username, groupName);
-    if (dryRun) {
-      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
-      return true;
-    }
-    try {
-      execSync(cmd, { stdio: 'inherit' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Create a Unix group (assumes running as root via sudo)
-   */
-  private createGroup(groupName: string, dryRun: boolean): boolean {
-    const cmd = UnixGroupCommands.createGroup(groupName);
-    if (dryRun) {
-      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
-      return true;
-    }
-    try {
-      execSync(cmd, { stdio: 'inherit' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Delete a Unix user (keeps home directory)
-   */
-  private deleteUser(username: string, dryRun: boolean): boolean {
-    const cmd = UnixUserCommands.deleteUser(username);
-    if (dryRun) {
-      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
-      return true;
-    }
-    try {
-      execSync(cmd, { stdio: 'inherit' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Delete a Unix group
-   */
-  private deleteGroup(groupName: string, dryRun: boolean): boolean {
-    const cmd = UnixGroupCommands.deleteGroup(groupName);
-    if (dryRun) {
-      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
-      return true;
-    }
-    try {
-      execSync(cmd, { stdio: 'inherit' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * List all agor_* users on the system (auto-generated format: agor_<8-hex>)
-   */
-  private listAgorUsers(): string[] {
-    try {
-      // Get all users from /etc/passwd matching agor_* pattern
-      const output = execSync("getent passwd | grep '^agor_' | cut -d: -f1", {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-      return output
-        .trim()
-        .split('\n')
-        .filter((u) => u && /^agor_[0-9a-f]{8}$/.test(u));
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * List all agor_wt_* groups on the system
-   */
-  private listWorktreeGroups(): string[] {
-    try {
-      // Get all groups from /etc/group matching agor_wt_* pattern
-      const output = execSync("getent group | grep '^agor_wt_' | cut -d: -f1", {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-      return output
-        .trim()
-        .split('\n')
-        .filter((g) => g && /^agor_wt_[0-9a-f]{8}$/.test(g));
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * List all agor_rp_* (repo) groups on the system
-   */
-  private listRepoGroups(): string[] {
-    try {
-      // Get all groups from /etc/group matching agor_rp_* pattern
-      const output = execSync("getent group | grep '^agor_rp_' | cut -d: -f1", {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-      return output
-        .trim()
-        .split('\n')
-        .filter((g) => g && /^agor_rp_[0-9a-f]{8}$/.test(g));
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * Get members of a Unix group from the system
-   */
-  private getGroupMembers(groupName: string): string[] {
-    try {
-      const output = execSync(UnixGroupCommands.listGroupMembers(groupName), {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      });
-      return output.trim().split(',').filter(Boolean);
-    } catch {
-      return [];
-    }
-  }
-
-  /**
-   * Remove user from a group
-   */
-  private removeUserFromGroup(username: string, groupName: string, dryRun: boolean): boolean {
-    const cmd = UnixGroupCommands.removeUserFromGroup(username, groupName);
-    if (dryRun) {
-      this.log(chalk.gray(`  [dry-run] Would run: ${cmd}`));
-      return true;
-    }
-    try {
-      execSync(cmd, { stdio: 'inherit' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Check if a worktree directory should be created/synced based on archive state.
-   *
-   * Returns:
-   * - 'sync': Directory exists, apply permissions
-   * - 'create': Directory missing, non-archived — create it
-   * - 'skip': Skip this worktree (archived+deleted, creating, failed, etc.)
-   */
-  private getWorktreeDirectoryAction(
-    dirExists: boolean,
-    archived: boolean,
-    filesystemStatus: string | null | undefined
-  ): 'sync' | 'create' | 'skip' {
-    // Creating or failed worktrees — not ready, skip
-    if (filesystemStatus === 'creating' || filesystemStatus === 'failed') {
-      return 'skip';
-    }
-
-    // Archived + deleted — directory was intentionally removed
-    if (archived && filesystemStatus === 'deleted') {
-      return 'skip';
-    }
-
-    // Directory exists — always sync permissions regardless of archive state
-    if (dirExists) {
-      return 'sync';
-    }
-
-    // Directory missing + not archived — create it
-    if (!archived) {
-      return 'create';
-    }
-
-    // Directory missing + archived (preserved or cleaned) — skip
-    // The directory was expected to exist but doesn't — log info but don't create
-    return 'skip';
-  }
-
   async run(): Promise<void> {
     const { flags } = await this.parse(SyncUnix);
     const dryRun = flags['dry-run'];
@@ -393,6 +140,29 @@ export default class SyncUnix extends Command {
     if (dryRun) {
       this.log(chalk.yellow('🔍 Dry run mode - no changes will be made\n'));
     }
+
+    // Create executor for all privileged operations (handles dry-run + verbose)
+    const executor = createAdminExecutor({ 'dry-run': dryRun, verbose });
+
+    // Helper: execute a single command, return true on success
+    const execCmd = async (cmd: string): Promise<boolean> => {
+      try {
+        await executor.exec(cmd);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    // Helper: execute multiple commands sequentially, return true on success
+    const execAllCmds = async (cmds: string[]): Promise<boolean> => {
+      try {
+        await executor.execAll(cmds);
+        return true;
+      } catch {
+        return false;
+      }
+    };
 
     // Track stats
     let groupsCreated = 0;
@@ -495,9 +265,9 @@ export default class SyncUnix extends Command {
 
       // Ensure agor_users group exists (global group for all managed users)
       this.log(chalk.cyan(`Checking ${AGOR_USERS_GROUP} group...\n`));
-      if (!this.groupExists(AGOR_USERS_GROUP)) {
+      if (!groupExists(AGOR_USERS_GROUP)) {
         this.log(chalk.yellow(`   → Creating ${AGOR_USERS_GROUP} group...`));
-        if (this.createGroup(AGOR_USERS_GROUP, dryRun)) {
+        if (await execCmd(UnixGroupCommands.createGroup(AGOR_USERS_GROUP))) {
           groupsCreated++;
           this.log(chalk.green(`   ✓ Created ${AGOR_USERS_GROUP} group\n`));
         } else {
@@ -595,13 +365,13 @@ export default class SyncUnix extends Command {
             this.log(chalk.gray(`   generated group: ${repoGroup}`));
 
             // Create the Unix group if it doesn't exist
-            const groupExistsOnSystem = this.groupExists(repoGroup);
+            const groupExistsOnSystem = groupExists(repoGroup);
 
             if (groupExistsOnSystem) {
               this.log(chalk.green(`   ✓ Unix group already exists`));
             } else {
               this.log(chalk.yellow(`   → Creating Unix group ${repoGroup}...`));
-              if (this.createGroup(repoGroup, dryRun)) {
+              if (await execCmd(UnixGroupCommands.createGroup(repoGroup))) {
                 groupsCreated++;
                 this.log(chalk.green(`   ✓ Created Unix group ${repoGroup}`));
               } else {
@@ -614,10 +384,10 @@ export default class SyncUnix extends Command {
 
             // Add daemon user to repo group
             if (daemonUser) {
-              const daemonInGroup = dryRun ? false : this.isUserInGroup(daemonUser, repoGroup);
+              const daemonInGroup = dryRun ? false : isUserInGroup(daemonUser, repoGroup);
               if (!daemonInGroup) {
                 this.log(chalk.yellow(`   → Adding daemon user ${daemonUser} to ${repoGroup}...`));
-                if (this.addUserToGroup(daemonUser, repoGroup, dryRun)) {
+                if (await execCmd(UnixGroupCommands.addUserToGroup(daemonUser, repoGroup))) {
                   daemonMembershipsAdded++;
                   this.log(chalk.green(`   ✓ Added daemon user to ${repoGroup}`));
                 } else {
@@ -659,28 +429,19 @@ export default class SyncUnix extends Command {
                 if (verbose) {
                   this.log(chalk.gray(`   ⊘ .git path missing (${gitPath}), skipping permissions`));
                 }
-              } else if (dryRun) {
-                this.log(chalk.gray(`   [dry-run] Would run: chgrp -R ${repoGroup} "${gitPath}"`));
-                this.log(
-                  chalk.gray(
-                    `   [dry-run] Would run: chmod -R ${REPO_GIT_PERMISSION_MODE} "${gitPath}"`
-                  )
-                );
               } else {
-                try {
-                  for (const cmd of UnixGroupCommands.setDirectoryGroup(
-                    gitPath,
-                    repoGroup,
-                    REPO_GIT_PERMISSION_MODE
-                  )) {
-                    execSync(cmd, { stdio: 'pipe' });
-                  }
+                const cmds = UnixGroupCommands.setDirectoryGroup(
+                  gitPath,
+                  repoGroup,
+                  REPO_GIT_PERMISSION_MODE
+                );
+                if (await execAllCmds(cmds)) {
                   this.log(
                     chalk.green(`   ✓ Applied .git permissions (${REPO_GIT_PERMISSION_MODE})`)
                   );
-                } catch (error) {
+                } else {
                   syncErrors++;
-                  this.log(chalk.red(`   ✗ Failed to set .git permissions: ${error}`));
+                  this.log(chalk.red(`   ✗ Failed to set .git permissions`));
                 }
               }
             } else {
@@ -730,7 +491,7 @@ export default class SyncUnix extends Command {
           this.log(chalk.gray(`   user_id: ${user.user_id.substring(0, 8)}`));
 
           // Check if Unix user exists
-          result.unixUserExists = this.userExists(user.unix_username);
+          result.unixUserExists = unixUserExists(user.unix_username);
 
           if (result.unixUserExists) {
             this.log(chalk.green(`   ✓ Unix user exists`));
@@ -738,7 +499,7 @@ export default class SyncUnix extends Command {
             this.log(chalk.red(`   ✗ Unix user does not exist`));
 
             this.log(chalk.yellow(`   → Creating Unix user...`));
-            if (this.createUser(user.unix_username, dryRun)) {
+            if (await execCmd(UnixUserCommands.createUser(user.unix_username))) {
               result.unixUserCreated = true;
               result.unixUserExists = true;
               this.log(chalk.green(`   ✓ Unix user created`));
@@ -750,9 +511,7 @@ export default class SyncUnix extends Command {
 
           // Get current groups (only if user exists)
           if (result.unixUserExists || dryRun) {
-            result.groups.actual = result.unixUserExists
-              ? this.getUserGroups(user.unix_username)
-              : [];
+            result.groups.actual = result.unixUserExists ? getUserGroups(user.unix_username) : [];
 
             if (verbose && result.groups.actual.length > 0) {
               this.log(chalk.gray(`   Current groups: ${result.groups.actual.join(', ')}`));
@@ -761,7 +520,11 @@ export default class SyncUnix extends Command {
             // Ensure user is in agor_users group
             if (!result.groups.actual.includes(AGOR_USERS_GROUP)) {
               this.log(chalk.yellow(`   → Adding to ${AGOR_USERS_GROUP}...`));
-              if (this.addUserToGroup(user.unix_username, AGOR_USERS_GROUP, dryRun)) {
+              if (
+                await execCmd(
+                  UnixGroupCommands.addUserToGroup(user.unix_username, AGOR_USERS_GROUP)
+                )
+              ) {
                 result.groups.added.push(AGOR_USERS_GROUP);
                 this.log(chalk.green(`   ✓ Added to ${AGOR_USERS_GROUP}`));
               } else {
@@ -785,7 +548,7 @@ export default class SyncUnix extends Command {
               result.groups.expected.push(expectedGroup);
 
               const isInGroup = result.groups.actual.includes(expectedGroup);
-              const groupExistsOnSystem = this.groupExists(expectedGroup);
+              const groupExistsOnSystem = groupExists(expectedGroup);
 
               if (verbose) {
                 this.log(
@@ -801,7 +564,7 @@ export default class SyncUnix extends Command {
               // Create group if it doesn't exist
               if (!groupExistsOnSystem) {
                 this.log(chalk.yellow(`   → Creating group ${expectedGroup}...`));
-                if (this.createGroup(expectedGroup, dryRun)) {
+                if (await execCmd(UnixGroupCommands.createGroup(expectedGroup))) {
                   groupsCreated++;
                   groupReady = true;
                   this.log(chalk.green(`   ✓ Created group ${expectedGroup}`));
@@ -814,7 +577,9 @@ export default class SyncUnix extends Command {
               // Add user to group if it exists/was created and user is not already in it
               if (groupReady && !isInGroup) {
                 this.log(chalk.yellow(`   → Adding to group ${expectedGroup}...`));
-                if (this.addUserToGroup(user.unix_username, expectedGroup, dryRun)) {
+                if (
+                  await execCmd(UnixGroupCommands.addUserToGroup(user.unix_username, expectedGroup))
+                ) {
                   result.groups.added.push(expectedGroup);
                   this.log(chalk.green(`   ✓ Added to ${expectedGroup}`));
                 } else {
@@ -825,14 +590,12 @@ export default class SyncUnix extends Command {
 
               // Add daemon user to worktree group
               if (groupReady && daemonUser) {
-                const daemonInWtGroup = dryRun
-                  ? false
-                  : this.isUserInGroup(daemonUser, expectedGroup);
+                const daemonInWtGroup = dryRun ? false : isUserInGroup(daemonUser, expectedGroup);
                 if (!daemonInWtGroup) {
                   this.log(
                     chalk.yellow(`   → Adding daemon user ${daemonUser} to ${expectedGroup}...`)
                   );
-                  if (this.addUserToGroup(daemonUser, expectedGroup, dryRun)) {
+                  if (await execCmd(UnixGroupCommands.addUserToGroup(daemonUser, expectedGroup))) {
                     daemonMembershipsAdded++;
                     this.log(chalk.green(`   ✓ Added daemon user to ${expectedGroup}`));
                   } else {
@@ -856,7 +619,7 @@ export default class SyncUnix extends Command {
               result.groups.expected.push(repoGroup);
 
               const isInRepoGroup = result.groups.actual.includes(repoGroup);
-              const repoGroupExistsOnSystem = this.groupExists(repoGroup);
+              const repoGroupExistsOnSystem = groupExists(repoGroup);
 
               if (verbose) {
                 this.log(
@@ -872,7 +635,7 @@ export default class SyncUnix extends Command {
               // Create repo group if it doesn't exist
               if (!repoGroupExistsOnSystem) {
                 this.log(chalk.yellow(`   → Creating repo group ${repoGroup}...`));
-                if (this.createGroup(repoGroup, dryRun)) {
+                if (await execCmd(UnixGroupCommands.createGroup(repoGroup))) {
                   groupsCreated++;
                   repoGroupReady = true;
                   this.log(chalk.green(`   ✓ Created repo group ${repoGroup}`));
@@ -885,7 +648,9 @@ export default class SyncUnix extends Command {
               // Add user to repo group if it exists/was created and user is not already in it
               if (repoGroupReady && !isInRepoGroup) {
                 this.log(chalk.yellow(`   → Adding to repo group ${repoGroup}...`));
-                if (this.addUserToGroup(user.unix_username, repoGroup, dryRun)) {
+                if (
+                  await execCmd(UnixGroupCommands.addUserToGroup(user.unix_username, repoGroup))
+                ) {
                   result.groups.added.push(repoGroup);
                   this.log(chalk.green(`   ✓ Added to ${repoGroup}`));
                 } else {
@@ -896,12 +661,12 @@ export default class SyncUnix extends Command {
 
               // Add daemon user to repo group
               if (repoGroupReady && daemonUser) {
-                const daemonInRpGroup = dryRun ? false : this.isUserInGroup(daemonUser, repoGroup);
+                const daemonInRpGroup = dryRun ? false : isUserInGroup(daemonUser, repoGroup);
                 if (!daemonInRpGroup) {
                   this.log(
                     chalk.yellow(`   → Adding daemon user ${daemonUser} to ${repoGroup}...`)
                   );
-                  if (this.addUserToGroup(daemonUser, repoGroup, dryRun)) {
+                  if (await execCmd(UnixGroupCommands.addUserToGroup(daemonUser, repoGroup))) {
                     daemonMembershipsAdded++;
                     this.log(chalk.green(`   ✓ Added daemon user to ${repoGroup}`));
                   } else {
@@ -956,13 +721,13 @@ export default class SyncUnix extends Command {
           this.log(chalk.gray(`   generated group: ${wtGroup}`));
 
           // Create the Unix group if it doesn't exist
-          const groupExistsOnSystem = this.groupExists(wtGroup);
+          const groupExistsOnSystem = groupExists(wtGroup);
 
           if (groupExistsOnSystem) {
             this.log(chalk.green(`   ✓ Unix group already exists`));
           } else {
             this.log(chalk.yellow(`   → Creating Unix group ${wtGroup}...`));
-            if (this.createGroup(wtGroup, dryRun)) {
+            if (await execCmd(UnixGroupCommands.createGroup(wtGroup))) {
               groupsCreated++;
               this.log(chalk.green(`   ✓ Created Unix group ${wtGroup}`));
             } else {
@@ -975,10 +740,10 @@ export default class SyncUnix extends Command {
 
           // Add daemon user to worktree group
           if (daemonUser) {
-            const daemonInGroup = dryRun ? false : this.isUserInGroup(daemonUser, wtGroup);
+            const daemonInGroup = dryRun ? false : isUserInGroup(daemonUser, wtGroup);
             if (!daemonInGroup) {
               this.log(chalk.yellow(`   → Adding daemon user ${daemonUser} to ${wtGroup}...`));
-              if (this.addUserToGroup(daemonUser, wtGroup, dryRun)) {
+              if (await execCmd(UnixGroupCommands.addUserToGroup(daemonUser, wtGroup))) {
                 daemonMembershipsAdded++;
                 this.log(chalk.green(`   ✓ Added daemon user to ${wtGroup}`));
               } else {
@@ -1064,7 +829,7 @@ export default class SyncUnix extends Command {
           }
 
           const dirExists = existsSync(worktreePath);
-          const action = this.getWorktreeDirectoryAction(
+          const action = getWorktreeDirectoryAction(
             dirExists,
             rawWorktree.archived,
             rawWorktree.filesystem_status
@@ -1101,19 +866,14 @@ export default class SyncUnix extends Command {
           // Create missing directory for non-archived worktrees
           if (action === 'create') {
             this.log(chalk.yellow(`   → Directory missing, creating...`));
-            if (dryRun) {
-              this.log(chalk.gray(`   [dry-run] Would run: mkdir -p "${worktreePath}"`));
+            if (await execCmd(`sudo -n mkdir -p "${worktreePath}"`)) {
+              worktreeDirsCreated++;
+              this.log(chalk.green(`   ✓ Created directory`));
             } else {
-              try {
-                execSync(`sudo -n mkdir -p "${worktreePath}"`, { stdio: 'pipe' });
-                worktreeDirsCreated++;
-                this.log(chalk.green(`   ✓ Created directory`));
-              } catch (error) {
-                syncErrors++;
-                this.log(chalk.red(`   ✗ Failed to create directory: ${error}`));
-                this.log('');
-                continue;
-              }
+              syncErrors++;
+              this.log(chalk.red(`   ✗ Failed to create directory`));
+              this.log('');
+              continue;
             }
           }
 
@@ -1123,47 +883,30 @@ export default class SyncUnix extends Command {
 
           this.log(chalk.gray(`   others_fs_access: ${othersAccess} → mode: ${permissionMode}`));
 
-          if (dryRun) {
-            this.log(
-              chalk.gray(
-                `   [dry-run] Would set group ${rawWorktree.unix_group} with mode ${permissionMode}`
-              )
-            );
+          const permCmds = UnixGroupCommands.setDirectoryGroup(
+            worktreePath,
+            rawWorktree.unix_group,
+            permissionMode
+          );
+          if (await execAllCmds(permCmds)) {
+            worktreesSynced++;
+            this.log(chalk.green(`   ✓ Applied permissions (${permissionMode})`));
           } else {
-            try {
-              for (const cmd of UnixGroupCommands.setDirectoryGroup(
-                worktreePath,
-                rawWorktree.unix_group,
-                permissionMode
-              )) {
-                execSync(cmd, { stdio: 'pipe' });
-              }
-
-              worktreesSynced++;
-              this.log(chalk.green(`   ✓ Applied permissions (${permissionMode})`));
-            } catch (error) {
-              syncErrors++;
-              this.log(chalk.red(`   ✗ Failed to set permissions: ${error}`));
-            }
+            syncErrors++;
+            this.log(chalk.red(`   ✗ Failed to set permissions`));
           }
 
           // Apply daemon user ACL so the running daemon can access without restart
           if (daemonUser && (dirExists || action === 'create')) {
-            if (dryRun) {
-              this.log(chalk.gray(`   [dry-run] Would set daemon user ACL for ${daemonUser}`));
-            } else {
-              try {
-                for (const cmd of UnixGroupCommands.setUserAcl(worktreePath, daemonUser)) {
-                  execSync(cmd, { stdio: 'pipe' });
-                }
-                daemonAclsApplied++;
-                if (verbose) {
-                  this.log(chalk.green(`   ✓ Applied daemon ACL for ${daemonUser}`));
-                }
-              } catch (error) {
-                syncErrors++;
-                this.log(chalk.red(`   ✗ Failed to set daemon ACL: ${error}`));
+            const aclCmds = UnixGroupCommands.setUserAcl(worktreePath, daemonUser);
+            if (await execAllCmds(aclCmds)) {
+              daemonAclsApplied++;
+              if (verbose) {
+                this.log(chalk.green(`   ✓ Applied daemon ACL for ${daemonUser}`));
               }
+            } else {
+              syncErrors++;
+              this.log(chalk.red(`   ✗ Failed to set daemon ACL`));
             }
           }
 
@@ -1244,12 +987,12 @@ export default class SyncUnix extends Command {
           if (daemonUser) {
             const daemonInThisRepoGroup = dryRun
               ? false
-              : this.isUserInGroup(daemonUser, rawRepo.unix_group);
+              : isUserInGroup(daemonUser, rawRepo.unix_group);
             if (!daemonInThisRepoGroup) {
               this.log(
                 chalk.yellow(`   → Adding daemon user ${daemonUser} to ${rawRepo.unix_group}...`)
               );
-              if (this.addUserToGroup(daemonUser, rawRepo.unix_group, dryRun)) {
+              if (await execCmd(UnixGroupCommands.addUserToGroup(daemonUser, rawRepo.unix_group))) {
                 daemonMembershipsAdded++;
                 this.log(chalk.green(`   ✓ Added daemon user to ${rawRepo.unix_group}`));
               } else {
@@ -1260,35 +1003,17 @@ export default class SyncUnix extends Command {
             }
           }
 
-          if (dryRun) {
-            this.log(
-              chalk.gray(`   [dry-run] Would run: chgrp -R ${rawRepo.unix_group} "${gitPath}"`)
-            );
-            this.log(
-              chalk.gray(
-                `   [dry-run] Would run: chmod -R ${REPO_GIT_PERMISSION_MODE} "${gitPath}"`
-              )
-            );
-            this.log('');
+          const repoCmds = UnixGroupCommands.setDirectoryGroup(
+            gitPath,
+            rawRepo.unix_group,
+            REPO_GIT_PERMISSION_MODE
+          );
+          if (await execAllCmds(repoCmds)) {
+            reposPermSynced++;
+            this.log(chalk.green(`   ✓ Applied .git permissions (${REPO_GIT_PERMISSION_MODE})\n`));
           } else {
-            try {
-              // Run each command separately (no sh -c wrapper for security)
-              for (const cmd of UnixGroupCommands.setDirectoryGroup(
-                gitPath,
-                rawRepo.unix_group,
-                REPO_GIT_PERMISSION_MODE
-              )) {
-                execSync(cmd, { stdio: 'pipe' });
-              }
-
-              reposPermSynced++;
-              this.log(
-                chalk.green(`   ✓ Applied .git permissions (${REPO_GIT_PERMISSION_MODE})\n`)
-              );
-            } catch (error) {
-              syncErrors++;
-              this.log(chalk.red(`   ✗ Failed: ${error}\n`));
-            }
+            syncErrors++;
+            this.log(chalk.red(`   ✗ Failed to set .git permissions\n`));
           }
         }
 
@@ -1348,7 +1073,7 @@ export default class SyncUnix extends Command {
         // Iterate ALL worktree groups (including those with zero owners)
         let pruneChecked = 0;
         for (const [, group] of wtGroupMap.entries()) {
-          if (!this.groupExists(group)) continue;
+          if (!groupExists(group)) continue;
           pruneChecked++;
 
           // Get expected unix_usernames for this group (may be empty if no owners)
@@ -1362,7 +1087,7 @@ export default class SyncUnix extends Command {
           if (daemonUser) expectedUsernames.add(daemonUser);
 
           // Get actual members from OS
-          const actualMembers = this.getGroupMembers(group);
+          const actualMembers = getGroupMembers(group);
 
           for (const member of actualMembers) {
             if (expectedUsernames.has(member)) continue;
@@ -1372,7 +1097,7 @@ export default class SyncUnix extends Command {
             if (!unixNameToUserId.has(member)) continue;
 
             this.log(chalk.yellow(`   → Removing ${member} from ${group} (no longer owner)`));
-            if (this.removeUserFromGroup(member, group, dryRun)) {
+            if (await execCmd(UnixGroupCommands.removeUserFromGroup(member, group))) {
               membershipsRemoved++;
               this.log(chalk.green(`   ✓ Removed ${member} from ${group}`));
             } else {
@@ -1450,31 +1175,20 @@ export default class SyncUnix extends Command {
 
           // Ensure ~/agor/worktrees/ directory exists
           if (!existsSync(worktreesDir)) {
-            if (dryRun) {
-              this.log(chalk.gray(`   [dry-run] Would create ${worktreesDir}`));
-            } else {
-              try {
-                for (const cmd of UnixUserCommands.setupWorktreesDir(user.unix_username)) {
-                  execSync(cmd, { stdio: 'pipe' });
-                }
-              } catch {
-                // May already exist or user home may not exist yet
-                if (verbose) {
-                  this.log(chalk.gray(`   ⚠ Could not create ${worktreesDir}`));
-                }
-                continue;
+            const setupCmds = UnixUserCommands.setupWorktreesDir(user.unix_username);
+            if (!(await execAllCmds(setupCmds))) {
+              // May already exist or user home may not exist yet
+              if (verbose) {
+                this.log(chalk.gray(`   ⚠ Could not create ${worktreesDir}`));
               }
+              continue;
             }
           }
 
           // Clean up broken symlinks
-          if (!dryRun && existsSync(worktreesDir)) {
-            try {
-              execSync(SymlinkCommands.removeBrokenSymlinks(worktreesDir), { stdio: 'pipe' });
-              symlinksCleaned++; // Count users cleaned, not individual symlinks
-            } catch {
-              // Non-fatal
-            }
+          if (existsSync(worktreesDir)) {
+            await execCmd(SymlinkCommands.removeBrokenSymlinks(worktreesDir));
+            symlinksCleaned++; // Count users cleaned, not individual symlinks
           }
 
           // Create symlinks for owned worktrees where directory exists
@@ -1504,33 +1218,24 @@ export default class SyncUnix extends Command {
 
             if (!needsCreate) continue;
 
-            if (dryRun) {
-              this.log(
-                chalk.gray(`   [dry-run] Would create symlink: ${wtInfo.name} → ${wtInfo.path}`)
-              );
+            // SymlinkCommands don't include sudo prefix, so prepend it
+            const symlinkCmds = SymlinkCommands.createSymlinkWithOwnership(
+              wtInfo.path,
+              symlinkPath,
+              user.unix_username
+            ).map((cmd) => `sudo -n ${cmd}`);
+            if (await execAllCmds(symlinkCmds)) {
               symlinksCreated++;
-            } else {
-              try {
-                // Uses ln -sfn which replaces existing symlinks
-                for (const cmd of SymlinkCommands.createSymlinkWithOwnership(
-                  wtInfo.path,
-                  symlinkPath,
-                  user.unix_username
-                )) {
-                  execSync(`sudo -n ${cmd}`, { stdio: 'pipe' });
-                }
-                symlinksCreated++;
-                if (verbose) {
-                  this.log(
-                    chalk.green(`   ✓ ${user.unix_username}: ${wtInfo.name} → ${wtInfo.path}`)
-                  );
-                }
-              } catch {
-                if (verbose) {
-                  this.log(chalk.red(`   ✗ Failed to create symlink for ${wtInfo.name}`));
-                }
-                syncErrors++;
+              if (verbose) {
+                this.log(
+                  chalk.green(`   ✓ ${user.unix_username}: ${wtInfo.name} → ${wtInfo.path}`)
+                );
               }
+            } else {
+              if (verbose) {
+                this.log(chalk.red(`   ✗ Failed to create symlink for ${wtInfo.name}`));
+              }
+              syncErrors++;
             }
           }
         }
@@ -1568,7 +1273,7 @@ export default class SyncUnix extends Command {
         );
 
         // Get all agor_wt_* groups on the system
-        const systemGroups = this.listWorktreeGroups();
+        const systemGroups = listWorktreeGroups();
 
         if (verbose) {
           this.log(chalk.gray(`   Found ${systemGroups.length} agor_wt_* group(s) on system`));
@@ -1585,7 +1290,7 @@ export default class SyncUnix extends Command {
 
           for (const groupName of staleGroups) {
             this.log(chalk.yellow(`   → Deleting group ${groupName}...`));
-            if (this.deleteGroup(groupName, dryRun)) {
+            if (await execCmd(UnixGroupCommands.deleteGroup(groupName))) {
               groupsDeleted++;
               this.log(chalk.green(`   ✓ Deleted ${groupName}`));
             } else {
@@ -1609,7 +1314,7 @@ export default class SyncUnix extends Command {
         );
 
         // Get all agor_rp_* groups on the system
-        const systemRepoGroups = this.listRepoGroups();
+        const systemRepoGroups = listRepoGroups();
 
         if (verbose) {
           this.log(chalk.gray(`   Found ${systemRepoGroups.length} agor_rp_* group(s) on system`));
@@ -1628,7 +1333,7 @@ export default class SyncUnix extends Command {
 
           for (const groupName of staleRepoGroups) {
             this.log(chalk.yellow(`   → Deleting group ${groupName}...`));
-            if (this.deleteGroup(groupName, dryRun)) {
+            if (await execCmd(UnixGroupCommands.deleteGroup(groupName))) {
               groupsDeleted++;
               this.log(chalk.green(`   ✓ Deleted ${groupName}`));
             } else {
@@ -1651,7 +1356,7 @@ export default class SyncUnix extends Command {
         );
 
         // Get all agor_* users on the system (only auto-generated format)
-        const systemUsers = this.listAgorUsers();
+        const systemUsers = listAgorUsers();
 
         if (verbose) {
           this.log(chalk.gray(`   Found ${systemUsers.length} agor_* user(s) on system`));
@@ -1669,7 +1374,7 @@ export default class SyncUnix extends Command {
 
           for (const username of staleUsers) {
             this.log(chalk.yellow(`   → Deleting user ${username}...`));
-            if (this.deleteUser(username, dryRun)) {
+            if (await execCmd(UnixUserCommands.deleteUser(username))) {
               usersDeleted++;
               this.log(chalk.green(`   ✓ Deleted ${username}`));
             } else {

--- a/apps/agor-cli/src/commands/admin/sync-unix.ts
+++ b/apps/agor-cli/src/commands/admin/sync-unix.ts
@@ -23,7 +23,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readlinkSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { loadConfig } from '@agor/core/config';
@@ -650,13 +650,16 @@ export default class SyncUnix extends Command {
               }
             }
 
-            // Set .git permissions if the repo has a local_path
+            // Set .git permissions if the repo has a local_path and .git exists
             const repoPath = rawRepo.data?.local_path;
             if (repoPath) {
               const gitPath = `${repoPath}/.git`;
-              this.log(chalk.gray(`   .git path: ${gitPath}`));
 
-              if (dryRun) {
+              if (!existsSync(gitPath)) {
+                if (verbose) {
+                  this.log(chalk.gray(`   ⊘ .git path missing (${gitPath}), skipping permissions`));
+                }
+              } else if (dryRun) {
                 this.log(chalk.gray(`   [dry-run] Would run: chgrp -R ${repoGroup} "${gitPath}"`));
                 this.log(
                   chalk.gray(
@@ -1342,12 +1345,14 @@ export default class SyncUnix extends Command {
           }
         }
 
+        // Iterate ALL worktree groups (including those with zero owners)
         let pruneChecked = 0;
-        for (const [group, ownerIds] of groupToOwnerIds.entries()) {
+        for (const [, group] of wtGroupMap.entries()) {
           if (!this.groupExists(group)) continue;
           pruneChecked++;
 
-          // Get expected unix_usernames for this group
+          // Get expected unix_usernames for this group (may be empty if no owners)
+          const ownerIds = groupToOwnerIds.get(group) || new Set<string>();
           const expectedUsernames = new Set<string>();
           for (const ownerId of ownerIds) {
             const uname = userIdToUnixName.get(ownerId);
@@ -1363,8 +1368,8 @@ export default class SyncUnix extends Command {
             if (expectedUsernames.has(member)) continue;
             // Skip the daemon user (safety)
             if (daemonUser && member === daemonUser) continue;
-            // Skip non-agor users (manually added system users)
-            if (!member.startsWith('agor_') && member !== daemonUser) continue;
+            // Only prune DB-managed users (skip manually-added system users)
+            if (!unixNameToUserId.has(member)) continue;
 
             this.log(chalk.yellow(`   → Removing ${member} from ${group} (no longer owner)`));
             if (this.removeUserFromGroup(member, group, dryRun)) {
@@ -1486,8 +1491,18 @@ export default class SyncUnix extends Command {
 
             const symlinkPath = getWorktreeSymlinkPath(user.unix_username, wtInfo.name);
 
-            // Skip if symlink already exists and points to the right target
-            if (existsSync(symlinkPath)) continue;
+            // Check if symlink already exists and points to the correct target
+            let needsCreate = true;
+            try {
+              const currentTarget = readlinkSync(symlinkPath);
+              if (currentTarget === wtInfo.path) {
+                needsCreate = false;
+              }
+            } catch {
+              // Symlink doesn't exist or isn't a symlink — needs creation
+            }
+
+            if (!needsCreate) continue;
 
             if (dryRun) {
               this.log(
@@ -1496,6 +1511,7 @@ export default class SyncUnix extends Command {
               symlinksCreated++;
             } else {
               try {
+                // Uses ln -sfn which replaces existing symlinks
                 for (const cmd of SymlinkCommands.createSymlinkWithOwnership(
                   wtInfo.path,
                   symlinkPath,

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -296,7 +296,9 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
         unique_id: worktree.worktree_unique_id,
         name: worktree.name,
         path: worktree.path,
-        gid: (worktree as { data?: { unix_gid?: number } }).data?.unix_gid,
+        // GID is resolved dynamically at execution time by the executor,
+        // not available in the browser for template preview
+        gid: undefined,
       },
       repo: {
         slug: repo.slug,

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -517,7 +517,8 @@ export const worktrees = sqliteTable(
         mcp_server_ids?: string[];
 
         // Unix integration
-        unix_gid?: number; // GID of worktree's unix_group (best effort capture)
+        // Note: unix_gid was previously stored here but is now resolved dynamically
+        // via getGidFromGroupName(unix_group) at execution time. See id-lookups.ts.
 
         // Schedule configuration (full config in JSON blob)
         schedule?: {

--- a/packages/core/src/templates/handlebars-helpers.ts
+++ b/packages/core/src/templates/handlebars-helpers.ts
@@ -223,7 +223,7 @@ export function renderTemplate(templateString: string, context: Record<string, u
  * - {{worktree.unique_id}} - Auto-assigned unique number (1, 2, 3, ...)
  * - {{worktree.name}} - Worktree name (slug format)
  * - {{worktree.path}} - Absolute path to worktree directory
- * - {{worktree.gid}} - Unix GID of worktree's unix_group (if captured)
+ * - {{worktree.gid}} - Unix GID of worktree's unix_group (resolved dynamically at execution time)
  * - {{repo.slug}} - Repository slug
  * - {{custom.*}} - Any custom context from worktree.custom_context
  */

--- a/packages/core/src/unix/index.ts
+++ b/packages/core/src/unix/index.ts
@@ -18,6 +18,8 @@ export * from './id-lookups.js';
 export * from './run-as-user.js';
 // Symlink management
 export * from './symlink-manager.js';
+// System queries (read-only OS state + pure logic helpers)
+export * from './system-queries.js';
 // Main orchestration service
 export * from './unix-integration-service.js';
 // Unix user management

--- a/packages/core/src/unix/system-queries.ts
+++ b/packages/core/src/unix/system-queries.ts
@@ -1,0 +1,196 @@
+/**
+ * Unix System Queries
+ *
+ * Read-only queries against the OS for Unix user/group state.
+ * These are shared between CLI admin commands and the daemon service.
+ *
+ * Also includes pure logic helpers for worktree directory decisions.
+ *
+ * @see context/guides/rbac-and-unix-isolation.md
+ */
+
+import { execSync } from 'node:child_process';
+import { UnixGroupCommands } from './group-manager.js';
+import { UnixUserCommands } from './user-manager.js';
+
+// ============================================================
+// USER QUERIES
+// ============================================================
+
+// Note: userExists is exported from user-manager.ts as unixUserExists()
+
+/**
+ * Get all groups a Unix user belongs to
+ *
+ * @param username - Unix username
+ * @returns Array of group names (empty if user doesn't exist)
+ */
+export function getUserGroups(username: string): string[] {
+  try {
+    const output = execSync(UnixUserCommands.getUserGroups(username), {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return output.trim().split(/\s+/).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List all agor_* users on the system (auto-generated format: agor_<8-hex>)
+ *
+ * @returns Array of matching usernames
+ */
+export function listAgorUsers(): string[] {
+  try {
+    const output = execSync("getent passwd | grep '^agor_' | cut -d: -f1", {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return output
+      .trim()
+      .split('\n')
+      .filter((u) => u && /^agor_[0-9a-f]{8}$/.test(u));
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================
+// GROUP QUERIES
+// ============================================================
+
+/**
+ * Check if a Unix group exists on the system
+ *
+ * @param groupName - Group name to check
+ * @returns true if group exists
+ */
+export function groupExists(groupName: string): boolean {
+  try {
+    execSync(UnixGroupCommands.groupExists(groupName), { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a Unix user is a member of a group
+ *
+ * @param username - Unix username
+ * @param groupName - Group name
+ * @returns true if user is in group
+ */
+export function isUserInGroup(username: string, groupName: string): boolean {
+  try {
+    execSync(UnixGroupCommands.isUserInGroup(username, groupName), { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get members of a Unix group from the system
+ *
+ * @param groupName - Group name
+ * @returns Array of usernames in the group (empty if group doesn't exist)
+ */
+export function getGroupMembers(groupName: string): string[] {
+  try {
+    const output = execSync(UnixGroupCommands.listGroupMembers(groupName), {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return output.trim().split(',').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List all agor_wt_* (worktree) groups on the system
+ *
+ * @returns Array of matching group names
+ */
+export function listWorktreeGroups(): string[] {
+  try {
+    const output = execSync("getent group | grep '^agor_wt_' | cut -d: -f1", {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return output
+      .trim()
+      .split('\n')
+      .filter((g) => g && /^agor_wt_[0-9a-f]{8}$/.test(g));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List all agor_rp_* (repo) groups on the system
+ *
+ * @returns Array of matching group names
+ */
+export function listRepoGroups(): string[] {
+  try {
+    const output = execSync("getent group | grep '^agor_rp_' | cut -d: -f1", {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return output
+      .trim()
+      .split('\n')
+      .filter((g) => g && /^agor_rp_[0-9a-f]{8}$/.test(g));
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================
+// PURE LOGIC HELPERS
+// ============================================================
+
+/**
+ * Determine what action to take for a worktree directory based on archive state.
+ *
+ * @param dirExists - Whether the directory currently exists on disk
+ * @param archived - Whether the worktree is archived
+ * @param filesystemStatus - The worktree's filesystem_status field
+ * @returns Action to take:
+ *   - 'sync': Directory exists, apply permissions
+ *   - 'create': Directory missing, non-archived — create it
+ *   - 'skip': Skip this worktree (archived+deleted, creating, failed, etc.)
+ */
+export function getWorktreeDirectoryAction(
+  dirExists: boolean,
+  archived: boolean,
+  filesystemStatus: string | null | undefined
+): 'sync' | 'create' | 'skip' {
+  // Creating or failed worktrees — not ready, skip
+  if (filesystemStatus === 'creating' || filesystemStatus === 'failed') {
+    return 'skip';
+  }
+
+  // Archived + deleted — directory was intentionally removed
+  if (archived && filesystemStatus === 'deleted') {
+    return 'skip';
+  }
+
+  // Directory exists — always sync permissions regardless of archive state
+  if (dirExists) {
+    return 'sync';
+  }
+
+  // Directory missing + not archived — create it
+  if (!archived) {
+    return 'create';
+  }
+
+  // Directory missing + archived (preserved or cleaned) — skip
+  // The directory was expected to exist but doesn't — log info but don't create
+  return 'skip';
+}

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -13,11 +13,8 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
-import { eq } from 'drizzle-orm';
-import { update } from '../db/database-wrapper.js';
 import type { Database } from '../db/index.js';
 import { RepoRepository, UsersRepository, WorktreeRepository } from '../db/repositories/index.js';
-import * as schema from '../db/schema.sqlite.js';
 import type { RepoID, UserID, UUID, WorktreeID } from '../types/index.js';
 import type { CommandExecutor } from './command-executor.js';
 import { NoOpExecutor } from './command-executor.js';
@@ -29,7 +26,6 @@ import {
   REPO_GIT_PERMISSION_MODE,
   UnixGroupCommands,
 } from './group-manager.js';
-import { getGidFromGroupName } from './id-lookups.js';
 import { getWorktreeSymlinkPath, SymlinkCommands } from './symlink-manager.js';
 import {
   AGOR_DEFAULT_SHELL,
@@ -98,7 +94,6 @@ export interface UnixOperationResult {
 export class UnixIntegrationService {
   private config: Required<Omit<UnixIntegrationConfig, 'daemonUser'>> & { daemonUser?: string };
   private executor: CommandExecutor;
-  private db: Database;
   private worktreeRepo: WorktreeRepository;
   private usersRepo: UsersRepository;
   private repoRepo: RepoRepository;
@@ -108,7 +103,6 @@ export class UnixIntegrationService {
     executor: CommandExecutor,
     config: UnixIntegrationConfig = { enabled: false }
   ) {
-    this.db = db;
     // daemonUser should be resolved by the caller via getAgorDaemonUser()
     // If not provided, daemon user operations will be skipped
     this.config = {
@@ -231,9 +225,6 @@ export class UnixIntegrationService {
       await this.executor.exec(UnixGroupCommands.createGroup(groupName));
     }
 
-    // Lookup GID for the group (best effort, don't fail if can't get it)
-    const unixGid = getGidFromGroupName(groupName);
-
     // Fetch current worktree to get existing data and path
     const worktree = await this.worktreeRepo.findById(worktreeId);
 
@@ -241,18 +232,6 @@ export class UnixIntegrationService {
     await this.worktreeRepo.update(worktreeId, {
       unix_group: groupName,
     });
-
-    // Update data blob separately (direct SQL update since data is JSON)
-    if (unixGid !== undefined && worktree) {
-      const updatedData = {
-        ...((worktree as { data?: Record<string, unknown> }).data ?? {}),
-        unix_gid: unixGid,
-      };
-
-      await update(this.db, schema.worktrees)
-        .set({ data: updatedData })
-        .where(eq(schema.worktrees.worktree_id, worktreeId));
-    }
 
     // Apply group ownership and permissions to worktree directory
     if (worktree?.path) {


### PR DESCRIPTION
## Summary

Hardens `agor admin sync-unix` to support partial box migrations where worktree directories may not all exist on the target system.

- **Virtualize `unix_gid`**: Stop storing GID in worktree data blob; resolve dynamically via `getGidFromGroupName()` at execution time. Eliminates stale GIDs after migration.
- **Archive-aware directory handling**: Check `filesystem_status` before applying permissions. Creates missing dirs for non-archived worktrees, skips archived+deleted gracefully.
- **`existsSync` guards**: Check paths exist before running `chgrp`/`setfacl` on worktree dirs and repo `.git` dirs.
- **Worktree group backfill**: New phase that creates `agor_wt_*` groups for worktrees missing `unix_group`.
- **Membership pruning**: Compares OS group members against DB owners, removes stale memberships.
- **Daemon user ACL**: Applies `setUserAcl()` so the running daemon can access worktrees without restart.
- **Symlink rebuild**: Creates missing symlinks, cleans broken ones for all users.

## Test plan

- [ ] Run `sudo agor admin sync-unix --dry-run` on existing box — verify no destructive changes proposed
- [ ] Run on a box with missing worktree directories — verify dirs are created for non-archived worktrees
- [ ] Verify archived+deleted worktrees are skipped
- [ ] Verify stale group memberships are detected and removed
- [ ] Verify symlinks are created for owned worktrees with existing directories
- [ ] Verify `{{worktree.gid}}` still resolves correctly in environment templates at execution time

🤖 Generated with [Claude Code](https://claude.com/claude-code)