### PR TITLE
fix: inherit permission_config and model_config in session fork

### DIFF
--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -189,6 +189,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
           children: [],
         },
         contextFiles: [...(parent.contextFiles || [])],
+        permission_config: parent.permission_config,
+        model_config: parent.model_config,
         tasks: [],
         // Don't copy sdk_session_id - fork will get its own via forkSession:true
       },


### PR DESCRIPTION
## Summary

- The `fork()` method in `SessionsService` was not copying `permission_config` or `model_config` from the parent session, causing BTW forks (and regular forks) to fall back to user/workspace defaults instead of inheriting the parent's settings
- The `spawn()` method already correctly inherited these configs — this aligns `fork()` with that behavior

## Root Cause

In `apps/agor-daemon/src/services/sessions.ts`, the `fork()` method's `create()` call was missing `permission_config` and `model_config` fields. When a BTW session was forked from a parent with `bypassPermissions` mode, the child would get the default permission mode instead.

## Test plan

- [ ] Create a session with `bypassPermissions` mode
- [ ] Use BTW to fork a side-task from that session
- [ ] Verify the BTW fork inherits `bypassPermissions` mode
- [ ] Verify model_config is also inherited
- [ ] Verify regular (non-BTW) forks also inherit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)