### PR TITLE
fix(mcp): accept modelConfig at session create/spawn, surface MCP attach errors

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for session-creating MCP tools (`agor_sessions_create`,
+ * `agor_sessions_spawn`, `agor_sessions_prompt` subsession mode).
+ *
+ * Focus: regression coverage for two param-drop bugs in the session-create
+ * path:
+ *   1. `mcpServerIds` were silently dropped on attach failure, making it look
+ *      like the MCP server "didn't stick".
+ *   2. `modelConfig` wasn't in the tool's input schema at all, so callers
+ *      asking for `claude-opus-4-6` got the default model instead.
+ *
+ * We capture each tool's registered handler, stub the Feathers services it
+ * calls, and assert on the session payload + attach calls.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../resolve-ids.js', () => ({
+  resolveBoardId: async (_ctx: unknown, id: string) => id,
+  resolveSessionId: async (_ctx: unknown, id: string) => id,
+  resolveWorktreeId: async (_ctx: unknown, id: string) => id,
+  resolveMcpServerId: async (_ctx: unknown, id: string) => `full-${id}`,
+}));
+
+vi.mock('../../utils/worktree-authorization.js', () => ({
+  ensureCanPromptTargetSession: vi.fn(async () => undefined),
+}));
+
+vi.mock('@agor/core/db', () => ({
+  WorktreeRepository: class FakeWorktreeRepository {},
+}));
+
+// Helper to build a minimal fake Feathers app. Each test supplies spies for
+// the services it exercises; unknown services throw so we don't silently drop
+// side-effects the assertion cares about.
+type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
+function makeFakeApp(services: Record<string, ServiceStub>) {
+  return {
+    service: (name: string) => {
+      const svc = services[name];
+      if (!svc) {
+        throw new Error(`Unexpected service call: ${name}`);
+      }
+      return svc;
+    },
+  };
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+async function registerAndCaptureHandlers(
+  ctx: {
+    app: unknown;
+    userId: string;
+    sessionId: string;
+  },
+  toolNames: string[]
+): Promise<Record<string, ToolHandler>> {
+  const { registerSessionTools } = await import('./sessions.js');
+  const captured: Record<string, ToolHandler> = {};
+  const fakeServer = {
+    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+      if (toolNames.includes(name)) {
+        captured[name] = cb;
+      }
+    },
+  } as unknown as McpServer;
+
+  registerSessionTools(fakeServer, {
+    app: ctx.app as any,
+    db: {} as any,
+    userId: ctx.userId as any,
+    sessionId: ctx.sessionId as any,
+    authenticatedUser: { user_id: ctx.userId, role: 'member' } as any,
+    baseServiceParams: {},
+  });
+
+  for (const name of toolNames) {
+    if (!captured[name]) throw new Error(`Tool ${name} was not registered`);
+  }
+  return captured;
+}
+
+describe('agor_sessions_create', () => {
+  const baseWorktree = {
+    worktree_id: 'wt-1',
+    path: '/tmp/wt',
+    mcp_server_ids: [],
+  };
+  const baseUser = {
+    user_id: 'user-1',
+    unix_username: 'alice',
+    default_agentic_config: {
+      'claude-code': {
+        permissionMode: 'acceptEdits',
+        modelConfig: {
+          mode: 'alias',
+          model: 'claude-sonnet-4-6', // user default
+          effort: 'medium',
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    vi.doMock('@agor/core/git', () => ({
+      getGitState: async () => 'sha-abc',
+      getCurrentBranch: async () => 'main',
+    }));
+    vi.doMock('@agor/core/types', async () => {
+      const actual = await vi.importActual<Record<string, unknown>>('@agor/core/types');
+      return {
+        ...actual,
+        getDefaultPermissionMode: () => 'acceptEdits',
+      };
+    });
+    vi.doMock('@agor/core/utils/permission-mode-mapper', () => ({
+      mapPermissionMode: (m: string) => m,
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('threads explicit modelConfig through to session.model_config (Bug 2)', async () => {
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      worktrees: { get: async () => baseWorktree },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+      },
+      'session-mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      worktreeId: 'wt-1',
+      agenticTool: 'claude-code',
+      modelConfig: { model: 'claude-opus-4-6', mode: 'alias', effort: 'max' },
+    });
+
+    expect(sessionCreates).toHaveLength(1);
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.model_config).toBeDefined();
+    // Explicit override wins over user default ('claude-sonnet-4-6').
+    expect(created.model_config.model).toBe('claude-opus-4-6');
+    expect(created.model_config.mode).toBe('alias');
+    expect(created.model_config.effort).toBe('max');
+    expect(typeof created.model_config.updated_at).toBe('string');
+  });
+
+  it('falls back to user default modelConfig when none is explicitly provided', async () => {
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      worktrees: { get: async () => baseWorktree },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+      },
+      'session-mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      worktreeId: 'wt-1',
+      agenticTool: 'claude-code',
+      // no modelConfig
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.model_config.model).toBe('claude-sonnet-4-6'); // user default
+    expect(created.model_config.effort).toBe('medium');
+  });
+
+  it('attaches explicit mcpServerIds to the session via session-mcp-servers (Bug 1)', async () => {
+    const attachCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      worktrees: { get: async () => baseWorktree },
+      sessions: {
+        create: async (data: unknown) => ({
+          session_id: 'sess-new',
+          ...(data as Record<string, unknown>),
+        }),
+      },
+      'session-mcp-servers': {
+        create: async (data: unknown) => {
+          attachCalls.push(data);
+          return data;
+        },
+      },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      worktreeId: 'wt-1',
+      agenticTool: 'claude-code',
+      mcpServerIds: ['short-id-1', 'short-id-2'],
+    });
+
+    expect(attachCalls).toHaveLength(2);
+    // resolveMcpServerId mock prefixes with 'full-'
+    expect((attachCalls[0] as any).mcp_server_id).toBe('full-short-id-1');
+    expect((attachCalls[0] as any).session_id).toBe('sess-new');
+    expect((attachCalls[1] as any).mcp_server_id).toBe('full-short-id-2');
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.mcpAttachFailures).toBeUndefined();
+  });
+
+  it('surfaces attach failures in the response when caller explicitly requested mcpServerIds', async () => {
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      worktrees: { get: async () => baseWorktree },
+      sessions: {
+        create: async () => ({ session_id: 'sess-new' }),
+      },
+      'session-mcp-servers': {
+        create: async () => {
+          throw new Error('RBAC: forbidden');
+        },
+      },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      worktreeId: 'wt-1',
+      agenticTool: 'claude-code',
+      mcpServerIds: ['short-id-1'],
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.mcpAttachFailures).toHaveLength(1);
+    expect(parsed.mcpAttachFailures[0].mcp_server_id).toBe('full-short-id-1');
+    expect(parsed.mcpAttachFailures[0].reason).toContain('RBAC');
+  });
+
+  it('silently skips (does not surface) attach failures for inherited mcpServerIds', async () => {
+    const worktreeWithMcps = {
+      ...baseWorktree,
+      mcp_server_ids: ['inherited-1'],
+    };
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      worktrees: { get: async () => worktreeWithMcps },
+      sessions: {
+        create: async () => ({ session_id: 'sess-new' }),
+      },
+      'session-mcp-servers': {
+        create: async () => {
+          throw new Error('boom');
+        },
+      },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      worktreeId: 'wt-1',
+      agenticTool: 'claude-code',
+      // no explicit mcpServerIds → inherits from worktree
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.mcpAttachFailures).toBeUndefined();
+  });
+});
+
+describe('agor_sessions_spawn', () => {
+  beforeEach(() => {
+    vi.doMock('@agor/core/git', () => ({
+      getGitState: async () => 'sha-abc',
+      getCurrentBranch: async () => 'main',
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('threads modelConfig into SpawnConfig (Bug 2)', async () => {
+    const spawnCalls: Array<{ id: string; data: any }> = [];
+    const app = makeFakeApp({
+      sessions: {
+        spawn: async (id: string, data: any) => {
+          spawnCalls.push({ id, data });
+          return {
+            session_id: 'sess-child',
+            permission_config: { mode: 'acceptEdits' },
+          };
+        },
+      },
+      '/sessions/:id/prompt': {
+        create: async () => ({ taskId: 't1', status: 'running' }),
+      },
+    });
+
+    const { agor_sessions_spawn } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-parent' },
+      ['agor_sessions_spawn']
+    );
+
+    await agor_sessions_spawn({
+      prompt: 'do the thing',
+      modelConfig: { model: 'claude-opus-4-6', effort: 'high' },
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].data.modelConfig).toEqual({
+      model: 'claude-opus-4-6',
+      effort: 'high',
+    });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -343,4 +343,93 @@ describe('agor_sessions_spawn', () => {
       effort: 'high',
     });
   });
+
+  it('threads provider through SpawnConfig.modelConfig (OpenCode)', async () => {
+    const spawnCalls: Array<{ id: string; data: any }> = [];
+    const app = makeFakeApp({
+      sessions: {
+        spawn: async (id: string, data: any) => {
+          spawnCalls.push({ id, data });
+          return {
+            session_id: 'sess-child',
+            permission_config: { mode: 'acceptEdits' },
+          };
+        },
+      },
+      '/sessions/:id/prompt': {
+        create: async () => ({ taskId: 't1', status: 'running' }),
+      },
+    });
+
+    const { agor_sessions_spawn } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-parent' },
+      ['agor_sessions_spawn']
+    );
+
+    await agor_sessions_spawn({
+      prompt: 'do the thing',
+      modelConfig: { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+    });
+
+    // Regression guard: without `provider` on SpawnConfig, Zod-validated input
+    // would reach the spawn service with provider set, but the service's merge
+    // would drop it (or TS would reject the field). This asserts the full
+    // shape survives the MCP → service boundary.
+    expect(spawnCalls[0].data.modelConfig).toEqual({
+      model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+    });
+  });
+});
+
+describe('agor_sessions_prompt (subsession mode)', () => {
+  beforeEach(() => {
+    vi.doMock('@agor/core/git', () => ({
+      getGitState: async () => 'sha-abc',
+      getCurrentBranch: async () => 'main',
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('threads modelConfig into SpawnConfig when mode="subsession"', async () => {
+    const spawnCalls: Array<{ id: string; data: any }> = [];
+    const app = makeFakeApp({
+      sessions: {
+        spawn: async (id: string, data: any) => {
+          spawnCalls.push({ id, data });
+          return {
+            session_id: 'sess-sub',
+            permission_config: { mode: 'acceptEdits' },
+          };
+        },
+      },
+      '/sessions/:id/prompt': {
+        create: async () => ({ taskId: 't1', status: 'running' }),
+      },
+    });
+
+    const { agor_sessions_prompt } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_prompt']
+    );
+
+    await agor_sessions_prompt({
+      sessionId: 'sess-target',
+      prompt: 'delegated work',
+      mode: 'subsession',
+      modelConfig: { model: 'claude-opus-4-6', effort: 'max', provider: 'anthropic' },
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].id).toBe('sess-target');
+    expect(spawnCalls[0].data.modelConfig).toEqual({
+      model: 'claude-opus-4-6',
+      effort: 'max',
+      provider: 'anthropic',
+    });
+  });
 });

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -24,10 +24,11 @@ import { textResult } from '../server.js';
 
 /**
  * Shared Zod schema for specifying a model override at session-create / spawn /
- * subsession time. Mirrors Session['model_config'] but keeps every field
- * optional so callers can pass e.g. just `{ model: 'claude-opus-4-6' }` and
- * inherit the rest. Wired through to `session.model_config` so the executor
- * actually spawns on the requested model (see query-builder.ts).
+ * subsession time. Mirrors Session['model_config']: `model` is required (the
+ * whole point of this object is to pin a specific model), while `mode`,
+ * `effort`, and `provider` are optional and fall back to sensible defaults.
+ * Wired through to `session.model_config` so the executor actually spawns on
+ * the requested model (see query-builder.ts).
  */
 const modelConfigInputSchema = z
   .object({
@@ -750,7 +751,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           mode: userToolDefaults.modelConfig.mode || 'alias',
           model: userToolDefaults.modelConfig.model,
           updated_at: new Date().toISOString(),
-          effort: userToolDefaults.modelConfig.effort,
+          ...(userToolDefaults.modelConfig.effort !== undefined && {
+            effort: userToolDefaults.modelConfig.effort,
+          }),
         };
       }
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -34,7 +34,12 @@ import { textResult } from '../server.js';
 const modelConfigInputSchema = z
   .object({
     mode: z.enum(['alias', 'exact']).optional().describe("Model selection mode (default: 'alias')"),
-    model: z.string().describe("Model identifier (e.g. 'claude-opus-4-6', 'claude-sonnet-4-6')"),
+    // .min(1): reject empty-string model explicitly so callers don't silently
+    // fall through to user defaults when they meant to pin a specific model.
+    model: z
+      .string()
+      .min(1)
+      .describe("Model identifier (e.g. 'claude-opus-4-6', 'claude-sonnet-4-6')"),
     effort: z
       .enum(['low', 'medium', 'high', 'max'])
       .optional()

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -22,6 +22,28 @@ import {
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
+/**
+ * Shared Zod schema for specifying a model override at session-create / spawn /
+ * subsession time. Mirrors Session['model_config'] but keeps every field
+ * optional so callers can pass e.g. just `{ model: 'claude-opus-4-6' }` and
+ * inherit the rest. Wired through to `session.model_config` so the executor
+ * actually spawns on the requested model (see query-builder.ts).
+ */
+const modelConfigInputSchema = z
+  .object({
+    mode: z.enum(['alias', 'exact']).optional().describe("Model selection mode (default: 'alias')"),
+    model: z.string().describe("Model identifier (e.g. 'claude-opus-4-6', 'claude-sonnet-4-6')"),
+    effort: z
+      .enum(['low', 'medium', 'high', 'max'])
+      .optional()
+      .describe('Reasoning effort level (default: high)'),
+    provider: z.string().optional().describe("Provider ID (OpenCode only, e.g. 'anthropic')"),
+  })
+  .optional()
+  .describe(
+    'Model override for this session. When set, overrides the user default model_config. Threaded through to the spawned agent process so it actually runs on the requested model.'
+  );
+
 export function registerSessionTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_sessions_list
   server.registerTool(
@@ -411,6 +433,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'MCP server IDs to attach. Overrides parent session inheritance. Omit to inherit from parent. Pass empty array for no MCPs.'
           ),
+        modelConfig: modelConfigInputSchema,
       }),
     },
     async (args) => {
@@ -424,6 +447,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         extraInstructions: args.extraInstructions,
         task_id: args.taskId,
         mcpServerIds: args.mcpServerIds,
+        modelConfig: args.modelConfig,
       };
 
       const childSession = await (
@@ -479,6 +503,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'MCP server IDs for subsession mode. Overrides parent inheritance. Omit to inherit from parent. Pass empty array for no MCPs.'
           ),
+        modelConfig: modelConfigInputSchema,
       }),
     },
     async (args) => {
@@ -575,6 +600,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         const spawnData: Partial<import('@agor/core/types').SpawnConfig> = {
           prompt: args.prompt,
           mcpServerIds: args.mcpServerIds,
+          modelConfig: args.modelConfig,
         };
         if (args.title) spawnData.title = args.title;
         if (args.agenticTool) spawnData.agent = args.agenticTool as AgenticToolName;
@@ -610,7 +636,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_create',
     {
       description:
-        'Create a new session in an existing worktree. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the worktree (if configured) or user defaults. Supports optional callbacks to notify the creating session when the new session completes.',
+        'Create a new session in an existing worktree. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the worktree (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig`. Supports optional callbacks to notify the creating session when the new session completes.',
       inputSchema: z.object({
         worktreeId: z.string().describe('Worktree ID where the session will run (required)'),
         agenticTool: z
@@ -660,6 +686,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'MCP server IDs to attach. Overrides worktree and user default inheritance. Omit to use worktree config > user defaults.'
           ),
+        modelConfig: modelConfigInputSchema,
       }),
     },
     async (args) => {
@@ -704,8 +731,21 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         };
       }
 
+      // Model selection: explicit modelConfig arg > user default.
+      // An explicit modelConfig overrides any user-default settings and is
+      // threaded through to session.model_config so the executor picks it up
+      // when spawning the agent (see query-builder.ts: rawModel is read from
+      // session.model_config.model).
       let modelConfig: Record<string, unknown> | undefined;
-      if (userToolDefaults?.modelConfig?.model) {
+      if (args.modelConfig?.model) {
+        modelConfig = {
+          mode: args.modelConfig.mode || 'alias',
+          model: args.modelConfig.model,
+          updated_at: new Date().toISOString(),
+          ...(args.modelConfig.effort !== undefined && { effort: args.modelConfig.effort }),
+          ...(args.modelConfig.provider !== undefined && { provider: args.modelConfig.provider }),
+        };
+      } else if (userToolDefaults?.modelConfig?.model) {
         modelConfig = {
           mode: userToolDefaults.modelConfig.mode || 'alias',
           model: userToolDefaults.modelConfig.model,
@@ -723,6 +763,12 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           : worktree.mcp_server_ids && worktree.mcp_server_ids.length > 0
             ? worktree.mcp_server_ids
             : userToolDefaults?.mcpServerIds || [];
+      // Track whether the caller explicitly requested these servers. When they
+      // did, we surface attach failures in the response instead of silently
+      // dropping them (the "mcpServerId doesn't stick" bug). For inherited
+      // servers (worktree/user defaults) we preserve the existing "gracefully
+      // skip deleted/invalid" behavior so startup doesn't get chatty.
+      const mcpServerIdsFromArgs = args.mcpServerIds !== undefined;
 
       // Build callback configuration for remote session callbacks
       const callbackConfig: Record<string, unknown> = {};
@@ -783,7 +829,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       const session = await ctx.app.service('sessions').create(sessionData, ctx.baseServiceParams);
 
-      // Attach MCP servers (inherited from worktree or user defaults)
+      // Attach MCP servers (inherited from worktree or user defaults, or
+      // explicitly requested via args.mcpServerIds). Explicit failures are
+      // collected and returned to the caller so they don't silently vanish.
+      const mcpAttachFailures: Array<{ mcp_server_id: string; reason: string }> = [];
       if (mcpServerIds && mcpServerIds.length > 0) {
         for (const mcpServerId of mcpServerIds) {
           try {
@@ -794,10 +843,16 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
                 ctx.baseServiceParams
               );
           } catch (error) {
-            // Gracefully skip deleted/invalid MCP servers
-            console.warn(
-              `Skipped MCP server ${mcpServerId} for session ${session.session_id}: ${error instanceof Error ? error.message : String(error)}`
-            );
+            const reason = error instanceof Error ? error.message : String(error);
+            if (mcpServerIdsFromArgs) {
+              // Caller explicitly asked for this server — surface the failure.
+              mcpAttachFailures.push({ mcp_server_id: mcpServerId, reason });
+            } else {
+              // Inherited from worktree/user defaults — gracefully skip.
+              console.warn(
+                `Skipped MCP server ${mcpServerId} for session ${session.session_id}: ${reason}`
+              );
+            }
           }
         }
       }
@@ -817,12 +872,18 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         ? ` Callback will be sent to session ${(callbackConfig.callback_session_id as string).substring(0, 8)} on completion.`
         : '';
 
+      const mcpFailureNote =
+        mcpAttachFailures.length > 0
+          ? ` Warning: ${mcpAttachFailures.length} requested MCP server(s) failed to attach — see mcpAttachFailures.`
+          : '';
+
       return textResult({
         session,
         taskId: promptResponse?.taskId,
         note: args.initialPrompt
-          ? `Session created and initial prompt execution started.${callbackNote}`
-          : `Session created successfully.${callbackNote}`,
+          ? `Session created and initial prompt execution started.${callbackNote}${mcpFailureNote}`
+          : `Session created successfully.${callbackNote}${mcpFailureNote}`,
+        ...(mcpAttachFailures.length > 0 && { mcpAttachFailures }),
       });
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1,4 +1,5 @@
 import { WorktreeRepository, type WorktreeWithZoneAndSessions } from '@agor/core/db';
+import { resolveModelConfigPrecedence } from '@agor/core/models';
 import {
   AGENTIC_TOOL_CAPABILITIES,
   type AgenticToolName,
@@ -737,25 +738,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // threaded through to session.model_config so the executor picks it up
       // when spawning the agent (see query-builder.ts: rawModel is read from
       // session.model_config.model).
-      let modelConfig: Record<string, unknown> | undefined;
-      if (args.modelConfig?.model) {
-        modelConfig = {
-          mode: args.modelConfig.mode || 'alias',
-          model: args.modelConfig.model,
-          updated_at: new Date().toISOString(),
-          ...(args.modelConfig.effort !== undefined && { effort: args.modelConfig.effort }),
-          ...(args.modelConfig.provider !== undefined && { provider: args.modelConfig.provider }),
-        };
-      } else if (userToolDefaults?.modelConfig?.model) {
-        modelConfig = {
-          mode: userToolDefaults.modelConfig.mode || 'alias',
-          model: userToolDefaults.modelConfig.model,
-          updated_at: new Date().toISOString(),
-          ...(userToolDefaults.modelConfig.effort !== undefined && {
-            effort: userToolDefaults.modelConfig.effort,
-          }),
-        };
-      }
+      const modelConfig = resolveModelConfigPrecedence([
+        args.modelConfig,
+        userToolDefaults?.modelConfig,
+      ]);
 
       // MCP server inheritance: explicit param > worktree config > user defaults
       // An explicit empty array means "no MCPs" — does NOT fall through to worktree/user defaults.

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -1,5 +1,6 @@
 import { isWorktreeRbacEnabled } from '@agor/core/config';
 import { WorktreeRepository } from '@agor/core/db';
+import { resolveModelConfig } from '@agor/core/models';
 import type {
   AgenticToolName,
   BoardID,
@@ -799,16 +800,10 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
             };
           }
 
-          // Build model config from user defaults
-          let modelConfig: Record<string, unknown> | undefined;
-          if (userToolDefaults?.modelConfig?.model) {
-            modelConfig = {
-              mode: userToolDefaults.modelConfig.mode || 'alias',
-              model: userToolDefaults.modelConfig.model,
-              updated_at: new Date().toISOString(),
-              effort: userToolDefaults.modelConfig.effort,
-            };
-          }
+          // Build model config from user defaults. resolveModelConfig stamps
+          // updated_at and conditionally includes effort/provider so we write
+          // the same normalized shape as every other session-create path.
+          const modelConfig = resolveModelConfig(userToolDefaults?.modelConfig);
 
           // MCP server inheritance: worktree config > user defaults
           const mcpServerIds =

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -22,6 +22,7 @@ import {
   hasConnector,
   parseGitHubThreadId,
 } from '@agor/core/gateway';
+import { resolveModelConfig } from '@agor/core/models';
 import type {
   AgenticToolName,
   ChannelType,
@@ -595,14 +596,7 @@ export class GatewayService {
         status: SessionStatus.IDLE,
         agentic_tool: agenticTool,
         permission_config: { mode: permissionMode },
-        model_config: modelConfig
-          ? {
-              mode: modelConfig.mode ?? 'alias',
-              model: modelConfig.model ?? '',
-              updated_at: new Date().toISOString(),
-              effort: modelConfig.effort,
-            }
-          : undefined,
+        model_config: resolveModelConfig(modelConfig),
         tasks: [],
         // Denormalized gateway metadata (immutable snapshot at creation time)
         // Avoids N+1 lookups when rendering board cards

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -15,6 +15,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import { type Application, Forbidden } from '@agor/core/feathers';
+import { resolveModelConfig } from '@agor/core/models';
 import type {
   AuthenticatedParams,
   MCPServerID,
@@ -436,19 +437,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
                 : {}),
             };
 
-            if (toolDefaults.modelConfig) {
-              modelConfig = {
-                mode: toolDefaults.modelConfig.mode || 'alias',
-                model: toolDefaults.modelConfig.model || '',
-                updated_at: new Date().toISOString(),
-                ...(toolDefaults.modelConfig.effort !== undefined && {
-                  effort: toolDefaults.modelConfig.effort,
-                }),
-                ...(toolDefaults.modelConfig.provider !== undefined && {
-                  provider: toolDefaults.modelConfig.provider,
-                }),
-              };
-            }
+            modelConfig = resolveModelConfig(toolDefaults.modelConfig) ?? modelConfig;
           }
         } catch (error) {
           // If we can't fetch user preferences, fall back to parent settings
@@ -478,15 +467,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       };
     }
 
-    if (data.modelConfig) {
-      modelConfig = {
-        mode: data.modelConfig.mode || 'alias',
-        model: data.modelConfig.model || '',
-        updated_at: new Date().toISOString(),
-        ...(data.modelConfig.effort !== undefined && { effort: data.modelConfig.effort }),
-        ...(data.modelConfig.provider !== undefined && { provider: data.modelConfig.provider }),
-      };
-    }
+    modelConfig = resolveModelConfig(data.modelConfig) ?? modelConfig;
 
     // Build callback configuration
     // callback_session_id is the single source of truth for where to deliver callbacks.

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -441,7 +441,12 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
                 mode: toolDefaults.modelConfig.mode || 'alias',
                 model: toolDefaults.modelConfig.model || '',
                 updated_at: new Date().toISOString(),
-                effort: toolDefaults.modelConfig.effort,
+                ...(toolDefaults.modelConfig.effort !== undefined && {
+                  effort: toolDefaults.modelConfig.effort,
+                }),
+                ...(toolDefaults.modelConfig.provider !== undefined && {
+                  provider: toolDefaults.modelConfig.provider,
+                }),
               };
             }
           }
@@ -478,7 +483,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         mode: data.modelConfig.mode || 'alias',
         model: data.modelConfig.model || '',
         updated_at: new Date().toISOString(),
-        effort: data.modelConfig.effort,
+        ...(data.modelConfig.effort !== undefined && { effort: data.modelConfig.effort }),
+        ...(data.modelConfig.provider !== undefined && { provider: data.modelConfig.provider }),
       };
     }
 

