### PR TITLE
chore: patch bump agor-live + client for publish

### DIFF
--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `agor-live` and `@agor-live/client` from `0.17.0` → `0.17.1` (patch) in prep for an npm publish.
- No code changes; lockfile unchanged (workspace `workspace:*` refs don't pin versions).

## Test plan
- [ ] `pnpm install` completes clean (no lockfile churn)
- [ ] `pnpm typecheck` passes (ran via pre-commit hook)
- [ ] `pnpm -w --filter @agor-live/client build && pnpm -w --filter @agor-live/client check:pack` before publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)