### PR TITLE
feat(boards): add custom CSS animations support

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -98,6 +98,12 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           .string()
           .optional()
           .describe('Board background color (hex format, optional)'),
+        customCss: z
+          .string()
+          .optional()
+          .describe(
+            'Custom CSS for board canvas animations (@keyframes, animation, background-size, etc.). Rendered in a scoped <style> tag. Dangerous patterns like url(), expression(), @import are blocked.'
+          ),
         slug: z.string().optional().describe('URL-friendly slug (optional)'),
         customContext: z
           .object({})
@@ -129,6 +135,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       if (args.color !== undefined) metadataUpdates.color = args.color;
       if (args.backgroundColor !== undefined)
         metadataUpdates.background_color = args.backgroundColor;
+      if (args.customCss !== undefined) metadataUpdates.custom_css = args.customCss;
       if (args.slug !== undefined) metadataUpdates.slug = args.slug;
       if (args.customContext !== undefined) metadataUpdates.custom_context = args.customContext;
 
@@ -184,6 +191,12 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           .string()
           .optional()
           .describe('Board background color in hex format (optional)'),
+        customCss: z
+          .string()
+          .optional()
+          .describe(
+            'Custom CSS for board canvas animations (@keyframes, animation, etc.). Optional.'
+          ),
       }),
     },
     async (args) => {
@@ -200,6 +213,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       if (args.color !== undefined) boardData.color = coerceString(args.color);
       if (args.backgroundColor !== undefined)
         boardData.background_color = coerceString(args.backgroundColor);
+      if (args.customCss !== undefined) boardData.custom_css = coerceString(args.customCss);
 
       const board = await ctx.app.service('boards').create(boardData, ctx.baseServiceParams);
       return textResult(board);

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -303,6 +303,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
       icon: blob.icon,
       color: blob.color,
       background_color: blob.background_color,
+      custom_css: blob.custom_css,
       objects: blob.objects,
       custom_context: blob.custom_context,
       created_by: userId,

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -945,7 +945,11 @@ export const App: React.FC<AppProps> = ({
           {/* Invisible mount of antd Upload so its CSS-in-JS styles stay
               registered even after the SessionPanel (which contains FileUpload)
               unmounts. Without this, antd GC's the Upload CSS on panel close. */}
-          <Upload style={{ display: 'none' }} openFileDialogOnClick={false} showUploadList={false} />
+          <Upload
+            style={{ display: 'none' }}
+            openFileDialogOnClick={false}
+            showUploadList={false}
+          />
           {newSessionWorktreeId && (
             <NewSessionModal
               open={true}

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
@@ -31,6 +31,7 @@ export const BoardTab: React.FC<BoardTabProps> = ({ onValidityChange, formRef })
             ? values.background_color
             : values.background_color.toHexString()
           : undefined,
+        custom_css: values.custom_css || undefined,
       };
     } catch {
       return null;

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -59,6 +59,7 @@ import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
 import { usePresence } from '../../hooks/usePresence';
 import type { AgenticToolOption } from '../../types';
+import { sanitizeBoardCss } from '../../utils/sanitizeCss';
 import { isDarkTheme } from '../../utils/theme';
 import { AutocompleteTextarea } from '../AutocompleteTextarea/AutocompleteTextarea';
 import CardModal from '../CardModal';
@@ -307,6 +308,13 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
     const canvasBackground = board?.background_color ?? defaultBackground;
+
+    // Sanitize and scope custom CSS for this board (enables @keyframes, animations, etc.)
+    const boardCssClass = board?.board_id ? `board-css-${board.board_id.slice(0, 8)}` : '';
+    const scopedCustomCss = useMemo(
+      () => sanitizeBoardCss(board?.custom_css, `.${boardCssClass}`),
+      [board?.custom_css, boardCssClass]
+    );
 
     // Note: sessionsByWorktree is now passed as prop (no longer computed locally)
     // This enables efficient O(1) lookups and stable references across re-renders
@@ -2191,8 +2199,10 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           />
         )}
 
+        {scopedCustomCss && <style>{scopedCustomCss}</style>}
         <div
           ref={reactFlowWrapperRef}
+          className={boardCssClass || undefined}
           style={{
             width: '100%',
             height: '100%',

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -103,6 +103,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
             ? values.background_color
             : values.background_color.toHexString()
           : undefined,
+        custom_css: values.custom_css || undefined,
         custom_context: values.custom_context ? JSON.parse(values.custom_context) : undefined,
       });
       form.resetFields();
@@ -120,6 +121,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
       icon: board.icon,
       description: board.description,
       background_color: board.background_color,
+      custom_css: board.custom_css,
       custom_context: board.custom_context ? JSON.stringify(board.custom_context, null, 2) : '',
     });
     setEditModalOpen(true);
