### PR TITLE
feat: add GPT-5.5 support (bump codex cli + openai sdk + model list)

### DIFF
--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -69,7 +69,7 @@
     "@oclif/plugin-help": "^6.2.37",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.120.0",
+    "@openai/codex-sdk": "^0.124.0",
     "@opencode-ai/sdk": "^1.2.15",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -247,7 +247,7 @@
     "@libsql/client": "^0.17.2",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.120.0",
+    "@openai/codex-sdk": "^0.124.0",
     "@opencode-ai/sdk": "^1.2.15",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.14.1",

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -19,7 +19,13 @@ export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
  * Uses `as const satisfies` to preserve literal key types for CodexModel.
  */
 const _CODEX_MODEL_METADATA = {
-  // GPT-5.4 models (newest)
+  // GPT-5.5 models (newest — released 2026-04-23, codename "Spud")
+  'gpt-5.5': {
+    name: 'GPT-5.5',
+    description:
+      "OpenAI's newest frontier model - complex coding, computer use, research. ChatGPT-auth only at launch; API access rolling out.",
+  },
+  // GPT-5.4 models
   'gpt-5.4': {
     name: 'GPT-5.4 (Recommended)',
     description: 'Most capable model - unified coding, reasoning, and computer use',
@@ -112,6 +118,8 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
  * Values mirror OpenAI's public docs (Dec 2025) and fall back to 200k if unknown.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
+  // GPT-5.5 models (400k context in Codex; 1M in API when GA)
+  'gpt-5.5': 400_000,
   // GPT-5.4 models
   'gpt-5.4': 1_050_000,
   'gpt-5.4-mini': 400_000,

--- a/packages/executor/src/sdk-handlers/codex/models.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/models.test.ts
@@ -6,6 +6,7 @@ describe('getCodexContextWindowLimit', () => {
 
   it('returns expected limits for known Codex-compatible models', () => {
     const cases: Array<{ model: string; expected: number }> = [
+      { model: 'gpt-5.5', expected: 400_000 },
       { model: 'gpt-5.4', expected: 1_050_000 },
       { model: 'gpt-5.4-mini', expected: 400_000 },
       { model: 'gpt-5.3-codex', expected: 400_000 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,8 +508,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.120.0
-        version: 0.120.0
+        specifier: ^0.124.0
+        version: 0.124.0
       '@opencode-ai/sdk':
         specifier: ^1.2.15
         version: 1.2.15
@@ -704,8 +704,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.120.0
-        version: 0.120.0
+        specifier: ^0.124.0
+        version: 0.124.0
       '@opencode-ai/sdk':
         specifier: ^1.2.15
         version: 1.2.15
@@ -2810,47 +2810,47 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
-  '@openai/codex-sdk@0.120.0':
-    resolution: {integrity: sha512-Y6y3EyLpSSJjRGqIFxxb1G9X6Hod+B1CnWzGoO7qrg3URPnjBL/DLLQWdZSENU5yIlRjHEQDSu7y1rKBlx+jUA==}
+  '@openai/codex-sdk@0.124.0':
+    resolution: {integrity: sha512-CfL0JRBbjXdR6BdmCtEEWA0Z+7O2+4ZP4rEf+TggyX2kQAWaDDAXPZbgH4iQuGR7hjV/oyr++d7vmheNc2U1Tg==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.120.0':
-    resolution: {integrity: sha512-e2P1Gya3dwsRe9IPOiswVz5JfR700u+/sWCqDc3jkqv2QViPkNiBmZoGhFnZL5jBpKakSjehC4/Fpspg70nHTw==}
+  '@openai/codex@0.124.0':
+    resolution: {integrity: sha512-1EVAuPyAQZ8zIVMw3bPJ6a4R8ifLAZ7LGsOyknj5c2he9AFXVRCmWx12WrdZJ25wcBvOEKt1n1Zx+QAj0EVGbQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.120.0-darwin-arm64':
-    resolution: {integrity: sha512-7CU+I5kBaMuoqfG3xisq0mUWzxoEHvfu34cB8a0KpBiIhAgu12fKpmYgZ4/DvRP6Wm9Fu6LJYKVF5apUHFp8nQ==}
+  '@openai/codex@0.124.0-darwin-arm64':
+    resolution: {integrity: sha512-lnuqeAdl+RjPWsqVZ8rrPskRIOZmzlyr8e5q/wFVEnMPsm9dWgjRW1PKa84UmDSQVOuz9GObF28DEHFyC4A8NA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.120.0-darwin-x64':
-    resolution: {integrity: sha512-d7joNYuwrmd5iIdp/xAE5f8bZT1r82MnmU6Hzgxq3G+xClwEyhxU737ZWnstFSpnZNfxJ5zXCuFUJh4CAkHNtQ==}
+  '@openai/codex@0.124.0-darwin-x64':
+    resolution: {integrity: sha512-Br+VlL83IOu96Urw+mkZ1PQXLsQXGAYEH6kXNt4ULuVt7qAdQY2FKYwIgLLVLl0vpMk8qWxdfdVMqhiu2uCHlg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.120.0-linux-arm64':
-    resolution: {integrity: sha512-sVYY25/URlpZPtb0Q0ryLh+lcq9UTEtHAkdZKa0a/R7mAdyPuhpU9V6jWmxwiUh7s53XZOEVFoKmLfH8YIDWCQ==}
+  '@openai/codex@0.124.0-linux-arm64':
+    resolution: {integrity: sha512-QXafFVQJxPfU1LSCI5afuHsF5evKAcbQpFuKou0Kl241/HG/zYHdwoWj546zH844gJgegIPAxPf36+RSkUsbbA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.120.0-linux-x64':
-    resolution: {integrity: sha512-VcP9B/c/O+EFEgqoetCzvHrLfAdo8vrt09Gx1lJ8ikewctqAuJ/ozj/6wuvlz7XaaK64ib5cge01pOAeCyt2Sg==}
+  '@openai/codex@0.124.0-linux-x64':
+    resolution: {integrity: sha512-cJ4QfQIrz2gkXVWephiGo9JDyD3qLKhvkTTLk7gI8rKd7MZpVXn9/1e7pZCQnJVA7Dk6ocA5G+sxnR78SoIejw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.120.0-win32-arm64':
-    resolution: {integrity: sha512-SAaTQU1XHa1qDnmQldmbyROIY5SiaspF+Cw3ziWeeTgyAET3rWusm4ELOElx6QiY1ugYW5ZD+7AFufS2z1xtpQ==}
+  '@openai/codex@0.124.0-win32-arm64':
+    resolution: {integrity: sha512-oDSI/CQh0kagBwWVPG9EiUBfHiY27ju3LPrjTVZg4VMpVJVNA31JTK8rHMZ6G/2gfNmOl6DMBA6+0ICxSkkshg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.120.0-win32-x64':
-    resolution: {integrity: sha512-zja1GNrbHyOUTvOy5FVMa+rAYIs3m+FOS8rAXftxMEhodMmkMw2O8zcvso657SHhZR0hIEiZ6T70lcyH2YX0mQ==}
+  '@openai/codex@0.124.0-win32-x64':
+    resolution: {integrity: sha512-t+lAwmCWwIWQKk6dKaYetRhQsmA+uDmQy1NLka1xAAv3PlNOH8iNz9Lsisr3qYkBR8Tf7tbQlt+pl9tw/A5mfA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -6893,7 +6893,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -12042,35 +12041,35 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
-  '@openai/codex-sdk@0.120.0':
+  '@openai/codex-sdk@0.124.0':
     dependencies:
-      '@openai/codex': 0.120.0
+      '@openai/codex': 0.124.0
 
-  '@openai/codex@0.120.0':
+  '@openai/codex@0.124.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.120.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.120.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.120.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.120.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.120.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.120.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.124.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.124.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.124.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.124.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.124.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.124.0-win32-x64'
 
-  '@openai/codex@0.120.0-darwin-arm64':
+  '@openai/codex@0.124.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.120.0-darwin-x64':
+  '@openai/codex@0.124.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.120.0-linux-arm64':
+  '@openai/codex@0.124.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.120.0-linux-x64':
+  '@openai/codex@0.124.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.120.0-win32-arm64':
+  '@openai/codex@0.124.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.120.0-win32-x64':
+  '@openai/codex@0.124.0-win32-x64':
     optional: true
 
   '@opencode-ai/sdk@1.2.15': {}


### PR DESCRIPTION
## Summary

OpenAI released GPT-5.5 (codename "Spud") on 2026-04-23. This PR wires it up end-to-end in Agor.

## Version bumps

| Package | Before | After |
|---|---|---|
| `@openai/codex-sdk` (packages/core) | `^0.120.0` | `^0.124.0` |
| `@openai/codex-sdk` (packages/agor-live) | `^0.120.0` | `^0.124.0` |

No separate `codex` CLI is pinned in this repo — only the SDK.

## Model IDs added

- `gpt-5.5` — only the flagship variant was announced. Added with a 400k context limit (matches Codex-surface tier; API GA will expose 1M but is not yet available).

**Not added:** `gpt-5.5-mini`, `gpt-5.5-codex`, `gpt-5.5-pro`. OpenAI's launch post and Codex docs do not confirm these IDs as of 2026-04-23 — did not want to invent model strings. Happy to follow up once OpenAI publishes them.

## Default behavior

**Default unchanged** (`DEFAULT_CODEX_MODEL = 'gpt-5.4'`). Rationale:
- GPT-5.5 released *today*; `@openai/codex-sdk@0.124.0` still bundles `gpt-5.4` as its own default.
- Per OpenAI, GPT-5.5 is currently ChatGPT-auth only in Codex — API-key auth ("coming very soon") isn't GA yet, and I haven't verified which auth path Agor's codex sessions take end-to-end.
- Safer to add the option and let users opt in via the model dropdown; we can flip the default in a follow-up once it's battle-tested.

## Integration sanity

- Model parameter flow through `DEFAULT_CODEX_MODEL` in `packages/executor/src/sdk-handlers/codex/` (prompt-service, codex-tool, normalizer) uses the constant directly — no hardcoded `gpt-5.4` strings.
- UI picker (`apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx`) renders from `CODEX_MODEL_METADATA`, so `gpt-5.5` will appear automatically at the top of the Codex model list.
- No pricing/tokenizer tables in the repo — nothing to update there.
- Did **not** touch the `sessions.create` model-param bug — that's being fixed in a parallel worktree.

## Testing

- [x] `pnpm install` succeeded, lockfile updated.
- [x] `pnpm typecheck` — 9/9 packages pass.
- [x] `pnpm lint` — passes (5 pre-existing warnings unrelated to this change).
- [x] `pnpm vitest run src/sdk-handlers/codex/models.test.ts` — 5/5 pass (added a `gpt-5.5` → 400k case).
- [ ] Live end-to-end run against a Codex session (requires valid ChatGPT auth — not verified here).

## Open questions for Max

1. **Default bump?** Happy to flip `DEFAULT_CODEX_MODEL` to `'gpt-5.5'` in a follow-up — just wanted your call given same-day release + API-auth uncertainty.
2. **Context window.** Set to 400k (Codex tier). OpenAI advertises 1M in the API once GA — should we assume 1M like we did for `gpt-5.4` (1.05M), or keep 400k until we see real-world limits?
3. **Variants.** If you know the exact IDs for any `gpt-5.5-*` sibling models (mini / codex / pro), let me know and I'll add them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)