### PR TITLE
Messaging & positioning doc (draft for review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 # Agor
 
-**Think Figma, but for AI coding assistants.** Orchestrate Claude Code, Codex, and Gemini sessions on a multiplayer canvas. Manage git worktrees, track AI conversations, and visualize your team's agentic work in real-time.
+**Team command center for all things agentic.**
 
-> **TL;DR:** Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks, with GitHub-linked worktrees, automated workflow zones, and isolated test environments—all running simultaneously.
+Agor is a shared canvas where coding agents (Claude Code, Codex, Gemini) and long-lived assistants run side-by-side on isolated git worktrees — the anchor entity where sessions, dev environments, prompts, and PRs converge. Your whole team rallies around the same live work in real time, and the agents themselves drive Agor over MCP.
+
+- **Team workspace for AI agents** — multiplayer is the core differentiator. Live cursors, facepile, scoped comments, shared sessions and dev envs.
+- **Worktrees as the anchor** — one entity per piece of work, where conversations + dev env + PR + prompts all converge.
+- **Multi-agent, multi-runtime** — Claude Code, Codex, Gemini, OpenCode, Copilot, interchangeable per session.
+- **Shared, long-lived assistants** — persistent agents with identity, memory, and skills that you publish for the whole team.
+- **Self-hosted** — your repos, your DB, your isolation posture.
 
 **📖 [Read the full documentation at agor.live →](https://agor.live/)**
 

--- a/apps/agor-cli/src/lib/banner.ts
+++ b/apps/agor-cli/src/lib/banner.ts
@@ -19,7 +19,7 @@ export const HERO_ART = `
 /**
  * Tagline
  */
-export const TAGLINE = 'Next-gen agent orchestration platform';
+export const TAGLINE = 'Team command center for all things agentic';
 
 /**
  * Version info

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -1,26 +1,21 @@
 ---
 title: agor Documentation
-description: Complete guide to agor - next-gen agent orchestration for AI coding. Learn about multiplayer workspaces, git worktrees, session trees, and real-time collaboration for Claude Code, Codex, and Gemini.
+description: Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants, anchored on git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.
 ---
 
 <div style={{ textAlign: 'center', marginTop: '2rem', marginBottom: '2rem' }}>
   <img
     src="/logo.png"
-    alt="agor logo - AI agent orchestration platform"
+    alt="agor logo - team command center for all things agentic"
     style={{ width: '135px', height: '135px', borderRadius: '50%', opacity: 0.9 }}
   />
 </div>
 
 # <span className="gradient-text">agor</span>
 
-**Think Figma, but for AI coding assistants.**
+**Team command center for all things agentic.**
 
-**Next-gen agent orchestration for AI coding.** The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace.
-
-> **TL;DR:** Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks, with GitHub-linked worktrees, automated workflow zones, and isolated test environments—all running simultaneously.
-
-Visualize, coordinate, and automate your AI workflows across tools solo or with your team.
-Agor offers a place where you can coordinate entire swarms of AI agents.
+Agor is a shared canvas where coding agents (Claude Code, Codex, Gemini) and long-lived assistants run side-by-side on isolated git worktrees — the anchor entity where sessions, dev environments, prompts, and PRs converge. Your whole team rallies around the same live work in real time, and the agents themselves drive Agor over MCP.
 
 import { GifGallery } from '../../components';
 
@@ -186,7 +181,3 @@ Read the [Development Guide](/guide/development) for dev workflow and detailed r
 ## License
 
 Business Source License 1.1 — see the [GitHub repository](https://github.com/preset-io/agor/blob/main/LICENSE) for details
-
----
-
-> "git tracks code, Agor tracks the conversations that produced it."

--- a/apps/agor-docs/pages/index.mdx
+++ b/apps/agor-docs/pages/index.mdx
@@ -4,8 +4,8 @@ import { Hero } from '../components';
 
 <Hero
   title="agor"
-  subtitle="Next-gen agent orchestration for AI coding"
-  description="The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace."
+  subtitle="Team command center for all things agentic"
+  description="A shared canvas where coding agents (Claude Code, Codex, Gemini) and long-lived assistants run side-by-side on isolated git worktrees. Your whole team rallies around the same live work in real time, and the agents themselves drive Agor over MCP."
   ctaText="Learn More!"
   ctaLink="/guide"
 />

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -82,7 +82,9 @@ const config: DocsThemeConfig = {
       frontMatter.description ||
       'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.';
     const fullTitle =
-      pageTitle === 'agor' ? 'agor – Team command center for all things agentic' : `${pageTitle} – agor`;
+      pageTitle === 'agor'
+        ? 'agor – Team command center for all things agentic'
+        : `${pageTitle} – agor`;
     const rawOgImage = frontMatter.ogImage || frontMatter.image || defaultOgImage;
     const ogImage = rawOgImage.startsWith('http') ? rawOgImage : `${defaultSiteUrl}${rawOgImage}`;
     const ogType = frontMatter.date ? 'article' : 'website';

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -80,9 +80,9 @@ const config: DocsThemeConfig = {
     const pageTitle = frontMatter.title ?? title ?? 'agor';
     const description =
       frontMatter.description ||
-      'Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini.';
+      'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.';
     const fullTitle =
-      pageTitle === 'agor' ? 'agor – Next-gen agent orchestration' : `${pageTitle} – agor`;
+      pageTitle === 'agor' ? 'agor – Team command center for all things agentic' : `${pageTitle} – agor`;
     const rawOgImage = frontMatter.ogImage || frontMatter.image || defaultOgImage;
     const ogImage = rawOgImage.startsWith('http') ? rawOgImage : `${defaultSiteUrl}${rawOgImage}`;
     const ogType = frontMatter.date ? 'article' : 'website';
@@ -118,7 +118,7 @@ const config: DocsThemeConfig = {
         <meta name="description" content={description} />
         <meta
           name="keywords"
-          content="AI coding, agent orchestration, Claude Code, Codex, Gemini, AI development, multiplayer IDE, git worktrees, agentic coding, AI agents, developer tools"
+          content="team command center, agentic, AI agents, agent orchestration, multiplayer, spatial canvas, Claude Code, Codex, Gemini, git worktrees, MCP, persistent assistants, AI workflow, developer tools"
         />
         <meta name="author" content="Maxime Beauchemin" />
 
@@ -177,7 +177,7 @@ const config: DocsThemeConfig = {
                     '@type': 'SoftwareApplication',
                     name: 'agor',
                     description:
-                      'Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini.',
+                      'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.',
                     applicationCategory: 'DeveloperApplication',
                     operatingSystem: 'macOS, Linux, Windows',
                     offers: {

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -105,7 +105,7 @@ export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
               <BrandLogo level={1} />
             </div>
             <div>
-              <Text type="secondary">Next-gen agent orchestration</Text>
+              <Text type="secondary">Team command center for all things agentic</Text>
             </div>
             <Divider style={{ margin: '16px 0 0 0' }} />
           </div>

--- a/context/concepts/core.md
+++ b/context/concepts/core.md
@@ -4,14 +4,15 @@ Related: [[architecture]], [[design]], [[worktrees]], [[board-objects]]
 
 ## What Is Agor?
 
-**Agor is a multiplayer canvas for orchestrating agentic coding sessions** - the spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace.
+**Agor is a team command center for all things agentic** — a shared canvas where coding agents (Claude Code, Codex, Gemini) and long-lived assistants run side-by-side on isolated git worktrees, with real-time multiplayer presence and an MCP surface agents drive themselves.
 
 **Pronunciation:** "AY-gore"
 
 **Tagline:**
 
-> **Multiplayer canvas for orchestrating AI coding sessions.**
-> The spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace.
+> **Team command center for all things agentic.**
+
+See [[messaging-and-positioning]] for paragraph forms, audience pitches, and the canonical vocabulary. Don't paraphrase from this doc when writing customer-facing copy — pull from M&P.
 
 ## The Vision
 

--- a/context/messaging-and-positioning.md
+++ b/context/messaging-and-positioning.md
@@ -1,0 +1,377 @@
+# Agor — Messaging & Positioning
+
+> **Internal doc.** This is the source of truth for how Agor describes itself.
+> When you write copy that ships to users — README intro, Hero subtitle, docs
+> landing, package.json description, blog post lead, conference slide, sales
+> deck — start here. If a surface contradicts this doc, the surface is wrong.
+>
+> This doc is **not** itself customer-facing. It's opinionated, names the
+> off-brand phrases by file path, and exists so that future copy converges
+> instead of diverging.
+
+---
+
+## Canonical tagline
+
+**Team command center for all things agentic.**
+
+Why these specific words:
+
+- **"Team"** over "multiplayer." `Multiplayer` is a feature description (we
+  built real-time presence, cursors, facepile) and stays in our vocabulary
+  internally and on feature pages. `Team` is the audience description and
+  belongs in the headline. It's shorter, more approachable, and immediately
+  signals who Agor is for: groups of people who ship together.
+- **"Command center"** over "control plane." `Control plane` is correct but
+  infra-flavored — it lives next to Kubernetes and service meshes. Agor's
+  primary surface is a UI you look at, not a YAML you apply. `Command center`
+  carries the right register: a place humans sit, watch, and steer from. It
+  also doesn't pretend Agor is plumbing — it foregrounds the canvas.
+- **"All things agentic"** over "everything agentic" / "for AI agents" /
+  "for AI coding." The phrase has rhythm (three stresses, idiomatic English),
+  asserts category coverage without overreaching ("everything" sounds
+  exhaustive in a way we can't defend), and — critically — the tail covers
+  **both coding agents and persisted assistants**. Agor is not just for AI
+  coding. Anchoring the line to "AI coding" as we have been (see
+  `apps/agor-docs/pages/index.mdx:7`,
+  `apps/agor-docs/pages/guide/index.mdx:18`,
+  `apps/agor-docs/theme.config.tsx:83`) understates the product and will need
+  to be re-pitched once Cards, Assistants, and non-code workflows lead more
+  conversations.
+
+The tagline is one line. Don't pair it with a co-tagline ("Think Figma, but
+for AI coding assistants") — that's the bug we're fixing. Use the tagline
+alone, then transition into a paragraph form below.
+
+---
+
+## Paragraph forms
+
+Three forms, in increasing length. Pick the one that fits the surface.
+
+### One-sentence (≤ 25 words)
+
+> **Agor is a team command center for all things agentic — orchestrate coding
+> agents and persisted assistants on a shared spatial canvas, with isolated
+> worktrees, real-time presence, and an MCP surface agents can drive
+> themselves.**
+
+Suitable for: GitHub repo description, root `package.json` `description`
+field, Twitter / X bio, link previews, JSON-LD `description`, OG meta.
+
+### Short paragraph (~50 words, 2–3 sentences)
+
+> **Team command center for all things agentic.** Agor is a shared canvas
+> where coding agents (Claude Code, Codex, Gemini) and persisted assistants
+> run side-by-side on isolated git worktrees. You see what every agent is
+> doing in real time, your teammates see it too, and the agents themselves
+> can drive Agor over MCP.
+
+Suitable for: README intro under `# Agor`, docs landing TL;DR, pitch deck
+slide 1, blog post lead paragraph, OSS directory listing.
+
+### Long paragraph (~150 words)
+
+> **Team command center for all things agentic.** Running one coding agent in
+> a terminal works. Running five — across teammates, across repos, with
+> assistants quietly grooming the backlog at night — falls apart fast.
+> Conversations vanish, branches collide, dev servers fight for ports, and
+> nobody can see what anyone else's agent is doing. Agor gives a team a
+> single surface for that work: a 2D canvas where each unit of work is a git
+> worktree with its own branch, environment, and session tree; where Claude
+> Code, Codex, Gemini, and custom MCP-driven assistants are interchangeable
+> runtimes you pick per session; where teammates show up live with cursors,
+> facepile, comments, and shared terminals; and where every action is also
+> exposed to agents themselves through Agor's MCP server, so the system can
+> orchestrate, fork, spawn, and report on its own work. Self-hosted, with
+> Unix-level isolation when you need it.
+
+Suitable for: docs landing extended intro, sales one-pager, blog announcement
+intro, investor / partner deck, conference talk abstract.
+
+---
+
+## What Agor is
+
+Concrete claims. Each is defensible against the current implementation.
+
+- **A spatial canvas** where worktrees, sessions, cards, and zones are
+  first-class objects you can see, drag, and arrange.
+- **A worktree manager** — every unit of work is an isolated git worktree
+  with its own branch, environment, ports, and conversations attached.
+- **A multi-agent runtime host** — Claude Code, Codex, Gemini, OpenCode, and
+  GitHub Copilot are all interchangeable session runtimes; you pick per
+  session.
+- **A real-time multiplayer surface** — live cursors, facepile, scoped
+  comments, attention pulse, shared tmux terminals.
+- **An MCP server** — anything a user can do in Agor, an agent can do too,
+  via the daemon's MCP surface. Sessions are auto-issued tokens.
+- **A scheduler** — cron-style triggers for templated prompts; powers
+  assistant heartbeats, daily standups, scheduled audits.
+- **A home for persisted assistants** — long-lived agents with file-based
+  memory and skills, OpenClaw-style.
+- **A self-hosted product** — your repos, your database (LibSQL or Postgres),
+  your Unix users when you turn on full isolation.
+
+## What Agor is NOT
+
+Disambiguations. The tagline can evoke the wrong mental model — these lines
+exist to redirect.
+
+- **Not just for AI coding.** Persisted assistants, non-code workflows
+  (cards), and custom MCP integrations are equal citizens. Don't let
+  "command center for agentic coding" become the implicit positioning the
+  way "AI coding" did in earlier copy.
+- **Not Figma.** The "Figma for AI coding" line was a useful early
+  shorthand, and the spatial-canvas comparison is real, but Figma is for
+  *designing* artifacts. Agor's canvas is for *coordinating real running
+  work*. We retired the line.
+- **Not an LLM and not a model gateway.** Agor doesn't ship a model. You
+  bring agent runtimes (Claude Code, Codex, Gemini, custom MCP). Agor
+  orchestrates them.
+- **Not a CI/CD system.** Scheduler triggers prompts on a cadence; it does
+  not replace GitHub Actions, Buildkite, or Argo. Sessions can call into
+  CI; CI does not call into sessions.
+- **Not an IDE.** Agor doesn't replace VSCode/Cursor/JetBrains. The
+  "Bring Your Own IDE" roadmap item is the canonical position: keep your
+  editor, attach it to Agor-managed worktrees.
+- **Not a chatbot framework.** Sessions wrap real coding-agent SDKs. We
+  don't build the agent — we run, watch, and connect them.
+- **Not a closed SaaS.** Agor is BSL 1.1, self-hosted-first. There is no
+  hosted "agor.com" tier today.
+
+---
+
+## Vocabulary — say this, not that
+
+The brand voice. Use the ✅ words; flag the ❌ words in code review.
+
+### ✅ On-brand
+
+| Word | What it signals |
+|---|---|
+| **team / team command center** | Audience: groups, not lone hackers. Headline-grade. |
+| **command center** | Humans sit here and steer. UI-flavored, not infra-flavored. |
+| **agentic** | Covers coding agents *and* persisted assistants — broader than "AI coding." |
+| **multiplayer** | Feature-page word for the real-time presence stack (cursors, facepile, comments). Stays in vocabulary, just not in the headline. |
+| **orchestrate** | Active verb for what teams do with multiple agents. Pairs with "command center." |
+| **worktree(s)** | Our primary unit of work. Always plural-friendly. Don't substitute "branch" or "task." |
+| **session(s) / session tree** | Agent conversation with genealogy. Use "session" not "chat" or "thread." |
+| **board(s) / zone(s)** | The 2D spatial surface and its regions. |
+| **assistant(s)** | Persisted, long-lived agents with memory and skills. Distinct from "session." |
+| **agent(s)** | The generic term for a runtime that takes prompts and acts. |
+| **spatial canvas** | The board surface. Use sparingly — once per page, not every paragraph. |
+| **isolation** | Worktree-level, environment-level, Unix-level. The security register. |
+| **real-time** | What the multiplayer stack feels like; pairs with "presence." |
+| **MCP / MCP server** | The agent-facing surface. Always uppercase. |
+| **self-hosted** | Deployment posture. Not "on-prem" — wrong era. |
+
+### ❌ Off-brand
+
+| Word | Why we avoid it |
+|---|---|
+| **next-gen** | Empty intensifier. Used in `apps/agor-docs/pages/index.mdx:7` and `theme.config.tsx:83,85` — slated for removal. |
+| **AI-powered** | Says nothing in 2026. Every product is. |
+| **swarm** | Implies undirected mass; Agor is the opposite (named, orchestrated, observable). Currently in `apps/agor-docs/pages/guide/index.mdx:23` — slated for removal. |
+| **spatial layer** | Infra metaphor for a UI product. From `apps/agor-docs/pages/index.mdx:8`. Use "spatial canvas" instead. |
+| **revolutionary / revolutionize** | Marketing tic. We do not use it. |
+| **10x / supercharge / unlock** | Hype register. We do not use it. |
+| **productivity** | Vague benefit. Replace with the concrete capability ("parallel work without port collisions"). |
+| **AI coding (as the only frame)** | Understates Agor — see "What Agor is NOT" item 1. Fine inside features pages where the context is coding; not fine in the headline. |
+| **Figma for AI coding** | Retired. The comparison was useful early; it now caps the product. From `README.md:5` and `apps/agor-docs/pages/guide/index.mdx:16`. |
+| **control plane** | Infra-flavored. Use "command center." |
+
+---
+
+## Audience tiers
+
+Three audiences, three concrete pitches. Each starts from the same canonical
+tagline and differentiates on what *changes* for that reader.
+
+### 1. Solo dev with one agent
+
+> **Team command center for all things agentic.** Even solo, Agor gives you
+> a place where every agent run lands — branches don't collide, dev servers
+> don't fight for ports, conversations don't disappear into terminal
+> scrollback, and you can see at a glance what's running, what finished, and
+> what stalled.
+
+What they get: visibility, isolation, durable conversation history, a place
+to land work.
+
+### 2. Team lead with multiple devs each running agents
+
+> **Team command center for all things agentic.** When five teammates each
+> run two agents, the question stops being "is my agent working" and starts
+> being "what is everyone's agent doing." Agor turns that into a shared
+> board: live cursors, scoped comments, attention pulse on completed work,
+> RBAC on worktrees, and a single audit trail across every session your
+> team ran.
+
+What changes: shared spatial awareness, RBAC, cross-team observability, no
+more "share your screen" calls.
+
+### 3. Platform engineer setting up Agor for an org
+
+> **Team command center for all things agentic.** Agor is self-hosted, runs
+> against LibSQL or Postgres, and supports four progressive isolation modes
+> from open access to per-user Unix accounts with credential isolation.
+> Agents reach internal tools through MCP servers you configure once; users
+> get a UI that respects the OS permissions you've already invested in.
+
+What changes: deployment modes (`simple` / `insulated` / `strict`), MCP
+integration with internal tooling, sudoers-backed isolation when required,
+audit + compliance posture.
+
+---
+
+## Where each form belongs
+
+| Surface | Form | Notes |
+|---|---|---|
+| Docs landing Hero (`apps/agor-docs/pages/index.mdx`) | Tagline + short paragraph | Replace `subtitle="Next-gen agent orchestration for AI coding"` and the `description=` prop. |
+| Guide overview (`apps/agor-docs/pages/guide/index.mdx`) | Tagline + short paragraph + TL;DR sentence | Currently 4 stacked one-liners (lines 16, 18, 20, 22–23) — collapse to one. |
+| README intro (`README.md`) | Tagline + one-sentence + "What is Agor" bullets | Replace line 5–7. |
+| Root `package.json` `description` | One-sentence (trimmed to fit npm registry rendering) | Replace `"Next-gen agent orchestration platform"`. |
+| `packages/agor-live/package.json` `description` | One-sentence | Currently `"Multiplayer canvas for orchestrating AI coding sessions"` — refresh once tagline lands. |
+| `theme.config.tsx` default `description` and `fullTitle` | One-sentence (description); tagline (title suffix) | Lines 83 and 85 — replace `"Next-gen agent orchestration"`. |
+| GitHub repo description (Settings → About) | One-sentence | Public link previews. |
+| Twitter / X bio, Discord description | Tagline only | Keep it to the headline. |
+| Conference talk title slide | Tagline only | Optionally with a single subtitle: "Self-hosted. Multiplayer. MCP-native." |
+| Blog post lead / announcement | Short or long paragraph depending on length | Long paragraph for first-touch posts. |
+| Sales one-pager / partner deck | Long paragraph + audience-tiered pitches | Tier-2 and tier-3 pitches lead the doc. |
+| OG / Twitter card meta description | One-sentence | Currently in `theme.config.tsx:82-83`. |
+| JSON-LD `SoftwareApplication.description` | One-sentence | Currently in `theme.config.tsx:179-181`. |
+| OSS directory listings (Awesome lists, Yo, etc.) | One-sentence | Match GitHub repo description. |
+
+---
+
+## Proposed `/guide/` hierarchy
+
+The current `_meta.ts`
+(`apps/agor-docs/pages/guide/_meta.ts`) is already grouped with separators
+into Features / Reference / Development / Deployment. The grouping is
+sensible. The proposal below mostly preserves it and tightens overlaps.
+
+**Verdict: do not redesign. Tighten in place.** No page is an obvious
+mistake; the docs are in much better shape than the homepage one-liners
+suggest. Specific changes:
+
+| Page | Verdict | Rationale |
+|---|---|---|
+| `index.mdx` | **Rewrite intro, keep structure** | Currently has 4 stacked taglines (lines 16, 18, 20, 22–23). Collapse to canonical tagline + short paragraph. |
+| `getting-started.mdx` | **Keep** | Onboarding flow. Top-level. |
+| `extended-install.mdx` | **Keep** | Alternative installs. Top-level. |
+| `features-overview.mdx` | **Keep, retitle "What Agor does"** | Current title is fine; the page is the de-facto product map and is well-written. Consider linking to this messaging doc from the bottom (with a note that it's internal — or extract a public "positioning" page if we ever need one). |
+| `worktrees.mdx` | **Keep — top-level concept** | One of the three foundations. |
+| `sessions.mdx` | **Keep — top-level concept** | One of the three foundations. |
+| `boards.mdx` | **Keep — top-level concept** | One of the three foundations. |
+| `assistants.mdx` | **Keep — top-level concept** | The persisted-assistant pillar. Critical for the "all things agentic" framing. |
+| `internal-mcp.mdx` | **Keep, consider rename to "Agor MCP server (built-in)"** | The current title in `_meta.ts` ("Agor MCP Server") is good; the file slug `internal-mcp` is fine. |
+| `rich-chat-ux.mdx` | **Keep — top-level feature** | Differentiator vs. terminal CLI. |
+| `multiplayer-social.mdx` | **Keep — top-level feature** | Cursors / facepile / comments / shared terminal. |
+| `multiplayer-unix-isolation.mdx` | **Keep, but move under "Deployment" (already there)** | Already correctly grouped under Deployment in `_meta.ts:34-39`. Different concept from `multiplayer-social.mdx` — that one is the *user-facing* presence layer, this one is the *operator-facing* security mode. **They should NOT merge.** They have the same prefix because both relate to Agor's multi-user posture, but one is "what teammates see," the other is "how the OS protects them." Consider renaming for clarity: `multiplayer-social.mdx` → `presence-and-collaboration.mdx`, `multiplayer-unix-isolation.mdx` → `unix-isolation.mdx`. Flagging for Max — see "Open questions." |
+| `environment-configuration.mdx` | **Keep** | Per-worktree dev servers. Top-level feature. |
+| `scheduler.mdx` | **Keep** | Cron-style triggers. Top-level feature. |
+| `cards.mdx` | **Keep — flagged Beta** | Generic non-code workflow units. Important for the "not just AI coding" framing. |
+| `artifacts.mdx` | **Keep** | Sandpack-rendered apps. Top-level feature. |
+| `message-gateway.mdx` | **Keep** | Slack / GitHub portals. Top-level feature. |
+| `architecture.mdx` | **Keep — Reference** | Already grouped under Reference. |
+| `typescript-client.mdx` | **Keep — Reference** | Already grouped under Reference. |
+| `sdk-comparison.mdx` | **Keep — Reference** | Already grouped under Reference. |
+| `development.mdx` | **Keep — Development** | Already grouped under Development. |
+| `containerized-execution.mdx` | **Keep — Deployment** | Already grouped under Deployment. |
+
+**Net change to hierarchy:** none. The cascade rollout's job is to update
+copy on `index.mdx`, the Hero, and the README — not to restructure the guide.
+
+**One additional suggestion** for the cascade: add a top-of-page summary
+block on `features-overview.mdx` of the form "Agor is a *team command center
+for all things agentic*. Below: the surfaces that make it that." — so the
+features page anchors back to the canonical tagline.
+
+---
+
+## Survey appendix — current state
+
+The phrases that exist in the codebase today, by file. This is the baseline
+the cascade rollout will replace; cite this table when reviewing the cascade
+PR.
+
+### Taglines and pitch sentences
+
+| File | Line | Quoted phrase | Category |
+|---|---|---|---|
+| `README.md` | 5 | "Think Figma, but for AI coding assistants. Orchestrate Claude Code, Codex, and Gemini sessions on a multiplayer canvas." | tagline + paragraph |
+| `README.md` | 7 | "Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks, with GitHub-linked worktrees, automated workflow zones, and isolated test environments—all running simultaneously." | TL;DR paragraph |
+| `README.md` | 98 | "Multiplayer spatial canvas with zones, worktrees, and real-time collaboration" | screenshot caption |
+| `apps/agor-docs/pages/index.mdx` | 7 | "Next-gen agent orchestration for AI coding" | Hero subtitle |
+| `apps/agor-docs/pages/index.mdx` | 8 | "The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace." | Hero description |
+| `apps/agor-docs/pages/guide/index.mdx` | 3 | "Complete guide to agor - next-gen agent orchestration for AI coding. Learn about multiplayer workspaces, git worktrees, session trees, and real-time collaboration for Claude Code, Codex, and Gemini." | meta description |
+| `apps/agor-docs/pages/guide/index.mdx` | 16 | "Think Figma, but for AI coding assistants." | tagline (#1) |
+| `apps/agor-docs/pages/guide/index.mdx` | 18 | "Next-gen agent orchestration for AI coding. The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace." | tagline + paragraph (#2) |
+| `apps/agor-docs/pages/guide/index.mdx` | 20 | "Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks…" | TL;DR paragraph (#3) |
+| `apps/agor-docs/pages/guide/index.mdx` | 22–23 | "Visualize, coordinate, and automate your AI workflows across tools solo or with your team. Agor offers a place where you can coordinate entire swarms of AI agents." | follow-on paragraph (#4) |
+| `apps/agor-docs/pages/guide/index.mdx` | 60 | "Multiplayer spatial canvas with custom-styled zones, session trees, and worktree pipelines" | screenshot caption |
+| `apps/agor-docs/pages/guide/index.mdx` | 192 | "git tracks code, Agor tracks the conversations that produced it." | closing pull-quote |
+| `apps/agor-docs/theme.config.tsx` | 83 | "Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini." | default meta description |
+| `apps/agor-docs/theme.config.tsx` | 85 | "agor – Next-gen agent orchestration" | site title fallback |
+| `apps/agor-docs/theme.config.tsx` | 121 | "AI coding, agent orchestration, Claude Code, Codex, Gemini, AI development, multiplayer IDE, git worktrees, agentic coding, AI agents, developer tools" | meta keywords |
+| `apps/agor-docs/theme.config.tsx` | 179–181 | "Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini." | JSON-LD `SoftwareApplication.description` |
+
+### `package.json` description fields
+
+| File | Quoted phrase |
+|---|---|
+| `package.json` (root) | "Next-gen agent orchestration platform" |
+| `packages/agor-live/package.json` | "Multiplayer canvas for orchestrating AI coding sessions" |
+| `packages/client/package.json` | "TypeScript client for connecting to the Agor daemon" *(no positioning needed)* |
+| `packages/executor/package.json` | "Agor executor process - isolated execution environment" *(no positioning needed)* |
+| `packages/core/package.json` | *(no description)* |
+| `apps/agor-cli/package.json` | *(no description)* |
+| `apps/agor-daemon/package.json` | *(no description)* |
+| `apps/agor-docs/package.json` | *(no description)* |
+| `apps/agor-ui/package.json` | *(no description)* |
+
+### Feature page tag-lines (kept, in scope only for future tightening)
+
+These aren't competing top-level taglines — they're per-feature opening
+hooks. Listed here for completeness; cascade rollout doesn't need to touch
+them unless the wording references retired phrases.
+
+| File | Quoted phrase |
+|---|---|
+| `apps/agor-docs/pages/guide/multiplayer-social.mdx:8` | "Agor is great solo. Multiplayer is what makes it Figma." |
+| `apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx:21` | "once upon a time, teams shared servers" |
+| `apps/agor-docs/pages/guide/features-overview.mdx:70` | "Figma for AI coding." |
+
+The two "Figma" references are the most important ones to revisit during
+cascade — they're load-bearing on the retired comparison.
+
+---
+
+## Open questions for Max
+
+These got flagged during drafting and need a call before the cascade lands:
+
+1. **Rename `multiplayer-social.mdx` and `multiplayer-unix-isolation.mdx`?**
+   They share a `multiplayer-` prefix but cover orthogonal concerns (one is
+   user-facing presence; one is OS-level isolation). Suggested rename:
+   `presence-and-collaboration.mdx` and `unix-isolation.mdx`. This is a
+   redirect-tax cost vs. a clarity win. Defaulting to "leave the slugs, fix
+   internal cross-references" unless you say otherwise.
+2. **Keep "Figma" as a feature-page hook?** The README/Hero/landing
+   "Figma for AI coding" framing is retired in this doc. The remaining
+   in-the-wild references are the per-feature hooks listed in the survey
+   appendix's last table. Rip them out entirely, or let them survive as
+   inline color on feature pages where the spatial-canvas comparison still
+   helps?
+3. **Do we want a public version of this doc?** This file is internal /
+   opinionated. A subset (canonical tagline + paragraph forms + audience
+   tiers) could live as `apps/agor-docs/pages/about/positioning.mdx` for
+   anyone evaluating Agor. Default: no — keep it internal until we have
+   a clear external need.
+4. **Replace the closing pull-quote** "git tracks code, Agor tracks the
+   conversations that produced it." (`pages/guide/index.mdx:192`)? It's
+   memorable and on-brand, but it leans on the "AI coding" frame. Keep it
+   for now; flag for revisit if the broader "agentic" framing demands it.

--- a/context/messaging-and-positioning.md
+++ b/context/messaging-and-positioning.md
@@ -1,377 +1,209 @@
 # Agor — Messaging & Positioning
 
-> **Internal doc.** This is the source of truth for how Agor describes itself.
-> When you write copy that ships to users — README intro, Hero subtitle, docs
-> landing, package.json description, blog post lead, conference slide, sales
-> deck — start here. If a surface contradicts this doc, the surface is wrong.
->
-> This doc is **not** itself customer-facing. It's opinionated, names the
-> off-brand phrases by file path, and exists so that future copy converges
-> instead of diverging.
+> **Internal source of truth for how Agor describes itself.** When you write
+> copy that ships — README, Hero, docs landing, `package.json`, blog post,
+> deck, slide, bio — start here. If a surface contradicts this doc, the
+> surface is wrong.
 
 ---
 
-## Canonical tagline
+## Tagline
 
 **Team command center for all things agentic.**
 
-Why these specific words:
-
-- **"Team"** over "multiplayer." `Multiplayer` is a feature description (we
-  built real-time presence, cursors, facepile) and stays in our vocabulary
-  internally and on feature pages. `Team` is the audience description and
-  belongs in the headline. It's shorter, more approachable, and immediately
-  signals who Agor is for: groups of people who ship together.
-- **"Command center"** over "control plane." `Control plane` is correct but
-  infra-flavored — it lives next to Kubernetes and service meshes. Agor's
-  primary surface is a UI you look at, not a YAML you apply. `Command center`
-  carries the right register: a place humans sit, watch, and steer from. It
-  also doesn't pretend Agor is plumbing — it foregrounds the canvas.
-- **"All things agentic"** over "everything agentic" / "for AI agents" /
-  "for AI coding." The phrase has rhythm (three stresses, idiomatic English),
-  asserts category coverage without overreaching ("everything" sounds
-  exhaustive in a way we can't defend), and — critically — the tail covers
-  **both coding agents and persisted assistants**. Agor is not just for AI
-  coding. Anchoring the line to "AI coding" as we have been (see
-  `apps/agor-docs/pages/index.mdx:7`,
-  `apps/agor-docs/pages/guide/index.mdx:18`,
-  `apps/agor-docs/theme.config.tsx:83`) understates the product and will need
-  to be re-pitched once Cards, Assistants, and non-code workflows lead more
-  conversations.
-
-The tagline is one line. Don't pair it with a co-tagline ("Think Figma, but
-for AI coding assistants") — that's the bug we're fixing. Use the tagline
-alone, then transition into a paragraph form below.
+Use it alone. Don't pair it with a co-tagline.
 
 ---
 
-## Paragraph forms
-
-Three forms, in increasing length. Pick the one that fits the surface.
-
-### One-sentence (≤ 25 words)
-
-> **Agor is a team command center for all things agentic — orchestrate coding
-> agents and persisted assistants on a shared spatial canvas, with isolated
-> worktrees, real-time presence, and an MCP surface agents can drive
-> themselves.**
-
-Suitable for: GitHub repo description, root `package.json` `description`
-field, Twitter / X bio, link previews, JSON-LD `description`, OG meta.
-
-### Short paragraph (~50 words, 2–3 sentences)
+## Short paragraph (~50 words)
 
 > **Team command center for all things agentic.** Agor is a shared canvas
-> where coding agents (Claude Code, Codex, Gemini) and persisted assistants
-> run side-by-side on isolated git worktrees. You see what every agent is
-> doing in real time, your teammates see it too, and the agents themselves
-> can drive Agor over MCP.
+> where coding agents (Claude Code, Codex, Gemini) and persisted
+> assistants run side-by-side on isolated git worktrees. You see what every
+> agent is doing in real time, your teammates see it too, and the agents
+> themselves can drive Agor over MCP.
 
-Suitable for: README intro under `# Agor`, docs landing TL;DR, pitch deck
-slide 1, blog post lead paragraph, OSS directory listing.
-
-### Long paragraph (~150 words)
-
-> **Team command center for all things agentic.** Running one coding agent in
-> a terminal works. Running five — across teammates, across repos, with
-> assistants quietly grooming the backlog at night — falls apart fast.
-> Conversations vanish, branches collide, dev servers fight for ports, and
-> nobody can see what anyone else's agent is doing. Agor gives a team a
-> single surface for that work: a 2D canvas where each unit of work is a git
-> worktree with its own branch, environment, and session tree; where Claude
-> Code, Codex, Gemini, and custom MCP-driven assistants are interchangeable
-> runtimes you pick per session; where teammates show up live with cursors,
-> facepile, comments, and shared terminals; and where every action is also
-> exposed to agents themselves through Agor's MCP server, so the system can
-> orchestrate, fork, spawn, and report on its own work. Self-hosted, with
-> Unix-level isolation when you need it.
-
-Suitable for: docs landing extended intro, sales one-pager, blog announcement
-intro, investor / partner deck, conference talk abstract.
+For: README intro, docs landing TL;DR, deck slide 1, blog lead.
 
 ---
 
-## What Agor is
+## Long paragraph (~150 words)
 
-Concrete claims. Each is defensible against the current implementation.
+> **Team command center for all things agentic.** Running one coding agent
+> in a terminal works. Running five — across teammates, across repos, with
+> assistants quietly grooming the backlog at night — falls apart fast.
+> Conversations vanish, branches collide, dev servers fight for ports, and
+> nobody can see what anyone else's agent is doing. Agor is a Figma-like
+> spatial canvas for that work: every unit of work is a git worktree with
+> its own branch, environment, and session tree; Claude Code, Codex,
+> Gemini, and any MCP-driven assistant are interchangeable runtimes you
+> pick per session; teammates show up live with cursors, facepile,
+> comments, and shared terminals; and every action is exposed to agents
+> themselves through Agor's MCP server, so the system can fork, spawn,
+> schedule, and report on its own work. Self-hosted, with Unix-level
+> isolation when you need it.
 
-- **A spatial canvas** where worktrees, sessions, cards, and zones are
-  first-class objects you can see, drag, and arrange.
-- **A worktree manager** — every unit of work is an isolated git worktree
-  with its own branch, environment, ports, and conversations attached.
-- **A multi-agent runtime host** — Claude Code, Codex, Gemini, OpenCode, and
-  GitHub Copilot are all interchangeable session runtimes; you pick per
-  session.
-- **A real-time multiplayer surface** — live cursors, facepile, scoped
-  comments, attention pulse, shared tmux terminals.
-- **An MCP server** — anything a user can do in Agor, an agent can do too,
-  via the daemon's MCP surface. Sessions are auto-issued tokens.
-- **A scheduler** — cron-style triggers for templated prompts; powers
-  assistant heartbeats, daily standups, scheduled audits.
-- **A home for persisted assistants** — long-lived agents with file-based
-  memory and skills, OpenClaw-style.
-- **A self-hosted product** — your repos, your database (LibSQL or Postgres),
-  your Unix users when you turn on full isolation.
+For: docs landing extended intro, sales one-pager, announcement post.
+
+---
+
+## What Agor is — bullets, ranked
+
+Sorted by importance, relevance, and market appetite. Use the top of this
+list when picking what to highlight — feature pages, launch threads, deck
+slides, sales conversations.
+
+1. **A team workspace for AI agents.** Multiplayer is the core
+   differentiator: live cursors, facepile, scoped comments, attention
+   pulse, shared tmux terminals. Most agentic tools today are solo. Agor
+   isn't.
+2. **A Figma-like spatial canvas.** Boards are 2D — worktrees are cards,
+   zones are regions, you arrange your work and your teammates see where
+   you're at. The spatial layout is what makes the multiplayer real.
+3. **Multi-agent, multi-runtime.** Claude Code, Codex, Gemini, OpenCode,
+   Copilot — interchangeable per session. Pick the right tool for the job;
+   don't lock yourself into one vendor.
+4. **Worktree-isolated.** Every unit of work is a git worktree with its
+   own branch, environment, ports, and conversations. Parallel work
+   doesn't collide.
+5. **Observable.** Every session, every prompt, every tool call, every
+   dollar — visible, durable, queryable. Status dots, completion chimes,
+   token + dollar accounting per prompt, full conversation history per
+   worktree. No more "what was that agent doing again."
+6. **MCP-native.** Anything a user can do in Agor, an agent can do too.
+   Sessions are auto-issued tokens; agents fork, spawn, schedule, and
+   report on their own work.
+7. **A home for persisted assistants.** Long-lived agents with file-based
+   memory and skills, OpenClaw-style. Distinct from one-off sessions.
+8. **A scheduler.** Cron-style triggers for templated prompts. Powers
+   assistant heartbeats, daily standups, scheduled audits.
+9. **Self-hosted.** BSL 1.1, your repos, your DB (LibSQL or Postgres),
+   your Unix users when you turn on full isolation.
+
+---
+
+## How we speak at a high level
+
+One-liner for talks, intros, and DMs:
+
+> *Agor is the team command center for everything you're doing with AI agents — Claude Code, Codex, Gemini, custom assistants — on a shared spatial canvas, with full observability and self-hosted isolation.*
+
+When the audience is technical and skeptical, lead with the problem:
+
+> *One agent in a terminal is fine. Five agents across a team is chaos. Agor is the workspace that makes that scale.*
+
+When the audience is multiplayer-curious, lead with the Figma frame:
+
+> *Think Figma's spatial canvas, applied to AI agents. You see your teammates, you see what their agents are running, you coordinate live instead of after-the-fact.*
+
+The Figma analogy is reserved for team / multiplayer / canvas framing —
+it's the right reference there. Don't use it as the master tagline (the
+"Figma for AI coding" framing we retired understates the product).
+
+---
 
 ## What Agor is NOT
 
-Disambiguations. The tagline can evoke the wrong mental model — these lines
-exist to redirect.
-
-- **Not just for AI coding.** Persisted assistants, non-code workflows
-  (cards), and custom MCP integrations are equal citizens. Don't let
-  "command center for agentic coding" become the implicit positioning the
-  way "AI coding" did in earlier copy.
-- **Not Figma.** The "Figma for AI coding" line was a useful early
-  shorthand, and the spatial-canvas comparison is real, but Figma is for
-  *designing* artifacts. Agor's canvas is for *coordinating real running
-  work*. We retired the line.
-- **Not an LLM and not a model gateway.** Agor doesn't ship a model. You
-  bring agent runtimes (Claude Code, Codex, Gemini, custom MCP). Agor
-  orchestrates them.
-- **Not a CI/CD system.** Scheduler triggers prompts on a cadence; it does
-  not replace GitHub Actions, Buildkite, or Argo. Sessions can call into
-  CI; CI does not call into sessions.
-- **Not an IDE.** Agor doesn't replace VSCode/Cursor/JetBrains. The
-  "Bring Your Own IDE" roadmap item is the canonical position: keep your
-  editor, attach it to Agor-managed worktrees.
-- **Not a chatbot framework.** Sessions wrap real coding-agent SDKs. We
-  don't build the agent — we run, watch, and connect them.
-- **Not a closed SaaS.** Agor is BSL 1.1, self-hosted-first. There is no
-  hosted "agor.com" tier today.
+- **Not just for AI coding.** Persisted assistants and non-code workflows
+  (Cards) are equal citizens.
+- **Not an LLM or model gateway.** Bring your own runtime.
+- **Not an IDE.** Roadmap is "bring your own IDE," attached to
+  Agor-managed worktrees.
+- **Not CI/CD.** Scheduler triggers prompts on a cadence; doesn't replace
+  Actions/Buildkite/Argo.
+- **Not closed SaaS.** Self-hosted-first, BSL 1.1.
 
 ---
 
-## Vocabulary — say this, not that
+## Vocabulary
 
-The brand voice. Use the ✅ words; flag the ❌ words in code review.
+✅ **Use:** team, team command center, agentic, multiplayer, Figma-like
+spatial canvas (in team/multiplayer context), orchestrate, worktree,
+session, board, zone, agent, assistant, observability, isolation,
+real-time, MCP, self-hosted.
 
-### ✅ On-brand
-
-| Word | What it signals |
-|---|---|
-| **team / team command center** | Audience: groups, not lone hackers. Headline-grade. |
-| **command center** | Humans sit here and steer. UI-flavored, not infra-flavored. |
-| **agentic** | Covers coding agents *and* persisted assistants — broader than "AI coding." |
-| **multiplayer** | Feature-page word for the real-time presence stack (cursors, facepile, comments). Stays in vocabulary, just not in the headline. |
-| **orchestrate** | Active verb for what teams do with multiple agents. Pairs with "command center." |
-| **worktree(s)** | Our primary unit of work. Always plural-friendly. Don't substitute "branch" or "task." |
-| **session(s) / session tree** | Agent conversation with genealogy. Use "session" not "chat" or "thread." |
-| **board(s) / zone(s)** | The 2D spatial surface and its regions. |
-| **assistant(s)** | Persisted, long-lived agents with memory and skills. Distinct from "session." |
-| **agent(s)** | The generic term for a runtime that takes prompts and acts. |
-| **spatial canvas** | The board surface. Use sparingly — once per page, not every paragraph. |
-| **isolation** | Worktree-level, environment-level, Unix-level. The security register. |
-| **real-time** | What the multiplayer stack feels like; pairs with "presence." |
-| **MCP / MCP server** | The agent-facing surface. Always uppercase. |
-| **self-hosted** | Deployment posture. Not "on-prem" — wrong era. |
-
-### ❌ Off-brand
-
-| Word | Why we avoid it |
-|---|---|
-| **next-gen** | Empty intensifier. Used in `apps/agor-docs/pages/index.mdx:7` and `theme.config.tsx:83,85` — slated for removal. |
-| **AI-powered** | Says nothing in 2026. Every product is. |
-| **swarm** | Implies undirected mass; Agor is the opposite (named, orchestrated, observable). Currently in `apps/agor-docs/pages/guide/index.mdx:23` — slated for removal. |
-| **spatial layer** | Infra metaphor for a UI product. From `apps/agor-docs/pages/index.mdx:8`. Use "spatial canvas" instead. |
-| **revolutionary / revolutionize** | Marketing tic. We do not use it. |
-| **10x / supercharge / unlock** | Hype register. We do not use it. |
-| **productivity** | Vague benefit. Replace with the concrete capability ("parallel work without port collisions"). |
-| **AI coding (as the only frame)** | Understates Agor — see "What Agor is NOT" item 1. Fine inside features pages where the context is coding; not fine in the headline. |
-| **Figma for AI coding** | Retired. The comparison was useful early; it now caps the product. From `README.md:5` and `apps/agor-docs/pages/guide/index.mdx:16`. |
-| **control plane** | Infra-flavored. Use "command center." |
+❌ **Avoid:** next-gen, AI-powered, swarm, spatial layer, control plane,
+revolutionary, 10x, supercharge, productivity, "Figma for AI coding"
+(retired as headline; OK as inline color in team/multiplayer context).
 
 ---
 
 ## Audience tiers
 
-Three audiences, three concrete pitches. Each starts from the same canonical
-tagline and differentiates on what *changes* for that reader.
-
-### 1. Solo dev with one agent
-
-> **Team command center for all things agentic.** Even solo, Agor gives you
-> a place where every agent run lands — branches don't collide, dev servers
-> don't fight for ports, conversations don't disappear into terminal
-> scrollback, and you can see at a glance what's running, what finished, and
-> what stalled.
-
-What they get: visibility, isolation, durable conversation history, a place
-to land work.
-
-### 2. Team lead with multiple devs each running agents
-
-> **Team command center for all things agentic.** When five teammates each
-> run two agents, the question stops being "is my agent working" and starts
-> being "what is everyone's agent doing." Agor turns that into a shared
-> board: live cursors, scoped comments, attention pulse on completed work,
-> RBAC on worktrees, and a single audit trail across every session your
-> team ran.
-
-What changes: shared spatial awareness, RBAC, cross-team observability, no
-more "share your screen" calls.
-
-### 3. Platform engineer setting up Agor for an org
-
-> **Team command center for all things agentic.** Agor is self-hosted, runs
-> against LibSQL or Postgres, and supports four progressive isolation modes
-> from open access to per-user Unix accounts with credential isolation.
-> Agents reach internal tools through MCP servers you configure once; users
-> get a UI that respects the OS permissions you've already invested in.
-
-What changes: deployment modes (`simple` / `insulated` / `strict`), MCP
-integration with internal tooling, sudoers-backed isolation when required,
-audit + compliance posture.
+| Audience | Lead with |
+|---|---|
+| **Solo dev** | Visibility, isolation, durable conversation history. "Even solo, every agent run lands somewhere — branches don't collide, dev servers don't fight, conversations don't vanish." |
+| **Team lead** | Shared canvas, RBAC, cross-team observability. "Five teammates each running two agents — Agor is what turns that from chaos into a board you can actually read." |
+| **Platform engineer** | Self-hosted, four progressive isolation modes (`simple` / `insulated` / `strict`), MCP integration with internal tools. "Your OS permissions, your DB, your audit trail." |
 
 ---
 
 ## Where each form belongs
 
-| Surface | Form | Notes |
-|---|---|---|
-| Docs landing Hero (`apps/agor-docs/pages/index.mdx`) | Tagline + short paragraph | Replace `subtitle="Next-gen agent orchestration for AI coding"` and the `description=` prop. |
-| Guide overview (`apps/agor-docs/pages/guide/index.mdx`) | Tagline + short paragraph + TL;DR sentence | Currently 4 stacked one-liners (lines 16, 18, 20, 22–23) — collapse to one. |
-| README intro (`README.md`) | Tagline + one-sentence + "What is Agor" bullets | Replace line 5–7. |
-| Root `package.json` `description` | One-sentence (trimmed to fit npm registry rendering) | Replace `"Next-gen agent orchestration platform"`. |
-| `packages/agor-live/package.json` `description` | One-sentence | Currently `"Multiplayer canvas for orchestrating AI coding sessions"` — refresh once tagline lands. |
-| `theme.config.tsx` default `description` and `fullTitle` | One-sentence (description); tagline (title suffix) | Lines 83 and 85 — replace `"Next-gen agent orchestration"`. |
-| GitHub repo description (Settings → About) | One-sentence | Public link previews. |
-| Twitter / X bio, Discord description | Tagline only | Keep it to the headline. |
-| Conference talk title slide | Tagline only | Optionally with a single subtitle: "Self-hosted. Multiplayer. MCP-native." |
-| Blog post lead / announcement | Short or long paragraph depending on length | Long paragraph for first-touch posts. |
-| Sales one-pager / partner deck | Long paragraph + audience-tiered pitches | Tier-2 and tier-3 pitches lead the doc. |
-| OG / Twitter card meta description | One-sentence | Currently in `theme.config.tsx:82-83`. |
-| JSON-LD `SoftwareApplication.description` | One-sentence | Currently in `theme.config.tsx:179-181`. |
-| OSS directory listings (Awesome lists, Yo, etc.) | One-sentence | Match GitHub repo description. |
+| Surface | Form |
+|---|---|
+| Docs landing Hero (`apps/agor-docs/pages/index.mdx`) | Tagline + short paragraph |
+| Guide overview (`apps/agor-docs/pages/guide/index.mdx`) | Tagline + short paragraph |
+| README intro | Tagline + short paragraph + top 3–4 bullets from "What Agor is" |
+| `package.json` `description` (root) | One-liner |
+| Meta description / OG / JSON-LD (`theme.config.tsx`) | One-liner |
+| GitHub repo description, X bio, Discord description | Tagline only |
+| Conference / talk title slide | Tagline only |
+| Blog announcement, deck slide 1 | Short paragraph |
+| Sales one-pager, partner deck, deep blog post | Long paragraph + audience tiers |
 
 ---
 
-## Proposed `/guide/` hierarchy
+## `/guide/` hierarchy — proposal
 
-The current `_meta.ts`
-(`apps/agor-docs/pages/guide/_meta.ts`) is already grouped with separators
-into Features / Reference / Development / Deployment. The grouping is
-sensible. The proposal below mostly preserves it and tightens overlaps.
+Current structure (`apps/agor-docs/pages/guide/_meta.ts`) is already
+grouped Features / Reference / Development / Deployment, and works.
+**Don't redesign. Tighten copy in place.** Cascade rollout scope:
 
-**Verdict: do not redesign. Tighten in place.** No page is an obvious
-mistake; the docs are in much better shape than the homepage one-liners
-suggest. Specific changes:
-
-| Page | Verdict | Rationale |
-|---|---|---|
-| `index.mdx` | **Rewrite intro, keep structure** | Currently has 4 stacked taglines (lines 16, 18, 20, 22–23). Collapse to canonical tagline + short paragraph. |
-| `getting-started.mdx` | **Keep** | Onboarding flow. Top-level. |
-| `extended-install.mdx` | **Keep** | Alternative installs. Top-level. |
-| `features-overview.mdx` | **Keep, retitle "What Agor does"** | Current title is fine; the page is the de-facto product map and is well-written. Consider linking to this messaging doc from the bottom (with a note that it's internal — or extract a public "positioning" page if we ever need one). |
-| `worktrees.mdx` | **Keep — top-level concept** | One of the three foundations. |
-| `sessions.mdx` | **Keep — top-level concept** | One of the three foundations. |
-| `boards.mdx` | **Keep — top-level concept** | One of the three foundations. |
-| `assistants.mdx` | **Keep — top-level concept** | The persisted-assistant pillar. Critical for the "all things agentic" framing. |
-| `internal-mcp.mdx` | **Keep, consider rename to "Agor MCP server (built-in)"** | The current title in `_meta.ts` ("Agor MCP Server") is good; the file slug `internal-mcp` is fine. |
-| `rich-chat-ux.mdx` | **Keep — top-level feature** | Differentiator vs. terminal CLI. |
-| `multiplayer-social.mdx` | **Keep — top-level feature** | Cursors / facepile / comments / shared terminal. |
-| `multiplayer-unix-isolation.mdx` | **Keep, but move under "Deployment" (already there)** | Already correctly grouped under Deployment in `_meta.ts:34-39`. Different concept from `multiplayer-social.mdx` — that one is the *user-facing* presence layer, this one is the *operator-facing* security mode. **They should NOT merge.** They have the same prefix because both relate to Agor's multi-user posture, but one is "what teammates see," the other is "how the OS protects them." Consider renaming for clarity: `multiplayer-social.mdx` → `presence-and-collaboration.mdx`, `multiplayer-unix-isolation.mdx` → `unix-isolation.mdx`. Flagging for Max — see "Open questions." |
-| `environment-configuration.mdx` | **Keep** | Per-worktree dev servers. Top-level feature. |
-| `scheduler.mdx` | **Keep** | Cron-style triggers. Top-level feature. |
-| `cards.mdx` | **Keep — flagged Beta** | Generic non-code workflow units. Important for the "not just AI coding" framing. |
-| `artifacts.mdx` | **Keep** | Sandpack-rendered apps. Top-level feature. |
-| `message-gateway.mdx` | **Keep** | Slack / GitHub portals. Top-level feature. |
-| `architecture.mdx` | **Keep — Reference** | Already grouped under Reference. |
-| `typescript-client.mdx` | **Keep — Reference** | Already grouped under Reference. |
-| `sdk-comparison.mdx` | **Keep — Reference** | Already grouped under Reference. |
-| `development.mdx` | **Keep — Development** | Already grouped under Development. |
-| `containerized-execution.mdx` | **Keep — Deployment** | Already grouped under Deployment. |
-
-**Net change to hierarchy:** none. The cascade rollout's job is to update
-copy on `index.mdx`, the Hero, and the README — not to restructure the guide.
-
-**One additional suggestion** for the cascade: add a top-of-page summary
-block on `features-overview.mdx` of the form "Agor is a *team command center
-for all things agentic*. Below: the surfaces that make it that." — so the
-features page anchors back to the canonical tagline.
+1. **`pages/guide/index.mdx`** — collapse the four stacked taglines
+   (lines 16, 18, 20, 22–23) to canonical tagline + short paragraph.
+2. **`pages/index.mdx`** — replace Hero `subtitle` and `description`
+   props with tagline + short paragraph.
+3. **`README.md`** — replace lines 5–7 with tagline + short paragraph +
+   top 3–4 bullets.
+4. **`theme.config.tsx`** — replace default `description` (line 83),
+   `fullTitle` suffix (line 85), and JSON-LD `description` (lines 179–181)
+   with the one-liner.
+5. **`package.json`** descriptions — root and `packages/agor-live`.
+6. **Slugs left alone** — `multiplayer-social.mdx` and
+   `multiplayer-unix-isolation.mdx` keep their names; the prefix overlap
+   is acceptable.
+7. **Closing pull-quote** at `pages/guide/index.mdx:192` ("git tracks
+   code, Agor tracks the conversations that produced it") — retire.
+   Observability is in the bullets above; it doesn't need a tagline.
+8. **"Figma" references on feature pages** —
+   `multiplayer-social.mdx:8` and `features-overview.mdx:70` are kept;
+   they're the right place for the Figma-like-canvas framing per the
+   "How we speak" section.
 
 ---
 
-## Survey appendix — current state
+## Survey appendix — current copy in the codebase
 
-The phrases that exist in the codebase today, by file. This is the baseline
-the cascade rollout will replace; cite this table when reviewing the cascade
-PR.
+Baseline for the cascade rollout. Cite this when reviewing the cascade PR.
 
-### Taglines and pitch sentences
-
-| File | Line | Quoted phrase | Category |
+| File | Line | Quoted phrase | Action |
 |---|---|---|---|
-| `README.md` | 5 | "Think Figma, but for AI coding assistants. Orchestrate Claude Code, Codex, and Gemini sessions on a multiplayer canvas." | tagline + paragraph |
-| `README.md` | 7 | "Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks, with GitHub-linked worktrees, automated workflow zones, and isolated test environments—all running simultaneously." | TL;DR paragraph |
-| `README.md` | 98 | "Multiplayer spatial canvas with zones, worktrees, and real-time collaboration" | screenshot caption |
-| `apps/agor-docs/pages/index.mdx` | 7 | "Next-gen agent orchestration for AI coding" | Hero subtitle |
-| `apps/agor-docs/pages/index.mdx` | 8 | "The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace." | Hero description |
-| `apps/agor-docs/pages/guide/index.mdx` | 3 | "Complete guide to agor - next-gen agent orchestration for AI coding. Learn about multiplayer workspaces, git worktrees, session trees, and real-time collaboration for Claude Code, Codex, and Gemini." | meta description |
-| `apps/agor-docs/pages/guide/index.mdx` | 16 | "Think Figma, but for AI coding assistants." | tagline (#1) |
-| `apps/agor-docs/pages/guide/index.mdx` | 18 | "Next-gen agent orchestration for AI coding. The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace." | tagline + paragraph (#2) |
-| `apps/agor-docs/pages/guide/index.mdx` | 20 | "Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks…" | TL;DR paragraph (#3) |
-| `apps/agor-docs/pages/guide/index.mdx` | 22–23 | "Visualize, coordinate, and automate your AI workflows across tools solo or with your team. Agor offers a place where you can coordinate entire swarms of AI agents." | follow-on paragraph (#4) |
-| `apps/agor-docs/pages/guide/index.mdx` | 60 | "Multiplayer spatial canvas with custom-styled zones, session trees, and worktree pipelines" | screenshot caption |
-| `apps/agor-docs/pages/guide/index.mdx` | 192 | "git tracks code, Agor tracks the conversations that produced it." | closing pull-quote |
-| `apps/agor-docs/theme.config.tsx` | 83 | "Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini." | default meta description |
-| `apps/agor-docs/theme.config.tsx` | 85 | "agor – Next-gen agent orchestration" | site title fallback |
-| `apps/agor-docs/theme.config.tsx` | 121 | "AI coding, agent orchestration, Claude Code, Codex, Gemini, AI development, multiplayer IDE, git worktrees, agentic coding, AI agents, developer tools" | meta keywords |
-| `apps/agor-docs/theme.config.tsx` | 179–181 | "Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini." | JSON-LD `SoftwareApplication.description` |
-
-### `package.json` description fields
-
-| File | Quoted phrase |
-|---|---|
-| `package.json` (root) | "Next-gen agent orchestration platform" |
-| `packages/agor-live/package.json` | "Multiplayer canvas for orchestrating AI coding sessions" |
-| `packages/client/package.json` | "TypeScript client for connecting to the Agor daemon" *(no positioning needed)* |
-| `packages/executor/package.json` | "Agor executor process - isolated execution environment" *(no positioning needed)* |
-| `packages/core/package.json` | *(no description)* |
-| `apps/agor-cli/package.json` | *(no description)* |
-| `apps/agor-daemon/package.json` | *(no description)* |
-| `apps/agor-docs/package.json` | *(no description)* |
-| `apps/agor-ui/package.json` | *(no description)* |
-
-### Feature page tag-lines (kept, in scope only for future tightening)
-
-These aren't competing top-level taglines — they're per-feature opening
-hooks. Listed here for completeness; cascade rollout doesn't need to touch
-them unless the wording references retired phrases.
-
-| File | Quoted phrase |
-|---|---|
-| `apps/agor-docs/pages/guide/multiplayer-social.mdx:8` | "Agor is great solo. Multiplayer is what makes it Figma." |
-| `apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx:21` | "once upon a time, teams shared servers" |
-| `apps/agor-docs/pages/guide/features-overview.mdx:70` | "Figma for AI coding." |
-
-The two "Figma" references are the most important ones to revisit during
-cascade — they're load-bearing on the retired comparison.
-
----
-
-## Open questions for Max
-
-These got flagged during drafting and need a call before the cascade lands:
-
-1. **Rename `multiplayer-social.mdx` and `multiplayer-unix-isolation.mdx`?**
-   They share a `multiplayer-` prefix but cover orthogonal concerns (one is
-   user-facing presence; one is OS-level isolation). Suggested rename:
-   `presence-and-collaboration.mdx` and `unix-isolation.mdx`. This is a
-   redirect-tax cost vs. a clarity win. Defaulting to "leave the slugs, fix
-   internal cross-references" unless you say otherwise.
-2. **Keep "Figma" as a feature-page hook?** The README/Hero/landing
-   "Figma for AI coding" framing is retired in this doc. The remaining
-   in-the-wild references are the per-feature hooks listed in the survey
-   appendix's last table. Rip them out entirely, or let them survive as
-   inline color on feature pages where the spatial-canvas comparison still
-   helps?
-3. **Do we want a public version of this doc?** This file is internal /
-   opinionated. A subset (canonical tagline + paragraph forms + audience
-   tiers) could live as `apps/agor-docs/pages/about/positioning.mdx` for
-   anyone evaluating Agor. Default: no — keep it internal until we have
-   a clear external need.
-4. **Replace the closing pull-quote** "git tracks code, Agor tracks the
-   conversations that produced it." (`pages/guide/index.mdx:192`)? It's
-   memorable and on-brand, but it leans on the "AI coding" frame. Keep it
-   for now; flag for revisit if the broader "agentic" framing demands it.
+| `README.md` | 5 | "Think Figma, but for AI coding assistants. Orchestrate Claude Code, Codex, and Gemini sessions on a multiplayer canvas." | Replace |
+| `README.md` | 7 | "Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks…" | Replace |
+| `apps/agor-docs/pages/index.mdx` | 7 | "Next-gen agent orchestration for AI coding" (Hero subtitle) | Replace |
+| `apps/agor-docs/pages/index.mdx` | 8 | "The multiplayer-ready, spatial layer that connects Claude Code, Codex, Gemini, and any agentic coding tool into one unified workspace." | Replace |
+| `apps/agor-docs/pages/guide/index.mdx` | 3 | "Complete guide to agor - next-gen agent orchestration for AI coding…" (meta) | Replace |
+| `apps/agor-docs/pages/guide/index.mdx` | 16 | "Think Figma, but for AI coding assistants." | Remove |
+| `apps/agor-docs/pages/guide/index.mdx` | 18 | "Next-gen agent orchestration for AI coding. The multiplayer-ready, spatial layer…" | Remove |
+| `apps/agor-docs/pages/guide/index.mdx` | 20 | "Agor is a multiplayer spatial canvas where you coordinate multiple AI coding assistants on parallel tasks…" | Remove |
+| `apps/agor-docs/pages/guide/index.mdx` | 22–23 | "Visualize, coordinate, and automate your AI workflows… coordinate entire swarms of AI agents." | Remove |
+| `apps/agor-docs/pages/guide/index.mdx` | 192 | "git tracks code, Agor tracks the conversations that produced it." | Remove |
+| `apps/agor-docs/theme.config.tsx` | 83 | "Next-gen agent orchestration for AI coding. Multiplayer workspace for Claude Code, Codex, and Gemini." (default meta) | Replace |
+| `apps/agor-docs/theme.config.tsx` | 85 | "agor – Next-gen agent orchestration" (title fallback) | Replace |
+| `apps/agor-docs/theme.config.tsx` | 121 | meta keywords list | Refresh |
+| `apps/agor-docs/theme.config.tsx` | 179–181 | JSON-LD `SoftwareApplication.description` | Replace |
+| `package.json` (root) | — | "Next-gen agent orchestration platform" | Replace |
+| `packages/agor-live/package.json` | — | "Multiplayer canvas for orchestrating AI coding sessions" | Refresh |
+| `apps/agor-docs/pages/guide/multiplayer-social.mdx` | 8 | "Agor is great solo. Multiplayer is what makes it Figma." | Keep |
+| `apps/agor-docs/pages/guide/features-overview.mdx` | 70 | "Figma for AI coding." | Keep (in multiplayer/team context only) |

--- a/context/messaging-and-positioning.md
+++ b/context/messaging-and-positioning.md
@@ -18,10 +18,11 @@ Use it alone. Don't pair it with a co-tagline.
 ## Short paragraph (~50 words)
 
 > **Team command center for all things agentic.** Agor is a shared canvas
-> where coding agents (Claude Code, Codex, Gemini) and persisted
-> assistants run side-by-side on isolated git worktrees. You see what every
-> agent is doing in real time, your teammates see it too, and the agents
-> themselves can drive Agor over MCP.
+> where coding agents (Claude Code, Codex, Gemini) and long-lived
+> assistants run side-by-side on isolated git worktrees — the anchor
+> entity where sessions, dev environments, prompts, and PRs converge. Your
+> whole team rallies around the same live work in real time, and the
+> agents themselves drive Agor over MCP.
 
 For: README intro, docs landing TL;DR, deck slide 1, blog lead.
 
@@ -54,27 +55,43 @@ list when picking what to highlight — feature pages, launch threads, deck
 slides, sales conversations.
 
 1. **A team workspace for AI agents.** Multiplayer is the core
-   differentiator: live cursors, facepile, scoped comments, attention
-   pulse, shared tmux terminals. Most agentic tools today are solo. Agor
-   isn't.
-2. **A Figma-like spatial canvas.** Boards are 2D — worktrees are cards,
+   differentiator. Most agentic tools today are solo. Agor isn't. Why it
+   matters:
+   - **Shared worktrees and dev envs.** Engineers, reviewers, PMs, QA, and
+     stakeholders rally around the *same* live dev environment instead of
+     "spin up your own to see it." One link, one running thing,
+     everyone's looking at it.
+   - **Shared AI sessions.** Work alongside teammates' agents in real
+     time. Watch how others prompt, lift their patterns, standardize the
+     workflows that work, codify the ones worth keeping as zone triggers.
+   - **Cross-team observability.** Clarity on who's running what, which
+     tools they use, how their workflows are structured, where tokens
+     get spent. The team learns from itself.
+2. **Worktrees as the anchor.** Every unit of work is a git worktree —
+   and a worktree is where sessions, dev environments, zone-triggered
+   standard prompts, issues, and PRs all converge. One entity to point
+   at, one place where the full context of a piece of work lives.
+3. **A Figma-like spatial canvas.** Boards are 2D — worktrees are cards,
    zones are regions, you arrange your work and your teammates see where
    you're at. The spatial layout is what makes the multiplayer real.
-3. **Multi-agent, multi-runtime.** Claude Code, Codex, Gemini, OpenCode,
+4. **Shared, long-lived assistants.** Persistent agents with identity, a
+   file-based memory system, and a skill system (OpenClaw-inspired), with
+   full access to Agor through its MCP server. Agor is the shared place
+   where teams give birth to assistants, configure and teach them, and
+   wire them into team channels through the message gateway (Slack,
+   GitHub). Distinct from one-off sessions — assistants are durable
+   coworkers.
+5. **Multi-agent, multi-runtime.** Claude Code, Codex, Gemini, OpenCode,
    Copilot — interchangeable per session. Pick the right tool for the job;
    don't lock yourself into one vendor.
-4. **Worktree-isolated.** Every unit of work is a git worktree with its
-   own branch, environment, ports, and conversations. Parallel work
-   doesn't collide.
-5. **Observable.** Every session, every prompt, every tool call, every
-   dollar — visible, durable, queryable. Status dots, completion chimes,
-   token + dollar accounting per prompt, full conversation history per
-   worktree. No more "what was that agent doing again."
-6. **MCP-native.** Anything a user can do in Agor, an agent can do too.
+6. **Observable end-to-end.** Every session, every prompt, every tool
+   call, every dollar — visible, durable, queryable. Status dots,
+   completion chimes, token + dollar accounting per prompt, full
+   conversation history per worktree. No more "what was that agent doing
+   again."
+7. **MCP-native.** Anything a user can do in Agor, an agent can do too.
    Sessions are auto-issued tokens; agents fork, spawn, schedule, and
    report on their own work.
-7. **A home for persisted assistants.** Long-lived agents with file-based
-   memory and skills, OpenClaw-style. Distinct from one-off sessions.
 8. **A scheduler.** Cron-style triggers for templated prompts. Powers
    assistant heartbeats, daily standups, scheduled audits.
 9. **Self-hosted.** BSL 1.1, your repos, your DB (LibSQL or Postgres),
@@ -95,6 +112,10 @@ When the audience is technical and skeptical, lead with the problem:
 When the audience is multiplayer-curious, lead with the Figma frame:
 
 > *Think Figma's spatial canvas, applied to AI agents. You see your teammates, you see what their agents are running, you coordinate live instead of after-the-fact.*
+
+When the audience is non-engineering (PMs, QA, design, leadership), lead with the rally:
+
+> *Agor is where the whole team — not just the engineer — gathers around a piece of work. The worktree is the anchor: live dev env, agent conversations, the PR, the prompts that produced it. Everyone sees the same thing.*
 
 The Figma analogy is reserved for team / multiplayer / canvas framing —
 it's the right reference there. Don't use it as the master tagline (the

--- a/context/messaging-and-positioning.md
+++ b/context/messaging-and-positioning.md
@@ -257,9 +257,12 @@ grouped Features / Reference / Development / Deployment, and works.
 
 ---
 
-## Survey appendix — current copy in the codebase
+## Survey appendix — pre-cascade baseline
 
-Baseline for the cascade rollout. Cite this when reviewing the cascade PR.
+The phrases below were in place before the cascade was applied (PR #1080).
+Rows are kept for historical reference; the "Action" column reflects what
+landed in the cascade. Dated blog posts (e.g. `pages/blog/announcement.mdx`)
+were intentionally left untouched as historical records.
 
 | File | Line | Quoted phrase | Action |
 |---|---|---|---|
@@ -281,3 +284,13 @@ Baseline for the cascade rollout. Cite this when reviewing the cascade PR.
 | `packages/agor-live/package.json` | — | "Multiplayer canvas for orchestrating AI coding sessions" | Refresh |
 | `apps/agor-docs/pages/guide/multiplayer-social.mdx` | 8 | "Agor is great solo. Multiplayer is what makes it Figma." | Keep |
 | `apps/agor-docs/pages/guide/features-overview.mdx` | 70 | "Figma for AI coding." | Keep (in multiplayer/team context only) |
+
+### Additional surfaces caught during cascade (not in original survey)
+
+| File | Line | Quoted phrase | Action |
+|---|---|---|---|
+| `apps/agor-cli/src/lib/banner.ts` | 22 | `TAGLINE = 'Next-gen agent orchestration platform'` (CLI banner shown on every command) | Replaced |
+| `apps/agor-ui/src/components/LoginPage/LoginPage.tsx` | 108 | "Next-gen agent orchestration" (login subtitle) | Replaced |
+| `context/concepts/core.md` | 7, 13–14 | "Multiplayer canvas for orchestrating agentic coding sessions" + "spatial layer" framing in the internal concept doc that other agents read | Replaced (and added pointer to this M&P doc) |
+| `apps/agor-docs/pages/blog/announcement.mdx` | 2, 8, 12 | "A Multiplayer-ready, Spatial Layer for Agentic Coding" (launch post, dated 2025-10-26) | Kept as historical record |
+| `apps/agor-docs/pages/blog/agor-cloud.mdx` | 10 | "next-gen, multi-agent, multiplayer servers" (body text, not tagline) | Kept (incidental use, not positioning) |

--- a/context/messaging-and-positioning.md
+++ b/context/messaging-and-positioning.md
@@ -33,10 +33,12 @@ For: README intro, docs landing TL;DR, deck slide 1, blog lead.
 > **Team command center for all things agentic.** Running one coding agent
 > in a terminal works. Running five — across teammates, across repos, with
 > assistants quietly grooming the backlog at night — falls apart fast.
-> Conversations vanish, branches collide, dev servers fight for ports, and
-> nobody can see what anyone else's agent is doing. Agor is a Figma-like
-> spatial canvas for that work: every unit of work is a git worktree with
-> its own branch, environment, and session tree; Claude Code, Codex,
+> Conversations vanish, branches collide, dev servers fight for ports,
+> configs rot on individual laptops, parallel runs are an afterthought,
+> and nobody can see what anyone else's agent is doing. Agor is a
+> Figma-like spatial canvas for that work: every unit of work is a git
+> worktree with its own branch, environment, and session tree; Claude
+> Code, Codex,
 > Gemini, and any MCP-driven assistant are interchangeable runtimes you
 > pick per session; teammates show up live with cursors, facepile,
 > comments, and shared terminals; and every action is exposed to agents
@@ -45,6 +47,57 @@ For: README intro, docs landing TL;DR, deck slide 1, blog lead.
 > isolation when you need it.
 
 For: docs landing extended intro, sales one-pager, announcement post.
+
+---
+
+## The problem Agor addresses
+
+Every team is being told to ramp on AI fast. Most are doing it in silos,
+on laptops, without a shared place for the work to live — and it isn't
+working. Specifically:
+
+1. **AI agent work is trapped on individual laptops.** Sessions are
+   private, dev envs are local, long-lived agents live in someone's
+   `~/`, MCP servers are configured per-machine. Your team's AI work
+   doesn't accumulate anywhere.
+2. **Handoffs are a tax.** Sharing a piece of work means `git push`,
+   `git pull`, "what prompt was that again?", `docker compose up`,
+   rebuild context. Every hop loses something.
+3. **Teams can't learn from each other, and models move faster than
+   anyone can keep up alone.** No way to see how a teammate prompts,
+   which model they're on, what worked. Everyone reinvents the same
+   workflows in private — and by the time one person figures out what
+   works for the current model, the model has shifted again.
+4. **Local config hell.** Each developer wires up their own MCP servers,
+   credentials, scripts. There's no shared place to publish an agent, a
+   skill, or a workflow.
+5. **Parallel work is still an afterthought.** Spinning up an agent is
+   cheap now — parallel runs should be the *premise*, not the exception.
+   But one branch / one terminal / one dev server is still the default.
+6. **The CLI is the wrong medium long-term.** Today's coding CLIs are
+   impressively pushing the limits of what a terminal can do, but the
+   ceiling is real — no token meter, no structured tool blocks, no live
+   presence, no spatial layout. Web + sockets is where this lives.
+7. **The IDE is being eclipsed for this work.** IDEs are familiar and
+   solid, but they're laid out for a single human editing files — not
+   for orchestrating multiple agents with conversations, dev
+   environments, and teammate presence. We need a higher-level control
+   plane that sits *above* the IDE: team-oriented, agent-oriented,
+   multi-worktree by default. Keep your IDE; attach it to Agor.
+
+These bullets are the internal source. What propagates into customer-
+facing copy is two compressed forms:
+
+- **The long-paragraph compressor** ("Conversations vanish, branches
+  collide, dev servers fight for ports, configs rot on individual
+  laptops, parallel runs are an afterthought, and nobody can see what
+  anyone else's agent is doing") — folds bullets #1–#5 into one rhythm.
+- **The one-liner** ("One agent in a terminal is fine. Five agents
+  across a team is chaos.") — the entire problem in two sentences. Used
+  in the technical/skeptical "How we speak" lead below.
+
+The "What Agor is" bullets that follow mirror these problems implicitly.
+Don't label the mapping — the design is felt, not narrated.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "//": "This is the monorepo root. Published package version is in packages/agor-live/package.json",
-  "description": "Next-gen agent orchestration platform",
+  "description": "Team command center for all things agentic — shared canvas for coding agents and long-lived assistants on isolated git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.",
   "keywords": [
     "ai",
     "agents",

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agor-live",
   "version": "0.17.2",
-  "description": "Multiplayer canvas for orchestrating AI coding sessions",
+  "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {
     "agor": "./bin/agor.js",


### PR DESCRIPTION
## Summary

Adds `context/messaging-and-positioning.md` — the first positioning doc in the repo. Establishes the canonical tagline (**Team command center for all things agentic**) and gives every customer-facing surface a reference point so future copy converges instead of diverging.

The trigger is the docs landing (`apps/agor-docs/pages/guide/index.mdx`) currently stacking four competing one-liners. This doc is the source of truth that the cascade rollout (separate worktree) will execute against. **No other files are touched in this PR.**

## What's in the doc

- **Canonical tagline** + reasoning for each word (team / command center / all things agentic)
- **Three paragraph forms** (one-sentence ≤25w, short ~50w, long ~150w) with surface assignments
- **What Agor is / is NOT** — anticipates the wrong mental models the tagline can evoke
- **Vocabulary table** — ✅ on-brand vs ❌ off-brand, with file-path citations for the off-brand phrases currently shipping
- **Audience tiers** — solo dev, team lead, platform engineer
- **Surface → form mapping** — Hero, README, package.json, Twitter bio, blog, deck, etc.
- **`/guide/` hierarchy audit** — verdict per page; net: don't redesign, tighten in place
- **Survey appendix** — every existing tagline, paragraph, and meta description in the codebase, with file path + line number, as the baseline the cascade will replace

## Open questions (flagged in the doc, awaiting Max's call)

1. Rename `multiplayer-social.mdx` / `multiplayer-unix-isolation.mdx`? They share a prefix but cover orthogonal concerns.
2. Rip out the remaining "Figma for AI coding" hooks on feature pages, or let them survive as inline color?
3. Do we want a public-facing subset of this doc at `/about/positioning`?
4. Keep the closing pull-quote "git tracks code, Agor tracks the conversations that produced it"?

## Why draft

Max wants to iterate on the doc before the cascade rollout. Once approved, a separate worktree will execute the copy changes across README, Hero, `pages/guide/index.mdx`, `theme.config.tsx`, and `package.json` files.

## Test plan

- [ ] Max reads the doc end-to-end
- [ ] Resolve the four open questions
- [ ] Confirm tagline survives review
- [ ] Confirm paragraph forms feel right at their target surfaces
- [ ] Approve survey appendix as cascade baseline