### PR TITLE
feat(security): configurable CSP + CORS with sandpack-friendly defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,6 +525,37 @@ pnpm agor config set ui.port 5174
 - `VITE_DAEMON_URL` - Full daemon URL for UI
 - `VITE_DAEMON_PORT` - Daemon port for UI
 
+### Security Headers (CSP + CORS)
+
+Content-Security-Policy and CORS are tunable from `~/.agor/config.yaml` under
+the `security.*` block — see `context/concepts/security.md` for the full
+model and recipes. Quick examples:
+
+```yaml
+# Add an external analytics script
+security:
+  csp:
+    extras:
+      script-src: ["https://plausible.io"]
+
+# Allow a specific origin to call the daemon
+security:
+  cors:
+    origins: ["https://dashboard.internal.example.com"]
+
+# Iterate on policy without breaking the app
+security:
+  csp:
+    report_only: true
+    report_uri: "/api/csp-report"
+```
+
+The legacy `daemon.cors_origins` and `daemon.cors_allow_sandpack` keys still
+work for backwards compatibility but emit a deprecation warning — migrate
+to `security.cors.*` on your next config touch. The resolved CSP/CORS
+posture is surfaced in Settings → About for admins so you can confirm what
+the daemon booted with without reading response headers.
+
 ---
 
 ## Troubleshooting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,34 +527,8 @@ pnpm agor config set ui.port 5174
 
 ### Security Headers (CSP + CORS)
 
-Content-Security-Policy and CORS are tunable from `~/.agor/config.yaml` under
-the `security.*` block — see `context/concepts/security.md` for the full
-model and recipes. Quick examples:
-
-```yaml
-# Add an external analytics script
-security:
-  csp:
-    extras:
-      script-src: ["https://plausible.io"]
-
-# Allow a specific origin to call the daemon
-security:
-  cors:
-    origins: ["https://dashboard.internal.example.com"]
-
-# Iterate on policy without breaking the app
-security:
-  csp:
-    report_only: true
-    report_uri: "/api/csp-report"
-```
-
-The legacy `daemon.cors_origins` and `daemon.cors_allow_sandpack` keys still
-work for backwards compatibility but emit a deprecation warning — migrate
-to `security.cors.*` on your next config touch. The resolved CSP/CORS
-posture is surfaced in Settings → About for admins so you can confirm what
-the daemon booted with without reading response headers.
+Tunable from `~/.agor/config.yaml` under `security.*` — see
+`context/concepts/security.md`.
 
 ---
 

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -341,7 +341,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // `application/reports+json` modern), log at warn level with pino, and
   // respond 204. Rate-limited to protect against report floods.
   const reportUri = resolvedSecurity.csp.reportUri;
-  if (reportUri && reportUri.startsWith('/')) {
+  if (reportUri?.startsWith('/')) {
     const { default: rateLimit } = await import('express-rate-limit');
     const reportLimiter = rateLimit({
       windowMs: 60_000,

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -20,8 +20,8 @@ import { patchConsole } from '@agor/core/utils/logger';
 
 patchConsole();
 
-import type { AgorConfig } from '@agor/core/config';
-import { loadConfig, loadConfigFromFile } from '@agor/core/config';
+import type { AgorConfig, ResolvedSecurity } from '@agor/core/config';
+import { loadConfig, loadConfigFromFile, resolveSecurity } from '@agor/core/config';
 import { getDatabaseUrl } from '@agor/core/db';
 import {
   authenticate,
@@ -245,18 +245,34 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     }
   };
 
+  // Resolve the `security.*` config block once and reuse it everywhere that
+  // cares (CSP middleware, CORS middleware, /health response, CSP report
+  // endpoint). The resolver handles:
+  //   - merging defaults ⊕ extras ⊕ override for CSP
+  //   - CORS mode/origins (plus legacy daemon.cors_* backcompat)
+  //   - CORS_ORIGIN env var precedence
+  //   - credentials:true + wildcard/reflect rejection at load time
+  const resolvedSecurity: ResolvedSecurity = resolveSecurity(config, {
+    daemonUrl,
+    corsOriginEnv: process.env.CORS_ORIGIN,
+    legacyCorsOrigins: config.daemon?.cors_origins,
+    legacyAllowSandpack:
+      config.daemon?.cors_allow_sandpack !== undefined
+        ? config.daemon.cors_allow_sandpack
+        : undefined,
+  });
+
   // CORS
   const {
     origin: corsOrigin,
     credentialsAllowed,
     isWildcard,
     isAllowedOrigin,
+    extraOptions: corsExtraOptions,
   } = buildCorsConfig({
     uiPort: UI_PORT,
     isCodespaces: process.env.CODESPACES === 'true',
-    corsOriginOverride: process.env.CORS_ORIGIN,
-    allowSandpack: config.daemon?.cors_allow_sandpack !== false,
-    configOrigins: config.daemon?.cors_origins,
+    resolved: resolvedSecurity.cors,
   });
 
   // Refuse to boot when a hardened deployment is configured to reflect any
@@ -313,11 +329,44 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     next();
   });
 
-  app.use(cors({ origin: corsOrigin, credentials: credentialsAllowed }));
+  app.use(cors({ origin: corsOrigin, credentials: credentialsAllowed, ...corsExtraOptions }));
 
   // Security headers (CSP, X-Frame-Options, nosniff, Referrer-Policy, HSTS).
   // Must run after CORS so preflights still get the Access-Control-* headers.
-  app.use(securityHeaders({ daemonUrl }) as never);
+  app.use(securityHeaders({ csp: resolvedSecurity.csp }) as never);
+
+  // CSP violation reporting endpoint. Only mounted when operators opt in via
+  // `security.csp.report_uri`. Handler is deliberately minimal: accept POSTs
+  // of either shape (`application/csp-report` legacy or
+  // `application/reports+json` modern), log at warn level with pino, and
+  // respond 204. Rate-limited to protect against report floods.
+  const reportUri = resolvedSecurity.csp.reportUri;
+  if (reportUri && reportUri.startsWith('/')) {
+    const { default: rateLimit } = await import('express-rate-limit');
+    const reportLimiter = rateLimit({
+      windowMs: 60_000,
+      limit: 120, // 2 reports/sec average per IP — tight but avoids total silence
+      standardHeaders: 'draft-7',
+      legacyHeaders: false,
+      message: 'Too many CSP reports',
+    });
+    app.use(
+      reportUri,
+      express.json({
+        type: ['application/csp-report', 'application/reports+json', 'application/json'],
+        limit: '16kb',
+      }),
+      reportLimiter as never,
+      ((req: express.Request, res: express.Response) => {
+        if (req.method !== 'POST') {
+          res.status(405).end();
+          return;
+        }
+        console.warn('[csp-report]', JSON.stringify(req.body));
+        res.status(204).end();
+      }) as never
+    );
+  }
 
   // Default to a 10MB JSON body. The previous 10MB pre-hardening default was
   // unbounded enough to allow trivial memory-pressure DoS, and a 1MB ceiling
@@ -502,6 +551,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     DAEMON_PORT,
     DAEMON_VERSION,
     servicesConfig,
+    resolvedSecurity,
     sessionsService: services.sessionsService,
     messagesService: services.messagesService,
     boardsService: services.boardsService,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -147,6 +147,11 @@ export interface RegisterRoutesContext {
   DAEMON_PORT: number;
   DAEMON_VERSION: string;
   servicesConfig: DaemonServicesConfig;
+  /**
+   * Resolved security config (CSP/CORS after defaults+extras+override merge).
+   * Used by /health to surface the effective policy to admin users.
+   */
+  resolvedSecurity: import('@agor/core/config').ResolvedSecurity;
 
   // Service instances from registerServices()
   sessionsService: SessionsServiceImpl;
@@ -181,6 +186,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     DAEMON_PORT: _DAEMON_PORT,
     DAEMON_VERSION,
     servicesConfig,
+    resolvedSecurity,
     sessionsService,
     messagesService,
     boardsService,
@@ -2564,6 +2570,25 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           execution: {
             worktreeRbac: config.execution?.worktree_rbac === true,
             unixUserMode: config.execution?.unix_user_mode ?? 'simple',
+          },
+          // Resolved security posture — admins can confirm in Settings → About
+          // which CSP/CORS policy the daemon booted with, without tailing logs
+          // or reading response headers by hand. Keep the shape tight: the
+          // full CSP header value is the one piece operators actually need
+          // when debugging a blocked resource.
+          security: {
+            csp: {
+              enabled: !resolvedSecurity.csp.disabled,
+              reportOnly: resolvedSecurity.csp.reportOnly,
+              reportUri: resolvedSecurity.csp.reportUri,
+              header: resolvedSecurity.csp.headerValue,
+            },
+            cors: {
+              mode: resolvedSecurity.cors.mode,
+              credentials: resolvedSecurity.cors.credentials,
+              originCount: resolvedSecurity.cors.origins.length,
+              allowSandpack: resolvedSecurity.cors.allowSandpack,
+            },
           },
         };
       }

--- a/apps/agor-daemon/src/setup/cors.test.ts
+++ b/apps/agor-daemon/src/setup/cors.test.ts
@@ -39,6 +39,32 @@ describe('buildCorsConfig', () => {
     expect(result.isAllowedOrigin('https://anything.example.com')).toBe(false);
   });
 
