### PR TITLE
fix: preserve typed prompt on fork/spawn failure + surface executor errors

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1017,18 +1017,38 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               `✅ [Daemon] Executor spawned for session ${id.substring(0, 8)}, waiting for task completion`
             );
           } catch (error) {
-            console.error(`❌ [Daemon] Executor spawn failed:`, error);
+            // Structured error with full context so silent fork/prompt failures
+            // are traceable in logs. Previously these failures left the task
+            // marked FAILED with no error_message and the session sitting idle
+            // — the user saw no feedback at all.
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(
+              `❌ [Daemon] Executor spawn failed for session=${id.substring(0, 8)} task=${task.task_id.substring(0, 8)} agent=${session.agentic_tool} unix_username=${session.unix_username ?? 'null'}: ${errorMessage}`,
+              error
+            );
             await safePatch(
               'tasks',
               task.task_id,
               {
                 status: TaskStatus.FAILED,
                 completed_at: new Date().toISOString(),
+                error_message: errorMessage,
               },
               'Task',
               params
             );
-            console.log(`❌ [Daemon] Executor spawn failed for session ${id.substring(0, 8)}`);
+            // Surface the failure to subscribed clients so the UI can show
+            // a toast / inline error instead of letting the session sit idle
+            // with a ghost task.
+            try {
+              app.service('tasks').emit('failed', {
+                task_id: task.task_id,
+                session_id: id,
+                error_message: errorMessage,
+              });
+            } catch (emitErr) {
+              console.warn('[Daemon] Failed to emit tasks:failed event:', emitErr);
+            }
           }
         });
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -179,7 +179,10 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   );
 
   app.use('/tasks', createTasksService(db, app), {
-    events: ['tool:start', 'tool:complete', 'thinking:chunk'],
+    // 'failed' is emitted by the prompt route when executor spawn throws so
+    // clients can surface the error instead of silently seeing an idle
+    // session with a ghost task.
+    events: ['tool:start', 'tool:complete', 'thinking:chunk', 'failed'],
   });
   if (svcEnabled('leaderboard')) {
     app.use('/leaderboard', createLeaderboardService(db));

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -12,6 +12,7 @@ import {
   SessionMCPServerRepository,
   SessionRepository,
   type SessionWithLastMessage,
+  UsersRepository,
 } from '@agor/core/db';
 import { type Application, Forbidden } from '@agor/core/feathers';
 import type {
@@ -25,7 +26,12 @@ import type {
 } from '@agor/core/types';
 import { ROLES, SessionStatus } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
-import { determineSpawnIdentity, isSuperAdmin } from '../utils/worktree-authorization.js';
+import {
+  determineSpawnIdentity,
+  isSuperAdmin,
+  loadUnixUsernameForUser,
+  resolveChildUnixUsername,
+} from '../utils/worktree-authorization.js';
 
 /**
  * Session runtime configuration that should be inherited across forks, spawns, and btw.
@@ -120,6 +126,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   private app: Application;
   private sessionMCPRepo: SessionMCPServerRepository;
   private sessionEnvSelectionRepo: SessionEnvSelectionRepository;
+  private usersRepo: UsersRepository;
 
   constructor(db: Database, app: Application) {
     const sessionRepo = new SessionRepository(db);
@@ -137,6 +144,10 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     this.app = app;
     this.sessionMCPRepo = new SessionMCPServerRepository(db);
     this.sessionEnvSelectionRepo = new SessionEnvSelectionRepository(db);
+    // Used by resolveChildIdentity to stamp unix_username on fork/spawn children
+    // without going through app.service('users') — matches the convention used
+    // by scheduler.ts / gateway.ts / terminals.ts.
+    this.usersRepo = new UsersRepository(db);
   }
 
   /**
@@ -211,11 +222,17 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    * fires for these paths. Omitting unix_username silently breaks strict-mode
    * deployments where the executor refuses to launch without one.
    *
-   * - When the child inherits parent identity (internal call / legacy
-   *   sharing) → inherit the parent's unix_username too, so execution stays
-   *   consistent with attribution.
-   * - When the child is attributed to the caller → load the caller's current
-   *   `unix_username` so the executor runs as the attributed user.
+   * Resolution rules (kept aligned with the hook's behavior on normal creates):
+   * - Internal call (no provider) → inherit parent.unix_username. The scheduler /
+   *   service-to-service callers have no human caller to attribute to, and the
+   *   parent's stamped value is the closest thing to ground truth.
+   * - Legacy sharing (`dangerously_allow_session_sharing` triggers) → inherit
+   *   parent's unix_username by design — this is the point of identity borrowing.
+   * - Otherwise (including the common same-user path) → load the attributed
+   *   caller's CURRENT unix_username via {@link loadUnixUsernameForUser}. We
+   *   do NOT inherit parent.unix_username on same-user forks, because the user's
+   *   unix_username may have changed since the parent was created, and
+   *   `validateSessionUnixUsername` would then reject every prompt on the child.
    */
   private async resolveChildIdentity(
     parent: Session,
@@ -249,18 +266,16 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const result = determineSpawnIdentity(parent, caller, worktree);
     const createdBy = result.created_by as Session['created_by'];
 
-    // Stamp unix_username based on attribution outcome:
-    // - Legacy sharing (child inherits parent.created_by) → inherit parent's unix_username
-    // - Otherwise (caller-attributed) → load caller's current unix_username
-    let unixUsername: Session['unix_username'] = null;
-    if (result.usedLegacySharing || createdBy === parent.created_by) {
-      unixUsername = parent.unix_username ?? null;
-    } else {
+    // Legacy sharing → inherit parent's unix_username (identity borrowing by design).
+    // Otherwise (including same-user) → resolve the attributed user's CURRENT
+    // unix_username. Same-user forks must NOT inherit stale parent.unix_username,
+    // because validateSessionUnixUsername would later reject prompts when the
+    // user's unix_username drifts. The decision is delegated to the pure helper
+    // `resolveChildUnixUsername` so it can be unit tested without DB mocks.
+    let callerUnixUsername: string | null = null;
+    if (!result.usedLegacySharing) {
       try {
-        const callerUser = (await this.app
-          .service('users')
-          .get(createdBy as string, { provider: undefined })) as { unix_username?: string | null };
-        unixUsername = callerUser?.unix_username ?? null;
+        callerUnixUsername = await loadUnixUsernameForUser(this.usersRepo, createdBy as string);
       } catch (err) {
         // If we can't load the caller user, fail closed rather than silently
         // creating a session with no unix_username (which would hang forever
@@ -270,6 +285,12 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         );
       }
     }
+
+    const unixUsername = resolveChildUnixUsername(
+      parent.unix_username,
+      callerUnixUsername,
+      result.usedLegacySharing
+    ) as Session['unix_username'];
 
     return { created_by: createdBy, unix_username: unixUsername };
   }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -190,8 +190,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   }
 
   /**
-   * Resolve the `created_by` identity for a child session being created via
-   * spawn / fork / btw. See {@link determineSpawnIdentity} for the rules.
+   * Resolve the `created_by` AND `unix_username` identity for a child session
+   * being created via spawn / fork / btw. See {@link determineSpawnIdentity}
+   * for the rules.
    *
    * Defaults the child to the MCP-authenticated caller; only inherits the
    * parent's identity when the worktree explicitly opts in via the
@@ -203,15 +204,27 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    * to attribute. External calls (REST/socketio/MCP) must always be routed
    * through `determineSpawnIdentity`, which fails closed if the caller has
    * no `user_id`.
+   *
+   * `unix_username` is stamped explicitly here (not via a Feathers hook)
+   * because fork()/spawn() call `this.create(...)` directly, which bypasses
+   * the `before.create` hook pipeline — so `setSessionUnixUsername` never
+   * fires for these paths. Omitting unix_username silently breaks strict-mode
+   * deployments where the executor refuses to launch without one.
+   *
+   * - When the child inherits parent identity (internal call / legacy
+   *   sharing) → inherit the parent's unix_username too, so execution stays
+   *   consistent with attribution.
+   * - When the child is attributed to the caller → load the caller's current
+   *   `unix_username` so the executor runs as the attributed user.
    */
   private async resolveChildIdentity(
     parent: Session,
     params?: SessionParams
-  ): Promise<{ created_by: Session['created_by'] }> {
+  ): Promise<{ created_by: Session['created_by']; unix_username: Session['unix_username'] }> {
     // Internal call (no transport provider) → service-to-service or scheduler.
     // Preserve parent attribution; helper-level identity checks don't apply.
     if (!params?.provider) {
-      return { created_by: parent.created_by };
+      return { created_by: parent.created_by, unix_username: parent.unix_username ?? null };
     }
 
     const caller = params.user;
@@ -234,7 +247,31 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     }
 
     const result = determineSpawnIdentity(parent, caller, worktree);
-    return { created_by: result.created_by as Session['created_by'] };
+    const createdBy = result.created_by as Session['created_by'];
+
+    // Stamp unix_username based on attribution outcome:
+    // - Legacy sharing (child inherits parent.created_by) → inherit parent's unix_username
+    // - Otherwise (caller-attributed) → load caller's current unix_username
+    let unixUsername: Session['unix_username'] = null;
+    if (result.usedLegacySharing || createdBy === parent.created_by) {
+      unixUsername = parent.unix_username ?? null;
+    } else {
+      try {
+        const callerUser = (await this.app
+          .service('users')
+          .get(createdBy as string, { provider: undefined })) as { unix_username?: string | null };
+        unixUsername = callerUser?.unix_username ?? null;
+      } catch (err) {
+        // If we can't load the caller user, fail closed rather than silently
+        // creating a session with no unix_username (which would hang forever
+        // in strict mode).
+        throw new Forbidden(
+          `Cannot resolve unix_username for caller ${createdBy}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+
+    return { created_by: createdBy, unix_username: unixUsername };
   }
 
   /**
@@ -252,7 +289,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     // Default: attribute the child to the MCP-authenticated caller, not the
     // parent owner. Legacy parent-inheriting "identity borrowing" is preserved
     // only when the worktree opts in via dangerously_allow_session_sharing.
-    const { created_by } = await this.resolveChildIdentity(parent, params);
+    const { created_by, unix_username } = await this.resolveChildIdentity(parent, params);
 
     const forkedSession = await this.create(
       {
@@ -262,9 +299,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         description: data.prompt,
         worktree_id: parent.worktree_id,
         created_by, // See resolveChildIdentity — defaults to caller, not parent owner
-        // unix_username intentionally omitted: setSessionUnixUsername hook
-        // stamps the child with the *caller's* current unix_username so that
-        // the execution context matches the attributed `created_by`.
+        unix_username, // Stamped by resolveChildIdentity — this.create() bypasses
+        // the setSessionUnixUsername hook so we must set it explicitly here.
+        // Strict-mode deployments refuse to launch sessions with null unix_username.
         git_state: { ...parent.git_state },
         genealogy: {
           forked_from_session_id: parent.session_id,
@@ -452,7 +489,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     // Default: attribute the child to the MCP-authenticated caller, not the
     // parent owner. Legacy parent-inheriting "identity borrowing" is preserved
     // only when the worktree opts in via dangerously_allow_session_sharing.
-    const { created_by } = await this.resolveChildIdentity(parent, params);
+    const { created_by, unix_username } = await this.resolveChildIdentity(parent, params);
 
     const spawnedSession = await this.create(
       {
@@ -462,9 +499,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         description: finalPrompt, // Use final prompt with extra instructions if provided
         worktree_id: parent.worktree_id,
         created_by, // See resolveChildIdentity — defaults to caller, not parent owner
-        // unix_username intentionally omitted: setSessionUnixUsername hook
-        // stamps the child with the *caller's* current unix_username so that
-        // the execution context matches the attributed `created_by`.
+        unix_username, // Stamped by resolveChildIdentity — this.create() bypasses
+        // the setSessionUnixUsername hook so we must set it explicitly here.
+        // Strict-mode deployments refuse to launch sessions with null unix_username.
         git_state: { ...parent.git_state },
         genealogy: {
           parent_session_id: parent.session_id,

--- a/apps/agor-daemon/src/utils/resolve-child-unix-username.test.ts
+++ b/apps/agor-daemon/src/utils/resolve-child-unix-username.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for `resolveChildUnixUsername` — the pure helper that decides the
+ * `unix_username` stamped on a child session created via fork() / spawn().
+ *
+ * Behavior must stay aligned with {@link determineSpawnIdentity}:
+ * - Legacy sharing (worktree opt-in `dangerously_allow_session_sharing`)
+ *   inherits `parent.unix_username` (identity borrowing by design).
+ * - Default path (same-user forks and cross-user spawns without opt-in)
+ *   uses the CALLER's current `unix_username`. We must NOT inherit
+ *   `parent.unix_username` on same-user forks, because the user's
+ *   unix_username may have drifted since the parent was created, and
+ *   `validateSessionUnixUsername` would then reject every prompt.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveChildUnixUsername } from './worktree-authorization';
+
+describe('resolveChildUnixUsername', () => {
+  it('legacy sharing: inherits parent.unix_username (identity borrowing)', () => {
+    expect(resolveChildUnixUsername('alice-unix', 'bob-unix', true)).toBe('alice-unix');
+  });
+
+  it('legacy sharing with null parent.unix_username returns null', () => {
+    expect(resolveChildUnixUsername(null, 'bob-unix', true)).toBeNull();
+  });
+
+  it('legacy sharing with undefined parent.unix_username normalizes to null', () => {
+    expect(resolveChildUnixUsername(undefined, 'bob-unix', true)).toBeNull();
+  });
+
+  it('non-legacy (same-user fork): uses caller current unix_username, NOT parent stale value', () => {
+    // Regression guard: same-user fork must NOT fall back to parent.unix_username.
+    // If the user's unix_username drifted after the parent was created, we want
+    // the CURRENT value so validateSessionUnixUsername later accepts prompts.
+    expect(resolveChildUnixUsername('alice-old-unix', 'alice-new-unix', false)).toBe(
+      'alice-new-unix'
+    );
+  });
+
+  it('non-legacy (cross-user, flag off): uses caller current unix_username', () => {
+    // Cross-user spawn without legacy opt-in → attributed to caller, so stamp
+    // caller's unix_username. Parent's value is irrelevant.
+    expect(resolveChildUnixUsername('bob-unix', 'alice-unix', false)).toBe('alice-unix');
+  });
+
+  it('non-legacy with null caller unix_username returns null', () => {
+    // Caller has no unix_username set → null is a valid stamp in non-strict modes.
+    expect(resolveChildUnixUsername('alice-unix', null, false)).toBeNull();
+  });
+
+  it('non-legacy with null caller AND null parent returns null', () => {
+    expect(resolveChildUnixUsername(null, null, false)).toBeNull();
+  });
+});

--- a/apps/agor-daemon/src/utils/worktree-authorization.ts
+++ b/apps/agor-daemon/src/utils/worktree-authorization.ts
@@ -835,6 +835,66 @@ export function ensureSessionImmutability() {
 }
 
 /**
+ * Decide which `unix_username` to stamp on a child session created via
+ * fork() or spawn(). Pure function — no DB, no context — so it can be unit
+ * tested directly and kept aligned with {@link determineSpawnIdentity}.
+ *
+ * Rules:
+ * - Legacy sharing (worktree opt-in `dangerously_allow_session_sharing` triggered) →
+ *   inherit `parent.unix_username`. Identity borrowing is the whole point of this flag.
+ * - Otherwise (including the common same-user path) → use the caller's CURRENT
+ *   `unix_username`. We must NOT fall back to `parent.unix_username` just because
+ *   caller and parent owner share an id: the user's unix_username may have drifted
+ *   since the parent was created, and `validateSessionUnixUsername` would then
+ *   reject every prompt on the child.
+ *
+ * @param parentUnixUsername  - `parent.unix_username` from the parent session (may be null)
+ * @param callerUnixUsername  - Caller's CURRENT unix_username (loaded fresh via
+ *                              {@link loadUnixUsernameForUser}); may be null
+ * @param usedLegacySharing   - Whether {@link determineSpawnIdentity} fell into
+ *                              the legacy identity-borrowing branch
+ * @returns The unix_username to stamp on the child (string or null)
+ */
+export function resolveChildUnixUsername(
+  parentUnixUsername: string | null | undefined,
+  callerUnixUsername: string | null,
+  usedLegacySharing: boolean
+): string | null {
+  if (usedLegacySharing) {
+    return parentUnixUsername ?? null;
+  }
+  return callerUnixUsername;
+}
+
+/**
+ * Load a user's current `unix_username` by user id.
+ *
+ * Single source of truth used by both the `setSessionUnixUsername` hook
+ * (external session create) and `SessionsService.fork()` / `spawn()`
+ * (internal create that bypasses the hook pipeline). Keeps the two paths
+ * from drifting on loader choice, error type, or null-handling.
+ *
+ * Throws `NotAuthenticated` when the user record can't be loaded — callers
+ * should let this bubble up rather than swallowing it, because a session
+ * stamped with the wrong unix_username is a latent security/UX bug.
+ *
+ * @param userRepo - UsersRepository instance
+ * @param userId   - User id to resolve
+ * @returns The user's current `unix_username`, or `null` if they don't have one set
+ */
+export async function loadUnixUsernameForUser(
+  // biome-ignore lint/suspicious/noExplicitAny: UsersRepository type lives in @agor/core/db but both callers pass compatible instances
+  userRepo: any,
+  userId: string
+): Promise<string | null> {
+  const user = await userRepo.findById(userId);
+  if (!user) {
+    throw new NotAuthenticated(`User ${userId} not found`);
+  }
+  return user.unix_username ?? null;
+}
+
+/**
  * Set session unix_username from creator's current unix_username
  *
  * When a session is created, stamp it with the creator's current unix_username.
@@ -844,6 +904,11 @@ export function ensureSessionImmutability() {
  *
  * IMPORTANT: Run this hook BEFORE any permission checks that might need the unix_username.
  *
+ * NOTE: This hook only fires for external calls (`params.provider != null`).
+ * Internal callers that bypass the hook pipeline (e.g. `SessionsService.fork()` /
+ * `spawn()` calling `this.create(...)`) must stamp `unix_username` themselves via
+ * {@link loadUnixUsernameForUser} to keep the two paths in sync.
+ *
  * @param userRepo - UserRepository instance
  */
 export function setSessionUnixUsername(
@@ -851,21 +916,13 @@ export function setSessionUnixUsername(
   userRepo: any
 ) {
   return async (context: HookContext) => {
-    console.log('[setSessionUnixUsername] Hook entry', {
-      method: context.method,
-      path: context.path,
-      hasProvider: !!context.params.provider,
-    });
-
     // Only for session creation
     if (context.method !== 'create' || context.path !== 'sessions') {
-      console.log('[setSessionUnixUsername] Skipping - not session creation');
       return context;
     }
 
     // Skip for internal calls
     if (!context.params.provider) {
-      console.log('[setSessionUnixUsername] Skipping - no provider (internal call)');
       return context;
     }
 
@@ -873,33 +930,13 @@ export function setSessionUnixUsername(
     const data = context.data as any;
     const userId = context.params.user?.user_id;
 
-    console.log('[setSessionUnixUsername] Hook called for session creation', {
-      userId,
-      hasProvider: !!context.params.provider,
-    });
-
     if (!userId) {
       throw new NotAuthenticated('Authentication required to create session');
     }
 
-    // Load user to get current unix_username
-    const user = await userRepo.findById(userId);
-
-    console.log('[setSessionUnixUsername] Loaded user:', {
-      userId,
-      email: user?.email,
-      unix_username: user?.unix_username,
-    });
-
-    if (!user) {
-      throw new NotAuthenticated('User not found');
-    }
-
-    // Stamp session with creator's current unix_username
-    // This is IMMUTABLE - even if user's unix_username changes later, session keeps this value
-    data.unix_username = user.unix_username || null;
-
-    console.log('[setSessionUnixUsername] Stamped session with unix_username:', data.unix_username);
+    // Stamp session with creator's current unix_username.
+    // IMMUTABLE - even if user's unix_username changes later, session keeps this value.
+    data.unix_username = await loadUnixUsernameForUser(userRepo, userId);
 
     return context;
   };

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -534,25 +534,45 @@ function AppContent() {
   };
 
   // Handle fork session
+  //
+  // On failure we RETHROW the error so upstream modals (ForkSpawnModal) can
+  // stay open and preserve the user's typed prompt. The error toast is still
+  // surfaced here so the user gets immediate feedback either way. We also
+  // mirror the prompt onto the forked session's per-session draft so that if
+  // the async executor spawn fails later (the fork REST call can succeed
+  // while the background executor errors out silently), the user can still
+  // find their prompt in the new session's compose box.
   const handleForkSession = async (sessionId: string, prompt: string) => {
-    const session = await forkSession(sessionId as SessionID, prompt);
-    if (session) {
-      showSuccess('Session forked successfully!');
-      // Clear the draft after forking
-      handleClearDraft(sessionId);
-    } else {
-      showError('Failed to fork session');
+    try {
+      const session = await forkSession(sessionId as SessionID, prompt);
+      if (session) {
+        showSuccess('Session forked successfully!');
+        // Seed a per-session draft on the new fork so the prompt is recoverable
+        // even if the background executor fails after the REST call returned.
+        handleUpdateDraft(session.session_id, prompt);
+        // Clear the parent's draft after a successful fork
+        handleClearDraft(sessionId);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fork session';
+      showError(`Failed to fork session: ${message}`);
+      throw err;
     }
   };
 
   // Handle btw fork session (ephemeral fork for side questions)
   const handleBtwForkSession = async (sessionId: string, prompt: string) => {
-    const session = await btwForkSession(sessionId as SessionID, prompt);
-    if (session) {
-      showSuccess('Side question sent via btw fork');
-      handleClearDraft(sessionId);
-    } else {
-      showError('Failed to create btw fork');
+    try {
+      const session = await btwForkSession(sessionId as SessionID, prompt);
+      if (session) {
+        showSuccess('Side question sent via btw fork');
+        handleUpdateDraft(session.session_id, prompt);
+        handleClearDraft(sessionId);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create btw fork';
+      showError(`Failed to create btw fork: ${message}`);
+      throw err;
     }
   };
 
@@ -560,13 +580,20 @@ function AppContent() {
   const handleSpawnSession = async (sessionId: string, config: string | Partial<SpawnConfig>) => {
     // Handle both string prompt and full SpawnConfig
     const spawnConfig = typeof config === 'string' ? { prompt: config } : config;
-    const session = await spawnSession(sessionId as SessionID, spawnConfig);
-    if (session) {
-      showSuccess('Subsession session spawned successfully!');
-      // Clear the draft after spawning subsession
-      handleClearDraft(sessionId);
-    } else {
-      showError('Failed to spawn session');
+    try {
+      const session = await spawnSession(sessionId as SessionID, spawnConfig);
+      if (session) {
+        showSuccess('Subsession session spawned successfully!');
+        if (spawnConfig.prompt?.trim()) {
+          handleUpdateDraft(session.session_id, spawnConfig.prompt);
+        }
+        // Clear the draft after spawning subsession
+        handleClearDraft(sessionId);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to spawn session';
+      showError(`Failed to spawn session: ${message}`);
+      throw err;
     }
   };
 

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -545,14 +545,12 @@ function AppContent() {
   const handleForkSession = async (sessionId: string, prompt: string) => {
     try {
       const session = await forkSession(sessionId as SessionID, prompt);
-      if (session) {
-        showSuccess('Session forked successfully!');
-        // Seed a per-session draft on the new fork so the prompt is recoverable
-        // even if the background executor fails after the REST call returned.
-        handleUpdateDraft(session.session_id, prompt);
-        // Clear the parent's draft after a successful fork
-        handleClearDraft(sessionId);
-      }
+      showSuccess('Session forked successfully!');
+      // Seed a per-session draft on the new fork so the prompt is recoverable
+      // even if the background executor fails after the REST call returned.
+      handleUpdateDraft(session.session_id, prompt);
+      // Clear the parent's draft after a successful fork
+      handleClearDraft(sessionId);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fork session';
       showError(`Failed to fork session: ${message}`);
@@ -564,11 +562,9 @@ function AppContent() {
   const handleBtwForkSession = async (sessionId: string, prompt: string) => {
     try {
       const session = await btwForkSession(sessionId as SessionID, prompt);
-      if (session) {
-        showSuccess('Side question sent via btw fork');
-        handleUpdateDraft(session.session_id, prompt);
-        handleClearDraft(sessionId);
-      }
+      showSuccess('Side question sent via btw fork');
+      handleUpdateDraft(session.session_id, prompt);
+      handleClearDraft(sessionId);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create btw fork';
       showError(`Failed to create btw fork: ${message}`);
@@ -582,14 +578,12 @@ function AppContent() {
     const spawnConfig = typeof config === 'string' ? { prompt: config } : config;
     try {
       const session = await spawnSession(sessionId as SessionID, spawnConfig);
-      if (session) {
-        showSuccess('Subsession session spawned successfully!');
-        if (spawnConfig.prompt?.trim()) {
-          handleUpdateDraft(session.session_id, spawnConfig.prompt);
-        }
-        // Clear the draft after spawning subsession
-        handleClearDraft(sessionId);
+      showSuccess('Subsession session spawned successfully!');
+      if (spawnConfig.prompt?.trim()) {
+        handleUpdateDraft(session.session_id, spawnConfig.prompt);
       }
+      // Clear the draft after spawning subsession
+      handleClearDraft(sessionId);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to spawn session';
       showError(`Failed to spawn session: ${message}`);

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.test.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for ForkSpawnModal prompt preservation.
+ *
+ * Bug: when a fork failed (sync error from onConfirm), the modal used to
+ * unconditionally reset fields and close — the user's typed prompt was
+ * wiped from the compose box with no way to recover it.
+ *
+ * These tests pin the guardrail: on onConfirm rejection the modal stays
+ * open and the typed prompt is preserved.
+ */
+
+import type { Session } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ForkSpawnModal } from './ForkSpawnModal';
+
+// The AutocompleteTextarea depends on a live client + DOM APIs that are
+// expensive to mock. Replace it with a plain textarea that forwards value
+// through the provided onChange so we can drive the form deterministically.
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      data-testid="prompt-textarea"
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const mockSession: Partial<Session> = {
+  session_id: 'session-parent',
+  title: 'Parent Session',
+  agentic_tool: 'claude-code',
+};
+
+describe('ForkSpawnModal prompt preservation', () => {
+  it('keeps the modal open and preserves the typed prompt when fork fails', async () => {
+    const typedPrompt = 'please investigate the failing migration';
+    const onConfirm = vi.fn().mockRejectedValue(new Error('Executor spawn failed'));
+    const onCancel = vi.fn();
+
+    render(
+      <ForkSpawnModal
+        open
+        action="fork"
+        session={mockSession as Session}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        client={null}
+        userById={new Map()}
+      />
+    );
+
+    // Type the prompt
+    const textarea = screen.getByTestId('prompt-textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: typedPrompt } });
+
+    // Submit
+    fireEvent.click(screen.getByRole('button', { name: /Fork Session/i }));
+
+    // Fork should have been attempted with the typed prompt
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(typedPrompt));
+
+    // After the rejection, the modal must NOT have been dismissed and the
+    // prompt must still be in the textarea so the user can retry.
+    expect(onCancel).not.toHaveBeenCalled();
+    expect((screen.getByTestId('prompt-textarea') as HTMLTextAreaElement).value).toBe(typedPrompt);
+  });
+
+  it('clears the form and closes only after a successful confirm', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onCancel = vi.fn();
+
+    render(
+      <ForkSpawnModal
+        open
+        action="fork"
+        session={mockSession as Session}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        client={null}
+        userById={new Map()}
+      />
+    );
+
+    const textarea = screen.getByTestId('prompt-textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'do the thing' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Fork Session/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith('do the thing'));
+    await waitFor(() => expect(onCancel).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -92,18 +92,26 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
   }, [open, session, configPreset, form, currentUser]);
 
   const handleOk = async () => {
+    // Validate fields first. If validation fails, bail out WITHOUT clearing
+    // the form — the user's prompt text must be preserved.
     try {
       await form.validateFields();
-      // Use getFieldsValue(true) to include values from collapsed panels
-      const values = form.getFieldsValue(true);
-      const prompt = values.prompt?.trim();
+    } catch (error) {
+      console.error('Form validation failed:', error);
+      return;
+    }
 
-      if (!prompt) {
-        return;
-      }
+    // Use getFieldsValue(true) to include values from collapsed panels
+    const values = form.getFieldsValue(true);
+    const prompt = values.prompt?.trim();
 
-      setLoading(true);
+    if (!prompt) {
+      return;
+    }
 
+    setLoading(true);
+
+    try {
       if (action === 'fork') {
         await onConfirm(prompt);
       } else {
@@ -141,10 +149,15 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
         await onConfirm(spawnConfig);
       }
 
+      // Only reset + close on success. If onConfirm rejects, the modal stays
+      // open so the user's typed prompt is not lost.
       form.resetFields();
       onCancel();
     } catch (error) {
-      console.error('Form validation failed:', error);
+      console.error(
+        `Failed to ${action} session — keeping modal open so prompt is preserved:`,
+        error
+      );
     } finally {
       setLoading(false);
     }

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -578,19 +578,31 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
-  const handleFork = () => {
+  const handleFork = async () => {
     if (!session) return;
     const value = promptRef.current?.getValue() ?? '';
-    onFork?.(session.session_id, value.trim());
-    promptRef.current?.clear();
+    const promptToSend = value.trim();
+    if (!promptToSend) return;
+    try {
+      await onFork?.(session.session_id, promptToSend);
+      // Only clear the compose box + draft on success, so a failed fork
+      // leaves the typed prompt intact for the user to retry.
+      promptRef.current?.clear();
+    } catch (error) {
+      console.error('Fork failed — keeping prompt in compose box:', error);
+    }
   };
 
   const handleBtwSend = async () => {
     const value = promptRef.current?.getValue() ?? '';
     if (!value.trim() || connectionDisabled) return;
     const promptToSend = value.trim();
-    promptRef.current?.clear();
-    await onBtwFork?.(session.session_id, promptToSend);
+    try {
+      await onBtwFork?.(session.session_id, promptToSend);
+      promptRef.current?.clear();
+    } catch (error) {
+      console.error('BTW fork failed — keeping prompt in compose box:', error);
+    }
   };
 
   const handleSpawnModalConfirm = async (config: string | Partial<SpawnConfig>) => {

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -103,7 +103,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
   const forkSession = async (sessionId: SessionID, prompt: string): Promise<Session | null> => {
     if (!client) {
       setError('Client not connected');
-      return null;
+      throw new Error('Client not connected');
     }
 
     try {
@@ -128,7 +128,9 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       const message = err instanceof Error ? err.message : 'Failed to fork session';
       setError(message);
       console.error('Failed to fork session:', err);
-      return null;
+      // Re-throw so callers (and modals) can distinguish failure from success
+      // and keep the user's typed prompt from being silently discarded.
+      throw err instanceof Error ? err : new Error(message);
     } finally {
       setCreating(false);
     }
@@ -137,7 +139,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
   const btwForkSession = async (sessionId: SessionID, prompt: string): Promise<Session | null> => {
     if (!client) {
       setError('Client not connected');
-      return null;
+      throw new Error('Client not connected');
     }
 
     try {
@@ -166,7 +168,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       const message = err instanceof Error ? err.message : 'Failed to create btw fork';
       setError(message);
       console.error('Failed to create btw fork:', err);
-      return null;
+      throw err instanceof Error ? err : new Error(message);
     } finally {
       setCreating(false);
     }
@@ -178,7 +180,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
   ): Promise<Session | null> => {
     if (!client) {
       setError('Client not connected');
-      return null;
+      throw new Error('Client not connected');
     }
 
     try {
@@ -202,7 +204,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       const message = err instanceof Error ? err.message : 'Failed to spawn session';
       setError(message);
       console.error('Failed to spawn session:', err);
-      return null;
+      throw err instanceof Error ? err : new Error(message);
     } finally {
       setCreating(false);
     }

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -22,9 +22,12 @@ interface UseSessionActionsResult {
   deleteSession: (sessionId: SessionID) => Promise<boolean>;
   archiveSession: (sessionId: SessionID) => Promise<Session | null>;
   unarchiveSession: (sessionId: SessionID) => Promise<Session | null>;
-  forkSession: (sessionId: SessionID, prompt: string) => Promise<Session | null>;
-  btwForkSession: (sessionId: SessionID, prompt: string) => Promise<Session | null>;
-  spawnSession: (sessionId: SessionID, config: Partial<SpawnConfig>) => Promise<Session | null>;
+  // Throw on failure (do NOT return null) so callers can preserve the user's
+  // typed prompt in the compose box. See SessionPanel.handleFork / handleBtwSend
+  // and ForkSpawnModal.handleOk for the preserved-on-failure invariants.
+  forkSession: (sessionId: SessionID, prompt: string) => Promise<Session>;
+  btwForkSession: (sessionId: SessionID, prompt: string) => Promise<Session>;
+  spawnSession: (sessionId: SessionID, config: Partial<SpawnConfig>) => Promise<Session>;
   creating: boolean;
   error: string | null;
 }
@@ -100,7 +103,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
     }
   };
 
-  const forkSession = async (sessionId: SessionID, prompt: string): Promise<Session | null> => {
+  const forkSession = async (sessionId: SessionID, prompt: string): Promise<Session> => {
     if (!client) {
       setError('Client not connected');
       throw new Error('Client not connected');
@@ -136,7 +139,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
     }
   };
 
-  const btwForkSession = async (sessionId: SessionID, prompt: string): Promise<Session | null> => {
+  const btwForkSession = async (sessionId: SessionID, prompt: string): Promise<Session> => {
     if (!client) {
       setError('Client not connected');
       throw new Error('Client not connected');
@@ -177,7 +180,7 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
   const spawnSession = async (
     sessionId: SessionID,
     config: Partial<SpawnConfig>
-  ): Promise<Session | null> => {
+  ): Promise<Session> => {
     if (!client) {
       setError('Client not connected');
       throw new Error('Client not connected');

--- a/apps/agor-ui/src/test/setup.ts
+++ b/apps/agor-ui/src/test/setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom';
+
+// jsdom does not implement matchMedia, but antd's responsive helpers
+// (Grid, Modal, etc.) subscribe to it during layout effects. Stub it out
+// so component tests can render antd-based UI without throwing.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -684,6 +684,31 @@ describe('TaskRepository.update', () => {
       EntityNotFoundError
     );
   });
+
+  // Regression: forked sessions used to go FAILED silently with no trace of
+  // why. The prompt route now stamps `error_message` on the task so the
+  // reason is preserved in the DB and visible to UI + logs.
+  dbTest('should round-trip error_message on failed task update', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const data = createTaskData({ session_id: sessionId, status: TaskStatus.RUNNING });
+    await taskRepo.create(data);
+
+    const errorMessage =
+      'Unix user agor_123 not found. Ensure the Unix user is created before attempting to execute sessions.';
+    const updated = await taskRepo.update(data.task_id!, {
+      status: TaskStatus.FAILED,
+      completed_at: new Date().toISOString(),
+      error_message: errorMessage,
+    });
+
+    expect(updated.status).toBe(TaskStatus.FAILED);
+    expect(updated.error_message).toBe(errorMessage);
+
+    // Fetching fresh from the repo must still surface the error.
+    const refetched = await taskRepo.findById(data.task_id!);
+    expect(refetched?.error_message).toBe(errorMessage);
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -79,6 +79,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         tool_use_count: task.tool_use_count ?? 0,
         duration_ms: task.duration_ms, // Task execution duration
         agent_session_id: task.agent_session_id, // SDK session ID
+        error_message: task.error_message, // Human-readable failure reason when status='failed'
         raw_sdk_response: task.raw_sdk_response, // Raw SDK response - single source of truth for token accounting
         normalized_sdk_response: task.normalized_sdk_response, // Normalized for UI consumption
         computed_context_window: task.computed_context_window, // Cumulative context window (computed by tool.computeContextWindow())

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -241,6 +241,10 @@ export const tasks = pgTable(
         duration_ms?: number;
         agent_session_id?: string;
 
+        // Populated when a task transitions to `failed` so the cause is
+        // preserved instead of the session silently sitting idle.
+        error_message?: string;
+
         // Raw SDK response - single source of truth for token accounting
         raw_sdk_response?: Task['raw_sdk_response'];
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -229,6 +229,10 @@ export const tasks = sqliteTable(
         duration_ms?: number;
         agent_session_id?: string;
 
+        // Populated when a task transitions to `failed` so the cause is
+        // preserved instead of the session silently sitting idle.
+        error_message?: string;
+
         // Raw SDK response - single source of truth for token accounting
         raw_sdk_response?: Task['raw_sdk_response'];
 

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -57,6 +57,13 @@ export interface Task {
   duration_ms?: number; // Total execution time from SDK
   agent_session_id?: string; // SDK's internal session ID for debugging
 
+  /**
+   * Human-readable error message populated when the task transitions to the
+   * `failed` state. Captures the reason so UI and logs can surface a clear
+   * cause instead of silently leaving the session idle with a ghost task.
+   */
+  error_message?: string;
+
   // Model (resolved model ID used for this task, e.g., "claude-sonnet-4-5-20250929")
   model?: string;
 

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -514,6 +514,9 @@ export async function executeToolTask(params: {
     const patchData: Partial<Task> = {
       status: 'failed',
       completed_at: new Date().toISOString(),
+      // Surface the actual failure reason so the UI / DB show what went wrong,
+      // instead of the task silently flipping to FAILED with no context.
+      error_message: err.message || String(err),
     };
 
     // Add git_state if we captured a SHA

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -78,6 +78,7 @@ export class AgorExecutor {
           await this.client.service('tasks').patch(this.config.taskId, {
             status: 'failed',
             completed_at: new Date().toISOString(),
+            error_message: error instanceof Error ? error.message : String(error),
           });
         } catch (patchError) {
           console.error('[executor] Failed to update task status:', patchError);
@@ -223,6 +224,7 @@ export class AgorExecutor {
           await this.client.service('tasks').patch(this.config.taskId, {
             status: 'failed',
             completed_at: new Date().toISOString(),
+            error_message: `uncaughtException: ${error instanceof Error ? error.message : String(error)}`,
           });
         } catch (patchError) {
           console.error('[executor] Failed to update task status:', patchError);
@@ -241,6 +243,7 @@ export class AgorExecutor {
           await this.client.service('tasks').patch(this.config.taskId, {
             status: 'failed',
             completed_at: new Date().toISOString(),
+            error_message: `unhandledRejection: ${reason instanceof Error ? reason.message : String(reason)}`,
           });
         } catch (patchError) {
           console.error('[executor] Failed to update task status:', patchError);


### PR DESCRIPTION
## Summary

Forking a session from the UI could silently fail: the user's multi-line typed prompt would disappear from the compose box, no error was shown, and the newly-created child session was left idle with no trace of why. Root causes span the whole stack.

### Root cause A1 — in-pane fork button wiped the prompt unconditionally

The fork button on the main conversation pane (`SessionPanel.handleFork`) fired `onFork` without awaiting, then called `promptRef.current?.clear()` immediately — which blanks the textarea **and** deletes the persisted draft. Any fork failure silently wiped the user's prompt. `handleBtwSend` had the same pattern (cleared first, awaited after).

**Fix:** `handleFork` / `handleBtwSend` now await the action and only clear the compose box on success. On failure the prompt stays intact so the user can retry.

### Root cause A2 — hooks swallowed errors (made A1 invisible)

`useSessionActions.forkSession` / `btwForkSession` / `spawnSession` caught errors and returned `null` instead of throwing — so even if the in-pane handlers *had* awaited, they'd never see a failure.

**Fix:** hooks re-throw on failure. `App.tsx` fork/spawn handlers re-throw after toasting, and additionally seed the *new child session's* draft with the typed prompt right after a successful create, so even if the async executor fails later the user can still recover the prompt in the child session's compose box.

### Root cause A3 — the spawn modal (`ForkSpawnModal`) had the same bug

Unrelated to the in-pane button but same shape: `handleOk` ran `resetFields() + onCancel()` regardless of `onConfirm` outcome. Fixed so the modal stays open with prompt preserved on submission rejection.

### Root cause B — backend silently marked tasks FAILED with no context

- `/sessions/:id/prompt` fires `setImmediate(executeTask)` and returns success.
- The `setImmediate` catch block patched task `status=FAILED` but did **not** record an error message, did **not** emit any event, and only wrote an unstructured `console.error`.
- Result: the UI had no way to know the spawn had died, and ops had no structured log to correlate with executor failures.

**Fix:**
- Added optional `error_message` to `Task` type + SQLite/Postgres data blob; persisted through the tasks repository.
- Structured log on executor spawn failure includes session / task / agent / unix_username identifiers.
- `task.error_message` is patched alongside `status=FAILED` so the cause surfaces in the DB + UI.
- New `tasks:failed` WebSocket event `{task_id, session_id, error_message}` so UIs can react without polling.
- Executor-side FAILED patches (fatal try/catch, uncaughtException, unhandledRejection, per-tool SDK handler catch) now populate `error_message` too — previously they only set `status=failed` with no context, so tool-level crashes looked identical to "everything fine" in the DB.

### Root cause C — **strict-mode fork hole (the actual upstream cause on the prod reproducer)**

`SessionsService.fork()` and `spawn()` call `this.create(...)` directly, which bypasses the Feathers `before.create` hook pipeline — so `setSessionUnixUsername` never fires for forked/spawned children. In `unix_user_mode: strict` deployments the executor refuses to launch a session with `unix_username: null`, so every fork and spawn silently failed: the child session was created, the task was created, and the executor never attached.

**Fix:** `resolveChildIdentity` now resolves `unix_username` alongside `created_by`:
- Child inherits parent identity (internal calls, legacy session sharing via `dangerously_allow_session_sharing`) → inherit parent's `unix_username`
- Child attributed to caller (default) → load caller's current `unix_username` via the users service
- Fail closed if the caller user can't be loaded — better a `Forbidden` with a clear message than a session that hangs forever waiting for an executor that will never launch

`fork()` and `spawn()` now pass the stamped `unix_username` into `this.create(...)` directly. The misleading comments that claimed the hook handled this have been replaced.

## Tests added

- `packages/core/src/db/repositories/tasks.test.ts` — regression: `error_message` round-trips through update/fetch.
- `apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.test.tsx` — two regression tests for the spawn modal (prompt preserved on reject; form cleared + closed on success).
- `apps/agor-ui/src/test/setup.ts` — stub `window.matchMedia` so antd responsive helpers don't throw under jsdom.

No isolated unit test was added for `SessionPanel.handleFork` or the strict-mode unix_username stamping — the service-level fork path has extensive dependencies (app, worktrees service, users service, FeathersJS internals). The fix follows the same invariant the modal test pins (prompt preserved on failure, cleared only on success) and is straightforward enough to verify by reading `handleFork`/`handleBtwSend` + `resolveChildIdentity`.

## Test plan
- [x] `pnpm --filter agor-ui typecheck`
- [x] `pnpm --filter @agor/core typecheck`
- [x] `pnpm --filter agor-daemon typecheck`
- [x] `pnpm --filter @agor/core test` (incl. new error_message test)
- [x] Vitest in `agor-ui` — 48 pass across 7 files (incl. 2 new ForkSpawnModal tests)
- [x] `pnpm lint` clean
- [ ] Manual: trigger a fork in strict mode and confirm the child session gets the caller's unix_username + executor launches
- [ ] Manual: trigger a fork with a deliberately-broken executor and confirm prompt is preserved in the compose box + task.error_message populated + `tasks:failed` event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)