### PR TITLE
fix(ui): CodePreviewModal YAML staircase rendering

### DIFF
--- a/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.test.tsx
+++ b/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ThemedSyntaxHighlighter } from './ThemedSyntaxHighlighter';
+
+describe('ThemedSyntaxHighlighter', () => {
+  it('renders a block-level <pre> wrapper by default (prevents staircase on wrapped lines)', () => {
+    const { container } = render(
+      <ThemedSyntaxHighlighter language="yaml" showLineNumbers>
+        {'# comment line 1\n# comment line 2\nversion: 2\n'}
+      </ThemedSyntaxHighlighter>
+    );
+
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    // Must not be an inline <code> wrapper — that caused the staircase bug
+    // because soft-wrapped long lines flowed inline from the previous line.
+    expect(pre?.tagName.toLowerCase()).toBe('pre');
+  });
+
+  it('honors an explicit PreTag override', () => {
+    const { container } = render(
+      <ThemedSyntaxHighlighter language="bash" PreTag="span">
+        {'echo hi'}
+      </ThemedSyntaxHighlighter>
+    );
+    // When overridden to span, there should be no <pre> wrapper.
+    expect(container.querySelector('pre')).toBeNull();
+    expect(container.querySelector('span')).not.toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.test.tsx
+++ b/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.test.tsx
@@ -10,11 +10,9 @@ describe('ThemedSyntaxHighlighter', () => {
       </ThemedSyntaxHighlighter>
     );
 
-    const pre = container.querySelector('pre');
-    expect(pre).not.toBeNull();
-    // Must not be an inline <code> wrapper — that caused the staircase bug
-    // because soft-wrapped long lines flowed inline from the previous line.
-    expect(pre?.tagName.toLowerCase()).toBe('pre');
+    // Assert the *outer* wrapper tag specifically — inner token spans
+    // would mask a regression if we searched anywhere in the subtree.
+    expect(container.firstElementChild?.tagName.toLowerCase()).toBe('pre');
   });
 
   it('honors an explicit PreTag override', () => {
@@ -23,8 +21,9 @@ describe('ThemedSyntaxHighlighter', () => {
         {'echo hi'}
       </ThemedSyntaxHighlighter>
     );
-    // When overridden to span, there should be no <pre> wrapper.
+    // Check the outer wrapper tag directly — querySelector('span') would
+    // pass trivially due to inner token spans even if the wrapper changed.
+    expect(container.firstElementChild?.tagName.toLowerCase()).toBe('span');
     expect(container.querySelector('pre')).toBeNull();
-    expect(container.querySelector('span')).not.toBeNull();
   });
 });

--- a/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.tsx
+++ b/apps/agor-ui/src/components/ThemedSyntaxHighlighter/ThemedSyntaxHighlighter.tsx
@@ -37,8 +37,11 @@ export interface ThemedSyntaxHighlighterProps {
    */
   customStyle?: CSSProperties;
   /**
-   * HTML tag to use for wrapping (default is 'code', can be 'span' for inline)
-   * @default 'code'
+   * HTML tag to use for wrapping. Must be a block-level element when
+   * `showLineNumbers` is set or when the content can wrap, otherwise soft
+   * wraps flow inline from the previous line's end (the "staircase" bug).
+   * Use 'span' only for truly inline single-line snippets.
+   * @default 'pre'
    */
   PreTag?: keyof JSX.IntrinsicElements;
   /**
@@ -54,7 +57,7 @@ export const ThemedSyntaxHighlighter: React.FC<ThemedSyntaxHighlighterProps> = (
   language = 'typescript',
   showLineNumbers = false,
   customStyle,
-  PreTag = 'code',
+  PreTag = 'pre',
   codeTagProps,
 }) => {
   const { token } = theme.useToken();


### PR DESCRIPTION
## Summary

- Opening a `.yml` / `.yaml` file in WorktreeModal's File tab rendered comment lines diagonally offset (a "staircase"), each wrapped line starting further right than the last, with stacked highlight rectangles — see screenshot below.
- Root cause: `ThemedSyntaxHighlighter` defaulted `PreTag` to `'code'`. `<code>` is an **inline** element, so `react-syntax-highlighter`'s outer wrapper had no block semantics. When long comment lines soft-wrapped, each wrap continued at the previous line's end x-position, producing the staircase. Short lines that don't wrap rendered fine, which matches the screenshot.
- Fix: change the default to `'pre'` (matches the library's own default). The two existing call sites that explicitly cared — `BashRenderer` and `ToolUseRenderer` — already pass `PreTag="pre"` explicitly, so they're unchanged. `CodePreviewModal` was the only affected consumer.

## Changes

- `ThemedSyntaxHighlighter.tsx`: default `PreTag` from `'code'` → `'pre'`; refresh JSDoc to explain the inline-vs-block trap.
- `ThemedSyntaxHighlighter.test.tsx` (new): asserts the default wrapper is `<pre>` and that the `PreTag="span"` override still works.

## Before / After

- **Before:** https://github.com/preset-io/agor/pull/new — see user-attached screenshot (`/tmp/yaml-viewer-bug.png` locally). Top ~20 comment lines of `.agor.yml` staircase; short lines at the bottom render correctly.
- **After:** verified by unit tests (`<pre>` wrapper present). The dev env was up at http://10.33.92.175:5647 but Playwright MCP wasn't available to this agent for an automated screenshot — happy to attach one on request.

## Test plan

- [x] `pnpm test src/components/ThemedSyntaxHighlighter/` — 2 tests pass
- [x] `tsc --noEmit` — clean
- [ ] Manual: open a `.yml` file in WorktreeModal → File tab, confirm no staircase
- [ ] Manual: open `.json`, `.ts`, `.py`, `.md` in FileViewer — all render correctly (the change only affects the outer tag, not syntax coloring)
- [ ] Manual: verify `BashRenderer` and `ToolUseRenderer` tool blocks still look correct (they already pass `PreTag="pre"` explicitly)

## Notes

- `MarkdownModal.tsx` uses `MarkdownRenderer` (not `ThemedSyntaxHighlighter`) — not affected.
- Scope kept tight per task constraints; no refactor of the component beyond the default change and the docstring it belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)