### PR TITLE
feat(scheduler): execute-now trigger + allow_concurrent_runs (#999)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,260 @@
+# Plan: "Execute Now" for scheduled worktree sessions (#999)
+
+Design-only pass. No production code changes yet.
+
+---
+
+## 1. Current scheduling architecture
+
+**Storage (per-worktree, no separate schedule table):**
+- `packages/core/src/db/schema.sqlite.ts` (+ `schema.postgres.ts`): worktree columns
+  `schedule_enabled`, `schedule_cron`, `schedule_last_triggered_at`,
+  `schedule_next_run_at`, and a JSON `schedule` blob with `agentic_tool`,
+  `prompt_template`, `retention`, `timezone`, `permission_mode`, `model_config`,
+  `mcp_server_ids`, `context_files`.
+
+**Scheduler worker:**
+- `apps/agor-daemon/src/services/scheduler.ts` — `SchedulerService`, tick interval
+  30s, grace period 2min.
+- Flow: `tick()` → `getEnabledSchedules()` (repo-level, bypasses auth) →
+  `processSchedule(worktree, now)` (due-check via `getPrevRunTime`) →
+  `spawnScheduledSession(worktree, scheduledRunAt, now)`.
+- `spawnScheduledSession` (lines 299–433): dedupes by `scheduled_run_at`,
+  renders Handlebars prompt, resolves creator's `unix_username`, calls
+  `app.service('sessions').create(...)` with `scheduled_from_worktree: true`,
+  attaches MCP servers, then calls `/sessions/:id/prompt` with
+  `provider: undefined, user: creator` to bypass auth and get a proper session
+  token. Finally updates metadata and enforces retention.
+- **No concurrency guard** — scheduler does not check whether a session is
+  already running in the worktree; it spawns regardless.
+- **Audit log:** stdout `console.log` only. Session create itself is the
+  persistent record (row in `sessions` with `scheduled_from_worktree`).
+
+**Schedule UI:**
+- `apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx` — a tab
+  inside the WorktreeModal (not a standalone drawer). Enable toggle + cron
+  picker + prompt template textarea + agent/permission/model/MCP selection.
+  Submits via `onUpdate(worktreeId, { schedule_enabled, schedule_cron, schedule })`
+  which PATCHes the worktree.
+
+**Board card actions:**
+- `apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx` ~L820–895:
+  header button row with Pin, Drag, Terminal (CodeOutlined), Edit
+  (EditOutlined → opens settings modal), Archive (DeleteOutlined). Hover-
+  revealed, `stopPropagation` + `className="nodrag"`. Session-level buttons
+  live separately on `SessionItemWithActions`.
+
+**RBAC on schedule edits:**
+- `apps/agor-daemon/src/register-hooks.ts` L542–548: patching a worktree
+  requires `ensureWorktreePermission('all', ...)` when RBAC is on.
+  → Editing a schedule already requires tier `all`.
+- Tiers: `none/view/session/prompt/all` with ranks -1/0/1/2/3
+  (`apps/agor-daemon/src/utils/worktree-authorization.ts`).
+
+**Session create endpoint:**
+- `app.service('sessions').create(...)` is the canonical path (Feathers).
+  Scheduler reuses it directly.
+
+---
+
+## 2. Recommended trigger placement — **B (WorktreeCard) with a small concession toward C**
+
+**Recommendation:** Put the primary "Execute Now" button on **WorktreeCard's
+header action row**, next to Edit/Archive. Also surface it in the
+`ScheduleTab` footer as a secondary entry point (so users configuring the
+schedule can dry-run it in place).
+
+**Reasoning:**
+1. The whole product is worktree-centric and spatial — the board is the
+   primary interface, and `WorktreeCard` is where every other worktree-level
+   action already lives (Terminal, Edit, Archive). That is the established
+   pattern; a schedule run is a worktree-level action.
+2. Placement A (inside the drawer next to the Enable toggle) is
+   configuration-adjacent but requires two clicks to even see the button
+   and encourages conflating "save config" with "fire now." The issue's
+   intuition (next to the toggle) is reasonable but the drawer is the wrong
+   home for a frequent action.
+3. Placement C (both) is good for discoverability but adding the secondary
+   entry in `ScheduleTab` is cheap — one button, same handler. I'd include
+   it because users who just finished editing a cron will naturally want to
+   test it without closing the drawer.
+4. A global "scheduled jobs" view does not exist today — not worth
+   introducing one for this feature.
+
+**Visibility/enablement rules on the card button:**
+- Only render when `worktree.schedule_enabled === true` **and**
+  `worktree.schedule_cron` and `worktree.schedule.prompt_template` exist.
+  If the schedule is disabled, don't render (keeps header uncluttered).
+- Disabled + tooltip if user lacks `all` permission.
+- Disabled + tooltip "A scheduled run is already starting…" while a request
+  is in flight (local optimistic lock).
+- Icon: `ThunderboltOutlined` or `PlayCircleOutlined` (a quick-fire symbol
+  — distinct from the schedule/clock iconography).
+
+---
+
+## 3. Backend change — extract shared core, add one endpoint
+
+**Endpoint:** `POST /worktrees/:worktree_id/execute-schedule-now`
+
+Not `POST /sessions/:id/execute-now` — the issue's original shape is wrong:
+a scheduled run creates a *new* session, it does not act on an existing
+session. The resource is the worktree (which owns the schedule).
+
+**Request body:** (all optional overrides; server falls back to schedule
+config if omitted — keep the first cut minimal: no overrides)
+```json
+{}
+```
+Future-proof fields we might add later: `prompt_override`, `context`
+overrides. Leave out of v1.
+
+**Response (201):**
+```json
+{
+  "session_id": "…",
+  "worktree_id": "…",
+  "scheduled_run_at": 1713398400000,
+  "triggered_manually": true
+}
+```
+
+**Auth:** require tier `all` — matches schedule-edit permission, so anyone
+who could edit the schedule can fire it. This is stricter than `session`
+(creating arbitrary sessions) but is the right match because this action
+spawns a session using the *creator's* Unix identity via the scheduler
+path, not the triggerer's.
+
+**Implementation plan (reuse exactly one code path):**
+1. Refactor `spawnScheduledSession` in `scheduler.ts`:
+   - Extract a new public method `executeScheduleNow(worktreeId, { triggeredBy, manual: true })`.
+   - Internally refactor the existing private body into a helper
+     `runSchedule(worktree, { scheduledRunAt, manual, triggeredBy })` that
+     both the tick path and the new endpoint call.
+   - `scheduledRunAt` for manual runs is `Date.now()` rounded to the
+     nearest minute (keeps dedup semantics consistent with cron runs).
+2. New Feathers service `worktree-execute-now` (or add as a custom route on
+   the worktrees service): thin wrapper that:
+   - Loads worktree, runs `ensureWorktreePermission('all', ...)`.
+   - Validates: `schedule_enabled === true`, `schedule_cron` set,
+     `schedule.prompt_template` set — otherwise 400 with a clear error.
+   - Calls `SchedulerService.executeScheduleNow(...)`.
+   - Returns the created session's id.
+3. Add the new endpoint to `register-routes.ts` and hooks to
+   `register-hooks.ts`.
+4. Emit a normal session `created` websocket event (happens automatically
+   via `sessionsService.create`), which keeps the UI in sync with no
+   extra plumbing.
+
+---
+
+## 4. Edge cases
+
+| Case | Handling |
+|---|---|
+| Schedule disabled | Endpoint returns 400 `schedule_disabled`. Card button not rendered. |
+| Cron/template missing | Endpoint returns 400 `schedule_incomplete`. Button disabled with tooltip. |
+| Session already running in worktree | **Do NOT block.** Scheduler itself permits this today; blocking here would surprise users and diverge from scheduled behavior. Document it. (The issue's "no-op with tooltip" guidance is inconsistent with current scheduler semantics; recommend we raise this and align on allowing, matching the existing cron path.) |
+| Rapid double-click | (a) Optimistic UI disables button for ~3s after click. (b) Server dedup: `scheduled_run_at` is minute-rounded, so two triggers within the same minute will hit the existing dedup branch in `spawnScheduledSession` and the second becomes a no-op returning the already-created session. |
+| Concurrent manual + cron collision | Same minute-rounding dedup covers it. If cron fires at 09:00 and user clicks at 09:00:30, both map to `scheduled_run_at=09:00:00` and second call is a no-op. |
+| Creator deleted or missing `unix_username` in strict mode | Scheduler already throws (`resolveCreatorUnixUsername`). Surface as 409 with the existing error message. |
+| RBAC disabled | No permission check needed (same as PATCH behavior); only `requireMinimumRole(MEMBER)` applies. |
+| Non-owner user triggers | Requires `all` tier — for a non-owner, `others_can` must be `all`, which is consistent with being able to edit schedule. |
+| Retention enforcement | Already runs at end of `spawnScheduledSession`; will still run after a manual trigger. No change needed. |
+| Audit | Add a structured `console.log` line including `triggered_manually: true, triggered_by: <userId>` so ops can grep. The session row already carries `scheduled_from_worktree: true`; add a `triggered_manually: true` marker on `custom_context.scheduled_run` (same JSON field already used for snapshot data) — no schema migration. |
+
+---
+
+## 5. UI change list
+
+**New/modified components:**
+1. `apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx` — add
+   `ThunderboltOutlined` button between Terminal and Edit, gated by
+   `schedule_enabled && schedule_cron && prompt_template && canAll`. Hooks
+   into a new prop `onExecuteScheduleNow(worktreeId)`.
+2. `apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx` — add a
+   secondary "Run now" button next to the Save/Close footer, same handler.
+   Show a small info callout: "Runs the schedule immediately using the
+   current saved config."
+3. New hook `apps/agor-ui/src/hooks/useExecuteScheduleNow.ts` — wraps the
+   Feathers call, handles toast on success/error, and optimistic button
+   lock (disable for 3s).
+4. Wire `onExecuteScheduleNow` from whatever parent passes `onOpenSettings`
+   to `WorktreeCard` (board view container) down to the card.
+
+**No new types needed** — session payload already exists; the hook just
+returns `{ session_id }` and we navigate/open the session panel on success
+(reuse existing "focus session" behavior after session creation).
+
+---
+
+## 6. Test plan
+
+**Backend unit tests** (`apps/agor-daemon/src/services/scheduler.test.ts` or
+new `scheduler.execute-now.test.ts`):
+- Happy path: enabled schedule → manual trigger → session created with
+  `scheduled_from_worktree=true` and `custom_context.scheduled_run.triggered_manually=true`.
+- Disabled schedule → 400.
+- Missing cron / missing template → 400.
+- Two rapid manual triggers in same minute → dedup, same session returned.
+- Manual trigger + cron-due in same tick → dedup.
+- Creator missing / no `unix_username` in strict mode → 409 with existing
+  error.
+
+**Authorization tests** (reuse `worktree-authorization.test.ts` pattern):
+- `all` owner: allowed.
+- `others_can=all` non-owner: allowed.
+- `others_can=prompt` non-owner: denied.
+- `others_can=session` non-owner: denied.
+- RBAC disabled: only role check applies.
+
+**UI tests** (Storybook or RTL component tests):
+- Button hidden when `schedule_enabled=false`.
+- Button disabled w/ tooltip when cron or template missing.
+- Button disabled after click for 3s.
+- Toast + navigation on success; toast on error.
+
+**Manual QA:**
+- Enable a cron that runs in 5 min, click Execute Now, verify a session
+  spawns immediately AND the 5-min cron run still fires and is distinct.
+- Click twice in the same minute → exactly one session.
+- Flip RBAC modes (simple → insulated → strict) and re-verify.
+
+---
+
+## 7. Work breakdown
+
+**PR 1 (this feature — single PR):**
+- Scheduler refactor (extract `runSchedule` helper, add
+  `executeScheduleNow` public method).
+- New endpoint + hooks + RBAC check.
+- Card button + ScheduleTab "Run now" button + hook.
+- Tests above.
+
+**Follow-ups (not in this PR):**
+- (F1) Dedicated audit-log table for scheduler events (both manual and
+  cron). Today it's stdout only; worth promoting once we have two triggers.
+- (F2) Optional "running-now" indicator on the card if a
+  `scheduled_from_worktree` session is active, so users get visual
+  feedback without having to open the session panel.
+- (F3) Optional `prompt_override` / `context_override` fields on the
+  endpoint for ad-hoc runs. Defer until someone actually asks — YAGNI.
+- (F4) Reconcile the "allow concurrent runs?" question across scheduler
+  and execute-now. If product wants "one at a time," change it in the
+  scheduler path too, so both paths agree.
+
+---
+
+## Summary for reviewer
+
+- **Placement:** WorktreeCard header button (primary) + ScheduleTab footer
+  button (secondary). Reject the issue's "only inside the drawer" framing.
+- **Endpoint:** `POST /worktrees/:worktree_id/execute-schedule-now`, not
+  session-scoped. Reuses the scheduler's exact code path via a shared
+  helper so cron and manual triggers are indistinguishable downstream.
+- **Auth:** tier `all` (matches schedule-edit).
+- **Dedup:** minute-rounded `scheduled_run_at` already handles
+  double-clicks and manual-vs-cron collisions.
+- **Known product question:** the issue says "block if session already
+  running"; scheduler does not block today. Recommend we keep behavior
+  consistent (don't block) unless product wants both paths changed.

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -23,6 +23,7 @@ import type { Application } from '@agor/core/feathers';
 import {
   AuthenticationService,
   BadRequest,
+  Conflict,
   errorHandler,
   Forbidden,
   LocalStrategy,
@@ -47,6 +48,7 @@ import type {
   Task,
   User,
   UUID,
+  WorktreeID,
 } from '@agor/core/types';
 import {
   AGENTIC_TOOL_CAPABILITIES,
@@ -67,6 +69,11 @@ import type {
   WorktreesServiceImpl,
 } from './declarations.js';
 import { killExecutorProcess } from './executor-tracking.js';
+import {
+  ScheduleBusyError,
+  ScheduleNotReadyError,
+  type SchedulerService,
+} from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { createUserApiKeysService } from './services/user-api-keys.js';
 import { applyTierHooks } from './setup/service-tiers.js';
@@ -2264,6 +2271,91 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               if (!isOwner && !hasMinimumRole(userRole, ROLES.ADMIN)) {
                 throw new Forbidden(
                   'You must be the worktree owner or a global admin to unarchive worktrees'
+                );
+              }
+              return context;
+            },
+      ],
+    },
+  });
+
+  // ============================================================================
+  // Execute-schedule-now: manually trigger a scheduled run for a worktree
+  // ============================================================================
+  // Reuses the scheduler's spawn code path so scheduled and manual triggers
+  // produce indistinguishable sessions (beyond a triggered_manually marker).
+  // Requires worktree-level 'all' permission (same tier as editing the schedule).
+  app.use('/worktrees/:id/execute-schedule-now', {
+    async create(_data: unknown, params: RouteParams) {
+      const id = params.route?.id;
+      if (!id) throw new BadRequest('Worktree ID required');
+
+      const scheduler = app.get('scheduler') as SchedulerService | undefined;
+      if (!scheduler) {
+        throw new NotFound('Scheduler service is not enabled on this instance.');
+      }
+
+      const triggeredBy = params.user?.user_id;
+      if (!triggeredBy) {
+        // Should already be caught by requireAuth, but guard anyway so the
+        // scheduler isn't passed an undefined userId.
+        throw new NotAuthenticated('Authentication required to trigger schedule.');
+      }
+
+      try {
+        const session = await scheduler.executeScheduleNow({
+          worktreeId: id as WorktreeID,
+          triggeredBy: triggeredBy as UUID,
+        });
+        return {
+          session_id: session.session_id,
+          worktree_id: session.worktree_id,
+          scheduled_run_at: session.scheduled_run_at,
+          triggered_manually: true,
+        };
+      } catch (err) {
+        if (err instanceof ScheduleBusyError) {
+          throw new Conflict(err.message, { code: err.code });
+        }
+        if (err instanceof ScheduleNotReadyError) {
+          throw new BadRequest(err.message, { code: err.code });
+        }
+        throw err;
+      }
+    },
+  });
+
+  app.service('/worktrees/:id/execute-schedule-now').hooks({
+    before: {
+      create: [
+        requireAuth,
+        requireMinimumRole(ROLES.MEMBER, 'execute scheduled runs'),
+        async (context: HookContext) => {
+          const id = context.params.route?.id;
+          if (!id) throw new BadRequest('Worktree ID required');
+
+          const worktree = await worktreeRepository.findById(id);
+          if (!worktree) {
+            throw new NotFound(`Worktree not found: ${id}`);
+          }
+
+          const userId = context.params.user?.user_id as UUID | undefined;
+          const isOwner = userId
+            ? await worktreeRepository.isOwner(worktree.worktree_id, userId)
+            : false;
+
+          context.params.worktree = worktree;
+          context.params.isWorktreeOwner = isOwner;
+          return context;
+        },
+        worktreeRbacEnabled
+          ? ensureWorktreePermission('all', 'execute scheduled runs', superadminOpts)
+          : (context: HookContext) => {
+              const isOwner = context.params.isWorktreeOwner;
+              const userRole = context.params.user?.role;
+              if (!isOwner && !hasMinimumRole(userRole, ROLES.ADMIN)) {
+                throw new Forbidden(
+                  'You must be the worktree owner or a global admin to execute scheduled runs'
                 );
               }
               return context;

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -286,17 +286,11 @@ export class SchedulerService {
    * @throws ScheduleBusyError when allow_concurrent_runs is false and the
    *   worktree already has an active session.
    */
-  async executeScheduleNow(opts: {
-    worktreeId: WorktreeID;
-    triggeredBy: UUID;
-  }): Promise<Session> {
+  async executeScheduleNow(opts: { worktreeId: WorktreeID; triggeredBy: UUID }): Promise<Session> {
     const { worktreeId, triggeredBy } = opts;
     const worktree = await this.worktreeRepo.findById(worktreeId);
     if (!worktree) {
-      throw new ScheduleNotReadyError(
-        'schedule_incomplete',
-        `Worktree not found: ${worktreeId}`
-      );
+      throw new ScheduleNotReadyError('schedule_incomplete', `Worktree not found: ${worktreeId}`);
     }
 
     if (!worktree.schedule_enabled) {

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -42,7 +42,7 @@ import type {
 } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
-import { getNextRunTime, getPrevRunTime } from '@agor/core/utils/cron';
+import { getNextRunTime, getPrevRunTime, roundToMinute } from '@agor/core/utils/cron';
 import Handlebars from 'handlebars';
 import type { Application } from '../declarations';
 
@@ -51,7 +51,7 @@ import type { Application } from '../declarations';
  * Used for the schedule concurrency guard: if any session in a worktree is
  * in one of these states, the schedule is considered "busy".
  */
-const ACTIVE_SESSION_STATUSES: ReadonlySet<string> = new Set([
+const ACTIVE_SESSION_STATUSES: ReadonlySet<SessionStatus> = new Set([
   SessionStatus.RUNNING,
   SessionStatus.STOPPING,
   SessionStatus.AWAITING_PERMISSION,
@@ -271,7 +271,7 @@ export class SchedulerService {
     // Schedule is due - spawn session
     console.log(`   ✅ ${worktree.name}: Schedule is due, spawning session...`);
 
-    await this.spawnScheduledSession(worktree, scheduledRunAt, now, { manual: false });
+    await this.spawnScheduledSession(worktree, scheduledRunAt, now, { source: 'cron' });
   }
 
   /**
@@ -315,14 +315,14 @@ export class SchedulerService {
     const now = Date.now();
     // Minute-rounded so back-to-back manual clicks (and manual+cron collisions
     // within the same minute) dedupe via scheduled_run_at.
-    const scheduledRunAt = Math.floor(now / 60000) * 60000;
+    const scheduledRunAt = roundToMinute(new Date(now)).getTime();
 
     console.log(
       `   🖐️  ${worktree.name}: manual execute-now triggered by ${triggeredBy.substring(0, 8)}`
     );
 
     const session = await this.spawnScheduledSession(worktree, scheduledRunAt, now, {
-      manual: true,
+      source: 'manual',
       triggeredBy,
     });
     // Manual path always returns a Session or throws (the `null` return is
@@ -389,11 +389,11 @@ export class SchedulerService {
    * Spawn a scheduled session for a worktree.
    *
    * Shared path for both cron-driven and manual (execute-now) runs. Callers
-   * set `options.manual` to distinguish:
+   * set `options.source` to distinguish:
    *
-   * - `manual=false` (cron tick): concurrency violation is a silent skip
+   * - `source: 'cron'` (tick): concurrency violation is a silent skip
    *   (metadata still advanced to avoid repeated checks).
-   * - `manual=true` (execute-now): concurrency violation throws
+   * - `source: 'manual'` (execute-now): concurrency violation throws
    *   `ScheduleBusyError` so the API route can surface a 409.
    *
    * Steps:
@@ -409,7 +409,7 @@ export class SchedulerService {
    * @param worktree - The worktree to spawn a session for
    * @param scheduledRunAt - The scheduled run timestamp (may be recomputed from cron)
    * @param now - Current timestamp
-   * @param options.manual - Whether this is a manual execute-now call
+   * @param options.source - 'cron' for tick-driven runs, 'manual' for execute-now
    * @param options.triggeredBy - User ID that triggered the manual run
    * @returns The newly created session on success. Returns the pre-existing
    *   session when dedup hits. Returns `null` when a cron-path run is skipped
@@ -420,7 +420,7 @@ export class SchedulerService {
     worktree: Worktree,
     scheduledRunAt: number,
     now: number,
-    options: { manual: boolean; triggeredBy?: UUID } = { manual: false }
+    options: { source: 'cron' | 'manual'; triggeredBy?: UUID } = { source: 'cron' }
   ): Promise<Session | null> {
     if (!worktree.schedule || !worktree.schedule_cron) {
       console.error(`❌ Worktree ${worktree.worktree_id} missing schedule config`);
@@ -431,7 +431,8 @@ export class SchedulerService {
     }
 
     const schedule = worktree.schedule;
-    const { manual, triggeredBy } = options;
+    const { source, triggeredBy } = options;
+    const manual = source === 'manual';
 
     // 1. Check deduplication using repository
     // Use repository to check for existing sessions (bypasses auth)

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -36,13 +36,55 @@ import type {
   Session,
   SessionID,
   User,
+  UUID,
   Worktree,
+  WorktreeID,
 } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import { getNextRunTime, getPrevRunTime } from '@agor/core/utils/cron';
 import Handlebars from 'handlebars';
 import type { Application } from '../declarations';
+
+/**
+ * Session statuses that indicate a session is actively consuming resources.
+ * Used for the schedule concurrency guard: if any session in a worktree is
+ * in one of these states, the schedule is considered "busy".
+ */
+const ACTIVE_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  SessionStatus.RUNNING,
+  SessionStatus.STOPPING,
+  SessionStatus.AWAITING_PERMISSION,
+  SessionStatus.AWAITING_INPUT,
+]);
+
+/**
+ * Error thrown when execute-now is blocked because a session is already running
+ * in the worktree and allow_concurrent_runs is not enabled. Routes can catch
+ * this and surface it as a 409 Conflict.
+ */
+export class ScheduleBusyError extends Error {
+  public readonly code = 'schedule_busy';
+  constructor(worktreeName: string) {
+    super(
+      `A session is already running in worktree "${worktreeName}" and allow_concurrent_runs is disabled.`
+    );
+    this.name = 'ScheduleBusyError';
+  }
+}
+
+/**
+ * Error thrown when execute-now is called on a worktree whose schedule is not
+ * fully configured (disabled, missing cron, or missing prompt template).
+ */
+export class ScheduleNotReadyError extends Error {
+  public readonly code: 'schedule_disabled' | 'schedule_incomplete';
+  constructor(code: 'schedule_disabled' | 'schedule_incomplete', message: string) {
+    super(message);
+    this.name = 'ScheduleNotReadyError';
+    this.code = code;
+  }
+}
 
 export interface SchedulerConfig {
   /** Tick interval in milliseconds (default: 30000 = 30s) */
@@ -229,7 +271,74 @@ export class SchedulerService {
     // Schedule is due - spawn session
     console.log(`   ✅ ${worktree.name}: Schedule is due, spawning session...`);
 
-    await this.spawnScheduledSession(worktree, scheduledRunAt, now);
+    await this.spawnScheduledSession(worktree, scheduledRunAt, now, { manual: false });
+  }
+
+  /**
+   * Public: trigger a scheduled run on-demand for a worktree.
+   *
+   * Used by the `POST /worktrees/:id/execute-schedule-now` route. Reuses the
+   * exact same spawn path as the cron tick (via spawnScheduledSession) so
+   * scheduled and manual runs are indistinguishable downstream, except for a
+   * `triggered_manually: true` marker in custom_context and a different title.
+   *
+   * @throws ScheduleNotReadyError when the schedule is disabled or incomplete.
+   * @throws ScheduleBusyError when allow_concurrent_runs is false and the
+   *   worktree already has an active session.
+   */
+  async executeScheduleNow(opts: {
+    worktreeId: WorktreeID;
+    triggeredBy: UUID;
+  }): Promise<Session> {
+    const { worktreeId, triggeredBy } = opts;
+    const worktree = await this.worktreeRepo.findById(worktreeId);
+    if (!worktree) {
+      throw new ScheduleNotReadyError(
+        'schedule_incomplete',
+        `Worktree not found: ${worktreeId}`
+      );
+    }
+
+    if (!worktree.schedule_enabled) {
+      throw new ScheduleNotReadyError(
+        'schedule_disabled',
+        'Schedule is disabled for this worktree. Enable it before running manually.'
+      );
+    }
+    if (!worktree.schedule_cron) {
+      throw new ScheduleNotReadyError(
+        'schedule_incomplete',
+        'Schedule has no cron expression configured.'
+      );
+    }
+    if (!worktree.schedule?.prompt_template) {
+      throw new ScheduleNotReadyError(
+        'schedule_incomplete',
+        'Schedule has no prompt template configured.'
+      );
+    }
+
+    const now = Date.now();
+    // Minute-rounded so back-to-back manual clicks (and manual+cron collisions
+    // within the same minute) dedupe via scheduled_run_at.
+    const scheduledRunAt = Math.floor(now / 60000) * 60000;
+
+    console.log(
+      `   🖐️  ${worktree.name}: manual execute-now triggered by ${triggeredBy.substring(0, 8)}`
+    );
+
+    const session = await this.spawnScheduledSession(worktree, scheduledRunAt, now, {
+      manual: true,
+      triggeredBy,
+    });
+    // Manual path always returns a Session or throws (the `null` return is
+    // reserved for silent cron-path concurrency skips). Defensive check:
+    if (!session) {
+      throw new Error(
+        `Unexpected null result from spawnScheduledSession for manual run on worktree ${worktreeId}`
+      );
+    }
+    return session;
   }
 
   /**
@@ -283,30 +392,52 @@ export class SchedulerService {
   }
 
   /**
-   * Spawn a scheduled session for a worktree
+   * Spawn a scheduled session for a worktree.
    *
+   * Shared path for both cron-driven and manual (execute-now) runs. Callers
+   * set `options.manual` to distinguish:
+   *
+   * - `manual=false` (cron tick): concurrency violation is a silent skip
+   *   (metadata still advanced to avoid repeated checks).
+   * - `manual=true` (execute-now): concurrency violation throws
+   *   `ScheduleBusyError` so the API route can surface a 409.
+   *
+   * Steps:
    * 1. Check deduplication (no existing session with same scheduled_run_at)
-   * 2. Render prompt template with Handlebars
-   * 3. Look up creator's unix_username for execution context
-   * 4. Create session with schedule metadata
-   * 5. Update worktree schedule metadata (last_triggered_at, next_run_at)
-   * 6. Enforce retention policy
+   * 2. Enforce `allow_concurrent_runs` (skip/throw if an active session exists)
+   * 3. Render prompt template with Handlebars
+   * 4. Look up creator's unix_username for execution context
+   * 5. Create session with schedule metadata (+ triggered_manually marker)
+   * 6. Attach MCP servers and trigger prompt
+   * 7. Update worktree schedule metadata (last_triggered_at, next_run_at)
+   * 8. Enforce retention policy
    *
    * @param worktree - The worktree to spawn a session for
    * @param scheduledRunAt - The scheduled run timestamp (may be recomputed from cron)
    * @param now - Current timestamp
+   * @param options.manual - Whether this is a manual execute-now call
+   * @param options.triggeredBy - User ID that triggered the manual run
+   * @returns The newly created session on success. Returns the pre-existing
+   *   session when dedup hits. Returns `null` when a cron-path run is skipped
+   *   due to concurrency. Throws `ScheduleBusyError` when a manual run is
+   *   blocked by concurrency.
    */
   private async spawnScheduledSession(
     worktree: Worktree,
     scheduledRunAt: number,
-    now: number
-  ): Promise<void> {
+    now: number,
+    options: { manual: boolean; triggeredBy?: UUID } = { manual: false }
+  ): Promise<Session | null> {
     if (!worktree.schedule || !worktree.schedule_cron) {
       console.error(`❌ Worktree ${worktree.worktree_id} missing schedule config`);
-      return;
+      throw new ScheduleNotReadyError(
+        'schedule_incomplete',
+        `Worktree ${worktree.worktree_id} missing schedule config`
+      );
     }
 
     const schedule = worktree.schedule;
+    const { manual, triggeredBy } = options;
 
     // 1. Check deduplication using repository
     // Use repository to check for existing sessions (bypasses auth)
@@ -317,7 +448,30 @@ export class SchedulerService {
     if (existingSession) {
       // Still update next_run_at to prevent repeated checks
       await this.updateScheduleMetadata(worktree, scheduledRunAt, now);
-      return;
+      return existingSession;
+    }
+
+    // 2. Concurrency guard — applies to BOTH the cron path and manual path.
+    // Default is to block concurrent runs; opt-in via schedule.allow_concurrent_runs.
+    const allowConcurrent = schedule.allow_concurrent_runs === true;
+    if (!allowConcurrent) {
+      const active = worktreeSessions.some((s) => ACTIVE_SESSION_STATUSES.has(s.status));
+      if (active) {
+        if (manual) {
+          // Manual trigger: surface as an error the API can convert to 409.
+          console.log(
+            `   ⛔ ${worktree.name}: manual run blocked — active session present (allow_concurrent_runs=false)`
+          );
+          throw new ScheduleBusyError(worktree.name);
+        }
+        // Cron tick: silent skip. Advance metadata so we don't re-evaluate
+        // the same scheduled_run_at every tick.
+        console.log(
+          `   ⏭️  ${worktree.name}: scheduled run skipped — active session present (allow_concurrent_runs=false)`
+        );
+        await this.updateScheduleMetadata(worktree, scheduledRunAt, now);
+        return null;
+      }
     }
 
     // 2. Render prompt template
@@ -340,7 +494,9 @@ export class SchedulerService {
         unix_username: unixUsername, // Set unix_username for strict mode execution
         scheduled_run_at: scheduledRunAt,
         scheduled_from_worktree: true,
-        title: `[Scheduled run - ${new Date(scheduledRunAt).toISOString()}]`,
+        title: manual
+          ? `[Manual run - ${new Date(scheduledRunAt).toISOString()}]`
+          : `[Scheduled run - ${new Date(scheduledRunAt).toISOString()}]`,
         contextFiles: schedule.context_files ?? [],
         permission_config: schedule.permission_mode
           ? { mode: schedule.permission_mode as PermissionMode }
@@ -357,10 +513,13 @@ export class SchedulerService {
           scheduled_run: {
             rendered_prompt: renderedPrompt,
             run_index: runIndex,
+            triggered_manually: manual,
+            triggered_by: manual ? triggeredBy : undefined,
             schedule_config_snapshot: {
               cron: worktree.schedule_cron,
               timezone: schedule.timezone,
               retention: schedule.retention,
+              allow_concurrent_runs: schedule.allow_concurrent_runs === true,
             },
           },
         },
@@ -370,7 +529,10 @@ export class SchedulerService {
       // But still need to bypass auth - use the service with no params
       const sessionsService = this.app.service('sessions');
       const createdSession = await sessionsService.create(session);
-      console.log(`      ✅ Spawned scheduled session for ${worktree.name} (run #${runIndex})`);
+      console.log(
+        `      ✅ Spawned ${manual ? 'manual' : 'scheduled'} session for ${worktree.name} (run #${runIndex})` +
+          (manual && triggeredBy ? ` triggered_by=${triggeredBy.substring(0, 8)}` : '')
+      );
 
       // 6. Attach MCP servers BEFORE triggering prompt (so agent has tools from the start)
       // Precedence: schedule config (if defined) > worktree defaults
@@ -426,6 +588,8 @@ export class SchedulerService {
 
       // 8. Enforce retention policy
       await this.enforceRetentionPolicy(worktree);
+
+      return createdSession;
     } catch (error) {
       console.error(`      ❌ Failed to spawn session for ${worktree.name}:`, error);
       throw error;

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -239,6 +239,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
       unixUserMode: config.execution?.unix_user_mode ?? 'simple',
     });
     schedulerService.start();
+    // Expose on app so route handlers (e.g. /worktrees/:id/execute-schedule-now)
+    // can reuse the scheduler's spawn code path.
+    app.set('scheduler', schedulerService);
     console.log(`🔄 Scheduler started (tick interval: 30s)`);
   }
 

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -910,6 +910,24 @@ function AppContent() {
     }
   };
 
+  // Manually trigger a scheduled run for a worktree (execute-now).
+  // Reuses the scheduler's spawn path server-side so the session is a
+  // first-class scheduled session, just with triggered_manually=true.
+  const handleExecuteScheduleNow = async (worktreeId: string) => {
+    if (!client) return;
+    try {
+      showLoading('Starting scheduled run...', { key: 'execute-now' });
+      await client.service(`worktrees/${worktreeId}/execute-schedule-now`).create({});
+      showSuccess('Scheduled run started!', { key: 'execute-now' });
+    } catch (error) {
+      // Surface 409 (schedule_busy) and 400 (schedule_disabled/incomplete)
+      // with the server-provided message — it's already user-facing.
+      const msg = error instanceof Error ? error.message : String(error);
+      showError(`Failed to start scheduled run: ${msg}`, { key: 'execute-now' });
+      throw error;
+    }
+  };
+
   // Handle MCP server CRUD
   const handleCreateMCPServer = async (data: CreateMCPServerInput) => {
     if (!client) return;
@@ -1260,6 +1278,7 @@ function AppContent() {
                   onStartEnvironment={handleStartEnvironment}
                   onStopEnvironment={handleStopEnvironment}
                   onNukeEnvironment={handleNukeEnvironment}
+                  onExecuteScheduleNow={handleExecuteScheduleNow}
                   onCreateUser={handleCreateUser}
                   onUpdateUser={handleUpdateUser}
                   onDeleteUser={handleDeleteUser}
@@ -1344,6 +1363,7 @@ function AppContent() {
                   onStartEnvironment={handleStartEnvironment}
                   onStopEnvironment={handleStopEnvironment}
                   onNukeEnvironment={handleNukeEnvironment}
+                  onExecuteScheduleNow={handleExecuteScheduleNow}
                   onCreateUser={handleCreateUser}
                   onUpdateUser={handleUpdateUser}
                   onDeleteUser={handleDeleteUser}
@@ -1428,6 +1448,7 @@ function AppContent() {
                   onStartEnvironment={handleStartEnvironment}
                   onStopEnvironment={handleStopEnvironment}
                   onNukeEnvironment={handleNukeEnvironment}
+                  onExecuteScheduleNow={handleExecuteScheduleNow}
                   onCreateUser={handleCreateUser}
                   onUpdateUser={handleUpdateUser}
                   onDeleteUser={handleDeleteUser}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -130,6 +130,7 @@ export interface AppProps {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
+  onExecuteScheduleNow?: (worktreeId: string) => Promise<void>;
   onCreateUser?: (data: CreateUserInput) => void;
   onUpdateUser?: (userId: string, updates: UpdateUserInput) => void;
   onDeleteUser?: (userId: string) => void;
@@ -208,6 +209,7 @@ export const App: React.FC<AppProps> = ({
   onStartEnvironment,
   onStopEnvironment,
   onNukeEnvironment,
+  onExecuteScheduleNow,
   onCreateUser,
   onUpdateUser,
   onDeleteUser,
@@ -1085,6 +1087,7 @@ export const App: React.FC<AppProps> = ({
               openSettings();
             }}
             onSessionClick={handleSessionClick}
+            onExecuteScheduleNow={onExecuteScheduleNow}
           />
           <WorktreeListDrawer
             open={listDrawerOpen}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -126,6 +126,7 @@ interface SessionCanvasProps {
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
+  onExecuteScheduleNow?: (worktreeId: string) => Promise<void>;
   onOpenCommentsPanel?: () => void;
   onCommentHover?: (commentId: string | null) => void;
   onCommentSelect?: (commentId: string | null) => void;
@@ -197,6 +198,7 @@ interface WorktreeNodeData {
   onStartEnvironment?: (worktreeId: string) => void;
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
+  onExecuteScheduleNow?: (worktreeId: string) => Promise<void>;
   onUnpin?: (worktreeId: string) => void;
   compact?: boolean;
   isPinned?: boolean;
@@ -239,6 +241,7 @@ const WorktreeNode = React.memo(({ data }: { data: WorktreeNodeData }) => {
         onStartEnvironment={data.onStartEnvironment}
         onStopEnvironment={data.onStopEnvironment}
         onViewLogs={data.onViewLogs}
+        onExecuteScheduleNow={data.onExecuteScheduleNow}
         onUnpin={data.onUnpin}
         isPinned={data.isPinned}
         zoneName={data.zoneName}
@@ -298,6 +301,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onStopEnvironment,
       onViewLogs,
       onNukeEnvironment,
+      onExecuteScheduleNow,
       onOpenCommentsPanel,
       onCommentHover,
       onCommentSelect,
@@ -640,6 +644,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onStopEnvironment,
             onViewLogs,
             onNukeEnvironment,
+            onExecuteScheduleNow,
             onUnpin: handleUnpinWorktree,
             compact: false,
             isPinned: !!zoneId,
@@ -672,6 +677,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onStopEnvironment,
       onViewLogs,
       onNukeEnvironment,
+      onExecuteScheduleNow,
       handleUnpinWorktree,
       zoneLabels,
       userById,

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -28,6 +28,7 @@ import {
   RobotOutlined,
   SettingOutlined,
   SubnodeOutlined,
+  ThunderboltOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import {
@@ -159,6 +160,7 @@ interface WorktreeCardProps {
   onStopEnvironment?: (worktreeId: string) => void;
   onViewLogs?: (worktreeId: string) => void;
   onNukeEnvironment?: (worktreeId: string) => void;
+  onExecuteScheduleNow?: (worktreeId: string) => Promise<void>;
   onUnpin?: (worktreeId: string) => void;
   isPinned?: boolean;
   zoneName?: string;
@@ -188,6 +190,7 @@ const WorktreeCardComponent = ({
   onStopEnvironment,
   onViewLogs,
   onNukeEnvironment,
+  onExecuteScheduleNow,
   onUnpin,
   isPinned = false,
   zoneName,
@@ -215,6 +218,7 @@ const WorktreeCardComponent = ({
 
   // Archive/Delete modal state
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
+  const [isExecutingScheduleNow, setIsExecutingScheduleNow] = useState(false);
 
   // Tree expansion state - track which nodes are expanded
   const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
@@ -865,6 +869,36 @@ const WorktreeCardComponent = ({
                 title="Open terminal in worktree directory"
               />
             )}
+            {/*
+              Execute-now button: only shown when the worktree has an active,
+              fully-configured schedule. Permission enforcement is server-side
+              (requires worktree 'all' tier); a click by an unauthorized user
+              will produce a Forbidden toast from the API call.
+            */}
+            {onExecuteScheduleNow &&
+              worktree.schedule_enabled &&
+              worktree.schedule_cron &&
+              worktree.schedule?.prompt_template && (
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<ThunderboltOutlined />}
+                  loading={isExecutingScheduleNow}
+                  disabled={isExecutingScheduleNow || connectionDisabled}
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    setIsExecutingScheduleNow(true);
+                    try {
+                      await onExecuteScheduleNow(worktree.worktree_id);
+                    } catch {
+                      // error toast shown by handler; swallow here
+                    } finally {
+                      setIsExecutingScheduleNow(false);
+                    }
+                  }}
+                  title="Run scheduled session now"
+                />
+              )}
             {onOpenSettings && (
               <Button
                 type="text"

--- a/apps/agor-ui/src/components/WorktreeModal/WorktreeModal.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/WorktreeModal.tsx
@@ -49,6 +49,7 @@ export interface WorktreeModalProps {
   ) => void;
   onOpenSettings?: () => void; // Navigate to Settings → Repositories
   onSessionClick?: (sessionId: string) => void;
+  onExecuteScheduleNow?: (worktreeId: string) => Promise<void>;
   defaultTab?: WorktreeModalTab; // Open modal to a specific tab
 }
 
@@ -68,6 +69,7 @@ export const WorktreeModal: React.FC<WorktreeModalProps> = ({
   onArchiveOrDelete,
   onOpenSettings,
   onSessionClick,
+  onExecuteScheduleNow,
   defaultTab,
 }) => {
   const { token } = theme.useToken();
@@ -181,6 +183,7 @@ export const WorktreeModal: React.FC<WorktreeModalProps> = ({
           worktree={worktree}
           mcpServerById={mcpServerById}
           onUpdate={onUpdateWorktree}
+          onExecuteScheduleNow={onExecuteScheduleNow}
         />
       ),
     },

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -189,8 +189,8 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
           <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
             <div>
               <Text type="secondary" style={{ fontSize: '12px' }}>
-                Configure when to create new sessions. All cron expressions are
-                evaluated in <Text strong>UTC</Text> (your local time is{' '}
+                Configure when to create new sessions. All cron expressions are evaluated in{' '}
+                <Text strong>UTC</Text> (your local time is{' '}
                 {new Date().toLocaleTimeString(undefined, { timeZoneName: 'short' })}).
               </Text>
             </div>

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -189,7 +189,9 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
           <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
             <div>
               <Text type="secondary" style={{ fontSize: '12px' }}>
-                Configure when to create new sessions
+                Configure when to create new sessions. All cron expressions are
+                evaluated in <Text strong>UTC</Text> (your local time is{' '}
+                {new Date().toLocaleTimeString(undefined, { timeZoneName: 'short' })}).
               </Text>
             </div>
 
@@ -213,7 +215,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
 
             {/* Human-readable description */}
             <Alert
-              message={humanReadable}
+              message={`${humanReadable} (UTC)`}
               type="info"
               showIcon
               icon={<ClockCircleOutlined />}

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -1,6 +1,11 @@
 import type { AgenticToolName, MCPServer, Worktree } from '@agor-live/client';
 import { getDefaultPermissionMode } from '@agor-live/client';
-import { ClockCircleOutlined, PlayCircleOutlined, StopOutlined } from '@ant-design/icons';
+import {
+  ClockCircleOutlined,
+  PlayCircleOutlined,
+  StopOutlined,
+  ThunderboltOutlined,
+} from '@ant-design/icons';
 import {
   Alert,
   Button,
@@ -29,12 +34,14 @@ interface ScheduleTabProps {
   worktree: Worktree;
   mcpServerById?: Map<string, MCPServer>;
   onUpdate?: (worktreeId: string, updates: Partial<Worktree>) => void;
+  onExecuteScheduleNow?: (worktreeId: string) => Promise<void>;
 }
 
 export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   worktree,
   mcpServerById = new Map(),
   onUpdate,
+  onExecuteScheduleNow,
 }) => {
   const [form] = Form.useForm();
   const [isInitialized, setIsInitialized] = useState(false);
@@ -44,10 +51,14 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
     worktree.schedule?.agentic_tool || 'claude-code'
   );
   const [retention, setRetention] = useState<number>(worktree.schedule?.retention || 5);
+  const [allowConcurrentRuns, setAllowConcurrentRuns] = useState<boolean>(
+    worktree.schedule?.allow_concurrent_runs === true
+  );
   const [promptTemplate, setPromptTemplate] = useState<string>(
     worktree.schedule?.prompt_template || ''
   );
   const [humanReadable, setHumanReadable] = useState<string>('');
+  const [isExecutingNow, setIsExecutingNow] = useState(false);
 
   // Initialize local state and form on first mount
   useEffect(() => {
@@ -60,6 +71,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
       setCronExpression(worktree.schedule_cron || '0 0 * * *');
       setAgenticTool(tool);
       setRetention(scheduleConfig?.retention || 5);
+      setAllowConcurrentRuns(scheduleConfig?.allow_concurrent_runs === true);
       setPromptTemplate(
         scheduleConfig?.prompt_template ||
           'Review the current state of the worktree and provide a status update.'
@@ -109,6 +121,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
         prompt_template: promptTemplate,
         agentic_tool: agenticTool as 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot',
         retention: retention,
+        allow_concurrent_runs: allowConcurrentRuns,
         permission_mode: formValues.permissionMode,
         model_config: formValues.modelConfig,
         mcp_server_ids: formValues.mcpServerIds || [],
@@ -136,6 +149,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
     cronExpression !== (worktree.schedule_cron || '0 0 * * *') ||
     agenticTool !== (worktree.schedule?.agentic_tool || 'claude-code') ||
     retention !== (worktree.schedule?.retention || 5) ||
+    allowConcurrentRuns !== (worktree.schedule?.allow_concurrent_runs === true) ||
     promptTemplate !== (worktree.schedule?.prompt_template || '') ||
     formValues.permissionMode !==
       (worktree.schedule?.permission_mode ||
@@ -294,13 +308,63 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
           </Space>
         </Card>
 
+        {/* Concurrency Policy */}
+        <Card size="small" title="Concurrency">
+          <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+            <Space>
+              <Switch
+                checked={allowConcurrentRuns}
+                onChange={setAllowConcurrentRuns}
+                checkedChildren="Allow"
+                unCheckedChildren="Block"
+              />
+              <Text strong>Allow concurrent runs</Text>
+            </Space>
+            <Text type="secondary" style={{ fontSize: '12px' }}>
+              {allowConcurrentRuns
+                ? 'New runs will always start, even if another session is still active in this worktree.'
+                : 'If a session is already active in this worktree, scheduled runs are skipped and manual "Run now" triggers return an error. This is the default.'}
+            </Text>
+          </Space>
+        </Card>
+
         <Divider style={{ margin: '12px 0' }} />
 
-        {/* Save Button */}
+        {/* Save + Run Now Buttons */}
         <Space>
           <Button type="primary" onClick={handleSave} disabled={!hasChanges}>
             Save Schedule Configuration
           </Button>
+          {onExecuteScheduleNow && (
+            <Button
+              icon={<ThunderboltOutlined />}
+              loading={isExecutingNow}
+              disabled={
+                isExecutingNow ||
+                hasChanges ||
+                !scheduleEnabled ||
+                !cronExpression ||
+                !promptTemplate
+              }
+              onClick={async () => {
+                setIsExecutingNow(true);
+                try {
+                  await onExecuteScheduleNow(worktree.worktree_id);
+                } finally {
+                  setIsExecutingNow(false);
+                }
+              }}
+              title={
+                hasChanges
+                  ? 'Save your changes before running'
+                  : !scheduleEnabled
+                    ? 'Enable the schedule before running'
+                    : 'Run this schedule immediately using the saved configuration'
+              }
+            >
+              Run now
+            </Button>
+          )}
           {hasChanges && (
             <Text type="warning" style={{ fontSize: '12px' }}>
               You have unsaved changes

--- a/packages/core/src/feathers/index.ts
+++ b/packages/core/src/feathers/index.ts
@@ -20,7 +20,7 @@ export {
 export { default as authClient } from '@feathersjs/authentication-client';
 export { LocalStrategy } from '@feathersjs/authentication-local';
 // Errors
-export { BadRequest, Forbidden, NotAuthenticated, NotFound } from '@feathersjs/errors';
+export { BadRequest, Conflict, Forbidden, NotAuthenticated, NotFound } from '@feathersjs/errors';
 export type { Application as ExpressApplication } from '@feathersjs/express';
 // Express Integration
 export { default as feathersExpress, errorHandler, rest } from '@feathersjs/express';

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -471,6 +471,17 @@ export interface ScheduledRunMetadata {
   run_index: number;
 
   /**
+   * Whether this run was triggered manually via execute-now (vs. cron tick).
+   */
+  triggered_manually?: boolean;
+
+  /**
+   * User ID that manually triggered this run. Only set when
+   * `triggered_manually` is true.
+   */
+  triggered_by?: string;
+
+  /**
    * Snapshot of schedule config at execution time
    *
    * Preserves configuration even if schedule is later modified or deleted.
@@ -483,6 +494,8 @@ export interface ScheduledRunMetadata {
     timezone: string;
     /** Retention policy at run time */
     retention: number;
+    /** Concurrency policy at run time (applies to both cron and manual paths) */
+    allow_concurrent_runs?: boolean;
   };
 }
 

--- a/packages/core/src/types/worktree.ts
+++ b/packages/core/src/types/worktree.ts
@@ -430,6 +430,20 @@ export interface WorktreeScheduleConfig {
   retention: number;
 
   /**
+   * Whether the schedule may spawn a new session while another session is
+   * already actively running in the same worktree.
+   *
+   * Applies to BOTH the cron tick path and the "execute now" manual trigger.
+   *
+   * Default: false (concurrent runs blocked — if a session is active, new runs are skipped).
+   *
+   * "Active" means a session with status RUNNING / STOPPING / AWAITING_PERMISSION /
+   * AWAITING_INPUT in the same worktree. IDLE / COMPLETED / FAILED / TIMED_OUT do
+   * not count as active.
+   */
+  allow_concurrent_runs?: boolean;
+
+  /**
    * Permission mode for spawned sessions
    *
    * Controls tool approval behavior.


### PR DESCRIPTION
## Summary

Closes #999 — adds a manual "Run now" trigger for scheduled worktree sessions, plus a per-schedule concurrency policy that applies to both cron and manual paths.

- **Backend:** `POST /worktrees/:id/execute-schedule-now` (requires `all` tier). Reuses the cron spawn path via `SchedulerService.executeScheduleNow()` so manual and scheduled runs are indistinguishable beyond a `triggered_manually` marker. Minute-rounded `scheduled_run_at` dedups rapid double-clicks and manual/cron collisions.
- **Concurrency guard:** new `WorktreeScheduleConfig.allow_concurrent_runs` (default `false`). Cron tick silently skips; manual trigger returns **409 Conflict** with `schedule_busy` code.
- **UI (ScheduleTab):** Concurrency card with Allow/Block switch; "Run now" button (disabled when unsaved changes or incomplete schedule); UTC clarification added to the Schedule Frequency intro and human-readable cron description.
- **UI (WorktreeCard):** ⚡ `ThunderboltOutlined` quick-run button gated on `schedule_enabled + schedule_cron + prompt_template`.

Design notes and rationale live in [`PLAN.md`](./PLAN.md) (merged earlier in this branch).

## Test plan

- [ ] Enable a schedule on a worktree, click ⚡ on the card → new scheduled session spawns.
- [ ] Double-click ⚡ within the same minute → second call hits dedup, same session returned.
- [ ] With a session running and `allow_concurrent_runs=false`, click ⚡ → 409 / toast error.
- [ ] Flip `allow_concurrent_runs=true`, click ⚡ → second session starts.
- [ ] Disable the schedule, attempt ⚡ → button hidden on card; 400 from API if bypassed.
- [ ] In `ScheduleTab`, make an unsaved change → "Run now" is disabled until saved.
- [ ] Run passes `pnpm check` (typecheck + lint + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)