### PR TITLE
sec(daemon): authenticate terminal:* websocket events

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -478,6 +478,11 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     jwtSecret,
     allowAnonymous,
     credentialsAllowed,
+    // Mirror the HTTP terminals service gate (register-hooks.ts) so the
+    // `allow_web_terminal: false` kill-switch is enforced on the WebSocket
+    // transport too. Without this the terminal:* relay events would still
+    // accept traffic when the HTTP modal is disabled.
+    webTerminalEnabled: config.execution?.allow_web_terminal !== false,
   });
   app.configure(socketio(socketIOConfig.serverOptions, socketIOConfig.callback));
   configureChannels(app);

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -144,9 +144,28 @@ const BOB = '22222222-bbbb-bbbb-bbbb-222222222222';
 function asUser(socket: FakeSocket, userId: string) {
   socket.feathers = { user: { user_id: userId } };
 }
-function asService(socket: FakeSocket) {
-  socket.feathers = {};
+/**
+ * Simulate a socket that presented a service token in the initial handshake.
+ * The handshake middleware sets socket.data.isService AND attaches a synthetic
+ * service user to feathers.user — we mirror both markers here.
+ */
+function asServiceHandshake(socket: FakeSocket) {
+  socket.feathers = {
+    user: { user_id: 'executor-service', _isServiceAccount: true },
+  };
   socket.data.isService = true;
+}
+/**
+ * Simulate an executor that connected anonymously and then authenticated
+ * post-connect via `client.authenticate({ strategy: 'jwt', ... })`. The
+ * Feathers login flow attaches the synthetic user with `_isServiceAccount:
+ * true` but does NOT set socket.data.isService. This path is what
+ * packages/executor/src/services/feathers-client.ts actually does.
+ */
+function asServicePostConnect(socket: FakeSocket) {
+  socket.feathers = {
+    user: { user_id: 'executor-service', _isServiceAccount: true },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -172,34 +191,45 @@ describe('getSocketAuthState', () => {
   it('reports user auth when feathers.user.user_id is present', () => {
     const s = makeSocket();
     asUser(s, ALICE);
-    expect(getSocketAuthState(s as any)).toEqual({
-      userId: ALICE,
-      isService: false,
-      isAuthenticated: true,
-    });
+    expect(getSocketAuthState(s as any)).toEqual({ userId: ALICE, isService: false });
   });
-  it('reports service auth when socket.data.isService is set', () => {
+  it('reports service auth for handshake-tagged sockets (socket.data.isService)', () => {
     const s = makeSocket();
-    asService(s);
-    expect(getSocketAuthState(s as any)).toEqual({
-      userId: null,
-      isService: true,
-      isAuthenticated: true,
-    });
+    asServiceHandshake(s);
+    expect(getSocketAuthState(s as any)).toEqual({ userId: null, isService: true });
   });
-  it('reports unauthenticated when neither marker is present', () => {
+  it('reports service auth for post-connect authed sockets (_isServiceAccount only)', () => {
+    // This is the path the executor actually takes:
+    //   client.io.connect()  → anonymous, no socket.data.isService
+    //   client.authenticate({ strategy: 'jwt', ... })
+    //     → ServiceJWTStrategy.getEntity attaches _isServiceAccount: true
+    // The previous implementation rejected these sockets for terminal:output /
+    // exit / tab because it only checked socket.data.isService.
     const s = makeSocket();
-    expect(getSocketAuthState(s as any)).toEqual({
-      userId: null,
-      isService: false,
-      isAuthenticated: false,
-    });
+    asServicePostConnect(s);
+    expect(getSocketAuthState(s as any)).toEqual({ userId: null, isService: true });
+  });
+  it('service account wins over user_id: synthetic executor user is not treated as a real user', () => {
+    // The synthetic service user carries user_id='executor-service'. If we
+    // checked user_id first, we'd treat that as a real user and allow
+    // terminal:input/resize (which are disallowed for service sockets).
+    const s = makeSocket();
+    asServicePostConnect(s);
+    const auth = getSocketAuthState(s as any);
+    expect(auth.userId).toBeNull();
+    expect(auth.isService).toBe(true);
+  });
+  it('reports unauthenticated when no markers are present', () => {
+    const s = makeSocket();
+    expect(getSocketAuthState(s as any)).toEqual({ userId: null, isService: false });
   });
   it('treats an empty feathers object without isService as anonymous', () => {
     // Defends against confusing service ↔ "feathers attached but no user yet".
     const s = makeSocket();
     s.feathers = {};
-    expect(getSocketAuthState(s as any).isAuthenticated).toBe(false);
+    const auth = getSocketAuthState(s as any);
+    expect(auth.userId).toBeNull();
+    expect(auth.isService).toBe(false);
   });
 });
 
@@ -358,10 +388,13 @@ describe('terminal:* handler authorization', () => {
       expect(io.emitted).toEqual([]);
     });
 
-    it('terminal:output accepts service sockets and relays to the channel', () => {
+    it('terminal:output accepts post-connect authed service sockets and relays to channel', () => {
+      // Regression for executor flow: connect anonymously, then
+      // client.authenticate() attaches `_isServiceAccount: true` to feathers.user
+      // without ever setting socket.data.isService. Previous impl rejected this.
       const { io } = buildHarness();
       const s = makeSocket('exec-sock');
-      asService(s);
+      asServicePostConnect(s);
       connect(io, s);
       s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'hello' });
       expect(io.emitted).toEqual([
@@ -373,10 +406,26 @@ describe('terminal:* handler authorization', () => {
       ]);
     });
 
+    it('terminal:output also accepts handshake-token service sockets (socket.data.isService path)', () => {
+      // Separately covers the fast-path: service token presented at handshake.
+      const { io } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServiceHandshake(s);
+      connect(io, s);
+      s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'hi' });
+      expect(io.emitted).toEqual([
+        {
+          channel: `user/${ALICE}/terminal`,
+          event: 'terminal:output',
+          data: { userId: ALICE, data: 'hi' },
+        },
+      ]);
+    });
+
     it('all three reject when allow_web_terminal is false even for service sockets', () => {
       const { io } = buildHarness({ webTerminalEnabled: false });
       const s = makeSocket('exec-sock');
-      asService(s);
+      asServicePostConnect(s);
       connect(io, s);
       s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'x' });
       s.handlers.get('terminal:exit')?.({ userId: ALICE, exitCode: 0 });
@@ -419,7 +468,7 @@ describe('terminal:* handler authorization', () => {
     it('allows a service socket to join any user terminal channel', () => {
       const { io } = buildHarness();
       const s = makeSocket('exec-sock');
-      asService(s);
+      asServicePostConnect(s);
       connect(io, s);
       s.handlers.get('join')?.(`user/${ALICE}/terminal`);
       s.handlers.get('join')?.(`user/${BOB}/terminal`);

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Socket.io terminal-channel authorization tests.
+ *
+ * Covers the auth/identity boundary on `terminal:*` events and the
+ * `user/*\/terminal` channel join. The vulnerability we're testing for:
+ *
+ *   - An anonymous (or any other-user) socket must NOT be able to inject
+ *     keystrokes into another user's web terminal.
+ *   - A client-supplied `userId` in an event payload must NEVER be trusted
+ *     in place of the socket's authenticated identity.
+ *   - `execution.allow_web_terminal: false` must kill terminal:* on the WS
+ *     transport, not just on HTTP.
+ *   - Only service-token sockets (executor) may emit terminal:output /
+ *     terminal:exit / terminal:tab — otherwise a member could spoof output
+ *     into another user's terminal or open a Zellij tab in a worktree
+ *     they don't have RBAC on.
+ *   - terminal:input must be rate-limited per-socket.
+ *
+ * Strategy: build a minimal fake socket / fake io / fake app, run the
+ * connection callback, capture the registered handlers, and exercise them
+ * directly. Avoids spinning a real socket.io server / port.
+ */
+
+import type { Application } from '@agor/core/feathers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSocketIOConfig,
+  createTokenBucket,
+  getSocketAuthState,
+  parseTerminalChannel,
+  type SocketIOOptions,
+} from './socketio';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+interface FakeSocket {
+  id: string;
+  feathers?: any;
+  data: Record<string, any>;
+  handshake: { auth?: { token?: string }; headers?: Record<string, string> };
+  connected: boolean;
+  joined: Set<string>;
+  left: Set<string>;
+  handlers: Map<string, (...args: any[]) => void>;
+  on(event: string, fn: (...args: any[]) => void): void;
+  join(channel: string): void;
+  leave(channel: string): void;
+  broadcast: { emit: (...args: any[]) => void };
+}
+
+interface FakeIO {
+  connectionHandler?: (socket: FakeSocket) => void;
+  emitted: Array<{ channel: string; event: string; data: unknown }>;
+  sockets: { sockets: Map<string, FakeSocket> };
+  middlewares: Array<(socket: FakeSocket, next: (err?: Error) => void) => void>;
+  on(event: string, fn: any): void;
+  use(fn: any): void;
+  to(channel: string): { emit: (event: string, data: unknown) => void };
+}
+
+function makeSocket(id = 'sock1'): FakeSocket {
+  const handlers = new Map<string, (...args: any[]) => void>();
+  return {
+    id,
+    data: {},
+    handshake: { auth: {}, headers: {} },
+    connected: true,
+    joined: new Set(),
+    left: new Set(),
+    handlers,
+    on(event, fn) {
+      handlers.set(event, fn);
+    },
+    join(channel) {
+      this.joined.add(channel);
+    },
+    leave(channel) {
+      this.left.add(channel);
+    },
+    broadcast: { emit: () => {} },
+  };
+}
+
+function makeIO(): FakeIO {
+  const io: FakeIO = {
+    emitted: [],
+    sockets: { sockets: new Map() },
+    middlewares: [],
+    on(event, fn) {
+      if (event === 'connection') {
+        this.connectionHandler = fn;
+      }
+    },
+    use(fn) {
+      this.middlewares.push(fn);
+    },
+    to(channel: string) {
+      const emitted = this.emitted;
+      return {
+        emit(event: string, data: unknown) {
+          emitted.push({ channel, event, data });
+        },
+      };
+    },
+  };
+  return io;
+}
+
+function makeApp(): Application {
+  // Minimal Application surface used by createSocketIOConfig: app.service('users').get
+  // and app.on('login'). Tests don't exercise the login event path.
+  return {
+    service: () => ({ get: async () => ({ user_id: 'u' }) }),
+    on: () => {},
+  } as any;
+}
+
+function buildHarness(opts: Partial<SocketIOOptions> = {}) {
+  const app = makeApp();
+  const io = makeIO();
+  const config = createSocketIOConfig(app, {
+    corsOrigin: '*',
+    jwtSecret: 'test-secret',
+    allowAnonymous: false,
+    credentialsAllowed: false,
+    webTerminalEnabled: true,
+    ...opts,
+  } as SocketIOOptions);
+  config.callback(io as any);
+  return { io, config };
+}
+
+function connect(io: FakeIO, socket: FakeSocket) {
+  io.sockets.sockets.set(socket.id, socket);
+  io.connectionHandler?.(socket);
+}
+
+// Identity helpers — keep all strings UUID-shaped enough for log slicing.
+const ALICE = '11111111-aaaa-aaaa-aaaa-111111111111';
+const BOB = '22222222-bbbb-bbbb-bbbb-222222222222';
+
+function asUser(socket: FakeSocket, userId: string) {
+  socket.feathers = { user: { user_id: userId } };
+}
+function asService(socket: FakeSocket) {
+  socket.feathers = {};
+  socket.data.isService = true;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('parseTerminalChannel', () => {
+  it('extracts user id from a well-formed channel', () => {
+    expect(parseTerminalChannel(`user/${ALICE}/terminal`)).toBe(ALICE);
+  });
+  it('rejects non-terminal channels', () => {
+    expect(parseTerminalChannel('user/abc/other')).toBeNull();
+    expect(parseTerminalChannel('foo/abc/terminal')).toBeNull();
+    expect(parseTerminalChannel('')).toBeNull();
+  });
+  it('rejects empty or nested userIds', () => {
+    expect(parseTerminalChannel('user//terminal')).toBeNull();
+    expect(parseTerminalChannel('user/a/b/terminal')).toBeNull();
+  });
+});
+
+describe('getSocketAuthState', () => {
+  it('reports user auth when feathers.user.user_id is present', () => {
+    const s = makeSocket();
+    asUser(s, ALICE);
+    expect(getSocketAuthState(s as any)).toEqual({
+      userId: ALICE,
+      isService: false,
+      isAuthenticated: true,
+    });
+  });
+  it('reports service auth when socket.data.isService is set', () => {
+    const s = makeSocket();
+    asService(s);
+    expect(getSocketAuthState(s as any)).toEqual({
+      userId: null,
+      isService: true,
+      isAuthenticated: true,
+    });
+  });
+  it('reports unauthenticated when neither marker is present', () => {
+    const s = makeSocket();
+    expect(getSocketAuthState(s as any)).toEqual({
+      userId: null,
+      isService: false,
+      isAuthenticated: false,
+    });
+  });
+  it('treats an empty feathers object without isService as anonymous', () => {
+    // Defends against confusing service ↔ "feathers attached but no user yet".
+    const s = makeSocket();
+    s.feathers = {};
+    expect(getSocketAuthState(s as any).isAuthenticated).toBe(false);
+  });
+});
+
+describe('createTokenBucket', () => {
+  it('allows up to capacity immediately, then rejects until refill', () => {
+    let now = 0;
+    const limit = createTokenBucket(3, 1, () => now);
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(false); // capacity exhausted
+    now += 1000; // +1 token
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(false);
+  });
+
+  it('caps refilled tokens at capacity', () => {
+    let now = 0;
+    const limit = createTokenBucket(2, 1, () => now);
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(true);
+    now += 1_000_000; // would refill far past capacity
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(true);
+    expect(limit()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler authorization
+// ---------------------------------------------------------------------------
+
+describe('terminal:* handler authorization', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  describe('terminal:input', () => {
+    it('rejects anonymous sockets', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('anon');
+      connect(io, s);
+      s.handlers.get('terminal:input')?.({ userId: ALICE, input: 'rm -rf ~\r' });
+      expect(io.emitted).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('terminal:input rejected'));
+    });
+
+    it('rejects when payload userId does not match authed user (impersonation)', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      // Alice forges Bob's userId — must be rejected.
+      s.handlers.get('terminal:input')?.({ userId: BOB, input: ': pwn\r' });
+      expect(io.emitted).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does not match'));
+    });
+
+    it('accepts and re-emits with the AUTHED userId when payload matches', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:input')?.({ userId: ALICE, input: 'echo hi\r' });
+      expect(io.emitted).toEqual([
+        {
+          channel: `user/${ALICE}/terminal`,
+          event: 'terminal:input',
+          // The handler must re-emit with the trusted userId (not whatever
+          // the client sent), so executors never see attacker-controlled ids.
+          data: { userId: ALICE, input: 'echo hi\r' },
+        },
+      ]);
+    });
+
+    it('rejects when allow_web_terminal is false', () => {
+      const { io } = buildHarness({ webTerminalEnabled: false });
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:input')?.({ userId: ALICE, input: 'echo hi\r' });
+      expect(io.emitted).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('web terminal disabled'));
+    });
+
+    it('rate-limits per socket (drops events past the burst cap)', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      // Burst = 1000 tokens. Fire 1500 events back-to-back; expect ~1000
+      // through, the rest dropped. Use ≤1000 / ≥500 bounds to allow tiny
+      // wall-clock refill during the loop without making the test flaky.
+      for (let i = 0; i < 1500; i++) {
+        s.handlers.get('terminal:input')?.({ userId: ALICE, input: 'x' });
+      }
+      expect(io.emitted.length).toBeLessThanOrEqual(1100);
+      expect(io.emitted.length).toBeGreaterThanOrEqual(900);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('rate limit exceeded'));
+    });
+  });
+
+  describe('terminal:resize', () => {
+    it('rejects when payload userId does not match authed user', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:resize')?.({ userId: BOB, cols: 1, rows: 1 });
+      expect(io.emitted).toEqual([]);
+    });
+
+    it('accepts when payload userId matches authed user', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:resize')?.({ userId: ALICE, cols: 80, rows: 24 });
+      expect(io.emitted).toEqual([
+        {
+          channel: `user/${ALICE}/terminal`,
+          event: 'terminal:resize',
+          data: { userId: ALICE, cols: 80, rows: 24 },
+        },
+      ]);
+    });
+  });
+
+  describe('terminal:output / terminal:exit / terminal:tab (executor-only)', () => {
+    it.each([
+      'terminal:output',
+      'terminal:exit',
+      'terminal:tab',
+    ])('%s rejects user-token sockets (only service may emit)', (event) => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      // Even an authenticated user must not be able to spoof these — a
+      // forged terminal:output could fake a "permission granted" prompt
+      // into another user's terminal, etc.
+      s.handlers.get(event)?.({
+        userId: ALICE,
+        data: 'x',
+        exitCode: 0,
+        action: 'create',
+        tabName: 't',
+      });
+      expect(io.emitted).toEqual([]);
+    });
+
+    it('terminal:output accepts service sockets and relays to the channel', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asService(s);
+      connect(io, s);
+      s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'hello' });
+      expect(io.emitted).toEqual([
+        {
+          channel: `user/${ALICE}/terminal`,
+          event: 'terminal:output',
+          data: { userId: ALICE, data: 'hello' },
+        },
+      ]);
+    });
+
+    it('all three reject when allow_web_terminal is false even for service sockets', () => {
+      const { io } = buildHarness({ webTerminalEnabled: false });
+      const s = makeSocket('exec-sock');
+      asService(s);
+      connect(io, s);
+      s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'x' });
+      s.handlers.get('terminal:exit')?.({ userId: ALICE, exitCode: 0 });
+      s.handlers.get('terminal:tab')?.({ userId: ALICE, action: 'create', tabName: 't' });
+      expect(io.emitted).toEqual([]);
+    });
+  });
+
+  describe('join / leave', () => {
+    it('rejects unauthenticated joins', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('anon');
+      connect(io, s);
+      s.handlers.get('join')?.(`user/${ALICE}/terminal`);
+      expect(s.joined.size).toBe(0);
+    });
+
+    it("rejects a user joining another user's terminal channel", () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      // Authed users are auto-joined to `user:<id>` presence room on
+      // connect — assert specifically that the terminal channel is NOT
+      // joined rather than `joined.size === 0`.
+      s.handlers.get('join')?.(`user/${BOB}/terminal`);
+      expect(s.joined.has(`user/${BOB}/terminal`)).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('join rejected'));
+    });
+
+    it('allows a user to join their own terminal channel', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('join')?.(`user/${ALICE}/terminal`);
+      expect(s.joined.has(`user/${ALICE}/terminal`)).toBe(true);
+    });
+
+    it('allows a service socket to join any user terminal channel', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asService(s);
+      connect(io, s);
+      s.handlers.get('join')?.(`user/${ALICE}/terminal`);
+      s.handlers.get('join')?.(`user/${BOB}/terminal`);
+      expect(s.joined.has(`user/${ALICE}/terminal`)).toBe(true);
+      expect(s.joined.has(`user/${BOB}/terminal`)).toBe(true);
+    });
+
+    it('rejects join when allow_web_terminal is false', () => {
+      const { io } = buildHarness({ webTerminalEnabled: false });
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('join')?.(`user/${ALICE}/terminal`);
+      expect(s.joined.has(`user/${ALICE}/terminal`)).toBe(false);
+    });
+
+    it("rejects a user leaving another user's terminal channel", () => {
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('leave')?.(`user/${BOB}/terminal`);
+      expect(s.left.size).toBe(0);
+    });
+
+    it('still allows leaving non-terminal channels (no auth check applied)', () => {
+      // The hardening is scoped to terminal channels; non-terminal channels
+      // (e.g. board-foo) keep the prior behavior so we don't regress
+      // unrelated WS features.
+      const { io } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('leave')?.('board:abc');
+      expect(s.left.has('board:abc')).toBe(true);
+    });
+  });
+});

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -3,6 +3,15 @@
  *
  * Configures WebSocket server with authentication middleware,
  * cursor presence tracking, and connection management.
