### PR TITLE
fix(repos): replace (not merge) environment on .agor.yml import

### DIFF
--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -796,16 +796,22 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     }
 
     // Preserve any existing DB-only template_overrides across import — the
-    // file never contains them, so a naive patch would otherwise wipe them.
-    const patch: Partial<Repo> = { environment };
-    if (repo.environment?.template_overrides) {
-      patch.environment = {
-        ...environment,
-        template_overrides: repo.environment.template_overrides,
-      };
-    }
+    // file never contains them, so a naive replace would otherwise wipe them.
+    const replacement: RepoEnvironment = repo.environment?.template_overrides
+      ? { ...environment, template_overrides: repo.environment.template_overrides }
+      : environment;
 
-    return this.patch(id, patch, params) as Promise<Repo>;
+    // Replace wholesale (NOT deep-merge) — otherwise deepMerge in
+    // RepoRepository.update would preserve stale variant keys that the user
+    // renamed or removed in .agor.yml, and fields dropped from a still-present
+    // variant would also linger. See packages/core/src/db/repositories/repos.ts
+    // setEnvironment() for the single-field replace semantics.
+    const updated = await this.repoRepo.setEnvironment(id, replacement);
+
+    // DrizzleService.patch would normally fire this; emit manually since we
+    // bypassed it to get replace semantics.
+    this.emit?.('patched', updated, params);
+    return updated;
   }
 
   /**

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -534,6 +534,144 @@ describe('RepoRepository.update', () => {
 });
 
 // ============================================================================
+// setEnvironment
+// ============================================================================
+
+describe('RepoRepository.setEnvironment', () => {
+  dbTest('should replace environment wholesale, clearing renamed variants', async ({ db }) => {
+    // Reproduces the .agor.yml import bug: user renames a variant in the
+    // YAML file, re-imports, and the old variant key must NOT linger in the
+    // DB. With deepMerge-based update() it did linger — setEnvironment
+    // replaces wholesale.
+    const repo = new RepoRepository(db);
+    const data = createRepoData();
+    await repo.create(data);
+
+    // Initial state: two variants, "default" and "with-manager"
+    await repo.setEnvironment(data.repo_id, {
+      default: 'with-manager',
+      variants: {
+        default: { start: 'echo d-start', stop: 'echo d-stop' },
+        'with-manager': { start: 'echo wm-start-v1', stop: 'echo wm-stop' },
+      },
+    });
+
+    // User renames "with-manager" → "without-manager" (different key), also
+    // points default at the unified variant
+    const renamed = await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: {
+        default: { start: 'echo d-start-v2', stop: 'echo d-stop-v2' },
+        'without-manager': { start: 'echo wom-start', stop: 'echo wom-stop' },
+      },
+    });
+
+    expect(Object.keys(renamed.environment!.variants).sort()).toEqual([
+      'default',
+      'without-manager',
+    ]);
+    expect(renamed.environment!.variants['with-manager']).toBeUndefined();
+    expect(renamed.environment!.variants.default.start).toBe('echo d-start-v2');
+  });
+
+  dbTest('should drop fields removed from a still-present variant', async ({ db }) => {
+    // Secondary symptom of the same merge bug: removing a field from a
+    // variant in .agor.yml should clear it from the DB.
+    const repo = new RepoRepository(db);
+    const data = createRepoData();
+    await repo.create(data);
+
+    await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: {
+        default: {
+          start: 'echo start',
+          stop: 'echo stop',
+          nuke: 'echo nuke',
+          logs: 'echo logs',
+        },
+      },
+    });
+
+    // User edits yaml, removes `nuke` and `logs`
+    const after = await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: {
+        default: { start: 'echo start', stop: 'echo stop' },
+      },
+    });
+
+    expect(after.environment!.variants.default.nuke).toBeUndefined();
+    expect(after.environment!.variants.default.logs).toBeUndefined();
+  });
+
+  dbTest('should preserve unrelated columns (name, slug, local_path)', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const data = createRepoData({ name: 'My Repo', slug: 'my-repo' });
+    await repo.create(data);
+
+    const updated = await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: { default: { start: 'echo s', stop: 'echo p' } },
+    });
+
+    expect(updated.name).toBe('My Repo');
+    expect(updated.slug).toBe('my-repo');
+    expect(updated.local_path).toBe(data.local_path);
+    expect(updated.remote_url).toBe(data.remote_url);
+  });
+
+  dbTest('should clear environment when passed null', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const data = createRepoData();
+    await repo.create(data);
+
+    await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: { default: { start: 'echo s', stop: 'echo p' } },
+    });
+
+    const cleared = await repo.setEnvironment(data.repo_id, null);
+    expect(cleared.environment).toBeUndefined();
+  });
+
+  dbTest('should re-derive the v1 environment_config projection', async ({ db }) => {
+    // rowToRepo derives environment_config from v2. Make sure setEnvironment
+    // keeps that projection in sync instead of leaving a stale v1 view.
+    const repo = new RepoRepository(db);
+    const data = createRepoData();
+    await repo.create(data);
+
+    const v1 = await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: {
+        default: { start: 'echo up-1', stop: 'echo down-1' },
+      },
+    });
+    expect(v1.environment_config?.up_command).toBe('echo up-1');
+
+    const v2 = await repo.setEnvironment(data.repo_id, {
+      default: 'default',
+      variants: {
+        default: { start: 'echo up-2', stop: 'echo down-2' },
+      },
+    });
+    expect(v2.environment_config?.up_command).toBe('echo up-2');
+    expect(v2.environment_config?.down_command).toBe('echo down-2');
+  });
+
+  dbTest('should throw EntityNotFoundError for non-existent ID', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    await expect(
+      repo.setEnvironment('99999999', {
+        default: 'default',
+        variants: { default: { start: 'echo s', stop: 'echo p' } },
+      })
+    ).rejects.toThrow(EntityNotFoundError);
+  });
+});
+
+// ============================================================================
 // Delete
 // ============================================================================
 

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -549,6 +549,7 @@ describe('RepoRepository.setEnvironment', () => {
 
     // Initial state: two variants, "default" and "with-manager"
     await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'with-manager',
       variants: {
         default: { start: 'echo d-start', stop: 'echo d-stop' },
@@ -559,6 +560,7 @@ describe('RepoRepository.setEnvironment', () => {
     // User renames "with-manager" → "without-manager" (different key), also
     // points default at the unified variant
     const renamed = await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: {
         default: { start: 'echo d-start-v2', stop: 'echo d-stop-v2' },
@@ -582,6 +584,7 @@ describe('RepoRepository.setEnvironment', () => {
     await repo.create(data);
 
     await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: {
         default: {
@@ -595,6 +598,7 @@ describe('RepoRepository.setEnvironment', () => {
 
     // User edits yaml, removes `nuke` and `logs`
     const after = await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: {
         default: { start: 'echo start', stop: 'echo stop' },
@@ -611,6 +615,7 @@ describe('RepoRepository.setEnvironment', () => {
     await repo.create(data);
 
     const updated = await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: { default: { start: 'echo s', stop: 'echo p' } },
     });
@@ -627,6 +632,7 @@ describe('RepoRepository.setEnvironment', () => {
     await repo.create(data);
 
     await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: { default: { start: 'echo s', stop: 'echo p' } },
     });
@@ -643,6 +649,7 @@ describe('RepoRepository.setEnvironment', () => {
     await repo.create(data);
 
     const v1 = await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: {
         default: { start: 'echo up-1', stop: 'echo down-1' },
@@ -651,6 +658,7 @@ describe('RepoRepository.setEnvironment', () => {
     expect(v1.environment_config?.up_command).toBe('echo up-1');
 
     const v2 = await repo.setEnvironment(data.repo_id, {
+      version: 2,
       default: 'default',
       variants: {
         default: { start: 'echo up-2', stop: 'echo down-2' },
@@ -664,6 +672,7 @@ describe('RepoRepository.setEnvironment', () => {
     const repo = new RepoRepository(db);
     await expect(
       repo.setEnvironment('99999999', {
+        version: 2,
         default: 'default',
         variants: { default: { start: 'echo s', stop: 'echo p' } },
       })

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -310,21 +310,21 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
   }
 
   /**
-   * Replace the repo's `environment` column wholesale.
+   * Replace specified top-level fields on the repo WITHOUT deep-merging.
    *
-   * Unlike {@link update}, this does NOT deep-merge — use this for imports
-   * and any other "source-of-truth refresh" that needs to CLEAR keys
-   * (renamed or removed variants, dropped fields inside a variant, etc).
+   * Unlike {@link update}, any key present in `patch` fully overwrites the
+   * corresponding value on the current row — nested objects are NOT merged.
+   * Fields omitted from `patch` are left untouched. Pass a field with value
+   * `undefined` to clear it.
    *
-   * Pass `null` to clear the environment entirely. `template_overrides` is
-   * not treated specially here; callers that need to preserve DB-only
-   * template overrides across a replace must fold them into the incoming
-   * `environment` object themselves.
+   * Used by named wrappers like {@link setEnvironment} that want replace
+   * semantics for a specific subset of fields. Kept private so callers must
+   * go through a wrapper where the decision to replace-vs-merge is explicit.
    *
    * Runs in a transaction so the read-replace-write is atomic, matching
    * {@link update}'s concurrency guarantees.
    */
