### PR TITLE
feat(mcp): agor_artifacts_update and agor_artifacts_land

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -5,11 +5,12 @@
  * Artifacts are DB-backed live web applications that render on the board canvas.
  */
 
+import type { BoardID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ArtifactsService } from '../../services/artifacts.js';
-import { resolveArtifactId, resolveBoardId } from '../resolve-ids.js';
+import { resolveArtifactId, resolveBoardId, resolveWorktreeId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -255,7 +256,144 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
     }
   );
 
-  // Tool 6: agor_artifacts_list
+  // Tool 6: agor_artifacts_update
+  server.registerTool(
+    'agor_artifacts_update',
+    {
+      description: `Update artifact metadata without re-reading files from disk. Use this to move an artifact to a different board, rename it, toggle visibility, archive it, or reposition its board placement.
+
+Primary use case: move an artifact to a different board via \`boardId\` when you no longer have the original source folder on disk.
+
+For file/content changes, use agor_artifacts_publish (which re-reads a folder and updates the stored files).
+
+Placement (x, y, width, height) is preserved across board moves unless you explicitly override it — so a cross-board move keeps the artifact in the same relative layout.
+
+Caller must own the artifact (or be an admin).`,
+      inputSchema: z.object({
+        artifactId: z.string().describe('Artifact ID to update (full UUID or short prefix)'),
+        boardId: z.string().optional().describe('Move the artifact to a different board'),
+        name: z.string().optional().describe('Rename the artifact'),
+        description: z.string().optional().describe('Update the description'),
+        public: z
+          .boolean()
+          .optional()
+          .describe('Change visibility (true = visible to all board viewers, false = owner only)'),
+        archived: z.boolean().optional().describe('Archive or unarchive the artifact'),
+        x: z.number().optional().describe('New X position on board'),
+        y: z.number().optional().describe('New Y position on board'),
+        width: z.number().optional().describe('New width in pixels'),
+        height: z.number().optional().describe('New height in pixels'),
+      }),
+    },
+    async (args) => {
+      const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
+
+      const boardIdInput = coerceString(args.boardId);
+      const resolvedBoardId = boardIdInput ? await resolveBoardId(ctx, boardIdInput) : undefined;
+
+      const updated = await service.updateMetadata(
+        artifactId,
+        {
+          name: coerceString(args.name),
+          description: coerceString(args.description),
+          public: args.public,
+          archived: args.archived,
+          board_id: resolvedBoardId as BoardID | undefined,
+          x: args.x,
+          y: args.y,
+          width: args.width,
+          height: args.height,
+        },
+        ctx.userId
+      );
+
+      const { files: _files, ...artifactSummary } = updated;
+      return textResult({
+        artifact: artifactSummary,
+        instructions: 'Artifact metadata updated.',
+      });
+    }
+  );
+
+  // Tool 7: agor_artifacts_land
+  server.registerTool(
+    'agor_artifacts_land',
+    {
+      description: `Materialize an artifact's stored files to disk inside a worktree. Inverse of agor_artifacts_publish.
+
+Use this when you want to tweak an artifact's code: land it into a worktree, edit the files locally, then call agor_artifacts_publish with the same artifactId to push the changes back.
+
+Writes a sandpack.json manifest alongside the files so agor_artifacts_publish can read the template/dependencies/entry back in a round-trip.
+
+Safety:
+- Destination must be inside the target worktree (cannot escape via ".." or absolute paths).
+- Default subpath is \`.agor/artifacts/<artifact-id>\` (inside the worktree). Pass a custom subpath if you want a different location.
+- Refuses to write to an existing non-empty destination unless overwrite=true is passed.
+- overwrite=true removes the destination directory first (symlinks are unlinked, not followed).
+
+Visibility: public artifacts are readable by anyone; private artifacts are only landable by their owner.`,
+      inputSchema: z.object({
+        artifactId: z.string().describe('Artifact ID to materialize (full UUID or short prefix)'),
+        worktreeId: z.string().describe('Destination worktree ID (full UUID or short prefix)'),
+        subpath: z
+          .string()
+          .optional()
+          .describe(
+            'Worktree-relative path for the destination folder. Default: .agor/artifacts/<artifact-id>. Must not be absolute or escape the worktree.'
+          ),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe('Remove the destination folder first if it exists. Default: false.'),
+      }),
+    },
+    async (args) => {
+      const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
+      const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
+
+      // Fetch artifact for visibility check.
+      let artifact: Awaited<ReturnType<typeof service.get>>;
+      try {
+        artifact = await service.get(artifactId, ctx.baseServiceParams);
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return textResult({ error: `Artifact ${artifactId} not found` });
+        }
+        throw err;
+      }
+      if (!artifact.public) {
+        if (!ctx.userId || !artifact.created_by || artifact.created_by !== ctx.userId) {
+          return textResult({ error: `Artifact ${artifactId} not found` });
+        }
+      }
+
+      // Resolve worktree through the service layer so worktree RBAC is enforced.
+      const worktree = (await ctx.app
+        .service('worktrees')
+        .get(worktreeId, ctx.baseServiceParams)) as {
+        worktree_id: string;
+        path: string;
+      };
+
+      const result = await service.land(artifactId, worktree.path, {
+        subpath: coerceString(args.subpath),
+        overwrite: args.overwrite,
+      });
+
+      return textResult({
+        artifactId,
+        worktreeId: worktree.worktree_id,
+        destinationPath: result.destinationPath,
+        fileCount: result.fileCount,
+        bytesWritten: result.bytesWritten,
+        instructions: `Artifact materialized to ${result.destinationPath}. Edit files there, then call agor_artifacts_publish with folderPath=${result.destinationPath} and artifactId=${artifactId} to push changes back.`,
+      });
+    }
+  );
+
+  // Tool 8: agor_artifacts_list
   server.registerTool(
     'agor_artifacts_list',
     {

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -5,11 +5,13 @@
  * Artifacts are DB-backed live web applications that render on the board canvas.
  */
 
-import type { BoardID } from '@agor/core/types';
+import { WorktreeRepository } from '@agor/core/db';
+import type { BoardID, UUID, WorktreeID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ArtifactsService } from '../../services/artifacts.js';
+import { hasWorktreePermission } from '../../utils/worktree-authorization.js';
 import { resolveArtifactId, resolveBoardId, resolveWorktreeId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
@@ -241,10 +243,8 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
       }
 
       // Visibility check: private artifacts are only visible to their creator
-      if (!artifact.public) {
-        if (!ctx.userId || !artifact.created_by || artifact.created_by !== ctx.userId) {
-          return textResult({ error: `Artifact ${artifactId} not found` });
-        }
+      if (!service.isVisibleTo(artifact, ctx.userId)) {
+        return textResult({ error: `Artifact ${artifactId} not found` });
       }
 
       // Return metadata (without files blob) + full file map separately
@@ -329,7 +329,7 @@ Writes a sandpack.json manifest alongside the files so agor_artifacts_publish ca
 Safety:
 - Destination must be inside the target worktree (cannot escape via ".." or absolute paths).
 - Default subpath is \`.agor/artifacts/<artifact-id>\` (inside the worktree). Pass a custom subpath if you want a different location.
-- Refuses to write to an existing non-empty destination unless overwrite=true is passed.
+- Refuses to write to an existing destination unless overwrite=true is passed (empty or not).
 - overwrite=true removes the destination directory first (symlinks are unlinked, not followed).
 
 Visibility: public artifacts are readable by anyone; private artifacts are only landable by their owner.`,
@@ -363,19 +363,42 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
         }
         throw err;
       }
-      if (!artifact.public) {
-        if (!ctx.userId || !artifact.created_by || artifact.created_by !== ctx.userId) {
-          return textResult({ error: `Artifact ${artifactId} not found` });
-        }
+      if (!service.isVisibleTo(artifact, ctx.userId)) {
+        return textResult({ error: `Artifact ${artifactId} not found` });
       }
 
-      // Resolve worktree through the service layer so worktree RBAC is enforced.
+      // Resolve worktree through the service layer (enforces `view` via RBAC
+      // hooks). Landing an artifact writes to disk, so `view` is not enough —
+      // require at least `session` (the same tier that lets a user create
+      // sessions that could themselves write files in the worktree).
       const worktree = (await ctx.app
         .service('worktrees')
         .get(worktreeId, ctx.baseServiceParams)) as {
         worktree_id: string;
         path: string;
+        others_can?: 'none' | 'view' | 'session' | 'prompt' | 'all';
       };
+
+      const worktreeRepo = new WorktreeRepository(ctx.db);
+      const worktreeIdBranded = worktree.worktree_id as WorktreeID;
+      const userIdBranded = ctx.userId as UUID;
+      const isOwner = await worktreeRepo.isOwner(worktreeIdBranded, userIdBranded);
+      const fullWorktree = await worktreeRepo.findById(worktreeIdBranded);
+      if (!fullWorktree) {
+        return textResult({ error: `Worktree ${worktreeId} not found` });
+      }
+      const canWrite = hasWorktreePermission(
+        fullWorktree,
+        userIdBranded,
+        isOwner,
+        'session',
+        ctx.authenticatedUser.role
+      );
+      if (!canWrite) {
+        return textResult({
+          error: `Forbidden: 'session' permission or higher is required to land artifacts into worktree ${worktreeId}`,
+        });
+      }
 
       const result = await service.land(artifactId, worktree.path, {
         subpath: coerceString(args.subpath),

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -445,6 +445,35 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     },
   });
 
+  /**
+   * Before-hook for artifacts patch/remove: only the creator or an
+   * admin/superadmin may modify an artifact. Without this, any `member` could
+   * PATCH /artifacts/:id and rename, re-board, archive, or unpublish another
+   * user's artifact — role-only gating is not enough.
+   *
+   * Runs AFTER requireMinimumRole (which guarantees `params.user`), skips
+   * internal calls (no provider) and service accounts (executor).
+   */
+  const ensureArtifactOwnerOrAdmin = () => async (context: HookContext) => {
+    if (!context.params.provider) return context;
+    const user = (context.params as { user?: User })?.user;
+    if (!user) throw new NotAuthenticated('Authentication required');
+    if ((user as unknown as { _isServiceAccount?: boolean })._isServiceAccount) return context;
+    if (hasMinimumRole(user.role, ROLES.ADMIN)) return context;
+
+    const artifactId = context.id;
+    if (artifactId === undefined || artifactId === null) return context;
+    const artifactRepo = new ArtifactRepository(db);
+    const artifact = await artifactRepo.findById(String(artifactId));
+    if (!artifact) {
+      throw new Forbidden(`Artifact ${artifactId} not found or not accessible`);
+    }
+    if (artifact.created_by && artifact.created_by === user.user_id) return context;
+    throw new Forbidden(
+      "Only the artifact's creator or an admin may modify it. Use agor_artifacts_publish to create your own copy."
+    );
+  };
+
   safeService('artifacts')?.hooks({
     before: {
       all: [...getReadAuthHooks()],
@@ -459,8 +488,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create artifacts'), injectCreatedBy()],
-      patch: [requireMinimumRole(ROLES.MEMBER, 'update artifacts')],
-      remove: [requireMinimumRole(ROLES.MEMBER, 'delete artifacts')],
+      patch: [requireMinimumRole(ROLES.MEMBER, 'update artifacts'), ensureArtifactOwnerOrAdmin()],
+      remove: [requireMinimumRole(ROLES.MEMBER, 'delete artifacts'), ensureArtifactOwnerOrAdmin()],
     },
   });
 

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1,0 +1,322 @@
+/**
+ * ArtifactsService Tests
+ *
+ * Covers updateMetadata (board moves, placement preservation, authz) and
+ * land (filesystem materialization, path-traversal defenses).
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { generateId } from '@agor/core';
+import { ArtifactRepository, BoardRepository, type Database } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { Artifact, BoardID } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { ArtifactsService } from './artifacts';
+
+/**
+ * Build a fake Feathers app whose services all no-op on emit. The service
+ * under test only calls `app.service(name).emit(event, payload)` for
+ * WebSocket broadcasts, which we don't care about in unit tests.
+ */
+function makeFakeApp(): Application {
+  const service = () => ({ emit: () => {} });
+  return { service } as unknown as Application;
+}
+
+/** Create a board directly via the repository, since the artifacts service
+ * doesn't own boards. */
+async function seedBoard(db: Database) {
+  const repo = new BoardRepository(db);
+  return repo.create({
+    board_id: generateId() as BoardID,
+    name: 'Test Board',
+    created_by: 'user-owner',
+  });
+}
+
+/** Seed an artifact with a known file map and a board placement. */
+async function seedArtifact(
+  db: Database,
+  boardId: BoardID,
+  options?: {
+    userId?: string;
+    isPublic?: boolean;
+    files?: Record<string, string>;
+    placement?: { x: number; y: number; width: number; height: number };
+  }
+): Promise<Artifact> {
+  const artifactRepo = new ArtifactRepository(db);
+  const boardRepo = new BoardRepository(db);
+  const artifactId = generateId();
+  const files = options?.files ?? {
+    '/index.js': 'console.log("hello")',
+    '/styles.css': 'body { color: red; }',
+  };
+
+  const created = await artifactRepo.create({
+    artifact_id: artifactId,
+    board_id: boardId,
+    name: 'Seeded Artifact',
+    template: 'react',
+    files,
+    content_hash: 'hash-seed',
+    public: options?.isPublic ?? true,
+    created_by: options?.userId ?? 'user-owner',
+  });
+
+  const placement = options?.placement ?? { x: 100, y: 200, width: 600, height: 400 };
+  await boardRepo.upsertBoardObject(boardId, `artifact-${artifactId}`, {
+    type: 'artifact',
+    artifact_id: created.artifact_id,
+    ...placement,
+  });
+
+  return created;
+}
+
+describe('ArtifactsService.updateMetadata', () => {
+  dbTest('moves artifact to a new board and preserves placement', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const boardRepo = new BoardRepository(db);
+    const boardA = await seedBoard(db);
+    const boardB = await seedBoard(db);
+    const artifact = await seedArtifact(db, boardA.board_id, {
+      userId: 'user-owner',
+      placement: { x: 42, y: 99, width: 800, height: 500 },
+    });
+
+    const updated = await service.updateMetadata(
+      artifact.artifact_id,
+      { board_id: boardB.board_id },
+      'user-owner'
+    );
+
+    expect(updated.board_id).toBe(boardB.board_id);
+
+    const refreshedA = await boardRepo.findById(boardA.board_id);
+    const refreshedB = await boardRepo.findById(boardB.board_id);
+    const objectKey = `artifact-${artifact.artifact_id}`;
+
+    expect(refreshedA?.objects?.[objectKey]).toBeUndefined();
+    const placed = refreshedB?.objects?.[objectKey];
+    expect(placed).toBeDefined();
+    expect(placed && placed.type === 'artifact' && placed.x).toBe(42);
+    expect(placed && placed.type === 'artifact' && placed.y).toBe(99);
+    expect(placed && placed.type === 'artifact' && placed.width).toBe(800);
+    expect(placed && placed.type === 'artifact' && placed.height).toBe(500);
+  });
+
+  dbTest('overrides placement when coordinates are passed with move', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const boardRepo = new BoardRepository(db);
+    const boardA = await seedBoard(db);
+    const boardB = await seedBoard(db);
+    const artifact = await seedArtifact(db, boardA.board_id, { userId: 'user-owner' });
+
+    await service.updateMetadata(
+      artifact.artifact_id,
+      { board_id: boardB.board_id, x: 10, y: 20 },
+      'user-owner'
+    );
+
+    const refreshed = await boardRepo.findById(boardB.board_id);
+    const placed = refreshed?.objects?.[`artifact-${artifact.artifact_id}`];
+    expect(placed && placed.type === 'artifact' && placed.x).toBe(10);
+    expect(placed && placed.type === 'artifact' && placed.y).toBe(20);
+    // Unset dimensions fall back to the existing placement.
+    expect(placed && placed.type === 'artifact' && placed.width).toBe(600);
+  });
+
+  dbTest('rejects callers who do not own the artifact', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id, { userId: 'user-owner' });
+
+    await expect(
+      service.updateMetadata(artifact.artifact_id, { name: 'Hijacked' }, 'user-stranger')
+    ).rejects.toThrow(/not the owner/i);
+  });
+
+  dbTest('updates name and public flag without touching placement', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const boardRepo = new BoardRepository(db);
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id, {
+      userId: 'user-owner',
+      placement: { x: 111, y: 222, width: 333, height: 444 },
+    });
+
+    const updated = await service.updateMetadata(
+      artifact.artifact_id,
+      { name: 'Renamed', public: false },
+      'user-owner'
+    );
+
+    expect(updated.name).toBe('Renamed');
+    expect(updated.public).toBe(false);
+
+    const refreshed = await boardRepo.findById(board.board_id);
+    const placed = refreshed?.objects?.[`artifact-${artifact.artifact_id}`];
+    expect(placed && placed.type === 'artifact' && placed.x).toBe(111);
+    expect(placed && placed.type === 'artifact' && placed.width).toBe(333);
+  });
+});
+
+describe('ArtifactsService.land', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'agor-land-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  dbTest('writes all files plus sandpack.json to default subpath', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id, {
+      files: { '/app.js': 'export const x = 1', '/nested/deep.js': 'export const y = 2' },
+    });
+
+    const result = await service.land(artifact.artifact_id, tmpRoot);
+
+    const expectedDest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
+    expect(result.destinationPath).toBe(expectedDest);
+    expect(result.fileCount).toBe(3); // 2 source files + sandpack.json
+    expect(readFileSync(path.join(expectedDest, 'app.js'), 'utf-8')).toBe('export const x = 1');
+    expect(readFileSync(path.join(expectedDest, 'nested', 'deep.js'), 'utf-8')).toBe(
+      'export const y = 2'
+    );
+
+    const manifest = JSON.parse(readFileSync(path.join(expectedDest, 'sandpack.json'), 'utf-8'));
+    expect(manifest.template).toBe('react');
+  });
+
+  dbTest('writes to a custom subpath inside the worktree', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    const result = await service.land(artifact.artifact_id, tmpRoot, {
+      subpath: 'apps/frontend/demo',
+    });
+
+    expect(result.destinationPath).toBe(path.join(tmpRoot, 'apps', 'frontend', 'demo'));
+  });
+
+  dbTest('rejects subpath that escapes the worktree via ".."', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    await expect(
+      service.land(artifact.artifact_id, tmpRoot, { subpath: '../escape' })
+    ).rejects.toThrow(/escapes worktree root/i);
+  });
+
+  dbTest('rejects absolute subpath', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    await expect(
+      service.land(artifact.artifact_id, tmpRoot, { subpath: '/etc/passwd' })
+    ).rejects.toThrow(/must be relative/i);
+  });
+
+  dbTest('rejects subpath that resolves to the worktree root', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    await expect(service.land(artifact.artifact_id, tmpRoot, { subpath: '.' })).rejects.toThrow(
+      /worktree root/i
+    );
+  });
+
+  dbTest('rejects when worktree path does not exist', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    await expect(
+      service.land(artifact.artifact_id, path.join(tmpRoot, 'does-not-exist'))
+    ).rejects.toThrow(/does not exist/i);
+  });
+
+  dbTest('rejects artifact whose file map contains a traversal key', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id, {
+      files: {
+        '/good.js': 'ok',
+        '/../../../bin/evil': 'pwn',
+      },
+    });
+
+    await expect(service.land(artifact.artifact_id, tmpRoot)).rejects.toThrow(
+      /escapes destination/i
+    );
+  });
+
+  dbTest('errors when destination exists and overwrite is false', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    // Pre-create the default destination with a file inside.
+    const dest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
+    const fs = await import('node:fs/promises');
+    await fs.mkdir(dest, { recursive: true });
+    writeFileSync(path.join(dest, 'pre-existing.txt'), 'preexisting');
+
+    await expect(service.land(artifact.artifact_id, tmpRoot)).rejects.toThrow(/already exists/i);
+  });
+
+  dbTest('with overwrite=true replaces existing destination', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id, {
+      files: { '/only.js': 'fresh' },
+    });
+
+    const dest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
+    const fs = await import('node:fs/promises');
+    await fs.mkdir(dest, { recursive: true });
+    writeFileSync(path.join(dest, 'stale.txt'), 'stale');
+
+    const result = await service.land(artifact.artifact_id, tmpRoot, { overwrite: true });
+
+    expect(result.fileCount).toBe(2); // /only.js + sandpack.json
+    expect(readFileSync(path.join(dest, 'only.js'), 'utf-8')).toBe('fresh');
+    // Stale file is gone.
+    const fsSync = await import('node:fs');
+    expect(fsSync.existsSync(path.join(dest, 'stale.txt'))).toBe(false);
+  });
+
+  dbTest('errors when artifact has no stored files', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'Empty',
+      template: 'react',
+      files: undefined,
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(service.land(created.artifact_id, tmpRoot)).rejects.toThrow(/no stored files/i);
+  });
+});

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -165,6 +165,49 @@ describe('ArtifactsService.updateMetadata', () => {
   });
 });
 
