### PR TITLE
fix(auth+env): password-change-required redirect flow + dev-env UID/GID pin

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -29,7 +29,18 @@ environment:
       # AGOR_BUILD_SHA / AGOR_BUILT_AT are injected by Agor's
       # spawnEnvironmentCommand from the host-side worktree gitdir; no need to
       # capture them here. See packages/core/src/unix/environment-command-spawn.ts.
+      #
+      # UID/GID are passed explicitly so docker-compose.override.yml's
+      # `user: '${UID:-1000}:${GID:-1000}'` resolves to the host's actual
+      # identity (and the `args: { UID, GID }` build args do too on rebuild).
+      # Bash's $UID/$GID are readonly but not exported, so without this prefix
+      # compose silently falls through to 1000:1000 — and once the image and
+      # runtime UIDs disagree, the container's UID has no /etc/passwd entry
+      # and the entrypoint dies on `sudo: you do not exist in the passwd
+      # database`. TODO: lift this into spawnEnvironmentCommand alongside
+      # AGOR_BUILD_SHA so every Docker-based .agor.yml gets it for free.
       start: >-
+        UID=$(id -u) GID=$(id -g)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         docker compose -p agor-{{worktree.name}} up -d
@@ -46,6 +57,7 @@ environment:
       # docker-compose.override.yml (UID/GID only) and skips the postgres
       # override. Listing both files explicitly replaces that default.
       start: >-
+        UID=$(id -u) GID=$(id -g)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         docker compose
@@ -107,6 +119,7 @@ environment:
         impersonation (each Agor user runs sessions as their own Unix identity).
         Requires the sudoers config shipped under docker/sudoers/.
       start: >-
+        UID=$(id -u) GID=$(id -g)
         DAEMON_PORT={{add 3000 worktree.unique_id}}
         UI_PORT={{add 5000 worktree.unique_id}}
         AGOR_RBAC_ENABLED=true

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -427,16 +427,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           audience: 'https://agor.dev',
         });
 
+        // Return the full user object — matches what POST /authentication
+        // returns via the FeathersJS auth service. Stripping fields here
+        // (previously: only user_id/email/name/emoji/role) silently dropped
+        // `must_change_password` after every token refresh, breaking the
+        // forced-password-change UI guard in App.tsx and showing the user a
+        // black page with "Failed to load data — Password change required."
+        // instead of the change-password modal. `usersService.get` already
+        // omits secrets (password hash, raw API keys, raw env var values)
+        // via rowToUser — see services/users.ts.
         return {
           accessToken,
           refreshToken: newRefreshToken,
-          user: {
-            user_id: user.user_id,
-            email: user.email,
-            name: user.name,
-            emoji: user.emoji,
-            role: user.role,
-          },
+          user,
         };
       } catch (_error) {
         throw new Error('Invalid or expired refresh token');

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -442,7 +442,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           user,
         };
       } catch (_error) {
-        throw new Error('Invalid or expired refresh token');
+        // Must throw NotAuthenticated (not plain Error) so the UI's
+        // isDefiniteAuthFailure classifier (apps/agor-ui/src/utils/authErrors.ts)
+        // recognizes a dead refresh token as a 401-class failure and clears
+        // session state. A plain Error has no status/name and gets treated as
+        // transient, leading the single-flight refresh loop to keep retrying.
+        throw new NotAuthenticated('Invalid or expired refresh token');
       }
     },
   });

--- a/apps/agor-ui/src/utils/tokenRefresh.ts
+++ b/apps/agor-ui/src/utils/tokenRefresh.ts
@@ -5,7 +5,7 @@
  * Used by both useAuth and useAgorClient hooks to avoid duplication.
  */
 
-import type { AgorClient } from '@agor-live/client';
+import type { AgorClient, User } from '@agor-live/client';
 
 export const ACCESS_TOKEN_KEY = 'agor-access-token';
 export const REFRESH_TOKEN_KEY = 'agor-refresh-token';
