### PR TITLE
test(leaderboard): cover userName/userEmail hydration for groupBy=user

### DIFF
--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -279,7 +279,13 @@ describe('LeaderboardService backward compatibility', () => {
     expect(bob?.userName).toBe('Bob');
     expect(bob?.userEmail).toBe('bob@example.com');
   });
+});
 
+// ---------------------------------------------------------------------------
+// Hydration (user/worktree display fields populated via JOINs)
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService hydration', () => {
   dbTest('groupBy: "user,worktree" hydrates both user and worktree names', async ({ db }) => {
     await seedCanonicalDataset(db);
     const service = new LeaderboardService(db);
@@ -300,6 +306,7 @@ describe('LeaderboardService backward compatibility', () => {
       expect(row.userId).toBeUndefined();
       expect(row.userName).toBeUndefined();
       expect(row.userEmail).toBeUndefined();
+      expect(row.userEmoji).toBeUndefined();
     }
   });
 });

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -270,6 +270,37 @@ describe('LeaderboardService backward compatibility', () => {
     // New split metrics
     expect(alice?.totalInputTokens).toBe(7_000);
     expect(alice?.totalOutputTokens).toBe(3_500);
+    // User display fields are hydrated via LEFT JOIN on users (avoids N+1)
+    expect(alice?.userName).toBe('Alice');
+    expect(alice?.userEmail).toBe('alice@example.com');
+    expect(alice?.userEmoji).toBe('emoji');
+
+    const bob = result.data.find((r) => r.userId === 'user-bob');
+    expect(bob?.userName).toBe('Bob');
+    expect(bob?.userEmail).toBe('bob@example.com');
+  });
+
+  dbTest('groupBy: "user,worktree" hydrates both user and worktree names', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user,worktree' } });
+    const alice = result.data.find((r) => r.userId === 'user-alice');
+    expect(alice?.userName).toBe('Alice');
+    expect(alice?.userEmail).toBe('alice@example.com');
+    expect(alice?.worktreeName).toBe('main-wt');
+  });
+
+  dbTest('groupBy without "user" does not populate user display fields', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'worktree' } });
+    for (const row of result.data) {
+      expect(row.userId).toBeUndefined();
+      expect(row.userName).toBeUndefined();
+      expect(row.userEmail).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The leaderboard service already LEFT JOINs `users` and populates `userName`, `userEmail`, and `userEmoji` when `groupBy` includes `user` (landed in #632 / refined in #1024). That avoids the N+1 hydration frontends would otherwise need, since the `users` query schema is `additionalProperties: false` with `user_id` typed as a single UUID — no `$in` operator means batch hydration via `users.find` isn't possible.

That behavior had no direct test coverage. This PR adds it:

- Extend the existing `groupBy=user` test to assert Alice/Bob names and emails come back alongside token metrics (and emoji too, since the fixture already sets it).
- Add a `groupBy=user,worktree` test confirming both dimensions hydrate their display fields simultaneously.
- Add a negative test confirming user display fields stay `undefined` when the `user` dimension isn't requested.

No production-code changes — the implementation was already in place; only tests were missing.

## Test plan

- [x] `pnpm --filter @agor/daemon test src/services/leaderboard.test.ts` — 18/18 passing (was 15)
- [x] `pnpm --filter @agor/daemon typecheck` — clean
- [x] Pre-commit hooks (typecheck + lint) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)