+ *
+ * SECURITY (terminal:* events):
+ * Browser-emitted terminal events (terminal:input, terminal:resize, join)
+ * are gated by per-event authentication checks. Without these checks any
+ * anonymous socket that knew a target user_id could inject keystrokes into
+ * that user's web terminal channel — which under unix_user_mode=strict is
+ * full impersonation of the victim's OS identity, and under simple mode is a
+ * shell as the daemon user (with read access to ~/.agor/config.yaml,
+ * agor.db, and the JWT secret). See `terminal:*` handlers below.
  */
 
 import type { Application } from '@agor/core/feathers';
@@ -12,7 +21,17 @@ import type { Server, Socket } from 'socket.io';
 import type { CorsOrigin } from './cors.js';
 
 /**
- * FeathersJS extends Socket.io socket with authentication context
+ * FeathersJS extends Socket.io socket with authentication context.
+ *
+ * `feathers` is populated either:
+ *   - synchronously by the io.use() handshake middleware below (handshake
+ *     token path: user, service, or empty for anonymous-allowed), OR
+ *   - asynchronously by FeathersJS itself when the client calls
+ *     `client.authenticate()` after connect (login event).
+ *
+ * Service-token sockets are additionally tagged with `socket.data.isService`
+ * so we can distinguish them from anonymous sockets that later authenticate
+ * as a user (where `feathers.user` would be set).
  */
 interface FeathersSocket extends Socket {
   feathers?: {
@@ -34,6 +53,97 @@ export interface SocketIOOptions {
    * creates spec-noncompliant credentialed cross-origin behavior.
    */
   credentialsAllowed: boolean;
+  /**
+   * Whether the web terminal feature is enabled (mirrors
+   * `execution.allow_web_terminal`). When false, ALL `terminal:*` events
+   * (and joins to `user/*\/terminal` channels) are rejected at the socket
+   * layer. This matches the HTTP terminals service gate in register-hooks.ts
+   * and keeps the kill-switch effective for both transports. Defaults to
+   * true if omitted.
+   */
+  webTerminalEnabled?: boolean;
+}
+
+/**
+ * Auth state derived from a socket. Returned by {@link getSocketAuthState}.
+ *
+ * - `userId` is the authenticated user's id, or null for anonymous/service.
+ * - `isService` is true for executor service tokens (no user, but trusted).
+ * - `isAuthenticated` is true if either a user OR a service token validated.
+ */
+export interface SocketAuthState {
+  userId: string | null;
+  isService: boolean;
+  isAuthenticated: boolean;
+}
+
+/**
+ * Extract the authenticated identity from a socket.
+ *
+ * Three valid states:
+ *   1. User-authenticated:    feathers.user set with a user_id
+ *   2. Service-authenticated: socket.data.isService === true (no user)
+ *   3. Anonymous:             neither
+ *
+ * Exported for unit tests and for handler authorization checks.
+ */
+export function getSocketAuthState(socket: Socket): SocketAuthState {
+  const f = (socket as FeathersSocket).feathers;
+  const user = f?.user;
+  if (user?.user_id) {
+    return { userId: user.user_id, isService: false, isAuthenticated: true };
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: socket.data shape is open
+  if ((socket.data as any)?.isService === true) {
+    return { userId: null, isService: true, isAuthenticated: true };
+  }
+  return { userId: null, isService: false, isAuthenticated: false };
+}
+
+/**
+ * Token-bucket rate limiter for per-socket terminal:input flooding.
+ *
+ * Generous defaults (500 events/sec, burst 1000) — even fast typists +
+ * paste-bomb rarely exceed this. The cap exists to prevent a hijacked
+ * (or buggy) client from saturating the executor's PTY input loop or
+ * filling logs. Returns a function: call() → boolean (true = allowed).
+ *
+ * Exported for unit tests.
+ */
+export function createTokenBucket(
+  capacity: number,
+  refillPerSec: number,
+  now: () => number = Date.now
+): () => boolean {
+  let tokens = capacity;
+  let last = now();
+  return () => {
+    const t = now();
+    const elapsed = (t - last) / 1000;
+    last = t;
+    tokens = Math.min(capacity, tokens + elapsed * refillPerSec);
+    if (tokens >= 1) {
+      tokens -= 1;
+      return true;
+    }
+    return false;
+  };
+}
+
+/**
+ * Validate a terminal channel name and extract its target user_id.
+ *
+ * Channel format: `user/<uuid>/terminal`. Returns null on bad shape.
+ * Exported for tests.
+ */
+export function parseTerminalChannel(channel: string): string | null {
+  if (typeof channel !== 'string') return null;
+  if (!channel.startsWith('user/') || !channel.endsWith('/terminal')) return null;
+  const inner = channel.slice('user/'.length, channel.length - '/terminal'.length);
+  // Reject empty / nested-slash channels — `user//terminal` or
+  // `user/foo/bar/terminal` must not parse as a valid terminal channel.
+  if (!inner || inner.includes('/')) return null;
+  return inner;
 }
 
 export interface SocketIOResult {
@@ -66,6 +176,8 @@ export function createSocketIOConfig(
   getSocketServer: () => Server | null;
 } {
   const { corsOrigin, jwtSecret, allowAnonymous, credentialsAllowed } = options;
+  // Default ON to mirror the daemon-wide default (see register-hooks.ts).
+  const webTerminalEnabled = options.webTerminalEnabled !== false;
 
   let socketServer: Server | null = null;
 
@@ -134,11 +246,16 @@ export function createSocketIOConfig(
 
         // Handle service tokens (used by executor for terminal streaming, git operations, etc.)
         if (tokenType === 'service') {
-          // Service tokens don't have a user - they authenticate the executor process
-          // Mark as service connection for potential authorization checks
+          // Service tokens don't have a user - they authenticate the executor process.
+          // Mark as service connection for terminal:* authorization checks below.
+          // We tag socket.data.isService so getSocketAuthState() can distinguish
+          // a service socket (trusted, no user) from an anonymous socket that
+          // simply hasn't authenticated yet (untrusted, no user).
           (socket as FeathersSocket).feathers = {
             // No user - this is a service connection
           };
+          // biome-ignore lint/suspicious/noExplicitAny: socket.data shape is open
+          (socket.data as any).isService = true;
           console.log(
             `🔐 WebSocket authenticated (service): ${socket.id} (role: ${decoded.role || 'unknown'})`
           );
@@ -223,62 +340,235 @@ export function createSocketIOConfig(
 
       // =========================================================================
       // TERMINAL CHANNEL SUPPORT
-      // Executors and browsers can join user-specific terminal channels
-      // for streaming PTY I/O.
+      //
+      // Executors and browsers join `user/<userId>/terminal` channels and
+      // exchange PTY I/O over them. Auth model:
+      //
+      //   Browser → daemon (relayed to executor):
+      //     - terminal:input    requires user auth + payload.userId === self
+      //     - terminal:resize   requires user auth + payload.userId === self
+      //
+      //   Executor → daemon (relayed to browser):
+      //     - terminal:output   requires service auth
+      //     - terminal:exit     requires service auth
+      //     - terminal:tab      requires service auth
+      //                         (the daemon ALSO emits terminal:tab via
+      //                          io.to(...) directly from terminals.ts after
+      //                          enforcing worktree RBAC at the HTTP layer;
+      //                          server-side emits never hit this handler.)
+      //
+      //   join / leave:
+      //     - require user auth
+      //     - channel MUST be `user/<self>/terminal` (or any user/*/terminal
+      //       for service sockets). This stops a member from joining another
+      //       user's terminal channel and harvesting their PTY output.
+      //
+      //   Worktree RBAC for opening a terminal against a specific worktree
+      //   is enforced at the HTTP `terminals.create({ worktreeId })` entry
+      //   point (see services/terminals.ts ~L194). Browsers cannot bypass
+      //   that gate from the WS side, because creating a Zellij tab in an
+      //   arbitrary worktree requires terminal:tab — and only service-token
+      //   sockets are allowed to emit terminal:tab here.
+      //
+      //   `webTerminalEnabled === false` short-circuits ALL of the above —
+      //   the kill-switch must work for both transports, not just HTTP.
       // =========================================================================
+
+      // Per-socket rate limiter for terminal:input. Generous cap (500/s,
+      // burst 1000) — enough for bracketed paste of large blocks, low enough
+      // to defang a hijacked or malfunctioning client trying to flood the
+      // executor PTY or the daemon log.
+      const inputRateLimit = createTokenBucket(1000, 500);
+
+      const rejectTerminal = (event: string, reason: string) => {
+        console.warn(
+          `🚫 ${event} rejected on socket ${socket.id}: ${reason} ` +
+            `(authState=${JSON.stringify(getSocketAuthState(socket))})`
+        );
+      };
+
+      // Common preflight for browser-emitted terminal events. Returns the
+      // authenticated user's id when the event should proceed, or null when
+      // the event was rejected (and the caller must return).
+      const requireUserForOwnUserId = (
+        event: 'terminal:input' | 'terminal:resize',
+        payloadUserId: unknown
+      ): string | null => {
+        if (!webTerminalEnabled) {
+          rejectTerminal(event, 'web terminal disabled (allow_web_terminal=false)');
+          return null;
+        }
+        const auth = getSocketAuthState(socket);
+        if (!auth.isAuthenticated || !auth.userId) {
+          rejectTerminal(event, 'no authenticated user');
+          return null;
+        }
+        if (typeof payloadUserId !== 'string' || payloadUserId !== auth.userId) {
+          // Critical: do NOT trust client-supplied userId. Mismatch = either
+          // a forged payload (hijack attempt) or a buggy client. Either way,
+          // refuse to relay.
+          rejectTerminal(
+            event,
+            `payload userId (${String(payloadUserId).slice(0, 8)}…) does not match ` +
+              `authed userId (${auth.userId.slice(0, 8)}…)`
+          );
+          return null;
+        }
+        return auth.userId;
+      };
 
       // Handle explicit channel joins (for terminal channels)
       socket.on('join', (channel: string) => {
-        // Validate channel format: user/${userId}/terminal
-        if (channel.startsWith('user/') && channel.endsWith('/terminal')) {
-          console.log(`🖥️  Socket ${socket.id} joining terminal channel: ${channel}`);
-          socket.join(channel);
-        } else {
-          console.warn(`⚠️  Socket ${socket.id} tried to join invalid channel: ${channel}`);
+        if (!webTerminalEnabled) {
+          rejectTerminal('join', 'web terminal disabled (allow_web_terminal=false)');
+          return;
         }
+        const target = parseTerminalChannel(channel);
+        if (!target) {
+          console.warn(`⚠️  Socket ${socket.id} tried to join invalid channel: ${channel}`);
+          return;
+        }
+        const auth = getSocketAuthState(socket);
+        if (!auth.isAuthenticated) {
+          rejectTerminal('join', `unauthenticated socket cannot join ${channel}`);
+          return;
+        }
+        // Service sockets (executor) are allowed to join any user's terminal
+        // channel — that's how they relay PTY I/O for the user they're
+        // proxying. User sockets may only join their OWN channel.
+        if (!auth.isService && auth.userId !== target) {
+          rejectTerminal(
+            'join',
+            `user ${auth.userId?.slice(0, 8)}… tried to join ${target.slice(0, 8)}…'s channel`
+          );
+          return;
+        }
+        console.log(`🖥️  Socket ${socket.id} joining terminal channel: ${channel}`);
+        socket.join(channel);
       });
 
-      // Handle explicit channel leaves
+      // Handle explicit channel leaves. Same auth model as join: service
+      // sockets can leave any channel, users can only leave their own. We
+      // also reject for unauthenticated sockets to prevent noise / probing.
       socket.on('leave', (channel: string) => {
+        const target = parseTerminalChannel(channel);
+        if (target) {
+          const auth = getSocketAuthState(socket);
+          if (!auth.isAuthenticated) {
+            rejectTerminal('leave', `unauthenticated socket cannot leave ${channel}`);
+            return;
+          }
+          if (!auth.isService && auth.userId !== target) {
+            rejectTerminal(
+              'leave',
+              `user ${auth.userId?.slice(0, 8)}… tried to leave ${target.slice(0, 8)}…'s channel`
+            );
+            return;
+          }
+        }
         console.log(`🖥️  Socket ${socket.id} leaving channel: ${channel}`);
         socket.leave(channel);
       });
 
-      // Route terminal output from executor to browser
-      // Executor emits: terminal:output { userId, data }
-      // Browser receives: terminal:output { userId, data }
+      // Route terminal output from executor to browser.
+      // Executor emits: terminal:output { userId, data } → broadcast to channel
+      // ONLY service sockets may emit this — otherwise a member could spoof
+      // arbitrary output (e.g. fake "permission granted" prompts) into
+      // another user's terminal.
       socket.on('terminal:output', (data: { userId: string; data: string }) => {
+        if (!webTerminalEnabled) {
+          rejectTerminal('terminal:output', 'web terminal disabled');
+          return;
+        }
+        const auth = getSocketAuthState(socket);
+        if (!auth.isService) {
+          rejectTerminal('terminal:output', 'only service tokens may emit terminal:output');
+          return;
+        }
+        if (typeof data?.userId !== 'string' || !data.userId) {
+          rejectTerminal('terminal:output', 'missing userId');
+          return;
+        }
         const channel = `user/${data.userId}/terminal`;
-        // Broadcast to channel (including sender for echo)
         io.to(channel).emit('terminal:output', data);
       });
 
-      // Route terminal input from browser to executor
-      // Browser emits: terminal:input { userId, input }
-      // Executor receives: terminal:input { userId, input }
+      // Route terminal input from browser to executor.
+      // Browser emits: terminal:input { userId, input } → broadcast to channel
+      // Auth: must be the authenticated user, and payload.userId MUST match.
       socket.on('terminal:input', (data: { userId: string; input: string }) => {
-        const channel = `user/${data.userId}/terminal`;
-        // Broadcast to channel (executor will filter by userId)
-        io.to(channel).emit('terminal:input', data);
+        const userId = requireUserForOwnUserId('terminal:input', data?.userId);
+        if (!userId) return;
+        if (!inputRateLimit()) {
+          rejectTerminal('terminal:input', 'rate limit exceeded (>500/s)');
+          return;
+        }
+        // Re-derive the channel and userId from the AUTHENTICATED identity.
+        // Even though we already validated payload.userId matches authed
+        // userId above, we send the trusted value downstream so executors
+        // never see attacker-controlled strings even if the check above is
+        // ever weakened.
+        const channel = `user/${userId}/terminal`;
+        io.to(channel).emit('terminal:input', { userId, input: data.input });
       });
 
-      // Route terminal resize events
+      // Route terminal resize events. Same auth model as terminal:input —
+      // browser-emitted, must match authed user. Resize events aren't a
+      // direct shell-injection vector but a hijacker could use them to
+      // disrupt the victim's session, so we lock them down anyway.
       socket.on('terminal:resize', (data: { userId: string; cols: number; rows: number }) => {
-        const channel = `user/${data.userId}/terminal`;
-        io.to(channel).emit('terminal:resize', data);
+        const userId = requireUserForOwnUserId('terminal:resize', data?.userId);
+        if (!userId) return;
+        const channel = `user/${userId}/terminal`;
+        io.to(channel).emit('terminal:resize', { userId, cols: data.cols, rows: data.rows });
       });
 
-      // Route terminal tab commands
+      // Route terminal tab commands. The daemon emits this server-side via
+      // io.to() (terminals.ts) AFTER enforcing worktree RBAC on the HTTP
+      // create() path. We must NOT let browsers emit it directly — doing so
+      // would let a user with 'view'-only on a worktree open a Zellij tab
+      // (and a shell) inside that worktree, bypassing the HTTP RBAC gate.
       socket.on(
         'terminal:tab',
         (data: { userId: string; action: string; tabName: string; cwd?: string }) => {
+          if (!webTerminalEnabled) {
+            rejectTerminal('terminal:tab', 'web terminal disabled');
+            return;
+          }
+          const auth = getSocketAuthState(socket);
+          if (!auth.isService) {
+            rejectTerminal(
+              'terminal:tab',
+              'only service tokens may emit terminal:tab (browsers must use HTTP terminals.create)'
+            );
+            return;
+          }
+          if (typeof data?.userId !== 'string' || !data.userId) {
+            rejectTerminal('terminal:tab', 'missing userId');
+            return;
+          }
           const channel = `user/${data.userId}/terminal`;
           io.to(channel).emit('terminal:tab', data);
         }
       );
 
-      // Handle terminal exit notification from executor
+      // Handle terminal exit notification from executor.
+      // Executor-only — a forged exit would let a member terminate or
+      // confuse another user's terminal session.
       socket.on('terminal:exit', (data: { userId: string; exitCode: number; signal?: number }) => {
+        if (!webTerminalEnabled) {
+          rejectTerminal('terminal:exit', 'web terminal disabled');
+          return;
+        }
+        const auth = getSocketAuthState(socket);
+        if (!auth.isService) {
+          rejectTerminal('terminal:exit', 'only service tokens may emit terminal:exit');
+          return;
+        }
+        if (typeof data?.userId !== 'string' || !data.userId) {
+          rejectTerminal('terminal:exit', 'missing userId');
+          return;
+        }
         const channel = `user/${data.userId}/terminal`;
         io.to(channel).emit('terminal:exit', data);
         console.log(`🖥️  Terminal exited for user ${data.userId}: code=${data.exitCode}`);

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -15,7 +15,12 @@
  */
 
 import type { Application } from '@agor/core/feathers';
-import type { CursorLeaveEvent, CursorMovedEvent, CursorMoveEvent, User } from '@agor/core/types';
+import type {
+  AuthenticatedUser,
+  CursorLeaveEvent,
+  CursorMovedEvent,
+  CursorMoveEvent,
+} from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import type { Server, Socket } from 'socket.io';
 import type { CorsOrigin } from './cors.js';
@@ -23,19 +28,32 @@ import type { CorsOrigin } from './cors.js';
 /**
  * FeathersJS extends Socket.io socket with authentication context.
  *
- * `feathers` is populated either:
+ * `feathers.user` is populated either:
  *   - synchronously by the io.use() handshake middleware below (handshake
  *     token path: user, service, or empty for anonymous-allowed), OR
  *   - asynchronously by FeathersJS itself when the client calls
  *     `client.authenticate()` after connect (login event).
  *
- * Service-token sockets are additionally tagged with `socket.data.isService`
- * so we can distinguish them from anonymous sockets that later authenticate
- * as a user (where `feathers.user` would be set).
+ * Service accounts (the executor) are identified via `user._isServiceAccount`,
+ * which is the canonical marker set by ServiceJWTStrategy and consumed by
+ * every other daemon authz path (worktree-authorization.ts, register-hooks.ts,
+ * utils/authorization.ts). We extend FeathersJS's `User` type locally to
+ * include it — see `AuthenticatedUser` in `@agor/core/types/feathers.ts`.
+ *
+ * `socket.data.isService` is ALSO set in the handshake path as a fast-path
+ * marker for sockets whose service token was presented at connect time (and
+ * therefore have no feathers.user). Post-connect `client.authenticate()`
+ * flows don't trip the handshake middleware, so `_isServiceAccount` on the
+ * feathers user is the only reliable signal for those sockets.
  */
 interface FeathersSocket extends Socket {
   feathers?: {
-    user?: User;
+    // `AuthenticatedUser` is the shape Feathers JWT strategies attach to
+    // params/connections — it already carries `_isServiceAccount?: boolean`.
+    user?: AuthenticatedUser;
+  };
+  data: {
+    isService?: boolean;
   };
 }
 
@@ -68,36 +86,60 @@ export interface SocketIOOptions {
  * Auth state derived from a socket. Returned by {@link getSocketAuthState}.
  *
  * - `userId` is the authenticated user's id, or null for anonymous/service.
- * - `isService` is true for executor service tokens (no user, but trusted).
- * - `isAuthenticated` is true if either a user OR a service token validated.
+ * - `isService` is true for executor service tokens (no backing real user,
+ *   but trusted).
+ *
+ * `isAuthenticated` is intentionally not a field — it's `!!(userId ||
+ * isService)` and would only create drift between the two representations.
+ * Callers that need it should compute `auth.userId !== null || auth.isService`.
  */
 export interface SocketAuthState {
   userId: string | null;
   isService: boolean;
-  isAuthenticated: boolean;
 }
 
 /**
  * Extract the authenticated identity from a socket.
  *
- * Three valid states:
- *   1. User-authenticated:    feathers.user set with a user_id
- *   2. Service-authenticated: socket.data.isService === true (no user)
- *   3. Anonymous:             neither
+ * Recognized states (checked in this order):
+ *   1. Service (post-connect auth, canonical):
+ *        feathers.user?._isServiceAccount === true
+ *        — executor's client.authenticate({strategy:'jwt',...}) path.
+ *        ServiceJWTStrategy attaches a synthetic user with this flag.
+ *   2. Service (handshake fast-path):
+ *        socket.data.isService === true
+ *        — socket presented a service token on connect; middleware tagged it.
+ *   3. User-authenticated:
+ *        feathers.user?.user_id set and NOT a service account.
+ *   4. Anonymous: none of the above.
+ *
+ * The service-account check is deliberately BEFORE the user-id check: the
+ * synthetic service user carries `user_id: 'executor-service'`, but we do not
+ * want to treat that as a real user for `terminal:input`/`resize` gating.
  *
  * Exported for unit tests and for handler authorization checks.
  */
 export function getSocketAuthState(socket: Socket): SocketAuthState {
-  const f = (socket as FeathersSocket).feathers;
-  const user = f?.user;
+  const s = socket as FeathersSocket;
+  const user = s.feathers?.user;
+  if (user?._isServiceAccount === true) {
+    return { userId: null, isService: true };
+  }
+  if (s.data?.isService === true) {
+    return { userId: null, isService: true };
+  }
   if (user?.user_id) {
-    return { userId: user.user_id, isService: false, isAuthenticated: true };
+    return { userId: user.user_id, isService: false };
   }
-  // biome-ignore lint/suspicious/noExplicitAny: socket.data shape is open
-  if ((socket.data as any)?.isService === true) {
-    return { userId: null, isService: true, isAuthenticated: true };
-  }
-  return { userId: null, isService: false, isAuthenticated: false };
+  return { userId: null, isService: false };
+}
+
+/**
+ * Convenience predicate — prefer this over duplicating the
+ * `userId || isService` pattern at call sites.
+ */
+function isAuthenticated(auth: SocketAuthState): boolean {
+  return auth.userId !== null || auth.isService;
 }
 
 /**
@@ -251,11 +293,22 @@ export function createSocketIOConfig(
           // We tag socket.data.isService so getSocketAuthState() can distinguish
           // a service socket (trusted, no user) from an anonymous socket that
           // simply hasn't authenticated yet (untrusted, no user).
-          (socket as FeathersSocket).feathers = {
-            // No user - this is a service connection
+          const fs = socket as FeathersSocket;
+          // Attach synthetic service user so getSocketAuthState returns
+          // isService=true via the canonical `_isServiceAccount` path. This
+          // mirrors what ServiceJWTStrategy.getEntity does on the Feathers
+          // side for sockets that authenticate post-connect.
+          fs.feathers = {
+            user: {
+              user_id: 'executor-service',
+              email: 'executor@agor.internal',
+              role: 'service',
+              _isServiceAccount: true,
+            },
           };
-          // biome-ignore lint/suspicious/noExplicitAny: socket.data shape is open
-          (socket.data as any).isService = true;
+          // Keep the handshake fast-path marker too — older code and any
+          // future callers that only look at socket.data still see it.
+          fs.data.isService = true;
           console.log(
             `🔐 WebSocket authenticated (service): ${socket.id} (role: ${decoded.role || 'unknown'})`
           );
@@ -399,7 +452,7 @@ export function createSocketIOConfig(
           return null;
         }
         const auth = getSocketAuthState(socket);
-        if (!auth.isAuthenticated || !auth.userId) {
+        if (!auth.userId) {
           rejectTerminal(event, 'no authenticated user');
           return null;
         }
@@ -429,7 +482,7 @@ export function createSocketIOConfig(
           return;
         }
         const auth = getSocketAuthState(socket);
-        if (!auth.isAuthenticated) {
+        if (!isAuthenticated(auth)) {
           rejectTerminal('join', `unauthenticated socket cannot join ${channel}`);
           return;
         }
@@ -454,7 +507,7 @@ export function createSocketIOConfig(
         const target = parseTerminalChannel(channel);
         if (target) {
           const auth = getSocketAuthState(socket);
-          if (!auth.isAuthenticated) {
+          if (!isAuthenticated(auth)) {
             rejectTerminal('leave', `unauthenticated socket cannot leave ${channel}`);
             return;
           }


### PR DESCRIPTION
## Summary

- Adds per-event authentication to `terminal:*` WebSocket handlers in `apps/agor-daemon/src/setup/socketio.ts`. Previously any socket could join `user/<id>/terminal` and emit `terminal:input` with a forged `userId`, injecting keystrokes into anyone's active web terminal.
- Direction-based auth model: browser→executor events (`terminal:input`, `terminal:resize`) require an authenticated user socket and derive the trusted `userId` from it; executor→browser events (`terminal:output`, `terminal:exit`, `terminal:tab`) require a service-token socket.
- Respects `execution.allow_web_terminal` at the WS layer (kill-switch drops all terminal events and channel joins when off) and adds a per-socket token-bucket rate limit on `terminal:input` (1000 burst, 500/sec refill).
- Worktree RBAC remains enforced at the `terminals.create({worktreeId})` HTTP service — `session` tier required to open a terminal.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — new suite `apps/agor-daemon/src/setup/socketio.test.ts` covers:
  - anonymous socket emitting `terminal:input` is rejected
  - authenticated user with mismatched `userId` payload is rejected
  - authenticated user with matching payload is accepted and re-emitted with trusted id
  - `allow_web_terminal=false` drops all terminal events and channel joins
  - `terminal:output` / `terminal:exit` / `terminal:tab` emitted by a user socket are rejected; same from a service socket are accepted
  - users cannot join another user's terminal channel; service sockets can proxy any
  - `terminal:input` rate limiter drops input once the burst bucket is empty
- [ ] Manual smoke: open browser terminal as authenticated user, confirm input/resize still flow and output/exit/tab render correctly.
- [ ] Manual smoke: set `execution.allow_web_terminal: false`, confirm WS terminal events are dropped with a single warn log per socket.