@@ -13,13 +13,13 @@ export const REFRESH_TOKEN_KEY = 'agor-refresh-token';
 export interface RefreshResult {
   accessToken: string;
   refreshToken?: string;
-  user: {
-    user_id: string;
-    email: string;
-    name?: string;
-    emoji?: string;
-    role: string;
-  };
+  /**
+   * Full user object — matches the shape returned by POST /authentication.
+   * Importantly includes `must_change_password` so the UI's force-password-
+   * change guard (App.tsx) keeps working across token refreshes; previously
+   * the field was stripped here and on the server, breaking that flow.
+   */
+  user: User;
 }
 
 /**


### PR DESCRIPTION
Bundles two small fixes in one PR — both blocked the operator from manually testing the password-change-required path locally.

## Part 1 — Password-change-required redirect (the original regression)

### Repro

A user with `must_change_password=true` reloads the app (or comes back after their 15-minute access-token TTL elapses, or after a visibility-change refresh). Instead of the password-change modal, they see a fullscreen black page with a single Alert: **Failed to load data — Password change required. Please update your password.** No path forward; can't reach Settings either.

### Root cause

`/authentication/refresh` (`apps/agor-daemon/src/register-routes.ts:430-440`) was hand-rolled and returned a deliberately-stripped user payload:

```ts
user: { user_id, email, name, emoji, role }
```

`POST /authentication` returns the **full** `User` (via FeathersJS' entity service → `usersService.get` → `rowToUser`), but the refresh endpoint silently drops `must_change_password`, `onboarding_completed`, `unix_username`, `preferences`, etc.

After refresh, `useAuth`'s `TOKENS_REFRESHED_EVENT` listener (`useAuth.ts:292-306`) writes that stripped object back into React state. From there:

1. `App.tsx:163` — `useAgorData(client, { enabled: !user?.must_change_password })` evaluates `!undefined = true` and triggers data fetches.
2. Daemon's global `enforcePasswordChange` hook (`register-routes.ts:3052` → `index.ts:149-180`) throws `Forbidden('Password change required. Please update your password.')` for every protected service call.
3. `App.tsx:429-443` — `dataError && !user?.must_change_password` evaluates `true && !undefined = true`, fullscreen-renders the **Failed to load data** Alert and short-circuits the rest of the tree, so `ForcePasswordChangeModal` (`App.tsx:1262`) never mounts.

This has been latent since the feature landed in [d513d3b7](https://github.com/preset-io/agor/commit/d513d3b7) (`feat(users): add force password change feature (#464)`) — that PR updated the auth-response shape on `POST /authentication` (free, via FeathersJS) but never touched the hand-rolled refresh endpoint. Manifests only after a refresh, which is now the common path post-`fdaafe48` (15-minute access-token TTL) — fresh logins worked, anything else broke.

### Fix

`apps/agor-daemon/src/register-routes.ts` — `/authentication/refresh` now returns the full `User` object (the same one `usersService.get` returns; it already omits the password hash, raw API keys, and raw env-var values via `rowToUser` in `services/users.ts:453-485`).

`apps/agor-ui/src/utils/tokenRefresh.ts` — `RefreshResult.user` now points at the canonical `User` type from `@agor-live/client` so server and client stay in lockstep on the field set.

**Follow-up commit (per Codex review):** the refresh endpoint's catch block was throwing a plain `Error('Invalid or expired refresh token')`, which the UI's `isDefiniteAuthFailure` classifier (`apps/agor-ui/src/utils/authErrors.ts:43-50`) does **not** recognize as an auth failure (no status code, no `NotAuthenticated` name). A dead refresh token would slip through the single-flight refresh loop's transient-error path and keep retrying instead of clearing session state. Now throws `NotAuthenticated` so the client correctly bounces to login.

## Part 2 — `.agor.yml` UID/GID pin (unblocks local repro)

### Repro

```
agor-dev-1  | 🚀 Starting Agor development environment...
agor-dev-1  | ✅ Using pre-built dependencies from Docker image
agor-dev-1  | 🔧 Fixing home directory permissions...
agor-dev-1  | sudo: you do not exist in the passwd database
```

…container exits before the daemon ever boots, so the bug above can't be exercised end-to-end locally.

### Root cause

`docker-compose.override.yml:3` runs the container with `user: '${UID:-1000}:${GID:-1000}'`, and `docker-compose.yml:84-85` builds the image with `args: { UID: ${UID:-1000}, GID: ${GID:-1000} }`. Both depend on `$UID`/`$GID` being set in the env when `docker compose` runs — but bash's `$UID`/`$GID` are readonly **and not exported**. Without an explicit pass-through, compose silently falls through to `1000:1000`. Once the shared `agor-dev:latest` image (built once with whichever UID was around) and the container's runtime UID disagree, the runtime UID has no `/etc/passwd` entry → `sudo` blows up at `docker/docker-entrypoint.sh:21` (and again, unsilenced, at line 24).

### Fix

Prepend `UID=$(id -u) GID=$(id -g)` to each variant's `start:` command in `.agor.yml` (sqlite, postgres, full). Pins both the runtime user and any rebuild's build args to the host's actual identity. `docs` variant has its own compose file with no UID-bound user override, so it's left alone. `stop`/`nuke`/`logs` don't bind a user-specific container, also left alone — keeps the diff small.

Logically belongs alongside the existing `AGOR_BUILD_SHA` host-side capture in `spawnEnvironmentCommand` — lifting this into the framework so every Docker-based `.agor.yml` gets it for free is a sensible follow-up.

## Tested

- `pnpm -F @agor/core build` ✅
- `pnpm -F @agor/daemon typecheck` ✅
- `pnpm -F agor-ui typecheck` ✅
- `pnpm biome check` on touched files ✅
- `python3 -c "import yaml; yaml.safe_load(open('.agor.yml'))"` ✅

Manual repro path for Part 1 (now actually runnable thanks to Part 2):

1. Create a user with `must_change_password=true` (`agor user create --force-password-change ...`) or flip the flag on an existing one.
2. Log in successfully (modal appears — this path always worked).
3. Wait 15 min, or hard-reload the page so the stored access token has expired and the refresh endpoint is hit.
4. **Before fix**: black page + "Failed to load data — Password change required." Alert. **After fix**: `ForcePasswordChangeModal` mounts and the user can change their password.

## Edge cases (Part 1)

- Password-change form on submit: untouched (`handleForcePasswordChange` in `App.tsx:658-666` still patches `users` with the new password; the `enforcePasswordChange` hook explicitly allows `users.patch` with `password` for the user's own id at `index.ts:166-173`).
- Post-change navigation: `reAuthenticate()` after the patch refreshes state with `must_change_password: false`, modal closes, user lands on the default board route — same as before.
- Deep-link URL during the flag state: `ForcePasswordChangeModal` renders **above** the `<Routes>` (`App.tsx:1262`), so deep links route normally underneath but the modal blocks interaction until the password is changed.
- Refresh response now includes additional fields (avatar, preferences, env-var metadata, `created_at`, etc.). These are already exposed via `users.get`, so no new surface — and consumers that destructure `{user_id, email, ...}` are unaffected.

## Follow-ups (not in this PR)

Surfaced by Codex review or by the host-side investigation — recorded here so they're not lost:

- **Auth-response builder consolidation.** `POST /authentication` (auth service + after-hook), `/authentication/refresh`, and `/authentication/impersonate` (`register-routes.ts:540-548`) each hand-build their own user payload. Same drift risk as this regression. Worth introducing one shared response builder/type, or moving refresh behind the auth service / a custom strategy. The shared auth contract is also split between `packages/core/src/types/feathers.ts:301-324` and the UI-local `RefreshResult` in `apps/agor-ui/src/utils/tokenRefresh.ts:13-22`.
- **Server error code as guard truth.** The daemon already emits structured `code: 'PASSWORD_CHANGE_REQUIRED'` in `index.ts:169-178`, but `useAgorData` collapses fetch failures to `string` (`useAgorData.ts:42-43,249-250`), forcing `App.tsx` to rely on the client-side `must_change_password` flag. Preserving the structured error and keying the UI off the server code would harden against this whole class of regression.
- **Lift `UID`/`GID` capture into `spawnEnvironmentCommand`** alongside `AGOR_BUILD_SHA` (`packages/core/src/unix/environment-command-spawn.ts`) so every Docker-based `.agor.yml` consumer gets it for free without per-repo plumbing.
- Integration test that exercises the full refresh → `useAuth` → `useAgorData` chain. The existing `auth-jwt-integration.test.ts` only covers the JWT hook layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)