### PR TITLE
feat(leaderboard): model/tool dimensions, split tokens, and time bucketing

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/analytics.ts
+++ b/apps/agor-daemon/src/mcp/tools/analytics.ts
@@ -6,11 +6,16 @@ import { textResult } from '../server.js';
 
 export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_analytics_leaderboard
+  //
+  // groupBy accepts a comma-separated combination of the supported dimensions:
+  //   user | worktree | repo | model | tool
+  // The service itself owns the list of valid dimensions; we keep the schema
+  // loose (a string) so new dimensions flow through without a second edit here.
   server.registerTool(
     'agor_analytics_leaderboard',
     {
       description:
-        'Get usage analytics leaderboard showing token and cost breakdown. Supports dynamic grouping by user, worktree, or repo (or combinations). Use groupBy parameter to control aggregation level.',
+        'Get usage analytics leaderboard showing token, cost, session, and duration breakdown. Supports dynamic grouping by user, worktree, repo, model, and/or tool (freely combined), plus optional time bucketing (hour/day/week/month) for time-series reports.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         userId: z.string().optional().describe('Filter by user ID (optional)'),
@@ -22,18 +27,16 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
           .describe('Filter by start date (ISO 8601 format, optional)'),
         endDate: z.string().optional().describe('Filter by end date (ISO 8601 format, optional)'),
         groupBy: z
-          .enum([
-            'user',
-            'worktree',
-            'repo',
-            'user,worktree',
-            'user,repo',
-            'worktree,repo',
-            'user,worktree,repo',
-          ])
+          .string()
           .optional()
           .describe(
-            'Group by dimension(s). Examples: "user" for per-user totals, "worktree" for per-worktree, "user,worktree" for user+worktree breakdown (default: user,worktree,repo)'
+            'Comma-separated list of dimensions to group by. Supported: user, worktree, repo, model, tool. Examples: "user", "user,model", "tool,worktree". Default: "user,worktree,repo".'
+          ),
+        bucket: z
+          .enum(['hour', 'day', 'week', 'month'])
+          .optional()
+          .describe(
+            'Optional time bucket. When set, adds a UTC ISO-8601 timestamp field per row, truncated to the given granularity, for time-series reporting.'
           ),
         sortBy: z
           .enum(['tokens', 'cost'])
@@ -58,6 +61,7 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
       if (args.startDate) query.startDate = args.startDate;
       if (args.endDate) query.endDate = args.endDate;
       if (args.groupBy) query.groupBy = args.groupBy;
+      if (args.bucket) query.bucket = args.bucket;
       if (args.sortBy) query.sortBy = args.sortBy;
       if (args.sortOrder) query.sortOrder = args.sortOrder;
       if (args.limit) query.limit = args.limit;

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -412,4 +412,168 @@ describe('LeaderboardService bucketing', () => {
       /Invalid bucket/
     );
   });
+
+  dbTest('bucket: "week" groups Mon-Sun (ISO) into one row', async ({ db }) => {
+    // Apr 13 2026 is a Monday. Apr 15/16/17 all fall into that week; Apr 20 is
+    // the start of the next week. We explicitly span the Sun→Mon boundary to
+    // verify the ISO-Monday truncation.
+    const aliceId = 'user-alice';
+    const worktreeId = 'wt-main';
+    const claudeSessionId = 'sess-claude';
+
+    await seedUser(db, aliceId, 'Alice', 'alice@example.com');
+    await seedRepoAndWorktree(db, {
+      slug: 'main',
+      worktreeId,
+      worktreeName: 'main-wt',
+      uniqueId: 1,
+    });
+    await seedSession(db, { sessionId: claudeSessionId, worktreeId, tool: 'claude-code' });
+
+    // Monday Apr 13
+    await seedTask(db, {
+      sessionId: claudeSessionId,
+      createdBy: aliceId,
+      createdAt: new Date('2026-04-13T10:00:00.000Z'),
+      model: 'claude-sonnet-4-6',
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.01,
+      durationMs: 1000,
+    });
+    // Sunday Apr 19 (still in the Apr 13 ISO week)
+    await seedTask(db, {
+      sessionId: claudeSessionId,
+      createdBy: aliceId,
+      createdAt: new Date('2026-04-19T23:30:00.000Z'),
+      model: 'claude-sonnet-4-6',
+      inputTokens: 200,
+      outputTokens: 100,
+      costUsd: 0.02,
+      durationMs: 2000,
+    });
+    // Monday Apr 20 (next ISO week)
+    await seedTask(db, {
+      sessionId: claudeSessionId,
+      createdBy: aliceId,
+      createdAt: new Date('2026-04-20T09:00:00.000Z'),
+      model: 'claude-sonnet-4-6',
+      inputTokens: 300,
+      outputTokens: 150,
+      costUsd: 0.03,
+      durationMs: 3000,
+    });
+
+    const service = new LeaderboardService(db);
+    const result = await service.find({ query: { bucket: 'week', groupBy: '' } });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].bucket).toBe('2026-04-13T00:00:00.000Z');
+    expect(result.data[0].taskCount).toBe(2);
+    expect(result.data[1].bucket).toBe('2026-04-20T00:00:00.000Z');
+    expect(result.data[1].taskCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date filters
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService date filters', () => {
+  dbTest('startDate/endDate bound the result set', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    // Include only Apr 16 (the opus task)
+    const result = await service.find({
+      query: {
+        startDate: '2026-04-16T00:00:00.000Z',
+        endDate: '2026-04-16T23:59:59.999Z',
+        groupBy: 'model',
+      },
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].model).toBe('claude-opus-4-6');
+    expect(result.data[0].taskCount).toBe(1);
+  });
+
+  dbTest('invalid startDate rejects with a clear error', async ({ db }) => {
+    const service = new LeaderboardService(db);
+    await expect(service.find({ query: { startDate: 'not-a-date' } })).rejects.toThrow(
+      /Invalid startDate/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy / partial rows
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService legacy rows', () => {
+  dbTest('tasks without normalized_sdk_response contribute 0 and still count', async ({ db }) => {
+    const aliceId = 'user-alice';
+    const worktreeId = 'wt-main';
+    const claudeSessionId = 'sess-claude';
+
+    await seedUser(db, aliceId, 'Alice', 'alice@example.com');
+    await seedRepoAndWorktree(db, {
+      slug: 'main',
+      worktreeId,
+      worktreeName: 'main-wt',
+      uniqueId: 1,
+    });
+    await seedSession(db, { sessionId: claudeSessionId, worktreeId, tool: 'claude-code' });
+
+    // Legacy task: no normalized_sdk_response at all, only top-level duration_ms
+    await insert(db, tasks)
+      .values({
+        task_id: generateId(),
+        session_id: claudeSessionId,
+        created_at: new Date('2026-04-15T12:00:00.000Z'),
+        status: TaskStatus.COMPLETED,
+        created_by: aliceId,
+        data: {
+          description: 'legacy',
+          full_prompt: 'legacy',
+          message_range: {
+            start_index: 0,
+            end_index: 0,
+            start_timestamp: '2026-04-15T12:00:00.000Z',
+          },
+          git_state: { ref_at_start: 'main', sha_at_start: 'abc' },
+          model: 'claude-sonnet-4-6',
+          tool_use_count: 0,
+          duration_ms: 1500,
+          // normalized_sdk_response intentionally absent
+        },
+      })
+      .run();
+
+    const service = new LeaderboardService(db);
+    const result = await service.find({ query: { groupBy: 'user' } });
+
+    const alice = result.data.find((r) => r.userId === aliceId);
+    expect(alice).toBeDefined();
+    expect(alice?.taskCount).toBe(1);
+    // Token/cost are absent → 0, duration falls back to top-level duration_ms
+    expect(alice?.totalTokens).toBe(0);
+    expect(alice?.totalInputTokens).toBe(0);
+    expect(alice?.totalOutputTokens).toBe(0);
+    expect(alice?.totalCost).toBe(0);
+    expect(alice?.totalDurationMs).toBe(1500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService input validation', () => {
+  dbTest('unknown groupBy dimension rejects with a clear error', async ({ db }) => {
+    const service = new LeaderboardService(db);
+    await expect(service.find({ query: { groupBy: 'user,wombat' } })).rejects.toThrow(
+      /Invalid groupBy dimension/
+    );
+  });
 });

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -1,0 +1,415 @@
+/**
+ * LeaderboardService tests.
+ *
+ * Exercises the aggregation service end-to-end against an in-memory SQLite
+ * instance. Tasks are inserted directly (bypassing the repository) because
+ * `TaskRepository.create` always stamps `created_at = new Date()`, and these
+ * tests need deterministic timestamps for bucketing assertions.
+ */
+
+import {
+  type Database,
+  generateId,
+  insert,
+  RepoRepository,
+  sessions,
+  tasks,
+  users,
+  worktrees,
+} from '@agor/core/db';
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { LeaderboardService } from './leaderboard';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * A fixed base timestamp (2026-04-15T12:00:00Z) so bucketing tests can assert
+ * exact day/week/month boundaries without relying on wall-clock time.
+ */
+const BASE_TS = new Date('2026-04-15T12:00:00.000Z').getTime();
+
+function tsAt({
+  daysOffset = 0,
+  hoursOffset = 0,
+}: {
+  daysOffset?: number;
+  hoursOffset?: number;
+} = {}): Date {
+  return new Date(BASE_TS + daysOffset * 86_400_000 + hoursOffset * 3_600_000);
+}
+
+async function seedUser(db: Database, id: string, name: string, email: string): Promise<void> {
+  await insert(db, users)
+    .values({
+      user_id: id,
+      created_at: new Date(),
+      email,
+      password: 'x',
+      name,
+      emoji: 'emoji',
+      role: 'member',
+      data: {},
+    })
+    .run();
+}
+
+async function seedRepoAndWorktree(
+  db: Database,
+  opts: { slug: string; worktreeId: string; worktreeName: string; uniqueId: number }
+): Promise<string> {
+  const repoRepo = new RepoRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId(),
+    slug: opts.slug,
+    name: `Repo ${opts.slug}`,
+    repo_type: 'remote' as const,
+    remote_url: `https://github.com/test/${opts.slug}.git`,
+    local_path: `/tmp/${opts.slug}`,
+    default_branch: 'main',
+  });
+
+  await insert(db, worktrees)
+    .values({
+      worktree_id: opts.worktreeId,
+      repo_id: repo.repo_id,
+      created_at: new Date(),
+      name: opts.worktreeName,
+      ref: 'main',
+      worktree_unique_id: opts.uniqueId,
+      data: { path: `/tmp/${opts.slug}/wt`, git_state: { ref_at_start: 'main' } },
+    })
+    .run();
+
+  return repo.repo_id;
+}
+
+async function seedSession(
+  db: Database,
+  opts: { sessionId: string; worktreeId: string; tool: 'claude-code' | 'codex' | 'gemini' }
+): Promise<void> {
+  await insert(db, sessions)
+    .values({
+      session_id: opts.sessionId,
+      created_at: new Date(),
+      status: 'idle',
+      agentic_tool: opts.tool,
+      worktree_id: opts.worktreeId,
+      created_by: 'anonymous',
+      data: { genealogy: { children: [] }, contextFiles: [], tasks: [], git_state: {} },
+    })
+    .run();
+}
+
+async function seedTask(
+  db: Database,
+  opts: {
+    sessionId: string;
+    createdBy: string;
+    createdAt: Date;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd?: number;
+    durationMs?: number;
+  }
+): Promise<void> {
+  const data = {
+    description: 'test',
+    full_prompt: 'test',
+    message_range: { start_index: 0, end_index: 0, start_timestamp: opts.createdAt.toISOString() },
+    git_state: { ref_at_start: 'main', sha_at_start: 'abc' },
+    model: opts.model,
+    tool_use_count: 0,
+    duration_ms: opts.durationMs,
+    normalized_sdk_response: {
+      tokenUsage: {
+        inputTokens: opts.inputTokens,
+        outputTokens: opts.outputTokens,
+        totalTokens: opts.inputTokens + opts.outputTokens,
+      },
+      costUsd: opts.costUsd,
+      durationMs: opts.durationMs,
+    },
+  };
+
+  await insert(db, tasks)
+    .values({
+      task_id: generateId(),
+      session_id: opts.sessionId,
+      created_at: opts.createdAt,
+      status: TaskStatus.COMPLETED,
+      created_by: opts.createdBy,
+      data,
+    })
+    .run();
+}
+
+/**
+ * Seed a canonical dataset used across several tests:
+ *
+ * - 2 users (alice, bob)
+ * - 1 repo / 1 worktree (simplifies most assertions)
+ * - 2 sessions, one claude-code (alice) and one codex (bob)
+ * - 4 tasks spanning 3 consecutive days (Apr 15, 16, 17) on 2 models
+ */
+async function seedCanonicalDataset(db: Database): Promise<{
+  aliceId: string;
+  bobId: string;
+  worktreeId: string;
+  claudeSessionId: string;
+  codexSessionId: string;
+}> {
+  const aliceId = 'user-alice';
+  const bobId = 'user-bob';
+  const worktreeId = 'wt-main';
+  const claudeSessionId = 'sess-claude';
+  const codexSessionId = 'sess-codex';
+
+  await seedUser(db, aliceId, 'Alice', 'alice@example.com');
+  await seedUser(db, bobId, 'Bob', 'bob@example.com');
+  await seedRepoAndWorktree(db, {
+    slug: 'main',
+    worktreeId,
+    worktreeName: 'main-wt',
+    uniqueId: 1,
+  });
+  await seedSession(db, { sessionId: claudeSessionId, worktreeId, tool: 'claude-code' });
+  await seedSession(db, { sessionId: codexSessionId, worktreeId, tool: 'codex' });
+
+  // Alice / claude-code / sonnet — 2 tasks on Apr 15 (same day)
+  await seedTask(db, {
+    sessionId: claudeSessionId,
+    createdBy: aliceId,
+    createdAt: tsAt({ daysOffset: 0, hoursOffset: 0 }),
+    model: 'claude-sonnet-4-6',
+    inputTokens: 1000,
+    outputTokens: 500,
+    costUsd: 0.1,
+    durationMs: 2000,
+  });
+  await seedTask(db, {
+    sessionId: claudeSessionId,
+    createdBy: aliceId,
+    createdAt: tsAt({ daysOffset: 0, hoursOffset: 2 }),
+    model: 'claude-sonnet-4-6',
+    inputTokens: 2000,
+    outputTokens: 1000,
+    costUsd: 0.2,
+    durationMs: 3000,
+  });
+  // Alice / claude-code / opus — Apr 16
+  await seedTask(db, {
+    sessionId: claudeSessionId,
+    createdBy: aliceId,
+    createdAt: tsAt({ daysOffset: 1 }),
+    model: 'claude-opus-4-6',
+    inputTokens: 4000,
+    outputTokens: 2000,
+    costUsd: 0.6,
+    durationMs: 5000,
+  });
+  // Bob / codex / gpt-5 — Apr 17
+  await seedTask(db, {
+    sessionId: codexSessionId,
+    createdBy: bobId,
+    createdAt: tsAt({ daysOffset: 2 }),
+    model: 'gpt-5',
+    inputTokens: 800,
+    outputTokens: 200,
+    costUsd: 0.05,
+    durationMs: 1000,
+  });
+
+  return { aliceId, bobId, worktreeId, claudeSessionId, codexSessionId };
+}
+
+// ---------------------------------------------------------------------------
+// Backward compatibility
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService backward compatibility', () => {
+  dbTest('legacy user/worktree/repo groupBy returns the same row shape', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find();
+
+    expect(result.limit).toBe(50);
+    expect(result.offset).toBe(0);
+    expect(result.data.length).toBeGreaterThan(0);
+
+    for (const row of result.data) {
+      // Legacy fields still present
+      expect(row.userId).toBeDefined();
+      expect(row.worktreeId).toBeDefined();
+      expect(row.repoId).toBeDefined();
+      expect(typeof row.totalTokens).toBe('number');
+      expect(typeof row.totalCost).toBe('number');
+      expect(typeof row.taskCount).toBe('number');
+      // No bucket field by default
+      expect(row.bucket).toBeUndefined();
+      // No model/tool fields since neither was requested
+      expect(row.model).toBeUndefined();
+      expect(row.tool).toBeUndefined();
+    }
+  });
+
+  dbTest('totalTokens still sums normalized totalTokens', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user' } });
+    const alice = result.data.find((r) => r.userId === 'user-alice');
+    expect(alice).toBeDefined();
+    // Alice: (1000+500) + (2000+1000) + (4000+2000) = 10500
+    expect(alice?.totalTokens).toBe(10_500);
+    // New split metrics
+    expect(alice?.totalInputTokens).toBe(7_000);
+    expect(alice?.totalOutputTokens).toBe(3_500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// New dimensions
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService dimensions', () => {
+  dbTest('groupBy: "model" returns one row per distinct model', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'model' } });
+    const modelNames = new Set(result.data.map((r) => r.model));
+    expect(modelNames).toEqual(new Set(['claude-sonnet-4-6', 'claude-opus-4-6', 'gpt-5']));
+
+    // Sonnet row aggregates both Apr 15 tasks
+    const sonnet = result.data.find((r) => r.model === 'claude-sonnet-4-6');
+    expect(sonnet?.taskCount).toBe(2);
+    expect(sonnet?.totalTokens).toBe(4_500);
+    expect(sonnet?.totalInputTokens).toBe(3_000);
+    expect(sonnet?.totalOutputTokens).toBe(1_500);
+  });
+
+  dbTest('groupBy: "tool" returns one row per agentic tool', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'tool' } });
+    const tools = new Set(result.data.map((r) => r.tool));
+    expect(tools).toEqual(new Set(['claude-code', 'codex']));
+
+    const claude = result.data.find((r) => r.tool === 'claude-code');
+    expect(claude?.taskCount).toBe(3);
+    expect(claude?.sessionCount).toBe(1);
+
+    const codex = result.data.find((r) => r.tool === 'codex');
+    expect(codex?.taskCount).toBe(1);
+    expect(codex?.sessionCount).toBe(1);
+  });
+
+  dbTest('groupBy: "user,model" returns rows keyed by both fields', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user,model' } });
+    // Alice has 2 models, Bob has 1
+    expect(result.data).toHaveLength(3);
+    for (const row of result.data) {
+      expect(row.userId).toBeDefined();
+      expect(row.model).toBeDefined();
+    }
+    const aliceOpus = result.data.find(
+      (r) => r.userId === 'user-alice' && r.model === 'claude-opus-4-6'
+    );
+    expect(aliceOpus?.totalTokens).toBe(6_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// New metrics
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService metrics', () => {
+  dbTest('sessionCount reflects distinct sessions per group', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user' } });
+    // Alice used 1 session (claude), Bob used 1 (codex)
+    const alice = result.data.find((r) => r.userId === 'user-alice');
+    const bob = result.data.find((r) => r.userId === 'user-bob');
+    expect(alice?.sessionCount).toBe(1);
+    expect(bob?.sessionCount).toBe(1);
+  });
+
+  dbTest('totalDurationMs sums normalized durationMs per group', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user' } });
+    const alice = result.data.find((r) => r.userId === 'user-alice');
+    // Alice durations: 2000 + 3000 + 5000 = 10_000
+    expect(alice?.totalDurationMs).toBe(10_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bucketing
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService bucketing', () => {
+  dbTest('bucket: "day" emits one row per day and orders chronologically', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { bucket: 'day', groupBy: '' } });
+    // 3 distinct days: Apr 15, 16, 17
+    expect(result.data).toHaveLength(3);
+    // Chronological order
+    expect(result.data[0].bucket).toBe('2026-04-15T00:00:00.000Z');
+    expect(result.data[1].bucket).toBe('2026-04-16T00:00:00.000Z');
+    expect(result.data[2].bucket).toBe('2026-04-17T00:00:00.000Z');
+    // Apr 15 aggregates the two sonnet tasks
+    expect(result.data[0].taskCount).toBe(2);
+    expect(result.data[0].totalTokens).toBe(4_500);
+  });
+
+  dbTest('bucket combined with groupBy:user returns per-user-per-day rows', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { bucket: 'day', groupBy: 'user' } });
+    // Alice has tasks on 2 days, Bob on 1 → 3 rows total
+    expect(result.data).toHaveLength(3);
+    // First chronologically is Alice on Apr 15
+    expect(result.data[0].bucket).toBe('2026-04-15T00:00:00.000Z');
+    expect(result.data[0].userId).toBe('user-alice');
+
+    // Each row has bucket + user dimension
+    for (const row of result.data) {
+      expect(row.bucket).toBeDefined();
+      expect(row.userId).toBeDefined();
+    }
+  });
+
+  dbTest('bucket: "month" collapses all fixture rows into one bucket', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { bucket: 'month', groupBy: '' } });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].bucket).toBe('2026-04-01T00:00:00.000Z');
+    expect(result.data[0].taskCount).toBe(4);
+  });
+
+  dbTest('invalid bucket value rejects with a clear error', async ({ db }) => {
+    const service = new LeaderboardService(db);
+    await expect(service.find({ query: { bucket: 'year' as never } })).rejects.toThrow(
+      /Invalid bucket/
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -14,7 +14,9 @@ import {
   dateTruncUtc,
   desc,
   eq,
+  gte,
   jsonExtract,
+  lte,
   type SQL,
   sessions,
   sql,
@@ -100,15 +102,21 @@ const VALID_BUCKETS = new Set<DateBucket>(['hour', 'day', 'week', 'month']);
 
 /**
  * Parse the comma-separated groupBy string into a set of known dimensions.
- * Unknown values are ignored (preserving forward compatibility).
+ * Throws on unknown values so typos surface loudly rather than silently
+ * collapsing the result set to an unexpected grouping. Matches the strict
+ * validation we do for `bucket`.
  */
 function parseGroupBy(groupBy: string): Set<LeaderboardDimension> {
   const dims = new Set<LeaderboardDimension>();
   for (const raw of groupBy.split(',')) {
-    const trimmed = raw.trim() as LeaderboardDimension;
-    if (ALL_DIMENSIONS.includes(trimmed)) {
-      dims.add(trimmed);
+    const trimmed = raw.trim();
+    if (trimmed === '') continue;
+    if (!ALL_DIMENSIONS.includes(trimmed as LeaderboardDimension)) {
+      throw new Error(
+        `Invalid groupBy dimension: "${trimmed}". Expected one of: ${ALL_DIMENSIONS.join(', ')}.`
+      );
     }
+    dims.add(trimmed as LeaderboardDimension);
   }
   return dims;
 }
@@ -174,12 +182,16 @@ export class LeaderboardService {
       conditions.push(eq(worktrees.repo_id, repoId));
     }
 
+    // Use gte/lte so drizzle encodes the bound via the column's timestamp mapper
+    // (integer ms on SQLite, timestamp-with-tz on Postgres). Passing an ISO string
+    // through `sql` compared SQLite ms-epoch integers against text and excluded
+    // everything.
     if (startDate) {
       const parsed = new Date(startDate);
       if (Number.isNaN(parsed.getTime())) {
         throw new Error(`Invalid startDate: "${startDate}". Expected ISO 8601 format.`);
       }
-      conditions.push(sql`${tasks.created_at} >= ${parsed.toISOString()}`);
+      conditions.push(gte(tasks.created_at, parsed));
     }
 
     if (endDate) {
@@ -187,7 +199,7 @@ export class LeaderboardService {
       if (Number.isNaN(parsed.getTime())) {
         throw new Error(`Invalid endDate: "${endDate}". Expected ISO 8601 format.`);
       }
-      conditions.push(sql`${tasks.created_at} <= ${parsed.toISOString()}`);
+      conditions.push(lte(tasks.created_at, parsed));
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -316,47 +328,38 @@ export class LeaderboardService {
       .limit(limit)
       .offset(offset);
 
-    // Build distinct count for pagination. Each part is wrapped in COALESCE so NULLs
-    // (e.g. model on legacy rows) don't collapse the concatenation.
-    const distinctParts: string[] = [];
-    if (includeUser) distinctParts.push("COALESCE(tasks.created_by, '')");
-    if (includeWorktree) distinctParts.push("COALESCE(worktrees.worktree_id, '')");
-    if (includeRepo) distinctParts.push("COALESCE(worktrees.repo_id, '')");
-    if (includeTool) distinctParts.push("COALESCE(sessions.agentic_tool, '')");
-    // Model and bucket are SQL expressions, not columns; they're inlined separately below.
-
-    // biome-ignore lint/suspicious/noExplicitAny: Building dynamic SQL requires any
-    const distinctPieces: any[] = distinctParts.map((p) => sql.raw(p));
-    if (includeModel) {
-      distinctPieces.push(sql`COALESCE(${modelExpr}, '')`);
-    }
-    if (bucketExpr) {
-      distinctPieces.push(sql`COALESCE(${bucketExpr}, '')`);
-    }
-
-    let distinctExpr: SQL;
-    if (distinctPieces.length === 0) {
-      distinctExpr = sql`COUNT(*)`;
+    // Build distinct count for pagination. We wrap the aggregation query (without
+    // ordering/limits) as a subquery and COUNT its groups. This is exact — no NULL
+    // collisions and no dependence on a separator character — and always matches
+    // the GROUP BY used for the paginated query above.
+    let total: number;
+    if (groupByFields.length === 0) {
+      // No grouping: the main query returns a single aggregate row.
+      total = results.length;
     } else {
-      distinctExpr = sql`COUNT(DISTINCT ${sql.join(distinctPieces, sql` || '-' || `)})`;
+      // biome-ignore lint/suspicious/noExplicitAny: Database union type prevents calling .select() with dynamic fields
+      let countInner = (this.db as any)
+        .select({ one: sql`1` })
+        .from(tasks)
+        .innerJoin(sessions, eq(tasks.session_id, sessions.session_id))
+        .innerJoin(worktrees, eq(sessions.worktree_id, worktrees.worktree_id));
+
+      if (includeUser) {
+        countInner = countInner.leftJoin(users, eq(tasks.created_by, users.user_id));
+      }
+
+      const groupedSubquery = countInner
+        .where(whereClause)
+        .groupBy(...groupByFields)
+        .as('g');
+
+      // biome-ignore lint/suspicious/noExplicitAny: Database union type prevents calling .select() with dynamic fields
+      const countResult = await (this.db as any)
+        .select({ count: sql<number>`COUNT(*)` })
+        .from(groupedSubquery);
+
+      total = Number(countResult[0]?.count) || 0;
     }
-
-    // biome-ignore lint/suspicious/noExplicitAny: Database union type prevents calling .select() with dynamic fields
-    let countQb = (this.db as any)
-      .select({
-        count: sql<number>`${distinctExpr}`,
-      })
-      .from(tasks)
-      .innerJoin(sessions, eq(tasks.session_id, sessions.session_id))
-      .innerJoin(worktrees, eq(sessions.worktree_id, worktrees.worktree_id));
-
-    if (includeUser) {
-      countQb = countQb.leftJoin(users, eq(tasks.created_by, users.user_id));
-    }
-
-    const countResult = await countQb.where(whereClause);
-
-    const total = countResult[0]?.count || 0;
 
     // Define result row type based on selected fields
     interface ResultRow {

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -2,13 +2,16 @@
  * Leaderboard Service
  *
  * Provides usage analytics endpoint for token and cost tracking.
- * Allows breakdown by user, worktree, and repo with flexible filtering and sorting.
+ * Allows breakdown by user, worktree, repo, model, and agentic tool, with
+ * optional time bucketing (hour/day/week/month) and flexible filtering.
  */
 
 import {
   and,
   asc,
   type Database,
+  type DateBucket,
+  dateTruncUtc,
   desc,
   eq,
   jsonExtract,
@@ -24,6 +27,14 @@ interface Params {
   query?: Record<string, unknown>;
 }
 
+/**
+ * Supported groupBy dimensions. Callers can combine these in a comma-separated string,
+ * e.g. `'user,model'` or `'tool,worktree,repo'`.
+ */
+export type LeaderboardDimension = 'user' | 'worktree' | 'repo' | 'model' | 'tool';
+
+const ALL_DIMENSIONS: LeaderboardDimension[] = ['user', 'worktree', 'repo', 'model', 'tool'];
+
 export interface LeaderboardQuery {
   // Filters
   userId?: string;
@@ -34,17 +45,16 @@ export interface LeaderboardQuery {
   startDate?: string;
   endDate?: string;
 
-  // Group by dimension (optional - defaults to all three)
-  groupBy?:
-    | 'user'
-    | 'worktree'
-    | 'repo'
-    | 'user,worktree'
-    | 'user,repo'
-    | 'worktree,repo'
-    | 'user,worktree,repo';
+  // Group by dimensions (optional, comma-separated). Default matches legacy behaviour.
+  // Supported values: 'user' | 'worktree' | 'repo' | 'model' | 'tool' (any combination).
+  groupBy?: string;
 
-  // Sorting
+  // Time bucket (optional). When set, adds a `bucket` field (ISO-8601 UTC timestamp
+  // truncated to the given granularity) to each row and to the GROUP BY.
+  bucket?: DateBucket;
+
+  // Sorting. When bucket is set, results are ordered by bucket ASC first, then by
+  // sortBy within each bucket.
   sortBy?: 'tokens' | 'cost';
   sortOrder?: 'asc' | 'desc';
 
@@ -54,6 +64,7 @@ export interface LeaderboardQuery {
 }
 
 export interface LeaderboardEntry {
+  // Dimension fields (present only when the corresponding dimension is in groupBy)
   userId?: string;
   userName?: string;
   userEmail?: string;
@@ -62,9 +73,20 @@ export interface LeaderboardEntry {
   worktreeName?: string;
   repoId?: string;
   repoName?: string;
+  model?: string;
+  tool?: string;
+
+  // Time-series field (present only when `bucket` is set)
+  bucket?: string;
+
+  // Metrics (always present)
   totalTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
   totalCost: number;
   taskCount: number;
+  sessionCount: number;
+  totalDurationMs: number;
 }
 
 export interface LeaderboardResult {
@@ -72,6 +94,23 @@ export interface LeaderboardResult {
   total: number;
   limit: number;
   offset: number;
+}
+
+const VALID_BUCKETS = new Set<DateBucket>(['hour', 'day', 'week', 'month']);
+
+/**
+ * Parse the comma-separated groupBy string into a set of known dimensions.
+ * Unknown values are ignored (preserving forward compatibility).
+ */
+function parseGroupBy(groupBy: string): Set<LeaderboardDimension> {
+  const dims = new Set<LeaderboardDimension>();
+  for (const raw of groupBy.split(',')) {
+    const trimmed = raw.trim() as LeaderboardDimension;
+    if (ALL_DIMENSIONS.includes(trimmed)) {
+      dims.add(trimmed);
+    }
+  }
+  return dims;
 }
 
 /**
@@ -101,17 +140,24 @@ export class LeaderboardService {
       startDate,
       endDate,
       groupBy = 'user,worktree,repo',
+      bucket,
       sortBy = 'cost',
       sortOrder = 'desc',
       limit = 50,
       offset = 0,
     } = query;
 
+    if (bucket !== undefined && !VALID_BUCKETS.has(bucket)) {
+      throw new Error(`Invalid bucket: "${bucket}". Expected one of: hour, day, week, month.`);
+    }
+
     // Parse groupBy dimensions
-    const dimensions = groupBy.split(',').map((d) => d.trim());
-    const includeUser = dimensions.includes('user');
-    const includeWorktree = dimensions.includes('worktree');
-    const includeRepo = dimensions.includes('repo');
+    const dims = parseGroupBy(groupBy);
+    const includeUser = dims.has('user');
+    const includeWorktree = dims.has('worktree');
+    const includeRepo = dims.has('repo');
+    const includeModel = dims.has('model');
+    const includeTool = dims.has('tool');
 
     // Build WHERE conditions
     const conditions: SQL[] = [];
@@ -146,18 +192,56 @@ export class LeaderboardService {
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
-    // Build dynamic SELECT clause
-    // Aggregate token usage from normalized_sdk_response.tokenUsage
-    // The executor normalizes raw SDK responses into a consistent format across all agents
+    // Build dynamic SELECT clause.
+    //
+    // Metrics are sourced from `normalized_sdk_response` (written by the executor,
+    // agent-agnostic). For duration we prefer the normalized value; if unset we fall
+    // back to the top-level `tasks.data.duration_ms`. Tasks without either field
+    // (legacy / in-flight) contribute 0 duration, which is the same behaviour as
+    // tokens/cost today.
+    const modelExpr = jsonExtract(this.db, tasks.data, 'model');
+    const inputTokensExpr = jsonExtract(
+      this.db,
+      tasks.data,
+      'normalized_sdk_response.tokenUsage.inputTokens'
+    );
+    const outputTokensExpr = jsonExtract(
+      this.db,
+      tasks.data,
+      'normalized_sdk_response.tokenUsage.outputTokens'
+    );
+    const totalTokensExpr = jsonExtract(
+      this.db,
+      tasks.data,
+      'normalized_sdk_response.tokenUsage.totalTokens'
+    );
+    const costExpr = jsonExtract(this.db, tasks.data, 'normalized_sdk_response.costUsd');
+    const normalizedDurationExpr = jsonExtract(
+      this.db,
+      tasks.data,
+      'normalized_sdk_response.durationMs'
+    );
+    const topLevelDurationExpr = jsonExtract(this.db, tasks.data, 'duration_ms');
+
     // biome-ignore lint/suspicious/noExplicitAny: Dynamic SQL fields require any
     const selectFields: Record<string, any> = {
+      totalInputTokens: sql<number>`COALESCE(SUM(
+        CAST(${inputTokensExpr} AS INTEGER)
+      ), 0)`.as('total_input_tokens'),
+      totalOutputTokens: sql<number>`COALESCE(SUM(
+        CAST(${outputTokensExpr} AS INTEGER)
+      ), 0)`.as('total_output_tokens'),
       totalTokens: sql<number>`COALESCE(SUM(
-        CAST(${jsonExtract(this.db, tasks.data, 'normalized_sdk_response.tokenUsage.totalTokens')} AS INTEGER)
+        CAST(${totalTokensExpr} AS INTEGER)
       ), 0)`.as('total_tokens'),
       totalCost: sql<number>`COALESCE(SUM(
-        CAST(${jsonExtract(this.db, tasks.data, 'normalized_sdk_response.costUsd')} AS REAL)
+        CAST(${costExpr} AS REAL)
       ), 0.0)`.as('total_cost'),
       taskCount: sql<number>`COUNT(DISTINCT ${tasks.task_id})`.as('task_count'),
+      sessionCount: sql<number>`COUNT(DISTINCT ${tasks.session_id})`.as('session_count'),
+      totalDurationMs: sql<number>`COALESCE(SUM(
+        CAST(COALESCE(${normalizedDurationExpr}, ${topLevelDurationExpr}) AS INTEGER)
+      ), 0)`.as('total_duration_ms'),
     };
 
     if (includeUser) {
@@ -172,6 +256,18 @@ export class LeaderboardService {
     }
     if (includeRepo) {
       selectFields.repoId = worktrees.repo_id;
+    }
+    if (includeModel) {
+      selectFields.model = sql<string>`${modelExpr}`.as('model');
+    }
+    if (includeTool) {
+      selectFields.tool = sessions.agentic_tool;
+    }
+
+    // Bucketing: compute a UTC-truncated ISO timestamp string.
+    const bucketExpr = bucket ? dateTruncUtc(this.db, tasks.created_at, bucket) : undefined;
+    if (bucketExpr) {
+      selectFields.bucket = sql<string>`${bucketExpr}`.as('bucket');
     }
 
     // Build dynamic GROUP BY clause
@@ -188,10 +284,15 @@ export class LeaderboardService {
       groupByFields.push(worktrees.name);
     }
     if (includeRepo) groupByFields.push(worktrees.repo_id);
+    if (includeModel) groupByFields.push(sql`${modelExpr}`);
+    if (includeTool) groupByFields.push(sessions.agentic_tool);
+    if (bucketExpr) groupByFields.push(sql`${bucketExpr}`);
 
-    // Build sorting
+    // Build sorting. When bucketing, order by bucket ASC first so the caller receives
+    // chronologically-ordered time series, then by the requested metric within each bucket.
     const sortField = sortBy === 'tokens' ? sql`total_tokens` : sql`total_cost`;
-    const orderClause = sortOrder === 'desc' ? desc(sortField) : asc(sortField);
+    const metricOrder = sortOrder === 'desc' ? desc(sortField) : asc(sortField);
+    const orderClauses = bucketExpr ? [asc(sql`bucket`), metricOrder] : [metricOrder];
 
     // Execute aggregation query
     // Join: tasks -> sessions -> worktrees, optionally LEFT JOIN users for display info
@@ -211,19 +312,34 @@ export class LeaderboardService {
     const results = await qb
       .where(whereClause)
       .groupBy(...groupByFields)
-      .orderBy(orderClause)
+      .orderBy(...orderClauses)
       .limit(limit)
       .offset(offset);
 
-    // Build distinct count for pagination
+    // Build distinct count for pagination. Each part is wrapped in COALESCE so NULLs
+    // (e.g. model on legacy rows) don't collapse the concatenation.
     const distinctParts: string[] = [];
-    if (includeUser) distinctParts.push('tasks.created_by');
-    if (includeWorktree) distinctParts.push('worktrees.worktree_id');
-    if (includeRepo) distinctParts.push('worktrees.repo_id');
-    const distinctExpr =
-      distinctParts.length > 0
-        ? sql`COUNT(DISTINCT ${sql.raw(distinctParts.join(" || '-' || "))})`
-        : sql`COUNT(*)`;
+    if (includeUser) distinctParts.push("COALESCE(tasks.created_by, '')");
+    if (includeWorktree) distinctParts.push("COALESCE(worktrees.worktree_id, '')");
+    if (includeRepo) distinctParts.push("COALESCE(worktrees.repo_id, '')");
+    if (includeTool) distinctParts.push("COALESCE(sessions.agentic_tool, '')");
+    // Model and bucket are SQL expressions, not columns; they're inlined separately below.
+
+    // biome-ignore lint/suspicious/noExplicitAny: Building dynamic SQL requires any
+    const distinctPieces: any[] = distinctParts.map((p) => sql.raw(p));
+    if (includeModel) {
+      distinctPieces.push(sql`COALESCE(${modelExpr}, '')`);
+    }
+    if (bucketExpr) {
+      distinctPieces.push(sql`COALESCE(${bucketExpr}, '')`);
+    }
+
+    let distinctExpr: SQL;
+    if (distinctPieces.length === 0) {
+      distinctExpr = sql`COUNT(*)`;
+    } else {
+      distinctExpr = sql`COUNT(DISTINCT ${sql.join(distinctPieces, sql` || '-' || `)})`;
+    }
 
     // biome-ignore lint/suspicious/noExplicitAny: Database union type prevents calling .select() with dynamic fields
     let countQb = (this.db as any)
@@ -251,9 +367,16 @@ export class LeaderboardService {
       worktreeId?: string;
       worktreeName?: string;
       repoId?: string;
+      model?: string | null;
+      tool?: string | null;
+      bucket?: string | null;
       totalTokens: number;
+      totalInputTokens: number;
+      totalOutputTokens: number;
       totalCost: number;
       taskCount: number;
+      sessionCount: number;
+      totalDurationMs: number;
     }
 
     // Transform results to match our interface
@@ -271,9 +394,16 @@ export class LeaderboardService {
           worktreeName: r.worktreeName as string,
         }),
         ...(includeRepo && { repoId: r.repoId as string }),
-        totalTokens: r.totalTokens || 0,
-        totalCost: r.totalCost || 0,
-        taskCount: r.taskCount || 0,
+        ...(includeModel && { model: r.model || undefined }),
+        ...(includeTool && { tool: r.tool || undefined }),
+        ...(bucketExpr && { bucket: r.bucket || undefined }),
+        totalTokens: Number(r.totalTokens) || 0,
+        totalInputTokens: Number(r.totalInputTokens) || 0,
+        totalOutputTokens: Number(r.totalOutputTokens) || 0,
+        totalCost: Number(r.totalCost) || 0,
+        taskCount: Number(r.taskCount) || 0,
+        sessionCount: Number(r.sessionCount) || 0,
+        totalDurationMs: Number(r.totalDurationMs) || 0,
       };
     });
 

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -167,7 +167,13 @@ export function dateTruncUtc(db: Database, column: SQL | any, bucket: DateBucket
     }
   } else {
     // PostgreSQL date_trunc accepts 'hour'|'day'|'week'|'month'; week is already ISO (Monday).
-    return sql`to_char(date_trunc(${bucket}, ${column}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+    // IMPORTANT: `date_trunc(unit, timestamptz)` truncates in the session's timezone, so we
+    // convert to a UTC wall-clock timestamp *first* (`column AT TIME ZONE 'UTC'`) and truncate
+    // that. Otherwise day/week/month buckets misalign for any session not set to UTC.
+    return sql`to_char(
+      date_trunc(${bucket}, ${column} AT TIME ZONE 'UTC'),
+      'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+    )`;
   }
 }
 

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -119,6 +119,59 @@ export function jsonExtract(db: Database, column: SQL.Aliased | SQL | any, path:
 }
 
 /**
+ * Supported bucket granularities for {@link dateTruncUtc}.
+ */
+export type DateBucket = 'hour' | 'day' | 'week' | 'month';
+
+/**
+ * Truncate a timestamp column to a bucket boundary in UTC and return an ISO 8601 string.
+ *
+ * Produces stable bucket keys that can be grouped and ordered chronologically in both
+ * SQLite and PostgreSQL. Week buckets use ISO-8601 semantics (Monday as start of week).
+ *
+ * - SQLite: `created_at` is stored as integer ms since epoch (`mode: 'timestamp_ms'`),
+ *   so the column value is divided by 1000 to feed into `strftime` via the `unixepoch` modifier.
+ * - PostgreSQL: uses `date_trunc` on a `timestamp with time zone` column, cast to text in
+ *   `YYYY-MM-DDTHH24:MI:SS.MSZ` so the output matches SQLite's.
+ *
+ * @param db - Database instance (for dialect detection)
+ * @param column - Timestamp column to truncate
+ * @param bucket - Granularity
+ * @returns SQL expression producing an ISO-8601 UTC timestamp string
+ *
+ * @example
+ * // SELECT ... dateTruncUtc(db, tasks.created_at, 'day') AS bucket
+ * // → '2026-04-17T00:00:00.000Z'
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Drizzle columns have complex union types
+export function dateTruncUtc(db: Database, column: SQL | any, bucket: DateBucket): SQL {
+  if (isSQLiteDatabase(db)) {
+    // SQLite columns with timestamp_ms mode store integer ms — convert to unix seconds.
+    const unixSeconds = sql`${column} / 1000`;
+    switch (bucket) {
+      case 'hour':
+        return sql`strftime('%Y-%m-%dT%H:00:00.000Z', ${unixSeconds}, 'unixepoch')`;
+      case 'day':
+        return sql`strftime('%Y-%m-%dT00:00:00.000Z', ${unixSeconds}, 'unixepoch')`;
+      case 'month':
+        return sql`strftime('%Y-%m-01T00:00:00.000Z', ${unixSeconds}, 'unixepoch')`;
+      case 'week':
+        // Shift to the Monday of the same ISO week, then emit midnight UTC.
+        // %w returns 0 (Sun) … 6 (Sat); (wd + 6) mod 7 = days since Monday.
+        return sql`strftime(
+          '%Y-%m-%dT00:00:00.000Z',
+          ${unixSeconds},
+          'unixepoch',
+          '-' || ((strftime('%w', ${unixSeconds}, 'unixepoch') + 6) % 7) || ' days'
+        )`;
+    }
+  } else {
+    // PostgreSQL date_trunc accepts 'hour'|'day'|'week'|'month'; week is already ISO (Monday).
+    return sql`to_char(date_trunc(${bucket}, ${column}) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+  }
+}
+
+/**
  * Acquire a row-level lock within a transaction (PostgreSQL FOR UPDATE).
  *
  * On PostgreSQL, executes `SELECT 1 FROM <table> WHERE <pk> = <id> FOR UPDATE`

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -2,7 +2,19 @@
 
 // Drizzle ORM re-exports (so daemon doesn't import drizzle-orm directly)
 // Commonly used operators and utilities
-export { and, asc, desc, eq, inArray, like, or, type SQL, sql } from 'drizzle-orm';
+export {
+  and,
+  asc,
+  desc,
+  eq,
+  gte,
+  inArray,
+  like,
+  lte,
+  or,
+  type SQL,
+  sql,
+} from 'drizzle-orm';
 
 // bcryptjs re-export (for password hashing in daemon)
 // bcryptjs is a CommonJS module, so we import the default and re-export specific functions


### PR DESCRIPTION
## Summary

Unlocks the upcoming dashboard family by extending `/leaderboard` with:

- **2 new dimensions:** `model` and `tool`, freely combinable with existing `user` / `worktree` / `repo`.
- **4 new metrics** (additive — always returned): `totalInputTokens`, `totalOutputTokens`, `sessionCount`, `totalDurationMs`.
- **Server-side time bucketing:** new `bucket=hour|day|week|month` param emits a UTC ISO timestamp per row and groups accordingly. The existing Agor Usage Dashboard currently fires 30 parallel requests because there's no bucketing — this lets it fetch a time series in a single call.

The changes are additive only: legacy queries (no `bucket`, default `groupBy=user,worktree,repo`) return the same rows with the same field names, so the existing Agor Usage Dashboard artifact (`93f3b472-4e51-414a-9297-3203e31fc9b4`) keeps working unchanged.

## Data sources (verified against schema)

- `model` → `tasks.data.model` (stored at top level by `TaskRepository.taskToInsert`, not nested under `raw_sdk_response`)
- `tool` → `sessions.agentic_tool`
- `totalDurationMs` → `COALESCE(normalized_sdk_response.durationMs, tasks.data.duration_ms)`, summed
- `totalInputTokens` / `totalOutputTokens` → `normalized_sdk_response.tokenUsage.{inputTokens,outputTokens}`
- Bucket truncation → new `dateTruncUtc(db, column, bucket)` helper in `packages/core/src/db/database-wrapper.ts` (SQLite via `strftime`, Postgres via `date_trunc`; ISO Monday-based weeks in both dialects)

## Before / after

**Before** — fetching a 30-day user-level time series meant 30 round trips:
\`\`\`
GET /leaderboard?groupBy=user&startDate=2026-03-17T00:00:00Z&endDate=2026-03-17T23:59:59Z
GET /leaderboard?groupBy=user&startDate=2026-03-18T00:00:00Z&endDate=2026-03-18T23:59:59Z
... (×30)
\`\`\`

**After** — one request:
\`\`\`
GET /leaderboard?groupBy=user,model&bucket=day&startDate=2026-03-17T00:00:00Z&endDate=2026-04-17T00:00:00Z
\`\`\`

Response row shape:
\`\`\`json
{
  "userId": "user-alice",
  "userName": "Alice",
  "model": "claude-sonnet-4-6",
  "bucket": "2026-04-15T00:00:00.000Z",
  "totalTokens": 4500,
  "totalInputTokens": 3000,
  "totalOutputTokens": 1500,
  "totalCost": 0.3,
  "taskCount": 2,
  "sessionCount": 1,
  "totalDurationMs": 5000
}
\`\`\`

When `bucket` is set, rows come back ordered by `bucket ASC` first, then by `sortBy` within each bucket — so the caller can render a time series without re-sorting.

## Commits

1. `feat(db): add dateTruncUtc helper for dialect-agnostic bucketing`
2. `feat(leaderboard): add model/tool dims, split token & duration metrics, time bucketing`
3. `test(leaderboard): cover new dimensions, metrics, bucketing, and legacy shape`

## Test plan

- [x] `pnpm --filter @agor/daemon test leaderboard` — 11 new tests pass
- [x] `pnpm --filter @agor/daemon test` — full daemon suite green (211 passed / 30 skipped, same as main)
- [x] `pnpm typecheck` — green across all workspaces
- [x] `pnpm lint` — green
- [ ] Verify existing Agor Usage Dashboard artifact still renders against the deployed daemon (no field renames, no default-shape changes — should be a no-op)
- [ ] Smoke-test a bucketed request in the UI: `?groupBy=user&bucket=day&startDate=…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)