### PR TITLE
fix(boards): fix custom CSS clearing, specificity, and form state

### DIFF
--- a/apps/agor-docs/pages/guide/getting-started.mdx
+++ b/apps/agor-docs/pages/guide/getting-started.mdx
@@ -130,9 +130,37 @@ Agor supports multiple AI coding agents (Claude Code, Codex, Gemini, OpenCode). 
 
 Agor offers **three ways** to configure AI credentials, in order of priority:
 
-#### Option 1: CLI Login (Recommended for Claude)
+#### Option 1: Claude Max Pro / Pro Plan (Recommended) {#claude-max-pro}
 
-The fastest way to get started with Claude Code:
+If you have a **Claude Max Pro** (or Pro) subscription, you can use it directly with Agor — no API key needed.
+
+**Step 1: Install Claude CLI** on your local machine (skip if you already have it):
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+> Don't have `npm`? Install [Node.js](https://nodejs.org) first (download the LTS version), then retry the command above.
+
+**Step 2: Generate a session token:**
+
+```bash
+claude setup-token
+```
+
+This outputs a token value — copy it.
+
+**Step 3: Paste the token into Agor:**
+
+1. In Agor, click the **gear icon** (top right) to open **User Settings**
+2. Go to the **"Env vars"** section
+3. Add: **`CLAUDE_CODE_OAUTH_TOKEN`** = _your token_
+
+That's it! Agor will use your Claude subscription for all Claude Code sessions.
+
+#### Option 1b: CLI Login (Alternative for self-hosted)
+
+If you're running Agor on a machine where you can SSH in and run commands directly:
 
 ```bash
 claude login
@@ -189,10 +217,11 @@ export GOOGLE_AI_API_KEY="..."
 When you start a session, Agor checks for credentials in this order:
 
 1. **Per-user API keys** (if set in Settings → Agentic Tools)
-2. **`claude login` credentials** (if you ran `claude login`)
-3. **Environment variables** (global fallback)
+2. **`CLAUDE_CODE_OAUTH_TOKEN`** (if set via `claude setup-token` in User Settings → Env vars)
+3. **`claude login` credentials** (if you ran `claude login` on the server)
+4. **Environment variables** (global fallback)
 
-This lets you mix approaches - use `claude login` for yourself while teammates use per-user keys.
+This lets you mix approaches — use `claude setup-token` with your Max Pro plan while teammates use per-user API keys.
 
 ---
 

--- a/apps/agor-docs/pages/guide/getting-started.mdx
+++ b/apps/agor-docs/pages/guide/getting-started.mdx
@@ -130,7 +130,9 @@ Agor supports multiple AI coding agents (Claude Code, Codex, Gemini, OpenCode). 
 
 Agor offers **three ways** to configure AI credentials, in order of priority:
 
-#### Option 1: Claude Max Pro / Pro Plan (Recommended) {#claude-max-pro}
+<a id="claude-max-pro" />
+
+#### Option 1: Claude Max Pro / Pro Plan (Recommended)
 
 If you have a **Claude Max Pro** (or Pro) subscription, you can use it directly with Agor — no API key needed.
 

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -140,6 +140,15 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
               {docUrl}
             </Link>
           </Text>
+          {field === 'ANTHROPIC_API_KEY' && !isSet && (
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              Claude Max/Pro plan user? You don't need an API key — use{' '}
+              <Text code style={{ fontSize: token.fontSizeSM }}>claude setup-token</Text> instead.{' '}
+              <Link href="/guide/getting-started#claude-max-pro" target="_blank">
+                See the docs
+              </Link>
+            </Text>
+          )}
         </Space>
       </div>
     );

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -143,7 +143,10 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
           {field === 'ANTHROPIC_API_KEY' && !isSet && (
             <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
               Claude Max/Pro plan user? You don't need an API key — use{' '}
-              <Text code style={{ fontSize: token.fontSizeSM }}>claude setup-token</Text> instead.{' '}
+              <Text code style={{ fontSize: token.fontSizeSM }}>
+                claude setup-token
+              </Text>{' '}
+              instead.{' '}
               <Link href="/guide/getting-started#claude-max-pro" target="_blank">
                 See the docs
               </Link>

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
@@ -20,9 +20,12 @@ export const BoardTab: React.FC<BoardTabProps> = ({ onValidityChange, formRef })
 
   formRef.current = async () => {
     try {
-      await form.validateFields(['name']);
+      // Validate all fields (not just 'name') so custom_context JSON rules run
+      // before the extractor calls JSON.parse on it.
+      await form.validateFields();
       return extractBoardFormValues(form);
     } catch {
+      // Antd displays inline field errors; parent treats null as "not valid".
       return null;
     }
   };

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
@@ -1,7 +1,7 @@
 import type { Board } from '@agor-live/client';
 import { Form } from 'antd';
-import { useCallback, useState } from 'react';
-import { BoardFormFields } from '../../forms/BoardFormFields';
+import { useCallback } from 'react';
+import { BoardFormFields, extractBoardFormValues } from '../../forms/BoardFormFields';
 
 export interface BoardTabProps {
   onValidityChange: (valid: boolean) => void;
@@ -10,7 +10,6 @@ export interface BoardTabProps {
 
 export const BoardTab: React.FC<BoardTabProps> = ({ onValidityChange, formRef }) => {
   const [form] = Form.useForm();
-  const [useCustomCSS, setUseCustomCSS] = useState(false);
 
   const handleValuesChange = useCallback(() => {
     setTimeout(() => {
@@ -21,31 +20,16 @@ export const BoardTab: React.FC<BoardTabProps> = ({ onValidityChange, formRef })
 
   formRef.current = async () => {
     try {
-      const values = await form.validateFields();
-      return {
-        name: values.name,
-        icon: values.icon || '📋',
-        description: values.description,
-        background_color: values.background_color
-          ? typeof values.background_color === 'string'
-            ? values.background_color
-            : values.background_color.toHexString()
-          : undefined,
-        custom_css: values.custom_css || undefined,
-      };
+      await form.validateFields(['name']);
+      return extractBoardFormValues(form);
     } catch {
       return null;
     }
   };
 
   return (
-    <Form form={form} layout="vertical" onValuesChange={handleValuesChange}>
-      <BoardFormFields
-        form={form}
-        useCustomCSS={useCustomCSS}
-        onCustomCSSChange={setUseCustomCSS}
-        autoFocus
-      />
+    <Form form={form} layout="vertical" preserve onValuesChange={handleValuesChange}>
+      <BoardFormFields form={form} autoFocus />
     </Form>
   );
 };

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -307,14 +307,29 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const { token } = theme.useToken();
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
-    const canvasBackground = board?.background_color ?? defaultBackground;
+    const hasCustomCss = Boolean(board?.custom_css?.trim());
+
+    // When custom_css is active, move background into the <style> tag to avoid
+    // specificity conflicts (inline `background` shorthand resets background-size to auto)
+    const canvasBackground = hasCustomCss
+      ? undefined
+      : (board?.background_color ?? defaultBackground);
 
     // Sanitize and scope custom CSS for this board (enables @keyframes, animations, etc.)
     const boardCssClass = board?.board_id ? `board-css-${board.board_id.slice(0, 8)}` : '';
-    const scopedCustomCss = useMemo(
-      () => sanitizeBoardCss(board?.custom_css, `.${boardCssClass}`),
-      [board?.custom_css, boardCssClass]
-    );
+    const scopedCustomCss = useMemo(() => {
+      if (!hasCustomCss) return '';
+      // Prepend background_color as a CSS rule so it's at the same specificity as custom_css
+      const bgValue = board?.background_color || defaultBackground;
+      const bgRule = `background: ${bgValue};\n`;
+      return sanitizeBoardCss(bgRule + (board?.custom_css || ''), `.${boardCssClass}`);
+    }, [
+      board?.custom_css,
+      board?.background_color,
+      boardCssClass,
+      hasCustomCss,
+      defaultBackground,
+    ]);
 
     // Note: sessionsByWorktree is now passed as prop (no longer computed locally)
     // This enables efficient O(1) lookups and stable references across re-renders

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -308,28 +308,24 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
     const hasCustomCss = Boolean(board?.custom_css?.trim());
+    const hasUserBg = Boolean(board?.background_color?.trim());
+    // Any user-provided styling goes through the sanitized <style> tag so that
+    // background_color can't bypass the sanitizer with url()/expression()/etc.
+    const hasUserStyling = hasCustomCss || hasUserBg;
 
-    // When custom_css is active, move background into the <style> tag to avoid
-    // specificity conflicts (inline `background` shorthand resets background-size to auto)
-    const canvasBackground = hasCustomCss
-      ? undefined
-      : (board?.background_color ?? defaultBackground);
+    // Only the trusted defaultBackground is applied inline; anything user-provided
+    // is sanitized and routed through the scoped <style> tag below.
+    const canvasBackground = hasUserStyling ? undefined : defaultBackground;
 
     // Sanitize and scope custom CSS for this board (enables @keyframes, animations, etc.)
     const boardCssClass = board?.board_id ? `board-css-${board.board_id.slice(0, 8)}` : '';
     const scopedCustomCss = useMemo(() => {
-      if (!hasCustomCss) return '';
+      if (!hasUserStyling) return '';
       // Prepend background_color as a CSS rule so it's at the same specificity as custom_css
-      const bgValue = board?.background_color || defaultBackground;
-      const bgRule = `background: ${bgValue};\n`;
+      // and goes through the same sanitizer.
+      const bgRule = hasUserBg ? `background: ${board?.background_color};\n` : '';
       return sanitizeBoardCss(bgRule + (board?.custom_css || ''), `.${boardCssClass}`);
-    }, [
-      board?.custom_css,
-      board?.background_color,
-      boardCssClass,
-      hasCustomCss,
-      defaultBackground,
-    ]);
+    }, [board?.custom_css, board?.background_color, boardCssClass, hasUserStyling, hasUserBg]);
 
     // Note: sessionsByWorktree is now passed as prop (no longer computed locally)
     // This enables efficient O(1) lookups and stable references across re-renders

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -85,14 +85,18 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   }, [boardById, sessionsByWorktree, worktreeById]);
 
   const handleCreate = () => {
+    // Validate all fields (not just 'name') so custom_context JSON rules run.
+    // Otherwise the extractor's JSON.parse can throw and get swallowed.
     form
-      .validateFields(['name'])
+      .validateFields()
       .then(() => {
         onCreate?.(extractBoardFormValues(form));
         form.resetFields();
         setCreateModalOpen(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        // Antd displays inline field errors; nothing to do here.
+      });
   };
 
   const handleEdit = (board: Board) => {
@@ -112,14 +116,16 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
     if (!editingBoard) return;
 
     form
-      .validateFields(['name'])
+      .validateFields()
       .then(() => {
         onUpdate?.(editingBoard.board_id, extractBoardFormValues(form));
         form.resetFields();
         setEditModalOpen(false);
         setEditingBoard(null);
       })
-      .catch(() => {});
+      .catch(() => {
+        // Antd displays inline field errors; nothing to do here.
+      });
   };
 
   const handleDelete = (boardId: string) => {
@@ -412,7 +418,10 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         okText="Save"
       >
         <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
+          {/* Keyed on board_id so useCustomCSS state and Collapse defaultActiveKey
+              re-initialize when switching between boards (Modal stays mounted). */}
           <BoardFormFields
+            key={editingBoard?.board_id}
             form={form}
             extra={customContextField}
             initialCustomCSS={

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -26,7 +26,7 @@ import {
 import { useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
-import { BoardFormFields } from '../forms/BoardFormFields';
+import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 
 interface BoardsTableProps {
@@ -58,17 +58,9 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingBoard, setEditingBoard] = useState<Board | null>(null);
-  const [useCustomCSSCreate, setUseCustomCSSCreate] = useState(false);
-  const [useCustomCSSEdit, setUseCustomCSSEdit] = useState(false);
   const [archiveFilter, setArchiveFilter] = useState<'active' | 'archived' | 'all'>('active');
   const [hoveredArchiveButton, setHoveredArchiveButton] = useState<string | null>(null);
   const [form] = Form.useForm();
-
-  // Helper to detect if a background value is custom CSS (not a simple hex color)
-  const isCustomCSS = (value: string | undefined): boolean => {
-    if (!value) return false;
-    return !value.match(/^#[0-9a-fA-F]{3,8}$/) && !value.match(/^rgba?\(/);
-  };
 
   // Calculate session count per board (worktree-centric model)
   const boardSessionCounts = useMemo(() => {
@@ -93,29 +85,18 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   }, [boardById, sessionsByWorktree, worktreeById]);
 
   const handleCreate = () => {
-    form.validateFields().then((values) => {
-      onCreate?.({
-        name: values.name,
-        icon: values.icon || '📋',
-        description: values.description,
-        background_color: values.background_color
-          ? typeof values.background_color === 'string'
-            ? values.background_color
-            : values.background_color.toHexString()
-          : undefined,
-        custom_css: values.custom_css || undefined,
-        custom_context: values.custom_context ? JSON.parse(values.custom_context) : undefined,
-      });
-      form.resetFields();
-      setCreateModalOpen(false);
-      setUseCustomCSSCreate(false);
-    });
+    form
+      .validateFields(['name'])
+      .then(() => {
+        onCreate?.(extractBoardFormValues(form));
+        form.resetFields();
+        setCreateModalOpen(false);
+      })
+      .catch(() => {});
   };
 
   const handleEdit = (board: Board) => {
     setEditingBoard(board);
-    const hasCustomCSS = isCustomCSS(board.background_color);
-    setUseCustomCSSEdit(hasCustomCSS);
     form.setFieldsValue({
       name: board.name,
       icon: board.icon,
@@ -130,24 +111,15 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const handleUpdate = () => {
     if (!editingBoard) return;
 
-    form.validateFields().then((values) => {
-      onUpdate?.(editingBoard.board_id, {
-        name: values.name,
-        icon: values.icon,
-        description: values.description,
-        background_color: values.background_color
-          ? typeof values.background_color === 'string'
-            ? values.background_color
-            : values.background_color.toHexString()
-          : undefined,
-        custom_css: values.custom_css || undefined,
-        custom_context: values.custom_context ? JSON.parse(values.custom_context) : undefined,
-      });
-      form.resetFields();
-      setEditModalOpen(false);
-      setEditingBoard(null);
-      setUseCustomCSSEdit(false);
-    });
+    form
+      .validateFields(['name'])
+      .then(() => {
+        onUpdate?.(editingBoard.board_id, extractBoardFormValues(form));
+        form.resetFields();
+        setEditModalOpen(false);
+        setEditingBoard(null);
+      })
+      .catch(() => {});
   };
 
   const handleDelete = (boardId: string) => {
@@ -419,17 +391,11 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         onCancel={() => {
           form.resetFields();
           setCreateModalOpen(false);
-          setUseCustomCSSCreate(false);
         }}
         okText="Create"
       >
-        <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
-          <BoardFormFields
-            form={form}
-            useCustomCSS={useCustomCSSCreate}
-            onCustomCSSChange={setUseCustomCSSCreate}
-            extra={customContextField}
-          />
+        <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
+          <BoardFormFields form={form} extra={customContextField} />
         </Form>
       </Modal>
 
@@ -442,16 +408,16 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
           form.resetFields();
           setEditModalOpen(false);
           setEditingBoard(null);
-          setUseCustomCSSEdit(false);
         }}
         okText="Save"
       >
-        <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
           <BoardFormFields
             form={form}
-            useCustomCSS={useCustomCSSEdit}
-            onCustomCSSChange={setUseCustomCSSEdit}
             extra={customContextField}
+            initialCustomCSS={
+              isCustomCSS(editingBoard?.background_color) || Boolean(editingBoard?.custom_css)
+            }
           />
         </Form>
       </Modal>

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -1,5 +1,16 @@
 import type { FormInstance } from 'antd';
-import { Checkbox, ColorPicker, Flex, Form, Input, Select, Space, Typography } from 'antd';
+import {
+  Checkbox,
+  Collapse,
+  ColorPicker,
+  Flex,
+  Form,
+  Input,
+  Select,
+  Space,
+  Typography,
+} from 'antd';
+import { useState } from 'react';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 
 export const BACKGROUND_PRESETS = [
@@ -139,30 +150,74 @@ animation: agorHScroll 20s linear infinite;
   },
 ];
 
+/** Detect if a background value is custom CSS (not a simple hex color or rgba) */
+export function isCustomCSS(value: string | undefined | null): boolean {
+  if (!value) return false;
+  return !value.match(/^#[0-9a-fA-F]{3,8}$/) && !value.match(/^rgba?\(/);
+}
+
+/**
+ * Extract board form values from the form instance.
+ * Uses getFieldsValue(true) to include values from collapsed/unmounted fields.
+ * Sends null for cleared fields so the backend actually clears them.
+ */
+export function extractBoardFormValues(form: FormInstance): Partial<{
+  name: string;
+  icon: string;
+  description: string;
+  background_color: string | null;
+  custom_css: string | null;
+  custom_context: Record<string, unknown> | null;
+}> {
+  const values = form.getFieldsValue(true);
+  const bgColor = values.background_color;
+  return {
+    name: values.name,
+    icon: values.icon || '📋',
+    description: values.description,
+    // Send null to explicitly clear, not undefined (which gets dropped by JSON.stringify)
+    background_color: bgColor
+      ? typeof bgColor === 'string'
+        ? bgColor
+        : bgColor.toHexString()
+      : null,
+    custom_css: values.custom_css || null,
+    custom_context: values.custom_context ? JSON.parse(values.custom_context) : null,
+  };
+}
+
 export interface BoardFormFieldsProps {
   form: FormInstance;
-  useCustomCSS: boolean;
-  onCustomCSSChange: (checked: boolean) => void;
   /** Whether to auto-focus the name input */
   autoFocus?: boolean;
-  /** Extra content rendered after the background section (e.g. custom context JSON) */
+  /** Extra content rendered inside the "Advanced" collapse panel */
   extra?: React.ReactNode;
+  /** Initial custom CSS mode — auto-detected from board values if not provided */
+  initialCustomCSS?: boolean;
 }
 
 /**
  * Shared board form fields used in the CreateDialog BoardTab
  * and the SettingsModal BoardsTable create/edit modals.
  *
- * Renders: Name (icon + text), Description, Background (color picker / CSS presets).
+ * Renders: Name, Description, and collapsible CSS / Advanced sections.
+ * Manages useCustomCSS state internally.
  * Does NOT render a <Form> wrapper — the parent owns the form instance.
  */
 export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
   form,
-  useCustomCSS,
-  onCustomCSSChange,
   autoFocus,
   extra,
+  initialCustomCSS = false,
 }) => {
+  const [useCustomCSS, setUseCustomCSS] = useState(initialCustomCSS);
+
+  // Auto-expand CSS section if the board already has background or custom_css values
+  const defaultActiveKeys: string[] = [];
+  if (initialCustomCSS) {
+    defaultActiveKeys.push('css');
+  }
+
   return (
     <>
       <Form.Item label="Name" style={{ marginBottom: 24 }}>
@@ -185,94 +240,118 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
         <Input.TextArea placeholder="Optional description..." rows={3} />
       </Form.Item>
 
-      <Form.Item label="Background">
-        <Space direction="vertical" style={{ width: '100%' }}>
-          <Checkbox
-            checked={useCustomCSS}
-            onChange={(e) => {
-              onCustomCSSChange(e.target.checked);
-              if (e.target.checked) {
-                form.setFieldsValue({ background_color: undefined });
-              }
-            }}
-          >
-            Use custom CSS background
-          </Checkbox>
+      <Collapse
+        defaultActiveKey={defaultActiveKeys}
+        ghost
+        style={{ marginBottom: 16 }}
+        items={[
+          {
+            key: 'css',
+            label: 'CSS Background',
+            children: (
+              <>
+                <Space direction="vertical" style={{ width: '100%', marginBottom: 16 }}>
+                  <Checkbox
+                    checked={useCustomCSS}
+                    onChange={(e) => {
+                      setUseCustomCSS(e.target.checked);
+                      if (e.target.checked) {
+                        // Clear color picker value when switching to custom CSS mode
+                        const current = form.getFieldValue('background_color');
+                        if (current && typeof current !== 'string') {
+                          form.setFieldsValue({ background_color: current.toHexString() });
+                        }
+                      }
+                    }}
+                  >
+                    Use custom CSS background
+                  </Checkbox>
 
-          {!useCustomCSS ? (
-            <Form.Item name="background_color" noStyle>
-              <ColorPicker showText format="hex" allowClear />
-            </Form.Item>
-          ) : (
-            <>
-              <Select
-                placeholder="Load a preset..."
-                style={{ width: '100%', marginBottom: 8 }}
-                allowClear
-                showSearch
-                options={BACKGROUND_PRESETS}
-                onChange={(value) => {
-                  if (value) {
-                    form.setFieldsValue({ background_color: value });
-                  }
-                }}
-              />
-              <Form.Item name="background_color" noStyle>
-                <Input.TextArea
-                  placeholder="Enter custom CSS or select a preset above"
-                  rows={3}
-                  style={{ fontFamily: 'monospace', fontSize: '12px' }}
-                />
-              </Form.Item>
-            </>
-          )}
+                  {!useCustomCSS ? (
+                    <Form.Item name="background_color" noStyle>
+                      <ColorPicker showText format="hex" allowClear />
+                    </Form.Item>
+                  ) : (
+                    <>
+                      <Select
+                        placeholder="Load a preset..."
+                        style={{ width: '100%', marginBottom: 8 }}
+                        allowClear
+                        showSearch
+                        options={BACKGROUND_PRESETS}
+                        onChange={(value) => {
+                          if (value) {
+                            form.setFieldsValue({ background_color: value });
+                          }
+                        }}
+                      />
+                      <Form.Item name="background_color" noStyle>
+                        <Input.TextArea
+                          placeholder="Enter custom CSS background value (gradients, patterns, etc.)"
+                          rows={3}
+                          style={{ fontFamily: 'monospace', fontSize: '12px' }}
+                        />
+                      </Form.Item>
+                    </>
+                  )}
 
-          <Typography.Text
-            type="secondary"
-            style={{ fontSize: '12px', display: 'block', marginTop: 4 }}
-          >
-            {!useCustomCSS
-              ? 'Set a solid background color for the board canvas'
-              : 'Choose a preset or enter any valid CSS background property (gradients, patterns, etc.)'}
-          </Typography.Text>
-        </Space>
-      </Form.Item>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: '12px', display: 'block', marginTop: 4 }}
+                  >
+                    {!useCustomCSS
+                      ? 'Set a solid background color for the board canvas'
+                      : 'Enter any valid CSS background value (gradients, patterns, etc.)'}
+                  </Typography.Text>
+                </Space>
 
-      {useCustomCSS && (
-        <Form.Item
-          label="Animation CSS"
-          tooltip="Add @keyframes, animation, background-size, and other CSS properties. Rendered in a scoped <style> tag."
-        >
-          <Select
-            placeholder="Load an animation preset..."
-            style={{ width: '100%', marginBottom: 8 }}
-            allowClear
-            showSearch
-            options={ANIMATION_PRESETS}
-            onChange={(value) => {
-              if (value) {
-                form.setFieldsValue({ custom_css: value });
-              }
-            }}
-          />
-          <Form.Item name="custom_css" noStyle>
-            <Input.TextArea
-              placeholder={`@keyframes bioGlow {\n  0%, 100% { background-position: 0% 50%; }\n  50% { background-position: 100% 50%; }\n}\n\nbackground-size: 400% 400%;\nanimation: bioGlow 12s ease infinite;`}
-              rows={6}
-              style={{ fontFamily: 'monospace', fontSize: '12px' }}
-            />
-          </Form.Item>
-          <Typography.Text
-            type="secondary"
-            style={{ fontSize: '12px', display: 'block', marginTop: 4 }}
-          >
-            Supports @keyframes, animation, background-size, and other CSS. Dangerous patterns (url,
-            expression, @import) are blocked for security.
-          </Typography.Text>
-        </Form.Item>
-      )}
-
-      {extra}
+                {useCustomCSS && (
+                  <Space direction="vertical" style={{ width: '100%' }}>
+                    <Typography.Text strong style={{ fontSize: '13px' }}>
+                      Animation CSS
+                    </Typography.Text>
+                    <Select
+                      placeholder="Load an animation preset..."
+                      style={{ width: '100%', marginBottom: 8 }}
+                      allowClear
+                      showSearch
+                      options={ANIMATION_PRESETS}
+                      onChange={(value) => {
+                        if (value) {
+                          form.setFieldsValue({ custom_css: value });
+                        }
+                      }}
+                    />
+                    <Form.Item name="custom_css" noStyle>
+                      <Input.TextArea
+                        placeholder={`@keyframes bioGlow {\n  0%, 100% { background-position: 0% 50%; }\n  50% { background-position: 100% 50%; }\n}\n\nbackground-size: 400% 400%;\nanimation: bioGlow 12s ease infinite;`}
+                        rows={6}
+                        style={{ fontFamily: 'monospace', fontSize: '12px' }}
+                      />
+                    </Form.Item>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: '12px', display: 'block', marginTop: 4 }}
+                    >
+                      Supports @keyframes, animation, background-size, and other CSS. Dangerous
+                      patterns (url, expression, @import) are blocked for security.
+                    </Typography.Text>
+                  </Space>
+                )}
+              </>
+            ),
+          },
+          ...(extra
+            ? [
+                {
+                  key: 'advanced',
+                  label: 'Advanced',
+                  children: extra,
+                },
+              ]
+            : []),
+        ]}
+      />
     </>
   );
 };

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -1,3 +1,4 @@
+import type { Board } from '@agor-live/client';
 import type { FormInstance } from 'antd';
 import {
   Checkbox,
@@ -159,23 +160,19 @@ export function isCustomCSS(value: string | undefined | null): boolean {
 /**
  * Extract board form values from the form instance.
  * Uses getFieldsValue(true) to include values from collapsed/unmounted fields.
- * Sends null for cleared fields so the backend actually clears them.
+ * Sends `null` for cleared fields so the backend actually clears them
+ * (undefined is dropped by JSON.stringify and never reaches the server's
+ * shallow-merge patch). The `Board` type uses `string | undefined`, but at
+ * runtime the boards repository treats `null` as "clear this field", so the
+ * cast is honest about wire semantics even though TS can't express them.
  */
-export function extractBoardFormValues(form: FormInstance): Partial<{
-  name: string;
-  icon: string;
-  description: string;
-  background_color: string | null;
-  custom_css: string | null;
-  custom_context: Record<string, unknown> | null;
-}> {
+export function extractBoardFormValues(form: FormInstance): Partial<Board> {
   const values = form.getFieldsValue(true);
   const bgColor = values.background_color;
   return {
     name: values.name,
     icon: values.icon || '📋',
     description: values.description,
-    // Send null to explicitly clear, not undefined (which gets dropped by JSON.stringify)
     background_color: bgColor
       ? typeof bgColor === 'string'
         ? bgColor
@@ -183,7 +180,7 @@ export function extractBoardFormValues(form: FormInstance): Partial<{
       : null,
     custom_css: values.custom_css || null,
     custom_context: values.custom_context ? JSON.parse(values.custom_context) : null,
-  };
+  } as unknown as Partial<Board>;
 }
 
 export interface BoardFormFieldsProps {


### PR DESCRIPTION
## Summary
- **Clearing bug fix**: Sends `null` instead of `undefined` when clearing `background_color`/`custom_css`, so the backend actually clears the values
- **CSS specificity fix**: When `custom_css` is active, moves `background_color` into the scoped `<style>` tag instead of inline style (inline `background` shorthand was resetting `background-size` to `auto`)
- **Form state centralization**: `useCustomCSS` state moved inside `BoardFormFields`, form handlers use `getFieldsValue(true)` to include values from collapsed sections
- **Collapsible sections**: CSS Background and Advanced (custom context) now in `Collapse` panels

## Changes
- `apps/agor-ui/src/components/forms/BoardFormFields.tsx` — centralized state, Collapse panels, `extractBoardFormValues()` helper
- `apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx` — simplified (removed useCustomCSS state)
- `apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx` — simplified (removed useCustomCSS states, uses extractBoardFormValues)
- `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx` — moves background into `<style>` tag when custom_css is active

Also includes unrelated docs updates from another agent.

## Test plan
- [ ] Edit board with gradient background → clear the background field → save → verify it's actually cleared
- [ ] Set both background gradient + animation CSS → verify animation plays (no specificity conflict)
- [ ] Collapse the CSS section → save → verify CSS values are preserved
- [ ] Create new board with collapsed sections → verify no stale values

🤖 Generated with [Claude Code](https://claude.com/claude-code)