### PR TITLE
refactor(ui): consolidate antd ConfigProvider to single root

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -92,7 +92,6 @@ function DeviceRouter() {
 
 function AppContent() {
   const { token } = theme.useToken();
-  const { getCurrentThemeConfig } = useTheme();
   const { showSuccess, showError, showWarning, showLoading, destroy } = useThemedMessage();
   const navigate = useNavigate();
 
@@ -269,21 +268,19 @@ function AppContent() {
   // Show loading while fetching auth config
   if (authConfigLoading) {
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: token.colorBgLayout,
-          }}
-        >
-          <Spin size="large" />
-          <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>Loading...</div>
-        </div>
-      </ConfigProvider>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: token.colorBgLayout,
+        }}
+      >
+        <Spin size="large" />
+        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>Loading...</div>
+      </div>
     );
   }
 
@@ -291,32 +288,30 @@ function AppContent() {
   // If we already have a config cached, continue with that even if there's an error
   if (authConfigError && !authConfig) {
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '2rem',
-          }}
-        >
-          <Alert
-            type="warning"
-            message="Could not fetch daemon configuration"
-            description={
-              <div>
-                <p>{authConfigError.message}</p>
-                <p>Defaulting to requiring authentication. Start the daemon with:</p>
-                <p>
-                  <code>cd apps/agor-daemon && pnpm dev</code>
-                </p>
-              </div>
-            }
-            showIcon
-          />
-        </div>
-      </ConfigProvider>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '2rem',
+        }}
+      >
+        <Alert
+          type="warning"
+          message="Could not fetch daemon configuration"
+          description={
+            <div>
+              <p>{authConfigError.message}</p>
+              <p>Defaulting to requiring authentication. Start the daemon with:</p>
+              <p>
+                <code>cd apps/agor-daemon && pnpm dev</code>
+              </p>
+            </div>
+          }
+          showIcon
+        />
+      </div>
     );
   }
 
@@ -327,55 +322,47 @@ function AppContent() {
     !!(localStorage.getItem('agor-access-token') || localStorage.getItem('agor-refresh-token'));
 
   if (authConfig?.requireAuth && !authLoading && !authenticated && !hasTokens) {
-    return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <LoginPage onLogin={login} error={authError} />
-      </ConfigProvider>
-    );
+    return <LoginPage onLogin={login} error={authError} />;
   }
 
   // Show reconnecting state if we have tokens but lost connection
   // ONLY show fullscreen on initial connection, not during reconnections
   if (authConfig?.requireAuth && hasTokens && (!connected || !authenticated) && !hasLoadedOnce) {
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: token.colorBgLayout,
-          }}
-        >
-          <Spin size="large" />
-          <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>
-            Reconnecting to daemon...
-          </div>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: token.colorBgLayout,
+        }}
+      >
+        <Spin size="large" />
+        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>
+          Reconnecting to daemon...
         </div>
-      </ConfigProvider>
+      </div>
     );
   }
 
   // Show loading while checking authentication (only if auth is required)
   if (authConfig?.requireAuth && authLoading) {
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: token.colorBgLayout,
-          }}
-        >
-          <Spin size="large" />
-          <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>Authenticating...</div>
-        </div>
-      </ConfigProvider>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: token.colorBgLayout,
+        }}
+      >
+        <Spin size="large" />
+        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>Authenticating...</div>
+      </div>
     );
   }
 
@@ -386,39 +373,33 @@ function AppContent() {
 
     if (authConfig?.requireAuth && isAnonymousAuthError && !authenticated) {
       // Anonymous auth failed but auth is required - show login page
-      return (
-        <ConfigProvider theme={getCurrentThemeConfig()}>
-          <LoginPage onLogin={login} error={authError || connectionError} />
-        </ConfigProvider>
-      );
+      return <LoginPage onLogin={login} error={authError || connectionError} />;
     }
 
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '2rem',
-          }}
-        >
-          <Alert
-            type="error"
-            message="Failed to connect to Agor daemon"
-            description={
-              <div>
-                <p>{connectionError}</p>
-                <p>
-                  Start the daemon with: <code>cd apps/agor-daemon && pnpm dev</code>
-                </p>
-              </div>
-            }
-            showIcon
-          />
-        </div>
-      </ConfigProvider>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '2rem',
+        }}
+      >
+        <Alert
+          type="error"
+          message="Failed to connect to Agor daemon"
+          description={
+            <div>
+              <p>{connectionError}</p>
+              <p>
+                Start the daemon with: <code>cd apps/agor-daemon && pnpm dev</code>
+              </p>
+            </div>
+          }
+          showIcon
+        />
+      </div>
     );
   }
 
