### PR TITLE
fix(ui): show stopped/unknown todo items when parent task is no longer running

### DIFF
--- a/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.stories.tsx
+++ b/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.stories.tsx
@@ -1,0 +1,152 @@
+/**
+ * StickyTodoRenderer Storybook Stories
+ *
+ * Exercises the parent-task-status → display-status override matrix:
+ *   - RUNNING        → in_progress items keep spinner (no override)
+ *   - STOPPED        → in_progress items render as 'stopped'
+ *   - COMPLETED      → in_progress items render as 'unknown' (agent forgot to update)
+ *   - FAILED         → in_progress items render as 'unknown'
+ *   - TIMED_OUT      → in_progress items render as 'unknown'
+ *   - AWAITING_INPUT → in_progress items keep spinner (task is paused, not stopped)
+ */
+
+import type { Message } from '@agor-live/client';
+import { TaskStatus } from '@agor-live/client';
+import type { Meta, StoryObj } from '@storybook/react';
+import { StickyTodoRenderer } from './StickyTodoRenderer';
+
+/**
+ * Build a minimal Message[] containing a single TodoWrite tool_use block.
+ * The renderer scans for the latest TodoWrite, so anything else is irrelevant.
+ */
+function buildMessages(
+  todos: Array<{ content: string; activeForm: string; status: string }>
+): Message[] {
+  return [
+    {
+      message_id: 'msg-1',
+      session_id: 'session-1',
+      type: 'assistant',
+      role: 'assistant',
+      index: 0,
+      timestamp: '2026-04-18T00:00:00Z',
+      content_preview: 'TodoWrite',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool-use-1',
+          name: 'TodoWrite',
+          input: { todos },
+        },
+      ],
+    } as unknown as Message,
+  ];
+}
+
+const SAMPLE_TODOS = [
+  {
+    content: 'Read existing TodoListRenderer implementation',
+    activeForm: 'Reading TodoListRenderer implementation',
+    status: 'completed',
+  },
+  {
+    content: 'Wire taskStatus through StickyTodoRenderer',
+    activeForm: 'Wiring taskStatus through',
+    status: 'in_progress',
+  },
+  {
+    content: 'Add stopped/unknown display states',
+    activeForm: 'Adding display states',
+    status: 'pending',
+  },
+];
+
+const meta = {
+  title: 'Components/StickyTodoRenderer',
+  component: StickyTodoRenderer,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof StickyTodoRenderer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Task is running — in_progress items show the live spinner (no override).
+ */
+export const Running: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.RUNNING,
+  },
+};
+
+/**
+ * User halted the task — in_progress items render as 'stopped' (StopOutlined, muted).
+ */
+export const Stopped: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.STOPPED,
+  },
+};
+
+/**
+ * Stop requested but SDK hasn't halted yet — same treatment as STOPPED.
+ */
+export const Stopping: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.STOPPING,
+  },
+};
+
+/**
+ * Task completed but agent never marked this item done — render as 'unknown'.
+ */
+export const CompletedWithUnmarkedItem: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.COMPLETED,
+  },
+};
+
+/**
+ * Task failed mid-run — leftover in_progress items render as 'unknown'.
+ */
+export const Failed: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.FAILED,
+  },
+};
+
+/**
+ * Task timed out — leftover in_progress items render as 'unknown'.
+ */
+export const TimedOut: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.TIMED_OUT,
+  },
+};
+
+/**
+ * Task is waiting for user input — items remain in_progress (task can resume).
+ */
+export const AwaitingInput: Story = {
+  args: {
+    messages: buildMessages(SAMPLE_TODOS),
+    taskStatus: TaskStatus.AWAITING_INPUT,
+  },
+};
+
+/**
+ * No TodoWrite in the message stream — renders nothing.
+ */
+export const NoTodos: Story = {
+  args: {
+    messages: [],
+    taskStatus: TaskStatus.RUNNING,
+  },
+};

--- a/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
+++ b/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
@@ -97,7 +97,7 @@ export function StickyTodoRenderer({ messages, taskStatus }: StickyTodoRendererP
     const override = inProgressOverrideFor(taskStatus);
     if (!override) return latestTodo;
     return latestTodo.map((todo) =>
-      todo.status === 'in_progress' ? { ...todo, status: override } : todo,
+      todo.status === 'in_progress' ? { ...todo, status: override } : todo
     );
   }, [latestTodo, taskStatus]);
 

--- a/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
+++ b/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
@@ -12,16 +12,52 @@
  * - Only renders when TODOs exist (returns null otherwise)
  */
 
-import type { Message } from '@agor-live/client';
+import { type Message, TaskStatus } from '@agor-live/client';
 import { theme } from 'antd';
 import { useMemo } from 'react';
