### PR TITLE
fix: add daemon port to CORS allowed origins

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -531,6 +531,7 @@ async function main() {
   // Configure CORS based on deployment environment (extracted to setup/cors.ts)
   const { origin: corsOrigin } = buildCorsConfig({
     uiPort: UI_PORT,
+    daemonPort: DAEMON_PORT,
     isCodespaces: process.env.CODESPACES === 'true',
     corsOriginOverride: process.env.CORS_ORIGIN,
   });

--- a/apps/agor-daemon/src/setup/cors.ts
+++ b/apps/agor-daemon/src/setup/cors.ts
@@ -16,6 +16,8 @@ export type CorsOrigin =
 export interface CorsConfigOptions {
   /** UI port for localhost origins */
   uiPort: number;
+  /** Daemon port (UI may be served from here too) */
+  daemonPort: number;
   /** Whether running in GitHub Codespaces */
   isCodespaces: boolean;
   /** Explicit CORS_ORIGIN environment variable override */
@@ -41,10 +43,11 @@ export interface CorsConfigResult {
  * @returns CORS origin configuration ready for express cors middleware
  */
 export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
-  const { uiPort, isCodespaces, corsOriginOverride } = options;
+  const { uiPort, daemonPort, isCodespaces, corsOriginOverride } = options;
 
-  // Support UI port and 3 additional ports (for parallel dev servers)
+  // Support UI port, daemon port (serves UI in production), and 3 additional ports (for parallel dev servers)
   const localhostOrigins = [
+    `http://localhost:${daemonPort}`,
     `http://localhost:${uiPort}`,
     `http://localhost:${uiPort + 1}`,
     `http://localhost:${uiPort + 2}`,

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Multiplayer canvas for orchestrating AI coding sessions",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- When `agor-live` is installed via npm, the UI is served by the daemon at `http://localhost:3030/ui/`, but CORS only allowed the dev UI port (5173), causing all requests to fail with 500
- Added the daemon's own port to the CORS allowed origins list so the UI works in both dev mode (Vite on 5173) and production mode (served by daemon)
- Bumps agor-live to 0.13.1

## Test plan
- [ ] Install `agor-live` via npm, run `agor daemon start`, access UI in browser — no CORS errors
- [ ] Dev mode (`pnpm dev` with separate UI server) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)