+describe('ArtifactsService.patch (board move routing)', () => {
+  dbTest('board_id patch moves the board_objects entry to the new board', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const boardRepo = new BoardRepository(db);
+    const boardA = await seedBoard(db);
+    const boardB = await seedBoard(db);
+    const artifact = await seedArtifact(db, boardA.board_id, {
+      placement: { x: 70, y: 80, width: 500, height: 300 },
+    });
+
+    const patched = await service.patch(artifact.artifact_id, {
+      board_id: boardB.board_id,
+    });
+    expect((patched as Artifact).board_id).toBe(boardB.board_id);
+
+    const key = `artifact-${artifact.artifact_id}`;
+    const refreshedA = await boardRepo.findById(boardA.board_id);
+    const refreshedB = await boardRepo.findById(boardB.board_id);
+    expect(refreshedA?.objects?.[key]).toBeUndefined();
+    const placed = refreshedB?.objects?.[key];
+    expect(placed && placed.type === 'artifact' && placed.x).toBe(70);
+    expect(placed && placed.type === 'artifact' && placed.width).toBe(500);
+  });
+
+  dbTest('metadata-only patch does not touch board_objects', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const boardRepo = new BoardRepository(db);
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id, {
+      placement: { x: 11, y: 22, width: 333, height: 444 },
+    });
+
+    await service.patch(artifact.artifact_id, { name: 'Renamed via patch' });
+
+    const key = `artifact-${artifact.artifact_id}`;
+    const refreshed = await boardRepo.findById(board.board_id);
+    const placed = refreshed?.objects?.[key];
+    // Placement is untouched.
+    expect(placed && placed.type === 'artifact' && placed.x).toBe(11);
+    expect(placed && placed.type === 'artifact' && placed.width).toBe(333);
+  });
+});
+
 describe('ArtifactsService.land', () => {
   let tmpRoot: string;
 

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -5,7 +5,7 @@
  * land (filesystem materialization, path-traversal defenses).
  */
 
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { generateId } from '@agor/core';
@@ -138,6 +138,32 @@ describe('ArtifactsService.updateMetadata', () => {
     await expect(
       service.updateMetadata(artifact.artifact_id, { name: 'Hijacked' }, 'user-stranger')
     ).rejects.toThrow(/not the owner/i);
+  });
+
+  dbTest('rejects move to a nonexistent board without mutating the row', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const artifactRepo = new ArtifactRepository(db);
+    const boardRepo = new BoardRepository(db);
+    const boardA = await seedBoard(db);
+    const artifact = await seedArtifact(db, boardA.board_id, { userId: 'user-owner' });
+    const bogusBoardId = generateId() as BoardID;
+
+    await expect(
+      service.updateMetadata(
+        artifact.artifact_id,
+        { board_id: bogusBoardId, name: 'Should-not-apply' },
+        'user-owner'
+      )
+    ).rejects.toThrow(/destination board.*not found/i);
+
+    // Row is untouched: no orphaned board_id, no renamed metadata.
+    const after = await artifactRepo.findById(artifact.artifact_id);
+    expect(after?.board_id).toBe(boardA.board_id);
+    expect(after?.name).toBe('Seeded Artifact');
+
+    // board_objects on source board is still there.
+    const refreshedA = await boardRepo.findById(boardA.board_id);
+    expect(refreshedA?.objects?.[`artifact-${artifact.artifact_id}`]).toBeDefined();
   });
 
   dbTest('updates name and public flag without touching placement', async ({ db }) => {
@@ -344,6 +370,53 @@ describe('ArtifactsService.land', () => {
     // Stale file is gone.
     const fsSync = await import('node:fs');
     expect(fsSync.existsSync(path.join(dest, 'stale.txt'))).toBe(false);
+  });
+
+  dbTest(
+    'rejects subpath that escapes through a symlinked directory inside the worktree',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifact = await seedArtifact(db, board.board_id);
+
+      // Attack shape: the worktree contains a symlink `.agor` -> `/tmp/...`
+      // that points outside the worktree. The default subpath uses `.agor/...`,
+      // so without realpath canonicalization, a lexical containment check
+      // would let the write escape into the symlink target.
+      const outside = mkdtempSync(path.join(tmpdir(), 'agor-land-outside-'));
+      try {
+        symlinkSync(outside, path.join(tmpRoot, '.agor'), 'dir');
+
+        await expect(service.land(artifact.artifact_id, tmpRoot)).rejects.toThrow(
+          /escapes worktree root/i
+        );
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    }
+  );
+
+  dbTest('canonicalizes a symlinked worktree path before containment check', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifact = await seedArtifact(db, board.board_id);
+
+    // The worktree.path column may be a symlink (common when cloning the
+    // repo under /home vs. /var/home). Landing must still write inside the
+    // real (canonicalized) worktree — it should not throw and not land
+    // somewhere else.
+    const realWorktree = path.join(tmpRoot, 'real-worktree');
+    mkdirSync(realWorktree, { recursive: true });
+    const symlinkedWorktree = path.join(tmpRoot, 'linked-worktree');
+    symlinkSync(realWorktree, symlinkedWorktree, 'dir');
+
+    const result = await service.land(artifact.artifact_id, symlinkedWorktree);
+
+    // Destination path is reported under the real root (post-canonicalize).
+    expect(result.destinationPath.startsWith(realWorktree)).toBe(true);
+    expect(readFileSync(path.join(result.destinationPath, 'index.js'), 'utf-8')).toBe(
+      'console.log("hello")'
+    );
   });
 
   dbTest('errors when artifact has no stored files', async ({ db }) => {

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -166,6 +166,57 @@ describe('ArtifactsService.updateMetadata', () => {
     expect(refreshedA?.objects?.[`artifact-${artifact.artifact_id}`]).toBeDefined();
   });
 
+  dbTest('preserves old board_object when destination upsert fails mid-move', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const artifactRepo = new ArtifactRepository(db);
+    const boardRepo = new BoardRepository(db);
+    const boardA = await seedBoard(db);
+    const boardB = await seedBoard(db);
+    const artifact = await seedArtifact(db, boardA.board_id, {
+      userId: 'user-owner',
+      placement: { x: 55, y: 66, width: 700, height: 500 },
+    });
+
+    // Simulate a storage failure on the destination upsert. The service must
+    // leave the artifact row on boardA AND leave boardA's board_object intact
+    // — otherwise the artifact would be orphaned (row says boardA, but no
+    // board_object there).
+    const repo = (service as unknown as { boardRepo: BoardRepository }).boardRepo;
+    const originalUpsert = repo.upsertBoardObject.bind(repo);
+    repo.upsertBoardObject = async (boardId: BoardID, objectId: string, obj: unknown) => {
+      if (boardId === boardB.board_id) {
+        throw new Error('simulated storage failure');
+      }
+      return originalUpsert(boardId, objectId, obj as Parameters<typeof originalUpsert>[2]);
+    };
+
+    try {
+      await expect(
+        service.updateMetadata(artifact.artifact_id, { board_id: boardB.board_id }, 'user-owner')
+      ).rejects.toThrow(/simulated storage failure/i);
+    } finally {
+      repo.upsertBoardObject = originalUpsert;
+    }
+
+    // Row was rolled back to the original board.
+    const after = await artifactRepo.findById(artifact.artifact_id);
+    expect(after?.board_id).toBe(boardA.board_id);
+
+    // Critically: the original board_object on boardA is still there —
+    // upsert happens BEFORE removal, so a failed upsert never reaches the
+    // remove step.
+    const key = `artifact-${artifact.artifact_id}`;
+    const refreshedA = await boardRepo.findById(boardA.board_id);
+    const placed = refreshedA?.objects?.[key];
+    expect(placed).toBeDefined();
+    expect(placed && placed.type === 'artifact' && placed.x).toBe(55);
+    expect(placed && placed.type === 'artifact' && placed.width).toBe(700);
+
+    // Destination board has nothing.
+    const refreshedB = await boardRepo.findById(boardB.board_id);
+    expect(refreshedB?.objects?.[key]).toBeUndefined();
+  });
+
   dbTest('updates name and public flag without touching placement', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const boardRepo = new BoardRepository(db);

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -107,6 +107,47 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     );
   }
 
+  /**
+   * Feathers patch override: route board_id and placement changes through
+   * updateMetadata so the board_objects entry is moved/resized alongside the
+   * row update. Plain metadata patches (name, description, public, archived,
+   * build state, etc.) fall through to the default DrizzleService patch.
+   *
+   * Ownership is enforced by Feathers hooks (role-based) rather than here, to
+   * match the existing patch behavior.
+   */
+  async patch(id: string | number, data: Partial<Artifact>, params?: unknown): Promise<Artifact> {
+    const d = data as Partial<Artifact> & {
+      x?: number;
+      y?: number;
+      width?: number;
+      height?: number;
+    };
+    const placementFields =
+      d.x !== undefined || d.y !== undefined || d.width !== undefined || d.height !== undefined;
+
+    if (d.board_id !== undefined || placementFields) {
+      const artifactId = String(id);
+      // Resolve short IDs to a full ID through the repository.
+      const existing = await this.artifactRepo.findById(artifactId);
+      if (!existing) throw new Error(`Artifact ${artifactId} not found`);
+
+      return this.updateMetadata(existing.artifact_id, {
+        name: d.name,
+        description: d.description,
+        public: d.public,
+        archived: d.archived,
+        board_id: d.board_id,
+        x: d.x,
+        y: d.y,
+        width: d.width,
+        height: d.height,
+      });
+    }
+
+    return (await super.patch(id, data as Partial<Artifact>, params as never)) as Artifact;
+  }
+
   async remove(id: string | number, _params?: unknown): Promise<Artifact> {
     const artifactId = String(id);
     const artifact = await this.artifactRepo.findById(artifactId);

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -12,7 +12,7 @@
 
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { generateId } from '@agor/core';
 import { PAGINATION } from '@agor/core/config';
@@ -53,6 +53,31 @@ import type { UsersService } from './users.js';
  *   {{ artifact.boardId }}  - Board ID
  */
 const AGOR_CONFIG_FILE = '/agor.config.js';
+
+/**
+ * Resolve a destination path by canonicalizing the longest existing prefix via
+ * `realpath` and re-joining the still-nonexistent tail. Used by `land()` to
+ * detect symlinked ancestors that would otherwise defeat a lexical
+ * containment check.
+ *
+ * Example: if `/wt/.agor` is a symlink to `/etc` and the caller passes
+ * `.agor/artifacts/x`, the canonicalized destination is `/etc/artifacts/x`,
+ * which fails the worktree-root containment check.
+ */
+async function canonicalizeExistingPrefix(target: string): Promise<string> {
+  const segments = target.split(path.sep);
+  for (let i = segments.length; i >= 1; i--) {
+    const prefix = segments.slice(0, i).join(path.sep) || path.sep;
+    try {
+      const real = await realpath(prefix);
+      const tail = segments.slice(i).join(path.sep);
+      return tail ? path.join(real, tail) : real;
+    } catch {
+      // prefix does not exist yet — shrink and try again
+    }
+  }
+  return target;
+}
 
 export type ArtifactParams = QueryParams<{
   board_id?: BoardID;
@@ -132,20 +157,42 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       const existing = await this.artifactRepo.findById(artifactId);
       if (!existing) throw new Error(`Artifact ${artifactId} not found`);
 
-      return this.updateMetadata(existing.artifact_id, {
-        name: d.name,
-        description: d.description,
-        public: d.public,
-        archived: d.archived,
-        board_id: d.board_id,
-        x: d.x,
-        y: d.y,
-        width: d.width,
-        height: d.height,
-      });
+      // Pass through the caller's user_id when available (external REST/MCP
+      // calls) so updateMetadata's owner check engages. Feathers hooks are
+      // the primary gate; this is defence-in-depth for internal callers that
+      // forward a user. Internal service-to-service calls without a user
+      // still bypass the inline check (matches existing publish() behavior).
+      const callerUserId = (params as { user?: { user_id?: string } } | undefined)?.user?.user_id;
+
+      return this.updateMetadata(
+        existing.artifact_id,
+        {
+          name: d.name,
+          description: d.description,
+          public: d.public,
+          archived: d.archived,
+          board_id: d.board_id,
+          x: d.x,
+          y: d.y,
+          width: d.width,
+          height: d.height,
+        },
+        callerUserId
+      );
     }
 
     return (await super.patch(id, data as Partial<Artifact>, params as never)) as Artifact;
+  }
+
+  /**
+   * Centralized visibility predicate.
+   * Private artifacts are only readable by their creator; public artifacts
+   * are readable by anyone. Used by MCP tools (get, land) to avoid drift.
+   */
+  isVisibleTo(artifact: Pick<Artifact, 'public' | 'created_by'>, userId?: string): boolean {
+    if (artifact.public) return true;
+    if (!userId || !artifact.created_by) return false;
+    return artifact.created_by === userId;
   }
 
   async remove(id: string | number, _params?: unknown): Promise<Artifact> {
@@ -343,6 +390,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const newBoardId = updates.board_id ?? oldBoardId;
     const moving = newBoardId !== oldBoardId;
 
+    // Pre-validate destination board exists when moving. This avoids persisting
+    // a dangling `artifact.board_id` with no matching board_objects entry if
+    // the upsert would fail.
+    if (moving) {
+      const destBoard = await this.boardRepo.findById(newBoardId);
+      if (!destBoard) {
+        throw new Error(`Destination board ${newBoardId} not found`);
+      }
+    }
+
     // Read the current board object (if present) so we can preserve placement
     // when moving or when only some placement fields are provided.
     let currentPlacement: { x: number; y: number; width: number; height: number } | null = null;
@@ -399,8 +456,36 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         }
       }
 
-      const targetBoard = await this.boardRepo.upsertBoardObject(newBoardId, objectId, placement);
-      this.app.service('boards').emit('patched', targetBoard);
+      try {
+        const targetBoard = await this.boardRepo.upsertBoardObject(newBoardId, objectId, placement);
+        this.app.service('boards').emit('patched', targetBoard);
+      } catch (upsertError) {
+        // Compensate: if we already updated the DB row (in particular, moved
+        // `board_id` to newBoardId), roll it back so the artifact row and
+        // board_objects stay consistent.
+        if (Object.keys(dbUpdates).length > 0) {
+          try {
+            const rollback: Partial<Artifact> = {};
+            if (moving) rollback.board_id = oldBoardId;
+            if (updates.name !== undefined) rollback.name = existing.name;
+            if (updates.description !== undefined) rollback.description = existing.description;
+            if (updates.public !== undefined) rollback.public = existing.public;
+            if (updates.archived !== undefined) {
+              rollback.archived = existing.archived;
+              rollback.archived_at = existing.archived_at;
+            }
+            if (Object.keys(rollback).length > 0) {
+              await this.artifactRepo.update(fullArtifactId, rollback);
+            }
+          } catch (rollbackError) {
+            console.error(
+              `Rollback failed after board_objects upsert error for artifact ${fullArtifactId}:`,
+              rollbackError
+            );
+          }
+        }
+        throw upsertError;
+      }
     }
 
     this.app.service('artifacts').emit('patched', updated);
