### PR TITLE
fix(ui): show permission mode label in session settings (formalize compact prop)

### DIFF
--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -22,6 +22,14 @@ export interface PermissionModeSelectorProps {
   agentic_tool?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
   /** If true, renders as a compact Select dropdown instead of Radio buttons */
   compact?: boolean;
+  /**
+   * When in Select (compact) mode, render only the icon in the trigger.
+   * Defaults to `false` — trigger shows icon + label so users in roomy
+   * contexts (e.g. session settings dropdown) can read the mode name.
+   * Set `true` for tight surfaces like the conversation footer where
+   * only the icon fits. The tooltip preserves the label either way.
+   */
+  iconOnly?: boolean;
   /** Size for compact mode */
   size?: 'small' | 'middle' | 'large';
   /** Codex-specific: sandbox mode value */
@@ -248,6 +256,7 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
   onChange,
   agentic_tool = 'claude-code',
   compact = false,
+  iconOnly = false,
   size = 'middle',
   codexSandboxMode = 'workspace-write',
   codexApprovalPolicy = 'on-request',
@@ -329,7 +338,14 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
           popupMatchSelectWidth={false}
           optionLabelProp="label"
           options={modes.map(({ mode, label, description, icon, color }) => ({
-            label: <span style={{ color, fontSize: token.fontSizeSM }}>{icon}</span>,
+            label: iconOnly ? (
+              <span style={{ color, fontSize: token.fontSizeSM }}>{icon}</span>
+            ) : (
+              <Space size={4} style={{ fontSize: token.fontSizeSM }}>
+                <span style={{ color }}>{icon}</span>
+                <span>{label}</span>
+              </Space>
+            ),
             value: mode,
             title: description,
             icon,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -868,6 +868,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               codexApprovalPolicy={codexApprovalPolicy}
               onCodexChange={handleCodexPermissionChange}
               compact
+              iconOnly
               size="small"
             />
             {isRunning && <Spin size="small" />}


### PR DESCRIPTION
## Summary

The `PermissionModeSelector`'s Select-mode trigger was icon-only in every context because the conversation footer's tight space drove the visual style. Result: the field in Session Settings (where there's plenty of room) looked like a bare icon — confusing.

This PR formalizes the distinction with a new `iconOnly?: boolean` prop (default `false`) layered on top of the existing `compact` prop:

- **Conversation footer** (`SessionPanel`) opts in with `iconOnly` — unchanged icon-only look.
- **Session Settings dropdown** (`AgenticToolConfigForm` compact path → `SessionSettingsModal`) inherits the default — trigger now shows icon + label.

### Why a new prop instead of repurposing `compact`

`compact` on this component already means "render as Select dropdown vs. Radio.Group" — flipping its semantics would have broken `NewSessionModal`, `ForkSpawnModal`, `ScheduleTab`, `ZoneTriggerModal`, and the SettingsModal forms that rely on the Radio rendering. `iconOnly` cleanly layers the new dimension on top, scoped to the Select trigger.

## Files touched

- `apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx` — added `iconOnly?: boolean` prop, branched the Select trigger label to render icon + text by default and just the icon when `iconOnly` is set.
- `apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx` — passed `iconOnly` at the conversation footer call site to preserve the icon-only look.

## Accessibility note

The `Tooltip` wrapping the Select still surfaces `${label} — ${description}` as the hover/focus title in both modes. Screen readers and keyboard users get the mode name even in `iconOnly` mode — unchanged from before. The dropdown's option panel (when open) still renders icon + label + description per option in both modes; only the trigger varies.

## Test plan

- [ ] Boot the worktree's docker dev env.
- [ ] Conversation footer: still icon-only, looks unchanged. Tooltip on hover/focus shows the mode name.
- [ ] Session Settings dropdown (Permission Mode field): now shows icon + label in the trigger.
- [ ] Open the dropdown in both contexts — option panel still shows icon + label + description per row.
- [ ] Capture before/after screenshots and attach to this PR.
- [ ] Flip from draft → ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)