### PR TITLE
feat(daemon): render {{ agor.token }} for artifact daemon auth

### DIFF
--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -39,6 +39,7 @@ import type {
   WorktreeID,
 } from '@agor/core/types';
 import Handlebars from 'handlebars';
+import jwt from 'jsonwebtoken';
 import { DrizzleService } from '../adapters/drizzle.js';
 import type { UsersService } from './users.js';
 
@@ -47,7 +48,13 @@ import type { UsersService } from './users.js';
  * the backend treats it as a Handlebars template and renders it per-user
  * at payload fetch time. Template variables:
  *   {{ user.env.VAR_NAME }} - User's encrypted env var
- *   {{ agor.token }}        - Scoped artifact API token (future)
+ *   {{ agor.token }}        - Short-lived (15m) daemon JWT for the viewing
+ *                              user. Same shape as a regular access token —
+ *                              attach as `Authorization: Bearer ...` to
+ *                              authenticate against the daemon (e.g. when
+ *                              calling `/proxies/<vendor>/...`). Trust model
+ *                              matches `user.env.X`: rendered into artifact
+ *                              JS at view time, never enters LLM context.
  *   {{ agor.apiUrl }}       - Daemon URL
  *   {{ artifact.id }}       - Artifact ID
  *   {{ artifact.boardId }}  - Board ID
@@ -937,9 +944,34 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       console.warn('[artifacts] failed to resolve proxies for template context:', err);
     }
 
+    // Mint a short-lived daemon JWT for the viewing user so artifacts can
+    // authenticate to the daemon's own routes (notably `/proxies/<vendor>`).
+    // Shape matches the regular access token issued at login — `sub`,
+    // `type:'access'`, `iss:'agor'`, `aud:'https://agor.dev'` — so the same
+    // verification path accepts it. 15-minute TTL is intentional: the
+    // payload is re-rendered on every viewer load, so a fresh token is
+    // always within reach. No new token type/scope is introduced —
+    // exposing this is the same trust decision as exposing
+    // `{{ user.env.SHORTCUT_API_TOKEN }}` (rendered into artifact JS, never
+    // enters LLM context, scoped to the viewing user only).
+    let agorToken = '';
+    if (userId) {
+      const authConfig = this.app.get('authentication') as { secret?: string } | undefined;
+      const jwtSecret = authConfig?.secret;
+      if (jwtSecret) {
+        agorToken = jwt.sign({ sub: userId, type: 'access' }, jwtSecret, {
+          expiresIn: '15m',
+          issuer: 'agor',
+          audience: 'https://agor.dev',
+        });
+      } else {
+        console.warn('[artifacts] no auth.secret set — {{ agor.token }} will render empty');
+      }
+    }
+
     const context: Record<string, unknown> = {
       artifact: { id: artifact.artifact_id, boardId: artifact.board_id },
-      agor: { apiUrl: daemonUrl, proxies: proxiesContext },
+      agor: { apiUrl: daemonUrl, proxies: proxiesContext, token: agorToken },
       board: { id: artifact.board_id, slug: board?.slug ?? '' },
     };
 


### PR DESCRIPTION
## Summary

Follow-up to #1098. With the URL origin fix in place, artifacts can find the proxy at the correct host — but they still get `401 unauthorized` because the proxy requires an `Authorization: Bearer <daemon-jwt>` and artifacts had no way to obtain one. The original design left `{{ agor.token }}` as a documented `future` placeholder.

This PR mints a 15-minute access token for the viewing user with the same shape as the regular login JWT (`sub` / `type:'access'` / `iss:'agor'` / `aud:'https://agor.dev'`) and surfaces it as `{{ agor.token }}` in the agor.config.js template context.

## Why two tokens?

There are two distinct auth hops:

```
artifact (codesandbox.io iframe)
    │  Authorization: Bearer <agor JWT>          ← who is calling our daemon?
    ▼
daemon /proxies/shortcut
    │  Shortcut-Token: <SHORTCUT_API_TOKEN>      ← upstream's own auth
    ▼
api.app.shortcut.com
```

The Shortcut token is the upstream's credential — it doesn't tell our daemon anything. The daemon JWT answers "is the caller a logged-in Agor user?" Without it, the proxy mount becomes an open relay: anyone on the internet could route requests through our daemon using their own Shortcut tokens, sharing our IP's rate-limit and burning our egress.

## Trust model

Identical to `{{ user.env.X }}`:
- Rendered into artifact JS at view time, scoped to the viewing user
- Never enters LLM context or conversation history
- A re-render gets a fresh token, so the short TTL is invisible to artifact code

The choice not to introduce a new scoped-token type (e.g. proxy-only JWT) is intentional for v1: the existing access-token verification path already works, and a scoped-token variant can be layered on later if we want to tighten blast radius.

## Usage

```js
// /agor.config.js
export const proxyUrl = "{{ agor.proxies.shortcut.url }}";
export const agorToken = "{{ agor.token }}";
export const shortcutToken = "{{ user.env.SHORTCUT_API_TOKEN }}";

// App.js
fetch(`${proxyUrl}/api/v3/member`, {
  headers: {
    Authorization: `Bearer ${agorToken}`,    // daemon auth
    'Shortcut-Token': shortcutToken,         // upstream auth
  },
});
```

## Test plan

- [ ] Deploy and reopen the Shortcut diagnostic artifact — Test 3 should return real Shortcut JSON
- [ ] Verify `{{ agor.token }}` renders a JWT that the proxy's `authenticateRequest` accepts
- [ ] Verify a re-render of the same artifact mints a fresh token (different `iat`)
- [ ] Confirm template renders an empty string for unauthenticated requests (no `userId`)

## Known follow-ups

- 15-min TTL means a long-lived artifact view will eventually 401. For v1, a re-open of the artifact suffices. A proper fix is either a longer TTL, a refresh endpoint, or auto-rotation. Open question — not blocking this PR.
- A scoped proxy-only token type would tighten blast radius (currently the rendered JWT is full-power within the daemon API). Worth doing later if we expand the surface area exposed via templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)