@@ -138,6 +140,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
             ? values.background_color
             : values.background_color.toHexString()
           : undefined,
+        custom_css: values.custom_css || undefined,
         custom_context: values.custom_context ? JSON.parse(values.custom_context) : undefined,
       });
       form.resetFields();

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -72,6 +72,73 @@ export const BACKGROUND_PRESETS = [
   },
 ];
 
+/**
+ * Animation CSS presets — each sets background-size + animation + @keyframes.
+ * Designed to pair with gradient backgrounds from BACKGROUND_PRESETS.
+ */
+export const ANIMATION_PRESETS = [
+  {
+    label: 'Slow gradient shift (12s)',
+    value: `background-size: 400% 400%;
+animation: agorGradientShift 12s ease infinite;
+
+@keyframes agorGradientShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}`,
+  },
+  {
+    label: 'Fast gradient shift (4s)',
+    value: `background-size: 400% 400%;
+animation: agorGradientFast 4s ease infinite;
+
+@keyframes agorGradientFast {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}`,
+  },
+  {
+    label: 'Diagonal sweep (8s)',
+    value: `background-size: 400% 400%;
+animation: agorDiagonalSweep 8s linear infinite;
+
+@keyframes agorDiagonalSweep {
+  0% { background-position: 0% 0%; }
+  50% { background-position: 100% 100%; }
+  100% { background-position: 0% 0%; }
+}`,
+  },
+  {
+    label: 'Pulse zoom (6s)',
+    value: `background-size: 200% 200%;
+animation: agorPulse 6s ease-in-out infinite;
+
+@keyframes agorPulse {
+  0%, 100% { background-size: 200% 200%; background-position: center; }
+  50% { background-size: 300% 300%; background-position: center; }
+}`,
+  },
+  {
+    label: 'Horizontal scroll (20s)',
+    value: `background-size: 200% 100%;
+animation: agorHScroll 20s linear infinite;
+
+@keyframes agorHScroll {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}`,
+  },
+  {
+    label: 'Rotate (conic, 10s)',
+    value: `animation: agorRotate 10s linear infinite;
+
+@keyframes agorRotate {
+  0% { filter: hue-rotate(0deg); }
+  100% { filter: hue-rotate(360deg); }
+}`,
+  },
+];
+
 export interface BoardFormFieldsProps {
   form: FormInstance;
   useCustomCSS: boolean;
@@ -170,6 +237,40 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
           </Typography.Text>
         </Space>
       </Form.Item>
+
+      {useCustomCSS && (
+        <Form.Item
+          label="Animation CSS"
+          tooltip="Add @keyframes, animation, background-size, and other CSS properties. Rendered in a scoped <style> tag."
+        >
+          <Select
+            placeholder="Load an animation preset..."
+            style={{ width: '100%', marginBottom: 8 }}
+            allowClear
+            showSearch
+            options={ANIMATION_PRESETS}
+            onChange={(value) => {
+              if (value) {
+                form.setFieldsValue({ custom_css: value });
+              }
+            }}
+          />
+          <Form.Item name="custom_css" noStyle>
+            <Input.TextArea
+              placeholder={`@keyframes bioGlow {\n  0%, 100% { background-position: 0% 50%; }\n  50% { background-position: 100% 50%; }\n}\n\nbackground-size: 400% 400%;\nanimation: bioGlow 12s ease infinite;`}
+              rows={6}
+              style={{ fontFamily: 'monospace', fontSize: '12px' }}
+            />
+          </Form.Item>
+          <Typography.Text
+            type="secondary"
+            style={{ fontSize: '12px', display: 'block', marginTop: 4 }}
+          >
+            Supports @keyframes, animation, background-size, and other CSS. Dangerous patterns (url,
+            expression, @import) are blocked for security.
+          </Typography.Text>
+        </Form.Item>
+      )}
 
       {extra}
     </>

--- a/apps/agor-ui/src/utils/sanitizeCss.ts
+++ b/apps/agor-ui/src/utils/sanitizeCss.ts
@@ -1,0 +1,118 @@
+/**
+ * CSS sanitizer for board custom CSS.
+ *
+ * Allows safe CSS properties and @keyframes while blocking XSS vectors.
+ * Returns sanitized CSS scoped to a board-specific class selector.
+ */
+
+/** Patterns that are dangerous in CSS and must be stripped */
+const DANGEROUS_PATTERNS = [
+  /url\s*\(/gi, // External resource loading, data exfiltration
+  /expression\s*\(/gi, // IE CSS expressions (JS execution)
+  /javascript\s*:/gi, // JS protocol
+  /behavior\s*:/gi, // IE .htc behaviors
+  /-moz-binding\s*:/gi, // Firefox XBL bindings
+  /@import/gi, // External stylesheet loading
+  /@charset/gi, // Encoding attacks
+  /@font-face/gi, // External font loading
+  /@namespace/gi, // Namespace injection
+  /\\00/gi, // Null byte escapes
+];
+
+/**
+ * Check if a CSS string contains dangerous patterns.
+ */
+function containsDangerousPattern(css: string): string | null {
+  for (const pattern of DANGEROUS_PATTERNS) {
+    pattern.lastIndex = 0; // Reset regex state
+    if (pattern.test(css)) {
+      return pattern.source;
+    }
+  }
+  return null;
+}
+
+/**
+ * Sanitize and scope custom CSS for a board canvas.
+ *
+ * - Strips dangerous CSS patterns (url(), expression(), @import, etc.)
+ * - Separates @keyframes blocks from property declarations
+ * - Scopes property declarations to the board's canvas element
+ * - Returns empty string if input is empty or entirely dangerous
+ *
+ * @param css - Raw CSS input from the user
+ * @param scopeSelector - CSS selector to scope declarations to (e.g. ".board-css-abc123")
+ * @returns Sanitized and scoped CSS string, or empty string
+ */
+export function sanitizeBoardCss(css: string | undefined, scopeSelector: string): string {
+  if (!css?.trim()) return '';
+
+  // Check for dangerous patterns and strip them
+  let sanitized = css;
+  for (const pattern of DANGEROUS_PATTERNS) {
+    pattern.lastIndex = 0;
+    sanitized = sanitized.replace(pattern, '/* blocked */');
+  }
+
+  // Extract @keyframes blocks (they must remain at top level, not scoped)
+  const keyframesBlocks: string[] = [];
+  const withoutKeyframes = sanitized.replace(
+    /@keyframes\s+[\w-]+\s*\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}/gi,
+    (match) => {
+      // Validate the keyframes block itself doesn't contain dangerous patterns
+      const danger = containsDangerousPattern(match);
+      if (!danger) {
+        keyframesBlocks.push(match);
+      }
+      return '';
+    }
+  );
+
+  // Everything remaining is treated as property declarations to be scoped
+  const declarations = withoutKeyframes.trim();
+
+  const parts: string[] = [];
+
+  // Scope property declarations to the board canvas
+  if (declarations) {
+    // If the user wrote raw declarations (no selector), wrap them
+    // If they wrote selectors, we still scope them under the board selector
+    const hasSelector = /[^{}]+\{/.test(declarations);
+    if (hasSelector) {
+      // User wrote CSS rules with selectors — scope each rule
+      parts.push(
+        `${scopeSelector} { }\n${declarations.replace(/([^{}]+)\{/g, `${scopeSelector} $1{`)}`
+      );
+    } else {
+      // Raw property declarations — wrap in scoped selector
+      parts.push(`${scopeSelector} {\n${declarations}\n}`);
+    }
+  }
+
+  // Append @keyframes blocks (global, not scoped)
+  for (const kf of keyframesBlocks) {
+    parts.push(kf);
+  }
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Validate CSS input and return a list of issues found.
+ * Used for UI warnings before saving.
+ */
+export function validateBoardCss(css: string | undefined): string[] {
+  if (!css?.trim()) return [];
+
+  const issues: string[] = [];
+
+  for (const pattern of DANGEROUS_PATTERNS) {
+    pattern.lastIndex = 0;
+    if (pattern.test(css)) {
+      const name = pattern.source.replace(/\\s\*\\\(/g, '()').replace(/\\s\*:/g, ':');
+      issues.push(`Blocked pattern: ${name}`);
+    }
+  }
+
+  return issues;
+}

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -39,6 +39,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       color?: string;
       icon?: string;
       background_color?: string;
+      custom_css?: string;
       objects?: Record<string, BoardObject>;
       custom_context?: Record<string, unknown>;
     };
@@ -83,6 +84,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
         color: board.color,
         icon: board.icon,
         background_color: board.background_color,
+        custom_css: board.custom_css,
         objects: board.objects,
         custom_context: board.custom_context,
       },
@@ -540,6 +542,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       icon: board.icon,
       color: board.color,
       background_color: board.background_color,
+      custom_css: board.custom_css,
       objects: board.objects,
       custom_context: board.custom_context,
     };

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -384,6 +384,7 @@ export const boards = pgTable(
         color?: string;
         icon?: string;
         background_color?: string; // Background color for the board canvas
+        custom_css?: string; // Custom CSS for animations, keyframes, etc. (rendered in scoped <style> tag)
         objects?: Record<string, import('@agor/core/types').BoardObject>; // Board objects (text, zone)
         custom_context?: Record<string, unknown>; // Custom context for Handlebars templates
       }>()

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -376,6 +376,7 @@ export const boards = sqliteTable(
         color?: string;
         icon?: string;
         background_color?: string; // Background color for the board canvas
+        custom_css?: string; // Custom CSS for animations, keyframes, etc. (rendered in scoped <style> tag)
         objects?: Record<string, import('@agor/core/types').BoardObject>; // Board objects (text, zone)
         custom_context?: Record<string, unknown>; // Custom context for Handlebars templates
       }>()

--- a/packages/core/src/types/board.ts
+++ b/packages/core/src/types/board.ts
@@ -253,6 +253,13 @@ export interface Board {
   background_color?: string;
 
   /**
+   * Custom CSS for the board canvas (rendered in a scoped <style> tag).
+   * Supports @keyframes, animation, background-size, and other CSS that
+   * can't be expressed as inline styles. Sanitized before rendering.
+   */
+  custom_css?: string;
+
+  /**
    * Custom context for Handlebars templates (board-level)
    * Example: { "team": "Backend", "sprint": 42, "deadline": "2025-03-15" }
    * Access in templates: {{ board.context.team }}
@@ -291,6 +298,7 @@ export interface BoardExportBlob {
   icon?: string;
   color?: string;
   background_color?: string;
+  custom_css?: string;
 
   // Annotations (zones, text, markdown)
   objects?: {


### PR DESCRIPTION
## Summary
- Adds a `custom_css` field to boards that renders in a scoped `<style>` tag, enabling `@keyframes`, `animation`, `background-size`, and other CSS that can't be expressed as inline styles
- Includes CSS sanitizer that blocks XSS vectors (`url()`, `expression()`, `@import`, `javascript:`, `-moz-binding`, etc.) while allowing `@keyframes`
- Adds "Animation CSS" textarea with 6 animation presets (gradient shift, diagonal sweep, pulse zoom, etc.) to the board settings form

## Motivation
Board backgrounds previously only supported the `background` inline style property. Users trying to set animated gradient backgrounds like:
```css
background: linear-gradient(200deg, #001a0c, #004530, #002a38, #001218, #001a0c);
background-size: 400% 400%;
animation: bioGlow 12s ease infinite;
```
would see the gradient but no animation, since `@keyframes` blocks can't exist in inline styles.

## Changes
- **`packages/core/src/types/board.ts`** — `custom_css?: string` on `Board` and `BoardExportBlob`
- **`packages/core/src/db/schema.{sqlite,postgres}.ts`** — `custom_css` in board JSON data type
- **`packages/core/src/db/repositories/boards.ts`** — map `custom_css` in/out + export blob
- **`apps/agor-ui/src/utils/sanitizeCss.ts`** — CSS sanitizer with XSS protection
- **`apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx`** — scoped `<style>` tag rendering
- **`apps/agor-ui/src/components/forms/BoardFormFields.tsx`** — animation CSS textarea + presets
- **`apps/agor-ui/src/components/{CreateDialog,SettingsModal}`** — wire `custom_css` in forms
- **`apps/agor-daemon/src/{services,mcp/tools}/boards.ts`** — backend + MCP tool support

## Security
CSS sanitizer blocks: `url()`, `expression()`, `javascript:`, `behavior:`, `-moz-binding`, `@import`, `@charset`, `@font-face`, `@namespace`, null byte escapes. All declarations are scoped to a board-specific CSS class (`.board-css-{id}`).

## Test plan
- [ ] Create a board with a gradient background + animation CSS preset → verify animation plays
- [ ] Edit existing board to add custom CSS → verify it applies without page reload
- [ ] Try entering `url()`, `@import`, `expression()` in custom CSS → verify they're blocked
- [ ] Verify existing boards with `background_color` only still render correctly (backward compat)
- [ ] Board export/import preserves `custom_css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)