### PR TITLE
fix(ui): MCP server pill stays connected after OAuth revocation

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1878,7 +1878,7 @@ async function registerMCPServices(
   app.use('/mcp-servers/oauth-disconnect', {
     async create(data: { mcp_server_id: string }, params?: AuthenticatedParams) {
       const { clearAuthCodeTokenCache } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
-      return performOAuthDisconnect({
+      const result = await performOAuthDisconnect({
         userId: params?.user?.user_id,
         mcpServerId: data.mcp_server_id,
         userTokenRepo: new UserMCPOAuthTokenRepository(db),
@@ -1886,6 +1886,16 @@ async function registerMCPServices(
         oauthTokenCache: oauth21TokenCache,
         clearCoreTokenCache: clearAuthCodeTokenCache,
       });
+
+      // Notify all of the user's tabs so the UI can flip pills to "needs auth"
+      // immediately — mirrors the additive `oauth:completed` event.
+      if (result.success && params?.user?.user_id) {
+        app.io
+          .to(userRoomName(params.user.user_id))
+          .emit('oauth:disconnected', { mcp_server_id: data.mcp_server_id });
+      }
+
+      return result;
     },
   });
   app.service('mcp-servers/oauth-disconnect').hooks({ before: { create: [ctx.requireAuth] } });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -934,6 +934,35 @@ export function useAgorData(
     };
     client.io.on('oauth:completed', handleOAuthCompleted);
 
+    // Mirror of `oauth:completed`: when a user disconnects OAuth from Settings,
+    // the daemon emits `oauth:disconnected` so every tab flips the pill to
+    // "needs auth" immediately instead of staying purple until the next page
+    // reload.
+    const handleOAuthDisconnected = async (event: { mcp_server_id: string }) => {
+      if (!event.mcp_server_id) return;
+      setUserAuthenticatedMcpServerIds((prev) => {
+        if (!prev.has(event.mcp_server_id)) return prev;
+        const next = new Set(prev);
+        next.delete(event.mcp_server_id);
+        return next;
+      });
+
+      // Refetch so `server.auth.oauth_access_token` is cleared in mcpServerById
+      // — without this, `mcpServerNeedsAuth` may still see the stale token and
+      // return false.
+      try {
+        const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
+        setMcpServerById((prev) => {
+          const next = new Map(prev);
+          next.set(fresh.mcp_server_id, fresh);
+          return next;
+        });
+      } catch (err) {
+        console.warn('[OAuth] Failed to refetch MCP server after disconnect:', err);
+      }
+    };
+    client.io.on('oauth:disconnected', handleOAuthDisconnected);
+
     // Re-fetch the global byId maps on every socket reconnect after the
     // initial mount. Feathers real-time events (`created`/`patched`/`removed`)
     // that fired while we were disconnected are gone — the daemon doesn't
@@ -976,6 +1005,7 @@ export function useAgorData(
     // Cleanup listeners on unmount
     return () => {
       client.io.off('oauth:completed', handleOAuthCompleted);
+      client.io.off('oauth:disconnected', handleOAuthDisconnected);
       client.io.off('connect', refetchSilently);
       window.removeEventListener(TOKENS_REFRESHED_EVENT, handleTokensRefreshed);
       sessionsService.removeListener('created', handleSessionCreated);


### PR DESCRIPTION
## Summary

- When a user revokes OAuth for an MCP server in Settings, the UI kept showing the server as "connected" (purple pill) because the daemon emitted no WebSocket event on disconnect
- Emit `oauth:disconnected` from the daemon (mirroring `oauth:completed`) and listen for it in `useAgorData` to remove the server from `userAuthenticatedMcpServerIds` and refetch fresh auth state
- The pill now correctly flips from purple to orange ("needs auth") across all tabs immediately after revocation

## Details

**Root cause:** `performOAuthDisconnect` deleted the token from the DB and cleared caches, but the UI's `userAuthenticatedMcpServerIds` Set was only updated additively (on `oauth:completed`), never subtractively. The existing `MCPServerPill` already rendered the correct orange/login state for `needsAuth=true` — it just never received the signal.

**Daemon** (`register-services.ts`): After successful disconnect, emit `oauth:disconnected` to the user's socket room via `userRoomName()`.

**UI** (`useAgorData.ts`): Listen for `oauth:disconnected`, remove the server ID from the Set, and refetch the MCPServer to clear stale `oauth_access_token` from `mcpServerById`. Cleanup on unmount.

## Current issue:

Disabling a connected MCP server:

https://github.com/user-attachments/assets/38824dc1-4328-45df-a38e-84372e1a7c1c




New sessions still show the BirdsAI MCP server as connected even when I cannot use any tool because auth is required:

<img width="835" height="149" alt="Screenshot 2026-05-06 at 12 14 25 PM" src="https://github.com/user-attachments/assets/6e716b24-65d2-4e75-af8b-b6f6d4fc6774" />


## Test plan

- [ ] Configure an OAuth MCP server (e.g. BirdsAI) and authenticate
- [ ] Verify purple pill with expiry tooltip in session panel
- [ ] Go to Settings > MCP Servers > Disconnect OAuth
- [ ] Verify pill flips to orange with "Click to authenticate" tooltip
- [ ] Verify the auth warning banner appears above the prompt box
- [ ] Open a second tab — verify it also flips to orange
- [ ] Re-authenticate and verify pill returns to purple

🤖 Generated with [Claude Code](https://claude.com/claude-code)