### PR TITLE
fix(mcp): OAuth token expiry resolution cascade + research doc

### DIFF
--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -14,7 +14,7 @@ import type { MCPServerID, UserID } from '@agor/core/types';
  * all. This is ONLY used to bound the lifetime of the daemon-local
  * `oauth21TokenCache` map (so it doesn't grow unbounded), NOT to fabricate
  * an expiry on the persisted DB row. The DB row gets `expires_at = NULL`
- * via `resolveTokenExpiry` → `saveToken({ expiresInSeconds: null })`.
+ * via `resolveTokenExpiry` → `saveToken({ expiresAt: null })`.
  */
 const UNKNOWN_EXPIRY_CACHE_TTL_SECONDS = 3600;
 
@@ -104,12 +104,16 @@ export async function persistOAuthToken(
   const expiry = resolveTokenExpiry(tokenResponse, tokenResponse.access_token);
 
   // The in-memory daemon cache still wants *some* TTL so its map doesn't
-  // grow unbounded. Use the resolved value when known, otherwise the
-  // UNKNOWN_EXPIRY_CACHE_TTL_SECONDS guard (1h). This is local-cache hygiene
-  // only — the persisted DB row uses `expiry.seconds` directly so `NULL`
-  // makes it through to `oauth_token_expires_at` when the provider was
-  // silent, and the UI can correctly render "expires in: unknown".
-  const cacheTtlSeconds = expiry.seconds ?? UNKNOWN_EXPIRY_CACHE_TTL_SECONDS;
+  // grow unbounded. Derive seconds-from-now from the resolved Date when
+  // known, otherwise fall back to UNKNOWN_EXPIRY_CACHE_TTL_SECONDS (1h).
+  // This is local-cache hygiene only — the persisted DB row uses
+  // `expiry.expiresAt` directly so `NULL` makes it through to
+  // `oauth_token_expires_at` when the provider was silent, and the UI can
+  // correctly render "expires in: unknown".
+  const cacheTtlSeconds =
+    expiry.expiresAt !== null
+      ? Math.max(1, Math.floor((expiry.expiresAt.getTime() - Date.now()) / 1000))
+      : UNKNOWN_EXPIRY_CACHE_TTL_SECONDS;
   cacheOAuth21Token(cacheKey, tokenResponse.access_token, cacheTtlSeconds);
 
   if (!pendingFlow.mcpServerId) {
@@ -132,7 +136,7 @@ export async function persistOAuthToken(
 
   await userTokenRepo.saveToken(tokenUserId, pendingFlow.mcpServerId as MCPServerID, {
     accessToken: tokenResponse.access_token,
-    expiresInSeconds: expiry.seconds, // number | null — null means "unknown"
+    expiresAt: expiry.expiresAt, // Date | null — null means "unknown"
     refreshToken: tokenResponse.refresh_token,
     clientId: pendingFlow.clientId,
     clientSecret: pendingFlow.clientSecret,
@@ -142,7 +146,7 @@ export async function persistOAuthToken(
     `[${logPrefix}] ${oauthMode === 'per_user' ? 'Per-user' : 'Shared'} token saved ` +
       `for user=${tokenUserId ?? '<shared>'} server=${pendingFlow.mcpServerId}` +
       ` (expiry source: ${expiry.source}` +
-      `${expiry.seconds !== null ? `, ttl=${expiry.seconds}s` : ', ttl=unknown'})` +
+      `${expiry.expiresAt !== null ? `, expires=${expiry.expiresAt.toISOString()}` : ', expires=unknown'})` +
       `${pendingFlow.clientId ? ' (with DCR client creds)' : ''}`
   );
 }

--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -6,7 +6,17 @@
  */
 
 import { UserMCPOAuthTokenRepository } from '@agor/core/db';
+import { resolveTokenExpiry } from '@agor/core/tools/mcp/oauth-token-expiry';
 import type { MCPServerID, UserID } from '@agor/core/types';
+
+/**
+ * Default in-memory cache TTL when the provider gives us no expiry signal at
+ * all. This is ONLY used to bound the lifetime of the daemon-local
+ * `oauth21TokenCache` map (so it doesn't grow unbounded), NOT to fabricate
+ * an expiry on the persisted DB row. The DB row gets `expires_at = NULL`
+ * via `resolveTokenExpiry` → `saveToken({ expiresInSeconds: null })`.
+ */
+const UNKNOWN_EXPIRY_CACHE_TTL_SECONDS = 3600;
 
 // ============================================================================
 // In-memory OAuth 2.1 Token Cache
@@ -86,10 +96,21 @@ export async function persistOAuthToken(
   },
   logPrefix: string
 ): Promise<void> {
-  const expiresIn = tokenResponse.expires_in ?? 3600;
+  // Walk the precedence cascade for the token TTL — see Phase 3.5 of
+  // `context/explorations/mcp-oauth-token-lifecycle.md`. Replaces the prior
+  // `tokenResponse.expires_in ?? 3600` defaulting that was asymmetric with
+  // the refresh path and lied to the DB for providers like Notion that omit
+  // `expires_in` entirely.
+  const expiry = resolveTokenExpiry(tokenResponse, tokenResponse.access_token);
 
-  // Cache the token at daemon level
-  cacheOAuth21Token(cacheKey, tokenResponse.access_token, expiresIn);
+  // The in-memory daemon cache still wants *some* TTL so its map doesn't
+  // grow unbounded. Use the resolved value when known, otherwise the
+  // UNKNOWN_EXPIRY_CACHE_TTL_SECONDS guard (1h). This is local-cache hygiene
+  // only — the persisted DB row uses `expiry.seconds` directly so `NULL`
+  // makes it through to `oauth_token_expires_at` when the provider was
+  // silent, and the UI can correctly render "expires in: unknown".
+  const cacheTtlSeconds = expiry.seconds ?? UNKNOWN_EXPIRY_CACHE_TTL_SECONDS;
+  cacheOAuth21Token(cacheKey, tokenResponse.access_token, cacheTtlSeconds);
 
   if (!pendingFlow.mcpServerId) {
     return;
@@ -111,7 +132,7 @@ export async function persistOAuthToken(
 
   await userTokenRepo.saveToken(tokenUserId, pendingFlow.mcpServerId as MCPServerID, {
     accessToken: tokenResponse.access_token,
-    expiresInSeconds: expiresIn,
+    expiresInSeconds: expiry.seconds, // number | null — null means "unknown"
     refreshToken: tokenResponse.refresh_token,
     clientId: pendingFlow.clientId,
     clientSecret: pendingFlow.clientSecret,
@@ -120,6 +141,8 @@ export async function persistOAuthToken(
   console.log(
     `[${logPrefix}] ${oauthMode === 'per_user' ? 'Per-user' : 'Shared'} token saved ` +
       `for user=${tokenUserId ?? '<shared>'} server=${pendingFlow.mcpServerId}` +
+      ` (expiry source: ${expiry.source}` +
+      `${expiry.seconds !== null ? `, ttl=${expiry.seconds}s` : ', ttl=unknown'})` +
       `${pendingFlow.clientId ? ' (with DCR client creds)' : ''}`
   );
 }

--- a/apps/agor-ui/src/components/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServerPill.tsx
@@ -138,9 +138,22 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
       </>
     );
   } else {
-    // No expiry surfaced (e.g. pre-migration row or provider that doesn't
-    // return expires_in). Still allow manual refresh as a diagnostic.
-    authedTooltip = 'Click to refresh token';
+    // No expiry surfaced. With the resolveTokenExpiry cascade in place, this
+    // is now an honest "we couldn't determine a TTL from anything the
+    // provider returned" — Notion is the canonical example (omits expires_in
+    // on both initial grant and refresh). The token is still usable; the
+    // daemon falls back to retrying on 401 when the provider eventually
+    // rejects it. See `context/explorations/mcp-oauth-token-lifecycle.md`
+    // (Phase 3.5) for the cascade and the reasoning.
+    authedTooltip = (
+      <>
+        <div>Expires in: unknown</div>
+        <div style={{ opacity: 0.75, fontSize: 12 }}>
+          Provider returned no expiry — token will be refreshed on demand.
+        </div>
+        <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>
+      </>
+    );
   }
 
   return (

--- a/apps/agor-ui/src/components/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServerPill.tsx
@@ -142,14 +142,14 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
     // is now an honest "we couldn't determine a TTL from anything the
     // provider returned" — Notion is the canonical example (omits expires_in
     // on both initial grant and refresh). The token is still usable; the
-    // daemon falls back to retrying on 401 when the provider eventually
-    // rejects it. See `context/explorations/mcp-oauth-token-lifecycle.md`
-    // (Phase 3.5) for the cascade and the reasoning.
+    // operator can force a refresh from this pill if it stops working.
+    // (A retry-on-401 transport shim is tracked as a follow-up — see
+    // `context/explorations/mcp-oauth-token-lifecycle.md` Phase 5.)
     authedTooltip = (
       <>
         <div>Expires in: unknown</div>
         <div style={{ opacity: 0.75, fontSize: 12 }}>
-          Provider returned no expiry — token will be refreshed on demand.
+          Provider returned no expiry. Token is used until it stops working.
         </div>
         <div style={{ opacity: 0.75, fontSize: 12, marginTop: 4 }}>Click to refresh now</div>
       </>

--- a/apps/agor-ui/src/utils/jwtExpiry.ts
+++ b/apps/agor-ui/src/utils/jwtExpiry.ts
@@ -1,57 +1,14 @@
 /**
  * Client-side JWT expiry helpers.
  *
+ * Thin re-export of `@agor-live/client/jwt`, which itself re-exports the
+ * shared decoder from `@agor/core/utils/jwt`. The daemon-side
+ * `resolveTokenExpiry` cascade uses the same implementation, so there is
+ * exactly one decoder in the tree — no drift between client and server.
+ *
  * We decode (NOT verify) the payload purely to learn when the token will be
  * rejected by the server, so we can schedule a proactive refresh. The server
  * is still the only party that validates signatures.
- *
- * ⚠ KEEP IN SYNC with `packages/core/src/utils/jwt.ts` (used daemon-side by
- * `resolveTokenExpiry`). The implementations are intentionally identical;
- * we duplicate rather than import because `apps/agor-ui` does not depend on
- * `@agor/core` (and adding it would pull Node-only deps into the browser
- * bundle). If the API drifts, update both files.
  */
 
-/**
- * Extract the `exp` claim from a JWT, in milliseconds since epoch.
- *
- * Returns null if the token is malformed or has no numeric `exp`.
- */
-export function decodeJwtExpMs(token: string): number | null {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-
-    // base64url → base64
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    // atob is available in all browser targets we support
-    const json = atob(base64);
-    const payload = JSON.parse(json) as { exp?: unknown };
-
-    if (typeof payload.exp !== 'number') return null;
-    return payload.exp * 1000;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Milliseconds until the token expires. Negative if already expired.
- * Null if we cannot decode the token.
- */
-export function msUntilExpiry(token: string, now: number = Date.now()): number | null {
-  const expMs = decodeJwtExpMs(token);
-  return expMs === null ? null : expMs - now;
-}
-
-/**
- * True if the token is expired or will expire within `bufferMs`.
- *
- * If the token cannot be decoded, returns `true` so callers refresh
- * defensively rather than ride a bad token.
- */
-export function isExpiringSoon(token: string, bufferMs: number): boolean {
-  const ms = msUntilExpiry(token);
-  if (ms === null) return true;
-  return ms <= bufferMs;
-}
+export { decodeJwtExpMs, isExpiringSoon, msUntilExpiry } from '@agor-live/client/jwt';

--- a/apps/agor-ui/src/utils/jwtExpiry.ts
+++ b/apps/agor-ui/src/utils/jwtExpiry.ts
@@ -4,6 +4,12 @@
  * We decode (NOT verify) the payload purely to learn when the token will be
  * rejected by the server, so we can schedule a proactive refresh. The server
  * is still the only party that validates signatures.
+ *
+ * ⚠ KEEP IN SYNC with `packages/core/src/utils/jwt.ts` (used daemon-side by
+ * `resolveTokenExpiry`). The implementations are intentionally identical;
+ * we duplicate rather than import because `apps/agor-ui` does not depend on
+ * `@agor/core` (and adding it would pull Node-only deps into the browser
+ * bundle). If the API drifts, update both files.
  */
 
 /**

--- a/context/explorations/mcp-oauth-token-lifecycle.md
+++ b/context/explorations/mcp-oauth-token-lifecycle.md
@@ -1,0 +1,555 @@
+# MCP OAuth Token Lifecycle for Unattended / Scheduled Agents
+
+> Research doc — no code changes proposed in this PR.
+> Audience: agor maintainers thinking about cron / schedule-driven agents.
+> Last reviewed: 2026-05-05.
+
+## TL;DR
+
+Agor's MCP OAuth implementation is **already in good shape** for the
+interactive case: tokens live in `user_mcp_oauth_tokens` (per-user or shared),
+JIT refresh is wired into both the read hook and the executor's auth-header
+service, refreshes are mutexed per `(user, server)` to survive rotating refresh
+tokens, and `invalid_grant` cleanly surfaces "please re-auth".
+
+For **unattended / scheduled agents** there are three gaps:
+
+1. **No retry-on-401 at the MCP transport.** A token that expires *mid-call*
+   (after the JIT preflight) just fails the tool call. Explicitly listed as a
+   known follow-up in `packages/core/src/tools/mcp/oauth-refresh.ts`.
+2. **No proactive refresh hook for scheduled triggers.** Cron fires → executor
+   spawns → JIT refresh runs. Fine when refresh succeeds; silent failure when
+   it doesn't (revoked grant, network blip).
+3. **Provider-specific failure modes.** Notion's refresh response omits
+   `expires_in`, so `needsRefresh(undefined) === false` — JIT will never
+   proactively refresh a Notion token. Slack's MCP server requires user-token
+   rotation (12h TTL) but the rotation toggle is one-way and easy to forget.
+   Atlassian needs `offline_access` in scopes or no refresh_token is issued.
+
+The 80/20 fix is **(a)** a retry-on-401 shim in the executor's MCP transport,
+**(b)** a pre-cron refresh pass in the scheduler service, and **(c)** loud
+"needs re-auth" notifications on scheduled-run failure. After that, declarative
+per-provider lifecycle config papers over Notion-style quirks.
+
+---
+
+## Phase 1 — Audit of Agor's current OAuth lifecycle
+
+### Storage
+
+`user_mcp_oauth_tokens` (drizzle schema in `packages/core/src/db/schema.*`)
+holds:
+
+| column | purpose |
+|---|---|
+| `user_id` | Per-user token; `NULL` = shared-mode token for the server |
+| `mcp_server_id` | FK to `mcp_servers` |
+| `oauth_access_token` | Bearer to attach |
+| `oauth_token_expires_at` | Absolute Date or NULL (when provider omits `expires_in`) |
+| `oauth_refresh_token` | nullable — present iff provider issued one |
+| `oauth_client_id` / `oauth_client_secret` | Bound to the grant (DCR-issued or admin-pre-registered) |
+| `created_at` / `updated_at` | timestamps |
+
+Co-locating client credentials with the refresh_token is correct: refreshing
+requires the *exact* `client_id`/`client_secret` the grant was issued under,
+because each DCR registration is its own client.
+
+Repository: `packages/core/src/db/repositories/user-mcp-oauth-tokens.ts`.
+Notable: `getValidToken` returns `undefined` when expired without refreshing —
+the refresh decision is the caller's. Good separation; the daemon's
+`oauth-auth-headers` service is the single integration point.
+
+### Refresh path
+
+`packages/core/src/tools/mcp/oauth-refresh.ts` is the canonical implementation.
+
+- `refreshMCPToken(opts)` — pure HTTP `grant_type=refresh_token` call. Mirrors
+  `exchangeCodeForToken` in transport: HTTP Basic when `client_secret` is
+  present, body params for public clients.
+- `refreshAndPersistToken(deps)` — wraps the HTTP call with:
+  - **Per-`(user|shared, server)` mutex** (`_inFlightRefreshes` map) to collapse
+    concurrent refreshes against the same refresh_token. Critical for
+    providers that rotate (Linear / Atlassian) or treat replay as a compromise
+    (Atlassian fires breach-detection if the 10-minute grace is exceeded).
+  - **Atomic persist** of the new access_token + rotated refresh_token (per
+    RFC 6749 §6, an absent `refresh_token` in the response means keep the
+    old one).
+  - **`invalid_grant` cleanup** — deletes the token row so the user is
+    surfaced "please re-auth", with an optional `onInvalidGrant` hook.
+  - **Transient errors are surfaced**, not swallowed. Callers fall back to the
+    stale token rather than 500ing.
+- `needsRefresh(expiresAt)` — `true` when token is absent, expired, or within
+  `REFRESH_BUFFER_MS` (60s) of expiry. Returns **`false`** when `expiresAt` is
+  null/undefined. **This is a quiet correctness gap for Notion** (see Phase 3).
+
+### Daemon wiring
+
+Refresh is invoked from three places:
+
+1. **`apps/agor-daemon/src/register-hooks.ts:825-856`** — the
+   `injectPerUserOAuthTokens` hook on MCP server reads. JIT-refreshes when the
+   user/socket reads MCP server records (e.g., session-start), so the
+   executor receives a fresh token in the server payload. Fall-through on
+   transient error keeps the response from blocking session boot.
+2. **`apps/agor-daemon/src/register-services.ts:1931-2018`** — the
+   `/mcp-servers/oauth-auth-headers` Feathers service. Executor calls it
+   before each MCP request burst with a list of in-scope server IDs; daemon
+   returns either `{ authorization: 'Bearer …' }` or `{ error: 'needs_reauth' }`.
+   This is the **authoritative** path during an active session: the executor
+   never holds raw refresh tokens, can never request someone else's row
+   (no `forUserId` override), and shared-mode rows are returned only to
+   callers who can already see the server.
+3. **`apps/agor-daemon/src/register-services.ts:2034-2094`** —
+   `/mcp-servers/oauth-refresh`, the manual "refresh now" UI affordance.
+
+### Two-phase OAuth flow (initial auth)
+
+For remote daemons, `startMCPOAuthFlow` / `completeMCPOAuthFlow` in
+`oauth-mcp-transport.ts` split the auth-code flow so the daemon's public
+callback URL receives the redirect (the legacy CLI `performMCPOAuthFlow`
+spins up a `127.0.0.1:0` listener — unsuitable for any deployed daemon, and
+the file's docstring is explicit about that). PR #1078 extended discovery to
+walk the full RFC 9728 → RFC 8414 → OIDC cascade with RFC 7591 DCR for
+client registration. Notable consequence: the `client_id` / `client_secret`
+persisted on the token row are DCR-issued and **scoped to that grant**, not
+reusable across users.
+
+### What the audit confirms works
+
+- ✅ Per-user isolation in storage and at the auth-headers service boundary.
+- ✅ Mutexed refresh — race-safe under rotating refresh tokens.
+- ✅ Correct semantics on absent `refresh_token` in refresh response (keep
+  old).
+- ✅ `invalid_grant` → delete row → UI shows re-auth prompt.
+- ✅ Transient refresh failures fall through to stale token (better than
+  hard-failing the agent).
+- ✅ 60s safety buffer in `needsRefresh`.
+
+### What the audit flags
+
+- ⚠️ **No retry-on-401 shim** at the MCP HTTP transport. Listed in
+  `oauth-refresh.ts` header as known follow-up.
+- ⚠️ **`needsRefresh(null) === false`** — for providers that don't return
+  `expires_in` (Notion), proactive refresh never fires. Combined with no
+  retry-on-401, the first call after the silent provider-side rotation
+  hard-fails.
+- ⚠️ **In-memory `authCodeTokenCache`** in `oauth-mcp-transport.ts` is
+  vestigial in daemon mode (the DB-backed path is authoritative). Worth
+  pruning to one cache to avoid drift. `getCachedOAuth21Token` is referenced
+  from `apps/agor-daemon/src/oauth-cache.ts` and `services/gateway.ts`, and
+  this in-memory map is what backs it.
+- ⚠️ **Token endpoint inference on refresh.** `refreshAndPersistToken` falls
+  back to `inferOAuthTokenUrl(server.url)` when `oauth_token_url` isn't
+  persisted on the server config. We should persist the *discovered* token
+  endpoint at DCR time so refresh never depends on heuristics.
+- ⚠️ **No notification on unattended refresh failure.** A scheduled trigger
+  hitting `invalid_grant` deletes the row but emits only a console warn —
+  the user finds out when they wake up to a missed run.
+
+---
+
+## Phase 2 — Provider research
+
+Each subsection cites the upstream docs inline. All summaries are based on
+public docs as of 2026-05-05.
+
+### Slack — `https://mcp.slack.com/mcp`
+
+- **Two regimes.** With **Token Rotation OFF** (legacy default for many apps),
+  bot/user tokens are non-expiring. With **Token Rotation ON**, access tokens
+  expire after exactly **12 hours / `expires_in: 43200`** — fixed by Slack,
+  not configurable per-app. Rotated tokens carry the `xoxe.` prefix.
+  ([docs.slack.dev/authentication/using-token-rotation](https://docs.slack.dev/authentication/using-token-rotation))
+- **Refresh tokens** are issued **only** when rotation is enabled (`xoxe-1-`
+  prefix). Rotation cannot be turned off once enabled. No documented refresh
+  TTL — but refresh tokens are **single-use** with a short grace, and Slack
+  enforces a **2-active-token limit** if refreshed repeatedly within 12h.
+- **Refresh endpoint**: `POST https://slack.com/api/oauth.v2.access` with
+  `grant_type=refresh_token`. Response shape is RFC 6749-compliant; deviation
+  is the rotated/single-use refresh token. HTTP 200 with `{"ok": false,
+  "error": "..."}` is a possible failure mode (already handled in
+  `oauth-mcp-transport.ts`).
+  ([docs.slack.dev/reference/methods/oauth.v2.access](https://docs.slack.dev/reference/methods/oauth.v2.access))
+- **Slack's MCP server** uses **user tokens (`xoxp-`)**, with distinct OAuth
+  endpoints (`/oauth/v2_user/authorize`, `/api/oauth.v2.user.access`). Whether
+  rotation is *required* for the MCP variant isn't explicitly stated in the
+  MCP docs, but the user's empirical "~1 hour" observation suggests an
+  even-shorter MCP-specific TTL or a 1h rotation policy worth confirming
+  empirically. ([docs.slack.dev/ai/slack-mcp-server/](https://docs.slack.dev/ai/slack-mcp-server/))
+- **Implication**: turn rotation on, store the refresh token, refresh ~30 min
+  before the 12h boundary. Don't burn through the 2-token grace window with
+  bursts of refreshes.
+
+### Notion — `https://mcp.notion.com/mcp`
+
+- **Access token TTL is undocumented.** The published OAuth/auth docs do not
+  state an expiration. The introspection endpoint exposes `active`, `scope`,
+  `iat`, `request_id` — **no `exp` field**.
+  ([developers.notion.com/reference/introspect-token](https://developers.notion.com/reference/introspect-token))
+- **Refresh tokens** are issued for public OAuth integrations and the refresh
+  call **rotates both** (access + refresh). The refresh endpoint is `POST
+  https://api.notion.com/v1/oauth/token` (HTTP Basic with `client_id:client_secret`).
+  ([developers.notion.com/reference/refresh-a-token](https://developers.notion.com/reference/refresh-a-token))
+- **Refresh response omits `expires_in`.** Returns `access_token`, `token_type`,
+  `refresh_token`, plus workspace metadata — no TTL field. This is the
+  single biggest correctness hazard: clients that key off `expires_in` will
+  store `expires_at = NULL`, and any `needsRefresh(null) === false`-style
+  check (Agor's current behavior) will never proactively refresh.
+- **Internal-integration bearer tokens** (created in admin's own workspace)
+  appear to remain long-lived / non-expiring per the docs — useful for
+  schedule-only workspaces.
+  ([developers.notion.com/docs/authorization](https://developers.notion.com/docs/authorization))
+- **Implication**: for Notion, either (a) treat tokens as ~1h by convention
+  and force a refresh at that cadence, or (b) rely on retry-on-401, or (c)
+  use Internal Integration tokens via a skill for unattended cases.
+
+### Linear — `https://mcp.linear.app/mcp`
+
+- **Access token TTL: 24h (`expires_in: 86399`).** Refresh tokens issued and
+  **rotated on every use**. **30-minute grace window** allows retrying a
+  failed refresh with the original refresh_token — the friendliest of all
+  providers in the matrix. As of 2026-04-01, all OAuth2 apps were migrated to
+  the rotating system.
+  ([linear.app/developers/oauth-2-0-authentication](https://linear.app/developers/oauth-2-0-authentication))
+- Refresh endpoint: `POST https://api.linear.app/oauth/token`. RFC 6749-clean.
+- The MCP server appears to share OAuth with Linear's REST/GraphQL — no
+  separate auth doc page. The older `/sse` endpoint was deprecated; current
+  MCP is on the streamable-HTTP `/mcp` URL.
+- **Implication**: Linear is the easy case. Current Agor code handles it
+  correctly out of the box.
+
+### Atlassian — `https://mcp.atlassian.com/v1/mcp/authv2` (legacy `/v1/sse` deprecated 2026-06-30)
+
+- **Access token TTL: 1h (`expires_in: 3600`).** Fixed. Not user-configurable.
+  ([developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/))
+- **Rotating refresh tokens** with a **90-day inactivity sliding window**.
+  No documented absolute cap — a healthy daily refresh keeps the grant alive
+  indefinitely. **10-minute reuse grace** for network/concurrency retries.
+- Requires the **`offline_access`** scope on initial auth or no refresh
+  token is issued — *easy to miss during DCR*. Worth a guardrail in Agor's
+  scope auto-population path.
+- Refresh endpoint: `POST https://auth.atlassian.com/oauth/token`. Standard
+  shape.
+- **MCP server** supports OAuth 2.1 with **DCR** (no manual app creation
+  needed). Optional API-token auth path exists but requires admin approval.
+- **Implication**: Atlassian is well-specified and Agor handles it; the only
+  pitfall is the `offline_access` scope. Document it.
+
+### GitHub — `https://api.githubcopilot.com/mcp/`
+
+Three distinct token types — pick deliberately for unattended:
+
+- **OAuth Apps (legacy):** non-expiring by default unless the "Expire user
+  authorization tokens" toggle is on (default on for newly-created apps).
+  When non-expiring, auto-revoked after 1 year of non-use.
+- **GitHub App user-to-server tokens (`ghu_`):** **8h access** + **6mo
+  refresh** (`ghr_`), refresh tokens rotate. Endpoint: `POST
+  https://github.com/login/oauth/access_token` with `grant_type=refresh_token`.
+  Response includes both `expires_in` and `refresh_token_expires_in`.
+  ([docs.github.com/.../refreshing-user-access-tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens))
+- **GitHub App installation tokens:** **1h, no refresh token.** Re-minted by
+  `POST /app/installations/{id}/access_tokens` authenticated with a 10-min
+  RS256 JWT signed by the App's private key.
+  ([docs.github.com/.../generating-an-installation-access-token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app))
+- **Implication**: for unattended/scheduled agents, **installation tokens
+  are the right primitive** — no human refresh-token to babysit, no UI
+  re-auth flow needed, the only secret is the App's private key sitting in
+  config. Worth a dedicated skill or an MCP-server config option that says
+  "this server uses GitHub App installation auth" and the daemon mints a
+  fresh 1h token on each request burst.
+
+### MCP spec / OAuth 2.1 / DPoP
+
+- **MCP Authorization spec** delegates lifetime entirely to the AS. No
+  MCP-mandated TTL. Refresh tokens are **permitted, not required**: clients
+  *MUST NOT* assume refresh tokens will be issued; ASes *SHOULD* issue
+  short-lived access tokens; **public clients MUST rotate refresh tokens**
+  (inherited from OAuth 2.1 §4.3.1).
+  ([modelcontextprotocol.io/specification/draft/basic/authorization](https://modelcontextprotocol.io/specification/draft/basic/authorization))
+- **Mid-call expiry**: spec says only that 401 *MUST* be returned and
+  clients *MUST* parse `WWW-Authenticate`. Retry-with-refresh is **not
+  specified** — it's a client concern.
+- **DPoP (RFC 9449)** is *SHOULD* in OAuth 2.1 (sender-constrained tokens),
+  not a current MCP requirement. **None of Slack/Notion/Linear/Atlassian/
+  GitHub publicly support DPoP** in their OAuth flows. Out of scope for now.
+
+### Provider matrix (cheat sheet)
+
+| Provider | Access TTL | Refresh TTL | Refresh rotates? | Quirk |
+|---|---|---|---|---|
+| Slack (rotation on) | 12h | none documented | Yes, single-use | 2-token limit; rotation one-way |
+| Slack (rotation off) | ∞ | n/a | n/a | Legacy; long-lived bot/user token |
+| Notion | **undocumented** | undocumented | Yes | No `expires_in` in response |
+| Linear | 24h | undocumented | Yes | 30-min grace window — best-in-class |
+| Atlassian | 1h | 90-day sliding | Yes | Needs `offline_access` scope |
+| GitHub OAuth App | ∞ or 8h | (n/a or 6mo) | If expiring, yes | App-level toggle |
+| GitHub App user-to-server | 8h | 6mo | Yes | `ghu_`/`ghr_` prefix |
+| GitHub App installation | 1h | **no refresh token** | re-mint via JWT | Best for unattended |
+
+---
+
+## Phase 3 — Gap analysis (Agor vs providers)
+
+### Coverage matrix
+
+| Capability needed | Agor implements? | Notes |
+|---|---|---|
+| Refresh token storage | ✅ | `user_mcp_oauth_tokens.oauth_refresh_token` |
+| Rotated refresh on persist | ✅ | `refreshAndPersistToken` saves new value atomically |
+| Per-(user, server) mutex | ✅ | `_inFlightRefreshes` map |
+| `invalid_grant` cleanup | ✅ | Row deleted; UI surfaces re-auth |
+| Transient error fallback | ✅ | Use stale token, emit warn |
+| Proactive refresh near expiry | ⚠️ Partial | Works only when `expires_at` is set; **silent on Notion** |
+| Retry-on-401 mid-call | ❌ | Listed as known follow-up |
+| Pre-cron / scheduled refresh hook | ❌ | Scheduler doesn't pre-warm tokens |
+| Notification on unattended re-auth | ❌ | Console warn only |
+| `offline_access` scope guardrail | ❌ | DCR scope auto-pop won't add it for Atlassian |
+| Persisted token endpoint | ⚠️ Partial | Falls back to `inferOAuthTokenUrl` heuristic |
+| DPoP / sender-constrained tokens | ❌ | Not needed yet — no provider supports it |
+| API-key fallback path | ✅ | env vars + per-tool credential storage (PR #1077) |
+
+### Specific gaps & their consequence
+
+1. **Mid-call expiry kills the tool call.** A 1h Atlassian token retrieved at
+   minute 0 still fails at minute 65 if the agent never returns to the auth-
+   headers service in between. The MCP HTTP transport should retry once on
+   401 with a fresh-from-refresh Bearer.
+
+2. **Notion silently breaks at provider rotation.** Without `expires_in`,
+   `needsRefresh` is permanently false; refresh only happens on manual UI
+   click or via the gap-1 retry-on-401 (which doesn't exist). Two-step fix:
+   add a per-server "default access token TTL" hint *and* implement
+   retry-on-401.
+
+3. **Scheduled triggers can fire into a near-expired token.** A trigger
+   scheduled for 03:00 UTC with a Slack token that expires at 03:15 will
+   refresh fine on first request but then expire mid-run. Pre-cron refresh
+   would warm the cache to the full window before spawn.
+
+4. **Failures in unattended refresh are invisible.** No durable signal on
+   `invalid_grant` during a cron run — the next interactive session gets a
+   "please re-auth" pill, the missed run goes unnoticed.
+
+5. **Slack rotation is one-way and easy to forget.** If an admin sets up an
+   MCP server with a Slack app that has rotation OFF, tokens are non-expiring
+   and Agor's code is correct (no refresh needed). But the user *thinks*
+   they're using a 12h-rotating setup. We can detect by inspecting
+   `expires_in` on first issuance.
+
+6. **Atlassian without `offline_access` leaves no refresh_token.** First
+   tool call after 1h returns 401, Agor sees no refresh_token, falls to
+   `needs_reauth`. DCR scope auto-population should include
+   `offline_access` for any AS that advertises it in `scopes_supported`.
+
+---
+
+## Phase 4 — Options
+
+### A. Improve the existing JIT refresh path *(recommended baseline)*
+
+Status: most of this is shipped. The remaining work is:
+
+- **Retry-on-401 shim** in the executor's MCP HTTP transport. On 401 with a
+  Bearer challenge, call `oauth-auth-headers` to get a fresh token and
+  retry the original request **once**. Hard-fail the second time.
+- **Persist the discovered token endpoint** at DCR time so refresh never
+  depends on `inferOAuthTokenUrl`.
+- **`offline_access` auto-include** when AS advertises it.
+
+Trade-offs: smallest blast radius; provider-agnostic; closes gaps (1) and
+partially (2) and (6). Doesn't address (3) or (4).
+
+### B. Background daemon refresher
+
+Status: explicitly rejected in `oauth-refresh.ts` ("JIT is simpler, avoids
+wasted refreshes on idle users").
+
+Re-evaluating for the unattended case: a background sweep that refreshes any
+token within ~30 min of expiry would close gap (2) for Notion (treat
+no-`expires_in` as a configurable "assume X hours" default) and pre-warm
+cron runs. Cost: a write-heavy idle workload on rotating providers, plus
+the operational hazard that a refresh-during-sweep can race with an
+in-flight tool call (`refreshAndPersistToken` mutex protects correctness,
+but the sweep wastes provider quota).
+
+Trade-offs: heavier; only justified once we see real cron-driven failures
+that A and F don't catch.
+
+### C. Skills with API-key wrappers (per provider)
+
+Status: Agor already supports per-tool credential storage (PR #1077) and
+env var injection. A skill like `slack-bot` or `notion-internal` can wrap a
+provider's REST API with a long-lived PAT/internal token.
+
+Trade-offs:
+- ➕ No expiry, no refresh, no UI loop. Survives any token-lifecycle
+  weirdness.
+- ➖ Loses the MCP UX wins: server-side tool definitions, scope-narrowing,
+  per-user attribution, OAuth-style consent screen.
+- ➖ Multiplayer story is awkward: whose PAT is the "shared" credential?
+  PR #1077 stores per-user tool credentials but doesn't filter spawn env
+  per SDK at runtime (logged in `project_credential_scoping_gap.md`).
+- ➖ Not all providers offer scoped long-lived tokens (Slack PATs are
+  limited, Atlassian admin API tokens are coarse, GitHub PATs are very
+  coarse).
+
+### D. Hybrid — MCP for interactive, API-key skill for unattended
+
+Status: complementary to A. Recommended **only** for providers where MCP
+refresh is empirically unreliable (currently Notion, possibly Slack-with-
+rotation-off).
+
+Trade-offs:
+- ➕ Always-on path for cron without giving up MCP for humans.
+- ➖ Two code paths to maintain per provider; users have to set both up.
+- ➖ Risk of behavioral drift (a cron agent calls a Slack channel via a
+  skill, an interactive agent calls it via MCP, and the same prompt
+  produces slightly different tool surfaces).
+
+### E. Provider-specific service-account tokens
+
+Where the provider offers a long-lived service-account/installation token
+that doesn't depend on a human user:
+
+- **GitHub App installation tokens** (1h, JWT-derived) — best in class for
+  unattended.
+- **Atlassian "OAuth 2.0 credentials for service accounts"** — admin-issued,
+  long-lived, scope-controlled.
+- **Notion Internal Integration tokens** — non-expiring, scoped to a single
+  workspace.
+- **Slack non-rotating bot tokens** — only available if rotation has never
+  been enabled on the app.
+
+Trade-offs: requires per-provider plumbing in the MCP server config (e.g., a
+`auth.type === 'github_app_installation'` variant that mints tokens
+on-demand), but the payoff is "scheduled agents just work, forever".
+
+### F. Pre-cron refresh hook
+
+Status: not implemented.
+
+When a scheduled trigger fires, the daemon's scheduler service walks the
+in-scope MCP servers, refreshes any token within ~30 min of expiry, *then*
+spawns the executor. Single integration point; handles gap (3) cleanly.
+
+Trade-offs:
+- ➕ Bounded work — only fires when a cron actually runs.
+- ➕ Fails loudly: refresh failure happens *before* the agent spawns, so we
+  can route it to a "trigger failed" notification path.
+- ➖ Doesn't help for in-session expiry (gap 1) or Notion's missing TTL
+  (gap 2). Pair with A.
+
+### G. Declarative per-provider lifecycle hints
+
+Status: not implemented.
+
+Add an optional `auth.lifecycle` block on `mcp_servers.data`:
+
+```yaml
+lifecycle:
+  default_access_ttl_seconds: 3600   # for providers that omit expires_in
+  require_offline_access_scope: true # auto-add to DCR scopes
+  refresh_strategy: rotated_single_use | non_rotating | none
+```
+
+Trade-offs: small data-only change; lets us encode the matrix in this doc as
+config rather than provider-detection logic. Pair with A and F.
+
+---
+
+## Phase 5 — Sequenced recommendation
+
+### Ship first (the 80/20)
+
+**1. Retry-on-401 shim in MCP transport.** Single biggest leverage. Closes
+the mid-call expiry race for every provider in the matrix. Implementation
+is small: detect 401 + Bearer challenge in the executor's MCP HTTP client,
+call `oauth-auth-headers` to get a fresh Bearer, retry once, give up
+otherwise. Already listed as a known follow-up — promote it.
+
+**2. Pre-cron refresh hook in the scheduler.** Adds a single
+`refreshAndPersistToken`-loop call before the trigger spawns its agent.
+Resolves "scheduled run expires mid-flight" cleanly and, when refresh
+fails, gives us a hook to surface a trigger-level failure (no more
+silent misses).
+
+**3. Loud notifications on unattended `invalid_grant`.** Wire a
+`onInvalidGrant` hook from `refreshAndPersistToken` through the scheduler
+to (a) the trigger's run record (mark it failed) and (b) the user's
+notification channel. Costs almost nothing to add and dramatically improves
+trust in cron agents.
+
+These three items together cover the unattended case for Linear (already
+fine), Atlassian, Slack (rotation on), and most GitHub configurations.
+
+### Ship next
+
+**4. Declarative per-provider lifecycle hints (option G).** Closes the
+Notion gap by letting the server config carry `default_access_ttl_seconds`,
+which `needsRefresh` consults when `expires_at` is null. Also lets us
+auto-include `offline_access` for ASes that advertise it.
+
+**5. Persist the discovered token endpoint.** One-line schema follow-up:
+write `auth.oauth_token_url` at DCR completion so refresh stops depending
+on `inferOAuthTokenUrl` heuristics.
+
+**6. Documentation page.** A guide-page section on "Which MCP servers play
+well with scheduled agents", with the provider matrix and the per-provider
+gotchas (Slack rotation, Atlassian `offline_access`, GitHub App
+installation route).
+
+### Defer / consider carefully
+
+**7. Background refresher (option B).** Only if real workloads show A+F
+isn't enough. The current code's stance against this still seems right.
+
+**8. GitHub App installation auth path (option E for GitHub).** High
+leverage for power users who want bulletproof scheduled GitHub agents —
+but non-trivial plumbing. Worth a dedicated design doc when prioritized.
+
+**9. API-key fallback skills for problematic providers (option D).** Only
+once we know a specific provider's MCP path is genuinely too unreliable.
+Don't build it speculatively — the maintenance cost is double.
+
+### Not recommended
+
+- **Background sweep without retry-on-401.** Doesn't address mid-call
+  expiry; trades real latency on the cron path for the same failure mode.
+- **Mass-removing the in-memory `authCodeTokenCache`**. Vestigial but works.
+  Cleanup is a chore, not a fix.
+
+---
+
+## Quick wins / follow-up bugs noted (not to be fixed in this PR)
+
+- `inferOAuthTokenUrl` is a fallback used by `refreshAndPersistToken` — should
+  be replaced by a persisted `oauth_token_url` written at DCR completion.
+- `needsRefresh(undefined) === false` — quietly correct in spirit (we don't
+  know when to refresh) but creates the Notion silent-break failure mode
+  when paired with no retry-on-401. Document the contract.
+- `authCodeTokenCache` (in-memory, in `oauth-mcp-transport.ts`) is vestigial
+  in daemon mode. Worth auditing whether `getCachedOAuth21Token` callsites
+  in `apps/agor-daemon/src/oauth-cache.ts` and `services/gateway.ts` can
+  read directly from `user_mcp_oauth_tokens` instead.
+- DCR scope auto-population strips scopes when `client_id` is pre-registered
+  (intentional). When DCR is used, we should **add** `offline_access` if
+  advertised by the AS — currently we just join `scopes_supported`.
+- Atlassian's 10-min refresh-token reuse grace window is friendlier than the
+  current mutex-only approach assumes. Worth confirming our mutex doesn't
+  drop a refresh request and leave us reuse-blocked.
+
+---
+
+## Appendix — Where to look in the codebase
+
+| Topic | Path |
+|---|---|
+| OAuth transport (discovery, two-phase auth, in-mem cache) | `packages/core/src/tools/mcp/oauth-mcp-transport.ts` |
+| Refresh logic (HTTP call + persist + mutex) | `packages/core/src/tools/mcp/oauth-refresh.ts` |
+| Token storage repo | `packages/core/src/db/repositories/user-mcp-oauth-tokens.ts` |
+| JIT refresh hook (server reads) | `apps/agor-daemon/src/register-hooks.ts` (`injectPerUserOAuthTokens`) |
+| Auth-headers service (executor JIT) | `apps/agor-daemon/src/register-services.ts` (`/mcp-servers/oauth-auth-headers`) |
+| Manual refresh endpoint | `apps/agor-daemon/src/register-services.ts` (`/mcp-servers/oauth-refresh`) |
+| OAuth-status (UI green-pill) | `apps/agor-daemon/src/register-services.ts` (`/mcp-servers/oauth-status`) |
+| OAuth 2.1 discovery upgrade | PR #1078 (`feat(mcp): support full OAuth 2.1 discovery`) |
+| Recent UI fixes around expired-token state | PRs #1084, #1086 |

--- a/context/explorations/mcp-oauth-token-lifecycle.md
+++ b/context/explorations/mcp-oauth-token-lifecycle.md
@@ -12,8 +12,23 @@ JIT refresh is wired into both the read hook and the executor's auth-header
 service, refreshes are mutexed per `(user, server)` to survive rotating refresh
 tokens, and `invalid_grant` cleanly surfaces "please re-auth".
 
-For **unattended / scheduled agents** there are three gaps:
+For **unattended / scheduled agents** there are four gaps, one of which is
+a real bug:
 
+0. **🔴 The 1-hour default lies to the DB on initial auth, then disappears on
+   refresh.** `apps/agor-daemon/src/oauth-cache.ts:89` (`persistOAuthToken`)
+   does `const expiresIn = tokenResponse.expires_in ?? 3600;` and writes that
+   default into `user_mcp_oauth_tokens.oauth_token_expires_at`. The
+   refresh-time persist (`refreshAndPersistToken` in
+   `packages/core/src/tools/mcp/oauth-refresh.ts`) does **not** apply the
+   same default — it passes `result.expires_in` (undefined for Notion) through
+   to `saveToken`, which writes `expires_at = NULL`. Same row, same provider,
+   two different defaults at two stages of the same lifecycle. Net effect for
+   Notion: Agor declares the initial token expired at +1h *whether or not the
+   MCP server would still accept it*, then after the auto-refresh forgets to
+   set any expiry at all and `needsRefresh(null) === false` keeps the row
+   stuck on whatever access_token was last written until something 401s. See
+   "🔴 The 1-hour default bug" in the audit.
 1. **No retry-on-401 at the MCP transport.** A token that expires *mid-call*
    (after the JIT preflight) just fails the tool call. Explicitly listed as a
    known follow-up in `packages/core/src/tools/mcp/oauth-refresh.ts`.
@@ -21,8 +36,7 @@ For **unattended / scheduled agents** there are three gaps:
    spawns → JIT refresh runs. Fine when refresh succeeds; silent failure when
    it doesn't (revoked grant, network blip).
 3. **Provider-specific failure modes.** Notion's refresh response omits
-   `expires_in`, so `needsRefresh(undefined) === false` — JIT will never
-   proactively refresh a Notion token. Slack's MCP server requires user-token
+   `expires_in` (compounds gap 0). Slack's MCP server requires user-token
    rotation (12h TTL) but the rotation toggle is one-way and easy to forget.
    Atlassian needs `offline_access` in scopes or no refresh_token is issued.
 
@@ -125,14 +139,81 @@ reusable across users.
   hard-failing the agent).
 - ✅ 60s safety buffer in `needsRefresh`.
 
-### What the audit flags
+### 🔴 The 1-hour default bug (asymmetric defaulting between persist paths)
+
+Two callsites write to `user_mcp_oauth_tokens.oauth_token_expires_at` and they
+disagree on what to do when the provider omits `expires_in`:
+
+**Initial-auth path** — `apps/agor-daemon/src/oauth-cache.ts:73-118`
+(`persistOAuthToken`, called from the OAuth callback handlers in
+`register-services.ts`):
+
+```ts
+const expiresIn = tokenResponse.expires_in ?? 3600;   // ← defaults to 1h
+cacheOAuth21Token(cacheKey, tokenResponse.access_token, expiresIn);
+...
+await userTokenRepo.saveToken(tokenUserId, ..., {
+  accessToken: tokenResponse.access_token,
+  expiresInSeconds: expiresIn,                        // ← 3600 lands in DB
+  ...
+});
+```
+
+**Refresh path** — `packages/core/src/tools/mcp/oauth-refresh.ts:300-306`
+(`refreshAndPersistToken`):
+
+```ts
+await userTokenRepo.saveToken(deps.userId, deps.mcpServerId, {
+  accessToken: result.access_token,
+  expiresInSeconds: result.expires_in,                // ← undefined → NULL in DB
+  refreshToken: result.refresh_token,
+});
+```
+
+Repository (`saveToken`,
+`packages/core/src/db/repositories/user-mcp-oauth-tokens.ts:146-148`):
+
+```ts
+const expiresAt = input.expiresInSeconds
+  ? new Date(Date.now() + input.expiresInSeconds * 1000)
+  : undefined;                                        // ← becomes NULL
+```
+
+For a provider like **Notion** (which returns no `expires_in` on either grant
+or refresh) the resulting row evolves as:
+
+| Phase | `expires_at` | `needsRefresh()` returns | Net behavior |
+|---|---|---|---|
+| Right after first auth | `now + 1h` (fake) | `false` (until 1h elapses) | Agor *thinks* token is good for 1h regardless of provider truth |
+| ~59 min later | `now + 1h` minus ~59 min | `true` (within 60s buffer) | JIT refresh fires |
+| Right after first refresh | `NULL` | **`false` forever** | Stale token returned indefinitely until 401 — and there's no retry-on-401 |
+
+So your suspicion is exactly right: the 1H comes from
+`oauth-cache.ts:89` and **Agor may incorrectly mark the token as expired
+even though the MCP server would still accept it**. Notion in particular
+suffers because the asymmetry between the two persist paths means the row
+oscillates between a fake-1h expiry and a NULL expiry, never matching the
+provider's actual lifetime.
+
+Two follow-ups suggested (out of scope here):
+
+- Move both persist sites to a single helper that applies one consistent
+  policy. Two reasonable choices:
+  - **Always store NULL when the provider omits `expires_in`**, and treat
+    NULL as "trust the token until the provider says otherwise" (i.e. rely
+    on retry-on-401 for these). Faithful to provider truth; needs gap (1)
+    fixed first.
+  - **Always default to a per-provider hint** (config-driven, see option G)
+    rather than the hardcoded 3600. Lets us encode "Notion ≈ 1h" without
+    lying about Slack non-rotating tokens.
+- Adopt a per-provider `default_access_ttl_seconds` config (option G).
+
+### Other audit flags
 
 - ⚠️ **No retry-on-401 shim** at the MCP HTTP transport. Listed in
-  `oauth-refresh.ts` header as known follow-up.
-- ⚠️ **`needsRefresh(null) === false`** — for providers that don't return
-  `expires_in` (Notion), proactive refresh never fires. Combined with no
-  retry-on-401, the first call after the silent provider-side rotation
-  hard-fails.
+  `oauth-refresh.ts` header as known follow-up. Combined with the 1-hour
+  default bug above, the failure mode for Notion is silent stale-token use
+  until the provider rejects.
 - ⚠️ **In-memory `authCodeTokenCache`** in `oauth-mcp-transport.ts` is
   vestigial in daemon mode (the DB-backed path is authoritative). Worth
   pruning to one cache to avoid drift. `getCachedOAuth21Token` is referenced
@@ -522,6 +603,12 @@ Don't build it speculatively — the maintenance cost is double.
 
 ## Quick wins / follow-up bugs noted (not to be fixed in this PR)
 
+- 🔴 **The 1-hour default in `persistOAuthToken` (`oauth-cache.ts:89`) is the
+  source of "Agor thinks this token expired after exactly 1 hour" reports.**
+  And it's asymmetric — `refreshAndPersistToken` doesn't apply the same
+  default, so the row oscillates between fake-1h expiry and NULL expiry over
+  the lifetime of a single grant. Unify both persist sites and pick one
+  consistent policy (see "🔴 The 1-hour default bug" above).
 - `inferOAuthTokenUrl` is a fallback used by `refreshAndPersistToken` — should
   be replaced by a persisted `oauth_token_url` written at DCR completion.
 - `needsRefresh(undefined) === false` — quietly correct in spirit (we don't

--- a/context/explorations/mcp-oauth-token-lifecycle.md
+++ b/context/explorations/mcp-oauth-token-lifecycle.md
@@ -424,6 +424,100 @@ Three distinct token types — pick deliberately for unattended:
 
 ---
 
+## Phase 3.5 — Empirical probing & a TTL-discovery precedence cascade
+
+This section was added after the rest of Phase 3 to act on the audit. Before
+designing remediation, we curl-probed the actual MCP servers to confirm what
+discovery paths are realistically available.
+
+### Empirical findings (curl probes, 2026-05-05)
+
+Probed each MCP server's RFC 8414 / RFC 9728 metadata + bearer-challenge:
+
+| Server | `authorization_endpoint` | `token_endpoint` | `registration_endpoint` (DCR) | `introspection_endpoint` | `revocation_endpoint` |
+|---|---|---|---|---|---|
+| `mcp.slack.com` | ✅ | ✅ (`/api/oauth.v2.user.access`) | ✅ | ❌ **not advertised** | ❌ |
+| `mcp.notion.com` | ✅ | ✅ (`/v1/oauth/token`) | ✅ | ❌ **not advertised** | ✅ |
+| `mcp.linear.app` | ✅ | ✅ | ✅ | ❌ **not advertised** | ✅ |
+| `api.githubcopilot.com/mcp` | ✅ (via `WWW-Authenticate: resource_metadata=`) | ✅ | varies | ❌ | varies |
+
+**Decisive finding**: **none of the MCP servers we care about advertise an
+`introspection_endpoint`** in their AS metadata. RFC 7662 token introspection
+is therefore not a viable runtime discovery path for our actual targets.
+(Notion does expose a private `/v1/oauth/introspect` endpoint, but it requires
+HTTP Basic with `client_id:client_secret` and — per upstream docs — returns
+no `exp` field anyway. So even if we hit it, it doesn't tell us when the
+token expires.)
+
+This kills "introspect on every refresh to learn the real TTL" as a strategy.
+We're stuck with whatever the token-endpoint response gives us, plus whatever
+we can read off the access token if it happens to be a JWT.
+
+### Precedence cascade for resolving `expires_in`
+
+Replace the current `tokenResponse.expires_in ?? 3600` with a small resolver
+that walks a deterministic list, returning the first hit (or `null` =
+"unknown"):
+
+```
+resolveTokenExpiry(tokenResponse, accessToken, serverConfig) → seconds | null
+```
+
+Order, with rationale for each:
+
+| # | Source | Rationale |
+|---|---|---|
+| 1 | `tokenResponse.expires_in` | RFC 6749 §5.1 standard — the canonical answer when present. |
+| 2 | `tokenResponse.expires_at` (absolute → relative) | Some Auth0 / Spotify configs return absolute Unix timestamps instead. Convert to relative. |
+| 3 | `tokenResponse.exp` (top-level, JWT-style) | A handful of providers leak a top-level `exp` claim. Cheap to check. |
+| 4 | `tokenResponse.ext_expires_in` | Microsoft / Azure AD's "extended expiry" field used during outages. Better than nothing. |
+| 5 | JWT-decode `accessToken` and read `exp` claim | Only if the token has the JWT shape (`header.payload.sig` with valid base64url segments). Skip for opaque tokens. **No signature verification needed** — we're reading our own token, not validating it. |
+| 6 | `serverConfig.auth.lifecycle.default_access_ttl_seconds` | Per-server config hint (option G). Lets an admin encode "Notion ≈ 1h" without lying about other providers. |
+| 7 | **`null`** ("unknown") | Surface as "expires in: unknown" in the UI tooltip; rely on retry-on-401 (gap 1) for actual lifecycle handling. |
+
+Notes on the cascade:
+
+- **No hardcoded global default** anywhere in the chain. `?? 3600` was the
+  bug; we don't reintroduce it under a different name.
+- **Symmetric**: same resolver runs at `persistOAuthToken` (initial auth) and
+  `refreshAndPersistToken` (refresh persist). One source of truth.
+- **JWT decode is shape-gated**: we never attempt to decode opaque tokens
+  (Slack `xoxe.`, Notion `secret_`, etc.) — the JWT step is a fast `if
+  isJwtShape(token) { peek payload }` and is a no-op otherwise.
+- **Step 6 is config-only, not provider-detection**. We resist the urge to
+  hardcode `if (origin === 'mcp.notion.com') return 3600` — that's a
+  maintenance hazard. Either the server config carries a hint or it doesn't.
+- **`null` is a first-class state**, not an error. `needsRefresh(null)`
+  remains `false` (we don't speculate); the UI shows "unknown"; the
+  retry-on-401 shim from gap 1 catches actual expiry.
+
+### What "expires in: unknown" looks like in the UI
+
+The tooltip text already lives near `apps/agor-ui/src/components/MCPServerPill.tsx`
+(token expiry display) and `apps/agor-ui/src/utils/mcpAuth.ts`
+(`describeOAuthExpiry` / equivalent). When `oauth_token_expires_at` is null,
+swap the existing "expires in 47 min" copy for "expires in: unknown — relies
+on retry-on-401" (or similar). Keeps the green pill green; the explanatory
+hover is what changes.
+
+### Why not introspection?
+
+Worth being explicit about the rejected option, so a future contributor
+doesn't re-litigate it:
+
+- **None of our target MCP providers advertise it** (table above).
+- **Even where it exists privately (Notion)**, the response omits `exp`.
+- **It doubles every refresh cost** (token call + introspect call) without a
+  payoff, and serializes us behind a second provider RTT on the JIT path.
+- **DPoP would obviate the need** (sender-constrained tokens carry their own
+  proof), but no provider in our matrix supports DPoP.
+
+If a future MCP provider *does* advertise introspection AND returns `exp`, it
+slots in as step 1.5 of the cascade as a per-server opt-in (config flag
+`auth.lifecycle.use_introspection: true`). Don't enable it by default.
+
+---
+
 ## Phase 4 — Options
 
 ### A. Improve the existing JIT refresh path *(recommended baseline)*
@@ -542,6 +636,13 @@ config rather than provider-detection logic. Pair with A and F.
 
 ### Ship first (the 80/20)
 
+**0. Replace `?? 3600` with the TTL precedence cascade (Phase 3.5).**
+Smallest possible diff with the largest correctness payoff: kill the
+asymmetric defaulting that makes Notion oscillate between fake-1h and NULL,
+and make "unknown" a real state surfaced as such in the UI. Pairs naturally
+with item 1 below — once the cascade can return `null`, retry-on-401 becomes
+the safety net for the unknown case.
+
 **1. Retry-on-401 shim in MCP transport.** Single biggest leverage. Closes
 the mid-call expiry race for every provider in the matrix. Implementation
 is small: detect 401 + Bearer challenge in the executor's MCP HTTP client,
@@ -607,8 +708,9 @@ Don't build it speculatively — the maintenance cost is double.
   source of "Agor thinks this token expired after exactly 1 hour" reports.**
   And it's asymmetric — `refreshAndPersistToken` doesn't apply the same
   default, so the row oscillates between fake-1h expiry and NULL expiry over
-  the lifetime of a single grant. Unify both persist sites and pick one
-  consistent policy (see "🔴 The 1-hour default bug" above).
+  the lifetime of a single grant. Prescribed fix: the precedence cascade in
+  Phase 3.5 (resolver shared by both persist sites; `null` becomes a
+  first-class state surfaced as "expires in: unknown" in the UI).
 - `inferOAuthTokenUrl` is a fallback used by `refreshAndPersistToken` — should
   be replaced by a persisted `oauth_token_url` written at DCR completion.
 - `needsRefresh(undefined) === false` — quietly correct in spirit (we don't

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,6 +20,11 @@
       "types": "./dist/yaml.d.ts",
       "import": "./dist/yaml.js",
       "require": "./dist/yaml.cjs"
+    },
+    "./jwt": {
+      "types": "./dist/jwt.d.ts",
+      "import": "./dist/jwt.js",
+      "require": "./dist/jwt.cjs"
     }
   },
   "files": [

--- a/packages/client/src/jwt.ts
+++ b/packages/client/src/jwt.ts
@@ -1,0 +1,13 @@
+/**
+ * Browser-safe JWT decode helpers — thin re-export of `@agor/core/utils/jwt`.
+ *
+ * Exposed on `@agor-live/client` so UI/browser consumers can decode JWT
+ * `exp` claims (e.g. for proactive refresh) without taking a direct dep on
+ * `@agor/core`. Same implementation the daemon-side `resolveTokenExpiry`
+ * cascade uses, so behavior never drifts between server and client.
+ *
+ * No signature verification — we read our own tokens to learn when WE think
+ * they expire. The server is still the only party that validates.
+ */
+
+export * from '@agor/core/utils/jwt';

--- a/packages/client/tsup.config.ts
+++ b/packages/client/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: 'src/index.ts',
     config: 'src/config.ts',
     yaml: 'src/yaml.ts',
+    jwt: 'src/jwt.ts',
   },
   format: ['cjs', 'esm'],
   dts: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -140,6 +140,11 @@
       "import": "./dist/utils/logger.js",
       "require": "./dist/utils/logger.cjs"
     },
+    "./utils/jwt": {
+      "types": "./dist/utils/jwt.d.ts",
+      "import": "./dist/utils/jwt.js",
+      "require": "./dist/utils/jwt.cjs"
+    },
     "./seed": {
       "types": "./dist/seed/index.d.ts",
       "import": "./dist/seed/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -200,6 +200,11 @@
       "import": "./dist/tools/mcp/oauth-refresh.js",
       "require": "./dist/tools/mcp/oauth-refresh.cjs"
     },
+    "./tools/mcp/oauth-token-expiry": {
+      "types": "./dist/tools/mcp/oauth-token-expiry.d.ts",
+      "import": "./dist/tools/mcp/oauth-token-expiry.js",
+      "require": "./dist/tools/mcp/oauth-token-expiry.cjs"
+    },
     "./unix": {
       "types": "./dist/unix/index.d.ts",
       "import": "./dist/unix/index.js",

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -40,19 +40,23 @@ export interface UserMCPOAuthToken {
 export interface SaveTokenInput {
   accessToken: string;
   /**
-   * Seconds until expiry, as resolved by `resolveTokenExpiry`. Three states:
-   *   - `number` → write `now + N seconds` to `oauth_token_expires_at`
-   *   - `null`   → explicitly write `NULL` ("expiry unknown — provider gave no
-   *                 hint we could decode"). Surfaces as "expires in: unknown"
-   *                 in the UI; relies on retry-on-401 for lifecycle handling.
-   *   - omitted  → preserve any existing value on update; absent on insert
+   * Absolute expiry, as resolved by `resolveTokenExpiry`. Three states:
+   *   - `Date`     → write that timestamp to `oauth_token_expires_at`
+   *   - `null`     → explicitly write `NULL` ("expiry unknown — provider gave
+   *                   no hint we could decode"). Surfaces as "expires in:
+   *                   unknown" in the UI.
+   *   - `undefined`→ preserve any existing value on update; absent on insert
    *
    * The `null` vs `undefined` distinction matters: the previous code used a
    * truthy check that conflated the two, which produced asymmetric defaulting
    * between the initial-auth and refresh persist sites. See
    * `context/explorations/mcp-oauth-token-lifecycle.md` (Phase 3.5).
+   *
+   * The repository takes an absolute `Date` rather than a relative TTL so
+   * OAuth-spec semantics (cascade, JWT decode, etc.) stay in the resolver and
+   * out of the storage layer.
    */
-  expiresInSeconds?: number | null;
+  expiresAt?: Date | null;
   /** If absent on update, the existing refresh_token is kept. */
   refreshToken?: string;
   /** If absent on update, the existing client_id is kept. */
@@ -152,23 +156,14 @@ export class UserMCPOAuthTokenRepository {
   ): Promise<void> {
     try {
       const now = new Date();
-      // Store the EXACT expiry the provider returned. The proactive-refresh
-      // buffer lives in `needsRefresh` (REFRESH_BUFFER_MS) so we don't apply
-      // it twice.
+      // Three-state `expiresAt` flows straight onto Drizzle's `.set()`
+      // semantics: `Date` writes, `null` writes NULL via conditional spread,
+      // `undefined` preserves the existing value on update.
       //
-      // Three-state handling of `expiresInSeconds`:
-      //   - number → set to (now + N seconds)
-      //   - null   → explicitly write NULL (provider gave no hint; surfaces
-      //              as "expires in: unknown" in UI)
-      //   - undef  → preserve existing value on update; absent on insert
-      // `expiresAtField` reflects this: `Date` / `null` / `undefined` map
-      // straight onto Drizzle's `.set()` semantics.
-      const expiresAtField: Date | null | undefined =
-        typeof input.expiresInSeconds === 'number'
-          ? new Date(Date.now() + input.expiresInSeconds * 1000)
-          : input.expiresInSeconds === null
-            ? null
-            : undefined;
+      // The exact value here is what `resolveTokenExpiry` produced — no
+      // buffer is applied at write time. Proactive-refresh buffering lives
+      // in `needsRefresh` (REFRESH_BUFFER_MS) so we don't apply it twice.
+      const expiresAtField: Date | null | undefined = input.expiresAt;
 
       const existing = await this.getToken(userId, serverId);
 

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -39,8 +39,20 @@ export interface UserMCPOAuthToken {
 /** Input shape for `saveToken`. */
 export interface SaveTokenInput {
   accessToken: string;
-  /** Seconds until expiry, matching the OAuth token response. */
-  expiresInSeconds?: number;
+  /**
+   * Seconds until expiry, as resolved by `resolveTokenExpiry`. Three states:
+   *   - `number` → write `now + N seconds` to `oauth_token_expires_at`
+   *   - `null`   → explicitly write `NULL` ("expiry unknown — provider gave no
+   *                 hint we could decode"). Surfaces as "expires in: unknown"
+   *                 in the UI; relies on retry-on-401 for lifecycle handling.
+   *   - omitted  → preserve any existing value on update; absent on insert
+   *
+   * The `null` vs `undefined` distinction matters: the previous code used a
+   * truthy check that conflated the two, which produced asymmetric defaulting
+   * between the initial-auth and refresh persist sites. See
+   * `context/explorations/mcp-oauth-token-lifecycle.md` (Phase 3.5).
+   */
+  expiresInSeconds?: number | null;
   /** If absent on update, the existing refresh_token is kept. */
   refreshToken?: string;
   /** If absent on update, the existing client_id is kept. */
@@ -143,9 +155,20 @@ export class UserMCPOAuthTokenRepository {
       // Store the EXACT expiry the provider returned. The proactive-refresh
       // buffer lives in `needsRefresh` (REFRESH_BUFFER_MS) so we don't apply
       // it twice.
-      const expiresAt = input.expiresInSeconds
-        ? new Date(Date.now() + input.expiresInSeconds * 1000)
-        : undefined;
+      //
+      // Three-state handling of `expiresInSeconds`:
+      //   - number → set to (now + N seconds)
+      //   - null   → explicitly write NULL (provider gave no hint; surfaces
+      //              as "expires in: unknown" in UI)
+      //   - undef  → preserve existing value on update; absent on insert
+      // `expiresAtField` reflects this: `Date` / `null` / `undefined` map
+      // straight onto Drizzle's `.set()` semantics.
+      const expiresAtField: Date | null | undefined =
+        typeof input.expiresInSeconds === 'number'
+          ? new Date(Date.now() + input.expiresInSeconds * 1000)
+          : input.expiresInSeconds === null
+            ? null
+            : undefined;
 
       const existing = await this.getToken(userId, serverId);
 
@@ -153,7 +176,8 @@ export class UserMCPOAuthTokenRepository {
         await update(this.db, userMcpOauthTokens)
           .set({
             oauth_access_token: input.accessToken,
-            oauth_token_expires_at: expiresAt,
+            // Spread so `undefined` ⇒ omit field (preserve), but `null` ⇒ write NULL.
+            ...(expiresAtField !== undefined ? { oauth_token_expires_at: expiresAtField } : {}),
             ...(input.refreshToken != null ? { oauth_refresh_token: input.refreshToken } : {}),
             ...(input.clientId != null ? { oauth_client_id: input.clientId } : {}),
             ...(input.clientSecret != null ? { oauth_client_secret: input.clientSecret } : {}),
@@ -170,7 +194,11 @@ export class UserMCPOAuthTokenRepository {
           user_id: userId,
           mcp_server_id: serverId,
           oauth_access_token: input.accessToken,
-          oauth_token_expires_at: expiresAt,
+          // On insert, `null` and `undefined` both write a missing column
+          // (Drizzle treats `undefined` on insert as "use default", which for
+          // a nullable column is NULL). Coerce to `undefined` to keep the
+          // insert payload uniform regardless of which the caller passed.
+          oauth_token_expires_at: expiresAtField ?? undefined,
           oauth_refresh_token: input.refreshToken,
           oauth_client_id: input.clientId,
           oauth_client_secret: input.clientSecret,

--- a/packages/core/src/tools/mcp/oauth-auth.ts
+++ b/packages/core/src/tools/mcp/oauth-auth.ts
@@ -57,11 +57,16 @@ export interface OAuthDebugInfo {
   tokenExpiresAt?: Date;
 }
 
+import { resolveTokenExpiry } from './oauth-token-expiry';
+
 // Cache tokens per unique credential set to avoid cross-tenant leakage
 const oauthTokenCache = new Map<string, CachedToken>();
 
-// Default token validity: 15 minutes if not specified by OAuth server
-const DEFAULT_TOKEN_TTL_SECONDS = 900;
+// In-memory cache TTL fallback when `resolveTokenExpiry` cannot determine an
+// expiry from the token response. This bounds the lifetime of THIS module's
+// `oauthTokenCache` map only — there is no DB persistence for client-credentials
+// tokens, so this is purely local-cache hygiene.
+const UNKNOWN_EXPIRY_CACHE_TTL_SECONDS = 900;
 
 // Buffer before expiry to avoid using soon-to-expire tokens
 const EXPIRY_BUFFER_SECONDS = 30;
@@ -292,10 +297,18 @@ export async function fetchOAuthToken(
     throw new Error('OAuth response missing access_token field');
   }
 
-  // Step 7: Cache token
-  const expiresInSeconds = data.expires_in || DEFAULT_TOKEN_TTL_SECONDS;
-  const expiresAt = Date.now() + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
+  // Step 7: Cache token. Walk the shared cascade so this client-credentials
+  // path agrees with the MCP user-grant paths on TTL resolution. When the
+  // cascade returns null (provider gave no hint we could decode), fall back
+  // to UNKNOWN_EXPIRY_CACHE_TTL_SECONDS — local-cache hygiene only.
   const fetchedAt = Date.now();
+  const resolved = resolveTokenExpiry(data, data.access_token, fetchedAt);
+  const ttlSeconds =
+    resolved.expiresAt !== null
+      ? Math.max(1, Math.floor((resolved.expiresAt.getTime() - fetchedAt) / 1000))
+      : UNKNOWN_EXPIRY_CACHE_TTL_SECONDS;
+  const expiresInSeconds = ttlSeconds;
+  const expiresAt = fetchedAt + (ttlSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
 
   oauthTokenCache.set(cacheKey, {
     token: data.access_token,

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -9,6 +9,7 @@
 import crypto from 'node:crypto';
 import http from 'node:http';
 import type { OAuthTokenResponse } from './oauth-auth.js';
+import { resolveTokenExpiry } from './oauth-token-expiry.js';
 
 export interface OAuthMetadata {
   authorization_servers: string[];
@@ -26,8 +27,12 @@ interface CachedAuthCodeToken {
 // Key is the resource metadata URL to avoid cross-tenant leakage
 const authCodeTokenCache = new Map<string, CachedAuthCodeToken>();
 
-// Default token validity: 1 hour if not specified by OAuth server
-const DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS = 3600;
+// In-memory cache TTL fallback when `resolveTokenExpiry` cannot determine an
+// expiry from the token response. This bounds the lifetime of THIS module's
+// `authCodeTokenCache` map only — local-cache hygiene, not a persisted DB
+// value. The persisted lifecycle is handled in `oauth-cache.ts` (initial
+// auth) and `oauth-refresh.ts` (refresh) which both use the resolver.
+const UNKNOWN_EXPIRY_CACHE_TTL_SECONDS = 3600;
 
 /**
  * Raw OAuth 2.0 token response shape.
@@ -889,10 +894,15 @@ export async function performMCPOAuthFlow(
 
     console.log('[MCP OAuth] Access token received successfully');
 
-    // Step 10: Cache token
-    const expiresInSeconds = tokenResponse.expires_in ?? DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS;
-    const expiresAt = Date.now() + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
+    // Step 10: Cache token. Walk the shared cascade so this site agrees with
+    // the persisted-token paths on TTL resolution.
     const fetchedAt = Date.now();
+    const resolved = resolveTokenExpiry(tokenResponse, tokenResponse.access_token, fetchedAt);
+    const expiresInSeconds =
+      resolved.expiresAt !== null
+        ? Math.max(1, Math.floor((resolved.expiresAt.getTime() - fetchedAt) / 1000))
+        : UNKNOWN_EXPIRY_CACHE_TTL_SECONDS;
+    const expiresAt = fetchedAt + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
 
     authCodeTokenCache.set(metadataUrl, {
       token: tokenResponse.access_token,
@@ -1384,10 +1394,15 @@ export async function completeMCPOAuthFlow(
 
   console.log('[MCP OAuth] Access token received successfully');
 
-  // Cache token
-  const expiresInSeconds = tokenResponse.expires_in ?? DEFAULT_AUTHCODE_TOKEN_TTL_SECONDS;
-  const expiresAt = Date.now() + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
+  // Cache token. Walk the shared cascade so this site agrees with the
+  // persisted-token paths on TTL resolution.
   const fetchedAt = Date.now();
+  const resolved = resolveTokenExpiry(tokenResponse, tokenResponse.access_token, fetchedAt);
+  const expiresInSeconds =
+    resolved.expiresAt !== null
+      ? Math.max(1, Math.floor((resolved.expiresAt.getTime() - fetchedAt) / 1000))
+      : UNKNOWN_EXPIRY_CACHE_TTL_SECONDS;
+  const expiresAt = fetchedAt + (expiresInSeconds - EXPIRY_BUFFER_SECONDS) * 1000;
 
   authCodeTokenCache.set(context.metadataUrl, {
     token: tokenResponse.access_token,

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -273,9 +273,14 @@ describe('refreshAndPersistToken', () => {
     expect(token).toBe('new-a');
     expect(mockSaveToken).toHaveBeenCalledWith(USER_ID, SERVER_ID, {
       accessToken: 'new-a',
-      expiresInSeconds: 3600,
+      expiresAt: expect.any(Date), // resolved from expires_in: 3600 → ~now+1h
       refreshToken: undefined, // provider omitted — repo preserves existing
     });
+    // Spot-check the resolved expiry is roughly +1h from now (within 5s slop).
+    const call = mockSaveToken.mock.calls[0]?.[2] as { expiresAt: Date };
+    const deltaSec = (call.expiresAt.getTime() - Date.now()) / 1000;
+    expect(deltaSec).toBeGreaterThan(3595);
+    expect(deltaSec).toBeLessThanOrEqual(3600);
   });
 
   it('writes rotated refresh_token when provider returns one', async () => {

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -28,6 +28,7 @@ import type { Database } from '../../db/client';
 import { MCPServerRepository, UserMCPOAuthTokenRepository } from '../../db/repositories';
 import type { MCPServerID, UserID } from '../../types';
 import { inferOAuthTokenUrl } from './oauth-auth';
+import { resolveTokenExpiry } from './oauth-token-expiry';
 
 /** 60s safety window before hard expiry. */
 export const REFRESH_BUFFER_MS = 60_000;
@@ -294,19 +295,31 @@ export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promi
         clientSecret,
       });
 
+      // Resolve expiry via the shared cascade so this site behaves
+      // identically to `persistOAuthToken` (initial-auth path). For providers
+      // that omit `expires_in` on refresh (e.g. Notion), `expiry.seconds`
+      // will be `null`, which `saveToken` writes as a literal `NULL` to
+      // `oauth_token_expires_at` — surfaced in the UI as
+      // "expires in: unknown" rather than the previous silent oscillation
+      // between fake-1h and stale-NULL values. See Phase 3.5 in
+      // `context/explorations/mcp-oauth-token-lifecycle.md`.
+      const expiry = resolveTokenExpiry(result, result.access_token);
+
       // Persist atomically. Per RFC 6749 §6, an omitted refresh_token in the
       // response means the old one is still valid — keep it. When present,
       // the rotation replaces the old value.
       await userTokenRepo.saveToken(deps.userId, deps.mcpServerId, {
         accessToken: result.access_token,
-        expiresInSeconds: result.expires_in,
+        expiresInSeconds: expiry.seconds, // number | null — null means "unknown"
         refreshToken: result.refresh_token, // undefined = keep existing
         // Don't touch client_id / client_secret — same grant, same client.
       });
 
       console.log(
         `[MCP OAuth Refresh] ✓ Refreshed token for user=${deps.userId ?? '<shared>'} ` +
-          `server=${deps.mcpServerId}${result.refresh_token ? ' (with rotated refresh_token)' : ''}`
+          `server=${deps.mcpServerId} (expiry source: ${expiry.source}` +
+          `${expiry.seconds !== null ? `, ttl=${expiry.seconds}s` : ', ttl=unknown'})` +
+          `${result.refresh_token ? ' (with rotated refresh_token)' : ''}`
       );
 
       return result.access_token;

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -297,7 +297,7 @@ export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promi
 
       // Resolve expiry via the shared cascade so this site behaves
       // identically to `persistOAuthToken` (initial-auth path). For providers
-      // that omit `expires_in` on refresh (e.g. Notion), `expiry.seconds`
+      // that omit `expires_in` on refresh (e.g. Notion), `expiry.expiresAt`
       // will be `null`, which `saveToken` writes as a literal `NULL` to
       // `oauth_token_expires_at` — surfaced in the UI as
       // "expires in: unknown" rather than the previous silent oscillation
@@ -310,7 +310,7 @@ export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promi
       // the rotation replaces the old value.
       await userTokenRepo.saveToken(deps.userId, deps.mcpServerId, {
         accessToken: result.access_token,
-        expiresInSeconds: expiry.seconds, // number | null — null means "unknown"
+        expiresAt: expiry.expiresAt, // Date | null — null means "unknown"
         refreshToken: result.refresh_token, // undefined = keep existing
         // Don't touch client_id / client_secret — same grant, same client.
       });
@@ -318,7 +318,7 @@ export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promi
       console.log(
         `[MCP OAuth Refresh] ✓ Refreshed token for user=${deps.userId ?? '<shared>'} ` +
           `server=${deps.mcpServerId} (expiry source: ${expiry.source}` +
-          `${expiry.seconds !== null ? `, ttl=${expiry.seconds}s` : ', ttl=unknown'})` +
+          `${expiry.expiresAt !== null ? `, expires=${expiry.expiresAt.toISOString()}` : ', expires=unknown'})` +
           `${result.refresh_token ? ' (with rotated refresh_token)' : ''}`
       );
 

--- a/packages/core/src/tools/mcp/oauth-token-expiry.test.ts
+++ b/packages/core/src/tools/mcp/oauth-token-expiry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the OAuth token expiry resolution cascade.
+ *
+ * One test per cascade step + the unknown fallthrough + a few rejection
+ * cases for malformed inputs.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveTokenExpiry } from './oauth-token-expiry';
+
+// Fixed "now" so absolute-timestamp tests stay deterministic.
+const NOW_MS = 1_750_000_000_000; // some date in 2025
+const NOW_SEC = Math.floor(NOW_MS / 1000);
+
+/** Build a minimal JWT with the given payload (no signature verification). */
+function makeJwt(payload: object): string {
+  const b64 = (s: string) =>
+    Buffer.from(s, 'utf8')
+      .toString('base64')
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  return [b64('{"alg":"none"}'), b64(JSON.stringify(payload)), 'sig'].join('.');
+}
+
+describe('resolveTokenExpiry', () => {
+  describe('cascade order', () => {
+    it('1. uses tokenResponse.expires_in when present', () => {
+      const r = resolveTokenExpiry({ expires_in: 3600 }, undefined, NOW_MS);
+      expect(r).toEqual({ seconds: 3600, source: 'expires_in' });
+    });
+
+    it('2. falls through to expires_at when expires_in is missing', () => {
+      const r = resolveTokenExpiry({ expires_at: NOW_SEC + 7200 }, undefined, NOW_MS);
+      expect(r).toEqual({ seconds: 7200, source: 'expires_at' });
+    });
+
+    it('3. falls through to top-level exp when expires_in/at missing', () => {
+      const r = resolveTokenExpiry({ exp: NOW_SEC + 1800 }, undefined, NOW_MS);
+      expect(r).toEqual({ seconds: 1800, source: 'exp' });
+    });
+
+    it('4. falls through to ext_expires_in (Microsoft style)', () => {
+      const r = resolveTokenExpiry({ ext_expires_in: 5400 }, undefined, NOW_MS);
+      expect(r).toEqual({ seconds: 5400, source: 'ext_expires_in' });
+    });
+
+    it('5. JWT-decodes the access_token when nothing else works', () => {
+      const jwt = makeJwt({ exp: NOW_SEC + 900 });
+      const r = resolveTokenExpiry({}, jwt, NOW_MS);
+      expect(r).toEqual({ seconds: 900, source: 'jwt_exp' });
+    });
+
+    it('7. returns null/unknown when no source can supply a TTL', () => {
+      const r = resolveTokenExpiry({}, 'opaque-secret_abc', NOW_MS);
+      expect(r).toEqual({ seconds: null, source: 'unknown' });
+    });
+  });
+
+  describe('precedence (earlier sources win)', () => {
+    it('expires_in wins over a JWT exp claim that disagrees', () => {
+      const jwt = makeJwt({ exp: NOW_SEC + 9999 });
+      const r = resolveTokenExpiry({ expires_in: 60 }, jwt, NOW_MS);
+      expect(r.seconds).toBe(60);
+      expect(r.source).toBe('expires_in');
+    });
+
+    it('expires_at wins over ext_expires_in', () => {
+      const r = resolveTokenExpiry(
+        { expires_at: NOW_SEC + 100, ext_expires_in: 9999 },
+        undefined,
+        NOW_MS
+      );
+      expect(r.seconds).toBe(100);
+      expect(r.source).toBe('expires_at');
+    });
+  });
+
+  describe('input rejection', () => {
+    it('rejects non-positive expires_in', () => {
+      expect(resolveTokenExpiry({ expires_in: 0 }, undefined, NOW_MS).source).toBe('unknown');
+      expect(resolveTokenExpiry({ expires_in: -5 }, undefined, NOW_MS).source).toBe('unknown');
+    });
+
+    it('rejects NaN / Infinity expires_in', () => {
+      expect(resolveTokenExpiry({ expires_in: NaN }, undefined, NOW_MS).source).toBe('unknown');
+      expect(resolveTokenExpiry({ expires_in: Infinity }, undefined, NOW_MS).source).toBe(
+        'unknown'
+      );
+    });
+
+    it('rejects already-past expires_at', () => {
+      const r = resolveTokenExpiry({ expires_at: NOW_SEC - 100 }, undefined, NOW_MS);
+      expect(r.source).toBe('unknown');
+    });
+
+    it('rejects opaque (non-JWT-shape) access tokens silently', () => {
+      const r = resolveTokenExpiry({}, 'xoxe.xoxp-1-abc', NOW_MS);
+      expect(r.source).toBe('unknown');
+    });
+
+    it('rejects malformed JWT payloads (non-JSON, missing exp, etc.) silently', () => {
+      // Three segments but middle is not valid base64-encoded JSON.
+      expect(resolveTokenExpiry({}, 'aaa.!!!.ccc', NOW_MS).source).toBe('unknown');
+
+      // Three segments, valid JSON, but no exp claim.
+      const noExp = makeJwt({ sub: 'user-1' });
+      expect(resolveTokenExpiry({}, noExp, NOW_MS).source).toBe('unknown');
+
+      // Three segments, valid JSON, but exp is in the past.
+      const pastExp = makeJwt({ exp: NOW_SEC - 1 });
+      expect(resolveTokenExpiry({}, pastExp, NOW_MS).source).toBe('unknown');
+    });
+  });
+
+  describe('the bug we are fixing', () => {
+    // Documents the regression we're guarding against: the old code did
+    // `tokenResponse.expires_in ?? 3600`. The new resolver must NOT
+    // fabricate a 3600 default — Notion-style responses (no expires_in)
+    // must produce null so callers persist `expires_at = NULL`.
+    it('Notion-style response (no expires_in, no expires_at, opaque token) returns null', () => {
+      const notionLike = {
+        access_token: 'secret_abcdefghijklmnop',
+        token_type: 'bearer',
+        // no expires_in, no expires_at, no exp, no ext_expires_in
+      };
+      const r = resolveTokenExpiry(notionLike, notionLike.access_token, NOW_MS);
+      expect(r).toEqual({ seconds: null, source: 'unknown' });
+    });
+  });
+});

--- a/packages/core/src/tools/mcp/oauth-token-expiry.test.ts
+++ b/packages/core/src/tools/mcp/oauth-token-expiry.test.ts
@@ -24,37 +24,42 @@ function makeJwt(payload: object): string {
   return [b64('{"alg":"none"}'), b64(JSON.stringify(payload)), 'sig'].join('.');
 }
 
+/** Convert seconds-from-NOW_MS to the absolute Date the resolver should produce. */
+function expectedDate(secondsFromNow: number): Date {
+  return new Date(NOW_MS + secondsFromNow * 1000);
+}
+
 describe('resolveTokenExpiry', () => {
   describe('cascade order', () => {
     it('1. uses tokenResponse.expires_in when present', () => {
       const r = resolveTokenExpiry({ expires_in: 3600 }, undefined, NOW_MS);
-      expect(r).toEqual({ seconds: 3600, source: 'expires_in' });
+      expect(r).toEqual({ expiresAt: expectedDate(3600), source: 'expires_in' });
     });
 
     it('2. falls through to expires_at when expires_in is missing', () => {
       const r = resolveTokenExpiry({ expires_at: NOW_SEC + 7200 }, undefined, NOW_MS);
-      expect(r).toEqual({ seconds: 7200, source: 'expires_at' });
+      expect(r).toEqual({ expiresAt: expectedDate(7200), source: 'expires_at' });
     });
 
     it('3. falls through to top-level exp when expires_in/at missing', () => {
       const r = resolveTokenExpiry({ exp: NOW_SEC + 1800 }, undefined, NOW_MS);
-      expect(r).toEqual({ seconds: 1800, source: 'exp' });
+      expect(r).toEqual({ expiresAt: expectedDate(1800), source: 'exp' });
     });
 
     it('4. falls through to ext_expires_in (Microsoft style)', () => {
       const r = resolveTokenExpiry({ ext_expires_in: 5400 }, undefined, NOW_MS);
-      expect(r).toEqual({ seconds: 5400, source: 'ext_expires_in' });
+      expect(r).toEqual({ expiresAt: expectedDate(5400), source: 'ext_expires_in' });
     });
 
     it('5. JWT-decodes the access_token when nothing else works', () => {
       const jwt = makeJwt({ exp: NOW_SEC + 900 });
       const r = resolveTokenExpiry({}, jwt, NOW_MS);
-      expect(r).toEqual({ seconds: 900, source: 'jwt_exp' });
+      expect(r).toEqual({ expiresAt: expectedDate(900), source: 'jwt_exp' });
     });
 
     it('7. returns null/unknown when no source can supply a TTL', () => {
       const r = resolveTokenExpiry({}, 'opaque-secret_abc', NOW_MS);
-      expect(r).toEqual({ seconds: null, source: 'unknown' });
+      expect(r).toEqual({ expiresAt: null, source: 'unknown' });
     });
   });
 
@@ -62,7 +67,7 @@ describe('resolveTokenExpiry', () => {
     it('expires_in wins over a JWT exp claim that disagrees', () => {
       const jwt = makeJwt({ exp: NOW_SEC + 9999 });
       const r = resolveTokenExpiry({ expires_in: 60 }, jwt, NOW_MS);
-      expect(r.seconds).toBe(60);
+      expect(r.expiresAt).toEqual(expectedDate(60));
       expect(r.source).toBe('expires_in');
     });
 
@@ -72,7 +77,7 @@ describe('resolveTokenExpiry', () => {
         undefined,
         NOW_MS
       );
-      expect(r.seconds).toBe(100);
+      expect(r.expiresAt).toEqual(expectedDate(100));
       expect(r.source).toBe('expires_at');
     });
   });
@@ -112,6 +117,17 @@ describe('resolveTokenExpiry', () => {
       const pastExp = makeJwt({ exp: NOW_SEC - 1 });
       expect(resolveTokenExpiry({}, pastExp, NOW_MS).source).toBe('unknown');
     });
+
+    it('rejects absolute timestamps beyond the sanity horizon (likely ms-vs-seconds bug)', () => {
+      // A provider returning epoch *milliseconds* in `expires_at` (instead of
+      // seconds) would resolve to year ~+58k. Reject silently and let the
+      // cascade fall through rather than persist a thousand-year expiry.
+      const tooFar = NOW_MS; // i.e. NOW_SEC * 1000 — used as if it were seconds
+      expect(resolveTokenExpiry({ expires_at: tooFar }, undefined, NOW_MS).source).toBe('unknown');
+      expect(resolveTokenExpiry({ exp: tooFar }, undefined, NOW_MS).source).toBe('unknown');
+      const jwtMsExp = makeJwt({ exp: tooFar });
+      expect(resolveTokenExpiry({}, jwtMsExp, NOW_MS).source).toBe('unknown');
+    });
   });
 
   describe('the bug we are fixing', () => {
@@ -126,7 +142,7 @@ describe('resolveTokenExpiry', () => {
         // no expires_in, no expires_at, no exp, no ext_expires_in
       };
       const r = resolveTokenExpiry(notionLike, notionLike.access_token, NOW_MS);
-      expect(r).toEqual({ seconds: null, source: 'unknown' });
+      expect(r).toEqual({ expiresAt: null, source: 'unknown' });
     });
   });
 });

--- a/packages/core/src/tools/mcp/oauth-token-expiry.ts
+++ b/packages/core/src/tools/mcp/oauth-token-expiry.ts
@@ -9,8 +9,10 @@
  * The resolver walks a deterministic precedence cascade and returns the
  * first hit, or `null` ("unknown") if no source can supply a TTL. `null` is
  * a first-class state — callers persist it as `expires_at = NULL` and the
- * UI surfaces "expires in: unknown". The retry-on-401 transport shim
- * (tracked as a follow-up) is the safety net for the unknown case.
+ * UI surfaces "expires in: unknown". Until the retry-on-401 transport shim
+ * lands (tracked as a follow-up — see Phase 5 of the research doc), the
+ * unknown case is operator-driven: the user can force a refresh from the
+ * MCP pill if the token stops working.
  *
  * Cascade order:
  *   1. tokenResponse.expires_in        (RFC 6749 §5.1 — canonical)
@@ -21,14 +23,17 @@
  *   6. (future) per-server config hint default_access_ttl_seconds
  *   7. null                            ("unknown")
  *
+ * The cascade returns an absolute `Date` (or null). Storage takes that Date
+ * verbatim — keeping OAuth-spec semantics out of the repository layer.
+ *
  * Notes:
  * - We never speculate a hardcoded global default. The 1h default was the bug.
  * - Same resolver runs at both initial-auth persist and refresh persist —
  *   no asymmetry between the two sites.
- * - JWT decode is shape-gated and signature-free: we are reading our own
- *   token to learn when WE think it expires, not validating it. Any decode
- *   failure quietly falls through to the next step.
+ * - JWT decode is shape-gated and signature-free (see `@agor/core/utils/jwt`).
  */
+
+import { readJwtExpClaim } from '../../utils/jwt';
 
 /** Minimal token-response shape we need from any provider. */
 export interface OAuthTokenResponseLike {
@@ -43,10 +48,10 @@ export interface OAuthTokenResponseLike {
   // Other fields (refresh_token, scope, etc.) are not relevant here.
 }
 
-/** Result of the cascade. `seconds === null` means "unknown — store NULL". */
+/** Result of the cascade. `expiresAt === null` means "unknown — store NULL". */
 export interface ResolvedTokenExpiry {
-  /** Seconds-from-now until expiry, or `null` if no source could supply one. */
-  seconds: number | null;
+  /** Absolute expiry as a `Date`, or `null` if no source could supply one. */
+  expiresAt: Date | null;
   /**
    * Which step of the cascade produced the answer. Useful for logging /
    * debugging when a provider behaves unexpectedly. `'unknown'` for null.
@@ -62,6 +67,17 @@ export interface ResolvedTokenExpiry {
 }
 
 /**
+ * Sanity bound for absolute timestamps. Anything more than 10 years in the
+ * future is treated as a units mistake (e.g., a provider returning
+ * milliseconds where we expect seconds, which would resolve to year ~+58k).
+ *
+ * Relative TTLs (`expires_in`) are NOT bounded here — providers like
+ * Atlassian advertise multi-hour-but-finite TTLs and some long-lived JWTs
+ * legitimately span months. Only the absolute-timestamp branches use this.
+ */
+const ABSOLUTE_TIMESTAMP_SANITY_HORIZON_SEC = 10 * 365 * 24 * 60 * 60;
+
+/**
  * Walk the precedence cascade and return the first usable expiry.
  *
  * @param tokenResponse - parsed JSON body from the OAuth token endpoint
@@ -75,39 +91,45 @@ export function resolveTokenExpiry(
 ): ResolvedTokenExpiry {
   // Step 1 — RFC 6749 §5.1 standard
   if (isPositiveFiniteNumber(tokenResponse.expires_in)) {
-    return { seconds: Math.floor(tokenResponse.expires_in), source: 'expires_in' };
+    return {
+      expiresAt: new Date(now + Math.floor(tokenResponse.expires_in) * 1000),
+      source: 'expires_in',
+    };
   }
 
   // Step 2 — absolute Unix-seconds variant
-  const fromExpiresAt = absoluteSecondsToRelative(tokenResponse.expires_at, now);
+  const fromExpiresAt = absoluteSecondsToDate(tokenResponse.expires_at, now);
   if (fromExpiresAt !== null) {
-    return { seconds: fromExpiresAt, source: 'expires_at' };
+    return { expiresAt: fromExpiresAt, source: 'expires_at' };
   }
 
   // Step 3 — top-level JWT-style claim leaked into the response
-  const fromExp = absoluteSecondsToRelative(tokenResponse.exp, now);
+  const fromExp = absoluteSecondsToDate(tokenResponse.exp, now);
   if (fromExp !== null) {
-    return { seconds: fromExp, source: 'exp' };
+    return { expiresAt: fromExp, source: 'exp' };
   }
 
   // Step 4 — Microsoft / Azure AD extended expiry
   if (isPositiveFiniteNumber(tokenResponse.ext_expires_in)) {
-    return { seconds: Math.floor(tokenResponse.ext_expires_in), source: 'ext_expires_in' };
+    return {
+      expiresAt: new Date(now + Math.floor(tokenResponse.ext_expires_in) * 1000),
+      source: 'ext_expires_in',
+    };
   }
 
   // Step 5 — JWT-decode the access token if it has the JWT shape
   if (accessToken) {
     const jwtExp = readJwtExpClaim(accessToken);
-    const fromJwt = absoluteSecondsToRelative(jwtExp, now);
+    const fromJwt = absoluteSecondsToDate(jwtExp, now);
     if (fromJwt !== null) {
-      return { seconds: fromJwt, source: 'jwt_exp' };
+      return { expiresAt: fromJwt, source: 'jwt_exp' };
     }
   }
 
   // Step 6 (config_hint) is reserved for the per-server lifecycle config
   // (option G in the research doc). Not yet plumbed through to this resolver.
 
-  return { seconds: null, source: 'unknown' };
+  return { expiresAt: null, source: 'unknown' };
 }
 
 /**
@@ -119,62 +141,15 @@ function isPositiveFiniteNumber(v: unknown): v is number {
 }
 
 /**
- * Convert an absolute Unix-seconds timestamp to a positive seconds-from-now
- * delta. Returns null for missing values, non-numbers, and any timestamp
- * already in the past (which would yield a non-positive TTL).
+ * Convert an absolute Unix-seconds timestamp to a `Date`. Returns null for
+ * missing values, non-numbers, anything in the past, and anything beyond the
+ * sanity horizon (likely a units mistake — see ABSOLUTE_TIMESTAMP_SANITY_HORIZON_SEC).
  */
-function absoluteSecondsToRelative(absSec: unknown, nowMs: number): number | null {
+function absoluteSecondsToDate(absSec: unknown, nowMs: number): Date | null {
   if (!isPositiveFiniteNumber(absSec)) return null;
-  const deltaSec = Math.floor(absSec - nowMs / 1000);
-  return deltaSec > 0 ? deltaSec : null;
-}
-
-/**
- * Best-effort JWT decode: returns the `exp` claim (Unix seconds) if the input
- * has the three-segment JWT shape AND the payload base64url-decodes to JSON
- * containing a numeric `exp`. Returns null on any failure — never throws.
- *
- * No signature verification: we are reading our own token to learn when WE
- * think it expires, not asserting trust. Opaque tokens (Slack `xoxe.`,
- * Notion `secret_…`, etc.) fail the shape check and short-circuit cleanly.
- */
-function readJwtExpClaim(token: string): number | null {
-  // JWT shape: header.payload.signature — three segments, all base64url.
-  const parts = token.split('.');
-  if (parts.length !== 3) return null;
-  const payloadSegment = parts[1];
-  if (!payloadSegment) return null;
-
-  try {
-    const decoded = base64UrlDecodeToString(payloadSegment);
-    const parsed = JSON.parse(decoded) as unknown;
-    if (parsed && typeof parsed === 'object' && 'exp' in parsed) {
-      const exp = (parsed as { exp: unknown }).exp;
-      if (isPositiveFiniteNumber(exp)) return exp;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Decode a base64url string (no padding, `-`/`_` instead of `+`/`/`) to UTF-8.
- * Works in both Node and browser-ish runtimes — we use Buffer where available
- * and fall back to atob otherwise.
- */
-function base64UrlDecodeToString(input: string): string {
-  // Convert base64url → base64 and pad to a multiple of 4.
-  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
-
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(padded, 'base64').toString('utf8');
-  }
-  // Browser fallback. atob returns a "binary string"; convert to UTF-8.
-  // biome-ignore lint/suspicious/noExplicitAny: atob may not be typed in this env
-  const bin = (globalThis as any).atob(padded) as string;
-  const bytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-  return new TextDecoder().decode(bytes);
+  const nowSec = nowMs / 1000;
+  const deltaSec = absSec - nowSec;
+  if (deltaSec <= 0) return null;
+  if (deltaSec > ABSOLUTE_TIMESTAMP_SANITY_HORIZON_SEC) return null;
+  return new Date(Math.floor(absSec) * 1000);
 }

--- a/packages/core/src/tools/mcp/oauth-token-expiry.ts
+++ b/packages/core/src/tools/mcp/oauth-token-expiry.ts
@@ -1,0 +1,180 @@
+/**
+ * MCP OAuth Token Expiry Resolution
+ *
+ * Replaces the previous `tokenResponse.expires_in ?? 3600` defaulting that
+ * lived in two persist sites with different policies. See
+ * `context/explorations/mcp-oauth-token-lifecycle.md` (Phase 3.5) for the
+ * full rationale.
+ *
+ * The resolver walks a deterministic precedence cascade and returns the
+ * first hit, or `null` ("unknown") if no source can supply a TTL. `null` is
+ * a first-class state — callers persist it as `expires_at = NULL` and the
+ * UI surfaces "expires in: unknown". The retry-on-401 transport shim
+ * (tracked as a follow-up) is the safety net for the unknown case.
+ *
+ * Cascade order:
+ *   1. tokenResponse.expires_in        (RFC 6749 §5.1 — canonical)
+ *   2. tokenResponse.expires_at        (absolute Unix seconds; some Auth0 / Spotify configs)
+ *   3. tokenResponse.exp               (top-level JWT-style absolute claim)
+ *   4. tokenResponse.ext_expires_in    (Microsoft / Azure AD extended expiry)
+ *   5. JWT-decode access_token.exp     (only if token has JWT shape)
+ *   6. (future) per-server config hint default_access_ttl_seconds
+ *   7. null                            ("unknown")
+ *
+ * Notes:
+ * - We never speculate a hardcoded global default. The 1h default was the bug.
+ * - Same resolver runs at both initial-auth persist and refresh persist —
+ *   no asymmetry between the two sites.
+ * - JWT decode is shape-gated and signature-free: we are reading our own
+ *   token to learn when WE think it expires, not validating it. Any decode
+ *   failure quietly falls through to the next step.
+ */
+
+/** Minimal token-response shape we need from any provider. */
+export interface OAuthTokenResponseLike {
+  access_token?: string;
+  expires_in?: number;
+  /** Absolute Unix-seconds expiry — alternative form some providers use. */
+  expires_at?: number;
+  /** Top-level JWT-style absolute expiry claim — rare but observed. */
+  exp?: number;
+  /** Microsoft / Azure AD extended expiry during outages. */
+  ext_expires_in?: number;
+  // Other fields (refresh_token, scope, etc.) are not relevant here.
+}
+
+/** Result of the cascade. `seconds === null` means "unknown — store NULL". */
+export interface ResolvedTokenExpiry {
+  /** Seconds-from-now until expiry, or `null` if no source could supply one. */
+  seconds: number | null;
+  /**
+   * Which step of the cascade produced the answer. Useful for logging /
+   * debugging when a provider behaves unexpectedly. `'unknown'` for null.
+   */
+  source:
+    | 'expires_in'
+    | 'expires_at'
+    | 'exp'
+    | 'ext_expires_in'
+    | 'jwt_exp'
+    | 'config_hint'
+    | 'unknown';
+}
+
+/**
+ * Walk the precedence cascade and return the first usable expiry.
+ *
+ * @param tokenResponse - parsed JSON body from the OAuth token endpoint
+ * @param accessToken - the access_token (only used for the JWT-decode step)
+ * @param now - current epoch ms; injectable for tests
+ */
+export function resolveTokenExpiry(
+  tokenResponse: OAuthTokenResponseLike,
+  accessToken?: string,
+  now: number = Date.now()
+): ResolvedTokenExpiry {
+  // Step 1 — RFC 6749 §5.1 standard
+  if (isPositiveFiniteNumber(tokenResponse.expires_in)) {
+    return { seconds: Math.floor(tokenResponse.expires_in), source: 'expires_in' };
+  }
+
+  // Step 2 — absolute Unix-seconds variant
+  const fromExpiresAt = absoluteSecondsToRelative(tokenResponse.expires_at, now);
+  if (fromExpiresAt !== null) {
+    return { seconds: fromExpiresAt, source: 'expires_at' };
+  }
+
+  // Step 3 — top-level JWT-style claim leaked into the response
+  const fromExp = absoluteSecondsToRelative(tokenResponse.exp, now);
+  if (fromExp !== null) {
+    return { seconds: fromExp, source: 'exp' };
+  }
+
+  // Step 4 — Microsoft / Azure AD extended expiry
+  if (isPositiveFiniteNumber(tokenResponse.ext_expires_in)) {
+    return { seconds: Math.floor(tokenResponse.ext_expires_in), source: 'ext_expires_in' };
+  }
+
+  // Step 5 — JWT-decode the access token if it has the JWT shape
+  if (accessToken) {
+    const jwtExp = readJwtExpClaim(accessToken);
+    const fromJwt = absoluteSecondsToRelative(jwtExp, now);
+    if (fromJwt !== null) {
+      return { seconds: fromJwt, source: 'jwt_exp' };
+    }
+  }
+
+  // Step 6 (config_hint) is reserved for the per-server lifecycle config
+  // (option G in the research doc). Not yet plumbed through to this resolver.
+
+  return { seconds: null, source: 'unknown' };
+}
+
+/**
+ * True for finite numbers strictly greater than zero. Rejects NaN, ±Infinity,
+ * 0, negatives, strings, etc. — anything we wouldn't want to use as a TTL.
+ */
+function isPositiveFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && v > 0;
+}
+
+/**
+ * Convert an absolute Unix-seconds timestamp to a positive seconds-from-now
+ * delta. Returns null for missing values, non-numbers, and any timestamp
+ * already in the past (which would yield a non-positive TTL).
+ */
+function absoluteSecondsToRelative(absSec: unknown, nowMs: number): number | null {
+  if (!isPositiveFiniteNumber(absSec)) return null;
+  const deltaSec = Math.floor(absSec - nowMs / 1000);
+  return deltaSec > 0 ? deltaSec : null;
+}
+
+/**
+ * Best-effort JWT decode: returns the `exp` claim (Unix seconds) if the input
+ * has the three-segment JWT shape AND the payload base64url-decodes to JSON
+ * containing a numeric `exp`. Returns null on any failure — never throws.
+ *
+ * No signature verification: we are reading our own token to learn when WE
+ * think it expires, not asserting trust. Opaque tokens (Slack `xoxe.`,
+ * Notion `secret_…`, etc.) fail the shape check and short-circuit cleanly.
+ */
+function readJwtExpClaim(token: string): number | null {
+  // JWT shape: header.payload.signature — three segments, all base64url.
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const payloadSegment = parts[1];
+  if (!payloadSegment) return null;
+
+  try {
+    const decoded = base64UrlDecodeToString(payloadSegment);
+    const parsed = JSON.parse(decoded) as unknown;
+    if (parsed && typeof parsed === 'object' && 'exp' in parsed) {
+      const exp = (parsed as { exp: unknown }).exp;
+      if (isPositiveFiniteNumber(exp)) return exp;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode a base64url string (no padding, `-`/`_` instead of `+`/`/`) to UTF-8.
+ * Works in both Node and browser-ish runtimes — we use Buffer where available
+ * and fall back to atob otherwise.
+ */
+function base64UrlDecodeToString(input: string): string {
+  // Convert base64url → base64 and pad to a multiple of 4.
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(padded, 'base64').toString('utf8');
+  }
+  // Browser fallback. atob returns a "binary string"; convert to UTF-8.
+  // biome-ignore lint/suspicious/noExplicitAny: atob may not be typed in this env
+  const bin = (globalThis as any).atob(padded) as string;
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}

--- a/packages/core/src/utils/jwt.ts
+++ b/packages/core/src/utils/jwt.ts
@@ -6,12 +6,12 @@
  * three-segment shape check and short-circuit cleanly with `null`.
  *
  * Browser-safe: uses `Buffer` when available (Node), `atob` otherwise (browser).
- * Consumed by `packages/core/src/tools/mcp/oauth-token-expiry.ts` (cascade
- * step 5).
  *
- * ⚠ KEEP IN SYNC with `apps/agor-ui/src/utils/jwtExpiry.ts`. The UI
- * intentionally duplicates these helpers rather than importing them, because
- * `agor-ui` does not depend on `@agor/core`. If the API drifts, update both.
+ * Consumers:
+ *   - `packages/core/src/tools/mcp/oauth-token-expiry.ts` (cascade step 5)
+ *   - `packages/client/src/jwt.ts` (re-export → `@agor-live/client/jwt`),
+ *     which is what the UI's `apps/agor-ui/src/utils/jwtExpiry.ts` uses.
+ *     One implementation, no drift between server and browser.
  */
 
 /**

--- a/packages/core/src/utils/jwt.ts
+++ b/packages/core/src/utils/jwt.ts
@@ -1,0 +1,85 @@
+/**
+ * JWT decode utilities (no signature verification).
+ *
+ * We read our own tokens to learn when WE think they expire — never to assert
+ * trust. Opaque tokens (Slack `xoxe.…`, Notion `secret_…`, etc.) fail the
+ * three-segment shape check and short-circuit cleanly with `null`.
+ *
+ * Browser-safe: uses `Buffer` when available (Node), `atob` otherwise (browser).
+ * Consumed by `packages/core/src/tools/mcp/oauth-token-expiry.ts` (cascade
+ * step 5).
+ *
+ * ⚠ KEEP IN SYNC with `apps/agor-ui/src/utils/jwtExpiry.ts`. The UI
+ * intentionally duplicates these helpers rather than importing them, because
+ * `agor-ui` does not depend on `@agor/core`. If the API drifts, update both.
+ */
+
+/**
+ * Return the `exp` claim (Unix seconds) from a JWT, or null on any failure.
+ * Never throws. Does not verify the signature.
+ */
+export function readJwtExpClaim(token: string): number | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const payloadSegment = parts[1];
+  if (!payloadSegment) return null;
+
+  try {
+    const decoded = base64UrlDecodeToString(payloadSegment);
+    const parsed = JSON.parse(decoded) as unknown;
+    if (parsed && typeof parsed === 'object' && 'exp' in parsed) {
+      const exp = (parsed as { exp: unknown }).exp;
+      if (typeof exp === 'number' && Number.isFinite(exp) && exp > 0) return exp;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convenience wrapper: returns the `exp` claim in epoch milliseconds, or null.
+ * Matches the API the UI's `jwtExpiry.ts` previously exposed.
+ */
+export function decodeJwtExpMs(token: string): number | null {
+  const expSec = readJwtExpClaim(token);
+  return expSec === null ? null : expSec * 1000;
+}
+
+/**
+ * Milliseconds remaining until the JWT's `exp`, or null if no decodable `exp`.
+ * Negative values mean already-expired.
+ */
+export function msUntilExpiry(token: string, now: number = Date.now()): number | null {
+  const expMs = decodeJwtExpMs(token);
+  return expMs === null ? null : expMs - now;
+}
+
+/**
+ * True when the token expires within `bufferMs`, OR when no `exp` could be
+ * decoded (treat-as-expiring is the safe default for the UI's pre-emptive
+ * refresh path).
+ */
+export function isExpiringSoon(token: string, bufferMs: number): boolean {
+  const ms = msUntilExpiry(token);
+  if (ms === null) return true;
+  return ms <= bufferMs;
+}
+
+/**
+ * Decode a base64url string (no padding, `-`/`_` instead of `+`/`/`) to UTF-8.
+ * Works in both Node and browser runtimes.
+ */
+function base64UrlDecodeToString(input: string): string {
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(padded, 'base64').toString('utf8');
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: atob may not be typed in this env
+  const bin = (globalThis as any).atob(padded) as string;
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport
     'tools/mcp/oauth-refresh': 'src/tools/mcp/oauth-refresh.ts', // MCP OAuth refresh_token persistence + mutex
+    'tools/mcp/oauth-token-expiry': 'src/tools/mcp/oauth-token-expiry.ts', // MCP OAuth token expiry resolution cascade
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for worktree isolation
     'mcp/index': 'src/mcp/index.ts', // MCP template resolution utilities
     'gateway/index': 'src/gateway/index.ts', // Gateway platform connectors (Slack, etc.)

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     'utils/host-ip': 'src/utils/host-ip.ts', // Host IP detection for {{host.ip_address}} template var
     'utils/path': 'src/utils/path.ts', // Path expansion utilities (tilde to home directory)
     'utils/logger': 'src/utils/logger.ts', // Console monkey-patch for log level filtering
+    'utils/jwt': 'src/utils/jwt.ts', // Browser-safe JWT decode (no signature verification)
     'seed/index': 'src/seed/index.ts', // Development database seeding
     'callbacks/child-completion-template': 'src/callbacks/child-completion-template.ts', // Parent session callback templates
     'client/index': 'src/client/index.ts', // Client-safe core entrypoint for browser/SDK consumers


### PR DESCRIPTION
## Summary

Audits Agor's MCP OAuth lifecycle for unattended/scheduled agents and lands the highest-leverage fix the audit surfaced: a deterministic precedence cascade for resolving access-token expiry, replacing the asymmetric `?? 3600` defaulting that produced the "Agor thinks this token expired after exactly 1 hour" reports.

**The bug.** Two persist sites disagreed on what to do when a provider omits `expires_in`. `apps/agor-daemon/src/oauth-cache.ts:89` (initial-auth) wrote a fake 1h expiry; `packages/core/src/tools/mcp/oauth-refresh.ts:300-306` (refresh) wrote NULL. Net effect on Notion (which omits `expires_in` on both grant and refresh): row oscillated between "fake-1h-expired" and "stale forever", regardless of whether the MCP server still accepted the token.

**The fix.** New `resolveTokenExpiry` resolver shared by both sites. Walks a deterministic cascade: `expires_in` → `expires_at` → top-level `exp` → `ext_expires_in` → JWT-decode access token → `null` ("unknown"). `null` is now a first-class state — persisted as a literal `NULL` to `oauth_token_expires_at` and surfaced as "Expires in: unknown" in the `MCPServerPill` tooltip with copy explaining the token will be refreshed on demand.

**Empirical backing.** Curl probes against `mcp.slack.com`, `mcp.notion.com`, `mcp.linear.app` confirmed none advertise an `introspection_endpoint` — RFC 7662 introspection is not a viable runtime-discovery path for our actual targets, so the cascade is the right primitive. Findings + provider matrix in the research doc.

## What's in this PR

**Code (cascade fix):**
- `packages/core/src/tools/mcp/oauth-token-expiry.ts` — new resolver + tests
- `packages/core/src/tools/mcp/oauth-token-expiry.test.ts` — cascade-order, precedence, and rejection coverage
- `packages/core/src/tools/mcp/oauth-refresh.ts` — refresh persist now uses resolver
- `apps/agor-daemon/src/oauth-cache.ts` — initial-auth persist now uses resolver; the legacy 1h default survives only as a bound on the in-memory daemon cache (so its map can't grow unbounded), not as a DB-row value
- `packages/core/src/db/repositories/user-mcp-oauth-tokens.ts` — `SaveTokenInput.expiresInSeconds` now `number | null | undefined`; `null` writes a literal NULL, `undefined` preserves
- `apps/agor-ui/src/components/MCPServerPill.tsx` — explicit "Expires in: unknown" tooltip when expiry is NULL
- `packages/core/{tsup.config.ts,package.json}` — register the new module subpath

**Research (`context/explorations/mcp-oauth-token-lifecycle.md`):**
- Phase 1 audit of current OAuth lifecycle code with a "🔴 The 1-hour default bug" section explaining the asymmetric defaulting
- Phase 2 provider matrix with cited URLs (Slack / Notion / Linear / Atlassian / GitHub + MCP Authorization spec / OAuth 2.1 / DPoP context)
- Phase 3 gap analysis (retry-on-401, pre-cron refresh hook, unattended-failure notifications, `offline_access` scope guardrail)
- **Phase 3.5** — empirical curl findings (no `introspection_endpoint` advertised by any target MCP server) + the precedence cascade design that this PR implements
- Phase 4 options A–G with trade-offs
- Phase 5 sequenced recommendation (cascade is item #0, then retry-on-401, then pre-cron refresh, then loud notifications)

## Out of scope (follow-ups noted in the doc)

- Retry-on-401 shim at the MCP transport (the safety net for the new "unknown" expiry case)
- Pre-cron refresh hook + loud notifications on unattended `invalid_grant`
- Per-server `auth.lifecycle.default_access_ttl_seconds` config hint (slot 6 of the cascade — reserved but not yet plumbed through)
- `offline_access` auto-include for Atlassian DCR
- Persist the discovered token endpoint at DCR time (kill `inferOAuthTokenUrl` heuristic)

## Test plan

- [ ] Maintainer review of the research doc and the resolver design
- [ ] Run `pnpm --filter @agor/core test -- oauth-token-expiry` (cascade unit tests)
- [ ] Manual: connect a Notion MCP server fresh; verify the pill tooltip says "Expires in: unknown" instead of a fake "Expires in 59m" countdown
- [ ] Manual: connect an Atlassian/Linear MCP server; verify the tooltip still shows the real countdown (cascade step 1 returns `expires_in` unchanged)
- [ ] Manual: confirm log lines from `persistOAuthToken` and `refreshAndPersistToken` now include `(expiry source: <step>, ttl=<N>s|unknown)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
