### PR TITLE
fix(rbac): grant superadmins full worktree access

### DIFF
--- a/apps/agor-daemon/src/utils/worktree-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.test.ts
@@ -76,30 +76,25 @@ describe('hasWorktreePermission', () => {
   });
 
   describe('superadmin behavior', () => {
-    it('superadmin can view worktrees with others_can=none', () => {
+    it('superadmin has full access to worktrees with others_can=none', () => {
       const wt = makeWorktree({ others_can: 'none' });
+      expect(hasWorktreePermission(wt, USER_ID, false, 'all', ROLES.SUPERADMIN)).toBe(true);
+      expect(hasWorktreePermission(wt, USER_ID, false, 'prompt', ROLES.SUPERADMIN)).toBe(true);
       expect(hasWorktreePermission(wt, USER_ID, false, 'view', ROLES.SUPERADMIN)).toBe(true);
     });
 
-    it('superadmin CANNOT prompt worktrees with others_can=none (must own first)', () => {
-      const wt = makeWorktree({ others_can: 'none' });
-      expect(hasWorktreePermission(wt, USER_ID, false, 'prompt', ROLES.SUPERADMIN)).toBe(false);
+    it('superadmin has full access regardless of others_can level', () => {
+      for (const othersCan of ['none', 'view', 'session', 'prompt', 'all'] as const) {
+        const wt = makeWorktree({ others_can: othersCan });
+        expect(hasWorktreePermission(wt, USER_ID, false, 'all', ROLES.SUPERADMIN)).toBe(true);
+      }
     });
 
-    it('superadmin CANNOT get all permission on worktrees with others_can=none', () => {
+    it('deprecated owner role gets same superadmin full access', () => {
       const wt = makeWorktree({ others_can: 'none' });
-      expect(hasWorktreePermission(wt, USER_ID, false, 'all', ROLES.SUPERADMIN)).toBe(false);
-    });
-
-    it('superadmin can prompt worktrees with others_can=prompt', () => {
-      const wt = makeWorktree({ others_can: 'prompt' });
-      expect(hasWorktreePermission(wt, USER_ID, false, 'prompt', ROLES.SUPERADMIN)).toBe(true);
-    });
-
-    it('deprecated owner role gets same superadmin bypass', () => {
-      const wt = makeWorktree({ others_can: 'none' });
+      expect(hasWorktreePermission(wt, USER_ID, false, 'all', 'owner')).toBe(true);
+      expect(hasWorktreePermission(wt, USER_ID, false, 'prompt', 'owner')).toBe(true);
       expect(hasWorktreePermission(wt, USER_ID, false, 'view', 'owner')).toBe(true);
-      expect(hasWorktreePermission(wt, USER_ID, false, 'prompt', 'owner')).toBe(false);
     });
   });
 
@@ -157,14 +152,14 @@ describe('resolveWorktreePermission', () => {
     expect(resolveWorktreePermission(wt, USER_ID, true)).toBe('all');
   });
 
-  it('superadmin resolves to at least view on others_can=none', () => {
+  it('superadmin resolves to all on others_can=none', () => {
     const wt = makeWorktree({ others_can: 'none' });
-    expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.SUPERADMIN)).toBe('view');
+    expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.SUPERADMIN)).toBe('all');
   });
 
-  it('superadmin inherits higher permission from others_can', () => {
+  it('superadmin resolves to all regardless of others_can', () => {
     const wt = makeWorktree({ others_can: 'prompt' });
-    expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.SUPERADMIN)).toBe('prompt');
+    expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.SUPERADMIN)).toBe('all');
   });
 
   it('member gets others_can level', () => {
@@ -182,9 +177,9 @@ describe('resolveWorktreePermission', () => {
     expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.MEMBER)).toBe('session');
   });
 
-  it('superadmin inherits session permission from others_can', () => {
+  it('superadmin resolves to all even with others_can=session', () => {
     const wt = makeWorktree({ others_can: 'session' });
-    expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.SUPERADMIN)).toBe('session');
+    expect(resolveWorktreePermission(wt, USER_ID, false, ROLES.SUPERADMIN)).toBe('all');
   });
 });
 

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -75,9 +75,8 @@ export function hasWorktreePermission(
     return true;
   }
 
-  // Superadmins can always view any worktree (including others_can=none)
-  // For prompt/all, they must self-assign ownership first
-  if (isSuperAdmin(userRole, allowSuperadmin) && requiredLevel === 'view') {
+  // Superadmins have full access to all worktrees
+  if (isSuperAdmin(userRole, allowSuperadmin)) {
     return true;
   }
 

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -110,15 +110,11 @@ export function resolveWorktreePermission(
   if (isOwner) {
     return 'all';
   }
-  // Superadmins get at least 'view' on all worktrees, even others_can=none
-  const basePermission = worktree.others_can ?? 'session';
-  if (
-    isSuperAdmin(userRole, allowSuperadmin) &&
-    PERMISSION_RANK[basePermission] < PERMISSION_RANK.view
-  ) {
-    return 'view';
+  // Superadmins get full access to all worktrees
+  if (isSuperAdmin(userRole, allowSuperadmin)) {
+    return 'all';
   }
-  return basePermission;
+  return worktree.others_can ?? 'session';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Superadmins now get `'all'` permission on all worktrees instead of just `'view'`
- Enables admin operations (archive, delete, update) on worktrees they don't own
- Updated tests to reflect the new behavior

## Test plan
- [ ] Verify superadmin can archive/delete worktrees they don't own
- [ ] Verify non-superadmin permissions are unchanged
- [ ] Verify `allow_superadmin=false` still disables the bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)