### PR TITLE
feat(ui): promote MCP servers to first-class field in NewSessionModal

### DIFF
--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -16,11 +16,9 @@
 
 import type { AgenticToolName, MCPServer } from '@agor-live/client';
 import { Form, Select } from 'antd';
-import { mapToArray } from '@/utils/mapHelpers';
-import { useServiceReadable } from '../../hooks/useServicesConfig';
 import { CodexNetworkAccessToggle } from '../CodexNetworkAccessToggle';
 import { EffortSelector } from '../EffortSelector';
-import { MCPServerSelect } from '../MCPServerSelect';
+import { SessionMcpServersField } from '../MCPServerSelect';
 import { ModelSelector } from '../ModelSelector';
 import {
   CODEX_APPROVAL_POLICIES,
@@ -42,6 +40,13 @@ export interface AgenticToolConfigFormProps {
    *   Use CodexSettingsForm separately for those.
    */
   compact?: boolean;
+  /**
+   * Suppress the MCP Servers field. Use when the parent renders MCP as a
+   * standalone first-class field elsewhere in the form (e.g., NewSessionModal
+   * promotes it to the primary zone). Avoids duplicate `mcpServerIds`
+   * Form.Items in the same Form.
+   */
+  hideMcpServers?: boolean;
 }
 
 const MODEL_LABELS: Record<string, string> = {
@@ -56,10 +61,10 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
   mcpServerById,
   showHelpText = true,
   compact = false,
+  hideMcpServers = false,
 }) => {
   const modelLabel = MODEL_LABELS[agenticTool] ?? 'Claude Model';
   const showCodexFields = agenticTool === 'codex' && !compact;
-  const mcpReadable = useServiceReadable('mcp_servers');
 
   return (
     <>
@@ -150,17 +155,8 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
         </Form.Item>
       )}
 
-      {mcpReadable && (
-        <Form.Item
-          name="mcpServerIds"
-          label="MCP Servers"
-          help={showHelpText ? 'Select MCP servers to make available in this session' : undefined}
-        >
-          <MCPServerSelect
-            mcpServers={mapToArray(mcpServerById)}
-            placeholder="No MCP servers attached"
-          />
-        </Form.Item>
+      {!hideMcpServers && (
+        <SessionMcpServersField mcpServerById={mcpServerById} showHelpText={showHelpText} />
       )}
     </>
   );

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -7,7 +7,8 @@
  * - MCP server attachments
  * - Codex-specific fields (sandbox, approval, network) — only in full mode
  *
- * Used in both NewSessionModal (full mode) and SessionSettingsModal (compact mode).
+ * Used by session creation, settings, defaults, schedules, gateway channels,
+ * forks/spawns, and zone triggers.
  *
  * In compact mode:
  * - PermissionModeSelector renders as a dropdown instead of radio group

--- a/apps/agor-ui/src/components/MCPServerSelect/SessionMcpServersField.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/SessionMcpServersField.tsx
@@ -7,8 +7,6 @@ import { MCPServerSelect } from './MCPServerSelect';
 export interface SessionMcpServersFieldProps {
   mcpServerById: Map<string, MCPServer>;
   showHelpText?: boolean;
-  /** Form field name. Defaults to 'mcpServerIds'. */
-  name?: string;
 }
 
 /**
@@ -22,14 +20,13 @@ export interface SessionMcpServersFieldProps {
 export const SessionMcpServersField: React.FC<SessionMcpServersFieldProps> = ({
   mcpServerById,
   showHelpText = false,
-  name = 'mcpServerIds',
 }) => {
   const mcpReadable = useServiceReadable('mcp_servers');
   if (!mcpReadable) return null;
 
   return (
     <Form.Item
-      name={name}
+      name="mcpServerIds"
       label="MCP Servers"
       help={showHelpText ? 'Select MCP servers to make available in this session' : undefined}
     >

--- a/apps/agor-ui/src/components/MCPServerSelect/SessionMcpServersField.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/SessionMcpServersField.tsx
@@ -1,0 +1,42 @@
+import type { MCPServer } from '@agor-live/client';
+import { Form } from 'antd';
+import { useServiceReadable } from '@/hooks/useServicesConfig';
+import { mapToArray } from '@/utils/mapHelpers';
+import { MCPServerSelect } from './MCPServerSelect';
+
+export interface SessionMcpServersFieldProps {
+  mcpServerById: Map<string, MCPServer>;
+  showHelpText?: boolean;
+  /** Form field name. Defaults to 'mcpServerIds'. */
+  name?: string;
+}
+
+/**
+ * MCP servers picker as a first-class form field.
+ *
+ * Bundles the readability gate (`mcp_servers` service tier) and the
+ * `Form.Item` shell so callers (NewSessionModal, AgenticToolConfigForm, …)
+ * can drop a single component wherever they need MCP selection — primary
+ * zone or collapsed advanced section — without duplicating the gate.
+ */
+export const SessionMcpServersField: React.FC<SessionMcpServersFieldProps> = ({
+  mcpServerById,
+  showHelpText = false,
+  name = 'mcpServerIds',
+}) => {
+  const mcpReadable = useServiceReadable('mcp_servers');
+  if (!mcpReadable) return null;
+
+  return (
+    <Form.Item
+      name={name}
+      label="MCP Servers"
+      help={showHelpText ? 'Select MCP servers to make available in this session' : undefined}
+    >
+      <MCPServerSelect
+        mcpServers={mapToArray(mcpServerById)}
+        placeholder="No MCP servers attached"
+      />
+    </Form.Item>
+  );
+};

