### PR TITLE
fix(ui): make all ToolBlocks expanded by default

### DIFF
--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -43,7 +43,6 @@ import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
 import { CollapsibleText } from '../CollapsibleText';
 import { Tag } from '../Tag';
 import {
-  ALWAYS_EXPANDED_TOOLS,
   buildBashDescriptionNode,
   deriveToolStatus,
   IMPLICIT_RESULT_TOOLS,
@@ -79,7 +78,7 @@ interface AgentChainProps {
   messages: Message[];
   /** Whether the parent task is still running (controls spinner vs stale for pending tools) */
   isTaskRunning?: boolean;
-  /** Whether this is the latest (most recent) agent chain block in the task */
+  /** Whether this is the latest (most recent) agent chain block — used for pending/stale status detection */
   isLatest?: boolean;
 }
 
@@ -137,10 +136,9 @@ function getToolIcon(toolName: string): React.ReactElement {
 export const AgentChain = React.memo<AgentChainProps>(
   ({ messages, isTaskRunning = false, isLatest }) => {
     const { token } = theme.useToken();
-    // Track whether user manually toggled this chain (null = auto-managed)
+    // Track whether user manually toggled this chain
     const [userOverride, setUserOverride] = useState<boolean | null>(null);
-    // Auto-managed: expand if latest (or if isLatest not provided, for backward compat)
-    const expanded = userOverride !== null ? userOverride : isLatest !== false;
+    const expanded = userOverride !== null ? userOverride : true;
 
     // Extract chain items (thoughts and tools) from messages
     const chainItems = useMemo(() => {
@@ -449,7 +447,6 @@ export const AgentChain = React.memo<AgentChainProps>(
       };
       const isError = toolResult?.is_error;
       const displayName = resolveDisplayName(toolUse);
-      const isAlwaysExpanded = ALWAYS_EXPANDED_TOOLS.has(toolUse.name);
       const hasImplicitResult = IMPLICIT_RESULT_TOOLS.has(toolUse.name);
 
       // Derive status and icon via shared helper.
@@ -491,7 +488,7 @@ export const AgentChain = React.memo<AgentChainProps>(
           description={description ?? undefined}
           descriptionNode={descriptionNode}
           status={status}
-          expandedByDefault={isAlwaysExpanded}
+          expandedByDefault
         >
           <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
         </ToolBlock>

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -136,9 +136,7 @@ function getToolIcon(toolName: string): React.ReactElement {
 export const AgentChain = React.memo<AgentChainProps>(
   ({ messages, isTaskRunning = false, isLatest }) => {
     const { token } = theme.useToken();
-    // Track whether user manually toggled this chain
-    const [userOverride, setUserOverride] = useState<boolean | null>(null);
-    const expanded = userOverride !== null ? userOverride : true;
+    const [expanded, setExpanded] = useState(true);
 
     // Extract chain items (thoughts and tools) from messages
     const chainItems = useMemo(() => {
@@ -587,7 +585,7 @@ export const AgentChain = React.memo<AgentChainProps>(
       <div style={{ margin: `${token.sizeUnit * 1.5}px 0` }}>
         {/* Collapsed summary - clickable */}
         <div
-          onClick={() => setUserOverride(!expanded)}
+          onClick={() => setExpanded(!expanded)}
           style={{
             padding: token.sizeUnit * 1.5,
             borderRadius: token.borderRadius,

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -36,7 +36,6 @@ import { MarkdownRenderer } from '../MarkdownRenderer';
 import { PermissionRequestBlock } from '../PermissionRequestBlock';
 import { ThinkingBlock } from '../ThinkingBlock';
 import {
-  ALWAYS_EXPANDED_TOOLS,
   buildBashDescriptionNode,
   deriveToolStatus,
   IMPLICIT_RESULT_TOOLS,
@@ -657,7 +656,6 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
             }
             return toolBlocks.map(({ toolUse, toolResult }, toolIndex) => {
               const displayName = getToolDisplayName(toolUse.name, toolUse.input);
-              const isAlwaysExpanded = ALWAYS_EXPANDED_TOOLS.has(toolUse.name);
               const hasImplicitResult = IMPLICIT_RESULT_TOOLS.has(toolUse.name);
 
               // A tool is potentially still running when no subsequent tool in
@@ -687,7 +685,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
                   description={bashNode ? undefined : getToolDescription(toolUse)}
                   descriptionNode={bashNode}
                   status={status}
-                  expandedByDefault={isAlwaysExpanded}
+                  expandedByDefault
                 >
                   <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
                 </ToolBlock>

--- a/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
@@ -35,7 +35,7 @@ export const ToolBlock: React.FC<ToolBlockProps> = ({
   description,
   descriptionNode,
   status,
-  expandedByDefault = false,
+  expandedByDefault = true,
   children,
 }) => {
   const [expanded, setExpanded] = useState(expandedByDefault);

--- a/apps/agor-ui/src/components/ToolBlock/index.ts
+++ b/apps/agor-ui/src/components/ToolBlock/index.ts
@@ -1,7 +1,6 @@
 export { ToolBlock, type ToolBlockProps } from './ToolBlock';
 export { buildBashDescriptionNode } from './toolDescriptions';
 export {
-  ALWAYS_EXPANDED_TOOLS,
   deriveToolStatus,
   IMPLICIT_RESULT_TOOLS,
   renderToolStatusIcon,

--- a/apps/agor-ui/src/components/ToolBlock/toolStatus.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/toolStatus.tsx
@@ -11,9 +11,6 @@ import type React from 'react';
 
 export type ToolStatus = 'success' | 'error' | 'pending' | 'stale';
 
-/** Tools whose content is always shown expanded by default */
-export const ALWAYS_EXPANDED_TOOLS = new Set(['Edit', 'Write', 'edit', 'write', 'edit_files']);
-
 /**
  * Tools whose invocation payload itself represents terminal state, even without
  * a dedicated tool_result block.


### PR DESCRIPTION
## Summary

- **All ToolBlocks now default to expanded** — no more auto-collapsing when new messages arrive
- **Removed `ALWAYS_EXPANDED_TOOLS` set** — no longer needed since all tools expand by default
- **Removed `isLatest`-based auto-collapse logic** from `AgentChain` — chains always expand by default
- **Kept manual collapse toggle** — users can still click to collapse individual blocks or chains
- **Kept `isLatest` prop** on AgentChain for pending/stale status detection (not collapse)

### Files changed

| File | Change |
|------|--------|
| `ToolBlock.tsx` | Default `expandedByDefault` from `false` → `true` |
| `AgentChain.tsx` | Always expanded by default; removed `ALWAYS_EXPANDED_TOOLS` import/usage |
| `MessageBlock.tsx` | Removed `ALWAYS_EXPANDED_TOOLS` import/usage; pass `expandedByDefault` unconditionally |
| `toolStatus.tsx` | Removed `ALWAYS_EXPANDED_TOOLS` constant |
| `index.ts` | Removed `ALWAYS_EXPANDED_TOOLS` export |

### Why

ToolBlock content has become dense and informative enough to always show. The auto-collapse behavior was hiding useful context and requiring extra clicks to review agent work.

## Test plan

- [ ] Verify all ToolBlocks render expanded on page load
- [ ] Verify new tool blocks appear expanded as conversation streams
- [ ] Verify manual collapse/expand toggle still works on individual ToolBlocks
- [ ] Verify AgentChain collapse/expand toggle still works
- [ ] Verify pending/stale status icons still display correctly for running tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)