### PR TITLE
fix(executor): suppress noisy SDK system/status 'requesting' lifecycle messages

### DIFF
--- a/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
+++ b/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
@@ -32,6 +32,23 @@ export const RateLimitBlock: React.FC<RateLimitBlockProps> = ({ message, agentic
   const block = rateLimitBlock || apiWaitBlock || sdkEventBlock;
   if (!block) return null;
 
+  // Defensive filter: hide already-persisted system/status messages with status='requesting'.
+  // Server-side filter in message-processor.ts drops these going forward; this catches noise
+  // already in the DB from sessions created between the SDK bump and this fix.
+  if (
+    block.type === 'sdk_event' &&
+    'sdkType' in block &&
+    block.sdkType === 'system' &&
+    'sdkSubtype' in block &&
+    block.sdkSubtype === 'status' &&
+    'metadata' in block &&
+    typeof block.metadata === 'object' &&
+    block.metadata !== null &&
+    (block.metadata as { status?: unknown }).status === 'requesting'
+  ) {
+    return null;
+  }
+
   const text = ('text' in block ? block.text : '') as string;
   const isRateLimit = block.type === 'rate_limit';
   const isSdkEvent = block.type === 'sdk_event';

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -683,6 +683,13 @@ export class SDKMessageProcessor {
       ];
     }
 
+    // Suppress status='requesting' — pure API-call lifecycle telemetry, fires on every request.
+    // Other status subtype variants (null, permissionMode change, compact_result/error) still flow
+    // through and get surfaced as generic sdk_event messages below.
+    if ('status' in msg && msg.status === 'requesting') {
+      return [];
+    }
+
     if ('subtype' in msg && msg.subtype === 'init') {
       const initMsg = msg as SDKSystemMessage;
       console.debug(`ℹ️  SDK system init:`, {


### PR DESCRIPTION
## Summary

Claude Agent SDK 0.2.112+ added `status: 'requesting'` to `SDKStatusMessage` (fires on every API call). Our blacklist-based handler in `handleSystem()` had no branch for it, so it fell through to the generic `sdk_event` surfacer — spamming **\"Status: requesting\"** blurbs into the conversation feed between/inside tool-call blocks.

## Changes

- **Server-side** (`packages/executor/src/sdk-handlers/claude/message-processor.ts`): drop only `subtype:'status'` messages where `status === 'requesting'`. The existing `compacting` branch above stays untouched, and other status variants (`null`, `permissionMode` change, `compact_result`/`compact_error`) still flow through and surface as generic sdk_event messages — surgical, not blanket.
- **UI defensive filter** (`apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx`): return `null` for already-persisted sdk_event blocks matching `system/status` with `metadata.status === 'requesting'`. Catches noise already in the DB from sessions created between the SDK bump (#1114) and this fix without needing a backfill.

No new UI affordance — session \"is working\" state is already covered by `tool_start`/`message_start`/`session.is_busy`.

## Test plan

- [ ] Spawn a fresh claude-code session, run a few tool calls — confirm no \"Status: requesting\" blurbs in the conversation feed
- [ ] Confirm tool-call blocks render contiguously (no longer broken up by status messages)
- [ ] Confirm \"Compacting conversation context…\" still surfaces during compaction
- [ ] Trigger a compaction error (or other non-requesting status variant) and confirm it still surfaces
- [ ] Open an existing session that has persisted requesting-status messages — confirm UI no longer renders them
- [ ] Confirm Codex sessions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)