@@ -426,42 +407,38 @@ function AppContent() {
   // Once data is loaded, keep UI mounted and show connection status in header instead
   if ((connecting || loading) && !hasLoadedOnce) {
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            backgroundColor: token.colorBgLayout,
-          }}
-        >
-          <Spin size="large" />
-          <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>
-            Connecting to daemon...
-          </div>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: token.colorBgLayout,
+        }}
+      >
+        <Spin size="large" />
+        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>
+          Connecting to daemon...
         </div>
-      </ConfigProvider>
+      </div>
     );
   }
 
   // Show data error (but not if user needs to change password - let the modal render)
   if (dataError && !user?.must_change_password) {
     return (
-      <ConfigProvider theme={getCurrentThemeConfig()}>
-        <div
-          style={{
-            height: '100vh',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '2rem',
-          }}
-        >
-          <Alert type="error" message="Failed to load data" description={dataError} showIcon />
-        </div>
-      </ConfigProvider>
+      <div
+        style={{
+          height: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '2rem',
+        }}
+      >
+        <Alert type="error" message="Failed to load data" description={dataError} showIcon />
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary

Removed 9 redundant `<ConfigProvider>` wrappers from `AppContent`'s early-return branches in `apps/agor-ui/src/App.tsx`. They were all nested inside `AppWrapper`'s ConfigProvider and passed the same `getCurrentThemeConfig()` value — pure no-ops that only added DOM noise and style-cache churn on every state transition (auth loading, connection error, reconnecting, etc.).

The root ConfigProvider in `AppWrapper` is now the single source of theme truth.

## Inventory before

| File | Lines (open) | Theme prop | Status |
|---|---|---|---|
| `App.tsx` | 1613 (AppWrapper) | `getCurrentThemeConfig()` | **Kept — root** |
| `App.tsx` | 272, 294, 331, 341, 364, 390, 397, 429, 452 | `getCurrentThemeConfig()` (early returns) | **Removed (9 redundant)** |
| `WorktreeCard.tsx` | 485 | `{ components: { Tree: { colorBgContainer: 'transparent' } } }` | **Kept — intentional component override** |
| `.storybook/preview.tsx` | 37 | algorithm toggle | **Kept — Storybook root** |
| `*.stories.tsx` (×2) | 13 | `darkAlgorithm` | **Out of scope — Storybook decorators** |

**Total in `apps/agor-ui/src/`:** 11 → 2 (1 root + 1 component-scoped). Storybook untouched (3 unchanged).

## Validation

**Verdict: case (b)** — hypothesis mostly right, with one legitimate exception.

- All 9 inner `App.tsx` ConfigProviders received the *identical* theme object from `useTheme().getCurrentThemeConfig()` and were rendered inside `AppWrapper`'s ConfigProvider, so they were pure redundant nesting.
- `WorktreeCard.tsx:485` is a different case: it scopes a `Tree.colorBgContainer: 'transparent'` override to a single subtree. That's the recommended antd pattern for component-level token overrides — kept as-is.
- antd portal pattern (Modal/Drawer) is handled via `<App />` (`AntApp` from antd), wrapped at the root in `AppWrapper`. No portal-specific ConfigProvider duplication exists in the codebase.

## After

- 1 root `<ConfigProvider>` in `AppWrapper` (unchanged)
- 1 intentional component-scoped `<ConfigProvider>` in `WorktreeCard` (unchanged)
- All 9 redundant copies removed
- Removed unused `getCurrentThemeConfig` destructure from `AppContent` (line 95)

## Theme access pattern

**No new hook introduced.** The existing surface already covers all needs:
- `theme.useToken()` from antd — for token values (already used in `App.tsx:94`)
- `useTheme()` from `contexts/ThemeContext.tsx` — for `themeMode`, `isDark`, `getCurrentThemeConfig`, etc.

A custom `useTheme` wrapper already exists; antd's `theme.useToken()` covers token access. **Don't add abstraction we don't need** — kept both as-is.

## Risk + testing

- ✅ `pnpm typecheck` passes
- ✅ `pnpm lint` (biome) passes
- ✅ Pre-commit hooks (turbo typecheck + lint) passed

**Risk surface:** the removed wrappers are early-return states (loading spinners, error alerts, login page). They render *inside* `AppWrapper`'s ConfigProvider, so antd theme/locale/AntApp message context is preserved. No portal-rendering surface (Modal/Drawer/Popover/notification) is touched.

## Test plan

- [ ] Visual smoke-test: trigger each early-return state — auth loading, connection error, reconnecting, login page, generic loading, data error — and confirm theme still renders correctly (dark mode, primary color, fonts)
- [ ] Visual smoke-test modals/drawers/notifications post-merge (`AntApp` wrapper is unchanged, so this should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)