### PR TITLE
fix(sessions): centralize config defaults so dragged sessions don't hang (closes #1064)

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -6,8 +6,8 @@ import {
   DEFAULT_CODEX_MODEL,
   DEFAULT_GEMINI_MODEL,
   GEMINI_MODELS,
-  resolveModelConfigPrecedence,
 } from '@agor/core/models';
+import { resolveSessionDefaults } from '@agor/core/sessions';
 import {
   AGENTIC_TOOL_CAPABILITIES,
   type AgenticToolName,
@@ -774,51 +774,31 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       const currentSha = await getGitState(worktree.path);
       const currentRef = await getCurrentBranch(worktree.path);
 
-      // Determine permission mode from user defaults only
-      const { getDefaultPermissionMode } = await import('@agor/core/types');
-      const { mapPermissionMode } = await import('@agor/core/utils/permission-mode-mapper');
-
-      const userToolDefaults = user?.default_agentic_config?.[agenticTool];
-      const requestedMode =
-        userToolDefaults?.permissionMode || getDefaultPermissionMode(agenticTool);
-      const permissionMode = mapPermissionMode(requestedMode, agenticTool);
-
-      const permissionConfig: Record<string, unknown> = {
-        mode: permissionMode,
-        allowedTools: [],
-      };
-
-      if (
-        agenticTool === 'codex' &&
-        userToolDefaults?.codexSandboxMode &&
-        userToolDefaults?.codexApprovalPolicy
-      ) {
-        permissionConfig.codex = {
-          sandboxMode: userToolDefaults.codexSandboxMode,
-          approvalPolicy: userToolDefaults.codexApprovalPolicy,
-          networkAccess: userToolDefaults.codexNetworkAccess,
-        };
-      }
-
-      // Model selection: explicit modelConfig arg > user default.
-      // An explicit modelConfig overrides any user-default settings and is
-      // threaded through to session.model_config so the executor picks it up
-      // when spawning the agent (see query-builder.ts: rawModel is read from
-      // session.model_config.model).
-      const modelConfig = resolveModelConfigPrecedence([
-        coerceModelConfig(args.modelConfig),
-        userToolDefaults?.modelConfig,
-      ]);
-
-      // MCP server inheritance: explicit param > worktree config > user defaults
-      // An explicit empty array means "no MCPs" — does NOT fall through to worktree/user defaults.
-      // Resolve short IDs when from user input; worktree/user defaults are already full UUIDs.
-      const mcpServerIds =
+      // Resolve permission_config / model_config / inherited mcp_server_ids
+      // from the explicit MCP args (highest priority) > user defaults > system
+      // fallback. Single source of truth for this dance lives in
+      // `@agor/core/sessions` so MCP tools, the gateway, and the
+      // `before:create` hook can't drift apart.
+      //
+      // For the explicit MCP args we resolve short IDs first; worktree/user
+      // defaults are already full UUIDs, so the helper passes them through.
+      const explicitMcpServerIds =
         args.mcpServerIds !== undefined
           ? await Promise.all(args.mcpServerIds.map((id) => resolveMcpServerId(ctx, id)))
-          : worktree.mcp_server_ids && worktree.mcp_server_ids.length > 0
-            ? worktree.mcp_server_ids
-            : userToolDefaults?.mcpServerIds || [];
+          : undefined;
+      const resolvedDefaults = resolveSessionDefaults({
+        agenticTool,
+        user,
+        worktree,
+        overrides: {
+          modelConfig: coerceModelConfig(args.modelConfig),
+          mcpServerIds: explicitMcpServerIds,
+        },
+      });
+      const permissionConfig = resolvedDefaults.permission_config;
+      const modelConfig = resolvedDefaults.model_config;
+      const mcpServerIds = resolvedDefaults.mcp_server_ids;
+      const permissionMode = permissionConfig.mode;
       // Track whether the caller explicitly requested these servers. When they
       // did, we surface attach failures in the response instead of silently
       // dropping them (the "mcpServerId doesn't stick" bug). For inherited

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -1,6 +1,6 @@
 import { isWorktreeRbacEnabled } from '@agor/core/config';
 import { WorktreeRepository } from '@agor/core/db';
-import { resolveModelConfig } from '@agor/core/models';
+import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   AgenticToolName,
   BoardID,
@@ -776,41 +776,15 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
           const currentSha = await getGitState(worktree.path);
           const currentRef = await getCurrentBranch(worktree.path);
 
-          // Resolve permission mode from user defaults
-          const { getDefaultPermissionMode } = await import('@agor/core/types');
-          const { mapPermissionMode } = await import('@agor/core/utils/permission-mode-mapper');
-          const userToolDefaults = user?.default_agentic_config?.[agenticTool];
-          const requestedMode =
-            userToolDefaults?.permissionMode || getDefaultPermissionMode(agenticTool);
-          const permissionMode = mapPermissionMode(requestedMode, agenticTool);
-
-          // Build permission config
-          const permissionConfig: Record<string, unknown> = {
-            mode: permissionMode,
-            allowedTools: [],
-          };
-          if (
-            agenticTool === 'codex' &&
-            userToolDefaults?.codexSandboxMode &&
-            userToolDefaults?.codexApprovalPolicy
-          ) {
-            permissionConfig.codex = {
-              sandboxMode: userToolDefaults.codexSandboxMode,
-              approvalPolicy: userToolDefaults.codexApprovalPolicy,
-              networkAccess: userToolDefaults.codexNetworkAccess,
-            };
-          }
-
-          // Build model config from user defaults. resolveModelConfig stamps
-          // updated_at and conditionally includes effort/provider so we write
-          // the same normalized shape as every other session-create path.
-          const modelConfig = resolveModelConfig(userToolDefaults?.modelConfig);
-
-          // MCP server inheritance: worktree config > user defaults
-          const mcpServerIds =
-            worktree.mcp_server_ids && worktree.mcp_server_ids.length > 0
-              ? worktree.mcp_server_ids
-              : userToolDefaults?.mcpServerIds || [];
+          // Resolve permission_config / model_config / inherited mcp_server_ids
+          // from the user's defaults via the shared helper. Same logic the
+          // sessions `before:create` hook applies to UI/REST callers, kept
+          // explicit here so the rest of this handler can pass full sessionData.
+          const {
+            permission_config: permissionConfig,
+            model_config: modelConfig,
+            mcp_server_ids: mcpServerIds,
+          } = resolveSessionDefaults({ agenticTool, user, worktree });
 
           // Create new session
           const sessionData: Record<string, unknown> = {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -50,6 +50,7 @@ import type {
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
+import { applySessionConfigDefaults } from './utils/apply-session-config-defaults.js';
 import {
   ensureMinimumRole,
   registerAuthenticatedRoute,
@@ -1522,6 +1523,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             ]
           : []),
         injectCreatedBy(),
+        // Auto-fill permission_config / model_config from the creator's
+        // default_agentic_config[tool] when the caller omits them. Must run
+        // after injectCreatedBy() so `data.created_by` is the trusted user
+        // ID. See utils/apply-session-config-defaults.ts.
+        applySessionConfigDefaults(),
         async (context) => {
           // Populate repo field and auto-populate git_state from worktree_id
           if (!Array.isArray(context.data) && context.data?.worktree_id) {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -22,7 +22,7 @@ import {
   hasConnector,
   parseGitHubThreadId,
 } from '@agor/core/gateway';
-import { resolveModelConfig } from '@agor/core/models';
+import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   AgenticToolName,
   ChannelType,
@@ -35,7 +35,7 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import { getDefaultPermissionMode, SessionStatus } from '@agor/core/types';
+import { SessionStatus } from '@agor/core/types';
 
 /**
  * Inbound message data (platform → session)
@@ -515,15 +515,21 @@ export class GatewayService {
     let created = false;
     let mcpAuthWarning: string | undefined;
 
-    // Resolve agentic config: channel config > user defaults > system defaults
+    // Resolve agentic config: channel config > user defaults > system defaults.
+    // Channel-level agentic_config maps to the helper's `overrides` (it's the
+    // gateway's analogue of an MCP tool's explicit args).
     const agenticConfig = channel.agentic_config;
     const agenticTool: AgenticToolName = (agenticConfig?.agent as AgenticToolName) ?? 'claude-code';
-    const userDefaults = user.default_agentic_config?.[agenticTool];
-    const permissionMode =
-      agenticConfig?.permissionMode ??
-      userDefaults?.permissionMode ??
-      getDefaultPermissionMode(agenticTool);
-    const modelConfig = agenticConfig?.modelConfig ?? userDefaults?.modelConfig;
+    const { permission_config: gatewayPermissionConfig, model_config: gatewayModelConfig } =
+      resolveSessionDefaults({
+        agenticTool,
+        user,
+        overrides: {
+          permissionMode: agenticConfig?.permissionMode,
+          modelConfig: agenticConfig?.modelConfig,
+        },
+      });
+    const permissionMode = gatewayPermissionConfig.mode;
 
     if (existingMapping) {
       // Existing thread → existing session
@@ -596,8 +602,8 @@ export class GatewayService {
         unix_username: user.unix_username ?? null,
         status: SessionStatus.IDLE,
         agentic_tool: agenticTool,
-        permission_config: { mode: permissionMode },
-        model_config: resolveModelConfig(modelConfig),
+        permission_config: gatewayPermissionConfig,
+        model_config: gatewayModelConfig,
         tasks: [],
         // Denormalized gateway metadata (immutable snapshot at creation time)
         // Avoids N+1 lookups when rendering board cards

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -517,18 +517,29 @@ export class GatewayService {
 
     // Resolve agentic config: channel config > user defaults > system defaults.
     // Channel-level agentic_config maps to the helper's `overrides` (it's the
-    // gateway's analogue of an MCP tool's explicit args).
+    // gateway's analogue of an MCP tool's explicit args). Codex sub-config and
+    // MCP server lists are first-class fields on `GatewayAgenticConfig`, so
+    // thread them all through the helper — otherwise the executor's per-tool
+    // settings (which Codex reads from `permission_config.codex`, not `mode`)
+    // get silently dropped.
     const agenticConfig = channel.agentic_config;
     const agenticTool: AgenticToolName = (agenticConfig?.agent as AgenticToolName) ?? 'claude-code';
-    const { permission_config: gatewayPermissionConfig, model_config: gatewayModelConfig } =
-      resolveSessionDefaults({
-        agenticTool,
-        user,
-        overrides: {
-          permissionMode: agenticConfig?.permissionMode,
-          modelConfig: agenticConfig?.modelConfig,
-        },
-      });
+    const {
+      permission_config: gatewayPermissionConfig,
+      model_config: gatewayModelConfig,
+      mcp_server_ids: gatewayMcpServerIds,
+    } = resolveSessionDefaults({
+      agenticTool,
+      user,
+      overrides: {
+        permissionMode: agenticConfig?.permissionMode,
+        modelConfig: agenticConfig?.modelConfig,
+        codexSandboxMode: agenticConfig?.codexSandboxMode,
+        codexApprovalPolicy: agenticConfig?.codexApprovalPolicy,
+        codexNetworkAccess: agenticConfig?.codexNetworkAccess,
+        mcpServerIds: agenticConfig?.mcpServerIds,
+      },
+    });
     const permissionMode = gatewayPermissionConfig.mode;
 
     if (existingMapping) {
@@ -616,17 +627,18 @@ export class GatewayService {
       created = true;
 
       // Attach MCP servers from channel agentic config (reuses sessions service logic)
-      const mcpServerIds = agenticConfig?.mcpServerIds;
-      if (mcpServerIds && mcpServerIds.length > 0) {
+      // gatewayMcpServerIds came out of resolveSessionDefaults, so user-default
+      // inheritance is already applied (channel config > user defaults > []).
+      if (gatewayMcpServerIds.length > 0) {
         await sessionsService.setMCPServers(
           session.session_id as SessionID,
-          mcpServerIds,
+          gatewayMcpServerIds,
           'gateway'
         );
 
         // Check which MCP servers are not authenticated for this user
         const unauthedMcpNames: string[] = [];
-        for (const serverId of mcpServerIds) {
+        for (const serverId of gatewayMcpServerIds) {
           try {
             const server = await this.mcpServerRepo.findById(serverId);
             if (server?.auth?.type === 'oauth') {

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -414,29 +414,34 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     let modelConfig = inherited.model_config;
 
     // If spawning a different tool and no explicit overrides, fall through to
-    // the user's defaults for the target tool (parent's config is meaningless
-    // for a different agent — e.g. a Claude session's `acceptEdits` mode means
-    // nothing for a Codex spawn). Same resolution helper used by all other
-    // session-creation paths so we can't drift.
+    // the helper for the target tool. The parent's permission_config is
+    // meaningless for a different agent — e.g. a Claude session's `acceptEdits`
+    // mode means nothing for a Codex spawn, and Codex reads its own
+    // `permission_config.codex` sub-config that the parent doesn't carry.
+    // Always adopt the helper's resolved values (user defaults > system
+    // fallback) instead of partially keeping the parent's, so cross-agent
+    // permission-mode mapping and Codex sub-config defaults flow through.
     if (!isSameTool && !data.permissionMode && !data.modelConfig) {
       const userId = parent.created_by;
       if (userId && this.app) {
         try {
           const user = await this.app.service('users').get(userId, params);
           const userResolved = resolveSessionDefaults({ agenticTool: targetTool, user });
-          // Only adopt user-resolved values if the user has explicit defaults
-          // for this tool — otherwise keep the parent's settings rather than
-          // fall through to the system default (matches prior behavior).
-          if (user?.default_agentic_config?.[targetTool]) {
-            permissionConfig = userResolved.permission_config;
-            modelConfig = userResolved.model_config ?? modelConfig;
-          }
+          permissionConfig = userResolved.permission_config;
+          // model_config: prefer user default, but if user has no model
+          // pinned, keep the parent's so cross-tool spawns inherit the
+          // family-level "use the smart model" choice rather than nothing.
+          modelConfig = userResolved.model_config ?? modelConfig;
         } catch (error) {
-          // If we can't fetch user preferences, fall back to parent settings
+          // If we can't fetch user preferences, fall back to the helper with
+          // no user (system defaults) — still better than parent's stale
+          // cross-agent config.
           console.warn(
-            'Could not fetch user preferences for spawned session, using parent settings:',
+            'Could not fetch user preferences for spawned session, using system defaults:',
             error
           );
+          const sysResolved = resolveSessionDefaults({ agenticTool: targetTool });
+          permissionConfig = sysResolved.permission_config;
         }
       }
     }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -16,6 +16,7 @@ import {
 } from '@agor/core/db';
 import { type Application, Forbidden } from '@agor/core/feathers';
 import { resolveModelConfig } from '@agor/core/models';
+import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   MCPServerID,
@@ -412,32 +413,23 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     let permissionConfig = inherited.permission_config;
     let modelConfig = inherited.model_config;
 
-    // If spawning a different tool and no explicit overrides, fetch user preferences
+    // If spawning a different tool and no explicit overrides, fall through to
+    // the user's defaults for the target tool (parent's config is meaningless
+    // for a different agent — e.g. a Claude session's `acceptEdits` mode means
+    // nothing for a Codex spawn). Same resolution helper used by all other
+    // session-creation paths so we can't drift.
     if (!isSameTool && !data.permissionMode && !data.modelConfig) {
       const userId = parent.created_by;
       if (userId && this.app) {
         try {
           const user = await this.app.service('users').get(userId, params);
-          const toolDefaults = user?.default_agentic_config?.[targetTool];
-
-          if (toolDefaults) {
-            // Use user's preferred settings for this tool
-            permissionConfig = {
-              mode: toolDefaults.permissionMode,
-              ...(targetTool === 'codex' &&
-              toolDefaults.codexSandboxMode &&
-              toolDefaults.codexApprovalPolicy
-                ? {
-                    codex: {
-                      sandboxMode: toolDefaults.codexSandboxMode,
-                      approvalPolicy: toolDefaults.codexApprovalPolicy,
-                      networkAccess: toolDefaults.codexNetworkAccess,
-                    },
-                  }
-                : {}),
-            };
-
-            modelConfig = resolveModelConfig(toolDefaults.modelConfig) ?? modelConfig;
+          const userResolved = resolveSessionDefaults({ agenticTool: targetTool, user });
+          // Only adopt user-resolved values if the user has explicit defaults
+          // for this tool — otherwise keep the parent's settings rather than
+          // fall through to the system default (matches prior behavior).
+          if (user?.default_agentic_config?.[targetTool]) {
+            permissionConfig = userResolved.permission_config;
+            modelConfig = userResolved.model_config ?? modelConfig;
           }
         } catch (error) {
           // If we can't fetch user preferences, fall back to parent settings

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for `applySessionConfigDefaults` — the before-create hook that
+ * auto-fills `permission_config` and `model_config` from the creator's
+ * default_agentic_config[tool] when the caller omits them.
+ *
+ * Regression target: preset-io/agor#1064 — UI drag-into-zone created
+ * sessions with `permission_config: null`, which Claude Code interprets as
+ * the most restrictive mode and which made every dragged session hang.
+ */
+
+import type { HookContext } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applySessionConfigDefaults } from './apply-session-config-defaults';
+
+const ALICE = 'user-alice';
+
+interface FakeUser {
+  user_id: string;
+  default_agentic_config?: Record<string, unknown>;
+}
+
+function makeContext(opts: {
+  provider?: string;
+  data?: Record<string, unknown>;
+  users?: Record<string, FakeUser | null>;
+  user?: { user_id: string };
+}): HookContext {
+  const usersService = {
+    get: vi.fn(async (id: string) => {
+      const u = opts.users?.[id];
+      if (u === undefined) throw new Error(`user ${id} not found`);
+      return u;
+    }),
+  };
+  return {
+    params: { provider: opts.provider, user: opts.user },
+    data: opts.data,
+    app: { service: vi.fn(() => usersService) },
+  } as unknown as HookContext;
+}
+
+describe('applySessionConfigDefaults', () => {
+  beforeEach(() => {
+    // Restore any prior spies first so per-test `vi.spyOn(console, 'warn')`
+    // calls get a fresh spy rather than appending to a shared call history.
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  it("fills missing permission_config from the user's default for the tool", async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: { 'claude-code': { permissionMode: 'bypassPermissions' } },
+        },
+      },
+    });
+    await hook(ctx);
+    expect((ctx.data as { permission_config: { mode: string } }).permission_config.mode).toBe(
+      'bypassPermissions'
+    );
+  });
+
+  it('does not overwrite an explicit permission_config supplied by the caller', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'claude-code',
+        created_by: ALICE,
+        permission_config: { mode: 'plan' },
+      },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: { 'claude-code': { permissionMode: 'bypassPermissions' } },
+        },
+      },
+    });
+    await hook(ctx);
+    expect((ctx.data as { permission_config: { mode: string } }).permission_config.mode).toBe(
+      'plan'
+    );
+  });
+
+  it("fills missing model_config from the user's default", async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: {
+            'claude-code': { modelConfig: { model: 'claude-opus-4-6' } },
+          },
+        },
+      },
+    });
+    await hook(ctx);
+    expect((ctx.data as { model_config: { model: string } }).model_config.model).toBe(
+      'claude-opus-4-6'
+    );
+  });
+
+  it('falls back to system default permission mode when user has no defaults', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+    await hook(ctx);
+    // System default for claude-code is 'acceptEdits'
+    expect((ctx.data as { permission_config: { mode: string } }).permission_config.mode).toBe(
+      'acceptEdits'
+    );
+  });
+
+  it('does nothing when both fields are already set', async () => {
+    const usersGet = vi.fn();
+    const ctx = {
+      params: { provider: 'rest', user: { user_id: ALICE } },
+      data: {
+        agentic_tool: 'claude-code',
+        created_by: ALICE,
+        permission_config: { mode: 'plan' },
+        model_config: { mode: 'alias', model: 'x', updated_at: 'now' },
+      },
+      app: { service: vi.fn(() => ({ get: usersGet })) },
+    } as unknown as HookContext;
+    await applySessionConfigDefaults({ warnOnExternalDefaultFill: false })(ctx);
+    expect(usersGet).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when agentic_tool is missing (cannot resolve defaults)', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { created_by: ALICE },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+    await hook(ctx);
+    expect((ctx.data as { permission_config?: unknown }).permission_config).toBeUndefined();
+  });
+
+  it('is a no-op when created_by is missing', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      data: { agentic_tool: 'claude-code' },
+      users: {},
+    });
+    await hook(ctx);
+    expect((ctx.data as { permission_config?: unknown }).permission_config).toBeUndefined();
+  });
+
+  it('still fills defaults if the user lookup fails (degrades to system fallback)', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: { [ALICE]: undefined as unknown as null }, // triggers throw in fake
+    });
+    await hook(ctx);
+    // System default for claude-code
+    expect((ctx.data as { permission_config: { mode: string } }).permission_config.mode).toBe(
+      'acceptEdits'
+    );
+  });
+
+  it('warns when filling defaults on an external call (when warnOnExternalDefaultFill: true)', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: true });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+    await hook(ctx);
+    const matched = warnSpy.mock.calls.some(
+      ([msg]) => typeof msg === 'string' && msg.includes('Filled missing permission_config')
+    );
+    expect(matched).toBe(true);
+  });
+
+  it('does not warn for internal calls (no provider)', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: true });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const ctx = makeContext({
+      // no provider
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+    await hook(ctx);
+    const matched = warnSpy.mock.calls.some(
+      ([msg]) => typeof msg === 'string' && msg.includes('Filled missing permission_config')
+    );
+    expect(matched).toBe(false);
+  });
+
+  describe('regression: issue #1064', () => {
+    it('UI-shaped payload (no permission_config) gets bypassPermissions when user default is bypassPermissions', async () => {
+      // Mirrors the exact UI drag-into-zone payload from
+      // SessionCanvas.tsx: just {worktree_id, description, status, agentic_tool}.
+      const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+      const ctx = makeContext({
+        provider: 'rest',
+        user: { user_id: ALICE },
+        data: {
+          worktree_id: 'wt-1',
+          description: 'Session from zone "Yolo refactor"',
+          status: 'idle',
+          agentic_tool: 'claude-code',
+          created_by: ALICE,
+        },
+        users: {
+          [ALICE]: {
+            user_id: ALICE,
+            default_agentic_config: { 'claude-code': { permissionMode: 'bypassPermissions' } },
+          },
+        },
+      });
+      await hook(ctx);
+      const data = ctx.data as { permission_config: { mode: string } };
+      expect(data.permission_config).not.toBeNull();
+      expect(data.permission_config.mode).toBe('bypassPermissions');
+    });
+  });
+});

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
@@ -1,0 +1,117 @@
+/**
+ * Before-create hook that auto-fills `permission_config` and `model_config`
+ * from the creator's `default_agentic_config[tool]` when the caller omits them.
+ *
+ * Why this hook exists
+ * --------------------
+ * Multiple session-creation paths (MCP `agor_sessions_create`, MCP
+ * `agor_worktrees_set_zone`, gateway, the UI drag-into-zone handler, raw
+ * REST) used to each carry their own copy of the "fetch user → read tool
+ * defaults → resolve permission mode → build permission_config" dance. The UI
+ * drag handler shipped without it (issue #1064), so dragged sessions were
+ * created with `permission_config: null` — which Claude Code interprets as
+ * the most restrictive mode and which made every dragged session hang
+ * waiting for manual approval.
+ *
+ * Centralizing the resolution as a `before:create` hook means:
+ *  - Every caller benefits, including future ones.
+ *  - Callers that DO want to set explicit config (MCP tools with `modelConfig`
+ *    args, gateway with channel-level config, spawn/fork with parent
+ *    inheritance) just pre-populate the field — the hook leaves populated
+ *    fields untouched.
+ *
+ * The shared resolution logic lives in `@agor/core/sessions`
+ * ({@link resolveSessionDefaults}); this hook is just the FeathersJS adapter
+ * around it.
+ *
+ * Caveats
+ * -------
+ *  - The hook ONLY fills `permission_config` and `model_config`. MCP server
+ *    attachment is intentionally left to caller-side code because the
+ *    "explicit-failures-must-surface" semantics differ between
+ *    explicitly-requested servers (caller wants to know about failures) and
+ *    inherited servers (best-effort, log-and-skip). See the open follow-up
+ *    in `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx`.
+ *  - Internal calls (no `params.provider`) only resolve via `data.created_by`,
+ *    so service-to-service callers must stamp it (or the helper falls back to
+ *    the system default — same behavior as the bug today, just no longer
+ *    reachable via REST/MCP/UI).
+ */
+
+import { resolveSessionDefaults } from '@agor/core/sessions';
+import type { AgenticToolName, HookContext, Session, User } from '@agor/core/types';
+
+interface UsersService {
+  get: (id: string, params?: unknown) => Promise<User | null | undefined>;
+}
+
+/**
+ * @param opts.warnOnExternalDefaultFill — when `true` (recommended in dev),
+ *   logs a warning whenever an external (REST/socketio/MCP) caller omits
+ *   `permission_config`. This surfaces lazy callers without breaking them.
+ *   The hook still applies defaults; the warning is purely diagnostic.
+ */
+export interface ApplySessionConfigDefaultsOpts {
+  warnOnExternalDefaultFill?: boolean;
+}
+
+export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts = {}) {
+  const { warnOnExternalDefaultFill = true } = opts;
+
+  return async (context: HookContext): Promise<HookContext> => {
+    if (Array.isArray(context.data)) {
+      // Bulk create not supported for sessions; bail rather than guessing.
+      return context;
+    }
+    const data = context.data as Partial<Session> | undefined;
+    if (!data) return context;
+
+    const hasPermission = data.permission_config != null;
+    const hasModel = data.model_config != null;
+    if (hasPermission && hasModel) return context; // nothing to fill
+
+    const agenticTool = data.agentic_tool as AgenticToolName | undefined;
+    if (!agenticTool) return context; // can't resolve defaults without a tool
+
+    // Identify the user whose defaults to apply. External calls go through
+    // injectCreatedBy() first, which stamps `data.created_by` from
+    // `params.user.user_id`, so by the time we run, `created_by` is the
+    // ground truth. Internal calls may set it explicitly or not at all.
+    const userId = data.created_by;
+    if (!userId) return context;
+
+    let user: User | null | undefined;
+    try {
+      const usersService = context.app.service('users') as unknown as UsersService;
+      // Bypass auth for the lookup — we're inside a hook on behalf of the
+      // already-authenticated caller (or an internal call).
+      user = await usersService.get(userId, { provider: undefined });
+    } catch (err) {
+      // If we can't load the user, fall back to system defaults (no user-tier
+      // values) rather than failing the create.
+      console.warn(
+        `[apply-session-config-defaults] Failed to load user ${userId} for defaults:`,
+        err instanceof Error ? err.message : String(err)
+      );
+      user = null;
+    }
+
+    const resolved = resolveSessionDefaults({ agenticTool, user });
+
+    if (!hasPermission) {
+      data.permission_config = resolved.permission_config;
+      if (warnOnExternalDefaultFill && context.params.provider) {
+        console.warn(
+          `[apply-session-config-defaults] Filled missing permission_config for ${agenticTool} session ` +
+            `(user=${userId}, provider=${context.params.provider}, mode=${resolved.permission_config.mode}). ` +
+            `Caller should send permission_config explicitly.`
+        );
+      }
+    }
+    if (!hasModel && resolved.model_config) {
+      data.model_config = resolved.model_config;
+    }
+
+    return context;
+  };
+}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1626,7 +1626,21 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                           const template = Handlebars.compile(trigger.template);
                           const renderedPrompt = template(context);
 
