### PR TITLE
sec: session-identity hardening — Chain D + created_by trust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,6 +409,17 @@ The `session` tier is the safe default — it lets collaborators work independen
 
 ---
 
+### Worktree-Level Flags
+
+Beyond `others_can`/`others_fs_access`, individual worktrees expose opt-in
+security toggles stored alongside permissions:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `dangerously_allow_session_sharing` | `false` | When OFF (safe default), `agor_sessions_spawn` and `agor_sessions_prompt(mode:"fork"\|"subsession")` attribute the new child session to the **calling** user — it runs under the caller's Unix identity, env vars, and credentials. When ON, legacy behavior is restored: the child inherits `parent.created_by`, so a collaborator can effectively spawn agents that execute as the original session owner. Admins are always attributed to themselves regardless of this flag. Cross-user spawns under the legacy path emit `[SECURITY]` warning logs. See `context/explorations/session-sharing.md`. |
+
+---
+
 ### Implementation Notes
 
 **Database Schema:**

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -56,6 +56,7 @@ import {
   requireAdminForEnvConfig,
   requireMinimumRole,
 } from './utils/authorization.js';
+import { injectCreatedBy } from './utils/inject-created-by.js';
 import {
   createServiceToken,
   getDaemonUrl,
@@ -403,7 +404,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('cards')?.hooks({
     before: {
       all: [...getReadAuthHooks()],
-      create: [requireMinimumRole(ROLES.MEMBER, 'create cards')],
+      create: [requireMinimumRole(ROLES.MEMBER, 'create cards'), injectCreatedBy()],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update cards')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete cards')],
     },
@@ -422,7 +423,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           ? [scopeFindToAccessibleWorktrees(worktreeRepository, superadminOpts)]
           : []),
       ],
-      create: [requireMinimumRole(ROLES.MEMBER, 'create artifacts')],
+      create: [requireMinimumRole(ROLES.MEMBER, 'create artifacts'), injectCreatedBy()],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update artifacts')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete artifacts')],
     },
@@ -498,7 +499,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('board-comments')?.hooks({
     before: {
       all: [typedValidateQuery(boardCommentQueryValidator), ...getReadAuthHooks()],
-      create: [requireMinimumRole(ROLES.MEMBER, 'create board comments')],
+      create: [requireMinimumRole(ROLES.MEMBER, 'create board comments'), injectCreatedBy()],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update board comments')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete board comments')],
     },
@@ -537,7 +538,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             ]
           : []),
       ],
-      create: [requireMinimumRole(ROLES.MEMBER, 'create worktrees'), requireAdminForEnvConfig()],
+      create: [
+        requireMinimumRole(ROLES.MEMBER, 'create worktrees'),
+        requireAdminForEnvConfig(),
+        injectCreatedBy(),
+      ],
       update: [requireMinimumRole(ROLES.MEMBER, 'update worktrees'), requireAdminForEnvConfig()],
       patch: [
         requireAdminForEnvConfig(),
@@ -1426,27 +1431,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureCanCreateSession(superadminOpts), // Require 'all' permission to create sessions
             ]
           : []),
+        injectCreatedBy(),
         async (context) => {
-          // Inject user_id if authenticated, otherwise use 'anonymous'
-          const user = (context.params as { user?: { user_id: string; email: string } }).user;
-          const userId = user?.user_id || 'anonymous';
-
-          // DEBUG: Log authentication state
-          console.log(
-            '🔍 Session create hook - user:',
-            user ? `${user.user_id} (${user.email})` : 'none',
-            '→ userId:',
-            userId
-          );
-
-          if (Array.isArray(context.data)) {
-            context.data.forEach((item: Record<string, unknown>) => {
-              if (!item.created_by) item.created_by = userId;
-            });
-          } else if (context.data && !(context.data as Record<string, unknown>).created_by) {
-            (context.data as Record<string, unknown>).created_by = userId;
-          }
-
           // Populate repo field and auto-populate git_state from worktree_id
           if (!Array.isArray(context.data) && context.data?.worktree_id) {
             try {
@@ -1809,28 +1795,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
             ]
           : []),
-        async (context) => {
-          // Inject user_id if authenticated, otherwise use 'anonymous'
-          const user = (context.params as { user?: { user_id: string; email: string } }).user;
-          const userId = user?.user_id || 'anonymous';
-
-          // DEBUG: Log authentication state
-          console.log(
-            '🔍 Task create hook - user:',
-            user ? `${user.user_id} (${user.email})` : 'none',
-            '→ userId:',
-            userId
-          );
-
-          if (Array.isArray(context.data)) {
-            context.data.forEach((item) => {
-              if (!item.created_by) (item as Record<string, unknown>).created_by = userId;
-            });
-          } else if (context.data && !context.data.created_by) {
-            (context.data as Record<string, unknown>).created_by = userId;
-          }
-          return context;
-        },
+        injectCreatedBy(),
       ],
       patch: [
         ...(worktreeRbacEnabled
@@ -1878,24 +1843,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           ? [scopeFindToAccessibleBoards(boardRepository, superadminOpts)]
           : []),
       ],
