### PR TITLE
fix(agor-live): 0.17.4 — repair WS reconnect + add publish smoke-test CI

### DIFF
--- a/.github/workflows/agor-live-smoke.yml
+++ b/.github/workflows/agor-live-smoke.yml
@@ -1,0 +1,201 @@
+# Smoke-test the agor-live npm publish artifact.
+#
+# Purpose: catch broken releases (e.g. 0.17.1's `workspace:*` leak, or
+# 0.17.3's blank-page/500) BEFORE they ship to npm.
+#
+# Strategy:
+#   1. Build the package the same way `./build.sh` does (no --publish).
+#   2. `pnpm pack` (this resolves `workspace:*` refs the same way `pnpm publish`
+#      does — so the tarball matches what would actually get pushed to npm).
+#   3. Defense-in-depth grep: assert the packed manifest has no `workspace:*`
+#      strings. This is the single check that would have caught the 0.17.1
+#      regression even if someone bypassed `pnpm publish` and used `npm publish`.
+#   4. Install the tarball into a clean project with plain `npm install`.
+#   5. Run migrations, boot the daemon (background → NODE_ENV=production), and
+#      curl `/health`, `/ui/`, and a JS asset. Assert real HTML + a non-trivial
+#      JS bundle come back.
+#
+# This is the minimum viable "does the published artifact even start?" check.
+# A tag-triggered auto-publish workflow can build on top of this later (see
+# the PR description for the spec).
+
+name: agor-live publish smoke-test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/agor-live/**'
+      - 'packages/client/**'
+      - 'packages/core/**'
+      - 'packages/executor/**'
+      - 'apps/agor-daemon/**'
+      - 'apps/agor-cli/**'
+      - 'apps/agor-ui/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/agor-live-smoke.yml'
+  workflow_dispatch:
+
+env:
+  PNPM_VERSION: '9.15.1'
+  NODE_VERSION: '22'
+
+jobs:
+  smoke:
+    name: Pack + boot + curl
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      # Build dist/ in packages/agor-live the same way `./build.sh` does
+      # (no --publish, no --bump). This stages cli/core/daemon/executor/ui
+      # under packages/agor-live/dist.
+      - name: Build agor-live
+        run: |
+          cd packages/agor-live
+          ./build.sh --skip-install
+        env:
+          # Match build.sh's heap ceiling so DTS / vite bundle steps don't OOM.
+          NODE_OPTIONS: --max-old-space-size=4096
+
+      # Use `pnpm pack` (not `npm pack`) so workspace:* refs are rewritten
+      # to concrete semver — same transform `pnpm publish` does.
+      - name: Pack tarball
+        id: pack
+        run: |
+          set -euo pipefail
+          cd packages/agor-live
+          pnpm pack --pack-destination "$RUNNER_TEMP" 2>&1 | tee pack.log
+          TARBALL=$(ls "$RUNNER_TEMP"/agor-live-*.tgz | head -1)
+          if [ -z "$TARBALL" ]; then
+            echo "::error::pnpm pack produced no tarball"
+            exit 1
+          fi
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          echo "Packed: $TARBALL"
+
+      # The single grep that would have caught agor-live@0.17.1.
+      # If this ever fails, someone packed/published with a tool that
+      # doesn't rewrite `workspace:` (e.g. plain `npm publish`).
+      - name: Assert no workspace:* refs in packed manifest
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/inspect"
+          tar -xzf "${{ steps.pack.outputs.tarball }}" -C "$RUNNER_TEMP/inspect"
+          MANIFEST="$RUNNER_TEMP/inspect/package/package.json"
+          echo "=== Packed manifest deps ==="
+          node -e "const p=require('$MANIFEST'); console.log(JSON.stringify({d:p.dependencies,pd:p.peerDependencies,od:p.optionalDependencies},null,2))"
+          if grep -nE '"workspace:' "$MANIFEST"; then
+            echo "::error::workspace:* leaked into the published manifest. \
+              The tarball would break `npm install agor-live` once published. \
+              Use `pnpm publish` (not `npm publish`) — see packages/agor-live/build.sh."
+            exit 1
+          fi
+          echo "✓ No workspace:* refs in packed manifest"
+
+      - name: Install tarball in a clean project
+        id: install
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/smoke-install"
+          cd "$RUNNER_TEMP/smoke-install"
+          npm init -y >/dev/null
+          npm install --no-fund --no-audit "${{ steps.pack.outputs.tarball }}"
+          echo "=== Installed dist/ ==="
+          ls node_modules/agor-live/dist
+          echo "=== Postinstall artifact (@agor/core symlink) ==="
+          ls -la node_modules/agor-live/node_modules/@agor/core
+          # Confirm the UI bundle index.html is present and references a JS asset.
+          if [ ! -f node_modules/agor-live/dist/ui/index.html ]; then
+            echo "::error::dist/ui/index.html missing from installed package"
+            exit 1
+          fi
+
+      - name: Boot daemon and curl /ui/
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/smoke-home"
+          mkdir -p "$HOME/.agor"
+          cat > "$HOME/.agor/config.yaml" <<'EOF'
+          daemon:
+            port: 3030
+          EOF
+          BIN="$RUNNER_TEMP/smoke-install/node_modules/agor-live/bin"
+          cd "$RUNNER_TEMP/smoke-install"
+
+          # `agor db migrate` prompts "press any key to continue" — feed it a newline.
+          echo "" | node "$BIN/agor.js" db migrate
+
+          # Background start sets NODE_ENV=production (see dist/cli/commands/daemon/start.js).
+          node "$BIN/agor.js" daemon start
+
+          # Wait for /health (max 45s).
+          for i in $(seq 1 45); do
+            if curl -fsS -o /dev/null http://localhost:3030/health; then
+              echo "daemon ready after ${i}s"
+              break
+            fi
+            if [ "$i" = "45" ]; then
+              echo "::error::daemon never became healthy"
+              tail -200 "$HOME/.agor/logs/daemon.log" || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # /ui/ should serve the SPA shell.
+          echo "=== GET /ui/ ==="
+          curl -fsS -o /tmp/ui.html -w "HTTP=%{http_code} bytes=%{size_download} ctype=%{content_type}\n" \
+            http://localhost:3030/ui/
+          if ! grep -q '<div id="root">' /tmp/ui.html; then
+            echo "::error::/ui/ response is missing <div id=\"root\"> — UI shell not being served"
+            head -80 /tmp/ui.html
+            tail -200 "$HOME/.agor/logs/daemon.log" || true
+            exit 1
+          fi
+          if ! grep -qE '/ui/assets/index-[A-Za-z0-9_-]+\.js' /tmp/ui.html; then
+            echo "::error::/ui/ response is missing a JS asset reference — index.html not stamped"
+            head -80 /tmp/ui.html
+            exit 1
+          fi
+
+          # Actually fetch the JS asset to confirm static-file serving works end-to-end.
+          ASSET_PATH=$(grep -oE '/ui/assets/index-[A-Za-z0-9_-]+\.js' /tmp/ui.html | head -1)
+          echo "=== GET $ASSET_PATH ==="
+          SIZE=$(curl -fsS -o /dev/null -w "%{size_download}" "http://localhost:3030$ASSET_PATH")
+          echo "JS asset size: $SIZE bytes"
+          # The UI bundle is multi-MB. <100KB means we're getting an error page or empty body.
+          if [ "$SIZE" -lt 100000 ]; then
+            echo "::error::/ui/ JS asset is suspiciously small (${SIZE} bytes) — static serving broken"
+            exit 1
+          fi
+          echo "✓ Smoke test passed"
+
+      - name: Stop daemon
+        if: always()
+        run: |
+          export HOME="$RUNNER_TEMP/smoke-home"
+          BIN="$RUNNER_TEMP/smoke-install/node_modules/agor-live/bin"
+          if [ -d "$BIN" ]; then
+            node "$BIN/agor.js" daemon stop || true
+          fi
+
+      - name: Upload daemon log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daemon-log
+          path: ${{ runner.temp }}/smoke-home/.agor/logs/
+          if-no-files-found: warn

--- a/.github/workflows/agor-live-smoke.yml
+++ b/.github/workflows/agor-live-smoke.yml
@@ -72,19 +72,31 @@ jobs:
 
       # Use `pnpm pack` (not `npm pack`) so workspace:* refs are rewritten
       # to concrete semver — same transform `pnpm publish` does.
-      - name: Pack tarball
+      #
+      # We pack BOTH agor-live and its sibling @agor-live/client. agor-live's
+      # manifest declares "@agor-live/client": "<exact version>", and that
+      # version doesn't exist on the npm registry yet (the whole point of
+      # this smoke test is to validate before publishing). Installing both
+      # tarballs in a single `npm install` lets npm satisfy the sibling
+      # dep locally — zero registry hits.
+      - name: Pack tarballs (agor-live + @agor-live/client)
         id: pack
         run: |
           set -euo pipefail
-          cd packages/agor-live
-          pnpm pack --pack-destination "$RUNNER_TEMP" 2>&1 | tee pack.log
-          TARBALL=$(ls "$RUNNER_TEMP"/agor-live-*.tgz | head -1)
-          if [ -z "$TARBALL" ]; then
-            echo "::error::pnpm pack produced no tarball"
+          pnpm pack -C packages/client    --pack-destination "$RUNNER_TEMP"
+          pnpm pack -C packages/agor-live --pack-destination "$RUNNER_TEMP"
+          CLIENT=$(ls "$RUNNER_TEMP"/agor-live-client-*.tgz | head -1)
+          LIVE=$(ls "$RUNNER_TEMP"/agor-live-[0-9]*.tgz | head -1)
+          if [ -z "$CLIENT" ] || [ -z "$LIVE" ]; then
+            echo "::error::pnpm pack produced incomplete tarballs"
+            ls "$RUNNER_TEMP"
             exit 1
           fi
-          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
-          echo "Packed: $TARBALL"
+          echo "client=$CLIENT" >> "$GITHUB_OUTPUT"
+          echo "live=$LIVE" >> "$GITHUB_OUTPUT"
+          echo "Packed:"
+          echo "  client: $CLIENT"
+          echo "  live:   $LIVE"
 
       # The single grep that would have caught agor-live@0.17.1.
       # If this ever fails, someone packed/published with a tool that
@@ -93,7 +105,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/inspect"
-          tar -xzf "${{ steps.pack.outputs.tarball }}" -C "$RUNNER_TEMP/inspect"
+          tar -xzf "${{ steps.pack.outputs.live }}" -C "$RUNNER_TEMP/inspect"
           MANIFEST="$RUNNER_TEMP/inspect/package/package.json"
           echo "=== Packed manifest deps ==="
           node -e "const p=require('$MANIFEST'); console.log(JSON.stringify({d:p.dependencies,pd:p.peerDependencies,od:p.optionalDependencies},null,2))"
@@ -105,14 +117,19 @@ jobs:
           fi
           echo "✓ No workspace:* refs in packed manifest"
 
-      - name: Install tarball in a clean project
+      # Install BOTH tarballs together. List the client first so npm registers
+      # it before resolving agor-live's "@agor-live/client" dep — guarantees
+      # the local file: source wins over the (non-existent) registry version.
+      - name: Install tarballs in a clean project
         id: install
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/smoke-install"
           cd "$RUNNER_TEMP/smoke-install"
           npm init -y >/dev/null
-          npm install --no-fund --no-audit "${{ steps.pack.outputs.tarball }}"
+          npm install --no-fund --no-audit \
+            "${{ steps.pack.outputs.client }}" \
+            "${{ steps.pack.outputs.live }}"
           echo "=== Installed dist/ ==="
           ls node_modules/agor-live/dist
           echo "=== Postinstall artifact (@agor/core symlink) ==="

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -281,6 +281,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     extraOptions: corsExtraOptions,
   } = buildCorsConfig({
     uiPort: UI_PORT,
+    daemonPort: DAEMON_PORT,
     isCodespaces: process.env.CODESPACES === 'true',
     resolved: resolvedSecurity.cors,
   });

--- a/apps/agor-daemon/src/setup/cors.test.ts
+++ b/apps/agor-daemon/src/setup/cors.test.ts
@@ -26,6 +26,7 @@ describe('buildCorsConfig', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({}, { corsOriginEnv: '*' }),
     });
@@ -43,6 +44,7 @@ describe('buildCorsConfig', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({ security: { cors: { mode: 'wildcard', credentials: false } } }),
     });
@@ -57,6 +59,7 @@ describe('buildCorsConfig', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({ security: { cors: { mode: 'reflect', credentials: false } } }),
     });
@@ -68,6 +71,7 @@ describe('buildCorsConfig', () => {
   it('only allows the configured UI port range on localhost', () => {
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve(),
     });
@@ -78,9 +82,32 @@ describe('buildCorsConfig', () => {
     expect(result.isAllowedOrigin('http://localhost:80')).toBe(false);
   });
 
+  // Regression: 0.17.3 npm-installed users got "Reconnecting to daemon" with
+  // a WS connection failure because the daemon serves the UI from its own
+  // port (3030) but only 5173-5176 were in the allow-list. PR #1106.
+  it('allows the daemon port itself on localhost (UI served from daemon origin)', () => {
+    const result = buildCorsConfig({
+      uiPort: 5173,
+      daemonPort: 3030,
+      isCodespaces: false,
+      resolved: resolve(),
+    });
+    expect(result.isAllowedOrigin('http://localhost:3030')).toBe(true);
+    // Honour a non-default daemon port too — operators routinely rebind.
+    const custom = buildCorsConfig({
+      uiPort: 5173,
+      daemonPort: 4040,
+      isCodespaces: false,
+      resolved: resolve(),
+    });
+    expect(custom.isAllowedOrigin('http://localhost:4040')).toBe(true);
+    expect(custom.isAllowedOrigin('http://localhost:3030')).toBe(false);
+  });
+
   it('treats Sandpack origins as accepted but not "allowed" for credentials', () => {
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({ security: { cors: { allow_sandpack: true } } }),
     });
@@ -93,6 +120,7 @@ describe('buildCorsConfig', () => {
   it('honours security.cors.origins with exact strings and regex patterns', () => {
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({
         security: {
@@ -110,6 +138,7 @@ describe('buildCorsConfig', () => {
   it('passes methods/allowedHeaders/maxAge through to cors() extraOptions', () => {
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({
         security: {
@@ -130,6 +159,7 @@ describe('buildCorsConfig', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = buildCorsConfig({
       uiPort: 5173,
+      daemonPort: 3030,
       isCodespaces: false,
       resolved: resolve({ security: { cors: { mode: 'null-origin' } } }),
     });

--- a/apps/agor-daemon/src/setup/cors.ts
+++ b/apps/agor-daemon/src/setup/cors.ts
@@ -29,8 +29,16 @@ import type { CorsOptions } from 'cors';
 export type CorsOrigin = CorsOptions['origin'];
 
 export interface CorsConfigOptions {
-  /** UI port for localhost origins */
+  /** UI port for localhost origins (Vite dev server) */
   uiPort: number;