-                          // Create new root session
+                          // Create new root session.
+                          //
+                          // permission_config / model_config are intentionally
+                          // omitted: the daemon's `applySessionConfigDefaults`
+                          // before:create hook fills them from the user's
+                          // default_agentic_config[tool] (see
+                          // apps/agor-daemon/src/utils/apply-session-config-defaults.ts).
+                          // Sending them here would mask the hook in tests
+                          // and re-introduce the drift this hook exists to
+                          // prevent. See preset-io/agor#1064.
+                          //
+                          // TODO(#1064 follow-up): MCP server inheritance from
+                          // worktree / user defaults is still caller-side on the
+                          // other paths; this UI handler does not attach any.
+                          // Resolve when MCP attach moves to a centralized hook.
                           const newSession = await client.service('sessions').create({
                             worktree_id: nodeId as WorktreeID,
                             description: `Session from zone "${zoneData.label}"`,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -11,7 +11,12 @@ import type {
   User,
   Worktree,
 } from '@agor-live/client';
-import { AGENTIC_TOOL_CAPABILITIES, SessionStatus, TaskStatus } from '@agor-live/client';
+import {
+  AGENTIC_TOOL_CAPABILITIES,
+  getDefaultPermissionMode,
+  SessionStatus,
+  TaskStatus,
+} from '@agor-live/client';
 import {
   BranchesOutlined,
   CloseOutlined,
@@ -314,12 +319,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [hasInput, setHasInput] = React.useState(() => !!inputValueRef.current.trim());
   const handleHasInputChange = React.useCallback((v: boolean) => setHasInput(v), []);
 
-  const getDefaultPermissionMode = React.useCallback((agent?: string): PermissionMode => {
-    return agent === 'codex' ? 'auto' : 'acceptEdits';
-  }, []);
+  // getDefaultPermissionMode imported from @agor-live/client — canonical
+  // per-tool defaults live in core's `getDefaultPermissionMode`. The local
+  // shadow that used to live here was stale (missing gemini/opencode/copilot)
+  // and silently drifted from the core definition.
 
   const [permissionMode, setPermissionMode] = React.useState<PermissionMode>(
-    session?.permission_config?.mode || getDefaultPermissionMode(session?.agentic_tool)
+    session?.permission_config?.mode ||
+      (session?.agentic_tool ? getDefaultPermissionMode(session.agentic_tool) : 'acceptEdits')
   );
   const [codexSandboxMode, setCodexSandboxMode] = React.useState<CodexSandboxMode>(
     session?.permission_config?.codex?.sandboxMode || 'workspace-write'
@@ -487,12 +494,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       setCodexSandboxMode(session.permission_config.codex.sandboxMode);
       setCodexApprovalPolicy(session.permission_config.codex.approvalPolicy);
     }
-  }, [
-    session?.permission_config?.mode,
-    session?.permission_config?.codex,
-    session?.agentic_tool,
-    getDefaultPermissionMode,
-  ]);
+  }, [session?.permission_config?.mode, session?.permission_config?.codex, session?.agentic_tool]);
 
   // Update effort level when session changes (default to 'high' for sessions without effort config)
   React.useEffect(() => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -160,6 +160,11 @@
       "import": "./dist/models/index.js",
       "require": "./dist/models/index.cjs"
     },
