### PR TITLE
feat: add frontend/backend version-sync banner

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -21,12 +21,10 @@ environment:
   variants:
     sqlite:
       description: Single-user dev with SQLite. No RBAC. Fastest to boot.
-      # AGOR_BUILD_SHA is captured here on the HOST (where git works) and
-      # forwarded into the container — git can't run inside the container
-      # because Agor worktrees use a /app/.git file pointing to a host-side
-      # gitdir that isn't bind-mounted. See loadBuildInfo() in agor-daemon.
+      # AGOR_BUILD_SHA / AGOR_BUILT_AT are injected by Agor's
+      # spawnEnvironmentCommand from the host-side worktree gitdir; no need to
+      # capture them here. See packages/core/src/unix/environment-command-spawn.ts.
       start: >-
-        AGOR_BUILD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         docker compose -p agor-{{worktree.name}} up -d
@@ -43,7 +41,6 @@ environment:
       # docker-compose.override.yml (UID/GID only) and skips the postgres
       # override. Listing both files explicitly replaces that default.
       start: >-
-        AGOR_BUILD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         docker compose
@@ -74,7 +71,6 @@ environment:
         impersonation (each Agor user runs sessions as their own Unix identity).
         Requires the sudoers config shipped under docker/sudoers/.
       start: >-
-        AGOR_BUILD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         AGOR_RBAC_ENABLED=true

--- a/.agor.yml
+++ b/.agor.yml
@@ -21,7 +21,12 @@ environment:
   variants:
     sqlite:
       description: Single-user dev with SQLite. No RBAC. Fastest to boot.
+      # AGOR_BUILD_SHA is captured here on the HOST (where git works) and
+      # forwarded into the container — git can't run inside the container
+      # because Agor worktrees use a /app/.git file pointing to a host-side
+      # gitdir that isn't bind-mounted. See loadBuildInfo() in agor-daemon.
       start: >-
+        AGOR_BUILD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         docker compose -p agor-{{worktree.name}} up -d
@@ -38,6 +43,7 @@ environment:
       # docker-compose.override.yml (UID/GID only) and skips the postgres
       # override. Listing both files explicitly replaces that default.
       start: >-
+        AGOR_BUILD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         docker compose
@@ -68,6 +74,7 @@ environment:
         impersonation (each Agor user runs sessions as their own Unix identity).
         Requires the sudoers config shipped under docker/sudoers/.
       start: >-
+        AGOR_BUILD_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo dev)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         AGOR_RBAC_ENABLED=true

--- a/apps/agor-cli/src/commands/version.ts
+++ b/apps/agor-cli/src/commands/version.ts
@@ -1,0 +1,89 @@
+/**
+ * `agor version` - Print daemon build identity
+ *
+ * Reports the build SHA so operators can verify which deploy is live.
+ * Resolution order mirrors the daemon's loadBuildInfo():
+ *   1. /health (when the daemon is reachable)
+ *   2. <daemon-dist>/.build-info file (offline fallback)
+ *   3. 'dev' (source-mode contributors)
+ */
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getDaemonUrl } from '@agor-live/client/config';
+import { Command } from '@oclif/core';
+import chalk from 'chalk';
+
+interface HealthBuildInfo {
+  buildSha?: string;
+  builtAt?: string | null;
+  version?: string;
+}
+
+export default class Version extends Command {
+  static description = 'Show daemon build SHA + CLI package version';
+
+  static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  async run(): Promise<void> {
+    // 1. Try the running daemon first — this is what the UI sees.
+    const daemonUrl = await getDaemonUrl();
+    const liveInfo = await fetchHealth(daemonUrl);
+    if (liveInfo?.buildSha) {
+      this.log(`${chalk.bold('Daemon (live):')} ${chalk.cyan(liveInfo.buildSha)}`);
+      if (liveInfo.builtAt) this.log(`  built: ${chalk.dim(liveInfo.builtAt)}`);
+      if (liveInfo.version) this.log(`  pkg version: ${chalk.dim(liveInfo.version)}`);
+      this.log(`  source: ${chalk.dim(`/health @ ${daemonUrl}`)}`);
+      return;
+    }
+
+    // 2. Daemon not reachable — fall back to the .build-info file. This works
+    //    in agor-live installs even when the daemon is stopped.
+    const fileInfo = await readBuildInfoFile();
+    if (fileInfo?.sha) {
+      this.log(`${chalk.bold('Daemon (file):')} ${chalk.cyan(fileInfo.sha)}`);
+      if (fileInfo.builtAt) this.log(`  built: ${chalk.dim(fileInfo.builtAt)}`);
+      this.log(`  source: ${chalk.dim('<daemon-dist>/.build-info (daemon not running)')}`);
+      return;
+    }
+
+    // 3. No daemon, no file — this is a source checkout that hasn't been built.
+    this.log(
+      `${chalk.bold('Daemon:')} ${chalk.yellow('dev')} ${chalk.dim('(no .build-info; daemon offline)')}`
+    );
+  }
+}
+
+async function fetchHealth(daemonUrl: string): Promise<HealthBuildInfo | null> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1000);
+    const res = await fetch(`${daemonUrl}/health`, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    return (await res.json()) as HealthBuildInfo;
+  } catch {
+    return null;
+  }
+}
+
+async function readBuildInfoFile(): Promise<{ sha?: string; builtAt?: string | null } | null> {
+  // Look next to the CLI bundle. In agor-live, `cli/` and `daemon/` are
+  // siblings under dist/, so the file lives at ../daemon/.build-info.
+  const cliDir = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(cliDir, '../daemon/.build-info'),
+    join(cliDir, '../../daemon/.build-info'),
+  ];
+  for (const path of candidates) {
+    try {
+      const raw = await readFile(path, 'utf-8');
+      const parsed = JSON.parse(raw) as { sha?: string; builtAt?: string | null };
+      if (parsed.sha) return parsed;
+    } catch {
+      // try next
+    }
+  }
+  return null;
+}

--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/stamp-build-info.mjs",
     "dev": "concurrently -k -n core,daemon -c cyan,green \"pnpm --filter @agor/core dev\" \"./node_modules/.bin/tsx watch --clear-screen=false --ignore 'node_modules/**' src/main.ts\"",
     "dev:daemon-only": "tsx watch --clear-screen=false --ignore 'node_modules/**' src/main.ts",
     "start": "node dist/main.js",

--- a/apps/agor-daemon/scripts/stamp-build-info.mjs
+++ b/apps/agor-daemon/scripts/stamp-build-info.mjs
@@ -11,7 +11,16 @@
  * order:
  *   1. AGOR_BUILD_SHA env (CI / Docker --build-arg)
  *   2. git rev-parse --short HEAD
- *   3. 'unknown' (build still succeeds; loadBuildInfo will fall through)
+ *   3. (none) — skip writing the file entirely
+ *
+ * IMPORTANT: when neither env nor git produces a SHA we DO NOT write a
+ * placeholder. loadBuildInfo() treats any non-empty `.build-info` SHA as
+ * authoritative (see build-info.ts:58), so writing 'unknown' would lock the
+ * daemon to a fake concrete SHA that can never match anything else and
+ * would falsely trigger the out-of-sync banner on every redeploy. By not
+ * writing the file, loadBuildInfo's own fallback chain runs at startup —
+ * its own runtime git attempt, then the 'dev' sentinel which disables the
+ * version check entirely. Both are safer than a poisoned baseline.
  *
  * This file is what loadBuildInfo()'s "file" precedence step (#2) reads at
  * daemon startup. The runtime git fallback (#3 in loadBuildInfo) still
@@ -40,13 +49,20 @@ function resolveSha() {
   } catch {
     // Not a git checkout, or git not installed
   }
-  return { sha: 'unknown', source: 'fallback' };
+  return { sha: null, source: 'fallback' };
 }
 
 const { sha, source } = resolveSha();
-const builtAt = process.env.AGOR_BUILT_AT?.trim() || new Date().toISOString();
 