+  /**
+   * Daemon port. Must be in the localhost allow-list because in npm-installed
+   * deployments the daemon serves the UI from its own origin (e.g.
+   * `http://localhost:3030/ui/`), so same-origin XHR / Socket.io requests
+   * carry `Origin: http://localhost:<daemonPort>` and would otherwise be
+   * rejected by the cors() callback. Bug surfaced in 0.17.3 — see PR #1106.
+   */
+  daemonPort: number;
   /** Whether running in GitHub Codespaces */
   isCodespaces: boolean;
   /** Resolved CORS config (from `@agor/core/config` `resolveSecurity()`). */
@@ -106,10 +114,13 @@ function parseRegexPattern(entry: string): RegExp | null {
  * PNA, credential stripping, etc.
  */
 export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
-  const { uiPort, isCodespaces, resolved } = options;
+  const { uiPort, daemonPort, isCodespaces, resolved } = options;
 
-  // Support UI port and 3 additional ports (for parallel dev servers)
+  // Localhost allow-list:
+  //   - daemon port (npm-installed mode serves the UI from the daemon origin)
+  //   - UI port + 3 successors (Vite + parallel dev servers)
   const localhostOrigins = [
+    `http://localhost:${daemonPort}`,
     `http://localhost:${uiPort}`,
     `http://localhost:${uiPort + 1}`,
     `http://localhost:${uiPort + 2}`,
@@ -166,11 +177,11 @@ export function buildCorsConfig(options: CorsConfigOptions): CorsConfigResult {
   const exactOrigins = new Set(localhostOrigins);
   const patterns: RegExp[] = [];
 
-  // Tightened localhost regex: only the configured UI port range, not "any port".
-  // We accept both http and https for localhost so that operators terminating
-  // TLS in front of a local UI dev server still work.
-  const uiPortRange = [uiPort, uiPort + 1, uiPort + 2, uiPort + 3].join('|');
-  patterns.push(new RegExp(`^https?:\\/\\/localhost:(${uiPortRange})$`));
+  // Tightened localhost regex: only the daemon port + configured UI port range,
+  // not "any port". We accept both http and https for localhost so that
+  // operators terminating TLS in front of a local UI dev server still work.
+  const localhostPortRange = [daemonPort, uiPort, uiPort + 1, uiPort + 2, uiPort + 3].join('|');
+  patterns.push(new RegExp(`^https?:\\/\\/localhost:(${localhostPortRange})$`));
 
   // Sandpack/CodeSandbox bundler (on by default, configurable).
   if (resolved.allowSandpack) {

--- a/packages/agor-live/build.sh
+++ b/packages/agor-live/build.sh
@@ -131,37 +131,26 @@ rm -rf "$CLIENT_DIR/dist"
 mkdir -p "$DIST_STAGE"
 
 # ── Build all components ─────────────────────────────────────────────────────
+#
+# Use turbo to build everything in workspace-dependency order. turbo.json
+# declares `"dependsOn": ["^build"]`, so e.g. @agor/cli (which imports types
+# from @agor/daemon) waits for daemon's dist/index.d.ts before its own DTS
+# step runs. Hand-ordering this sequence is fragile — every time someone
+# adds a new cross-package import the wrong order silently passes locally
+# (because of stale dist/) and explodes on a clean CI checkout.
+#
+# Excludes @agor/docs (Nextra docs site, not part of the published artifact).
+# NODE_ENV=production matters for the UI's vite build; harmless for the rest.
 
 echo ""
-echo "📦 Building @agor/core..."
-cd "$REPO_ROOT/packages/core"
-pnpm build
+echo "📦 Building all workspace packages (turbo, dep-ordered)..."
+cd "$REPO_ROOT"
+NODE_ENV=production pnpm exec turbo run build --filter='!@agor/docs'
 
 echo ""
-echo "📦 Building @agor-live/client..."
+echo "🔍 Verifying @agor-live/client pack..."
 cd "$CLIENT_DIR"
-pnpm build
 pnpm check:pack
-
-echo ""
-echo "🖥️  Building CLI..."
-cd "$REPO_ROOT/apps/agor-cli"
-pnpm build
-
-echo ""
-echo "⚙️  Building Daemon..."
-cd "$REPO_ROOT/apps/agor-daemon"
-pnpm build
-
-echo ""
-echo "🔧 Building Executor..."
-cd "$REPO_ROOT/packages/executor"
-pnpm build
-
-echo ""
-echo "🎨 Building UI..."
-cd "$REPO_ROOT/apps/agor-ui"
-NODE_ENV=production pnpm build
 
 # ── Build self-hosted Sandpack bundler (optional) ────────────────────────────
 

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- **Fix:** agor-live 0.17.3 served the UI from the daemon's own origin (`http://localhost:3030/ui/`) but the daemon's CORS allow-list only included UI dev-server ports — so the browser's Socket.IO client got rejected and the UI hung on "Reconnecting to daemon...". Plumb `daemonPort` into `buildCorsConfig` and add it to the localhost allow-list. (Adapted from #1106, which had merge conflicts against the post-#1027 `cors.ts` shape.)
- **Bump:** `packages/agor-live` and `packages/client` 0.17.3 → 0.17.4
- **CI:** New `agor-live-smoke.yml` workflow that builds, `pnpm pack`s, installs the tarball into a clean dir, boots the daemon, and asserts `/ui/` returns real HTML + a sizeable JS bundle. Designed to catch:
  - `workspace:*` leaks (the 0.17.1 regression)
  - WS/CORS regressions that leave the UI blank (this one)
  - Anything else that breaks the published install path

## Why two-commit split

1. `fix(daemon): allow daemon port in CORS localhost allow-list (agor-live 0.17.4)` — actual user-visible fix + version bump
2. `ci: publish smoke-test for agor-live releases` — independent guardrail

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm check` (typecheck + lint + build) green
- [x] `pnpm vitest run apps/agor-daemon/src/setup/cors.test.ts` — 11/11 pass, including new regression test that asserts `localhost:3030` is allowed when `daemonPort=3030` and `localhost:4040` is allowed when `daemonPort=4040` (custom port)
- [ ] CI smoke-test workflow runs against this PR (workflow only triggers when agor-live deps change — may need manual `workflow_dispatch` to validate)
- [ ] Manual: `cd packages/agor-live && ./build.sh` produces a tarball; `npm i agor-live-0.17.4.tgz` in a clean dir; `agor daemon start`; load `/ui/` and confirm Socket.IO connects (no "Reconnecting to daemon...")
- [ ] After merge: `cd packages/agor-live && ./build.sh` to publish 0.17.4 to npm

## Notes

- Original PR #1106 author identified the bug; this PR re-implements the fix on top of the current `cors.ts` shape (which now takes `resolved: ResolvedCors`).
- Smoke-test workflow does NOT run `npm publish` — strictly a pre-flight check on the packed tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)