@@ -431,10 +516,15 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       throw new Error(`Artifact ${artifactId} has no stored files to land`);
     }
 
-    const worktreeRoot = path.resolve(worktreePath);
-    if (!fs.existsSync(worktreeRoot)) {
-      throw new Error(`Worktree path does not exist: ${worktreeRoot}`);
+    if (!fs.existsSync(worktreePath)) {
+      throw new Error(`Worktree path does not exist: ${worktreePath}`);
     }
+    // Canonicalize the worktree root so a symlinked root (e.g. a worktree
+    // whose `path` column is a symlink into $HOME) cannot be used to defeat
+    // the containment check below. Mirrors the pattern in
+    // apps/agor-daemon/src/services/file.ts and
+    // packages/core/src/git/index.ts.
+    const worktreeRoot = await realpath(worktreePath);
 
     // Default destination: .agor/artifacts/<artifact-id>
     const rawSubpath =
@@ -449,16 +539,25 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     const destination = path.resolve(worktreeRoot, rawSubpath);
 
+    // Canonicalize any existing portion of the destination path (a
+    // pre-existing symlinked parent directory must not lift the write outside
+    // the worktree root).
+    const canonicalDestination = await canonicalizeExistingPrefix(destination);
+
     // Path-escape check: destination must be strictly inside the worktree.
     // Equal to worktree root is refused — writing the artifact at the worktree
     // root would stomp user code.
-    if (destination === worktreeRoot) {
-      throw new Error('subpath must not resolve to the worktree root');
-    }
-    const prefix = worktreeRoot + path.sep;
-    if (!destination.startsWith(prefix)) {
-      throw new Error(`subpath escapes worktree root: ${rawSubpath}`);
-    }
+    const assertInsideRoot = (candidate: string, reason: string): void => {
+      if (candidate === worktreeRoot) {
+        throw new Error(`${reason}: must not resolve to the worktree root`);
+      }
+      const rel = path.relative(worktreeRoot, candidate);
+      if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`${reason}: escapes worktree root`);
+      }
+    };
+    assertInsideRoot(destination, `subpath ${rawSubpath}`);
+    assertInsideRoot(canonicalDestination, `subpath ${rawSubpath} (canonical)`);
 
     // Validate file-map keys for traversal. Artifact file keys are stored as
     // `/path/to/file` (leading slash, forward slashes). Strip leading slash,
