### PR TITLE
fix(ui): use native emoji style so picker works under default CSP

### DIFF
--- a/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
+++ b/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
@@ -32,10 +32,10 @@ import {
   Typography,
   theme,
 } from 'antd';
-import EmojiPicker, { EmojiStyle, Theme } from 'emoji-picker-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { AgorAvatar } from '../AgorAvatar';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
+import { AgorEmojiPicker } from '../EmojiPickerInput';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { ZONE_CONTENT_OPACITY } from '../SessionCanvas/canvas/BoardObjectNodes';
 
@@ -138,15 +138,11 @@ const EmojiPickerButton: React.FC<{
   return (
     <Popover
       content={
-        <EmojiPicker
+        <AgorEmojiPicker
           onEmojiClick={(emojiData) => {
             onToggle(emojiData.emoji);
             setPickerOpen(false);
           }}
-          theme={Theme.DARK}
-          emojiStyle={EmojiStyle.NATIVE}
-          width={350}
-          height={400}
         />
       }
       trigger="click"

--- a/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
+++ b/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
@@ -32,7 +32,7 @@ import {
   Typography,
   theme,
 } from 'antd';
-import EmojiPicker, { Theme } from 'emoji-picker-react';
+import EmojiPicker, { EmojiStyle, Theme } from 'emoji-picker-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { AgorAvatar } from '../AgorAvatar';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
@@ -144,6 +144,7 @@ const EmojiPickerButton: React.FC<{
             setPickerOpen(false);
           }}
           theme={Theme.DARK}
+          emojiStyle={EmojiStyle.NATIVE}
           width={350}
           height={400}
         />

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
@@ -1,7 +1,28 @@
 import { SmileOutlined } from '@ant-design/icons';
 import { Button, Form, Input, Popover } from 'antd';
-import EmojiPicker, { type EmojiClickData, EmojiStyle, Theme } from 'emoji-picker-react';
+import EmojiPicker, {
+  type EmojiClickData,
+  EmojiStyle,
+  type PickerProps,
+  Theme,
+} from 'emoji-picker-react';
 import { useState } from 'react';
+
+/**
+ * Shared <EmojiPicker /> wrapper that pins CSP-safe and visually-consistent
+ * defaults. Always use this instead of importing EmojiPicker directly — the
+ * library defaults to EmojiStyle.APPLE which lazy-loads PNGs from
+ * cdn.jsdelivr.net, blocked by Agor's default img-src CSP.
+ */
+export const AgorEmojiPicker: React.FC<Pick<PickerProps, 'onEmojiClick'>> = ({ onEmojiClick }) => (
+  <EmojiPicker
+    onEmojiClick={onEmojiClick}
+    theme={Theme.DARK}
+    emojiStyle={EmojiStyle.NATIVE}
+    width={350}
+    height={400}
+  />
+);
 
 interface EmojiPickerInputProps {
   value?: string;
@@ -38,15 +59,7 @@ export const EmojiPickerInput: React.FC<EmojiPickerInputProps> = ({
         }}
       />
       <Popover
-        content={
-          <EmojiPicker
-            onEmojiClick={handleEmojiClick}
-            theme={Theme.DARK}
-            emojiStyle={EmojiStyle.NATIVE}
-            width={350}
-            height={400}
-          />
-        }
+        content={<AgorEmojiPicker onEmojiClick={handleEmojiClick} />}
         trigger="click"
         open={pickerOpen}
         onOpenChange={setPickerOpen}

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
@@ -1,6 +1,6 @@
 import { SmileOutlined } from '@ant-design/icons';
 import { Button, Form, Input, Popover } from 'antd';
-import EmojiPicker, { type EmojiClickData, Theme } from 'emoji-picker-react';
+import EmojiPicker, { type EmojiClickData, EmojiStyle, Theme } from 'emoji-picker-react';
 import { useState } from 'react';
 
 interface EmojiPickerInputProps {
@@ -42,6 +42,7 @@ export const EmojiPickerInput: React.FC<EmojiPickerInputProps> = ({
           <EmojiPicker
             onEmojiClick={handleEmojiClick}
             theme={Theme.DARK}
+            emojiStyle={EmojiStyle.NATIVE}
             width={350}
             height={400}
           />

--- a/apps/agor-ui/src/components/EmojiPickerInput/index.ts
+++ b/apps/agor-ui/src/components/EmojiPickerInput/index.ts
@@ -1,1 +1,1 @@
-export { EmojiPickerInput, FormEmojiPickerInput } from './EmojiPickerInput';
+export { AgorEmojiPicker, EmojiPickerInput, FormEmojiPickerInput } from './EmojiPickerInput';

--- a/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
@@ -71,7 +71,7 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
       </Form.Item>
 
       <Form.Item name="emoji" label="Icon">
-        <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="\u{1F916}" />
+        <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="🤖" />
       </Form.Item>
 
       <Form.Item


### PR DESCRIPTION
## Summary

In prod, the emoji picker (used by CRUD modals for boards/worktrees and by the comments panel for reactions) renders an empty grid.

**Root cause:** `emoji-picker-react` defaults to `EmojiStyle.APPLE`, which lazy-loads PNGs from `https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/<unified>.png`. Agor's default CSP (set in `apps/agor-daemon/src/setup/security-headers.ts` via the resolver in `packages/core/src/config/security-resolver.ts`) restricts `img-src` to `'self' data: blob:`, so every emoji image request is blocked. The user diagnosed this as CORS, but it's CSP — same symptom (assets fail to load), different mechanism.

**Fix:** Set `emojiStyle={EmojiStyle.NATIVE}` on the two `<EmojiPicker />` instances:

- `apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx`
- `apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx`

Native style renders system emoji glyphs directly (the `emoji` field on `EmojiClickData` is the unicode character, which is what we want anyway — it gets stored as text on the worktree/board/etc.). No CDN, no extra bundle weight, no CSP changes required.

## Why not the other options

- **Bundle the emoji-datasource PNGs locally**: ~1MB+ per style, and we don't actually want PNG-rendered emoji — native looks better and matches the rest of the UI (where `worktree.icon`, etc. is already rendered as a unicode character).
- **Loosen CSP to allow `cdn.jsdelivr.net`**: The `security.csp.extras.img-src` config knob in `~/.agor/config.yaml` already supports this for operators who want it, but making the bundled UI rely on an external CDN is the wrong default for a self-hosted product.

## Follow-up (not in this PR)

The user originally asked about a CORS knob in `~/.agor/config.yaml`. The mechanism that exists today is `security.csp.extras` / `security.csp.override` (see `packages/core/src/config/security-resolver.ts`). If we ever want a higher-level "trusted_cdns" knob that fans out into `img-src` / `font-src` / `connect-src`, that's a separate config-surface change.

## Test plan

- [x] `pnpm --filter agor-ui typecheck` — passes
- [x] `pnpm --filter agor-ui build` — succeeds
- [ ] Manual smoke: open a CRUD modal that uses the icon picker (e.g. create board, create worktree), confirm emoji grid renders
- [ ] Manual smoke: in the comments panel, open the reaction picker and confirm the grid renders
- [ ] Confirm picked emoji is correctly stored (it's the same unicode `emojiData.emoji` field as before — handler unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)