-import { parseTodosInput, TodoListRenderer } from '../ToolUseRenderer/renderers/TodoListRenderer';
+import {
+  parseTodosInput,
+  type RenderableTodoItem,
+  type RenderableTodoStatus,
+  TodoListRenderer,
+} from '../ToolUseRenderer/renderers/TodoListRenderer';
 
 interface StickyTodoRendererProps {
   /**
    * Messages from the task - will be scanned in reverse to find latest TodoWrite
    */
   messages: Message[];
+
+  /**
+   * Status of the parent task. Used to decide whether items still marked
+   * `in_progress` should be displayed as `stopped` (user halted the task) or
+   * `unknown` (task ended without the agent updating this item).
+   */
+  taskStatus: TaskStatus;
+}
+
+/**
+ * If the parent task is no longer running, items still in `in_progress` cannot
+ * truly be running. Map them to a display-only status that conveys what we
+ * actually know:
+ *
+ * - User halted (STOPPED/STOPPING): we know the work didn't finish → 'stopped'
+ * - Task ended otherwise (COMPLETED/FAILED/TIMED_OUT) without the agent
+ *   updating this item: we don't know if it finished → 'unknown'
+ * - Active/waiting states (RUNNING, CREATED, AWAITING_*): leave as-is
+ */
+function inProgressOverrideFor(taskStatus: TaskStatus): RenderableTodoStatus | null {
+  switch (taskStatus) {
+    case TaskStatus.STOPPED:
+    case TaskStatus.STOPPING:
+      return 'stopped';
+    case TaskStatus.COMPLETED:
+    case TaskStatus.FAILED:
+    case TaskStatus.TIMED_OUT:
+      return 'unknown';
+    default:
+      return null;
+  }
 }
 
 /**
@@ -30,7 +66,7 @@ interface StickyTodoRendererProps {
  *
  * Performance: Uses useMemo + early exit strategy (O(1) to O(5) in practice)
  */
-export function StickyTodoRenderer({ messages }: StickyTodoRendererProps) {
+export function StickyTodoRenderer({ messages, taskStatus }: StickyTodoRendererProps) {
   const { token } = theme.useToken();
 
   // Scan messages in reverse to find latest TodoWrite
@@ -53,8 +89,20 @@ export function StickyTodoRenderer({ messages }: StickyTodoRendererProps) {
     return null;
   }, [messages]);
 
+  // Apply display-only transform: items still `in_progress` are rewritten when
+  // the parent task can no longer be making progress. Underlying message data
+  // is untouched — historical tool blocks render the original status.
+  const displayTodos = useMemo<RenderableTodoItem[] | null>(() => {
+    if (!latestTodo) return null;
+    const override = inProgressOverrideFor(taskStatus);
+    if (!override) return latestTodo;
+    return latestTodo.map((todo) =>
+      todo.status === 'in_progress' ? { ...todo, status: override } : todo,
+    );
+  }, [latestTodo, taskStatus]);
+
   // Don't render if no TODOs found
-  if (!latestTodo) return null;
+  if (!displayTodos) return null;
 
   return (
     <div
@@ -67,7 +115,7 @@ export function StickyTodoRenderer({ messages }: StickyTodoRendererProps) {
         transition: 'opacity 0.3s ease',
       }}
     >
-      <TodoListRenderer toolUseId="sticky-todo" input={{ todos: latestTodo }} />
+      <TodoListRenderer toolUseId="sticky-todo" input={{ todos: displayTodos }} />
     </div>
   );
 }

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -693,7 +693,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                   })}
 
                 {/* Keep latest TODO visible even after completion (Claude parity). */}
-                <StickyTodoRenderer messages={messages} />
+                <StickyTodoRenderer messages={messages} taskStatus={task.status} />
 
                 {/* Show typing indicator whenever task is actively running */}
                 {task.status === TaskStatus.RUNNING && (

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.stories.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.stories.tsx
@@ -246,3 +246,62 @@ export const Empty: Story = {
     },
   },
 };
