### PR TITLE
fix(executor): restore AskUserQuestion widget rendering in chat pane

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
@@ -1,0 +1,140 @@
+import type { SessionID, TaskID } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core', () => ({
+  generateId: vi.fn(() => 'test-generated-id'),
+}));
+
+import { createCanUseToolCallback } from './permission-hooks.js';
+
+/**
+ * Regression coverage for the AskUserQuestion widget fix.
+ *
+ * The Claude Agent SDK marks `AskUserQuestion` (and `ExitPlanMode`) with
+ * `requiresUserInteraction: true`, which forces the SDK to invoke
+ * `canUseTool` even when the session is in `bypassPermissions` mode. We
+ * register the callback unconditionally and rely on the bypass fast-path
+ * inside the callback to preserve bypass semantics for everything except
+ * `AskUserQuestion`, which always routes through Agor's input-request UI.
+ */
+describe('createCanUseToolCallback', () => {
+  const sessionId = 'test-session' as SessionID;
+  const taskId = 'test-task' as TaskID;
+  const noopOptions = {
+    signal: new AbortController().signal,
+  };
+
+  function createBaseDeps() {
+    return {
+      permissionService: {
+        emitRequest: vi.fn(),
+        waitForDecision: vi.fn(),
+        cancelPendingRequests: vi.fn(),
+      } as any,
+      inputRequestService: {
+        emitRequest: vi.fn(),
+        waitForResponse: vi.fn(),
+      } as any,
+      tasksService: {
+        patch: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      sessionsRepo: {} as any,
+      messagesRepo: {
+        findBySessionId: vi.fn().mockResolvedValue([]),
+      } as any,
+      messagesService: {
+        create: vi.fn().mockResolvedValue(undefined),
+        patch: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      sessionsService: {
+        patch: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      permissionLocks: new Map(),
+      mcpServerRepo: {
+        findById: vi.fn(),
+      } as any,
+      sessionMCPRepo: {
+        findBySessionId: vi.fn().mockResolvedValue([]),
+      } as any,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('bypass-mode fast-path', () => {
+    it('auto-allows a regular tool in bypassPermissions without entering the permission flow', async () => {
+      const deps = createBaseDeps();
+      const callback = createCanUseToolCallback(sessionId, taskId, {
+        ...deps,
+        permissionMode: 'bypassPermissions',
+      });
+
+      const toolInput = { command: 'ls' };
+      const result = await callback('Bash', toolInput, noopOptions);
+
+      expect(result).toEqual({
+        behavior: 'allow',
+        updatedInput: toolInput,
+      });
+      // None of the heavy permission/input-request machinery should fire.
+      expect(deps.permissionService.emitRequest).not.toHaveBeenCalled();
+      expect(deps.permissionService.waitForDecision).not.toHaveBeenCalled();
+      expect(deps.messagesService.create).not.toHaveBeenCalled();
+      expect(deps.tasksService.patch).not.toHaveBeenCalled();
+    });
+
+    // ExitPlanMode is the other built-in `requiresUserInteraction` tool.
+    // The fast-path must auto-allow it in bypass mode — the bug we fixed
+    // would otherwise force it through the SDK's default-deny path.
+    it('auto-allows ExitPlanMode in bypassPermissions', async () => {
+      const deps = createBaseDeps();
+      const callback = createCanUseToolCallback(sessionId, taskId, {
+        ...deps,
+        permissionMode: 'bypassPermissions',
+      });
+
+      const toolInput = { plan: 'do the thing' };
+      const result = await callback('ExitPlanMode', toolInput, noopOptions);
+
+      expect(result).toEqual({
+        behavior: 'allow',
+        updatedInput: toolInput,
+      });
+      expect(deps.inputRequestService.emitRequest).not.toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit AskUserQuestion in bypass mode — intercept must run first', async () => {
+      const deps = createBaseDeps();
+      // Stub the full happy-path so the AskUserQuestion intercept resolves cleanly.
+      deps.inputRequestService.waitForResponse.mockResolvedValue({
+        timedOut: false,
+        answers: ['option-a'],
+        annotations: [],
+        respondedBy: 'test-user',
+      });
+
+      const callback = createCanUseToolCallback(sessionId, taskId, {
+        ...deps,
+        permissionMode: 'bypassPermissions',
+      });
+
+      const toolInput = {
+        questions: [{ question: 'pick one', header: 'h', options: [], multiSelect: false }],
+      };
+      const result = await callback('AskUserQuestion', toolInput, noopOptions);
+
+      // Intercept ran (input-request emitted, message created, response awaited).
+      expect(deps.inputRequestService.emitRequest).toHaveBeenCalledTimes(1);
+      expect(deps.inputRequestService.waitForResponse).toHaveBeenCalledTimes(1);
+      expect(deps.messagesService.create).toHaveBeenCalledTimes(1);
+
+      // Result carries the user's answers, not the bypass fast-path's bare updatedInput.
+      expect(result.behavior).toBe('allow');
+      expect(result.updatedInput).toMatchObject({
+        answers: ['option-a'],
+      });
+    });
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -7,7 +7,7 @@
  */
 
 import { generateId } from '@agor/core';
-import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
+import type { Message, MessageID, PermissionMode, SessionID, TaskID } from '@agor/core/types';
 import {
   InputRequestStatus,
   MessageRole,
@@ -47,6 +47,14 @@ export function createCanUseToolCallback(
     permissionLocks: Map<SessionID, Promise<void>>;
     mcpServerRepo: MCPServerRepository;
     sessionMCPRepo: SessionMCPServerRepository;
+    /**
+     * Effective permission mode for this query. Used to fast-path non-
+     * AskUserQuestion tools to `allow` when running in `bypassPermissions`,
+     * since the callback is now registered in bypass mode too (see
+     * query-builder.ts for why — AskUserQuestion's `requiresUserInteraction`
+     * forces the SDK to invoke `canUseTool` regardless of mode).
+     */
+    permissionMode?: PermissionMode;
   }
 ) {
   return async (
@@ -214,6 +222,19 @@ export function createCanUseToolCallback(
           message: error instanceof Error ? error.message : 'Error processing user question',
         };
       }
+    }
+
+    // Bypass-mode fast-path: when permissionMode is `bypassPermissions`, the SDK
+    // would normally skip canUseTool entirely. We register the callback anyway
+    // so AskUserQuestion (handled above) still routes through Agor's UI — but
+    // every other tool should be auto-allowed without prompting, matching the
+    // mode's semantics. Without this, registering canUseTool in bypass mode
+    // would force every tool through the WebSocket permission flow.
+    if (deps.permissionMode === 'bypassPermissions') {
+      return {
+        behavior: 'allow' as const,
+        updatedInput: toolInput,
+      };
     }
 
     // Auto-approve MCP tools only if they belong to an attached MCP server

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -1,4 +1,4 @@
-import type { SessionID, WorktreeID } from '@agor/core/types';
+import type { SessionID, TaskID, WorktreeID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock minimal dependencies
@@ -52,5 +52,80 @@ describe('setupQuery - Local Settings Support', () => {
     expect(callArgs.options.settingSources).toEqual(
       expect.arrayContaining(['user', 'project', 'local'])
     );
+  });
+});
+
+describe('setupQuery - canUseTool registration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Claude.query).mockReturnValue({
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.resolve({ done: true }) }),
+      interrupt: () => Promise.resolve(),
+    } as any);
+  });
+
+  function createPermissionDeps(): QuerySetupDeps {
+    return {
+      sessionsRepo: {
+        findById: vi.fn().mockResolvedValue({
+          session_id: 'test-session' as SessionID,
+          worktree_id: 'test-worktree' as WorktreeID,
+        }),
+      } as any,
+      worktreesRepo: {
+        findById: vi.fn().mockResolvedValue({ path: '/test/project/path' }),
+      } as any,
+      messagesRepo: {} as any,
+      sessionMCPRepo: {} as any,
+      mcpServerRepo: {} as any,
+      permissionService: {} as any,
+      tasksService: {} as any,
+      messagesService: {} as any,
+      sessionsService: {} as any,
+      inputRequestService: {} as any,
+      permissionLocks: new Map(),
+    };
+  }
+
+  // Regression guard for the AskUserQuestion widget bug: the SDK's
+  // `requiresUserInteraction` short-circuit forces AskUserQuestion through
+  // canUseTool even in `bypassPermissions` mode. If we don't register the
+  // callback, the SDK falls back to its default deny and surfaces
+  // "Answer questions?" to the model instead of routing to Agor's UI.
+  it('registers canUseTool when permissionMode is "bypassPermissions"', async () => {
+    const deps = createPermissionDeps();
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps, {
+      taskId: 'test-task' as TaskID,
+      permissionMode: 'bypassPermissions',
+    });
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(callArgs.options.canUseTool).toBeTypeOf('function');
+    expect(callArgs.options.permissionMode).toBe('bypassPermissions');
+  });
+
+  it('registers canUseTool in default permission mode', async () => {
+    const deps = createPermissionDeps();
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps, {
+      taskId: 'test-task' as TaskID,
+      permissionMode: 'default',
+    });
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(callArgs.options.canUseTool).toBeTypeOf('function');
+  });
+
+  it('does not register canUseTool when required deps are missing (no taskId)', async () => {
+    const deps = createPermissionDeps();
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps, {
+      permissionMode: 'bypassPermissions',
+      // no taskId
+    });
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(callArgs.options.canUseTool).toBeUndefined();
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -324,14 +324,16 @@ export async function setupQuery(
   // Add canUseTool callback if permission service is available and taskId provided
   // This enables Agor's custom permission UI (WebSocket-based) when SDK would show a prompt
   // Fires AFTER SDK checks settings.json - respects user's existing Claude CLI permissions!
-  // IMPORTANT: Only skip for bypassPermissions (which never asks for permissions)
-  if (
-    deps.permissionService &&
-    taskId &&
-    effectivePermissionMode !== 'bypassPermissions' &&
-    deps.sessionMCPRepo &&
-    deps.mcpServerRepo
-  ) {
+  //
+  // We register canUseTool even in `bypassPermissions` mode. AskUserQuestion's tool
+  // descriptor sets `requiresUserInteraction: true`, which makes the SDK's permission
+  // resolver return `{behavior: "ask", message: "Answer questions?"}` BEFORE checking
+  // the bypass-mode shortcut (see @anthropic-ai/claude-agent-sdk 0.2.x). With no
+  // canUseTool registered, the SDK's default deny fires and the model receives
+  // "Answer questions?" as the tool error — bypassing Agor's input-request UI.
+  // The callback itself fast-paths non-AskUserQuestion tools to `allow` when in
+  // bypass mode so the rest of bypass semantics are preserved.
+  if (deps.permissionService && taskId && deps.sessionMCPRepo && deps.mcpServerRepo) {
     queryOptions.canUseTool = createCanUseToolCallback(sessionId, taskId, {
       permissionService: deps.permissionService,
       inputRequestService: deps.inputRequestService,
@@ -343,6 +345,7 @@ export async function setupQuery(
       permissionLocks: deps.permissionLocks,
       mcpServerRepo: deps.mcpServerRepo,
       sessionMCPRepo: deps.sessionMCPRepo,
+      permissionMode: effectivePermissionMode,
     });
     console.log(`✅ canUseTool callback added (permission mode: ${effectivePermissionMode})`);
     console.log(`   SDK will check settings.json first, then call Agor UI if needed`);


### PR DESCRIPTION
## Repro

1. Start an orchestrator session in `bypassPermissions` mode.
2. Have the agent call the `AskUserQuestion` SDK tool (e.g., \"Ask me which approach to take with options A/B/C\").
3. **Expected:** an `InputRequestBlock` widget renders in the chat pane with radio/checkbox options.
4. **Actual (before fix):** the tool call returns the literal string `Answer questions?` as a tool error and the conversation continues with no UI.

## Root cause

The Claude Agent SDK's built-in `AskUserQuestion` tool defines its own `checkPermissions` that always returns `{ behavior: \"ask\", message: \"Answer questions?\" }`, and the tool is flagged with `requiresUserInteraction: true`. Inside the SDK, that interaction flag short-circuits the bypass-mode early-return — so even in `bypassPermissions` the tool **must** route through the host's `canUseTool` callback or it falls back to the SDK's default deny path (which surfaces the `\"Answer questions?\"` string the user saw).

Agor's executor was skipping `canUseTool` registration entirely in bypass mode (`packages/executor/src/sdk-handlers/claude/query-builder.ts`), under the assumption that bypass means \"no permission gating needed\". That gate prevented Agor's `AskUserQuestion` intercept (`permission-hooks.ts`, which creates the `input_request` message and pauses the SDK until the UI submits an answer) from ever being reached. The widget rendering pipeline (`InputRequestBlock`, `MessageBlock` `input_request` branch) was always intact — it just never received an `input_request` message to render.

This has been broken for any bypass-mode session since the bypass gate was originally introduced; it is not a recent regression.

## Fix

`packages/executor/src/sdk-handlers/claude/query-builder.ts`
- Always register the `canUseTool` callback when the required deps are present, regardless of `permissionMode`.
- Pass `permissionMode` into `createCanUseToolCallback` so it can fast-path non-interactive tools in bypass mode.

`packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts`
- Add `permissionMode?: PermissionMode` to the deps interface (imported from `@agor/core/types`, which is broader than the Claude SDK's `PermissionMode` and covers Codex/Gemini modes like `autoEdit`/`yolo`).
- After the existing `AskUserQuestion` intercept runs, short-circuit with `{ behavior: 'allow' }` when `permissionMode === 'bypassPermissions'`. This preserves bypass semantics for every other tool while letting the AskUserQuestion intercept take over.

Net effect: the AskUserQuestion intercept now runs in bypass mode, posts an `input_request` message, the UI renders the widget, the user submits answers, and the SDK resumes with the response — exactly as designed.

## Tested

- ✅ `pnpm -w typecheck` — clean (9/9 tasks)
- ✅ `pnpm -w lint` — clean (only pre-existing warnings unrelated to this change)
- ⚠️ Live end-to-end repro not run in this session (the orchestrator brief flagged the env as annoying to set up). Recommend a manual smoke test post-merge: orchestrator session in bypass mode → agent calls `AskUserQuestion` → confirm widget renders + selection round-trips.

## Other Claude-Code-native widgets

While auditing the chat pane I checked the other interaction-style tools the Claude Agent SDK exposes:

- **TodoWrite** — has its own dedicated rendering path (`TodoWriteBlock`); unaffected by this bug, renders fine.
- **ExitPlanMode / EnterPlanMode** — these tools currently have no dedicated widget; they fall through to the generic tool-call rendering. Not in scope for this PR, but worth a follow-up: a dedicated plan-mode widget would mirror the AskUserQuestion treatment and surface plan content prominently.
- No other native widget regressions surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)