+  it('mode=wildcard emits literal "*" (not origin reflection)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = buildCorsConfig({
+      uiPort: 5173,
+      isCodespaces: false,
+      resolved: resolve({ security: { cors: { mode: 'wildcard', credentials: false } } }),
+    });
+    // `origin: '*'` makes cors() emit Access-Control-Allow-Origin: *, which is
+    // observably different from `origin: true` (which reflects the Origin
+    // header). This test pins the distinction so wildcard doesn't regress into
+    // reflect.
+    expect(result.origin).toBe('*');
+  });
+
+  it('mode=reflect echoes the request origin (distinct from wildcard)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = buildCorsConfig({
+      uiPort: 5173,
+      isCodespaces: false,
+      resolved: resolve({ security: { cors: { mode: 'reflect', credentials: false } } }),
+    });
+    // `origin: true` in cors() echoes the request's Origin header back — this
+    // is the reflect mode behaviour per the cors package docs.
+    expect(result.origin).toBe(true);
+  });
+
   it('only allows the configured UI port range on localhost', () => {
     const result = buildCorsConfig({
       uiPort: 5173,

--- a/apps/agor-daemon/src/setup/cors.test.ts
+++ b/apps/agor-daemon/src/setup/cors.test.ts
@@ -2,37 +2,49 @@
  * CORS hardening tests.
  *
  * Covers:
- *   - Wildcard reflection (CORS_ORIGIN=*) drops credentials.
+ *   - Wildcard reflection drops credentials.
  *   - Tightened localhost regex only matches the configured UI port range.
  *   - Sandpack origins are reachable but excluded from `isAllowedOrigin`
  *     (so they don't get credentials / private-network).
+ *   - Configured methods/headers/max_age are passed through to cors().
  */
 
+import type { AgorConfig } from '@agor/core/config';
+import { resolveSecurity } from '@agor/core/config';
 import { describe, expect, it, vi } from 'vitest';
 import { buildCorsConfig, isSandpackOrigin } from './cors';
 
+function resolve(
+  config: AgorConfig = {},
+  opts: Parameters<typeof resolveSecurity>[1] = {}
+): ReturnType<typeof resolveSecurity>['cors'] {
+  return resolveSecurity(config, { onWarning: vi.fn(), ...opts }).cors;
+}
+
 describe('buildCorsConfig', () => {
-  it('drops credentials when CORS_ORIGIN=* is set', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('drops credentials when resolved mode is wildcard', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = buildCorsConfig({
       uiPort: 5173,
       isCodespaces: false,
-      corsOriginOverride: '*',
+      resolved: resolve({}, { corsOriginEnv: '*' }),
     });
     expect(result.isWildcard).toBe(true);
     expect(result.credentialsAllowed).toBe(false);
     // The cors() origin callback returns true (accept any origin), but the
     // isAllowedOrigin predicate is the gate for PNA / credentials. Even in
     // wildcard mode, only the localhost UI port range gets PNA — random
-    // origins do NOT, so a public site cannot use the daemon to reach a
-    // private/loopback target.
+    // origins do NOT.
     expect(result.isAllowedOrigin('http://localhost:5173')).toBe(true);
     expect(result.isAllowedOrigin('https://anything.example.com')).toBe(false);
-    warn.mockRestore();
   });
 
   it('only allows the configured UI port range on localhost', () => {
-    const result = buildCorsConfig({ uiPort: 5173, isCodespaces: false });
+    const result = buildCorsConfig({
+      uiPort: 5173,
+      isCodespaces: false,
+      resolved: resolve(),
+    });
     expect(result.isAllowedOrigin('http://localhost:5173')).toBe(true);
     expect(result.isAllowedOrigin('http://localhost:5176')).toBe(true);
     // Out-of-range port must be rejected (this was the bug in the old regex).
@@ -44,23 +56,63 @@ describe('buildCorsConfig', () => {
     const result = buildCorsConfig({
       uiPort: 5173,
       isCodespaces: false,
-      allowSandpack: true,
+      resolved: resolve({ security: { cors: { allow_sandpack: true } } }),
     });
     // The actual cors origin callback would still permit the request through,
-    // but the public isAllowedOrigin predicate (used to gate
-    // Access-Control-Allow-Private-Network and credentials) excludes them.
+    // but the public isAllowedOrigin predicate (used to gate PNA + credentials)
+    // excludes them.
     expect(result.isAllowedOrigin('https://2-19-8-sandpack.codesandbox.io')).toBe(false);
   });
 
-  it('honours configOrigins exact strings and regex patterns', () => {
+  it('honours security.cors.origins with exact strings and regex patterns', () => {
     const result = buildCorsConfig({
       uiPort: 5173,
       isCodespaces: false,
-      configOrigins: ['https://dash.example.com', '/\\.internal\\.example\\.com$/'],
+      resolved: resolve({
+        security: {
+          cors: {
+            origins: ['https://dash.example.com', '/\\.internal\\.example\\.com$/'],
+          },
+        },
+      }),
     });
     expect(result.isAllowedOrigin('https://dash.example.com')).toBe(true);
     expect(result.isAllowedOrigin('https://api.internal.example.com')).toBe(true);
     expect(result.isAllowedOrigin('https://other.example.com')).toBe(false);
+  });
+
+  it('passes methods/allowedHeaders/maxAge through to cors() extraOptions', () => {
+    const result = buildCorsConfig({
+      uiPort: 5173,
+      isCodespaces: false,
+      resolved: resolve({
+        security: {
+          cors: {
+            methods: ['GET', 'POST'],
+            allowed_headers: ['Authorization', 'X-MCP-Token'],
+            max_age_seconds: 600,
+          },
+        },
+      }),
+    });
+    expect(result.extraOptions.methods).toEqual(['GET', 'POST']);
+    expect(result.extraOptions.allowedHeaders).toEqual(['Authorization', 'X-MCP-Token']);
+    expect(result.extraOptions.maxAge).toBe(600);
+  });
+
+  it('mode=null-origin only accepts Origin: null', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = buildCorsConfig({
+      uiPort: 5173,
+      isCodespaces: false,
+      resolved: resolve({ security: { cors: { mode: 'null-origin' } } }),
+    });
+    const cb = vi.fn();
+    (result.origin as (o: string | undefined, cb: typeof cb) => void)('null', cb);
+    expect(cb).toHaveBeenLastCalledWith(null, true);
+    cb.mockReset();
+    (result.origin as (o: string | undefined, cb: typeof cb) => void)('https://attacker.com', cb);
+    expect(cb.mock.calls[0][0]).toBeInstanceOf(Error);
   });
 });
 

--- a/apps/agor-daemon/src/setup/cors.ts
+++ b/apps/agor-daemon/src/setup/cors.ts
@@ -122,17 +122,16 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
   if (resolved.maxAgeSeconds !== undefined) extraOptions.maxAge = resolved.maxAgeSeconds;
 
   // --- Wildcard / reflect: accept any origin, credentials are forced off. ---
+  // `wildcard` emits Access-Control-Allow-Origin: *  (cors() option `origin: '*'`).
+  // `reflect`  echoes the request's Origin header back (cors() option `origin: true`).
+  // These are observably different (a `*` response cannot carry credentials even
+  // via a mistake; a reflected origin can) so we keep them distinct.
   if (resolved.mode === 'wildcard' || resolved.mode === 'reflect') {
     console.warn(
       `⚠️  CORS mode=${resolved.mode} — any origin will be accepted, credentials disabled.`
     );
     return {
-      // In both modes the cors() package accepts any origin when `origin: true`.
-      // The spec requires the response header to echo the request origin in
-      // "reflect" mode (which cors() does when origin=true AND the request has
-      // an Origin header) and `*` in "wildcard" mode. Since cors() handles
-      // both via `origin: true` + `credentials: false`, we unify them here.
-      origin: true,
+      origin: resolved.mode === 'wildcard' ? '*' : true,
       localhostOrigins,
       credentialsAllowed: false,
       isWildcard: true,

--- a/apps/agor-daemon/src/setup/cors.ts
+++ b/apps/agor-daemon/src/setup/cors.ts
@@ -1,11 +1,28 @@
 /**
  * CORS Configuration
  *
- * Builds CORS origin configuration based on deployment environment.
- * Supports local development, GitHub Codespaces, Sandpack/CodeSandbox
- * bundler origins, and configurable extra origins via config or env var.
+ * Builds CORS origin configuration based on deployment environment and the
+ * resolved `security.cors.*` config block.
+ *
+ * Inputs from the resolver (`packages/core/src/config/security-resolver.ts`):
+ *   - `mode`            — list | wildcard | reflect | null-origin
+ *   - `origins`         — exact strings or /regex/ patterns (used when mode=list)
+ *   - `credentials`     — whether to echo Access-Control-Allow-Credentials
+ *   - `methods`         — allowed methods (optional)
+ *   - `allowedHeaders`  — allowed request headers (optional; reflect when unset)
+ *   - `maxAgeSeconds`   — preflight cache TTL (optional)
+ *   - `allowSandpack`   — accept `https://*.codesandbox.io`
+ *
+ * Environment-derived inputs (not part of the config block) remain here:
+ *   - UI port (for the localhost allow-list)
+ *   - Codespaces detection (`*.github.dev`, `*.githubpreview.dev`)
+ *
+ * Backcompat: the legacy `daemon.cors_origins`, `daemon.cors_allow_sandpack`,
+ * and `CORS_ORIGIN` env var continue to work via `resolveSecurity()` — by the
+ * time values reach this module, they've already been merged and warned on.
  */
 
+import type { ResolvedCors } from '@agor/core/config';
 import type { CorsOptions } from 'cors';
 
 /** CORS origin type — derived from the cors package's own CorsOptions */
@@ -16,31 +33,25 @@ export interface CorsConfigOptions {
   uiPort: number;
   /** Whether running in GitHub Codespaces */
   isCodespaces: boolean;
-  /** Explicit CORS_ORIGIN environment variable override */
-  corsOriginOverride?: string;
-  /** Allow Sandpack/CodeSandbox bundler origins (default: true) */
-  allowSandpack?: boolean;
-  /** Additional allowed origins from config (exact strings or /regex/ patterns) */
-  configOrigins?: string[];
+  /** Resolved CORS config (from `@agor/core/config` `resolveSecurity()`). */
+  resolved: ResolvedCors;
 }
 
 export interface CorsConfigResult {
-  /** The resolved CORS origin configuration */
+  /** The resolved CORS origin configuration passed to `cors()` middleware. */
   origin: CorsOrigin;
   /** Localhost origins for local development */
   localhostOrigins: string[];
   /**
    * True when the caller should allow `credentials: true` on the global cors()
-   * middleware. False when the resolved policy is a wildcard reflector (origin
-   * `*` or any-origin reflection), in which case `credentials` MUST be off to
-   * comply with the CORS spec and avoid credentialed cross-origin requests
-   * from arbitrary sites.
+   * middleware. False when the resolved policy is a wildcard reflector, in
+   * which case `credentials` MUST be off per the CORS spec.
    */
   credentialsAllowed: boolean;
   /**
-   * True when the resolved policy reflects any origin (wildcard mode).
+   * True when the resolved policy reflects any origin (wildcard/reflect).
    * Surfaced so the daemon entrypoint can refuse to boot in hardened
-   * deployment modes (solo/team) and emit a loud warning otherwise.
+   * deployment modes and emit a loud warning otherwise.
    */
   isWildcard: boolean;
   /**
@@ -49,6 +60,8 @@ export interface CorsConfigResult {
    * trusted origins instead of echoing it for everyone.
    */
   isAllowedOrigin: (origin: string) => boolean;
+  /** Additional options (methods, allowedHeaders, maxAge) to pass to cors(). */
+  extraOptions: Pick<CorsOptions, 'methods' | 'allowedHeaders' | 'maxAge'>;
 }
 
 /** Matches hosted Sandpack bundler origins like https://2-19-8-sandpack.codesandbox.io */
@@ -80,22 +93,20 @@ function parseRegexPattern(entry: string): RegExp | null {
 }
 
 /**
- * Build CORS origin configuration based on deployment environment
+ * Build CORS origin configuration from a pre-resolved `security.cors` block.
  *
- * Priority:
- * 1. CORS_ORIGIN='*' → Allow all origins (dangerous; credentials are forced off)
- * 2. Otherwise → Callback-based handler combining:
- *    - The configured UI port on localhost (http only)
- *    - Sandpack/CodeSandbox origins (unless allowSandpack=false)
- *    - GitHub Codespaces domains (when CODESPACES=true)
- *    - Additional origins from config.yaml (cors_origins)
- *    - Additional origins from CORS_ORIGIN env var (comma-separated)
+ * The resolver (in @agor/core) has already:
+ *   - applied CORS_ORIGIN env var precedence over config
+ *   - merged legacy `daemon.cors_origins` / `daemon.cors_allow_sandpack`
+ *   - emitted deprecation warnings
+ *   - rejected credentials:true + wildcard/reflect at load time
  *
- * @param options - Configuration options
- * @returns CORS origin configuration ready for express cors middleware
+ * This function is left concerned only with turning that into the runtime
+ * `cors()` origin callback + the predicates the rest of the daemon uses for
+ * PNA, credential stripping, etc.
  */
 export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
-  const { uiPort, isCodespaces, corsOriginOverride, allowSandpack = true, configOrigins } = options;
+  const { uiPort, isCodespaces, resolved } = options;
 
   // Support UI port and 3 additional ports (for parallel dev servers)
   const localhostOrigins = [
@@ -105,25 +116,54 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
     `http://localhost:${uiPort + 3}`,
   ];
 
-  // Explicit wildcard - allow all origins (use with caution!)
-  if (corsOriginOverride?.trim() === '*') {
-    console.warn('⚠️  CORS set to allow ALL origins (CORS_ORIGIN=*) — credentials disabled');
+  const extraOptions: Pick<CorsOptions, 'methods' | 'allowedHeaders' | 'maxAge'> = {};
+  if (resolved.methods) extraOptions.methods = resolved.methods;
+  if (resolved.allowedHeaders) extraOptions.allowedHeaders = resolved.allowedHeaders;
+  if (resolved.maxAgeSeconds !== undefined) extraOptions.maxAge = resolved.maxAgeSeconds;
+
+  // --- Wildcard / reflect: accept any origin, credentials are forced off. ---
+  if (resolved.mode === 'wildcard' || resolved.mode === 'reflect') {
+    console.warn(
+      `⚠️  CORS mode=${resolved.mode} — any origin will be accepted, credentials disabled.`
+    );
     return {
+      // In both modes the cors() package accepts any origin when `origin: true`.
+      // The spec requires the response header to echo the request origin in
+      // "reflect" mode (which cors() does when origin=true AND the request has
+      // an Origin header) and `*` in "wildcard" mode. Since cors() handles
+      // both via `origin: true` + `credentials: false`, we unify them here.
       origin: true,
       localhostOrigins,
       credentialsAllowed: false,
       isWildcard: true,
-      // SECURITY: in wildcard mode we accept ANY origin for normal CORS, but
-      // we deliberately do NOT echo Access-Control-Allow-Private-Network for
-      // unknown origins. PNA is a chrome-style escape hatch that lets a
-      // public origin reach a private/loopback target — even in wildcard
-      // mode, only localhost (the configured UI dev port range) gets the
-      // PNA header. Anyone else has to be added to the explicit allow-list.
+      // SECURITY: in wildcard/reflect mode we accept ANY origin for normal CORS,
+      // but we deliberately do NOT echo Access-Control-Allow-Private-Network for
+      // unknown origins. PNA is a chrome-style escape hatch that lets a public
+      // origin reach a private/loopback target — even in wildcard mode, only
+      // localhost (the configured UI dev port range) gets the PNA header.
       isAllowedOrigin: (origin: string) => localhostOrigins.includes(origin),
+      extraOptions,
     };
   }
 
-  // Collect exact origins and regex patterns from all sources
+  // --- Null-origin: the only allowed origin is the literal string "null". ---
+  if (resolved.mode === 'null-origin') {
+    console.warn('⚠️  CORS mode=null-origin — only "Origin: null" requests are allowed.');
+    return {
+      origin: (requestOrigin, callback) => {
+        if (!requestOrigin) return callback(null, true);
+        if (requestOrigin === 'null') return callback(null, true);
+        callback(new Error('Not allowed by CORS'));
+      },
+      localhostOrigins,
+      credentialsAllowed: resolved.credentials,
+      isWildcard: false,
+      isAllowedOrigin: () => false,
+      extraOptions,
+    };
+  }
+
+  // --- List mode: localhost + codespaces + sandpack + user-provided. ------
   const exactOrigins = new Set(localhostOrigins);
   const patterns: RegExp[] = [];
 
@@ -133,8 +173,8 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
   const uiPortRange = [uiPort, uiPort + 1, uiPort + 2, uiPort + 3].join('|');
   patterns.push(new RegExp(`^https?:\\/\\/localhost:(${uiPortRange})$`));
 
-  // Sandpack/CodeSandbox bundler (on by default).
-  if (allowSandpack) {
+  // Sandpack/CodeSandbox bundler (on by default, configurable).
+  if (resolved.allowSandpack) {
     patterns.push(SANDPACK_ORIGIN_PATTERN);
   }
 
@@ -144,36 +184,21 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
     console.log('🔒 CORS configured for GitHub Codespaces (*.github.dev, *.githubpreview.dev)');
   }
 
-  // Additional origins from config.yaml (cors_origins)
-  if (configOrigins) {
-    for (const raw of configOrigins) {
-      const entry = raw.trim();
-      if (!entry) continue;
-      const regex = parseRegexPattern(entry);
-      if (regex) {
-        patterns.push(regex);
-      } else {
-        exactOrigins.add(entry);
-      }
+  // Additional origins from resolved config (security.cors.origins merged
+  // with legacy daemon.cors_origins merged with CORS_ORIGIN env var — the
+  // resolver has already done precedence resolution).
+  for (const raw of resolved.origins) {
+    const entry = raw.trim();
+    if (!entry) continue;
+    const regex = parseRegexPattern(entry);
+    if (regex) {
+      patterns.push(regex);
+    } else {
+      exactOrigins.add(entry);
     }
   }
 
-  // Additional origins from CORS_ORIGIN env var (comma-separated)
-  if (corsOriginOverride) {
-    for (const entry of corsOriginOverride
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)) {
-      const regex = parseRegexPattern(entry);
-      if (regex) {
-        patterns.push(regex);
-      } else {
-        exactOrigins.add(entry);
-      }
-    }
-  }
-
-  if (allowSandpack) {
+  if (resolved.allowSandpack) {
     console.log('🔒 CORS allows Sandpack/CodeSandbox bundler origins (*.codesandbox.io)');
   }
 
@@ -184,8 +209,8 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
 
   // Sandpack origins are third-party multi-tenant; we never allow credentials
   // to be sent from them even though we accept the request.
-  const isSandpackOrigin = (requestOrigin: string): boolean =>
-    allowSandpack && SANDPACK_ORIGIN_PATTERN.test(requestOrigin);
+  const isSandpack = (requestOrigin: string): boolean =>
+    resolved.allowSandpack && SANDPACK_ORIGIN_PATTERN.test(requestOrigin);
 
   const origin: CorsOrigin = (requestOrigin, callback) => {
     // Allow requests with no origin (curl, Postman, mobile apps)
@@ -201,13 +226,12 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
     callback(new Error('Not allowed by CORS'));
   };
 
-  // Wrap origin so that we can attach per-request credential decisions in the
-  // calling middleware. The returned `isAllowedOrigin` is the canonical check.
   return {
     origin,
     localhostOrigins,
-    credentialsAllowed: true,
+    credentialsAllowed: resolved.credentials,
     isWildcard: false,
-    isAllowedOrigin: (o: string) => isAllowedOrigin(o) && !isSandpackOrigin(o),
+    isAllowedOrigin: (o: string) => isAllowedOrigin(o) && !isSandpack(o),
+    extraOptions,
   };
 }

--- a/apps/agor-daemon/src/setup/security-headers.test.ts
+++ b/apps/agor-daemon/src/setup/security-headers.test.ts
@@ -5,6 +5,7 @@
  * response headers via a fake req/res rather than running a real listener.
  */
 
+import { resolveSecurity } from '@agor/core/config';
 import type { Request, Response } from 'express';
 import { describe, expect, it } from 'vitest';
 import { securityHeaders } from './security-headers';
@@ -27,9 +28,13 @@ function fakeRes(): Response & {
   return res;
 }
 
+function resolvedCsp(config: Parameters<typeof resolveSecurity>[0] = {}) {
+  return resolveSecurity(config, { daemonUrl: 'http://localhost:3030' }).csp;
+}
+
 describe('securityHeaders', () => {
   it('sets CSP, X-Frame-Options, nosniff, and Referrer-Policy on every response', () => {
-    const mw = securityHeaders({ daemonUrl: 'http://localhost:3030' });
+    const mw = securityHeaders({ csp: resolvedCsp() });
     const res = fakeRes();
     mw({ secure: false } as Request, res, () => {});
 
@@ -42,6 +47,9 @@ describe('securityHeaders', () => {
     expect(csp).toContain('http://localhost:3030');
     expect(csp).toContain('ws:');
     expect(csp).toContain('wss:');
+    // Sandpack defaults in — artifacts render out of the box.
+    expect(csp).toContain('https://*.codesandbox.io');
+    expect(csp).toContain('blob:');
 
     expect(res._headers['x-frame-options']).toBe('DENY');
     expect(res._headers['x-content-type-options']).toBe('nosniff');
@@ -49,17 +57,64 @@ describe('securityHeaders', () => {
   });
 
   it('omits HSTS over plain http', () => {
-    const mw = securityHeaders();
+    const mw = securityHeaders({ csp: resolvedCsp() });
     const res = fakeRes();
     mw({ secure: false } as Request, res, () => {});
     expect(res._has('strict-transport-security')).toBe(false);
   });
 
   it('emits HSTS when req.secure is true', () => {
-    const mw = securityHeaders();
+    const mw = securityHeaders({ csp: resolvedCsp() });
     const res = fakeRes();
     mw({ secure: true } as Request, res, () => {});
     expect(res._headers['strict-transport-security']).toMatch(/max-age=\d+/);
     expect(res._headers['strict-transport-security']).toContain('includeSubDomains');
+  });
+
+  it('emits Content-Security-Policy-Report-Only when report_only=true', () => {
+    const mw = securityHeaders({
+      csp: resolvedCsp({ security: { csp: { report_only: true } } }),
+    });
+    const res = fakeRes();
+    mw({ secure: false } as Request, res, () => {});
+    expect(res._has('content-security-policy-report-only')).toBe(true);
+    expect(res._has('content-security-policy')).toBe(false);
+  });
+
+  it('emits neither CSP header when disabled=true', () => {
+    const mw = securityHeaders({
+      csp: resolvedCsp({ security: { csp: { disabled: true } } }),
+    });
+    const res = fakeRes();
+    mw({ secure: false } as Request, res, () => {});
+    expect(res._has('content-security-policy')).toBe(false);
+    expect(res._has('content-security-policy-report-only')).toBe(false);
+    // Other headers are still emitted — disabling CSP should NOT drop the rest.
+    expect(res._headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('emits Report-To header when report_uri is set', () => {
+    const mw = securityHeaders({
+      csp: resolvedCsp({ security: { csp: { report_uri: '/api/csp-report' } } }),
+    });
+    const res = fakeRes();
+    mw({ secure: false } as Request, res, () => {});
+    const reportTo = res._headers['report-to'];
+    expect(reportTo).toBeDefined();
+    expect(JSON.parse(reportTo)).toMatchObject({
+      group: 'agor-csp',
+      endpoints: [{ url: '/api/csp-report' }],
+    });
+  });
+
+  it('extras are reflected in the emitted header', () => {
+    const mw = securityHeaders({
+      csp: resolvedCsp({
+        security: { csp: { extras: { 'script-src': ['https://plausible.io'] } } },
+      }),
+    });
+    const res = fakeRes();
+    mw({ secure: false } as Request, res, () => {});
+    expect(res._headers['content-security-policy']).toContain('https://plausible.io');
   });
 });

--- a/apps/agor-daemon/src/setup/security-headers.test.ts
+++ b/apps/agor-daemon/src/setup/security-headers.test.ts
@@ -107,6 +107,26 @@ describe('securityHeaders', () => {
     });
   });
 
+  it('Report-To group tracks a custom report-to override (no drift)', () => {
+    // Pins the fix for a bug where the CSP directive advertised `custom-group`
+    // but the Report-To header hardcoded `agor-csp`, causing browsers to drop
+    // reports silently.
+    const mw = securityHeaders({
+      csp: resolvedCsp({
+        security: {
+          csp: {
+            report_uri: '/api/csp-report',
+            override: { 'report-to': ['custom-group'] },
+          },
+        },
+      }),
+    });
+    const res = fakeRes();
+    mw({ secure: false } as Request, res, () => {});
+    expect(JSON.parse(res._headers['report-to'])).toMatchObject({ group: 'custom-group' });
+    expect(res._headers['content-security-policy']).toContain('report-to custom-group');
+  });
+
   it('extras are reflected in the emitted header', () => {
     const mw = securityHeaders({
       csp: resolvedCsp({

--- a/apps/agor-daemon/src/setup/security-headers.ts
+++ b/apps/agor-daemon/src/setup/security-headers.ts
@@ -9,6 +9,13 @@
  *   - Referrer-Policy: strict-origin-when-cross-origin
  *   - Strict-Transport-Security      (only when the request is over TLS)
  *
+ * The CSP is resolved from `~/.agor/config.yaml` (`security.csp.*`) via
+ * `resolveSecurity()` in @agor/core, so operators can append per-directive
+ * sources (`extras`) or replace them wholesale (`override`) without touching
+ * code. Built-in defaults are chosen so every bundled Agor feature works out
+ * of the box — notably Sandpack-backed artifacts, which need `frame-src` and
+ * `worker-src` to be non-restrictive.
+ *
  * The CSP intentionally allows `style-src 'unsafe-inline'` because Ant Design
  * still injects inline styles. TODO: migrate to nonces and tighten.
  *
@@ -17,42 +24,25 @@
  * set here — `setHeader` replaces, so per-route CSPs continue to work.
  */
 
+import type { ResolvedCsp } from '@agor/core/config';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 
 export interface SecurityHeadersOptions {
-  /** The daemon's own URL (e.g. `http://localhost:3030`) — added to connect-src. */
-  daemonUrl?: string;
-  /** Extra connect-src origins (UI dev server etc). Optional. */
-  extraConnectSrc?: string[];
+  /**
+   * Resolved CSP (from `resolveSecurity()`). When omitted, CSP is emitted as
+   * an empty `default-src 'self'` — safe but likely to block legitimate
+   * resources. The daemon entrypoint always passes a resolved value; this
+   * default exists for unit tests that need a no-config middleware.
+   */
+  csp?: ResolvedCsp;
 }
 
-/**
- * Build the CSP header value. `connect-src` includes `'self'`, `ws:`/`wss:`
- * (for the FeathersJS socket.io transport in dev/prod), the daemon's own URL
- * if known, and any extra origins the operator wants to allow.
- */
-function buildCsp(opts: SecurityHeadersOptions): string {
-  const connectSrc = ["'self'", 'ws:', 'wss:'];
-  if (opts.daemonUrl) connectSrc.push(opts.daemonUrl);
-  if (opts.extraConnectSrc) connectSrc.push(...opts.extraConnectSrc);
-
-  const directives: Record<string, string[]> = {
-    'default-src': ["'self'"],
-    'script-src': ["'self'"],
-    // TODO: drop 'unsafe-inline' once Ant Design supports CSP nonces.
-    'style-src': ["'self'", "'unsafe-inline'"],
-    'img-src': ["'self'", 'data:', 'blob:'],
-    'font-src': ["'self'", 'data:'],
-    'connect-src': connectSrc,
-    'frame-ancestors': ["'none'"],
-    'object-src': ["'none'"],
-    'base-uri': ["'self'"],
-  };
-
-  return Object.entries(directives)
-    .map(([k, v]) => `${k} ${v.join(' ')}`)
-    .join('; ');
-}
+const MINIMAL_FALLBACK_CSP: ResolvedCsp = {
+  directives: { 'default-src': ["'self'"] },
+  disabled: false,
+  reportOnly: false,
+  headerValue: "default-src 'self'",
+};
 
 /**
  * Returns an Express middleware that sets the standard security headers.
@@ -62,10 +52,31 @@ function buildCsp(opts: SecurityHeadersOptions): string {
  * http://localhost development.
  */
 export function securityHeaders(opts: SecurityHeadersOptions = {}): RequestHandler {
-  const csp = buildCsp(opts);
+  const csp = opts.csp ?? MINIMAL_FALLBACK_CSP;
+  const cspHeaderName = csp.reportOnly
+    ? 'Content-Security-Policy-Report-Only'
+    : 'Content-Security-Policy';
+
+  // When `report_uri` is set, emit a matching `Report-To` header so that
+  // modern browsers prefer the Reporting API over the legacy `report-uri`
+  // directive. We point it at a group name that matches the `report-to`
+  // directive value produced by the resolver (`agor-csp`).
+  const reportToHeader =
+    csp.reportUri !== undefined
+      ? JSON.stringify({
+          group: 'agor-csp',
+          max_age: 10886400, // 126 days — Chrome caps at ~1yr; this matches Mozilla's recommendation
+          endpoints: [{ url: csp.reportUri }],
+        })
+      : undefined;
 
   return (req: Request, res: Response, next: NextFunction): void => {
-    res.setHeader('Content-Security-Policy', csp);
+    if (!csp.disabled) {
+      res.setHeader(cspHeaderName, csp.headerValue);
+      if (reportToHeader) {
+        res.setHeader('Report-To', reportToHeader);
+      }
+    }
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');

--- a/apps/agor-daemon/src/setup/security-headers.ts
+++ b/apps/agor-daemon/src/setup/security-headers.ts
@@ -59,12 +59,13 @@ export function securityHeaders(opts: SecurityHeadersOptions = {}): RequestHandl
 
   // When `report_uri` is set, emit a matching `Report-To` header so that
   // modern browsers prefer the Reporting API over the legacy `report-uri`
-  // directive. We point it at a group name that matches the `report-to`
-  // directive value produced by the resolver (`agor-csp`).
+  // directive. The group name is taken from the resolver (which derives it
+  // from the `report-to` directive — either our default `agor-csp` or the
+  // operator's override) so the header and directive can't drift.
   const reportToHeader =
-    csp.reportUri !== undefined
+    csp.reportUri !== undefined && csp.reportToGroup !== undefined
       ? JSON.stringify({
-          group: 'agor-csp',
+          group: csp.reportToGroup,
           max_age: 10886400, // 126 days — Chrome caps at ~1yr; this matches Mozilla's recommendation
           endpoints: [{ url: csp.reportUri }],
         })

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { AgorClient, UnixUserMode } from '@agor-live/client';
-import { Card, Descriptions, Space, Typography } from 'antd';
+import { Card, Descriptions, Space, Tag, Tooltip, Typography } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 
@@ -45,6 +45,20 @@ interface HealthInfo {
   execution?: {
     worktreeRbac: boolean;
     unixUserMode: UnixUserMode;
+  };
+  security?: {
+    csp: {
+      enabled: boolean;
+      reportOnly: boolean;
+      reportUri?: string;
+      header: string;
+    };
+    cors: {
+      mode: 'list' | 'wildcard' | 'reflect' | 'null-origin';
+      credentials: boolean;
+      originCount: number;
+      allowSandpack: boolean;
+    };
   };
 }
 
@@ -212,6 +226,92 @@ export const AboutTab: React.FC<AboutTabProps> = ({
                   )}
                 </Descriptions>
               </Card>
+
+              {/* Security Headers (CSP + CORS posture) */}
+              {healthInfo?.security && (
+                <Card
+                  title="Security Headers (Admin Only)"
+                  variant="borderless"
+                  style={{ maxWidth: 800, margin: '0 auto' }}
+                >
+                  <Descriptions column={1} bordered size="small">
+                    <Descriptions.Item label="CSP">
+                      {healthInfo.security.csp.enabled ? (
+                        healthInfo.security.csp.reportOnly ? (
+                          <Tag color="warning">Report-Only</Tag>
+                        ) : (
+                          <Tag color="success">Enforced</Tag>
+                        )
+                      ) : (
+                        <Tag color="error">Disabled</Tag>
+                      )}
+                      {healthInfo.security.csp.reportUri && (
+                        <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
+                          Reports → <code>{healthInfo.security.csp.reportUri}</code>
+                        </Typography.Text>
+                      )}
+                    </Descriptions.Item>
+                    <Descriptions.Item label="CSP Header">
+                      <Tooltip title="Full Content-Security-Policy header the daemon is emitting. If a resource is blocked, check which directive matches.">
+                        <Typography.Paragraph
+                          copyable={{ text: healthInfo.security.csp.header }}
+                          style={{
+                            margin: 0,
+                            fontFamily: 'monospace',
+                            fontSize: 12,
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-all',
+                          }}
+                        >
+                          {healthInfo.security.csp.header}
+                        </Typography.Paragraph>
+                      </Tooltip>
+                    </Descriptions.Item>
+                    <Descriptions.Item label="CORS Mode">
+                      <code>{healthInfo.security.cors.mode}</code>
+                      {healthInfo.security.cors.mode === 'wildcard' && (
+                        <Typography.Text type="danger" style={{ marginLeft: 8 }}>
+                          ⚠️ Any origin accepted
+                        </Typography.Text>
+                      )}
+                      {healthInfo.security.cors.mode === 'reflect' && (
+                        <Typography.Text type="warning" style={{ marginLeft: 8 }}>
+                          ⚠️ Origin header echoed
+                        </Typography.Text>
+                      )}
+                    </Descriptions.Item>
+                    <Descriptions.Item label="CORS Credentials">
+                      {healthInfo.security.cors.credentials ? (
+                        <Tag color="success">Enabled</Tag>
+                      ) : (
+                        <Tag color="default">Disabled</Tag>
+                      )}
+                    </Descriptions.Item>
+                    <Descriptions.Item label="Allowed Origins">
+                      {healthInfo.security.cors.originCount} configured{' '}
+                      <Typography.Text type="secondary">
+                        (+ localhost dev ports
+                        {healthInfo.security.cors.allowSandpack && ', + Sandpack'})
+                      </Typography.Text>
+                    </Descriptions.Item>
+                  </Descriptions>
+                  <Typography.Paragraph
+                    type="secondary"
+                    style={{ marginTop: 12, marginBottom: 0, fontSize: 12 }}
+                  >
+                    Configure via <code>security.csp</code> and <code>security.cors</code> in{' '}
+                    <code>~/.agor/config.yaml</code>. See{' '}
+                    <a
+                      href="https://github.com/preset-io/agor/blob/main/context/concepts/security.md"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      context/concepts/security.md
+                    </a>
+                    .
+                  </Typography.Paragraph>
+                </Card>
+              )}
 
               {/* System Debug Info */}
               <Card

--- a/context/concepts/security.md
+++ b/context/concepts/security.md
@@ -1,0 +1,244 @@
+# Security Headers & CORS
+
+How Agor's daemon handles Content-Security-Policy (CSP) and Cross-Origin
+Resource Sharing (CORS), and how operators tune both from `~/.agor/config.yaml`.
+
+> This document is scoped to **web-layer hardening** (CSP / CORS / response
+> headers). For authentication, RBAC, and Unix isolation see `auth.md` and
+> `rbac-and-unix-isolation.md`.
+
+---
+
+## Why configurable at all?
+
+PR #1027 landed strict, hardcoded CSP + CORS. Two problems surfaced:
+
+1. **Hardcoded defaults hid a bug for Sandpack artifacts.** CSP lacked
+   `frame-src` and `worker-src`, so both fell back to `default-src 'self'` —
+   which blocks the hosted CodeSandbox bundler iframes Agor uses for
+   artifacts. Operators saw a silent render failure on a fresh deploy with
+   no config knob to fix it.
+2. **Custom integrations couldn't be added.** An operator with a custom
+   analytics script, LLM proxy, embedded dashboard, or IDP had to fork and
+   rebuild the daemon. That's a poor upgrade story.
+
+The `security.*` config block solves both: the defaults now make every
+bundled Agor feature work, and operators can append or replace per-directive
+without leaving YAML.
+
+---
+
+## Config model
+
+### CSP: two-tier (extras / override)
+
+```yaml
+security:
+  csp:
+    # (1) APPEND to built-in defaults — the 95% case.
+    extras:
+      script-src: ["https://plausible.io"]
+      connect-src: ["https://api.anthropic.com"]
+      frame-src: ["https://my-sandbox.example.com"]
+
+    # (2) REPLACE a directive wholesale — escape hatch, rare.
+    # Setting a directive here wipes both defaults AND extras for that key.
+    override:
+      img-src: ["'self'", "data:"]
+
+    # (3) Reporting + debug toggles.
+    report_uri: "/api/csp-report"   # daemon mounts a handler here
+    report_only: false              # true = emit Content-Security-Policy-Report-Only
+    disabled: false                 # dev/debug only, emits loud warning
+```
+
+**Why the split?** Every operator we've asked about CSP wanted "keep what
+Agor ships, just let me add `https://plausible.io` to `script-src`." That's
+append. Replacement is for operators with a fully bespoke policy. Offering
+both avoids the common footgun where "I wanted to add X" ended up silently
+dropping the defaults and breaking unrelated features.
+
+**Empty override is meaningful.** `override: { "script-src": [] }` emits
+`script-src` with no sources — i.e. blocks that directive entirely. This is
+distinct from *omitting* the key, which means "use defaults+extras." If you
+find yourself reaching for this, double-check it's really what you meant.
+
+### CORS: mode-based
+
+```yaml
+security:
+  cors:
+    mode: list                              # list | wildcard | reflect | null-origin
+    origins: ["https://agor.mydomain.com"]  # used when mode=list
+    credentials: true                       # default true; forced false in wildcard/reflect
+    methods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+    allowed_headers: ["Authorization", "Content-Type", "X-MCP-Token"]
+    max_age_seconds: 600
+    allow_sandpack: true                    # include *.codesandbox.io (default true)
+```
+
+**Mode semantics:**
+
+| Mode          | Behaviour                                                         | Credentials |
+| ------------- | ----------------------------------------------------------------- | ----------- |
+| `list`        | Only origins in `origins[]` + built-ins (localhost, Sandpack, Codespaces) | Allowed (default) |
+| `wildcard`    | Accept any origin (returns `Access-Control-Allow-Origin: *`)      | Forced off  |
+| `reflect`     | Echo the request's `Origin` header back                           | Forced off  |
+| `null-origin` | Only accept `Origin: null` (sandboxed iframes, file:// docs)      | Allowed     |
+
+`credentials: true` + `mode: wildcard` (or `reflect`) is rejected at config
+load with a clear error — the CORS spec explicitly forbids this combination
+because it would allow credentialed requests from any origin.
+
+---
+
+## Built-in defaults
+
+These are hardcoded into `resolveSecurity()` and make every bundled feature
+work. Operators rarely need to override them:
+
+```
+default-src        'self'
+script-src         'self'
+style-src          'self' 'unsafe-inline'           # Ant Design injects inline styles
+img-src            'self' data: blob: https://*.codesandbox.io
+font-src           'self' data:
+connect-src        'self' ws: wss: <daemon-url>
+frame-src          'self' https://*.codesandbox.io  # Sandpack iframes
+worker-src         'self' blob:                     # Sandpack workers
+frame-ancestors    'none'
+object-src         'none'
+base-uri           'self'
+```
+
+The Sandpack origins (`https://*.codesandbox.io` + `blob:` for workers) are
+the load-bearing piece — without them the hosted bundler iframe renders but
+its workers fail to spawn and artifacts never mount. Setting
+`security.cors.allow_sandpack: false` removes them from *both* the CSP and
+the CORS allow-list (the two need to stay in sync or you get weird
+half-broken states).
+
+---
+
+## Common recipes
+
+### I want to allow an external analytics script
+
+```yaml
+security:
+  csp:
+    extras:
+      script-src: ["https://plausible.io"]
+      connect-src: ["https://plausible.io"]
+```
+
+### I want to embed an external iframe
+
+```yaml
+security:
+  csp:
+    extras:
+      frame-src: ["https://my-embed.example.com"]
+```
+
+### I want to relax CORS for a specific origin
+
+```yaml
+security:
+  cors:
+    origins: ["https://dashboard.internal.example.com"]
+```
+
+Regex patterns are supported inside `/slashes/`:
+
+```yaml
+security:
+  cors:
+    origins:
+      - "https://dashboard.example.com"
+      - "/\\.internal\\.example\\.com$/"
+```
+
+### I want to watch what's being blocked before enforcing
+
+```yaml
+security:
+  csp:
+    report_only: true
+    report_uri: "/api/csp-report"
+```
+
+The daemon mounts a rate-limited handler at `report_uri` that logs incoming
+reports at `warn` level via pino. Watch your logs, tighten your `extras`,
+flip `report_only: false` when the floor is quiet.
+
+---
+
+## Backwards compatibility
+
+The legacy `daemon.cors_origins` and `daemon.cors_allow_sandpack` keys from
+#1027 still work. When present they're merged into the resolved CORS config
+with a deprecation warning at daemon startup. The `CORS_ORIGIN` environment
+variable continues to win over all config sources for deployment
+compatibility.
+
+Migration path: move values to `security.cors.origins` +
+`security.cors.allow_sandpack` on your next config touch — the deprecation
+will be promoted to a hard error in a future release.
+
+---
+
+## Debugging a blocked resource
+
+When Sandpack-like "silent render failure" strikes again:
+
+1. Open DevTools → Network tab → click the failing resource.
+2. In the response headers, find `Content-Security-Policy` (or
+   `-Report-Only`). The daemon also surfaces this in Settings → About →
+   Security Headers so you don't have to dig.
+3. Find the directive that governs that resource type (`script-src` for
+   JS, `frame-src` for iframes, `connect-src` for fetch/XHR, `worker-src`
+   for web workers, etc.).
+4. Add the required source to `security.csp.extras.<directive>` in
+   `~/.agor/config.yaml`, restart the daemon.
+
+If you can't afford a restart cycle, flip on `report_only: true` first, wait
+for the next violation report in logs, then make the change — you'll know
+exactly which origin + directive the browser wanted.
+
+---
+
+## Architecture
+
+Resolution lives in `packages/core/src/config/security-resolver.ts`:
+
+```
+AgorConfig.security          →  resolveSecurity()  →  ResolvedSecurity
+  + daemonUrl                                           { csp: ResolvedCsp,
+  + legacyCorsOrigins                                     cors: ResolvedCors }
+  + legacyAllowSandpack
+  + CORS_ORIGIN env var
+```
+
+The resolver is pure — no file I/O, no side effects except warnings — and
+is imported by:
+
+- `apps/agor-daemon/src/setup/security-headers.ts` — consumes `ResolvedCsp`
+- `apps/agor-daemon/src/setup/cors.ts` — consumes `ResolvedCors`
+- `apps/agor-daemon/src/register-routes.ts` — surfaces it on `/health`
+- `apps/agor-ui/src/components/SettingsModal/AboutTab.tsx` — renders it
+
+Validation errors surface at daemon startup, not request-time. If your
+`config.yaml` has an unknown CSP directive or a `credentials: true +
+mode: wildcard` combination, the daemon refuses to boot with an actionable
+error message.
+
+---
+
+## See also
+
+- `apps/agor-daemon/src/setup/security-headers.ts` — CSP middleware
+- `apps/agor-daemon/src/setup/cors.ts` — CORS policy builder
+- `packages/core/src/config/security-resolver.ts` — config resolver
+- `auth.md` — daemon auth (JWT, RBAC, session tokens)
+- `rbac-and-unix-isolation.md` — OS-level isolation tiers

--- a/context/concepts/security.md
+++ b/context/concepts/security.md
@@ -84,7 +84,7 @@ security:
 | `list`        | Only origins in `origins[]` + built-ins (localhost, Sandpack, Codespaces) | Allowed (default) |
 | `wildcard`    | Accept any origin (returns `Access-Control-Allow-Origin: *`)      | Forced off  |
 | `reflect`     | Echo the request's `Origin` header back                           | Forced off  |
-| `null-origin` | Only accept `Origin: null` (sandboxed iframes, file:// docs)      | Allowed     |
+| `null-origin` | Accept `Origin: null` (sandboxed iframes, `file://` docs) plus no-origin non-browser clients (curl, server-to-server) | Allowed     |
 
 `credentials: true` + `mode: wildcard` (or `reflect`) is rejected at config
 load with a clear error — the CORS spec explicitly forbids this combination

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,5 +16,15 @@ export * from './repo-list';
 export * from './repo-reference';
 export * from './resource-schemas';
 export * from './resource-sync';
-export * from './security-resolver';
+export type {
+  ResolvedCors,
+  ResolvedCsp,
+  ResolvedSecurity,
+  ResolveSecurityOptions,
+} from './security-resolver';
+export {
+  resolveSecurity,
+  SANDPACK_CSP_FRAME_SRC,
+  SANDPACK_CSP_WORKER_SRC,
+} from './security-resolver';
 export * from './types';

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,4 +16,5 @@ export * from './repo-list';
 export * from './repo-reference';
 export * from './resource-schemas';
 export * from './resource-sync';
+export * from './security-resolver';
 export * from './types';

--- a/packages/core/src/config/security-resolver.test.ts
+++ b/packages/core/src/config/security-resolver.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Security config resolver tests.
+ *
+ * Covers:
+ *   - Defaults include sandpack frame-src/worker-src so artifacts work OOTB
+ *   - extras append to defaults (and de-duplicate)
+ *   - override replaces defaults+extras per-directive
+ *   - report_only / disabled flags are surfaced
+ *   - Unknown CSP directives are rejected with a friendly error
+ *   - CORS defaults, wildcard forces credentials off, mode=null-origin
+ *   - credentials:true + wildcard/reflect throws at load time
+ *   - CORS_ORIGIN env var overrides config values
+ *   - Legacy daemon.cors_* keys merge in with a deprecation warning
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveSecurity,
+  SANDPACK_CSP_FRAME_SRC,
+  SANDPACK_CSP_WORKER_SRC,
+  serializeCsp,
+} from './security-resolver';
+import type { AgorConfig } from './types';
+
+const EMPTY: AgorConfig = {};
+
+describe('resolveSecurity — CSP defaults', () => {
+  it('bakes in sandpack frame-src + worker-src so artifacts render out of the box', () => {
+    const { csp } = resolveSecurity(EMPTY, { daemonUrl: 'http://localhost:3030' });
+    expect(csp.directives['frame-src']).toContain("'self'");
+    expect(csp.directives['frame-src']).toContain(SANDPACK_CSP_FRAME_SRC);
+    expect(csp.directives['worker-src']).toContain(SANDPACK_CSP_WORKER_SRC);
+  });
+
+  it('honours allowSandpack=false by dropping *.codesandbox.io from frame-src', () => {
+    const { csp } = resolveSecurity(
+      { security: { cors: { allow_sandpack: false } } },
+      { daemonUrl: 'http://localhost:3030' }
+    );
+    expect(csp.directives['frame-src']).not.toContain(SANDPACK_CSP_FRAME_SRC);
+    // Worker-src still allows blob: because Agor itself may use workers.
+    expect(csp.directives['worker-src']).toContain(SANDPACK_CSP_WORKER_SRC);
+  });
+
+  it('injects the daemon URL into connect-src', () => {
+    const { csp } = resolveSecurity(EMPTY, { daemonUrl: 'http://localhost:3030' });
+    expect(csp.directives['connect-src']).toContain('http://localhost:3030');
+    expect(csp.directives['connect-src']).toContain('ws:');
+    expect(csp.directives['connect-src']).toContain('wss:');
+  });
+});
+
+describe('resolveSecurity — CSP extras/override', () => {
+  it('extras append to defaults without duplicating', () => {
+    const { csp } = resolveSecurity(
+      {
+        security: {
+          csp: {
+            extras: {
+              'script-src': ['https://plausible.io', "'self'"], // 'self' already in defaults
+              'connect-src': ['https://api.anthropic.com'],
+            },
+          },
+        },
+      },
+      { daemonUrl: 'http://localhost:3030' }
+    );
+    expect(csp.directives['script-src']).toEqual(["'self'", 'https://plausible.io']);
+    expect(csp.directives['connect-src']).toContain('https://api.anthropic.com');
+  });
+
+  it('override replaces defaults AND extras for that directive', () => {
+    const { csp } = resolveSecurity({
+      security: {
+        csp: {
+          extras: { 'img-src': ['https://should-be-dropped.example.com'] },
+          override: { 'img-src': ["'self'", 'data:'] },
+        },
+      },
+    });
+    expect(csp.directives['img-src']).toEqual(["'self'", 'data:']);
+  });
+
+  it('override with empty array emits the directive with no sources (blocks it)', () => {
+    const { csp } = resolveSecurity({
+      security: { csp: { override: { 'script-src': [] } } },
+    });
+    expect(csp.directives['script-src']).toEqual([]);
+    expect(csp.headerValue).toContain('script-src;');
+  });
+
+  it('rejects unknown directive names with a helpful error', () => {
+    expect(() =>
+      resolveSecurity({
+        security: { csp: { extras: { 'not-a-directive': ['x'] } } },
+      })
+    ).toThrow(/unknown CSP directive/);
+  });
+
+  it('rejects non-array directive values', () => {
+    expect(() =>
+      resolveSecurity({
+        security: {
+          csp: {
+            extras: { 'script-src': 'https://x.com' as unknown as string[] },
+          },
+        },
+      })
+    ).toThrow(/must be an array/);
+  });
+});
+
+describe('resolveSecurity — CSP reporting + flags', () => {
+  it('sets report_only flag and header name', () => {
+    const { csp } = resolveSecurity({
+      security: { csp: { report_only: true } },
+    });
+    expect(csp.reportOnly).toBe(true);
+  });
+
+  it('when report_uri is set, report-uri and report-to directives are injected', () => {
+    const { csp } = resolveSecurity({
+      security: { csp: { report_uri: '/api/csp-report' } },
+    });
+    expect(csp.reportUri).toBe('/api/csp-report');
+    expect(csp.directives['report-uri']).toEqual(['/api/csp-report']);
+    expect(csp.directives['report-to']).toEqual(['agor-csp']);
+  });
+
+  it('disabled=true emits a warning and surfaces the flag', () => {
+    const warn = vi.fn();
+    const { csp } = resolveSecurity({ security: { csp: { disabled: true } } }, { onWarning: warn });
+    expect(csp.disabled).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('disabled=true'));
+  });
+});
+
+describe('resolveSecurity — CORS', () => {
+  it('defaults to list mode with empty origins and credentials=true', () => {
+    const { cors } = resolveSecurity(EMPTY);
+    expect(cors.mode).toBe('list');
+    expect(cors.origins).toEqual([]);
+    expect(cors.credentials).toBe(true);
+    expect(cors.allowSandpack).toBe(true);
+  });
+
+  it('mode=wildcard forces credentials=false with a warning when user left it default', () => {
+    const warn = vi.fn();
+    const { cors } = resolveSecurity(
+      { security: { cors: { mode: 'wildcard' } } },
+      { onWarning: warn }
+    );
+    expect(cors.mode).toBe('wildcard');
+    expect(cors.credentials).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('forces credentials=false'));
+  });
+
+  it('mode=wildcard + explicit credentials=true throws at load time', () => {
+    expect(() =>
+      resolveSecurity({
+        security: { cors: { mode: 'wildcard', credentials: true } },
+      })
+    ).toThrow(/incompatible with cors.mode/);
+  });
+
+  it('mode=reflect + explicit credentials=true throws at load time', () => {
+    expect(() =>
+      resolveSecurity({
+        security: { cors: { mode: 'reflect', credentials: true } },
+      })
+    ).toThrow(/incompatible with cors.mode/);
+  });
+
+  it('mode=null-origin is surfaced verbatim', () => {
+    const { cors } = resolveSecurity({
+      security: { cors: { mode: 'null-origin' } },
+    });
+    expect(cors.mode).toBe('null-origin');
+  });
+
+  it('CORS_ORIGIN="*" env var overrides config to wildcard', () => {
+    const { cors } = resolveSecurity(
+      { security: { cors: { mode: 'list', origins: ['https://dash.example.com'] } } },
+      { corsOriginEnv: '*', onWarning: vi.fn() }
+    );
+    expect(cors.mode).toBe('wildcard');
+    expect(cors.origins).toEqual([]);
+    expect(cors.credentials).toBe(false);
+  });
+
+  it('CORS_ORIGIN env var wins over security.cors.origins with a deprecation warning', () => {
+    const warn = vi.fn();
+    const { cors } = resolveSecurity(
+      { security: { cors: { origins: ['https://config-only.example.com'] } } },
+      { corsOriginEnv: 'https://env-wins.example.com', onWarning: warn }
+    );
+    expect(cors.origins).toEqual(['https://env-wins.example.com']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('CORS_ORIGIN env var overrides'));
+  });
+
+  it('legacy daemon.cors_origins merges in when security.cors.origins is absent', () => {
+    const warn = vi.fn();
+    const { cors } = resolveSecurity(EMPTY, {
+      legacyCorsOrigins: ['https://legacy.example.com'],
+      onWarning: warn,
+    });
+    expect(cors.origins).toEqual(['https://legacy.example.com']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('daemon.cors_origins is deprecated'));
+  });
+
+  it('legacy daemon.cors_allow_sandpack=false carries through with deprecation warning', () => {
+    const warn = vi.fn();
+    const { cors, csp } = resolveSecurity(EMPTY, {
+      legacyAllowSandpack: false,
+      onWarning: warn,
+    });
+    expect(cors.allowSandpack).toBe(false);
+    expect(csp.directives['frame-src']).not.toContain(SANDPACK_CSP_FRAME_SRC);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('daemon.cors_allow_sandpack is deprecated')
+    );
+  });
+
+  it('security.cors.allow_sandpack explicitly set wins over legacy value', () => {
+    const { cors } = resolveSecurity(
+      { security: { cors: { allow_sandpack: true } } },
+      { legacyAllowSandpack: false, onWarning: vi.fn() }
+    );
+    expect(cors.allowSandpack).toBe(true);
+  });
+
+  it('passes methods, allowed_headers, max_age_seconds through verbatim', () => {
+    const { cors } = resolveSecurity({
+      security: {
+        cors: {
+          methods: ['GET', 'POST'],
+          allowed_headers: ['X-MCP-Token', 'Authorization'],
+          max_age_seconds: 600,
+        },
+      },
+    });
+    expect(cors.methods).toEqual(['GET', 'POST']);
+    expect(cors.allowedHeaders).toEqual(['X-MCP-Token', 'Authorization']);
+    expect(cors.maxAgeSeconds).toBe(600);
+  });
+});
+
+describe('serializeCsp', () => {
+  it('joins directives with "; " and sources with spaces', () => {
+    expect(
+      serializeCsp({
+        'default-src': ["'self'"],
+        'script-src': ["'self'", 'https://x.com'],
+      })
+    ).toBe("default-src 'self'; script-src 'self' https://x.com");
+  });
+
+  it('emits empty-source directives as just the name (no trailing space)', () => {
+    expect(serializeCsp({ 'script-src': [] })).toBe('script-src');
+  });
+});

--- a/packages/core/src/config/security-resolver.test.ts
+++ b/packages/core/src/config/security-resolver.test.ts
@@ -18,7 +18,6 @@ import {
   resolveSecurity,
   SANDPACK_CSP_FRAME_SRC,
   SANDPACK_CSP_WORKER_SRC,
-  serializeCsp,
 } from './security-resolver';
 import type { AgorConfig } from './types';
 
@@ -125,6 +124,36 @@ describe('resolveSecurity — CSP reporting + flags', () => {
     expect(csp.reportUri).toBe('/api/csp-report');
     expect(csp.directives['report-uri']).toEqual(['/api/csp-report']);
     expect(csp.directives['report-to']).toEqual(['agor-csp']);
+    expect(csp.reportToGroup).toBe('agor-csp');
+  });
+
+  it('report_uri + override of report-to uses the operator group (no drift)', () => {
+    // Prevents a subtle bug where the CSP directive says `report-to my-group`
+    // but the Report-To header advertises `agor-csp` — browsers would see the
+    // two as unrelated and silently drop reports.
+    const { csp } = resolveSecurity({
+      security: {
+        csp: {
+          report_uri: '/api/csp-report',
+          override: { 'report-to': ['my-group'] },
+        },
+      },
+    });
+    expect(csp.directives['report-to']).toEqual(['my-group']);
+    expect(csp.reportToGroup).toBe('my-group');
+  });
+
+  it('report_uri + override of report-to with empty array throws (would drift)', () => {
+    expect(() =>
+      resolveSecurity({
+        security: {
+          csp: {
+            report_uri: '/api/csp-report',
+            override: { 'report-to': [] },
+          },
+        },
+      })
+    ).toThrow(/must contain at least one group name/);
   });
 
   it('disabled=true emits a warning and surfaces the flag', () => {
@@ -208,6 +237,21 @@ describe('resolveSecurity — CORS', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('daemon.cors_origins is deprecated'));
   });
 
+  it('when BOTH legacy and new origins are set, the new key wins and legacy is warned as ignored', () => {
+    const warn = vi.fn();
+    const { cors } = resolveSecurity(
+      { security: { cors: { origins: ['https://new.example.com'] } } },
+      {
+        legacyCorsOrigins: ['https://legacy.example.com'],
+        onWarning: warn,
+      }
+    );
+    expect(cors.origins).toEqual(['https://new.example.com']);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('daemon.cors_origins is deprecated AND ignored')
+    );
+  });
+
   it('legacy daemon.cors_allow_sandpack=false carries through with deprecation warning', () => {
     const warn = vi.fn();
     const { cors, csp } = resolveSecurity(EMPTY, {
@@ -245,17 +289,24 @@ describe('resolveSecurity — CORS', () => {
   });
 });
 
-describe('serializeCsp', () => {
+describe('resolveSecurity — headerValue serialization', () => {
   it('joins directives with "; " and sources with spaces', () => {
-    expect(
-      serializeCsp({
-        'default-src': ["'self'"],
-        'script-src': ["'self'", 'https://x.com'],
-      })
-    ).toBe("default-src 'self'; script-src 'self' https://x.com");
+    const { csp } = resolveSecurity(
+      { security: { csp: { override: { 'script-src': ["'self'", 'https://x.com'] } } } },
+      { onWarning: vi.fn() }
+    );
+    expect(csp.headerValue).toContain("script-src 'self' https://x.com");
+    expect(csp.headerValue).toContain('; ');
   });
 
-  it('emits empty-source directives as just the name (no trailing space)', () => {
-    expect(serializeCsp({ 'script-src': [] })).toBe('script-src');
+  it('emits empty-source override directives as just the name (no trailing space)', () => {
+    const { csp } = resolveSecurity(
+      { security: { csp: { override: { 'script-src': [] } } } },
+      { onWarning: vi.fn() }
+    );
+    // The directive list is segment-joined with "; ", so each segment is either
+    // `name` or `name src1 src2`. An empty-array override yields just `script-src`.
+    const segments = csp.headerValue.split('; ');
+    expect(segments).toContain('script-src');
   });
 });

--- a/packages/core/src/config/security-resolver.ts
+++ b/packages/core/src/config/security-resolver.ts
@@ -117,6 +117,16 @@ export interface ResolvedCsp {
   reportOnly: boolean;
   /** When set, CSP violation reports are POSTed here. */
   reportUri?: string;
+  /**
+   * The reporting-group name that the `Report-To` header should advertise.
+   * Kept in the resolved object (rather than hardcoded in the middleware) so
+   * that the group in the `report-to` CSP directive and the group in the
+   * `Report-To` header can never drift. When the operator overrides the
+   * `report-to` directive with a custom group, this field reflects their
+   * choice; otherwise it's the built-in default (`agor-csp`). Undefined when
+   * reporting is not configured.
+   */
+  reportToGroup?: string;
   /** Pre-serialized header value (handy for tests and /health). */
   headerValue: string;
 }
@@ -261,8 +271,12 @@ function mergeDirectives(
  * Directives with empty source lists are emitted as `directive-name` (no
  * sources after the name) — this is the correct way to block a directive
  * entirely.
+ *
+ * Internal: the serialized value is already attached to `ResolvedCsp.headerValue`,
+ * so callers outside this module should read that field instead of calling
+ * this function directly.
  */
-export function serializeCsp(directives: AgorCspDirectives): string {
+function serializeCsp(directives: AgorCspDirectives): string {
   return Object.entries(directives)
     .map(([name, sources]) => (sources.length === 0 ? name : `${name} ${sources.join(' ')}`))
     .join('; ');
@@ -311,6 +325,7 @@ export function resolveSecurity(
 
   // Wire up reporting: when report_uri is set, add it to the directive
   // set AND surface it so the daemon can mount a handler at that path.
+  let reportToGroup: string | undefined;
   if (csp.report_uri) {
     if (typeof csp.report_uri !== 'string' || !csp.report_uri.trim()) {
       throw new Error('security.csp.report_uri must be a non-empty string.');
@@ -322,6 +337,20 @@ export function resolveSecurity(
     }
     if (!merged['report-to']) {
       merged['report-to'] = ['agor-csp'];
+      reportToGroup = 'agor-csp';
+    } else {
+      // The operator pinned their own `report-to` group via override — use it
+      // verbatim for the matching `Report-To` header so the two stay in sync.
+      // If they wrote multiple groups, take the first (the first-listed group
+      // is the one browsers try first per CSP3 §6.2.1).
+      reportToGroup = merged['report-to'][0];
+      if (!reportToGroup) {
+        throw new Error(
+          'security.csp.override.report-to must contain at least one group name ' +
+            'when security.csp.report_uri is set, otherwise the Report-To header ' +
+            'and the report-to directive will drift.'
+        );
+      }
     }
   }
 
@@ -330,6 +359,7 @@ export function resolveSecurity(
     disabled: csp.disabled === true,
     reportOnly: csp.report_only === true,
     reportUri: csp.report_uri,
+    reportToGroup,
     headerValue: serializeCsp(merged),
   };
 
@@ -357,15 +387,18 @@ export function resolveSecurity(
       mode = parsed.mode;
       origins = parsed.origins;
     }
-  } else if (
-    opts.legacyCorsOrigins &&
-    opts.legacyCorsOrigins.length > 0 &&
-    corsSettings.origins === undefined
-  ) {
-    warn(
-      'daemon.cors_origins is deprecated; migrate to security.cors.origins. ' +
-        'The legacy value is still applied for now.'
-    );
+  } else if (opts.legacyCorsOrigins && opts.legacyCorsOrigins.length > 0) {
+    if (corsSettings.origins === undefined) {
+      warn(
+        'daemon.cors_origins is deprecated; migrate to security.cors.origins. ' +
+          'The legacy value is still applied for now.'
+      );
+    } else {
+      warn(
+        'daemon.cors_origins is deprecated AND ignored because security.cors.origins ' +
+          'is set. Remove daemon.cors_origins from your config.'
+      );
+    }
   }
 
   if (opts.legacyAllowSandpack !== undefined && corsSettings.allow_sandpack === undefined) {
@@ -398,16 +431,4 @@ export function resolveSecurity(
   };
 
   return { csp: cspResult, cors: corsResult };
-}
-
-/**
- * Convenience: resolve and return only the CSP header value. Exposed for
- * the /health endpoint, which surfaces the current policy so admins can
- * diagnose blocked resources without tailing logs.
- */
-export function resolveCspHeaderValue(
-  config: AgorConfig,
-  opts: ResolveSecurityOptions = {}
-): string {
-  return resolveSecurity(config, opts).csp.headerValue;
 }

--- a/packages/core/src/config/security-resolver.ts
+++ b/packages/core/src/config/security-resolver.ts
@@ -1,0 +1,413 @@
+/**
+ * Security config resolver.
+ *
+ * Takes the raw `security` block from `~/.agor/config.yaml` and produces a
+ * resolved shape the daemon can plug into `securityHeaders()` and `cors()`.
+ *
+ * The two-tier CSP model:
+ *   - built-in defaults (hardcoded, make bundled features work)
+ *   - `extras`: append to defaults (95% of operators)
+ *   - `override`: replace a directive wholesale (escape hatch)
+ *
+ * Validation is done here (not in `config-manager`) so that the daemon can
+ * surface clear, actionable errors at startup when config is malformed —
+ * rather than emitting a subtly-broken header and failing at request time.
+ */
+
+import type { AgorConfig, AgorCorsMode, AgorCspDirectives, AgorSecuritySettings } from './types';
+
+/**
+ * Known CSP directive names (lowercase, hyphenated). Used to validate config
+ * keys and surface typos as friendly errors. Covers Level 2 + Level 3 widely
+ * supported directives; we deliberately DON'T include legacy aliases.
+ */
+const KNOWN_CSP_DIRECTIVES: ReadonlySet<string> = new Set([
+  'default-src',
+  'script-src',
+  'script-src-elem',
+  'script-src-attr',
+  'style-src',
+  'style-src-elem',
+  'style-src-attr',
+  'img-src',
+  'font-src',
+  'connect-src',
+  'media-src',
+  'object-src',
+  'child-src',
+  'frame-src',
+  'worker-src',
+  'manifest-src',
+  'prefetch-src',
+  'frame-ancestors',
+  'form-action',
+  'base-uri',
+  'sandbox',
+  'upgrade-insecure-requests',
+  'block-all-mixed-content',
+  'require-trusted-types-for',
+  'trusted-types',
+  'report-uri',
+  'report-to',
+]);
+
+/**
+ * Origins a browser is allowed to embed Sandpack iframes/workers from.
+ *
+ * The hosted CodeSandbox bundler iframes are served from `*.codesandbox.io`.
+ * Web workers in those iframes are spawned from `blob:` URLs.
+ *
+ * Keeping this exported so tests can assert on the exact string and the
+ * daemon can reuse it for its CORS allow-list (the two need to stay in sync
+ * or sandpack breaks in subtle ways — iframe loads but posts cross-origin
+ * requests the daemon rejects).
+ */
+export const SANDPACK_CSP_FRAME_SRC = 'https://*.codesandbox.io';
+export const SANDPACK_CSP_WORKER_SRC = 'blob:';
+
+/**
+ * Built-in CSP defaults.
+ *
+ * These are designed to make every *bundled* Agor feature work out of the
+ * box — notably Sandpack-backed artifacts (`frame-src`, `worker-src`) and
+ * the FeathersJS socket.io transport (`connect-src ws:/wss:`).
+ *
+ * `connect-src` is extended at resolve-time with the daemon's own URL and
+ * any caller-supplied extras.
+ */
+function buildDefaultDirectives(opts: {
+  daemonUrl?: string;
+  extraConnectSrc?: string[];
+  allowSandpack: boolean;
+}): AgorCspDirectives {
+  const connectSrc = ["'self'", 'ws:', 'wss:'];
+  if (opts.daemonUrl) connectSrc.push(opts.daemonUrl);
+  if (opts.extraConnectSrc) connectSrc.push(...opts.extraConnectSrc);
+
+  const imgSrc = ["'self'", 'data:', 'blob:'];
+  const frameSrc = ["'self'"];
+  const workerSrc = ["'self'", SANDPACK_CSP_WORKER_SRC];
+  if (opts.allowSandpack) {
+    frameSrc.push(SANDPACK_CSP_FRAME_SRC);
+    imgSrc.push(SANDPACK_CSP_FRAME_SRC);
+  }
+
+  return {
+    'default-src': ["'self'"],
+    'script-src': ["'self'"],
+    // TODO: drop 'unsafe-inline' once Ant Design supports CSP nonces.
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': imgSrc,
+    'font-src': ["'self'", 'data:'],
+    'connect-src': connectSrc,
+    'frame-src': frameSrc,
+    'worker-src': workerSrc,
+    'frame-ancestors': ["'none'"],
+    'object-src': ["'none'"],
+    'base-uri': ["'self'"],
+  };
+}
+
+export interface ResolvedCsp {
+  /** The resolved directives (built-in ⊕ extras ⊕ override). */
+  directives: AgorCspDirectives;
+  /** True when operator set `csp.disabled: true` (no CSP header emitted). */
+  disabled: boolean;
+  /** True when the CSP should be emitted as `Content-Security-Policy-Report-Only`. */
+  reportOnly: boolean;
+  /** When set, CSP violation reports are POSTed here. */
+  reportUri?: string;
+  /** Pre-serialized header value (handy for tests and /health). */
+  headerValue: string;
+}
+
+export interface ResolvedCors {
+  /** Resolution strategy (see AgorCorsMode). */
+  mode: AgorCorsMode;
+  /** Explicit origins (used when mode=list). */
+  origins: string[];
+  /** Whether to emit Access-Control-Allow-Credentials. */
+  credentials: boolean;
+  /** Allowed methods (undefined = cors() default). */
+  methods?: string[];
+  /** Allowed request headers (undefined = reflect). */
+  allowedHeaders?: string[];
+  /** Preflight cache TTL in seconds (undefined = cors() default). */
+  maxAgeSeconds?: number;
+  /** Whether Sandpack origins are accepted. */
+  allowSandpack: boolean;
+}
+
+export interface ResolvedSecurity {
+  csp: ResolvedCsp;
+  cors: ResolvedCors;
+}
+
+export interface ResolveSecurityOptions {
+  /**
+   * Daemon's own URL (added to `connect-src` so the UI can talk to it).
+   */
+  daemonUrl?: string;
+  /**
+   * Additional `connect-src` origins the caller wants unconditionally.
+   * Usually empty — most operators should use `security.csp.extras` instead.
+   */
+  extraConnectSrc?: string[];
+  /**
+   * Legacy `daemon.cors_origins` values (for backwards compatibility).
+   * Merged with `security.cors.origins` when the new key is absent.
+   */
+  legacyCorsOrigins?: string[];
+  /**
+   * Legacy `daemon.cors_allow_sandpack` value. When `security.cors.allow_sandpack`
+   * is explicitly set (true OR false), that wins. When the new key is absent,
+   * this legacy value is used. Defaults to `true`.
+   */
+  legacyAllowSandpack?: boolean;
+  /**
+   * `CORS_ORIGIN` environment variable value. Takes precedence over all config.
+   * Parsed as comma-separated origins (same semantics as #1027).
+   */
+  corsOriginEnv?: string;
+  /**
+   * Callback for surfacing warnings to the operator (deprecation notices,
+   * dangerous combinations, etc.). Defaults to `console.warn`.
+   */
+  onWarning?: (message: string) => void;
+}
+
+function isValidDirectiveName(name: string): boolean {
+  return KNOWN_CSP_DIRECTIVES.has(name);
+}
+
+function validateDirectives(
+  directives: AgorCspDirectives | undefined,
+  label: 'extras' | 'override'
+): void {
+  if (!directives) return;
+  for (const key of Object.keys(directives)) {
+    if (!isValidDirectiveName(key)) {
+      throw new Error(
+        `security.csp.${label} contains unknown CSP directive "${key}". ` +
+          `Directive names must be lowercase-hyphenated (e.g. "script-src"). ` +
+          `Known directives: ${[...KNOWN_CSP_DIRECTIVES].sort().join(', ')}.`
+      );
+    }
+    const sources = directives[key];
+    if (!Array.isArray(sources)) {
+      throw new Error(
+        `security.csp.${label}.${key} must be an array of source strings, got ${typeof sources}.`
+      );
+    }
+    for (const src of sources) {
+      if (typeof src !== 'string') {
+        throw new Error(
+          `security.csp.${label}.${key} contains a non-string source (${typeof src}).`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Merge defaults, extras, and override into a final directive set.
+ *
+ * Semantics:
+ *   - `override` is authoritative per-directive: setting a key there wipes
+ *     whatever defaults+extras produced for the same key.
+ *   - `override: { "script-src": [] }` is legal and means "emit `script-src`
+ *     with no sources" (effectively blocks that directive entirely). It is
+ *     distinct from *omitting* the key, which means "use defaults+extras".
+ *   - Duplicate source strings are de-duplicated while preserving order.
+ */
+function mergeDirectives(
+  defaults: AgorCspDirectives,
+  extras: AgorCspDirectives | undefined,
+  override: AgorCspDirectives | undefined
+): AgorCspDirectives {
+  const result: AgorCspDirectives = {};
+
+  for (const [key, sources] of Object.entries(defaults)) {
+    result[key] = [...sources];
+  }
+
+  if (extras) {
+    for (const [key, sources] of Object.entries(extras)) {
+      const existing = result[key] ?? [];
+      const seen = new Set(existing);
+      const merged = [...existing];
+      for (const src of sources) {
+        if (!seen.has(src)) {
+          seen.add(src);
+          merged.push(src);
+        }
+      }
+      result[key] = merged;
+    }
+  }
+
+  if (override) {
+    for (const [key, sources] of Object.entries(override)) {
+      result[key] = [...sources];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Serialize a directive map into a CSP header value.
+ *
+ * Directives with empty source lists are emitted as `directive-name` (no
+ * sources after the name) — this is the correct way to block a directive
+ * entirely.
+ */
+export function serializeCsp(directives: AgorCspDirectives): string {
+  return Object.entries(directives)
+    .map(([name, sources]) => (sources.length === 0 ? name : `${name} ${sources.join(' ')}`))
+    .join('; ');
+}
+
+function parseCorsEnv(value: string): { mode: AgorCorsMode; origins: string[] } | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed === '*') {
+    return { mode: 'wildcard', origins: [] };
+  }
+  const origins = trimmed
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return { mode: 'list', origins };
+}
+
+/**
+ * Resolve the `security` config block into a ready-to-apply shape.
+ */
+export function resolveSecurity(
+  config: AgorConfig,
+  opts: ResolveSecurityOptions = {}
+): ResolvedSecurity {
+  const security: AgorSecuritySettings = config.security ?? {};
+  const warn = opts.onWarning ?? ((m: string) => console.warn(m));
+
+  // --- CSP ---------------------------------------------------------------
+  const csp = security.csp ?? {};
+  validateDirectives(csp.extras, 'extras');
+  validateDirectives(csp.override, 'override');
+
+  // Sandpack allow decision (shared with CORS below) — new key wins, then
+  // legacy daemon.cors_allow_sandpack, defaulting to true.
+  const corsSettings = security.cors ?? {};
+  const allowSandpack = corsSettings.allow_sandpack ?? opts.legacyAllowSandpack ?? true;
+
+  const defaults = buildDefaultDirectives({
+    daemonUrl: opts.daemonUrl,
+    extraConnectSrc: opts.extraConnectSrc,
+    allowSandpack,
+  });
+
+  const merged = mergeDirectives(defaults, csp.extras, csp.override);
+
+  // Wire up reporting: when report_uri is set, add it to the directive
+  // set AND surface it so the daemon can mount a handler at that path.
+  if (csp.report_uri) {
+    if (typeof csp.report_uri !== 'string' || !csp.report_uri.trim()) {
+      throw new Error('security.csp.report_uri must be a non-empty string.');
+    }
+    // Only auto-inject into the directive set if the operator hasn't already
+    // pinned `report-uri`/`report-to` via override (which we honour verbatim).
+    if (!merged['report-uri']) {
+      merged['report-uri'] = [csp.report_uri];
+    }
+    if (!merged['report-to']) {
+      merged['report-to'] = ['agor-csp'];
+    }
+  }
+
+  const cspResult: ResolvedCsp = {
+    directives: merged,
+    disabled: csp.disabled === true,
+    reportOnly: csp.report_only === true,
+    reportUri: csp.report_uri,
+    headerValue: serializeCsp(merged),
+  };
+
+  if (cspResult.disabled) {
+    warn(
+      '⚠️  security.csp.disabled=true — Content-Security-Policy header is NOT being emitted. ' +
+        'This leaves the daemon vulnerable to script injection attacks and should only be used for debugging.'
+    );
+  }
+
+  // --- CORS --------------------------------------------------------------
+  // Env var takes precedence over all config (legacy behaviour preserved).
+  let mode: AgorCorsMode = corsSettings.mode ?? 'list';
+  let origins: string[] = [...(corsSettings.origins ?? opts.legacyCorsOrigins ?? [])];
+
+  if (opts.corsOriginEnv) {
+    const parsed = parseCorsEnv(opts.corsOriginEnv);
+    if (parsed) {
+      if (corsSettings.mode !== undefined || corsSettings.origins !== undefined) {
+        warn(
+          'CORS_ORIGIN env var overrides security.cors.* config values. ' +
+            'Unset the env var to use config-file values.'
+        );
+      }
+      mode = parsed.mode;
+      origins = parsed.origins;
+    }
+  } else if (
+    opts.legacyCorsOrigins &&
+    opts.legacyCorsOrigins.length > 0 &&
+    corsSettings.origins === undefined
+  ) {
+    warn(
+      'daemon.cors_origins is deprecated; migrate to security.cors.origins. ' +
+        'The legacy value is still applied for now.'
+    );
+  }
+
+  if (opts.legacyAllowSandpack !== undefined && corsSettings.allow_sandpack === undefined) {
+    warn('daemon.cors_allow_sandpack is deprecated; migrate to security.cors.allow_sandpack.');
+  }
+
+  // Credentials default: true, unless mode is wildcard/reflect (spec forbids).
+  let credentials = corsSettings.credentials ?? true;
+  if ((mode === 'wildcard' || mode === 'reflect') && credentials === true) {
+    if (corsSettings.credentials === true) {
+      throw new Error(
+        `security.cors.credentials=true is incompatible with cors.mode="${mode}". ` +
+          'The CORS spec forbids credentialed wildcard/reflect responses (a credentialed ' +
+          'request from any site would succeed). Either set mode: list, or set credentials: false.'
+      );
+    }
+    // Default was true but mode forces false — downgrade silently with warning.
+    warn(`⚠️  security.cors.mode=${mode} forces credentials=false (spec requirement).`);
+    credentials = false;
+  }
+
+  const corsResult: ResolvedCors = {
+    mode,
+    origins,
+    credentials,
+    methods: corsSettings.methods,
+    allowedHeaders: corsSettings.allowed_headers,
+    maxAgeSeconds: corsSettings.max_age_seconds,
+    allowSandpack,
+  };
+
+  return { csp: cspResult, cors: corsResult };
+}
+
+/**
+ * Convenience: resolve and return only the CSP header value. Exposed for
+ * the /health endpoint, which surfaces the current policy so admins can
+ * diagnose blocked resources without tailing logs.
+ */
+export function resolveCspHeaderValue(
+  config: AgorConfig,
+  opts: ResolveSecurityOptions = {}
+): string {
+  return resolveSecurity(config, opts).csp.headerValue;
+}

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -373,6 +373,162 @@ export interface AgorExecutionSettings {
 }
 
 /**
+ * Security headers & CORS settings.
+ *
+ * Makes the daemon's Content-Security-Policy and CORS policy tunable from
+ * `~/.agor/config.yaml` without code changes. See `context/concepts/security.md`
+ * for the full model and the rationale behind the two-tier CSP shape.
+ */
+
+/**
+ * Per-directive CSP source lists, keyed by the standard directive names.
+ *
+ * Keys must be lowercase-hyphenated directive names (e.g. `script-src`,
+ * `frame-src`, `connect-src`). Values are arrays of CSP source expressions
+ * (`'self'`, `'unsafe-inline'`, URLs, schemes, nonces, etc.). The loader
+ * rejects unknown directive names with a friendly error.
+ */
+export type AgorCspDirectives = Record<string, string[]>;
+
+/**
+ * CSP configuration.
+ *
+ * Two-tier model:
+ *   - `extras`: append to built-in defaults (append-only, 95% case)
+ *   - `override`: fully replace a directive's source list (escape hatch)
+ *
+ * Setting a directive in `override` causes defaults AND extras for that
+ * directive to be ignored — `override` is authoritative per-directive.
+ *
+ * Examples:
+ * ```yaml
+ * security:
+ *   csp:
+ *     extras:
+ *       script-src: ["https://plausible.io"]
+ *       frame-src: ["https://my-sandbox.example.com"]
+ *     override:
+ *       img-src: ["'self'", "data:"]
+ * ```
+ */
+export interface AgorCspSettings {
+  /**
+   * Per-directive APPEND to built-in defaults. This is the 95% case.
+   * Entries are merged and de-duplicated with the built-in default sources.
+   */
+  extras?: AgorCspDirectives;
+
+  /**
+   * Full replacement of a directive's source list. Escape hatch — rarely needed.
+   * Setting a directive here ignores defaults AND extras for that directive.
+   */
+  override?: AgorCspDirectives;
+
+  /**
+   * Path (or absolute URL) that receives CSP violation reports. When set:
+   *   - emits the `report-uri` directive on the CSP header (deprecated but
+   *     still supported by all browsers)
+   *   - emits a `Report-To` header pointing at the same path (modern browsers)
+   *   - the daemon hosts a rate-limited endpoint at this path that logs
+   *     incoming reports at `warn` level.
+   * @example "/api/csp-report"
+   */
+  report_uri?: string;
+
+  /**
+   * Emit as `Content-Security-Policy-Report-Only` instead of enforcing.
+   * Useful for iterating on policy without breaking the app.
+   * Default: false.
+   */
+  report_only?: boolean;
+
+  /**
+   * Fully disable the CSP header. Dev/debug only — the daemon emits a loud
+   * startup warning when this is true. Default: false.
+   */
+  disabled?: boolean;
+}
+
+/**
+ * How CORS origins are resolved.
+ *
+ * - `list` (default): only origins in `origins` are allowed (plus built-ins:
+ *   localhost, Sandpack if enabled, GitHub Codespaces if detected).
+ * - `wildcard`: reflect ANY origin. Forces `credentials: false`. Dangerous
+ *   outside of local dev; the daemon refuses to boot in hardened deployment
+ *   modes when this is set.
+ * - `reflect`: echo the request's `Origin` header back as the allowed origin.
+ *   Less permissive than wildcard for caches (Vary: Origin), but still permits
+ *   any caller — treat it like wildcard for threat-model purposes.
+ * - `null-origin`: allow the literal `Origin: null` header (sandboxed iframes,
+ *   file:// documents). Rarely needed.
+ */
+export type AgorCorsMode = 'list' | 'wildcard' | 'reflect' | 'null-origin';
+
+/**
+ * CORS configuration.
+ *
+ * Supersedes the legacy `daemon.cors_origins` and `daemon.cors_allow_sandpack`
+ * keys. Those still work for backwards compatibility — their values are merged
+ * in when `security.cors.origins` is absent — but they emit a deprecation
+ * warning at startup. The `CORS_ORIGIN` env var continues to win over all
+ * config sources to keep existing deployments working.
+ */
+export interface AgorCorsSettings {
+  /**
+   * Origin resolution strategy. Defaults to `list`.
+   */
+  mode?: AgorCorsMode;
+
+  /**
+   * Exact origins or `/regex/` patterns to allow (used when `mode: list`).
+   * Plain strings are exact matches; wrap in `/slashes/` for regex.
+   */
+  origins?: string[];
+
+  /**
+   * Whether to emit `Access-Control-Allow-Credentials: true`. Default: true.
+   * Rejected at config load when combined with `mode: wildcard` or `reflect`
+   * (the CORS spec forbids credentialed wildcard reflection).
+   */
+  credentials?: boolean;
+
+  /**
+   * Allowed methods. Defaults to the `cors` package's default set.
+   */
+  methods?: string[];
+
+  /**
+   * Allowed request headers. When omitted, the `cors` package reflects
+   * `Access-Control-Request-Headers` (its default behaviour).
+   */
+  allowed_headers?: string[];
+
+  /**
+   * Value for the `Access-Control-Max-Age` preflight cache header, in seconds.
+   * Default: unset (leaves it to the `cors` package default, usually 5s).
+   */
+  max_age_seconds?: number;
+
+  /**
+   * Allow Sandpack/CodeSandbox bundler origins (`https://*.codesandbox.io`).
+   * Defaults to true so first-party artifacts work out of the box.
+   */
+  allow_sandpack?: boolean;
+}
+
+/**
+ * Top-level security config block.
+ */
+export interface AgorSecuritySettings {
+  /** Content-Security-Policy configuration (extras/override/report-only/disabled). */
+  csp?: AgorCspSettings;
+
+  /** CORS configuration (origins, credentials, methods, headers, max-age). */
+  cors?: AgorCorsSettings;
+}
+
+/**
  * Path configuration settings
  *
  * Allows separation of daemon operating files from git data files.
@@ -477,6 +633,9 @@ export interface AgorConfig {
   /** Execution isolation settings */
   execution?: AgorExecutionSettings;
 
+  /** Security headers & CORS (CSP extras/override, CORS mode/origins, etc.) */
+  security?: AgorSecuritySettings;
+
   /** Path configuration (data_home for repos/worktrees separation) */
   paths?: AgorPathSettings;
 
@@ -521,6 +680,7 @@ export type ConfigKey =
   | `opencode.${keyof AgorOpenCodeSettings}`
   | `codex.${keyof AgorCodexSettings}`
   | `execution.${keyof AgorExecutionSettings}`
+  | `security.${keyof AgorSecuritySettings}`
   | `paths.${keyof AgorPathSettings}`
   | `credentials.${keyof AgorCredentials}`
   | `onboarding.${keyof AgorOnboardingSettings}`


### PR DESCRIPTION
## Summary

Makes the daemon's Content-Security-Policy and CORS configurable via `~/.agor/config.yaml` under a new `security:` block, while baking in Sandpack-friendly defaults so bundled features (notably Sandpack-backed artifacts) keep working out of the box.

This addresses a regression from #1027, which shipped a hardcoded CSP that lacked `frame-src` / `worker-src` entries for `https://*.codesandbox.io` + `blob:`, breaking Sandpack iframes.

### What's new

- **`security.csp`** — two-tier model: `extras` (append) + `override` (replace). Unknown directives are rejected at load time with an actionable error. Optional `report_only` and `report_uri` (auto-wires both `report-uri` directive and a modern `Report-To` header under the `agor-csp` group).
- **`security.cors`** — mode-based (`list` | `wildcard` | `reflect` | `null-origin`) + explicit `origins`, `credentials`, `methods`, `allowed_headers`, `max_age_seconds`, `allow_sandpack`. Rejects `credentials: true` combined with `wildcard`/`reflect` at load time (spec violation).
- **Backcompat** — legacy `daemon.cors_origins`, `daemon.cors_allow_sandpack`, and the `CORS_ORIGIN` env var continue to work and are merged into the resolved config with deprecation warnings.
- **Violation reporting** — when `report_uri` points at a path (e.g. `/csp-report`), the daemon mounts a rate-limited (2 req/s, 16kb) report collector endpoint automatically.
- **About page** — new "Security Headers (Admin Only)" card surfaces CSP/CORS posture, full CSP header value (copyable), and origin counts so operators can verify config at a glance.
- **Docs** — new `context/concepts/security.md` with design rationale, recipes, debugging guide; AGENTS.md gets a short pointer.
- **Tests** — 24 resolver tests + rewritten middleware tests covering defaults, overrides, wildcards, null-origin, env-var precedence, and deprecation warnings.

### Shape

```yaml
security:
  csp:
    extras:
      script-src: ["https://plausible.io"]
    override:
      frame-src: ["'self'", "https://*.codesandbox.io", "https://my-embed.example"]
    report_only: false
    report_uri: /csp-report
  cors:
    mode: list           # list | wildcard | reflect | null-origin
    origins: ["https://app.example.com", "/^https:\\/\\/.*\\.example\\.com$/"]
    credentials: true
    allow_sandpack: true
```

## Test plan

- [x] `pnpm check` passes (lint + typecheck + tests)
- [x] Security resolver tests cover defaults, extras, override (including empty-array blocking), unknown-directive rejection, wildcard+credentials rejection, null-origin, env-var precedence, legacy key warnings
- [x] CORS middleware tests cover wildcard, null-origin, list mode with localhost range + sandpack + configured origins + regex patterns
- [x] Security headers middleware tests cover report-only, disabled, Report-To emission, extras passthrough
- [ ] Manual: start daemon with default config, verify Sandpack iframes render
- [ ] Manual: set `security.csp.report_only: true`, trigger a violation, verify endpoint receives the report
- [ ] Manual: About → Security Headers (admin) shows resolved CSP + CORS posture

🤖 Generated with [Claude Code](https://claude.com/claude-code)