### PR TITLE
feat(ui): add modifier-scroll canvas zoom

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2296,14 +2296,13 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             panOnDrag={!drawingZone} // Always allow drag to pan (left mouse in select, any in other modes)
             selectionOnDrag={false} // Disable selection box - not useful for worktree cards
             className={`tool-mode-${activeTool}`}
-            // Disable React Flow's default keyboard shortcuts to prevent conflicts
-            // Note: React Flow keyboard shortcuts were causing Spatial Messages to appear
-            // undesirably when clicking/typing. Disabling all keyboard shortcuts for now.
+            // Disable React Flow's keyboard shortcuts that conflict with typing/spatial messages.
+            // Keep modifier-scroll zoom enabled so Command/Control + scroll behaves like Figma.
             deleteKeyCode={null}
             selectionKeyCode={null}
             multiSelectionKeyCode={null}
             panActivationKeyCode={null}
-            zoomActivationKeyCode={null}
+            zoomActivationKeyCode={['Meta', 'Control']}
             disableKeyboardA11y={true}
             style={{ background: 'transparent' }}
           >

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
-import type { ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import type { MouseEventHandler, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SessionCanvas from './SessionCanvas';
 
 let reactFlowProps: Record<string, unknown> | null = null;
@@ -12,7 +12,7 @@ vi.mock('reactflow', () => ({
     onClick,
   }: {
     children?: ReactNode;
-    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
   }) => (
     <button type="button" onClick={onClick}>
       {children}
@@ -37,6 +37,10 @@ vi.mock('./canvas/AppNode', () => ({
 vi.mock('./canvas/ArtifactNode', () => ({
   ArtifactNode: () => <div data-testid="artifact-node" />,
 }));
+
+beforeEach(() => {
+  reactFlowProps = null;
+});
 
 describe('SessionCanvas zoom shortcuts', () => {
   it('uses Command or Control plus scroll to zoom while preserving scroll panning', () => {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import SessionCanvas from './SessionCanvas';
+
+let reactFlowProps: Record<string, unknown> | null = null;
+
+vi.mock('reactflow', () => ({
+  Background: () => <div data-testid="react-flow-background" />,
+  ControlButton: ({
+    children,
+    onClick,
+  }: {
+    children?: ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Controls: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="react-flow-controls">{children}</div>
+  ),
+  MiniMap: () => <div data-testid="react-flow-minimap" />,
+  ReactFlow: (props: Record<string, unknown> & { children?: ReactNode }) => {
+    reactFlowProps = props;
+    return <div data-testid="react-flow">{props.children}</div>;
+  },
+  useEdgesState: (initialEdges: unknown[]) => [initialEdges, vi.fn(), vi.fn()],
+  useNodesState: (initialNodes: unknown[]) => [initialNodes, vi.fn(), vi.fn()],
+}));
+
+vi.mock('./canvas/AppNode', () => ({
+  AppNode: () => <div data-testid="app-node" />,
+}));
+
+vi.mock('./canvas/ArtifactNode', () => ({
+  ArtifactNode: () => <div data-testid="artifact-node" />,
+}));
+
+describe('SessionCanvas zoom shortcuts', () => {
+  it('uses Command or Control plus scroll to zoom while preserving scroll panning', () => {
+    render(
+      <SessionCanvas
+        board={null}
+        client={null}
+        sessionById={new Map()}
+        sessionsByWorktree={new Map()}
+        userById={new Map()}
+        repoById={new Map()}
+        worktrees={[]}
+        worktreeById={new Map()}
+        boardObjectById={new Map()}
+        commentById={new Map()}
+        cardById={new Map()}
+      />
+    );
+
+    expect(reactFlowProps?.panOnScroll).toBe(true);
+    expect(reactFlowProps?.zoomActivationKeyCode).toEqual(['Meta', 'Control']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Figma-style Command/Control + scroll zooming to the board canvas while preserving regular scroll panning.

## Validation

- pnpm --filter agor-ui test -- src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
- pnpm --filter agor-ui typecheck
- pnpm exec biome check apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
- Manual canvas testing confirmed the shortcut works