### PR TITLE
fix(mcp): require public base URL for OAuth callback, no localhost fallback

### DIFF
--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for the daemon-side MCP OAuth callback URL.
+ *
+ * Background: a previous bug had `apps/agor-daemon/src/register-services.ts`
+ * routing some OAuth flows (Settings UI Discover, Test OAuth → Start Browser
+ * Flow) through `performMCPOAuthFlow()` from `@agor/core/tools/mcp/...`. That
+ * helper spins up a `127.0.0.1:<random>` HTTP listener and uses it as the
+ * OAuth `redirect_uri`. Upstream OAuth providers (Notion, Linear, etc.) then
+ * send the redirect to the END USER'S BROWSER, which generally cannot reach
+ * the daemon's `127.0.0.1` — symptom: per-user "OAuth login redirected me to
+ * localhost" failures for any user not running on the daemon host.
+ *
+ * The fix funnels every daemon OAuth path through `startTwoPhaseMCPOAuthFlow`,
+ * which builds the `redirect_uri` from `requirePublicBaseUrl()` —
+ * `<daemon base_url>/mcp-servers/oauth-callback` — never from `localhost` or
+ * `127.0.0.1`.
+ *
+ * These structural assertions are intentionally coarse: they prevent the
+ * specific regression of any new daemon code re-introducing
+ * `performMCPOAuthFlow` or hand-rolling a `127.0.0.1` callback URL.
+ */
+describe('register-services OAuth callback URL regression', () => {
+  const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
+
+  /**
+   * Strip comments and string literals so the structural checks below can't be
+   * fooled by (a) explanatory prose mentioning the old 127.0.0.1 behavior or
+   * (b) unrelated `http://localhost:` strings (e.g. the UI dev URL, which has
+   * nothing to do with OAuth).
+   */
+  const codeOnly = rawSource
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/(^|[^:])\/\/.*$/gm, '$1'); // line comments (keep `://`)
+
+  it('never calls performMCPOAuthFlow from the daemon', () => {
+    // The CLI helper is now documented as CLI-only. Daemon code MUST go
+    // through startTwoPhaseMCPOAuthFlow + the daemon-side oauth-callback
+    // handler so the redirect_uri is the daemon's public base URL.
+    expect(codeOnly).not.toMatch(/\bperformMCPOAuthFlow\s*\(/);
+  });
+
+  it('never constructs an OAuth redirect URI pointing at 127.0.0.1 or localhost', () => {
+    // Catch hand-rolled redirect URIs in any new code path that bypasses
+    // requirePublicBaseUrl(). Narrow the check to `redirect`-adjacent usage
+    // so it can't be tripped by unrelated hosts (e.g. `http://localhost:UI_PORT`).
+    const redirectContextWindows = codeOnly.match(/.{0,80}redirect.{0,160}/gi) || [];
+    for (const window of redirectContextWindows) {
+      expect(window).not.toMatch(/127\.0\.0\.1/);
+      expect(window).not.toMatch(/http:\/\/localhost/);
+    }
+  });
+
+  it('builds the OAuth redirect URI from the public base URL', () => {
+    // startTwoPhaseMCPOAuthFlow is the single entry point and must use
+    // requirePublicBaseUrl() (not getBaseUrl(), which silently falls back
+    // to localhost in dev).
+    expect(codeOnly).toMatch(/requirePublicBaseUrl\s*\(/);
+    expect(codeOnly).toMatch(/['"]\/mcp-servers\/oauth-callback['"]/);
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -963,14 +963,23 @@ async function registerMCPServices(
       state: string;
       authorizationUrl: string;
     };
+    /**
+     * Origin-stable key used by {@link persistOAuthToken} to populate the
+     * daemon-level token cache (`oauth21TokenCache`). MUST be the MCP server
+     * URL — NOT `context.metadataUrl` — because subsequent lookups via
+     * {@link getOAuth21Token} are keyed by MCP URL origin. RFC 9728 metadata
+     * URLs *should* sit on the resource-server origin, but nothing enforces
+     * that, and a drift would silently bust the cache.
+     */
+    mcpUrl: string;
     mcpServerId?: string;
     userId?: string;
     oauthMode?: 'per_user' | 'shared';
     socketId?: string;
     createdAt: number;
     /**
-     * Optional resolver wired up by {@link startTwoPhaseMCPOAuthFlow} when the
-     * caller wants to block on token acquisition (discover / test-oauth flows).
+     * Resolver wired up by `startTwoPhaseMCPOAuthFlowAndAwaitToken` when the
+     * caller wants to block on token acquisition (discover / test-oauth).
      * The daemon-side `oauthCallbackHandler` calls these after the token has
      * been exchanged + persisted so the original HTTP request can complete.
      */
@@ -980,6 +989,15 @@ async function registerMCPServices(
 
   // Store pending OAuth flow contexts
   const pendingOAuthFlows = new Map<string, PendingOAuthFlow>();
+
+  /**
+   * Hard ceiling on how long an inbound HTTP request will block waiting for
+   * the user to complete the browser-side OAuth flow. The 10-minute sweeper
+   * below is the *cleanup* upper bound; this is the *request* upper bound.
+   * Most reverse proxies time out long before 10 minutes, so we surface a
+   * clear error sooner than that and free the pending entry.
+   */
+  const AWAIT_TOKEN_TIMEOUT_MS = 5 * 60 * 1000;
 
   // Clean up expired flows (older than 10 minutes)
   setInterval(() => {
@@ -998,16 +1016,25 @@ async function registerMCPServices(
    * Shared helper for starting the daemon's two-phase MCP OAuth flow.
    *
    * All daemon-side OAuth paths (Settings "Start OAuth Flow", discover probe,
-   * test-oauth `start_browser_flow`) MUST go through this helper so that:
+   * test-oauth `start_browser_flow`) MUST go through one of these two helpers
+   * so that:
    *   1. The `redirect_uri` is always the daemon's PUBLIC base URL, not
    *      `127.0.0.1:<random>` — the browser completing the flow may be on a
    *      different machine than the daemon (e.g. any remotely-deployed Agor).
    *   2. The `oauth:open_browser` socket event is emitted consistently to the
    *      user who initiated the flow.
-   *   3. Callers that need to block until token acquisition (discover,
-   *      test-oauth) can opt in via `awaitToken: true` and receive a Promise
-   *      that resolves when `oauthCallbackHandler` finishes exchanging the
-   *      authorization code for a token.
+   *   3. The pending-flow entry carries `mcpUrl` so the post-callback cache
+   *      key matches the MCP server origin used by all subsequent lookups.
+   *
+   * Two flavors:
+   *   - {@link startTwoPhaseMCPOAuthFlow} — fire-and-forget. Used by
+   *     `oauth-start`, where the UI completes the flow asynchronously and the
+   *     daemon broadcasts `oauth:completed` over the socket.
+   *   - {@link startTwoPhaseMCPOAuthFlowAndAwaitToken} — blocks on a Promise
+   *     that resolves once `oauthCallbackHandler` finishes exchanging + persisting
+   *     the token. Used by `discover` and `test-oauth start_browser_flow`,
+   *     which need to return the token-validation result in the same HTTP
+   *     response. Bounded by {@link AWAIT_TOKEN_TIMEOUT_MS}.
    */
   type StartTwoPhaseOAuthOptions = {
     mcpUrl: string;
@@ -1022,21 +1049,37 @@ async function registerMCPServices(
     tokenUrlOverride?: string;
     scope?: string;
     socketId?: string;
-    /** When true, the returned object exposes an `awaitToken()` promise. */
-    awaitToken?: boolean;
   };
 
   type StartTwoPhaseOAuthResult = {
     state: string;
     authorizationUrl: string;
     redirectUri: string;
-    /** Present only when `awaitToken: true` was passed. */
-    awaitToken?: () => Promise<OAuthTokenResponse>;
+  };
+
+  type StartTwoPhaseOAuthAndAwaitResult = StartTwoPhaseOAuthResult & {
+    awaitToken: () => Promise<OAuthTokenResponse>;
   };
 
   async function startTwoPhaseMCPOAuthFlow(
     opts: StartTwoPhaseOAuthOptions
   ): Promise<StartTwoPhaseOAuthResult> {
+    return startTwoPhaseMCPOAuthFlowInternal(opts, false);
+  }
+
+  async function startTwoPhaseMCPOAuthFlowAndAwaitToken(
+    opts: StartTwoPhaseOAuthOptions
+  ): Promise<StartTwoPhaseOAuthAndAwaitResult> {
+    return (await startTwoPhaseMCPOAuthFlowInternal(
+      opts,
+      true
+    )) as StartTwoPhaseOAuthAndAwaitResult;
+  }
+
+  async function startTwoPhaseMCPOAuthFlowInternal(
+    opts: StartTwoPhaseOAuthOptions,
+    awaitToken: boolean
+  ): Promise<StartTwoPhaseOAuthResult | StartTwoPhaseOAuthAndAwaitResult> {
     const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
 
     // Strict public base URL — see oauth-start endpoint for the rationale.
@@ -1054,15 +1097,39 @@ async function registerMCPServices(
     let tokenPromise: Promise<OAuthTokenResponse> | undefined;
     let tokenResolve: ((t: OAuthTokenResponse) => void) | undefined;
     let tokenReject: ((err: Error) => void) | undefined;
-    if (opts.awaitToken) {
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    if (awaitToken) {
       tokenPromise = new Promise<OAuthTokenResponse>((resolve, reject) => {
-        tokenResolve = resolve;
-        tokenReject = reject;
+        // Wrap resolve/reject to also clear the per-request timeout so it
+        // can't fire after a fast success/error path.
+        tokenResolve = (t) => {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+          resolve(t);
+        };
+        tokenReject = (err) => {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+          reject(err);
+        };
+        timeoutHandle = setTimeout(() => {
+          // Drop the pending entry so the eventual callback (if any) sees
+          // "expired or not found" instead of double-resolving.
+          const pending = pendingOAuthFlows.get(context.state);
+          if (pending) {
+            pendingOAuthFlows.delete(context.state);
+          }
+          reject(
+            new Error(
+              `Timed out after ${Math.round(AWAIT_TOKEN_TIMEOUT_MS / 1000)}s waiting for OAuth callback. ` +
+                'The user may not have completed the browser sign-in.'
+            )
+          );
+        }, AWAIT_TOKEN_TIMEOUT_MS);
       });
     }
 
     pendingOAuthFlows.set(context.state, {
       context,
+      mcpUrl: opts.mcpUrl,
       mcpServerId: opts.mcpServerId,
       userId: opts.userId,
       oauthMode: opts.oauthMode,
@@ -1081,12 +1148,15 @@ async function registerMCPServices(
       }
     }
 
-    return {
+    const base: StartTwoPhaseOAuthResult = {
       state: context.state,
       authorizationUrl: context.authorizationUrl,
       redirectUri,
-      awaitToken: tokenPromise ? () => tokenPromise! : undefined,
     };
+    if (tokenPromise) {
+      return { ...base, awaitToken: () => tokenPromise! };
+    }
+    return base;
   }
 
   // Set the OAuth callback handler
@@ -1145,7 +1215,7 @@ async function registerMCPServices(
         await persistOAuthToken(
           db,
           tokenResponse,
-          pendingFlow.context.metadataUrl,
+          pendingFlow.mcpUrl,
           pendingFlow,
           'OAuth Callback'
         );
@@ -1302,9 +1372,9 @@ async function registerMCPServices(
               // is the daemon's public base URL (browser-reachable for any
               // user) rather than a 127.0.0.1 callback server bound to the
               // daemon process.
-              let started: StartTwoPhaseOAuthResult;
+              let started: StartTwoPhaseOAuthAndAwaitResult;
               try {
-                started = await startTwoPhaseMCPOAuthFlow({
+                started = await startTwoPhaseMCPOAuthFlowAndAwaitToken({
                   mcpUrl: data.mcp_url,
                   wwwAuthenticate: wwwAuthenticate || '',
                   resourceMetadataUrl: metadataUrl,
@@ -1315,7 +1385,6 @@ async function registerMCPServices(
                   oauthMode: 'shared',
                   clientId: data.client_id,
                   socketId: connection?.id,
-                  awaitToken: true,
                 });
               } catch (err) {
                 if (err instanceof PublicBaseUrlNotConfiguredError) {
@@ -1324,7 +1393,7 @@ async function registerMCPServices(
                 throw err;
               }
 
-              const tokenResponse = await started.awaitToken!();
+              const tokenResponse = await started.awaitToken();
 
               const testResponse = await fetch(data.mcp_url, {
                 method: 'POST',
@@ -1665,7 +1734,7 @@ async function registerMCPServices(
         await persistOAuthToken(
           db,
           tokenResponse,
-          pendingFlow.context.metadataUrl,
+          pendingFlow.mcpUrl,
           pendingFlow,
           'OAuth Complete'
         );
@@ -1865,36 +1934,31 @@ async function registerMCPServices(
             // public URL) instead of the legacy 127.0.0.1 callback server, so
             // remote browsers can complete the redirect on a deployed Agor.
             const connection = params?.connection as { id?: string } | undefined;
-            let started: StartTwoPhaseOAuthResult;
-            try {
-              started = await startTwoPhaseMCPOAuthFlow({
-                mcpUrl,
-                wwwAuthenticate: wwwAuthenticate || '',
-                resourceMetadataUrl: resolved.metadataUrl,
-                mcpServerId: serverId,
-                userId: params?.user?.user_id,
-                // Discover writes the token via the shared MCP server row when
-                // a serverId is known (matches the previous saveOAuth21TokenToDB
-                // call). Without a serverId nothing is persisted to the DB; the
-                // daemon-level cache below carries the token for this request.
-                oauthMode: 'shared',
-                socketId: connection?.id,
-                awaitToken: true,
-              });
-            } catch (err) {
-              if (err instanceof PublicBaseUrlNotConfiguredError) {
-                console.error('[MCP Discovery]', err.message);
-                return undefined;
-              }
-              throw err;
-            }
+            const started = await startTwoPhaseMCPOAuthFlowAndAwaitToken({
+              mcpUrl,
+              wwwAuthenticate: wwwAuthenticate || '',
+              resourceMetadataUrl: resolved.metadataUrl,
+              mcpServerId: serverId,
+              userId: params?.user?.user_id,
+              // Discover writes the token via the shared MCP server row when
+              // a serverId is known (matches the previous saveOAuth21TokenToDB
+              // call). Without a serverId nothing is persisted to the DB; the
+              // daemon-level cache below carries the token for this request.
+              oauthMode: 'shared',
+              socketId: connection?.id,
+            });
 
-            const tokenResponse = await started.awaitToken!();
+            const tokenResponse = await started.awaitToken();
             // persistOAuthToken (run inside oauthCallbackHandler) already
             // populated the daemon cache + the MCP server row, so we just
             // return the access token to the caller.
             return tokenResponse.access_token;
           } catch (error) {
+            // Misconfigured public base URL is a daemon-level problem, not a
+            // missing-token signal — re-throw so the discover endpoint can
+            // surface it to the caller instead of silently falling through to
+            // an unauthenticated MCP probe.
+            if (error instanceof PublicBaseUrlNotConfiguredError) throw error;
             console.error('[MCP Discovery] OAuth token acquisition failed:', error);
             return undefined;
           }
@@ -2080,6 +2144,10 @@ async function registerMCPServices(
           }
         }
       } catch (error) {
+        if (error instanceof PublicBaseUrlNotConfiguredError) {
+          console.error('[MCP Discovery]', error.message);
+          return { success: false, error: error.message };
+        }
         console.error('MCP discovery error:', error);
         return { success: false, error: error instanceof Error ? error.message : String(error) };
       }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -48,7 +48,6 @@ import {
   getOAuth21TokenFromDBByUrl,
   oauth21TokenCache,
   persistOAuthToken,
-  saveOAuth21TokenToDB,
 } from './oauth-cache.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import { createArtifactsService } from './services/artifacts.js';
@@ -946,27 +945,41 @@ async function registerMCPServices(
 <body><div class="card"><div class="icon">${icon}</div><p>${safeMessage}</p></div></body></html>`;
   }
 
+  type OAuthTokenResponse = {
+    access_token: string;
+    token_type?: string;
+    expires_in?: number;
+    refresh_token?: string;
+  };
+
+  type PendingOAuthFlow = {
+    context: {
+      metadataUrl: string;
+      tokenEndpoint: string;
+      redirectUri: string;
+      pkceVerifier: string;
+      clientId: string;
+      clientSecret?: string;
+      state: string;
+      authorizationUrl: string;
+    };
+    mcpServerId?: string;
+    userId?: string;
+    oauthMode?: 'per_user' | 'shared';
+    socketId?: string;
+    createdAt: number;
+    /**
+     * Optional resolver wired up by {@link startTwoPhaseMCPOAuthFlow} when the
+     * caller wants to block on token acquisition (discover / test-oauth flows).
+     * The daemon-side `oauthCallbackHandler` calls these after the token has
+     * been exchanged + persisted so the original HTTP request can complete.
+     */
+    tokenResolve?: (tokenResponse: OAuthTokenResponse) => void;
+    tokenReject?: (err: Error) => void;
+  };
+
   // Store pending OAuth flow contexts
-  const pendingOAuthFlows = new Map<
-    string,
-    {
-      context: {
-        metadataUrl: string;
-        tokenEndpoint: string;
-        redirectUri: string;
-        pkceVerifier: string;
-        clientId: string;
-        clientSecret?: string;
-        state: string;
-        authorizationUrl: string;
-      };
-      mcpServerId?: string;
-      userId?: string;
-      oauthMode?: 'per_user' | 'shared';
-      socketId?: string;
-      createdAt: number;
-    }
-  >();
+  const pendingOAuthFlows = new Map<string, PendingOAuthFlow>();
 
   // Clean up expired flows (older than 10 minutes)
   setInterval(() => {
@@ -975,10 +988,106 @@ async function registerMCPServices(
     for (const [state, flow] of pendingOAuthFlows.entries()) {
       if (now - flow.createdAt > tenMinutes) {
         pendingOAuthFlows.delete(state);
+        flow.tokenReject?.(new Error('OAuth flow expired before callback was received'));
         console.log('[OAuth] Cleaned up expired flow:', state);
       }
     }
   }, 60_000);
+
+  /**
+   * Shared helper for starting the daemon's two-phase MCP OAuth flow.
+   *
+   * All daemon-side OAuth paths (Settings "Start OAuth Flow", discover probe,
+   * test-oauth `start_browser_flow`) MUST go through this helper so that:
+   *   1. The `redirect_uri` is always the daemon's PUBLIC base URL, not
+   *      `127.0.0.1:<random>` — the browser completing the flow may be on a
+   *      different machine than the daemon (e.g. any remotely-deployed Agor).
+   *   2. The `oauth:open_browser` socket event is emitted consistently to the
+   *      user who initiated the flow.
+   *   3. Callers that need to block until token acquisition (discover,
+   *      test-oauth) can opt in via `awaitToken: true` and receive a Promise
+   *      that resolves when `oauthCallbackHandler` finishes exchanging the
+   *      authorization code for a token.
+   */
+  type StartTwoPhaseOAuthOptions = {
+    mcpUrl: string;
+    wwwAuthenticate: string;
+    resourceMetadataUrl: string;
+    mcpServerId?: string;
+    userId?: string;
+    oauthMode?: 'per_user' | 'shared';
+    clientId?: string;
+    clientSecret?: string;
+    authorizationUrlOverride?: string;
+    tokenUrlOverride?: string;
+    scope?: string;
+    socketId?: string;
+    /** When true, the returned object exposes an `awaitToken()` promise. */
+    awaitToken?: boolean;
+  };
+
+  type StartTwoPhaseOAuthResult = {
+    state: string;
+    authorizationUrl: string;
+    redirectUri: string;
+    /** Present only when `awaitToken: true` was passed. */
+    awaitToken?: () => Promise<OAuthTokenResponse>;
+  };
+
+  async function startTwoPhaseMCPOAuthFlow(
+    opts: StartTwoPhaseOAuthOptions
+  ): Promise<StartTwoPhaseOAuthResult> {
+    const { startMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
+
+    // Strict public base URL — see oauth-start endpoint for the rationale.
+    const baseUrl = await requirePublicBaseUrl();
+    const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
+
+    const context = await startMCPOAuthFlow(opts.wwwAuthenticate, opts.clientId, redirectUri, {
+      authorizationUrlOverride: opts.authorizationUrlOverride,
+      tokenUrlOverride: opts.tokenUrlOverride,
+      clientSecret: opts.clientSecret,
+      scope: opts.scope,
+      resourceMetadataUrl: opts.resourceMetadataUrl,
+    });
+
+    let tokenPromise: Promise<OAuthTokenResponse> | undefined;
+    let tokenResolve: ((t: OAuthTokenResponse) => void) | undefined;
+    let tokenReject: ((err: Error) => void) | undefined;
+    if (opts.awaitToken) {
+      tokenPromise = new Promise<OAuthTokenResponse>((resolve, reject) => {
+        tokenResolve = resolve;
+        tokenReject = reject;
+      });
+    }
+
+    pendingOAuthFlows.set(context.state, {
+      context,
+      mcpServerId: opts.mcpServerId,
+      userId: opts.userId,
+      oauthMode: opts.oauthMode,
+      socketId: opts.socketId,
+      createdAt: Date.now(),
+      tokenResolve,
+      tokenReject,
+    });
+
+    if (app.io) {
+      const payload = { authUrl: context.authorizationUrl };
+      if (opts.socketId) {
+        app.io.to(opts.socketId).emit('oauth:open_browser', payload);
+      } else {
+        app.io.emit('oauth:open_browser', payload);
+      }
+    }
+
+    return {
+      state: context.state,
+      authorizationUrl: context.authorizationUrl,
+      redirectUri,
+      awaitToken: tokenPromise ? () => tokenPromise! : undefined,
+    };
+  }
 
   // Set the OAuth callback handler
   const oauthCallbackHandler = async (req: express.Request, res: express.Response) => {
@@ -994,6 +1103,13 @@ async function registerMCPServices(
       if (error) {
         const errorDescription = (req.query.error_description as string) || error;
         console.error('[OAuth Callback] Authorization error:', errorDescription);
+        // Reject any awaitToken() promise from the originating flow so the
+        // caller (discover / test-oauth) can surface the failure.
+        if (state) {
+          const pending = pendingOAuthFlows.get(state);
+          pending?.tokenReject?.(new Error(`Authorization failed: ${errorDescription}`));
+          pendingOAuthFlows.delete(state);
+        }
         res.status(400).send(oauthResultPage(false, `Authorization failed: ${errorDescription}`));
         return;
       }
@@ -1021,34 +1137,49 @@ async function registerMCPServices(
         return;
       }
 
-      const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
-      const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
-      pendingOAuthFlows.delete(state);
+      try {
+        const { completeMCPOAuthFlow } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
+        const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
+        pendingOAuthFlows.delete(state);
 
-      await persistOAuthToken(
-        db,
-        tokenResponse,
-        pendingFlow.context.metadataUrl,
-        pendingFlow,
-        'OAuth Callback'
-      );
+        await persistOAuthToken(
+          db,
+          tokenResponse,
+          pendingFlow.context.metadataUrl,
+          pendingFlow,
+          'OAuth Callback'
+        );
 
-      if (app.io) {
-        const oauthEvent = {
-          state,
-          success: true,
-          mcp_server_id: pendingFlow.mcpServerId,
-          oauth_mode: pendingFlow.oauthMode || 'per_user',
-        };
-        if (pendingFlow.socketId) {
-          app.io.to(pendingFlow.socketId).emit('oauth:completed', oauthEvent);
-        } else {
-          app.io.emit('oauth:completed', oauthEvent);
+        if (app.io) {
+          const oauthEvent = {
+            state,
+            success: true,
+            mcp_server_id: pendingFlow.mcpServerId,
+            oauth_mode: pendingFlow.oauthMode || 'per_user',
+          };
+          if (pendingFlow.socketId) {
+            app.io.to(pendingFlow.socketId).emit('oauth:completed', oauthEvent);
+          } else {
+            app.io.emit('oauth:completed', oauthEvent);
+          }
         }
-      }
 
-      console.log('[OAuth Callback] Flow completed successfully');
-      res.send(oauthResultPage(true, 'OAuth authentication successful! You can close this tab.'));
+        // Notify any awaitToken() callers (discover / test-oauth) that the
+        // token has been exchanged + persisted so their HTTP request can
+        // complete with a real result instead of timing out.
+        pendingFlow.tokenResolve?.(tokenResponse);
+
+        console.log('[OAuth Callback] Flow completed successfully');
+        res.send(oauthResultPage(true, 'OAuth authentication successful! You can close this tab.'));
+      } catch (innerErr) {
+        // Drop the pending entry and reject any awaitToken() promise so the
+        // originating service call returns an error rather than hanging.
+        pendingOAuthFlows.delete(state);
+        pendingFlow.tokenReject?.(
+          innerErr instanceof Error ? innerErr : new Error(String(innerErr))
+        );
+        throw innerErr;
+      }
     } catch (err) {
       console.error('[OAuth Callback] Error:', err);
       res
@@ -1115,7 +1246,6 @@ async function registerMCPServices(
       },
       params?: { connection?: { id?: string } }
     ) {
-      const mcpServerRepo = new MCPServerRepository(db);
       try {
         console.log('[OAuth Test] Probing MCP URL:', data.mcp_url);
 
@@ -1162,41 +1292,39 @@ async function registerMCPServices(
 
           if (data.start_browser_flow) {
             console.log('[OAuth Test] Starting browser-based OAuth 2.1 flow...');
-            const { performMCPOAuthFlow } = await import(
-              '@agor/core/tools/mcp/oauth-mcp-transport'
-            );
 
             try {
-              const browserOpener = async (authUrl: string) => {
-                const connection = (params as AuthenticatedParams)?.connection as
-                  | { id?: string }
-                  | undefined;
-                const socketId = connection?.id;
-                if (socketId && app.io) {
-                  app.io.to(socketId).emit('oauth:open_browser', { authUrl });
-                } else if (app.io) {
-                  app.io.emit('oauth:open_browser', { authUrl });
+              const connection = (params as AuthenticatedParams)?.connection as
+                | { id?: string }
+                | undefined;
+
+              // Route through the daemon's two-phase flow so the redirect_uri
+              // is the daemon's public base URL (browser-reachable for any
+              // user) rather than a 127.0.0.1 callback server bound to the
+              // daemon process.
+              let started: StartTwoPhaseOAuthResult;
+              try {
+                started = await startTwoPhaseMCPOAuthFlow({
+                  mcpUrl: data.mcp_url,
+                  wwwAuthenticate: wwwAuthenticate || '',
+                  resourceMetadataUrl: metadataUrl,
+                  mcpServerId: data.mcp_server_id,
+                  userId: (params as AuthenticatedParams)?.user?.user_id,
+                  // Test endpoint mirrors the previous saveOAuth21TokenToDB
+                  // call (writes to the shared MCP server row, not per-user).
+                  oauthMode: 'shared',
+                  clientId: data.client_id,
+                  socketId: connection?.id,
+                  awaitToken: true,
+                });
+              } catch (err) {
+                if (err instanceof PublicBaseUrlNotConfiguredError) {
+                  return { success: false, error: err.message, oauthType: 'oauth2.1' };
                 }
-              };
-
-              const tokenResponse = await performMCPOAuthFlow(
-                wwwAuthenticate || '',
-                data.client_id,
-                browserOpener,
-                metadataUrl
-              );
-              const testExpiresIn = tokenResponse.expires_in ?? 3600;
-              cacheOAuth21Token(data.mcp_url, tokenResponse.access_token, testExpiresIn);
-
-              if (data.mcp_server_id) {
-                await saveOAuth21TokenToDB(
-                  mcpServerRepo,
-                  data.mcp_server_id,
-                  tokenResponse.access_token,
-                  testExpiresIn,
-                  tokenResponse.refresh_token
-                );
+                throw err;
               }
+
+              const tokenResponse = await started.awaitToken!();
 
               const testResponse = await fetch(data.mcp_url, {
                 method: 'POST',
@@ -1451,7 +1579,7 @@ async function registerMCPServices(
         }
 
         const wwwAuthenticate = probeResponse.headers.get('www-authenticate') || '';
-        const { resolveResourceMetadataUrl, startMCPOAuthFlow } = await import(
+        const { resolveResourceMetadataUrl } = await import(
           '@agor/core/tools/mcp/oauth-mcp-transport'
         );
         const resolved = await resolveResourceMetadataUrl(wwwAuthenticate, data.mcp_url);
@@ -1463,14 +1591,25 @@ async function registerMCPServices(
           };
         }
 
-        // Use the strict public base URL — the redirect_uri is sent to the upstream
-        // OAuth provider (Notion, etc.) and then loaded by the END USER'S BROWSER.
-        // Falling back to http://localhost:PORT silently breaks for any user whose
-        // browser is not running on the daemon machine (e.g. anyone accessing a
-        // deployed Agor instance remotely).
-        let baseUrl: string;
+        const connection = params?.connection as { id?: string } | undefined;
+        const socketId = connection?.id;
+
+        let result: StartTwoPhaseOAuthResult;
         try {
-          baseUrl = await requirePublicBaseUrl();
+          result = await startTwoPhaseMCPOAuthFlow({
+            mcpUrl: data.mcp_url,
+            wwwAuthenticate,
+            resourceMetadataUrl: resolved.metadataUrl,
+            mcpServerId: data.mcp_server_id,
+            userId,
+            oauthMode,
+            clientId: data.client_id || clientIdFromConfig,
+            clientSecret: clientSecretOverride,
+            authorizationUrlOverride,
+            tokenUrlOverride,
+            scope: scopeOverride,
+            socketId,
+          });
         } catch (err) {
           if (err instanceof PublicBaseUrlNotConfiguredError) {
             console.error('[OAuth Start]', err.message);
@@ -1478,38 +1617,11 @@ async function registerMCPServices(
           }
           throw err;
         }
-        const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
-        const effectiveClientId = data.client_id || clientIdFromConfig;
-        const context = await startMCPOAuthFlow(wwwAuthenticate, effectiveClientId, redirectUri, {
-          authorizationUrlOverride,
-          tokenUrlOverride,
-          clientSecret: clientSecretOverride,
-          scope: scopeOverride,
-          resourceMetadataUrl: resolved.metadataUrl,
-        });
-
-        const connection = params?.connection as { id?: string } | undefined;
-        const socketId = connection?.id;
-
-        pendingOAuthFlows.set(context.state, {
-          context,
-          mcpServerId: data.mcp_server_id,
-          userId,
-          oauthMode,
-          socketId,
-          createdAt: Date.now(),
-        });
-
-        if (socketId && app.io) {
-          app.io.to(socketId).emit('oauth:open_browser', { authUrl: context.authorizationUrl });
-        } else if (app.io) {
-          app.io.emit('oauth:open_browser', { authUrl: context.authorizationUrl });
-        }
 
         return {
           success: true,
-          authorizationUrl: context.authorizationUrl,
-          state: context.state,
+          authorizationUrl: result.authorizationUrl,
+          state: result.state,
           message:
             'Browser opened for authentication. After signing in, copy the callback URL and paste it below.',
         };
@@ -1735,16 +1847,6 @@ async function registerMCPServices(
 
         let authHeaders = await resolveMCPAuthHeaders(serverConfig.auth, serverConfig.url);
 
-        const openOAuthBrowser = async (authUrl: string) => {
-          const connection = params?.connection as { id?: string } | undefined;
-          const socketId = connection?.id;
-          if (socketId && app.io) {
-            app.io.to(socketId).emit('oauth:open_browser', { authUrl });
-          } else if (app.io) {
-            app.io.emit('oauth:open_browser', { authUrl });
-          }
-        };
-
         const probeAndAcquireOAuthToken = async (mcpUrl: string): Promise<string | undefined> => {
           try {
             const probeResponse = await fetch(mcpUrl, {
@@ -1752,33 +1854,46 @@ async function registerMCPServices(
               headers: { Accept: 'application/json' },
             });
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
-            if (probeResponse.status === 401) {
-              const { resolveResourceMetadataUrl, performMCPOAuthFlow } = await import(
-                '@agor/core/tools/mcp/oauth-mcp-transport'
-              );
-              const resolved = await resolveResourceMetadataUrl(wwwAuthenticate, mcpUrl);
-              if (resolved) {
-                const tokenResponse = await performMCPOAuthFlow(
-                  wwwAuthenticate || '',
-                  undefined,
-                  openOAuthBrowser,
-                  resolved.metadataUrl
-                );
-                const discoveryExpiresIn = tokenResponse.expires_in ?? 3600;
-                cacheOAuth21Token(mcpUrl, tokenResponse.access_token, discoveryExpiresIn);
-                if (serverId) {
-                  await saveOAuth21TokenToDB(
-                    mcpServerRepo,
-                    serverId,
-                    tokenResponse.access_token,
-                    discoveryExpiresIn,
-                    tokenResponse.refresh_token
-                  );
-                }
-                return tokenResponse.access_token;
+            if (probeResponse.status !== 401) return undefined;
+            const { resolveResourceMetadataUrl } = await import(
+              '@agor/core/tools/mcp/oauth-mcp-transport'
+            );
+            const resolved = await resolveResourceMetadataUrl(wwwAuthenticate, mcpUrl);
+            if (!resolved) return undefined;
+
+            // Route through the daemon's two-phase flow (callback → daemon's
+            // public URL) instead of the legacy 127.0.0.1 callback server, so
+            // remote browsers can complete the redirect on a deployed Agor.
+            const connection = params?.connection as { id?: string } | undefined;
+            let started: StartTwoPhaseOAuthResult;
+            try {
+              started = await startTwoPhaseMCPOAuthFlow({
+                mcpUrl,
+                wwwAuthenticate: wwwAuthenticate || '',
+                resourceMetadataUrl: resolved.metadataUrl,
+                mcpServerId: serverId,
+                userId: params?.user?.user_id,
+                // Discover writes the token via the shared MCP server row when
+                // a serverId is known (matches the previous saveOAuth21TokenToDB
+                // call). Without a serverId nothing is persisted to the DB; the
+                // daemon-level cache below carries the token for this request.
+                oauthMode: 'shared',
+                socketId: connection?.id,
+                awaitToken: true,
+              });
+            } catch (err) {
+              if (err instanceof PublicBaseUrlNotConfiguredError) {
+                console.error('[MCP Discovery]', err.message);
+                return undefined;
               }
+              throw err;
             }
-            return undefined;
+
+            const tokenResponse = await started.awaitToken!();
+            // persistOAuthToken (run inside oauthCallbackHandler) already
+            // populated the daemon cache + the MCP server row, so we just
+            // return the access token to the caller.
+            return tokenResponse.access_token;
           } catch (error) {
             console.error('[MCP Discovery] OAuth token acquisition failed:', error);
             return undefined;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5,7 +5,12 @@
  * Extracted from index.ts for maintainability.
  */
 
-import { type AgorConfig, getBaseUrl } from '@agor/core/config';
+import {
+  type AgorConfig,
+  getBaseUrl,
+  PublicBaseUrlNotConfiguredError,
+  requirePublicBaseUrl,
+} from '@agor/core/config';
 import {
   and,
   type Database,
@@ -1458,7 +1463,21 @@ async function registerMCPServices(
           };
         }
 
-        const baseUrl = await getBaseUrl();
+        // Use the strict public base URL — the redirect_uri is sent to the upstream
+        // OAuth provider (Notion, etc.) and then loaded by the END USER'S BROWSER.
+        // Falling back to http://localhost:PORT silently breaks for any user whose
+        // browser is not running on the daemon machine (e.g. anyone accessing a
+        // deployed Agor instance remotely).
+        let baseUrl: string;
+        try {
+          baseUrl = await requirePublicBaseUrl();
+        } catch (err) {
+          if (err instanceof PublicBaseUrlNotConfiguredError) {
+            console.error('[OAuth Start]', err.message);
+            return { success: false, error: err.message };
+          }
+          throw err;
+        }
         const redirectUri = new URL('/mcp-servers/oauth-callback', baseUrl).toString();
         const effectiveClientId = data.client_id || clientIdFromConfig;
         const context = await startMCPOAuthFlow(wwwAuthenticate, effectiveClientId, redirectUri, {

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -21,6 +21,8 @@ import {
   getWorktreesDir,
   initConfig,
   loadConfig,
+  PublicBaseUrlNotConfiguredError,
+  requirePublicBaseUrl,
   resolveCodexHome,
   saveConfig,
   setConfigValue,
@@ -186,6 +188,75 @@ describe('loadConfig', () => {
     expect(loaded.daemon?.port).toBe(4040);
     expect(loaded.defaults).toBeUndefined();
     expect(loaded.display).toBeUndefined();
+  });
+});
+
+describe('requirePublicBaseUrl', () => {
+  let tempDir: string;
+  let originalBaseUrl: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-base-url-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+    originalBaseUrl = process.env.AGOR_BASE_URL;
+    delete process.env.AGOR_BASE_URL;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    if (originalBaseUrl === undefined) {
+      delete process.env.AGOR_BASE_URL;
+    } else {
+      process.env.AGOR_BASE_URL = originalBaseUrl;
+    }
+  });
+
+  it('returns AGOR_BASE_URL env when set', async () => {
+    process.env.AGOR_BASE_URL = 'https://agor.example.com';
+    await expect(requirePublicBaseUrl()).resolves.toBe('https://agor.example.com');
+  });
+
+  it('returns daemon.base_url from config when env is unset', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agorDir, 'config.yaml'),
+      yaml.dump({ daemon: { base_url: 'https://agor.sandbox.example.com' } }),
+      'utf-8'
+    );
+
+    await expect(requirePublicBaseUrl()).resolves.toBe('https://agor.sandbox.example.com');
+  });
+
+  it('throws PublicBaseUrlNotConfiguredError when neither env nor config is set', async () => {
+    await expect(requirePublicBaseUrl()).rejects.toBeInstanceOf(PublicBaseUrlNotConfiguredError);
+  });
+
+  it('never silently falls back to localhost (regression: OAuth callback URL bug)', async () => {
+    // Even with daemon.host / daemon.port configured, requirePublicBaseUrl must NOT
+    // construct an http://{host}:{port} URL — that fallback is what caused remote
+    // users to receive an unreachable localhost OAuth callback URL from upstream
+    // providers like Notion.
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agorDir, 'config.yaml'),
+      yaml.dump({ daemon: { host: 'localhost', port: 3030 } }),
+      'utf-8'
+    );
+
+    await expect(requirePublicBaseUrl()).rejects.toBeInstanceOf(PublicBaseUrlNotConfiguredError);
+  });
+
+  it('strips a trailing slash from the configured base URL', async () => {
+    process.env.AGOR_BASE_URL = 'https://agor.example.com/';
+    await expect(requirePublicBaseUrl()).resolves.toBe('https://agor.example.com');
+  });
+
+  it('rejects a base URL without an http(s) scheme', async () => {
+    process.env.AGOR_BASE_URL = 'agor.example.com';
+    await expect(requirePublicBaseUrl()).rejects.toThrow(/must start with http/i);
   });
 });
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -389,6 +389,61 @@ export async function getBaseUrl(): Promise<string> {
 }
 
 /**
+ * Error thrown by {@link requirePublicBaseUrl} when no public base URL is configured.
+ *
+ * Carries a stable `code` so callers (e.g. OAuth start endpoint) can distinguish a
+ * missing-config failure from other unexpected errors and surface a clean,
+ * actionable message to the UI.
+ */
+export class PublicBaseUrlNotConfiguredError extends Error {
+  readonly code = 'PUBLIC_BASE_URL_NOT_CONFIGURED' as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'PublicBaseUrlNotConfiguredError';
+  }
+}
+
+/**
+ * Get the daemon's public, browser-reachable base URL.
+ *
+ * Strict variant of {@link getBaseUrl} — required for any URL that will be handed
+ * to a remote system (e.g. an OAuth `redirect_uri` registered with an upstream
+ * provider) and then loaded by an end-user's browser.
+ *
+ * Resolution:
+ * 1. `AGOR_BASE_URL` environment variable
+ * 2. `daemon.base_url` from `~/.agor/config.yaml`
+ * 3. **Throws** {@link PublicBaseUrlNotConfiguredError}
+ *
+ * Unlike {@link getBaseUrl}, this never silently falls back to
+ * `http://localhost:{port}` — that fallback is broken for any browser not on
+ * the daemon's host (e.g. a remote user of a deployed Agor instance), and
+ * results in OAuth providers redirecting to an unreachable URL.
+ *
+ * @returns Base URL without trailing slash (e.g., "https://agor.sandbox.preset.zone")
+ * @throws {PublicBaseUrlNotConfiguredError} if neither source is set
+ */
+export async function requirePublicBaseUrl(): Promise<string> {
+  if (process.env.AGOR_BASE_URL) {
+    return validateBaseUrl(process.env.AGOR_BASE_URL);
+  }
+
+  const config = await loadConfig();
+  if (config.daemon?.base_url) {
+    return validateBaseUrl(config.daemon.base_url);
+  }
+
+  throw new PublicBaseUrlNotConfiguredError(
+    'No public base URL configured. Set the AGOR_BASE_URL environment variable ' +
+      "or `daemon.base_url` in ~/.agor/config.yaml to the daemon's " +
+      'browser-reachable URL (e.g. https://agor.example.com). This is required ' +
+      'so OAuth providers can redirect users back to a URL their browser can reach — ' +
+      'the localhost fallback only works for browsers on the daemon machine.'
+  );
+}
+
+/**
  * Load config from ~/.agor/config.yaml (synchronous)
  *
  * Returns default config if file doesn't exist.

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -548,14 +548,30 @@ async function exchangeCodeForToken(
 }
 
 /**
- * Perform MCP OAuth 2.1 Authorization Code flow with PKCE
+ * Perform MCP OAuth 2.1 Authorization Code flow with PKCE.
  *
- * Uses token caching to avoid repeated browser-based authentication flows.
- * Tokens are cached per resource metadata URL with automatic expiry handling.
+ * ⚠️  CLI-ONLY — DO NOT CALL FROM THE DAEMON.
+ *
+ * This helper spins up a local HTTP listener on `127.0.0.1:<random>` and uses
+ * that as the OAuth `redirect_uri`. That works for the local CLI (where the
+ * user's browser and the listener share `localhost`) but BREAKS for any
+ * deployed daemon: the upstream OAuth provider (Notion, Linear, etc.) sends
+ * the redirect to the END USER'S BROWSER, which generally cannot reach the
+ * daemon's `127.0.0.1`. Symptom: per-user "Notion login redirected me to
+ * localhost" bug for any user not running on the daemon host.
+ *
+ * Daemon-side OAuth MUST go through the two-phase flow instead:
+ *   1. `startMCPOAuthFlow(...)` with a public `redirect_uri` pointing at
+ *      `<daemon base_url>/mcp-servers/oauth-callback`.
+ *   2. The browser completes the redirect, the daemon's callback handler
+ *      exchanges the code via `completeMCPOAuthFlow(...)`, and the result
+ *      is broadcast back to the originating socket.
+ *
+ * See `apps/agor-daemon/src/register-services.ts > startTwoPhaseMCPOAuthFlow`.
  *
  * @param wwwAuthenticateHeader - The WWW-Authenticate header from 401 response
  * @param clientId - OAuth client ID (optional, generated if not provided)
- * @param onBrowserOpen - Callback when browser is opened (for UI notification)
+ * @param browserOpener - Callback when browser is opened (for UI notification)
  * @returns Access token to use for authenticated requests
  */
 export async function performMCPOAuthFlow(


### PR DESCRIPTION
## Summary

The OAuth `redirect_uri` sent to upstream MCP providers (Notion, etc.) was built from `getBaseUrl()` ([config-manager.ts:369-389](https://github.com/preset-io/agor/blob/main/packages/core/src/config/config-manager.ts#L369-L389)), which silently falls back to `http://${daemon.host}:${daemon.port}` (i.e. `http://localhost:3030`) when neither `AGOR_BASE_URL` env nor `daemon.base_url` config is set.

That URL is then used by the **end user's browser** to complete the OAuth redirect — so anyone whose browser is not on the daemon machine (e.g. remote users of a deployed Agor instance) lands on a URL they can't reach. Developers running locally see it work because their browser *is* on the daemon machine.

This was reported as a per-user bug (one user works, another gets `localhost`), but it's actually per-browser-location: the daemon emits the same broken `localhost` redirect URI for every user; it just happens to "work" for whoever is on the daemon's host.

### Fix

- Add `requirePublicBaseUrl()` — strict variant of `getBaseUrl()` that throws `PublicBaseUrlNotConfiguredError` (with an actionable message) instead of silently falling back to localhost.
- Use it for the MCP OAuth start endpoint in `register-services.ts` so the failure is surfaced cleanly to the UI at OAuth-initiation time, before a broken URL is ever sent to the provider.
- `getBaseUrl()` itself is unchanged — other callers (Slack URLs, Sandpack bundler) keep their existing behavior. Scoping was deliberately tight per the task; if those should also be tightened, that's a follow-up.

### Repro

1. Deploy Agor with neither `AGOR_BASE_URL` env nor `daemon.base_url` config set.
2. From a remote browser, configure a Notion MCP server and start the OAuth flow.
3. **Before**: complete OAuth in Notion, get redirected to `http://localhost:3030/mcp-servers/oauth-callback` — unreachable, OAuth fails silently.
4. **After**: OAuth start fails immediately with a clear error: *\"No public base URL configured. Set the AGOR_BASE_URL environment variable or `daemon.base_url` in ~/.agor/config.yaml to the daemon's browser-reachable URL...\"*

### Notes

- Recent history on this code path: #797 (introduced public-URL redirect via `daemonUrl`), #802 (switched to `getBaseUrl()`), #960 (refactor — preserved `getBaseUrl()`). The silent `localhost` fallback in `getBaseUrl()` re-introduced the bug for any deployment that doesn't explicitly set `daemon.base_url`.
- No DB changes; no migration needed. The config field (`daemon.base_url`) already exists.

## Test plan

- [x] `pnpm typecheck` — passes for `@agor/core` and `@agor/daemon`
- [x] `pnpm test src/config/config-manager.test.ts` — all 73 tests pass, including 6 new ones for `requirePublicBaseUrl`:
  - returns `AGOR_BASE_URL` env when set
  - returns `daemon.base_url` from config when env unset
  - throws `PublicBaseUrlNotConfiguredError` when neither is set
  - **regression**: never silently falls back to localhost even with `daemon.host`/`port` configured
  - strips trailing slash
  - rejects URL without http(s) scheme
- [ ] Manual: deploy with no `daemon.base_url`, attempt Notion OAuth from remote browser → expect clean error, not silent failure
- [ ] Manual: deploy with `daemon.base_url: https://...`, attempt Notion OAuth from remote browser → expect successful redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)