### PR TITLE
fix(core): add Vertex AI and Bedrock env vars to executor allowlist

### DIFF
--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -76,13 +76,26 @@ export const ALLOWED_ENV_VARS = new Set([
   'GIT_COMMITTER_EMAIL',
   'GIT_SSH_COMMAND',
 
-  // Anthropic / AI SDK
+  // Anthropic / AI SDK — Edited by Claude
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
   'OPENAI_API_KEY',
   'GEMINI_API_KEY',
   'GOOGLE_API_KEY',
+
+  // Vertex AI (Claude Code on GCP)
+  'CLAUDE_CODE_USE_VERTEX',
+  'ANTHROPIC_VERTEX_PROJECT_ID',
+  'ANTHROPIC_VERTEX_REGION',
+  'GOOGLE_CLOUD_PROJECT',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'CLOUD_ML_REGION',
+  'CLOUD_ML_PROJECT_ID',
+
+  // Bedrock (Claude Code on AWS)
+  'CLAUDE_CODE_USE_BEDROCK',
+  'ANTHROPIC_BEDROCK_BASE_URL',
 
   // Agor session context (safe for executor/sessions)
   'DAEMON_URL',
@@ -95,6 +108,8 @@ export const ALLOWED_ENV_VARS = new Set([
 export const ALLOWED_ENV_PREFIXES = [
   'LC_', // Locale settings (LC_ALL, LC_CTYPE, etc.)
   'XDG_', // Freedesktop directories (XDG_DATA_HOME, XDG_CONFIG_HOME, etc.)
+  'CLAUDE_CODE_', // All Claude Code config vars (use_vertex, use_bedrock, etc.)
+  'ANTHROPIC_', // All Anthropic SDK vars (catches future additions)
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Add missing Vertex AI env vars (`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `ANTHROPIC_VERTEX_REGION`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_APPLICATION_CREDENTIALS`, `CLOUD_ML_REGION`, `CLOUD_ML_PROJECT_ID`) to `ALLOWED_ENV_VARS`
- Add missing Bedrock env vars (`CLAUDE_CODE_USE_BEDROCK`, `ANTHROPIC_BEDROCK_BASE_URL`) to `ALLOWED_ENV_VARS`
- Add `CLAUDE_CODE_` and `ANTHROPIC_` to `ALLOWED_ENV_PREFIXES` to future-proof against missing individual vars

## Problem

Running an Agor session with Claude Code on Vertex AI fails with "Not logged in · Please run /login" despite all Vertex env vars being correctly set in the daemon's environment. The `buildAllowlistedEnv()` function strips Vertex/Bedrock-specific vars because they are not in the allowlist, so the executor process inherits a clean environment with no cloud provider config. Claude Code falls back to direct API auth, which fails.

## Test plan

- [x] Verify Vertex AI sessions authenticate correctly (`CLAUDE_CODE_USE_VERTEX=1`)
- [ ] Verify Bedrock sessions authenticate correctly (`CLAUDE_CODE_USE_BEDROCK=1`)
- [ ] Verify direct API key auth still works (`ANTHROPIC_API_KEY`)
- [ ] Verify no daemon-internal vars leak (e.g., `AGOR_MASTER_SECRET`, `DATABASE_URL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)