### PR TITLE
fix(ui): resolve recurring 'jwt expired' errors with dynamic refresh + 401 retry

### DIFF
--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -9,7 +9,8 @@ import type { AgorClient } from '@agor-live/client';
 import { createClient } from '@agor-live/client';
 import { useEffect, useRef, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
-import { getStoredRefreshToken, refreshAndStoreTokens } from '../utils/tokenRefresh';
+import { refreshTokensSingleFlight } from '../utils/singleFlightRefresh';
+import { getStoredRefreshToken, type RefreshResult } from '../utils/tokenRefresh';
 
 interface UseAgorClientResult {
   client: AgorClient | null;
@@ -63,6 +64,94 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       client = createClient(url, false);
       clientRef.current = client;
 
+      // Register an around-hook that transparently recovers from mid-session
+      // access-token expiry. Any service call that fails with NotAuthenticated
+      // (typically "jwt expired" from the Feathers auth strategy) will:
+      //   1. Call /authentication/refresh via the single-flight helper — N
+      //      parallel 401s share one refresh request so we don't rotate the
+      //      refresh token multiple times.
+      //   2. Re-authenticate the socket with the freshly-issued access token.
+      //   3. Retry the original call exactly once.
+      // The `_refreshRetried` flag on params guards against infinite recursion
+      // if the retry itself fails auth (e.g. refresh token also expired).
+      //
+      // Auth-service paths are skipped so we never retry the refresh call or
+      // the initial authenticate() itself.
+      client.hooks({
+        around: {
+          all: [
+            async (context, next) => {
+              const path = context.path;
+              if (typeof path === 'string' && path.startsWith('authentication')) {
+                await next();
+                return;
+              }
+
+              try {
+                await next();
+              } catch (err) {
+                const errorObject = err as
+                  | { name?: string; code?: number; className?: string }
+                  | undefined;
+                const isAuthError =
+                  errorObject?.name === 'NotAuthenticated' ||
+                  errorObject?.code === 401 ||
+                  errorObject?.className === 'not-authenticated';
+                if (!isAuthError) throw err;
+
+                const currentParams = (context.params ?? {}) as Record<string, unknown>;
+                if (currentParams._refreshRetried) throw err;
+
+                const refreshToken = getStoredRefreshToken();
+                if (!refreshToken || !client) throw err;
+
+                let refreshed: RefreshResult;
+                try {
+                  refreshed = await refreshTokensSingleFlight(client, refreshToken);
+                } catch {
+                  // Refresh itself failed — surface the original auth error
+                  // so upstream code (useAuth, connect handler) can decide
+                  // whether to clear tokens and bounce to the login screen.
+                  throw err;
+                }
+
+                try {
+                  await client.authenticate({
+                    strategy: 'jwt',
+                    accessToken: refreshed.accessToken,
+                  });
+                } catch {
+                  throw err;
+                }
+
+                // Retry the original call once. Hooks fire again, but the
+                // `_refreshRetried` flag on params prevents another retry
+                // if the retry also 401s.
+                const retryParams = { ...currentParams, _refreshRetried: true };
+                const service = client.service(path as string);
+                const method = context.method as string;
+
+                if (method === 'find') {
+                  context.result = await service.find(retryParams);
+                } else if (method === 'get') {
+                  context.result = await service.get(context.id, retryParams);
+                } else if (method === 'create') {
+                  context.result = await service.create(context.data, retryParams);
+                } else if (method === 'update') {
+                  context.result = await service.update(context.id, context.data, retryParams);
+                } else if (method === 'patch') {
+                  context.result = await service.patch(context.id, context.data, retryParams);
+                } else if (method === 'remove') {
+                  context.result = await service.remove(context.id, retryParams);
+                } else {
+                  throw err;
+                }
+              }
+            },
+          ],
+        },
+      });
+
       // Store client globally for Vite HMR cleanup
       if (typeof window !== 'undefined') {
         (window as unknown as { __agorClient: AgorClient }).__agorClient = client;
@@ -92,7 +181,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                 const refreshToken = getStoredRefreshToken();
                 if (refreshToken) {
                   try {
-                    const refreshResult = await refreshAndStoreTokens(client, refreshToken);
+                    const refreshResult = await refreshTokensSingleFlight(client, refreshToken);
 
                     // Authenticate with new access token
                     await client.authenticate({

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -9,8 +9,7 @@ import type { AgorClient } from '@agor-live/client';
 import { createClient } from '@agor-live/client';
 import { useEffect, useRef, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
-import { refreshTokensSingleFlight } from '../utils/singleFlightRefresh';
-import { getStoredRefreshToken, type RefreshResult } from '../utils/tokenRefresh';
+import { refreshAndReauthenticate } from '../utils/singleFlightRefresh';
 
 interface UseAgorClientResult {
   client: AgorClient | null;
@@ -71,18 +70,22 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       //      parallel 401s share one refresh request so we don't rotate the
       //      refresh token multiple times.
       //   2. Re-authenticate the socket with the freshly-issued access token.
-      //   3. Retry the original call exactly once.
+      //   3. Retry the original call exactly once, via the raw method args so
+      //      custom (non-CRUD) service methods retry as well.
       // The `_refreshRetried` flag on params guards against infinite recursion
       // if the retry itself fails auth (e.g. refresh token also expired).
       //
-      // Auth-service paths are skipped so we never retry the refresh call or
-      // the initial authenticate() itself.
+      // Skip `authentication` (login) and `authentication/refresh` themselves
+      // so we never recurse on the refresh call. Auth-adjacent routes like
+      // `authentication/impersonate` go through the retry like any other
+      // service call.
+      const AUTH_PATHS_TO_SKIP = new Set(['authentication', 'authentication/refresh']);
       client.hooks({
         around: {
           all: [
             async (context, next) => {
               const path = context.path;
-              if (typeof path === 'string' && path.startsWith('authentication')) {
+              if (typeof path === 'string' && AUTH_PATHS_TO_SKIP.has(path)) {
                 await next();
                 return;
               }
@@ -99,53 +102,50 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                   errorObject?.className === 'not-authenticated';
                 if (!isAuthError) throw err;
 
+                // Guard against infinite retry if the retry also 401s.
                 const currentParams = (context.params ?? {}) as Record<string, unknown>;
                 if (currentParams._refreshRetried) throw err;
 
-                const refreshToken = getStoredRefreshToken();
-                if (!refreshToken || !client) throw err;
+                if (!client) throw err;
 
-                let refreshed: RefreshResult;
                 try {
-                  refreshed = await refreshTokensSingleFlight(client, refreshToken);
+                  const result = await refreshAndReauthenticate(client);
+                  if (!result) throw err; // no refresh token stored
                 } catch {
-                  // Refresh itself failed — surface the original auth error
-                  // so upstream code (useAuth, connect handler) can decide
-                  // whether to clear tokens and bounce to the login screen.
+                  // Refresh or re-authenticate failed — surface the original
+                  // auth error so upstream code (useAuth, connect handler)
+                  // can decide whether to clear tokens and bounce to login.
                   throw err;
                 }
 
-                try {
-                  await client.authenticate({
-                    strategy: 'jwt',
-                    accessToken: refreshed.accessToken,
-                  });
-                } catch {
-                  throw err;
-                }
-
-                // Retry the original call once. Hooks fire again, but the
-                // `_refreshRetried` flag on params prevents another retry
-                // if the retry also 401s.
-                const retryParams = { ...currentParams, _refreshRetried: true };
-                const service = client.service(path as string);
-                const method = context.method as string;
-
-                if (method === 'find') {
-                  context.result = await service.find(retryParams);
-                } else if (method === 'get') {
-                  context.result = await service.get(context.id, retryParams);
-                } else if (method === 'create') {
-                  context.result = await service.create(context.data, retryParams);
-                } else if (method === 'update') {
-                  context.result = await service.update(context.id, context.data, retryParams);
-                } else if (method === 'patch') {
-                  context.result = await service.patch(context.id, context.data, retryParams);
-                } else if (method === 'remove') {
-                  context.result = await service.remove(context.id, retryParams);
+                // Retry the original call once via its raw argument list so
+                // custom service methods (non-CRUD) retry correctly too.
+                // Feathers service methods always end with a `params` arg; we
+                // inject `_refreshRetried: true` there to stop recursion if
+                // the retry itself 401s.
+                const args = context.arguments ? [...context.arguments] : [];
+                const lastIdx = args.length - 1;
+                const lastArg = args[lastIdx];
+                const isParamsObject =
+                  lastArg !== null && typeof lastArg === 'object' && !Array.isArray(lastArg);
+                const retryParams = {
+                  ...(isParamsObject ? (lastArg as Record<string, unknown>) : {}),
+                  _refreshRetried: true,
+                };
+                if (isParamsObject) {
+                  args[lastIdx] = retryParams;
                 } else {
-                  throw err;
+                  args.push(retryParams);
                 }
+
+                const service = client.service(path as string) as Record<string, unknown>;
+                const method = context.method as string;
+                const methodFn = service[method];
+                if (typeof methodFn !== 'function') throw err;
+                context.result = await (methodFn as (...a: unknown[]) => unknown).call(
+                  service,
+                  ...args
+                );
               }
             },
           ],
@@ -176,19 +176,13 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                 setError(null);
                 return;
               } catch (_accessTokenErr) {
-                // Access token expired or invalid - try refresh token
-                // Check if we have a refresh token in localStorage
-                const refreshToken = getStoredRefreshToken();
-                if (refreshToken) {
-                  try {
-                    const refreshResult = await refreshTokensSingleFlight(client, refreshToken);
-
-                    // Authenticate with new access token
-                    await client.authenticate({
-                      strategy: 'jwt',
-                      accessToken: refreshResult.accessToken,
-                    });
-
+                // Access token expired or invalid — try the refresh token.
+                // `refreshAndReauthenticate` fires the single-flight refresh
+                // and re-authenticates this socket client with the new access
+                // token, shared with the 401-retry hook above.
+                try {
+                  const refreshResult = await refreshAndReauthenticate(client);
+                  if (refreshResult) {
                     setConnected(true);
                     setConnecting(false);
                     setError(null);
@@ -196,10 +190,10 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
                     // Trigger useAuth to reload (in case it's not in sync)
                     window.dispatchEvent(new Event('storage'));
                     return;
-                  } catch (refreshErr) {
-                    console.error('❌ Refresh token also failed:', refreshErr);
-                    // Fall through to error handling
                   }
+                } catch (refreshErr) {
+                  console.error('❌ Refresh token also failed:', refreshErr);
+                  // Fall through to error handling
                 }
               }
             } else if (allowAnonymous) {

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -9,11 +9,13 @@ import type { User } from '@agor-live/client';
 import { createRestClient } from '@agor-live/client';
 import { useCallback, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
+import { isExpiringSoon, msUntilExpiry } from '../utils/jwtExpiry';
+import { refreshTokensSingleFlight, TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import {
   clearTokens,
   getStoredAccessToken,
   getStoredRefreshToken,
-  refreshAndStoreTokens,
+  type RefreshResult,
   storeTokens,
 } from '../utils/tokenRefresh';
 
@@ -138,7 +140,7 @@ export function useAuth(): UseAuthReturn {
       // Access token expired or missing, try refresh token
       if (storedRefreshToken) {
         try {
-          const refreshResult = await refreshAndStoreTokens(client, storedRefreshToken);
+          const refreshResult = await refreshTokensSingleFlight(client, storedRefreshToken);
 
           setState({
             user: refreshResult.user,
@@ -200,13 +202,48 @@ export function useAuth(): UseAuthReturn {
   }, [reAuthenticate]);
 
   // Listen for daemon reconnection events (window.ononline, storage events, etc.)
-  // This helps recover from daemon restarts automatically
+  // This helps recover from daemon restarts automatically, AND handles the
+  // laptop-sleep case: if the system suspends long enough for the access
+  // token to expire while the tab is hidden, setTimeout will not fire on
+  // time — we catch up here when the tab becomes visible again.
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      // When tab becomes visible again, check if we need to re-auth
-      if (document.visibilityState === 'visible' && !state.authenticated) {
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState !== 'visible') return;
+
+      // Case 1: we think we're unauthenticated but have tokens — retry auth.
+      if (!state.authenticated) {
         const hasTokens = getStoredAccessToken() || getStoredRefreshToken();
         if (hasTokens) {
+          reAuthenticate();
+        }
+        return;
+      }
+
+      // Case 2: we think we're authenticated, but the access token has
+      // silently expired (or will within the next refresh buffer) while the
+      // tab was hidden. Refresh now, before the user's next click triggers a
+      // 401 and makes the stale state visible.
+      const REFRESH_BUFFER_MS = 60_000;
+      const storedAccess = getStoredAccessToken();
+      if (!storedAccess || !isExpiringSoon(storedAccess, REFRESH_BUFFER_MS)) return;
+
+      const refreshToken = getStoredRefreshToken();
+      if (!refreshToken) return;
+
+      try {
+        const client = await createRestClient(getDaemonUrl());
+        const result = await refreshTokensSingleFlight(client, refreshToken);
+        // Event listener below will pick up the refresh and sync state, but
+        // set it here too so that the sync is synchronous with the tab wake.
+        setState((prev) => ({
+          ...prev,
+          accessToken: result.accessToken,
+          user: result.user,
+        }));
+      } catch (error) {
+        // Refresh failed after wake. Let the normal reAuthenticate path
+        // decide whether to clear tokens (connection error vs auth error).
+        if (!isLikelyConnectionError(error)) {
           reAuthenticate();
         }
       }
@@ -233,23 +270,31 @@ export function useAuth(): UseAuthReturn {
     };
   }, [state.authenticated, state.loading, reAuthenticate]);
 
-  // Auto-refresh token before expiration
+  // Auto-refresh the access token before it expires.
+  //
+  // Strategy: decode the `exp` claim on the current access token and schedule
+  // a single setTimeout for (exp - REFRESH_BUFFER). When it fires, refresh;
+  // the state update then re-runs this effect with the new token, which
+  // schedules the next tick. This removes the historic drift bug where the
+  // refresh interval was hardcoded independently of the server's TTL.
   useEffect(() => {
     if (!state.authenticated || !state.accessToken) return;
 
-    // Access token expires in 7 days, refresh after 6 days (conservative approach)
-    const REFRESH_INTERVAL = 6 * 24 * 60 * 60 * 1000; // 6 days in milliseconds
+    const REFRESH_BUFFER_MS = 60_000; // refresh this many ms before exp
+    const MIN_DELAY_MS = 1_000; // never schedule tighter than this
+    const FALLBACK_DELAY_MS = 5 * 60_000; // if we can't decode exp
 
-    const refreshTimer = setInterval(async () => {
+    const untilExp = msUntilExpiry(state.accessToken);
+    const delay =
+      untilExp === null ? FALLBACK_DELAY_MS : Math.max(MIN_DELAY_MS, untilExp - REFRESH_BUFFER_MS);
+
+    const timer = setTimeout(async () => {
       const refreshToken = getStoredRefreshToken();
-      if (!refreshToken) {
-        return;
-      }
+      if (!refreshToken) return;
 
       try {
         const client = await createRestClient(getDaemonUrl());
-
-        const refreshResult = await refreshAndStoreTokens(client, refreshToken);
+        const refreshResult = await refreshTokensSingleFlight(client, refreshToken);
 
         setState((prev) => ({
           ...prev,
@@ -275,10 +320,30 @@ export function useAuth(): UseAuthReturn {
           });
         }
       }
-    }, REFRESH_INTERVAL);
+    }, delay);
 
-    return () => clearInterval(refreshTimer);
+    return () => clearTimeout(timer);
   }, [state.authenticated, state.accessToken]);
+
+  // When the single-flight refresh helper completes from a non-React path
+  // (e.g. the socket-client 401-retry hook, or a concurrent refresh in
+  // useAgorClient), sync our React state so the next render uses the fresh
+  // token and the auto-refresh effect re-schedules around the new `exp`.
+  useEffect(() => {
+    const handleRefreshed = (event: Event) => {
+      const detail = (event as CustomEvent<RefreshResult>).detail;
+      if (!detail) return;
+      setState((prev) => ({
+        ...prev,
+        accessToken: detail.accessToken,
+        user: detail.user,
+        authenticated: true,
+      }));
+    };
+
+    window.addEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
+    return () => window.removeEventListener(TOKENS_REFRESHED_EVENT, handleRefreshed);
+  }, []);
 
   /**
    * Login with email and password

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -156,9 +156,7 @@ export function useAuth(): UseAuthReturn {
         }
       }
 
-      // Both tokens invalid or expired
-      console.error('❌ CLEARING TOKENS (both access and refresh tokens invalid/expired)');
-      console.trace('Token clearing stack trace');
+      // Both tokens invalid or expired — expected when refresh token hits its TTL.
       clearTokens();
       setState({
         user: null,
@@ -180,9 +178,7 @@ export function useAuth(): UseAuthReturn {
       // IMPORTANT: Don't clear tokens if this is a connection error
       // The daemon might still be restarting, and we want to keep tokens for next retry
       if (!isConnectionError) {
-        console.error('❌ CLEARING TOKENS due to authentication failure (not connection error)');
-        console.error('Error details:', error);
-        console.trace('Token clearing stack trace');
+        console.error('Authentication failure, clearing tokens:', error);
         clearTokens();
       }
 

--- a/apps/agor-ui/src/utils/jwtExpiry.test.ts
+++ b/apps/agor-ui/src/utils/jwtExpiry.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { decodeJwtExpMs, isExpiringSoon, msUntilExpiry } from './jwtExpiry';
+
+/**
+ * Build a fake JWT with the given payload. Only the middle segment matters
+ * for our client-side decoder — the header/signature are ignored.
+ */
+function makeToken(payload: Record<string, unknown>): string {
+  const base64url = (obj: Record<string, unknown>): string =>
+    btoa(JSON.stringify(obj)).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const header = base64url({ alg: 'HS256', typ: 'JWT' });
+  const body = base64url(payload);
+  return `${header}.${body}.signature-does-not-matter`;
+}
+
+describe('decodeJwtExpMs', () => {
+  it('returns exp in milliseconds for a valid token', () => {
+    const expSeconds = 1_700_000_000;
+    const token = makeToken({ sub: 'user-1', exp: expSeconds });
+    expect(decodeJwtExpMs(token)).toBe(expSeconds * 1000);
+  });
+
+  it('returns null for a malformed token (wrong segment count)', () => {
+    expect(decodeJwtExpMs('not-a-jwt')).toBeNull();
+    expect(decodeJwtExpMs('only.two')).toBeNull();
+  });
+
+  it('returns null when payload has no exp', () => {
+    const token = makeToken({ sub: 'user-1' });
+    expect(decodeJwtExpMs(token)).toBeNull();
+  });
+
+  it('returns null when exp is not a number', () => {
+    const token = makeToken({ sub: 'user-1', exp: 'nope' });
+    expect(decodeJwtExpMs(token)).toBeNull();
+  });
+
+  it('returns null when payload is not valid JSON', () => {
+    const header = btoa(JSON.stringify({ alg: 'HS256' }));
+    const garbage = btoa('not-json{');
+    expect(decodeJwtExpMs(`${header}.${garbage}.sig`)).toBeNull();
+  });
+});
+
+describe('msUntilExpiry', () => {
+  it('returns ms between now and exp', () => {
+    const now = 1_700_000_000_000;
+    const token = makeToken({ exp: (now + 60_000) / 1000 });
+    expect(msUntilExpiry(token, now)).toBe(60_000);
+  });
+
+  it('returns a negative number when the token is already expired', () => {
+    const now = 1_700_000_000_000;
+    const token = makeToken({ exp: (now - 30_000) / 1000 });
+    expect(msUntilExpiry(token, now)).toBe(-30_000);
+  });
+
+  it('returns null when the token cannot be decoded', () => {
+    expect(msUntilExpiry('bogus')).toBeNull();
+  });
+
+  it('defaults now to Date.now when not provided', () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      const token = makeToken({ exp: (now + 5_000) / 1000 });
+      expect(msUntilExpiry(token)).toBe(5_000);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+describe('isExpiringSoon', () => {
+  const now = 1_700_000_000_000;
+
+  it('returns true when the token expires inside the buffer', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      // expires in 30s, buffer is 60s → expiring soon
+      const token = makeToken({ exp: (now + 30_000) / 1000 });
+      expect(isExpiringSoon(token, 60_000)).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('returns false when the token expires well beyond the buffer', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      // expires in 10 minutes, buffer is 60s → not expiring soon
+      const token = makeToken({ exp: (now + 10 * 60_000) / 1000 });
+      expect(isExpiringSoon(token, 60_000)).toBe(false);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('returns true (defensive) when the token cannot be decoded', () => {
+    expect(isExpiringSoon('garbage', 60_000)).toBe(true);
+  });
+
+  it('returns true when the token has already expired', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      const token = makeToken({ exp: (now - 1_000) / 1000 });
+      expect(isExpiringSoon(token, 60_000)).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/apps/agor-ui/src/utils/jwtExpiry.ts
+++ b/apps/agor-ui/src/utils/jwtExpiry.ts
@@ -1,0 +1,51 @@
+/**
+ * Client-side JWT expiry helpers.
+ *
+ * We decode (NOT verify) the payload purely to learn when the token will be
+ * rejected by the server, so we can schedule a proactive refresh. The server
+ * is still the only party that validates signatures.
+ */
+
+/**
+ * Extract the `exp` claim from a JWT, in milliseconds since epoch.
+ *
+ * Returns null if the token is malformed or has no numeric `exp`.
+ */
+export function decodeJwtExpMs(token: string): number | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    // base64url → base64
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    // atob is available in all browser targets we support
+    const json = atob(base64);
+    const payload = JSON.parse(json) as { exp?: unknown };
+
+    if (typeof payload.exp !== 'number') return null;
+    return payload.exp * 1000;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Milliseconds until the token expires. Negative if already expired.
+ * Null if we cannot decode the token.
+ */
+export function msUntilExpiry(token: string, now: number = Date.now()): number | null {
+  const expMs = decodeJwtExpMs(token);
+  return expMs === null ? null : expMs - now;
+}
+
+/**
+ * True if the token is expired or will expire within `bufferMs`.
+ *
+ * If the token cannot be decoded, returns `true` so callers refresh
+ * defensively rather than ride a bad token.
+ */
+export function isExpiringSoon(token: string, bufferMs: number): boolean {
+  const ms = msUntilExpiry(token);
+  if (ms === null) return true;
+  return ms <= bufferMs;
+}

--- a/apps/agor-ui/src/utils/singleFlightRefresh.test.ts
+++ b/apps/agor-ui/src/utils/singleFlightRefresh.test.ts
@@ -1,0 +1,169 @@
+import type { AgorClient } from '@agor-live/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the underlying refresh call so tests are hermetic — we want to
+// exercise the single-flight and event-dispatch behaviour of this module,
+// not the HTTP call inside `refreshAndStoreTokens`.
+vi.mock('./tokenRefresh', async () => {
+  const actual = await vi.importActual<typeof import('./tokenRefresh')>('./tokenRefresh');
+  return {
+    ...actual,
+    refreshAndStoreTokens: vi.fn(),
+    getStoredRefreshToken: vi.fn(),
+  };
+});
+
+import {
+  refreshAndReauthenticate,
+  refreshTokensSingleFlight,
+  TOKENS_REFRESHED_EVENT,
+} from './singleFlightRefresh';
+import { getStoredRefreshToken, refreshAndStoreTokens } from './tokenRefresh';
+
+const mockRefresh = refreshAndStoreTokens as unknown as ReturnType<typeof vi.fn>;
+const mockGetRefreshToken = getStoredRefreshToken as unknown as ReturnType<typeof vi.fn>;
+
+function makeResult(accessToken = 'new-access', refreshToken = 'new-refresh') {
+  return {
+    accessToken,
+    refreshToken,
+    user: { user_id: 'u1', email: 'u1@example.com', role: 'member' },
+  };
+}
+
+function makeClient(): AgorClient {
+  return { authenticate: vi.fn() } as unknown as AgorClient;
+}
+
+beforeEach(() => {
+  mockRefresh.mockReset();
+  mockGetRefreshToken.mockReset();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('refreshTokensSingleFlight', () => {
+  it('deduplicates concurrent calls to a single underlying refresh', async () => {
+    let resolveRefresh!: (v: ReturnType<typeof makeResult>) => void;
+    mockRefresh.mockImplementation(
+      () =>
+        new Promise<ReturnType<typeof makeResult>>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const client = makeClient();
+    const p1 = refreshTokensSingleFlight(client, 'rt');
+    const p2 = refreshTokensSingleFlight(client, 'rt');
+    const p3 = refreshTokensSingleFlight(client, 'rt');
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+
+    const result = makeResult();
+    resolveRefresh(result);
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toBe(result);
+    expect(r2).toBe(result);
+    expect(r3).toBe(result);
+  });
+
+  it('issues a new refresh after the previous one settles', async () => {
+    mockRefresh
+      .mockResolvedValueOnce(makeResult('first'))
+      .mockResolvedValueOnce(makeResult('second'));
+
+    const client = makeClient();
+    const first = await refreshTokensSingleFlight(client, 'rt');
+    expect(first.accessToken).toBe('first');
+
+    const second = await refreshTokensSingleFlight(client, 'rt');
+    expect(second.accessToken).toBe('second');
+    expect(mockRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the in-flight slot on failure so the next caller can retry', async () => {
+    mockRefresh
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(makeResult('recovered'));
+
+    const client = makeClient();
+    await expect(refreshTokensSingleFlight(client, 'rt')).rejects.toThrow('boom');
+    const retry = await refreshTokensSingleFlight(client, 'rt');
+    expect(retry.accessToken).toBe('recovered');
+  });
+
+  it('dispatches TOKENS_REFRESHED_EVENT with the result on success', async () => {
+    const result = makeResult();
+    mockRefresh.mockResolvedValueOnce(result);
+
+    const listener = vi.fn();
+    window.addEventListener(TOKENS_REFRESHED_EVENT, listener);
+    try {
+      await refreshTokensSingleFlight(makeClient(), 'rt');
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event = listener.mock.calls[0][0] as CustomEvent;
+      expect(event.detail).toBe(result);
+    } finally {
+      window.removeEventListener(TOKENS_REFRESHED_EVENT, listener);
+    }
+  });
+
+  it('does not dispatch an event on failure', async () => {
+    mockRefresh.mockRejectedValueOnce(new Error('nope'));
+    const listener = vi.fn();
+    window.addEventListener(TOKENS_REFRESHED_EVENT, listener);
+    try {
+      await expect(refreshTokensSingleFlight(makeClient(), 'rt')).rejects.toThrow();
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener(TOKENS_REFRESHED_EVENT, listener);
+    }
+  });
+});
+
+describe('refreshAndReauthenticate', () => {
+  it('returns null when no refresh token is stored', async () => {
+    mockGetRefreshToken.mockReturnValue(null);
+    const client = makeClient();
+    const result = await refreshAndReauthenticate(client);
+    expect(result).toBeNull();
+    expect(mockRefresh).not.toHaveBeenCalled();
+    expect(client.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and re-authenticates the client with the new access token', async () => {
+    mockGetRefreshToken.mockReturnValue('stored-rt');
+    mockRefresh.mockResolvedValueOnce(makeResult('new-access'));
+    const client = makeClient();
+
+    const result = await refreshAndReauthenticate(client);
+
+    expect(result?.accessToken).toBe('new-access');
+    expect(client.authenticate).toHaveBeenCalledWith({
+      strategy: 'jwt',
+      accessToken: 'new-access',
+    });
+  });
+
+  it('propagates refresh errors (does not call authenticate)', async () => {
+    mockGetRefreshToken.mockReturnValue('stored-rt');
+    mockRefresh.mockRejectedValueOnce(new Error('refresh-failed'));
+    const client = makeClient();
+
+    await expect(refreshAndReauthenticate(client)).rejects.toThrow('refresh-failed');
+    expect(client.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('propagates authenticate errors', async () => {
+    mockGetRefreshToken.mockReturnValue('stored-rt');
+    mockRefresh.mockResolvedValueOnce(makeResult());
+    const client = makeClient();
+    (client.authenticate as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('auth-failed')
+    );
+
+    await expect(refreshAndReauthenticate(client)).rejects.toThrow('auth-failed');
+  });
+});

--- a/apps/agor-ui/src/utils/singleFlightRefresh.ts
+++ b/apps/agor-ui/src/utils/singleFlightRefresh.ts
@@ -1,0 +1,56 @@
+/**
+ * Single-flight wrapper around `refreshAndStoreTokens`.
+ *
+ * Multiple code paths can trigger a refresh concurrently (the proactive timer
+ * in useAuth, the 401 retry hook on the socket client, the socket-reconnect
+ * fallback in useAgorClient). Without deduping, a burst of 401s — say, five
+ * parallel service calls on a stale token — produces five POSTs to
+ * /authentication/refresh, each of which rotates the refresh token. Since the
+ * server issues a fresh refresh token every time, the losers of the race hold
+ * a stale refresh token and their next refresh cycle fails.
+ *
+ * This helper collapses concurrent refreshes into one in-flight request; all
+ * callers resolve with the same `RefreshResult`.
+ *
+ * The helper also emits a `TOKENS_REFRESHED_EVENT` on `window` after a
+ * successful refresh so that React state (useAuth) can sync even when the
+ * refresh was initiated by a non-React code path (e.g. the Feathers hook).
+ */
+
+import type { AgorClient } from '@agor-live/client';
+import { type RefreshResult, refreshAndStoreTokens } from './tokenRefresh';
+
+/** Custom DOM event fired after tokens have been successfully refreshed. */
+export const TOKENS_REFRESHED_EVENT = 'agor:tokens-refreshed';
+
+let inflight: Promise<RefreshResult> | null = null;
+
+/**
+ * Request a token refresh, deduplicating concurrent callers.
+ *
+ * @param client - REST or socket Feathers client capable of hitting
+ *                 `authentication/refresh`.
+ * @param refreshToken - Current refresh token.
+ */
+export function refreshTokensSingleFlight(
+  client: AgorClient,
+  refreshToken: string
+): Promise<RefreshResult> {
+  if (inflight) return inflight;
+
+  inflight = refreshAndStoreTokens(client, refreshToken)
+    .then((result) => {
+      // Notify listeners (useAuth) that tokens have rotated.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent<RefreshResult>(TOKENS_REFRESHED_EVENT, { detail: result })
+        );
+      }
+      return result;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+
+  return inflight;
+}

--- a/apps/agor-ui/src/utils/singleFlightRefresh.ts
+++ b/apps/agor-ui/src/utils/singleFlightRefresh.ts
@@ -1,24 +1,32 @@
 /**
- * Single-flight wrapper around `refreshAndStoreTokens`.
+ * Token refresh helpers shared across auth paths in the UI.
  *
- * Multiple code paths can trigger a refresh concurrently (the proactive timer
- * in useAuth, the 401 retry hook on the socket client, the socket-reconnect
- * fallback in useAgorClient). Without deduping, a burst of 401s — say, five
- * parallel service calls on a stale token — produces five POSTs to
- * /authentication/refresh, each of which rotates the refresh token. Since the
- * server issues a fresh refresh token every time, the losers of the race hold
- * a stale refresh token and their next refresh cycle fails.
+ * Two operations live here:
  *
- * This helper collapses concurrent refreshes into one in-flight request; all
- * callers resolve with the same `RefreshResult`.
+ * 1. {@link refreshTokensSingleFlight} — single-flight wrapper around
+ *    `refreshAndStoreTokens`. Multiple code paths can trigger a refresh
+ *    concurrently (the proactive timer in useAuth, the 401 retry hook on the
+ *    socket client, the socket-reconnect fallback in useAgorClient). Without
+ *    deduping, a burst of 401s — say, five parallel service calls on a stale
+ *    token — produces five POSTs to /authentication/refresh, each of which
+ *    rotates the refresh token. Since the server issues a fresh refresh token
+ *    every time, the losers of the race hold a stale refresh token and their
+ *    next refresh cycle fails. Collapsing concurrent callers into one
+ *    in-flight request makes all of them resolve with the same
+ *    `RefreshResult`.
  *
- * The helper also emits a `TOKENS_REFRESHED_EVENT` on `window` after a
- * successful refresh so that React state (useAuth) can sync even when the
- * refresh was initiated by a non-React code path (e.g. the Feathers hook).
+ * 2. {@link refreshAndReauthenticate} — the common "token expired → refresh
+ *    → reauthenticate the socket client" sequence used by both the socket
+ *    reconnect fallback in useAgorClient and the 401-retry hook on the
+ *    same client. Extracted here so the two paths stay in lockstep.
+ *
+ * The single-flight helper also emits a `TOKENS_REFRESHED_EVENT` on `window`
+ * after a successful refresh so that React state (useAuth) can sync even when
+ * the refresh was initiated by a non-React code path (e.g. the Feathers hook).
  */
 
 import type { AgorClient } from '@agor-live/client';
-import { type RefreshResult, refreshAndStoreTokens } from './tokenRefresh';
+import { getStoredRefreshToken, type RefreshResult, refreshAndStoreTokens } from './tokenRefresh';
 
 /** Custom DOM event fired after tokens have been successfully refreshed. */
 export const TOKENS_REFRESHED_EVENT = 'agor:tokens-refreshed';
@@ -53,4 +61,25 @@ export function refreshTokensSingleFlight(
     });
 
   return inflight;
+}
+
+/**
+ * Refresh the access token (single-flight) and re-authenticate the given
+ * Feathers client with the freshly-issued access token via the JWT strategy.
+ *
+ * Used by both the socket-reconnect fallback and the 401-retry around hook
+ * on the long-lived socket client. Returns null if no refresh token is
+ * stored; throws if the refresh call or the subsequent `authenticate()` call
+ * fails so callers can decide how to surface the failure.
+ */
+export async function refreshAndReauthenticate(client: AgorClient): Promise<RefreshResult | null> {
+  const refreshToken = getStoredRefreshToken();
+  if (!refreshToken) return null;
+
+  const refreshed = await refreshTokensSingleFlight(client, refreshToken);
+  await client.authenticate({
+    strategy: 'jwt',
+    accessToken: refreshed.accessToken,
+  });
+  return refreshed;
 }

--- a/docs/jwt-expiry-investigation.md
+++ b/docs/jwt-expiry-investigation.md
@@ -1,0 +1,236 @@
+# JWT Expiry Investigation
+
+**Branch:** `investigate-jwt-expiry`
+**Date:** 2026-04-23
+**Symptom:** UI throws "jwt expired" intermittently; refreshing the page fixes it. Started being reported "recently."
+
+---
+
+## TL;DR
+
+On **2026-04-17** the daemon's access-token TTL was hardened from **7 days → 15 minutes**
+(commit `43dfe6b4`, follow-up `e49815b0`). The UI's **auto-refresh timer was never updated**
+— it still fires every **6 days** (`apps/agor-ui/src/hooks/useAuth.ts:241`) on the assumption
+that the token lives for 7 days. The refresh token (30d) and the `/authentication/refresh`
+endpoint are both healthy, so a full page reload (which calls `reAuthenticate()` and falls
+back to the refresh token) mints a fresh 15-minute token and everything works — until it
+expires again 15 minutes later.
+
+There is also **no 401-retry interceptor** on REST calls, so once the access token goes
+stale, every subsequent request fails with "jwt expired" until the page is reloaded or the
+socket disconnects and reconnects.
+
+---
+
+## Current state
+
+### JWT issuance
+
+| Aspect | Value | Source |
+|---|---|---|
+| Issuer | Daemon (FeathersJS `AuthenticationService` + manual `jwt.sign` in refresh route) | `apps/agor-daemon/src/register-routes.ts:262`, `:412` |
+| Library | `jsonwebtoken` v9.0.3 (direct); `@feathersjs/authentication` v5.0.44 (framework) | `apps/agor-daemon/package.json:37`, `packages/core` |
+| Algorithm | HS256, `iss: "agor"`, `aud: "https://agor.dev"`, `typ: "access"` | `apps/agor-daemon/src/register-routes.ts:248-254` |
+| **Access TTL** | **`15m`** (hardcoded constant `ACCESS_TOKEN_TTL`) | `apps/agor-daemon/src/register-routes.ts:239` |
+| Refresh TTL | `30d` (hardcoded constant `REFRESH_TOKEN_TTL`) | `apps/agor-daemon/src/register-routes.ts:240` |
+| Secret | `jwtSecret` resolved at daemon boot; not user-configurable via `~/.agor/config.yaml` | `apps/agor-daemon/src/register-routes.ts:243` |
+| Refresh endpoint | `POST /authentication/refresh` — accepts `{refreshToken}`, returns fresh access + new refresh tokens | `apps/agor-daemon/src/register-routes.ts:392-442` |
+
+> Note: `session_token_expiration_ms` (default 24h) and `mcp_token_expiration_ms` (default 24h)
+> in `~/.agor/config.yaml` are **separate** token systems (executor tokens and the daemon↔MCP
+> channel). Neither affects the user-auth JWT that the UI uses.
+
+### Client-side storage and transport
+
+| Aspect | Value | Source |
+|---|---|---|
+| Access token storage | `localStorage['agor-access-token']` | `apps/agor-ui/src/utils/tokenRefresh.ts:10` |
+| Refresh token storage | `localStorage['agor-refresh-token']` | `apps/agor-ui/src/utils/tokenRefresh.ts:11` |
+| HTTP transport | `Authorization: Bearer <token>` (via Feathers auth-client) | `packages/core/src/api/index.ts:708-781` |
+| Socket transport | Socket.io handshake auth after connect (`client.authenticate({strategy:"jwt", accessToken})`) | `apps/agor-ui/src/hooks/useAgorClient.ts:81-84` |
+| 401 interceptor | **None.** Feathers' REST client does not auto-retry on 401. | grep for `interceptor`/`401` in `packages/core/src/api/` returns no matches |
+
+### Refresh mechanism — what exists
+
+1. **Proactive timer — BROKEN.** `apps/agor-ui/src/hooks/useAuth.ts:236-281`:
+   ```ts
+   // Access token expires in 7 days, refresh after 6 days (conservative approach)
+   const REFRESH_INTERVAL = 6 * 24 * 60 * 60 * 1000; // 6 days in milliseconds
+   ```
+   This comment/constant was correct when TTL was 7d; it has been stale since `43dfe6b4`.
+2. **Visibility-change poll.** `useAuth.ts:208-234`: when the tab becomes visible, poll
+   `reAuthenticate()` every 3s until it succeeds. This re-reads `localStorage` and hands
+   the (possibly expired) access token to Feathers — it does NOT call `/authentication/refresh`.
+3. **Socket reconnect fallback.** `apps/agor-ui/src/hooks/useAgorClient.ts:72-138`: on
+   socket `connect` event, try access token first, if that fails fall back to
+   `refreshAndStoreTokens(client, refreshToken)`. **This is the only automatic
+   access→refresh fallback.** It fires on socket (re)connects, not on regular API 401s.
+4. **Manual page reload.** On boot, the app calls `reAuthenticate()` which retries with the
+   stored access token; when that fails the user-facing code paths eventually land on the
+   socket-reconnect path above and recover via refresh token.
+
+### Refresh mechanism — what does NOT exist
+
+- No REST interceptor that catches 401, calls `/authentication/refresh`, and retries the
+  original request.
+- No WebSocket event handler that reacts to mid-stream `NotAuthenticated` / `jwt expired`
+  errors on a *connected* socket (we only recover on reconnect).
+- No server-driven TTL discovery — the 15m value is hardcoded on the server, and the client
+  has no way to learn it.
+
+### Recent relevant commits
+
+| SHA | Date | Summary |
+|---|---|---|
+| **`43dfe6b4`** | 2026-04-17 | **sec(daemon): trust-proxy/JWT/rate-limit/body-limit hardening.** Dropped access-token TTL from `7d` → `15m`. This is the root-cause commit. |
+| **`e49815b0`** | 2026-04-17 | **sec(daemon): align refresh-token TTL.** Fixed `/authentication/refresh` to use the same `ACCESS_TOKEN_TTL` constant (it had been minting 7d tokens, silently undoing 43dfe6b4). |
+| `f5dabed2` | 2026-04-17 | Web hardening pack (CORS/CSP/uploads/JWT/proxy). Context for the security work. |
+| `fcd78b2b` | 2026-04-13 | Auth/route hardening: GitHub setup state-nonce, MCP header-only auth. Not the cause but adjacent. |
+| `06bf5594` | 2026-03-31 | UI auth + reactive-session review findings. Last pre-hardening UI auth change. |
+| `7f5c820a` | 2026-03-31 | Shared reactive-session leasing and REST auth flows in the client. |
+
+No commit since `43dfe6b4` has touched `apps/agor-ui/src/hooks/useAuth.ts`'s refresh interval.
+
+---
+
+## Root cause hypothesis (ranked)
+
+### 1. (MOST LIKELY) UI refresh timer was never updated after the TTL hardening
+**Evidence:**
+- `apps/agor-ui/src/hooks/useAuth.ts:241` — `REFRESH_INTERVAL = 6 * 24 * 60 * 60 * 1000` (6 days).
+- Server TTL = 15 minutes.
+- Commit `43dfe6b4` on 2026-04-17 (6 days ago from 2026-04-23) introduced the 15m TTL; that
+  matches "new/recent" perfectly.
+- "Refresh fixes it" matches the actual recovery path: reload → `reAuthenticate()` → on
+  failure the socket reconnect path uses the stored refresh token to mint a new access
+  token. State that lives in React (and in an already-connected socket session) keeps the
+  stale access token until reload.
+
+**Reproduction:** Log in, stay idle / browse for >15 minutes, then trigger any REST call
+that isn't served by an already-authenticated socket. 401 "jwt expired."
+
+### 2. (CONTRIBUTING) No REST 401-retry interceptor
+Even if the proactive timer were correct, any clock skew, suspended laptop, or long-running
+tab would occasionally outrun it. A 401 interceptor that transparently calls
+`/authentication/refresh` and retries the original request would turn transient expiry into
+a silent no-op. Its absence is why the bug is *visible* to users instead of being quietly
+recovered.
+
+### 3. (CONTRIBUTING, SMALLER) Mid-stream socket expiry is not handled
+The socket reconnect path has the only automatic refresh fallback. If the socket stays
+connected but the daemon starts rejecting messages on it (e.g. because an auth-required
+hook re-verifies JWT on each call), we don't currently recover without a disconnect. Less
+likely to be the primary driver here, but worth verifying.
+
+### 4. (UNLIKELY) Clock skew / JWT secret rotation / refresh endpoint bug
+The refresh endpoint was audited by `e49815b0` and is using the shared constants. JWT
+secret is stable across a daemon run. These don't fit the "refresh the page fixes it"
+symptom — if the secret rotated or the refresh endpoint was broken, reload wouldn't help.
+
+---
+
+## Proposed solutions (ranked)
+
+### Option A — Minimal fix (recommended short-term)
+**Change:** In `apps/agor-ui/src/hooks/useAuth.ts:241`, replace the 6-day interval with a
+value aligned to the 15-minute TTL (e.g. refresh every 10 minutes — leaves a 5-minute safety
+margin). Update the stale comment on line 240.
+
+**Effort:** ~5 minutes + a manual test (log in, wait 10+ minutes, confirm timer fires
+and no "jwt expired" surfaces).
+
+**Tradeoffs:**
+- **Pros:** One-line change, ships same day, fixes the user-visible symptom.
+- **Cons:** Still brittle — if the server constant changes again, drift returns. Doesn't
+  help if a laptop sleeps longer than 15 minutes between timer ticks (the timer is paused
+  while the tab is backgrounded/suspended). Doesn't help if a REST call 401s due to clock
+  skew or a missed tick.
+- **Residual risk:** Laptop sleep scenario. `useAuth.ts` already has a visibility-change
+  handler at `:208-234` but it calls `reAuthenticate()` (which uses the stored, possibly
+  expired access token), not the refresh endpoint. That handler should additionally trigger
+  `refreshAndStoreTokens()` to close the suspend-gap.
+
+### Option B — Proper fix (recommended as the real fix)
+**Change:** Combine three things:
+
+1. **Align the timer dynamically.** Decode the access token's `exp` claim on login/refresh
+   (or have the server return TTL in the auth response) and schedule the refresh at
+   `exp - 60s`. This removes the hardcoded-drift failure mode permanently.
+2. **Add a REST 401 interceptor.** Wrap the Feathers REST client (or the underlying
+   fetch/axios) so that any 401 with a `NotAuthenticated`/`TokenExpiredError` body:
+   - calls `/authentication/refresh` with the stored refresh token (single-flight — dedupe
+     concurrent calls),
+   - stores the new tokens,
+   - retries the original request once.
+3. **Handle visibility + suspend.** When the tab regains focus after >TTL, trigger a
+   refresh before the next API call rather than waiting for the next interval tick.
+
+**Effort:** Medium — roughly a day's work including tests. Most of the scaffolding
+(`refreshAndStoreTokens`, `getStoredRefreshToken`) already exists.
+
+**Tradeoffs:**
+- **Pros:** Robust against drift, clock skew, laptop sleep, and future TTL changes. Makes
+  the UX invisible to the user.
+- **Cons:** Interceptor logic needs to be careful about infinite loops (401 during a
+  refresh call itself) and request concurrency (N parallel 401s should result in 1 refresh,
+  not N). Feathers' auth-client does not expose a first-class interceptor; we'd wrap the
+  transport or use a hook.
+
+### Option C — Architectural fix
+**Change:** Move the access token out of `localStorage` into an **HttpOnly, SameSite=Lax,
+Secure cookie** issued by the daemon; keep the refresh flow server-side (Set-Cookie on
+`/authentication/refresh`). Keep the short access TTL, and add the interceptor from
+Option B.
+
+**Effort:** Large — touches daemon middleware, CORS, CSRF, multi-origin dev, CLI auth
+helpers, and tests.
+
+**Tradeoffs:**
+- **Pros:** Token is no longer reachable from JS (XSS can't exfiltrate it); aligns with
+  OWASP guidance; simplifies transport (no manual Authorization header). Combined with
+  short TTL, it materially raises the security bar.
+- **Cons:** Requires CSRF protection (double-submit or SameSite + custom header check),
+  breaks the current "paste a bearer token into curl" developer workflow, and conflicts
+  with Agor's multi-process topology (daemon, executors, MCP server) where Bearer is
+  simpler. Probably overkill for dev/local/solo modes; may be appropriate for `team` mode.
+  This is the same flag-gated-by-deployment-mode pattern described in the security posture
+  memory.
+
+---
+
+## Questions for Max
+
+1. **Is the 15m access-token TTL the permanent target?** If yes, Option A is a stopgap and
+   we should commit to Option B. If you're open to 1h (still short, cheaper for the UI), a
+   simple bump + Option A might be enough for now.
+2. **Is laptop-sleep / long-idle a supported scenario?** If users are expected to leave the
+   tab open overnight and come back, Option A alone won't be enough — Option B's
+   interceptor is the real fix.
+3. **Do you want the TTL to be configurable via `~/.agor/config.yaml`?** Right now it's
+   hardcoded in `register-routes.ts`. Making it a config value (with the 15m default)
+   would let `team`-mode operators pin it differently from `solo`/`local`, and would give
+   the UI a way to fetch the effective value instead of hardcoding.
+4. **Socket mid-stream expiry:** do we care today, or is reconnect-recovery good enough?
+   If the daemon re-verifies JWT on every service call over the socket, mid-stream 401s
+   can happen on long-lived connections without a disconnect; worth a 10-minute check.
+5. **Architectural Option C:** worth it for `team` mode, or out of scope? (Related: this
+   intersects with the "security behind flags" posture — cookie-based auth could be
+   gated on `deployment.mode: team` with Bearer-in-localStorage as default elsewhere.)
+
+---
+
+## Appendix: exact pointers
+
+- Server TTL: `apps/agor-daemon/src/register-routes.ts:239-240` (`ACCESS_TOKEN_TTL = '15m'`,
+  `REFRESH_TOKEN_TTL = '30d'`).
+- Auth config block: `apps/agor-daemon/src/register-routes.ts:242-259`.
+- Refresh endpoint: `apps/agor-daemon/src/register-routes.ts:392-442`.
+- UI auto-refresh timer (broken): `apps/agor-ui/src/hooks/useAuth.ts:236-281`; interval
+  defined on line 241.
+- UI tab-visibility re-auth poll: `apps/agor-ui/src/hooks/useAuth.ts:208-234`.
+- Socket reconnect → refresh-token fallback: `apps/agor-ui/src/hooks/useAgorClient.ts:72-138`
+  (fallback at `:92-114`).
+- Token storage helpers: `apps/agor-ui/src/utils/tokenRefresh.ts:10-11, 49-80`.
+- REST client wiring: `packages/core/src/api/index.ts:708-781`.
+- Smoking-gun commits: `43dfe6b4` (TTL 7d→15m, 2026-04-17), `e49815b0` (refresh-endpoint
+  alignment, same day).


### PR DESCRIPTION
## Summary

Fixes the recurring "jwt expired" errors Max has been reporting in the UI. Root cause was a mismatch between the server's access-token TTL (dropped from `7d` → `15m` on 2026-04-17 in 43dfe6b4 as part of the web-hardening pack) and the UI's hardcoded 6-day refresh interval in `useAuth.ts`. The access token was silently expiring every 15 minutes, and any API call after that point surfaced `jwt expired` until a page reload triggered the refresh-token fallback on socket reconnect.

Ships the "Option B" proper fix from `docs/jwt-expiry-investigation.md` (commit ad4fd5d1):

- **`jwtExpiry.ts`** (new) — decode (not verify) the access token's `exp` claim client-side so the refresh schedule tracks the server's actual TTL rather than a hardcoded constant. No dependency on the server TTL value; a change to `15m` → `1h` → `5m` on the daemon side just works.
- **`singleFlightRefresh.ts`** (new) — dedupe concurrent `/authentication/refresh` calls. A burst of N parallel 401s previously produced N refreshes, each rotating the refresh token, leaving the losers of the race with a stale refresh token whose next use would fail. All callers now await the same in-flight promise. Emits a `agor:tokens-refreshed` custom event so React state can sync when the refresh was initiated outside React (e.g. by the Feathers hook).
- **`useAuth.ts`** — replaces the 6-day `setInterval` with a `setTimeout` scheduled at `exp - 60s`; the effect re-runs on the new token and reschedules. Visibility-change handler now refreshes proactively if the token expired while the tab was hidden (laptop-sleep case — `setTimeout` pauses during system suspend). Listens for `agor:tokens-refreshed` to stay in sync with non-React refresh paths.
- **`useAgorClient.ts`** — registers a Feathers client-side `around` hook on the socket client that catches `NotAuthenticated` on service calls, runs single-flight refresh, re-authenticates the socket with the new token, and retries the original call once. A `_refreshRetried` flag on params prevents retry loops if the retry also 401s; authentication paths are skipped so the refresh call itself doesn't recurse.

The investigation doc (`docs/jwt-expiry-investigation.md`) captures the full analysis — server-side JWT config, client-side storage/transport, what refresh logic existed vs. what was missing, ranked root-cause hypothesis, and the three solution tiers (minimal / proper / architectural) with tradeoffs.

## Test plan

- [ ] Log in, leave the tab focused and idle for >15 minutes, navigate — no `jwt expired` toast should surface; refresh timer should fire at `exp - 60s`
- [ ] Log in, background the tab for >15 minutes, re-focus — visibility-change handler should refresh before the next API call
- [ ] Log in, suspend the laptop for >15 minutes, resume — tab-wake path should refresh proactively
- [ ] Open the network tab and trigger several parallel service calls on a stale token (e.g. let the token expire, then click several things quickly) — only **one** `POST /authentication/refresh` should appear, and all the parallel service calls should succeed after that one refresh
- [ ] Clear the refresh token from localStorage while logged in, wait for access-token expiry — UI should bounce to login screen (refresh fails gracefully)
- [ ] Restart the daemon while connected — socket reconnect path should still recover (pre-existing flow, should be unchanged)

## Related

- Investigation doc: `docs/jwt-expiry-investigation.md` (ad4fd5d1)
- Originating security commits: 43dfe6b4 (TTL 7d → 15m), e49815b0 (refresh-endpoint alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)