@@ -469,7 +568,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         throw new Error(`Artifact contains absolute file path: ${filePath}`);
       }
       const resolved = path.resolve(destination, key);
-      if (resolved !== destination && !resolved.startsWith(destination + path.sep)) {
+      const rel = path.relative(destination, resolved);
+      if (rel.startsWith('..') || path.isAbsolute(rel)) {
         throw new Error(`Artifact file path escapes destination: ${filePath}`);
       }
     }

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -138,8 +138,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * row update. Plain metadata patches (name, description, public, archived,
    * build state, etc.) fall through to the default DrizzleService patch.
    *
-   * Ownership is enforced by Feathers hooks (role-based) rather than here, to
-   * match the existing patch behavior.
+   * Ownership is enforced by Feathers hooks (creator-or-admin); this method
+   * additionally forwards the caller's user_id into updateMetadata as a
+   * defence-in-depth check for direct internal callers.
    */
   async patch(id: string | number, data: Partial<Artifact>, params?: unknown): Promise<Artifact> {
     const d = data as Partial<Artifact> & {
@@ -447,15 +448,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         height: updates.height ?? currentPlacement?.height ?? 400,
       };
 
-      if (moving) {
-        try {
-          const cleaned = await this.boardRepo.removeBoardObject(oldBoardId, objectId);
-          this.app.service('boards').emit('patched', cleaned);
-        } catch {
-          // Old board may not have this object (e.g. was already cleaned up).
-        }
-      }
-
+      // Upsert the destination board object FIRST. Only once the new placement
+      // is safely in place do we remove the old one — this way, a failing
+      // upsert leaves the old board object intact (we only have to roll back
+      // the DB row), rather than leaving the artifact orphaned on both boards.
       try {
         const targetBoard = await this.boardRepo.upsertBoardObject(newBoardId, objectId, placement);
         this.app.service('boards').emit('patched', targetBoard);
@@ -485,6 +481,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           }
         }
         throw upsertError;
