### PR TITLE
fix(oauth): clear DCR cache on disconnect + optimistic UI token strip

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1878,7 +1878,7 @@ async function registerMCPServices(
   app.use('/mcp-servers/oauth-disconnect', {
     async create(data: { mcp_server_id: string }, params?: AuthenticatedParams) {
       const { clearAuthCodeTokenCache } = await import('@agor/core/tools/mcp/oauth-mcp-transport');
-      return performOAuthDisconnect({
+      const result = await performOAuthDisconnect({
         userId: params?.user?.user_id,
         mcpServerId: data.mcp_server_id,
         userTokenRepo: new UserMCPOAuthTokenRepository(db),
@@ -1886,6 +1886,16 @@ async function registerMCPServices(
         oauthTokenCache: oauth21TokenCache,
         clearCoreTokenCache: clearAuthCodeTokenCache,
       });
+
+      // Notify all of the user's tabs so the UI can flip pills to "needs auth"
+      // immediately — mirrors the additive `oauth:completed` event.
+      if (result.success && params?.user?.user_id) {
+        app.io
+          .to(userRoomName(params.user.user_id))
+          .emit('oauth:disconnected', { mcp_server_id: data.mcp_server_id });
+      }
+
+      return result;
     },
   });
   app.service('mcp-servers/oauth-disconnect').hooks({ before: { create: [ctx.requireAuth] } });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -947,9 +947,28 @@ export function useAgorData(
         return next;
       });
 
-      // Refetch so `server.auth.oauth_access_token` is cleared in mcpServerById
-      // — without this, `mcpServerNeedsAuth` may still see the stale token and
-      // return false.
+      // Optimistically strip the token from the local server object so
+      // `mcpServerNeedsAuth` flips to true immediately. Without this, the
+      // stale `oauth_access_token` in mcpServerById short-circuits the
+      // `userAuthenticatedMcpServerIds` check — and for tokens with no
+      // expiry (e.g. Notion), `isExpired` is always false, so the pill
+      // stays purple forever even though the Set was updated above.
+      setMcpServerById((prev) => {
+        const existing = prev.get(event.mcp_server_id);
+        if (!existing?.auth?.oauth_access_token) return prev;
+        const next = new Map(prev);
+        next.set(event.mcp_server_id, {
+          ...existing,
+          auth: {
+            ...existing.auth,
+            oauth_access_token: undefined,
+            oauth_token_expires_at: undefined,
+          },
+        });
+        return next;
+      });
+
+      // Still refetch to get the canonical server state from the daemon.
       try {
         const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
         setMcpServerById((prev) => {

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -934,6 +934,35 @@ export function useAgorData(
     };
     client.io.on('oauth:completed', handleOAuthCompleted);
 
+    // Mirror of `oauth:completed`: when a user disconnects OAuth from Settings,
+    // the daemon emits `oauth:disconnected` so every tab flips the pill to
+    // "needs auth" immediately instead of staying purple until the next page
+    // reload.
+    const handleOAuthDisconnected = async (event: { mcp_server_id: string }) => {
+      if (!event.mcp_server_id) return;
+      setUserAuthenticatedMcpServerIds((prev) => {
+        if (!prev.has(event.mcp_server_id)) return prev;
+        const next = new Set(prev);
+        next.delete(event.mcp_server_id);
+        return next;
+      });
+
+      // Refetch so `server.auth.oauth_access_token` is cleared in mcpServerById
+      // — without this, `mcpServerNeedsAuth` may still see the stale token and
+      // return false.
+      try {
+        const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
+        setMcpServerById((prev) => {
+          const next = new Map(prev);
+          next.set(fresh.mcp_server_id, fresh);
+          return next;
+        });
+      } catch (err) {
+        console.warn('[OAuth] Failed to refetch MCP server after disconnect:', err);
+      }
+    };
+    client.io.on('oauth:disconnected', handleOAuthDisconnected);
+
     // Re-fetch the global byId maps on every socket reconnect after the
     // initial mount. Feathers real-time events (`created`/`patched`/`removed`)
     // that fired while we were disconnected are gone — the daemon doesn't
@@ -976,6 +1005,7 @@ export function useAgorData(
     // Cleanup listeners on unmount
     return () => {
       client.io.off('oauth:completed', handleOAuthCompleted);
+      client.io.off('oauth:disconnected', handleOAuthDisconnected);
       client.io.off('connect', refetchSilently);
       window.removeEventListener(TOKENS_REFRESHED_EVENT, handleTokensRefreshed);
       sessionsService.removeListener('created', handleSessionCreated);

--- a/apps/agor-ui/src/utils/mcpAuth.test.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { mcpServerNeedsAuth } from './mcpAuth';
+import type { MCPServer } from '@agor-live/client';
+
+/** Helper: build a minimal MCPServer with OAuth auth fields. */
+function makeOAuthServer(
+  overrides: {
+    oauth_access_token?: string;
+    oauth_token_expires_at?: number;
+  } = {}
+): MCPServer {
+  return {
+    mcp_server_id: 'test-server-id',
+    name: 'test',
+    transport: 'http',
+    scope: 'global',
+    enabled: true,
+    source: 'user',
+    created_at: new Date(),
+    updated_at: new Date(),
+    auth: {
+      type: 'oauth',
+      oauth_access_token: overrides.oauth_access_token,
+      oauth_token_expires_at: overrides.oauth_token_expires_at,
+    },
+  } as unknown as MCPServer;
+}
+
+describe('mcpServerNeedsAuth', () => {
+  it('returns false for undefined server', () => {
+    expect(mcpServerNeedsAuth(undefined, new Set())).toBe(false);
+  });
+
+  it('returns false for non-OAuth server', () => {
+    const server = makeOAuthServer();
+    (server.auth as { type: string }).type = 'bearer';
+    expect(mcpServerNeedsAuth(server, new Set())).toBe(false);
+  });
+
+  it('returns false when token present and no expiry', () => {
+    const server = makeOAuthServer({ oauth_access_token: 'tok-123' });
+    expect(mcpServerNeedsAuth(server, new Set())).toBe(false);
+  });
+
+  it('returns false when token present and expiry is in the future', () => {
+    const server = makeOAuthServer({
+      oauth_access_token: 'tok-123',
+      oauth_token_expires_at: Date.now() + 60_000,
+    });
+    expect(mcpServerNeedsAuth(server, new Set())).toBe(false);
+  });
+
+  it('returns true when token present but expired', () => {
+    const server = makeOAuthServer({
+      oauth_access_token: 'tok-123',
+      oauth_token_expires_at: Date.now() - 1000,
+    });
+    expect(mcpServerNeedsAuth(server, new Set())).toBe(true);
+  });
+
+  it('returns false when no token but server is in authenticated Set (no expiry)', () => {
+    const server = makeOAuthServer();
+    const set = new Set(['test-server-id']);
+    expect(mcpServerNeedsAuth(server, set)).toBe(false);
+  });
+
+  it('returns true when no token and server is NOT in Set', () => {
+    const server = makeOAuthServer();
+    expect(mcpServerNeedsAuth(server, new Set())).toBe(true);
+  });
+
+  it('returns true when no token, server in Set, but expiry is in the past', () => {
+    const server = makeOAuthServer({
+      oauth_token_expires_at: Date.now() - 1000,
+    });
+    const set = new Set(['test-server-id']);
+    expect(mcpServerNeedsAuth(server, set)).toBe(true);
+  });
+
+  // This is the bug scenario: after disconnect, token was stripped but the
+  // Set was also updated — both sources agree "needs auth".
+  it('returns true when token is undefined and server removed from Set', () => {
+    const server = makeOAuthServer({ oauth_access_token: undefined });
+    expect(mcpServerNeedsAuth(server, new Set())).toBe(true);
+  });
+});

--- a/apps/agor-ui/src/utils/mcpAuth.test.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.test.ts
@@ -1,13 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { mcpServerNeedsAuth } from './mcpAuth';
 import type { MCPServer } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+
+import { mcpServerNeedsAuth } from './mcpAuth';
 
 /** Helper: build a minimal MCPServer with OAuth auth fields. */
 function makeOAuthServer(
-  overrides: {
-    oauth_access_token?: string;
-    oauth_token_expires_at?: number;
-  } = {}
+  overrides: { oauth_access_token?: string; oauth_token_expires_at?: number } = {}
 ): MCPServer {
   return {
     mcp_server_id: 'test-server-id',

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -10,6 +10,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  __dynamicClientCacheSizeForTests,
+  __seedAuthCodeTokenCacheForTests,
+  __seedDynamicClientCacheForTests,
   clearAuthCodeTokenCache,
   discoverAuthorizationServerFromMcpOrigin,
   discoverResourceMetadataUrl,
@@ -18,9 +21,6 @@ import {
   resolveMCPOAuthDiscovery,
   resolveResourceMetadataUrl,
   startMCPOAuthFlow,
-  __dynamicClientCacheSizeForTests,
-  __seedAuthCodeTokenCacheForTests,
-  __seedDynamicClientCacheForTests,
 } from './oauth-mcp-transport';
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -10,13 +10,93 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  clearAuthCodeTokenCache,
   discoverAuthorizationServerFromMcpOrigin,
   discoverResourceMetadataUrl,
+  getAuthCodeTokenCacheStats,
   isOAuthRequired,
   resolveMCPOAuthDiscovery,
   resolveResourceMetadataUrl,
   startMCPOAuthFlow,
+  __dynamicClientCacheSizeForTests,
+  __seedAuthCodeTokenCacheForTests,
+  __seedDynamicClientCacheForTests,
 } from './oauth-mcp-transport';
+
+// ---------------------------------------------------------------------------
+// clearAuthCodeTokenCache — cache clearing semantics
+// ---------------------------------------------------------------------------
+
+describe('clearAuthCodeTokenCache', () => {
+  beforeEach(() => {
+    // Start each test with a clean slate
+    clearAuthCodeTokenCache();
+  });
+
+  it('blanket clear removes all authCode entries', () => {
+    __seedAuthCodeTokenCacheForTests('https://a.example/.well-known/oauth', {
+      token: 'tok-a',
+      expiresAt: Date.now() + 60_000,
+      fetchedAt: Date.now(),
+    });
+    __seedAuthCodeTokenCacheForTests('https://b.example/.well-known/oauth', {
+      token: 'tok-b',
+      expiresAt: Date.now() + 60_000,
+      fetchedAt: Date.now(),
+    });
+
+    expect(getAuthCodeTokenCacheStats().totalEntries).toBe(2);
+    clearAuthCodeTokenCache();
+    expect(getAuthCodeTokenCacheStats().totalEntries).toBe(0);
+  });
+
+  it('blanket clear also clears the DCR client cache', () => {
+    __seedDynamicClientCacheForTests('https://a.example/register', {
+      client_id: 'client-a',
+      redirect_uri: 'https://agor.dev/callback',
+    });
+    __seedDynamicClientCacheForTests('https://b.example/register', {
+      client_id: 'client-b',
+      redirect_uri: 'https://agor.dev/callback',
+    });
+
+    expect(__dynamicClientCacheSizeForTests()).toBe(2);
+    clearAuthCodeTokenCache();
+    expect(__dynamicClientCacheSizeForTests()).toBe(0);
+  });
+
+  it('per-key clear removes only the specified authCode entry', () => {
+    __seedAuthCodeTokenCacheForTests('https://a.example/.well-known/oauth', {
+      token: 'tok-a',
+      expiresAt: Date.now() + 60_000,
+      fetchedAt: Date.now(),
+    });
+    __seedAuthCodeTokenCacheForTests('https://b.example/.well-known/oauth', {
+      token: 'tok-b',
+      expiresAt: Date.now() + 60_000,
+      fetchedAt: Date.now(),
+    });
+
+    clearAuthCodeTokenCache('https://a.example/.well-known/oauth');
+    expect(getAuthCodeTokenCacheStats().totalEntries).toBe(1);
+  });
+
+  it('per-key clear does NOT clear the DCR client cache', () => {
+    __seedAuthCodeTokenCacheForTests('https://a.example/.well-known/oauth', {
+      token: 'tok-a',
+      expiresAt: Date.now() + 60_000,
+      fetchedAt: Date.now(),
+    });
+    __seedDynamicClientCacheForTests('https://a.example/register', {
+      client_id: 'client-a',
+      redirect_uri: 'https://agor.dev/callback',
+    });
+
+    clearAuthCodeTokenCache('https://a.example/.well-known/oauth');
+    // DCR cache should be untouched on per-key clears
+    expect(__dynamicClientCacheSizeForTests()).toBe(1);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // isOAuthRequired — pure function, no mocking

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -27,6 +27,17 @@ interface CachedAuthCodeToken {
 // Key is the resource metadata URL to avoid cross-tenant leakage
 const authCodeTokenCache = new Map<string, CachedAuthCodeToken>();
 
+/**
+ * Test-only hook: seed the auth-code token cache so tests can verify
+ * clearing behavior without performing a real OAuth flow.
+ */
+export function __seedAuthCodeTokenCacheForTests(
+  metadataUrl: string,
+  entry: { token: string; expiresAt: number; fetchedAt: number }
+): void {
+  authCodeTokenCache.set(metadataUrl, entry);
+}
+
 // In-memory cache TTL fallback when `resolveTokenExpiry` cannot determine an
 // expiry from the token response. This bounds the lifetime of THIS module's
 // `authCodeTokenCache` map only — local-cache hygiene, not a persisted DB
@@ -346,6 +357,26 @@ const dynamicClientCache = new Map<
   string,
   { client_id: string; client_secret?: string; redirect_uri: string }
 >();
+
+/**
+ * Test-only hook: snapshot the DCR client cache size. Used to verify that
+ * `clearAuthCodeTokenCache` clears DCR registrations on blanket clears.
+ * Do NOT call from production code.
+ */
+export function __dynamicClientCacheSizeForTests(): number {
+  return dynamicClientCache.size;
+}
+
+/**
+ * Test-only hook: seed the DCR cache with a fake entry so tests can verify
+ * clearing behavior without performing a real HTTP registration.
+ */
+export function __seedDynamicClientCacheForTests(
+  registrationEndpoint: string,
+  entry: { client_id: string; client_secret?: string; redirect_uri: string }
+): void {
+  dynamicClientCache.set(registrationEndpoint, entry);
+}
 
 /**
  * Perform Dynamic Client Registration (RFC 7591)
@@ -1007,6 +1038,12 @@ export function clearAuthCodeTokenCache(metadataUrl?: string): void {
     authCodeTokenCache.delete(metadataUrl);
   } else {
     authCodeTokenCache.clear();
+    // Also clear the DCR client cache on blanket clears (disconnect flow).
+    // Stale DCR registrations cause "client_id not found" errors on re-auth
+    // when the provider has evicted the registration (e.g. Birdsai).
+    // Only on the blanket path — per-key callers clearing a single authCode
+    // entry should not nuke unrelated DCR registrations.
+    dynamicClientCache.clear();
   }
 }
 


### PR DESCRIPTION
## Summary

- **UI pill stays connected after disconnect** — For tokens without expiry (Notion, Birdsai), the stale `oauth_access_token` in the local `mcpServerById` map short-circuited `mcpServerNeedsAuth` before the `userAuthenticatedMcpServerIds` Set check was reached. Now optimistically strips the token synchronously on `oauth:disconnected`.

- **Re-auth fails with "client_id not found"** — `clearAuthCodeTokenCache()` only cleared `authCodeTokenCache` but not `dynamicClientCache` (DCR client registrations). After disconnect, the stale DCR `client_id` was reused and rejected by providers like Birdsai. Now clears `dynamicClientCache` on blanket clears (per-key clears left untouched).

## Test plan

- [ ] `pnpm -C packages/core test -- --run oauth-mcp-transport.test` — 4 new tests for cache-clearing semantics
- [ ] `pnpm -C apps/agor-ui test -- --run mcpAuth.test` — 8 new tests for `mcpServerNeedsAuth` branch coverage
- [ ] Manual: Disconnect Birdsai OAuth → pill turns orange immediately → re-auth succeeds with fresh DCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)