+    "./sessions": {
+      "types": "./dist/sessions/index.d.ts",
+      "import": "./dist/sessions/index.js",
+      "require": "./dist/sessions/index.cjs"
+    },
     "./models/browser": {
       "types": "./dist/models/browser.d.ts",
       "import": "./dist/models/browser.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from './environment/render-snapshot.js';
 export * from './git/index.js';
 export * from './lib/validation.js';
 export * from './mcp/index.js';
+export * from './sessions/index.js';
 // Re-export everything from submodules
 export * from './types/index.js';
 export * from './unix/index.js';

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -1,0 +1,1 @@
+export * from './resolve-session-defaults.js';

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type { User, UserID } from '../types/index.js';
+import { resolveSessionDefaults } from './resolve-session-defaults.js';
+
+const now = new Date('2026-05-03T00:00:00.000Z');
+
+function makeUser(partial: Partial<User['default_agentic_config']> = {}): User {
+  return {
+    user_id: 'user-1' as UserID,
+    email: 'a@b.c',
+    role: 'member',
+    onboarding_completed: true,
+    must_change_password: false,
+    created_at: new Date(),
+    scheduled_from_worktree: false,
+    default_agentic_config: partial,
+  } as unknown as User;
+}
+
+describe('resolveSessionDefaults', () => {
+  describe('permission_config', () => {
+    it('falls back to system default when nothing else is set', () => {
+      const r = resolveSessionDefaults({ agenticTool: 'claude-code' });
+      expect(r.permission_config).toEqual({ mode: 'acceptEdits' });
+    });
+
+    it("uses the user's tool default when present", () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { permissionMode: 'bypassPermissions' } }),
+      });
+      expect(r.permission_config.mode).toBe('bypassPermissions');
+    });
+
+    it('explicit override wins over user default', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { permissionMode: 'bypassPermissions' } }),
+        overrides: { permissionMode: 'plan' },
+      });
+      expect(r.permission_config.mode).toBe('plan');
+    });
+
+    it('maps cross-agent modes through mapPermissionMode', () => {
+      // User stored a Claude mode but the target tool is Gemini → must map.
+      const r = resolveSessionDefaults({
+        agenticTool: 'gemini',
+        user: makeUser({ gemini: { permissionMode: 'bypassPermissions' } }),
+      });
+      expect(r.permission_config.mode).toBe('yolo');
+    });
+
+    it('emits codex sub-config when sandboxMode + approvalPolicy both present (user defaults)', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        user: makeUser({
+          codex: {
+            permissionMode: 'auto',
+            codexSandboxMode: 'workspace-write',
+            codexApprovalPolicy: 'on-request',
+            codexNetworkAccess: false,
+          },
+        }),
+      });
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'on-request',
+        networkAccess: false,
+      });
+    });
+
+    it('explicit codex sub-config overrides user defaults', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        user: makeUser({
+          codex: {
+            permissionMode: 'auto',
+            codexSandboxMode: 'workspace-write',
+            codexApprovalPolicy: 'on-request',
+          },
+        }),
+        overrides: {
+          codexSandboxMode: 'read-only',
+          codexApprovalPolicy: 'untrusted',
+          codexNetworkAccess: true,
+        },
+      });
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'read-only',
+        approvalPolicy: 'untrusted',
+        networkAccess: true,
+      });
+    });
+
+    it('omits codex sub-config for non-codex tools', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        overrides: { codexSandboxMode: 'read-only', codexApprovalPolicy: 'untrusted' },
+      });
+      expect(r.permission_config.codex).toBeUndefined();
+    });
+  });
+
+  describe('model_config', () => {
+    it('returns undefined when no model is configured anywhere', () => {
+      const r = resolveSessionDefaults({ agenticTool: 'claude-code', now });
+      expect(r.model_config).toBeUndefined();
+    });
+
+    it("uses the user's tool default model when present", () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { modelConfig: { model: 'claude-sonnet-4-6' } } }),
+        now,
+      });
+      expect(r.model_config?.model).toBe('claude-sonnet-4-6');
+      expect(r.model_config?.updated_at).toBe(now.toISOString());
+    });
+
+    it('explicit override wins over user default (no field merging)', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({
+          'claude-code': { modelConfig: { model: 'claude-sonnet-4-6', effort: 'high' } },
+        }),
+        overrides: { modelConfig: { model: 'claude-opus-4-6' } },
+        now,
+      });
+      expect(r.model_config?.model).toBe('claude-opus-4-6');
+      // first-wins, not merge — must NOT inherit effort from user default
+      expect(r.model_config).not.toHaveProperty('effort');
+    });
+  });
+
+  describe('mcp_server_ids', () => {
+    it('explicit override wins, including empty array (= "no MCPs")', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { mcpServerIds: ['user-1', 'user-2'] } }),
+        worktree: { mcp_server_ids: ['wt-1'] },
+        overrides: { mcpServerIds: [] },
+      });
+      expect(r.mcp_server_ids).toEqual([]);
+    });
+
+    it('worktree config wins over user defaults when no override', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { mcpServerIds: ['user-1'] } }),
+        worktree: { mcp_server_ids: ['wt-1'] },
+      });
+      expect(r.mcp_server_ids).toEqual(['wt-1']);
+    });
+
+    it('falls through to user defaults when worktree has no config', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { mcpServerIds: ['user-1'] } }),
+        worktree: { mcp_server_ids: [] },
+      });
+      expect(r.mcp_server_ids).toEqual(['user-1']);
+    });
+
+    it('returns empty array when nothing is configured anywhere', () => {
+      const r = resolveSessionDefaults({ agenticTool: 'claude-code' });
+      expect(r.mcp_server_ids).toEqual([]);
+    });
+  });
+
+  describe('regression: issue #1064', () => {
+    it("a Claude session with user default 'bypassPermissions' resolves to bypassPermissions, not the most restrictive default", () => {
+      // Previously the UI drag-into-zone path created sessions with
+      // permission_config: null, which Claude Code interprets as "ask for
+      // every tool". With the helper + before:create hook, the user's
+      // saved default is honored.
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { permissionMode: 'bypassPermissions' } }),
+      });
+      expect(r.permission_config.mode).toBe('bypassPermissions');
+    });
+  });
+});

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -180,4 +180,73 @@ describe('resolveSessionDefaults', () => {
       expect(r.permission_config.mode).toBe('bypassPermissions');
     });
   });
