### PR TITLE
docs(mcp): expand agor_proxies_list with two-token model, caps, and error envelope

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/proxies.ts
+++ b/apps/agor-daemon/src/mcp/tools/proxies.ts
@@ -47,17 +47,77 @@ export function registerProxyTools(server: McpServer, _ctx: McpContext): void {
     {
       description: `List HTTP proxies the daemon is configured to expose for third-party APIs.
 
-Each proxy forwards requests from /proxies/<vendor>/X to <upstream>/X. They exist so Sandpack artifacts can call APIs (Shortcut, Linear, Jira, etc.) that don't return CORS headers.
+Each proxy forwards requests from /proxies/<vendor>/X to <upstream>/X so Sandpack artifacts (which run in *.codesandbox.io iframes) can call APIs that don't return CORS headers — Shortcut, Linear, Jira, GitHub Enterprise, etc.
 
-Use the returned 'url' as the base URL in your artifact. Auth headers are YOUR responsibility — set them in agor.config.js using {{ user.env.X }} and forward them on every request. The daemon does not inject auth.
+# Two-token model (read this carefully)
 
-Example artifact usage:
+EVERY request to a proxy needs TWO credentials, in the same headers object:
+
+  1. Authorization: Bearer <agor.token>     ← daemon JWT, protects the proxy from being an open relay
+  2. <Vendor's auth header>                  ← whatever the upstream API actually wants
+
+Both render via Handlebars in /agor.config.js — the daemon mints {{ agor.token }} per-user at view time (15-min TTL). Vendor secrets come from {{ user.env.NAME }} (configured by the user in Settings → Environment Variables).
+
+# Canonical example
+
   // /agor.config.js
-  export const shortcut = "{{ agor.proxies.shortcut.url }}";
-  export const token = "{{ user.env.SHORTCUT_TOKEN }}";
+  export const shortcutUrl = "{{ agor.proxies.shortcut.url }}";
+  export const agorToken   = "{{ agor.token }}";
+  export const scToken     = "{{ user.env.SHORTCUT_API_TOKEN }}";
 
   // App.js
-  fetch(shortcut + "/api/v3/projects", { headers: { 'Shortcut-Token': token } })`,
+  import { shortcutUrl, agorToken, scToken } from "./agor.config.js";
+
+  if (!scToken) {
+    // Render a "configure SHORTCUT_API_TOKEN in Settings" prompt — missing
+    // env vars render as empty string, not undefined.
+    return <ConfigurePrompt name="SHORTCUT_API_TOKEN" />;
+  }
+
+  const r = await fetch(\`\${shortcutUrl}/api/v3/member\`, {
+    headers: {
+      Authorization: \`Bearer \${agorToken}\`,
+      "Shortcut-Token": scToken,
+    },
+  });
+
+# Operational caps your code must respect
+
+  - Response body cap: 5 MB. Endpoints that can return more (e.g. Shortcut /workflows, big search results) must use vendor pagination — the proxy will not page for you. Past the cap the connection is closed mid-stream and the browser sees a truncated body.
+  - Upstream timeout: 30 s. Slow endpoints return HTTP 502 {error:"upstream_error"}.
+  - Rate limit: 600 req/min per (user, vendor). Bursts past this return HTTP 429 {error:"rate_limited"} with no queueing.
+  - Methods: 'allowed_methods' on each descriptor is authoritative. Default is read-only [GET]. Other methods require operator yaml config; calling them otherwise yields HTTP 405 {error:"method_not_allowed", allowed:[...]}.
+
+# Error envelope to handle in fetch wrappers
+
+  401 {error:"unauthorized"}          ← missing/expired agor.token (refresh by reloading the artifact)
+  404 {error:"unknown_vendor"}        ← vendor not configured on this daemon
+  405 {error:"method_not_allowed"}    ← method not in allowed_methods
+  413 {error:"request_too_large"}     ← request body > 5 MB
+  429 {error:"rate_limited"}
+  502 {error:"upstream_error"}        ← upstream timeout / network failure
+  502 {error:"upstream_too_large"}    ← upstream Content-Length > 5 MB
+
+Always check r.ok before JSON.parse, and surface the error JSON to the user — opaque "failed to fetch" hangs are usually one of the above.
+
+# What the proxy does NOT do
+
+  - No auth injection: the daemon does not read {{ user.env.X }} for you and does not add vendor headers. You forward them yourself on every request.
+  - No transformation: bytes pass through unchanged. No JSON re-encoding, no schema validation.
+  - No caching, no retries.
+  - No 'pageThrough' helper for pagination.
+
+# Cookies & headers
+
+  - Outbound: cookie / host / connection / content-length / accept-encoding are stripped. Anything else you set is forwarded.
+  - Inbound: set-cookie / transfer-encoding / connection / content-length / content-encoding are stripped. Don't rely on cookie-based session auth — pass tokens explicitly.
+
+# Discovery flow for an agent building an artifact
+
+  1. Call agor_proxies_list to see what vendors are configured.
+  2. For each vendor you'll use, write its url, the daemon Authorization header, and the vendor-specific auth header into /agor.config.js as Handlebars references (never hardcode secrets).
+  3. Wire up a fetch wrapper that includes both headers on every call and renders the error envelope above on !r.ok.
+  4. If the user hasn't configured the env var, the secret renders as "" — detect this and prompt them, don't make the API call.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({}),
     },


### PR DESCRIPTION
## Summary

Make the \`agor_proxies_list\` MCP tool's own description self-sufficient as the canonical guide for any agent building a Sandpack artifact that hits a proxied API.

The old description showed a one-line example that would 401 today (it omitted the daemon JWT mandated by #1100), didn't mention the 5 MB body cap (which silently broke our Shortcut POC), and didn't document the \`{error: \"...\"}\` envelope agents need to surface to users.

Now an agent can discover the entire contract via MCP — no source reading required.

## What's added

- **Two-token model** spelled out: \`Authorization: Bearer {{ agor.token }}\` (daemon) + vendor-specific auth (e.g. \`Shortcut-Token\`). Both required, both rendered via Handlebars in \`agor.config.js\`.
- **Copy-pasteable example**: full \`agor.config.js\` + fetch wrapper with \"configure env var\" guard.
- **Operational caps**: 5 MB response body, 30 s upstream timeout, 600 rpm rate limit, default-GET-only \`allowed_methods\`.
- **Error envelope**: every \`{error: \"...\"}\` shape the proxy returns, with HTTP status codes.
- **Header policy**: what's stripped both directions (cookies, content-encoding, accept-encoding, etc.) so agents don't try to rely on cookie auth or override compression.
- **Discovery flow**: 4-step recipe for an agent picking this up cold.

## Why now

Built a Shortcut artifact this week and hit every gap the old description had. \`/workflows\` hangs (5 MB cap, no warning in docs), \`failed to fetch\` with no actionable error (caller didn't know about the \`{error}\` envelope), \"why is auth failing?\" (didn't know about \`{{ agor.token }}\`). After the runtime fix in #1104, the only remaining gap is making the next agent not have to learn this empirically.

## Test plan

- [x] Description-only change — no schema or runtime behavior changes
- [x] Pre-commit typecheck passes
- [ ] Pull \`agor_proxies_list\` from a fresh agent session post-deploy and confirm the description renders cleanly
- [ ] Hand the description to Sophie / artifact-building agents and see whether \"use the proxy, instructions are in MCP\" is a sufficient brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)