### PR TITLE
fix(ui): collapse tool bodies by default, keep Write expanded

### DIFF
--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -486,7 +486,10 @@ export const AgentChain = React.memo<AgentChainProps>(
           description={description ?? undefined}
           descriptionNode={descriptionNode}
           status={status}
-          expandedByDefault
+          // Tool bodies stay collapsed by default so the chain reads as a
+          // scannable list of headers. Write is the exception — its diff is
+          // the whole point of the call, so land it open.
+          expandedByDefault={toolUse.name === 'Write'}
         >
           <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
         </ToolBlock>

--- a/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
+++ b/apps/agor-ui/src/components/AgentChain/AgentChain.tsx
@@ -47,6 +47,7 @@ import {
   deriveToolStatus,
   IMPLICIT_RESULT_TOOLS,
   renderToolStatusIcon,
+  shouldExpandToolByDefault,
   ToolBlock,
 } from '../ToolBlock';
 import { ToolUseRenderer } from '../ToolUseRenderer';
@@ -486,10 +487,7 @@ export const AgentChain = React.memo<AgentChainProps>(
           description={description ?? undefined}
           descriptionNode={descriptionNode}
           status={status}
-          // Tool bodies stay collapsed by default so the chain reads as a
-          // scannable list of headers. Write is the exception — its diff is
-          // the whole point of the call, so land it open.
-          expandedByDefault={toolUse.name === 'Write'}
+          expandedByDefault={shouldExpandToolByDefault(toolUse.name)}
         >
           <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
         </ToolBlock>

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -40,6 +40,7 @@ import {
   deriveToolStatus,
   IMPLICIT_RESULT_TOOLS,
   renderToolStatusIcon,
+  shouldExpandToolByDefault,
   ToolBlock,
 } from '../ToolBlock';
 import { ToolIcon } from '../ToolIcon';
@@ -685,9 +686,7 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
                   description={bashNode ? undefined : getToolDescription(toolUse)}
                   descriptionNode={bashNode}
                   status={status}
-                  // Match AgentChain: tools land collapsed except Write,
-                  // whose diff is the primary content of the call.
-                  expandedByDefault={toolUse.name === 'Write'}
+                  expandedByDefault={shouldExpandToolByDefault(toolUse.name)}
                 >
                   <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
                 </ToolBlock>

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -685,7 +685,9 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
                   description={bashNode ? undefined : getToolDescription(toolUse)}
                   descriptionNode={bashNode}
                   status={status}
-                  expandedByDefault
+                  // Match AgentChain: tools land collapsed except Write,
+                  // whose diff is the primary content of the call.
+                  expandedByDefault={toolUse.name === 'Write'}
                 >
                   <ToolUseRenderer toolUse={toolUse} toolResult={toolResult} />
                 </ToolBlock>

--- a/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
@@ -23,7 +23,9 @@ export interface ToolBlockProps {
   descriptionNode?: React.ReactNode;
   /** Status indicator */
   status?: 'success' | 'error' | 'pending' | 'stale';
-  /** Whether to expand by default */
+  /** Whether to expand by default. Defaults to false — body is hidden behind
+   *  the chevron so the tool stream stays scannable as a list of headers.
+   *  Callers can opt specific tools in (e.g. Write) by passing true. */
   expandedByDefault?: boolean;
   /** Body content shown when expanded */
   children?: React.ReactNode;
@@ -35,7 +37,7 @@ export const ToolBlock: React.FC<ToolBlockProps> = ({
   description,
   descriptionNode,
   status,
-  expandedByDefault = true,
+  expandedByDefault = false,
   children,
 }) => {
   const [expanded, setExpanded] = useState(expandedByDefault);

--- a/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
@@ -23,9 +23,8 @@ export interface ToolBlockProps {
   descriptionNode?: React.ReactNode;
   /** Status indicator */
   status?: 'success' | 'error' | 'pending' | 'stale';
-  /** Whether to expand by default. Defaults to false — body is hidden behind
-   *  the chevron so the tool stream stays scannable as a list of headers.
-   *  Callers can opt specific tools in (e.g. Write) by passing true. */
+  /** Whether to expand by default. Defaults to false; the caller decides
+   *  which tools should land open. */
   expandedByDefault?: boolean;
   /** Body content shown when expanded */
   children?: React.ReactNode;

--- a/apps/agor-ui/src/components/ToolBlock/defaultExpansion.ts
+++ b/apps/agor-ui/src/components/ToolBlock/defaultExpansion.ts
@@ -1,0 +1,26 @@
+/**
+ * Policy for which tool calls should land expanded by default in the
+ * conversation UI. Most tools stay collapsed so the chain reads as a
+ * scannable list of headers; a small set whose body IS the point of the
+ * call (file writes) are promoted.
+ *
+ * Keep this set in sync with the tool renderer registry
+ * (`ToolUseRenderer/renderers/index.ts`) when adding cross-agent equivalents.
+ */
+
+/**
+ * Tool names whose ToolBlock body is the primary payload of the call
+ * (i.e. you almost always want to see it without a click).
+ *
+ * Includes cross-agent equivalents:
+ * - Claude Code: `Write`
+ * - Codex: `edit_files`
+ */
+const TOOLS_EXPANDED_BY_DEFAULT = new Set<string>(['Write', 'edit_files']);
+
+/**
+ * Whether a tool call should render its ToolBlock body expanded by default.
+ */
+export function shouldExpandToolByDefault(toolName: string): boolean {
+  return TOOLS_EXPANDED_BY_DEFAULT.has(toolName);
+}

--- a/apps/agor-ui/src/components/ToolBlock/index.ts
+++ b/apps/agor-ui/src/components/ToolBlock/index.ts
@@ -1,3 +1,4 @@
+export { shouldExpandToolByDefault } from './defaultExpansion';
 export { ToolBlock, type ToolBlockProps } from './ToolBlock';
 export { buildBashDescriptionNode } from './toolDescriptions';
 export {


### PR DESCRIPTION
## Summary

After #1013 every ToolBlock landed open, which made long agent chains hard to scan — each Bash/Read/Edit dumped its full body inline. This reverses that for tools while keeping the AgentChain summary expanded.

### Behavior

- **AgentChain summary (the outer \"X thoughts, Y tools\" wrapper)** — still expanded, so you see every entry in the chain.
- **Per-tool ToolBlock bodies** — now **collapsed by default**. Each tool reads as a single-line header (icon + name + truncated description) until clicked.
- **Write** — special-cased to land **expanded**, since the file content is the whole point of a Write call.
- **Thinking blocks** — collapse too (they already used the ToolBlock default), matching the scannable-list intent.

### Changes

- \`ToolBlock.expandedByDefault\` default flipped from \`true\` → \`false\`.
- \`AgentChain.tsx\` and \`MessageBlock.tsx\` now pass \`expandedByDefault={toolUse.name === 'Write'}\`.

## Test plan

- [ ] Open a session with a mix of tool calls (Bash, Read, Edit, Grep, Write) and confirm:
  - Outer AgentChain shows everything expanded by default.
  - Each tool row is collapsed, showing only its header.
  - Clicking a header expands its body; clicking again collapses.
  - Write tool calls land expanded, showing the full diff/content immediately.
- [ ] Thinking blocks default collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)