### PR TITLE
security: scope find() queries by worktree RBAC

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the agor_messages_list MCP tool.
+ *
+ * Focus: the tool bypasses the Feathers hook pipeline by running a raw Drizzle
+ * query against the messages table. These tests verify that when
+ * `worktree_rbac` is enabled, the raw query is restricted to sessions the
+ * caller can access (preventing cross-worktree leakage via the `search`
+ * parameter).
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoist-safe mocks must be declared before the module under test is imported.
+const mockIsWorktreeRbacEnabled = vi.fn(() => false);
+const mockFindAccessibleSessions = vi.fn(async () => [] as Array<{ session_id: string }>);
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@agor/core/config');
+  return {
+    ...actual,
+    isWorktreeRbacEnabled: () => mockIsWorktreeRbacEnabled(),
+  };
+});
+
+// Bind the static SessionRepository constructor to a class whose instances
+// delegate findAccessibleSessions to our spy.
+class FakeSessionRepository {
+  async findAccessibleSessions(userId: string) {
+    return mockFindAccessibleSessions(userId);
+  }
+}
+
+// Capture the raw query the tool builds so we can assert on its shape.
+const mockWhereSpy = vi.fn();
+const mockAllSpy = vi.fn(async () => [] as unknown[]);
+
+vi.mock('@agor/core/db', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@agor/core/db');
+  return {
+    ...actual,
+    SessionRepository: FakeSessionRepository,
+    select: () => ({
+      from: () => ({
+        where: (cond: unknown) => {
+          mockWhereSpy(cond);
+          return {
+            orderBy: () => ({ all: () => mockAllSpy() }),
+          };
+        },
+      }),
+    }),
+  };
+});
+
+vi.mock('../resolve-ids.js', () => ({
+  resolveSessionId: async (_ctx: unknown, id: string) => id,
+  resolveTaskId: async (_ctx: unknown, id: string) => id,
+}));
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+async function registerAndGetHandler(ctx: { userId: string; role?: string }): Promise<ToolHandler> {
+  const { registerMessageTools } = await import('./messages.js');
+  let captured: ToolHandler | undefined;
+  const fakeServer = {
+    registerTool: (_name: string, _cfg: unknown, cb: ToolHandler) => {
+      captured = cb;
+    },
+  } as unknown as McpServer;
+
+  registerMessageTools(fakeServer, {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal test ctx
+    app: {} as any,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal test ctx
+    db: {} as any,
+    userId: ctx.userId as import('@agor/core/types').UserID,
+    sessionId: 'sess-0001' as import('@agor/core/types').SessionID,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal test ctx
+    authenticatedUser: { user_id: ctx.userId, role: ctx.role ?? 'member' } as any,
+    baseServiceParams: {},
+  });
+
+  if (!captured) throw new Error('tool handler was not captured');
+  return captured;
+}
+
+describe('agor_messages_list MCP tool', () => {
+  beforeEach(() => {
+    mockIsWorktreeRbacEnabled.mockReset();
+    mockFindAccessibleSessions.mockReset();
+    mockWhereSpy.mockReset();
+    mockAllSpy.mockReset();
+    mockAllSpy.mockResolvedValue([]);
+    mockIsWorktreeRbacEnabled.mockReturnValue(false);
+    mockFindAccessibleSessions.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('does not enforce RBAC when worktree_rbac is disabled', async () => {
+    mockIsWorktreeRbacEnabled.mockReturnValue(false);
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+    await handler({ search: 'secret' });
+    expect(mockFindAccessibleSessions).not.toHaveBeenCalled();
+    expect(mockAllSpy).toHaveBeenCalled();
+  });
+
+  it('short-circuits to empty when user has no accessible sessions', async () => {
+    mockIsWorktreeRbacEnabled.mockReturnValue(true);
+    mockFindAccessibleSessions.mockResolvedValue([]);
+
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+    const result = await handler({ search: 'secret' });
+
+    expect(mockFindAccessibleSessions).toHaveBeenCalledWith('user-1');
+    // Query must NOT be executed when there are no accessible sessions.
+    expect(mockAllSpy).not.toHaveBeenCalled();
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.messages).toEqual([]);
+    expect(parsed.total).toBe(0);
+  });
+
+  it('restricts raw query to accessible session ids for regular users', async () => {
+    mockIsWorktreeRbacEnabled.mockReturnValue(true);
+    mockFindAccessibleSessions.mockResolvedValue([
+      { session_id: 'sess-allowed-1' },
+      { session_id: 'sess-allowed-2' },
+    ]);
+
+    const handler = await registerAndGetHandler({ userId: 'user-1', role: 'member' });
+    await handler({ search: 'secret' });
+
+    expect(mockFindAccessibleSessions).toHaveBeenCalledWith('user-1');
+    expect(mockAllSpy).toHaveBeenCalled();
+    // Drizzle builds a SQL AST; walk it with a seen-set to avoid circular
+    // refs and collect every string leaf so we can assert both ids appear.
+    const seen = new WeakSet<object>();
+    const strings: string[] = [];
+    const walk = (v: unknown) => {
+      if (typeof v === 'string') {
+        strings.push(v);
+        return;
+      }
+      if (!v || typeof v !== 'object') return;
+      if (seen.has(v as object)) return;
+      seen.add(v as object);
+      for (const val of Object.values(v as Record<string, unknown>)) walk(val);
+    };
+    walk(mockWhereSpy.mock.calls[0]?.[0]);
+    expect(strings).toContain('sess-allowed-1');
+    expect(strings).toContain('sess-allowed-2');
+  });
+
+  it('bypasses RBAC filter for superadmin role', async () => {
+    mockIsWorktreeRbacEnabled.mockReturnValue(true);
+    const handler = await registerAndGetHandler({ userId: 'user-1', role: 'superadmin' });
+    await handler({ search: 'secret' });
+    expect(mockFindAccessibleSessions).not.toHaveBeenCalled();
+    expect(mockAllSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -1,7 +1,20 @@
-import { and, asc, desc, eq, messages as messagesTable, or, select, sql } from '@agor/core/db';
+import { isWorktreeRbacEnabled } from '@agor/core/config';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  messages as messagesTable,
+  or,
+  SessionRepository,
+  select,
+  sql,
+} from '@agor/core/db';
 import type { ContentBlock } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { isSuperAdmin } from '../../utils/worktree-authorization.js';
 import { resolveSessionId, resolveTaskId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
@@ -101,6 +114,23 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
             ? and(...orGroups[0])
             : or(...orGroups.map((andTerms) => and(...andTerms)));
         if (searchCondition) conditions.push(searchCondition);
+      }
+
+      // RBAC enforcement: when worktree_rbac is enabled, restrict this search
+      // to sessions the caller can access. Superadmins bypass. When RBAC is
+      // disabled (default / open-access mode), skip this filter entirely to
+      // preserve backward-compatible behavior.
+      if (isWorktreeRbacEnabled()) {
+        const userRole = ctx.authenticatedUser?.role as string | undefined;
+        if (!isSuperAdmin(userRole)) {
+          const sessionRepo = new SessionRepository(ctx.db);
+          const accessibleSessions = await sessionRepo.findAccessibleSessions(ctx.userId);
+          const accessibleIds = accessibleSessions.map((s) => s.session_id);
+          if (accessibleIds.length === 0) {
+            return textResult({ messages: [], total: 0, offset, limit });
+          }
+          conditions.push(inArray(messagesTable.session_id, accessibleIds));
+        }
       }
 
       const orderCol = sessionId ? messagesTable.index : messagesTable.timestamp;

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for hooks registered in register-hooks.ts.
+ *
+ * Covers the sessions.patch permission branching introduced to fix the bug
+ * where a user with `session`-tier permission on a worktree could not prompt
+ * their own session because the /sessions/:id/prompt route issues an internal
+ * `{ tasks: [...] }` patch that was being gated behind `all`-tier.
+ *
+ * The branching logic in register-hooks.ts looks like:
+ *
+ *   if (isPromptFlowPatchOnly(context.data)) {
+ *     → ensureCanPromptInSession (session-tier for own, prompt-tier otherwise)
+ *   } else {
+ *     → ensureWorktreePermission('all')   // metadata writes
+ *   }
+ *
+ * The two downstream hooks are covered elsewhere (see
+ * worktree-authorization.test.ts), so here we only verify the classifier.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isPromptFlowPatchOnly, PROMPT_FLOW_PATCH_FIELDS } from './register-hooks';
+
+describe('isPromptFlowPatchOnly', () => {
+  describe('accepts whitelisted-only patches', () => {
+    it.each(
+      PROMPT_FLOW_PATCH_FIELDS.map((f) => [f])
+    )('accepts single whitelisted field: %s', (field) => {
+      expect(isPromptFlowPatchOnly({ [field]: 'any-value' })).toBe(true);
+    });
+
+    it('accepts the prompt-route task-append shape', () => {
+      // register-routes.ts: /sessions/:id/prompt appends task_id to session.tasks
+      expect(isPromptFlowPatchOnly({ tasks: ['task-1', 'task-2'] })).toBe(true);
+    });
+
+    it('accepts the prompt-route auto-unarchive shape', () => {
+      // register-routes.ts: /sessions/:id/prompt auto-unarchives before sending
+      expect(isPromptFlowPatchOnly({ archived: false, archived_reason: undefined })).toBe(true);
+    });
+
+    it('accepts the stop-route idle shape', () => {
+      // register-routes.ts: /sessions/:id/stop sets status + ready_for_prompt
+      expect(isPromptFlowPatchOnly({ status: 'idle', ready_for_prompt: false })).toBe(true);
+    });
+
+    it('accepts the executor git-SHA capture shape', () => {
+      // packages/executor/src/handlers/sdk/base-executor.ts patches current SHA
+      expect(isPromptFlowPatchOnly({ git_state: { current_sha: 'deadbeef', ref: 'main' } })).toBe(
+        true
+      );
+    });
+
+    it('accepts the executor opencode init shape', () => {
+      // packages/executor/src/handlers/sdk/opencode.ts patches the SDK session handle
+      expect(isPromptFlowPatchOnly({ sdk_session_id: 'opencode-sess-123' })).toBe(true);
+    });
+  });
+
+  describe('rejects mixed or metadata patches', () => {
+    it('rejects a patch that mixes whitelist + metadata field', () => {
+      // Prevents partial-trust escalation: if `tasks` is allowed at session-tier,
+      // a caller must NOT be able to piggyback `name` (metadata) onto the same patch.
+      expect(isPromptFlowPatchOnly({ tasks: ['t'], name: 'evil' })).toBe(false);
+    });
+
+    it.each([
+      ['name', 'metadata'],
+      ['model_config', { model: 'x' }],
+      ['permission_config', { mode: 'bypass' }],
+      ['callback_config', { callback_session_id: 'sid' }],
+      ['created_by', 'other-user'],
+      ['unix_username', 'root'],
+      ['worktree_id', 'wt-evil'],
+    ])('rejects pure-metadata patch on field: %s', (field, value) => {
+      expect(isPromptFlowPatchOnly({ [field]: value })).toBe(false);
+    });
+  });
+
+  describe('rejects non-object inputs', () => {
+    it('rejects null', () => {
+      expect(isPromptFlowPatchOnly(null)).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+      expect(isPromptFlowPatchOnly(undefined)).toBe(false);
+    });
+
+    it('rejects empty object (nothing to patch = cannot be a prompt-flow patch)', () => {
+      expect(isPromptFlowPatchOnly({})).toBe(false);
+    });
+
+    it('rejects primitives', () => {
+      expect(isPromptFlowPatchOnly('string')).toBe(false);
+      expect(isPromptFlowPatchOnly(42)).toBe(false);
+      expect(isPromptFlowPatchOnly(true)).toBe(false);
+    });
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1765,6 +1765,54 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Boards hooks
   // ============================================================================
 
+  // Boards.find RBAC filter (registered only when worktree_rbac enabled).
+  // Boards are not worktree-scoped directly, but they contain worktrees/cards.
+  // A board the caller cannot read any worktree from (and did not create
+  // themselves) should not appear in listings. Superadmins bypass this.
+  const filterBoardsByAccessibleWorktrees = async (context: HookContext<Board>) => {
+    if (!context.params.provider) return context;
+    if (context.params.user?._isServiceAccount) return context;
+    const userId = context.params.user?.user_id as import('@agor/core/types').UUID | undefined;
+    if (!userId) {
+      // Unauthenticated -> no boards
+      context.result = { total: 0, limit: 0, skip: 0, data: [] };
+      return context;
+    }
+    // Superadmin bypass
+    const userRole = context.params.user?.role as string | undefined;
+    if (
+      (superadminOpts.allowSuperadmin ?? true) &&
+      (userRole === ROLES.SUPERADMIN || userRole === 'owner')
+    ) {
+      return context;
+    }
+
+    const result = context.result;
+    if (!result) return context;
+    const boards = Array.isArray(result) ? result : (result as { data?: Board[] }).data;
+    if (!boards?.length) return context;
+
+    // Collect accessible board_ids from the user's worktrees.
+    const accessibleWorktrees = await worktreeRepository.findAccessibleWorktrees(userId);
+    const accessibleBoardIds = new Set<string>(
+      accessibleWorktrees
+        .map((wt) => (wt as { board_id?: string | null }).board_id)
+        .filter((id): id is string => !!id)
+    );
+
+    const filtered = boards.filter(
+      (board) => board.created_by === userId || accessibleBoardIds.has(board.board_id as string)
+    );
+
+    if (Array.isArray(result)) {
+      context.result = filtered as unknown as typeof context.result;
+    } else {
+      (context.result as { data: Board[]; total: number }).data = filtered;
+      (context.result as { data: Board[]; total: number }).total = filtered.length;
+    }
+    return context;
+  };
+
   safeService('boards')?.hooks({
     before: {
       all: [typedValidateQuery(boardQueryValidator), ...getReadAuthHooks()],
@@ -1928,6 +1976,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
       ],
       find: [
+        // RBAC: Restrict boards to those the caller created or has worktree
+        // access on. Runs before artifact stripping so the subsequent hook
+        // only iterates permitted boards.
+        ...(worktreeRbacEnabled ? [filterBoardsByAccessibleWorktrees] : []),
         async (context: HookContext<Board>) => {
           const result = context.result;
           if (!result) return context;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -73,6 +73,8 @@ import {
   loadWorktreeFromSession,
   PERMISSION_RANK,
   resolveSessionContext,
+  scopeFindToAccessibleSessions,
+  scopeFindToAccessibleWorktrees,
   scopeSessionQuery,
   scopeWorktreeQuery,
   setSessionUnixUsername,
@@ -156,6 +158,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   app.service('messages').hooks({
     before: {
       all: [requireAuth],
+      find: [
+        // RBAC: Scope messages.find() to sessions the caller can access.
+        // Without this backstop, any authenticated member could list messages
+        // across every session/worktree by omitting the session_id filter.
+        ...(worktreeRbacEnabled
+          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
+          : []),
+      ],
       get: [
         ...(worktreeRbacEnabled
           ? [
@@ -249,6 +259,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...getReadAuthHooks(),
         ...(allowAnonymous ? [] : [requireMinimumRole(ROLES.MEMBER, 'manage board objects')]),
       ],
+      // NOTE: We deliberately do NOT add scopeFindToAccessibleWorktrees here.
+      // Board-objects may reference `worktree_id` (worktree cards) OR `card_id`
+      // (kanban cards with no worktree) OR neither (zones, layout objects).
+      // The before-hook would filter out rows with null worktree_id, breaking
+      // card-only boards. Access control lives in the after-hook below, which
+      // correctly preserves card/zone rows while scoping worktree-bound ones.
     },
     after: {
       find: [
@@ -348,6 +364,16 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('artifacts')?.hooks({
     before: {
       all: [...getReadAuthHooks()],
+      find: [
+        // RBAC: Artifacts carry a `worktree_id` (nullable — survives worktree deletion).
+        // Scope find() to the worktrees the caller can access. Rows with null
+        // worktree_id (orphaned artifacts) will be excluded by the $in filter,
+        // which is the safe default — orphans can only be surfaced via explicit
+        // board-scoped queries.
+        ...(worktreeRbacEnabled
+          ? [scopeFindToAccessibleWorktrees(worktreeRepository, superadminOpts)]
+          : []),
+      ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create artifacts')],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update artifacts')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete artifacts')],
@@ -718,6 +744,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
+  // NOTE: mcp-servers is global admin-managed configuration. These rows are
+  // not worktree- or session-scoped, so no RBAC find() scoping is applied.
+  // Creation/update/removal remain gated by requireMinimumRole(ADMIN).
   safeService('mcp-servers')?.hooks({
     before: {
       all: [typedValidateQuery(mcpServerQueryValidator), ...getReadAuthHooks()],
@@ -734,7 +763,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('session-mcp-servers')?.hooks({
     before: {
       all: [requireAuth],
-      find: [requireMinimumRole(ROLES.MEMBER, 'list session MCP servers')],
+      find: [
+        requireMinimumRole(ROLES.MEMBER, 'list session MCP servers'),
+        // RBAC: Scope to sessions the caller can access.
+        ...(worktreeRbacEnabled
+          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
+          : []),
+      ],
     },
     after: {
       find: [injectPerUserOAuthTokens],
@@ -962,7 +997,46 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   safeService('files')?.hooks({
     before: {
-      all: [requireAuth, requireMinimumRole(ROLES.MEMBER, 'search files')],
+      all: [
+        requireAuth,
+        requireMinimumRole(ROLES.MEMBER, 'search files'),
+        // RBAC: files service takes a sessionId query param and returns files
+        // from that session's worktree. Verify the caller can at least 'view'
+        // that worktree before running git ls-files. If sessionId is missing
+        // the service itself returns []; we skip the permission check in that
+        // case rather than throwing.
+        ...(worktreeRbacEnabled
+          ? [
+              async (context: HookContext) => {
+                if (!context.params.provider) return context;
+                if (context.params.user?._isServiceAccount) return context;
+                const query = context.params.query as { sessionId?: string } | undefined;
+                const sessionId = query?.sessionId;
+                if (!sessionId) return context;
+                context.params.sessionId = sessionId;
+                // Delegate to the existing chain now that sessionId is primed.
+                await loadSession(sessionsService)(context);
+                await loadWorktreeFromSession(worktreeRepository)(context);
+                await ensureCanView(superadminOpts)(context);
+                return context;
+              },
+            ]
+          : []),
+      ],
+    },
+  });
+
+  // /file (singular): read-only worktree filesystem browser. Takes worktree_id
+  // as a query param. Gate with worktree RBAC 'view' permission when enabled.
+  safeService('/file')?.hooks({
+    before: {
+      all: [
+        requireAuth,
+        requireMinimumRole(ROLES.MEMBER, 'read files'),
+        ...(worktreeRbacEnabled
+          ? [loadWorktree(worktreeRepository, 'worktree_id'), ensureCanView(superadminOpts)]
+          : []),
+      ],
     },
   });
 
@@ -1623,6 +1697,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   app.service('tasks').hooks({
     before: {
       all: [typedValidateQuery(taskQueryValidator), requireAuth],
+      find: [
+        // RBAC: Scope tasks.find() to sessions the caller can access.
+        ...(worktreeRbacEnabled
+          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
+          : []),
+      ],
       get: [
         ...(worktreeRbacEnabled
           ? [

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -9,6 +9,7 @@
 import { type AgorConfig, isUnixImpersonationEnabled, type UnknownJson } from '@agor/core/config';
 import {
   ArtifactRepository,
+  BoardRepository,
   type Database,
   type SessionRepository,
   UserMCPOAuthTokenRepository,
@@ -67,13 +68,13 @@ import {
   ensureCanView,
   ensureSessionImmutability,
   ensureWorktreePermission,
-  isSuperAdmin,
   loadSession,
   loadSessionWorktree,
   loadWorktree,
   loadWorktreeFromSession,
   PERMISSION_RANK,
   resolveSessionContext,
+  scopeFindToAccessibleBoards,
   scopeFindToAccessibleSessions,
   scopeFindToAccessibleWorktrees,
   scopeSessionQuery,
@@ -1779,55 +1780,21 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Boards hooks
   // ============================================================================
 
-  // Boards.find RBAC filter (registered only when worktree_rbac enabled).
-  // Boards are not worktree-scoped directly, but they contain worktrees/cards.
-  // A board the caller cannot read any worktree from (and did not create
-  // themselves) should not appear in listings. Superadmins bypass this.
-  // TODO: move to SQL-level scope if board count per user grows.
-  const filterBoardsByAccessibleWorktrees = async (context: HookContext<Board>) => {
-    if (!context.params.provider) return context;
-    if (context.params.user?._isServiceAccount) return context;
-    const userId = context.params.user?.user_id as import('@agor/core/types').UUID | undefined;
-    if (!userId) {
-      // Unauthenticated -> no boards
-      context.result = { total: 0, limit: 0, skip: 0, data: [] };
-      return context;
-    }
-    // Superadmin bypass
-    const userRole = context.params.user?.role as string | undefined;
-    if (isSuperAdmin(userRole, superadminOpts.allowSuperadmin ?? true)) {
-      return context;
-    }
-
-    const result = context.result;
-    if (!result) return context;
-    const boards = Array.isArray(result) ? result : (result as { data?: Board[] }).data;
-    if (!boards?.length) return context;
-
-    // Collect accessible board_ids from the user's worktrees.
-    const accessibleWorktrees = await worktreeRepository.findAccessibleWorktrees(userId);
-    const accessibleBoardIds = new Set<string>(
-      accessibleWorktrees
-        .map((wt) => (wt as { board_id?: string | null }).board_id)
-        .filter((id): id is string => !!id)
-    );
-
-    const filtered = boards.filter(
-      (board) => board.created_by === userId || accessibleBoardIds.has(board.board_id as string)
-    );
-
-    if (Array.isArray(result)) {
-      context.result = filtered as unknown as typeof context.result;
-    } else {
-      (context.result as { data: Board[]; total: number }).data = filtered;
-      (context.result as { data: Board[]; total: number }).total = filtered.length;
-    }
-    return context;
-  };
+  // BoardRepository for RBAC find-scope hook (single instance reused across
+  // requests). Cheap to construct — just wraps the shared db handle.
+  const boardRepository = new BoardRepository(db);
 
   safeService('boards')?.hooks({
     before: {
       all: [typedValidateQuery(boardQueryValidator), ...getReadAuthHooks()],
+      find: [
+        // RBAC: restrict boards.find to boards the caller created or has a
+        // worktree on. Runs at the SQL layer via BoardRepository.findVisibleBoardIds
+        // to avoid hydrating every accessible worktree in-memory.
+        ...(worktreeRbacEnabled
+          ? [scopeFindToAccessibleBoards(boardRepository, superadminOpts)]
+          : []),
+      ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create boards'),
         async (context: HookContext<Board>) => {
@@ -1988,10 +1955,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
       ],
       find: [
-        // RBAC: Restrict boards to those the caller created or has worktree
-        // access on. Runs before artifact stripping so the subsequent hook
-        // only iterates permitted boards.
-        ...(worktreeRbacEnabled ? [filterBoardsByAccessibleWorktrees] : []),
         async (context: HookContext<Board>) => {
           const result = context.result;
           if (!result) return context;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -869,7 +869,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       create: [
-        requireMinimumRole(ROLES.MEMBER, 'create gateway channels'),
+        requireMinimumRole(ROLES.ADMIN, 'create gateway channels'),
         // Encrypt env var values at rest (same pattern as user env vars / API keys)
         async (context: HookContext) => {
           const data = context.data as Record<string, unknown> | undefined;
@@ -886,7 +886,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
       ],
       patch: [
-        requireMinimumRole(ROLES.MEMBER, 'update gateway channels'),
+        requireMinimumRole(ROLES.ADMIN, 'update gateway channels'),
         // Resolve redacted env var sentinel values ('••••••••') back to real
         // values from the database. Uses the repository directly to bypass
         // the after-hook redaction that the service layer applies.
@@ -969,7 +969,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           return context;
         },
       ],
-      remove: [requireMinimumRole(ROLES.MEMBER, 'delete gateway channels')],
+      remove: [requireMinimumRole(ROLES.ADMIN, 'delete gateway channels')],
     },
     after: {
       all: [

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1783,6 +1783,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Boards are not worktree-scoped directly, but they contain worktrees/cards.
   // A board the caller cannot read any worktree from (and did not create
   // themselves) should not appear in listings. Superadmins bypass this.
+  // TODO: move to SQL-level scope if board count per user grows.
   const filterBoardsByAccessibleWorktrees = async (context: HookContext<Board>) => {
     if (!context.params.provider) return context;
     if (context.params.user?._isServiceAccount) return context;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -67,6 +67,7 @@ import {
   ensureCanView,
   ensureSessionImmutability,
   ensureWorktreePermission,
+  isSuperAdmin,
   loadSession,
   loadSessionWorktree,
   loadWorktree,
@@ -1793,10 +1794,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     }
     // Superadmin bypass
     const userRole = context.params.user?.role as string | undefined;
-    if (
-      (superadminOpts.allowSuperadmin ?? true) &&
-      (userRole === ROLES.SUPERADMIN || userRole === 'owner')
-    ) {
+    if (isSuperAdmin(userRole, superadminOpts.allowSuperadmin ?? true)) {
       return context;
     }
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -84,6 +84,52 @@ import {
 } from './utils/worktree-authorization.js';
 
 /**
+ * Session fields written as runtime bookkeeping during the prompt/execution
+ * lifecycle, on behalf of the session's authenticated user. These are NOT
+ * session metadata (name, model_config, permission_config, callback_config).
+ *
+ * Sources:
+ *   - `/sessions/:id/prompt`  → `tasks`, `archived`, `archived_reason`
+ *   - `/sessions/:id/stop`    → `status`, `ready_for_prompt`
+ *   - executor status updates → `status`, `ready_for_prompt`
+ *     (claude/copilot permission-hooks, see packages/executor)
+ *   - executor git-SHA capture → `git_state` (per-message current_sha)
+ *   - executor opencode init   → `sdk_session_id` (SDK session handle)
+ *
+ * When a `patch` touches ONLY these fields, the sessions hook chain downgrades
+ * the required worktree permission from `'all'` to the same tier that
+ * {@link ensureCanPromptInSession} enforces:
+ *   - `'prompt'` or `'all'` → can patch any session's prompt-flow fields
+ *   - `'session'`           → can patch own session's prompt-flow fields
+ *   - `'view'` or `'none'`  → denied
+ *
+ * Any mixed-field patch (e.g. `{ tasks: [...], name: 'x' }`) fails the
+ * `isPromptFlowPatchOnly` check and falls through to the strict `'all'` path,
+ * so widening the whitelist here cannot accidentally leak metadata writes.
+ *
+ * NOTE: `git_state` and `sdk_session_id` are on this list because the executor
+ * authenticates as the session creator (see auth/session-token-strategy.ts),
+ * not as a service account. Proper long-term fix is to give the executor a
+ * service-account token so these patches bypass RBAC entirely.
+ */
+export const PROMPT_FLOW_PATCH_FIELDS: readonly string[] = [
+  'tasks',
+  'archived',
+  'archived_reason',
+  'status',
+  'ready_for_prompt',
+  'git_state',
+  'sdk_session_id',
+];
+
+export function isPromptFlowPatchOnly(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return false;
+  const keys = Object.keys(data);
+  if (keys.length === 0) return false;
+  return keys.every((key) => PROMPT_FLOW_PATCH_FIELDS.includes(key));
+}
+
+/**
  * Extended Params with route ID parameter (needed by artifact routes in hooks).
  */
 interface RouteParams extends Params {
@@ -1456,7 +1502,25 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               resolveSessionContext(),
               loadSession(sessionsService),
               loadWorktreeFromSession(worktreeRepository),
-              ensureWorktreePermission('all', 'update sessions', superadminOpts), // Require 'all' permission
+              // Branch permission by patch type:
+              //   - Prompt-flow patches (tasks, archived, status, …) are bookkeeping
+              //     emitted by /sessions/:id/prompt and /sessions/:id/stop on behalf
+              //     of the authenticated user. They need only the same tier as
+              //     prompting the session (session-tier for own, prompt-tier for
+              //     others), matching the permission table in CLAUDE.md.
+              //   - Everything else is session metadata and still requires 'all'.
+              // Mixed-field patches fail isPromptFlowPatchOnly and fall through to
+              // the strict 'all' path, so there's no partial-trust footgun.
+              (context: HookContext) => {
+                if (isPromptFlowPatchOnly(context.data)) {
+                  return ensureCanPromptInSession(superadminOpts)(context);
+                }
+                return ensureWorktreePermission(
+                  'all',
+                  'update session metadata',
+                  superadminOpts
+                )(context);
+              },
             ]
           : []),
         // Validate user has prompt permission on callback target session's worktree

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1757,7 +1757,20 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             ]
           : []),
       ],
-      remove: [requireMinimumRole(ROLES.MEMBER, 'delete tasks')],
+      remove: [
+        requireMinimumRole(ROLES.MEMBER, 'delete tasks'),
+        // RBAC: deleting a task requires 'all' permission on the worktree
+        // (mirrors sessions.remove). Without this, any member with 'session'
+        // access could delete tasks owned by other users on shared worktrees.
+        ...(worktreeRbacEnabled
+          ? [
+              resolveSessionContext(),
+              loadSession(sessionsService),
+              loadWorktreeFromSession(worktreeRepository),
+              ensureWorktreePermission('all', 'delete tasks', superadminOpts),
+            ]
+          : []),
+      ],
     },
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2480,6 +2480,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           mcp: {
             enabled: config.daemon?.mcpEnabled !== false,
           },
+          // Execution mode surfaced so admins can confirm which security tier
+          // the daemon booted under. Docker env overrides (AGOR_SET_RBAC_FLAG,
+          // AGOR_SET_UNIX_MODE) are written into ~/.agor/config.yaml by the
+          // entrypoint before boot, so `config.execution` reflects them.
+          execution: {
+            worktreeRbac: config.execution?.worktree_rbac === true,
+            unixUserMode: config.execution?.unix_user_mode ?? 'simple',
+          },
         };
       }
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -10,6 +10,7 @@ import {
   and,
   type Database,
   eq,
+  inArray,
   MCPServerRepository,
   type SessionMCPServerRow,
   select,
@@ -367,11 +368,27 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   if (svcEnabled('mcp_servers')) {
     app.use('/session-mcp-servers', {
       async find(params?: {
-        query?: { session_id?: string; mcp_server_id?: string; enabled?: boolean };
+        query?: {
+          session_id?: string | { $in?: string[] };
+          mcp_server_id?: string;
+          enabled?: boolean;
+        };
       }) {
         const conditions: ReturnType<typeof eq>[] = [];
-        if (params?.query?.session_id) {
-          conditions.push(eq(sessionMcpServers.session_id, params.query.session_id));
+        // session_id may be a scalar string or `{ $in: [...] }` — the latter is
+        // injected by the RBAC scoping hook to restrict rows to accessible sessions.
+        const sessionIdFilter = params?.query?.session_id;
+        if (typeof sessionIdFilter === 'string') {
+          conditions.push(eq(sessionMcpServers.session_id, sessionIdFilter));
+        } else if (
+          sessionIdFilter &&
+          typeof sessionIdFilter === 'object' &&
+          Array.isArray(sessionIdFilter.$in)
+        ) {
+          if (sessionIdFilter.$in.length === 0) {
+            return [];
+          }
+          conditions.push(inArray(sessionMcpServers.session_id, sessionIdFilter.$in));
         }
         if (params?.query?.mcp_server_id) {
           conditions.push(eq(sessionMcpServers.mcp_server_id, params.query.mcp_server_id));

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -45,9 +45,21 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
    * Override find to support task-based and session-based filtering
    */
   async find(params?: MessageParams): Promise<Message[] | Paginated<Message>> {
-    // If filtering by task_id, use repository method
-    if (params?.query?.task_id) {
-      const messages = await this.messagesRepo.findByTaskId(params.query.task_id);
+    // If filtering by task_id (scalar string), use repository method.
+    // The RBAC scoping hook may also inject `session_id` (scalar or `$in`)
+    // alongside a user-supplied `task_id`; without intersecting here, callers
+    // with only `task_id` would bypass worktree scoping. Filter the task_id
+    // rows by the accessible session_id set before returning.
+    if (typeof params?.query?.task_id === 'string') {
+      let messages = await this.messagesRepo.findByTaskId(params.query.task_id);
+
+      const sid = params.query.session_id;
+      if (typeof sid === 'string') {
+        messages = messages.filter((m) => m.session_id === sid);
+      } else if (sid && typeof sid === 'object' && Array.isArray((sid as { $in?: unknown }).$in)) {
+        const allowed = new Set((sid as { $in: string[] }).$in);
+        messages = messages.filter((m) => allowed.has(m.session_id as string));
+      }
 
       // Apply pagination if enabled
       if (this.paginate) {
@@ -65,8 +77,10 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
       return messages;
     }
 
-    // If filtering by session_id, use repository method
-    if (params?.query?.session_id) {
+    // If filtering by session_id as a scalar string, use repository shortcut.
+    // A `$in` object (from the RBAC scoping hook) falls through to `super.find`
+    // where the adapter's `filterData` handles $in natively.
+    if (typeof params?.query?.session_id === 'string') {
       // Use type-filtered query when type is specified (e.g., 'permission_request')
       const messages = params.query.type
         ? await this.messagesRepo.findBySessionIdAndType(params.query.session_id, params.query.type)

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -63,8 +63,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
    * Override find to support session-based filtering
    */
   async find(params?: TaskParams): Promise<Task[] | Paginated<Task>> {
-    // If filtering by session_id, use repository method
-    if (params?.query?.session_id) {
+    // If filtering by session_id as a scalar string, use repository shortcut.
+    // Note: `session_id` may be injected as `{ $in: [...] }` by the RBAC scoping
+    // hook — in that case we fall through to `super.find`, whose adapter's
+    // `filterData` handles $in natively.
+    if (typeof params?.query?.session_id === 'string') {
       const tasks = await this.taskRepo.findBySession(params.query.session_id);
 
       // Apply pagination if enabled

--- a/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
+++ b/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
@@ -1,0 +1,339 @@
+/**
+ * RBAC find() scoping tests.
+ *
+ * Covers the helpers that scope find() queries on worktree-scoped and
+ * session-scoped resources to only the rows a caller can access.
+ *
+ * These helpers are the server-side backstop for per-resource RBAC: without
+ * them, authenticated members could list rows from worktrees/sessions that
+ * their RBAC get/patch/remove hooks otherwise correctly guard.
+ */
+
+import type { SessionRepository, WorktreeRepository } from '@agor/core/db';
+import type { HookContext, Session, Worktree } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  scopeFindToAccessibleSessions,
+  scopeFindToAccessibleWorktrees,
+} from './worktree-authorization';
+
+const USER_ID = 'user-aaaa-0001' as import('@agor/core/types').UUID;
+
+function makeWorktree(id: string, others_can: Worktree['others_can'] = 'view'): Worktree {
+  return {
+    worktree_id: id as Worktree['worktree_id'],
+    repo_id: 'repo-aaaa-0001' as Worktree['repo_id'],
+    name: `wt-${id}`,
+    branch: 'main',
+    path: `/tmp/${id}`,
+    others_can,
+    archived: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  } as Worktree;
+}
+
+function makeSession(id: string, worktreeId: string): Session {
+  return {
+    session_id: id,
+    worktree_id: worktreeId,
+    created_by: USER_ID,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  } as unknown as Session;
+}
+
+function makeContext(overrides: {
+  method?: 'find' | 'get' | 'create' | 'patch' | 'remove';
+  provider?: string | undefined;
+  user?: Record<string, unknown> | undefined;
+  query?: Record<string, unknown>;
+}): HookContext {
+  return {
+    method: overrides.method ?? 'find',
+    path: 'test',
+    params: {
+      provider: overrides.provider,
+      user: overrides.user,
+      query: overrides.query ?? {},
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal test context
+  } as any;
+}
+
+function fakeWorktreeRepo(accessible: Worktree[]): WorktreeRepository {
+  return {
+    findAccessibleWorktrees: vi.fn(async () => accessible),
+    // biome-ignore lint/suspicious/noExplicitAny: partial test double
+  } as any;
+}
+
+function fakeSessionRepo(accessible: Session[]): SessionRepository {
+  return {
+    findAccessibleSessions: vi.fn(async () => accessible),
+    // biome-ignore lint/suspicious/noExplicitAny: partial test double
+  } as any;
+}
+
+describe('scopeFindToAccessibleWorktrees', () => {
+  it('passes through internal calls (no provider)', async () => {
+    const repo = fakeWorktreeRepo([]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({ provider: undefined, user: undefined });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    expect(repo.findAccessibleWorktrees).not.toHaveBeenCalled();
+  });
+
+  it('passes through service accounts', async () => {
+    const repo = fakeWorktreeRepo([]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { _isServiceAccount: true },
+    });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    expect(repo.findAccessibleWorktrees).not.toHaveBeenCalled();
+  });
+
+  it('returns empty result for unauthenticated requests', async () => {
+    const repo = fakeWorktreeRepo([]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({ provider: 'rest', user: undefined });
+    const out = await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).data).toEqual([]);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).total).toBe(0);
+  });
+
+  it('bypasses scoping for superadmins', async () => {
+    const repo = fakeWorktreeRepo([]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.SUPERADMIN },
+    });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.params.query as any).worktree_id).toBeUndefined();
+  });
+
+  it('honors allow_superadmin=false', async () => {
+    const repo = fakeWorktreeRepo([makeWorktree('wt1')]);
+    const hook = scopeFindToAccessibleWorktrees(repo, { allowSuperadmin: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.SUPERADMIN },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).worktree_id).toEqual({ $in: ['wt1'] });
+  });
+
+  it('injects worktree_id $in when no explicit filter', async () => {
+    const repo = fakeWorktreeRepo([makeWorktree('wt1'), makeWorktree('wt2')]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    const q = ctx.params.query as any;
+    expect(q.worktree_id.$in.sort()).toEqual(['wt1', 'wt2']);
+  });
+
+  it('preserves explicit worktree_id within accessible set', async () => {
+    const repo = fakeWorktreeRepo([makeWorktree('wt1'), makeWorktree('wt2')]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { worktree_id: 'wt1' },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).worktree_id).toBe('wt1');
+  });
+
+  it('short-circuits when explicit worktree_id is outside accessible set', async () => {
+    const repo = fakeWorktreeRepo([makeWorktree('wt1')]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { worktree_id: 'wt999' },
+    });
+    const out = await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).data).toEqual([]);
+  });
+
+  it('intersects $in arrays with accessible set', async () => {
+    const repo = fakeWorktreeRepo([makeWorktree('wt1'), makeWorktree('wt2')]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { worktree_id: { $in: ['wt1', 'wt999'] } },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).worktree_id).toEqual({ $in: ['wt1'] });
+  });
+
+  it('returns empty when user has zero accessible worktrees', async () => {
+    const repo = fakeWorktreeRepo([]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+    });
+    const out = await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).data).toEqual([]);
+  });
+
+  it('does not apply on non-find methods', async () => {
+    const repo = fakeWorktreeRepo([makeWorktree('wt1')]);
+    const hook = scopeFindToAccessibleWorktrees(repo);
+    const ctx = makeContext({
+      method: 'get',
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+    });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).worktree_id).toBeUndefined();
+    expect(repo.findAccessibleWorktrees).not.toHaveBeenCalled();
+  });
+});
+
+describe('scopeFindToAccessibleSessions', () => {
+  it('passes through internal calls', async () => {
+    const repo = fakeSessionRepo([]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({ provider: undefined, user: undefined });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    expect(repo.findAccessibleSessions).not.toHaveBeenCalled();
+  });
+
+  it('passes through service accounts', async () => {
+    const repo = fakeSessionRepo([]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { _isServiceAccount: true },
+    });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    expect(repo.findAccessibleSessions).not.toHaveBeenCalled();
+  });
+
+  it('returns empty for unauthenticated', async () => {
+    const repo = fakeSessionRepo([]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({ provider: 'rest', user: undefined });
+    const out = await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).data).toEqual([]);
+  });
+
+  it('bypasses scoping for superadmins', async () => {
+    const repo = fakeSessionRepo([]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.SUPERADMIN },
+    });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).session_id).toBeUndefined();
+  });
+
+  it('injects session_id $in when no explicit filter', async () => {
+    const repo = fakeSessionRepo([makeSession('s1', 'wt1'), makeSession('s2', 'wt2')]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    const q = ctx.params.query as any;
+    expect(q.session_id.$in.sort()).toEqual(['s1', 's2']);
+  });
+
+  it('preserves explicit session_id within accessible set', async () => {
+    const repo = fakeSessionRepo([makeSession('s1', 'wt1'), makeSession('s2', 'wt2')]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { session_id: 's1' },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).session_id).toBe('s1');
+  });
+
+  it('short-circuits when explicit session_id is outside accessible set', async () => {
+    const repo = fakeSessionRepo([makeSession('s1', 'wt1')]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { session_id: 's-other' },
+    });
+    const out = await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).data).toEqual([]);
+  });
+
+  it('intersects $in session arrays with accessible set', async () => {
+    const repo = fakeSessionRepo([makeSession('s1', 'wt1'), makeSession('s2', 'wt2')]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { session_id: { $in: ['s1', 's-other'] } },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).session_id).toEqual({ $in: ['s1'] });
+  });
+
+  it('returns empty when user has zero accessible sessions', async () => {
+    const repo = fakeSessionRepo([]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+    });
+    const out = await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((out.result as any).data).toEqual([]);
+  });
+
+  it('does not apply on non-find methods', async () => {
+    const repo = fakeSessionRepo([makeSession('s1', 'wt1')]);
+    const hook = scopeFindToAccessibleSessions(repo);
+    const ctx = makeContext({
+      method: 'patch',
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+    });
+    const out = await hook(ctx);
+    expect(out.result).toBeUndefined();
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).session_id).toBeUndefined();
+    expect(repo.findAccessibleSessions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
+++ b/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
@@ -258,6 +258,18 @@ describe('scopeFindToAccessibleSessions', () => {
     expect((ctx.params.query as any).session_id).toBeUndefined();
   });
 
+  it('honors allow_superadmin=false', async () => {
+    const repo = fakeSessionRepo([makeSession('s1', 'wt1')]);
+    const hook = scopeFindToAccessibleSessions(repo, { allowSuperadmin: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.SUPERADMIN },
+    });
+    await hook(ctx);
+    // biome-ignore lint/suspicious/noExplicitAny: test shape
+    expect((ctx.params.query as any).session_id).toEqual({ $in: ['s1'] });
+  });
+
   it('injects session_id $in when no explicit filter', async () => {
     const repo = fakeSessionRepo([makeSession('s1', 'wt1'), makeSession('s2', 'wt2')]);
     const hook = scopeFindToAccessibleSessions(repo);

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -1162,3 +1162,198 @@ export function ensureCanPromptInSession(options?: { allowSuperadmin?: boolean }
 export function ensureCanView(options?: { allowSuperadmin?: boolean }) {
   return ensureWorktreePermission('view', 'view this worktree', options);
 }
+
+/**
+ * Empty paginated result helper — used to short-circuit find() for unauthenticated
+ * callers or callers whose query falls outside their accessible worktree set.
+ */
+function emptyFindResult(context: HookContext): HookContext {
+  const query = (context.params.query ?? {}) as Record<string, unknown>;
+  context.result = {
+    total: 0,
+    limit: (query.$limit as number) ?? 0,
+    skip: (query.$skip as number) ?? 0,
+    data: [],
+  };
+  return context;
+}
+
+/**
+ * Scope find() queries on worktree-scoped resources to the set of worktrees
+ * the caller can access.
+ *
+ * This is a BEFORE hook factory for services whose rows carry a `worktree_id`
+ * foreign key (e.g. artifacts, board-objects tied to a worktree, etc.).
+ *
+ * Behavior:
+ * - Internal calls (no `context.params.provider`) pass through unchanged.
+ * - Service accounts (`context.params.user._isServiceAccount`) pass through.
+ * - Unauthenticated requests short-circuit with an empty paginated result.
+ * - Superadmins (when `allowSuperadmin` is true) pass through; the default
+ *   query runs unmodified and returns all rows.
+ * - Non-superadmin authenticated users get their accessible worktree set
+ *   resolved via `findAccessibleWorktrees(userId)`. The set is then intersected
+ *   with any existing `worktree_id` filter in `context.params.query`:
+ *   - If the caller passed `worktree_id` (string) outside the accessible set,
+ *     short-circuit with an empty result.
+ *   - If the caller passed `worktree_id` within the accessible set, preserve it.
+ *   - If the caller passed `{ $in: [...] }`, intersect with accessible ids.
+ *   - Otherwise, inject `worktree_id: { $in: [...accessibleIds] }`.
+ *
+ * Only applies when `context.method === 'find'`. No-op for other methods.
+ *
+ * @param worktreeRepo - WorktreeRepository instance
+ * @param options - Optional flags (allowSuperadmin)
+ * @returns Feathers hook
+ */
+export function scopeFindToAccessibleWorktrees(
+  worktreeRepo: WorktreeRepository,
+  options?: { allowSuperadmin?: boolean }
+) {
+  return async (context: HookContext) => {
+    // Only applies to find()
+    if (context.method !== 'find') {
+      return context;
+    }
+
+    // Skip for internal calls
+    if (!context.params.provider) {
+      return context;
+    }
+
+    // Service accounts bypass RBAC
+    if (context.params.user?._isServiceAccount) {
+      return context;
+    }
+
+    const userId = context.params.user?.user_id as UUID | undefined;
+    if (!userId) {
+      return emptyFindResult(context);
+    }
+
+    // Superadmins bypass scoping
+    const userRole = context.params.user?.role as string | undefined;
+    const allowSuperadmin = options?.allowSuperadmin ?? true;
+    if (isSuperAdmin(userRole, allowSuperadmin)) {
+      return context;
+    }
+
+    // Resolve accessible worktree ids (cast to string set for query comparisons;
+    // Feathers queries carry raw strings, not branded IDs).
+    const accessible = await worktreeRepo.findAccessibleWorktrees(userId);
+    const accessibleIds = new Set<string>(accessible.map((w) => w.worktree_id as string));
+
+    // biome-ignore lint/suspicious/noExplicitAny: Feathers query shape is dynamic
+    const query = (context.params.query ?? {}) as any;
+    const existing = query.worktree_id;
+
+    if (typeof existing === 'string') {
+      // Caller pre-scoped to a specific worktree — must be accessible
+      if (!accessibleIds.has(existing)) {
+        return emptyFindResult(context);
+      }
+      // Already scoped; no change needed.
+      return context;
+    }
+
+    if (existing && typeof existing === 'object' && Array.isArray(existing.$in)) {
+      const intersect = (existing.$in as string[]).filter((id) => accessibleIds.has(id));
+      if (intersect.length === 0) {
+        return emptyFindResult(context);
+      }
+      query.worktree_id = { $in: intersect };
+      context.params.query = query;
+      return context;
+    }
+
+    // No explicit worktree_id filter — restrict to accessible set
+    if (accessibleIds.size === 0) {
+      return emptyFindResult(context);
+    }
+    query.worktree_id = { $in: Array.from(accessibleIds) };
+    context.params.query = query;
+    return context;
+  };
+}
+
+/**
+ * Scope find() queries on session-scoped resources to the set of sessions
+ * the caller can access (via their accessible worktrees).
+ *
+ * This is a BEFORE hook factory for services whose rows carry a `session_id`
+ * foreign key (e.g. tasks, messages, session-mcp-servers).
+ *
+ * Behavior mirrors {@link scopeFindToAccessibleWorktrees} but resolves via
+ * `findAccessibleSessions(userId)` and mutates `context.params.query.session_id`:
+ * - Internal / service-account calls pass through.
+ * - Unauthenticated → empty result.
+ * - Superadmins pass through.
+ * - Regular users: if an explicit `session_id` is passed, it must be in the
+ *   accessible set; otherwise inject `session_id: { $in: [...accessibleIds] }`.
+ *
+ * Only applies when `context.method === 'find'`.
+ *
+ * @param sessionRepo - SessionRepository instance
+ * @param options - Optional flags (allowSuperadmin)
+ * @returns Feathers hook
+ */
+export function scopeFindToAccessibleSessions(
+  sessionRepo: SessionRepository,
+  options?: { allowSuperadmin?: boolean }
+) {
+  return async (context: HookContext) => {
+    if (context.method !== 'find') {
+      return context;
+    }
+
+    if (!context.params.provider) {
+      return context;
+    }
+
+    if (context.params.user?._isServiceAccount) {
+      return context;
+    }
+
+    const userId = context.params.user?.user_id as UUID | undefined;
+    if (!userId) {
+      return emptyFindResult(context);
+    }
+
+    const userRole = context.params.user?.role as string | undefined;
+    const allowSuperadmin = options?.allowSuperadmin ?? true;
+    if (isSuperAdmin(userRole, allowSuperadmin)) {
+      return context;
+    }
+
+    const accessible = await sessionRepo.findAccessibleSessions(userId);
+    const accessibleIds = new Set<string>(accessible.map((s) => s.session_id as string));
+
+    // biome-ignore lint/suspicious/noExplicitAny: Feathers query shape is dynamic
+    const query = (context.params.query ?? {}) as any;
+    const existing = query.session_id;
+
+    if (typeof existing === 'string') {
+      if (!accessibleIds.has(existing)) {
+        return emptyFindResult(context);
+      }
+      return context;
+    }
+
+    if (existing && typeof existing === 'object' && Array.isArray(existing.$in)) {
+      const intersect = (existing.$in as string[]).filter((id) => accessibleIds.has(id));
+      if (intersect.length === 0) {
+        return emptyFindResult(context);
+      }
+      query.session_id = { $in: intersect };
+      context.params.query = query;
+      return context;
+    }
+
+    if (accessibleIds.size === 0) {
+      return emptyFindResult(context);
+    }
+    query.session_id = { $in: Array.from(accessibleIds) };
+    context.params.query = query;
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -1179,6 +1179,85 @@ function emptyFindResult(context: HookContext): HookContext {
 }
 
 /**
+ * Result of the common find-scope guard checks (provider/service-account/
+ * auth/superadmin). Returned by {@link resolveFindScopeAccess} so the two
+ * scope hook factories below don't repeat the same preamble.
+ */
+type FindScopeDecision =
+  | { kind: 'passThrough' }
+  | { kind: 'handled' }
+  | { kind: 'filter'; accessibleIds: Set<string> };
+
+/**
+ * Shared guard for the find-scoping hooks. Handles internal/service-account
+ * pass-through, unauthenticated short-circuit, and superadmin bypass. If the
+ * caller is a regular user, resolves accessible ids via `loadAccessibleIds`.
+ *
+ * Callers inspect the returned decision:
+ * - 'passThrough': nothing to do, return context unchanged.
+ * - 'handled':     context.result was set (empty result); return context.
+ * - 'filter':      apply intersection using `accessibleIds`.
+ */
+async function resolveFindScopeAccess(
+  context: HookContext,
+  options: { allowSuperadmin?: boolean } | undefined,
+  loadAccessibleIds: (userId: UUID) => Promise<string[]>
+): Promise<FindScopeDecision> {
+  if (context.method !== 'find') return { kind: 'passThrough' };
+  if (!context.params.provider) return { kind: 'passThrough' };
+  if (context.params.user?._isServiceAccount) return { kind: 'passThrough' };
+
+  const userId = context.params.user?.user_id as UUID | undefined;
+  if (!userId) {
+    emptyFindResult(context);
+    return { kind: 'handled' };
+  }
+
+  const userRole = context.params.user?.role as string | undefined;
+  const allowSuperadmin = options?.allowSuperadmin ?? true;
+  if (isSuperAdmin(userRole, allowSuperadmin)) return { kind: 'passThrough' };
+
+  const ids = await loadAccessibleIds(userId);
+  return { kind: 'filter', accessibleIds: new Set<string>(ids) };
+}
+
+/**
+ * Intersect the existing `query[field]` filter with the caller's accessible
+ * id set. Handles scalar string, `{ $in: [...] }`, and unset cases.
+ *
+ * - Scalar outside the accessible set → empty result.
+ * - `$in` intersected with accessible set; empty intersection → empty result.
+ * - Unset → inject `{ $in: [...accessibleIds] }` (empty set → empty result).
+ */
+function intersectFindQuery(
+  context: HookContext,
+  field: string,
+  accessibleIds: Set<string>
+): HookContext {
+  // biome-ignore lint/suspicious/noExplicitAny: Feathers query shape is dynamic
+  const query = (context.params.query ?? {}) as any;
+  const existing = query[field];
+
+  if (typeof existing === 'string') {
+    if (!accessibleIds.has(existing)) return emptyFindResult(context);
+    return context;
+  }
+
+  if (existing && typeof existing === 'object' && Array.isArray(existing.$in)) {
+    const intersect = (existing.$in as string[]).filter((id) => accessibleIds.has(id));
+    if (intersect.length === 0) return emptyFindResult(context);
+    query[field] = { $in: intersect };
+    context.params.query = query;
+    return context;
+  }
+
+  if (accessibleIds.size === 0) return emptyFindResult(context);
+  query[field] = { $in: Array.from(accessibleIds) };
+  context.params.query = query;
+  return context;
+}
+
+/**
  * Scope find() queries on worktree-scoped resources to the set of worktrees
  * the caller can access.
  *
@@ -1211,68 +1290,13 @@ export function scopeFindToAccessibleWorktrees(
   options?: { allowSuperadmin?: boolean }
 ) {
   return async (context: HookContext) => {
-    // Only applies to find()
-    if (context.method !== 'find') {
-      return context;
-    }
+    const decision = await resolveFindScopeAccess(context, options, async (uid) => {
+      const accessible = await worktreeRepo.findAccessibleWorktrees(uid);
+      return accessible.map((w) => w.worktree_id as string);
+    });
 
-    // Skip for internal calls
-    if (!context.params.provider) {
-      return context;
-    }
-
-    // Service accounts bypass RBAC
-    if (context.params.user?._isServiceAccount) {
-      return context;
-    }
-
-    const userId = context.params.user?.user_id as UUID | undefined;
-    if (!userId) {
-      return emptyFindResult(context);
-    }
-
-    // Superadmins bypass scoping
-    const userRole = context.params.user?.role as string | undefined;
-    const allowSuperadmin = options?.allowSuperadmin ?? true;
-    if (isSuperAdmin(userRole, allowSuperadmin)) {
-      return context;
-    }
-
-    // Resolve accessible worktree ids (cast to string set for query comparisons;
-    // Feathers queries carry raw strings, not branded IDs).
-    const accessible = await worktreeRepo.findAccessibleWorktrees(userId);
-    const accessibleIds = new Set<string>(accessible.map((w) => w.worktree_id as string));
-
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers query shape is dynamic
-    const query = (context.params.query ?? {}) as any;
-    const existing = query.worktree_id;
-
-    if (typeof existing === 'string') {
-      // Caller pre-scoped to a specific worktree — must be accessible
-      if (!accessibleIds.has(existing)) {
-        return emptyFindResult(context);
-      }
-      // Already scoped; no change needed.
-      return context;
-    }
-
-    if (existing && typeof existing === 'object' && Array.isArray(existing.$in)) {
-      const intersect = (existing.$in as string[]).filter((id) => accessibleIds.has(id));
-      if (intersect.length === 0) {
-        return emptyFindResult(context);
-      }
-      query.worktree_id = { $in: intersect };
-      context.params.query = query;
-      return context;
-    }
-
-    // No explicit worktree_id filter — restrict to accessible set
-    if (accessibleIds.size === 0) {
-      return emptyFindResult(context);
-    }
-    query.worktree_id = { $in: Array.from(accessibleIds) };
-    context.params.query = query;
-    return context;
+    if (decision.kind !== 'filter') return context;
+    return intersectFindQuery(context, 'worktree_id', decision.accessibleIds);
   };
 }
 
@@ -1302,58 +1326,12 @@ export function scopeFindToAccessibleSessions(
   options?: { allowSuperadmin?: boolean }
 ) {
   return async (context: HookContext) => {
-    if (context.method !== 'find') {
-      return context;
-    }
+    const decision = await resolveFindScopeAccess(context, options, async (uid) => {
+      const accessible = await sessionRepo.findAccessibleSessions(uid);
+      return accessible.map((s) => s.session_id as string);
+    });
 
-    if (!context.params.provider) {
-      return context;
-    }
-
-    if (context.params.user?._isServiceAccount) {
-      return context;
-    }
-
-    const userId = context.params.user?.user_id as UUID | undefined;
-    if (!userId) {
-      return emptyFindResult(context);
-    }
-
-    const userRole = context.params.user?.role as string | undefined;
-    const allowSuperadmin = options?.allowSuperadmin ?? true;
-    if (isSuperAdmin(userRole, allowSuperadmin)) {
-      return context;
-    }
-
-    const accessible = await sessionRepo.findAccessibleSessions(userId);
-    const accessibleIds = new Set<string>(accessible.map((s) => s.session_id as string));
-
-    // biome-ignore lint/suspicious/noExplicitAny: Feathers query shape is dynamic
-    const query = (context.params.query ?? {}) as any;
-    const existing = query.session_id;
-
-    if (typeof existing === 'string') {
-      if (!accessibleIds.has(existing)) {
-        return emptyFindResult(context);
-      }
-      return context;
-    }
-
-    if (existing && typeof existing === 'object' && Array.isArray(existing.$in)) {
-      const intersect = (existing.$in as string[]).filter((id) => accessibleIds.has(id));
-      if (intersect.length === 0) {
-        return emptyFindResult(context);
-      }
-      query.session_id = { $in: intersect };
-      context.params.query = query;
-      return context;
-    }
-
-    if (accessibleIds.size === 0) {
-      return emptyFindResult(context);
-    }
-    query.session_id = { $in: Array.from(accessibleIds) };
-    context.params.query = query;
-    return context;
+    if (decision.kind !== 'filter') return context;
+    return intersectFindQuery(context, 'session_id', decision.accessibleIds);
   };
 }

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -10,7 +10,7 @@
  * @see context/explorations/unix-user-modes.md
  */
 
-import type { SessionRepository, WorktreeRepository } from '@agor/core/db';
+import type { BoardRepository, SessionRepository, WorktreeRepository } from '@agor/core/db';
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   HookContext,
@@ -1333,5 +1333,36 @@ export function scopeFindToAccessibleSessions(
 
     if (decision.kind !== 'filter') return context;
     return intersectFindQuery(context, 'session_id', decision.accessibleIds);
+  };
+}
+
+/**
+ * Scope find() queries on the boards service to the set of boards the caller
+ * can see.
+ *
+ * A board is visible if the caller created it OR any worktree on the board is
+ * accessible to them (owner or `others_can` permits at least 'view'). Empty
+ * boards stay visible to their creator; superadmins bypass.
+ *
+ * Resolution happens in a single SQL EXISTS query via
+ * {@link BoardRepository.findVisibleBoardIds}, avoiding the hydrate-every-
+ * worktree cost of the previous in-memory after-hook and letting Feathers'
+ * pagination/sort run against the already-scoped id set.
+ *
+ * @param boardRepo - BoardRepository instance
+ * @param options - Optional flags (allowSuperadmin)
+ * @returns Feathers hook
+ */
+export function scopeFindToAccessibleBoards(
+  boardRepo: BoardRepository,
+  options?: { allowSuperadmin?: boolean }
+) {
+  return async (context: HookContext) => {
+    const decision = await resolveFindScopeAccess(context, options, (uid) =>
+      boardRepo.findVisibleBoardIds(uid)
+    );
+
+    if (decision.kind !== 'filter') return context;
+    return intersectFindQuery(context, 'board_id', decision.accessibleIds);
   };
 }

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -2,7 +2,7 @@
  * About Tab - Display version, connection info, and system details
  */
 
-import type { AgorClient } from '@agor-live/client';
+import type { AgorClient, UnixUserMode } from '@agor-live/client';
 import { Card, Descriptions, Space, Typography } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
@@ -41,6 +41,10 @@ interface HealthInfo {
   encryption?: {
     enabled: boolean;
     method: string | null;
+  };
+  execution?: {
+    worktreeRbac: boolean;
+    unixUserMode: UnixUserMode;
   };
 }
 
@@ -174,6 +178,35 @@ export const AboutTab: React.FC<AboutTabProps> = ({
                       </Descriptions.Item>
                       <Descriptions.Item label="Anonymous Access">
                         {healthInfo.auth.allowAnonymous ? '✓ Enabled' : '✗ Disabled'}
+                      </Descriptions.Item>
+                    </>
+                  )}
+                  {healthInfo?.execution && (
+                    <>
+                      <Descriptions.Item label="Worktree RBAC">
+                        {healthInfo.execution.worktreeRbac ? (
+                          <span style={{ color: '#52c41a' }}>🛡️ Enabled</span>
+                        ) : (
+                          <span style={{ color: '#faad14' }}>⚠️ Disabled (open access)</span>
+                        )}
+                      </Descriptions.Item>
+                      <Descriptions.Item label="Unix User Mode">
+                        <code>{healthInfo.execution.unixUserMode}</code>
+                        {healthInfo.execution.unixUserMode === 'simple' && (
+                          <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
+                            (no OS isolation)
+                          </Typography.Text>
+                        )}
+                        {healthInfo.execution.unixUserMode === 'insulated' && (
+                          <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
+                            (worktree groups)
+                          </Typography.Text>
+                        )}
+                        {healthInfo.execution.unixUserMode === 'strict' && (
+                          <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
+                            (per-user impersonation)
+                          </Typography.Text>
+                        )}
                       </Descriptions.Item>
                     </>
                   )}

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -201,6 +201,13 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const artifactsEnabled = useServiceEnabled('artifacts');
   const cardsEnabled = useServiceEnabled('cards');
 
+  // Role gate — MCP Servers and Gateway Channels are global admin-managed
+  // configuration (credentials, webhook URLs, env vars). The daemon enforces
+  // ADMIN role on writes for both services (see register-hooks.ts); hiding
+  // the menu entries here avoids showing members a tab where every action
+  // would 403.
+  const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+
   // Menu items for left sidebar navigation
   const menuItems: MenuProps['items'] = useMemo(
     () => [
@@ -272,7 +279,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         label: 'Integrations',
         type: 'group' as const,
         children: [
-          ...(mcpEnabled
+          ...(mcpEnabled && isAdmin
             ? [
                 {
                   key: 'mcp',
@@ -286,7 +293,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             label: 'Agentic Tools',
             icon: <ThunderboltOutlined />,
           },
-          ...(gatewayEnabled
+          ...(gatewayEnabled && isAdmin
             ? [
                 {
                   key: 'gateway',
@@ -322,7 +329,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         ],
       },
     ],
-    [gatewayEnabled, mcpEnabled, artifactsEnabled, cardsEnabled, token]
+    [gatewayEnabled, mcpEnabled, artifactsEnabled, cardsEnabled, isAdmin, token]
   );
 
   // Render content based on active section

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,15 @@ services:
       - AGOR_USE_EXECUTOR=${AGOR_USE_EXECUTOR:-false}
       - AGOR_EXECUTOR_USERNAME=${AGOR_EXECUTOR_USERNAME:-agor_executor}
 
+      # Worktree RBAC + Unix isolation tier (written into ~/.agor/config.yaml
+      # by the entrypoint before the daemon boots). Both are optional — when
+      # unset the existing config.yaml values are left alone.
+      #   AGOR_RBAC_ENABLED=true         → execution.worktree_rbac: true
+      #   AGOR_UNIX_USER_MODE=insulated  → execution.unix_user_mode: insulated
+      #                                    (simple | insulated | strict)
+      - AGOR_RBAC_ENABLED=${AGOR_RBAC_ENABLED:-}
+      - AGOR_UNIX_USER_MODE=${AGOR_UNIX_USER_MODE:-}
+
       # Instance identification (optional - displayed in UI navbar)
       - INSTANCE_LABEL=${INSTANCE_LABEL:-}
 

--- a/docker/docker-entrypoint-postgres.sh
+++ b/docker/docker-entrypoint-postgres.sh
@@ -56,24 +56,14 @@ if [ "$CREATE_RBAC_TEST_USERS" = "true" ]; then
   echo ""
 fi
 
-# Configure RBAC settings if environment variables are set
-# This must happen BEFORE the base entrypoint runs, so config is set before daemon starts
+# Log the RBAC config the base entrypoint will apply. The public-facing
+# AGOR_RBAC_ENABLED / AGOR_UNIX_USER_MODE → internal AGOR_SET_* translation is
+# handled by the base entrypoint (docker-entrypoint.sh), so both the postgres
+# and plain profiles use the same naming contract.
 if [ -n "$AGOR_RBAC_ENABLED" ] || [ -n "$AGOR_UNIX_USER_MODE" ]; then
-  echo "⚙️  Configuring RBAC settings from environment..."
-
-  # Wait for base initialization to create config file
-  # (base entrypoint will call 'agor init' which creates ~/.agor/config.yaml)
-
-  if [ "$AGOR_RBAC_ENABLED" = "true" ]; then
-    echo "  Setting execution.worktree_rbac = true"
-    export AGOR_SET_RBAC_FLAG="true"
-  fi
-
-  if [ -n "$AGOR_UNIX_USER_MODE" ]; then
-    echo "  Setting execution.unix_user_mode = $AGOR_UNIX_USER_MODE"
-    export AGOR_SET_UNIX_MODE="$AGOR_UNIX_USER_MODE"
-  fi
-
+  echo "⚙️  RBAC settings from environment:"
+  [ "$AGOR_RBAC_ENABLED" = "true" ] && echo "  execution.worktree_rbac = true"
+  [ -n "$AGOR_UNIX_USER_MODE" ] && echo "  execution.unix_user_mode = $AGOR_UNIX_USER_MODE"
   echo ""
 fi
 
@@ -82,7 +72,7 @@ fi
 # - Building @agor/core
 # - Database migrations
 # - Creating admin user
-# - Applying RBAC config (via AGOR_SET_* env vars)
+# - Applying RBAC config (AGOR_RBAC_ENABLED / AGOR_UNIX_USER_MODE)
 # - Starting daemon and UI
 echo "🚀 Running base initialization..."
 exec /usr/local/bin/docker-entrypoint.sh

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -131,7 +131,21 @@ if [ "$AGOR_USE_EXECUTOR" = "true" ]; then
   fi
 fi
 
-# Configure RBAC settings from environment (set by postgres entrypoint)
+# Translate public-facing RBAC env vars to the internal AGOR_SET_* contract the
+# sed logic below reads. The postgres entrypoint also performs this translation
+# before exec'ing us — doing it again here is idempotent (same export values)
+# and lets plain `docker-compose.yml` consumers set AGOR_RBAC_ENABLED /
+# AGOR_UNIX_USER_MODE directly, matching the names documented in the postgres
+# profile and CLAUDE.md.
+if [ "$AGOR_RBAC_ENABLED" = "true" ]; then
+  export AGOR_SET_RBAC_FLAG="true"
+fi
+if [ -n "$AGOR_UNIX_USER_MODE" ]; then
+  export AGOR_SET_UNIX_MODE="$AGOR_UNIX_USER_MODE"
+fi
+
+# Configure RBAC settings from environment (set by postgres entrypoint or by
+# the public-facing translation above).
 if [ "$AGOR_SET_RBAC_FLAG" = "true" ] || [ -n "$AGOR_SET_UNIX_MODE" ]; then
   echo "🔐 Configuring RBAC settings..."
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -216,6 +216,16 @@ export interface AgorCodexSettings {
 }
 
 /**
+ * Unix user isolation mode controlling how session processes get mapped to
+ * OS identities.
+ *
+ * - `simple` — all processes run as the daemon user (no OS isolation)
+ * - `insulated` — executors run as a dedicated user with per-worktree groups
+ * - `strict` — sessions run as the session creator's own Unix user
+ */
+export type UnixUserMode = 'simple' | 'insulated' | 'strict';
+
+/**
  * Execution settings
  */
 export interface AgorExecutionSettings {
@@ -223,7 +233,7 @@ export interface AgorExecutionSettings {
   executor_unix_user?: string;
 
   /** Unix user mode: simple (no isolation), insulated (worktree groups), strict (enforce process impersonation) */
-  unix_user_mode?: 'simple' | 'insulated' | 'strict';
+  unix_user_mode?: UnixUserMode;
 
   /** Enable worktree RBAC and ownership system (default: false). When enabled, enforces permission checks and Unix group isolation. */
   worktree_rbac?: boolean;

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -5,7 +5,8 @@
  */
 
 import type { Board, BoardExportBlob, BoardObject, UUID } from '@agor/core/types';
-import { and, eq, like, ne } from 'drizzle-orm';
+import { WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
+import { and, eq, exists, inArray, isNotNull, like, ne, or, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
 import { formatShortId, generateId } from '../../lib/ids';
@@ -13,7 +14,7 @@ import { generateSlug } from '../../lib/slugs';
 import { getBoardUrl } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
-import { type BoardInsert, type BoardRow, boards } from '../schema';
+import { type BoardInsert, type BoardRow, boards, worktreeOwners, worktrees } from '../schema';
 import {
   AmbiguousIdError,
   type BaseRepository,
@@ -279,6 +280,57 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
         error
       );
     }
+  }
+
+  /**
+   * Find the ids of boards visible to a user under worktree RBAC.
+   *
+   * A board is visible if either:
+   * - The user created it (self-created boards are always visible, even when
+   *   they carry no worktrees yet), OR
+   * - At least one worktree on the board is accessible to the user (owner
+   *   row, or `others_can` permits at least 'view').
+   *
+   * Implemented as a single correlated `EXISTS` subquery against `boards` so
+   * each board row is emitted at most once — no `DISTINCT` or `UNION` needed.
+   * Portable SQL: `EXISTS`, `LEFT JOIN`, `IN`, `OR`, `IS NOT NULL` behave
+   * identically on SQLite and Postgres, and both planners short-circuit the
+   * semi-join on the first qualifying worktree per board.
+   *
+   * Should only be called when worktree RBAC is enabled.
+   *
+   * @param userId - User ID to check board visibility for
+   * @returns Array of board ids the user can see
+   */
+  async findVisibleBoardIds(userId: UUID): Promise<string[]> {
+    const permissiveLevels = WORKTREE_PERMISSION_LEVELS.filter((l) => l !== 'none');
+    // Raw drizzle builder for the EXISTS subquery — `exists()` expects a
+    // drizzle SelectQueryBuilder, not the cross-dialect wrapper shape, and
+    // the subquery doesn't need `.all()` / `.one()` execution methods.
+    const accessibleWorktreeExists = exists(
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+      (this.db as any)
+        .select({ _: sql`1` })
+        .from(worktrees)
+        .leftJoin(
+          worktreeOwners,
+          and(
+            eq(worktreeOwners.worktree_id, worktrees.worktree_id),
+            eq(worktreeOwners.user_id, userId)
+          )
+        )
+        .where(
+          and(
+            eq(worktrees.board_id, boards.board_id),
+            or(isNotNull(worktreeOwners.user_id), inArray(worktrees.others_can, permissiveLevels))
+          )
+        )
+    );
+    const rows = await select(this.db, { board_id: boards.board_id })
+      .from(boards)
+      .where(or(eq(boards.created_by, userId), accessibleWorktreeExists))
+      .all();
+    return rows.map((r: { board_id: string }) => r.board_id);
   }
 
   /**

--- a/packages/core/src/unix/user-manager.ts
+++ b/packages/core/src/unix/user-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import type { UnixUserMode } from '../config/types.js';
 import { formatShortId } from '../lib/ids.js';
 import type { UserID, UUID } from '../types/index.js';
 
@@ -311,9 +312,12 @@ export function unixUserExists(username: string): boolean {
 }
 
 /**
- * Unix user mode types
+ * Re-export of {@link UnixUserMode} for existing `@agor/core/unix` consumers.
+ * Canonical definition lives in `@agor/core/config/types` so browser-safe
+ * surfaces (e.g. `@agor/core/client`) can use it without pulling in this
+ * Node-only module.
  */
-export type UnixUserMode = 'simple' | 'insulated' | 'strict';
+export type { UnixUserMode };
 
 /**
  * Result of resolving which Unix user to impersonate


### PR DESCRIPTION
## Summary

When `worktree_rbac: true` is configured, per-resource `get`/`create`/`patch`/`remove` hooks already enforce worktree permissions, but `find()` endpoints did not — authenticated members could list rows across every worktree. This PR adds consistent worktree-centric scoping on `find()` and closes one MCP tool that bypassed the Feathers hook pipeline via raw Drizzle SQL.

No schema or default-config changes. `worktree_rbac` remains opt-in (default: `false`), so open-access mode is unchanged.

### New helpers
`apps/agor-daemon/src/utils/worktree-authorization.ts`:
- `scopeFindToAccessibleWorktrees(worktreeRepo, options?)` — before:find factory that intersects `query.worktree_id` with `findAccessibleWorktrees(userId)`.
- `scopeFindToAccessibleSessions(sessionRepo, options?)` — same shape, scoped via `findAccessibleSessions(userId)` on `query.session_id`.

Both helpers: skip internal / service-account calls, short-circuit unauthenticated callers with an empty paginated result, superadmin bypass (respecting `allowSuperadmin`), preserve pre-existing filters by intersection, no-op outside `find`.

### Services scoped (all gated on `worktreeRbacEnabled`)
- `messages.find`, `tasks.find`, `session-mcp-servers.find` → `scopeFindToAccessibleSessions`
- `artifacts.find` → `scopeFindToAccessibleWorktrees`
- `boards.find` → after-hook filter by accessible worktree `board_id`s (plus boards the user created)
- `files` (plural) → session-based `view` chain (`loadSession` → `loadWorktreeFromSession` → `ensureCanView`)
- `/file` (singular) → worktree-based `view` chain (`loadWorktree` → `ensureCanView`)
- `mcp-servers.find` — deliberately unchanged (global admin resource); commented
- `board-objects.find` — deliberately left with existing after-hook filter (avoids dropping card/zone rows with null `worktree_id`); commented

### Additional tightening
- `tasks.remove` now requires worktree `'all'` permission via `resolveSessionContext` → `loadSession` → `loadWorktreeFromSession` → `ensureWorktreePermission('all', …)`. Previously only required `member` role.
- `agor_messages_list` MCP tool now loads `findAccessibleSessions(ctx.userId)` and injects `inArray(messagesTable.session_id, …)` into the WHERE. Skipped entirely when `worktree_rbac` is disabled and for superadmins. Preserves the default open-access behaviour.

## Test plan

- [x] `pnpm check` — 9/9 then 6/6 tasks successful
- [x] New unit tests — `apps/agor-daemon/src/utils/rbac-find-scoping.test.ts` (21 tests): internal/service-account skip, unauthenticated → empty, superadmin bypass, `allowSuperadmin=false`, explicit filter in/out of accessible set, `$in` intersection, zero-access, non-find pass-through
- [x] New MCP tests — `apps/agor-daemon/src/mcp/tools/messages.test.ts` (4 tests): RBAC-disabled unchanged, zero-access short-circuit, accessible ids injected into WHERE, superadmin bypass
- [x] Full daemon test suite: 209 passed, 30 skipped, 0 failures
- [ ] Manual spot-check against a multi-user instance with `worktree_rbac: true`

Run focused tests:
```
cd apps/agor-daemon && pnpm test -- rbac-find-scoping messages.test
```