### PR TITLE
feat(daemon): support Private Network Access for Sandpack artifacts

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -372,6 +372,23 @@ async function main() {
     })
   );
 
+  // Support Chrome's Private Network Access (PNA) spec — required for
+  // Sandpack artifacts (which run on codesandbox.io, a public origin) to
+  // call this daemon when it's on a private/local network address.
+  // Chrome sends `Access-Control-Request-Private-Network: true` in the
+  // OPTIONS preflight; without this response header the browser hard-blocks
+  // the request regardless of the regular CORS config.
+  // Security note: this only grants the *ability* to attempt a cross-origin
+  // request from a public page to a private address — the existing CORS
+  // origin check still runs and will reject unknown origins.  The PNA header
+  // has no effect when both sides are on the same network tier.
+  app.use((req, res, next) => {
+    if (req.headers['access-control-request-private-network']) {
+      res.setHeader('Access-Control-Allow-Private-Network', 'true');
+    }
+    next();
+  });
+
   // Parse JSON with size limits (security: prevent DoS via large payloads)
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));


### PR DESCRIPTION
## Problem

Sandpack artifacts rendered on Agor boards run inside an iframe served from `codesandbox.io` (a public origin). When the Agor daemon is hosted on a private/local network address (e.g. `agor.sandbox.preset.zone`), Chrome's **Private Network Access (PNA)** policy blocks any cross-origin `fetch` from that public iframe to the private address — even if regular CORS headers are present.

The browser error:
```
Access to fetch at 'https://agor.sandbox.preset.zone/...' from origin
'https://2-19-8-sandpack.codesandbox.io' has been blocked by CORS policy:
Permission was denied for this request to access the `local` address space.
```

This makes it impossible for artifact code (e.g. triage dashboards, kanban widgets) to call the Agor API to create sessions or worktrees — which is the intended use of `{{ agor.apiUrl }}` in artifact configs.

## Fix

Add a small Express middleware **after** the existing CORS middleware that responds to Chrome's PNA preflight:

- **Request signal:** `Access-Control-Request-Private-Network: true` in the OPTIONS preflight
- **Required response:** `Access-Control-Allow-Private-Network: true`

Without this header, Chrome hard-blocks the request before it reaches auth or CORS origin checks. With it, the request proceeds normally and the existing CORS origin check still gates access.

## Security Analysis

- **Does NOT bypass CORS.** The existing `origin` check in the `cors()` middleware still runs for every request. Rejected origins are still rejected.
- **Scope is narrow.** The PNA header only permits the browser to *attempt* a cross-origin request from a public page to a private address. Actual access is still controlled by the CORS origin allowlist.
- **Network tier restriction has no effect on same-tier traffic.** If both the browser and server are on the same network (e.g. both public, or both private), Chrome doesn't apply PNA restrictions at all — this header is a no-op in those cases.
- **Risk surface:** A page from a CORS-allowed origin, running inside a Sandpack iframe (codesandbox.io), can now call the daemon API. This is the intended behavior for board artifacts accessing Agor.

## Testing

After deploying, Sandpack artifacts with `{{ agor.apiUrl }}` in their config should be able to call `POST /authentication` and subsequent API endpoints from codesandbox.io-hosted iframes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)