### PR TITLE
fix(ui): refresh MCP auth state in real-time after OAuth re-auth

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -77,6 +77,7 @@ import { createThreadSessionMapService } from './services/thread-session-map.js'
 import { createUsersService } from './services/users.js';
 import { setupWorktreeOwnersService } from './services/worktree-owners.js';
 import { createWorktreesService } from './services/worktrees.js';
+import { userRoomName } from './setup/socketio.js';
 import { escapeHtml } from './utils/html.js';
 import {
   computeFileHash,
@@ -1285,26 +1286,27 @@ async function registerMCPServices(
             oauth_mode: pendingFlow.oauthMode || 'per_user',
           };
           // Targeting precedence:
-          //   1. Originating socket — narrowest, used when the flow was started
-          //      from a live tab.
-          //   2. Per-user room (`user:<userId>`) — every tab owned by the user
-          //      who initiated the flow. Sockets auto-join this room on
-          //      connect/login (see `apps/agor-daemon/src/setup/socketio.ts`).
-          //   3. Global broadcast — only safe for `shared` oauth_mode, where
-          //      tokens live on the server record itself and every tab needs
-          //      to refetch. Never used for `per_user` flows: doing so would
-          //      let the event reach OTHER users and incorrectly mark their
-          //      `userAuthenticatedMcpServerIds` set as authed for a server
-          //      they don't own a token for.
-          if (pendingFlow.socketId) {
-            app.io.to(pendingFlow.socketId).emit('oauth:completed', oauthEvent);
-          } else if (oauthEvent.oauth_mode === 'per_user' && pendingFlow.userId) {
-            app.io.to(`user:${pendingFlow.userId}`).emit('oauth:completed', oauthEvent);
+          //   1. `per_user` mode + `userId` known — emit to the user's room so
+          //      every tab the user owns updates (including the tab that
+          //      kicked off the flow, which already auto-joined the room on
+          //      connect/login). Targeting only the originating socket would
+          //      leave that user's other tabs stuck on the pre-auth state.
+          //   2. `shared` mode — broadcast: shared tokens live on the server
+          //      record itself, every tab on every user needs to refetch.
+          //   3. Originating socket — defensive fallback for the unusual case
+          //      where we have a `socketId` but no `userId` (shouldn't happen
+          //      for normal flows but keeps single-tab UX working).
+          //   4. Otherwise log + skip; the UI will catch up on its next
+          //      `mcp-servers` fetch.
+          if (oauthEvent.oauth_mode === 'per_user' && pendingFlow.userId) {
+            app.io.to(userRoomName(pendingFlow.userId)).emit('oauth:completed', oauthEvent);
           } else if (oauthEvent.oauth_mode === 'shared') {
             app.io.emit('oauth:completed', oauthEvent);
+          } else if (pendingFlow.socketId) {
+            app.io.to(pendingFlow.socketId).emit('oauth:completed', oauthEvent);
           } else {
             console.warn(
-              `[OAuth Callback] per_user flow ${state} has no socketId or userId — skipping oauth:completed emit (UI will catch up on next mcp-servers find)`
+              `[OAuth Callback] per_user flow ${state} has no userId or socketId — skipping oauth:completed emit (UI will catch up on next mcp-servers find)`
             );
           }
         }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1284,10 +1284,28 @@ async function registerMCPServices(
             mcp_server_id: pendingFlow.mcpServerId,
             oauth_mode: pendingFlow.oauthMode || 'per_user',
           };
+          // Targeting precedence:
+          //   1. Originating socket — narrowest, used when the flow was started
+          //      from a live tab.
+          //   2. Per-user room (`user:<userId>`) — every tab owned by the user
+          //      who initiated the flow. Sockets auto-join this room on
+          //      connect/login (see `apps/agor-daemon/src/setup/socketio.ts`).
+          //   3. Global broadcast — only safe for `shared` oauth_mode, where
+          //      tokens live on the server record itself and every tab needs
+          //      to refetch. Never used for `per_user` flows: doing so would
+          //      let the event reach OTHER users and incorrectly mark their
+          //      `userAuthenticatedMcpServerIds` set as authed for a server
+          //      they don't own a token for.
           if (pendingFlow.socketId) {
             app.io.to(pendingFlow.socketId).emit('oauth:completed', oauthEvent);
-          } else {
+          } else if (oauthEvent.oauth_mode === 'per_user' && pendingFlow.userId) {
+            app.io.to(`user:${pendingFlow.userId}`).emit('oauth:completed', oauthEvent);
+          } else if (oauthEvent.oauth_mode === 'shared') {
             app.io.emit('oauth:completed', oauthEvent);
+          } else {
+            console.warn(
+              `[OAuth Callback] per_user flow ${state} has no socketId or userId — skipping oauth:completed emit (UI will catch up on next mcp-servers find)`
+            );
           }
         }
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -183,6 +183,18 @@ export function createTokenBucket(
 }
 
 /**
+ * Per-user socket.io room name. Sockets owned by `userId` auto-join this room
+ * on connect / login (see the connection handler and the `app.on('login', …)`
+ * hook in this file). Use this everywhere we want to emit to "every tab the
+ * user owns" — e.g. user-scoped notifications like `oauth:completed`.
+ *
+ * Centralized so the prefix can change in one place without drift.
+ */
+export function userRoomName(userId: string): string {
+  return `user:${userId}`;
+}
+
+/**
  * Validate a terminal channel name and extract its target user_id.
  *
  * Channel format: `user/<uuid>/terminal`. Returns null on bad shape.
@@ -364,7 +376,7 @@ export function createSocketIOConfig(
       // Auto-join per-user room for user-scoped events (OAuth prompts, notifications)
       // Try at connection time (for sockets that authenticate via handshake token)
       if (user?.user_id) {
-        socket.join(`user:${user.user_id}`);
+        socket.join(userRoomName(user.user_id));
         console.log(
           `🏠 Socket ${socket.id} joined user room at connection: user:${user.user_id.substring(0, 8)}`
         );
@@ -677,7 +689,7 @@ export function createSocketIOConfig(
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
-          socket.join(`user:${userId}`);
+          socket.join(userRoomName(userId));
           console.log(
             `🏠 Socket ${socket.id} joined user room after login: user:${userId.substring(0, 8)}`
           );

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -840,8 +840,10 @@ export function useAgorData(
     // Listen for OAuth completion events to update per-user token state in real-time.
     // Only update the per-user set when oauth_mode is 'per_user' (or unset, which defaults
     // to per_user). Shared-mode completions update the server record itself and don't need
-    // per-user tracking. This also prevents stale data when the event is broadcast globally
-    // (fallback path when socketId is absent).
+    // per-user tracking — and shared events ARE broadcast to all sockets on purpose, since
+    // every tab needs to refetch. Per-user events are scoped to the originating socket or
+    // the user's per-user room on the daemon side (see register-services.ts oauth callback),
+    // so we never receive another user's per_user completion here.
     const handleOAuthCompleted = async (event: {
       state: string;
       success: boolean;

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -842,20 +842,39 @@ export function useAgorData(
     // to per_user). Shared-mode completions update the server record itself and don't need
     // per-user tracking. This also prevents stale data when the event is broadcast globally
     // (fallback path when socketId is absent).
-    const handleOAuthCompleted = (event: {
+    const handleOAuthCompleted = async (event: {
       state: string;
       success: boolean;
       mcp_server_id?: string;
       oauth_mode?: string;
     }) => {
+      if (!event.success || !event.mcp_server_id) return;
       const mode = event.oauth_mode || 'per_user';
-      if (event.success && event.mcp_server_id && mode === 'per_user') {
+      if (mode === 'per_user') {
         setUserAuthenticatedMcpServerIds((prev) => {
           if (prev.has(event.mcp_server_id!)) return prev;
           const next = new Set(prev);
           next.add(event.mcp_server_id!);
           return next;
         });
+      }
+
+      // Refetch the server so the daemon's `injectPerUserOAuthTokens` find-hook
+      // re-hydrates `auth.oauth_access_token` / `oauth_token_expires_at` from the
+      // freshly-persisted token row. Without this, `mcpServerById` keeps the stale
+      // (often-expired) auth fields and `mcpServerNeedsAuth` keeps returning true —
+      // chip stays orange and the above-prompt auth banner stays up until the user
+      // reloads. The hook is registered for both `find` and `get` (see
+      // `apps/agor-daemon/src/register-hooks.ts`), so a single `get` is enough.
+      try {
+        const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
+        setMcpServerById((prev) => {
+          const next = new Map(prev);
+          next.set(fresh.mcp_server_id, fresh);
+          return next;
+        });
+      } catch (err) {
+        console.warn('[OAuth] Failed to refetch MCP server after re-auth:', err);
       }
     };
     client.io.on('oauth:completed', handleOAuthCompleted);

--- a/apps/agor-ui/src/utils/mcpAuth.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.ts
@@ -3,12 +3,21 @@ import type { MCPServer } from '@agor-live/client';
 /**
  * Determine if an MCP server needs authentication from the current user.
  *
- * A server is considered authenticated if EITHER:
- * - It has a token (oauth_access_token) that hasn't passed its expiry —
- *   covers both shared-mode tokens and per-user tokens hydrated by the
- *   daemon's `injectPerUserOAuthTokens` find-hook.
- * - The current user has a per-user token (and the daemon-provided
- *   `userAuthenticatedMcpServerIds` set already filters expired ones).
+ * Two sources of truth, intentionally:
+ *   1. `server.auth.oauth_access_token` / `oauth_token_expires_at` — populated
+ *      by the daemon's `injectPerUserOAuthTokens` find-hook on every
+ *      `mcp-servers` find/get. Authoritative, but only as fresh as the last
+ *      fetch. Covers both shared-mode and per-user tokens.
+ *   2. `userAuthenticatedMcpServerIds` — a Set populated at boot from
+ *      `/mcp-servers/oauth-status` and then *additively* updated when an
+ *      `oauth:completed` socket event arrives. Acts as an optimistic flip
+ *      that lights the chip green the instant OAuth completes (before the
+ *      `mcp-servers.get(id)` refetch resolves) and as a fallback if that
+ *      refetch ever fails.
+ *
+ * Both branches are gated on `!isExpired` so the optimistic Set can never
+ * outlive the actual token: stale "authenticated" state degrades back to
+ * "needs auth" once expiry passes, even if nothing pruned the Set.
  *
  * The expiry check on the access-token branch matters because the daemon's
  * find-hook reflects the row verbatim: when JIT refresh has failed (no
@@ -35,9 +44,9 @@ export function mcpServerNeedsAuth(
   // A token only counts as "authenticated" while it's still valid.
   if (server.auth.oauth_access_token && !isExpired) return false;
 
-  // Per-user fallback. The set is populated once at boot (and adds on
-  // `oauth:completed` events) but is never pruned when tokens expire on a
-  // long-lived tab — so we re-check expiry here too.
+  // Optimistic flip / refetch fallback. See the docstring above for why this
+  // Set exists alongside `server.auth`. Re-check expiry here too because the
+  // Set is never pruned when tokens expire on a long-lived tab.
   if (userAuthenticatedMcpServerIds.has(server.mcp_server_id) && !isExpired) return false;
 
   return true;


### PR DESCRIPTION
## Summary

Fixes a bug where, after a successful OAuth re-auth flow, the MCP chip stays orange and the above-prompt auth banner stays up until the user reloads the page.

The `oauth:completed` socket handler in `useAgorData.ts` was adding the server ID to `userAuthenticatedMcpServerIds` but leaving `mcpServerById`'s entry with the stale (often-expired) `auth.oauth_access_token` / `oauth_token_expires_at`. Since `mcpServerNeedsAuth` checks `isExpired` against those fields on **both** its access-token and per-user-set branches, it kept returning `true` until a full refetch re-ran the daemon's `injectPerUserOAuthTokens` find-hook.

The fix refetches the affected server via `mcp-servers.get(id)` (the find-hook is registered for both `find` and `get` — see `apps/agor-daemon/src/register-hooks.ts:902-903`) so the freshly-persisted token row is hydrated into the in-memory map immediately. Also runs in shared-mode now, which has the same staleness problem.

Follow-up to #1084 — that PR fixed the *display* of the expired state; this one fixes the *transition out* of it.

## Test plan

- [ ] OAuth a server that has an expired token → chip turns purple, banner disappears, no page reload required
- [ ] First-time OAuth on a server → same
- [ ] OAuth in shared mode → same
- [ ] OAuth flow that fails or is cancelled → no spurious chip flip (`!event.success` early return preserves existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)