+      }
+
+      if (moving) {
+        try {
+          const cleaned = await this.boardRepo.removeBoardObject(oldBoardId, objectId);
+          this.app.service('boards').emit('patched', cleaned);
+        } catch {
+          // Old board may not have this object (e.g. was already cleaned up),
+          // or the old board was deleted. The destination upsert already
+          // succeeded, so the artifact is reachable on its new board.
+        }
       }
     }
 

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -12,6 +12,7 @@
 
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { generateId } from '@agor/core';
 import { PAGINATION } from '@agor/core/config';
@@ -259,6 +260,217 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     this.app.service('artifacts').emit('created', artifact);
     return artifact;
+  }
+
+  /**
+   * Update artifact metadata without touching file contents.
+   *
+   * Supports: name, description, public, archived flag, board move,
+   * and board placement (x/y/width/height).
+   *
+   * When moving between boards, the old board object is removed and a new one
+   * is created on the destination board. Placement (x/y/width/height) is
+   * preserved unless caller explicitly overrides — this makes cross-board
+   * moves layout-preserving by default.
+   *
+   * For file/content updates use publish() instead.
+   */
+  async updateMetadata(
+    artifactId: string,
+    updates: {
+      name?: string;
+      description?: string;
+      public?: boolean;
+      archived?: boolean;
+      board_id?: BoardID;
+      x?: number;
+      y?: number;
+      width?: number;
+      height?: number;
+    },
+    userId?: string
+  ): Promise<Artifact> {
+    const existing = await this.artifactRepo.findById(artifactId);
+    if (!existing) throw new Error(`Artifact ${artifactId} not found`);
+    if (userId && existing.created_by && existing.created_by !== userId) {
+      throw new Error('Cannot update artifact: not the owner');
+    }
+
+    const fullArtifactId = existing.artifact_id;
+    const objectId = `artifact-${fullArtifactId}`;
+    const oldBoardId = existing.board_id;
+    const newBoardId = updates.board_id ?? oldBoardId;
+    const moving = newBoardId !== oldBoardId;
+
+    // Read the current board object (if present) so we can preserve placement
+    // when moving or when only some placement fields are provided.
+    let currentPlacement: { x: number; y: number; width: number; height: number } | null = null;
+    try {
+      const oldBoard = await this.boardRepo.findById(oldBoardId);
+      const obj = oldBoard?.objects?.[objectId];
+      if (obj && obj.type === 'artifact') {
+        currentPlacement = { x: obj.x, y: obj.y, width: obj.width, height: obj.height };
+      }
+    } catch {
+      // Board may have been deleted out from under the artifact — placement
+      // falls back to defaults below.
+    }
+
+    // Apply DB updates (metadata + board_id).
+    const dbUpdates: Partial<Artifact> = {};
+    if (updates.name !== undefined) dbUpdates.name = updates.name;
+    if (updates.description !== undefined) dbUpdates.description = updates.description;
+    if (updates.public !== undefined) dbUpdates.public = updates.public;
+    if (updates.archived !== undefined) {
+      dbUpdates.archived = updates.archived;
+      dbUpdates.archived_at = updates.archived ? new Date().toISOString() : undefined;
+    }
+    if (moving) dbUpdates.board_id = newBoardId;
+
+    let updated = existing;
+    if (Object.keys(dbUpdates).length > 0) {
+      updated = await this.artifactRepo.update(fullArtifactId, dbUpdates);
+    }
+
+    // Sync board_objects if moving OR if placement fields were supplied.
+    const placementChanged =
+      updates.x !== undefined ||
+      updates.y !== undefined ||
+      updates.width !== undefined ||
+      updates.height !== undefined;
+
+    if (moving || placementChanged) {
+      const placement = {
+        type: 'artifact' as const,
+        artifact_id: fullArtifactId,
+        x: updates.x ?? currentPlacement?.x ?? 0,
+        y: updates.y ?? currentPlacement?.y ?? 0,
+        width: updates.width ?? currentPlacement?.width ?? 600,
+        height: updates.height ?? currentPlacement?.height ?? 400,
+      };
+
+      if (moving) {
+        try {
+          const cleaned = await this.boardRepo.removeBoardObject(oldBoardId, objectId);
+          this.app.service('boards').emit('patched', cleaned);
+        } catch {
+          // Old board may not have this object (e.g. was already cleaned up).
+        }
+      }
+
+      const targetBoard = await this.boardRepo.upsertBoardObject(newBoardId, objectId, placement);
+      this.app.service('boards').emit('patched', targetBoard);
+    }
+
+    this.app.service('artifacts').emit('patched', updated);
+    return updated;
+  }
+
+  /**
+   * Materialize an artifact's stored file map to a destination under a worktree.
+   * Inverse of publish().
+   *
+   * Security:
+   * - destination must resolve strictly inside the worktree (not equal to the
+   *   worktree root) — prevents overwriting random files via `subpath`.
+   * - per-file paths from the artifact's `files` map are re-validated to block
+   *   traversal keys like `../../etc/passwd` that could have been snuck into
+   *   the serialized file map.
+   * - when overwriting, uses `fs.rm` which removes symlinks rather than
+   *   following them.
+   */
+  async land(
+    artifactId: string,
+    worktreePath: string,
+    options?: { subpath?: string; overwrite?: boolean }
+  ): Promise<{ destinationPath: string; fileCount: number; bytesWritten: number }> {
+    const artifact = await this.artifactRepo.findById(artifactId);
+    if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
+    if (!artifact.files || Object.keys(artifact.files).length === 0) {
+      throw new Error(`Artifact ${artifactId} has no stored files to land`);
+    }
+
+    const worktreeRoot = path.resolve(worktreePath);
+    if (!fs.existsSync(worktreeRoot)) {
+      throw new Error(`Worktree path does not exist: ${worktreeRoot}`);
+    }
+
+    // Default destination: .agor/artifacts/<artifact-id>
+    const rawSubpath =
+      options?.subpath && options.subpath.trim().length > 0
+        ? options.subpath
+        : path.join('.agor', 'artifacts', artifact.artifact_id);
+
+    // Absolute subpath is always rejected — caller must pass a worktree-relative path.
+    if (path.isAbsolute(rawSubpath)) {
+      throw new Error(`subpath must be relative to the worktree root: ${rawSubpath}`);
+    }
+
+    const destination = path.resolve(worktreeRoot, rawSubpath);
+
+    // Path-escape check: destination must be strictly inside the worktree.
+    // Equal to worktree root is refused — writing the artifact at the worktree
+    // root would stomp user code.
+    if (destination === worktreeRoot) {
+      throw new Error('subpath must not resolve to the worktree root');
+    }
+    const prefix = worktreeRoot + path.sep;
+    if (!destination.startsWith(prefix)) {
+      throw new Error(`subpath escapes worktree root: ${rawSubpath}`);
+    }
+
+    // Validate file-map keys for traversal. Artifact file keys are stored as
+    // `/path/to/file` (leading slash, forward slashes). Strip leading slash,
+    // resolve inside destination, and verify containment.
+    for (const filePath of Object.keys(artifact.files)) {
+      const key = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+      if (path.isAbsolute(key)) {
+        throw new Error(`Artifact contains absolute file path: ${filePath}`);
+      }
+      const resolved = path.resolve(destination, key);
+      if (resolved !== destination && !resolved.startsWith(destination + path.sep)) {
+        throw new Error(`Artifact file path escapes destination: ${filePath}`);
+      }
+    }
+
+    // Handle existing destination.
+    if (fs.existsSync(destination)) {
+      if (!options?.overwrite) {
+        throw new Error(
+          `Destination already exists: ${destination} (pass overwrite=true to replace)`
+        );
+      }
+      // fs.rm with recursive unlinks symlinks rather than following them.
+      await rm(destination, { recursive: true, force: true });
+    }
+
+    await mkdir(destination, { recursive: true });
+
+    // Write the file map.
+    let bytesWritten = 0;
+    let fileCount = 0;
+    for (const [filePath, content] of Object.entries(artifact.files)) {
+      const key = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+      const fullPath = path.join(destination, key);
+      await mkdir(path.dirname(fullPath), { recursive: true });
+      await writeFile(fullPath, content, 'utf-8');
+      bytesWritten += Buffer.byteLength(content, 'utf-8');
+      fileCount += 1;
+    }
+
+    // Reconstruct sandpack.json for round-trip with publish() (publish skips
+    // sandpack.json when reading, and reconstitutes manifest state from DB
+    // columns).
+    const manifest: SandpackManifest = { template: artifact.template };
+    if (artifact.dependencies) manifest.dependencies = artifact.dependencies;
+    if (artifact.entry) manifest.entry = artifact.entry;
+    if (artifact.use_local_bundler) manifest.use_local_bundler = artifact.use_local_bundler;
+    const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
+    await writeFile(path.join(destination, 'sandpack.json'), manifestJson, 'utf-8');
+    bytesWritten += Buffer.byteLength(manifestJson, 'utf-8');
+    fileCount += 1;
+
+    return { destinationPath: destination, fileCount, bytesWritten };
   }
 
   /**

--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -57,16 +57,21 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
   const handleUpdate = () => {
     if (!editingArtifact) return;
     form.validateFields().then((values) => {
-      const updates: Partial<Artifact> = {
-        name: values.name,
-        description: values.description || undefined,
-      };
-      // Only include board_id if it actually changed — keeps patch payloads
-      // focused and avoids triggering a board-move round-trip for no reason.
+      // Build a patch of only fields that actually changed. If nothing
+      // changed, skip the network round-trip entirely — avoids firing a
+      // spurious `patched` broadcast for a no-op submit.
+      const updates: Partial<Artifact> = {};
+      const nextName = values.name;
+      const nextDescription = values.description || undefined;
+      const currentDescription = editingArtifact.description || undefined;
+      if (nextName !== editingArtifact.name) updates.name = nextName;
+      if (nextDescription !== currentDescription) updates.description = nextDescription;
       if (values.board_id && values.board_id !== editingArtifact.board_id) {
         updates.board_id = values.board_id;
       }
-      onUpdate?.(editingArtifact.artifact_id, updates);
+      if (Object.keys(updates).length > 0) {
+        onUpdate?.(editingArtifact.artifact_id, updates);
+      }
       form.resetFields();
       setEditModalOpen(false);
       setEditingArtifact(null);
@@ -215,7 +220,8 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
         >
           <Empty description="No artifacts yet">
             <Typography.Text type="secondary">
-              Artifacts are created by agents using the <code>agor_artifacts_create</code> MCP tool.
+              Artifacts are created by agents using the <code>agor_artifacts_publish</code> MCP
+              tool.
             </Typography.Text>
           </Empty>
         </div>

--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Modal,
   Popconfirm,
+  Select,
   Space,
   Table,
   Tag,
@@ -15,7 +16,7 @@ import {
   Typography,
 } from 'antd';
 import { useState } from 'react';
-import { mapToSortedArray } from '@/utils/mapHelpers';
+import { mapToArray, mapToSortedArray } from '@/utils/mapHelpers';
 
 interface ArtifactsTableProps {
   artifactById: Map<string, Artifact>;
@@ -48,6 +49,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
     form.setFieldsValue({
       name: artifact.name,
       description: artifact.description || '',
+      board_id: artifact.board_id,
     });
     setEditModalOpen(true);
   };
@@ -55,15 +57,29 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
   const handleUpdate = () => {
     if (!editingArtifact) return;
     form.validateFields().then((values) => {
-      onUpdate?.(editingArtifact.artifact_id, {
+      const updates: Partial<Artifact> = {
         name: values.name,
         description: values.description || undefined,
-      });
+      };
+      // Only include board_id if it actually changed — keeps patch payloads
+      // focused and avoids triggering a board-move round-trip for no reason.
+      if (values.board_id && values.board_id !== editingArtifact.board_id) {
+        updates.board_id = values.board_id;
+      }
+      onUpdate?.(editingArtifact.artifact_id, updates);
       form.resetFields();
       setEditModalOpen(false);
       setEditingArtifact(null);
     });
   };
+
+  const boardOptions = mapToArray(boardById)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((board) => ({
+      value: board.board_id,
+      label: `${board.icon || '📋'} ${board.name}`,
+    }));
 
   const columns = [
     {
@@ -151,7 +167,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
       width: 90,
       render: (_: unknown, artifact: Artifact) => (
         <Space size="small">
-          <Tooltip title="Edit name and description">
+          <Tooltip title="Edit artifact">
             <Button
               type="text"
               size="small"
@@ -234,6 +250,21 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
           </Form.Item>
           <Form.Item label="Description" name="description">
             <Input.TextArea rows={3} placeholder="Optional description" />
+          </Form.Item>
+          <Form.Item
+            label="Board"
+            name="board_id"
+            tooltip="Move this artifact to a different board. Its position on the board is preserved."
+            rules={[{ required: true, message: 'Please select a board' }]}
+          >
+            <Select
+              showSearch
+              placeholder="Select board..."
+              options={boardOptions}
+              filterOption={(input, option) =>
+                (option?.label?.toString() ?? '').toLowerCase().includes(input.toLowerCase())
+              }
+            />
           </Form.Item>
         </Form>
       </Modal>

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -231,6 +231,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
 
       if (updates.name !== undefined) setData.name = updates.name;
       if (updates.description !== undefined) setData.description = updates.description ?? null;
+      if (updates.board_id !== undefined) setData.board_id = updates.board_id;
       if (updates.template !== undefined) setData.template = updates.template;
       if (updates.build_status !== undefined) setData.build_status = updates.build_status;
       if (updates.build_errors !== undefined) {


### PR DESCRIPTION
## Summary

Two new MCP tools for agents operating on artifacts:

- **`agor_artifacts_update`** — cheap metadata PATCH. Primary use case: move an artifact to another board (`boardId`) when the original source folder on disk is gone. Also handles `name`, `description`, `public`, `archived`, and board placement (`x/y/width/height`). Cross-board moves preserve placement by default so layout stays consistent.
- **`agor_artifacts_land`** — inverse of `agor_artifacts_publish`. Materializes the artifact's stored file map onto disk under a worktree (default subpath `.agor/artifacts/<artifact-id>`). Also writes a reconstructed `sandpack.json` so `publish()` on the landed folder round-trips cleanly.

## Design decisions

- **Placement preservation on board move.** When `boardId` changes, existing `x/y/width/height` are copied to the new board object unless caller explicitly overrides. Rationale: the only information we have is the previous layout, and "same position on a new board" is the least surprising default.
- **No filesystem cleanup on old board.** `updateMetadata` removes the `board_objects` entry on the old board but does not touch the artifact's `path` provenance column — that is historical.
- **Default land subpath.** `.agor/artifacts/<artifact-id>` — mirrors the convention publish already knows about, fits naturally inside worktrees.
- **Authz.** `update` reuses the "owner or admin" pattern from `publish`'s update path. `land` visibility matches `agor_artifacts_get` (public readable by anyone, private only by owner) and routes the worktree lookup through the Feathers service so worktree RBAC is enforced.

## Security

On `land()`:
- destination must resolve strictly inside the worktree (equal-to-root is refused)
- `subpath` must be relative (absolute rejected) and must not escape via `..`
- per-file keys in the stored file map are re-validated against traversal — a malicious artifact with a file key of `../../bin/evil` is refused before any write
- overwrite uses `fs.rm({ recursive: true })` which unlinks symlinks rather than following them

## Files touched

- `packages/core/src/db/repositories/artifacts.ts` — adds `board_id` to the fields the `update` method can set.
- `apps/agor-daemon/src/services/artifacts.ts` — adds `updateMetadata()` and `land()` methods.
- `apps/agor-daemon/src/mcp/tools/artifacts.ts` — registers `agor_artifacts_update` and `agor_artifacts_land`.
- `apps/agor-daemon/src/services/artifacts.test.ts` — 14 new tests.

## Test plan

- [x] `pnpm test` in `apps/agor-daemon` — 456 passed (14 new)
- [x] `pnpm test` in `packages/core` — 1967 passed
- [x] `pnpm typecheck` clean on both daemon and core
- [x] `biome check` clean on touched files
- [ ] Exercise via live daemon once MCP client picks up the new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)