### PR TITLE
fix: board icon emoji shows as unicode text on create modal

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -446,7 +446,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item label="Name" style={{ marginBottom: 24 }}>
             <Flex gap={8}>
-              <Form.Item name="icon" noStyle>
+              <Form.Item name="icon" initialValue="📋" noStyle>
                 <FormEmojiPickerInput form={form} fieldName="icon" defaultEmoji="📋" />
               </Form.Item>
               <Form.Item
@@ -545,7 +545,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item label="Name" style={{ marginBottom: 24 }}>
             <Flex gap={8}>
-              <Form.Item name="icon" noStyle>
+              <Form.Item name="icon" initialValue="📋" noStyle>
                 <FormEmojiPickerInput form={form} fieldName="icon" defaultEmoji="📋" />
               </Form.Item>
               <Form.Item


### PR DESCRIPTION
## Problem

When opening the **Create Agent** modal in Settings, the board icon field displays the default emoji (`📋`) as raw unicode text (e.g. `📋`) instead of rendering the actual emoji character. Once you pick an emoji from the picker, it displays correctly.

## Root Cause

`Form.Item name="icon"` was missing `initialValue="📋"`. Without it, Ant Design's form has no stored value for the field until the user interacts with it. `FormEmojiPickerInput` reads the form value via `form.getFieldValue(fieldName)`, which returns `undefined` initially — falling through to the `defaultEmoji` prop. But the inner `<Input>` renders with the form's `FieldContext`, and without an initialValue the field value shown can differ from the prefix display.

## Fix

Added `initialValue="📋"` to both the create and edit modal's `Form.Item name="icon"`, matching the existing pattern in `UsersTable.tsx` (which correctly has `initialValue="👤"`).

```tsx
// Before
<Form.Item name="icon" noStyle>

// After  
<Form.Item name="icon" initialValue="📋" noStyle>
```

The edit modal already calls `form.setFieldsValue({ icon: board.icon })` before opening, so `initialValue` there is redundant but harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)