### PR TITLE
use asUser=undefined for repo.clone and worktree.add

### DIFF
--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -185,7 +185,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const rbacEnabled = isWorktreeRbacEnabled();
 
     // Resolve Unix user for impersonation (handles simple/insulated/strict modes)
-    const asUser = rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
+    const asUser =
+      rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
 
     // Fire and forget - spawn executor and return immediately.
     // Executor handles: git clone, .agor.yml parsing, DB record creation.
@@ -702,7 +703,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       const rbacEnabled = isWorktreeRbacEnabled();
 
       // Resolve Unix user for impersonation (handles simple/insulated/strict modes)
-      const asUser = rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
+      const asUser =
+        rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
 
       spawnExecutorFireAndForget(
         {

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -185,7 +185,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const rbacEnabled = isWorktreeRbacEnabled();
 
     // Resolve Unix user for impersonation (handles simple/insulated/strict modes)
-    const asUser = userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
+    const asUser = rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
 
     // Fire and forget - spawn executor and return immediately.
     // Executor handles: git clone, .agor.yml parsing, DB record creation.

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -702,7 +702,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       const rbacEnabled = isWorktreeRbacEnabled();
 
       // Resolve Unix user for impersonation (handles simple/insulated/strict modes)
-      const asUser = userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
+      const asUser = rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
 
       spawnExecutorFireAndForget(
         {

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -478,7 +478,10 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       console.log(`🗑️  Spawning executor to remove worktree from filesystem: ${worktree.path}`);
 
       // Resolve Unix user for impersonation (handles simple/insulated/strict modes)
-      const asUser = await resolveGitImpersonationForWorktree(this.db, worktree);
+      const rbacEnabled = isWorktreeRbacEnabled();
+      const asUser = rbacEnabled
+        ? await resolveGitImpersonationForWorktree(this.db, worktree)
+        : undefined;
 
       // Generate session token for executor authentication
       const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as


### PR DESCRIPTION
Fixes https://github.com/preset-io/agor/issues/1140

I don't know much about the code base but unsetting them when not `rbacEnabled` seems to match the definition of "simple mode" . And they fixed my local instance.