--- a/context/concepts/mcp-session-tools.md
+++ b/context/concepts/mcp-session-tools.md
@@ -17,9 +17,16 @@ All tools enforce the worktree-centric data model—sessions must point to a wor
 
 ## Implementation Notes
 
-- Tool handlers live in `apps/agor-daemon/src/mcp/routes.ts` (search for `agor_sessions_...`).
+- Tool handlers live in `apps/agor-daemon/src/mcp/tools/sessions.ts` (search for `agor_sessions_...`).
 - Reuses existing services so audit trails, genealogy, and WebSocket broadcasts stay consistent.
-- Tests in `apps/agor-daemon/src/mcp/routes.test.ts` cover prompt continuation, metadata updates, and session creation with initial prompts.
+- Tests in `apps/agor-daemon/src/mcp/tools/sessions.test.ts` cover prompt continuation, metadata updates, session creation with initial prompts, and the `modelConfig` / `mcpServerIds` overrides described below.
+
+## Overrides at create / spawn / subsession time
+
+`agor_sessions_create`, `agor_sessions_spawn`, and `agor_sessions_prompt` (with `mode: "subsession"`) all accept two optional override fields with consistent semantics:
+
+- **`modelConfig`** — pins a specific model for the new session. Shape: `{ model: string, mode?: 'alias' | 'exact', effort?: 'low' | 'medium' | 'high' | 'max', provider?: string }`. `model` is required when the object is provided. When omitted, the session falls back to the user's default `model_config` for that agent. Threaded through to `session.model_config` so the executor actually runs on the requested model (see `packages/executor/src/sdk-handlers/claude/query-builder.ts`).
+- **`mcpServerIds`** — pins which MCP servers attach to the new session. Overrides worktree/parent/user-default inheritance. Pass `[]` for "no MCPs"; omit the field entirely to inherit. When explicitly provided, any attach failures (RBAC denials, deleted server references) surface in the tool's response as `mcpAttachFailures: [{ mcp_server_id, reason }]` instead of being silently logged, so callers can distinguish "stuck silently" from "attached successfully."
 
 ## Usage
 

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -13,3 +13,6 @@ export * from './codex.js';
 
 // Gemini models
 export * from './gemini.js';
