### PR TITLE
fix(daemon): strip accept-encoding so proxy doesn't double-handle gzip

### DIFF
--- a/apps/agor-daemon/src/setup/proxies.ts
+++ b/apps/agor-daemon/src/setup/proxies.ts
@@ -55,8 +55,22 @@ const UPSTREAM_TIMEOUT_MS = 30_000;
  * - `cookie`: Agor auth cookies must not leak to third parties.
  * - `host`: must reflect the upstream, not the daemon.
  * - `connection`, `content-length`: hop-by-hop / recomputed by `fetch`.
+ * - `accept-encoding`: Node's undici fetch transparently decompresses gzip/br,
+ *   so we always receive raw bytes from upstream regardless of what we ask
+ *   for. Forwarding the browser's `accept-encoding: gzip, br` causes upstream
+ *   to compress, undici to silently decompress, and us to relay the
+ *   decompressed bytes — but the upstream `content-encoding: gzip` header
+ *   leaks through to the caller, who then tries to gunzip raw JSON and hangs
+ *   the body stream forever. Asking upstream for `identity` sidesteps the
+ *   whole double-handling problem.
  */
-const REQUEST_HEADER_STRIP = new Set(['cookie', 'host', 'connection', 'content-length']);
+const REQUEST_HEADER_STRIP = new Set([
+  'cookie',
+  'host',
+  'connection',
+  'content-length',
+  'accept-encoding',
+]);
 
 /**
  * Headers stripped from the upstream response before relaying to the caller.
@@ -64,12 +78,18 @@ const REQUEST_HEADER_STRIP = new Set(['cookie', 'host', 'connection', 'content-l
  * - `set-cookie`: never let upstream set cookies on the daemon's domain.
  * - `transfer-encoding`, `connection`: hop-by-hop.
  * - `content-length`: we may truncate or re-encode and don't want a stale value.
+ * - `content-encoding`: defense-in-depth pair to the `accept-encoding` strip
+ *   above. Even if upstream ignores `accept-encoding: identity` and sends
+ *   compressed bytes, undici has already decompressed them by the time we
+ *   read `body` — so the original `content-encoding` value is a lie that
+ *   makes browsers fail to decode the relayed body.
  */
 const RESPONSE_HEADER_STRIP = new Set([
   'set-cookie',
   'transfer-encoding',
   'connection',
   'content-length',
+  'content-encoding',
 ]);
 
 interface AuthedUser {
@@ -304,6 +324,11 @@ export function registerProxies(
         upstreamHeaders[lower] = value;
       }
     }
+    // Force `identity` so upstream sends uncompressed bytes. undici defaults
+    // to `gzip, br` if not specified, and silently decompresses — leaving us
+    // serving raw bytes under a stale `content-encoding: gzip` header that
+    // hangs the browser's body decoder. See the comment on REQUEST_HEADER_STRIP.
+    upstreamHeaders['accept-encoding'] = 'identity';
 
     const hasBody = method !== 'GET' && method !== 'HEAD';
     const upstreamUrl = buildUpstreamUrl(proxy.upstream, tail);


### PR DESCRIPTION
## Summary

The artifact HTTP proxy (`/proxies/<vendor>/...`) was hanging on any upstream response large enough that the upstream gzipped it.

**Root cause**: Node's undici `fetch()` transparently decompresses `Content-Encoding: gzip|br` responses. The proxy was forwarding the (already-decompressed) bytes to the browser BUT also forwarding the upstream `content-encoding: gzip` header. The browser then tried to gunzip raw JSON and stalled the body decoder forever — observable as `200 OK` headers arriving fine, but `await r.text()` never resolving.

**Empirical hit**: Building a Shortcut artifact POC (`What's on your plate`). `/member` round-tripped fine (~426 B, sent uncompressed). `/workflows` and `/search/stories` both hung at body-read regardless of `page_size`. Same pathology would hit Linear, Jira, GitHub, and basically any vendor whose API supports gzip.

## Fix

Two layers, deliberately redundant:

1. **Strip `accept-encoding` from the inbound request and force `accept-encoding: identity` on outbound.** Upstream sends raw bytes in the first place — no decompression needed.
2. **Strip `content-encoding` from the relayed response.** Defense-in-depth: even if upstream ignores `identity` and ships compressed bytes, undici will have decompressed them by the time we read `body`, so the original `content-encoding` value is a lie.

Both comments in the source explain the reasoning.

## Test plan

- [x] Local `pnpm typecheck` clean (pre-commit hook)
- [ ] Deploy to sandbox and verify the Shortcut POC artifact (`019dfb34-5166-7070-a88b-662a42ad094d`) renders stories
- [ ] Re-confirm `/member` (small) still works post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)