-  async setEnvironment(id: string, environment: RepoEnvironment | null): Promise<Repo> {
+  private async replaceFields(id: string, patch: Partial<Repo>): Promise<Repo> {
     try {
       const fullId = await this.resolveId(id);
 
@@ -341,11 +341,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         }
 
         const current = this.rowToRepo(currentRow);
-        const next: Repo = { ...current, environment: environment ?? undefined };
-        // environment_config (v1 projection) is re-derived from the new v2
-        // environment by repoToInsert; drop the stale one so we don't carry
-        // a ghost projection through.
-        delete (next as Partial<Repo>).environment_config;
+        const next: Repo = { ...current, ...patch };
 
         const insertData = this.repoToInsert(next);
         const newUpdatedAt = new Date();
@@ -367,10 +363,33 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       if (error instanceof RepositoryError) throw error;
       if (error instanceof EntityNotFoundError) throw error;
       throw new RepositoryError(
-        `Failed to set repo environment: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to replace repo fields: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }
+  }
+
+  /**
+   * Replace the repo's `environment` column wholesale.
+   *
+   * Unlike {@link update}, this does NOT deep-merge — use this for imports
+   * and any other "source-of-truth refresh" that needs to CLEAR keys
+   * (renamed or removed variants, dropped fields inside a variant, etc).
+   *
+   * Pass `null` to clear the environment entirely. `template_overrides` is
+   * not treated specially here; callers that need to preserve DB-only
+   * template overrides across a replace must fold them into the incoming
+   * `environment` object themselves.
+   */
+  async setEnvironment(id: string, environment: RepoEnvironment | null): Promise<Repo> {
+    // Clear the v1 projection explicitly — repoToInsert re-derives it from
+    // the new v2 environment, but only when environment_config is undefined
+    // on the incoming patch. Without this, clearing environment would leave
+    // a ghost v1 projection around.
+    return this.replaceFields(id, {
+      environment: environment ?? undefined,
+      environment_config: undefined,
+    });
   }
 
   /**

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -356,6 +356,13 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
           .where(eq(repos.repo_id, fullId))
           .run();
 
+        // repoToInsert may re-derive computed fields from the patch (e.g. the
+        // v1 environment_config projection is derived from v2 environment).
+        // Sync those back onto `next` so the returned Repo matches what was
+        // actually persisted — otherwise callers see stale values for any
+        // field we explicitly undefined'd in `patch`.
+        next.environment = insertData.data.environment;
+        next.environment_config = insertData.data.environment_config;
         next.last_updated = newUpdatedAt.toISOString();
         return next;
       });

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -310,6 +310,70 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
   }
 
   /**
+   * Replace the repo's `environment` column wholesale.
+   *
+   * Unlike {@link update}, this does NOT deep-merge — use this for imports
+   * and any other "source-of-truth refresh" that needs to CLEAR keys
+   * (renamed or removed variants, dropped fields inside a variant, etc).
+   *
+   * Pass `null` to clear the environment entirely. `template_overrides` is
+   * not treated specially here; callers that need to preserve DB-only
+   * template overrides across a replace must fold them into the incoming
+   * `environment` object themselves.
+   *
+   * Runs in a transaction so the read-replace-write is atomic, matching
+   * {@link update}'s concurrency guarantees.
+   */
+  async setEnvironment(id: string, environment: RepoEnvironment | null): Promise<Repo> {
+    try {
+      const fullId = await this.resolveId(id);
+
+      return await this.db.transaction(async (tx) => {
+        await lockRowForUpdate(txAsDb(tx), this.db, repos, eq(repos.repo_id, fullId));
+
+        const currentRow = await select(txAsDb(tx))
+          .from(repos)
+          .where(eq(repos.repo_id, fullId))
+          .one();
+
+        if (!currentRow) {
+          throw new EntityNotFoundError('Repo', id);
+        }
+
+        const current = this.rowToRepo(currentRow);
+        const next: Repo = { ...current, environment: environment ?? undefined };
+        // environment_config (v1 projection) is re-derived from the new v2
+        // environment by repoToInsert; drop the stale one so we don't carry
+        // a ghost projection through.
+        delete (next as Partial<Repo>).environment_config;
+
+        const insertData = this.repoToInsert(next);
+        const newUpdatedAt = new Date();
+        await update(txAsDb(tx), repos)
+          .set({
+            slug: insertData.slug,
+            updated_at: newUpdatedAt,
+            repo_type: insertData.repo_type,
+            unix_group: next.unix_group ?? null,
+            data: insertData.data,
+          })
+          .where(eq(repos.repo_id, fullId))
+          .run();
+
+        next.last_updated = newUpdatedAt.toISOString();
+        return next;
+      });
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      throw new RepositoryError(
+        `Failed to set repo environment: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Delete repo by ID
    */
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes a silent data-retention bug in `importFromAgorYml`: re-importing a `.agor.yml` after renaming or removing a variant left the old variant lingering in `repo.environment.variants`, and render-at-worktree resolved against the ghost variant.

## Root cause

`ReposService.importFromAgorYml` called `this.patch(id, { environment: newEnv })`, which bottoms out in `RepoRepository.update()` → `deepMerge(current, updates)`. `deepMerge` only visits keys present in source, so:

- Renamed variant keys were preserved (old key stayed alongside the new one).
- Fields removed from a still-present variant were never cleared.

The worktree record in the failing case had `environment_variant: "with-manager"` pointing at a variant that was renamed out of the file two commits ago — yet render succeeded because the DB still held the stale key. Symptom looked like "import reads stale `.agor.yml`", but the file read is fine (`resolveAgorYmlPath` → `worktree.path/.agor.yml`). The staleness is in the DB write path.

See discussion in agor.live session `019daec3-b457-749b-8331-465fb7509106` for the reproduction + sentinel trace.

## Fix

- New `RepoRepository.setEnvironment(id, env | null)` that replaces the `environment` column wholesale inside a transaction. Same row-lock and v1-projection re-derivation as `update()`, but no `deepMerge`.
- `ReposService.importFromAgorYml` now calls `setEnvironment` instead of `patch`, preserving DB-only `template_overrides` by folding them into the replacement object first. Emits `patched` manually since we bypass `DrizzleService.patch` to get replace semantics.
- Blast radius is intentionally scoped: `deepMerge` still applies to every other repo field (`permission_config` partial patches, etc). Only `environment`, which mirrors an external file and needs removals to propagate, gets replace semantics.

## Tests

New `RepoRepository.setEnvironment` suite covers:
- Rename-a-variant regression (the exact reported bug)
- Removed-field-within-a-still-present variant
- Unrelated-column preservation (name/slug/local_path/remote_url untouched)
- `null` clearing
- v1 `environment_config` projection stays in sync across replaces
- `EntityNotFoundError` for non-existent id

## Manual verification (after deploy)

Max's sentinel `.agor.yml` is still in `/home/agorpg/.agor/worktrees/preset-io/superset-shell/agor-unified-env/.agor.yml` — re-import should now yield `variants: { sentinel }` only, with no `with-manager` / `without-manager` ghost keys from prior imports. `.agor.yml.bkp` is the real config for restoration.

## Out of scope (follow-up)

- The same `deepMerge`-preserves-removed-keys pattern exists in other repositories (sessions, worktrees) and likely has analogous edge cases, but this PR is scoped to the reported `.agor.yml` bug. Worth auditing separately.
- Whether `environment_config` should move to per-worktree storage (so different branches can have different configs) is a larger design question flagged in the original task — not addressed here.

## Test plan

- [ ] New `RepoRepository.setEnvironment` test suite passes
- [ ] Existing `RepoRepository.update` tests still pass (no behavior change to `update`)
- [ ] Deploy to Max's instance; re-import Max's sentinel `.agor.yml` and confirm DB holds only the `sentinel` variant (no ghost keys)
- [ ] Restore Max's real `.agor.yml` from `.bkp`; re-import; confirm render produces the `-c url.insteadOf=…` prefixed start command

🤖 Generated with [Claude Code](https://claude.com/claude-code)