### PR TITLE
sec: stop leaking secrets via sudo argv and startup logs

### DIFF
--- a/apps/agor-daemon/src/auth/session-token-strategy.ts
+++ b/apps/agor-daemon/src/auth/session-token-strategy.ts
@@ -40,7 +40,9 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
     const handshake = (socket as { handshake?: { auth?: { sessionToken?: string } } })?.handshake;
     const handshakeToken = handshake?.auth?.sessionToken;
 
-    // Debug logging to see what we're receiving
+    // Debug logging. SECURITY: never log any portion of the token value —
+    // session tokens are bearer credentials, even an 8-char prefix narrows a
+    // guess significantly. Log presence booleans only.
     console.log('[SessionTokenStrategy] parse() called:', {
       socketId: socket?.id,
       hasFeathers: !!socket?.feathers,
@@ -48,7 +50,6 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
       hasAuth: !!auth,
       strategy: auth?.strategy,
       hasToken: !!auth?.accessToken,
-      tokenPreview: auth?.accessToken?.substring(0, 8),
       hasHandshakeToken: !!handshakeToken,
       socketRef: socket === req ? 'same' : 'different',
     });
@@ -77,9 +78,11 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
     authentication: { sessionToken: string },
     params: Params
   ): Promise<AuthenticationResult> {
+    // SECURITY: do not log the authentication object — it contains the
+    // session token. Log shape only.
     console.log('[SessionTokenStrategy] authenticate() CALLED with:', {
       authKeys: Object.keys(authentication || {}),
-      authentication: authentication,
+      hasSessionToken: !!authentication?.sessionToken,
     });
 
     const { sessionToken } = authentication;
@@ -116,7 +119,8 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
       console.log('[SessionTokenStrategy] ✅ Stored auth on socket during authenticate():', {
         socketId,
         storedStrategy: socket.feathers.authentication.strategy,
-        storedTokenPreview: socket.feathers.authentication.accessToken?.substring(0, 8),
+        // SECURITY: no token preview — bearer credentials must never be logged.
+        hasStoredToken: !!socket.feathers.authentication.accessToken,
       });
     }
 
@@ -138,7 +142,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
 
     console.log('[SessionTokenStrategy] authenticate() returning:', {
       strategy: result.authentication.strategy,
-      tokenPreview: result.accessToken.substring(0, 8),
+      // SECURITY: no token preview.
       user_id: sessionInfo.user_id,
     });
 
@@ -150,8 +154,9 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
    * Called by Feathers authentication to validate stored tokens
    */
   async verifyAccessToken(accessToken: string): Promise<AuthenticationResult> {
+    // SECURITY: no token preview.
     console.log('[SessionTokenStrategy] verifyAccessToken() called:', {
-      tokenPreview: accessToken?.substring(0, 8),
+      hasToken: !!accessToken,
     });
 
     // Session tokens are opaque UUIDs, not JWTs

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -332,9 +332,12 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     jwtSecret = crypto.randomBytes(32).toString('hex');
     const { setConfigValue } = await import('@agor/core/config');
     await setConfigValue('daemon.jwtSecret', jwtSecret);
-    console.log('🔑 Generated and saved persistent JWT secret to config');
+    console.log(
+      `🔑 Generated and saved persistent JWT secret to config (length=${jwtSecret.length})`
+    );
   } else {
-    console.log('🔑 Loaded existing JWT secret from config:', `${jwtSecret.substring(0, 16)}...`);
+    // SECURITY: never log any prefix/substring of the secret. Length only.
+    console.log(`🔑 Loaded existing JWT secret from config (length=${jwtSecret.length})`);
   }
 
   const socketIOConfig = createSocketIOConfig(app, { corsOrigin, jwtSecret, allowAnonymous });

