### PR TITLE
Add session context to MCP zone trigger templates

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/worktrees.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { buildZoneTriggerTemplateContext } from './worktrees.js';
+
+describe('buildZoneTriggerTemplateContext', () => {
+  it('includes session context for existing-session zone triggers', () => {
+    const context = buildZoneTriggerTemplateContext({
+      worktree: {
+        name: 'demo-task',
+        ref: 'feature/demo-task',
+        issue_url: 'https://example.com/issues/1',
+        pull_request_url: 'https://example.com/pulls/2',
+        notes: 'Worktree notes',
+        custom_context: { priority: 'high' },
+      },
+      board: {
+        name: 'Compozy Delivery',
+        description: 'Board description',
+        custom_context: { team: 'delivery' },
+      },
+      session: {
+        description: 'Existing task session',
+        custom_context: { autoSelectRecommendations: true },
+      },
+      zone: {
+        label: 'PRD',
+        status: 'active',
+      },
+    });
+
+    expect(context).toEqual({
+      worktree: {
+        name: 'demo-task',
+        ref: 'feature/demo-task',
+        issue_url: 'https://example.com/issues/1',
+        pull_request_url: 'https://example.com/pulls/2',
+        notes: 'Worktree notes',
+        context: { priority: 'high' },
+        custom_context: { priority: 'high' },
+      },
+      board: {
+        name: 'Compozy Delivery',
+        description: 'Board description',
+        context: { team: 'delivery' },
+        custom_context: { team: 'delivery' },
+      },
+      session: {
+        description: 'Existing task session',
+        context: { autoSelectRecommendations: true },
+        custom_context: { autoSelectRecommendations: true },
+      },
+      zone: {
+        label: 'PRD',
+        status: 'active',
+      },
+    });
+  });
+
+  it('falls back to empty session context when no target session exists', () => {
+    const context = buildZoneTriggerTemplateContext({
+      worktree: {
+        name: 'demo-task',
+        ref: 'feature/demo-task',
+        issue_url: undefined,
+        pull_request_url: undefined,
+        notes: undefined,
+        custom_context: undefined,
+      },
+      board: {
+        name: 'Compozy Delivery',
+        description: undefined,
+        custom_context: undefined,
+      },
+      zone: {
+        label: 'Idea',
+        status: undefined,
+      },
+    });
+
+    expect(context).toEqual({
+      worktree: {
+        name: 'demo-task',
+        ref: 'feature/demo-task',
+        issue_url: '',
+        pull_request_url: '',
+        notes: '',
+        context: {},
+        custom_context: {},
+      },
+      board: {
+        name: 'Compozy Delivery',
+        description: '',
+        context: {},
+        custom_context: {},
+      },
+      session: {
+        description: '',
+        context: {},
+        custom_context: {},
+      },
+      zone: {
+        label: 'Idea',
+        status: '',
+      },
+    });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -3,6 +3,7 @@ import { WorktreeRepository } from '@agor/core/db';
 import type {
   AgenticToolName,
   BoardID,
+  Session,
   UUID,
   Worktree,
   WorktreeID,
@@ -28,6 +29,52 @@ import { coerceString, textResult } from '../server.js';
 
 const WORKTREE_NAME_PATTERN = /^[a-z0-9-]+$/;
 const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export function buildZoneTriggerTemplateContext(args: {
+  worktree: Pick<
+    Worktree,
+    'name' | 'ref' | 'issue_url' | 'pull_request_url' | 'notes' | 'custom_context'
+  >;
+  board: {
+    name?: string;
+    description?: string;
+    custom_context?: Record<string, unknown>;
+  };
+  session?: Pick<Session, 'description' | 'custom_context'> | null;
+  zone: {
+    label?: string;
+    status?: string;
+  };
+}): Record<string, unknown> {
+  const { worktree, board, session, zone } = args;
+
+  return {
+    worktree: {
+      name: worktree.name || '',
+      ref: worktree.ref || '',
+      issue_url: worktree.issue_url || '',
+      pull_request_url: worktree.pull_request_url || '',
+      notes: worktree.notes || '',
+      context: worktree.custom_context || {},
+      custom_context: worktree.custom_context || {},
+    },
+    board: {
+      name: board.name || '',
+      description: board.description || '',
+      context: board.custom_context || {},
+      custom_context: board.custom_context || {},
+    },
+    session: {
+      description: session?.description || '',
+      context: session?.custom_context || {},
+      custom_context: session?.custom_context || {},
+    },
+    zone: {
+      label: zone.label || '',
+      status: zone.status || '',
+    },
+  };
+}
 
 export function registerWorktreeTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_worktrees_get
@@ -678,24 +725,15 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
         );
 
         const { renderTemplate } = await import('@agor/core/templates/handlebars-helpers');
-        const templateContext = {
-          worktree: {
-            name: worktree.name,
-            ref: worktree.ref,
-            issue_url: worktree.issue_url,
-            pull_request_url: worktree.pull_request_url,
-            notes: worktree.notes,
-            custom_context: worktree.custom_context,
-          },
-          board: {
-            name: board.name,
-            custom_context: board.custom_context,
-          },
-          zone: {
-            label: zone.label,
-            status: zone.status,
-          },
-        };
+        const targetSession = (await ctx.app
+          .service('sessions')
+          .get(targetSessionId, ctx.baseServiceParams)) as Session;
+        const templateContext = buildZoneTriggerTemplateContext({
+          worktree,
+          board,
+          session: targetSession,
+          zone,
+        });
 
         const renderedPrompt = renderTemplate(zone.trigger!.template, templateContext);
 
@@ -738,24 +776,11 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
         );
 
         const { renderTemplate } = await import('@agor/core/templates/handlebars-helpers');
-        const templateContext = {
-          worktree: {
-            name: worktree.name,
-            ref: worktree.ref,
-            issue_url: worktree.issue_url,
-            pull_request_url: worktree.pull_request_url,
-            notes: worktree.notes,
-            custom_context: worktree.custom_context,
-          },
-          board: {
-            name: board.name,
-            custom_context: board.custom_context,
-          },
-          zone: {
-            label: zone.label,
-            status: zone.status,
-          },
-        };
+        const templateContext = buildZoneTriggerTemplateContext({
+          worktree,
+          board,
+          zone,
+        });
 
         const renderedPrompt = renderTemplate(zone.trigger!.template, templateContext);
 


### PR DESCRIPTION
## Summary
- include target session context when `agor_worktrees_set_zone` renders a zone trigger template for an existing session
- normalize the MCP zone-trigger template context through a shared helper
- add unit coverage for both existing-session and no-session cases

## Why
The UI worktree drop flow can render zone templates against an existing session context, but the MCP `agor_worktrees_set_zone(..., triggerTemplate: true, targetSessionId: ...)` path could not. This makes template behavior inconsistent between manual routing and agent-driven routing.

## Testing
- `pnpm --filter @agor/daemon test -- src/mcp/tools/worktrees.test.ts`
