### PR TITLE
feat(mcp): add variant parameter to environment_start and worktrees_create

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -1,0 +1,364 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../resolve-ids.js', () => ({
+  resolveRepoId: async (_ctx: unknown, id: string) => id,
+  resolveBoardId: async (_ctx: unknown, id: string) => id,
+  resolveWorktreeId: async (_ctx: unknown, id: string) => id,
+  resolveSessionId: async (_ctx: unknown, id: string) => id,
+  resolveMcpServerId: async (_ctx: unknown, id: string) => id,
+}));
+
+vi.mock('@agor/core/config', () => ({
+  isWorktreeRbacEnabled: () => false,
+}));
+
+vi.mock('@agor/core/db', () => ({
+  WorktreeRepository: class FakeWorktreeRepository {
+    async getActiveNamesByRepo() {
+      return [];
+    }
+  },
+}));
+
+type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
+function makeFakeApp(services: Record<string, ServiceStub>) {
+  return {
+    service: (name: string) => {
+      const svc = services[name];
+      if (!svc) throw new Error(`Unexpected service call: ${name}`);
+      return svc;
+    },
+  };
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function makeCtx(services: Record<string, ServiceStub>) {
+  return {
+    app: makeFakeApp(services) as any,
+    db: {} as any,
+    userId: 'user-1' as any,
+    sessionId: 'sess-1' as any,
+    authenticatedUser: { user_id: 'user-1', role: 'admin' } as any,
+    baseServiceParams: {},
+  };
+}
+
+async function captureEnvironmentTool(
+  ctx: ReturnType<typeof makeCtx>,
+  toolName: string
+): Promise<ToolHandler> {
+  const { registerEnvironmentTools } = await import('./environment.js');
+  let captured: ToolHandler | undefined;
+  const fakeServer = {
+    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+      if (name === toolName) captured = cb;
+    },
+  } as unknown as McpServer;
+  registerEnvironmentTools(fakeServer, ctx);
+  if (!captured) throw new Error(`Tool ${toolName} was not registered`);
+  return captured;
+}
+
+async function captureWorktreeTool(
+  ctx: ReturnType<typeof makeCtx>,
+  toolName: string
+): Promise<ToolHandler> {
+  const { registerWorktreeTools } = await import('./worktrees.js');
+  let captured: ToolHandler | undefined;
+  const fakeServer = {
+    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+      if (name === toolName) captured = cb;
+    },
+  } as unknown as McpServer;
+  registerWorktreeTools(fakeServer, ctx);
+  if (!captured) throw new Error(`Tool ${toolName} was not registered`);
+  return captured;
+}
+
+// ---------------------------------------------------------------------------
+// agor_environment_start tests
+// ---------------------------------------------------------------------------
+
+describe('agor_environment_start', () => {
+  it('1: renders environment then starts when variant differs from stored (env stopped)', async () => {
+    const renderCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      worktrees: {
+        get: async () => ({
+          worktree_id: 'wt-1',
+          environment_variant: 'dev',
+          environment_instance: { status: 'stopped' },
+        }),
+        renderEnvironment: async (...args: unknown[]) => {
+          renderCalls.push(args);
+          return {};
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { worktree_id: 'wt-1', environment_variant: 'e2e' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(renderCalls).toHaveLength(1);
+    expect(renderCalls[0][1]).toEqual({ variant: 'e2e' });
+    expect(startCalls).toHaveLength(1);
+  });
+
+  it('2: skips renderEnvironment when variant matches stored variant', async () => {
+    const renderCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      worktrees: {
+        get: async () => ({
+          worktree_id: 'wt-1',
+          environment_variant: 'dev',
+          environment_instance: { status: 'stopped' },
+        }),
+        renderEnvironment: async (...args: unknown[]) => {
+          renderCalls.push(args);
+          return {};
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { worktree_id: 'wt-1', environment_variant: 'dev' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ worktreeId: 'wt-1', variant: 'dev' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(renderCalls).toHaveLength(0);
+    expect(startCalls).toHaveLength(1);
+  });
+
+  it('3: skips get and renderEnvironment entirely when no variant provided (backward compat)', async () => {
+    const getCalls: unknown[][] = [];
+    const renderCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      worktrees: {
+        get: async (...args: unknown[]) => {
+          getCalls.push(args);
+          return { worktree_id: 'wt-1', environment_variant: 'dev' };
+        },
+        renderEnvironment: async (...args: unknown[]) => {
+          renderCalls.push(args);
+          return {};
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { worktree_id: 'wt-1' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ worktreeId: 'wt-1' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(getCalls).toHaveLength(0);
+    expect(renderCalls).toHaveLength(0);
+    expect(startCalls).toHaveLength(1);
+  });
+
+  it('4: returns error without calling renderEnvironment or startEnvironment when env is running with different variant', async () => {
+    const renderCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      worktrees: {
+        get: async () => ({
+          worktree_id: 'wt-1',
+          environment_variant: 'dev',
+          environment_instance: { status: 'running' },
+        }),
+        renderEnvironment: async (...args: unknown[]) => {
+          renderCalls.push(args);
+          return {};
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { worktree_id: 'wt-1' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/running/);
+    expect(parsed.error).toMatch(/Stop it first/);
+    expect(renderCalls).toHaveLength(0);
+    expect(startCalls).toHaveLength(0);
+  });
+
+  it('5: returns error without calling renderEnvironment or startEnvironment when env is starting with different variant', async () => {
+    const renderCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      worktrees: {
+        get: async () => ({
+          worktree_id: 'wt-1',
+          environment_variant: 'dev',
+          environment_instance: { status: 'starting' },
+        }),
+        renderEnvironment: async (...args: unknown[]) => {
+          renderCalls.push(args);
+          return {};
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { worktree_id: 'wt-1' };
+        },
+      },
+    });
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/starting/);
+    expect(parsed.error).toMatch(/Stop it first/);
+    expect(renderCalls).toHaveLength(0);
+    expect(startCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agor_worktrees_create tests
+// ---------------------------------------------------------------------------
+
+const fakeRepo = {
+  repo_id: 'repo-1',
+  slug: 'org/repo',
+  local_path: '/tmp/repo',
+  default_branch: 'main',
+  environment: {
+    version: 2,
+    default: 'dev',
+    variants: {
+      dev: { start: 'echo dev', stop: 'echo stop' },
+      e2e: { start: 'echo e2e', stop: 'echo stop' },
+    },
+  },
+};
+
+describe('agor_worktrees_create', () => {
+  it('6: passes environment_variant to createWorktree when variant is valid', async () => {
+    const createCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+        createWorktree: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return { worktree_id: 'wt-new', name: 'my-feature' };
+        },
+      },
+    });
+
+    const handler = await captureWorktreeTool(ctx, 'agor_worktrees_create');
+    await handler({
+      repoId: 'repo-1',
+      worktreeName: 'my-feature',
+      boardId: 'board-1',
+      variant: 'e2e',
+    });
+
+    expect(createCalls).toHaveLength(1);
+    const data = createCalls[0][1] as Record<string, unknown>;
+    expect(data.environment_variant).toBe('e2e');
+  });
+
+  it('7: throws error with available variants when variant is invalid', async () => {
+    const createCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+        createWorktree: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return { worktree_id: 'wt-new', name: 'my-feature' };
+        },
+      },
+    });
+
+    const handler = await captureWorktreeTool(ctx, 'agor_worktrees_create');
+    await expect(
+      handler({
+        repoId: 'repo-1',
+        worktreeName: 'my-feature',
+        boardId: 'board-1',
+        variant: 'nonexistent',
+      })
+    ).rejects.toThrow(/Invalid variant "nonexistent"/);
+
+    expect(createCalls).toHaveLength(0);
+  });
+
+  it('7 (detail): error message includes available variant names', async () => {
+    const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+        createWorktree: async () => ({ worktree_id: 'wt-new', name: 'my-feature' }),
+      },
+    });
+
+    const handler = await captureWorktreeTool(ctx, 'agor_worktrees_create');
+    await expect(
+      handler({
+        repoId: 'repo-1',
+        worktreeName: 'my-feature',
+        boardId: 'board-1',
+        variant: 'nonexistent',
+      })
+    ).rejects.toThrow(/dev.*e2e|e2e.*dev/);
+  });
+
+  it('8: does not include environment_variant in createWorktree data when variant is omitted', async () => {
+    const createCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+        createWorktree: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return { worktree_id: 'wt-new', name: 'my-feature' };
+        },
+      },
+    });
+
+    const handler = await captureWorktreeTool(ctx, 'agor_worktrees_create');
+    await handler({
+      repoId: 'repo-1',
+      worktreeName: 'my-feature',
+      boardId: 'board-1',
+    });
+
+    expect(createCalls).toHaveLength(1);
+    const data = createCalls[0][1] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(data, 'environment_variant')).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -36,6 +36,8 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   content: Array<{ type: string; text: string }>;
 }>;
 
