### PR TITLE
fix(ui): correct MCP OAuth status display for expired tokens

### DIFF
--- a/apps/agor-ui/src/components/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServerPill.tsx
@@ -12,12 +12,13 @@ interface MCPServerPillProps {
 }
 
 /**
- * Format a (future or past) timestamp as a short human-relative phrase
- * ("in 3m", "in 2h", "in 4d", "5m ago"). Unlike `formatRelativeTime`, this
- * renders future offsets, which is what an expiring token needs. Callers
- * prepend the verb ("Expires" / "Expired") so we don't double up on it.
+ * Format a (future or past) timestamp into the verb + phrase used in expiry
+ * tooltips: `{ verb: 'Expires', phrase: 'in 3m' }` for future,
+ * `{ verb: 'Expired', phrase: '5m ago' }` for past. Returning both from one
+ * `Date.now()` read makes mismatched output ("Expires 0s ago" or
+ * "Expired in 0s") impossible by construction at the expiry boundary.
  */
-function formatExpiresIn(expiresAtMs: number): string {
+function formatExpiresIn(expiresAtMs: number): { verb: 'Expires' | 'Expired'; phrase: string } {
   const diffMs = expiresAtMs - Date.now();
   const abs = Math.abs(diffMs);
   const sec = Math.floor(abs / 1000);
@@ -27,7 +28,9 @@ function formatExpiresIn(expiresAtMs: number): string {
 
   const value = sec < 60 ? `${sec}s` : min < 60 ? `${min}m` : hr < 24 ? `${hr}h` : `${day}d`;
 
-  return diffMs >= 0 ? `in ${value}` : `${value} ago`;
+  return diffMs >= 0
+    ? { verb: 'Expires', phrase: `in ${value}` }
+    : { verb: 'Expired', phrase: `${value} ago` };
 }
 
 /**
@@ -101,7 +104,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
         setExpiresAtOverride(result.expires_at);
         message.success(
           result.expires_at
-            ? `${server.display_name || server.name} refreshed — expires ${formatExpiresIn(result.expires_at)}`
+            ? `${server.display_name || server.name} refreshed — expires ${formatExpiresIn(result.expires_at).phrase}`
             : `${server.display_name || server.name} refreshed`
         );
       } else if (result.error === 'needs_reauth') {
@@ -124,11 +127,11 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
   let authedTooltip: React.ReactNode;
   if (expiresAt) {
     const date = new Date(expiresAt);
-    const verb = expiresAt - Date.now() >= 0 ? 'Expires' : 'Expired';
+    const { verb, phrase } = formatExpiresIn(expiresAt);
     authedTooltip = (
       <>
         <div>
-          {verb} {formatExpiresIn(expiresAt)}
+          {verb} {phrase}
         </div>
         <div style={{ opacity: 0.75, fontSize: 12 }}>{formatAbsoluteTime(date)}</div>
         <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>

--- a/apps/agor-ui/src/components/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServerPill.tsx
@@ -12,9 +12,10 @@ interface MCPServerPillProps {
 }
 
 /**
- * Format a future timestamp as a short human-relative string ("in 3m",
- * "in 2h", "in 4d", "expired 5m ago"). Unlike `formatRelativeTime`, this
- * renders future offsets, which is what an expiring token needs.
+ * Format a (future or past) timestamp as a short human-relative phrase
+ * ("in 3m", "in 2h", "in 4d", "5m ago"). Unlike `formatRelativeTime`, this
+ * renders future offsets, which is what an expiring token needs. Callers
+ * prepend the verb ("Expires" / "Expired") so we don't double up on it.
  */
 function formatExpiresIn(expiresAtMs: number): string {
   const diffMs = expiresAtMs - Date.now();
@@ -26,7 +27,7 @@ function formatExpiresIn(expiresAtMs: number): string {
 
   const value = sec < 60 ? `${sec}s` : min < 60 ? `${min}m` : hr < 24 ? `${hr}h` : `${day}d`;
 
-  return diffMs >= 0 ? `in ${value}` : `expired ${value} ago`;
+  return diffMs >= 0 ? `in ${value}` : `${value} ago`;
 }
 
 /**
@@ -123,9 +124,12 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
   let authedTooltip: React.ReactNode;
   if (expiresAt) {
     const date = new Date(expiresAt);
+    const verb = expiresAt - Date.now() >= 0 ? 'Expires' : 'Expired';
     authedTooltip = (
       <>
-        <div>Expires {formatExpiresIn(expiresAt)}</div>
+        <div>
+          {verb} {formatExpiresIn(expiresAt)}
+        </div>
         <div style={{ opacity: 0.75, fontSize: 12 }}>{formatAbsoluteTime(date)}</div>
         <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>
       </>

--- a/apps/agor-ui/src/utils/mcpAuth.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.ts
@@ -26,7 +26,11 @@ export function mcpServerNeedsAuth(
   if (!server || server.auth?.type !== 'oauth') return false;
 
   const expiresAt = server.auth.oauth_token_expires_at;
-  const isExpired = !!(expiresAt && expiresAt < Date.now());
+  // Use `<=` to match the daemon-side boundary: `oauth-status` treats
+  // `> now` as still-valid (so `<= now` is expired) and the executor's
+  // auth-headers path also flips at `<=`. Without this we'd silently
+  // disagree with the daemon at the exact expiry millisecond.
+  const isExpired = !!(expiresAt && expiresAt <= Date.now());
 
   // A token only counts as "authenticated" while it's still valid.
   if (server.auth.oauth_access_token && !isExpired) return false;

--- a/apps/agor-ui/src/utils/mcpAuth.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.ts
@@ -4,11 +4,18 @@ import type { MCPServer } from '@agor-live/client';
  * Determine if an MCP server needs authentication from the current user.
  *
  * A server is considered authenticated if EITHER:
- * - It has a shared token (oauth_access_token) — works regardless of mode
- * - The current user has a per-user token
+ * - It has a token (oauth_access_token) that hasn't passed its expiry —
+ *   covers both shared-mode tokens and per-user tokens hydrated by the
+ *   daemon's `injectPerUserOAuthTokens` find-hook.
+ * - The current user has a per-user token (and the daemon-provided
+ *   `userAuthenticatedMcpServerIds` set already filters expired ones).
  *
- * This avoids a regression where servers with a shared token but no explicit
- * oauth_mode would be treated as unauthenticated.
+ * The expiry check on the access-token branch matters because the daemon's
+ * find-hook reflects the row verbatim: when JIT refresh has failed (no
+ * refresh_token, invalid_grant, transient error), the cached row carries a
+ * now-past `oauth_token_expires_at`. Without re-checking expiry here, the UI
+ * surfaces a "happy" purple chip and suppresses the above-prompt-box auth
+ * banner — leaving users to send doomed prompts.
  *
  * Non-OAuth servers always return false (no auth needed).
  */
@@ -18,11 +25,16 @@ export function mcpServerNeedsAuth(
 ): boolean {
   if (!server || server.auth?.type !== 'oauth') return false;
 
-  // A shared token always means the server is authenticated
-  if (server.auth.oauth_access_token) return false;
+  const expiresAt = server.auth.oauth_token_expires_at;
+  const isExpired = !!(expiresAt && expiresAt < Date.now());
 
-  // For per_user mode (or unset mode), check the user's token set
-  if (userAuthenticatedMcpServerIds.has(server.mcp_server_id)) return false;
+  // A token only counts as "authenticated" while it's still valid.
+  if (server.auth.oauth_access_token && !isExpired) return false;
+
+  // Per-user fallback. The set is populated once at boot (and adds on
+  // `oauth:completed` events) but is never pruned when tokens expire on a
+  // long-lived tab — so we re-check expiry here too.
+  if (userAuthenticatedMcpServerIds.has(server.mcp_server_id) && !isExpired) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary

Two regressions from PR #1047 (OAuth 2.1 token refresh with JIT). Pre-existing — not caused by PR #1078 as initially suspected; #1078 only touched the daemon discovery cascade and core transport, no UI files.

**1. Tooltip on the worktree-header MCP chip read "Expires expired 6d ago".**
The static `Expires ` prefix was being concatenated with `formatExpiresIn` output that already included the verb (`expired 5m ago`). Strip the verb from the formatter and let the tooltip pick `Expires` (future) vs `Expired` (past).

**2. The above-prompt-box auth banner stopped appearing for expired tokens.**
`mcpServerNeedsAuth` short-circuited to `false` whenever `oauth_access_token` was present, regardless of expiry. The daemon's `injectPerUserOAuthTokens` find-hook reflects the `user_mcp_oauth_tokens` row verbatim — when JIT refresh has failed (no refresh_token, invalid_grant, transient error), the cached row carries a now-past `oauth_token_expires_at`. Without a client-side expiry check, the chip stayed purple, the banner stayed hidden, and users sent doomed prompts.

Now expired tokens flip the chip to "needs auth" (orange) and re-surface the above-prompt-box banner. Same expiry guard added to the `userAuthenticatedMcpServerIds` fallback branch — the set is populated at boot and on `oauth:completed` events but never pruned when tokens expire on a long-lived tab.

## Files

- `apps/agor-ui/src/utils/mcpAuth.ts` — `mcpServerNeedsAuth` now treats past-expiry as needing auth in both branches.
- `apps/agor-ui/src/components/MCPServerPill.tsx` — `formatExpiresIn` returns the bare phrase (`in 3m` / `5m ago`); tooltip prepends `Expires`/`Expired`. Post-refresh toast composition still reads naturally ("X refreshed — expires in 3m").

## Test plan

- [x] `pnpm typecheck` clean (turbo run, all packages)
- [x] `biome check` clean on touched files
- [ ] Manual: with an expired MCP token, verify the chip is orange + login icon + "Click to authenticate" tooltip
- [ ] Manual: with an expired MCP token, verify the warning banner re-appears above the prompt textarea
- [ ] Manual: with a fresh per-user token, verify the chip is purple and the tooltip reads "Expires in Xh" / "Expires in Xd"
- [ ] Manual: with a recently-refreshed token, verify the toast reads "{name} refreshed — expires in X{unit}"

🤖 Generated with [Claude Code](https://claude.com/claude-code)