### PR TITLE
fix(git): allow simple-git credential.helper for impersonated clone (hotfix)

### DIFF
--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -273,6 +273,15 @@ function createGit(
     config,
     unsafe: {
       allowUnsafeSshCommand: true,
+      // Required because we set credential.helper in `config` above
+      // (empty-reset on the inheritance line, store-with-tempfile when a
+      // token is present). simple-git's guard exists to block shell-
+      // injection via untrusted helper values; ours are server-constructed
+      // (credPath comes from writeGitCredentialsFile, never user input).
+      // TODO: drop both credential.helper lines, switch to env-var-based
+      // http.extraheader (GIT_CONFIG_COUNT/KEY/VALUE), then this flag and
+      // the on-disk tempfile can both go.
+      allowUnsafeCredentialHelper: true,
     },
     spawnOptions: env
       ? ({


### PR DESCRIPTION
## Summary

Hotfix for prod regression: worktree creation fails with `Configuring credential.helper is not permitted without enabling allowUnsafeCredentialHelper`.

Live repro: worktree `test-clone-worktree` (board id `019dfb03-...`) — failing right now in prod with this exact error after #1091 was deployed.

## Root cause

`packages/core/src/git/index.ts` adds two `credential.helper=...` entries to the simple-git config array (existing lines: empty-reset for inheritance kill, plus `store --file=...` when a token is present), but didn't pass the matching `unsafe.allowUnsafeCredentialHelper` flag. simple-git refuses any `credential.helper` config without that opt-in because the value is interpreted by git as a command to execute.

Both helper values here are 100% server-constructed:
- `credential.helper=` (empty reset, no exec vector)
- `credential.helper=store --file=${credPath}` where `credPath` comes from `writeGitCredentialsFile()` — `os.tmpdir()` + crypto-random filename, never user input.

Adding the flag is safe for our specific use. The change is one line + an explanatory comment block + a TODO pointing at the proper follow-up.

## Why this slipped through

Same class of gap PR #1091 called out: `@agor/core` was excluded from CI's test runner. Even with #1094 re-enabling `@agor/core` in CI, no test exercises `createGit()` end-to-end against a real `simple-git` invocation that would have tripped the guard. A regression test for this is folded into the follow-up.

## Follow-up (separate PR, queued)

Rip out **both** credential.helper lines. Switch to env-var-based config injection (`GIT_CONFIG_COUNT/KEY/VALUE`) setting `http.extraheader=Authorization: Basic <b64>`. That eliminates:

- The `unsafe.allowUnsafeCredentialHelper` flag (security smell, will trip security review)
- The on-disk tempfile entirely (`writeGitCredentialsFile` becomes dead code — delete)
- The `-c key=value` argv leak path that simple-git's `config: [...]` translates to

Real downsides to weigh in the follow-up: scoping `http.extraheader` per-host vs global (submodule token-leak risk), `GIT_CONFIG_GLOBAL` handling so we kill the daemon-user gitconfig but preserve the impersonated user's, and a redactor for any logging of `spawnOptions.env`. Roughly 200–300 line diff with proper docker verification.

## Test plan

- [ ] Apply this commit in prod
- [ ] Create a fresh worktree via the UI
- [ ] Confirm `filesystem_status` reaches `ready` (currently fails to `failed` with the credential-helper error)
- [ ] Existing `users.git-env.test.ts` still passes
- [ ] Once unblocked: queue follow-up worktree for the env-var-based refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)