### PR TITLE
fix(ui): prevent btw tag from wrapping to multiple lines

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -367,7 +367,7 @@ const WorktreeCardComponent = ({
       if (node.relationshipType === 'fork') {
         if (session.fork_origin === 'btw') {
           return (
-            <Typography.Text style={{ fontSize: 9, color: token.colorWarning, fontWeight: 'bold' }}>
+            <Typography.Text style={{ fontSize: 9, color: token.colorWarning, fontWeight: 'bold', whiteSpace: 'nowrap', flexShrink: 0 }}>
               btw
             </Typography.Text>
           );
@@ -448,7 +448,7 @@ const WorktreeCardComponent = ({
             }
           }}
         >
-          <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
+          <Space size={4} align="center" style={{ flex: 1, minWidth: 0, flexWrap: 'nowrap' }}>
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             {getRelationshipIcon()}
             <Typography.Text
@@ -456,6 +456,7 @@ const WorktreeCardComponent = ({
               style={{
                 fontSize: 12,
                 flex: 1,
+                minWidth: 0,
                 ...getSessionTitleStyles(2),
               }}
             >

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -367,7 +367,15 @@ const WorktreeCardComponent = ({
       if (node.relationshipType === 'fork') {
         if (session.fork_origin === 'btw') {
           return (
-            <Typography.Text style={{ fontSize: 9, color: token.colorWarning, fontWeight: 'bold', whiteSpace: 'nowrap', flexShrink: 0 }}>
+            <Typography.Text
+              style={{
+                fontSize: 9,
+                color: token.colorWarning,
+                fontWeight: 'bold',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}
+            >
               btw
             </Typography.Text>
           );

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -456,7 +456,7 @@ const WorktreeCardComponent = ({
             }
           }}
         >
-          <Space size={4} align="center" style={{ flex: 1, minWidth: 0, flexWrap: 'nowrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             {getRelationshipIcon()}
             <Typography.Text
@@ -470,7 +470,7 @@ const WorktreeCardComponent = ({
             >
               {getSessionDisplayTitle(session, { includeAgentFallback: true })}
             </Typography.Text>
-          </Space>
+          </div>
         </div>
       </SessionItemWithActions>
     );


### PR DESCRIPTION
## Summary
- Add `whiteSpace: 'nowrap'` and `flexShrink: 0` to the "btw" badge so it never wraps or shrinks
- Add `flexWrap: 'nowrap'` to the session row `Space` container to prevent line-breaking
- Add `minWidth: 0` to the session title `Typography.Text` so it can properly truncate via `text-overflow: ellipsis` when space is tight

## Test plan
- [ ] Open a WorktreeCard with a btw-forked session that has a long title
- [ ] Verify the "btw" badge stays on a single line next to the icon
- [ ] Verify the session title truncates (not the badge) when the card is narrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)