### PR TITLE
fix(api): register custom client RPC methods on Socket.io proxy

### DIFF
--- a/apps/agor-daemon/src/services/users.git-env.test.ts
+++ b/apps/agor-daemon/src/services/users.git-env.test.ts
@@ -7,6 +7,7 @@
  * - Unauthenticated callers are rejected
  */
 
+import { Forbidden } from '@agor/core/feathers';
 import type { AuthenticatedParams, UserID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
@@ -72,6 +73,10 @@ describe('UsersService.getGitEnvironment — permission checks', () => {
       },
     };
 
+    // Service throws a Feathers `Forbidden` (which the HTTP/WS layer maps to 403)
+    // with a human-readable message — assert both class and message so a future
+    // change to either is caught.
+    await expect(service.getGitEnvironment({ userId: userB }, params)).rejects.toThrow(Forbidden);
     await expect(service.getGitEnvironment({ userId: userB }, params)).rejects.toThrow(
       /Cannot access another user's git environment/
     );

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -538,7 +538,7 @@ describe('createClient', () => {
       const sessionsService = client.service('sessions') as unknown as {
         methods: MockedFunction<(...names: string[]) => unknown>;
       };
-      // sessions has no entry in CLIENT_CUSTOM_METHODS, so .methods() should not be called
+      // sessions has no extend*Service helper, so .methods() should not be called
       expect(sessionsService.methods).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -503,6 +503,45 @@ describe('createClient', () => {
       });
     });
 
+    // Regression: PR #1088 added users.getGitEnvironment + repos/worktrees.initializeUnixGroup
+    // server-side via `app.use(path, service, { methods })`, but the Feathers Socket.io
+    // client only wires standard CRUD at construction time. Without an explicit
+    // service.methods(...) call on the client, calling these threw
+    // "client.service(...).<method> is not a function" — observed during prod worktree
+    // creation. These assertions guard the client-side mirror of the daemon's methods list.
+    it('registers users.getGitEnvironment custom method on client', () => {
+      const client = createClient();
+      const usersService = client.service('users') as unknown as {
+        methods: MockedFunction<(...names: string[]) => unknown>;
+      };
+      expect(usersService.methods).toHaveBeenCalledWith('getGitEnvironment');
+    });
+
+    it('registers repos.initializeUnixGroup custom method on client', () => {
+      const client = createClient();
+      const reposService = client.service('repos') as unknown as {
+        methods: MockedFunction<(...names: string[]) => unknown>;
+      };
+      expect(reposService.methods).toHaveBeenCalledWith('initializeUnixGroup');
+    });
+
+    it('registers worktrees.initializeUnixGroup custom method on client', () => {
+      const client = createClient();
+      const worktreesService = client.service('worktrees') as unknown as {
+        methods: MockedFunction<(...names: string[]) => unknown>;
+      };
+      expect(worktreesService.methods).toHaveBeenCalledWith('initializeUnixGroup');
+    });
+
+    it('does not register custom methods on services without any', () => {
+      const client = createClient();
+      const sessionsService = client.service('sessions') as unknown as {
+        methods: MockedFunction<(...names: string[]) => unknown>;
+      };
+      // sessions has no entry in CLIENT_CUSTOM_METHODS, so .methods() should not be called
+      expect(sessionsService.methods).not.toHaveBeenCalled();
+    });
+
     it('should expose sessions.prompt helper that calls /sessions/:id/prompt route', async () => {
       const client = createClient();
       const routeService = client.service('sessions/session-123/prompt');

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -40,6 +40,9 @@ const DEFAULT_DAEMON_URL = `http://${DAEMON.DEFAULT_HOST}:${DAEMON.DEFAULT_PORT}
  * Using a symbol avoids clashing with existing service properties.
  */
 const BOARDS_SERVICE_EXTENDED = Symbol('agor.boardsServiceExtended');
+const USERS_SERVICE_EXTENDED = Symbol('agor.usersServiceExtended');
+const REPOS_SERVICE_EXTENDED = Symbol('agor.reposServiceExtended');
+const WORKTREES_SERVICE_EXTENDED = Symbol('agor.worktreesServiceExtended');
 const SERVICE_FIND_ALL_EXTENDED = Symbol('agor.serviceFindAllExtended');
 const CLIENT_SERVICE_FACTORY_EXTENDED = Symbol('agor.clientServiceFactoryExtended');
 const CLIENT_SESSIONS_HELPERS_EXTENDED = Symbol('agor.clientSessionsHelpersExtended');
@@ -626,37 +629,48 @@ function extendFindAllOnService(service: AgorService<unknown>): void {
 }
 
 /**
- * Custom RPC methods exposed by the daemon that aren't part of the Feathers
- * standard CRUD interface. The Socket.io client only wires the default
- * methods at construction time, so each path that has custom methods on the
- * server must be registered here too — otherwise calling them on the client
- * proxy throws "client.service(...).<method> is not a function".
- *
- * Keep this in sync with the `methods:` arrays in
+ * Wire client-side custom methods for services that expose RPCs beyond the
+ * standard Feathers CRUD interface. The Socket.io client only wires the
+ * default methods at construction time, so each path that has custom methods
+ * on the server must call `service.methods(...)` here too — otherwise calling
+ * them on the client proxy throws "client.service(...).<method> is not a
+ * function". Keep these in sync with the `methods:` arrays in
  * `apps/agor-daemon/src/register-services.ts`.
  */
-const CLIENT_CUSTOM_METHODS: Record<string, readonly string[]> = {
-  users: ['getGitEnvironment'],
-  repos: ['initializeUnixGroup'],
-  worktrees: ['initializeUnixGroup'],
-};
-
-function registerClientCustomMethods(path: string, service: unknown): void {
-  // Strip leading slash to match the keys above (paths can come in as either form).
-  const normalized = path.replace(/^\/+/, '');
-  const customMethods = CLIENT_CUSTOM_METHODS[normalized];
-  if (!customMethods || customMethods.length === 0) {
-    return;
+function extendUsersService(client: AgorClient): void {
+  const usersService = client.service('users') as AgorService<User> & {
+    [USERS_SERVICE_EXTENDED]?: boolean;
+    methods?: (...names: string[]) => unknown;
+  };
+  if (usersService[USERS_SERVICE_EXTENDED]) return;
+  if (typeof usersService.methods === 'function') {
+    usersService.methods('getGitEnvironment');
   }
+  usersService[USERS_SERVICE_EXTENDED] = true;
+}
 
-  const candidate = service as { methods?: (...names: string[]) => unknown };
-  if (typeof candidate.methods !== 'function') {
-    return;
+function extendReposService(client: AgorClient): void {
+  const reposService = client.service('repos') as AgorService<Repo> & {
+    [REPOS_SERVICE_EXTENDED]?: boolean;
+    methods?: (...names: string[]) => unknown;
+  };
+  if (reposService[REPOS_SERVICE_EXTENDED]) return;
+  if (typeof reposService.methods === 'function') {
+    reposService.methods('initializeUnixGroup');
   }
+  reposService[REPOS_SERVICE_EXTENDED] = true;
+}
 
-  // Idempotent: SocketService.methods() just (re)defines the named functions
-  // on the instance; calling it twice with the same names is harmless.
-  candidate.methods(...customMethods);
+function extendWorktreesService(client: AgorClient): void {
+  const worktreesService = client.service('worktrees') as AgorService<Worktree> & {
+    [WORKTREES_SERVICE_EXTENDED]?: boolean;
+    methods?: (...names: string[]) => unknown;
+  };
+  if (worktreesService[WORKTREES_SERVICE_EXTENDED]) return;
+  if (typeof worktreesService.methods === 'function') {
+    worktreesService.methods('initializeUnixGroup');
+  }
+  worktreesService[WORKTREES_SERVICE_EXTENDED] = true;
 }
 
 function extendServiceFactory(client: AgorClient): void {
@@ -673,7 +687,6 @@ function extendServiceFactory(client: AgorClient): void {
   augmentedClient.service = ((path: string) => {
     const service = rawService(path);
     extendFindAllOnService(service);
-    registerClientCustomMethods(path, service);
     return service;
   }) as AgorClient['service'];
 
@@ -765,6 +778,9 @@ export async function createRestClient(
 
   extendServiceFactory(client);
   extendBoardsService(client);
+  extendUsersService(client);
+  extendReposService(client);
+  extendWorktreesService(client);
   extendSessionsHelpers(client);
 
   return client;
@@ -840,6 +856,9 @@ export function createClient(
 
   extendServiceFactory(client);
   extendBoardsService(client);
+  extendUsersService(client);
+  extendReposService(client);
+  extendWorktreesService(client);
   extendSessionsHelpers(client);
 
   return client;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -625,6 +625,40 @@ function extendFindAllOnService(service: AgorService<unknown>): void {
   findAllService[SERVICE_FIND_ALL_EXTENDED] = true;
 }
 
+/**
+ * Custom RPC methods exposed by the daemon that aren't part of the Feathers
+ * standard CRUD interface. The Socket.io client only wires the default
+ * methods at construction time, so each path that has custom methods on the
+ * server must be registered here too — otherwise calling them on the client
+ * proxy throws "client.service(...).<method> is not a function".
+ *
+ * Keep this in sync with the `methods:` arrays in
+ * `apps/agor-daemon/src/register-services.ts`.
+ */
+const CLIENT_CUSTOM_METHODS: Record<string, readonly string[]> = {
+  users: ['getGitEnvironment'],
+  repos: ['initializeUnixGroup'],
+  worktrees: ['initializeUnixGroup'],
+};
+
+function registerClientCustomMethods(path: string, service: unknown): void {
+  // Strip leading slash to match the keys above (paths can come in as either form).
+  const normalized = path.replace(/^\/+/, '');
+  const customMethods = CLIENT_CUSTOM_METHODS[normalized];
+  if (!customMethods || customMethods.length === 0) {
+    return;
+  }
+
+  const candidate = service as { methods?: (...names: string[]) => unknown };
+  if (typeof candidate.methods !== 'function') {
+    return;
+  }
+
+  // Idempotent: SocketService.methods() just (re)defines the named functions
+  // on the instance; calling it twice with the same names is harmless.
+  candidate.methods(...customMethods);
+}
+
 function extendServiceFactory(client: AgorClient): void {
   const augmentedClient = client as AgorClient & {
     [CLIENT_SERVICE_FACTORY_EXTENDED]?: boolean;
@@ -639,6 +673,7 @@ function extendServiceFactory(client: AgorClient): void {
   augmentedClient.service = ((path: string) => {
     const service = rawService(path);
     extendFindAllOnService(service);
+    registerClientCustomMethods(path, service);
     return service;
   }) as AgorClient['service'];
 


### PR DESCRIPTION
## Summary

Production-blocking regression: worktree creation failed with `client.service(...).getGitEnvironment is not a function` (also observed for `repos/worktrees.initializeUnixGroup`).

**Root cause.** PR #1088 added three custom Feathers methods server-side (`users.getGitEnvironment`, `repos.initializeUnixGroup`, `worktrees.initializeUnixGroup`) and wired the executor to call them via the Feathers Socket.io client. The daemon's `app.use(path, service, { methods: [...] })` exposes them on the wire, but **does not propagate to the client**. The Socket.io client wires only standard CRUD at construction; custom methods must be registered on the client too via `service.methods(...)`. PR #1088 never did this on the client side.

A fix existed on a stale `feat/per-user-impersonated-clone` branch (commit `b04b38b5`, "fix(api): register custom client RPC methods on Socket.io proxy") but was never included in the squash-merge of PR #1088. This PR re-applies that fix verbatim and adds regression tests.

## Why pre-merge Docker testing didn't catch it

The unit tests for `users.getGitEnvironment` (`apps/agor-daemon/src/services/users.git-env.test.ts`) instantiate `UsersService` directly and call the method on the bare class — they never go through the Feathers Socket.io transport, so they pass even when the client proxy is missing the method. The bug only manifests on the wire path: `executor → Feathers client → Socket.io → daemon`.

In dev/Docker, Max likely tested this end-to-end on `unix_user_mode: simple` where the call should still happen (executor always calls `fetchUserGitEnvironment` when `userId` is set). The most plausible reasons it slipped through:

1. **CI gap.** `@agor/core` is currently excluded from the CI test runner (`ci.yml: pnpm turbo run test --filter=agor-ui --filter=@agor/daemon`). Even if a regression test had landed in `packages/core/src/api/index.test.ts` at the time of #1088, CI would not have run it. There's an in-progress local change in this worktree adding a TODO comment about that exclusion, but it was deliberately scoped out of this hotfix PR.
2. **Stale executor build.** Watch-mode dev (`tsx watch`) recompiles the daemon on save, but the executor is spawned per-clone from `packages/executor/dist`. If the executor wasn't rebuilt after pulling #1088, the running spawn payload still pointed to pre-#1088 code that didn't call `client.service('users').getGitEnvironment` at all.
3. **No socket-layer integration test.** There is no test that exercises `client → daemon → server-side custom method` round-trip. Adding one would turn this class of bug from "production-only" into "test failure on PR open".

The follow-up that closes the gap is (1) un-excluding `@agor/core` from CI and (3) adding a real socket-roundtrip integration test for custom methods. Both are out of scope for this hotfix.

## The fix

`packages/core/src/api/index.ts`:
- Add a `CLIENT_CUSTOM_METHODS` registry that mirrors the daemon's `methods:` arrays from `apps/agor-daemon/src/register-services.ts`:
  - `users → ['getGitEnvironment']`
  - `repos → ['initializeUnixGroup']`
  - `worktrees → ['initializeUnixGroup']`
- Hook into the existing `extendServiceFactory` wrapper so every `client.service(path)` lookup auto-calls `service.methods(...)` for the registered custom methods. Idempotent (safe to call repeatedly).

`packages/core/src/api/index.test.ts`:
- Four regression tests in the `service helpers` block verifying that `service.methods(...)` is invoked with the expected names for `users`, `repos`, `worktrees`, and **not** invoked for services without custom methods. Verified locally that all three positive tests fail when the fix is reverted (3 failed / 60 passed).

## Test plan

- [x] `pnpm typecheck` clean (ran via husky pre-commit)
- [x] `pnpm lint` clean (ran via husky pre-commit; only pre-existing warnings)
- [x] `pnpm --filter @agor/core test src/api/index.test.ts` → 63/63 pass
- [x] Sanity-check: revert the fix only, re-run the test file → 3 of the 4 new tests fail with `expected "vi.fn()" to be called with arguments: [ 'getGitEnvironment' ]` etc.; restoring the fix returns to 63/63
- [ ] **End-to-end verification needed in deploy:** create a fresh worktree on the prod branch with this commit applied; should succeed without the `is not a function` error

## Follow-ups (not in this PR)

- Un-exclude `@agor/core` (and `@agor/executor`) from CI's test filter — the current exclusion in `ci.yml` is what allowed #1088 to merge without a tripped test even if such a test had existed.
- Add a real socket-roundtrip integration test (boot daemon + client, call `client.service('users').getGitEnvironment(...)` and assert it doesn't 404) so that future custom-method additions can't regress this same way.
- Consider deriving `CLIENT_CUSTOM_METHODS` from the same source as the daemon's `methods:` arrays (e.g., a shared constants file) so the two lists can't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)