+
+/**
+ * Display-only `stopped` status — applied by StickyTodoRenderer when the
+ * parent task was halted by the user but items remain in_progress.
+ */
+export const StoppedItems: Story = {
+  args: {
+    toolUseId: 'tool_use_8',
+    input: {
+      todos: [
+        {
+          content: 'Run database migrations',
+          activeForm: 'Running database migrations',
+          status: 'completed',
+        },
+        {
+          content: 'Implement user registration endpoint',
+          activeForm: 'Implementing user registration endpoint',
+          status: 'stopped',
+        },
+        {
+          content: 'Add email verification',
+          activeForm: 'Adding email verification',
+          status: 'pending',
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * Display-only `unknown` status — applied by StickyTodoRenderer when the
+ * parent task ended (completed/failed/timed out) without the agent updating
+ * an item that was still in_progress.
+ */
+export const UnknownItems: Story = {
+  args: {
+    toolUseId: 'tool_use_9',
+    input: {
+      todos: [
+        {
+          content: 'Run database migrations',
+          activeForm: 'Running database migrations',
+          status: 'completed',
+        },
+        {
+          content: 'Implement user registration endpoint',
+          activeForm: 'Implementing user registration endpoint',
+          status: 'unknown',
+        },
+        {
+          content: 'Add email verification',
+          activeForm: 'Adding email verification',
+          status: 'pending',
+        },
+      ],
+    },
+  },
+};

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/TodoListRenderer.tsx
@@ -8,7 +8,7 @@
  * - Compact inline display
  */
 
-import { CheckCircleFilled } from '@ant-design/icons';
+import { CheckCircleFilled, QuestionCircleOutlined, StopOutlined } from '@ant-design/icons';
 import { Spin, theme } from 'antd';
 import type React from 'react';
 
@@ -18,8 +18,23 @@ export interface TodoItem {
   status: 'pending' | 'in_progress' | 'completed';
 }
 
+/**
+ * Display-only synthetic statuses applied by the sticky renderer when the
+ * parent task is no longer running. They never appear in the raw TodoWrite
+ * tool input and are only produced by the rendering layer.
+ *
+ * - 'stopped': user explicitly halted the task (TaskStatus.STOPPED/STOPPING)
+ * - 'unknown': task ended (completed/failed/timed_out) without the agent
+ *   marking this item — we can't tell whether it actually finished
+ */
+export type RenderableTodoStatus = TodoItem['status'] | 'stopped' | 'unknown';
+
+export interface RenderableTodoItem extends Omit<TodoItem, 'status'> {
+  status: RenderableTodoStatus;
+}
+
 interface TodoWriteInput {
-  todos: TodoItem[];
+  todos: RenderableTodoItem[];
 }
 
 /**
@@ -71,7 +86,7 @@ const CircleIcon: React.FC<{ color: string }> = ({ color }) => (
 /**
  * Renders a single todo item with status indicator
  */
-const TodoItemRow: React.FC<{ todo: TodoItem; index: number }> = ({ todo, index }) => {
+const TodoItemRow: React.FC<{ todo: RenderableTodoItem; index: number }> = ({ todo, index }) => {
   const { token } = theme.useToken();
 
   // Determine icon and color based on status
@@ -92,6 +107,26 @@ const TodoItemRow: React.FC<{ todo: TodoItem; index: number }> = ({ todo, index 
             size="small"
             style={{
               color: token.colorPrimary,
+              fontSize: 14,
+            }}
+          />
+        );
+      case 'stopped':
+        return (
+          <StopOutlined
+            aria-label="Stopped task"
+            style={{
+              color: token.colorTextTertiary,
+              fontSize: 14,
+            }}
+          />
+        );
+      case 'unknown':
+        return (
+          <QuestionCircleOutlined
+            aria-label="Unknown task state"
+            style={{
+              color: token.colorTextTertiary,
               fontSize: 14,
             }}
           />
@@ -121,6 +156,13 @@ const TodoItemRow: React.FC<{ todo: TodoItem; index: number }> = ({ todo, index 
           ...baseStyle,
           color: token.colorText,
           fontWeight: 500,
+        };
+      case 'stopped':
+      case 'unknown':
+        return {
+          ...baseStyle,
+          color: token.colorTextTertiary,
+          fontStyle: 'italic',
         };
       default:
         return {


### PR DESCRIPTION
## Summary

The bottom-of-session sticky todo list (`StickyTodoRenderer`) rendered items still in `in_progress` state with the live spinner even after the parent task had stopped, failed, timed out, or completed without the agent updating those items. That's misleading — nothing is actually running anymore.

This adds a display-only status override driven by `task.status`:

- **`stopped`** (new, `StopOutlined`, muted/italic) — applied when the user halted the task (`TaskStatus.STOPPED` / `STOPPING`). We *know* the work didn't finish.
- **`unknown`** (new, `QuestionCircleOutlined`, muted/italic) — applied when the task ended (`TaskStatus.COMPLETED` / `FAILED` / `TIMED_OUT`) but the agent never updated this item. We can't tell whether it actually got done.
- Active/waiting states (`RUNNING`, `CREATED`, `AWAITING_*`) — unchanged, items still spin as before.

The two display states are deliberately distinct: a user-initiated stop is a different signal than the agent simply forgetting to mark an item.

## Scope

- **Touched:** `StickyTodoRenderer` (the latest/live todo at the bottom of the session) and the shared `TodoListRenderer` switch — extended with two new display-only status branches.
- **Not touched:** Historical tool-block rendering. `TodoListRenderer` used inside `ToolUseRenderer` always receives the original `TodoWrite` tool input verbatim (only `pending` / `in_progress` / `completed`), so it never produces the new statuses. Past tool blocks render exactly as before.
- Underlying message data is not mutated. The override is computed in `StickyTodoRenderer` and passed via a new display-only `RenderableTodoItem` type.

## Test plan

- [ ] Start a task that calls `TodoWrite` with `in_progress` items, then **stop it** mid-run → in_progress items should render with the `StopOutlined` icon, muted/italic.
- [ ] Let a task end (or simulate FAILED / TIMED_OUT) without the agent marking all items done → leftover `in_progress` items render with `QuestionCircleOutlined`, muted/italic.
- [ ] While a task is `RUNNING` → in_progress items still show the spinner (unchanged).
- [ ] Scroll up to a historical `TodoWrite` tool block → renders the original status with original icons (spinner for `in_progress`), regardless of current task status.
- [ ] New Storybook stories `Tool Renderers/TodoListRenderer/StoppedItems` and `UnknownItems` render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)