### PR TITLE
fix(upload): use worktree RBAC instead of session ownership

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -46,6 +46,7 @@ import type {
   StreamingEventType,
   Task,
   User,
+  UUID,
 } from '@agor/core/types';
 import {
   AGENTIC_TOOL_CAPABILITIES,
@@ -76,10 +77,7 @@ import {
   requireMinimumRole,
 } from './utils/authorization.js';
 import { createUploadMiddleware } from './utils/upload.js';
-import {
-  ensureWorktreePermission,
-  hasWorktreePermission,
-} from './utils/worktree-authorization.js';
+import { ensureWorktreePermission, hasWorktreePermission } from './utils/worktree-authorization.js';
 
 /**
  * Extended Params with route ID parameter.
@@ -1094,11 +1092,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       if (worktreeRbacEnabled && session.worktree_id && params.user?.user_id) {
         const wt = await worktreeRepo.findById(session.worktree_id);
         if (wt) {
-          const isOwner = await worktreeRepo.isOwner(wt.worktree_id, params.user.user_id);
+          const userId = params.user.user_id as UUID;
+          const isOwner = await worktreeRepo.isOwner(wt.worktree_id, userId);
           if (
             !hasWorktreePermission(
               wt,
-              params.user.user_id,
+              userId,
               isOwner,
               'prompt',
               params.user.role,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -76,7 +76,10 @@ import {
   requireMinimumRole,
 } from './utils/authorization.js';
 import { createUploadMiddleware } from './utils/upload.js';
-import { ensureWorktreePermission } from './utils/worktree-authorization.js';
+import {
+  ensureWorktreePermission,
+  hasWorktreePermission,
+} from './utils/worktree-authorization.js';
 
 /**
  * Extended Params with route ID parameter.
@@ -1085,11 +1088,29 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         return res.status(404).json({ error: 'Session not found' });
       }
 
-      if (session.created_by !== params.user?.user_id) {
-        console.error(
-          `❌ [Upload Handler] User ${params.user?.user_id?.substring(0, 8)} not authorized for session ${sessionId.substring(0, 8)}`
-        );
-        return res.status(403).json({ error: 'Not authorized to upload to this session' });
+      // Worktree RBAC: check worktree-level permission instead of session ownership.
+      // Users with 'prompt' or higher on the worktree can upload files.
+      // When RBAC is disabled, fall back to allowing any authenticated member.
+      if (worktreeRbacEnabled && session.worktree_id && params.user?.user_id) {
+        const wt = await worktreeRepo.findById(session.worktree_id);
+        if (wt) {
+          const isOwner = await worktreeRepo.isOwner(wt.worktree_id, params.user.user_id);
+          if (
+            !hasWorktreePermission(
+              wt,
+              params.user.user_id,
+              isOwner,
+              'prompt',
+              params.user.role,
+              superadminOpts.allowSuperadmin
+            )
+          ) {
+            console.error(
+              `❌ [Upload Handler] User ${params.user.user_id.substring(0, 8)} lacks 'prompt' permission on worktree ${wt.worktree_id.substring(0, 8)}`
+            );
+            return res.status(403).json({ error: 'Not authorized to upload to this session' });
+          }
+        }
       }
 
       if (!files || files.length === 0) {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -77,7 +77,11 @@ import {
   requireMinimumRole,
 } from './utils/authorization.js';
 import { createUploadMiddleware } from './utils/upload.js';
-import { ensureWorktreePermission, hasWorktreePermission } from './utils/worktree-authorization.js';
+import {
+  ensureWorktreePermission,
+  PERMISSION_RANK,
+  resolveWorktreePermission,
+} from './utils/worktree-authorization.js';
 
 /**
  * Extended Params with route ID parameter.
@@ -1086,29 +1090,39 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         return res.status(404).json({ error: 'Session not found' });
       }
 
-      // Worktree RBAC: check worktree-level permission instead of session ownership.
-      // Users with 'prompt' or higher on the worktree can upload files.
-      // When RBAC is disabled, fall back to allowing any authenticated member.
-      if (worktreeRbacEnabled && session.worktree_id && params.user?.user_id) {
+      // Worktree RBAC: mirror ensureCanPromptInSession semantics.
+      // - 'prompt'/'all' → upload to any session
+      // - 'session'      → upload only to own sessions
+      // - 'view'/'none'  → denied
+      // Fail-closed: if RBAC is enabled but worktree can't be resolved, deny.
+      // When RBAC is disabled, any authenticated member can upload.
+      if (worktreeRbacEnabled) {
+        const userId = params.user?.user_id as UUID;
+        if (!session.worktree_id) {
+          return res.status(403).json({ error: 'Not authorized to upload to this session' });
+        }
         const wt = await worktreeRepo.findById(session.worktree_id);
-        if (wt) {
-          const userId = params.user.user_id as UUID;
-          const isOwner = await worktreeRepo.isOwner(wt.worktree_id, userId);
-          if (
-            !hasWorktreePermission(
-              wt,
-              userId,
-              isOwner,
-              'prompt',
-              params.user.role,
-              superadminOpts.allowSuperadmin
-            )
-          ) {
-            console.error(
-              `❌ [Upload Handler] User ${params.user.user_id.substring(0, 8)} lacks 'prompt' permission on worktree ${wt.worktree_id.substring(0, 8)}`
-            );
-            return res.status(403).json({ error: 'Not authorized to upload to this session' });
-          }
+        if (!wt) {
+          return res.status(404).json({ error: 'Worktree not found' });
+        }
+        const isOwner = await worktreeRepo.isOwner(wt.worktree_id, userId);
+        const effectiveLevel = resolveWorktreePermission(
+          wt,
+          userId,
+          isOwner,
+          params.user?.role,
+          superadminOpts.allowSuperadmin
+        );
+
+        const canUpload =
+          PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.prompt ||
+          (effectiveLevel === 'session' && session.created_by === userId);
+
+        if (!canUpload) {
+          console.error(
+            `❌ [Upload Handler] User ${userId.substring(0, 8)} has '${effectiveLevel}' permission, cannot upload to worktree ${wt.worktree_id.substring(0, 8)}`
+          );
+          return res.status(403).json({ error: 'Not authorized to upload to this session' });
         }
       }
 


### PR DESCRIPTION
## Summary

- **Old behavior:** File upload endpoint checked `session.created_by === user_id` — only the session creator could upload files, regardless of worktree permissions
- **New behavior:** When RBAC is enabled, uses `hasWorktreePermission()` with minimum level `prompt` — any user who can prompt a session can also upload files to it (owners, superadmins, and users with `others_can >= prompt`)
- **RBAC disabled:** Any authenticated member can upload (no permission gate beyond role check), preserving backward compatibility

## Why this is the correct model

File uploads are contextual to a worktree (files land in `.agor/uploads/`). The authorization should match worktree access, not session ownership. If a user has `prompt` permission on a worktree, they can already interact with sessions there — uploading files is a natural extension of that capability.

## Test plan

- [ ] Upload a file to your own session — should succeed (owner)
- [ ] Upload a file to another user's session on a worktree where you have `prompt` permission — should succeed
- [ ] Upload a file to a session on a worktree where you only have `view` — should get 403
- [ ] Upload with RBAC disabled — any authenticated member should succeed
- [ ] Superadmin upload to any session — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)