### PR TITLE
fix(scheduler): stop clobbering saved permission_mode on mount

### DIFF
--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -96,10 +96,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   const handleAgenticToolChange = (newTool: string) => {
     if (newTool === agenticTool) return;
     setAgenticTool(newTool);
-    form.setFieldValue(
-      'permissionMode',
-      getDefaultPermissionMode(newTool as AgenticToolName)
-    );
+    form.setFieldValue('permissionMode', getDefaultPermissionMode(newTool as AgenticToolName));
   };
 
   // Update human-readable cron description

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -88,15 +88,19 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
     }
   }, [isInitialized, worktree.schedule_enabled, worktree.schedule_cron, worktree.schedule, form]);
 
-  // Update permission mode when agent changes
-  useEffect(() => {
-    if (agenticTool) {
-      form.setFieldValue(
-        'permissionMode',
-        getDefaultPermissionMode(agenticTool as AgenticToolName)
-      );
-    }
-  }, [agenticTool, form]);
+  // Reset permission mode when the user picks a different agent tool.
+  // NOTE: This must NOT run on mount or remount — doing so would clobber the
+  // saved permission_mode that the initialize effect above just loaded into
+  // the form, causing the field to silently revert to the tool default on
+  // every save round-trip.
+  const handleAgenticToolChange = (newTool: string) => {
+    if (newTool === agenticTool) return;
+    setAgenticTool(newTool);
+    form.setFieldValue(
+      'permissionMode',
+      getDefaultPermissionMode(newTool as AgenticToolName)
+    );
+  };
 
   // Update human-readable cron description
   useEffect(() => {
@@ -243,7 +247,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
             <AgentSelectionGrid
               agents={AVAILABLE_AGENTS}
               selectedAgentId={agenticTool}
-              onSelect={setAgenticTool}
+              onSelect={handleAgenticToolChange}
               columns={2}
               showComparisonLink={true}
             />


### PR DESCRIPTION
## Summary

The Schedule tab's saved `permission_mode` field was reverting to the tool default on every save round-trip. Open a worktree's Schedule editor, change permission mode, save, reopen — the field shows the default again. Looked like the field "didn't persist."

**Root cause:** A second `useEffect` in `ScheduleTab.tsx` was firing on every mount and overwriting the form's `permissionMode` with `getDefaultPermissionMode(agenticTool)`. The initialize effect runs first (loading the saved value into the form), but this reset effect ran immediately after and silently reverted it. On Save, the clobbered default was the value sent back to the server.

```tsx
// BEFORE — runs on every mount, clobbers the saved value the first
// effect just loaded:
useEffect(() => {
  if (agenticTool) {
    form.setFieldValue('permissionMode', getDefaultPermissionMode(agenticTool));
  }
}, [agenticTool, form]);
```

**Fix:** Replace the `useEffect` with a handler tied to actual user-driven tool changes via `AgentSelectionGrid.onSelect`. The reset now only fires when the user picks a different agent — not on initial mount/remount.

## Notes on other reported fields

The original report listed `model_config`, `agentic_tool`, and `mcp_server_ids` alongside `permission_mode`. I traced the full save path and could not reproduce a static-analysis bug for those:

- Server side: `WorktreesService.patch` → `DrizzleService.patch` → `WorktreeRepository.update` uses `deepMerge` over the existing `data` JSON column. No schema validator strips the schedule fields, no hook filters them, and `deepMerge` correctly recurses into `schedule.*` while replacing arrays.
- Client side: `agentic_tool` is local React state included directly in `handleSave`; `model_config` and `mcp_server_ids` are loaded by the initialize `useEffect` and not touched by anything else. `getFieldsValue(true)` reads them on save.

`permission_mode` was the only field uniquely targeted by a clobbering effect, so it was the only field in this group I could trace to a real bug. If the user observes others not persisting after this fix lands, please re-file with steps to reproduce and we can dig deeper (likely candidates: stale React state from the modal staying mounted across `open` toggles, or an environment-specific WebSocket sync issue).

## Test plan

- [ ] Open a worktree's Schedule tab
- [ ] Set `permission_mode` to a non-default value (e.g., `plan` for claude-code, `yolo` for gemini)
- [ ] Save → close modal → reopen → confirm the field shows the saved value, not the tool default
- [ ] Change agent (e.g., claude-code → gemini) and confirm permission mode resets to that tool's default (preserves the desired UX of resetting on legitimate tool change)
- [ ] Confirm `model_config`, `mcp_server_ids`, and `agentic_tool` continue to persist as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)