### PR TITLE
fix(ui): fix cramped inline edit in User Settings → Env Vars

### DIFF
--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -53,6 +53,11 @@ const SCOPE_COLOR: Record<EnvVarScope, string> = {
   executor: 'default',
 };
 
+const SCOPE_OPTIONS = ENV_VAR_SCOPES_V05.map((s) => ({
+  value: s,
+  label: SCOPE_LABEL[s],
+}));
+
 export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   envVars,
   onSave,
@@ -144,10 +149,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
               popupMatchSelectWidth={false}
               disabled={disabled || loading[record.key]}
               onChange={(next) => handleScopeChange(record.key, next)}
-              options={ENV_VAR_SCOPES_V05.map((s) => ({
-                value: s,
-                label: SCOPE_LABEL[s],
-              }))}
+              options={SCOPE_OPTIONS}
             />
           );
         }
@@ -171,6 +173,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
                 onPressEnter={() => handleUpdate(record.key, record.scope)}
                 autoFocus
                 disabled={disabled}
+                style={{ flex: 1, minWidth: 180 }}
               />
               <Button
                 type="primary"
@@ -217,6 +220,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
           <Button
             danger
             type="text"
+            size="small"
             icon={<DeleteOutlined />}
             onClick={() => handleDeleteClick(record.key)}
             loading={loading[record.key]}
@@ -278,12 +282,9 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
           <Select<EnvVarScope>
             value={newScope}
             onChange={setNewScope}
-            style={{ width: 130 }}
+            style={{ width: 140 }}
             disabled={disabled}
-            options={ENV_VAR_SCOPES_V05.map((s) => ({
-              value: s,
-              label: SCOPE_LABEL[s],
-            }))}
+            options={SCOPE_OPTIONS}
           />
           <Input.Password
             placeholder="Value"

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -1,6 +1,6 @@
 import { ENV_VAR_SCOPES_V05, type EnvVarMetadata, type EnvVarScope } from '@agor-live/client';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
-import { Button, Input, Select, Space, Table, Typography } from 'antd';
+import { Button, Input, Select, Space, Table, Tooltip, Typography } from 'antd';
 import { useState } from 'react';
 import { Tag } from './Tag';
 
@@ -125,21 +125,23 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
       title: 'Variable Name',
       dataIndex: 'key',
       key: 'key',
-      width: '25%',
+      width: '30%',
+      ellipsis: true,
       render: (key: string) => <code>{key}</code>,
     },
     {
       title: 'Scope',
       dataIndex: 'scope',
       key: 'scope',
-      width: '20%',
+      width: 140,
       render: (scope: EnvVarScope, record: Row) => {
         if (onScopeChange) {
           return (
             <Select
               value={scope}
               size="small"
-              style={{ minWidth: 120 }}
+              style={{ width: '100%', minWidth: 0 }}
+              popupMatchSelectWidth={false}
               disabled={disabled || loading[record.key]}
               onChange={(next) => handleScopeChange(record.key, next)}
               options={ENV_VAR_SCOPES_V05.map((s) => ({
@@ -156,7 +158,6 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
       title: 'Value',
       dataIndex: 'isSet',
       key: 'value',
-      width: '30%',
       render: (isSet: boolean, record: Row) => {
         const isEditing = editingKey === record.key;
 
@@ -209,17 +210,20 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: '25%',
+      width: 72,
+      align: 'center' as const,
       render: (_: unknown, record: Row) => (
-        <Button
-          danger
-          icon={<DeleteOutlined />}
-          onClick={() => handleDeleteClick(record.key)}
-          loading={loading[record.key]}
-          disabled={disabled}
-        >
-          Delete
-        </Button>
+        <Tooltip title="Delete">
+          <Button
+            danger
+            type="text"
+            icon={<DeleteOutlined />}
+            onClick={() => handleDeleteClick(record.key)}
+            loading={loading[record.key]}
+            disabled={disabled}
+            aria-label={`Delete ${record.key}`}
+          />
+        </Tooltip>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -717,7 +717,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         </div>
       }
       closable
-      width={1050}
+      width="min(1050px, calc(100vw - 32px))"
       style={{ top: 40 }}
       styles={{
         wrapper: {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -717,7 +717,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         </div>
       }
       closable
-      width={900}
+      width={1050}
       style={{ top: 40 }}
       styles={{
         wrapper: {


### PR DESCRIPTION
## Summary

User reported that in **User Settings → Env Vars**, clicking **Update** on a row to change a value produced an inline `Input + Save + Cancel` group that was squeezed so tight (≈30–60px of input width) it was unusable. Root cause is a combination of the Actions column carrying 25% of the row for a word-sized **Delete** button, the Scope `<Select>` sitting in another 20%, and the modal being only 900px wide.

Three tightening moves:

- **Actions column**: `Delete` text → icon-only trash (`DeleteOutlined`) with `Tooltip title="Delete"` + `aria-label`, column width dropped from `25%` to a fixed `72px`. Matches the icon-button pattern already in `EventStreamPanel`, `WorktreeCard`, `ApiKeyFields`.
- **Scope column**: fixed `140px` (fits the longest label, `Artifact feature`), with `popupMatchSelectWidth={false}` so the dropdown popup can still stretch for long labels without forcing a wide column.
- **Modal width**: `UserSettingsModal` `width={900}` → `width={1050}` (+150px).

Also widened **Variable Name** to `30%` and added `ellipsis` so long keys truncate gracefully instead of fighting the Value column. **Value** column now has no explicit width and takes the remaining flex space — this is what actually gives the inline-edit `Space.Compact` room to breathe (≥200px input at default modal size).

No changes to behavior: same handlers, same confirm/loading/error flow, same add-new-variable form.

## Test plan

- [ ] Open **User Settings → Env Vars**, verify list view renders cleanly and long variable names truncate with ellipsis
- [ ] Click **Update** on a row — confirm Input + Save + Cancel all fit comfortably and the Input is ≥200px wide at default modal size
- [ ] Change **Scope** dropdown — confirm popup shows the longest label (`Artifact feature`) without the column ballooning
- [ ] Click the trash icon — confirm the Tooltip shows "Delete" and the delete still works
- [ ] Add a new env var via the bottom form — unchanged, should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)