### PR TITLE
fix(ui): add confirmation modal for session archive

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -31,6 +31,7 @@ import {
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import {
+  App,
   Badge,
   Button,
   Card,
@@ -196,6 +197,7 @@ const WorktreeCardComponent = ({
   client,
 }: WorktreeCardProps) => {
   const { token } = theme.useToken();
+  const { modal } = App.useApp();
   const connectionDisabled = useConnectionDisabled();
   const schedulerEnabled = useServiceEnabled('scheduler');
   const gatewayEnabled = useServiceEnabled('gateway');
@@ -239,26 +241,34 @@ const WorktreeCardComponent = ({
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
 
   const handleArchiveSession = useCallback(
-    async (sessionId: string, e: React.MouseEvent) => {
+    (sessionId: string, e: React.MouseEvent) => {
       e.stopPropagation();
 
-      setArchivingSessionIds((prev) => new Set(prev).add(sessionId));
-      try {
-        const result = await archiveSession(sessionId as SessionID);
-        if (result) {
-          message.success('Session archived');
-        } else {
-          message.error('Failed to archive session');
-        }
-      } finally {
-        setArchivingSessionIds((prev) => {
-          const next = new Set(prev);
-          next.delete(sessionId);
-          return next;
-        });
-      }
+      modal.confirm({
+        title: 'Archive Session',
+        content: 'Are you sure you want to archive this session?',
+        okText: 'Archive',
+        cancelText: 'Cancel',
+        onOk: async () => {
+          setArchivingSessionIds((prev) => new Set(prev).add(sessionId));
+          try {
+            const result = await archiveSession(sessionId as SessionID);
+            if (result) {
+              message.success('Session archived');
+            } else {
+              message.error('Failed to archive session');
+            }
+          } finally {
+            setArchivingSessionIds((prev) => {
+              const next = new Set(prev);
+              next.delete(sessionId);
+              return next;
+            });
+          }
+        },
+      });
     },
-    [archiveSession]
+    [archiveSession, modal]
   );
 
   // Gateway session helpers (delegating to @agor-live/client)


### PR DESCRIPTION
## Summary
- Adds a confirmation dialog (`modal.confirm()`) when clicking the archive button on session hover in WorktreeCard
- Prevents accidental session archival when short session names cause the hover buttons to overlap the clickable area

## Test plan
- [ ] Open a board with worktree cards containing sessions
- [ ] Hover over a session row — settings + archive buttons appear
- [ ] Click the archive button → confirmation modal should appear
- [ ] Click Cancel → session remains unchanged
- [ ] Click Archive → session archives with success message

## Screenshots:

Session archived:

https://github.com/user-attachments/assets/c02f2656-a6ee-47c1-b0af-99fa9a38e89e



Session un-archived and re-archived:

https://github.com/user-attachments/assets/68cd915b-7312-4e03-87b0-66c78dbd214e








🤖 Generated with [Claude Code](https://claude.com/claude-code)