+
+// Model config normalization (shared across session-creation paths)
+export * from './resolve-config.js';

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { resolveModelConfig, resolveModelConfigPrecedence } from './resolve-config.js';
+
+describe('resolveModelConfig', () => {
+  const now = new Date('2026-04-23T00:00:00.000Z');
+
+  it('returns undefined when input is undefined', () => {
+    expect(resolveModelConfig(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when input has no model', () => {
+    expect(resolveModelConfig({ mode: 'alias', effort: 'high' }, { now })).toBeUndefined();
+    expect(resolveModelConfig({ model: '' }, { now })).toBeUndefined();
+  });
+
+  it('normalizes a minimal input (defaults mode to alias, stamps updated_at)', () => {
+    expect(resolveModelConfig({ model: 'claude-opus-4-6' }, { now })).toEqual({
+      mode: 'alias',
+      model: 'claude-opus-4-6',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
+  it('preserves explicit mode', () => {
+    expect(
+      resolveModelConfig({ mode: 'exact', model: 'claude-sonnet-4-5-20250929' }, { now })
+    ).toMatchObject({ mode: 'exact' });
+  });
+
+  it('includes effort only when defined (omits the key otherwise)', () => {
+    const withEffort = resolveModelConfig({ model: 'x', effort: 'max' }, { now });
+    expect(withEffort).toHaveProperty('effort', 'max');
+
+    const withoutEffort = resolveModelConfig({ model: 'x' }, { now });
+    expect(withoutEffort).not.toHaveProperty('effort');
+  });
+
+  it('includes provider only when defined (omits the key otherwise)', () => {
+    const withProvider = resolveModelConfig(
+      { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+      { now }
+    );
+    expect(withProvider).toHaveProperty('provider', 'anthropic');
+
+    const withoutProvider = resolveModelConfig({ model: 'claude-sonnet-4-6' }, { now });
+    expect(withoutProvider).not.toHaveProperty('provider');
+  });
+
+  it('stamps updated_at from injected `now` (deterministic)', () => {
+    const pinned = new Date('2000-01-01T12:00:00.000Z');
+    expect(resolveModelConfig({ model: 'x' }, { now: pinned })?.updated_at).toBe(
+      '2000-01-01T12:00:00.000Z'
+    );
+  });
+});
+
+describe('resolveModelConfigPrecedence', () => {
+  const now = new Date('2026-04-23T00:00:00.000Z');
+
+  it('returns the first resolvable source', () => {
+    const explicit = { model: 'claude-opus-4-6', effort: 'max' as const };
+    const userDefault = { model: 'claude-sonnet-4-6', effort: 'medium' as const };
+    const result = resolveModelConfigPrecedence([explicit, userDefault], { now });
+    expect(result?.model).toBe('claude-opus-4-6');
+    expect(result?.effort).toBe('max');
+  });
+
+  it('falls through past sources with no model', () => {
+    const noModel = { mode: 'alias' as const };
+    const userDefault = { model: 'claude-sonnet-4-6' };
+    const result = resolveModelConfigPrecedence([undefined, noModel, userDefault], { now });
+    expect(result?.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('returns undefined when every source is empty', () => {
+    expect(resolveModelConfigPrecedence([undefined, null, { mode: 'alias' }])).toBeUndefined();
+  });
+
+  it('does not mix fields across sources (first-wins, not merge)', () => {
+    // Regression guard: the resolver picks ONE source and normalizes it.
+    // It must NOT fall back to userDefault.effort when explicit has no effort.
+    const explicit = { model: 'claude-opus-4-6' }; // no effort
+    const userDefault = { model: 'claude-sonnet-4-6', effort: 'high' as const };
+    const result = resolveModelConfigPrecedence([explicit, userDefault], { now });
+    expect(result?.model).toBe('claude-opus-4-6');
+    expect(result).not.toHaveProperty('effort');
+  });
+});

--- a/packages/core/src/models/resolve-config.ts
+++ b/packages/core/src/models/resolve-config.ts
@@ -1,0 +1,91 @@
+/**
+ * Model configuration normalization
+ *
+ * Single source of truth for turning a partial model-config input (from an
+ * MCP tool arg, a user default, a worktree setting, etc.) into the canonical
+ * shape persisted on `Session['model_config']`.
+ *
+ * Callers compose these helpers into a precedence chain instead of hand-rolling
+ * the normalization at every session-creation site (MCP create, spawn service,
+ * worktree auto-create, gateway session creation, ...). Centralizing here:
+ *
+ * - Guarantees every site writes the same shape (mode default, updated_at
+ *   stamp, conditional effort/provider inclusion), avoiding drift.
+ * - Makes it safe to add a new optional field (e.g. a future `notes` or
+ *   `temperature`) in exactly one place.
+ * - Returns `undefined` when there is no usable model, so callers can chain
+ *   with `??` or feed a list into `resolveModelConfigPrecedence`.
+ */
+import type { EffortLevel, Session } from '../types/session.js';
+
+/**
+ * Loose input shape accepted by the resolver.
+ *
+ * Mirrors `Session['model_config']` but every field is optional so we can
+ * accept partials from MCP Zod schemas, user/tool defaults, worktree
+ * overrides, and legacy callers — then either normalize or reject them
+ * based on whether `model` is set.
+ */
+export type ModelConfigInput = {
+  mode?: 'alias' | 'exact';
+  model?: string;
+  effort?: EffortLevel;
+  provider?: string;
+};
+
+/**
+ * Canonical persisted shape — a non-null `Session.model_config`.
+ */
+export type ResolvedModelConfig = NonNullable<Session['model_config']>;
+
+/**
+ * Normalize a partial model-config into the shape persisted on
+ * `session.model_config`. Returns `undefined` if no usable `model` was
+ * provided, so callers can fall through to the next source in a precedence
+ * chain.
+ *
+ * Behavior:
+ * - `mode` defaults to `'alias'` (matches every legacy call site).
+ * - `updated_at` is stamped from `opts.now ?? new Date()` (injectable for
+ *   determinism in tests).
+ * - `effort` and `provider` are only included when explicitly defined, so
+ *   we never write `undefined` values onto the persisted object.
+ */
+export function resolveModelConfig(
+  input: ModelConfigInput | undefined | null,
+  opts?: { now?: Date }
+): ResolvedModelConfig | undefined {
+  if (!input?.model) return undefined;
+  return {
+    mode: input.mode ?? 'alias',
+    model: input.model,
+    updated_at: (opts?.now ?? new Date()).toISOString(),
+    ...(input.effort !== undefined && { effort: input.effort }),
+    ...(input.provider !== undefined && { provider: input.provider }),
+  };
+}
+
+/**
+ * Walk a precedence list (highest priority first) and return the first
+ * source that yields a resolvable model config. Mirrors the "explicit arg >
+ * worktree override > user default" pattern used at session-create time.
+ *
+ * Example:
+ * ```ts
+ * const modelConfig = resolveModelConfigPrecedence([
+ *   args.modelConfig,              // explicit MCP arg
+ *   worktree.modelConfig,          // worktree override
+ *   userToolDefaults?.modelConfig, // user default
+ * ]);
+ * ```
+ */
+export function resolveModelConfigPrecedence(
+  sources: Array<ModelConfigInput | undefined | null>,
+  opts?: { now?: Date }
+): ResolvedModelConfig | undefined {
+  for (const src of sources) {
+    const resolved = resolveModelConfig(src, opts);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -523,6 +523,11 @@ export interface SpawnConfig {
     mode?: 'alias' | 'exact';
     model?: string;
     effort?: EffortLevel;
+    /**
+     * Provider ID (OpenCode only, e.g. 'anthropic', 'openai', 'opencode').
+     * Persisted on session.model_config.provider. Ignored for non-OpenCode tools.
+     */
+    provider?: string;
   };
 
   /** Codex sandbox mode (codex only) */


### PR DESCRIPTION
## Summary

Two related bugs in the session-creation path were causing caller-supplied
`model` and `mcpServerId` selections to silently disappear when using the
`agor_sessions_create` / `agor_sessions_spawn` / `agor_sessions_prompt`
(subsession) MCP tools.

## Root cause (per bug)

**Bug 1 — `mcpServerId` doesn't stick.** The input schema does accept
`mcpServerIds` and the handler attaches them via the `session-mcp-servers`
junction table. But when an attach failed (e.g. RBAC denial on a server the
caller could read but not attach), the error was swallowed with
`console.warn`. The session succeeded without the requested server, and
nothing in the response told the caller — it looked like the ID was
silently dropped.

Drop point: `apps/agor-daemon/src/mcp/tools/sessions.ts:844-849` (pre-fix)
— `catch (error) { console.warn(...) }` inside the attach loop.

**Bug 2 — Model selection doesn't carry through.** The MCP tool's Zod input
schema had no `model` or `modelConfig` field at all, so Zod silently stripped
anything the caller sent. The handler built `modelConfig` only from
`userToolDefaults?.modelConfig` — there was no code path for a caller to
override the default. The executor correctly reads `session.model_config.model`
in `packages/executor/src/sdk-handlers/claude/query-builder.ts`, so the
session always ran on whatever the user default was.

Drop point: `apps/agor-daemon/src/mcp/tools/sessions.ts:614-663` (pre-fix) —
no `modelConfig` in the `inputSchema` for `agor_sessions_create`. Same gap in
`agor_sessions_spawn` (~line 414) and `agor_sessions_prompt` subsession mode
(~line 482).

## Fix

- Add a shared `modelConfigInputSchema` and wire it into all three tools.
  For `create`, an explicit `args.modelConfig` now overrides the
  user-default fallback (`sessions.ts:735-762`). For `spawn` /
  `prompt(subsession)`, it threads into `SpawnConfig.modelConfig`, which the
  existing service layer already honors.
- Collect explicit `mcpServerIds` attach failures into a `mcpAttachFailures`
  array on the response and include a warning note in `note`
  (`sessions.ts:830-857`, `875-886`). Preserve the graceful-skip behavior
  for servers inherited from worktree/user defaults so startup doesn't get
  chatty.
- Update tool descriptions so agents can discover both overrides.

## Before / after

Before (Bug 2 repro):
```
agor_execute_tool(tool_name: "agor_sessions_create", arguments: {
  worktreeId: "wt-…", agenticTool: "claude-code",
  modelConfig: { model: "claude-opus-4-6" }
})
→ session.model_config.model === <user default>, not "claude-opus-4-6"
```

After:
```
→ session.model_config.model === "claude-opus-4-6"
→ executor spawns on the requested model
```

Before (Bug 1 repro): calling with a non-attachable `mcpServerIds` returned
a success response with no indication the attach failed.

After: response includes `mcpAttachFailures: [{ mcp_server_id, reason }]`
and a `note` line flagging the count.

## Schema / migration

None. No DB schema changes. The `session.model_config` column and
`session_mcp_servers` junction table already existed — this PR only plugs
caller input into them.

## Test plan

- [x] `pnpm --filter @agor/daemon run typecheck` — clean
- [x] `pnpm --filter @agor/daemon test` — 468 passed, 30 skipped (all
  pre-existing skips)
- [x] New `apps/agor-daemon/src/mcp/tools/sessions.test.ts` — 6 tests
  covering: explicit modelConfig wins over user default; user-default
  fallback preserved; mcpServerIds attached to junction table;
  mcpAttachFailures surfaced for explicit requests; inherited failures stay
  silent; spawn threads modelConfig into SpawnConfig.
- [ ] Smoke test via MCP against a running daemon (out of scope for this
  sandbox — no worktree/board fixtures loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)