### PR TITLE
fix(ui): worktree list filter dropdown loading forever for All/Archived

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
@@ -88,6 +88,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       return;
     }
 
+    let cancelled = false;
     archivedFetchingRef.current = true;
     setArchivedLoading(true);
 
@@ -95,6 +96,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       .service('worktrees')
       .findAll({ query: { archived: true, $limit: 1000, $sort: { created_at: -1 } } })
       .then((result) => {
+        if (cancelled) return;
         setArchivedWorktrees(result as Worktree[]);
         setArchivedLoaded(true);
       })
@@ -103,8 +105,14 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
       })
       .finally(() => {
         archivedFetchingRef.current = false;
-        setArchivedLoading(false);
+        if (!cancelled) {
+          setArchivedLoading(false);
+        }
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [archiveFilter, archivedLoaded, client]);
 
   // Validate form fields to enable/disable Create button

--- a/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/WorktreesTable.tsx
@@ -9,7 +9,7 @@ import {
   RobotOutlined,
 } from '@ant-design/icons';
 import { Button, Empty, Form, Input, Modal, Select, Space, Table, Typography, theme } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
 import { ArchiveDeleteWorktreeModal } from '../ArchiveDeleteWorktreeModal';
 import { ArchiveToggleButton } from '../ArchiveToggleButton';
@@ -76,6 +76,7 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
   const [archivedWorktrees, setArchivedWorktrees] = useState<Worktree[]>([]);
   const [archivedLoaded, setArchivedLoaded] = useState(false);
   const [archivedLoading, setArchivedLoading] = useState(false);
+  const archivedFetchingRef = useRef(false);
 
   // No need for reposById anymore, we already have it as a prop
 
@@ -83,18 +84,17 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
     if (archiveFilter !== 'archived' && archiveFilter !== 'all') {
       return;
     }
-    if (archivedLoaded || archivedLoading || !client) {
+    if (archivedLoaded || archivedFetchingRef.current || !client) {
       return;
     }
 
-    let cancelled = false;
+    archivedFetchingRef.current = true;
     setArchivedLoading(true);
 
     client
       .service('worktrees')
       .findAll({ query: { archived: true, $limit: 1000, $sort: { created_at: -1 } } })
       .then((result) => {
-        if (cancelled) return;
         setArchivedWorktrees(result as Worktree[]);
         setArchivedLoaded(true);
       })
@@ -102,15 +102,10 @@ export const WorktreesTable: React.FC<WorktreesTableProps> = ({
         // Keep table functional with active-only data if archived fetch fails
       })
       .finally(() => {
-        if (!cancelled) {
-          setArchivedLoading(false);
-        }
+        archivedFetchingRef.current = false;
+        setArchivedLoading(false);
       });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [archiveFilter, archivedLoaded, archivedLoading, client]);
+  }, [archiveFilter, archivedLoaded, client]);
 
   // Validate form fields to enable/disable Create button
   const validateForm = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixed the worktree CRUD list filter dropdown where selecting "All" or "Archived" caused an infinite loading spinner
- **Root cause**: `archivedLoading` state was included in the `useEffect` dependency array. When `setArchivedLoading(true)` ran inside the effect, React triggered a re-render, ran the cleanup (setting `cancelled = true`), then re-ran the effect (which bailed). The API response handlers skipped updates because `cancelled` was true, leaving loading stuck forever.
- **Fix**: Replaced the `archivedLoading` state guard with a `useRef` (`archivedFetchingRef`) that doesn't trigger re-renders or cleanup cycles

## Test plan
- [ ] Open Settings > Worktrees tab
- [ ] Verify "Active" filter loads worktrees normally (regression check)
- [ ] Switch to "All" — should load and show both active and archived worktrees
- [ ] Switch to "Archived" — should load and show only archived worktrees
- [ ] Switch back to "Active" and then to "All" again — should use cached data (no re-fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)