+
+  describe('cross-tool spawn fallback (covers SessionsService.spawn)', () => {
+    // Regression coverage for the spawn() cross-tool change in 7992a712:
+    // when the user has NO default for the target tool, the spawn path now
+    // adopts the helper's resolved values instead of partially keeping the
+    // parent's. Verify the helper produces sensible output for that case.
+
+    it('cross-tool spawn with no user default for target tool: returns mapped system default permission mode', () => {
+      // User has Claude defaults but is spawning a Codex child. There's no
+      // codex entry in default_agentic_config, so we should fall back to
+      // codex's system default ('auto'), not to whatever the parent had.
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        user: makeUser({ 'claude-code': { permissionMode: 'bypassPermissions' } }),
+      });
+      expect(r.permission_config.mode).toBe('auto');
+    });
+
+    it('cross-tool spawn from Claude → Gemini with no user default: returns gemini system default', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'gemini',
+        user: makeUser({ 'claude-code': { permissionMode: 'acceptEdits' } }),
+      });
+      expect(r.permission_config.mode).toBe('autoEdit');
+    });
+
+    it('cross-tool spawn with no user at all: returns system default and is non-null', () => {
+      // The helper is called from the catch branch in spawn() when the user
+      // lookup fails. Ensure it still returns a populated permission_config.
+      const r = resolveSessionDefaults({ agenticTool: 'codex' });
+      expect(r.permission_config).toBeDefined();
+      expect(r.permission_config.mode).toBe('auto');
+    });
+  });
+
+  describe('gateway-style overrides (covers GatewayService channel config)', () => {
+    // Regression coverage for 7992a712: gateway now threads codex sub-config
+    // and mcpServerIds from GatewayAgenticConfig through the helper. Verify
+    // that the full set of fields is honored as a single bundle.
+
+    it('threads codex sub-config + mcp ids + permission/model overrides together', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        user: makeUser({
+          codex: {
+            permissionMode: 'auto',
+            codexSandboxMode: 'workspace-write',
+            codexApprovalPolicy: 'on-request',
+            mcpServerIds: ['user-mcp'],
+          },
+        }),
+        overrides: {
+          // Simulates GatewayAgenticConfig fully populated by a Slack channel.
+          permissionMode: 'auto',
+          codexSandboxMode: 'danger-full-access',
+          codexApprovalPolicy: 'never',
+          codexNetworkAccess: true,
+          mcpServerIds: ['gateway-mcp-1', 'gateway-mcp-2'],
+        },
+      });
+      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'danger-full-access',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      });
+      expect(r.mcp_server_ids).toEqual(['gateway-mcp-1', 'gateway-mcp-2']);
+    });
+  });
 });