--- a/apps/agor-daemon/src/jwt-bootstrap-log.test.ts
+++ b/apps/agor-daemon/src/jwt-bootstrap-log.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Source-level regression test for JWT bootstrap log hygiene.
+ *
+ * The daemon's startup logs previously included the first 16 characters of
+ * the loaded JWT secret. Even a 16-char prefix is dangerous — it narrows
+ * offline brute-force guesses by 128 bits of entropy. This test asserts
+ * the anti-pattern does not return to `src/index.ts`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const indexPath = join(here, 'index.ts');
+
+describe('daemon JWT secret bootstrap log', () => {
+  const source = readFileSync(indexPath, 'utf8');
+
+  it('does not call .substring(... ) on jwtSecret anywhere', () => {
+    // Covers `jwtSecret.substring(` and `${jwtSecret.substring(...)}` etc.
+    expect(source).not.toMatch(/jwtSecret\s*\.\s*substring\s*\(/);
+    // Also guard against .slice, .substr
+    expect(source).not.toMatch(/jwtSecret\s*\.\s*slice\s*\(/);
+    expect(source).not.toMatch(/jwtSecret\s*\.\s*substr\s*\(/);
+  });
+
+  it('does not interpolate jwtSecret directly into a template literal', () => {
+    // Catches ${jwtSecret} with nothing chained onto it (length/hash is fine;
+    // raw value is not). We match `${jwtSecret}` and `${jwtSecret }`.
+    expect(source).not.toMatch(/\$\{\s*jwtSecret\s*\}/);
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -521,6 +521,9 @@ function createExecuteHandler(
       UnixUserNotFoundError,
       buildSpawnArgs,
       getHomedirFromUsername,
+      isSecretEnvKey,
+      writeUserEnvFile,
+      tryUnlinkEnvFile,
     } = await import('@agor/core/unix');
 
     const unixUserMode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
@@ -657,13 +660,38 @@ function createExecuteHandler(
       },
     };
 
+    // Route secret-looking env vars through an on-disk env file owned by the
+    // target user (mode 0600) so API keys/tokens never appear in argv.
+    let executorEnvFilePath: string | undefined;
+    let executorInlineEnv: Record<string, string> | undefined;
+    if (executorUnixUser) {
+      const secretEnv: Record<string, string> = {};
+      executorInlineEnv = {};
+      for (const [key, value] of Object.entries(executorEnv)) {
+        if (value === undefined) continue;
+        if (isSecretEnvKey(key)) {
+          secretEnv[key] = value;
+        } else {
+          executorInlineEnv[key] = value;
+        }
+      }
+      if (Object.keys(secretEnv).length > 0) {
+        executorEnvFilePath = writeUserEnvFile(executorUnixUser, secretEnv);
+      }
+    }
+
     const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
       asUser: executorUnixUser || undefined,
-      env: executorUnixUser ? executorEnv : undefined,
+      env: executorUnixUser ? executorInlineEnv : undefined,
+      envFilePath: executorEnvFilePath,
     });
 
     if (executorUnixUser) {
-      console.log(`[Daemon] Spawning executor as user: ${executorUnixUser}`);
+      console.log(
+        `[Daemon] Spawning executor as user=${executorUnixUser}${
+          executorEnvFilePath ? ' (secrets in env-file)' : ''
+        }`
+      );
     } else {
       console.log(`[Daemon] Spawning executor as current user (no impersonation)`);
     }
@@ -696,6 +724,16 @@ function createExecuteHandler(
       env: executorUnixUser ? undefined : executorEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+
+    // Safety-net cleanup for the env file. The inner bash script `rm -f`s
+    // the file before exec in the normal path, so this only fires if sudo
+    // or bash failed to launch at all.
+    if (executorEnvFilePath) {
+      const capturedEnvFile = executorEnvFilePath;
+      const cleanupEnvFile = () => tryUnlinkEnvFile(capturedEnvFile);
+      executorProcess.once('error', cleanupEnvFile);
+      executorProcess.once('exit', cleanupEnvFile);
+    }
 
     if (executorProcess.pid) {
       trackExecutorProcess(sessionId, executorProcess.pid);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -521,9 +521,8 @@ function createExecuteHandler(
       UnixUserNotFoundError,
       buildSpawnArgs,
       getHomedirFromUsername,
-      isSecretEnvKey,
-      writeUserEnvFile,
-      tryUnlinkEnvFile,
+      prepareImpersonationEnv,
+      attachEnvFileCleanup,
     } = await import('@agor/core/unix');
 
     const unixUserMode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
@@ -662,34 +661,20 @@ function createExecuteHandler(
 
     // Route secret-looking env vars through an on-disk env file owned by the
     // target user (mode 0600) so API keys/tokens never appear in argv.
-    let executorEnvFilePath: string | undefined;
-    let executorInlineEnv: Record<string, string> | undefined;
-    if (executorUnixUser) {
-      const secretEnv: Record<string, string> = {};
-      executorInlineEnv = {};
-      for (const [key, value] of Object.entries(executorEnv)) {
-        if (value === undefined) continue;
-        if (isSecretEnvKey(key)) {
-          secretEnv[key] = value;
-        } else {
-          executorInlineEnv[key] = value;
-        }
-      }
-      if (Object.keys(secretEnv).length > 0) {
-        executorEnvFilePath = writeUserEnvFile(executorUnixUser, secretEnv);
-      }
-    }
+    const prepared = executorUnixUser
+      ? prepareImpersonationEnv({ asUser: executorUnixUser, env: executorEnv })
+      : { inlineEnv: undefined, envFilePath: undefined };
 
     const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
       asUser: executorUnixUser || undefined,
-      env: executorUnixUser ? executorInlineEnv : undefined,
-      envFilePath: executorEnvFilePath,
+      env: executorUnixUser ? prepared.inlineEnv : undefined,
+      envFilePath: prepared.envFilePath,
     });
 
     if (executorUnixUser) {
       console.log(
         `[Daemon] Spawning executor as user=${executorUnixUser}${
-          executorEnvFilePath ? ' (secrets in env-file)' : ''
+          prepared.envFilePath ? ' (secrets in env-file)' : ''
         }`
       );
     } else {
@@ -727,13 +712,12 @@ function createExecuteHandler(
 
     // Safety-net cleanup for the env file. The inner bash script `rm -f`s
     // the file before exec in the normal path, so this only fires if sudo
-    // or bash failed to launch at all.
-    if (executorEnvFilePath) {
-      const capturedEnvFile = executorEnvFilePath;
-      const cleanupEnvFile = () => tryUnlinkEnvFile(capturedEnvFile);
-      executorProcess.once('error', cleanupEnvFile);
-      executorProcess.once('exit', cleanupEnvFile);
-    }
+    // or bash failed to launch at all, or `set -eu` aborted the source
+    // step. Uses sudo when asUser is set so it works under sticky /tmp.
+    attachEnvFileCleanup(executorProcess, {
+      envFilePath: prepared.envFilePath,
+      asUser: executorUnixUser || undefined,
+    });
 
     if (executorProcess.pid) {
       trackExecutorProcess(sessionId, executorProcess.pid);

--- a/apps/agor-daemon/src/utils/spawn-executor.secrets.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.secrets.test.ts
@@ -51,13 +51,18 @@ describe('spawn-executor log hygiene (source-level)', () => {
     expect(source).not.toMatch(/Env vars being passed/);
   });
 
-  it('routes secret env vars through writeUserEnvFile', () => {
-    expect(source).toMatch(/writeUserEnvFile\s*\(/);
+  it('routes secret env vars through the impersonation-env helper', () => {
+    // Uses `prepareImpersonationEnv` (DRY: splits + writes env-file in one call)
+    // rather than open-coding the secret/inline split per call site.
+    expect(source).toMatch(/prepareImpersonationEnv\s*\(/);
+    // Still uses isSecretEnvKey for the safe log-summary filter.
     expect(source).toMatch(/isSecretEnvKey\s*\(/);
   });
 
-  it('registers a best-effort cleanup via tryUnlinkEnvFile', () => {
-    expect(source).toMatch(/tryUnlinkEnvFile/);
+  it('registers a best-effort cleanup via attachEnvFileCleanup', () => {
+    // New helper that sudo-unlinks the file when asUser owns it, so it works
+    // under sticky /tmp where the daemon cannot unlink files owned by asUser.
+    expect(source).toMatch(/attachEnvFileCleanup\s*\(/);
   });
 });
 

--- a/apps/agor-daemon/src/utils/spawn-executor.secrets.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.secrets.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests: spawn-executor log hygiene.
+ *
+ * Runtime behavior is tested in packages/core/src/unix/run-as-user.test.ts
+ * (the REGRESSION test that secret values never land in argv). Here we
+ * guard the *caller* (spawn-executor) against re-introducing the old
+ * dangerous log patterns and against forgetting to route secret env vars
+ * through writeUserEnvFile.
+ *
+ * Source-level checks keep this test fast and free of any dependency on
+ * @agor/core being built, which matters because in normal dev the daemon
+ * runs against live TS via watch mode.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Mirror of the secret-key pattern from @agor/core/unix/run-as-user. Kept
+// inline here to avoid any build-order dependency on @agor/core when running
+// daemon tests in isolation. If these diverge, the core test suite will flag
+// a mismatch via its own comprehensive SECRET_ENV_KEY_PATTERN coverage.
+const LOCAL_SECRET_KEY_PATTERN = /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_KEY)$|^OAUTH_/i;
+const isSecretEnvKey = (name: string): boolean => LOCAL_SECRET_KEY_PATTERN.test(name);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const spawnExecutorPath = join(here, 'spawn-executor.ts');
+const source = readFileSync(spawnExecutorPath, 'utf8');
+
+describe('spawn-executor log hygiene (source-level)', () => {
+  it('does not log the full sudo command line (argv containing inlined secrets)', () => {
+    // The old code did `console.log('Full command:', cmd + args.join(' '))`.
+    // That string would include sudo ... bash -c 'env ANTHROPIC_API_KEY=... node ...'.
+    expect(source).not.toMatch(/Full command/i);
+    expect(source).not.toMatch(/\$\{\s*cmd\s*\}\s*\$\{\s*args\./);
+  });
+
+  it('does not console.log the whole env map under impersonation', () => {
+    // Catches `console.log(..., envWithDaemonUrl)` or spreading it into a log.
+    // Safe patterns (`Object.keys(...).filter(...)`) are allowed.
+    // This matches a direct interpolation of the env object in a template.
+    expect(source).not.toMatch(/\$\{\s*envWithDaemonUrl\s*\}/);
+    expect(source).not.toMatch(/console\.log\([^)]*,\s*envWithDaemonUrl\s*\)/);
+  });
+
+  it('does not log env var key names directly (old Env vars being passed: line)', () => {
+    // Old code printed `Env vars being passed: ${keys}`. Key names like
+    // ANTHROPIC_API_KEY in logs are already useful to an attacker scraping
+    // logs for valuable targets. Current safe summary filters with isSecretEnvKey.
+    expect(source).not.toMatch(/Env vars being passed/);
+  });
+
+  it('routes secret env vars through writeUserEnvFile', () => {
+    expect(source).toMatch(/writeUserEnvFile\s*\(/);
+    expect(source).toMatch(/isSecretEnvKey\s*\(/);
+  });
+
+  it('registers a best-effort cleanup via tryUnlinkEnvFile', () => {
+    expect(source).toMatch(/tryUnlinkEnvFile/);
+  });
+});
+
+describe('isSecretEnvKey matches the keys spawn-executor cares about', () => {
+  // Same allowlist that spawn-executor inherits from process.env.
+  const relevantKeys = [
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'OPENAI_API_KEY',
+    'GEMINI_API_KEY',
+    'GOOGLE_API_KEY',
+  ];
+
+  for (const key of relevantKeys) {
+    it(`treats ${key} as secret`, () => {
+      expect(isSecretEnvKey(key)).toBe(true);
+    });
+  }
+
+  // And non-secret ones stay non-secret.
+  const nonSecretKeys = ['PATH', 'NODE_ENV', 'DAEMON_URL', 'ANTHROPIC_BASE_URL'];
+  for (const key of nonSecretKeys) {
+    it(`does not treat ${key} as secret`, () => {
+      expect(isSecretEnvKey(key)).toBe(false);
+    });
+  }
+});

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -14,8 +14,11 @@
  * 1. Local subprocess (default): Spawns executor as a child process
  * 2. Templated/remote: Uses executor_command_template for k8s/docker/remote execution
  *
- * IMPERSONATION: When asUser is provided, the executor is spawned via `sudo su -`
- * to run as the target Unix user with fresh group memberships.
+ * IMPERSONATION: When asUser is provided, the executor is spawned via
+ * `sudo -n -u $asUser bash -c '...'` to run as the target Unix user with
+ * fresh group memberships. Secret-looking env vars are routed through a
+ * 0600 env-file owned by the target user so their values never appear in
+ * argv / /proc/<pid>/cmdline.
  */
 
 import { spawn } from 'node:child_process';
@@ -23,10 +26,10 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  attachEnvFileCleanup,
   buildSpawnArgs,
   isSecretEnvKey,
-  tryUnlinkEnvFile,
-  writeUserEnvFile,
+  prepareImpersonationEnv,
 } from '@agor/core/unix';
 import jwt from 'jsonwebtoken';
 
@@ -91,8 +94,10 @@ export interface SpawnExecutorOptions {
 
   /**
    * Unix user to run executor as (impersonation)
-   * When set, spawns via `sudo su - $asUser -c 'node executor --stdin'`
-   * This gives the executor fresh group memberships for the target user.
+   * When set, spawns via `sudo -n -u $asUser bash -c '...'` so the executor
+   * gets fresh group memberships for the target user. Secret env vars are
+   * routed through a 0600 env-file owned by `asUser` so their values stay
+   * out of argv / /proc/<pid>/cmdline.
    */
   asUser?: string;
 
@@ -285,36 +290,22 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   // target user (mode 0600). This keeps API keys/tokens out of argv and out
   // of /proc/<pid>/cmdline. Non-secret vars (PATH, DAEMON_URL, NODE_ENV)
   // are still inlined for simplicity.
-  let envFilePath: string | undefined;
-  let inlineEnv: Record<string, string> | undefined;
-  if (asUser) {
-    const secretEnv: Record<string, string> = {};
-    inlineEnv = {};
-    for (const [key, value] of Object.entries(envWithDaemonUrl)) {
-      if (value === undefined) continue;
-      if (isSecretEnvKey(key)) {
-        secretEnv[key] = value;
-      } else {
-        inlineEnv[key] = value;
-      }
-    }
-    if (Object.keys(secretEnv).length > 0) {
-      envFilePath = writeUserEnvFile(asUser, secretEnv);
-    }
-  }
+  const prepared = asUser
+    ? prepareImpersonationEnv({ asUser, env: envWithDaemonUrl })
+    : { inlineEnv: undefined, envFilePath: undefined };
 
   // Build spawn command - handles impersonation via sudo -u when asUser is set
   const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
     asUser,
-    env: asUser ? inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
-    envFilePath,
+    env: asUser ? prepared.inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
+    envFilePath: prepared.envFilePath,
   });
 
   if (asUser) {
     // Safe summary only — never log secret values or their key names.
-    const safeEnvKeys = Object.keys(inlineEnv ?? {}).filter((k) => !isSecretEnvKey(k));
+    const safeEnvKeys = Object.keys(prepared.inlineEnv ?? {}).filter((k) => !isSecretEnvKey(k));
     console.log(
-      `${logPrefix} Spawning executor as user=${asUser} tool=${payload.command ?? '?'} envKeys=[${safeEnvKeys.join(',')}]${envFilePath ? ' (secrets in env-file)' : ''}`
+      `${logPrefix} Spawning executor as user=${asUser} tool=${payload.command ?? '?'} envKeys=[${safeEnvKeys.join(',')}]${prepared.envFilePath ? ' (secrets in env-file)' : ''}`
     );
   }
   console.log(`${logPrefix} Spawning executor at: ${executorPath}`);
@@ -328,13 +319,10 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   });
 
   // Best-effort safety-net cleanup: the inner bash script `rm -f`s the env
-  // file before exec, but if sudo/bash failed to launch the file may remain.
-  if (envFilePath) {
-    const capturedEnvFile = envFilePath;
-    const cleanupEnvFile = () => tryUnlinkEnvFile(capturedEnvFile);
-    executorProcess.once('error', cleanupEnvFile);
-    executorProcess.once('exit', cleanupEnvFile);
-  }
+  // file before exec, but if sudo/bash failed to launch — or `set -eu`
+  // aborted the source step — the file may remain. attachEnvFileCleanup
+  // uses `sudo -u <asUser> rm -f` so it works under sticky /tmp.
+  attachEnvFileCleanup(executorProcess, { envFilePath: prepared.envFilePath, asUser });
 
   // Log if process fails to spawn
   executorProcess.on('error', (error) => {

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -22,7 +22,12 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildSpawnArgs } from '@agor/core/unix';
+import {
+  buildSpawnArgs,
+  isSecretEnvKey,
+  tryUnlinkEnvFile,
+  writeUserEnvFile,
+} from '@agor/core/unix';
 import jwt from 'jsonwebtoken';
 
 /**
@@ -276,17 +281,41 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
 
   const envWithDaemonUrl = essentialEnv;
 
+  // Route secret-looking env vars through an on-disk env file owned by the
+  // target user (mode 0600). This keeps API keys/tokens out of argv and out
+  // of /proc/<pid>/cmdline. Non-secret vars (PATH, DAEMON_URL, NODE_ENV)
+  // are still inlined for simplicity.
+  let envFilePath: string | undefined;
+  let inlineEnv: Record<string, string> | undefined;
+  if (asUser) {
+    const secretEnv: Record<string, string> = {};
+    inlineEnv = {};
+    for (const [key, value] of Object.entries(envWithDaemonUrl)) {
+      if (value === undefined) continue;
+      if (isSecretEnvKey(key)) {
+        secretEnv[key] = value;
+      } else {
+        inlineEnv[key] = value;
+      }
+    }
+    if (Object.keys(secretEnv).length > 0) {
+      envFilePath = writeUserEnvFile(asUser, secretEnv);
+    }
+  }
+
   // Build spawn command - handles impersonation via sudo -u when asUser is set
   const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
     asUser,
-    env: asUser ? envWithDaemonUrl : undefined, // Only inject env when impersonating (sudo -u needs env passed explicitly)
+    env: asUser ? inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
+    envFilePath,
   });
 
   if (asUser) {
-    console.log(`${logPrefix} Spawning executor as user: ${asUser}`);
-    console.log(`${logPrefix} DAEMON_URL being passed: ${envWithDaemonUrl.DAEMON_URL}`);
-    console.log(`${logPrefix} Env vars being passed: ${Object.keys(envWithDaemonUrl).join(', ')}`);
-    console.log(`${logPrefix} Full command: ${cmd} ${args.join(' ')}`);
+    // Safe summary only — never log secret values or their key names.
+    const safeEnvKeys = Object.keys(inlineEnv ?? {}).filter((k) => !isSecretEnvKey(k));
+    console.log(
+      `${logPrefix} Spawning executor as user=${asUser} tool=${payload.command ?? '?'} envKeys=[${safeEnvKeys.join(',')}]${envFilePath ? ' (secrets in env-file)' : ''}`
+    );
   }
   console.log(`${logPrefix} Spawning executor at: ${executorPath}`);
   console.log(`${logPrefix} Command: ${payload.command}`);
@@ -297,6 +326,15 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     stdio: ['pipe', 'inherit', 'inherit'], // stdin: pipe, stdout/stderr: inherit (show in daemon logs)
     detached: false, // Don't detach - let daemon manage lifecycle
   });
+
+  // Best-effort safety-net cleanup: the inner bash script `rm -f`s the env
+  // file before exec, but if sudo/bash failed to launch the file may remain.
+  if (envFilePath) {
+    const capturedEnvFile = envFilePath;
+    const cleanupEnvFile = () => tryUnlinkEnvFile(capturedEnvFile);
+    executorProcess.once('error', cleanupEnvFile);
+    executorProcess.once('exit', cleanupEnvFile);
+  }
 
   // Log if process fails to spawn
   executorProcess.on('error', (error) => {

--- a/docker/docker-entrypoint-prod.sh
+++ b/docker/docker-entrypoint-prod.sh
@@ -23,17 +23,13 @@ agor init \
 echo "👤 Ensuring admin user exists..."
 agor user create-admin 2>/dev/null || true
 
-# Display admin credentials for first-time setup
-echo ""
-echo "=========================================="
-echo "🔐 Admin Credentials"
-echo "=========================================="
-echo "Email:    admin@agor.live"
-echo "Password: admin"
-echo ""
-echo "⚠️  CHANGE PASSWORD AFTER FIRST LOGIN!"
-echo "=========================================="
-echo ""
+# SECURITY: do not echo the default admin credentials to stdout — container
+# log aggregators ingest stdout and make it searchable across the org.
+# Emit a short warning to stderr only, and only once per container start.
+# Operators can retrieve the bootstrap credentials via an authenticated
+# `agor user ...` CLI invocation inside the container.
+>&2 printf '\033[1;31m%s\033[0m\n' "⚠️  Admin user exists with the default bootstrap password."
+>&2 printf '\033[1;31m%s\033[0m\n' "⚠️  ROTATE IT NOW via the UI or: docker exec <container> agor user set-password"
 
 # Start daemon in foreground (this keeps container alive)
 echo "🚀 Starting daemon on port ${DAEMON_PORT:-3030}..."

--- a/packages/core/src/unix/environment-command-spawn.ts
+++ b/packages/core/src/unix/environment-command-spawn.ts
@@ -10,7 +10,12 @@ import { createUserProcessEnvironment } from '../config/index.js';
 import type { Database } from '../db/index.js';
 import { UsersRepository } from '../db/repositories/index.js';
 import type { Worktree } from '../types/index.js';
-import { buildSpawnArgs } from './run-as-user.js';
+import {
+  buildSpawnArgs,
+  isSecretEnvKey,
+  tryUnlinkEnvFile,
+  writeUserEnvFile,
+} from './run-as-user.js';
 import { resolveUnixUserForImpersonation, validateResolvedUnixUser } from './user-manager.js';
 
 /**
@@ -92,19 +97,52 @@ export async function spawnEnvironmentCommand(
   // If impersonating, strip HOME/USER/LOGNAME/SHELL so sudo -u can set them properly
   const env = await createUserProcessEnvironment(worktree.created_by, db, undefined, !!asUser);
 
+  // Route secret-looking env vars through an on-disk env file owned by the
+  // target user (mode 0600) so user-scoped API keys/tokens never appear in
+  // the `sudo bash -c '...'` argv exposed to /proc/<pid>/cmdline.
+  let envFilePath: string | undefined;
+  let inlineEnv: Record<string, string> | undefined;
+  if (asUser) {
+    const secretEnv: Record<string, string> = {};
+    inlineEnv = {};
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) continue;
+      if (isSecretEnvKey(key)) {
+        secretEnv[key] = value;
+      } else {
+        inlineEnv[key] = value;
+      }
+    }
+    if (Object.keys(secretEnv).length > 0) {
+      envFilePath = writeUserEnvFile(asUser, secretEnv);
+    }
+  }
+
   // Build spawn args with impersonation
   const { cmd, args } = buildSpawnArgs(command, [], {
     asUser,
-    env: asUser ? env : undefined, // Only pass env via sudo wrapper if impersonating
+    env: asUser ? inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
+    envFilePath,
   });
 
   // Spawn the command
   // When not impersonating (simple mode), buildSpawnArgs returns the raw command string,
   // so we need shell: true to handle multi-word commands like "docker compose up -d"
-  return spawn(cmd, args, {
+  const child = spawn(cmd, args, {
     cwd: worktree.path,
     env: asUser ? undefined : env, // Use process env if not impersonating
     stdio,
     shell: !asUser, // Use shell for simple mode, buildSpawnArgs wraps sudo in bash -c
   });
+
+  // Safety-net cleanup. Inner bash script rm -fs the file before exec,
+  // so this only fires if sudo/bash failed to launch at all.
+  if (envFilePath) {
+    const capturedPath = envFilePath;
+    const cleanup = () => tryUnlinkEnvFile(capturedPath);
+    child.once('error', cleanup);
+    child.once('exit', cleanup);
+  }
+
+  return child;
 }

--- a/packages/core/src/unix/environment-command-spawn.ts
+++ b/packages/core/src/unix/environment-command-spawn.ts
@@ -10,12 +10,8 @@ import { createUserProcessEnvironment } from '../config/index.js';
 import type { Database } from '../db/index.js';
 import { UsersRepository } from '../db/repositories/index.js';
 import type { Worktree } from '../types/index.js';
-import {
-  buildSpawnArgs,
-  isSecretEnvKey,
-  tryUnlinkEnvFile,
-  writeUserEnvFile,
-} from './run-as-user.js';
+import { buildSpawnArgs } from './run-as-user.js';
+import { attachEnvFileCleanup, prepareImpersonationEnv } from './user-env-file.js';
 import { resolveUnixUserForImpersonation, validateResolvedUnixUser } from './user-manager.js';
 
 /**
@@ -100,29 +96,15 @@ export async function spawnEnvironmentCommand(
   // Route secret-looking env vars through an on-disk env file owned by the
   // target user (mode 0600) so user-scoped API keys/tokens never appear in
   // the `sudo bash -c '...'` argv exposed to /proc/<pid>/cmdline.
-  let envFilePath: string | undefined;
-  let inlineEnv: Record<string, string> | undefined;
-  if (asUser) {
-    const secretEnv: Record<string, string> = {};
-    inlineEnv = {};
-    for (const [key, value] of Object.entries(env)) {
-      if (value === undefined) continue;
-      if (isSecretEnvKey(key)) {
-        secretEnv[key] = value;
-      } else {
-        inlineEnv[key] = value;
-      }
-    }
-    if (Object.keys(secretEnv).length > 0) {
-      envFilePath = writeUserEnvFile(asUser, secretEnv);
-    }
-  }
+  const prepared = asUser
+    ? prepareImpersonationEnv({ asUser, env })
+    : { inlineEnv: undefined, envFilePath: undefined };
 
   // Build spawn args with impersonation
   const { cmd, args } = buildSpawnArgs(command, [], {
     asUser,
-    env: asUser ? inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
-    envFilePath,
+    env: asUser ? prepared.inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
+    envFilePath: prepared.envFilePath,
   });
 
   // Spawn the command
@@ -135,14 +117,11 @@ export async function spawnEnvironmentCommand(
     shell: !asUser, // Use shell for simple mode, buildSpawnArgs wraps sudo in bash -c
   });
 
-  // Safety-net cleanup. Inner bash script rm -fs the file before exec,
-  // so this only fires if sudo/bash failed to launch at all.
-  if (envFilePath) {
-    const capturedPath = envFilePath;
-    const cleanup = () => tryUnlinkEnvFile(capturedPath);
-    child.once('error', cleanup);
-    child.once('exit', cleanup);
-  }
+  // Safety-net cleanup. The inner bash script `rm -f`s the file before exec
+  // in the normal path, so this only fires if sudo/bash fails to launch, or
+  // if `set -eu` aborts the source step. Uses sudo when asUser is set so
+  // it works under sticky /tmp.
+  attachEnvFileCleanup(child, { envFilePath: prepared.envFilePath, asUser });
 
   return child;
 }

--- a/packages/core/src/unix/index.ts
+++ b/packages/core/src/unix/index.ts
@@ -16,11 +16,15 @@ export * from './group-manager.js';
 export * from './id-lookups.js';
 // Central command execution as another user (preferred API)
 export * from './run-as-user.js';
+// Secret-aware env classification / redaction
+export * from './secret-env.js';
 // Symlink management
 export * from './symlink-manager.js';
 // System queries (read-only OS state + pure logic helpers)
 export * from './system-queries.js';
 // Main orchestration service
 export * from './unix-integration-service.js';
+// 0600 env-file primitive + impersonation-env helpers
+export * from './user-env-file.js';
 // Unix user management
 export * from './user-manager.js';

--- a/packages/core/src/unix/run-as-user.test.ts
+++ b/packages/core/src/unix/run-as-user.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  buildSpawnArgs,
-  escapeShellArg,
-  isSecretEnvKey,
-  redactSecretEnv,
-  SECRET_ENV_KEY_PATTERN,
-} from './run-as-user.js';
+import { buildSpawnArgs, escapeShellArg } from './run-as-user.js';
 
 describe('run-as-user', () => {
   describe('escapeShellArg', () => {
@@ -143,15 +137,29 @@ describe('run-as-user', () => {
         expect(result.cmd).toBe('sudo');
         expect(result.args.slice(0, 4)).toEqual(['-n', '-u', 'alice', 'bash']);
         expect(result.args[4]).toBe('-c');
-        // Script references ENVFILE from $1, not interpolated
+        // Script references ENVFILE from $1, not interpolated. Uses `set -eu`
+        // so a failed source aborts BEFORE rm+exec (fail-closed).
         expect(result.args[5]).toBe(
-          'ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f "$ENVFILE"; exec "$@"'
+          'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec "$@"'
         );
         // Positional args: separator, envFilePath, then the real command
         expect(result.args[6]).toBe('--');
         expect(result.args[7]).toBe('/tmp/agor-env-abc123');
         expect(result.args[8]).toBe('node');
         expect(result.args[9]).toBe('script.js');
+      });
+
+      it('inner script is fail-closed (set -eu aborts before exec on source failure)', () => {
+        const result = buildSpawnArgs('node', [], {
+          asUser: 'alice',
+          envFilePath: '/tmp/agor-env-x',
+        });
+        // `set -eu` MUST appear before the source step so that a failed
+        // `.  "$ENVFILE"` prevents the `exec "$@"` from launching with
+        // missing secrets.
+        const script = result.args[5];
+        expect(script.indexOf('set -eu')).toBeLessThan(script.indexOf('. "$ENVFILE"'));
+        expect(script.indexOf('. "$ENVFILE"')).toBeLessThan(script.indexOf('exec "$@"'));
       });
 
       it('REGRESSION: does NOT contain any secret values in argv', () => {
@@ -175,85 +183,47 @@ describe('run-as-user', () => {
         }
       });
 
-      it('rejects envFilePath containing shell metacharacters', () => {
-        expect(() =>
-          buildSpawnArgs('node', [], {
-            asUser: 'alice',
-            envFilePath: '/tmp/evil; rm -rf /',
-          })
-        ).toThrow(/suspicious envFilePath/);
-        expect(() =>
-          buildSpawnArgs('node', [], {
-            asUser: 'alice',
-            envFilePath: '/tmp/evil`whoami`',
-          })
-        ).toThrow(/suspicious envFilePath/);
+      it('throws when envFilePath is provided without asUser', () => {
+        expect(() => buildSpawnArgs('node', [], { envFilePath: '/tmp/agor-env-abc' })).toThrow(
+          /envFilePath requires asUser/
+        );
       });
-    });
-  });
 
-  describe('isSecretEnvKey / SECRET_ENV_KEY_PATTERN', () => {
-    it('matches *_API_KEY', () => {
-      expect(isSecretEnvKey('ANTHROPIC_API_KEY')).toBe(true);
-      expect(isSecretEnvKey('OPENAI_API_KEY')).toBe(true);
-      expect(isSecretEnvKey('GEMINI_API_KEY')).toBe(true);
-      expect(isSecretEnvKey('GOOGLE_API_KEY')).toBe(true);
-    });
+      it('rejects relative envFilePath', () => {
+        expect(() =>
+          buildSpawnArgs('node', [], {
+            asUser: 'alice',
+            envFilePath: 'relative/path',
+          })
+        ).toThrow(/envFilePath must be absolute/);
+      });
 
-    it('matches *_TOKEN', () => {
-      expect(isSecretEnvKey('GITHUB_TOKEN')).toBe(true);
-      expect(isSecretEnvKey('ANTHROPIC_AUTH_TOKEN')).toBe(true);
-    });
+      it('rejects envFilePath with NUL bytes or control chars', () => {
+        expect(() =>
+          buildSpawnArgs('node', [], {
+            asUser: 'alice',
+            envFilePath: '/tmp/evil\x00ish',
+          })
+        ).toThrow(/control characters/);
+        expect(() =>
+          buildSpawnArgs('node', [], {
+            asUser: 'alice',
+            envFilePath: '/tmp/line\nbreak',
+          })
+        ).toThrow(/control characters/);
+      });
 
-    it('matches *_SECRET', () => {
-      expect(isSecretEnvKey('JWT_SECRET')).toBe(true);
-      expect(isSecretEnvKey('CLIENT_SECRET')).toBe(true);
-    });
-
-    it('matches OAUTH_* prefix', () => {
-      expect(isSecretEnvKey('OAUTH_ACCESS_TOKEN')).toBe(true);
-      expect(isSecretEnvKey('OAUTH_REFRESH_TOKEN')).toBe(true);
-    });
-
-    it('does not match non-secret names', () => {
-      expect(isSecretEnvKey('PATH')).toBe(false);
-      expect(isSecretEnvKey('HOME')).toBe(false);
-      expect(isSecretEnvKey('NODE_ENV')).toBe(false);
-      expect(isSecretEnvKey('DAEMON_URL')).toBe(false);
-      expect(isSecretEnvKey('TERM')).toBe(false);
-    });
-
-    it('pattern is exported for caller use', () => {
-      expect(SECRET_ENV_KEY_PATTERN).toBeInstanceOf(RegExp);
-    });
-  });
-
-  describe('redactSecretEnv', () => {
-    it('drops secret keys by default', () => {
-      const input = {
-        PATH: '/usr/bin',
-        ANTHROPIC_API_KEY: 'sk-ant-leak',
-        GITHUB_TOKEN: 'ghp-leak',
-      };
-      const out = redactSecretEnv(input);
-      expect(out).toEqual({ PATH: '/usr/bin' });
-      // Values never appear
-      expect(JSON.stringify(out)).not.toContain('sk-ant-leak');
-      expect(JSON.stringify(out)).not.toContain('ghp-leak');
-    });
-
-    it('with keepKeys=true, redacts values but keeps keys', () => {
-      const out = redactSecretEnv(
-        { PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-leak' },
-        { keepKeys: true }
-      );
-      expect(out).toEqual({ PATH: '/usr/bin', ANTHROPIC_API_KEY: '***' });
-      expect(JSON.stringify(out)).not.toContain('sk-ant-leak');
-    });
-
-    it('drops undefined values', () => {
-      const out = redactSecretEnv({ PATH: '/usr/bin', MAYBE: undefined });
-      expect(out).toEqual({ PATH: '/usr/bin' });
+      it('accepts envFilePath with spaces (macOS TMPDIR, etc.)', () => {
+        // Path is passed as a positional argv entry and referenced as "$1"
+        // inside bash, so shell metachars like spaces are safe and must be
+        // accepted — e.g. macOS `/var/folders/.../T/` and custom TMPDIRs.
+        const result = buildSpawnArgs('node', [], {
+          asUser: 'alice',
+          envFilePath: '/var/folders/xx/T/agor env with spaces',
+        });
+        expect(result.cmd).toBe('sudo');
+        expect(result.args).toContain('/var/folders/xx/T/agor env with spaces');
+      });
     });
   });
 });

--- a/packages/core/src/unix/run-as-user.test.ts
+++ b/packages/core/src/unix/run-as-user.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildSpawnArgs, escapeShellArg } from './run-as-user.js';
+import {
+  buildSpawnArgs,
+  escapeShellArg,
+  isSecretEnvKey,
+  redactSecretEnv,
+  SECRET_ENV_KEY_PATTERN,
+} from './run-as-user.js';
 
 describe('run-as-user', () => {
   describe('escapeShellArg', () => {
@@ -45,11 +51,11 @@ describe('run-as-user', () => {
     });
 
     describe('with impersonation (string asUser - backward compat)', () => {
-      it('wraps with sudo su -', () => {
+      it('wraps with sudo -u bash -c', () => {
         const result = buildSpawnArgs('whoami', [], 'alice');
         expect(result).toEqual({
           cmd: 'sudo',
-          args: ['-n', 'su', '-', 'alice', '-c', 'whoami'],
+          args: ['-n', '-u', 'alice', 'bash', '-c', 'whoami'],
         });
       });
 
@@ -57,17 +63,17 @@ describe('run-as-user', () => {
         const result = buildSpawnArgs('zellij', ['attach', 'my session'], 'alice');
         expect(result).toEqual({
           cmd: 'sudo',
-          args: ['-n', 'su', '-', 'alice', '-c', "zellij 'attach' 'my session'"],
+          args: ['-n', '-u', 'alice', 'bash', '-c', "zellij 'attach' 'my session'"],
         });
       });
     });
 
     describe('with impersonation (options object)', () => {
-      it('wraps with sudo su - when asUser provided', () => {
+      it('wraps with sudo -u when asUser provided', () => {
         const result = buildSpawnArgs('whoami', [], { asUser: 'bob' });
         expect(result).toEqual({
           cmd: 'sudo',
-          args: ['-n', 'su', '-', 'bob', '-c', 'whoami'],
+          args: ['-n', '-u', 'bob', 'bash', '-c', 'whoami'],
         });
       });
 
@@ -78,41 +84,40 @@ describe('run-as-user', () => {
           args: [],
         });
       });
+
+      it('rejects invalid asUser (shell metacharacters)', () => {
+        expect(() => buildSpawnArgs('whoami', [], { asUser: 'alice; rm -rf /' })).toThrow(
+          /invalid Unix username/
+        );
+        expect(() => buildSpawnArgs('whoami', [], { asUser: '-oRemoteForward=...' })).toThrow(
+          /invalid Unix username/
+        );
+      });
     });
 
-    describe('with env vars', () => {
+    describe('with env vars (legacy inline path)', () => {
       it('injects env vars into inner command when impersonating', () => {
         const result = buildSpawnArgs('node', ['script.js'], {
           asUser: 'alice',
-          env: { GITHUB_TOKEN: 'abc123', NODE_ENV: 'test' },
+          env: { DAEMON_URL: 'http://localhost:3030', NODE_ENV: 'test' },
         });
         expect(result.cmd).toBe('sudo');
         expect(result.args[0]).toBe('-n');
-        expect(result.args[1]).toBe('su');
-        expect(result.args[2]).toBe('-');
-        expect(result.args[3]).toBe('alice');
+        expect(result.args[1]).toBe('-u');
+        expect(result.args[2]).toBe('alice');
+        expect(result.args[3]).toBe('bash');
         expect(result.args[4]).toBe('-c');
         // Inner command should have env prefix
         expect(result.args[5]).toContain('env ');
-        expect(result.args[5]).toContain("GITHUB_TOKEN='abc123'");
+        expect(result.args[5]).toContain("DAEMON_URL='http://localhost:3030'");
         expect(result.args[5]).toContain("NODE_ENV='test'");
         expect(result.args[5]).toContain("node 'script.js'");
       });
 
-      it('escapes env var values with special characters', () => {
-        const result = buildSpawnArgs('node', [], {
-          asUser: 'alice',
-          env: { SECRET: "pass'word" },
-        });
-        // Should escape the single quote in the value
-        expect(result.args[5]).toContain("SECRET='pass'\\''word'");
-      });
-
       it('ignores env vars when not impersonating', () => {
         const result = buildSpawnArgs('node', ['script.js'], {
-          env: { GITHUB_TOKEN: 'abc123' },
+          env: { NODE_ENV: 'test' },
         });
-        // Without asUser, env should not affect the output
         expect(result).toEqual({
           cmd: 'node',
           args: ['script.js'],
@@ -127,6 +132,128 @@ describe('run-as-user', () => {
         // Should not have env prefix
         expect(result.args[5]).toBe('node');
       });
+    });
+
+    describe('with envFilePath (secure path)', () => {
+      it('uses envFilePath to source env inside impersonated shell', () => {
+        const result = buildSpawnArgs('node', ['script.js'], {
+          asUser: 'alice',
+          envFilePath: '/tmp/agor-env-abc123',
+        });
+        expect(result.cmd).toBe('sudo');
+        expect(result.args.slice(0, 4)).toEqual(['-n', '-u', 'alice', 'bash']);
+        expect(result.args[4]).toBe('-c');
+        // Script references ENVFILE from $1, not interpolated
+        expect(result.args[5]).toBe(
+          'ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f "$ENVFILE"; exec "$@"'
+        );
+        // Positional args: separator, envFilePath, then the real command
+        expect(result.args[6]).toBe('--');
+        expect(result.args[7]).toBe('/tmp/agor-env-abc123');
+        expect(result.args[8]).toBe('node');
+        expect(result.args[9]).toBe('script.js');
+      });
+
+      it('REGRESSION: does NOT contain any secret values in argv', () => {
+        const secretValues = {
+          ANTHROPIC_API_KEY: 'sk-ant-super-secret-value-DO-NOT-LEAK',
+          OPENAI_API_KEY: 'sk-openai-super-secret-value-DO-NOT-LEAK',
+          GEMINI_API_KEY: 'gemini-super-secret-value-DO-NOT-LEAK',
+          GITHUB_TOKEN: 'ghp_super-secret-token-DO-NOT-LEAK',
+          OAUTH_REFRESH_TOKEN: 'oauth-super-secret-refresh-DO-NOT-LEAK',
+          SOMETHING_SECRET: 'some-super-secret-DO-NOT-LEAK',
+        };
+        // Using the secure path: envFilePath + no inline env
+        const result = buildSpawnArgs('node', ['executor', '--stdin'], {
+          asUser: 'alice',
+          envFilePath: '/tmp/agor-env-nonce',
+        });
+
+        const argvSerialized = [result.cmd, ...result.args].join('\n');
+        for (const value of Object.values(secretValues)) {
+          expect(argvSerialized).not.toContain(value);
+        }
+      });
+
+      it('rejects envFilePath containing shell metacharacters', () => {
+        expect(() =>
+          buildSpawnArgs('node', [], {
+            asUser: 'alice',
+            envFilePath: '/tmp/evil; rm -rf /',
+          })
+        ).toThrow(/suspicious envFilePath/);
+        expect(() =>
+          buildSpawnArgs('node', [], {
+            asUser: 'alice',
+            envFilePath: '/tmp/evil`whoami`',
+          })
+        ).toThrow(/suspicious envFilePath/);
+      });
+    });
+  });
+
+  describe('isSecretEnvKey / SECRET_ENV_KEY_PATTERN', () => {
+    it('matches *_API_KEY', () => {
+      expect(isSecretEnvKey('ANTHROPIC_API_KEY')).toBe(true);
+      expect(isSecretEnvKey('OPENAI_API_KEY')).toBe(true);
+      expect(isSecretEnvKey('GEMINI_API_KEY')).toBe(true);
+      expect(isSecretEnvKey('GOOGLE_API_KEY')).toBe(true);
+    });
+
+    it('matches *_TOKEN', () => {
+      expect(isSecretEnvKey('GITHUB_TOKEN')).toBe(true);
+      expect(isSecretEnvKey('ANTHROPIC_AUTH_TOKEN')).toBe(true);
+    });
+
+    it('matches *_SECRET', () => {
+      expect(isSecretEnvKey('JWT_SECRET')).toBe(true);
+      expect(isSecretEnvKey('CLIENT_SECRET')).toBe(true);
+    });
+
+    it('matches OAUTH_* prefix', () => {
+      expect(isSecretEnvKey('OAUTH_ACCESS_TOKEN')).toBe(true);
+      expect(isSecretEnvKey('OAUTH_REFRESH_TOKEN')).toBe(true);
+    });
+
+    it('does not match non-secret names', () => {
+      expect(isSecretEnvKey('PATH')).toBe(false);
+      expect(isSecretEnvKey('HOME')).toBe(false);
+      expect(isSecretEnvKey('NODE_ENV')).toBe(false);
+      expect(isSecretEnvKey('DAEMON_URL')).toBe(false);
+      expect(isSecretEnvKey('TERM')).toBe(false);
+    });
+
+    it('pattern is exported for caller use', () => {
+      expect(SECRET_ENV_KEY_PATTERN).toBeInstanceOf(RegExp);
+    });
+  });
+
+  describe('redactSecretEnv', () => {
+    it('drops secret keys by default', () => {
+      const input = {
+        PATH: '/usr/bin',
+        ANTHROPIC_API_KEY: 'sk-ant-leak',
+        GITHUB_TOKEN: 'ghp-leak',
+      };
+      const out = redactSecretEnv(input);
+      expect(out).toEqual({ PATH: '/usr/bin' });
+      // Values never appear
+      expect(JSON.stringify(out)).not.toContain('sk-ant-leak');
+      expect(JSON.stringify(out)).not.toContain('ghp-leak');
+    });
+
+    it('with keepKeys=true, redacts values but keeps keys', () => {
+      const out = redactSecretEnv(
+        { PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-leak' },
+        { keepKeys: true }
+      );
+      expect(out).toEqual({ PATH: '/usr/bin', ANTHROPIC_API_KEY: '***' });
+      expect(JSON.stringify(out)).not.toContain('sk-ant-leak');
+    });
+
+    it('drops undefined values', () => {
+      const out = redactSecretEnv({ PATH: '/usr/bin', MAYBE: undefined });
+      expect(out).toEqual({ PATH: '/usr/bin' });
     });
   });
 });

--- a/packages/core/src/unix/run-as-user.ts
+++ b/packages/core/src/unix/run-as-user.ts
@@ -2,8 +2,8 @@
  * Run As User - Central Unix Command Execution Utility
  *
  * Provides a unified interface for running commands as another Unix user.
- * When impersonation is needed, always uses `sudo -u $USER bash -c "..."` to ensure
- * fresh Unix group memberships are loaded.
+ * When impersonation is needed, always uses `sudo -n -u $USER bash -c "..."`
+ * to ensure fresh Unix group memberships are loaded.
  *
  * HOW `sudo -u` PROVIDES FRESH GROUP MEMBERSHIPS:
  * When sudo switches users (via -u), it calls the initgroups() syscall which reads
@@ -18,14 +18,15 @@
  * SECURITY NOTE: We use `sudo -u` instead of `sudo su` to avoid needing to
  * whitelist the /usr/bin/su binary in sudoers, which would be a security risk.
  *
+ * Secret-aware classification (`isSecretEnvKey`, `redactSecretEnv`) lives in
+ * {@link ./secret-env.js}. On-disk env-file primitives
+ * (`writeUserEnvFile`, `prepareImpersonationEnv`, cleanup helpers) live in
+ * {@link ./user-env-file.js}.
+ *
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
-import { execFileSync, execSync } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
-import { unlinkSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { execSync } from 'node:child_process';
 
 import { isValidUnixUsername } from './user-manager.js';
 
@@ -146,7 +147,7 @@ export interface BuildSpawnArgsOptions {
    * WARNING: values passed this way end up in the process's argv and are
    * visible via `ps`, `/proc/<pid>/cmdline`, audit logs, etc. Never pass
    * secrets (API keys, tokens) via `env` alone when impersonating — use
-   * {@link writeUserEnvFile} + `envFilePath` instead.
+   * `writeUserEnvFile` + `envFilePath` instead.
    */
   env?: Record<string, string>;
 
@@ -158,8 +159,11 @@ export interface BuildSpawnArgsOptions {
    * command. The env values never appear in argv. The path itself is in argv
    * but it is not secret.
    *
-   * Use {@link writeUserEnvFile} to produce a path that is owned by the
-   * target user with mode 0600.
+   * Use `writeUserEnvFile` to produce a path that is owned by the target
+   * user with mode 0600.
+   *
+   * Requires `asUser`: passing `envFilePath` without `asUser` throws, since
+   * the env-file is only sourced inside the impersonated shell.
    */
   envFilePath?: string;
 }
@@ -171,9 +175,10 @@ export interface BuildSpawnArgsOptions {
  * Use this when you need to spawn a long-running process rather than exec.
  *
  * IMPORTANT: When impersonating (asUser is set), env vars passed to spawn()
- * are ignored because `sudo su -` creates a fresh login shell. To pass env vars
- * to the inner command, provide them via the `env` option here - they will be
- * injected using the `env` command prefix.
+ * are ignored because `sudo -u` starts a fresh environment. To pass env vars
+ * to the inner command, provide them via the `env` option here — they will
+ * be injected using the `env` command prefix — or (for secrets) via
+ * `envFilePath`, which keeps values out of argv.
  *
  * @param command - Command to run (e.g., 'zellij')
  * @param args - Arguments to pass to the command
@@ -205,6 +210,14 @@ export function buildSpawnArgs(
     typeof options === 'string' ? { asUser: options } : (options ?? {});
   const { asUser, env, envFilePath } = opts;
 
+  // envFilePath only makes sense when impersonating — the env-file is sourced
+  // inside the impersonated shell. Fail loudly rather than silently dropping.
+  if (envFilePath !== undefined && !asUser) {
+    throw new Error(
+      'buildSpawnArgs: envFilePath requires asUser (env-file is only sourced inside the impersonated shell)'
+    );
+  }
+
   if (!asUser) {
     // No impersonation: return command/args as-is
     // Caller should pass env to spawn() directly
@@ -220,19 +233,35 @@ export function buildSpawnArgs(
 
   // Prefer env-file sourcing: secrets stay out of argv entirely.
   if (envFilePath) {
-    // Validate envFilePath too — it ends up in argv. It must not contain shell
-    // metachars or newlines; a tempfile path will not.
-    if (!/^[\w@%+=:,./-]+$/.test(envFilePath)) {
-      throw new Error(`buildSpawnArgs: suspicious envFilePath: ${JSON.stringify(envFilePath)}`);
+    // Structural validation only. The path is passed as a positional argv
+    // entry and referenced as "$1" inside bash, so shell metachars (spaces,
+    // parens, etc.) are safe and we must accept them — e.g. macOS TMPDIR
+    // lives under `/var/folders/.../T/` with fine characters but Linux
+    // sysadmins sometimes mount a shared TMPDIR with spaces.
+    //
+    // We reject: relative paths, NUL/newline/control chars (which would
+    // break `. "$ENVFILE"` or allow line-splitting tricks).
+    if (!envFilePath.startsWith('/')) {
+      throw new Error(
+        `buildSpawnArgs: envFilePath must be absolute: ${JSON.stringify(envFilePath)}`
+      );
+    }
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: explicitly rejecting control chars
+    if (/[\x00-\x1f\x7f]/.test(envFilePath)) {
+      throw new Error(
+        `buildSpawnArgs: envFilePath contains control characters: ${JSON.stringify(envFilePath)}`
+      );
     }
 
     // Inner bash script:
     //   $1 = env file path, $2... = real command + args
-    //   - source env into current shell
-    //   - unlink file (best effort) before exec so it does not linger on disk
+    //   - set -eu: if source fails, abort BEFORE rm+exec so we never
+    //     launch the real process with missing secrets
+    //   - source env into current shell (set -a auto-exports)
+    //   - unlink file before exec so it does not linger on disk
     //   - exec preserves env into the target process
     const innerScript =
-      'ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f "$ENVFILE"; exec "$@"';
+      'set -eu; ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f -- "$ENVFILE"; exec "$@"';
 
     return {
       cmd: 'sudo',
@@ -264,124 +293,4 @@ export function buildSpawnArgs(
     cmd: 'sudo',
     args: ['-n', '-u', asUser, 'bash', '-c', innerCommand],
   };
-}
-
-/**
- * Regex matching env var NAMES that are expected to hold secrets.
- *
- * Used by callers to decide whether to route a given env var through
- * {@link writeUserEnvFile} (keeps value out of argv/logs) vs inlining it
- * in the command. Also used by {@link redactSecretEnv} for log hygiene.
- */
-export const SECRET_ENV_KEY_PATTERN = /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_KEY)$|^OAUTH_/i;
-
-/**
- * Returns true if an env var name matches a well-known secret pattern.
- */
-export function isSecretEnvKey(name: string): boolean {
-  return SECRET_ENV_KEY_PATTERN.test(name);
-}
-
-/**
- * Redact an env map for logging. Secret keys (per {@link isSecretEnvKey})
- * have their values replaced with `"***"` and their key is preserved only
- * if `keepKeys` is true. Default drops the key entirely so we never log
- * e.g. `ANTHROPIC_API_KEY` at all.
- */
-export function redactSecretEnv(
-  env: Record<string, string | undefined>,
-  options: { keepKeys?: boolean } = {}
-): Record<string, string> {
-  const { keepKeys = false } = options;
-  const out: Record<string, string> = {};
-  for (const [key, value] of Object.entries(env)) {
-    if (value === undefined) continue;
-    if (isSecretEnvKey(key)) {
-      if (keepKeys) out[key] = '***';
-      continue;
-    }
-    out[key] = value;
-  }
-  return out;
-}
-
-/**
- * Write an env file owned by the target Unix user with mode 0600.
- *
- * Strategy: invoke `sudo -n -u <asUser> bash -c '...'` with stdin piped in.
- * The env content is passed via stdin (NOT argv), and the shell creates the
- * file under `umask 077` with `set -C` (noclobber) so pre-existing symlinks
- * or regular files cause a hard failure instead of being followed/truncated.
- *
- * The resulting file:
- * - Is owned by `asUser` (sudo switches uid before any write)
- * - Has mode 0600 (umask 077 applied to default 0666)
- * - Lives at an unpredictable path (16 random bytes) in the system tempdir
- * - Is created atomically relative to other files with the same name: if
- *   anything is there first, noclobber causes the shell to exit non-zero
- *
- * Caller is responsible for ensuring cleanup. The generated spawn command
- * from {@link buildSpawnArgs} with `envFilePath` will `rm -f` the file
- * inside the impersonated shell before `exec`, so in the normal path the
- * file is gone by the time the real executor starts. As a safety net,
- * callers should still attempt `unlinkSync` (or equivalent) from an
- * `exit`/`error` handler.
- *
- * Values never appear in argv at any stage.
- *
- * @param asUser - Target Unix user (must pass isValidUnixUsername)
- * @param env - Env vars to write
- * @returns Absolute path to the created env file
- * @throws if asUser is invalid, or sudo/bash fails (e.g. symlink race)
- */
-export function writeUserEnvFile(asUser: string, env: Record<string, string>): string {
-  if (!isValidUnixUsername(asUser)) {
-    throw new Error(`writeUserEnvFile: invalid Unix username: ${JSON.stringify(asUser)}`);
-  }
-
-  // Unpredictable filename — 16 bytes = 128 bits of entropy.
-  const nonce = randomBytes(16).toString('hex');
-  const envFilePath = join(tmpdir(), `agor-env-${nonce}`);
-
-  // Serialize env as `KEY='value'` lines, single-quote-escaped so they round-trip
-  // through `. "$ENVFILE"`. Keys are already env-var identifiers; reject anything
-  // else to avoid injection into the sourced file.
-  const lines: string[] = [];
-  for (const [key, value] of Object.entries(env)) {
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-      throw new Error(`writeUserEnvFile: invalid env var name: ${JSON.stringify(key)}`);
-    }
-    lines.push(`${key}=${escapeShellArg(value)}`);
-  }
-  const content = `${lines.join('\n')}\n`;
-
-  // Inner script:
-  //   - umask 077 so cat > creates 0600
-  //   - set -C (noclobber) so existing path (incl. symlink) aborts
-  //   - redirect stdin to the target path via cat
-  const script = 'umask 077; set -C; cat > "$1"';
-
-  execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script, '--', envFilePath], {
-    input: content,
-    stdio: ['pipe', 'ignore', 'pipe'],
-    timeout: DEFAULT_TIMEOUT_MS,
-  });
-
-  return envFilePath;
-}
-
-/**
- * Best-effort removal of an env file. Swallows ENOENT since the normal spawn
- * path `rm -f`s the file inside the impersonated shell before it execs.
- *
- * Note: if the file is owned by another user, `unlinkSync` from the daemon
- * will fail with EPERM. That is acceptable — the file is 0600 and unreadable
- * by the daemon anyway, and `/tmp` cleanup will reap it.
- */
-export function tryUnlinkEnvFile(path: string): void {
-  try {
-    unlinkSync(path);
-  } catch {
-    // best-effort; see doc above
-  }
 }

--- a/packages/core/src/unix/run-as-user.ts
+++ b/packages/core/src/unix/run-as-user.ts
@@ -21,7 +21,13 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { isValidUnixUsername } from './user-manager.js';
 
 /**
  * Default timeout for commands in milliseconds
@@ -130,14 +136,32 @@ export interface BuildSpawnArgsOptions {
   /**
    * Environment variables to pass to the inner command.
    *
-   * When impersonating (asUser is set), these env vars are injected into the
-   * inner command using the `env` command prefix. This is necessary because
-   * `sudo su -` creates a fresh login shell that ignores the env passed to spawn().
-   *
    * When NOT impersonating, these env vars should be passed to spawn() directly
    * via the `env` option (this function doesn't modify them).
+   *
+   * When impersonating (asUser is set) AND `envFilePath` is not set, env vars
+   * are inlined into the inner command via the `env` prefix. This path is
+   * retained for non-secret env (e.g., TERM, PATH, DAEMON_URL) and tests.
+   *
+   * WARNING: values passed this way end up in the process's argv and are
+   * visible via `ps`, `/proc/<pid>/cmdline`, audit logs, etc. Never pass
+   * secrets (API keys, tokens) via `env` alone when impersonating — use
+   * {@link writeUserEnvFile} + `envFilePath` instead.
    */
   env?: Record<string, string>;
+
+  /**
+   * Path to an on-disk env file to source before `exec`ing the inner command.
+   *
+   * When set together with `asUser`, the generated command sources this file
+   * inside the impersonated shell, then removes it, then `exec`s the real
+   * command. The env values never appear in argv. The path itself is in argv
+   * but it is not secret.
+   *
+   * Use {@link writeUserEnvFile} to produce a path that is owned by the
+   * target user with mode 0600.
+   */
+  envFilePath?: string;
 }
 
 /**
@@ -179,7 +203,7 @@ export function buildSpawnArgs(
   // Handle backward compatibility: options can be a string (asUser) or object
   const opts: BuildSpawnArgsOptions =
     typeof options === 'string' ? { asUser: options } : (options ?? {});
-  const { asUser, env } = opts;
+  const { asUser, env, envFilePath } = opts;
 
   if (!asUser) {
     // No impersonation: return command/args as-is
@@ -187,6 +211,36 @@ export function buildSpawnArgs(
     return { cmd: command, args };
   }
 
+  // Defence-in-depth: validate asUser format before it is used as an argv
+  // token to `sudo -u`. `isValidUnixUsername` rejects anything outside
+  // [a-z_][a-z0-9_-]{0,31} so it cannot be a shell metachar or a flag.
+  if (!isValidUnixUsername(asUser)) {
+    throw new Error(`buildSpawnArgs: invalid Unix username: ${JSON.stringify(asUser)}`);
+  }
+
+  // Prefer env-file sourcing: secrets stay out of argv entirely.
+  if (envFilePath) {
+    // Validate envFilePath too — it ends up in argv. It must not contain shell
+    // metachars or newlines; a tempfile path will not.
+    if (!/^[\w@%+=:,./-]+$/.test(envFilePath)) {
+      throw new Error(`buildSpawnArgs: suspicious envFilePath: ${JSON.stringify(envFilePath)}`);
+    }
+
+    // Inner bash script:
+    //   $1 = env file path, $2... = real command + args
+    //   - source env into current shell
+    //   - unlink file (best effort) before exec so it does not linger on disk
+    //   - exec preserves env into the target process
+    const innerScript =
+      'ENVFILE="$1"; shift; set -a; . "$ENVFILE"; set +a; rm -f "$ENVFILE"; exec "$@"';
+
+    return {
+      cmd: 'sudo',
+      args: ['-n', '-u', asUser, 'bash', '-c', innerScript, '--', envFilePath, command, ...args],
+    };
+  }
+
+  // Legacy/non-secret path: inline env vars into argv.
   // Build env prefix if env vars provided
   // Format: env VAR1='val1' VAR2='val2' ...
   let envPrefix = '';
@@ -210,4 +264,124 @@ export function buildSpawnArgs(
     cmd: 'sudo',
     args: ['-n', '-u', asUser, 'bash', '-c', innerCommand],
   };
+}
+
+/**
+ * Regex matching env var NAMES that are expected to hold secrets.
+ *
+ * Used by callers to decide whether to route a given env var through
+ * {@link writeUserEnvFile} (keeps value out of argv/logs) vs inlining it
+ * in the command. Also used by {@link redactSecretEnv} for log hygiene.
+ */
+export const SECRET_ENV_KEY_PATTERN = /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_KEY)$|^OAUTH_/i;
+
+/**
+ * Returns true if an env var name matches a well-known secret pattern.
+ */
+export function isSecretEnvKey(name: string): boolean {
+  return SECRET_ENV_KEY_PATTERN.test(name);
+}
+
+/**
+ * Redact an env map for logging. Secret keys (per {@link isSecretEnvKey})
+ * have their values replaced with `"***"` and their key is preserved only
+ * if `keepKeys` is true. Default drops the key entirely so we never log
+ * e.g. `ANTHROPIC_API_KEY` at all.
+ */
+export function redactSecretEnv(
+  env: Record<string, string | undefined>,
+  options: { keepKeys?: boolean } = {}
+): Record<string, string> {
+  const { keepKeys = false } = options;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if (isSecretEnvKey(key)) {
+      if (keepKeys) out[key] = '***';
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Write an env file owned by the target Unix user with mode 0600.
+ *
+ * Strategy: invoke `sudo -n -u <asUser> bash -c '...'` with stdin piped in.
+ * The env content is passed via stdin (NOT argv), and the shell creates the
+ * file under `umask 077` with `set -C` (noclobber) so pre-existing symlinks
+ * or regular files cause a hard failure instead of being followed/truncated.
+ *
+ * The resulting file:
+ * - Is owned by `asUser` (sudo switches uid before any write)
+ * - Has mode 0600 (umask 077 applied to default 0666)
+ * - Lives at an unpredictable path (16 random bytes) in the system tempdir
+ * - Is created atomically relative to other files with the same name: if
+ *   anything is there first, noclobber causes the shell to exit non-zero
+ *
+ * Caller is responsible for ensuring cleanup. The generated spawn command
+ * from {@link buildSpawnArgs} with `envFilePath` will `rm -f` the file
+ * inside the impersonated shell before `exec`, so in the normal path the
+ * file is gone by the time the real executor starts. As a safety net,
+ * callers should still attempt `unlinkSync` (or equivalent) from an
+ * `exit`/`error` handler.
+ *
+ * Values never appear in argv at any stage.
+ *
+ * @param asUser - Target Unix user (must pass isValidUnixUsername)
+ * @param env - Env vars to write
+ * @returns Absolute path to the created env file
+ * @throws if asUser is invalid, or sudo/bash fails (e.g. symlink race)
+ */
+export function writeUserEnvFile(asUser: string, env: Record<string, string>): string {
+  if (!isValidUnixUsername(asUser)) {
+    throw new Error(`writeUserEnvFile: invalid Unix username: ${JSON.stringify(asUser)}`);
+  }
+
+  // Unpredictable filename — 16 bytes = 128 bits of entropy.
+  const nonce = randomBytes(16).toString('hex');
+  const envFilePath = join(tmpdir(), `agor-env-${nonce}`);
+
+  // Serialize env as `KEY='value'` lines, single-quote-escaped so they round-trip
+  // through `. "$ENVFILE"`. Keys are already env-var identifiers; reject anything
+  // else to avoid injection into the sourced file.
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(`writeUserEnvFile: invalid env var name: ${JSON.stringify(key)}`);
+    }
+    lines.push(`${key}=${escapeShellArg(value)}`);
+  }
+  const content = `${lines.join('\n')}\n`;
+
+  // Inner script:
+  //   - umask 077 so cat > creates 0600
+  //   - set -C (noclobber) so existing path (incl. symlink) aborts
+  //   - redirect stdin to the target path via cat
+  const script = 'umask 077; set -C; cat > "$1"';
+
+  execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script, '--', envFilePath], {
+    input: content,
+    stdio: ['pipe', 'ignore', 'pipe'],
+    timeout: DEFAULT_TIMEOUT_MS,
+  });
+
+  return envFilePath;
+}
+
+/**
+ * Best-effort removal of an env file. Swallows ENOENT since the normal spawn
+ * path `rm -f`s the file inside the impersonated shell before it execs.
+ *
+ * Note: if the file is owned by another user, `unlinkSync` from the daemon
+ * will fail with EPERM. That is acceptable — the file is 0600 and unreadable
+ * by the daemon anyway, and `/tmp` cleanup will reap it.
+ */
+export function tryUnlinkEnvFile(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // best-effort; see doc above
+  }
 }

--- a/packages/core/src/unix/secret-env.test.ts
+++ b/packages/core/src/unix/secret-env.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSecretEnvKey,
+  redactSecretEnv,
+  SECRET_ENV_KEY_PATTERN,
+  splitSecretEnv,
+} from './secret-env.js';
+
+describe('isSecretEnvKey / SECRET_ENV_KEY_PATTERN', () => {
+  it('matches *_API_KEY', () => {
+    expect(isSecretEnvKey('ANTHROPIC_API_KEY')).toBe(true);
+    expect(isSecretEnvKey('OPENAI_API_KEY')).toBe(true);
+    expect(isSecretEnvKey('GEMINI_API_KEY')).toBe(true);
+    expect(isSecretEnvKey('GOOGLE_API_KEY')).toBe(true);
+  });
+
+  it('matches *_TOKEN', () => {
+    expect(isSecretEnvKey('GITHUB_TOKEN')).toBe(true);
+    expect(isSecretEnvKey('ANTHROPIC_AUTH_TOKEN')).toBe(true);
+  });
+
+  it('matches *_SECRET', () => {
+    expect(isSecretEnvKey('JWT_SECRET')).toBe(true);
+    expect(isSecretEnvKey('CLIENT_SECRET')).toBe(true);
+  });
+
+  it('matches OAUTH_* prefix', () => {
+    expect(isSecretEnvKey('OAUTH_ACCESS_TOKEN')).toBe(true);
+    expect(isSecretEnvKey('OAUTH_REFRESH_TOKEN')).toBe(true);
+  });
+
+  it('does not match non-secret names', () => {
+    expect(isSecretEnvKey('PATH')).toBe(false);
+    expect(isSecretEnvKey('HOME')).toBe(false);
+    expect(isSecretEnvKey('NODE_ENV')).toBe(false);
+    expect(isSecretEnvKey('DAEMON_URL')).toBe(false);
+    expect(isSecretEnvKey('TERM')).toBe(false);
+  });
+
+  it('pattern is exported for caller use', () => {
+    expect(SECRET_ENV_KEY_PATTERN).toBeInstanceOf(RegExp);
+  });
+});
+
+describe('redactSecretEnv', () => {
+  it('drops secret keys by default', () => {
+    const input = {
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'sk-ant-leak',
+      GITHUB_TOKEN: 'ghp-leak',
+    };
+    const out = redactSecretEnv(input);
+    expect(out).toEqual({ PATH: '/usr/bin' });
+    // Values never appear
+    expect(JSON.stringify(out)).not.toContain('sk-ant-leak');
+    expect(JSON.stringify(out)).not.toContain('ghp-leak');
+  });
+
+  it('with keepKeys=true, redacts values but keeps keys', () => {
+    const out = redactSecretEnv(
+      { PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-ant-leak' },
+      { keepKeys: true }
+    );
+    expect(out).toEqual({ PATH: '/usr/bin', ANTHROPIC_API_KEY: '***' });
+    expect(JSON.stringify(out)).not.toContain('sk-ant-leak');
+  });
+
+  it('drops undefined values', () => {
+    const out = redactSecretEnv({ PATH: '/usr/bin', MAYBE: undefined });
+    expect(out).toEqual({ PATH: '/usr/bin' });
+  });
+});
+
+describe('splitSecretEnv', () => {
+  it('partitions secret vs inline env entries', () => {
+    const { secret, inline } = splitSecretEnv({
+      PATH: '/usr/bin',
+      ANTHROPIC_API_KEY: 'sk-leak',
+      DAEMON_URL: 'http://x',
+      OAUTH_TOKEN: 'oauth-leak',
+    });
+    expect(inline).toEqual({ PATH: '/usr/bin', DAEMON_URL: 'http://x' });
+    expect(secret).toEqual({ ANTHROPIC_API_KEY: 'sk-leak', OAUTH_TOKEN: 'oauth-leak' });
+  });
+
+  it('drops undefined values', () => {
+    const { secret, inline } = splitSecretEnv({
+      PATH: '/usr/bin',
+      MISSING: undefined,
+      ANTHROPIC_API_KEY: undefined,
+    });
+    expect(inline).toEqual({ PATH: '/usr/bin' });
+    expect(secret).toEqual({});
+  });
+
+  it('returns empty objects for empty input', () => {
+    const { secret, inline } = splitSecretEnv({});
+    expect(secret).toEqual({});
+    expect(inline).toEqual({});
+  });
+});

--- a/packages/core/src/unix/secret-env.ts
+++ b/packages/core/src/unix/secret-env.ts
@@ -1,0 +1,75 @@
+/**
+ * Secret-aware env classification and redaction.
+ *
+ * Pure logic — no I/O. Lives here (not in run-as-user.ts) so it can be
+ * imported by log-hygiene paths without pulling in spawn/exec concerns.
+ */
+
+/**
+ * Regex matching env var NAMES that are expected to hold secrets.
+ *
+ * Used by callers to decide whether to route a given env var through an
+ * on-disk env file (keeps value out of argv/logs) vs inlining it into the
+ * impersonated shell command. Also used by {@link redactSecretEnv} for log
+ * hygiene.
+ *
+ * Intentionally broad: a false positive merely routes a non-secret through
+ * the env-file path (no functional change, child still sees the var). A
+ * false negative would leak the value into argv.
+ */
+export const SECRET_ENV_KEY_PATTERN = /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_KEY)$|^OAUTH_/i;
+
+/**
+ * Returns true if an env var name matches a well-known secret pattern.
+ */
+export function isSecretEnvKey(name: string): boolean {
+  return SECRET_ENV_KEY_PATTERN.test(name);
+}
+
+/**
+ * Redact an env map for logging. Secret keys (per {@link isSecretEnvKey})
+ * have their values replaced with `"***"` and their key is preserved only
+ * if `keepKeys` is true. Default drops the key entirely so we never log
+ * e.g. `ANTHROPIC_API_KEY` at all.
+ */
+export function redactSecretEnv(
+  env: Record<string, string | undefined>,
+  options: { keepKeys?: boolean } = {}
+): Record<string, string> {
+  const { keepKeys = false } = options;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if (isSecretEnvKey(key)) {
+      if (keepKeys) out[key] = '***';
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Partition an env map into secret vs non-secret ("inline") entries.
+ *
+ * Callers route `secret` through {@link import('./user-env-file.js').writeUserEnvFile}
+ * and pass `inline` through the legacy `env <K>='<V>'` argv path.
+ *
+ * Undefined values are dropped.
+ */
+export function splitSecretEnv(env: Record<string, string | undefined>): {
+  secret: Record<string, string>;
+  inline: Record<string, string>;
+} {
+  const secret: Record<string, string> = {};
+  const inline: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if (isSecretEnvKey(key)) {
+      secret[key] = value;
+    } else {
+      inline[key] = value;
+    }
+  }
+  return { secret, inline };
+}

--- a/packages/core/src/unix/user-env-file.ts
+++ b/packages/core/src/unix/user-env-file.ts
@@ -1,0 +1,218 @@
+/**
+ * On-disk env-file primitive for passing secrets to impersonated processes
+ * without putting their values in argv (`/proc/<pid>/cmdline`).
+ *
+ * Flow:
+ * 1. {@link writeUserEnvFile} creates a 0600 file owned by the target user.
+ * 2. {@link buildSpawnArgs} (see run-as-user.ts) emits a `bash -c` script
+ *    that sources the file, unlinks it, and execs the real command.
+ * 3. {@link attachEnvFileCleanup} wires a safety-net unlink on the spawned
+ *    child's `error`/`exit` events, using sudo when the file is owned by
+ *    a different user.
+ *
+ * {@link prepareImpersonationEnv} is the high-level helper that composes
+ * {@link splitSecretEnv} + {@link writeUserEnvFile} so call sites don't
+ * re-implement the split.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { escapeShellArg } from './run-as-user.js';
+import { splitSecretEnv } from './secret-env.js';
+import { isValidUnixUsername } from './user-manager.js';
+
+/**
+ * Default timeout for sudo helper commands (file write, cleanup).
+ * 5 seconds matches `run-as-user` — more than enough for a local `cat > file`.
+ */
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Prefix used for env-file names in the system tempdir. Also used by any
+ * future startup sweeper to identify stale files.
+ */
+const ENV_FILE_PREFIX = 'agor-env-';
+
+/**
+ * Write an env file owned by the target Unix user with mode 0600.
+ *
+ * Strategy: invoke `sudo -n -u <asUser> bash -c '...'` with stdin piped in.
+ * The env content is passed via stdin (NOT argv), and the shell creates the
+ * file under `umask 077` with `set -C` (noclobber) so pre-existing symlinks
+ * or regular files cause a hard failure instead of being followed/truncated.
+ *
+ * The resulting file:
+ * - Is owned by `asUser` (sudo switches uid before any write)
+ * - Has mode 0600 (umask 077 applied to default 0666)
+ * - Lives at an unpredictable path (16 random bytes = 128 bits of entropy)
+ *   in the system tempdir
+ * - Is created atomically relative to other files with the same name: if
+ *   anything is there first, noclobber causes the shell to exit non-zero
+ *
+ * Values never appear in argv at any stage.
+ *
+ * Caller is responsible for ensuring cleanup. The generated spawn command
+ * from `buildSpawnArgs` with `envFilePath` will `rm -f` the file inside
+ * the impersonated shell before `exec`, so in the normal path the file is
+ * gone by the time the real executor starts. As a safety net, callers
+ * should still attach {@link attachEnvFileCleanup} on the child process.
+ *
+ * @param asUser - Target Unix user (must pass isValidUnixUsername)
+ * @param env - Env vars to write
+ * @returns Absolute path to the created env file
+ * @throws if asUser is invalid, or sudo/bash fails (e.g. symlink race)
+ */
+export function writeUserEnvFile(asUser: string, env: Record<string, string>): string {
+  if (!isValidUnixUsername(asUser)) {
+    throw new Error(`writeUserEnvFile: invalid Unix username: ${JSON.stringify(asUser)}`);
+  }
+
+  // Unpredictable filename — 16 bytes = 128 bits of entropy.
+  const nonce = randomBytes(16).toString('hex');
+  const envFilePath = join(tmpdir(), `${ENV_FILE_PREFIX}${nonce}`);
+
+  // Serialize env as `KEY='value'` lines, single-quote-escaped so they round-trip
+  // through `. "$ENVFILE"`. Keys are already env-var identifiers; reject anything
+  // else to avoid injection into the sourced file.
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(`writeUserEnvFile: invalid env var name: ${JSON.stringify(key)}`);
+    }
+    lines.push(`${key}=${escapeShellArg(value)}`);
+  }
+  const content = `${lines.join('\n')}\n`;
+
+  // Inner script:
+  //   - umask 077 so cat > creates 0600
+  //   - set -C (noclobber) so existing path (incl. symlink) aborts
+  //   - redirect stdin to the target path via cat
+  const script = 'umask 077; set -C; cat > "$1"';
+
+  execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script, '--', envFilePath], {
+    input: content,
+    stdio: ['pipe', 'ignore', 'pipe'],
+    timeout: DEFAULT_TIMEOUT_MS,
+  });
+
+  return envFilePath;
+}
+
+/**
+ * Best-effort removal of an env file from the daemon user.
+ *
+ * Used as a safety net when the daemon owns the file (no impersonation) or
+ * when we simply don't know the owner. If the file is owned by a different
+ * Unix user and `/tmp` is sticky, this will fail with EPERM — prefer
+ * {@link tryUnlinkEnvFileAsUser} when `asUser` is known.
+ */
+export function tryUnlinkEnvFile(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Best-effort removal of an env file owned by another Unix user via
+ * `sudo -n -u <asUser> rm -f -- <path>`. Used as the safety-net cleanup
+ * path when the spawned child fails to launch (inner script's own `rm`
+ * never ran) and the file is owned by the impersonated user, where the
+ * daemon itself cannot `unlink()` due to sticky-tmp perms.
+ *
+ * Silently swallows failure.
+ */
+export function tryUnlinkEnvFileAsUser(asUser: string, path: string): void {
+  if (!isValidUnixUsername(asUser)) return;
+  if (!isEnvFilePath(path)) return;
+  try {
+    execFileSync('sudo', ['-n', '-u', asUser, 'rm', '-f', '--', path], {
+      stdio: 'ignore',
+      timeout: DEFAULT_TIMEOUT_MS,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Structural check that a path looks like one of our env-files: absolute,
+ * basename starts with `agor-env-`, no NUL/newline/control chars. Guards
+ * {@link tryUnlinkEnvFileAsUser} against being weaponized to remove
+ * arbitrary files via the daemon-held sudoers grant.
+ */
+function isEnvFilePath(path: string): boolean {
+  if (!path.startsWith('/')) return false;
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: we explicitly reject control chars in paths
+  if (/[\x00-\x1f\x7f]/.test(path)) return false;
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  return base.startsWith(ENV_FILE_PREFIX);
+}
+
+/**
+ * Minimal subset of `ChildProcess` we touch for cleanup — lets callers pass
+ * either a real `ChildProcess` or a mock without pulling in node:child_process.
+ */
+export interface CleanupTarget {
+  once(event: 'error' | 'exit', listener: () => void): unknown;
+}
+
+/**
+ * Register a safety-net `unlink` on the child's `error`/`exit` events. The
+ * inner bash script `rm -f`s the file before `exec` in the normal path, so
+ * this only fires when sudo/bash fails to launch at all (or when the source
+ * step fails under `set -eu`).
+ *
+ * Uses sudo when `asUser` is set so it works under sticky `/tmp` where the
+ * daemon user cannot unlink files owned by `asUser`.
+ */
+export function attachEnvFileCleanup(
+  child: CleanupTarget,
+  options: { envFilePath: string | undefined; asUser?: string }
+): void {
+  const { envFilePath, asUser } = options;
+  if (!envFilePath) return;
+  const capturedPath = envFilePath;
+  const capturedAsUser = asUser;
+  const cleanup = () => {
+    if (capturedAsUser) {
+      tryUnlinkEnvFileAsUser(capturedAsUser, capturedPath);
+    } else {
+      tryUnlinkEnvFile(capturedPath);
+    }
+  };
+  child.once('error', cleanup);
+  child.once('exit', cleanup);
+}
+
+/**
+ * Split `env` into secret vs non-secret (see {@link splitSecretEnv}) and,
+ * when impersonating, write the secrets to a 0600 env-file owned by
+ * `asUser`. Returns the non-secret subset and the env-file path (or
+ * `undefined` if no secrets were present).
+ *
+ * When `asUser` is undefined, no env-file is created — the daemon's own
+ * process env is fine since nothing switches uid. Callers should pass the
+ * whole `env` through to `spawn()` in that case.
+ */
+export interface PreparedImpersonationEnv {
+  /** Non-secret env to inline into the `sudo bash -c` argv. */
+  inlineEnv: Record<string, string>;
+  /** Path to 0600 env-file with secrets, or undefined if none. */
+  envFilePath: string | undefined;
+}
+
+export function prepareImpersonationEnv(options: {
+  asUser: string;
+  env: Record<string, string | undefined>;
+}): PreparedImpersonationEnv {
+  const { asUser, env } = options;
+  const { secret, inline } = splitSecretEnv(env);
+  const envFilePath = Object.keys(secret).length > 0 ? writeUserEnvFile(asUser, secret) : undefined;
+  return { inlineEnv: inline, envFilePath };
+}


### PR DESCRIPTION
## Summary

Hardening pass to keep API keys, OAuth tokens, JWT secrets, and session tokens out of process argv, startup logs, and container stdout.

- **Impersonation env vars → 0600 env-file**: when the daemon spawns executors via `sudo -u <user> bash -c …`, secret-looking env vars (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `OAUTH_*`) are now written to a per-invocation file owned by the target user (mode 0600, unpredictable name, `set -C` noclobber, content piped via stdin) and sourced inside the impersonated shell. Values never land in argv / `/proc/<pid>/cmdline`. Applied consistently across `spawn-executor`, `register-services` prompt-spawn, and `environment-command-spawn`. Also validates `asUser` at the spawn boundary via `isValidUnixUsername` and replaces the old `Full command: …` / `Env vars being passed: …` log with a safe summary.
- **JWT bootstrap log**: drops `jwtSecret.substring(0, 16)` — logs length only.
- **Session-token strategy logs**: drops every `tokenPreview: …substring(0, 8)` from `parse` / `authenticate` / `verifyAccessToken` / stored-auth logs; bearer credentials must not appear in any form.
- **Docker prod entrypoint**: no longer echoes the default admin email/password to container stdout; emits a rotation warning on stderr only.

## Test plan

- [x] `pnpm --filter @agor/core test run src/unix/run-as-user.test.ts` — 27 tests pass, incl. a regression test asserting known secret values never appear anywhere in the argv returned by `buildSpawnArgs` on the secure path
- [x] `apps/agor-daemon` vitest suites `spawn-executor.secrets.test.ts` (14) and `jwt-bootstrap-log.test.ts` (2) — source-level guards against re-introducing the old patterns
- [x] `pnpm check` (typecheck + lint + build across workspace) passes
- [ ] Manual smoke: spawn an executor under `unix_user_mode: insulated` and verify `ps auxf` / `/proc/<pid>/cmdline` shows no API key values
- [ ] Manual smoke: bring up the prod docker image and confirm container stdout no longer prints admin credentials