+type CapturedTool = { cfg: { inputSchema?: { parse: (v: unknown) => unknown } }; cb: ToolHandler };
+
 function makeCtx(services: Record<string, ServiceStub>) {
   return {
     app: makeFakeApp(services) as any,
@@ -50,12 +52,12 @@ function makeCtx(services: Record<string, ServiceStub>) {
 async function captureEnvironmentTool(
   ctx: ReturnType<typeof makeCtx>,
   toolName: string
-): Promise<ToolHandler> {
+): Promise<CapturedTool> {
   const { registerEnvironmentTools } = await import('./environment.js');
-  let captured: ToolHandler | undefined;
+  let captured: CapturedTool | undefined;
   const fakeServer = {
-    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
-      if (name === toolName) captured = cb;
+    registerTool: (name: string, cfg: unknown, cb: ToolHandler) => {
+      if (name === toolName) captured = { cfg: cfg as CapturedTool['cfg'], cb };
     },
   } as unknown as McpServer;
   registerEnvironmentTools(fakeServer, ctx);
@@ -80,6 +82,25 @@ async function captureWorktreeTool(
 }
 
 // ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+const fakeRepo = {
+  repo_id: 'repo-1',
+  slug: 'org/repo',
+  local_path: '/tmp/repo',
+  default_branch: 'main',
+  environment: {
+    version: 2,
+    default: 'dev',
+    variants: {
+      dev: { start: 'echo dev', stop: 'echo stop' },
+      e2e: { start: 'echo e2e', stop: 'echo stop' },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
 // agor_environment_start tests
 // ---------------------------------------------------------------------------
 
@@ -89,9 +110,13 @@ describe('agor_environment_start', () => {
     const startCalls: unknown[][] = [];
 
     const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+      },
       worktrees: {
         get: async () => ({
           worktree_id: 'wt-1',
+          repo_id: 'repo-1',
           environment_variant: 'dev',
           environment_instance: { status: 'stopped' },
         }),
@@ -106,7 +131,7 @@ describe('agor_environment_start', () => {
       },
     });
 
-    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const { cb: handler } = await captureEnvironmentTool(ctx, 'agor_environment_start');
     const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
     const parsed = JSON.parse(result.content[0].text);
 
@@ -121,9 +146,13 @@ describe('agor_environment_start', () => {
     const startCalls: unknown[][] = [];
 
     const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+      },
       worktrees: {
         get: async () => ({
           worktree_id: 'wt-1',
+          repo_id: 'repo-1',
           environment_variant: 'dev',
           environment_instance: { status: 'stopped' },
         }),
@@ -138,7 +167,7 @@ describe('agor_environment_start', () => {
       },
     });
 
-    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const { cb: handler } = await captureEnvironmentTool(ctx, 'agor_environment_start');
     const result = await handler({ worktreeId: 'wt-1', variant: 'dev' });
     const parsed = JSON.parse(result.content[0].text);
 
@@ -169,7 +198,7 @@ describe('agor_environment_start', () => {
       },
     });
 
-    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const { cb: handler } = await captureEnvironmentTool(ctx, 'agor_environment_start');
     const result = await handler({ worktreeId: 'wt-1' });
     const parsed = JSON.parse(result.content[0].text);
 
@@ -184,9 +213,13 @@ describe('agor_environment_start', () => {
     const startCalls: unknown[][] = [];
 
     const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+      },
       worktrees: {
         get: async () => ({
           worktree_id: 'wt-1',
+          repo_id: 'repo-1',
           environment_variant: 'dev',
           environment_instance: { status: 'running' },
         }),
@@ -201,7 +234,7 @@ describe('agor_environment_start', () => {
       },
     });
 
-    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const { cb: handler } = await captureEnvironmentTool(ctx, 'agor_environment_start');
     const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
     const parsed = JSON.parse(result.content[0].text);
 
@@ -217,9 +250,13 @@ describe('agor_environment_start', () => {
     const startCalls: unknown[][] = [];
 
     const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+      },
       worktrees: {
         get: async () => ({
           worktree_id: 'wt-1',
+          repo_id: 'repo-1',
           environment_variant: 'dev',
           environment_instance: { status: 'starting' },
         }),
@@ -234,7 +271,7 @@ describe('agor_environment_start', () => {
       },
     });
 
-    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const { cb: handler } = await captureEnvironmentTool(ctx, 'agor_environment_start');
     const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
     const parsed = JSON.parse(result.content[0].text);
 
@@ -244,26 +281,47 @@ describe('agor_environment_start', () => {
     expect(renderCalls).toHaveLength(0);
     expect(startCalls).toHaveLength(0);
   });
+
+  it('6: calls renderEnvironment then startEnvironment when environment_variant is null (legacy worktree)', async () => {
+    const renderCalls: unknown[][] = [];
+    const startCalls: unknown[][] = [];
+
+    const ctx = makeCtx({
+      repos: {
+        get: async () => fakeRepo,
+      },
+      worktrees: {
+        get: async () => ({
+          worktree_id: 'wt-1',
+          repo_id: 'repo-1',
+          environment_variant: null,
+          environment_instance: { status: 'stopped' },
+        }),
+        renderEnvironment: async (...args: unknown[]) => {
+          renderCalls.push(args);
+          return {};
+        },
+        startEnvironment: async (...args: unknown[]) => {
+          startCalls.push(args);
+          return { worktree_id: 'wt-1', environment_variant: 'e2e' };
+        },
+      },
+    });
+
+    const { cb: handler } = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ worktreeId: 'wt-1', variant: 'e2e' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(renderCalls).toHaveLength(1);
+    expect(renderCalls[0][1]).toEqual({ variant: 'e2e' });
+    expect(startCalls).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
 // agor_worktrees_create tests
 // ---------------------------------------------------------------------------
-
-const fakeRepo = {
-  repo_id: 'repo-1',
-  slug: 'org/repo',
-  local_path: '/tmp/repo',
-  default_branch: 'main',
-  environment: {
-    version: 2,
-    default: 'dev',
-    variants: {
-      dev: { start: 'echo dev', stop: 'echo stop' },
-      e2e: { start: 'echo e2e', stop: 'echo stop' },
-    },
-  },
-};
 
 describe('agor_worktrees_create', () => {
   it('6: passes environment_variant to createWorktree when variant is valid', async () => {
@@ -318,7 +376,7 @@ describe('agor_worktrees_create', () => {
     expect(createCalls).toHaveLength(0);
   });
 
-  it('7 (detail): error message includes available variant names', async () => {
+  it('8: error message includes available variant names', async () => {
     const ctx = makeCtx({
       repos: {
         get: async () => fakeRepo,
@@ -337,7 +395,31 @@ describe('agor_worktrees_create', () => {
     ).rejects.toThrow(/dev.*e2e|e2e.*dev/);
   });
 
-  it('8: does not include environment_variant in createWorktree data when variant is omitted', async () => {
+  it('9: throws with "no environment variants configured" when repo has no variants', async () => {
+    const repoWithNoVariants = {
+      ...fakeRepo,
+      environment: {},
+    };
+
+    const ctx = makeCtx({
+      repos: {
+        get: async () => repoWithNoVariants,
+        createWorktree: async () => ({ worktree_id: 'wt-new', name: 'my-feature' }),
+      },
+    });
+
+    const handler = await captureWorktreeTool(ctx, 'agor_worktrees_create');
+    await expect(
+      handler({
+        repoId: 'repo-1',
+        worktreeName: 'my-feature',
+        boardId: 'board-1',
+        variant: 'e2e',
+      })
+    ).rejects.toThrow(/no environment variants configured/);
+  });
+
+  it('10: does not include environment_variant in createWorktree data when variant is omitted', async () => {
     const createCalls: unknown[][] = [];
 
     const ctx = makeCtx({

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -10,16 +10,51 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
   server.registerTool(
     'agor_environment_start',
     {
-      description: 'Start the environment for a worktree by running its configured start command',
-      annotations: { idempotentHint: true },
+      description:
+        'Start the environment for a worktree by running its configured start command. ' +
+        'Optionally pass a variant to re-render environment commands from the repo config before starting.',
       inputSchema: z.object({
         worktreeId: z.string().describe('Worktree ID (UUIDv7 or short ID)'),
+        variant: z
+          .string()
+          .optional()
+          .describe(
+            'Environment variant name to render before starting. ' +
+              'Re-renders the worktree environment commands (start/stop/nuke/etc.) from the repo config. ' +
+              'If the environment is already running with a different variant, you must stop it first.'
+          ),
       }),
     },
     async (args) => {
       const worktreeId = coerceString(args.worktreeId)!;
+      const variant = coerceString(args.variant);
       const worktreesService = ctx.app.service('worktrees') as unknown as WorktreesServiceImpl;
       try {
+        if (variant) {
+          const worktree = await worktreesService.get(
+            worktreeId as WorktreeID,
+            ctx.baseServiceParams
+          );
+
+          if (variant !== worktree.environment_variant) {
+            const envStatus = worktree.environment_instance?.status;
+            if (envStatus === 'running' || envStatus === 'starting') {
+              return textResult({
+                success: false,
+                error:
+                  `Environment is ${envStatus} with variant "${worktree.environment_variant || '(none)'}". ` +
+                  `Stop it first, then start with variant "${variant}".`,
+              });
+            }
+
+            await worktreesService.renderEnvironment(
+              worktreeId as WorktreeID,
+              { variant },
+              ctx.baseServiceParams
+            );
+          }
+        }
+
         const worktree = await worktreesService.startEnvironment(
           worktreeId as WorktreeID,
           ctx.baseServiceParams

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -1,7 +1,7 @@
 import type { WorktreeID } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import type { WorktreesServiceImpl } from '../../declarations.js';
+import type { ReposServiceImpl, WorktreesServiceImpl } from '../../declarations.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -35,6 +35,21 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
             worktreeId as WorktreeID,
             ctx.baseServiceParams
           );
+
+          const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
+          const repo = await reposService.get(worktree.repo_id);
+          const repoEnv = repo.environment;
+          if (!repoEnv?.variants || !repoEnv.variants[variant]) {
+            const available = repoEnv?.variants ? Object.keys(repoEnv.variants) : [];
+            return textResult({
+              success: false,
+              error:
+                `Invalid variant "${variant}". ` +
+                (available.length > 0
+                  ? `Available variants: ${available.join(', ')}`
+                  : 'This repo has no environment variants configured.'),
+            });
+          }
 
           if (variant !== worktree.environment_variant) {
             const envStatus = worktree.environment_instance?.status;

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -2,6 +2,7 @@ import { isWorktreeRbacEnabled } from '@agor/core/config';
 import { WorktreeRepository } from '@agor/core/db';
 import type {
   BoardID,
+  Repo,
   UUID,
   Worktree,
   WorktreeID,
@@ -219,7 +220,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       }
 
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-      let repo: unknown;
+      let repo: Repo;
       try {
         repo = await reposService.get(repoId);
       } catch {
@@ -228,8 +229,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
 
       const variant = coerceString(args.variant);
       if (variant) {
-        const repoEnv = (repo as { environment?: { variants?: Record<string, unknown> } })
-          .environment;
+        const repoEnv = repo.environment;
         if (!repoEnv?.variants || !repoEnv.variants[variant]) {
           const available = repoEnv?.variants ? Object.keys(repoEnv.variants) : [];
           throw new Error(
@@ -257,8 +257,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
         }
       }
 
-      const defaultBranch =
-        coerceString((repo as { default_branch?: unknown }).default_branch) ?? 'main';
+      const defaultBranch = repo.default_branch ?? 'main';
       const refType = (coerceString(args.refType) as 'branch' | 'tag') || 'branch';
       let createBranch = typeof args.createBranch === 'boolean' ? args.createBranch : true;
       let ref = coerceString(args.ref);

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -196,6 +196,14 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
               'The creating user is always added as owner automatically. ' +
               'Owners have full access regardless of othersCan/othersFsAccess settings.'
           ),
+        variant: z
+          .string()
+          .optional()
+          .describe(
+            'Environment variant name to use for this worktree. ' +
+              'Must be a key in the repo environment config variants. ' +
+              'When omitted, the repo default variant is used.'
+          ),
       }),
     },
     async (args) => {
@@ -216,6 +224,21 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
         repo = await reposService.get(repoId);
       } catch {
         throw new Error(`Repository ${repoId} not found`);
+      }
+
+      const variant = coerceString(args.variant);
+      if (variant) {
+        const repoEnv = (repo as { environment?: { variants?: Record<string, unknown> } })
+          .environment;
+        if (!repoEnv?.variants || !repoEnv.variants[variant]) {
+          const available = repoEnv?.variants ? Object.keys(repoEnv.variants) : [];
+          throw new Error(
+            `Invalid variant "${variant}". ` +
+              (available.length > 0
+                ? `Available variants: ${available.join(', ')}`
+                : 'This repo has no environment variants configured.')
+          );
+        }
       }
 
       // Auto-suffix: resolve name conflicts by appending -2, -3, etc.
@@ -287,6 +310,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
           ...(zoneId ? { zoneId } : {}),
           ...(othersCan ? { others_can: othersCan } : {}),
           ...(othersFsAccess ? { others_fs_access: othersFsAccess } : {}),
+          ...(variant ? { environment_variant: variant } : {}),
         },
         ctx.baseServiceParams
       );

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -370,6 +370,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       zoneId?: string;
       others_can?: WorktreePermissionLevel;
       others_fs_access?: 'none' | 'read' | 'write';
+      environment_variant?: string;
     },
     params?: RepoParams
   ): Promise<Worktree> {
@@ -572,6 +573,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         // RBAC fields (optional, defaults handled by repository layer)
         ...(data.others_can ? { others_can: data.others_can } : {}),
         ...(data.others_fs_access ? { others_fs_access: data.others_fs_access } : {}),
+        ...(data.environment_variant ? { environment_variant: data.environment_variant } : {}),
         sessions: [],
         last_used: new Date().toISOString(),
         issue_url: data.issue_url,


### PR DESCRIPTION
## Summary

- Add optional `variant` parameter to `agor_environment_start` that re-renders environment commands from repo config before starting. Includes fail-fast guard when environment is running/starting with a different variant.
- Add optional `variant` parameter to `agor_worktrees_create` to set the initial environment variant at creation time, with validation against repo config.
- Thread `environment_variant` through the `createWorktree` service method to persist variant on the DB record at creation time.

**Shortcut:** https://app.shortcut.com/preset/story/106035

## Key design decisions

- **Fail-fast on running env**: If environment is running/starting with a different variant, returns a structured error _before_ any DB mutation. Neither `renderEnvironment` nor `startEnvironment` are called.
- **Single auth gate**: No authorization checks in MCP handlers — `renderEnvironment`'s existing admin check is the single source of truth for variant changes.
- **Backward compatible**: Omitting `variant` behaves identically to current behavior.
- **Validation in MCP handler**: Variant name validation for `worktrees_create` lives in the MCP handler, not the repos service.

## Test plan

- [x] 9 new test cases in `environment.test.ts` covering:
  - Start with explicit variant (render → start)
  - Start with same variant (skip render)
  - Start with no variant (backward compat)
  - Fail fast when running with different variant
  - Fail fast when starting with different variant
  - Create worktree with variant threaded through
  - Reject invalid variant with available variants listed
  - Omitting variant doesn't send `environment_variant`
  - Error message includes correct variant details
- [x] All 32 existing MCP tool tests pass (regression)
- [x] `tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)