--- a/apps/agor-ui/src/components/MCPServerSelect/index.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/index.ts
@@ -1,1 +1,3 @@
 export { MCPServerSelect } from './MCPServerSelect';
+export type { SessionMcpServersFieldProps } from './SessionMcpServersField';
+export { SessionMcpServersField } from './SessionMcpServersField';

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -19,6 +19,7 @@ import {
   AgentSelectionGrid,
 } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
+import { SessionMcpServersField } from '../MCPServerSelect';
 import type { ModelConfig } from '../ModelSelector';
 import { SessionEnvVarsSelector } from '../SessionEnvVarsSelector';
 
@@ -242,6 +243,9 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
           />
         </Form.Item>
 
+        {/* MCP Servers — first-class field, mirrors SessionSettingsModal */}
+        <SessionMcpServersField mcpServerById={mcpServerById} />
+
         {/* Advanced Configuration (Collapsible) */}
         <Collapse
           ghost
@@ -256,6 +260,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
                   agenticTool={(selectedAgent as AgenticToolName) || 'claude-code'}
                   mcpServerById={mcpServerById}
                   showHelpText={true}
+                  hideMcpServers
                 />
               ),
             },


### PR DESCRIPTION
## Summary

- Promotes the **MCP Servers** picker into the primary zone of `NewSessionModal`, mirroring the recent `SessionSettingsModal` promotion. The long-tail per-tool settings (model / permission mode / effort / codex sandbox) stay collapsed under "Agentic Tool Configuration" — MCP attachment is the much more common operation and now matches the visual treatment in session settings.
- Extracts `<SessionMcpServersField>` (Form.Item + `mcp_servers` service-readable gate + `<MCPServerSelect>`) so the field is a single drop-in across both modals.
- Adds `hideMcpServers` prop to `<AgenticToolConfigForm>` so callers that render MCP elsewhere in the same `<Form>` can suppress the bundled field (avoids duplicate `mcpServerIds` keys). The other 6 callers (ForkSpawn, Schedule, DefaultAgenticSettings, GatewayChannels, UserSettings, ZoneTrigger) keep current behavior via the default `false`.

## Files

- **new** `apps/agor-ui/src/components/MCPServerSelect/SessionMcpServersField.tsx`
- `apps/agor-ui/src/components/MCPServerSelect/index.ts` — export the new field
- `apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx` — replace inline MCP block with `<SessionMcpServersField>`; add `hideMcpServers` prop
- `apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx` — render `<SessionMcpServersField>` in primary zone, pass `hideMcpServers` to the collapsed `<AgenticToolConfigForm>`

## Test plan

- [ ] Open Create New Session modal → MCP Servers picker visible between Initial Prompt and the Agentic Tool Configuration collapse
- [ ] Worktree → user-default MCP inheritance still pre-fills the field on open and on agent switch
- [ ] Expand "Agentic Tool Configuration" → no duplicate MCP Servers field there
- [ ] Open Session Settings modal → MCP Servers still in primary zone, behavior unchanged
- [ ] Spot-check the other AgenticToolConfigForm callers (UserSettings, DefaultAgenticSettings, ForkSpawn, ZoneTrigger, ScheduleTab, GatewayChannels) — MCP still bundled in their forms
- [ ] `pnpm check` clean ✅ (already green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)