-      create: [
-        requireMinimumRole(ROLES.MEMBER, 'create boards'),
-        async (context: HookContext<Board>) => {
-          // Inject user_id if authenticated, otherwise use 'anonymous'
-          const userId =
-            (context.params as { user?: { user_id: string; email: string } }).user?.user_id ||
-            'anonymous';
-
-          if (Array.isArray(context.data)) {
-            context.data.forEach((item) => {
-              if (!item.created_by) (item as Record<string, unknown>).created_by = userId;
-            });
-          } else if (context.data && !context.data.created_by) {
-            (context.data as Record<string, unknown>).created_by = userId;
-          }
-          return context;
-        },
-      ],
+      create: [requireMinimumRole(ROLES.MEMBER, 'create boards'), injectCreatedBy()],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update boards'),
         async (context: HookContext<Board>) => {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2047,7 +2047,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           const id = params.route?.id;
           if (!id) throw new Error('Comment ID required');
           if (!data.content) throw new Error('content required');
-          if (!data.created_by) throw new Error('created_by required');
+          // Always attribute the reply to the authenticated caller — never trust
+          // a client-supplied `created_by`. `requireAuth` upstream guarantees
+          // `params.user.user_id`.
+          const callerId = (params as { user?: { user_id?: string } }).user?.user_id;
+          if (!callerId) throw new Error('Authentication required');
+          data.created_by = callerId as import('@agor/core/types').UserID;
           const reply = await boardCommentsService.createReply(id, data, params);
           app.service('board-comments').emit('created', reply);
           return reply;

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -25,7 +25,7 @@ import type {
 } from '@agor/core/types';
 import { ROLES, SessionStatus } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
-import { isSuperAdmin } from '../utils/worktree-authorization.js';
+import { determineSpawnIdentity, isSuperAdmin } from '../utils/worktree-authorization.js';
 
 /**
  * Session runtime configuration that should be inherited across forks, spawns, and btw.
@@ -190,6 +190,45 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   }
 
   /**
+   * Resolve the `created_by` identity for a child session being created via
+   * spawn / fork / btw. See {@link determineSpawnIdentity} for the rules.
+   *
+   * Defaults the child to the MCP-authenticated caller; only inherits the
+   * parent's identity when the worktree explicitly opts in via the
+   * `dangerously_allow_session_sharing` flag (and the caller is not an admin
+   * acting on someone else's session).
+   *
+   * Internal calls (no `params.user`) preserve parent attribution — they're
+   * service-to-service or scheduler-driven and have no human caller to attribute.
+   */
+  private async resolveChildIdentity(
+    parent: Session,
+    params?: SessionParams
+  ): Promise<{ created_by: Session['created_by'] }> {
+    // No authenticated user on params → internal call (scheduler, callbacks,
+    // service-to-service). Preserve parent attribution.
+    const caller = params?.user;
+    if (!caller || !caller.user_id) {
+      return { created_by: parent.created_by };
+    }
+
+    // Look up the parent's worktree to read the opt-in flag.
+    let worktree: { worktree_id: string; dangerously_allow_session_sharing?: boolean } | undefined;
+    try {
+      const wt = await this.app
+        .service('worktrees')
+        .get(parent.worktree_id, { provider: undefined });
+      worktree = wt as typeof worktree;
+    } catch {
+      // If we can't load the worktree, default to the safe (caller-as-owner) path.
+      worktree = undefined;
+    }
+
+    const result = determineSpawnIdentity(parent, caller, worktree);
+    return { created_by: result.created_by as Session['created_by'] };
+  }
+
+  /**
    * Custom method: Fork a session
    *
    * Creates a new session branching from the current session at a decision point.
@@ -201,6 +240,11 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   ): Promise<Session> {
     const parent = await this.get(id, params);
 
+    // Default: attribute the child to the MCP-authenticated caller, not the
+    // parent owner. Legacy parent-inheriting "identity borrowing" is preserved
+    // only when the worktree opts in via dangerously_allow_session_sharing.
+    const { created_by } = await this.resolveChildIdentity(parent, params);
+
     const forkedSession = await this.create(
       {
         agentic_tool: parent.agentic_tool,
@@ -208,8 +252,10 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         title: data.prompt.substring(0, 100), // First 100 chars as title
         description: data.prompt,
         worktree_id: parent.worktree_id,
-        created_by: parent.created_by, // Inherit parent's creator for proper attribution
-        unix_username: parent.unix_username, // Inherit parent's unix_username for consistent execution context
+        created_by, // See resolveChildIdentity — defaults to caller, not parent owner
+        // unix_username intentionally omitted: setSessionUnixUsername hook
+        // stamps the child with the *caller's* current unix_username so that
+        // the execution context matches the attributed `created_by`.
         git_state: { ...parent.git_state },
         genealogy: {
           forked_from_session_id: parent.session_id,
@@ -235,8 +281,11 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       'fork'
     );
 
-    // Copy session env var selections from parent to forked session
-    // (same creator, same selection context).
+    // Copy parent's env var *names* to forked session.
+    // Names resolve at execution time against the child session's owner's
+    // env vars (see env-var-access.md), so when a cross-user fork happens
+    // these names are looked up under the caller's namespace, not the parent
+    // owner's — no leakage of parent credentials into a fork the caller owns.
     const parentEnvSelections = await this.sessionEnvSelectionRepo.listNames(
       parent.session_id as SessionID
     );
@@ -391,6 +440,11 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       finalPrompt = `${data.prompt}\n\n${data.extraInstructions}`;
     }
 
+    // Default: attribute the child to the MCP-authenticated caller, not the
+    // parent owner. Legacy parent-inheriting "identity borrowing" is preserved
+    // only when the worktree opts in via dangerously_allow_session_sharing.
+    const { created_by } = await this.resolveChildIdentity(parent, params);
+
     const spawnedSession = await this.create(
       {
         agentic_tool: targetTool,
@@ -398,8 +452,10 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         title: data.title || data.prompt.substring(0, 100), // Use provided title or first 100 chars
         description: finalPrompt, // Use final prompt with extra instructions if provided
         worktree_id: parent.worktree_id,
-        created_by: parent.created_by, // Inherit parent's creator for proper attribution
-        unix_username: parent.unix_username, // Inherit parent's unix_username for consistent execution context
+        created_by, // See resolveChildIdentity — defaults to caller, not parent owner
+        // unix_username intentionally omitted: setSessionUnixUsername hook
+        // stamps the child with the *caller's* current unix_username so that
+        // the execution context matches the attributed `created_by`.
         git_state: { ...parent.git_state },
         genealogy: {
           parent_session_id: parent.session_id,

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -13,7 +13,7 @@ import {
   SessionRepository,
   type SessionWithLastMessage,
 } from '@agor/core/db';
-import type { Application } from '@agor/core/feathers';
+import { type Application, Forbidden } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   MCPServerID,
@@ -198,18 +198,27 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    * `dangerously_allow_session_sharing` flag (and the caller is not an admin
    * acting on someone else's session).
    *
-   * Internal calls (no `params.user`) preserve parent attribution — they're
-   * service-to-service or scheduler-driven and have no human caller to attribute.
+   * Internal calls (`params.provider == null`) preserve parent attribution —
+   * they're service-to-service or scheduler-driven and have no human caller
+   * to attribute. External calls (REST/socketio/MCP) must always be routed
+   * through `determineSpawnIdentity`, which fails closed if the caller has
+   * no `user_id`.
    */
   private async resolveChildIdentity(
     parent: Session,
     params?: SessionParams
   ): Promise<{ created_by: Session['created_by'] }> {
-    // No authenticated user on params → internal call (scheduler, callbacks,
-    // service-to-service). Preserve parent attribution.
-    const caller = params?.user;
-    if (!caller || !caller.user_id) {
+    // Internal call (no transport provider) → service-to-service or scheduler.
+    // Preserve parent attribution; helper-level identity checks don't apply.
+    if (!params?.provider) {
       return { created_by: parent.created_by };
+    }
+
+    const caller = params.user;
+    if (!caller) {
+      // External call without an authenticated user should never reach here
+      // (auth hooks run first), but fail closed defensively.
+      throw new Forbidden('Cannot spawn/fork session without an authenticated caller identity.');
     }
 
     // Look up the parent's worktree to read the opt-in flag.

--- a/apps/agor-daemon/src/utils/determine-spawn-identity.test.ts
+++ b/apps/agor-daemon/src/utils/determine-spawn-identity.test.ts
@@ -76,12 +76,14 @@ describe('determineSpawnIdentity', () => {
       expect(result.created_by).toBe(BOB); // child runs under parent owner's identity
       expect(result.usedLegacySharing).toBe(true);
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      const msg = String(warnSpy.mock.calls[0][0]);
-      expect(msg).toContain('[SECURITY]');
-      expect(msg).toContain('dangerously_allow_session_sharing');
-      expect(msg).toContain(ALICE); // caller
-      expect(msg).toContain(BOB); // parent owner
-      expect(msg).toContain('wt-on'); // worktree id
+      const [tag, fields] = warnSpy.mock.calls[0];
+      expect(String(tag)).toContain('[SECURITY]');
+      expect(fields).toMatchObject({
+        event: 'legacy_session_sharing',
+        caller_id: ALICE,
+        parent_owner_id: BOB,
+        worktree_id: 'wt-on',
+      });
     } finally {
       warnSpy.mockRestore();
     }

--- a/apps/agor-daemon/src/utils/determine-spawn-identity.test.ts
+++ b/apps/agor-daemon/src/utils/determine-spawn-identity.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for `determineSpawnIdentity` — the pure helper that decides the
+ * `created_by` identity stamped on a child session created via spawn / fork
+ * (sessions service: spawn() / fork(), MCP tools agor_sessions_spawn /
+ * agor_sessions_prompt(mode:"fork"|"subsession")).
+ *
+ * The default behavior MUST be "attribute child to caller" so that user A
+ * spawning from user B's session does NOT inherit user B's Unix identity,
+ * credentials, or env vars. The legacy parent-inheriting "identity borrowing"
+ * is gated behind the worktree opt-in `dangerously_allow_session_sharing`.
+ */
+
+import { Forbidden } from '@agor/core/feathers';
+import { ROLES } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { determineSpawnIdentity } from './worktree-authorization';
+
+const ALICE = 'user-alice';
+const BOB = 'user-bob';
+const ADMIN = 'user-admin';
+const SUPER = 'user-super';
+const WT_FLAG_OFF = { worktree_id: 'wt-off', dangerously_allow_session_sharing: false };
+const WT_FLAG_ON = { worktree_id: 'wt-on', dangerously_allow_session_sharing: true };
+const WT_UNSET = { worktree_id: 'wt-unset' };
+
+describe('determineSpawnIdentity', () => {
+  it('flag disabled: cross-user spawn (Alice spawns from Bob) attributes child to Alice', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: ALICE, role: ROLES.MEMBER },
+      WT_FLAG_OFF
+    );
+    expect(result.created_by).toBe(ALICE);
+    expect(result.usedLegacySharing).toBe(false);
+  });
+
+  it('flag unset (undefined): cross-user spawn attributes child to caller', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: ALICE, role: ROLES.MEMBER },
+      WT_UNSET
+    );
+    expect(result.created_by).toBe(ALICE);
+    expect(result.usedLegacySharing).toBe(false);
+  });
+
+  it('flag disabled: cross-user fork attributes child to caller (same as spawn)', () => {
+    // Fork and spawn use the same helper — exercise it through the fork path
+    // by passing a fork-shaped scenario.
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: ALICE, role: ROLES.MEMBER },
+      WT_FLAG_OFF
+    );
+    expect(result.created_by).toBe(ALICE);
+  });
+
+  it('flag enabled: same-user spawn attributes child to caller (no legacy path)', () => {
+    const result = determineSpawnIdentity(
+      { created_by: ALICE },
+      { user_id: ALICE, role: ROLES.MEMBER },
+      WT_FLAG_ON
+    );
+    expect(result.created_by).toBe(ALICE);
+    expect(result.usedLegacySharing).toBe(false);
+  });
+
+  it('flag enabled: cross-user spawn preserves parent identity AND warns (legacy borrowing)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = determineSpawnIdentity(
+        { created_by: BOB },
+        { user_id: ALICE, role: ROLES.MEMBER },
+        WT_FLAG_ON
+      );
+      expect(result.created_by).toBe(BOB); // child runs under parent owner's identity
+      expect(result.usedLegacySharing).toBe(true);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = String(warnSpy.mock.calls[0][0]);
+      expect(msg).toContain('[SECURITY]');
+      expect(msg).toContain('dangerously_allow_session_sharing');
+      expect(msg).toContain(ALICE); // caller
+      expect(msg).toContain(BOB); // parent owner
+      expect(msg).toContain('wt-on'); // worktree id
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('admin spawn of any user’s session attributes child to admin (flag-off)', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: ADMIN, role: ROLES.ADMIN },
+      WT_FLAG_OFF
+    );
+    expect(result.created_by).toBe(ADMIN);
+    expect(result.usedLegacySharing).toBe(false);
+  });
+
+  it('admin spawn ignores flag-on opt-in: still attributed to admin', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = determineSpawnIdentity(
+        { created_by: BOB },
+        { user_id: ADMIN, role: ROLES.ADMIN },
+        WT_FLAG_ON
+      );
+      expect(result.created_by).toBe(ADMIN);
+      expect(result.usedLegacySharing).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('superadmin is treated like admin (attributed to self)', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: SUPER, role: ROLES.SUPERADMIN },
+      WT_FLAG_OFF
+    );
+    expect(result.created_by).toBe(SUPER);
+  });
+
+  it('allowSuperadmin=false demotes superadmin to regular user (caller-as-owner)', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: SUPER, role: ROLES.SUPERADMIN },
+      WT_FLAG_OFF,
+      { allowSuperadmin: false }
+    );
+    // Without superadmin powers, falls into the "non-admin caller" branch
+    // and the safe default still attributes to caller.
+    expect(result.created_by).toBe(SUPER);
+  });
+
+  it('service accounts preserve parent attribution (no human caller)', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: 'executor-sa', _isServiceAccount: true },
+      WT_FLAG_OFF
+    );
+    expect(result.created_by).toBe(BOB);
+  });
+
+  it('throws Forbidden when no caller id is available and flag is off', () => {
+    expect(() =>
+      determineSpawnIdentity(
+        { created_by: BOB },
+        { role: ROLES.MEMBER }, // no user_id
+        WT_FLAG_OFF
+      )
+    ).toThrow(Forbidden);
+  });
+
+  it('falls back safely when worktree is undefined (treated as flag-off)', () => {
+    const result = determineSpawnIdentity(
+      { created_by: BOB },
+      { user_id: ALICE, role: ROLES.MEMBER },
+      undefined
+    );
+    expect(result.created_by).toBe(ALICE);
+    expect(result.usedLegacySharing).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/inject-created-by.test.ts
+++ b/apps/agor-daemon/src/utils/inject-created-by.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for `injectCreatedBy` — the shared before-create hook that stamps
+ * `created_by` on sessions/tasks/boards.
+ *
+ * The threat we're defending against: an authenticated external caller POSTs
+ * `/sessions` (or `/tasks`, `/boards`) with `created_by: <victim_user_id>`
+ * and the resource ends up attributed to the victim. The hook MUST
+ * unconditionally overwrite `created_by` for external calls and MUST NOT
+ * trust an absent-or-present client value.
+ */
+
+import { NotAuthenticated } from '@agor/core/feathers';
+import type { HookContext } from '@feathersjs/feathers';
+import { describe, expect, it } from 'vitest';
+import { injectCreatedBy } from './inject-created-by';
+
+const ALICE = 'user-alice';
+const BOB = 'user-bob';
+
+function makeContext(opts: {
+  provider?: string;
+  user?: { user_id?: string };
+  data?: unknown;
+}): HookContext {
+  return {
+    params: { provider: opts.provider, user: opts.user },
+    data: opts.data,
+  } as unknown as HookContext;
+}
+
+describe('injectCreatedBy', () => {
+  const hook = injectCreatedBy();
+
+  describe('external calls (params.provider set)', () => {
+    it('overwrites client-supplied created_by with caller user_id', () => {
+      // The attack: client POSTs claiming to be Bob; we attribute to Alice.
+      const ctx = makeContext({
+        provider: 'rest',
+        user: { user_id: ALICE },
+        data: { title: 'x', created_by: BOB },
+      });
+      hook(ctx);
+      expect((ctx.data as { created_by: string }).created_by).toBe(ALICE);
+    });
+
+    it('stamps created_by when missing on external call', () => {
+      const ctx = makeContext({
+        provider: 'socketio',
+        user: { user_id: ALICE },
+        data: { title: 'x' },
+      });
+      hook(ctx);
+      expect((ctx.data as { created_by: string }).created_by).toBe(ALICE);
+    });
+
+    it('handles array payloads (bulk create)', () => {
+      const ctx = makeContext({
+        provider: 'rest',
+        user: { user_id: ALICE },
+        data: [{ title: 'a', created_by: BOB }, { title: 'b' }],
+      });
+      hook(ctx);
+      const items = ctx.data as Array<{ created_by: string }>;
+      expect(items[0].created_by).toBe(ALICE);
+      expect(items[1].created_by).toBe(ALICE);
+    });
+
+    it('throws NotAuthenticated when external call has no user (defence-in-depth)', () => {
+      const ctx = makeContext({
+        provider: 'rest',
+        data: { title: 'x' },
+      });
+      expect(() => hook(ctx)).toThrow(NotAuthenticated);
+    });
+
+    it('throws NotAuthenticated when external call has user without user_id', () => {
+      const ctx = makeContext({
+        provider: 'rest',
+        user: {},
+        data: { title: 'x' },
+      });
+      expect(() => hook(ctx)).toThrow(NotAuthenticated);
+    });
+  });
+
+  describe('internal calls (no provider)', () => {
+    it('respects explicit created_by from internal callers', () => {
+      // Scheduler / service-to-service may legitimately set created_by.
+      const ctx = makeContext({
+        data: { title: 'x', created_by: BOB },
+      });
+      hook(ctx);
+      expect((ctx.data as { created_by: string }).created_by).toBe(BOB);
+    });
+
+    it('falls back to caller user_id when internal call omits created_by', () => {
+      const ctx = makeContext({
+        user: { user_id: ALICE },
+        data: { title: 'x' },
+      });
+      hook(ctx);
+      expect((ctx.data as { created_by: string }).created_by).toBe(ALICE);
+    });
+
+    it('falls back to "anonymous" when internal call has no user and no created_by', () => {
+      const ctx = makeContext({ data: { title: 'x' } });
+      hook(ctx);
+      expect((ctx.data as { created_by: string }).created_by).toBe('anonymous');
+    });
+  });
+
+  it('is a no-op when context.data is undefined', () => {
+    const ctx = makeContext({ provider: 'rest', user: { user_id: ALICE } });
+    expect(() => hook(ctx)).not.toThrow();
+  });
+});

--- a/apps/agor-daemon/src/utils/inject-created-by.ts
+++ b/apps/agor-daemon/src/utils/inject-created-by.ts
@@ -1,0 +1,57 @@
+/**
+ * Before-create hook that stamps `created_by` on incoming data.
+ *
+ * Why this hook exists
+ * --------------------
+ * The previous inline implementations on the sessions/tasks/boards services
+ * used `if (!item.created_by) item.created_by = userId` — which let an
+ * authenticated external caller POST `/sessions` (or `/tasks`, `/boards`)
+ * with `created_by: <other_user_id>` and have the new resource attributed to
+ * a different user. That is identity attribution forgery.
+ *
+ * Security model
+ * --------------
+ * - **External calls** (`params.provider != null` — REST, socketio, MCP):
+ *   ALWAYS overwrite `data.created_by` with `params.user.user_id`. Any
+ *   client-supplied value is silently discarded. Throws `NotAuthenticated`
+ *   if no user is on `params` (defence-in-depth — auth hooks should have
+ *   rejected the call already).
+ * - **Internal calls** (`params.provider == null` — scheduler, callbacks,
+ *   service-to-service): respect an explicitly-provided `data.created_by`,
+ *   defaulting to the (usually absent) caller user_id or `'anonymous'`.
+ *
+ * Place this hook AFTER any role/permission gate (e.g. `requireMinimumRole`)
+ * so that on external calls `params.user` is guaranteed to be populated.
+ */
+
+import { NotAuthenticated } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+
+export function injectCreatedBy() {
+  return (context: HookContext): HookContext => {
+    const isExternal = context.params.provider != null;
+    const user = (context.params as { user?: { user_id?: string } }).user;
+    const userId = user?.user_id;
+
+    const apply = (item: Record<string, unknown>) => {
+      if (isExternal) {
+        if (!userId) {
+          // Should be unreachable if auth hooks ran first; fail closed.
+          throw new NotAuthenticated('Authentication required to create this resource');
+        }
+        // Unconditional overwrite — never trust client-supplied created_by.
+        item.created_by = userId;
+      } else if (!item.created_by) {
+        // Internal: only fill the gap, never override.
+        item.created_by = userId ?? 'anonymous';
+      }
+    };
+
+    if (Array.isArray(context.data)) {
+      (context.data as Record<string, unknown>[]).forEach(apply);
+    } else if (context.data) {
+      apply(context.data as Record<string, unknown>);
+    }
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -1478,13 +1478,13 @@ export function ensureSessionOwnerOrAdmin(options?: { allowSuperadmin?: boolean 
  * @returns The created_by UUID to stamp on the child session
  */
 export function determineSpawnIdentity(
-  parent: Pick<Session, 'created_by'>,
+  parent: { created_by: string },
   caller: { user_id?: string; role?: string; _isServiceAccount?: boolean },
-  worktree: Pick<Worktree, 'worktree_id' | 'dangerously_allow_session_sharing'> | undefined,
+  worktree: { worktree_id: string; dangerously_allow_session_sharing?: boolean } | undefined,
   options?: { allowSuperadmin?: boolean }
-): { created_by: UUID; usedLegacySharing: boolean } {
+): { created_by: string; usedLegacySharing: boolean } {
   const allowSuperadmin = options?.allowSuperadmin ?? true;
-  const callerId = caller.user_id as UUID | undefined;
+  const callerId = caller.user_id;
   const role = caller.role;
 
   // Service accounts (executor, internal jobs) preserve parent attribution.
@@ -1528,9 +1528,7 @@ export function determineSpawnIdentity(
   // If we don't have a caller id at this point we cannot safely proceed —
   // refuse rather than silently fall back to parent ownership.
   if (!callerId) {
-    throw new Forbidden(
-      'Cannot spawn/fork session without an authenticated caller identity.'
-    );
+    throw new Forbidden('Cannot spawn/fork session without an authenticated caller identity.');
   }
   return { created_by: callerId, usedLegacySharing: false };
 }

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -1514,13 +1514,13 @@ export function determineSpawnIdentity(
   // else's session.
   if (worktree?.dangerously_allow_session_sharing === true) {
     // Opt-in legacy behavior: preserve identity borrowing. Log loudly.
-    console.warn(
-      '[SECURITY] cross-user session spawn/fork allowed by ' +
-        'dangerously_allow_session_sharing=true: ' +
-        `caller=${callerId ?? 'unknown'} ` +
-        `parent_owner=${parent.created_by} ` +
-        `worktree=${worktree.worktree_id}`
-    );
+    // Structured key/value form so it can be queried by log shippers.
+    console.warn('[SECURITY] legacy_session_sharing', {
+      event: 'legacy_session_sharing',
+      caller_id: callerId ?? null,
+      parent_owner_id: parent.created_by,
+      worktree_id: worktree.worktree_id,
+    });
     return { created_by: parent.created_by, usedLegacySharing: true };
   }
 

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -1451,3 +1451,86 @@ export function ensureSessionOwnerOrAdmin(options?: { allowSuperadmin?: boolean 
     return context;
   };
 }
+
+/**
+ * Decide the `created_by` identity for a child session created via spawn or
+ * fork (sessions service: spawn() / fork(), or MCP tools agor_sessions_spawn /
+ * agor_sessions_prompt(mode:"fork"|"subsession")).
+ *
+ * Default behavior — and the behavior whenever the caller is the parent owner,
+ * an admin, or a superadmin — attributes the child to the **caller** so it
+ * runs under the caller's Unix identity, credentials, and env vars.
+ *
+ * Legacy "identity borrowing" (child inherits parent.created_by, so it runs
+ * under the *parent owner's* identity even when spawned by a different user)
+ * is preserved only when the worktree opts in via
+ * `dangerously_allow_session_sharing: true`. When that legacy path triggers
+ * for a cross-user spawn, the daemon emits a loud warning so it appears in
+ * audit logs.
+ *
+ * Pure function — no DB, no FeathersJS context — so it can be unit tested
+ * directly and invoked from both service methods and MCP tool handlers.
+ *
+ * @param parent  - Parent session (must include created_by)
+ * @param caller  - Authenticated caller (MCP-authenticated user / Feathers user)
+ * @param worktree - Parent's worktree (used for the opt-in flag)
+ * @param options - allowSuperadmin (defaults to true)
+ * @returns The created_by UUID to stamp on the child session
+ */
+export function determineSpawnIdentity(
+  parent: Pick<Session, 'created_by'>,
+  caller: { user_id?: string; role?: string; _isServiceAccount?: boolean },
+  worktree: Pick<Worktree, 'worktree_id' | 'dangerously_allow_session_sharing'> | undefined,
+  options?: { allowSuperadmin?: boolean }
+): { created_by: UUID; usedLegacySharing: boolean } {
+  const allowSuperadmin = options?.allowSuperadmin ?? true;
+  const callerId = caller.user_id as UUID | undefined;
+  const role = caller.role;
+
+  // Service accounts (executor, internal jobs) preserve parent attribution.
+  // They have no human user_id to attribute to, and their callers (the
+  // scheduler, callbacks) already ran their own RBAC checks.
+  if (caller._isServiceAccount) {
+    return { created_by: parent.created_by, usedLegacySharing: false };
+  }
+
+  // Admin / superadmin → always attributed to themselves so the audit trail
+  // points at the human who pressed the button. Never inherit parent identity.
+  if (role === ROLES.ADMIN || isSuperAdmin(role, allowSuperadmin)) {
+    if (!callerId) {
+      // Should not happen — admins always have an id — but fall back safely.
+      return { created_by: parent.created_by, usedLegacySharing: false };
+    }
+    return { created_by: callerId, usedLegacySharing: false };
+  }
+
+  // Same user spawning their own session → attribute to caller (same value
+  // as parent.created_by, but explicit).
+  if (callerId && parent.created_by === callerId) {
+    return { created_by: callerId, usedLegacySharing: false };
+  }
+
+  // Cross-user spawn: a non-admin caller is spawning/forking from someone
+  // else's session.
+  if (worktree?.dangerously_allow_session_sharing === true) {
+    // Opt-in legacy behavior: preserve identity borrowing. Log loudly.
+    console.warn(
+      '[SECURITY] cross-user session spawn/fork allowed by ' +
+        'dangerously_allow_session_sharing=true: ' +
+        `caller=${callerId ?? 'unknown'} ` +
+        `parent_owner=${parent.created_by} ` +
+        `worktree=${worktree.worktree_id}`
+    );
+    return { created_by: parent.created_by, usedLegacySharing: true };
+  }
+
+  // Default: attribute child to caller (no identity borrowing).
+  // If we don't have a caller id at this point we cannot safely proceed —
+  // refuse rather than silently fall back to parent ownership.
+  if (!callerId) {
+    throw new Forbidden(
+      'Cannot spawn/fork session without an authenticated caller identity.'
+    );
+  }
+  return { created_by: callerId, usedLegacySharing: false };
+}

--- a/apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/components/OwnersSection.tsx
@@ -11,7 +11,7 @@
 import type { AgorClient, User, Worktree, WorktreePermissionLevel } from '@agor-live/client';
 import { hasMinimumRole, ROLES } from '@agor-live/client';
 import { UserOutlined, WarningOutlined } from '@ant-design/icons';
-import { Alert, Button, Form, Select, Space, Typography } from 'antd';
+import { Alert, Button, Form, Select, Space, Switch, Typography } from 'antd';
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
 import { Tag } from '../../Tag';
@@ -35,6 +35,9 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
   );
   const [othersFsAccessValue, setOthersFsAccessValue] = useState<'none' | 'read' | 'write'>(
     worktree.others_fs_access || 'read'
+  );
+  const [allowSessionSharing, setAllowSessionSharing] = useState<boolean>(
+    Boolean(worktree.dangerously_allow_session_sharing)
   );
 
   // Check if current user can edit owners
@@ -106,6 +109,7 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
     setSelectedOwnerIds(currentOwnerIds);
     setOthersCanValue(worktree.others_can || 'session');
     setOthersFsAccessValue(worktree.others_fs_access || 'read');
+    setAllowSessionSharing(Boolean(worktree.dangerously_allow_session_sharing));
     setSelectKey((prev) => prev + 1); // Force Select to remount
   };
 
@@ -137,6 +141,7 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
       await client.service('worktrees').patch(worktree.worktree_id, {
         others_can: othersCanValue,
         others_fs_access: othersFsAccessValue,
+        dangerously_allow_session_sharing: allowSessionSharing,
       });
 
       // Reload owners to get fresh data
@@ -174,7 +179,9 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
     selectedOwnerIds.length !== currentOwnerIds.length ||
     selectedOwnerIds.some((id) => !currentOwnerIds.includes(id));
   const permissionsChanged =
-    othersCanValue !== worktree.others_can || othersFsAccessValue !== worktree.others_fs_access;
+    othersCanValue !== worktree.others_can ||
+    othersFsAccessValue !== worktree.others_fs_access ||
+    allowSessionSharing !== Boolean(worktree.dangerously_allow_session_sharing);
   const hasUnsavedChanges = ownersChanged || permissionsChanged;
 
   const permissionLevelDescriptions: Record<WorktreePermissionLevel, string> = {
@@ -312,6 +319,37 @@ export const OwnersSection: React.FC<OwnersSectionProps> = ({ worktree, client, 
             ]}
           />
         </Form.Item>
+
+        {/*
+         * TODO(product): finalize copy for "Allow legacy session sharing" — the
+         * label/help/warning text below is provisional. Coordinate wording with
+         * docs + UI.
+         */}
+        <Form.Item
+          label="Allow legacy session sharing"
+          labelCol={{ span: 8 }}
+          wrapperCol={{ span: 16 }}
+          help="When OFF (default), spawning or forking another user's session attributes the new session to YOU. When ON, the new session keeps the original creator's identity, credentials, and Unix user — restoring legacy behavior."
+          style={{ marginBottom: 12 }}
+        >
+          <Switch
+            checked={allowSessionSharing}
+            onChange={setAllowSessionSharing}
+            disabled={!canEdit}
+          />
+        </Form.Item>
+
+        {allowSessionSharing && (
+          <Form.Item wrapperCol={{ offset: 8, span: 16 }} style={{ marginBottom: 12 }}>
+            <Alert
+              type="error"
+              showIcon
+              icon={<WarningOutlined />}
+              message="Dangerous: identity borrowing on spawn/fork"
+              description="With this enabled, sessions spawned or forked by other users in this worktree run under the original creator's OS identity, credentials, and environment variables. A collaborator can effectively execute code as you. Only enable for fully trusted collaborators or legacy automation that depends on the old behavior."
+            />
+          </Form.Item>
+        )}
 
         {hasUnsavedChanges && (
           <Form.Item wrapperCol={{ offset: 8, span: 16 }}>

--- a/context/explorations/session-sharing.md
+++ b/context/explorations/session-sharing.md
@@ -1,0 +1,132 @@
+# Session Sharing & Identity Borrowing
+
+**Status:** short-term flag **shipped** (`dangerously_allow_session_sharing`).
+Longer-term redesign options are tracked here for future work; none are
+scheduled yet.
+
+---
+
+## The problem
+
+Before this work, the sessions service's `fork()` and `spawn()` paths — and
+their MCP-tool front-ends `agor_sessions_spawn` and
+`agor_sessions_prompt(mode:"fork"|"subsession")` — created child sessions with:
+
+```ts
+created_by:   parent.created_by,   // inherits parent owner
+unix_username: parent.unix_username // inherits parent's Unix identity
+```
+
+The intent was "child belongs to the same person as the parent." In practice,
+combined with `others_can: 'session'` (the safe default that lets non-owners
+create sessions in a worktree) and the MCP surface, it meant any user able to
+*see* another user's session could spawn or fork from it and have that child
+session execute under the original creator's:
+
+- Unix user (filesystem permissions, `~/.claude/`, `~/.codex/` storage, etc.)
+- Encrypted env vars (`session_env_selections` resolved against
+  `parent.created_by`'s stored vars)
+- Provider credentials (Anthropic / OpenAI / Gemini / Copilot tokens)
+- SDK session state directories
+
+That is **identity borrowing** via the spawn/fork MCP surface: a collaborator
+running their own prompt would still have the agent run as the original user.
+This was effectively the same risk surface that `others_can: 'prompt'` already
+exposes for *direct* prompts — but it was unconditional on spawn/fork, with no
+opt-in toggle and no warning, even when the worktree was on the safe default
+of `others_can: 'session'`.
+
+Admins and superadmins also inherited rather than being attributed to
+themselves, which broke the audit trail on admin-driven spawns.
+
+---
+
+## Short-term flag (shipped)
+
+A new worktree-level boolean controls whether legacy identity borrowing is
+preserved on spawn/fork.
+
+```ts
+// packages/core/src/types/worktree.ts
+interface Worktree {
+  // ...
+  /** DANGEROUS: opt in to legacy parent-inheriting identity on spawn/fork */
+  dangerously_allow_session_sharing?: boolean; // default: false
+}
+```
+
+### New rules (see `apps/agor-daemon/src/utils/worktree-authorization.ts`
+`determineSpawnIdentity`)
+
+| Caller                          | Flag OFF (default)            | Flag ON                         |
+| ------------------------------- | ----------------------------- | ------------------------------- |
+| Same user as parent             | `created_by = caller`         | `created_by = caller`           |
+| Admin / superadmin              | `created_by = admin` (always) | `created_by = admin` (always)   |
+| Other user (cross-user spawn)   | `created_by = caller` (safe)  | `created_by = parent_owner` ⚠️  |
+| Service account (executor etc.) | `created_by = parent_owner`   | `created_by = parent_owner`     |
+
+When the legacy path triggers (cross-user spawn, flag ON), the daemon emits a
+loud `console.warn('[SECURITY] cross-user session spawn/fork allowed by …')`
+log line for audit trails.
+
+The new child session's `unix_username` is left to the existing
+`setSessionUnixUsername` hook, which stamps it with the *caller's* current
+Unix username. With the safe default this means the execution context now
+matches the attribution. Under the legacy flag the hook still writes the
+caller's username — operators relying on flag-ON behavior must be aware that
+the child runs under `parent.created_by`'s app identity but the caller's Unix
+account; if you need full Unix-level identity borrowing, switch to
+`unix_user_mode: simple` (where there is no per-user Unix identity to borrow).
+
+### UI
+
+`WorktreeModal → Owners & Permissions` exposes the toggle as
+"Allow legacy session sharing" with a red `Alert` describing the risk. Copy is
+marked TODO for product to finalize.
+
+### Tests
+
+`apps/agor-daemon/src/utils/determine-spawn-identity.test.ts` covers the
+matrix above plus admin/superadmin overrides, service-account fallback,
+missing-caller refusal, and the warn-log signal.
+
+---
+
+## Longer-term design options (not scheduled)
+
+The flag is a hardening fix, not a redesign. Four directions are worth
+considering before we either remove the flag or invert its default:
+
+### Option A — Worktree-scoped SDK home
+
+Move every SDK's per-user state (`~/.claude/`, `~/.codex/`, etc.) into a
+worktree-scoped directory, e.g. `<worktree.path>/.agor-sdk/<tool>/`. Sessions
+in the same worktree share SDK state, and "forking from another user's
+session" becomes meaningful (same on-disk SDK chain, attributed to the new
+caller). Removes the "child needs the parent's home directory" coupling that
+made identity borrowing tempting in the first place.
+
+### Option B — Fork = copy semantics
+
+On fork, snapshot the parent's SDK transcript / tool state into the child
+session's own storage instead of pointing at the parent's. Eliminates the
+shared-credentials problem but increases storage and breaks "talking to the
+same model context" expectations.
+
+### Option C — Stateless portability
+
+Persist SDK session state as portable artifacts (transcript + cached tool
+output) decoupled from any user's home directory. Sessions become
+"replayable" — any user with `prompt` access can resume one under their own
+identity without filesystem coupling. Largest effort, but cleanest long-term.
+
+### Option D — Executor sandbox always-on
+
+Force every session to run inside the executor sandbox (no user-home access),
+making "whose Unix identity does this run as?" a non-question. Pairs well
+with strict Unix mode and would let us remove the flag entirely once
+sandboxing is the default.
+
+These are sketches; each has open questions around SDK feature parity,
+backwards compatibility, and storage cost. Pick this back up when the
+short-term flag's friction surfaces real demand.

--- a/context/explorations/session-sharing.md
+++ b/context/explorations/session-sharing.md
@@ -66,17 +66,38 @@ interface Worktree {
 | Service account (executor etc.) | `created_by = parent_owner`   | `created_by = parent_owner`     |
 
 When the legacy path triggers (cross-user spawn, flag ON), the daemon emits a
-loud `console.warn('[SECURITY] cross-user session spawn/fork allowed by …')`
-log line for audit trails.
+structured `console.warn('[SECURITY] legacy_session_sharing', { event,
+caller_id, parent_owner_id, worktree_id })` log line for audit trails.
 
 The new child session's `unix_username` is left to the existing
 `setSessionUnixUsername` hook, which stamps it with the *caller's* current
 Unix username. With the safe default this means the execution context now
-matches the attribution. Under the legacy flag the hook still writes the
-caller's username — operators relying on flag-ON behavior must be aware that
-the child runs under `parent.created_by`'s app identity but the caller's Unix
-account; if you need full Unix-level identity borrowing, switch to
-`unix_user_mode: simple` (where there is no per-user Unix identity to borrow).
+matches the attribution.
+
+**Important caveat — flag scope is app-identity only:**
+
+The flag restores legacy attribution at the *application* layer
+(`session.created_by`) but does **not** propagate the parent's
+`unix_username` to the child. The downstream effect depends on
+`unix_user_mode`:
+
+- **`simple`** — no per-user Unix identity exists, so flag-ON behaves as
+  intended: the child is attributed to the parent owner and runs under the
+  daemon user.
+- **`insulated`** — sessions execute as a shared executor user. Same as
+  `simple` from an OS-identity perspective; flag-ON works.
+- **`strict`** — sessions execute as the *creator's* Unix user, and
+  `validateSessionUnixUsername` (in `worktree-authorization.ts`) compares the
+  session's stamped `unix_username` against the *current* `created_by`
+  user's `unix_username`. Because flag-ON sets `created_by = parent_owner`
+  but `unix_username = caller`, this check **fails** and the child session
+  refuses to execute.
+
+In other words, flag-ON is effectively a no-op in `strict` mode (sessions
+are created but cannot be prompted). This is intentional — strict mode is
+the security guarantee we don't want a worktree-level toggle to undermine.
+Operators who genuinely need cross-user identity borrowing should use
+`simple` or `insulated` mode.
 
 ### UI
 

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -160,6 +160,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
         last_used: worktree.last_used ?? new Date(now).toISOString(),
         custom_context: worktree.custom_context,
         mcp_server_ids: worktree.mcp_server_ids,
+        dangerously_allow_session_sharing: worktree.dangerously_allow_session_sharing,
         schedule: worktree.schedule,
       },
     };

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -567,6 +567,12 @@ export const worktrees = pgTable(
         // Default MCP servers for new sessions in this worktree
         mcp_server_ids?: string[];
 
+        // DANGEROUS: opt-in to legacy session-spawn identity borrowing.
+        // When true, agor_sessions_spawn / agor_sessions_prompt(mode:"fork"|"subsession")
+        // attribute the new child session to the parent owner instead of the
+        // MCP-authenticated caller. See packages/core/src/types/worktree.ts.
+        dangerously_allow_session_sharing?: boolean;
+
         // Schedule configuration (full config in JSON blob)
         schedule?: {
           timezone: string; // IANA timezone (default: 'UTC')

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -559,6 +559,12 @@ export const worktrees = sqliteTable(
         // Default MCP servers for new sessions in this worktree
         mcp_server_ids?: string[];
 
+        // DANGEROUS: opt-in to legacy session-spawn identity borrowing.
+        // When true, agor_sessions_spawn / agor_sessions_prompt(mode:"fork"|"subsession")
+        // attribute the new child session to the parent owner instead of the
+        // MCP-authenticated caller. See packages/core/src/types/worktree.ts.
+        dangerously_allow_session_sharing?: boolean;
+
         // Unix integration
         // Note: unix_gid was previously stored here but is now resolved dynamically
         // via getGidFromGroupName(unix_group) at execution time. See id-lookups.ts.

--- a/packages/core/src/types/worktree.ts
+++ b/packages/core/src/types/worktree.ts
@@ -370,6 +370,30 @@ export interface Worktree {
    * This controls OS-level permissions independent of app-layer 'others_can'.
    */
   others_fs_access?: 'none' | 'read' | 'write';
+
+  // ===== Session Sharing (legacy identity-borrow opt-in) =====
+
+  /**
+   * DANGEROUS: Allow legacy "identity borrowing" on session spawn/fork.
+   *
+   * Default (false / undefined): When user A calls `agor_sessions_spawn` or
+   * `agor_sessions_prompt(mode:"fork"|"subsession")` against user B's session,
+   * the new child session is attributed to A — `child.created_by = A.id` —
+   * and runs under A's Unix identity, credentials, and env vars.
+   *
+   * When true: legacy behavior is preserved — the child inherits
+   * `parent.created_by`, so it executes under the *parent owner's* identity
+   * even when spawned by a different caller. This effectively lets a
+   * collaborator run code as the session creator (similar to what
+   * `others_can: 'prompt'` already permits for direct prompts), and is
+   * preserved only for parity with pre-existing automation that relies on it.
+   *
+   * Admins (role >= admin) are *always* attributed to themselves regardless
+   * of this flag.
+   *
+   * Cross-user spawns under this flag are logged loudly by the daemon.
+   */
+  dangerously_allow_session_sharing?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the **identity attribution** vulnerability class on every external write
surface. Started as the Chain D fix (spawn/fork) and grew to cover the full
`created_by` trust pattern after a Codex review surfaced parallel bugs.

### Chain D — spawn/fork identity borrowing

`agor_sessions_spawn`, `agor_sessions_prompt(mode:"fork"|"subsession")`, and
`sessions.spawn()` / `sessions.fork()` previously inherited
`parent.created_by`, so any collaborator who could see another user's session
could spawn/fork an agent that ran under the original owner's Unix identity,
env vars, and provider credentials.

- New worktree flag `dangerously_allow_session_sharing` (default `false`)
- New pure helper `determineSpawnIdentity()` enforces:
  - Same user → caller-as-owner
  - Admin / superadmin → always self (audit trail)
  - Cross-user, flag OFF → caller-as-owner (safe default)
  - Cross-user, flag ON → parent_owner + structured `[SECURITY]` warn log
  - Service accounts → preserve parent attribution
  - No caller id (external call) → throws `Forbidden`
- `sessions.spawn()` / `sessions.fork()` route through the helper
- `resolveChildIdentity` gates the internal-call bypass on `params.provider`
  (not on missing `user_id`) so external calls fail closed
- Worktree modal exposes the toggle with a red `Alert`

### `created_by` trust — every other write surface

A follow-up audit found four parallel bugs sharing the same anti-pattern:
external POST callers could set `created_by` to any user_id and have new
resources attributed to a different user.

Confirmed bugs:
- `sessions.create` — `if (!item.created_by) item.created_by = userId`
- `tasks.create` — same pattern
- `boards.create` — same pattern
- `/board-comments/:id/reply` route — required `data.created_by` from the
  client and trusted it verbatim

Defense-in-depth (no inject hook at all → freely settable):
- `worktrees.create`
- `artifacts.create`
- `cards.create`
- `board-comments.create` (standalone)

Fix: extract a shared `injectCreatedBy()` before-create hook with a clear
security model:

- **External** (`params.provider != null`): UNCONDITIONALLY overwrite
  `data.created_by` with `params.user.user_id`. Any client value is
  silently discarded. Throws `NotAuthenticated` if no user.
- **Internal** (no provider): respect explicit `created_by` from the caller
  (scheduler / service-to-service), defaulting to caller user_id or
  `'anonymous'`.

Apply the helper to every create surface that has a `created_by` field;
patch the board-comments reply route inline.

### Test coverage

- 12 unit tests for `determineSpawnIdentity` (full identity matrix +
  admin/superadmin overrides + service accounts + missing-caller refusal +
  structured-log signal)
- 9 unit tests for `injectCreatedBy` (external overwrite single + array,
  NotAuthenticated when user missing, internal pass-through, no-op on
  missing data)
- `pnpm check` (typecheck + lint + build) passes

### Test plan

- [x] `pnpm check`: clean
- [x] All unit tests pass
- [ ] Manual: with two users in the same worktree, confirm Bob spawning
      from Alice's session creates a session attributed to Bob (flag OFF)
- [ ] Manual: flip `dangerously_allow_session_sharing` ON, repeat —
      confirm child is attributed to Alice and a structured `[SECURITY]
      legacy_session_sharing` log line appears in daemon logs
- [ ] Manual: admin spawning from any user's session is always attributed
      to the admin
- [ ] Manual: POST `/sessions` with `{ created_by: '<other_user_id>' }`
      and confirm the new session is attributed to the authenticated
      caller, not the supplied id (repeat for /tasks, /boards,
      /board-comments, /artifacts, /worktrees, /cards, and
      /board-comments/:id/reply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
