### PR TITLE
feat(mcp): OAuth 2.1 token refresh with JIT + UI force-refresh

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -16,14 +16,12 @@ async function getOAuthStatus(
     return { authenticated: true };
   }
 
-  if (oauthMode === 'shared') {
-    return { authenticated: !!mcpServer.auth?.oauth_access_token };
-  }
-
-  // per_user OAuth — check user-specific token
+  // Both shared and per_user live in `user_mcp_oauth_tokens` — shared rows use
+  // `user_id = NULL`. See migration 0038 (sqlite) / 0027 (postgres).
   const { UserMCPOAuthTokenRepository } = await import('@agor/core/db');
   const userTokenRepo = new UserMCPOAuthTokenRepository(ctx.db);
-  const tokenData = await userTokenRepo.getToken(ctx.userId, mcpServer.mcp_server_id);
+  const lookupUserId = oauthMode === 'shared' ? null : ctx.userId;
+  const tokenData = await userTokenRepo.getToken(lookupUserId, mcpServer.mcp_server_id);
   if (tokenData) {
     if (!tokenData.oauth_token_expires_at || tokenData.oauth_token_expires_at > new Date()) {
       return {

--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -5,7 +5,7 @@
  * Tokens are also persisted to the database for cross-process access.
  */
 
-import { MCPServerRepository, UserMCPOAuthTokenRepository } from '@agor/core/db';
+import { UserMCPOAuthTokenRepository } from '@agor/core/db';
 import type { MCPServerID, UserID } from '@agor/core/types';
 
 // ============================================================================
@@ -57,108 +57,17 @@ export { oauth21TokenCache };
 // ============================================================================
 
 /**
- * Save OAuth 2.1 token to the database for a specific MCP server.
- * Allows tokens to persist across daemon restarts and be used by other processes.
- */
-export async function saveOAuth21TokenToDB(
-  mcpServerRepo: MCPServerRepository,
-  serverId: string,
-  token: string,
-  expiresInSeconds: number,
-  refreshToken?: string
-): Promise<void> {
-  const expiresAt = Date.now() + (expiresInSeconds - 60) * 1000; // 60s buffer
-  const server = await mcpServerRepo.findById(serverId);
-  if (!server) {
-    console.log(`[OAuth 2.1 DB] Server ${serverId} not found, skipping token save`);
-    return;
-  }
-
-  const currentAuth = server.auth || { type: 'oauth' as const };
-
-  await mcpServerRepo.update(serverId, {
-    auth: {
-      ...currentAuth,
-      type: 'oauth',
-      oauth_access_token: token,
-      oauth_token_expires_at: expiresAt,
-      ...(refreshToken ? { oauth_refresh_token: refreshToken } : {}),
-    },
-  });
-  console.log(
-    `[OAuth 2.1 DB] Token saved for server ${serverId}, expires at ${new Date(expiresAt).toISOString()}${refreshToken ? ', with refresh token' : ''}`
-  );
-}
-
-/**
- * Get OAuth 2.1 token from database for a specific MCP server.
- */
-export async function getOAuth21TokenFromDB(
-  mcpServerRepo: MCPServerRepository,
-  serverId: string
-): Promise<string | undefined> {
-  const server = await mcpServerRepo.findById(serverId);
-  if (!server) {
-    console.log(`[OAuth 2.1 DB] Server ${serverId} not found`);
-    return undefined;
-  }
-
-  const auth = server.auth;
-  if (!auth || auth.type !== 'oauth') {
-    console.log(`[OAuth 2.1 DB] Server ${serverId} is not OAuth type`);
-    return undefined;
-  }
-
-  const token = auth.oauth_access_token;
-  const expiresAt = auth.oauth_token_expires_at;
-
-  if (!token) {
-    console.log(`[OAuth 2.1 DB] No token stored for server ${serverId}`);
-    return undefined;
-  }
-
-  if (expiresAt && expiresAt <= Date.now()) {
-    console.log(`[OAuth 2.1 DB] Token expired for server ${serverId}`);
-    return undefined;
-  }
-
-  console.log(`[OAuth 2.1 DB] Found valid token for server ${serverId}`);
-  return token;
-}
-
-/**
- * Get OAuth 2.1 token from database by MCP URL (searches all servers).
- */
-export async function getOAuth21TokenFromDBByUrl(
-  mcpServerRepo: MCPServerRepository,
-  mcpUrl: string
-): Promise<{ token: string; serverId: string } | undefined> {
-  const servers = await mcpServerRepo.findAll();
-  const targetOrigin = new URL(mcpUrl).origin;
-
-  for (const server of servers) {
-    const serverUrl = server.url;
-    if (!serverUrl) continue;
-
-    try {
-      const serverOrigin = new URL(serverUrl).origin;
-      if (serverOrigin === targetOrigin) {
-        const token = await getOAuth21TokenFromDB(mcpServerRepo, server.mcp_server_id);
-        if (token) {
-          return { token, serverId: server.mcp_server_id };
-        }
-      }
-    } catch {
-      // Invalid URL, skip
-    }
-  }
-
-  console.log(`[OAuth 2.1 DB] No valid token found for URL ${mcpUrl}`);
-  return undefined;
-}
-
-/**
  * Cache + persist an OAuth token after a successful flow completion.
+ *
+ * Writes to `user_mcp_oauth_tokens` for BOTH modes:
+ *   - per_user → row keyed by (userId, serverId)
+ *   - shared   → row keyed by (NULL, serverId)
+ *
+ * Co-locates `client_id` / `client_secret` (from DCR or pre-registration) on
+ * the token row. Refresh requires the exact credentials the grant was issued
+ * under, and DCR clients otherwise only live in the daemon's in-memory cache,
+ * which doesn't survive a restart.
+ *
  * Shared by both the callback handler and the manual oauth-complete service.
  */
 export async function persistOAuthToken(
@@ -170,6 +79,10 @@ export async function persistOAuthToken(
     mcpServerId?: string;
     userId?: string;
     oauthMode?: 'per_user' | 'shared';
+    /** client_id used for the grant — needed later for refresh. */
+    clientId?: string;
+    /** client_secret used for the grant (absent for public clients). */
+    clientSecret?: string;
   },
   logPrefix: string
 ): Promise<void> {
@@ -178,32 +91,35 @@ export async function persistOAuthToken(
   // Cache the token at daemon level
   cacheOAuth21Token(cacheKey, tokenResponse.access_token, expiresIn);
 
-  // Save to database based on OAuth mode
-  if (pendingFlow.mcpServerId) {
-    const oauthMode = pendingFlow.oauthMode || 'per_user';
-
-    if (oauthMode === 'per_user' && pendingFlow.userId) {
-      const userTokenRepo = new UserMCPOAuthTokenRepository(db);
-      await userTokenRepo.saveToken(
-        pendingFlow.userId as UserID,
-        pendingFlow.mcpServerId as MCPServerID,
-        tokenResponse.access_token,
-        expiresIn,
-        tokenResponse.refresh_token
-      );
-      console.log(
-        `[${logPrefix}] Per-user token saved for user ${pendingFlow.userId}, server ${pendingFlow.mcpServerId}`
-      );
-    } else {
-      const mcpServerRepo = new MCPServerRepository(db);
-      await saveOAuth21TokenToDB(
-        mcpServerRepo,
-        pendingFlow.mcpServerId,
-        tokenResponse.access_token,
-        expiresIn,
-        tokenResponse.refresh_token
-      );
-      console.log(`[${logPrefix}] Shared token saved for server ${pendingFlow.mcpServerId}`);
-    }
+  if (!pendingFlow.mcpServerId) {
+    return;
   }
+
+  const oauthMode = pendingFlow.oauthMode || 'per_user';
+  const userTokenRepo = new UserMCPOAuthTokenRepository(db);
+
+  // Shared tokens use user_id=NULL in the same table as per-user tokens — see
+  // migration 0038_mcp_oauth_token_refresh (sqlite) / 0027_ (postgres).
+  const tokenUserId: UserID | null =
+    oauthMode === 'per_user' && pendingFlow.userId ? (pendingFlow.userId as UserID) : null;
+
+  if (oauthMode === 'per_user' && !pendingFlow.userId) {
+    console.warn(
+      `[${logPrefix}] per_user mode but no userId on pending flow — falling back to shared-mode row for server ${pendingFlow.mcpServerId}`
+    );
+  }
+
+  await userTokenRepo.saveToken(tokenUserId, pendingFlow.mcpServerId as MCPServerID, {
+    accessToken: tokenResponse.access_token,
+    expiresInSeconds: expiresIn,
+    refreshToken: tokenResponse.refresh_token,
+    clientId: pendingFlow.clientId,
+    clientSecret: pendingFlow.clientSecret,
+  });
+
+  console.log(
+    `[${logPrefix}] ${oauthMode === 'per_user' ? 'Per-user' : 'Shared'} token saved ` +
+      `for user=${tokenUserId ?? '<shared>'} server=${pendingFlow.mcpServerId}` +
+      `${pendingFlow.clientId ? ' (with DCR client creds)' : ''}`
+  );
 }

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -770,49 +770,75 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     }
 
     const injectToken = async (server: MCPServer) => {
-      // Only process OAuth servers with per_user mode
-      if (server.auth?.type !== 'oauth' || server.auth?.oauth_mode !== 'per_user') {
-        console.log(
-          `[MCP OAuth] Server ${server.name}: authType=${server.auth?.type}, ` +
-            `oauthMode=${server.auth?.oauth_mode} - skipping (not per_user OAuth)`
-        );
+      if (server.auth?.type !== 'oauth') {
         return server;
       }
 
-      console.log(
-        `[MCP OAuth] Server ${server.name}: per_user OAuth mode - checking for user token...`
-      );
+      // Tokens for both modes live in user_mcp_oauth_tokens:
+      //   - per_user  → row keyed by (userId, serverId)
+      //   - shared    → row keyed by (NULL, serverId)
+      const mode = server.auth.oauth_mode ?? 'per_user';
+      const tokenUserId: import('@agor/core/types').UserID | null =
+        mode === 'per_user' ? (userId as import('@agor/core/types').UserID) : null;
 
       try {
         const userTokenRepo = new UserMCPOAuthTokenRepository(db);
-        const token = await userTokenRepo.getValidToken(
-          userId as import('@agor/core/types').UserID,
-          server.mcp_server_id
-        );
+        const row = await userTokenRepo.getToken(tokenUserId, server.mcp_server_id);
 
-        if (token) {
+        if (!row) {
           console.log(
-            `[MCP OAuth] ✅ Found valid token for user ${userId.substring(0, 8)}, ` +
-              `server ${server.name} - injecting into auth config`
+            `[MCP OAuth] No token row for user=${tokenUserId ?? '<shared>'} server=${server.name}`
           );
-          // Inject per-user token into the server's auth config
-          return {
-            ...server,
-            auth: {
-              ...server.auth,
-              oauth_access_token: token,
-              // Don't include expiry - the token is already validated
-            },
-          };
-        } else {
-          console.log(
-            `[MCP OAuth] ❌ No valid token for user ${userId.substring(0, 8)}, ` +
-              `server ${server.name} - user needs to authenticate`
-          );
+          return server;
         }
+
+        // JIT refresh — see `refreshAndPersistToken` for mutexing + invalid_grant cleanup.
+        let accessToken = row.oauth_access_token;
+        let expiresAt = row.oauth_token_expires_at;
+        const { needsRefresh, refreshAndPersistToken, InvalidGrantError } = await import(
+          '@agor/core/tools/mcp/oauth-refresh'
+        );
+        if (needsRefresh(row.oauth_token_expires_at) && row.oauth_refresh_token) {
+          console.log(`[MCP OAuth] Token near/past expiry for ${server.name} — refreshing`);
+          try {
+            accessToken = await refreshAndPersistToken({
+              db,
+              userId: tokenUserId,
+              mcpServerId: server.mcp_server_id,
+            });
+            // Re-read to pick up the rotated expiry for the UI.
+            const fresh = await userTokenRepo.getToken(tokenUserId, server.mcp_server_id);
+            if (fresh) expiresAt = fresh.oauth_token_expires_at;
+          } catch (refreshErr) {
+            if (refreshErr instanceof InvalidGrantError) {
+              console.warn(
+                `[MCP OAuth] invalid_grant refreshing ${server.name} — user must re-auth`
+              );
+              return server;
+            }
+            // Transient error: fall through with the stale access_token. The
+            // MCP call may still succeed or fail cleanly at the transport.
+            console.warn(
+              `[MCP OAuth] Refresh failed for ${server.name} (using stale token):`,
+              refreshErr instanceof Error ? refreshErr.message : refreshErr
+            );
+          }
+        }
+
+        return {
+          ...server,
+          auth: {
+            ...server.auth,
+            oauth_access_token: accessToken,
+            // Surface expiry so the UI can render "expires in X" tooltips.
+            // Stored as Date in the repo, emitted as ms epoch to match MCPAuth.
+            oauth_token_expires_at:
+              expiresAt instanceof Date ? expiresAt.getTime() : (expiresAt ?? undefined),
+          },
+        };
       } catch (error) {
         console.warn(
-          `[MCP OAuth] Failed to get per-user token for ${server.name}:`,
+          `[MCP OAuth] Failed to resolve OAuth token for ${server.name}:`,
           error instanceof Error ? error.message : error
         );
       }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -24,9 +24,11 @@ import {
   WorktreeRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
+import { NotAuthenticated } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   HookContext,
+  MCPServerID,
   MessageSource,
   SessionID,
   UserID,
@@ -44,8 +46,6 @@ import {
   cacheOAuth21Token,
   clearOAuth21Token,
   getOAuth21Token,
-  getOAuth21TokenFromDB,
-  getOAuth21TokenFromDBByUrl,
   oauth21TokenCache,
   persistOAuthToken,
 } from './oauth-cache.js';
@@ -1216,7 +1216,11 @@ async function registerMCPServices(
           db,
           tokenResponse,
           pendingFlow.mcpUrl,
-          pendingFlow,
+          {
+            ...pendingFlow,
+            clientId: pendingFlow.context.clientId,
+            clientSecret: pendingFlow.context.clientSecret,
+          },
           'OAuth Callback'
         );
 
@@ -1735,7 +1739,11 @@ async function registerMCPServices(
           db,
           tokenResponse,
           pendingFlow.mcpUrl,
-          pendingFlow,
+          {
+            ...pendingFlow,
+            clientId: pendingFlow.context.clientId,
+            clientSecret: pendingFlow.context.clientSecret,
+          },
           'OAuth Complete'
         );
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
@@ -1784,6 +1792,188 @@ async function registerMCPServices(
   });
   app.service('mcp-servers/oauth-status').hooks({ before: { find: [ctx.requireAuth] } });
 
+  // --------------------------------------------------------------------------
+  // OAuth auth-headers service
+  //
+  // Returns a map of { [mcp_server_id]: { authorization?, error? } } for the
+  // caller. Used by the executor to attach JIT-refreshed Bearer tokens only
+  // to in-scope MCP servers without ever exposing raw refresh_tokens or
+  // letting callers ask for someone else's token.
+  //
+  // Access control:
+  //   - per_user tokens are keyed on params.user.user_id — a caller cannot
+  //     request another user's row (no forUserId override here).
+  //   - shared tokens (user_id = NULL) are returned to any authenticated
+  //     caller who can see the server, matching existing shared-mode semantics.
+  //
+  // The caller is expected to pass only the server IDs it already resolved
+  // as in-scope for the session (see `getMcpServersForSession`).
+  // --------------------------------------------------------------------------
+  app.use('/mcp-servers/oauth-auth-headers', {
+    async create(
+      data: { mcp_server_ids: string[] },
+      params?: AuthenticatedParams
+    ): Promise<{
+      headers: Record<string, { authorization?: string; error?: string }>;
+    }> {
+      const userId = params?.user?.user_id;
+      if (!userId) {
+        throw new NotAuthenticated('oauth-auth-headers requires authentication');
+      }
+
+      const serverIds = Array.isArray(data?.mcp_server_ids) ? data.mcp_server_ids : [];
+      const headers: Record<string, { authorization?: string; error?: string }> = {};
+
+      if (serverIds.length === 0) {
+        return { headers };
+      }
+
+      const userTokenRepo = new UserMCPOAuthTokenRepository(db);
+      const mcpServerRepo = new MCPServerRepository(db);
+      const { needsRefresh, refreshAndPersistToken, InvalidGrantError } = await import(
+        '@agor/core/tools/mcp/oauth-refresh'
+      );
+
+      await Promise.all(
+        serverIds.map(async (serverId) => {
+          try {
+            const server = await mcpServerRepo.findById(serverId);
+            if (!server) {
+              headers[serverId] = { error: 'server_not_found' };
+              return;
+            }
+            if (server.auth?.type !== 'oauth') {
+              headers[serverId] = { error: 'not_oauth_server' };
+              return;
+            }
+
+            const mode = server.auth.oauth_mode ?? 'per_user';
+            const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
+
+            const row = await userTokenRepo.getToken(tokenUserId, serverId as MCPServerID);
+            if (!row) {
+              headers[serverId] = { error: 'needs_reauth' };
+              return;
+            }
+
+            let accessToken = row.oauth_access_token;
+            if (needsRefresh(row.oauth_token_expires_at) && row.oauth_refresh_token) {
+              try {
+                accessToken = await refreshAndPersistToken({
+                  db,
+                  userId: tokenUserId,
+                  mcpServerId: serverId as MCPServerID,
+                });
+              } catch (refreshErr) {
+                if (refreshErr instanceof InvalidGrantError) {
+                  headers[serverId] = { error: 'needs_reauth' };
+                  return;
+                }
+                // Transient: fall through with stale token rather than 500ing.
+                console.warn(
+                  `[OAuth AuthHeaders] Refresh failed for ${serverId} — using stale token:`,
+                  refreshErr instanceof Error ? refreshErr.message : refreshErr
+                );
+              }
+            } else if (
+              !accessToken ||
+              (row.oauth_token_expires_at && row.oauth_token_expires_at <= new Date())
+            ) {
+              // Expired with no refresh_token → must re-auth.
+              headers[serverId] = { error: 'needs_reauth' };
+              return;
+            }
+
+            headers[serverId] = { authorization: `Bearer ${accessToken}` };
+          } catch (err) {
+            console.error(`[OAuth AuthHeaders] Error for ${serverId}:`, err);
+            headers[serverId] = {
+              error: err instanceof Error ? err.message : 'unknown_error',
+            };
+          }
+        })
+      );
+
+      return { headers };
+    },
+  });
+  app.service('mcp-servers/oauth-auth-headers').hooks({
+    before: { create: [ctx.requireAuth] },
+  });
+
+  // --------------------------------------------------------------------------
+  // OAuth manual refresh
+  //
+  // POST { mcp_server_id } → force a refresh regardless of needsRefresh().
+  // Used by the UI "refresh now" action on the MCP pill so operators can
+  // probe / extend a token's lifetime on demand.
+  //
+  // Access control mirrors oauth-auth-headers: per_user rows are keyed on
+  // params.user.user_id (caller cannot refresh someone else's token); shared
+  // rows are accessible to any authenticated caller who can see the server.
+  // --------------------------------------------------------------------------
+  app.use('/mcp-servers/oauth-refresh', {
+    async create(
+      data: { mcp_server_id: string },
+      params?: AuthenticatedParams
+    ): Promise<{
+      success: boolean;
+      expires_at?: number;
+      error?: 'needs_reauth' | 'not_oauth_server' | 'server_not_found' | string;
+    }> {
+      const userId = params?.user?.user_id;
+      if (!userId) {
+        throw new NotAuthenticated('oauth-refresh requires authentication');
+      }
+
+      const serverId = data?.mcp_server_id;
+      if (!serverId) {
+        return { success: false, error: 'mcp_server_id is required' };
+      }
+
+      const userTokenRepo = new UserMCPOAuthTokenRepository(db);
+      const mcpServerRepo = new MCPServerRepository(db);
+      const { refreshAndPersistToken, InvalidGrantError, MissingRefreshTokenError } = await import(
+        '@agor/core/tools/mcp/oauth-refresh'
+      );
+
+      try {
+        const server = await mcpServerRepo.findById(serverId);
+        if (!server) return { success: false, error: 'server_not_found' };
+        if (server.auth?.type !== 'oauth') return { success: false, error: 'not_oauth_server' };
+
+        const mode = server.auth.oauth_mode ?? 'per_user';
+        const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
+
+        await refreshAndPersistToken({
+          db,
+          userId: tokenUserId,
+          mcpServerId: serverId as MCPServerID,
+        });
+
+        const fresh = await userTokenRepo.getToken(tokenUserId, serverId as MCPServerID);
+        const expiresAt =
+          fresh?.oauth_token_expires_at instanceof Date
+            ? fresh.oauth_token_expires_at.getTime()
+            : undefined;
+
+        return { success: true, expires_at: expiresAt };
+      } catch (err) {
+        if (err instanceof InvalidGrantError || err instanceof MissingRefreshTokenError) {
+          return { success: false, error: 'needs_reauth' };
+        }
+        console.error(`[OAuth Refresh] ${serverId}:`, err);
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : 'unknown_error',
+        };
+      }
+    },
+  });
+  app.service('mcp-servers/oauth-refresh').hooks({
+    before: { create: [ctx.requireAuth] },
+  });
+
   // Discover endpoint
   app.use('/mcp-servers/discover', {
     async create(
@@ -1802,6 +1992,7 @@ async function registerMCPServices(
           oauth_client_secret?: string;
           oauth_scope?: string;
           oauth_grant_type?: string;
+          oauth_mode?: 'per_user' | 'shared';
         };
       },
       params?: AuthenticatedParams
@@ -1966,15 +2157,23 @@ async function registerMCPServices(
 
         if (!authHeaders && serverConfig.auth?.type === 'oauth' && serverConfig.url) {
           let cachedToken = getOAuth21Token(serverConfig.url);
+          // Prefer a live row from the unified token table when we have a
+          // serverId. Look up the caller's per-user row, then fall back to
+          // the shared row (user_id IS NULL).
           if (!cachedToken && serverId) {
-            cachedToken = await getOAuth21TokenFromDB(mcpServerRepo, serverId);
-            if (cachedToken) cacheOAuth21Token(serverConfig.url, cachedToken, 3600);
-          }
-          if (!cachedToken && !serverId) {
-            const dbResult = await getOAuth21TokenFromDBByUrl(mcpServerRepo, serverConfig.url);
-            if (dbResult) {
-              cachedToken = dbResult.token;
-              cacheOAuth21Token(serverConfig.url, cachedToken, 3600);
+            const tokenRepo = new UserMCPOAuthTokenRepository(db);
+            const lookupUserId =
+              serverConfig.auth?.oauth_mode === 'shared'
+                ? null
+                : ((params?.user?.user_id as UserID | undefined) ?? null);
+            const dbToken =
+              (await tokenRepo.getValidToken(lookupUserId, serverId as MCPServerID)) ??
+              (lookupUserId !== null
+                ? await tokenRepo.getValidToken(null, serverId as MCPServerID)
+                : undefined);
+            if (dbToken) {
+              cachedToken = dbToken;
+              cacheOAuth21Token(serverConfig.url, dbToken, 3600);
             }
           }
           if (!cachedToken) {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -630,17 +630,19 @@ export class GatewayService {
             const server = await this.mcpServerRepo.findById(serverId);
             if (server?.auth?.type === 'oauth') {
               const oauthMode = server.auth.oauth_mode || 'per_user';
-              let hasToken = false;
-              if (oauthMode === 'shared') {
-                hasToken = !!server.auth.oauth_access_token;
-              } else {
-                const validToken = await this.userTokenRepo.getValidToken(
-                  user.user_id as UserID,
-                  serverId as MCPServerID
-                );
-                hasToken = !!validToken;
-              }
-              if (!hasToken) {
+              // Unified token store — shared rows key on user_id=NULL, per_user on the caller's id.
+              const tokenUserId = oauthMode === 'shared' ? null : (user.user_id as UserID);
+              // Count a row with a valid refresh_token as "authed" even if the
+              // access_token is expired — the inject hook will JIT-refresh it
+              // before handing it to the executor. This avoids spurious
+              // "not authenticated" warnings for users who are one refresh away.
+              const row = await this.userTokenRepo.getToken(tokenUserId, serverId as MCPServerID);
+              const accessValid = !!(
+                row?.oauth_access_token &&
+                (!row.oauth_token_expires_at || row.oauth_token_expires_at > new Date())
+              );
+              const refreshable = !!row?.oauth_refresh_token;
+              if (!accessValid && !refreshable) {
                 unauthedMcpNames.push(server.display_name || server.name);
               }
             }

--- a/apps/agor-daemon/src/services/oauth-disconnect.test.ts
+++ b/apps/agor-daemon/src/services/oauth-disconnect.test.ts
@@ -60,16 +60,14 @@ describe('performOAuthDisconnect', () => {
     expect(deps.clearCoreTokenCache).toHaveBeenCalled();
   });
 
-  it('clears shared token from auth config when present', async () => {
+  it('deletes the shared-mode row from the unified token table when mode is shared', async () => {
+    const deleteToken = vi.fn().mockResolvedValue(true);
     const deps = createMockDeps({
+      userTokenRepo: { deleteToken },
       mcpServerRepo: {
         findById: vi.fn().mockResolvedValue({
           url: 'https://mcp.example.com/api',
-          auth: {
-            oauth_access_token: 'shared-token-abc',
-            oauth_token_expires_at: 9999999,
-            oauth_client_id: 'keep-this',
-          },
+          auth: { type: 'oauth', oauth_mode: 'shared' },
         }),
         update: vi.fn().mockResolvedValue(undefined),
       },
@@ -77,13 +75,28 @@ describe('performOAuthDisconnect', () => {
 
     await performOAuthDisconnect(deps);
 
-    expect(deps.mcpServerRepo.update).toHaveBeenCalledWith('srv-5678-efgh', {
-      auth: expect.objectContaining({
-        oauth_client_id: 'keep-this',
-        oauth_access_token: undefined,
-        oauth_token_expires_at: undefined,
-      }),
+    // Per-user deletion happens first, then shared-row deletion with user_id=null.
+    expect(deleteToken).toHaveBeenCalledWith('user-1234-abcd', 'srv-5678-efgh');
+    expect(deleteToken).toHaveBeenCalledWith(null, 'srv-5678-efgh');
+  });
+
+  it('does not touch the shared-mode row for per_user servers', async () => {
+    const deleteToken = vi.fn().mockResolvedValue(true);
+    const deps = createMockDeps({
+      userTokenRepo: { deleteToken },
+      mcpServerRepo: {
+        findById: vi.fn().mockResolvedValue({
+          url: 'https://mcp.example.com/api',
+          auth: { type: 'oauth', oauth_mode: 'per_user' },
+        }),
+        update: vi.fn().mockResolvedValue(undefined),
+      },
     });
+
+    await performOAuthDisconnect(deps);
+
+    expect(deleteToken).toHaveBeenCalledWith('user-1234-abcd', 'srv-5678-efgh');
+    expect(deleteToken).not.toHaveBeenCalledWith(null, 'srv-5678-efgh');
   });
 
   it('succeeds even when no per-user token was found', async () => {

--- a/apps/agor-daemon/src/services/oauth-disconnect.ts
+++ b/apps/agor-daemon/src/services/oauth-disconnect.ts
@@ -11,7 +11,11 @@ export interface OAuthDisconnectDeps {
   userId: string | undefined;
   mcpServerId: string;
   userTokenRepo: {
-    deleteToken(userId: string, serverId: string): Promise<boolean>;
+    /**
+     * `userId` may be null to target the shared-mode row for this server.
+     * Unified token storage lives in `user_mcp_oauth_tokens` for both modes.
+     */
+    deleteToken(userId: string | null, serverId: string): Promise<boolean>;
   };
   mcpServerRepo: {
     findById(id: string): Promise<{ url?: string; auth?: MCPAuth } | null>;
@@ -55,13 +59,24 @@ export async function performOAuthDisconnect(
   );
 
   try {
-    // 1. Delete per-user token from database
-    const deleted = await userTokenRepo.deleteToken(userId, mcpServerId);
+    // 1. Delete the caller's per-user token row (if any).
+    const deletedPerUser = await userTokenRepo.deleteToken(userId, mcpServerId);
 
-    // 2. Clear in-memory caches (daemon-level + core-level)
+    // 2. Also delete the shared-mode row (user_id = NULL) so the server is
+    //    fully disconnected. Shared tokens no longer live on
+    //    `mcp_servers.data.auth` — they moved to `user_mcp_oauth_tokens` in
+    //    migration 0038/0027.
+    let deletedShared = false;
     const server = await mcpServerRepo.findById(mcpServerId);
+    if (server?.auth?.oauth_mode === 'shared') {
+      deletedShared = await userTokenRepo.deleteToken(null, mcpServerId);
+      if (deletedShared) {
+        console.log('[OAuth Disconnect] Deleted shared-mode token row');
+      }
+    }
+
+    // 3. Clear in-memory caches (daemon-level + core-level)
     if (server?.url) {
-      // Clear daemon-level cache by origin
       try {
         const origin = new URL(server.url).origin;
         oauthTokenCache.delete(origin);
@@ -70,28 +85,15 @@ export async function performOAuthDisconnect(
         // Invalid URL, skip cache clear
       }
 
-      // Clear core-level authCodeTokenCache
       clearCoreTokenCache();
       console.log('[OAuth Disconnect] Cleared core OAuth token cache');
     }
 
-    // 3. Clear oauth_access_token from server's auth config (shared mode token)
-    if (server?.auth?.oauth_access_token) {
-      await mcpServerRepo.update(mcpServerId, {
-        auth: {
-          ...server.auth,
-          oauth_access_token: undefined,
-          oauth_token_expires_at: undefined,
-        },
-      });
-      console.log('[OAuth Disconnect] Cleared shared OAuth token from server config');
-    }
-
-    if (deleted) {
+    if (deletedPerUser || deletedShared) {
       console.log('[OAuth Disconnect] Token deleted successfully');
       return { success: true, message: 'OAuth connection removed' };
     } else {
-      console.log('[OAuth Disconnect] No per-user token found, caches cleared');
+      console.log('[OAuth Disconnect] No token found, caches cleared');
       return { success: true, message: 'OAuth connection removed' };
     }
   } catch (error) {

--- a/apps/agor-ui/src/components/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServerPill.tsx
@@ -1,6 +1,8 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
-import { ApiOutlined, LoginOutlined } from '@ant-design/icons';
+import { ApiOutlined, LoginOutlined, ReloadOutlined } from '@ant-design/icons';
 import { App, Tooltip } from 'antd';
+import { useState } from 'react';
+import { formatAbsoluteTime } from '../utils/time';
 import { Tag } from './Tag';
 
 interface MCPServerPillProps {
@@ -10,12 +12,39 @@ interface MCPServerPillProps {
 }
 
 /**
- * Clickable MCP server pill. Shows orange with login icon when auth is needed,
- * purple with API icon otherwise. Clicking an unauthenticated pill starts the
- * OAuth flow and opens the provider in a new tab.
+ * Format a future timestamp as a short human-relative string ("in 3m",
+ * "in 2h", "in 4d", "expired 5m ago"). Unlike `formatRelativeTime`, this
+ * renders future offsets, which is what an expiring token needs.
+ */
+function formatExpiresIn(expiresAtMs: number): string {
+  const diffMs = expiresAtMs - Date.now();
+  const abs = Math.abs(diffMs);
+  const sec = Math.floor(abs / 1000);
+  const min = Math.floor(sec / 60);
+  const hr = Math.floor(min / 60);
+  const day = Math.floor(hr / 24);
+
+  const value = sec < 60 ? `${sec}s` : min < 60 ? `${min}m` : hr < 24 ? `${hr}h` : `${day}d`;
+
+  return diffMs >= 0 ? `in ${value}` : `expired ${value} ago`;
+}
+
+/**
+ * Clickable MCP server pill.
+ *
+ *   - Unauthenticated: orange + login icon, click starts OAuth.
+ *   - Authenticated:   purple + API icon, tooltip shows human-readable expiry,
+ *                      click force-refreshes the token (even before it's due)
+ *                      so operators can probe per-provider refresh policy.
  */
 export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth, client }) => {
   const { message } = App.useApp();
+  const [refreshing, setRefreshing] = useState(false);
+  // Local override so the tooltip reflects a just-refreshed expiry without
+  // waiting for a full MCPServer re-fetch from the parent.
+  const [expiresAtOverride, setExpiresAtOverride] = useState<number | undefined>(undefined);
+
+  const expiresAt = expiresAtOverride ?? server.auth?.oauth_token_expires_at;
 
   const handleOAuthClick = async () => {
     if (!client) return;
@@ -55,13 +84,67 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
     }
   };
 
+  const handleRefreshClick = async () => {
+    if (!client || refreshing) return;
+    setRefreshing(true);
+    try {
+      const result = (await client.service('mcp-servers/oauth-refresh').create({
+        mcp_server_id: server.mcp_server_id,
+      })) as {
+        success: boolean;
+        expires_at?: number;
+        error?: string;
+      };
+
+      if (result.success) {
+        setExpiresAtOverride(result.expires_at);
+        message.success(
+          result.expires_at
+            ? `${server.display_name || server.name} refreshed — expires ${formatExpiresIn(result.expires_at)}`
+            : `${server.display_name || server.name} refreshed`
+        );
+      } else if (result.error === 'needs_reauth') {
+        message.warning('Refresh token is no longer valid — sign in again.');
+        // Fall through to full OAuth flow so the user can re-auth in one click.
+        await handleOAuthClick();
+      } else {
+        message.error(`Refresh failed: ${result.error || 'unknown error'}`);
+      }
+    } catch (err) {
+      message.error(`Refresh error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  // Build a multi-line tooltip for the authenticated case so operators can
+  // see both the relative countdown and the absolute wall-clock time — handy
+  // for spotting providers with suspiciously short or long TTLs.
+  let authedTooltip: React.ReactNode;
+  if (expiresAt) {
+    const date = new Date(expiresAt);
+    authedTooltip = (
+      <>
+        <div>Expires {formatExpiresIn(expiresAt)}</div>
+        <div style={{ opacity: 0.75, fontSize: 12 }}>{formatAbsoluteTime(date)}</div>
+        <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>
+      </>
+    );
+  } else {
+    // No expiry surfaced (e.g. pre-migration row or provider that doesn't
+    // return expires_in). Still allow manual refresh as a diagnostic.
+    authedTooltip = 'Click to refresh token';
+  }
+
   return (
-    <Tooltip title={needsAuth ? 'Click to authenticate' : undefined}>
+    <Tooltip title={needsAuth ? 'Click to authenticate' : authedTooltip}>
       <Tag
         color={needsAuth ? 'orange' : 'purple'}
-        icon={needsAuth ? <LoginOutlined /> : <ApiOutlined />}
-        style={needsAuth ? { cursor: 'pointer' } : undefined}
-        onClick={needsAuth ? handleOAuthClick : undefined}
+        icon={
+          needsAuth ? <LoginOutlined /> : refreshing ? <ReloadOutlined spin /> : <ApiOutlined />
+        }
+        style={{ cursor: refreshing ? 'wait' : 'pointer' }}
+        onClick={needsAuth ? handleOAuthClick : handleRefreshClick}
       >
         {server.display_name || server.name}
       </Tag>

--- a/packages/core/drizzle/postgres/0027_mcp_oauth_token_refresh.sql
+++ b/packages/core/drizzle/postgres/0027_mcp_oauth_token_refresh.sql
@@ -1,0 +1,72 @@
+-- MCP OAuth Token Refresh — consolidate shared + per-user OAuth tokens
+--
+-- 1. Make `user_mcp_oauth_tokens.user_id` NULLABLE (NULL = shared-mode row
+--    for that mcp_server_id) and add `oauth_client_id`/`oauth_client_secret`
+--    co-located with the refresh_token.
+--
+-- 2. Backfill shared-mode tokens from `mcp_servers.data.auth.*`.
+--
+-- 3. Strip runtime token fields from `mcp_servers.data.auth`, keeping
+--    config fields (token_url, authorization_url, pre-registered
+--    client_id/secret, scope, mode).
+
+ALTER TABLE "user_mcp_oauth_tokens" ALTER COLUMN "user_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_mcp_oauth_tokens" ADD COLUMN IF NOT EXISTS "oauth_client_id" text;--> statement-breakpoint
+ALTER TABLE "user_mcp_oauth_tokens" ADD COLUMN IF NOT EXISTS "oauth_client_secret" text;--> statement-breakpoint
+
+-- Dedupe before creating the unique indexes. The previous schema had only a
+-- non-unique index on (user_id, mcp_server_id) and writes were check-then-
+-- insert, so duplicates are possible in pre-migration data. Keep the most-
+-- recently-touched row per key.
+DELETE FROM "user_mcp_oauth_tokens" t
+USING (
+	SELECT ctid, ROW_NUMBER() OVER (
+		PARTITION BY "user_id", "mcp_server_id"
+		ORDER BY COALESCE("updated_at", "created_at") DESC, "created_at" DESC
+	) AS rn
+	FROM "user_mcp_oauth_tokens"
+) dupes
+WHERE t.ctid = dupes.ctid AND dupes.rn > 1;--> statement-breakpoint
+
+-- Enforce one token per (user, server) for per-user rows, and one shared row per server.
+CREATE UNIQUE INDEX IF NOT EXISTS "user_mcp_oauth_tokens_user_server_uq"
+	ON "user_mcp_oauth_tokens" ("user_id", "mcp_server_id")
+	WHERE "user_id" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "user_mcp_oauth_tokens_shared_server_uq"
+	ON "user_mcp_oauth_tokens" ("mcp_server_id")
+	WHERE "user_id" IS NULL;--> statement-breakpoint
+
+-- Backfill shared-mode tokens.
+INSERT INTO "user_mcp_oauth_tokens" (
+	"user_id", "mcp_server_id", "oauth_access_token", "oauth_token_expires_at",
+	"oauth_refresh_token", "oauth_client_id", "oauth_client_secret",
+	"created_at"
+)
+SELECT
+	NULL,
+	"mcp_server_id",
+	"data"->'auth'->>'oauth_access_token',
+	CASE
+		WHEN "data"->'auth'->>'oauth_token_expires_at' ~ '^[0-9]+$'
+		THEN to_timestamp(("data"->'auth'->>'oauth_token_expires_at')::bigint / 1000.0)
+		ELSE NULL
+	END,
+	"data"->'auth'->>'oauth_refresh_token',
+	"data"->'auth'->>'oauth_client_id',
+	"data"->'auth'->>'oauth_client_secret',
+	NOW()
+FROM "mcp_servers"
+WHERE "data"->'auth'->>'type' = 'oauth'
+	AND "data"->'auth'->>'oauth_mode' = 'shared'
+	AND "data"->'auth'->>'oauth_access_token' IS NOT NULL
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+
+-- Strip runtime token fields from mcp_servers.data.auth.
+-- Leave oauth_client_id/oauth_client_secret in place — admin-entered
+-- pre-registered credentials are configuration, not grant artifacts.
+UPDATE "mcp_servers"
+SET "data" = (("data"::jsonb)
+	#- '{auth,oauth_access_token}'
+	#- '{auth,oauth_token_expires_at}'
+	#- '{auth,oauth_refresh_token}')::json
+WHERE "data"->'auth'->>'type' = 'oauth';

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1776600000000,
       "tag": "0026_env_command_variants",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1777000000000,
+      "tag": "0027_mcp_oauth_token_refresh",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0038_mcp_oauth_token_refresh.sql
+++ b/packages/core/drizzle/sqlite/0038_mcp_oauth_token_refresh.sql
@@ -1,0 +1,109 @@
+-- MCP OAuth Token Refresh — consolidate shared + per-user OAuth tokens
+--
+-- 1. Rebuild `user_mcp_oauth_tokens` with:
+--      - `user_id` NULLABLE (NULL = shared-mode token for that mcp_server_id)
+--      - new columns `oauth_client_id`, `oauth_client_secret` (co-located
+--        with the refresh_token because the refresh grant is bound to the
+--        client credentials it was issued under, especially for DCR).
+--    Preserves all existing per-user rows.
+--
+-- 2. Backfill shared-mode tokens from `mcp_servers.data.auth.*` into the
+--    same table with `user_id = NULL`.
+--
+-- 3. Strip runtime token fields from `mcp_servers.data.auth`
+--    (access/refresh/expiry). Leaves config fields (token_url,
+--    authorization_url, pre-registered client_id/secret, scope, mode)
+--    intact so admin-entered credentials still work.
+
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+
+CREATE TABLE `__new_user_mcp_oauth_tokens` (
+	`user_id` text(36),
+	`mcp_server_id` text(36) NOT NULL,
+	`oauth_access_token` text NOT NULL,
+	`oauth_token_expires_at` integer,
+	`oauth_refresh_token` text,
+	`oauth_client_id` text,
+	`oauth_client_secret` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`mcp_server_id`) REFERENCES `mcp_servers`(`mcp_server_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+-- Dedupe on the way in: the previous schema had a non-unique index on
+-- (user_id, mcp_server_id) and writes were check-then-insert, so duplicates
+-- are possible in pre-migration data. Keep the most-recently-touched row
+-- per key (coalesce(updated_at, created_at), newest wins).
+INSERT INTO `__new_user_mcp_oauth_tokens` (
+	`user_id`, `mcp_server_id`, `oauth_access_token`, `oauth_token_expires_at`,
+	`oauth_refresh_token`, `created_at`, `updated_at`
+)
+SELECT
+	`user_id`, `mcp_server_id`, `oauth_access_token`, `oauth_token_expires_at`,
+	`oauth_refresh_token`, `created_at`, `updated_at`
+FROM (
+	SELECT
+		`user_id`, `mcp_server_id`, `oauth_access_token`, `oauth_token_expires_at`,
+		`oauth_refresh_token`, `created_at`, `updated_at`,
+		ROW_NUMBER() OVER (
+			PARTITION BY `user_id`, `mcp_server_id`
+			ORDER BY COALESCE(`updated_at`, `created_at`) DESC, `created_at` DESC
+		) AS rn
+	FROM `user_mcp_oauth_tokens`
+) WHERE rn = 1;
+--> statement-breakpoint
+
+DROP TABLE `user_mcp_oauth_tokens`;
+--> statement-breakpoint
+ALTER TABLE `__new_user_mcp_oauth_tokens` RENAME TO `user_mcp_oauth_tokens`;
+--> statement-breakpoint
+
+PRAGMA foreign_keys=ON;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `user_mcp_oauth_tokens_pk` ON `user_mcp_oauth_tokens` (`user_id`,`mcp_server_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `user_mcp_oauth_tokens_user_idx` ON `user_mcp_oauth_tokens` (`user_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `user_mcp_oauth_tokens_server_idx` ON `user_mcp_oauth_tokens` (`mcp_server_id`);--> statement-breakpoint
+
+-- Enforce one token per (user, server) for per-user rows, and one shared row per server.
+CREATE UNIQUE INDEX IF NOT EXISTS `user_mcp_oauth_tokens_user_server_uq`
+	ON `user_mcp_oauth_tokens` (`user_id`, `mcp_server_id`)
+	WHERE `user_id` IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `user_mcp_oauth_tokens_shared_server_uq`
+	ON `user_mcp_oauth_tokens` (`mcp_server_id`)
+	WHERE `user_id` IS NULL;--> statement-breakpoint
+
+-- Backfill shared-mode tokens.
+INSERT OR IGNORE INTO `user_mcp_oauth_tokens` (
+	`user_id`, `mcp_server_id`, `oauth_access_token`, `oauth_token_expires_at`,
+	`oauth_refresh_token`, `oauth_client_id`, `oauth_client_secret`,
+	`created_at`, `updated_at`
+)
+SELECT
+	NULL,
+	`mcp_server_id`,
+	json_extract(`data`, '$.auth.oauth_access_token'),
+	json_extract(`data`, '$.auth.oauth_token_expires_at'),
+	json_extract(`data`, '$.auth.oauth_refresh_token'),
+	json_extract(`data`, '$.auth.oauth_client_id'),
+	json_extract(`data`, '$.auth.oauth_client_secret'),
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM `mcp_servers`
+WHERE json_extract(`data`, '$.auth.type') = 'oauth'
+	AND json_extract(`data`, '$.auth.oauth_mode') = 'shared'
+	AND json_extract(`data`, '$.auth.oauth_access_token') IS NOT NULL;--> statement-breakpoint
+
+-- Strip runtime token fields from mcp_servers.data.auth.
+-- Leave oauth_client_id/oauth_client_secret in place — admin-entered
+-- pre-registered credentials are configuration, not grant artifacts.
+UPDATE `mcp_servers`
+SET `data` = json_remove(
+	`data`,
+	'$.auth.oauth_access_token',
+	'$.auth.oauth_token_expires_at',
+	'$.auth.oauth_refresh_token'
+)
+WHERE json_extract(`data`, '$.auth.type') = 'oauth';

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1776600000000,
       "tag": "0037_env_command_variants",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1777000000000,
+      "tag": "0038_mcp_oauth_token_refresh",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -190,6 +190,11 @@
       "import": "./dist/tools/mcp/oauth-mcp-transport.js",
       "require": "./dist/tools/mcp/oauth-mcp-transport.cjs"
     },
+    "./tools/mcp/oauth-refresh": {
+      "types": "./dist/tools/mcp/oauth-refresh.d.ts",
+      "import": "./dist/tools/mcp/oauth-refresh.js",
+      "require": "./dist/tools/mcp/oauth-refresh.cjs"
+    },
     "./unix": {
       "types": "./dist/unix/index.d.ts",
       "import": "./dist/unix/index.js",

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -1,12 +1,17 @@
 /**
- * User MCP OAuth Token Repository
+ * MCP OAuth Token Repository
  *
- * Manages per-user OAuth 2.1 tokens for MCP servers.
- * Used when MCP servers are configured with oauth_mode: 'per_user'.
+ * Unified storage for both per-user and shared-mode OAuth tokens.
+ *   - `user_id` set  → per-user token (oauth_mode: 'per_user')
+ *   - `user_id` NULL → shared-mode token for that MCP server (oauth_mode: 'shared')
+ *
+ * DCR / registered client credentials are co-located with the refresh_token
+ * because refreshing requires the exact client_id/client_secret the grant was
+ * issued under.
  */
 
 import type { MCPServerID, UserID } from '@agor/core/types';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import {
@@ -17,54 +22,72 @@ import {
 import { RepositoryError } from './base';
 
 /**
- * User MCP OAuth Token data structure
+ * MCP OAuth token record. `user_id` is null for shared-mode rows.
  */
 export interface UserMCPOAuthToken {
-  user_id: UserID;
+  user_id: UserID | null;
   mcp_server_id: MCPServerID;
   oauth_access_token: string;
   oauth_token_expires_at?: Date;
   oauth_refresh_token?: string;
+  oauth_client_id?: string;
+  oauth_client_secret?: string;
   created_at: Date;
   updated_at?: Date;
 }
 
-/**
- * User MCP OAuth Token repository implementation
- */
+/** Input shape for `saveToken`. */
+export interface SaveTokenInput {
+  accessToken: string;
+  /** Seconds until expiry, matching the OAuth token response. */
+  expiresInSeconds?: number;
+  /** If absent on update, the existing refresh_token is kept. */
+  refreshToken?: string;
+  /** If absent on update, the existing client_id is kept. */
+  clientId?: string;
+  /** If absent on update, the existing client_secret is kept. */
+  clientSecret?: string;
+}
+
+function rowToToken(row: UserMCPOAuthTokenRow): UserMCPOAuthToken {
+  return {
+    user_id: (row.user_id as UserID | null) ?? null,
+    mcp_server_id: row.mcp_server_id as MCPServerID,
+    oauth_access_token: row.oauth_access_token,
+    oauth_token_expires_at: row.oauth_token_expires_at
+      ? new Date(row.oauth_token_expires_at)
+      : undefined,
+    oauth_refresh_token: row.oauth_refresh_token || undefined,
+    oauth_client_id: row.oauth_client_id || undefined,
+    oauth_client_secret: row.oauth_client_secret || undefined,
+    created_at: new Date(row.created_at),
+    updated_at: row.updated_at ? new Date(row.updated_at) : undefined,
+  };
+}
+
+/** Match either a per-user row (user_id = X) or the shared row (user_id IS NULL). */
+function matchKey(userId: UserID | null, serverId: MCPServerID) {
+  return and(
+    userId === null ? isNull(userMcpOauthTokens.user_id) : eq(userMcpOauthTokens.user_id, userId),
+    eq(userMcpOauthTokens.mcp_server_id, serverId)
+  );
+}
+
 export class UserMCPOAuthTokenRepository {
   constructor(private db: Database) {}
 
   /**
-   * Get OAuth token for a user and MCP server
+   * Look up the token row for a (user, server) pair. Pass `null` for userId
+   * to read the shared-mode row.
    */
-  async getToken(userId: UserID, serverId: MCPServerID): Promise<UserMCPOAuthToken | null> {
+  async getToken(userId: UserID | null, serverId: MCPServerID): Promise<UserMCPOAuthToken | null> {
     try {
       const row = await select(this.db)
         .from(userMcpOauthTokens)
-        .where(
-          and(
-            eq(userMcpOauthTokens.user_id, userId),
-            eq(userMcpOauthTokens.mcp_server_id, serverId)
-          )
-        )
+        .where(matchKey(userId, serverId))
         .one();
 
-      if (!row) {
-        return null;
-      }
-
-      return {
-        user_id: row.user_id as UserID,
-        mcp_server_id: row.mcp_server_id as MCPServerID,
-        oauth_access_token: row.oauth_access_token,
-        oauth_token_expires_at: row.oauth_token_expires_at
-          ? new Date(row.oauth_token_expires_at)
-          : undefined,
-        oauth_refresh_token: row.oauth_refresh_token || undefined,
-        created_at: new Date(row.created_at),
-        updated_at: row.updated_at ? new Date(row.updated_at) : undefined,
-      };
+      return row ? rowToToken(row) : null;
     } catch (error) {
       throw new RepositoryError(
         `Failed to get OAuth token: ${error instanceof Error ? error.message : String(error)}`,
@@ -74,10 +97,14 @@ export class UserMCPOAuthTokenRepository {
   }
 
   /**
-   * Get valid (non-expired) OAuth access token for a user and MCP server
-   * Returns undefined if token doesn't exist or is expired
+   * Return the access token if it exists and is not expired. Does NOT refresh.
+   *
+   * Refresh is performed via `refreshAndPersistToken` in
+   * `@agor/core/tools/mcp/oauth-refresh`, and is orchestrated by the daemon
+   * service `mcp-servers/oauth-auth-headers` — which enforces the caller's
+   * identity matches the token's `user_id` before exposing the header.
    */
-  async getValidToken(userId: UserID, serverId: MCPServerID): Promise<string | undefined> {
+  async getValidToken(userId: UserID | null, serverId: MCPServerID): Promise<string | undefined> {
     try {
       const token = await this.getToken(userId, serverId);
 
@@ -85,9 +112,10 @@ export class UserMCPOAuthTokenRepository {
         return undefined;
       }
 
-      // Check if token is expired
       if (token.oauth_token_expires_at && token.oauth_token_expires_at <= new Date()) {
-        console.log(`[UserMCPOAuthToken] Token expired for user ${userId}, server ${serverId}`);
+        console.log(
+          `[UserMCPOAuthToken] Token expired for user ${userId ?? '<shared>'}, server ${serverId}`
+        );
         return undefined;
       }
 
@@ -101,56 +129,59 @@ export class UserMCPOAuthTokenRepository {
   }
 
   /**
-   * Save or update OAuth token for a user and MCP server
+   * Save or update the token row. On update, undefined fields preserve their
+   * existing value — important for refresh_token (providers may omit it if not
+   * rotating) and client_id/client_secret (bound for the lifetime of the grant).
    */
   async saveToken(
-    userId: UserID,
+    userId: UserID | null,
     serverId: MCPServerID,
-    accessToken: string,
-    expiresInSeconds?: number,
-    refreshToken?: string
+    input: SaveTokenInput
   ): Promise<void> {
     try {
       const now = new Date();
-      const expiresAt = expiresInSeconds
-        ? new Date(Date.now() + (expiresInSeconds - 60) * 1000) // 60s buffer
+      // Store the EXACT expiry the provider returned. The proactive-refresh
+      // buffer lives in `needsRefresh` (REFRESH_BUFFER_MS) so we don't apply
+      // it twice.
+      const expiresAt = input.expiresInSeconds
+        ? new Date(Date.now() + input.expiresInSeconds * 1000)
         : undefined;
 
-      // Check if token already exists
       const existing = await this.getToken(userId, serverId);
 
       if (existing) {
-        // Update existing token — only overwrite refresh_token when a new one is provided
         await update(this.db, userMcpOauthTokens)
           .set({
-            oauth_access_token: accessToken,
+            oauth_access_token: input.accessToken,
             oauth_token_expires_at: expiresAt,
-            ...(refreshToken != null ? { oauth_refresh_token: refreshToken } : {}),
+            ...(input.refreshToken != null ? { oauth_refresh_token: input.refreshToken } : {}),
+            ...(input.clientId != null ? { oauth_client_id: input.clientId } : {}),
+            ...(input.clientSecret != null ? { oauth_client_secret: input.clientSecret } : {}),
             updated_at: now,
           })
-          .where(
-            and(
-              eq(userMcpOauthTokens.user_id, userId),
-              eq(userMcpOauthTokens.mcp_server_id, serverId)
-            )
-          )
+          .where(matchKey(userId, serverId))
           .run();
 
-        console.log(`[UserMCPOAuthToken] Updated token for user ${userId}, server ${serverId}`);
+        console.log(
+          `[UserMCPOAuthToken] Updated token for user ${userId ?? '<shared>'}, server ${serverId}`
+        );
       } else {
-        // Insert new token
         const newToken: UserMCPOAuthTokenInsert = {
           user_id: userId,
           mcp_server_id: serverId,
-          oauth_access_token: accessToken,
+          oauth_access_token: input.accessToken,
           oauth_token_expires_at: expiresAt,
-          oauth_refresh_token: refreshToken,
+          oauth_refresh_token: input.refreshToken,
+          oauth_client_id: input.clientId,
+          oauth_client_secret: input.clientSecret,
           created_at: now,
         };
 
         await insert(this.db, userMcpOauthTokens).values(newToken).run();
 
-        console.log(`[UserMCPOAuthToken] Saved new token for user ${userId}, server ${serverId}`);
+        console.log(
+          `[UserMCPOAuthToken] Saved new token for user ${userId ?? '<shared>'}, server ${serverId}`
+        );
       }
     } catch (error) {
       throw new RepositoryError(
@@ -161,17 +192,13 @@ export class UserMCPOAuthTokenRepository {
   }
 
   /**
-   * Delete OAuth token for a user and MCP server
+   * Delete a specific token row. Used on `invalid_grant` responses and from
+   * the OAuth-disconnect service.
    */
-  async deleteToken(userId: UserID, serverId: MCPServerID): Promise<boolean> {
+  async deleteToken(userId: UserID | null, serverId: MCPServerID): Promise<boolean> {
     try {
       const result = await deleteFrom(this.db, userMcpOauthTokens)
-        .where(
-          and(
-            eq(userMcpOauthTokens.user_id, userId),
-            eq(userMcpOauthTokens.mcp_server_id, serverId)
-          )
-        )
+        .where(matchKey(userId, serverId))
         .run();
 
       return result.rowsAffected > 0;
@@ -183,9 +210,6 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
-  /**
-   * Delete all OAuth tokens for a user
-   */
   async deleteAllForUser(userId: UserID): Promise<number> {
     try {
       const result = await deleteFrom(this.db, userMcpOauthTokens)
@@ -201,9 +225,6 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
-  /**
-   * Delete all OAuth tokens for an MCP server
-   */
   async deleteAllForServer(serverId: MCPServerID): Promise<number> {
     try {
       const result = await deleteFrom(this.db, userMcpOauthTokens)
@@ -219,9 +240,6 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
-  /**
-   * List all OAuth tokens for a user
-   */
   async listForUser(userId: UserID): Promise<UserMCPOAuthToken[]> {
     try {
       const rows = await select(this.db)
@@ -229,17 +247,7 @@ export class UserMCPOAuthTokenRepository {
         .where(eq(userMcpOauthTokens.user_id, userId))
         .all();
 
-      return rows.map((row: UserMCPOAuthTokenRow) => ({
-        user_id: row.user_id as UserID,
-        mcp_server_id: row.mcp_server_id as MCPServerID,
-        oauth_access_token: row.oauth_access_token,
-        oauth_token_expires_at: row.oauth_token_expires_at
-          ? new Date(row.oauth_token_expires_at)
-          : undefined,
-        oauth_refresh_token: row.oauth_refresh_token || undefined,
-        created_at: new Date(row.created_at),
-        updated_at: row.updated_at ? new Date(row.updated_at) : undefined,
-      }));
+      return rows.map(rowToToken);
     } catch (error) {
       throw new RepositoryError(
         `Failed to list OAuth tokens for user: ${error instanceof Error ? error.message : String(error)}`,
@@ -248,10 +256,7 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
-  /**
-   * Check if a user has a valid token for an MCP server
-   */
-  async hasValidToken(userId: UserID, serverId: MCPServerID): Promise<boolean> {
+  async hasValidToken(userId: UserID | null, serverId: MCPServerID): Promise<boolean> {
     const token = await this.getValidToken(userId, serverId);
     return token !== undefined;
   }

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1095,30 +1095,40 @@ export const sessionMcpServers = pgTable(
 );
 
 /**
- * User MCP OAuth Tokens table - Per-user OAuth 2.1 tokens for MCP servers
+ * MCP OAuth Tokens table - OAuth 2.1 tokens for MCP servers
  *
- * Used when MCP servers are configured with oauth_mode: 'per_user'.
- * Each user gets their own OAuth token for each MCP server.
+ * Holds BOTH per-user and shared-mode tokens:
+ *   - `user_id` set  → per-user token (oauth_mode: 'per_user')
+ *   - `user_id` NULL → shared token for this MCP server (oauth_mode: 'shared')
+ *
+ * `oauth_client_id`/`oauth_client_secret` are co-located because the
+ * refresh_token is bound to the client credentials that were used when
+ * it was issued (often via RFC 7591 Dynamic Client Registration).
  */
 export const userMcpOauthTokens = pgTable(
   'user_mcp_oauth_tokens',
   {
-    user_id: varchar('user_id', { length: 36 })
-      .notNull()
-      .references(() => users.user_id, { onDelete: 'cascade' }),
+    // NULL = shared-mode token (one per mcp_server_id)
+    user_id: varchar('user_id', { length: 36 }).references(() => users.user_id, {
+      onDelete: 'cascade',
+    }),
     mcp_server_id: varchar('mcp_server_id', { length: 36 })
       .notNull()
       .references(() => mcpServers.mcp_server_id, { onDelete: 'cascade' }),
     oauth_access_token: text('oauth_access_token').notNull(),
     oauth_token_expires_at: t.timestamp('oauth_token_expires_at'), // Unix timestamp in milliseconds
     oauth_refresh_token: text('oauth_refresh_token'),
+    // DCR / registered client credentials this grant was issued under.
+    // Must be preserved across refreshes.
+    oauth_client_id: text('oauth_client_id'),
+    oauth_client_secret: text('oauth_client_secret'),
     created_at: t.timestamp('created_at').notNull(),
     updated_at: t.timestamp('updated_at'),
   },
   (table) => ({
-    // Composite primary key via unique index
+    // Composite lookup indexes. Uniqueness enforced via partial unique indexes
+    // created in the migration (one for per-user rows, one for the shared row).
     pk: index('user_mcp_oauth_tokens_pk').on(table.user_id, table.mcp_server_id),
-    // Indexes for queries
     userIdx: index('user_mcp_oauth_tokens_user_idx').on(table.user_id),
     serverIdx: index('user_mcp_oauth_tokens_server_idx').on(table.mcp_server_id),
   })

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1097,30 +1097,43 @@ export const sessionMcpServers = sqliteTable(
 );
 
 /**
- * User MCP OAuth Tokens table - Per-user OAuth 2.1 tokens for MCP servers
+ * MCP OAuth Tokens table - OAuth 2.1 tokens for MCP servers
  *
- * Used when MCP servers are configured with oauth_mode: 'per_user'.
- * Each user gets their own OAuth token for each MCP server.
+ * Holds BOTH per-user and shared-mode tokens:
+ *   - `user_id` set  → per-user token (oauth_mode: 'per_user')
+ *   - `user_id` NULL → shared token for this MCP server (oauth_mode: 'shared')
+ *
+ * `oauth_client_id`/`oauth_client_secret` are co-located because the
+ * refresh_token is bound to the client credentials that were used when
+ * it was issued (often via RFC 7591 Dynamic Client Registration, which
+ * generates fresh per-grant credentials on each daemon restart). Storing
+ * them alongside the refresh_token keeps the refresh path correct even
+ * if the server-level DCR cache is rebuilt.
  */
 export const userMcpOauthTokens = sqliteTable(
   'user_mcp_oauth_tokens',
   {
-    user_id: text('user_id', { length: 36 })
-      .notNull()
-      .references(() => users.user_id, { onDelete: 'cascade' }),
+    // NULL = shared-mode token (one per mcp_server_id)
+    user_id: text('user_id', { length: 36 }).references(() => users.user_id, {
+      onDelete: 'cascade',
+    }),
     mcp_server_id: text('mcp_server_id', { length: 36 })
       .notNull()
       .references(() => mcpServers.mcp_server_id, { onDelete: 'cascade' }),
     oauth_access_token: text('oauth_access_token').notNull(),
     oauth_token_expires_at: t.timestamp('oauth_token_expires_at'), // Unix timestamp in milliseconds
     oauth_refresh_token: text('oauth_refresh_token'),
+    // DCR / registered client credentials this grant was issued under.
+    // Must be preserved across refreshes.
+    oauth_client_id: text('oauth_client_id'),
+    oauth_client_secret: text('oauth_client_secret'),
     created_at: t.timestamp('created_at').notNull(),
     updated_at: t.timestamp('updated_at'),
   },
   (table) => ({
-    // Composite primary key via unique index
+    // Composite lookup indexes. Uniqueness enforced via partial unique indexes
+    // created in the migration (one for per-user rows, one for the shared row).
     pk: index('user_mcp_oauth_tokens_pk').on(table.user_id, table.mcp_server_id),
-    // Indexes for queries
     userIdx: index('user_mcp_oauth_tokens_user_idx').on(table.user_id),
     serverIdx: index('user_mcp_oauth_tokens_server_idx').on(table.mcp_server_id),
   })

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -1,0 +1,645 @@
+/**
+ * Tests for MCP OAuth token refresh.
+ *
+ * Two layers:
+ *   1. `refreshMCPToken` — pure HTTP wiring (fetch mocking only)
+ *   2. `refreshAndPersistToken` — DB + mutex orchestration (repo mocking)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MCPServerID, UserID } from '../../types';
+import {
+  __refreshMutexSizeForTests,
+  __resetRefreshMutexForTests,
+  InvalidGrantError,
+  MissingRefreshTokenError,
+  MissingTokenEndpointError,
+  needsRefresh,
+  REFRESH_BUFFER_MS,
+  refreshAndPersistToken,
+  refreshMCPToken,
+} from './oauth-refresh';
+
+// ---------------------------------------------------------------------------
+// Repo mocks.
+//
+// `vi.mock()` is hoisted above all top-level `const` declarations, so the mock
+// factory would see `undefined` if we used plain `const`s here. Hoist the
+// mock fns via `vi.hoisted()` so they exist when the factory runs, and use
+// plain `function` constructors (not arrow factories) so `new X()` works.
+// ---------------------------------------------------------------------------
+
+const { mockGetToken, mockSaveToken, mockDeleteToken, mockFindById } = vi.hoisted(() => ({
+  mockGetToken: vi.fn(),
+  mockSaveToken: vi.fn(),
+  mockDeleteToken: vi.fn(),
+  mockFindById: vi.fn(),
+}));
+
+vi.mock('../../db/repositories', () => ({
+  UserMCPOAuthTokenRepository: function UserMCPOAuthTokenRepositoryMock() {
+    return {
+      getToken: mockGetToken,
+      saveToken: mockSaveToken,
+      deleteToken: mockDeleteToken,
+    };
+  },
+  MCPServerRepository: function MCPServerRepositoryMock() {
+    return {
+      findById: mockFindById,
+    };
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// refreshMCPToken — pure HTTP contract
+// ---------------------------------------------------------------------------
+
+describe('refreshMCPToken', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchOnce(body: unknown, init: { status?: number } = {}) {
+    const status = init.status ?? 200;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as typeof globalThis.fetch;
+  }
+
+  it('uses HTTP Basic auth when client_secret is present (RFC 6749 §2.3.1)', async () => {
+    mockFetchOnce({ access_token: 'new-a', token_type: 'Bearer', expires_in: 3600 });
+
+    const result = await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'rt-abc',
+      clientId: 'client-123',
+      clientSecret: 'secret-xyz',
+    });
+
+    expect(result.access_token).toBe('new-a');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.method).toBe('POST');
+    const expectedAuth = `Basic ${Buffer.from('client-123:secret-xyz').toString('base64')}`;
+    expect(init.headers.Authorization).toBe(expectedAuth);
+    // Body should NOT include client_id — it's conveyed via Basic auth.
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('rt-abc');
+    expect(body.get('client_id')).toBeNull();
+  });
+
+  it('puts client_id in the body for public clients (no secret)', async () => {
+    mockFetchOnce({ access_token: 'new-a', expires_in: 3600 });
+
+    await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'rt-abc',
+      clientId: 'public-client-42',
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('client_id')).toBe('public-client-42');
+    expect(body.get('refresh_token')).toBe('rt-abc');
+    expect(body.get('grant_type')).toBe('refresh_token');
+  });
+
+  it('surfaces invalid_grant as InvalidGrantError', async () => {
+    mockFetchOnce(
+      { error: 'invalid_grant', error_description: 'refresh token has been revoked' },
+      { status: 400 }
+    );
+
+    await expect(
+      refreshMCPToken({
+        tokenEndpoint: 'https://auth.example.com/token',
+        refreshToken: 'stale',
+        clientId: 'c',
+      })
+    ).rejects.toBeInstanceOf(InvalidGrantError);
+  });
+
+  it('throws generic Error for other OAuth errors', async () => {
+    mockFetchOnce({ error: 'server_error' }, { status: 500 });
+
+    await expect(
+      refreshMCPToken({
+        tokenEndpoint: 'https://auth.example.com/token',
+        refreshToken: 'rt',
+        clientId: 'c',
+      })
+    ).rejects.toThrow(/server_error/);
+  });
+
+  it('returns rotated refresh_token when provider rotates (OAuth 2.1)', async () => {
+    mockFetchOnce({
+      access_token: 'new-a',
+      refresh_token: 'new-rt',
+      expires_in: 3600,
+    });
+
+    const result = await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'old-rt',
+      clientId: 'c',
+    });
+
+    expect(result.refresh_token).toBe('new-rt');
+  });
+
+  it('leaves refresh_token undefined when provider omits it (RFC 6749 §6)', async () => {
+    mockFetchOnce({ access_token: 'new-a', expires_in: 3600 });
+
+    const result = await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'old-rt',
+      clientId: 'c',
+    });
+
+    expect(result.refresh_token).toBeUndefined();
+  });
+
+  it('throws when response is 200 but missing access_token', async () => {
+    mockFetchOnce({ token_type: 'Bearer' });
+
+    await expect(
+      refreshMCPToken({
+        tokenEndpoint: 'https://auth.example.com/token',
+        refreshToken: 'rt',
+        clientId: 'c',
+      })
+    ).rejects.toThrow(/no access_token/);
+  });
+
+  it('throws on non-JSON body (HTML error page etc.)', async () => {
+    mockFetchOnce('<!DOCTYPE html><h1>500 Internal Server Error</h1>', { status: 500 });
+
+    await expect(
+      refreshMCPToken({
+        tokenEndpoint: 'https://auth.example.com/token',
+        refreshToken: 'rt',
+        clientId: 'c',
+      })
+    ).rejects.toThrow(/non-JSON body/);
+  });
+
+  it('coerces numeric-string expires_in to number', async () => {
+    mockFetchOnce({ access_token: 'a', expires_in: '3600' });
+
+    const result = await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'rt',
+      clientId: 'c',
+    });
+
+    expect(result.expires_in).toBe(3600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshAndPersistToken — DB orchestration + mutex
+// ---------------------------------------------------------------------------
+
+describe('refreshAndPersistToken', () => {
+  const originalFetch = globalThis.fetch;
+  const USER_ID = 'user-1' as UserID;
+  const SERVER_ID = 'srv-1' as MCPServerID;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockGetToken.mockReset();
+    mockSaveToken.mockReset();
+    mockDeleteToken.mockReset();
+    mockFindById.mockReset();
+
+    __resetRefreshMutexForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchJson(body: unknown, status = 200) {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as typeof globalThis.fetch;
+  }
+
+  it('loads token row, refreshes, and persists atomically', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+      oauth_client_secret: 'csec',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockSaveToken.mockResolvedValue(undefined);
+    mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
+
+    const token = await refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+
+    expect(token).toBe('new-a');
+    expect(mockSaveToken).toHaveBeenCalledWith(USER_ID, SERVER_ID, {
+      accessToken: 'new-a',
+      expiresInSeconds: 3600,
+      refreshToken: undefined, // provider omitted — repo preserves existing
+    });
+  });
+
+  it('writes rotated refresh_token when provider returns one', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({
+      access_token: 'new-a',
+      refresh_token: 'rt-2',
+      expires_in: 3600,
+    });
+
+    await refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+
+    expect(mockSaveToken).toHaveBeenCalledWith(
+      USER_ID,
+      SERVER_ID,
+      expect.objectContaining({ refreshToken: 'rt-2' })
+    );
+  });
+
+  it('deletes token row on invalid_grant and invokes onInvalidGrant hook', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-revoked',
+      oauth_client_id: 'cid',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({ error: 'invalid_grant' }, 400);
+    mockDeleteToken.mockResolvedValue(true);
+
+    const onInvalidGrant = vi.fn();
+
+    await expect(
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+        onInvalidGrant,
+      })
+    ).rejects.toBeInstanceOf(InvalidGrantError);
+
+    expect(mockDeleteToken).toHaveBeenCalledWith(USER_ID, SERVER_ID);
+    expect(onInvalidGrant).toHaveBeenCalledWith({
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+    expect(mockSaveToken).not.toHaveBeenCalled();
+  });
+
+  it('throws MissingRefreshTokenError when row has no refresh_token', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'a',
+      oauth_refresh_token: undefined,
+      oauth_client_id: 'cid',
+    });
+
+    await expect(
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+      })
+    ).rejects.toBeInstanceOf(MissingRefreshTokenError);
+  });
+
+  it('throws MissingRefreshTokenError when no row exists', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    await expect(
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+      })
+    ).rejects.toBeInstanceOf(MissingRefreshTokenError);
+  });
+
+  it('falls back to inferred token endpoint when server.auth is missing one', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+    });
+    // No oauth_token_url — inferOAuthTokenUrl should kick in.
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: {},
+    });
+    mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
+
+    const token = await refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+
+    expect(token).toBe('new-a');
+    // The inferred endpoint should have been hit.
+    const [url] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(typeof url).toBe('string');
+  });
+
+  it('throws MissingTokenEndpointError when endpoint cannot be resolved', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'a',
+      oauth_refresh_token: 'rt',
+      oauth_client_id: 'cid',
+    });
+    // No server at all, so no url to infer from and no config endpoint.
+    mockFindById.mockResolvedValue(null);
+
+    await expect(
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+      })
+    ).rejects.toBeInstanceOf(MissingTokenEndpointError);
+  });
+
+  it('falls back to server config client_id when row has none', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: undefined, // row has no DCR credentials
+      oauth_client_secret: undefined,
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: {
+        oauth_token_url: 'https://auth.example.com/token',
+        oauth_client_id: 'admin-preregistered',
+        oauth_client_secret: 'admin-secret',
+      },
+    });
+    mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
+
+    await refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    // Pre-registered with secret → Basic auth
+    const expectedAuth = `Basic ${Buffer.from('admin-preregistered:admin-secret').toString('base64')}`;
+    expect(init.headers.Authorization).toBe(expectedAuth);
+  });
+
+  it('mutex: concurrent refreshes for same key collapse to ONE HTTP call', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+
+    // Slow-responding fetch so both calls land in flight simultaneously.
+    let resolveFetch!: (r: Response) => void;
+    globalThis.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise<Response>((res) => {
+          resolveFetch = res;
+        })
+    ) as typeof globalThis.fetch;
+
+    const p1 = refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+    const p2 = refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+
+    // Wait for the fetch mock to be invoked before resolving — the mock's
+    // `resolveFetch` is only assigned inside the Promise executor, which runs
+    // after the refresh helper has awaited the DB reads.
+    await vi.waitFor(() => expect(typeof resolveFetch).toBe('function'));
+    resolveFetch(
+      new Response(JSON.stringify({ access_token: 'shared-new-a', expires_in: 3600 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const [t1, t2] = await Promise.all([p1, p2]);
+
+    expect(t1).toBe('shared-new-a');
+    expect(t2).toBe('shared-new-a');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(mockSaveToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('mutex: different keys refresh independently', async () => {
+    const SERVER_ID_2 = 'srv-2' as MCPServerID;
+
+    mockGetToken.mockImplementation((_u, s) => ({
+      user_id: USER_ID,
+      mcp_server_id: s,
+      oauth_access_token: 'old',
+      oauth_refresh_token: `rt-${s}`,
+      oauth_client_id: 'cid',
+    }));
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    // `mockImplementation` returns a fresh Response per call — `Response.text()`
+    // consumes the body, so reusing a single instance across two calls throws
+    // "Body has already been read" on the second read.
+    globalThis.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ access_token: 'a', expires_in: 3600 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    ) as typeof globalThis.fetch;
+
+    await Promise.all([
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+      }),
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID_2,
+      }),
+    ]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('mutex: in-flight map is cleared after completion (success)', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old',
+      oauth_refresh_token: 'rt',
+      oauth_client_id: 'cid',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({ access_token: 'a', expires_in: 3600 });
+
+    await refreshAndPersistToken({
+      db: {} as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+    });
+
+    expect(__refreshMutexSizeForTests()).toBe(0);
+  });
+
+  it('mutex: in-flight map is cleared after completion (failure)', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old',
+      oauth_refresh_token: 'rt-bad',
+      oauth_client_id: 'cid',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({ error: 'invalid_grant' }, 400);
+    mockDeleteToken.mockResolvedValue(true);
+
+    await expect(
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+      })
+    ).rejects.toBeInstanceOf(InvalidGrantError);
+
+    expect(__refreshMutexSizeForTests()).toBe(0);
+  });
+
+  it('shared-mode refresh: keys on user_id=null', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: null,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old',
+      oauth_refresh_token: 'rt-shared',
+      oauth_client_id: 'cid',
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    mockFetchJson({ access_token: 'shared-new', expires_in: 3600 });
+
+    const token = await refreshAndPersistToken({
+      db: {} as any,
+      userId: null,
+      mcpServerId: SERVER_ID,
+    });
+
+    expect(token).toBe('shared-new');
+    expect(mockGetToken).toHaveBeenCalledWith(null, SERVER_ID);
+    expect(mockSaveToken).toHaveBeenCalledWith(null, SERVER_ID, expect.any(Object));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// needsRefresh — pure
+// ---------------------------------------------------------------------------
+
+describe('needsRefresh', () => {
+  it('returns false when expiresAt is null or undefined', () => {
+    expect(needsRefresh(null)).toBe(false);
+    expect(needsRefresh(undefined)).toBe(false);
+  });
+
+  it('returns true when already expired', () => {
+    expect(needsRefresh(new Date(Date.now() - 1000))).toBe(true);
+    expect(needsRefresh(Date.now() - 1000)).toBe(true);
+  });
+
+  it('returns true when within the buffer window', () => {
+    expect(needsRefresh(new Date(Date.now() + REFRESH_BUFFER_MS / 2))).toBe(true);
+  });
+
+  it('returns false when well before expiry', () => {
+    expect(needsRefresh(new Date(Date.now() + REFRESH_BUFFER_MS * 10))).toBe(false);
+  });
+});

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -1,0 +1,355 @@
+/**
+ * MCP OAuth Token Refresh (RFC 6749 §6)
+ *
+ * Exchanges a saved refresh_token for a new access_token without user
+ * interaction. Invoked just-in-time from the daemon service that hands
+ * auth headers to the executor.
+ *
+ * Contract with the refresh call site:
+ *   - The caller MUST hold a per-(user, server) mutex — two concurrent
+ *     refreshes against the same refresh_token can fail or, with strict
+ *     providers, revoke the entire grant chain. `refreshAndPersistToken`
+ *     in this module does the locking.
+ *   - On `invalid_grant`, the token row is deleted so the user gets an
+ *     "please re-auth" state. All other HTTP/network errors are surfaced
+ *     to the caller (NOT swallowed) — the access token stays in place
+ *     in case the failure is transient.
+ *
+ * Out of scope (tracked as follow-ups in the PR description):
+ *   - Retry-on-401 shim for the MCP transport.
+ *   - `registration_access_token` / `registration_client_uri` capture
+ *     from DCR for future client-management.
+ *   - Background refresh scheduler (deliberately rejected — JIT is
+ *     simpler, avoids wasted refreshes on idle users, and has the same
+ *     correctness properties for our access patterns).
+ */
+
+import type { Database } from '../../db/client';
+import { MCPServerRepository, UserMCPOAuthTokenRepository } from '../../db/repositories';
+import type { MCPServerID, UserID } from '../../types';
+import { inferOAuthTokenUrl } from './oauth-auth';
+
+/** 60s safety window before hard expiry. */
+export const REFRESH_BUFFER_MS = 60_000;
+
+export class InvalidGrantError extends Error {
+  readonly code = 'invalid_grant';
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidGrantError';
+  }
+}
+
+export class MissingRefreshTokenError extends Error {
+  readonly code = 'missing_refresh_token';
+  constructor(message: string = 'No stored refresh_token available for this grant') {
+    super(message);
+    this.name = 'MissingRefreshTokenError';
+  }
+}
+
+export class MissingTokenEndpointError extends Error {
+  readonly code = 'missing_token_endpoint';
+  constructor(message: string = 'Could not determine OAuth token endpoint for refresh') {
+    super(message);
+    this.name = 'MissingTokenEndpointError';
+  }
+}
+
+export interface RefreshMCPTokenOptions {
+  tokenEndpoint: string;
+  refreshToken: string;
+  clientId: string;
+  /** Public clients omit this. */
+  clientSecret?: string;
+}
+
+export interface RefreshMCPTokenResult {
+  access_token: string;
+  /**
+   * Present when the provider rotates refresh tokens (OAuth 2.1 / public
+   * clients). Callers must persist this and DISCARD the old value.
+   */
+  refresh_token?: string;
+  /** Seconds until the access token expires. */
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+}
+
+interface OAuthRefreshRawResponse {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number | string;
+  refresh_token?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/**
+ * Pure HTTP call: POST `grant_type=refresh_token` to the token endpoint.
+ *
+ * Mirrors `exchangeCodeForToken` in oauth-mcp-transport.ts for auth style —
+ * Basic auth when `client_secret` is present (RFC 6749 §2.3.1), otherwise
+ * `client_id` in the request body for public clients.
+ *
+ * Does NOT persist. Callers should prefer `refreshAndPersistToken`, which
+ * handles mutexing, DB lookup, and invalid_grant cleanup.
+ */
+export async function refreshMCPToken(
+  opts: RefreshMCPTokenOptions
+): Promise<RefreshMCPTokenResult> {
+  const body: Record<string, string> = {
+    grant_type: 'refresh_token',
+    refresh_token: opts.refreshToken,
+  };
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+
+  if (opts.clientSecret) {
+    headers.Authorization = `Basic ${Buffer.from(`${opts.clientId}:${opts.clientSecret}`).toString('base64')}`;
+  } else {
+    body.client_id = opts.clientId;
+  }
+
+  const response = await fetch(opts.tokenEndpoint, {
+    method: 'POST',
+    headers,
+    body: new URLSearchParams(body).toString(),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const rawText = await response.text();
+  let parsed: OAuthRefreshRawResponse;
+  try {
+    parsed = rawText ? (JSON.parse(rawText) as OAuthRefreshRawResponse) : {};
+  } catch {
+    throw new Error(
+      `Token refresh returned non-JSON body (HTTP ${response.status}): ${rawText.slice(0, 200)}`
+    );
+  }
+
+  if (!response.ok || parsed.error) {
+    const err = parsed.error || `http_${response.status}`;
+    const description = parsed.error_description ? ` — ${parsed.error_description}` : '';
+    if (err === 'invalid_grant') {
+      throw new InvalidGrantError(`invalid_grant${description}`);
+    }
+    throw new Error(`Token refresh failed (${response.status}): ${err}${description}`);
+  }
+
+  if (!parsed.access_token) {
+    throw new Error(
+      `Token refresh succeeded but response has no access_token. Keys: ${Object.keys(parsed).join(', ')}`
+    );
+  }
+
+  const expiresInNum =
+    parsed.expires_in != null
+      ? Number.isFinite(Number(parsed.expires_in))
+        ? Number(parsed.expires_in)
+        : undefined
+      : undefined;
+
+  return {
+    access_token: parsed.access_token,
+    refresh_token: parsed.refresh_token,
+    expires_in: expiresInNum,
+    token_type: parsed.token_type,
+    scope: parsed.scope,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persistence-aware refresh with per-key mutex
+// ---------------------------------------------------------------------------
+
+type MutexKey = string;
+
+/**
+ * Module-level map of in-flight refreshes. Keyed on `${user|shared}:${server}`.
+ *
+ * Rationale: if a provider rotates refresh_tokens and two callers both fire a
+ * refresh with the same (now-stale) refresh_token, the second call fails.
+ * Worse, some providers treat a replayed refresh_token as a compromise signal
+ * and revoke the whole grant chain. The mutex collapses concurrent refresh
+ * attempts into a single HTTP call that all callers await.
+ *
+ * Module-local to avoid leaking internals on the package API surface. Tests
+ * that need a clean slate should call {@link __resetRefreshMutexForTests}.
+ */
+const _inFlightRefreshes = new Map<MutexKey, Promise<string>>();
+
+/**
+ * Test-only hook: clears the in-flight refresh map. Do NOT call from
+ * production code; there's no race-free reason to reach in here at runtime.
+ */
+export function __resetRefreshMutexForTests(): void {
+  _inFlightRefreshes.clear();
+}
+
+/**
+ * Test-only hook: snapshot the number of in-flight refreshes. Used to assert
+ * the map clears after success/failure. Do NOT call from production code.
+ */
+export function __refreshMutexSizeForTests(): number {
+  return _inFlightRefreshes.size;
+}
+
+function mutexKey(userId: UserID | null, serverId: MCPServerID): MutexKey {
+  return `${userId ?? '<shared>'}:${serverId}`;
+}
+
+export interface RefreshAndPersistDeps {
+  db: Database;
+  userId: UserID | null;
+  mcpServerId: MCPServerID;
+  /** Optional hook for "re-auth needed" signals (FeathersJS app, etc.) */
+  onInvalidGrant?: (info: { userId: UserID | null; mcpServerId: MCPServerID }) => void;
+}
+
+/**
+ * Refresh the stored OAuth token and persist the rotation atomically.
+ *
+ * - Loads refresh_token + client_id + client_secret from `user_mcp_oauth_tokens`.
+ * - Loads token endpoint from `mcp_servers.data.auth.oauth_token_url`; if
+ *   missing, infers via {@link inferOAuthTokenUrl} from the server URL.
+ *   (Full RFC 8414 re-discovery is avoided here because the refresh path is
+ *   hot; if the server was originally DCR-registered, we persisted enough to
+ *   refresh without re-fetching metadata.)
+ * - On success: writes new access_token, rotated refresh_token if any, and
+ *   new expiry back. Preserves client_id / client_secret unchanged.
+ * - On `invalid_grant`: deletes the token row so the user is surfaced
+ *   "please re-auth", then re-throws.
+ *
+ * Returns the new access_token string.
+ */
+export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promise<string> {
+  const key = mutexKey(deps.userId, deps.mcpServerId);
+
+  const existing = _inFlightRefreshes.get(key);
+  if (existing) {
+    console.log(`[MCP OAuth Refresh] Piggybacking on in-flight refresh for ${key}`);
+    return existing;
+  }
+
+  const promise = (async () => {
+    const userTokenRepo = new UserMCPOAuthTokenRepository(deps.db);
+    const mcpServerRepo = new MCPServerRepository(deps.db);
+
+    const row = await userTokenRepo.getToken(deps.userId, deps.mcpServerId);
+    if (!row) {
+      throw new MissingRefreshTokenError(
+        `No OAuth token row for user=${deps.userId ?? '<shared>'} server=${deps.mcpServerId}`
+      );
+    }
+    if (!row.oauth_refresh_token) {
+      throw new MissingRefreshTokenError();
+    }
+
+    const server = await mcpServerRepo.findById(deps.mcpServerId);
+    const serverAuth = server?.auth;
+
+    // client_id/client_secret come from the token row first (DCR-bound), with
+    // fallback to server config for admin pre-registered apps where all users
+    // share the same client credentials.
+    const clientId = row.oauth_client_id ?? serverAuth?.oauth_client_id;
+    const clientSecret = row.oauth_client_secret ?? serverAuth?.oauth_client_secret;
+
+    if (!clientId) {
+      throw new Error(
+        `Cannot refresh OAuth token: no client_id available for server ${deps.mcpServerId}`
+      );
+    }
+
+    let tokenEndpoint = serverAuth?.oauth_token_url;
+    if (!tokenEndpoint && server?.url) {
+      try {
+        tokenEndpoint = inferOAuthTokenUrl(server.url);
+        console.log(
+          `[MCP OAuth Refresh] Inferred token endpoint from server URL: ${tokenEndpoint}`
+        );
+      } catch {
+        // fall through to the throw below
+      }
+    }
+    if (!tokenEndpoint) {
+      throw new MissingTokenEndpointError();
+    }
+
+    console.log(
+      `[MCP OAuth Refresh] Refreshing token for user=${deps.userId ?? '<shared>'} ` +
+        `server=${deps.mcpServerId} endpoint=${tokenEndpoint}`
+    );
+
+    try {
+      const result = await refreshMCPToken({
+        tokenEndpoint,
+        refreshToken: row.oauth_refresh_token,
+        clientId,
+        clientSecret,
+      });
+
+      // Persist atomically. Per RFC 6749 §6, an omitted refresh_token in the
+      // response means the old one is still valid — keep it. When present,
+      // the rotation replaces the old value.
+      await userTokenRepo.saveToken(deps.userId, deps.mcpServerId, {
+        accessToken: result.access_token,
+        expiresInSeconds: result.expires_in,
+        refreshToken: result.refresh_token, // undefined = keep existing
+        // Don't touch client_id / client_secret — same grant, same client.
+      });
+
+      console.log(
+        `[MCP OAuth Refresh] ✓ Refreshed token for user=${deps.userId ?? '<shared>'} ` +
+          `server=${deps.mcpServerId}${result.refresh_token ? ' (with rotated refresh_token)' : ''}`
+      );
+
+      return result.access_token;
+    } catch (err) {
+      if (err instanceof InvalidGrantError) {
+        console.warn(
+          `[MCP OAuth Refresh] invalid_grant for user=${deps.userId ?? '<shared>'} ` +
+            `server=${deps.mcpServerId} — deleting token row, user must re-auth`
+        );
+        try {
+          await userTokenRepo.deleteToken(deps.userId, deps.mcpServerId);
+        } catch (deleteErr) {
+          console.error(
+            '[MCP OAuth Refresh] Failed to delete token row after invalid_grant:',
+            deleteErr
+          );
+        }
+        if (deps.onInvalidGrant) {
+          try {
+            deps.onInvalidGrant({ userId: deps.userId, mcpServerId: deps.mcpServerId });
+          } catch (hookErr) {
+            console.error('[MCP OAuth Refresh] onInvalidGrant hook threw:', hookErr);
+          }
+        }
+      }
+      throw err;
+    }
+  })();
+
+  _inFlightRefreshes.set(key, promise);
+  try {
+    return await promise;
+  } finally {
+    _inFlightRefreshes.delete(key);
+  }
+}
+
+/**
+ * Check whether a token needs refreshing. Returns `true` when the token is
+ * absent, expired, or within {@link REFRESH_BUFFER_MS} of expiry.
+ */
+export function needsRefresh(expiresAt: Date | number | null | undefined): boolean {
+  if (expiresAt == null) return false; // unknown expiry → trust current token
+  const ms = expiresAt instanceof Date ? expiresAt.getTime() : expiresAt;
+  return Date.now() >= ms - REFRESH_BUFFER_MS;
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport
+    'tools/mcp/oauth-refresh': 'src/tools/mcp/oauth-refresh.ts', // MCP OAuth refresh_token persistence + mutex
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for worktree isolation
     'mcp/index': 'src/mcp/index.ts', // MCP template resolution utilities
     'gateway/index': 'src/gateway/index.ts', // Gateway platform connectors (Slack, etc.)


### PR DESCRIPTION
## Summary

- **OAuth refresh grants survive daemon restarts** — co-locate DCR `client_id` / `client_secret` on the token row (RFC 6749 §6 requires the exact credentials the grant was issued under; DCR clients otherwise only live in the daemon's in-memory cache).
- **Unified token storage** — per-user and shared OAuth tokens now both live in `user_mcp_oauth_tokens` (shared mode = `user_id NULL`), with partial unique indexes in migrations `0027_mcp_oauth_token_refresh.sql` (postgres) / `0038_` (sqlite).
- **JIT refresh at the executor/daemon boundary** — `refreshAndPersistToken` + a per-key async mutex coalesces concurrent refreshes so we never issue two refresh requests for the same (user, server).
- **Access-controlled executor service** — `/mcp-servers/oauth-auth-headers` keys access control on `params.user.user_id`; callers cannot inject headers for another user's tokens.
- **Force-refresh operator UX** — `/mcp-servers/oauth-refresh` + `MCPServerPill` click-to-force-refresh with a spinner and human-readable expiry tooltip. `needs_reauth` falls through to OAuth start so the user can re-auth in one click.

## Test plan

- [x] `pnpm --filter @agor/core test run src/tools/mcp/oauth-refresh.test.ts` — 26/26 pass, including mutex coalescing + per-key independence
- [x] `pnpm check` green (typecheck, lint, build, unit tests across all packages)
- [ ] Manual: disconnect + re-auth a DCR-registered MCP server, confirm refresh works after daemon restart
- [ ] Manual: click the authenticated pill before expiry, confirm tooltip shows countdown and force-refresh succeeds
- [ ] Manual: let a token expire, confirm JIT refresh fires on next executor call

🤖 Generated with [Claude Code](https://claude.com/claude-code)