--- a/packages/core/src/sessions/resolve-session-defaults.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.ts
@@ -1,0 +1,137 @@
+/**
+ * Session creation config resolution
+ *
+ * Single source of truth for "given a user (and optional overrides), what
+ * permission_config / model_config / mcp_server_ids should this new session
+ * be stamped with?"
+ *
+ * This collapses the resolution dance that was duplicated across:
+ * - `apps/agor-daemon/src/mcp/tools/sessions.ts`   (`agor_sessions_create`)
+ * - `apps/agor-daemon/src/mcp/tools/worktrees.ts`  (`agor_worktrees_set_zone`)
+ * - `apps/agor-daemon/src/services/gateway.ts`     (gateway session creation)
+ * - `apps/agor-daemon/src/services/sessions.ts`    (cross-tool spawn fallback)
+ * - `apps/agor-daemon/src/utils/apply-session-config-defaults.ts` (the
+ *   `before:create` hook, which applies these defaults to ANY caller — UI
+ *   drag-into-zone, raw REST, etc. — that omits permission/model config)
+ *
+ * Resolution order (highest priority first):
+ *   1. `overrides.*`         — explicit caller intent
+ *   2. `user.default_agentic_config[tool].*`  — user's saved default for this tool
+ *   3. Hardcoded `getDefaultPermissionMode(tool)` (permission only) /
+ *      `undefined` (model)
+ *
+ * MCP server inheritance (separate axis):
+ *   1. `overrides.mcpServerIds`  — explicit (incl. empty array = "no MCPs")
+ *   2. `worktree.mcp_server_ids` — worktree-level override
+ *   3. `user.default_agentic_config[tool].mcpServerIds`
+ *   4. `[]`
+ */
+
+import {
+  type ModelConfigInput,
+  type ResolvedModelConfig,
+  resolveModelConfig,
+} from '../models/resolve-config.js';
+import type {
+  AgenticToolName,
+  CodexApprovalPolicy,
+  CodexNetworkAccess,
+  CodexSandboxMode,
+  PermissionMode,
+  Session,
+  User,
+} from '../types/index.js';
+import { getDefaultPermissionMode } from '../types/session.js';
+import { mapPermissionMode } from '../utils/permission-mode-mapper.js';
+
+/** Explicit per-call overrides. Each field, when defined, wins over user defaults. */
+export interface SessionDefaultsOverrides {
+  permissionMode?: PermissionMode;
+  modelConfig?: ModelConfigInput;
+  codexSandboxMode?: CodexSandboxMode;
+  codexApprovalPolicy?: CodexApprovalPolicy;
+  codexNetworkAccess?: CodexNetworkAccess;
+  /**
+   * Explicit MCP server ID list. An empty array means "no MCPs" — does NOT
+   * fall through to worktree/user defaults. Pass `undefined` to fall through.
+   */
+  mcpServerIds?: string[];
+}
+
+export interface ResolveSessionDefaultsArgs {
+  agenticTool: AgenticToolName;
+  /** User whose `default_agentic_config[tool]` provides the next-priority defaults. */
+  user?: Pick<User, 'default_agentic_config'> | null;
+  /** Optional worktree for MCP server inheritance (worktree-level overrides user defaults). */
+  worktree?: { mcp_server_ids?: string[] | null } | null;
+  overrides?: SessionDefaultsOverrides;
+  /** Override `new Date()` for deterministic tests. */
+  now?: Date;
+}
+
+export interface ResolvedSessionDefaults {
+  /** Always populated — falls back to `getDefaultPermissionMode(tool)` mapped through `mapPermissionMode`. */
+  permission_config: NonNullable<Session['permission_config']>;
+  /** Optional — `undefined` when neither overrides nor user defaults specify a model. */
+  model_config?: ResolvedModelConfig;
+  /** Resolved MCP server list. Empty array means "no MCPs". */
+  mcp_server_ids: string[];
+}
+
+/**
+ * Resolve session creation defaults from caller overrides + user defaults.
+ *
+ * The returned `permission_config` is always populated (using the system
+ * fallback when nothing else applies), so callers can persist it directly.
+ * `model_config` may be `undefined` when no model has been chosen anywhere.
+ */
+export function resolveSessionDefaults(args: ResolveSessionDefaultsArgs): ResolvedSessionDefaults {
+  const { agenticTool, user, worktree, overrides, now } = args;
+  const userToolDefaults = user?.default_agentic_config?.[agenticTool];
+
+  // ---- permission_config ----
+  // Walk: explicit override → user default → hardcoded fallback.
+  const requestedMode: PermissionMode =
+    overrides?.permissionMode ??
+    userToolDefaults?.permissionMode ??
+    getDefaultPermissionMode(agenticTool);
+  const permissionMode = mapPermissionMode(requestedMode, agenticTool);
+
+  const permission_config: NonNullable<Session['permission_config']> = {
+    mode: permissionMode,
+  };
+
+  // Codex's dual permission config: explicit overrides win as a unit; otherwise
+  // copy user defaults if both required fields are present (legacy behavior).
+  if (agenticTool === 'codex') {
+    const sandboxMode = overrides?.codexSandboxMode ?? userToolDefaults?.codexSandboxMode;
+    const approvalPolicy = overrides?.codexApprovalPolicy ?? userToolDefaults?.codexApprovalPolicy;
+    const networkAccess = overrides?.codexNetworkAccess ?? userToolDefaults?.codexNetworkAccess;
+    if (sandboxMode && approvalPolicy) {
+      permission_config.codex = {
+        sandboxMode,
+        approvalPolicy,
+        ...(networkAccess !== undefined && { networkAccess }),
+      };
+    }
+  }
+
+  // ---- model_config ----
+  const model_config =
+    resolveModelConfig(overrides?.modelConfig, { now }) ??
+    resolveModelConfig(userToolDefaults?.modelConfig, { now });
+
+  // ---- mcp_server_ids ----
+  // Explicit override wins (incl. empty array = "no MCPs"). Otherwise:
+  // worktree config > user defaults > [].
+  let mcp_server_ids: string[];
+  if (overrides?.mcpServerIds !== undefined) {
+    mcp_server_ids = overrides.mcpServerIds;
+  } else if (worktree?.mcp_server_ids && worktree.mcp_server_ids.length > 0) {
+    mcp_server_ids = worktree.mcp_server_ids;
+  } else {
+    mcp_server_ids = userToolDefaults?.mcpServerIds ?? [];
+  }
+
+  return { permission_config, model_config, mcp_server_ids };
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
     'models/browser': 'src/models/browser.ts', // Browser-safe model metadata only
     'models/gemini-shared': 'src/models/gemini-shared.ts', // Shared Gemini metadata/constants
     'models/index': 'src/models/index.ts', // Model metadata (browser-safe)
+    'sessions/index': 'src/sessions/index.ts', // Session config defaults resolution
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities


### PR DESCRIPTION
## Summary

Fixes #1064. Sessions created via UI drag-into-zone shipped with `permission_config: null`, causing Claude Code to interpret the most restrictive mode and hang waiting for manual approval. Six other session-creation paths already resolved defaults from `default_agentic_config[tool]` — each carrying its own copy of the resolution dance — but the UI path didn't.

Rather than patching the UI handler in isolation, this PR consolidates the logic:

- **New `resolveSessionDefaults()`** in `@agor/core/sessions` — single source of truth for `permission_config` / `model_config` / `mcp_server_ids` precedence (explicit > worktree > user defaults > hardcoded fallback, with cross-agent permission-mode mapping).
- **New `applySessionConfigDefaults` `before:create` hook** — any caller that omits `permission_config`/`model_config` (UI drag, future REST callers, …) gets defaults filled from the creator's user config. Closes the structural gap that let #1064 happen.
- **Refactor 4 duplicated resolution sites** onto the shared helper: `agor_sessions_create`, `agor_worktrees_set_zone`, `gateway`, `SessionsService.spawn`. Removes ~120 lines of bespoke precedence logic.

Net diff: +770 / -113 across 14 files (most of the +770 is the helper, hook, and 26 new unit tests).

## Test plan

- [x] 15 new unit tests for `resolveSessionDefaults` (precedence, cross-agent mapping, codex sub-config, MCP inheritance)
- [x] 11 new unit tests for the hook (fill / no-overwrite / no-op / warn behavior, plus a regression test mirroring the exact UI drag payload from the bug report)
- [x] Full core suite: 2043/2043 pass
- [x] Full daemon suite: 499/499 pass
- [x] `pnpm check` green (typecheck + lint + build across all packages)
- [ ] Manual: drag a worktree into a zone, confirm session boots with the user's default permission mode (no hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)