-mkdirSync(distDir, { recursive: true });
-writeFileSync(outPath, `${JSON.stringify({ sha, builtAt })}\n`);
-
-console.log(`  .build-info: sha=${sha} builtAt=${builtAt} (source=${source})`);
+if (sha === null) {
+  // Intentional: see header comment. Better to skip the file than poison
+  // loadBuildInfo()'s file-step with a bogus 'unknown' SHA.
+  console.log(
+    `  .build-info: skipped (no SHA available; loadBuildInfo will fall through to git/dev)`
+  );
+} else {
+  const builtAt = process.env.AGOR_BUILT_AT?.trim() || new Date().toISOString();
+  mkdirSync(distDir, { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify({ sha, builtAt })}\n`);
+  console.log(`  .build-info: sha=${sha} builtAt=${builtAt} (source=${source})`);
+}

--- a/apps/agor-daemon/scripts/stamp-build-info.mjs
+++ b/apps/agor-daemon/scripts/stamp-build-info.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Stamp dist/.build-info with the current build SHA + timestamp.
+ *
+ * Runs as part of `pnpm --filter @agor/daemon build` (see package.json
+ * `build` script). This is the canonical place that produces .build-info —
+ * packages/agor-live/build.sh no longer writes it; it just `cp -r`s the
+ * daemon's dist (which now includes the file).
+ *
+ * Resolution mirrors loadBuildInfo() (build-info.ts) but in shell-friendly
+ * order:
+ *   1. AGOR_BUILD_SHA env (CI / Docker --build-arg)
+ *   2. git rev-parse --short HEAD
+ *   3. 'unknown' (build still succeeds; loadBuildInfo will fall through)
+ *
+ * This file is what loadBuildInfo()'s "file" precedence step (#2) reads at
+ * daemon startup. The runtime git fallback (#3 in loadBuildInfo) still
+ * exists for source-mode dev where this script may not have run recently.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const distDir = join(scriptDir, '..', 'dist');
+const outPath = join(distDir, '.build-info');
+
+function resolveSha() {
+  const envSha = process.env.AGOR_BUILD_SHA?.trim();
+  if (envSha) return { sha: envSha, source: 'env' };
+  try {
+    const sha = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: scriptDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (sha) return { sha, source: 'git' };
+  } catch {
+    // Not a git checkout, or git not installed
+  }
+  return { sha: 'unknown', source: 'fallback' };
+}
+
+const { sha, source } = resolveSha();
+const builtAt = process.env.AGOR_BUILT_AT?.trim() || new Date().toISOString();
+
+mkdirSync(distDir, { recursive: true });
+writeFileSync(outPath, `${JSON.stringify({ sha, builtAt })}\n`);
+
+console.log(`  .build-info: sha=${sha} builtAt=${builtAt} (source=${source})`);

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -41,6 +41,7 @@ import expressStaticGzip from 'express-static-gzip';
 import { registerHooks } from './register-hooks.js';
 import { registerRoutes } from './register-routes.js';
 import { registerServices } from './register-services.js';
+import { loadBuildInfo } from './setup/build-info.js';
 import { buildCorsConfig, isSandpackOrigin } from './setup/cors.js';
 import {
   initializeAnthropicApiKey,
@@ -58,6 +59,15 @@ import { configureDaemonUrl } from './utils/spawn-executor.js';
 
 // Load daemon version at startup
 const DAEMON_VERSION = await loadDaemonVersion(import.meta.url);
+
+// Resolve build SHA (env > .build-info file > git > 'dev'). UI tabs capture
+// this on first connect and prompt a refresh if a later handshake disagrees.
+const DAEMON_BUILD_INFO = loadBuildInfo(import.meta.url);
+console.log(
+  `🔖 Build: sha=${DAEMON_BUILD_INFO.sha} ` +
+    `builtAt=${DAEMON_BUILD_INFO.builtAt ?? 'unknown'} ` +
+    `(source=${DAEMON_BUILD_INFO.source})`
+);
 
 // Database URL (env vars > config.yaml > defaults)
 const DB_PATH = getDatabaseUrl();
@@ -483,6 +493,10 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     // transport too. Without this the terminal:* relay events would still
     // accept traffic when the HTTP modal is disabled.
     webTerminalEnabled: config.execution?.allow_web_terminal !== false,
+    // Build info for the version-sync banner. Emitted as the `server-info`
+    // welcome event on every connect (and reconnect), so UI tabs can detect
+    // FE/BE drift after a deploy without waiting for the next /health poll.
+    buildInfo: DAEMON_BUILD_INFO,
   });
   app.configure(socketio(socketIOConfig.serverOptions, socketIOConfig.callback));
   configureChannels(app);
@@ -555,6 +569,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     DB_PATH,
     DAEMON_PORT,
     DAEMON_VERSION,
+    DAEMON_BUILD_INFO,
     servicesConfig,
     resolvedSecurity,
     sessionsService: services.sessionsService,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -147,6 +147,12 @@ export interface RegisterRoutesContext {
   DB_PATH: string;
   DAEMON_PORT: number;
   DAEMON_VERSION: string;
+  /**
+   * Resolved build info (sha + builtAt). Surfaced on /health so the UI can
+   * detect FE/BE drift after a deploy. The SHA is the canonical version
+   * signal for the version-sync banner — see setup/build-info.ts.
+   */
+  DAEMON_BUILD_INFO: import('./setup/build-info.js').BuildInfo;
   servicesConfig: DaemonServicesConfig;
   /**
    * Resolved security config (CSP/CORS after defaults+extras+override merge).
@@ -189,6 +195,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     DB_PATH,
     DAEMON_PORT: _DAEMON_PORT,
     DAEMON_VERSION,
+    DAEMON_BUILD_INFO,
     servicesConfig,
     resolvedSecurity,
     sessionsService,
@@ -2703,6 +2710,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         status: 'ok',
         timestamp: Date.now(),
         version: DAEMON_VERSION,
+        // Build identity for the version-sync banner (apps/agor-ui ConnectionStatus).
+        // SHA precedence is resolved at startup — see setup/build-info.ts.
+        // Tabs capture this SHA on first connect and prompt a refresh whenever
+        // a later handshake reports a different value. 'dev' disables the check.
+        buildSha: DAEMON_BUILD_INFO.sha,
+        builtAt: DAEMON_BUILD_INFO.builtAt,
         auth: {
           requireAuth: config.daemon?.requireAuth === true,
           allowAnonymous: allowAnonymous,

--- a/apps/agor-daemon/src/setup/build-info.test.ts
+++ b/apps/agor-daemon/src/setup/build-info.test.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isDevSha, loadBuildInfo } from './build-info';
+
+/**
+ * loadBuildInfo precedence:
+ *   1. AGOR_BUILD_SHA env
+ *   2. .build-info file (next to the daemon entry)
+ *   3. git rev-parse --short HEAD
+ *   4. 'dev'
+ *
+ * We test 1, 2, and 4 deterministically. (3) is environment-dependent so we
+ * cover it implicitly: when env+file are absent inside the temp dir, the
+ * loader either returns a real git SHA (when run from inside this repo) or
+ * 'dev'. Both are valid outcomes; the test only asserts the source label.
+ */
+
+let tmpRoot: string;
+let originalEnv: string | undefined;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'agor-build-info-test-'));
+  originalEnv = process.env.AGOR_BUILD_SHA;
+  delete process.env.AGOR_BUILD_SHA;
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  if (originalEnv === undefined) {
+    delete process.env.AGOR_BUILD_SHA;
+  } else {
+    process.env.AGOR_BUILD_SHA = originalEnv;
+  }
+});
+
+/**
+ * loadBuildInfo() takes an `import.meta.url`-style file URL and walks up two
+ * candidate paths looking for `.build-info`. Build a fake module URL inside
+ * tmpRoot so each test controls its own filesystem.
+ */
+function fakeModuleUrl(): string {
+  // Mirror the dist layout: <tmp>/setup/build-info.js
+  const setupDir = join(tmpRoot, 'setup');
+  mkdirSync(setupDir, { recursive: true });
+  return pathToFileURL(join(setupDir, 'build-info.js')).toString();
+}
+
+describe('loadBuildInfo', () => {
+  it('prefers AGOR_BUILD_SHA env over everything else', () => {
+    process.env.AGOR_BUILD_SHA = 'env12345';
+    process.env.AGOR_BUILT_AT = '2026-04-24T12:00:00Z';
+    // Even with a file present, env wins.
+    writeFileSync(join(tmpRoot, '.build-info'), JSON.stringify({ sha: 'file9999' }));
+
+    const info = loadBuildInfo(fakeModuleUrl());
+    expect(info.sha).toBe('env12345');
+    expect(info.builtAt).toBe('2026-04-24T12:00:00Z');
+    expect(info.source).toBe('env');
+
+    delete process.env.AGOR_BUILT_AT;
+  });
+
+  it('falls back to .build-info file when env is unset', () => {
+    writeFileSync(
+      join(tmpRoot, '.build-info'),
+      JSON.stringify({ sha: 'abc1234', builtAt: '2026-04-23T10:00:00Z' })
+    );
+    const info = loadBuildInfo(fakeModuleUrl());
+    expect(info.sha).toBe('abc1234');
+    expect(info.builtAt).toBe('2026-04-23T10:00:00Z');
+    expect(info.source).toBe('file');
+  });
+
+  it('handles a .build-info file without builtAt', () => {
+    writeFileSync(join(tmpRoot, '.build-info'), JSON.stringify({ sha: 'shaonly' }));
+    const info = loadBuildInfo(fakeModuleUrl());
+    expect(info.sha).toBe('shaonly');
+    expect(info.builtAt).toBeNull();
+    expect(info.source).toBe('file');
+  });
+
+  it('skips a malformed .build-info and falls through', () => {
+    writeFileSync(join(tmpRoot, '.build-info'), 'not json');
+    const info = loadBuildInfo(fakeModuleUrl());
+    // Either git (if test runner happens to have git access from tmp) or dev.
+    // Both are acceptable here; the file itself was rejected.
+    expect(info.source === 'git' || info.source === 'fallback').toBe(true);
+    if (info.source === 'fallback') expect(info.sha).toBe('dev');
+  });
+
+  it("returns 'dev' fallback when nothing is resolvable", () => {
+    // tmpRoot has no .build-info, no env, and is not a git checkout.
+    const info = loadBuildInfo(fakeModuleUrl());
+    if (info.source === 'fallback') {
+      expect(info.sha).toBe('dev');
+      expect(info.builtAt).toBeNull();
+    } else {
+      // Git found one — fine, but at minimum the SHA must be non-empty.
+      expect(info.sha.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isDevSha', () => {
+  it("returns true for 'dev' and falsy values", () => {
+    expect(isDevSha('dev')).toBe(true);
+    expect(isDevSha('')).toBe(true);
+    expect(isDevSha(null)).toBe(true);
+    expect(isDevSha(undefined)).toBe(true);
+  });
+
+  it('returns false for any concrete SHA', () => {
+    expect(isDevSha('abc1234')).toBe(false);
+    expect(isDevSha('deadbeef')).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/setup/build-info.ts
+++ b/apps/agor-daemon/src/setup/build-info.ts
@@ -1,0 +1,98 @@
+/**
+ * Daemon Build Info Loader
+ *
+ * Resolves the daemon's build SHA so the UI can detect FE/BE drift after a
+ * deploy. The SHA is exposed via /health and the socket "welcome" event;
+ * browser tabs capture it on first connect and prompt a refresh whenever a
+ * subsequent handshake reports a different SHA.
+ *
+ * Precedence (first match wins):
+ *   1. process.env.AGOR_BUILD_SHA           — Docker --build-arg, CI
+ *   2. <daemon-dist>/.build-info            — written by packages/agor-live/build.sh
+ *   3. git rev-parse --short HEAD           — local source installs
+ *   4. 'dev'                                — disables the version check entirely
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface BuildInfo {
+  sha: string;
+  builtAt: string | null;
+  /** Where the SHA came from — useful for /health debugging and the CLI. */
+  source: 'env' | 'file' | 'git' | 'fallback';
+}
+
+const FALLBACK_SHA = 'dev';
+
+/**
+ * Resolve the daemon's build SHA + builtAt timestamp.
+ *
+ * Pure function — no app dependency. Synchronous so it can be cached at
+ * module load like loadDaemonVersion().
+ *
+ * @param importMetaUrl - Pass `import.meta.url` so we can locate the dist dir.
+ */
+export function loadBuildInfo(importMetaUrl: string): BuildInfo {
+  // 1. Env wins — set by Docker --build-arg or CI.
+  const envSha = process.env.AGOR_BUILD_SHA?.trim();
+  if (envSha) {
+    return {
+      sha: envSha,
+      builtAt: process.env.AGOR_BUILT_AT?.trim() || null,
+      source: 'env',
+    };
+  }
+
+  // 2. .build-info file written by packages/agor-live/build.sh into the
+  //    daemon dist. The file sits next to the entry point; try both common
+  //    layouts (src/setup/ in dev, dist/ root in agor-live).
+  const currentDir = dirname(fileURLToPath(importMetaUrl));
+  const candidates = [join(currentDir, '../.build-info'), join(currentDir, '../../.build-info')];
+  for (const path of candidates) {
+    try {
+      const raw = readFileSync(path, 'utf-8');
+      const parsed = JSON.parse(raw) as { sha?: unknown; builtAt?: unknown };
+      if (typeof parsed.sha === 'string' && parsed.sha) {
+        return {
+          sha: parsed.sha,
+          builtAt: typeof parsed.builtAt === 'string' ? parsed.builtAt : null,
+          source: 'file',
+        };
+      }
+    } catch {
+      // Try next path
+    }
+  }
+
+  // 3. git rev-parse for local source installs. Use execFileSync (not exec)
+  //    so the path is never interpreted as a shell argument.
+  try {
+    const sha = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: currentDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (sha) {
+      return { sha, builtAt: null, source: 'git' };
+    }
+  } catch {
+    // Not a git checkout, or git not installed
+  }
+
+  // 4. Fallback. The literal string 'dev' is special: the UI treats it as
+  //    "no version check" — handy for source-mode contributors hot-reloading
+  //    the daemon, where the SHA would otherwise change on every commit.
+  return { sha: FALLBACK_SHA, builtAt: null, source: 'fallback' };
+}
+
+/**
+ * True when version-sync banner should be disabled. The UI also short-circuits
+ * on this string, but keeping the helper close to the loader documents the
+ * contract on both sides.
+ */
+export function isDevSha(sha: string | null | undefined): boolean {
+  return !sha || sha === FALLBACK_SHA;
+}

--- a/apps/agor-daemon/src/setup/index.ts
+++ b/apps/agor-daemon/src/setup/index.ts
@@ -6,6 +6,8 @@
  * Phase 2: Configuration builders (swagger, socketio, database)
  */
 
+// Phase 1: Pure functions
+export { type BuildInfo, isDevSha, loadBuildInfo } from './build-info.js';
 export {
   buildCorsConfig,
   type CorsConfigOptions,
@@ -30,5 +32,4 @@ export {
 } from './socketio.js';
 // Phase 2: Configuration builders
 export { configureSwagger, type SwaggerOptions } from './swagger.js';
-// Phase 1: Pure functions
 export { loadDaemonVersion } from './version.js';

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -23,6 +23,7 @@ import type {
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import type { Server, Socket } from 'socket.io';
+import type { BuildInfo } from './build-info.js';
 import type { CorsOrigin } from './cors.js';
 
 /**
@@ -80,6 +81,15 @@ export interface SocketIOOptions {
    * true if omitted.
    */
   webTerminalEnabled?: boolean;
+  /**
+   * Daemon build identity emitted as the `server-info` welcome event on every
+   * (re)connection. UI tabs capture the first value and compare each
+   * subsequent one — a mismatch flips ConnectionStatus into the amber
+   * "out of sync" state. /health carries the same field as a poll fallback.
+   * Optional so unit tests don't have to plumb it; the welcome event is
+   * simply skipped when omitted.
+   */
+  buildInfo?: BuildInfo;
 }
 
 /**
@@ -217,7 +227,7 @@ export function createSocketIOConfig(
   callback: (io: Server) => void;
   getSocketServer: () => Server | null;
 } {
-  const { corsOrigin, jwtSecret, allowAnonymous, credentialsAllowed } = options;
+  const { corsOrigin, jwtSecret, allowAnonymous, credentialsAllowed, buildInfo } = options;
   // Default ON to mirror the daemon-wide default (see register-hooks.ts).
   const webTerminalEnabled = options.webTerminalEnabled !== false;
 
@@ -338,6 +348,18 @@ export function createSocketIOConfig(
       console.log(
         `🔌 Socket.io connection established: ${socket.id} (user: ${user ? user.user_id.substring(0, 8) : 'anonymous'}, total: ${activeConnections})`
       );
+
+      // Welcome event: ship the daemon's build identity so UI tabs can spot
+      // FE/BE drift after a deploy without waiting for the next /health poll.
+      // Emitted BEFORE auth so even login-page tabs (which connect anonymously)
+      // get a baseline SHA on first connect. The UI is the source of truth for
+      // dev-mode short-circuit; we always send what we have.
+      if (buildInfo) {
+        socket.emit('server-info', {
+          buildSha: buildInfo.sha,
+          builtAt: buildInfo.builtAt,
+        });
+      }
 
       // Auto-join per-user room for user-scoped events (OAuth prompts, notifications)
       // Try at connection time (for sockets that authenticate via handshake token)

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -36,6 +36,7 @@ import {
   useAuth,
   useAuthConfig,
   useBoardActions,
+  useServerVersion,
   useSessionActions,
 } from './hooks';
 import { StreamdownDemoPage } from './pages/StreamdownDemoPage';
@@ -129,6 +130,11 @@ function AppContent() {
     accessToken: authenticated ? accessToken : null,
     allowAnonymous: authConfig?.allowAnonymous ?? false,
   });
+
+  // Track FE/BE drift: capture the daemon's build SHA on first handshake and
+  // flip outOfSync when a later handshake disagrees. Surfaced through
+  // ConnectionContext → ConnectionStatus (amber tag with a refresh tooltip).
+  const { outOfSync } = useServerVersion(client);
 
   // Fetch data (only when connected and authenticated)
   // Skip data fetch if user needs to change password - the ForcePasswordChangeModal will handle that
@@ -1201,7 +1207,7 @@ function AppContent() {
   // Render main app
   return (
     <ServicesConfigContext.Provider value={servicesConfig}>
-      <ConnectionProvider value={{ connected, connecting }}>
+      <ConnectionProvider value={{ connected, connecting, outOfSync }}>
         {/* Force Password Change Modal - shown when user.must_change_password is true */}
         <ForcePasswordChangeModal
           open={!!currentUser?.must_change_password}

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -131,10 +131,12 @@ function AppContent() {
     allowAnonymous: authConfig?.allowAnonymous ?? false,
   });
 
-  // Track FE/BE drift: capture the daemon's build SHA on first handshake and
-  // flip outOfSync when a later handshake disagrees. Surfaced through
-  // ConnectionContext → ConnectionStatus (amber tag with a refresh tooltip).
-  const { outOfSync } = useServerVersion(client);
+  // Track FE/BE drift: capture the daemon's build SHA on first load (via
+  // /health) and flip outOfSync when the daemon later reports a different
+  // SHA on socket reconnect. Surfaced through ConnectionContext →
+  // ConnectionStatus (amber tag with a refresh tooltip) and AboutTab (debug
+  // rows). Mounted exactly once so all consumers share the same baseline.
+  const { capturedSha, currentSha, outOfSync } = useServerVersion(client);
 
   // Fetch data (only when connected and authenticated)
   // Skip data fetch if user needs to change password - the ForcePasswordChangeModal will handle that
@@ -1207,7 +1209,7 @@ function AppContent() {
   // Render main app
   return (
     <ServicesConfigContext.Provider value={servicesConfig}>
-      <ConnectionProvider value={{ connected, connecting, outOfSync }}>
+      <ConnectionProvider value={{ connected, connecting, outOfSync, capturedSha, currentSha }}>
         {/* Force Password Change Modal - shown when user.must_change_password is true */}
         <ForcePasswordChangeModal
           open={!!currentUser?.must_change_password}

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -1,6 +1,12 @@
-import { CheckCircleOutlined, LoadingOutlined, WarningOutlined } from '@ant-design/icons';
+import {
+  CheckCircleOutlined,
+  LoadingOutlined,
+  ReloadOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
 import { Space, Tooltip } from 'antd';
 import { useEffect, useState } from 'react';
+import { useConnectionState } from '../../contexts/ConnectionContext';
 import { Tag } from '../Tag';
 
 export interface ConnectionStatusProps {
@@ -13,17 +19,25 @@ export interface ConnectionStatusProps {
  * ConnectionStatus - Shows real-time WebSocket connection status
  *
  * States:
+ * - Out of sync: Amber refresh icon (FE/BE drift after a deploy — supersedes
+ *   Connected and Disconnected; click to hard-reload the tab)
  * - Connected: Green checkmark (only shown briefly after reconnect)
  * - Reconnecting: Yellow spinner (shown during reconnection)
  * - Disconnected: Red warning (shown when connection lost, click to retry)
  *
- * Auto-hides after 3 seconds when connected to reduce visual clutter
+ * Auto-hides after 3 seconds when connected to reduce visual clutter.
+ *
+ * `outOfSync` is read from ConnectionContext (populated by useServerVersion in
+ * App.tsx). It's deliberately checked first — when the daemon's build SHA has
+ * changed under us, refreshing the tab matters more than any other connection
+ * detail. We don't auto-reload (per design); the user clicks.
  */
 export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   connected,
   connecting,
   onRetry,
 }) => {
+  const { outOfSync } = useConnectionState();
   const [showConnected, setShowConnected] = useState(false);
   const [justReconnected, setJustReconnected] = useState(false);
 
@@ -45,6 +59,30 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
       setJustReconnected(true);
     }
   }, [connecting, connected]);
+
+  // Out of sync: backend was redeployed under us. Supersedes both connected
+  // and disconnected — the user needs to refresh, period. No auto-reload.
+  if (outOfSync) {
+    return (
+      <Tooltip title="Backend was updated — click to reload for the latest UI." placement="bottom">
+        <Tag
+          icon={<ReloadOutlined />}
+          color="warning"
+          onClick={() => window.location.reload()}
+          style={{
+            margin: 0,
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+          }}
+        >
+          <Space size={4}>
+            <span>Out of sync — refresh</span>
+          </Space>
+        </Tag>
+      </Tooltip>
+    );
+  }
 
   // Don't show anything when normally connected (reduces clutter)
   if (connected && !connecting && !showConnected) {

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -61,8 +61,8 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   }, [connecting, connected]);
 
   // Out of sync: backend was redeployed under us. Supersedes both connected
-  // and disconnected — the user needs to refresh, period. No auto-reload (we
-  // don't want to nuke a half-typed message or modal). Tooltip surfaces the
+  // and disconnected — the user needs to refresh, period. No auto-reload, since
+  // that would nuke a half-typed message or open modal. Tooltip surfaces the
   // actual SHA diff so the user can see *what* changed before reloading.
   if (outOfSync) {
     const tooltipTitle =

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -37,7 +37,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   connecting,
   onRetry,
 }) => {
-  const { outOfSync } = useConnectionState();
+  const { outOfSync, capturedSha, currentSha } = useConnectionState();
   const [showConnected, setShowConnected] = useState(false);
   const [justReconnected, setJustReconnected] = useState(false);
 
@@ -61,10 +61,16 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   }, [connecting, connected]);
 
   // Out of sync: backend was redeployed under us. Supersedes both connected
-  // and disconnected — the user needs to refresh, period. No auto-reload.
+  // and disconnected — the user needs to refresh, period. No auto-reload (we
+  // don't want to nuke a half-typed message or modal). Tooltip surfaces the
+  // actual SHA diff so the user can see *what* changed before reloading.
   if (outOfSync) {
+    const tooltipTitle =
+      capturedSha && currentSha
+        ? `Daemon was upgraded from ${capturedSha} to ${currentSha} since this tab loaded. Click to reload and pick up the latest UI. Anything unsaved (form text, etc.) will be lost.`
+        : 'Backend was updated — click to reload for the latest UI. Anything unsaved will be lost.';
     return (
-      <Tooltip title="Backend was updated — click to reload for the latest UI." placement="bottom">
+      <Tooltip title={tooltipTitle} placement="bottom">
         <Tag
           icon={<ReloadOutlined />}
           color="warning"

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -6,7 +6,8 @@ import type { AgorClient, UnixUserMode } from '@agor-live/client';
 import { Card, Descriptions, Space, Tag, Tooltip, Typography } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
-import { isOutOfSync, useServerVersion } from '../../hooks/useServerVersion';
+import { useConnectionState } from '../../contexts/ConnectionContext';
+import { isOutOfSync } from '../../hooks/useServerVersion';
 
 // Lazy load particles
 const ParticleBackground = lazy(() =>
@@ -76,10 +77,9 @@ export const AboutTab: React.FC<AboutTabProps> = ({
   const daemonUrl = getDaemonUrl();
   const [detectionMethod, setDetectionMethod] = useState<string>('');
   const [healthInfo, setHealthInfo] = useState<HealthInfo | null>(null);
-  // SHA captured on first connect for this tab (in-memory; resets on reload).
-  // Compared against the live SHA from /health so the user can confirm whether
-  // their tab is in sync with the daemon — same data the banner uses.
-  const { capturedSha } = useServerVersion(client);
+  // SHA captured at tab-load time (resets on hard reload). Provider-owned in
+  // App.tsx via useServerVersion so this and the banner stay in lockstep.
+  const { capturedSha } = useConnectionState();
 
   useEffect(() => {
     // Determine which detection method was used

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -6,6 +6,7 @@ import type { AgorClient, UnixUserMode } from '@agor-live/client';
 import { Card, Descriptions, Space, Tag, Tooltip, Typography } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
+import { isOutOfSync, useServerVersion } from '../../hooks/useServerVersion';
 
 // Lazy load particles
 const ParticleBackground = lazy(() =>
@@ -27,6 +28,10 @@ interface WindowWithAgorConfig extends Window {
 
 interface HealthInfo {
   version?: string;
+  /** Build SHA from /health (canonical version signal — see setup/build-info.ts). */
+  buildSha?: string;
+  /** ISO timestamp from /health, may be null when SHA came from env or git. */
+  builtAt?: string | null;
   database?:
     | string
     | {
@@ -71,6 +76,10 @@ export const AboutTab: React.FC<AboutTabProps> = ({
   const daemonUrl = getDaemonUrl();
   const [detectionMethod, setDetectionMethod] = useState<string>('');
   const [healthInfo, setHealthInfo] = useState<HealthInfo | null>(null);
+  // SHA captured on first connect for this tab (in-memory; resets on reload).
+  // Compared against the live SHA from /health so the user can confirm whether
+  // their tab is in sync with the daemon — same data the banner uses.
+  const { capturedSha } = useServerVersion(client);
 
   useEffect(() => {
     // Determine which detection method was used
@@ -129,6 +138,26 @@ export const AboutTab: React.FC<AboutTabProps> = ({
               )}
               {healthInfo?.version && (
                 <Descriptions.Item label="Version">{healthInfo.version}</Descriptions.Item>
+              )}
+              {healthInfo?.buildSha && (
+                <Descriptions.Item label="Daemon Build">
+                  <code>{healthInfo.buildSha}</code>
+                  {healthInfo.builtAt && (
+                    <Typography.Text type="secondary" style={{ marginLeft: 8 }}>
+                      built {healthInfo.builtAt}
+                    </Typography.Text>
+                  )}
+                </Descriptions.Item>
+              )}
+              {capturedSha && (
+                <Descriptions.Item label="Tab Captured">
+                  <code>{capturedSha}</code>
+                  {isOutOfSync(capturedSha, healthInfo?.buildSha) && (
+                    <Typography.Text type="warning" style={{ marginLeft: 8 }}>
+                      ⚠️ out of sync — refresh to load the latest UI
+                    </Typography.Text>
+                  )}
+                </Descriptions.Item>
               )}
               {healthInfo?.encryption && (
                 <Descriptions.Item label="Encryption">

--- a/apps/agor-ui/src/contexts/ConnectionContext.tsx
+++ b/apps/agor-ui/src/contexts/ConnectionContext.tsx
@@ -5,20 +5,27 @@ import { createContext, useContext } from 'react';
  *
  * Prevents queued actions from flooding the daemon when reconnecting.
  *
- * `outOfSync` is set by useServerVersion when the daemon's build SHA changes
- * mid-session (e.g. after a deploy). It supersedes connected/disconnected in
- * the ConnectionStatus tag — the user is asked to refresh, period.
+ * `outOfSync`, `capturedSha`, and `currentSha` are populated by
+ * useServerVersion in App.tsx and shared with any consumer that needs the
+ * version-drift signal — the ConnectionStatus tag (banner) and the AboutTab
+ * (debug rows). Provider-side ownership ensures every consumer sees the same
+ * captured baseline; mounting useServerVersion in two places would give each
+ * its own independent (and usually empty) capture.
  */
 interface ConnectionContextValue {
   connected: boolean;
   connecting: boolean;
   outOfSync: boolean;
+  capturedSha: string | null;
+  currentSha: string | null;
 }
 
 const ConnectionContext = createContext<ConnectionContextValue>({
   connected: false,
   connecting: false,
   outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
 });
 
 export const ConnectionProvider = ConnectionContext.Provider;

--- a/apps/agor-ui/src/contexts/ConnectionContext.tsx
+++ b/apps/agor-ui/src/contexts/ConnectionContext.tsx
@@ -3,16 +3,22 @@ import { createContext, useContext } from 'react';
 /**
  * ConnectionContext - Global connection state for disabling UI during disconnections
  *
- * Prevents queued actions from flooding the daemon when reconnecting
+ * Prevents queued actions from flooding the daemon when reconnecting.
+ *
+ * `outOfSync` is set by useServerVersion when the daemon's build SHA changes
+ * mid-session (e.g. after a deploy). It supersedes connected/disconnected in
+ * the ConnectionStatus tag — the user is asked to refresh, period.
  */
 interface ConnectionContextValue {
   connected: boolean;
   connecting: boolean;
+  outOfSync: boolean;
 }
 
 const ConnectionContext = createContext<ConnectionContextValue>({
   connected: false,
   connecting: false,
+  outOfSync: false,
 });
 
 export const ConnectionProvider = ConnectionContext.Provider;

--- a/apps/agor-ui/src/hooks/index.ts
+++ b/apps/agor-ui/src/hooks/index.ts
@@ -15,6 +15,7 @@ export * from './useLocalStorage';
 export * from './useMessages';
 export * from './usePermissions';
 export * from './useRecentBoards';
+export * from './useServerVersion';
 export * from './useServicesConfig';
 export * from './useSessionActions';
 export * from './useSettingsRoute';

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -221,13 +221,31 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       });
 
       client.io.on('disconnect', (reason) => {
-        if (mounted) {
-          setConnected(false);
+        if (!mounted) return;
+        setConnected(false);
 
-          // Auto-reconnect if disconnect was due to server restart (not intentional client disconnect)
-          if (reason === 'io server disconnect' || reason === 'transport close') {
-            // Socket.io will auto-reconnect, we just need to re-authenticate when it does
-          }
+        // Reason matters here. Per socket.io docs:
+        //   - 'io server disconnect' fires when the server explicitly closed
+        //     the socket (e.g. graceful shutdown calling io.close()). The
+        //     client will NOT auto-reconnect — we have to kick it manually.
+        //     This was the bug: tsx watch + production graceful restarts both
+        //     hit this path, and the UI got stuck on "Disconnected" until the
+        //     user clicked retry.
+        //   - 'transport close' / 'transport error' / 'ping timeout' fire on
+        //     network-level drops (container crash, wifi flap, etc.). Socket.io
+        //     handles auto-reconnect for these.
+        // In both auto-reconnect paths we flip connecting=true so the UI shows
+        // "Reconnecting" immediately rather than flashing "Disconnected" for
+        // the gap before the first connect_error fires.
+        if (reason === 'io server disconnect') {
+          setConnecting(true);
+          client?.io.connect();
+        } else if (
+          reason === 'transport close' ||
+          reason === 'transport error' ||
+          reason === 'ping timeout'
+        ) {
+          setConnecting(true);
         }
       });
 

--- a/apps/agor-ui/src/hooks/useServerVersion.test.ts
+++ b/apps/agor-ui/src/hooks/useServerVersion.test.ts
@@ -1,5 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEV_SHA, isOutOfSync, useServerVersion } from './useServerVersion';
 
 describe('isOutOfSync', () => {
@@ -54,10 +54,44 @@ function makeMockClient() {
   };
 }
 
+const TEST_URL = 'http://daemon.test:3030';
+
+/**
+ * Mock fetch with a resolvable promise. Returns a `respond` function the test
+ * uses to deliver the /health body, plus a `reject` to simulate an unreachable
+ * daemon. Tests that don't care about the fetch path can leave it pending.
+ */
+function mockFetch() {
+  let resolve!: (value: unknown) => void;
+  let reject!: (err: unknown) => void;
+  const fetchSpy = vi.fn(
+    () =>
+      new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      })
+  );
+  vi.stubGlobal('fetch', fetchSpy);
+  return {
+    fetchSpy,
+    respond: (body: { buildSha?: string }) =>
+      resolve({ ok: true, json: () => Promise.resolve(body) }),
+    fail: () => reject(new Error('fetch failed')),
+  };
+}
+
 describe('useServerVersion', () => {
+  beforeEach(() => {
+    mockFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('captures the first SHA on welcome event and stays stable across reconnects', () => {
     const client = makeMockClient();
-    const { result } = renderHook(() => useServerVersion(client as never));
+    const { result } = renderHook(() => useServerVersion(client as never, TEST_URL));
 
     expect(result.current.capturedSha).toBeNull();
     expect(result.current.outOfSync).toBe(false);
@@ -75,7 +109,7 @@ describe('useServerVersion', () => {
 
   it('flips outOfSync true when a later handshake reports a different SHA', () => {
     const client = makeMockClient();
-    const { result } = renderHook(() => useServerVersion(client as never));
+    const { result } = renderHook(() => useServerVersion(client as never, TEST_URL));
 
     act(() => client.io.emit('server-info', { buildSha: 'abc1234' }));
     expect(result.current.outOfSync).toBe(false);
@@ -88,7 +122,7 @@ describe('useServerVersion', () => {
 
   it('ignores welcome events without a buildSha', () => {
     const client = makeMockClient();
-    const { result } = renderHook(() => useServerVersion(client as never));
+    const { result } = renderHook(() => useServerVersion(client as never, TEST_URL));
 
     act(() => client.io.emit('server-info', {}));
     act(() => client.io.emit('server-info', { buildSha: undefined }));
@@ -98,7 +132,7 @@ describe('useServerVersion', () => {
 
   it('disables comparison when either side is the dev sentinel', () => {
     const client = makeMockClient();
-    const { result } = renderHook(() => useServerVersion(client as never));
+    const { result } = renderHook(() => useServerVersion(client as never, TEST_URL));
 
     act(() => client.io.emit('server-info', { buildSha: 'dev' }));
     act(() => client.io.emit('server-info', { buildSha: 'abc1234' }));
@@ -108,15 +142,65 @@ describe('useServerVersion', () => {
 
   it('unsubscribes on unmount', () => {
     const client = makeMockClient();
-    const { unmount } = renderHook(() => useServerVersion(client as never));
+    const { unmount } = renderHook(() => useServerVersion(client as never, TEST_URL));
     unmount();
     expect(client.io.off).toHaveBeenCalledWith('server-info', expect.any(Function));
   });
 
-  it('is a no-op when client is null', () => {
-    const { result } = renderHook(() => useServerVersion(null));
+  it('still seeds capturedSha via /health when client is null', async () => {
+    const fetchMock = mockFetch();
+    const { result } = renderHook(() => useServerVersion(null, TEST_URL));
+
     expect(result.current.capturedSha).toBeNull();
-    expect(result.current.currentSha).toBeNull();
+    fetchMock.respond({ buildSha: 'health1234' });
+
+    await waitFor(() => {
+      expect(result.current.capturedSha).toBe('health1234');
+    });
+    expect(result.current.currentSha).toBe('health1234');
+    expect(result.current.outOfSync).toBe(false);
+    expect(fetchMock.fetchSpy).toHaveBeenCalledWith(
+      `${TEST_URL}/health`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('seeds the baseline from /health BEFORE the socket emits a different SHA (regression)', async () => {
+    // The original bug: client was null on first render so the listener wasn't
+    // attached, the welcome event fired and was missed, and the next welcome
+    // event after a deploy was captured AS the baseline (no banner). The fetch
+    // path means we now capture the pre-deploy SHA even with a null client.
+    const fetchMock = mockFetch();
+    const client = makeMockClient();
+    const { result, rerender } = renderHook(
+      ({ c }: { c: ReturnType<typeof makeMockClient> | null }) =>
+        useServerVersion(c as never, TEST_URL),
+      { initialProps: { c: null } }
+    );
+
+    fetchMock.respond({ buildSha: 'pre-deploy' });
+    await waitFor(() => {
+      expect(result.current.capturedSha).toBe('pre-deploy');
+    });
+
+    // Now the client comes alive (auth completed) and a reconnect emits the
+    // post-deploy SHA. Banner should fire.
+    rerender({ c: client });
+    act(() => client.io.emit('server-info', { buildSha: 'post-deploy' }));
+
+    expect(result.current.capturedSha).toBe('pre-deploy');
+    expect(result.current.currentSha).toBe('post-deploy');
+    expect(result.current.outOfSync).toBe(true);
+  });
+
+  it('handles /health fetch failures gracefully (no baseline, but no crash)', async () => {
+    const fetchMock = mockFetch();
+    const { result } = renderHook(() => useServerVersion(null, TEST_URL));
+
+    fetchMock.fail();
+    // Give the rejected promise a microtask to settle.
+    await Promise.resolve();
+    expect(result.current.capturedSha).toBeNull();
     expect(result.current.outOfSync).toBe(false);
   });
 });

--- a/apps/agor-ui/src/hooks/useServerVersion.test.ts
+++ b/apps/agor-ui/src/hooks/useServerVersion.test.ts
@@ -1,0 +1,122 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DEV_SHA, isOutOfSync, useServerVersion } from './useServerVersion';
+
+describe('isOutOfSync', () => {
+  it('returns false when either SHA is missing (unknown is never out-of-sync)', () => {
+    expect(isOutOfSync(null, 'abc')).toBe(false);
+    expect(isOutOfSync('abc', null)).toBe(false);
+    expect(isOutOfSync(undefined, 'abc')).toBe(false);
+    expect(isOutOfSync('abc', undefined)).toBe(false);
+    expect(isOutOfSync('', 'abc')).toBe(false);
+    expect(isOutOfSync('abc', '')).toBe(false);
+  });
+
+  it('returns false when either SHA is the dev sentinel', () => {
+    expect(isOutOfSync(DEV_SHA, 'abc1234')).toBe(false);
+    expect(isOutOfSync('abc1234', DEV_SHA)).toBe(false);
+    expect(isOutOfSync(DEV_SHA, DEV_SHA)).toBe(false);
+  });
+
+  it('returns false when SHAs match', () => {
+    expect(isOutOfSync('abc1234', 'abc1234')).toBe(false);
+  });
+
+  it('returns true ONLY when both SHAs are concrete and disagree', () => {
+    expect(isOutOfSync('abc1234', 'def5678')).toBe(true);
+  });
+});
+
+/**
+ * Mock io client just enough to drive the `server-info` listener. The hook
+ * only touches `client.io.on` / `client.io.off`, so we don't need socket.io.
+ */
+function makeMockClient() {
+  const listeners = new Map<string, Array<(arg: unknown) => void>>();
+  return {
+    io: {
+      on: vi.fn((event: string, fn: (arg: unknown) => void) => {
+        const arr = listeners.get(event) ?? [];
+        arr.push(fn);
+        listeners.set(event, arr);
+      }),
+      off: vi.fn((event: string, fn: (arg: unknown) => void) => {
+        const arr = listeners.get(event) ?? [];
+        listeners.set(
+          event,
+          arr.filter((f) => f !== fn)
+        );
+      }),
+      emit: (event: string, payload: unknown) => {
+        for (const fn of listeners.get(event) ?? []) fn(payload);
+      },
+    },
+  };
+}
+
+describe('useServerVersion', () => {
+  it('captures the first SHA on welcome event and stays stable across reconnects', () => {
+    const client = makeMockClient();
+    const { result } = renderHook(() => useServerVersion(client as never));
+
+    expect(result.current.capturedSha).toBeNull();
+    expect(result.current.outOfSync).toBe(false);
+
+    act(() => client.io.emit('server-info', { buildSha: 'abc1234' }));
+    expect(result.current.capturedSha).toBe('abc1234');
+    expect(result.current.currentSha).toBe('abc1234');
+    expect(result.current.outOfSync).toBe(false);
+
+    // Reconnect with same SHA — capture stays put, no banner.
+    act(() => client.io.emit('server-info', { buildSha: 'abc1234' }));
+    expect(result.current.capturedSha).toBe('abc1234');
+    expect(result.current.outOfSync).toBe(false);
+  });
+
+  it('flips outOfSync true when a later handshake reports a different SHA', () => {
+    const client = makeMockClient();
+    const { result } = renderHook(() => useServerVersion(client as never));
+
+    act(() => client.io.emit('server-info', { buildSha: 'abc1234' }));
+    expect(result.current.outOfSync).toBe(false);
+
+    act(() => client.io.emit('server-info', { buildSha: 'def5678' }));
+    expect(result.current.capturedSha).toBe('abc1234'); // baseline unchanged
+    expect(result.current.currentSha).toBe('def5678');
+    expect(result.current.outOfSync).toBe(true);
+  });
+
+  it('ignores welcome events without a buildSha', () => {
+    const client = makeMockClient();
+    const { result } = renderHook(() => useServerVersion(client as never));
+
+    act(() => client.io.emit('server-info', {}));
+    act(() => client.io.emit('server-info', { buildSha: undefined }));
+    expect(result.current.capturedSha).toBeNull();
+    expect(result.current.outOfSync).toBe(false);
+  });
+
+  it('disables comparison when either side is the dev sentinel', () => {
+    const client = makeMockClient();
+    const { result } = renderHook(() => useServerVersion(client as never));
+
+    act(() => client.io.emit('server-info', { buildSha: 'dev' }));
+    act(() => client.io.emit('server-info', { buildSha: 'abc1234' }));
+    // Captured was 'dev' → comparison short-circuits to false.
+    expect(result.current.outOfSync).toBe(false);
+  });
+
+  it('unsubscribes on unmount', () => {
+    const client = makeMockClient();
+    const { unmount } = renderHook(() => useServerVersion(client as never));
+    unmount();
+    expect(client.io.off).toHaveBeenCalledWith('server-info', expect.any(Function));
+  });
+
+  it('is a no-op when client is null', () => {
+    const { result } = renderHook(() => useServerVersion(null));
+    expect(result.current.capturedSha).toBeNull();
+    expect(result.current.currentSha).toBeNull();
+    expect(result.current.outOfSync).toBe(false);
+  });
+});

--- a/apps/agor-ui/src/hooks/useServerVersion.test.ts
+++ b/apps/agor-ui/src/hooks/useServerVersion.test.ts
@@ -203,4 +203,64 @@ describe('useServerVersion', () => {
     expect(result.current.capturedSha).toBeNull();
     expect(result.current.outOfSync).toBe(false);
   });
+
+  it('polls /health on the configured interval and flips outOfSync on drift', async () => {
+    // Drive each fetch with its own resolver so we can return different SHAs
+    // across polls without races. Real socket reconnect is irrelevant here —
+    // this exercises the poll-only path that catches deploys while the socket
+    // stays connected.
+    const responders: Array<(body: { buildSha: string }) => void> = [];
+    const fetchSpy = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          responders.push((body) =>
+            resolve({ ok: true, json: () => Promise.resolve(body) } as never)
+          );
+        })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      const { result } = renderHook(() => useServerVersion(null, TEST_URL, 1000));
+
+      // Initial fetch fires immediately on mount.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      responders[0]({ buildSha: 'first-sha' });
+      await waitFor(() => {
+        expect(result.current.capturedSha).toBe('first-sha');
+      });
+
+      // Advance past the interval — the poll should fire a second fetch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      responders[1]({ buildSha: 'second-sha' });
+      await waitFor(() => {
+        expect(result.current.currentSha).toBe('second-sha');
+      });
+      expect(result.current.capturedSha).toBe('first-sha');
+      expect(result.current.outOfSync).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('disables polling when pollIntervalMs is 0', async () => {
+    const fetchMock = mockFetch();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderHook(() => useServerVersion(null, TEST_URL, 0));
+      // Initial fetch fires once.
+      expect(fetchMock.fetchSpy).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+      // Still one — no interval was set up.
+      expect(fetchMock.fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/agor-ui/src/hooks/useServerVersion.ts
+++ b/apps/agor-ui/src/hooks/useServerVersion.ts
@@ -36,6 +36,14 @@ import { getDaemonUrl } from '../config/daemon';
 export const DEV_SHA = 'dev';
 
 /**
+ * How often to re-poll /health for drift after the initial baseline. 60s
+ * catches deploys quickly without being wasteful — /health is a tiny JSON
+ * response. The socket `server-info` event still fires on reconnect; this
+ * just covers the case where the socket stays connected through a deploy.
+ */
+export const DEFAULT_POLL_INTERVAL_MS = 60_000;
+
+/**
  * Pure comparison helper. Exposed for testing.
  *
  * Returns true ONLY when both values are concrete, non-empty SHAs and they
@@ -80,10 +88,14 @@ export interface UseServerVersionResult {
  *   from a direct /health fetch and does not require the client.
  * @param daemonUrl Override the URL probed for /health. Defaults to the
  *   resolved daemon URL. Exposed for tests.
+ * @param pollIntervalMs How often to re-fetch /health to catch drift when the
+ *   socket stays connected through a deploy. Pass 0 to disable. Exposed for
+ *   tests.
  */
 export function useServerVersion(
   client: AgorClient | null,
-  daemonUrl: string = getDaemonUrl()
+  daemonUrl: string = getDaemonUrl(),
+  pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS
 ): UseServerVersionResult {
   const [capturedSha, setCapturedSha] = useState<string | null>(null);
   const [currentSha, setCurrentSha] = useState<string | null>(null);
@@ -104,25 +116,36 @@ export function useServerVersion(
     }
   }, []);
 
-  // Initial baseline: fetch /health on mount. This runs regardless of socket
-  // state and guarantees we capture the SHA the daemon is running RIGHT NOW,
-  // before the daemon ever has a chance to be rebuilt under us. Without this,
-  // we'd race the welcome event and usually lose (see top-of-file comment).
+  // Initial baseline + periodic poll: fetch /health on mount and then every
+  // pollIntervalMs. The mount fetch guarantees we capture the SHA the daemon
+  // is running RIGHT NOW (without it we'd race the welcome event — see
+  // top-of-file). The poll covers the case where a deploy happens while the
+  // socket stays connected, so server-info never re-fires.
   useEffect(() => {
     const controller = new AbortController();
-    fetch(`${daemonUrl.replace(/\/$/, '')}/health`, { signal: controller.signal })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((body: { buildSha?: string } | null) => {
-        if (typeof body?.buildSha === 'string') recordSha(body.buildSha);
-      })
-      .catch(() => {
-        // Daemon unreachable on first load — no baseline. The socket listener
-        // below will pick up the SHA on the first real connection. This is
-        // acceptable because if the daemon was unreachable at load time, the
-        // tab couldn't have rendered against a stale SHA anyway.
-      });
-    return () => controller.abort();
-  }, [daemonUrl, recordSha]);
+    const base = daemonUrl.replace(/\/$/, '');
+
+    const fetchOnce = () => {
+      fetch(`${base}/health`, { signal: controller.signal })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((body: { buildSha?: string } | null) => {
+          if (typeof body?.buildSha === 'string') recordSha(body.buildSha);
+        })
+        .catch(() => {
+          // Daemon unreachable — no-op. If this is the first call we just
+          // have no baseline yet; the socket listener will fill it in. If
+          // it's a poll, we keep the previously-known currentSha.
+        });
+    };
+
+    fetchOnce();
+    const interval = pollIntervalMs > 0 ? setInterval(fetchOnce, pollIntervalMs) : null;
+
+    return () => {
+      controller.abort();
+      if (interval !== null) clearInterval(interval);
+    };
+  }, [daemonUrl, pollIntervalMs, recordSha]);
 
   // Live updates: a fresh socket connection (e.g. after the daemon is
   // rebuilt and clients reconnect) emits server-info, which lets us see the

--- a/apps/agor-ui/src/hooks/useServerVersion.ts
+++ b/apps/agor-ui/src/hooks/useServerVersion.ts
@@ -1,10 +1,19 @@
 /**
  * useServerVersion - Detect frontend/backend version drift after a deploy.
  *
- * Captures the daemon's build SHA on first successful connect (in-memory,
- * per tab) and compares against subsequent values seen on the `server-info`
- * welcome event. A mismatch flips `outOfSync` true, which ConnectionStatus
- * surfaces as an amber "refresh to load latest" tag.
+ * Captures the daemon's build SHA on first load (in-memory, per tab) via a
+ * direct GET /health, then watches the `server-info` welcome event on every
+ * subsequent socket reconnect. If a later SHA disagrees, `outOfSync` flips
+ * true and ConnectionStatus surfaces an amber "refresh to load latest" tag.
+ *
+ * Why /health *and* the socket event: the welcome event fires inside the
+ * daemon's `io.on('connection', ...)` immediately when the socket connects.
+ * useAgorClient stores the client in a ref and only triggers re-renders via
+ * state, so by the time this hook re-runs with a non-null client and attaches
+ * its listener, the initial welcome event has already been fired and missed.
+ * The /health fetch sidesteps the timing entirely — it doesn't need the
+ * client and runs on mount. The socket listener still matters for capturing
+ * the *new* SHA after the daemon is rebuilt while the tab is open.
  *
  * Source-of-truth: daemon-only. The frontend never bakes its own SHA — the
  * baseline only resets on hard reload, which is exactly the signal we want.
@@ -14,13 +23,14 @@
  * absent in source installs), comparison is disabled. Otherwise contributors
  * hot-reloading the daemon would see the banner on every commit.
  *
- * Grace: outOfSync only flips true after a successful handshake confirms
- * the mismatch — never during a transient reconnect, since the welcome event
- * only arrives on a real connection.
+ * Grace: outOfSync only flips true after a successful response confirms the
+ * mismatch — never during a transient reconnect, since both /health and the
+ * welcome event only deliver values on a real, healthy connection.
  */
 
 import type { AgorClient } from '@agor-live/client';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getDaemonUrl } from '../config/daemon';
 
 /** SHA value treated as "no version check" — see setup/build-info.ts. */
 export const DEV_SHA = 'dev';
@@ -63,36 +73,72 @@ export interface UseServerVersionResult {
 }
 
 /**
- * Subscribe to the daemon's `server-info` welcome event and track drift.
+ * Track the daemon's build SHA against the SHA captured at tab-load time.
  *
- * @param client The Agor client instance (null while connecting / logged out).
+ * @param client The Agor client (null while connecting / logged out). Used
+ *   only for the post-load `server-info` listener; the initial baseline comes
+ *   from a direct /health fetch and does not require the client.
+ * @param daemonUrl Override the URL probed for /health. Defaults to the
+ *   resolved daemon URL. Exposed for tests.
  */
-export function useServerVersion(client: AgorClient | null): UseServerVersionResult {
+export function useServerVersion(
+  client: AgorClient | null,
+  daemonUrl: string = getDaemonUrl()
+): UseServerVersionResult {
   const [capturedSha, setCapturedSha] = useState<string | null>(null);
   const [currentSha, setCurrentSha] = useState<string | null>(null);
-  // Track captured value via ref so the listener closure doesn't capture a
-  // stale empty baseline. setState is async; the next welcome event after
-  // capture would otherwise still see capturedSha === null.
+  // Track captured value via ref so updates from /health and the socket
+  // listener don't race each other. setState is async; without the ref, two
+  // near-simultaneous updates could both see capturedSha === null and the
+  // second would clobber the first.
   const capturedShaRef = useRef<string | null>(null);
 
+  // Stable so both effects below can reference it without churning their
+  // dependency lists. Only uses the ref + setters, none of which change.
+  const recordSha = useCallback((sha: string | null) => {
+    if (!sha) return;
+    setCurrentSha(sha);
+    if (capturedShaRef.current === null) {
+      capturedShaRef.current = sha;
+      setCapturedSha(sha);
+    }
+  }, []);
+
+  // Initial baseline: fetch /health on mount. This runs regardless of socket
+  // state and guarantees we capture the SHA the daemon is running RIGHT NOW,
+  // before the daemon ever has a chance to be rebuilt under us. Without this,
+  // we'd race the welcome event and usually lose (see top-of-file comment).
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`${daemonUrl.replace(/\/$/, '')}/health`, { signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((body: { buildSha?: string } | null) => {
+        if (typeof body?.buildSha === 'string') recordSha(body.buildSha);
+      })
+      .catch(() => {
+        // Daemon unreachable on first load — no baseline. The socket listener
+        // below will pick up the SHA on the first real connection. This is
+        // acceptable because if the daemon was unreachable at load time, the
+        // tab couldn't have rendered against a stale SHA anyway.
+      });
+    return () => controller.abort();
+  }, [daemonUrl, recordSha]);
+
+  // Live updates: a fresh socket connection (e.g. after the daemon is
+  // rebuilt and clients reconnect) emits server-info, which lets us see the
+  // *new* SHA without the user touching anything.
   useEffect(() => {
     if (!client?.io) return;
 
     const handler = (info: ServerInfoEvent) => {
-      const sha = typeof info?.buildSha === 'string' ? info.buildSha : null;
-      if (!sha) return;
-      setCurrentSha(sha);
-      if (capturedShaRef.current === null) {
-        capturedShaRef.current = sha;
-        setCapturedSha(sha);
-      }
+      if (typeof info?.buildSha === 'string') recordSha(info.buildSha);
     };
 
     client.io.on('server-info', handler);
     return () => {
       client.io.off('server-info', handler);
     };
-  }, [client]);
+  }, [client, recordSha]);
 
   return {
     capturedSha,

--- a/apps/agor-ui/src/hooks/useServerVersion.ts
+++ b/apps/agor-ui/src/hooks/useServerVersion.ts
@@ -1,0 +1,102 @@
+/**
+ * useServerVersion - Detect frontend/backend version drift after a deploy.
+ *
+ * Captures the daemon's build SHA on first successful connect (in-memory,
+ * per tab) and compares against subsequent values seen on the `server-info`
+ * welcome event. A mismatch flips `outOfSync` true, which ConnectionStatus
+ * surfaces as an amber "refresh to load latest" tag.
+ *
+ * Source-of-truth: daemon-only. The frontend never bakes its own SHA — the
+ * baseline only resets on hard reload, which is exactly the signal we want.
+ *
+ * Dev mode short-circuit: when either side reports the literal string 'dev'
+ * (the daemon fallback when no SHA is resolvable, or when the file/env are
+ * absent in source installs), comparison is disabled. Otherwise contributors
+ * hot-reloading the daemon would see the banner on every commit.
+ *
+ * Grace: outOfSync only flips true after a successful handshake confirms
+ * the mismatch — never during a transient reconnect, since the welcome event
+ * only arrives on a real connection.
+ */
+
+import type { AgorClient } from '@agor-live/client';
+import { useEffect, useRef, useState } from 'react';
+
+/** SHA value treated as "no version check" — see setup/build-info.ts. */
+export const DEV_SHA = 'dev';
+
+/**
+ * Pure comparison helper. Exposed for testing.
+ *
+ * Returns true ONLY when both values are concrete, non-empty SHAs and they
+ * disagree. Any 'dev' / null / undefined / empty value short-circuits to
+ * false (no banner) — these represent "unknown" and we never cry wolf on
+ * unknown.
+ */
+export function isOutOfSync(
+  capturedSha: string | null | undefined,
+  currentSha: string | null | undefined
+): boolean {
+  if (!capturedSha || !currentSha) return false;
+  if (capturedSha === DEV_SHA || currentSha === DEV_SHA) return false;
+  return capturedSha !== currentSha;
+}
+
+interface ServerInfoEvent {
+  buildSha?: string;
+  builtAt?: string | null;
+}
+
+export interface UseServerVersionResult {
+  /**
+   * The SHA captured on the first successful handshake of this tab. Stays
+   * stable across reconnects and only resets on hard reload.
+   */
+  capturedSha: string | null;
+  /**
+   * The most recent SHA the daemon has reported (welcome event or /health
+   * fallback). Useful for the About tab to show "current" vs "captured".
+   */
+  currentSha: string | null;
+  /** True when capturedSha and currentSha disagree (and neither is 'dev'). */
+  outOfSync: boolean;
+}
+
+/**
+ * Subscribe to the daemon's `server-info` welcome event and track drift.
+ *
+ * @param client The Agor client instance (null while connecting / logged out).
+ */
+export function useServerVersion(client: AgorClient | null): UseServerVersionResult {
+  const [capturedSha, setCapturedSha] = useState<string | null>(null);
+  const [currentSha, setCurrentSha] = useState<string | null>(null);
+  // Track captured value via ref so the listener closure doesn't capture a
+  // stale empty baseline. setState is async; the next welcome event after
+  // capture would otherwise still see capturedSha === null.
+  const capturedShaRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!client?.io) return;
+
+    const handler = (info: ServerInfoEvent) => {
+      const sha = typeof info?.buildSha === 'string' ? info.buildSha : null;
+      if (!sha) return;
+      setCurrentSha(sha);
+      if (capturedShaRef.current === null) {
+        capturedShaRef.current = sha;
+        setCapturedSha(sha);
+      }
+    };
+
+    client.io.on('server-info', handler);
+    return () => {
+      client.io.off('server-info', handler);
+    };
+  }, [client]);
+
+  return {
+    capturedSha,
+    currentSha,
+    outOfSync: isOutOfSync(capturedSha, currentSha),
+  };
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,14 @@ services:
       # Instance identification (optional - displayed in UI navbar)
       - INSTANCE_LABEL=${INSTANCE_LABEL:-}
 
+      # Version-sync banner: SHA captured on the host (where git can resolve
+      # the worktree's gitdir) and forwarded into the container. Without this,
+      # loadBuildInfo() falls all the way through to 'dev' because the
+      # in-container git can't follow the /app/.git pointer to the host-side
+      # worktree metadata. See .agor.yml start commands for the capture.
+      - AGOR_BUILD_SHA=${AGOR_BUILD_SHA:-}
+      - AGOR_BUILT_AT=${AGOR_BUILT_AT:-}
+
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,6 +7,13 @@ echo "🚀 Starting Agor development environment..."
 # No pnpm install needed at runtime - this is the key to fast startups!
 echo "✅ Using pre-built dependencies from Docker image"
 
+# Mark /app as a safe git directory. The bind-mounted source tree is owned by
+# the host UID, which trips git's "dubious ownership" guard inside the
+# container — this silently breaks the daemon's git-rev-parse fallback for
+# loadBuildInfo() and the version-sync banner gets stuck on 'dev'. Setting
+# this here lets every tsx-watch restart pick up the current HEAD SHA.
+git config --global --add safe.directory /app 2>/dev/null || true
+
 # Fix home directory permissions (volumes may have wrong UID/GID from previous builds)
 echo "🔧 Fixing home directory permissions..."
 mkdir -p /home/agor/.agor /home/agor/.cache

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,11 +7,12 @@ echo "🚀 Starting Agor development environment..."
 # No pnpm install needed at runtime - this is the key to fast startups!
 echo "✅ Using pre-built dependencies from Docker image"
 
-# Mark /app as a safe git directory. The bind-mounted source tree is owned by
-# the host UID, which trips git's "dubious ownership" guard inside the
-# container — this silently breaks the daemon's git-rev-parse fallback for
-# loadBuildInfo() and the version-sync banner gets stuck on 'dev'. Setting
-# this here lets every tsx-watch restart pick up the current HEAD SHA.
+# Mark /app as a safe git directory for non-worktree clones (where the
+# bind-mounted source tree is owned by the host UID and trips git's
+# "dubious ownership" guard inside the container). Harmless in Agor's
+# worktree-managed setup, where /app/.git is a FILE pointing to a host-only
+# gitdir that can't be resolved from inside the container at all — those
+# setups feed AGOR_BUILD_SHA via env from .agor.yml's start command instead.
 git config --global --add safe.directory /app 2>/dev/null || true
 
 # Fix home directory permissions (volumes may have wrong UID/GID from previous builds)

--- a/packages/agor-live/build.sh
+++ b/packages/agor-live/build.sh
@@ -43,13 +43,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CLIENT_DIR="$REPO_ROOT/packages/client"
 
-# Capture build identity for the version-sync banner. The SHA is the canonical
-# version signal — UI tabs compare it on each handshake and prompt a refresh
-# when the daemon's SHA changes mid-session. Env var (AGOR_BUILD_SHA from
-# Docker --build-arg or CI) takes precedence over this file at runtime.
-BUILD_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
-BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
 echo "🏗️  Building agor-live + @agor-live/client"
 echo ""
 echo "📍 Repository root: $REPO_ROOT"
@@ -248,13 +241,10 @@ cp -r "$REPO_ROOT/apps/agor-cli/dist/"* "$DIST_STAGE/cli/"
 
 echo "  → Copying daemon..."
 mkdir -p "$DIST_STAGE/daemon"
+# .build-info (sha + builtAt) is stamped into apps/agor-daemon/dist by the
+# daemon's own build script (apps/agor-daemon/scripts/stamp-build-info.mjs)
+# and gets carried along by this cp -r. loadBuildInfo() reads it at boot.
 cp -r "$REPO_ROOT/apps/agor-daemon/dist/"* "$DIST_STAGE/daemon/"
-
-# Stamp the daemon dist with the build SHA. Read by loadBuildInfo() at boot
-# (env > file > git > 'dev'); printed to /health and the socket welcome.
-printf '{"sha":"%s","builtAt":"%s"}\n' "$BUILD_SHA" "$BUILT_AT" \
-  > "$DIST_STAGE/daemon/.build-info"
-echo "    .build-info: sha=$BUILD_SHA builtAt=$BUILT_AT"
 
 echo "  → Copying executor..."
 mkdir -p "$DIST_STAGE/executor"

--- a/packages/agor-live/build.sh
+++ b/packages/agor-live/build.sh
@@ -43,6 +43,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CLIENT_DIR="$REPO_ROOT/packages/client"
 
+# Capture build identity for the version-sync banner. The SHA is the canonical
+# version signal — UI tabs compare it on each handshake and prompt a refresh
+# when the daemon's SHA changes mid-session. Env var (AGOR_BUILD_SHA from
+# Docker --build-arg or CI) takes precedence over this file at runtime.
+BUILD_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
 echo "🏗️  Building agor-live + @agor-live/client"
 echo ""
 echo "📍 Repository root: $REPO_ROOT"
@@ -242,6 +249,12 @@ cp -r "$REPO_ROOT/apps/agor-cli/dist/"* "$DIST_STAGE/cli/"
 echo "  → Copying daemon..."
 mkdir -p "$DIST_STAGE/daemon"
 cp -r "$REPO_ROOT/apps/agor-daemon/dist/"* "$DIST_STAGE/daemon/"
+
+# Stamp the daemon dist with the build SHA. Read by loadBuildInfo() at boot
+# (env > file > git > 'dev'); printed to /health and the socket welcome.
+printf '{"sha":"%s","builtAt":"%s"}\n' "$BUILD_SHA" "$BUILT_AT" \
+  > "$DIST_STAGE/daemon/.build-info"
+echo "    .build-info: sha=$BUILD_SHA builtAt=$BUILT_AT"
 
 echo "  → Copying executor..."
 mkdir -p "$DIST_STAGE/executor"

--- a/packages/core/src/unix/environment-command-spawn.test.ts
+++ b/packages/core/src/unix/environment-command-spawn.test.ts
@@ -1,5 +1,56 @@
-import { describe, expect, it } from 'vitest';
-import { redactCommandForAudit } from './environment-command-spawn.js';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { simpleGit } from 'simple-git';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { captureWorktreeBuildSha, redactCommandForAudit } from './environment-command-spawn.js';
+
+describe('captureWorktreeBuildSha', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-build-sha-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns 7-char short SHA for a valid git repo', async () => {
+    const repoPath = path.join(tmpDir, 'repo');
+    await fs.mkdir(repoPath, { recursive: true });
+    const git = simpleGit(repoPath);
+    await git.init(['--initial-branch=main']);
+    await git.addConfig('user.name', 'Test User');
+    await git.addConfig('user.email', 'test@example.com');
+    await fs.writeFile(path.join(repoPath, 'README.md'), '# Test', 'utf-8');
+    await git.add('README.md');
+    await git.commit('Initial commit');
+
+    const sha = await captureWorktreeBuildSha(repoPath);
+    expect(sha).toMatch(/^[0-9a-f]{7}$/);
+  });
+
+  it('returns undefined for a non-git path', async () => {
+    const sha = await captureWorktreeBuildSha(tmpDir);
+    expect(sha).toBeUndefined();
+  });
+
+  it('returns undefined for a nonexistent path', async () => {
+    const sha = await captureWorktreeBuildSha(path.join(tmpDir, 'does-not-exist'));
+    expect(sha).toBeUndefined();
+  });
+
+  it('returns undefined for a git repo with no commits', async () => {
+    const repoPath = path.join(tmpDir, 'empty-repo');
+    await fs.mkdir(repoPath, { recursive: true });
+    const git = simpleGit(repoPath);
+    await git.init(['--initial-branch=main']);
+
+    const sha = await captureWorktreeBuildSha(repoPath);
+    expect(sha).toBeUndefined();
+  });
+});
 
 describe('redactCommandForAudit', () => {
   it('redacts inline TOKEN= assignments', () => {

--- a/packages/core/src/unix/environment-command-spawn.ts
+++ b/packages/core/src/unix/environment-command-spawn.ts
@@ -9,11 +9,32 @@ import { type ChildProcess, type SpawnOptions, spawn } from 'node:child_process'
 import { createUserProcessEnvironment } from '../config/index.js';
 import type { Database } from '../db/index.js';
 import { UsersRepository } from '../db/repositories/index.js';
+import { getCurrentSha } from '../git/index.js';
 import type { Worktree } from '../types/index.js';
 import { assertEnvCommandAllowed } from './environment-command-deny-list.js';
 import { buildSpawnArgs } from './run-as-user.js';
 import { attachEnvFileCleanup, prepareImpersonationEnv } from './user-env-file.js';
 import { resolveUnixUserForImpersonation, validateResolvedUnixUser } from './user-manager.js';
+
+/**
+ * Capture the worktree's current HEAD SHA on the host, where git can resolve
+ * the gitdir. Useful for env commands that spawn into containers (docker
+ * compose, kubectl etc.) — those containers usually can't run git themselves
+ * because Agor worktrees use a /app/.git file pointing to a host-only
+ * gitdir. Daemon process here has full host access, so we capture once and
+ * forward via env. Best-effort: returns undefined on any failure (detached
+ * worktree, corrupted .git, etc.). Never blocks env spawning.
+ *
+ * Exported for testability.
+ */
+export async function captureWorktreeBuildSha(worktreePath: string): Promise<string | undefined> {
+  try {
+    const sha = await getCurrentSha(worktreePath);
+    return sha ? sha.slice(0, 7) : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Environment command types for logging
@@ -152,9 +173,19 @@ export async function spawnEnvironmentCommand(
     console.log(`${logPrefix} Running as daemon user (mode: ${unixUserMode})`);
   }
 
+  // Capture current HEAD SHA on the host so downstream containers (which
+  // typically can't run git inside themselves — see captureWorktreeBuildSha)
+  // can read AGOR_BUILD_SHA / AGOR_BUILT_AT from their environment. The
+  // version-sync banner is the first consumer; future deploy markers,
+  // notification webhooks, etc. can use it without per-project plumbing.
+  const buildSha = await captureWorktreeBuildSha(worktree.path);
+  const additionalEnv: Record<string, string> | undefined = buildSha
+    ? { AGOR_BUILD_SHA: buildSha, AGOR_BUILT_AT: new Date().toISOString() }
+    : undefined;
+
   // Create clean environment for user process
   // If impersonating, strip HOME/USER/LOGNAME/SHELL so sudo -u can set them properly
-  const env = await createUserProcessEnvironment(worktree.created_by, db, undefined, !!asUser);
+  const env = await createUserProcessEnvironment(worktree.created_by, db, additionalEnv, !!asUser);
 
   // Route secret-looking env vars through an on-disk env file owned by the
   // target user (mode 0600) so user-scoped API keys/tokens never appear in


### PR DESCRIPTION
## Summary

After a deploy, browser tabs with stale JS hit auth loops against fresh daemons (the recurring symptom that PR #1058 worked around with JWT refresh + 401 retry). This PR makes the drift visible: an amber **Out of sync — refresh** tag in the connection status when the FE and BE disagree on build SHA.

- Daemon stamps a build SHA at install/run time. Resolution order: `AGOR_BUILD_SHA` env → `<daemon-dist>/.build-info` (written by `packages/agor-live/build.sh`) → `git rev-parse --short HEAD` → `'dev'` fallback.
- SHA is exposed two ways:
  - `GET /health` → `{ buildSha, builtAt, ... }`
  - Socket.io welcome event `server-info` (emitted before auth so anonymous tabs also get a baseline)
- UI captures the SHA on the **first** handshake (held in a ref to avoid stale-closure on the listener) and compares against subsequent handshakes via a pure `isOutOfSync(captured, current)` helper. `'dev'` on either side short-circuits the comparison so source-mode contributors don't get a banner on every commit.
- `useServerVersion(client)` hook surfaces `{ capturedSha, currentSha, outOfSync }`. `outOfSync` flows into `ConnectionContext` so any component can read it.
- `ConnectionStatus` gains a 4th variant (amber `ReloadOutlined` tag, click → `window.location.reload()`) that supersedes Connected/Disconnected — when the backend changed under us, that's the only thing the user needs to see. **No auto-reload** by design.
- `AboutTab` shows both the live daemon SHA and the SHA the current tab captured, with an "out of sync" warning row.
- New `agor version` CLI command for operators: tries `/health` first, falls back to `<cli-dist>/../daemon/.build-info`, then `'dev'`.

## Design constraints respected

- Daemon-only SHA source (no FE-baked SHA, no `vite define`)
- No auto-reload, no service workers
- No package.json bumping
- No JWT path changes (this is the user-visible counterpart to #1058)

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes (only pre-existing warnings remain)
- [x] `pnpm turbo run build` — passes
- [x] `vitest` for `build-info.test.ts` — 7/7 (env > file > fallback precedence, malformed file, no builtAt)
- [x] `vitest` for `useServerVersion.test.ts` — 10/10 (capture stability, drift detection, dev sentinel short-circuit, unmount unsubscribe, null client, ignored payloads)
- [ ] Manual smoke: deploy daemon under one SHA, swap `AGOR_BUILD_SHA`, refresh + verify amber tag appears on next reconnect; click tag → tab reloads
- [ ] Manual smoke: `agor version` with daemon up and down

🤖 Generated with [Claude Code](https://claude.com/claude-code)