### PR TITLE
fix(codex): unbreak ChatGPT subscription auth by removing per-session CODEX_HOME

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -909,7 +909,7 @@ function createExecuteHandler(
             try {
               let filePath: string;
               if (freshSession.agentic_tool === 'codex') {
-                const codexHome = getCodexHome(sessionId);
+                const codexHome = getCodexHome(executorHomeDir);
                 const found = await findCodexSessionFile(codexHome, freshSession.sdk_session_id);
                 filePath = found || '';
               } else {

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -204,25 +204,6 @@ export class ConfigService {
       }
     }
 
-    // Allow updating codex configuration
-    if (data.codex) {
-      if (!config.codex) {
-        config.codex = {};
-      }
-
-      if (data.codex.home !== undefined) {
-        const home = data.codex.home;
-        if (home === null || home === '') {
-          // Treat empty string as unset
-          delete config.codex.home;
-        } else if (typeof home === 'string') {
-          config.codex.home = home;
-        } else {
-          throw new Error('codex.home must be a string');
-        }
-      }
-    }
-
     await saveConfig(config);
     console.log('[Config Service] Config saved successfully');
 

--- a/apps/agor-daemon/src/utils/session-state-hooks.ts
+++ b/apps/agor-daemon/src/utils/session-state-hooks.ts
@@ -61,10 +61,15 @@ interface PushContext {
 export async function pullIfNeeded(ctx: PullContext): Promise<void> {
   const repo = new SerializedSessionRepository(ctx.db);
 
-  // For Codex, pass the per-session CODEX_HOME as homeOverride
-  const homeOverride = ctx.tool === 'codex' ? getCodexHome(ctx.sessionId) : ctx.executorHomeDir;
-
-  const filePath = getSessionFilePath(ctx.tool, ctx.worktreePath, ctx.sdkSessionId, homeOverride);
+  // Both claude-code and codex now resolve transcripts under the executor
+  // user's HOME (~/.claude or ~/.codex). For simple mode executorHomeDir is
+  // undefined and the helpers fall back to os.homedir().
+  const filePath = getSessionFilePath(
+    ctx.tool,
+    ctx.worktreePath,
+    ctx.sdkSessionId,
+    ctx.executorHomeDir
+  );
 
   // Check latest row (any status)
   let latest = await repo.findLatest(ctx.sessionId);
@@ -141,7 +146,7 @@ async function doPush(ctx: PushContext): Promise<void> {
   // For Codex, find the actual session file (may be in a date-based subdirectory)
   let filePath: string;
   if (ctx.tool === 'codex') {
-    const codexHome = getCodexHome(ctx.sessionId);
+    const codexHome = getCodexHome(ctx.executorHomeDir);
     const found = await findCodexSessionFile(codexHome, ctx.sdkSessionId);
     if (!found) {
       // No session file found — Codex may not have written one (e.g. error before first turn)
@@ -149,8 +154,12 @@ async function doPush(ctx: PushContext): Promise<void> {
     }
     filePath = found;
   } else {
-    const homeOverride = ctx.executorHomeDir;
-    filePath = getSessionFilePath(ctx.tool, ctx.worktreePath, ctx.sdkSessionId, homeOverride);
+    filePath = getSessionFilePath(
+      ctx.tool,
+      ctx.worktreePath,
+      ctx.sdkSessionId,
+      ctx.executorHomeDir
+    );
   }
 
   // Compute current hash

--- a/apps/agor-daemon/src/utils/session-state.ts
+++ b/apps/agor-daemon/src/utils/session-state.ts
@@ -19,11 +19,20 @@ import { getTranscriptPath } from '@agor/core/claude';
 import type { AgenticToolName } from '@agor/core/types';
 
 /**
- * Get the CODEX_HOME directory for a given Agor session.
- * Mirrors the logic in executor's prompt-service.ts ensureCodexSessionContext().
+ * Resolve the Codex home directory (where `auth.json`, `sessions/`, and
+ * any user-authored `config.toml` live).
+ *
+ * Defaults to `$HOME/.codex`. In strict / insulated unix-user modes the
+ * caller passes the impersonated user's home dir; in simple mode it is
+ * undefined and we fall back to the daemon process's `os.homedir()`.
+ *
+ * NOTE: this used to return a per-session `/tmp/agor-codex-<sessionId>`
+ * directory back when Agor overrode `$CODEX_HOME`. The executor no longer
+ * does that — Codex CLI is invoked with its default `$CODEX_HOME` so its
+ * subscription auth + user config keep working.
  */
-export function getCodexHome(agorSessionId: string): string {
-  return path.join(os.tmpdir(), `agor-codex-${agorSessionId}`);
+export function getCodexHome(executorHomeDir?: string): string {
+  return path.join(executorHomeDir || os.homedir(), '.codex');
 }
 
 export function getSessionFilePath(
@@ -44,10 +53,10 @@ export function getSessionFilePath(
       return getTranscriptPath(sdkSessionId, worktreePath);
     }
     case 'codex': {
-      // For Codex, homeOverride is the CODEX_HOME directory (per-session /tmp/ dir).
-      // Canonical restore path: $CODEX_HOME/sessions/<threadId>.jsonl
-      // The Codex CLI searches for threads by ID, so a flat path works.
-      const codexHome = homeOverride || getCodexHome('unknown');
+      // homeOverride here is the executor user's HOME dir (not CODEX_HOME).
+      // Codex stores threads at $CODEX_HOME/sessions, default $CODEX_HOME=$HOME/.codex.
+      // The Codex CLI searches for threads by ID, so a flat path works for restore.
+      const codexHome = getCodexHome(homeOverride);
       return path.join(codexHome, 'sessions', `${sdkSessionId}.jsonl`);
     }
     default:

--- a/apps/agor-docs/pages/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/pages/guide/sdk-comparison.mdx
@@ -260,10 +260,10 @@ Agor integrates with multiple AI coding agents. Each SDK has different capabilit
 - No manual injection needed
 - Agor sessions inherit project instructions automatically
 
-**Codex:** ✅ **AGENTS.md auto-loading**
+**Codex:** ✅ **Native instructions injection**
 
-- Codex automatically loads `AGENTS.md` from the working directory
-- Agor generates a per-session `AGENTS.md` with project context at the worktree's `CODEX_HOME`
+- Codex automatically loads `AGENTS.md` from the working directory and the user's `~/.codex/`
+- Agor renders per-session project context to a temp file and passes it via the SDK's `model_instructions_file` config — never mutates the user's `~/.codex/` directory
 - No manual injection needed
 
 **Gemini:** ⚠️ **Manual injection**

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -122,11 +122,6 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
   const [opencodeConnected, setOpencodeConnected] = useState<boolean | null>(null);
   const [opencodeTesting, setOpencodeTesting] = useState(false);
   const [loadingOpencode, setLoadingOpencode] = useState(true);
-  const defaultCodexHome = '~/.agor/codex';
-  const [codexHome, setCodexHome] = useState(defaultCodexHome);
-  const [initialCodexHome, setInitialCodexHome] = useState(defaultCodexHome);
-  const [loadingCodexConfig, setLoadingCodexConfig] = useState(true);
-  const [savingCodexHome, setSavingCodexHome] = useState(false);
 
   // Load API keys configuration
   useEffect(() => {
@@ -190,29 +185,6 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     loadOpenCode();
   }, [client]);
 
-  // Load Codex configuration
-  useEffect(() => {
-    if (!client) return;
-
-    const loadCodex = async () => {
-      try {
-        setLoadingCodexConfig(true);
-        const config = (await client.service('config').get('codex')) as { home?: string } | null;
-        const home = config?.home || defaultCodexHome;
-        setCodexHome(home);
-        setInitialCodexHome(home);
-      } catch (err) {
-        console.error('Failed to load Codex config:', err);
-        setCodexHome(defaultCodexHome);
-        setInitialCodexHome(defaultCodexHome);
-      } finally {
-        setLoadingCodexConfig(false);
-      }
-    };
-
-    loadCodex();
-  }, [client]);
-
   // Save API key
   const handleSaveKey = async (field: string, value: string) => {
     if (!client) return;
@@ -261,32 +233,6 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     }
   };
 
-  const handleSaveCodexHome = async () => {
-    if (!client) return;
-
-    const trimmed = codexHome.trim();
-    if (!trimmed) {
-      showError('Codex home directory cannot be empty');
-      return;
-    }
-
-    try {
-      setSavingCodexHome(true);
-      await client.service('config').patch(null, {
-        codex: {
-          home: trimmed,
-        },
-      });
-      setInitialCodexHome(trimmed);
-      showSuccess('Codex home updated');
-    } catch (err) {
-      console.error('Failed to save Codex home:', err);
-      showError(err instanceof Error ? err.message : 'Failed to save Codex home');
-    } finally {
-      setSavingCodexHome(false);
-    }
-  };
-
   // Test OpenCode connection
   const handleTestOpenCodeConnection = async () => {
     if (!client) return;
@@ -326,8 +272,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     }
   };
 
-  const codexHomeChanged = codexHome !== initialCodexHome;
-  const loading = loadingKeys || loadingOpencode || loadingCodexConfig;
+  const loading = loadingKeys || loadingOpencode;
 
   if (loading) {
     return (
@@ -362,53 +307,15 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
             key: 'codex',
             label: 'Codex',
             children: (
-              <div
-                style={{
-                  paddingTop: token.paddingMD,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: token.marginXL,
-                }}
-              >
-                <ApiKeyTabContent
-                  tool="codex"
-                  fieldStatus={fieldStatus}
-                  keysError={keysError}
-                  savingKeys={savingKeys}
-                  onSave={handleSaveKey}
-                  onClear={handleClearKey}
-                  onClearError={() => setKeysError(null)}
-                />
-
-                <Form layout="vertical">
-                  <Form.Item
-                    label="Codex home directory"
-                    extra="Agor sets CODEX_HOME before launching Codex. Point this at another directory to reuse an existing Codex configuration."
-                  >
-                    <Input
-                      value={codexHome}
-                      onChange={(event) => setCodexHome(event.target.value)}
-                      placeholder={defaultCodexHome}
-                    />
-                  </Form.Item>
-                  <Space>
-                    <Button
-                      type="primary"
-                      onClick={handleSaveCodexHome}
-                      disabled={!codexHomeChanged}
-                      loading={savingCodexHome}
-                    >
-                      Save Codex home
-                    </Button>
-                    <Button
-                      onClick={() => setCodexHome(defaultCodexHome)}
-                      disabled={codexHome === defaultCodexHome}
-                    >
-                      Reset to default
-                    </Button>
-                  </Space>
-                </Form>
-              </div>
+              <ApiKeyTabContent
+                tool="codex"
+                fieldStatus={fieldStatus}
+                keysError={keysError}
+                savingKeys={savingKeys}
+                onSave={handleSaveKey}
+                onClear={handleClearKey}
+                onClearError={() => setKeysError(null)}
+              />
             ),
           },
           {

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -29,9 +29,6 @@ export function getDefaultConfig(): AgorConfig {
       port: 5173,
       host: 'localhost',
     },
-    codex: {
-      home: '~/.agor/codex',
-    },
     execution: {
       session_token_expiration_ms: 86400000,
       session_token_max_uses: 1,

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -8,7 +8,6 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  ensureCodexHome,
   expandHomePath,
   getAgorHome,
   getConfigPath,
@@ -23,7 +22,6 @@ import {
   loadConfig,
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
-  resolveCodexHome,
   saveConfig,
   setConfigValue,
   unsetConfigValue,
@@ -257,61 +255,6 @@ describe('requirePublicBaseUrl', () => {
   it('rejects a base URL without an http(s) scheme', async () => {
     process.env.AGOR_BASE_URL = 'agor.example.com';
     await expect(requirePublicBaseUrl()).rejects.toThrow(/must start with http/i);
-  });
-});
-
-describe('resolveCodexHome & ensureCodexHome', () => {
-  let tempDir: string;
-
-  beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-config-'));
-    vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
-  });
-
-  afterEach(async () => {
-    await fs.rm(tempDir, { recursive: true, force: true });
-    vi.restoreAllMocks();
-  });
-
-  it('should resolve to default Codex home when not configured', async () => {
-    const home = await resolveCodexHome();
-    expect(home).toBe(path.join(tempDir, '.agor', 'codex'));
-  });
-
-  it('should resolve a configured tilde path', async () => {
-    const agorDir = path.join(tempDir, '.agor');
-    await fs.mkdir(agorDir, { recursive: true });
-    await fs.writeFile(
-      path.join(agorDir, 'config.yaml'),
-      yaml.dump({ codex: { home: '~/.custom-codex' } }),
-      'utf-8'
-    );
-
-    const home = await resolveCodexHome();
-    expect(home).toBe(path.join(tempDir, '.custom-codex'));
-  });
-
-  it('should create the default Codex home directory when ensuring', async () => {
-    const codexHome = await ensureCodexHome();
-    expect(codexHome).toBe(path.join(tempDir, '.agor', 'codex'));
-    const stats = await fs.stat(codexHome);
-    expect(stats.isDirectory()).toBe(true);
-  });
-
-  it('should create a configured Codex home directory if missing', async () => {
-    const customHome = path.join(tempDir, 'codex-data');
-    const agorDir = path.join(tempDir, '.agor');
-    await fs.mkdir(agorDir, { recursive: true });
-    await fs.writeFile(
-      path.join(agorDir, 'config.yaml'),
-      yaml.dump({ codex: { home: customHome } }),
-      'utf-8'
-    );
-
-    const codexHome = await ensureCodexHome();
-    expect(codexHome).toBe(customHome);
-    const stats = await fs.stat(customHome);
-    expect(stats.isDirectory()).toBe(true);
   });
 });
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -136,9 +136,6 @@ export function getDefaultConfig(): AgorConfig {
       port: 5173,
       host: 'localhost',
     },
-    codex: {
-      home: '~/.agor/codex',
-    },
     execution: {
       session_token_expiration_ms: 86400000, // 24 hours
       session_token_max_uses: 1, // Single-use tokens
@@ -159,27 +156,6 @@ export function expandHomePath(input: string): string {
     return path.join(os.homedir(), input.slice(2));
   }
   return input;
-}
-
-/**
- * Resolve configured Codex home directory (expanded to absolute path)
- */
-export async function resolveCodexHome(): Promise<string> {
-  const config = await loadConfig();
-  const configured = config.codex?.home;
-  const defaultHome = getDefaultConfig().codex?.home ?? '~/.agor/codex';
-  const selected =
-    typeof configured === 'string' && configured.trim().length > 0 ? configured : defaultHome;
-  return expandHomePath(selected.trim());
-}
-
-/**
- * Ensure Codex home directory exists and return its absolute path.
- */
-export async function ensureCodexHome(): Promise<string> {
-  const home = await resolveCodexHome();
-  await fs.mkdir(home, { recursive: true });
-  return home;
 }
 
 /**
@@ -217,7 +193,6 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
     display: { ...defaults.display, ...config.display },
     daemon: { ...defaults.daemon, ...config.daemon },
     ui: { ...defaults.ui, ...config.ui },
-    codex: { ...defaults.codex, ...config.codex },
     execution: { ...defaults.execution, ...config.execution },
     paths: { ...defaults.paths, ...config.paths },
   };

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -243,14 +243,6 @@ export interface AgorDatabaseSettings {
 }
 
 /**
- * Codex-specific configuration
- */
-export interface AgorCodexSettings {
-  /** Codex home directory (default: ~/.agor/codex) */
-  home?: string;
-}
-
-/**
  * Unix user isolation mode controlling how session processes get mapped to
  * OS identities.
  *
@@ -769,9 +761,6 @@ export interface AgorConfig {
   /** OpenCode.ai integration settings */
   opencode?: AgorOpenCodeSettings;
 
-  /** Codex-specific configuration */
-  codex?: AgorCodexSettings;
-
   /** Execution isolation settings */
   execution?: AgorExecutionSettings;
 
@@ -833,7 +822,6 @@ export type ConfigKey =
   | `ui.${keyof AgorUISettings}`
   | `database.${keyof AgorDatabaseSettings}`
   | `opencode.${keyof AgorOpenCodeSettings}`
-  | `codex.${keyof AgorCodexSettings}`
   | `execution.${keyof AgorExecutionSettings}`
   | `security.${keyof AgorSecuritySettings}`
   | `worktrees.${keyof AgorWorktreesSettings}`

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -83,7 +83,7 @@ export class CodexTool implements ITool {
     messagesService?: MessagesService,
     tasksService?: TasksService,
     tasksStreamingService?: TasksStreamingService,
-    _useNativeAuth?: boolean, // Codex doesn't have OAuth fallback, but accept for interface consistency
+    useNativeAuth?: boolean,
     mcpServerRepo?: MCPServerRepository,
     usersRepo?: UsersRepository
   ) {
@@ -103,7 +103,8 @@ export class CodexTool implements ITool {
         reposRepo,
         apiKey,
         mcpServerRepo,
-        usersRepo
+        usersRepo,
+        useNativeAuth ?? false
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -319,8 +319,13 @@ describe('CodexPromptService - Todo normalization', () => {
 
     // Avoid filesystem/config setup noise in this focused stream test
     const serviceWithPrivates = service as any;
-    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
-    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-mock.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 
     mockSessionsRepo.findById.mockResolvedValue({
@@ -390,8 +395,13 @@ describe('CodexPromptService - tool payload mapping', () => {
     );
 
     const serviceWithPrivates = service as any;
-    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
-    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-mock.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 
     mockSessionsRepo.findById.mockResolvedValue({
@@ -596,8 +606,13 @@ describe('CodexPromptService - tool payload mapping', () => {
     );
 
     const serviceWithPrivates = service as any;
-    serviceWithPrivates.ensureCodexSessionContext = vi.fn().mockResolvedValue('/tmp');
-    serviceWithPrivates.ensureCodexConfig = vi.fn().mockResolvedValue(0);
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-mock.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 
     mockSessionsRepo.findById.mockResolvedValue({

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -2,6 +2,17 @@
  * CodexPromptService Tests
  *
  * Focused test: Verify SDK instance caching to prevent memory leak (issue #133)
+ *
+ * KNOWN GAP: the `MockCodexClient` below only captures `apiKey` + `baseUrl`,
+ * not `config` (model_instructions_file, mcp_servers) or `env` (subscription-
+ * mode scrubbing). The streaming tests stub out `ensureCodexInstructionsFile`,
+ * `buildMcpServersConfig`, and `ensureCodexClient` outright. So the
+ * load-bearing behaviors of the per-session-CODEX_HOME removal —
+ * `model_instructions_file` injection, MCP server flattening, subscription-
+ * mode env scrubbing, fingerprint-based cache invalidation on token rotation
+ * — are NOT exercised here. End-to-end coverage for those lives in the
+ * manual test matrix in PR #1136. A proper SDK-call-shape assertion suite
+ * is queued as a follow-up.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -29,6 +29,8 @@ import * as path from 'node:path';
 import type { Thread, ThreadItem } from '@agor/core/sdk';
 import { Codex } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
+import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
+import type { EffortLevel } from '@agor/core/types';
 import { getDaemonUrl } from '../../config.js';
 import type {
   MCPServerRepository,
@@ -40,10 +42,25 @@ import type {
   WorktreeRepository,
 } from '../../db/feathers-repositories.js';
 import type { TokenUsage } from '../../types/token-usage.js';
-import type { PermissionMode, SessionID, TaskID } from '../../types.js';
+import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { DEFAULT_CODEX_MODEL } from './models.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
+
+/**
+ * Map Agor's effort level (`low`/`medium`/`high`/`max`) to Codex SDK's
+ * `ModelReasoningEffort` (`minimal`/`low`/`medium`/`high`/`xhigh`).
+ *
+ * Agor has no equivalent for `minimal`, and Codex has no equivalent for `max`
+ * — `max` is the user's "go as deep as possible" intent, which on Codex maps
+ * to `xhigh`.
+ */
+function toCodexReasoningEffort(
+  effort: EffortLevel | undefined
+): 'low' | 'medium' | 'high' | 'xhigh' | undefined {
+  if (!effort) return undefined;
+  return effort === 'max' ? 'xhigh' : effort;
+}
 
 /**
  * Mirrors the (unexported) `CodexConfigObject` shape from `@openai/codex-sdk`.
@@ -208,6 +225,49 @@ export class CodexPromptService {
     // MCP servers).
     this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, undefined));
     this.lastClientFingerprint = null;
+
+    // Best-effort sweep of orphaned per-session instructions files in
+    // tmpdir. `closeSession()` removes a session's file when called, but
+    // the daemon currently has no terminal-state hook that invokes it
+    // (also true for Gemini/Copilot — broader gap). This sweep self-heals
+    // long-running daemons that accumulate stale `agor-codex-instructions-*`
+    // across crashes / unclean shutdowns / never-fired close hooks.
+    void this.sweepStaleInstructionsFiles().catch((err) => {
+      console.warn('⚠️  [Codex] Stale-instructions-file sweep failed:', err);
+    });
+  }
+
+  /**
+   * Delete `agor-codex-instructions-*.md` files in `os.tmpdir()` (and the
+   * `~/.agor/tmp` fallback dir) older than 24h. Bounds the disk leak from
+   * the missing close hook described in the constructor.
+   */
+  private async sweepStaleInstructionsFiles(): Promise<void> {
+    const cutoffMs = Date.now() - 24 * 60 * 60 * 1000;
+    const candidateDirs = [os.tmpdir(), path.join(os.homedir(), '.agor', 'tmp')];
+
+    for (const dir of candidateDirs) {
+      let entries: string[];
+      try {
+        entries = await fs.readdir(dir);
+      } catch {
+        continue;
+      }
+      for (const name of entries) {
+        if (!name.startsWith('agor-codex-instructions-') || !name.endsWith('.md')) continue;
+        const full = path.join(dir, name);
+        try {
+          const stat = await fs.stat(full);
+          if (stat.mtimeMs < cutoffMs) {
+            await fs.unlink(full);
+          }
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            console.warn(`⚠️  [Codex] Failed to sweep ${full}:`, err);
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -276,9 +336,35 @@ export class CodexPromptService {
   }
 
   /**
+   * Snapshot the values of every `AGOR_MCP_*` env var (set by
+   * `buildMcpServersConfig` for built-in + per-server bearer tokens). Folded
+   * into the client fingerprint so a token rotation invalidates the cached
+   * Codex instance even when the config object's shape (server names,
+   * `bearer_token_env_var` keys) is unchanged.
+   *
+   * Without this, both subscription mode (where we pass `env` snapshot to
+   * `CodexOptions.env`) and API-key mode (where the SDK snapshots
+   * `process.env` at construction time) would keep spawning the cached Codex
+   * with a stale token after rotation.
+   */
+  private snapshotMcpEnvValues(): Record<string, string> {
+    const snapshot: Record<string, string> = {};
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('AGOR_MCP_')) {
+        snapshot[key] = process.env[key] ?? '';
+      }
+    }
+    return snapshot;
+  }
+
+  /**
    * Recreate `this.codex` with the per-session `config` payload (instructions
    * file + MCP servers) only when the fingerprint changed. Prevents per-turn
    * SDK churn (issue #133) while still reflecting fresh per-session config.
+   *
+   * The fingerprint includes a snapshot of `AGOR_MCP_*` env values so that
+   * rotated MCP bearer tokens invalidate the cache even when the config
+   * shape stays the same — see `snapshotMcpEnvValues()`.
    */
   private ensureCodexClient(config: CodexConfigObject): void {
     const baseUrl = this.resolveBaseUrl();
@@ -287,6 +373,7 @@ export class CodexPromptService {
       baseUrl: baseUrl ?? '',
       useNativeAuth: this.useNativeAuth,
       config,
+      mcpEnv: this.snapshotMcpEnvValues(),
     });
 
     if (this.lastClientFingerprint === fingerprint) {
@@ -344,6 +431,41 @@ export class CodexPromptService {
   }
 
   /**
+   * Claim a unique sanitized server name within this session's mcp_servers
+   * map. Sanitization collapses non-`[a-z0-9_-]` chars to `_`, so distinct
+   * input names can collide (`Foo Bar` and `foo_bar` both become `foo_bar`)
+   * — without de-collision the second would silently overwrite the first.
+   *
+   * On collision we suffix `_2`, `_3`, ... and warn so operators can spot
+   * the underlying naming clash.
+   */
+  private claimMcpServerName(
+    rawName: string,
+    claimed: Set<string>,
+    reservedReason?: string
+  ): string {
+    let base = rawName.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
+    if (reservedReason) {
+      base = `user_${base}`;
+      console.warn(
+        `   ⚠️  [Codex MCP] "${rawName}" ${reservedReason}, renamed to "${base}" to disambiguate`
+      );
+    }
+    if (!claimed.has(base)) {
+      claimed.add(base);
+      return base;
+    }
+    let suffix = 2;
+    while (claimed.has(`${base}_${suffix}`)) suffix++;
+    const final = `${base}_${suffix}`;
+    console.warn(
+      `   ⚠️  [Codex MCP] sanitized name "${base}" already claimed (raw="${rawName}"), using "${final}"`
+    );
+    claimed.add(final);
+    return final;
+  }
+
+  /**
    * Build the `mcp_servers` nested config object for `CodexOptions.config`.
    *
    * Includes the built-in Agor MCP server (when `mcpToken` is provided) plus
@@ -351,18 +473,26 @@ export class CodexPromptService {
    * SDK's `flattenConfigOverrides` turns this object into repeated
    * `--config mcp_servers.<name>.<field>=<value>` flags for the Codex CLI.
    *
-   * Bearer tokens are injected via env vars referenced by
-   * `bearer_token_env_var` (never inlined in the URL).
+   * Bearer tokens (whether plain bearer, JWT, or OAuth) are resolved via the
+   * shared `resolveMCPAuthHeaders` (matching Claude) and injected via env
+   * vars referenced by `bearer_token_env_var` (never inlined in the URL).
+   *
+   * `forUserId` is required for per-user OAuth token injection at the
+   * scoping layer — without it, OAuth-protected MCP servers won't pick up
+   * the requesting user's stored OAuth tokens.
    */
   private async buildMcpServersConfig(
     sessionId: SessionID,
-    mcpToken?: string
+    mcpToken: string | undefined,
+    forUserId: UserID | undefined
   ): Promise<{ servers: CodexConfigObject; total: number }> {
     console.log(`🔍 [Codex MCP] Fetching MCP servers for session ${sessionId.substring(0, 8)}...`);
+    console.log(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
 
     const serversWithSource = await getMcpServersForSession(sessionId, {
       sessionMCPRepo: this.sessionMCPServerRepo,
       mcpServerRepo: this.mcpServerRepo,
+      forUserId,
     });
 
     const mcpServers = serversWithSource.map((s) => s.server);
@@ -380,7 +510,7 @@ export class CodexPromptService {
     );
 
     const result: CodexConfigObject = {};
-    const managedNames = new Set<string>();
+    const claimedNames = new Set<string>();
 
     // Built-in Agor MCP server (streamable HTTP). Token travels via
     // bearer_token_env_var — never in the URL.
@@ -389,7 +519,7 @@ export class CodexPromptService {
       const agorBearerEnvVar = `AGOR_MCP_${sessionId.substring(0, 8)}_AGOR`;
       process.env[agorBearerEnvVar] = mcpToken;
 
-      managedNames.add('agor');
+      claimedNames.add('agor');
       result.agor = {
         url: `${daemonUrl}/mcp`,
         bearer_token_env_var: agorBearerEnvVar,
@@ -401,14 +531,11 @@ export class CodexPromptService {
     }
 
     for (const server of stdioServers) {
-      let serverName = server.name.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
-      if (serverName === 'agor') {
-        serverName = 'user_agor';
-        console.warn(
-          `   ⚠️  [Codex MCP] Server "${server.name}" conflicts with built-in Agor MCP server, renamed to "${serverName}"`
-        );
-      }
-      managedNames.add(serverName);
+      const serverName = this.claimMcpServerName(
+        server.name,
+        claimedNames,
+        server.name.toLowerCase() === 'agor' ? 'conflicts with built-in Agor MCP server' : undefined
+      );
 
       const serverConfig: CodexConfigObject = {};
       console.log(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
@@ -429,14 +556,11 @@ export class CodexPromptService {
     }
 
     for (const server of httpServers) {
-      let serverName = server.name.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
-      if (serverName === 'agor') {
-        serverName = 'user_agor';
-        console.warn(
-          `   ⚠️  [Codex MCP] Server "${server.name}" conflicts with built-in Agor MCP server, renamed to "${serverName}"`
-        );
-      }
-      managedNames.add(serverName);
+      const serverName = this.claimMcpServerName(
+        server.name,
+        claimedNames,
+        server.name.toLowerCase() === 'agor' ? 'conflicts with built-in Agor MCP server' : undefined
+      );
 
       const serverConfig: CodexConfigObject = {};
       console.log(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
@@ -445,11 +569,40 @@ export class CodexPromptService {
         console.log(`      url: ${server.url}`);
       }
 
-      if (server.auth?.type === 'bearer' && server.auth.token) {
-        const envVarName = `AGOR_MCP_${sessionId.substring(0, 8)}_${serverName.toUpperCase()}`;
-        process.env[envVarName] = server.auth.token;
-        serverConfig.bearer_token_env_var = envVarName;
-        console.log(`      auth: bearer token via ${envVarName}`);
+      // Resolve the Authorization header via the shared MCP auth helper —
+      // covers bearer / JWT (with token-mint) / OAuth (with cached & DB
+      // tokens). Codex passes the bearer through `bearer_token_env_var`,
+      // not a header map, so we extract the bearer token and route it via
+      // an env var. Non-bearer schemes log a warning since Codex's CLI
+      // only supports bearer auth.
+      try {
+        const headers = await resolveMCPAuthHeaders(server.auth, server.url);
+        const authHeader = headers?.Authorization;
+        if (authHeader) {
+          const bearerToken = /^Bearer\s+(.+)$/i.exec(authHeader)?.[1];
+          if (bearerToken) {
+            const envVarName = `AGOR_MCP_${sessionId.substring(0, 8)}_${serverName.toUpperCase()}`;
+            process.env[envVarName] = bearerToken;
+            serverConfig.bearer_token_env_var = envVarName;
+            console.log(`      auth: ${server.auth?.type ?? 'bearer'} token via ${envVarName}`);
+          } else {
+            console.warn(
+              `      ⚠️  auth: resolved Authorization header for "${server.name}" is not a Bearer scheme (Codex CLI only supports bearer); skipping injection`
+            );
+          }
+        } else if (server.auth?.type === 'oauth') {
+          console.warn(
+            `   ⚠️  [Codex MCP] Server "${server.name}" requires OAuth but no valid token found.`
+          );
+          console.warn(
+            `      💡 Go to Settings → MCP Servers → ${server.name} → Start OAuth Flow to authenticate.`
+          );
+        }
+      } catch (error) {
+        console.warn(
+          `   ⚠️  [Codex MCP] Failed to resolve auth headers for "${server.name}":`,
+          error instanceof Error ? error.message : String(error)
+        );
       }
 
       result[serverName] = serverConfig;
@@ -658,9 +811,14 @@ export class CodexPromptService {
       );
     }
 
+    // forUserId enables per-user OAuth token injection at the MCP scoping
+    // layer — mirrors Claude's contextUserId pattern so personal OAuth-
+    // protected MCP servers work for Codex too.
+    const forUserId = (session.created_by ?? undefined) as UserID | undefined;
     const { servers: mcpServersConfig, total: mcpServerCount } = await this.buildMcpServersConfig(
       sessionId,
-      mcpToken
+      mcpToken,
+      forUserId
     );
 
     const codexConfigPayload: CodexConfigObject = {
@@ -688,12 +846,18 @@ export class CodexPromptService {
 
     // Build thread options. approvalPolicy + networkAccessEnabled flow through
     // here (not config.toml); ThreadOptions override matching `--config` keys.
+    // model + modelReasoningEffort are passed through from session.model_config
+    // so the UI's per-session model picker actually controls what Codex runs.
+    const sessionModel = session.model_config?.model;
+    const sessionEffort = toCodexReasoningEffort(session.model_config?.effort);
     const threadOptions = {
       workingDirectory: worktree.path,
       skipGitRepoCheck: false,
       sandboxMode,
       approvalPolicy,
       networkAccessEnabled: networkAccess,
+      ...(sessionModel ? { model: sessionModel } : {}),
+      ...(sessionEffort ? { modelReasoningEffort: sessionEffort } : {}),
     };
 
     // Check if MCP servers were added after session creation
@@ -1166,6 +1330,13 @@ export class CodexPromptService {
    * Best-effort removal of the per-session instructions file. Both possible
    * paths (os.tmpdir + ~/.agor/tmp fallback) are attempted in case the
    * tmpdir base differs from the one we wrote to.
+   *
+   * NOTE: as of writing, no daemon code path actually invokes
+   * `closeSession()` for any tool (Codex/Gemini/Copilot all expose it; none
+   * are wired to a terminal-state hook). The constructor's
+   * `sweepStaleInstructionsFiles()` self-heals leaked files so this isn't
+   * load-bearing today — but the method stays in place so the fix becomes
+   * a one-line wire-up the day a real lifecycle hook lands.
    */
   async closeSession(sessionId: SessionID): Promise<void> {
     const fileName = `agor-codex-instructions-${sessionId}.md`;

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -4,10 +4,23 @@
  * Handles live execution of prompts against Codex sessions using OpenAI Codex SDK.
  * Wraps the @openai/codex-sdk for thread management and execution.
  *
- * IMPORTANT: This service caches the Codex SDK instance and only recreates it when
- * the API key or MCP server configuration actually changes. This prevents a memory leak
- * where new Codex CLI processes would be spawned on every prompt execution without cleanup.
- * See issue #133 for details.
+ * Auth: passes apiKey through CodexOptions when set; otherwise the spawned
+ * Codex CLI falls back to `$CODEX_HOME/auth.json` (ChatGPT subscription auth).
+ * In subscription mode (`useNativeAuth=true && !apiKey`) we override `env` and
+ * scrub `OPENAI_API_KEY` / `CODEX_API_KEY` from the spawn so the CLI is
+ * forced down the auth.json path.
+ *
+ * Per-session config (Agor session-context as `model_instructions_file`,
+ * MCP server registry) is passed via `CodexOptions.config`. We do NOT
+ * override `$CODEX_HOME` — Codex CLI's default `~/.codex` is preserved
+ * across all unix_user_modes (the daemon spawns the executor as the right
+ * user already).
+ *
+ * IMPORTANT: this service caches the Codex SDK instance and only recreates
+ * it when the relevant config (apiKey, baseUrl, useNativeAuth, MCP servers,
+ * instructions file path) actually changes. This prevents a memory leak
+ * where new Codex CLI processes would be spawned on every prompt execution
+ * without cleanup. See issue #133.
  */
 
 import * as fs from 'node:fs/promises';
@@ -16,7 +29,6 @@ import * as path from 'node:path';
 import type { Thread, ThreadItem } from '@agor/core/sdk';
 import { Codex } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
-import { type JsonMap, parse as parseToml, stringify as stringifyToml } from '@iarna/toml';
 import { getDaemonUrl } from '../../config.js';
 import type {
   MCPServerRepository,
@@ -32,6 +44,16 @@ import type { PermissionMode, SessionID, TaskID } from '../../types.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { DEFAULT_CODEX_MODEL } from './models.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
+
+/**
+ * Mirrors the (unexported) `CodexConfigObject` shape from `@openai/codex-sdk`.
+ * The SDK flattens nested objects into `--config key.path=value` flags and
+ * TOML-quotes string values automatically.
+ */
+type CodexConfigValue = string | number | boolean | CodexConfigValue[] | CodexConfigObject;
+interface CodexConfigObject {
+  [key: string]: CodexConfigValue;
+}
 
 export interface CodexPromptResult {
   /** Complete assistant response from Codex */
@@ -122,12 +144,13 @@ export type CodexStreamEvent =
 
 export class CodexPromptService {
   private codex: InstanceType<typeof Codex.Codex>;
-  private lastMCPServersHash: string | null = null;
   private lastApiKey: string | null = null;
   private lastBaseUrl: string | null = null;
+  private lastClientFingerprint: string | null = null;
   private stopRequested = new Map<SessionID, boolean>();
   private apiKey: string | undefined;
-  private lastCodexHome: string | null = null;
+  private useNativeAuth: boolean;
+  private instructionsFilePaths = new Map<SessionID, string>();
 
   /**
    * Resolve the per-user custom OpenAI-compatible base URL.
@@ -152,18 +175,27 @@ export class CodexPromptService {
     private reposRepo?: RepoRepository,
     apiKey?: string,
     private mcpServerRepo?: MCPServerRepository,
-    private usersRepo?: UsersRepository
+    private usersRepo?: UsersRepository,
+    useNativeAuth: boolean = false
   ) {
     // Store API key from base-executor (already resolved with proper precedence)
     this.apiKey = apiKey || '';
     this.lastApiKey = this.apiKey;
+    this.useNativeAuth = useNativeAuth;
     const baseUrl = this.resolveBaseUrl();
     this.lastBaseUrl = baseUrl ?? null;
 
-    if (!this.apiKey) {
-      console.warn(
-        '⚠️  [Codex] No OPENAI_API_KEY provided — Codex SDK requests will fail with 401. ' +
-          'Please configure your API key in Settings > Codex > Authentication.'
+    if (this.apiKey) {
+      // Source already logged by base-executor via resolveApiKeyForTask().
+    } else if (this.useNativeAuth) {
+      console.log(
+        '🔓 [Codex] No API key configured — falling back to ChatGPT subscription auth from $CODEX_HOME/auth.json. ' +
+          'Run `codex login` if you have not authenticated yet.'
+      );
+    } else {
+      console.error(
+        '❌ [Codex] No API key and native auth disabled — Codex requests will fail with 401. ' +
+          'Configure your API key in Settings > Codex > Authentication or sign in via `codex login`.'
       );
     }
 
@@ -171,71 +203,117 @@ export class CodexPromptService {
       console.debug(`🔗 [Codex] Using custom OPENAI_BASE_URL`);
     }
 
-    // Initialize Codex SDK with resolved API key + optional custom base URL
-    this.codex = new Codex.Codex({
-      apiKey: this.apiKey,
-      ...(baseUrl ? { baseUrl } : {}),
-    });
+    // Bootstrap Codex SDK without per-session config (rebuilt lazily in
+    // promptSessionStreaming once we know the session's instructions file +
+    // MCP servers).
+    this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, undefined));
+    this.lastClientFingerprint = null;
   }
 
   /**
-   * Reinitialize Codex SDK to pick up config changes
-   * Call this after updating ~/.codex/config.toml
+   * Build CodexOptions for `new Codex({...})`.
    *
-   * NOTE: This is only called when MCP server config changes, which requires
-   * a full SDK restart to pick up the new config.toml file
+   * Subscription mode (no apiKey + useNativeAuth) scrubs `OPENAI_API_KEY` and
+   * `CODEX_API_KEY` from the spawned Codex CLI process so it falls back to
+   * `$CODEX_HOME/auth.json`. The SDK does NOT inherit `process.env` when an
+   * `env` object is provided, so we forward all other vars explicitly.
+   *
+   * API-key mode omits `env` entirely so the SDK inherits `process.env`
+   * normally and injects `CODEX_API_KEY` itself.
    */
-  private reinitializeCodex(): void {
-    console.log('🔄 [Codex] Reinitializing SDK to pick up config changes...');
-    // Use the resolved API key from base-executor (no fallback to env needed)
-    const baseUrl = this.resolveBaseUrl();
-    this.codex = new Codex.Codex({
-      apiKey: this.apiKey,
+  private buildCodexOptions(
+    apiKey: string | undefined,
+    baseUrl: string | undefined,
+    config: CodexConfigObject | undefined
+  ): ConstructorParameters<typeof Codex.Codex>[0] {
+    const useSubscription = this.useNativeAuth && !apiKey;
+
+    const options: ConstructorParameters<typeof Codex.Codex>[0] = {
+      ...(apiKey ? { apiKey } : {}),
       ...(baseUrl ? { baseUrl } : {}),
-    });
-    this.lastApiKey = this.apiKey || null;
-    this.lastBaseUrl = baseUrl ?? null;
-    console.log('✅ [Codex] SDK reinitialized');
+      ...(config ? { config } : {}),
+    };
+
+    if (useSubscription) {
+      const env: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v === undefined) continue;
+        if (k === 'OPENAI_API_KEY' || k === 'CODEX_API_KEY') continue;
+        env[k] = v;
+      }
+      options.env = env;
+    }
+
+    return options;
   }
 
   /**
-   * Refresh Codex client with latest API key from config
-   * Ensures hot-reload of credentials from Settings UI
+   * Refresh Codex client with latest API key from config (no per-session
+   * config payload). Used at session start, before we have the instructions
+   * file path or MCP servers — `ensureCodexClient()` is the per-turn refresh
+   * that can change config.
    *
    * IMPORTANT: Only recreates Codex instance if API key OR base URL actually
-   * changed. This prevents memory leak from spawning multiple Codex CLI
-   * processes (issue #133).
+   * changed. This prevents the issue #133 memory leak where unbounded Codex
+   * CLI processes accumulate when we recreate without need.
    */
   private refreshClient(currentApiKey: string): void {
     const currentBaseUrl = this.resolveBaseUrl();
     const baseUrlChanged = (this.lastBaseUrl ?? null) !== (currentBaseUrl ?? null);
-    // Only recreate if API key OR base URL changed (prevents memory leak - issue #133)
     if (this.lastApiKey !== currentApiKey || baseUrlChanged) {
       console.log(
         `🔄 [Codex] ${this.lastApiKey !== currentApiKey ? 'API key' : 'Base URL'} changed, reinitializing SDK...`
       );
-      this.codex = new Codex.Codex({
-        apiKey: currentApiKey,
-        ...(currentBaseUrl ? { baseUrl: currentBaseUrl } : {}),
-      });
+      this.codex = new Codex.Codex(
+        this.buildCodexOptions(currentApiKey, currentBaseUrl, undefined)
+      );
+      this.apiKey = currentApiKey;
       this.lastApiKey = currentApiKey;
       this.lastBaseUrl = currentBaseUrl ?? null;
+      this.lastClientFingerprint = null;
       console.log('✅ [Codex] SDK reinitialized');
     }
   }
 
   /**
-   * Create per-session CODEX_HOME with Agor context
-   *
-   * Codex SDK uses $CODEX_HOME environment variable to locate config/AGENTS.md.
-   * We create a unique CODEX_HOME per session to:
-   * 1. Avoid race conditions between concurrent sessions
-   * 2. Inject rich session/worktree/repo context via AGENTS.md
-   * 3. Preserve user's project AGENTS.md files (still loaded hierarchically)
-   *
-   * Returns the per-session CODEX_HOME path.
+   * Recreate `this.codex` with the per-session `config` payload (instructions
+   * file + MCP servers) only when the fingerprint changed. Prevents per-turn
+   * SDK churn (issue #133) while still reflecting fresh per-session config.
    */
-  private async ensureCodexSessionContext(sessionId: SessionID): Promise<string> {
+  private ensureCodexClient(config: CodexConfigObject): void {
+    const baseUrl = this.resolveBaseUrl();
+    const fingerprint = JSON.stringify({
+      apiKey: this.apiKey || '',
+      baseUrl: baseUrl ?? '',
+      useNativeAuth: this.useNativeAuth,
+      config,
+    });
+
+    if (this.lastClientFingerprint === fingerprint) {
+      return;
+    }
+
+    console.log(
+      `🔄 [Codex] Per-session config changed, reinitializing SDK (apiKey=${this.apiKey ? 'set' : 'unset'}, useNativeAuth=${this.useNativeAuth})`
+    );
+    this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, config));
+    this.lastApiKey = this.apiKey || null;
+    this.lastBaseUrl = baseUrl ?? null;
+    this.lastClientFingerprint = fingerprint;
+  }
+
+  /**
+   * Write the rendered Agor session-context prompt to a single file under
+   * `os.tmpdir()` and return its absolute path.
+   *
+   * Replaces the per-session CODEX_HOME directory + AGENTS.md mechanism — we
+   * now point Codex at this file via the `model_instructions_file` config key
+   * (loaded by Codex CLI in addition to any project AGENTS.md files).
+   *
+   * `~/.codex/` is NEVER touched: the user's auth.json and any user-authored
+   * config.toml stay where they are.
+   */
+  private async ensureCodexInstructionsFile(sessionId: SessionID): Promise<string> {
     const agorSystemPrompt = await renderAgorSystemPrompt(sessionId, {
       sessions: this.sessionsRepo,
       worktrees: this.worktreesRepo,
@@ -243,67 +321,43 @@ export class CodexPromptService {
       users: this.usersRepo,
     });
 
-    // Create per-session CODEX_HOME (no race conditions!)
-    // Use mode 0o700 (rwx------) to prevent other users from reading session metadata
-    //
-    // NOTE: We try os.tmpdir() first, but fall back to ~/.agor/tmp if /tmp is unavailable
-    // (e.g., in sandboxed executor environments or containers without /tmp mounted)
-    const tmpBase = os.tmpdir();
-    const sessionDirName = `agor-codex-${sessionId}`;
-    let sessionCodexHome = path.join(tmpBase, sessionDirName);
+    const fileName = `agor-codex-instructions-${sessionId}.md`;
 
+    // Try /tmp first; fall back to ~/.agor/tmp if /tmp is unavailable
+    // (sandboxed executors / containers without /tmp).
+    let filePath = path.join(os.tmpdir(), fileName);
     try {
-      await fs.mkdir(sessionCodexHome, { recursive: true, mode: 0o700 });
-    } catch (mkdirError) {
+      await fs.writeFile(filePath, agorSystemPrompt, { encoding: 'utf-8', mode: 0o600 });
+    } catch (writeError) {
       const fallbackBase = path.join(os.homedir(), '.agor', 'tmp');
       console.warn(
-        `⚠️  [Codex] Failed to create CODEX_HOME in ${tmpBase} (${(mkdirError as Error).message}), falling back to ${fallbackBase}`
+        `⚠️  [Codex] Failed to write instructions file in ${os.tmpdir()} (${(writeError as Error).message}), falling back to ${fallbackBase}`
       );
-      sessionCodexHome = path.join(fallbackBase, sessionDirName);
-      await fs.mkdir(sessionCodexHome, { recursive: true, mode: 0o700 });
+      await fs.mkdir(fallbackBase, { recursive: true, mode: 0o700 });
+      filePath = path.join(fallbackBase, fileName);
+      await fs.writeFile(filePath, agorSystemPrompt, { encoding: 'utf-8', mode: 0o600 });
     }
 
-    // Write session context to AGENTS.md
-    // Use mode 0o600 (rw-------) to restrict file access
-    const agentsMdPath = path.join(sessionCodexHome, 'AGENTS.md');
-    await fs.writeFile(agentsMdPath, agorSystemPrompt, { encoding: 'utf-8', mode: 0o600 });
-
-    console.log(`✅ [Codex] Created per-session CODEX_HOME at ${sessionCodexHome}`);
-    console.log(`   Session context will be auto-loaded with any project AGENTS.md files`);
-
-    return sessionCodexHome;
+    this.instructionsFilePaths.set(sessionId, filePath);
+    console.log(`✅ [Codex] Wrote per-session instructions file at ${filePath}`);
+    return filePath;
   }
 
   /**
-   * Generate $CODEX_HOME/config.toml with approval_policy, network_access, and MCP servers
+   * Build the `mcp_servers` nested config object for `CodexOptions.config`.
    *
-   * NOTE: approval_policy, network_access, and MCP servers must be configured via config.toml
-   * (not available in ThreadOptions). We minimize file writes by tracking a hash
-   * of the configuration and only updating when it changes.
+   * Includes the built-in Agor MCP server (when `mcpToken` is provided) plus
+   * all session-scoped + global MCP servers, categorized by transport. The
+   * SDK's `flattenConfigOverrides` turns this object into repeated
+   * `--config mcp_servers.<name>.<field>=<value>` flags for the Codex CLI.
    *
-   * Codex supports two MCP transport types in config.toml:
-   * - STDIO: `command` + `args` + `env` fields
-   * - Streamable HTTP: `url` + optional `bearer_token_env_var` / `http_headers` / `env_http_headers`
-   *
-   * The built-in Agor MCP server is automatically configured as a streamable HTTP server,
-   * enabling Codex agents to access Agor resources (sessions, worktrees, boards, etc.)
-   *
-   * @param approvalPolicy - Codex approval policy (untrusted, on-request, on-failure, never)
-   * @param networkAccess - Whether to allow outbound network access in workspace-write mode
-   * @param sessionId - Session ID for fetching MCP servers
-   * @param codexHome - Path to CODEX_HOME directory (per-session or global)
-   * @param mcpToken - Optional MCP authentication token for the built-in Agor MCP server
-   * @returns Number of MCP servers configured
+   * Bearer tokens are injected via env vars referenced by
+   * `bearer_token_env_var` (never inlined in the URL).
    */
-  private async ensureCodexConfig(
-    approvalPolicy: 'untrusted' | 'on-request' | 'on-failure' | 'never',
-    networkAccess: boolean,
+  private async buildMcpServersConfig(
     sessionId: SessionID,
-    codexHome: string,
     mcpToken?: string
-  ): Promise<number> {
-    // Fetch MCP servers for this session using shared scoping utility
-    // This includes both global-scoped and session-assigned servers with template resolution
+  ): Promise<{ servers: CodexConfigObject; total: number }> {
     console.log(`🔍 [Codex MCP] Fetching MCP servers for session ${sessionId.substring(0, 8)}...`);
 
     const serversWithSource = await getMcpServersForSession(sessionId, {
@@ -318,8 +372,6 @@ export class CodexPromptService {
       console.log(`   Servers: ${mcpServers.map((s) => `${s.name} (${s.transport})`).join(', ')}`);
     }
 
-    // Categorize servers by transport type
-    // Codex supports both STDIO and streamable HTTP transports
     const stdioServers = mcpServers.filter((s) => s.transport === 'stdio');
     const httpServers = mcpServers.filter((s) => s.transport === 'http' || s.transport === 'sse');
 
@@ -327,216 +379,94 @@ export class CodexPromptService {
       `   📊 [Codex MCP] Transport breakdown: ${stdioServers.length} STDIO, ${httpServers.length} HTTP/SSE`
     );
 
-    // Create hash to detect changes
-    // Include server config fields (not just IDs) so URL/command/auth changes trigger a rewrite
-    const serverFingerprints = mcpServers
-      .map(
-        (s) =>
-          `${s.mcp_server_id}:${s.transport}:${s.url || ''}:${s.command || ''}:${JSON.stringify(s.args || [])}:${s.auth?.token || ''}`
-      )
-      .sort();
-    const configHash = `${approvalPolicy}:${networkAccess}:${mcpToken || ''}:${JSON.stringify(serverFingerprints)}`;
+    const result: CodexConfigObject = {};
+    const managedNames = new Set<string>();
 
-    // Skip if config and target directory haven't changed (avoid unnecessary file I/O)
-    if (this.lastMCPServersHash === configHash && this.lastCodexHome === codexHome) {
-      console.log(`✅ [Codex MCP] Config unchanged, skipping write`);
-      return stdioServers.length + httpServers.length + (mcpToken ? 1 : 0);
-    }
-
-    const configPath = path.join(codexHome, 'config.toml');
-    const metadataPath = path.join(codexHome, '.agor-managed.json');
-
-    console.log(`📁 [Codex MCP] Using CODEX_HOME: ${codexHome}`);
-    console.log(`📄 [Codex MCP] Updating config at: ${configPath}`);
-
-    const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-      typeof value === 'object' && value !== null && !Array.isArray(value);
-
-    let existingConfig: JsonMap | undefined;
-    let preservedHeader = '';
-
-    try {
-      const raw = await fs.readFile(configPath, 'utf-8');
-      const headerMatch = raw.match(/^(?:\s*#.*\n)*/);
-      preservedHeader = headerMatch?.[0] ?? '';
-      existingConfig = parseToml(raw) as JsonMap;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`⚠️  [Codex MCP] Failed to read existing config.toml: ${String(error)}`);
-      }
-    }
-
-    let previousManagedServers: string[] = [];
-    try {
-      const metadataRaw = await fs.readFile(metadataPath, 'utf-8');
-      const parsed = JSON.parse(metadataRaw) as { mcpServers?: string[] };
-      if (Array.isArray(parsed.mcpServers)) {
-        previousManagedServers = parsed.mcpServers;
-      }
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`⚠️  [Codex MCP] Failed to read managed metadata: ${String(error)}`);
-      }
-    }
-
-    const configData: JsonMap = existingConfig ? { ...existingConfig } : {};
-
-    configData.approval_policy = approvalPolicy;
-
-    const sandboxConfig = isPlainObject(configData.sandbox_workspace_write)
-      ? { ...(configData.sandbox_workspace_write as JsonMap) }
-      : ({} as JsonMap);
-    sandboxConfig.network_access = networkAccess;
-    configData.sandbox_workspace_write = sandboxConfig;
-
-    const existingMcpServersRaw = isPlainObject(configData.mcp_servers)
-      ? (configData.mcp_servers as JsonMap)
-      : undefined;
-    const mcpServersConfig: JsonMap = existingMcpServersRaw ? { ...existingMcpServersRaw } : {};
-
-    const managedServerNames = new Set<string>();
-
-    // Configure built-in Agor MCP server (streamable HTTP).
-    // Token travels in the Authorization header via bearer_token_env_var —
-    // never in the URL (URL query params leak via Referer, history, logs).
+    // Built-in Agor MCP server (streamable HTTP). Token travels via
+    // bearer_token_env_var — never in the URL.
     if (mcpToken) {
       const daemonUrl = await getDaemonUrl();
       const agorBearerEnvVar = `AGOR_MCP_${sessionId.substring(0, 8)}_AGOR`;
       process.env[agorBearerEnvVar] = mcpToken;
 
-      managedServerNames.add('agor');
-      mcpServersConfig.agor = {
+      managedNames.add('agor');
+      result.agor = {
         url: `${daemonUrl}/mcp`,
         bearer_token_env_var: agorBearerEnvVar,
         required: false,
-      } as JsonMap;
+      };
       console.log(
         `   📝 [Codex MCP] Configuring built-in Agor MCP server (HTTP) at ${daemonUrl}/mcp`
       );
     }
 
-    // Configure STDIO MCP servers
     for (const server of stdioServers) {
       let serverName = server.name.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
-      // Reserve 'agor' for the built-in Agor MCP server
       if (serverName === 'agor') {
         serverName = 'user_agor';
         console.warn(
           `   ⚠️  [Codex MCP] Server "${server.name}" conflicts with built-in Agor MCP server, renamed to "${serverName}"`
         );
       }
-      managedServerNames.add(serverName);
+      managedNames.add(serverName);
 
-      const serverConfig: JsonMap = {};
+      const serverConfig: CodexConfigObject = {};
       console.log(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
       if (server.command) {
         serverConfig.command = server.command;
         console.log(`      command: ${server.command}`);
       }
       if (server.args && server.args.length > 0) {
-        serverConfig.args = server.args;
+        serverConfig.args = server.args as CodexConfigValue[];
         console.log(`      args: ${JSON.stringify(server.args)}`);
       }
       if (server.env && Object.keys(server.env).length > 0) {
-        serverConfig.env = server.env;
+        serverConfig.env = server.env as CodexConfigObject;
         console.log(`      env vars: ${Object.keys(server.env).length} variable(s)`);
       }
 
-      mcpServersConfig[serverName] = serverConfig;
+      result[serverName] = serverConfig;
     }
 
-    // Configure HTTP/SSE MCP servers (streamable HTTP transport)
     for (const server of httpServers) {
       let serverName = server.name.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
-      // Reserve 'agor' for the built-in Agor MCP server
       if (serverName === 'agor') {
         serverName = 'user_agor';
         console.warn(
           `   ⚠️  [Codex MCP] Server "${server.name}" conflicts with built-in Agor MCP server, renamed to "${serverName}"`
         );
       }
-      managedServerNames.add(serverName);
+      managedNames.add(serverName);
 
-      const serverConfig: JsonMap = {};
+      const serverConfig: CodexConfigObject = {};
       console.log(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
       if (server.url) {
         serverConfig.url = server.url;
         console.log(`      url: ${server.url}`);
       }
 
-      // Handle authentication for HTTP servers
-      // Codex supports bearer_token_env_var, http_headers, and env_http_headers
-      // Note: 'env' field is only valid for STDIO servers in Codex config.toml
       if (server.auth?.type === 'bearer' && server.auth.token) {
-        // Inject resolved bearer token via a session-scoped env var
-        // Include sessionId to avoid collisions between concurrent sessions
         const envVarName = `AGOR_MCP_${sessionId.substring(0, 8)}_${serverName.toUpperCase()}`;
         process.env[envVarName] = server.auth.token;
         serverConfig.bearer_token_env_var = envVarName;
         console.log(`      auth: bearer token via ${envVarName}`);
       }
 
-      mcpServersConfig[serverName] = serverConfig;
+      result[serverName] = serverConfig;
     }
 
-    const previousManagedSet = new Set(previousManagedServers);
-    for (const serverName of previousManagedSet) {
-      if (!managedServerNames.has(serverName)) {
-        delete mcpServersConfig[serverName];
-      }
-    }
-
-    if (Object.keys(mcpServersConfig).length > 0) {
-      configData.mcp_servers = mcpServersConfig;
-    } else {
-      delete configData.mcp_servers;
-    }
-
-    let configBody = stringifyToml(configData);
-    if (configBody && !configBody.endsWith('\n')) {
-      configBody += '\n';
-    }
-
-    let header = preservedHeader;
-    if (!header.trim()) {
-      header = `# Codex configuration\n# Managed by Agor - ${new Date().toISOString()}\n\n`;
-    } else if (!header.endsWith('\n\n')) {
-      header = header.endsWith('\n') ? `${header}\n` : `${header}\n\n`;
-    }
-
-    await fs.writeFile(configPath, `${header}${configBody}`, 'utf-8');
-
-    const managedServerList = Array.from(managedServerNames.values()).sort();
-
-    await fs.writeFile(
-      metadataPath,
-      JSON.stringify({ mcpServers: managedServerList }, null, 2),
-      'utf-8'
-    );
-
-    this.lastMCPServersHash = configHash;
-    this.lastCodexHome = codexHome;
-    console.log(
-      `✅ [Codex] Updated config.toml with approval_policy = "${approvalPolicy}", network_access = ${networkAccess}`
-    );
-
-    // Reinitialize Codex SDK to pick up the new config
-    this.reinitializeCodex();
-
-    const totalConfigured = stdioServers.length + httpServers.length + (mcpToken ? 1 : 0);
-    if (totalConfigured > 0) {
+    const total = stdioServers.length + httpServers.length + (mcpToken ? 1 : 0);
+    if (total > 0) {
       const parts: string[] = [];
       if (mcpToken) parts.push('Agor (HTTP)');
       if (stdioServers.length > 0)
         parts.push(`${stdioServers.length} STDIO (${stdioServers.map((s) => s.name).join(', ')})`);
       if (httpServers.length > 0)
         parts.push(`${httpServers.length} HTTP (${httpServers.map((s) => s.name).join(', ')})`);
-      console.log(
-        `✅ [Codex MCP] Configured ${totalConfigured} MCP server(s): ${parts.join(', ')}`
-      );
+      console.log(`✅ [Codex MCP] Configured ${total} MCP server(s): ${parts.join(', ')}`);
     }
 
-    return totalConfigured;
+    return { servers: result, total };
   }
 
   /**
@@ -701,30 +631,26 @@ export class CodexPromptService {
     console.log(`   Permission mode: ${permissionMode || 'not specified (will use default)'}`);
     console.log(`   Existing thread ID: ${session.sdk_session_id || 'none (will create new)'}`);
 
-    // HYBRID APPROACH: Codex permissions require THREE settings:
-    // 1. sandboxMode (via ThreadOptions) - controls WHERE you can write
-    // 2. approval_policy (via config.toml) - controls WHETHER agent asks before executing
-    // 3. network_access (via config.toml) - controls network connectivity
-
-    // Read from session.permission_config.codex (dual config), fallback to defaults
+    // Codex permission settings split across two surfaces:
+    // - sandboxMode, approvalPolicy, networkAccessEnabled: per-thread via ThreadOptions
+    // - MCP servers + model_instructions_file: per-Codex-instance via CodexOptions.config
+    // ThreadOptions are emitted AFTER `--config` flags, so for keys that overlap
+    // (approval_policy, sandbox_workspace_write.network_access) ThreadOptions win.
     const codexConfig = session.permission_config?.codex;
     const sandboxMode = codexConfig?.sandboxMode || 'workspace-write';
     const approvalPolicy = codexConfig?.approvalPolicy || 'on-request';
-    const networkAccess = codexConfig?.networkAccess ?? false; // Default: disabled
+    const networkAccess = codexConfig?.networkAccess ?? false;
 
     console.log(
       `   Using Codex permissions: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}`
     );
 
-    // Create per-session CODEX_HOME with Agor context (avoids race conditions!)
-    // Returns temp directory path like /tmp/agor-codex-{sessionId}
-    const sessionCodexHome = await this.ensureCodexSessionContext(sessionId);
+    // Write per-session Agor instructions file (single .md, not a directory).
+    // CODEX_HOME is intentionally NOT overridden — Codex CLI uses the
+    // executor user's $HOME/.codex which already contains auth.json plus any
+    // user-authored config.toml.
+    const instructionsFile = await this.ensureCodexInstructionsFile(sessionId);
 
-    // Set CODEX_HOME for this session (Codex SDK will use it)
-    process.env.CODEX_HOME = sessionCodexHome;
-
-    // Set approval_policy, network_access, and MCP servers in config.toml
-    // Also configures the built-in Agor MCP server (streamable HTTP) if MCP token is available
     const mcpToken = session.mcp_token;
     if (!mcpToken) {
       console.warn(
@@ -732,16 +658,22 @@ export class CodexPromptService {
       );
     }
 
-    const mcpServerCount = await this.ensureCodexConfig(
-      approvalPolicy,
-      networkAccess,
+    const { servers: mcpServersConfig, total: mcpServerCount } = await this.buildMcpServersConfig(
       sessionId,
-      sessionCodexHome, // Pass per-session CODEX_HOME
-      mcpToken // Pass MCP token for built-in Agor MCP server
+      mcpToken
     );
 
+    const codexConfigPayload: CodexConfigObject = {
+      model_instructions_file: instructionsFile,
+      ...(Object.keys(mcpServersConfig).length > 0 ? { mcp_servers: mcpServersConfig } : {}),
+    };
+
+    // Recreate Codex instance only if the per-session config payload (or
+    // apiKey/baseUrl) actually changed — issue #133 protection.
+    this.ensureCodexClient(codexConfigPayload);
+
     console.log(
-      `   Configured: sandboxMode=${sandboxMode}, approval_policy + ${mcpServerCount} MCP server(s) via config.toml`
+      `   Configured: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}, ${mcpServerCount} MCP server(s)`
     );
 
     // Fetch worktree to get working directory
@@ -754,11 +686,14 @@ export class CodexPromptService {
 
     console.log(`   Working directory: ${worktree.path}`);
 
-    // Build thread options with sandbox mode and worktree working directory
+    // Build thread options. approvalPolicy + networkAccessEnabled flow through
+    // here (not config.toml); ThreadOptions override matching `--config` keys.
     const threadOptions = {
       workingDirectory: worktree.path,
       skipGitRepoCheck: false,
       sandboxMode,
+      approvalPolicy,
+      networkAccessEnabled: networkAccess,
     };
 
     // Check if MCP servers were added after session creation
@@ -845,7 +780,7 @@ export class CodexPromptService {
       console.log(`🆕 [Codex] Creating new thread`);
       if (mcpServerCount > 0) {
         console.log(
-          `✅ [Codex MCP] New thread will have ${mcpServerCount} MCP server(s) available from config.toml`
+          `✅ [Codex MCP] New thread will have ${mcpServerCount} MCP server(s) available via --config flags`
         );
       }
       thread = this.codex.startThread(threadOptions);
@@ -1089,10 +1024,12 @@ export class CodexPromptService {
 
             // Detect 401/auth errors and provide actionable guidance
             if (errorMessage.includes('401') || errorMessage.includes('Unauthorized')) {
-              const isEmptyKey = errorMessage.includes('Missing bearer');
-              const guidance = isEmptyKey
-                ? 'No OPENAI_API_KEY is configured. Please add your API key in Settings > Codex > Authentication.'
-                : 'Your OPENAI_API_KEY may be invalid or expired. Please check Settings > Codex > Authentication.';
+              const hasApiKey = !!this.apiKey;
+              const guidance = hasApiKey
+                ? 'Your OPENAI_API_KEY may be invalid or expired. Check Settings > Codex > Authentication, or run `codex login` for ChatGPT subscription auth.'
+                : this.useNativeAuth
+                  ? 'No API key configured and ChatGPT subscription auth (~/.codex/auth.json) was rejected or missing. Run `codex login` from the worktree terminal, or add an API key in Settings > Codex > Authentication.'
+                  : 'No API key configured. Add one in Settings > Codex > Authentication, or sign in via `codex login`.';
               console.error(
                 `❌ [Codex] Authentication failed for session ${sessionId.substring(0, 8)}: ${guidance}`
               );
@@ -1226,25 +1163,29 @@ export class CodexPromptService {
   /**
    * Clean up session resources (e.g., on session close)
    *
-   * Removes per-session CODEX_HOME directory with AGENTS.md and config.toml
+   * Best-effort removal of the per-session instructions file. Both possible
+   * paths (os.tmpdir + ~/.agor/tmp fallback) are attempted in case the
+   * tmpdir base differs from the one we wrote to.
    */
   async closeSession(sessionId: SessionID): Promise<void> {
-    // Clean up per-session CODEX_HOME directory from both possible locations
-    const sessionDirName = `agor-codex-${sessionId}`;
-    const possiblePaths = [
-      path.join(os.tmpdir(), sessionDirName),
-      path.join(os.homedir(), '.agor', 'tmp', sessionDirName),
-    ];
+    const fileName = `agor-codex-instructions-${sessionId}.md`;
+    const recordedPath = this.instructionsFilePaths.get(sessionId);
+    const candidatePaths = new Set<string>([
+      ...(recordedPath ? [recordedPath] : []),
+      path.join(os.tmpdir(), fileName),
+      path.join(os.homedir(), '.agor', 'tmp', fileName),
+    ]);
 
-    for (const sessionCodexHome of possiblePaths) {
+    for (const filePath of candidatePaths) {
       try {
-        await fs.rm(sessionCodexHome, { recursive: true, force: true });
+        await fs.unlink(filePath);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          console.warn(`⚠️  Failed to remove CODEX_HOME at ${sessionCodexHome}:`, error);
+          console.warn(`⚠️  Failed to remove Codex instructions file at ${filePath}:`, error);
         }
       }
     }
+    this.instructionsFilePaths.delete(sessionId);
 
     // Clean up session-scoped MCP bearer token env vars
     const envPrefix = `AGOR_MCP_${sessionId.substring(0, 8)}_`;


### PR DESCRIPTION
## Summary

- **Bug:** Codex sessions silently 401'd when users tried ChatGPT subscription auth. Root cause: Agor was setting `process.env.CODEX_HOME = /tmp/agor-codex-<sessionId>` per session, which orphaned the user's `~/.codex/auth.json` (Codex CLI uses `$CODEX_HOME` for everything including auth).
- **Fix:** Drop the per-session `CODEX_HOME` override entirely. Codex defaults to `$HOME/.codex` (correct in every `unix_user_mode`). Move per-session approval policy / network access to `ThreadOptions`, MCP servers to `CodexOptions.config`, and Agor's session context to a single `model_instructions_file` in `os.tmpdir()`. When using subscription auth, `OPENAI_API_KEY`/`CODEX_API_KEY` are scrubbed from the spawn env so Codex falls back to `~/.codex/auth.json` as intended. `useNativeAuth` is now properly plumbed end-to-end (was previously accepted and silently dropped). Auth-mode logging is branched.

## Why this works now

`@openai/codex-sdk@0.128.0` exposes everything we previously needed `CODEX_HOME` for:
- `ThreadOptions.approvalPolicy`, `ThreadOptions.networkAccessEnabled`
- `CodexOptions.config` — arbitrary nested overrides flattened to repeated `--config key.path=value` flags
- `CodexOptions.env` — per-instance env override (does NOT inherit `process.env` when set)
- `model_instructions_file` config key — loads agent instructions from any path on disk

Previously the SDK only supported these via `config.toml`, which is what forced the per-session `CODEX_HOME` workaround in the first place. The original tech debt is paid down.

## Net change

```
prompt-service.ts        +268/-299  (the main rewrite)
session-state.ts         +14/-11    (getCodexHome simplified — takes executorHomeDir? now)
session-state-hooks.ts   +12/-11
prompt-service.test.ts   +19/-8
codex-tool.ts            +3/-2
register-services.ts     +1/-1
                         ────────
                         net -25 LOC, 6 files
```

## What's intentionally NOT in this PR

User Settings → Codex → Authentication UI improvements (auth status indicator, "Test connection" button, copy improvements explaining subscription vs API-key paths, mutual-exclusion warning). That work is queued as a follow-up worktree — best to ship the functional fix first, verify it end-to-end, then build UX on top of known-good behavior.

Two stale `CODEX_HOME` mentions remain in `apps/agor-ui/.../AgenticToolsSection.tsx` and `apps/agor-docs/.../sdk-comparison.mdx` — also addressed in the follow-up.

## Test plan

Unit tests pass (861/861 across executor + daemon). The end-to-end test matrix below requires a running Agor instance and is what reviewers should walk through:

- [ ] **API-key path** — Set `OPENAI_API_KEY` in Settings → Codex → Authentication, spawn a Codex session, prompt it. Should succeed. Daemon log shows `Using API key from <source>`.
- [ ] **Subscription path** — Clear `OPENAI_API_KEY` in Settings, ensure `~/.codex/auth.json` exists from a prior `codex login`, spawn a Codex session. Should succeed. Daemon log shows the new subscription-auth log line. Inspect spawned `codex` process env (`ps eww`) and confirm `OPENAI_API_KEY` is absent.
- [ ] **No auth at all** — Empty Settings + no `~/.codex/auth.json`. Should fail with a clear error pointing at Settings, not a bare 401.
- [ ] **MCP servers reach the model** — Both built-in Agor MCP server and a user-defined stdio MCP server appear in the session's tool list and are callable.
- [ ] **Per-session approval policy** — Two parallel sessions with different `approvalPolicy` values behave differently.
- [ ] **Per-session network access** — Toggle `networkAccess: false`, confirm the agent can't reach the network.
- [ ] **Concurrent sessions** — Two sessions in parallel with different MCP server lists do not cross-pollute.
- [ ] **Session context injection** — Prompt "what's your Agor session ID?" — confirms `model_instructions_file` is being loaded.
- [ ] **Resume thread** — Two sequential prompts in the same session resume the same Codex thread.
- [ ] **`~/.codex/` is untouched** — After running several Agor sessions, `~/.codex/config.toml` and `~/.codex/AGENTS.md` are unchanged. No `/tmp/agor-codex-<id>/` directories are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)