### PR TITLE
fix(daemon): use base URL origin for artifact proxy template var

### DIFF
--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -902,7 +902,14 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     // proxy URLs surfaced to artifacts (`agor.proxies.<vendor>.url`) match
     // what `agor_proxies_list` returns and respect AGOR_BASE_URL /
     // daemon.base_url overrides for deployed instances.
+    //
+    // Take the .origin only (scheme + host + port) — the proxy mount lives
+    // at /proxies/<vendor> on the daemon root, NOT under whatever path the
+    // configured base URL points at (e.g. AGOR_BASE_URL=https://host/ui
+    // would otherwise produce https://host/ui/proxies/<vendor>, which hits
+    // the SPA shell instead of the proxy). Mirrors mcp/tools/proxies.ts.
     const daemonUrl = await getBaseUrl();
+    const daemonOrigin = new URL(daemonUrl).origin;
 
     // Resolve board slug for template context
     const board = await this.boardRepo.findById(artifact.board_id);
@@ -921,7 +928,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       const proxies = resolveProxies(config);
       for (const p of proxies) {
         proxiesContext[p.vendor] = {
-          url: `${daemonUrl.replace(/\/$/, '')}/proxies/${p.vendor}`,
+          url: `${daemonOrigin}/proxies/${p.vendor}`,
           upstream: p.upstream,
           allowed_methods: [...p.allowed_methods],
         };


### PR DESCRIPTION
## Summary

Follow-up to #1089. The artifact-side rendering of `{{ agor.proxies.<vendor>.url }}` was concatenating the *full* configured base URL with `/proxies/<vendor>`, instead of taking only its origin.

When `AGOR_BASE_URL` (or `daemon.base_url`) points at a path-prefixed mount (e.g. the UI at `https://host/ui`), the rendered URL becomes `https://host/ui/proxies/<vendor>/...` — that route hits the SPA shell and returns `200` with `index.html`, *not* the proxy. Silent failure: artifacts get a healthy-looking 200 back from a URL that never reached the daemon.

The MCP tool (`agor_proxies_list`) already does the right thing — it calls `new URL(baseUrl).origin` before composing the proxy URL. The artifact renderer was the outlier. This PR aligns them.

## Repro / proof

Caught while testing #1089 against the deployed daemon at `agor.sandbox.preset.zone` (which has the base URL set to `/ui`):

| Test | Before | After (expected) |
|---|---|---|
| Direct `https://api.app.shortcut.com/api/v3/member` (no preflight) | `NETWORK ERROR` | `NETWORK ERROR` (Shortcut has no CORS) |
| Direct `https://api.app.shortcut.com/api/v3/member` w/ token (preflight) | `NETWORK ERROR` | `NETWORK ERROR` |
| Via `{{ agor.proxies.shortcut.url }}/api/v3/member` | `HTTP 200 (non-JSON)` ← SPA shell | `HTTP 200` with member JSON |

## Test plan

- [ ] Deploy and re-run the Shortcut diagnostic artifact — Test 3 should return real JSON, not the SPA's index.html
- [ ] `agor_proxies_list` and `{{ agor.proxies.<vendor>.url }}` should resolve to the same URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)