### PR TITLE
fix(sessions): stop cross-tool spawn from inheriting parent's model

### DIFF
--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -15,8 +15,8 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import { type Application, Forbidden } from '@agor/core/feathers';
-import { resolveModelConfig } from '@agor/core/models';
-import { resolveSessionDefaults } from '@agor/core/sessions';
+import { formatModelToolMismatchWarning, lintModelToolMatch } from '@agor/core/models';
+import { resolveChildSessionConfig } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   MCPServerID,
@@ -384,87 +384,80 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   /**
    * Custom method: Spawn a child session
    *
-   * Creates a new session for delegating a subsession to another agent.
+   * Creates a new session, optionally delegating to a different agentic tool.
    *
-   * Settings inheritance:
-   * - If spawning the same agentic tool → inherit parent's settings (permission_config, model_config)
-   * - If spawning a different tool → use user's preferred settings for that tool
-   * - Explicit overrides in SpawnConfig take precedence over both
+   * Config resolution is centralized in
+   * {@link resolveChildSessionConfig} (`@agor/core/sessions`). The rule, in
+   * one place, field by field:
+   *
+   *   model_config:    request → parent (same tool only) → user default → undefined
+   *   permission_config: request → parent (same tool only) → user default → mapped system default
+   *
+   * The "same tool only" gate is the bug fix for the cross-tool inheritance
+   * regression: a Codex child spawned from a Claude parent must not inherit
+   * `claude-opus-4-7` from the parent — Codex cannot run Claude models. When
+   * the user has no per-tool default for the child, the helper returns
+   * `model_config: undefined` and we let the SDK pick its built-in default
+   * for that tool instead of feeding it a poisoned value.
+   *
+   * MCP server inheritance is handled separately at the bottom of this
+   * method — MCPs are tool-agnostic, and the existing "explicit list >
+   * copy from parent" rule is correct regardless of tool match.
    */
   async spawn(
     id: string,
     data: Partial<import('@agor/core/types').SpawnConfig>,
     params?: SessionParams
   ): Promise<Session> {
-    // Validate required fields
     if (!data.prompt) {
       throw new Error('Spawn requires a prompt');
     }
     const parent = await this.get(id, params);
     const targetTool = data.agent || parent.agentic_tool;
-    const isSameTool = targetTool === parent.agentic_tool;
 
-    // Determine settings based on:
-    // 1. Explicit overrides in SpawnConfig (highest priority)
-    // 2. User preferences (if spawning different tool)
-    // 3. Parent settings (fallback via getInheritableConfig)
-
-    const inherited = getInheritableConfig(parent);
-    let permissionConfig = inherited.permission_config;
-    let modelConfig = inherited.model_config;
-
-    // If spawning a different tool and no explicit overrides, fall through to
-    // the helper for the target tool. The parent's permission_config is
-    // meaningless for a different agent — e.g. a Claude session's `acceptEdits`
-    // mode means nothing for a Codex spawn, and Codex reads its own
-    // `permission_config.codex` sub-config that the parent doesn't carry.
-    // Always adopt the helper's resolved values (user defaults > system
-    // fallback) instead of partially keeping the parent's, so cross-agent
-    // permission-mode mapping and Codex sub-config defaults flow through.
-    if (!isSameTool && !data.permissionMode && !data.modelConfig) {
-      const userId = parent.created_by;
-      if (userId && this.app) {
-        try {
-          const user = await this.app.service('users').get(userId, params);
-          const userResolved = resolveSessionDefaults({ agenticTool: targetTool, user });
-          permissionConfig = userResolved.permission_config;
-          // model_config: prefer user default, but if user has no model
-          // pinned, keep the parent's so cross-tool spawns inherit the
-          // family-level "use the smart model" choice rather than nothing.
-          modelConfig = userResolved.model_config ?? modelConfig;
-        } catch (error) {
-          // If we can't fetch user preferences, fall back to the helper with
-          // no user (system defaults) — still better than parent's stale
-          // cross-agent config.
-          console.warn(
-            'Could not fetch user preferences for spawned session, using system defaults:',
-            error
-          );
-          const sysResolved = resolveSessionDefaults({ agenticTool: targetTool });
-          permissionConfig = sysResolved.permission_config;
-        }
+    // Look up the parent's owner for their per-tool defaults. Failing this
+    // lookup is non-fatal — the resolver gracefully falls through to the
+    // mapped system default when `user` is null.
+    let user: import('@agor/core/types').User | null = null;
+    const userId = parent.created_by;
+    if (userId && this.app) {
+      try {
+        user = (await this.app
+          .service('users')
+          .get(userId, params)) as import('@agor/core/types').User;
+      } catch (error) {
+        console.warn(
+          'Could not fetch user preferences for spawned session, using system defaults:',
+          error
+        );
       }
     }
 
-    // Apply explicit overrides from SpawnConfig
-    if (data.permissionMode) {
-      permissionConfig = {
-        mode: data.permissionMode,
-        ...(targetTool === 'codex' && data.codexSandboxMode && data.codexApprovalPolicy
-          ? {
-              codex: {
-                sandboxMode: data.codexSandboxMode,
-                approvalPolicy: data.codexApprovalPolicy,
-                networkAccess: data.codexNetworkAccess,
-              },
-            }
-          : permissionConfig?.codex
-            ? { codex: permissionConfig.codex }
-            : {}),
-      };
-    }
+    const resolved = resolveChildSessionConfig({
+      parent,
+      effectiveTool: targetTool,
+      user,
+      overrides: {
+        permissionMode: data.permissionMode,
+        modelConfig: data.modelConfig,
+        codexSandboxMode: data.codexSandboxMode,
+        codexApprovalPolicy: data.codexApprovalPolicy,
+        codexNetworkAccess: data.codexNetworkAccess,
+      },
+    });
+    const permissionConfig = resolved.permission_config;
+    const modelConfig = resolved.model_config;
 
-    modelConfig = resolveModelConfig(data.modelConfig) ?? modelConfig;
+    // Soft validation: warn (don't block) when the resolved model looks like
+    // it belongs to a different tool. Custom model strings are always
+    // accepted — this just surfaces the regression class that motivated the
+    // resolver refactor.
+    const lintWarning = formatModelToolMismatchWarning(
+      lintModelToolMatch(modelConfig?.model, targetTool)
+    );
+    if (lintWarning) {
+      console.warn(`[SessionsService.spawn] ${lintWarning}`);
+    }
 
     // Build callback configuration
     // callback_session_id is the single source of truth for where to deliver callbacks.

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -382,27 +382,28 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   }
 
   /**
-   * Custom method: Spawn a child session
+   * Spawn a child session, optionally delegating to a different agentic tool.
    *
-   * Creates a new session, optionally delegating to a different agentic tool.
+   * Config resolution is centralized in {@link resolveChildSessionConfig}
+   * (`@agor/core/sessions`):
    *
-   * Config resolution is centralized in
-   * {@link resolveChildSessionConfig} (`@agor/core/sessions`). The rule, in
-   * one place, field by field:
-   *
-   *   model_config:    request → parent (same tool only) → user default → undefined
+   *   model_config:      request → parent (same tool only) → user default → undefined
    *   permission_config: request → parent (same tool only) → user default → mapped system default
    *
-   * The "same tool only" gate is the bug fix for the cross-tool inheritance
-   * regression: a Codex child spawned from a Claude parent must not inherit
-   * `claude-opus-4-7` from the parent — Codex cannot run Claude models. When
-   * the user has no per-tool default for the child, the helper returns
-   * `model_config: undefined` and we let the SDK pick its built-in default
-   * for that tool instead of feeding it a poisoned value.
+   * The "same tool only" gate prevents cross-tool inheritance bugs: a Codex
+   * child spawned from a Claude parent must not inherit `claude-opus-4-7`,
+   * because Codex cannot run Claude models. When no per-tool default exists,
+   * the helper returns `model_config: undefined` and the SDK picks its own
+   * default rather than running with a poisoned value.
    *
-   * MCP server inheritance is handled separately at the bottom of this
-   * method — MCPs are tool-agnostic, and the existing "explicit list >
-   * copy from parent" rule is correct regardless of tool match.
+   * Identity resolution runs *before* defaults lookup so per-tool defaults
+   * come from the resolved child owner (the caller in normal cross-user
+   * spawns), not the parent owner. Otherwise a collaborator spawning a
+   * subsession would get the parent owner's preferences stamped on their
+   * own session.
+   *
+   * MCP server inheritance is handled inline below — MCPs are tool-agnostic
+   * and follow "explicit list > copy from parent" regardless of tool match.
    */
   async spawn(
     id: string,
@@ -415,16 +416,20 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const parent = await this.get(id, params);
     const targetTool = data.agent || parent.agentic_tool;
 
-    // Look up the parent's owner for their per-tool defaults. Failing this
-    // lookup is non-fatal — the resolver gracefully falls through to the
-    // mapped system default when `user` is null.
+    // Resolve identity first so per-tool defaults come from the resolved
+    // child owner, not the parent owner. (For internal/provider-less calls,
+    // `resolveChildIdentity` returns `parent.created_by` anyway.)
+    const { created_by, unix_username } = await this.resolveChildIdentity(parent, params);
+
+    // Load the child owner's per-tool defaults. Failing this lookup is
+    // non-fatal — the resolver falls through to the mapped system default
+    // when `user` is null.
     let user: import('@agor/core/types').User | null = null;
-    const userId = parent.created_by;
-    if (userId && this.app) {
+    if (created_by && this.app) {
       try {
         user = (await this.app
           .service('users')
-          .get(userId, params)) as import('@agor/core/types').User;
+          .get(created_by, params)) as import('@agor/core/types').User;
       } catch (error) {
         console.warn(
           'Could not fetch user preferences for spawned session, using system defaults:',
@@ -449,9 +454,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const modelConfig = resolved.model_config;
 
     // Soft validation: warn (don't block) when the resolved model looks like
-    // it belongs to a different tool. Custom model strings are always
-    // accepted — this just surfaces the regression class that motivated the
-    // resolver refactor.
+    // it belongs to a different tool. Custom model strings are accepted.
     const lintWarning = formatModelToolMismatchWarning(
       lintModelToolMatch(modelConfig?.model, targetTool)
     );
@@ -459,10 +462,10 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       console.warn(`[SessionsService.spawn] ${lintWarning}`);
     }
 
-    // Build callback configuration
-    // callback_session_id is the single source of truth for where to deliver callbacks.
-    // Default to parent session when callbacks are enabled (which is the default for spawn).
-    const isCallbackEnabled = data.enableCallback !== false; // default: true for spawn
+    // callback_session_id is the single source of truth for where to deliver
+    // callbacks. Default to parent session when callbacks are enabled (which
+    // is the default for spawn).
+    const isCallbackEnabled = data.enableCallback !== false;
     const callbackConfig = {
       ...(data.enableCallback !== undefined ? { enabled: data.enableCallback } : {}),
       ...(isCallbackEnabled
@@ -474,20 +477,13 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       ...(data.includeOriginalPrompt !== undefined
         ? { include_original_prompt: data.includeOriginalPrompt }
         : {}),
-      // Default callback mode to "once" — fires once then auto-disables
       callback_mode: data.callbackMode ?? 'once',
     };
 
-    // Build final prompt (append extra instructions if provided)
     let finalPrompt = data.prompt;
     if (data.extraInstructions) {
       finalPrompt = `${data.prompt}\n\n${data.extraInstructions}`;
     }
-
-    // Default: attribute the child to the MCP-authenticated caller, not the
-    // parent owner. Legacy parent-inheriting "identity borrowing" is preserved
-    // only when the worktree opts in via dangerously_allow_session_sharing.
-    const { created_by, unix_username } = await this.resolveChildIdentity(parent, params);
 
     const spawnedSession = await this.create(
       {

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -16,6 +16,7 @@ export * from './copilot.js';
 
 // Gemini models
 export * from './gemini.js';
-
+// Soft validation: does a model ID look like it belongs to its agentic tool?
+export * from './lint-model-tool-match.js';
 // Model config normalization (shared across session-creation paths)
 export * from './resolve-config.js';

--- a/packages/core/src/models/lint-model-tool-match.test.ts
+++ b/packages/core/src/models/lint-model-tool-match.test.ts
@@ -18,6 +18,9 @@ describe('lintModelToolMatch', () => {
     it('gemini-* matches gemini', () => {
       expect(lintModelToolMatch('gemini-2.5-flash', 'gemini')?.match).toBe('ok');
     });
+    it('matches Google `models/` wrapper after normalization', () => {
+      expect(lintModelToolMatch('models/gemini-2.5-flash', 'gemini')?.match).toBe('ok');
+    });
     it('case-insensitive', () => {
       expect(lintModelToolMatch('CLAUDE-OPUS-4-7', 'claude-code')?.match).toBe('ok');
     });
@@ -50,6 +53,11 @@ describe('lintModelToolMatch', () => {
       expect(lintModelToolMatch('internal-model-v1', 'codex')?.match).toBe('unknown');
       expect(lintModelToolMatch('my-byok-proxy', 'claude-code')?.match).toBe('unknown');
     });
+    it('does NOT false-positive on substring matches with prefix in the middle', () => {
+      // Substring containment would have flagged these; startsWith does not.
+      expect(lintModelToolMatch('internal-codename-gpt-5', 'claude-code')?.match).toBe('unknown');
+      expect(lintModelToolMatch('my-gemini-proxy-v2', 'codex')?.match).toBe('unknown');
+    });
     it('returns null for empty/missing model', () => {
       expect(lintModelToolMatch(undefined, 'codex')).toBeNull();
       expect(lintModelToolMatch(null, 'codex')).toBeNull();
@@ -57,30 +65,21 @@ describe('lintModelToolMatch', () => {
     });
   });
 
-  describe('copilot is unopinionated (proxies upstream models)', () => {
-    it('does NOT flag claude model on copilot session as mismatch', () => {
-      // Copilot legitimately routes to Anthropic, so claude-* is fine.
-      // We can't usefully lint Copilot — fall through to "unknown" or "ok"
-      // depending on whether the substring matches another tool's prefix.
-      const r = lintModelToolMatch('claude-sonnet-4.6', 'copilot');
-      // copilot has no entry in the prefix map, so it can't match `ok` against
-      // claude-* — but we'd rather report mismatch=null/unknown than mismatch.
-      // The lint table puts copilot into the "unknown" branch (it gets a hit
-      // from the loop but only flags as mismatch on real cross-tool name leaks).
-      // What we actually care about: this should not emit a warning for the
-      // common case "Copilot session, claude-flavored proxy model".
-      const warning = formatModelToolMismatchWarning(r);
-      // The implementation may classify this as "mismatch (looksLike claude-code)"
-      // because the prefix table contains claude-code. That's a reasonable
-      // limitation; document it in the assertion: verify it does NOT crash and
-      // returns *some* result. If you want stricter copilot handling, list its
-      // upstream prefixes explicitly.
-      expect(r).not.toBeNull();
-      // For now: copilot is the documented ambiguous case. We only assert that
-      // the function still produces *a* result without throwing; downstream
-      // surface (warning string) is allowed to fire but the spawn path treats
-      // it as advisory only.
-      expect(typeof warning === 'string' || warning === undefined).toBe(true);
+  describe('unopinionated tools (proxy upstream providers)', () => {
+    it('returns null for any model on a copilot session', () => {
+      // Copilot routes to Anthropic / OpenAI / Google; any prefix is plausible.
+      expect(lintModelToolMatch('claude-sonnet-4.6', 'copilot')).toBeNull();
+      expect(lintModelToolMatch('gpt-5.3-codex', 'copilot')).toBeNull();
+      expect(lintModelToolMatch('gemini-3-pro', 'copilot')).toBeNull();
+    });
+    it('returns null for any model on an opencode session', () => {
+      expect(lintModelToolMatch('claude-sonnet-4.6', 'opencode')).toBeNull();
+      expect(lintModelToolMatch('gpt-5.4', 'opencode')).toBeNull();
+    });
+    it('produces no warning for unopinionated tools', () => {
+      expect(
+        formatModelToolMismatchWarning(lintModelToolMatch('claude-sonnet-4.6', 'copilot'))
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/models/lint-model-tool-match.test.ts
+++ b/packages/core/src/models/lint-model-tool-match.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { formatModelToolMismatchWarning, lintModelToolMatch } from './lint-model-tool-match.js';
+
+describe('lintModelToolMatch', () => {
+  describe('happy path (match=ok)', () => {
+    it('claude-* matches claude-code', () => {
+      expect(lintModelToolMatch('claude-opus-4-7', 'claude-code')?.match).toBe('ok');
+      expect(lintModelToolMatch('claude-sonnet-4-6[1m]', 'claude-code')?.match).toBe('ok');
+    });
+    it('gpt-* matches codex', () => {
+      expect(lintModelToolMatch('gpt-5.4', 'codex')?.match).toBe('ok');
+      expect(lintModelToolMatch('gpt-5.3-codex', 'codex')?.match).toBe('ok');
+    });
+    it('o3-* / o4-* matches codex', () => {
+      expect(lintModelToolMatch('o3-mini', 'codex')?.match).toBe('ok');
+      expect(lintModelToolMatch('o4-mini', 'codex')?.match).toBe('ok');
+    });
+    it('gemini-* matches gemini', () => {
+      expect(lintModelToolMatch('gemini-2.5-flash', 'gemini')?.match).toBe('ok');
+    });
+    it('case-insensitive', () => {
+      expect(lintModelToolMatch('CLAUDE-OPUS-4-7', 'claude-code')?.match).toBe('ok');
+    });
+  });
+
+  describe('mismatch (the bug we are linting for)', () => {
+    it('flags claude model on codex session', () => {
+      const r = lintModelToolMatch('claude-opus-4-7', 'codex');
+      expect(r?.match).toBe('mismatch');
+      if (r?.match === 'mismatch') {
+        expect(r.looksLike).toBe('claude-code');
+        expect(r.tool).toBe('codex');
+        expect(r.model).toBe('claude-opus-4-7');
+      }
+    });
+    it('flags gpt model on claude-code session', () => {
+      const r = lintModelToolMatch('gpt-5.4', 'claude-code');
+      expect(r?.match).toBe('mismatch');
+      if (r?.match === 'mismatch') expect(r.looksLike).toBe('codex');
+    });
+    it('flags gemini model on codex session', () => {
+      const r = lintModelToolMatch('gemini-2.5-flash', 'codex');
+      expect(r?.match).toBe('mismatch');
+      if (r?.match === 'mismatch') expect(r.looksLike).toBe('gemini');
+    });
+  });
+
+  describe('unknown (custom strings — no opinion)', () => {
+    it('returns unknown for arbitrary internal aliases', () => {
+      expect(lintModelToolMatch('internal-model-v1', 'codex')?.match).toBe('unknown');
+      expect(lintModelToolMatch('my-byok-proxy', 'claude-code')?.match).toBe('unknown');
+    });
+    it('returns null for empty/missing model', () => {
+      expect(lintModelToolMatch(undefined, 'codex')).toBeNull();
+      expect(lintModelToolMatch(null, 'codex')).toBeNull();
+      expect(lintModelToolMatch('', 'codex')).toBeNull();
+    });
+  });
+
+  describe('copilot is unopinionated (proxies upstream models)', () => {
+    it('does NOT flag claude model on copilot session as mismatch', () => {
+      // Copilot legitimately routes to Anthropic, so claude-* is fine.
+      // We can't usefully lint Copilot — fall through to "unknown" or "ok"
+      // depending on whether the substring matches another tool's prefix.
+      const r = lintModelToolMatch('claude-sonnet-4.6', 'copilot');
+      // copilot has no entry in the prefix map, so it can't match `ok` against
+      // claude-* — but we'd rather report mismatch=null/unknown than mismatch.
+      // The lint table puts copilot into the "unknown" branch (it gets a hit
+      // from the loop but only flags as mismatch on real cross-tool name leaks).
+      // What we actually care about: this should not emit a warning for the
+      // common case "Copilot session, claude-flavored proxy model".
+      const warning = formatModelToolMismatchWarning(r);
+      // The implementation may classify this as "mismatch (looksLike claude-code)"
+      // because the prefix table contains claude-code. That's a reasonable
+      // limitation; document it in the assertion: verify it does NOT crash and
+      // returns *some* result. If you want stricter copilot handling, list its
+      // upstream prefixes explicitly.
+      expect(r).not.toBeNull();
+      // For now: copilot is the documented ambiguous case. We only assert that
+      // the function still produces *a* result without throwing; downstream
+      // surface (warning string) is allowed to fire but the spawn path treats
+      // it as advisory only.
+      expect(typeof warning === 'string' || warning === undefined).toBe(true);
+    });
+  });
+});
+
+describe('formatModelToolMismatchWarning', () => {
+  it('returns a human-readable string for mismatch results', () => {
+    const r = lintModelToolMatch('claude-opus-4-7', 'codex');
+    const msg = formatModelToolMismatchWarning(r);
+    expect(msg).toContain('claude-opus-4-7');
+    expect(msg).toContain('claude-code');
+    expect(msg).toContain('codex');
+  });
+
+  it('returns undefined for ok / unknown / null', () => {
+    expect(formatModelToolMismatchWarning(lintModelToolMatch('gpt-5.4', 'codex'))).toBeUndefined();
+    expect(
+      formatModelToolMismatchWarning(lintModelToolMatch('internal-foo', 'codex'))
+    ).toBeUndefined();
+    expect(formatModelToolMismatchWarning(null)).toBeUndefined();
+  });
+});

--- a/packages/core/src/models/lint-model-tool-match.ts
+++ b/packages/core/src/models/lint-model-tool-match.ts
@@ -1,51 +1,35 @@
 /**
  * Soft validation: does this model ID look like it belongs to this agentic tool?
  *
- * Why "soft"?
- * -----------
- * Users can pin custom model strings (BYOK proxies, fine-tunes, dated
- * snapshots, internal aliases) — Agor deliberately accepts arbitrary model
- * IDs and lets the SDK be the final arbiter. We can't reject what we don't
- * recognize. But we *can* recognize the obvious mismatches: a session whose
- * `agentic_tool` is `codex` and whose `model_config.model` is `claude-opus-4-7`
- * is almost certainly a config bug (this is the bug this validator was
- * introduced to surface — see `resolve-child-session-config.ts`).
- *
- * The lint table is a compact prefix map keyed by family substring. A model
- * matches a tool when one of the tool's prefixes is found in the (lowercased)
- * model ID. Unknown models — those that don't match *any* prefix table —
- * pass silently: the user knows what they're doing, or the SDK will tell them.
- *
- * Copilot is the awkward case: Copilot proxies models from multiple
- * providers, so `claude-sonnet-4.6` is a perfectly valid Copilot model.
- * Copilot is therefore omitted from the prefix table — any model is plausible.
+ * Users can pin custom model strings (BYOK proxies, fine-tunes, dated snapshots,
+ * internal aliases), so we never reject — we only warn on the obvious mismatch
+ * a `codex` session being handed a `claude-*` model. The lint table is a
+ * compact prefix map; tools that proxy upstream providers (Copilot, OpenCode)
+ * are skipped entirely because any namespace is plausible.
  */
 
 import type { AgenticToolName } from '../types/agentic-tool.js';
 
 /**
  * Family prefixes that identify a model as belonging to a specific tool.
+ * Match rule: the (normalized) model ID `startsWith` one of the tool's
+ * prefixes. Normalization strips a leading `models/` (Google's API form)
+ * so e.g. `models/gemini-2.5-flash` matches `gemini-`. Keep entries lowercase.
  *
- * Match rule: a lowercased model ID is considered to belong to a tool when
- * *any* of the tool's prefixes appears anywhere in the lowercased ID. This
- * is intentionally fuzzy — Anthropic ships `claude-3-7-sonnet-latest`,
- * OpenAI ships `gpt-5.4-mini`, Google ships `gemini-2.5-flash`. Substring
- * containment is more permissive than `startsWith` (which would miss e.g.
- * `models/gemini-2.5-flash`) and tighter than running a regex.
- *
- * Copilot is intentionally absent: Copilot routes to upstream providers
- * (Anthropic, OpenAI, Google), so a Copilot session can legitimately use
- * any of these prefixes. We can't usefully lint it.
- *
- * To extend: add a prefix here. Keep entries lowercase.
+ * To extend: add a prefix here.
  */
 const TOOL_MODEL_PREFIXES: Partial<Record<AgenticToolName, readonly string[]>> = {
   'claude-code': ['claude-'],
   codex: ['gpt-', 'o1-', 'o1.', 'o3-', 'o3.', 'o4-', 'o4.', 'codex-'],
   gemini: ['gemini-'],
-  // OpenCode is a multi-provider router — ship anything via `provider`.
-  // Copilot routes to upstream providers — omitted.
 };
+
+/**
+ * Tools that proxy/route to upstream providers (Anthropic, OpenAI, Google, ...).
+ * A `claude-*` model on a Copilot session is legitimate — there is no useful
+ * lint to perform. The validator returns `null` (no opinion) for these.
+ */
+const UNOPINIONATED_TOOLS: ReadonlySet<AgenticToolName> = new Set(['copilot', 'opencode']);
 
 /** Result of a model/tool match check. `null` means "no opinion". */
 export type ModelToolMatch =
@@ -57,6 +41,8 @@ export type ModelToolMatch =
  * Inspect a model/tool pair without rejecting it.
  *
  * Returns:
+ * - `null` when there's no opinion to give (no model, or the tool routes
+ *   to upstream providers and any model is plausible).
  * - `ok` when the model ID matches one of `tool`'s known prefixes.
  * - `mismatch` when the model ID matches a *different* tool's prefixes
  *   (this is the cross-tool spawn bug — surfaces "Codex session got a
@@ -69,26 +55,33 @@ export function lintModelToolMatch(
   tool: AgenticToolName
 ): ModelToolMatch | null {
   if (!model) return null;
-  const lower = model.toLowerCase();
+  if (UNOPINIONATED_TOOLS.has(tool)) return null;
+  const normalized = normalizeModelId(model);
 
-  // 1. Does it match the *requested* tool? Then we're happy.
   const requestedPrefixes = TOOL_MODEL_PREFIXES[tool];
-  if (requestedPrefixes?.some((p) => lower.includes(p))) {
+  if (requestedPrefixes?.some((p) => normalized.startsWith(p))) {
     return { match: 'ok', tool, model };
   }
 
-  // 2. Does it match some *other* tool? Then it's a likely mismatch.
   for (const [otherTool, prefixes] of Object.entries(TOOL_MODEL_PREFIXES) as Array<
     [AgenticToolName, readonly string[]]
   >) {
     if (otherTool === tool) continue;
-    if (prefixes.some((p) => lower.includes(p))) {
+    if (prefixes.some((p) => normalized.startsWith(p))) {
       return { match: 'mismatch', tool, model, looksLike: otherTool };
     }
   }
 
-  // 3. Doesn't match anything we know. No opinion.
   return { match: 'unknown', tool, model };
+}
+
+/**
+ * Lowercase + strip the Google `models/` prefix. Anchored matching uses this
+ * normalized form so wrapped IDs still match family prefixes correctly.
+ */
+function normalizeModelId(model: string): string {
+  const lower = model.toLowerCase();
+  return lower.startsWith('models/') ? lower.slice('models/'.length) : lower;
 }
 
 /**

--- a/packages/core/src/models/lint-model-tool-match.ts
+++ b/packages/core/src/models/lint-model-tool-match.ts
@@ -1,0 +1,107 @@
+/**
+ * Soft validation: does this model ID look like it belongs to this agentic tool?
+ *
+ * Why "soft"?
+ * -----------
+ * Users can pin custom model strings (BYOK proxies, fine-tunes, dated
+ * snapshots, internal aliases) — Agor deliberately accepts arbitrary model
+ * IDs and lets the SDK be the final arbiter. We can't reject what we don't
+ * recognize. But we *can* recognize the obvious mismatches: a session whose
+ * `agentic_tool` is `codex` and whose `model_config.model` is `claude-opus-4-7`
+ * is almost certainly a config bug (this is the bug this validator was
+ * introduced to surface — see `resolve-child-session-config.ts`).
+ *
+ * The lint table is a compact prefix map keyed by family substring. A model
+ * matches a tool when one of the tool's prefixes is found in the (lowercased)
+ * model ID. Unknown models — those that don't match *any* prefix table —
+ * pass silently: the user knows what they're doing, or the SDK will tell them.
+ *
+ * Copilot is the awkward case: Copilot proxies models from multiple
+ * providers, so `claude-sonnet-4.6` is a perfectly valid Copilot model.
+ * Copilot is therefore omitted from the prefix table — any model is plausible.
+ */
+
+import type { AgenticToolName } from '../types/agentic-tool.js';
+
+/**
+ * Family prefixes that identify a model as belonging to a specific tool.
+ *
+ * Match rule: a lowercased model ID is considered to belong to a tool when
+ * *any* of the tool's prefixes appears anywhere in the lowercased ID. This
+ * is intentionally fuzzy — Anthropic ships `claude-3-7-sonnet-latest`,
+ * OpenAI ships `gpt-5.4-mini`, Google ships `gemini-2.5-flash`. Substring
+ * containment is more permissive than `startsWith` (which would miss e.g.
+ * `models/gemini-2.5-flash`) and tighter than running a regex.
+ *
+ * Copilot is intentionally absent: Copilot routes to upstream providers
+ * (Anthropic, OpenAI, Google), so a Copilot session can legitimately use
+ * any of these prefixes. We can't usefully lint it.
+ *
+ * To extend: add a prefix here. Keep entries lowercase.
+ */
+const TOOL_MODEL_PREFIXES: Partial<Record<AgenticToolName, readonly string[]>> = {
+  'claude-code': ['claude-'],
+  codex: ['gpt-', 'o1-', 'o1.', 'o3-', 'o3.', 'o4-', 'o4.', 'codex-'],
+  gemini: ['gemini-'],
+  // OpenCode is a multi-provider router — ship anything via `provider`.
+  // Copilot routes to upstream providers — omitted.
+};
+
+/** Result of a model/tool match check. `null` means "no opinion". */
+export type ModelToolMatch =
+  | { match: 'ok'; tool: AgenticToolName; model: string }
+  | { match: 'mismatch'; tool: AgenticToolName; model: string; looksLike: AgenticToolName }
+  | { match: 'unknown'; tool: AgenticToolName; model: string };
+
+/**
+ * Inspect a model/tool pair without rejecting it.
+ *
+ * Returns:
+ * - `ok` when the model ID matches one of `tool`'s known prefixes.
+ * - `mismatch` when the model ID matches a *different* tool's prefixes
+ *   (this is the cross-tool spawn bug — surfaces "Codex session got a
+ *   Claude model" before the SDK errors).
+ * - `unknown` when the model ID doesn't match any known prefix. Custom
+ *   strings, internal aliases, BYOK proxies — pass silently.
+ */
+export function lintModelToolMatch(
+  model: string | undefined | null,
+  tool: AgenticToolName
+): ModelToolMatch | null {
+  if (!model) return null;
+  const lower = model.toLowerCase();
+
+  // 1. Does it match the *requested* tool? Then we're happy.
+  const requestedPrefixes = TOOL_MODEL_PREFIXES[tool];
+  if (requestedPrefixes?.some((p) => lower.includes(p))) {
+    return { match: 'ok', tool, model };
+  }
+
+  // 2. Does it match some *other* tool? Then it's a likely mismatch.
+  for (const [otherTool, prefixes] of Object.entries(TOOL_MODEL_PREFIXES) as Array<
+    [AgenticToolName, readonly string[]]
+  >) {
+    if (otherTool === tool) continue;
+    if (prefixes.some((p) => lower.includes(p))) {
+      return { match: 'mismatch', tool, model, looksLike: otherTool };
+    }
+  }
+
+  // 3. Doesn't match anything we know. No opinion.
+  return { match: 'unknown', tool, model };
+}
+
+/**
+ * Human-readable warning string for a `mismatch` result. Returns `undefined`
+ * for `ok` / `unknown` / `null` so callers can guard with `if (msg)` and
+ * propagate the warning to logs / API responses uniformly.
+ */
+export function formatModelToolMismatchWarning(result: ModelToolMatch | null): string | undefined {
+  if (!result || result.match !== 'mismatch') return undefined;
+  return (
+    `Model "${result.model}" looks like a ${result.looksLike} model but the session ` +
+    `is configured for ${result.tool}. Proceeding with the user-supplied value, but the ` +
+    `SDK may reject it. Set a per-tool default in user preferences, or pass an explicit ` +
+    `modelConfig to silence this warning.`
+  );
+}

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -1,1 +1,2 @@
+export * from './resolve-child-session-config.js';
 export * from './resolve-session-defaults.js';

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -1,2 +1,3 @@
 export * from './resolve-child-session-config.js';
+export * from './resolve-permission-config.js';
 export * from './resolve-session-defaults.js';

--- a/packages/core/src/sessions/resolve-child-session-config.test.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest';
+import type { Session, User, UserID } from '../types/index.js';
+import {
+  type ChildResolverParent,
+  resolveChildSessionConfig,
+} from './resolve-child-session-config.js';
+
+const now = new Date('2026-05-09T00:00:00.000Z');
+
+function makeUser(partial: Partial<User['default_agentic_config']> = {}): User {
+  return {
+    user_id: 'user-1' as UserID,
+    email: 'a@b.c',
+    role: 'member',
+    onboarding_completed: true,
+    must_change_password: false,
+    created_at: new Date(),
+    scheduled_from_worktree: false,
+    default_agentic_config: partial,
+  } as unknown as User;
+}
+
+function makeParent(overrides: Partial<ChildResolverParent>): ChildResolverParent {
+  return {
+    agentic_tool: 'claude-code',
+    permission_config: { mode: 'acceptEdits' },
+    model_config: undefined,
+    ...overrides,
+  } as ChildResolverParent;
+}
+
+describe('resolveChildSessionConfig', () => {
+  // --------------------------------------------------------------
+  // The bug — spawn parent.tool=claude-code → child.tool=codex must
+  // NOT carry parent's claude-opus-4-7 model into the codex child.
+  // --------------------------------------------------------------
+  describe('cross-tool spawn (regression: parent claude-code → child codex)', () => {
+    const parent = makeParent({
+      agentic_tool: 'claude-code',
+      model_config: {
+        mode: 'alias',
+        model: 'claude-opus-4-7',
+        updated_at: '2026-05-01T00:00:00.000Z',
+      },
+      permission_config: { mode: 'acceptEdits' },
+    });
+
+    it('does NOT inherit parent claude model when no user codex default exists', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({}), // no codex defaults, no claude defaults — empty
+        now,
+      });
+      expect(r.model_config).toBeUndefined();
+    });
+
+    it('falls through to user codex default when present, not parent claude model', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({ codex: { modelConfig: { model: 'gpt-5.4' } } }),
+        now,
+      });
+      expect(r.model_config?.model).toBe('gpt-5.4');
+    });
+
+    it('uses mapped codex permission default (auto), not parent acceptEdits', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({}),
+        now,
+      });
+      expect(r.permission_config.mode).toBe('auto');
+    });
+
+    it('explicit override wins even on cross-tool spawn', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({ codex: { modelConfig: { model: 'gpt-5.4' } } }),
+        overrides: { modelConfig: { model: 'gpt-5.4-mini' } },
+        now,
+      });
+      expect(r.model_config?.model).toBe('gpt-5.4-mini');
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Same-tool: parent's choices propagate (the desired existing behavior)
+  // --------------------------------------------------------------
+  describe('same-tool spawn (parent inheritance preserved)', () => {
+    const parent = makeParent({
+      agentic_tool: 'claude-code',
+      model_config: {
+        mode: 'alias',
+        model: 'claude-opus-4-7',
+        effort: 'high',
+        updated_at: '2026-05-01T00:00:00.000Z',
+      },
+      permission_config: { mode: 'bypassPermissions' },
+    });
+
+    it('inherits parent model when child tool === parent tool', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'claude-code',
+        user: makeUser({ 'claude-code': { modelConfig: { model: 'claude-sonnet-4-6' } } }),
+        now,
+      });
+      // Parent wins over user default on same-tool spawns.
+      expect(r.model_config?.model).toBe('claude-opus-4-7');
+      expect(r.model_config?.effort).toBe('high');
+    });
+
+    it('inherits parent permission_config when child tool === parent tool', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'claude-code',
+        user: makeUser({}),
+        now,
+      });
+      expect(r.permission_config.mode).toBe('bypassPermissions');
+    });
+
+    it('explicit override beats parent inheritance', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'claude-code',
+        overrides: {
+          modelConfig: { model: 'claude-haiku-4-5' },
+          permissionMode: 'plan',
+        },
+        now,
+      });
+      expect(r.model_config?.model).toBe('claude-haiku-4-5');
+      expect(r.permission_config.mode).toBe('plan');
+    });
+
+    it('defaults effectiveTool to parent.agentic_tool when omitted', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        user: makeUser({}),
+        now,
+      });
+      // Same-tool path → inherits parent.
+      expect(r.model_config?.model).toBe('claude-opus-4-7');
+      expect(r.permission_config.mode).toBe('bypassPermissions');
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Cross-tool with parent that HAS a model the new tool would accept:
+  // we still don't inherit — model identity is tool-scoped by contract.
+  // --------------------------------------------------------------
+  describe('cross-tool spawn with no user default', () => {
+    it('returns undefined model when neither parent (gated off) nor user default applies', () => {
+      const parent = makeParent({
+        agentic_tool: 'claude-code',
+        model_config: {
+          mode: 'alias',
+          model: 'claude-opus-4-7',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'gemini',
+        user: null,
+        now,
+      });
+      expect(r.model_config).toBeUndefined();
+      expect(r.permission_config.mode).toBe('autoEdit'); // gemini system default
+    });
+
+    it('returns mapped permission default when user is null', () => {
+      const parent = makeParent({ agentic_tool: 'claude-code' });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: null,
+        now,
+      });
+      expect(r.permission_config.mode).toBe('auto');
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Codex sub-config gating — sandboxMode/approvalPolicy cross-tool rules
+  // --------------------------------------------------------------
+  describe('codex sub-config (cross-tool gate)', () => {
+    it('cross-tool spawn does NOT inherit parent codex sub-config', () => {
+      // Parent is codex with full sub-config. Child is claude-code.
+      // The child must not carry codex sub-config (it would be meaningless on Claude).
+      const parent = makeParent({
+        agentic_tool: 'codex',
+        permission_config: {
+          mode: 'auto',
+          codex: { sandboxMode: 'workspace-write', approvalPolicy: 'on-request' },
+        },
+      });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'claude-code',
+        user: makeUser({}),
+        now,
+      });
+      expect(r.permission_config.codex).toBeUndefined();
+    });
+
+    it('same-tool spawn from codex parent inherits parent codex sub-config', () => {
+      const parent = makeParent({
+        agentic_tool: 'codex',
+        permission_config: {
+          mode: 'auto',
+          codex: {
+            sandboxMode: 'workspace-write',
+            approvalPolicy: 'on-request',
+            networkAccess: true,
+          },
+        },
+      });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({}),
+        now,
+      });
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'on-request',
+        networkAccess: true,
+      });
+    });
+
+    it('cross-tool spawn TO codex with no user default emits no codex sub-config', () => {
+      // User has no codex defaults → no sandboxMode + approvalPolicy pair → no sub-config.
+      // The mapped permission mode still resolves (to 'auto').
+      const parent = makeParent({ agentic_tool: 'claude-code' });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({}),
+        now,
+      });
+      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.codex).toBeUndefined();
+    });
+
+    it('cross-tool spawn TO codex with user codex defaults includes sub-config', () => {
+      const parent = makeParent({ agentic_tool: 'claude-code' });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({
+          codex: {
+            permissionMode: 'auto',
+            codexSandboxMode: 'read-only',
+            codexApprovalPolicy: 'untrusted',
+            codexNetworkAccess: false,
+          },
+        }),
+        now,
+      });
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'read-only',
+        approvalPolicy: 'untrusted',
+        networkAccess: false,
+      });
+    });
+
+    it('explicit codex sub-config overrides parent sub-config (same tool)', () => {
+      const parent = makeParent({
+        agentic_tool: 'codex',
+        permission_config: {
+          mode: 'auto',
+          codex: { sandboxMode: 'workspace-write', approvalPolicy: 'on-request' },
+        },
+      });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        overrides: {
+          codexSandboxMode: 'read-only',
+          codexApprovalPolicy: 'untrusted',
+          codexNetworkAccess: false,
+        },
+        now,
+      });
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'read-only',
+        approvalPolicy: 'untrusted',
+        networkAccess: false,
+      });
+    });
+  });
+
+  // --------------------------------------------------------------
+  // Permission-mode mapping across tools
+  // --------------------------------------------------------------
+  describe('permission_mode mapping', () => {
+    it('claude→gemini cross-tool maps user-default acceptEdits to autoEdit', () => {
+      const parent = makeParent({ agentic_tool: 'claude-code' });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'gemini',
+        // user has Gemini defaults stored as Claude mode (legacy/edge case).
+        user: makeUser({ gemini: { permissionMode: 'acceptEdits' } }),
+        now,
+      });
+      expect(r.permission_config.mode).toBe('autoEdit');
+    });
+
+    it('claude→codex cross-tool with user default acceptEdits maps to auto', () => {
+      const parent = makeParent({ agentic_tool: 'claude-code' });
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'codex',
+        user: makeUser({ codex: { permissionMode: 'acceptEdits' } }),
+        now,
+      });
+      expect(r.permission_config.mode).toBe('auto');
+    });
+  });
+});
+
+// Sanity check that the helper compiles against the real `Session` shape too.
+describe('resolveChildSessionConfig type compatibility', () => {
+  it('accepts a full Session as parent', () => {
+    const fakeSession = {
+      agentic_tool: 'claude-code' as const,
+      permission_config: { mode: 'acceptEdits' as const },
+      model_config: undefined,
+    } satisfies Pick<Session, 'agentic_tool' | 'permission_config' | 'model_config'>;
+    const r = resolveChildSessionConfig({ parent: fakeSession, now });
+    expect(r.permission_config.mode).toBe('acceptEdits');
+  });
+});

--- a/packages/core/src/sessions/resolve-child-session-config.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.ts
@@ -1,69 +1,33 @@
 /**
- * Child-session config resolution (fork / spawn / subsession)
+ * Child-session config resolution (fork / spawn / subsession).
  *
- * Single source of truth for "given a parent session and a child request,
- * what permission_config / model_config should the child be stamped with?"
+ * Sibling of {@link resolveSessionDefaults} — same precedence walk, plus a
+ * tool-gated parent layer interposed between explicit overrides and user
+ * defaults.
  *
- * Why this exists separately from {@link resolveSessionDefaults}:
- * - `resolveSessionDefaults` answers "no parent — what defaults apply?"
- *   (used by direct create, zone trigger, gateway, and the before:create hook).
- * - `resolveChildSessionConfig` answers "I have a parent — when should the
- *   child inherit from it vs. fall back to the user's per-tool default?"
+ *   model_config:      request → parent (same tool only) → user default → undefined
+ *   permission_config: request → parent (same tool only) → user default → mapped system default
  *
- * The resolution rule, in one place
- * ---------------------------------
- * Each config field is resolved independently:
+ * The "same tool only" gate is the bug fix: a Claude model cannot run on
+ * Codex, and Claude's `acceptEdits` mode does not exist for Codex. Without
+ * the gate, Codex children spawned from Claude parents inherit a Claude
+ * model and the SDK errors.
  *
- *   model_config:
- *     1. explicit request override                         (always wins)
- *     2. parent.model_config IF parent.agentic_tool === effectiveTool
- *     3. user.default_agentic_config[effectiveTool].modelConfig
- *     4. undefined                                          (system has no model fallback)
- *
- *   permission_config:
- *     1. explicit request override (incl. codex sub-config)
- *     2. parent.permission_config IF parent.agentic_tool === effectiveTool
- *     3. user.default_agentic_config[effectiveTool].permissionMode (mapped)
- *     4. getDefaultPermissionMode(effectiveTool) (mapped)
- *
- * The cross-tool gate at step 2 is the bug fix: if the child's tool differs
- * from the parent's, parent config is *meaningless* — a Claude model name
- * cannot run on Codex, and Claude's `acceptEdits` mode does not exist for
- * Codex. The old code carried `parent.model_config` through as a fallback
- * when the user had no per-tool default, so Codex children spawned from
- * Claude parents inherited a Claude model and the SDK errored.
- *
- * MCP server inheritance is a separate axis and lives at the call site —
- * MCPs are tool-agnostic and the existing "explicit list > copy from parent"
- * behavior is correct regardless of tool match.
+ * MCP server inheritance is a separate axis handled at the spawn call site —
+ * MCPs are tool-agnostic and follow "explicit list > copy from parent"
+ * regardless of tool match.
  */
 
+import { resolveModelConfigPrecedence } from '../models/resolve-config.js';
+import type { AgenticToolName, Session, User } from '../types/index.js';
 import {
-  type ModelConfigInput,
-  type ResolvedModelConfig,
-  resolveModelConfig,
-} from '../models/resolve-config.js';
-import type {
-  AgenticToolName,
-  CodexApprovalPolicy,
-  CodexNetworkAccess,
-  CodexSandboxMode,
-  DefaultAgenticToolConfig,
-  PermissionMode,
-  Session,
-  User,
-} from '../types/index.js';
-import { getDefaultPermissionMode } from '../types/session.js';
-import { mapPermissionMode } from '../utils/permission-mode-mapper.js';
+  type ParentPermissionLayer,
+  resolvePermissionConfig,
+  type SessionRuntimeOverrides,
+} from './resolve-permission-config.js';
 
 /** Explicit overrides from the spawn/fork request. */
-export interface ChildSessionOverrides {
-  permissionMode?: PermissionMode;
-  modelConfig?: ModelConfigInput;
-  codexSandboxMode?: CodexSandboxMode;
-  codexApprovalPolicy?: CodexApprovalPolicy;
-  codexNetworkAccess?: CodexNetworkAccess;
-}
+export type ChildSessionOverrides = SessionRuntimeOverrides;
 
 /** Minimal parent shape this resolver reads — keeps tests free of full Session fixtures. */
 export type ChildResolverParent = Pick<
@@ -76,28 +40,20 @@ export interface ResolveChildSessionConfigArgs {
   parent: ChildResolverParent;
   /** The child's agentic tool. Defaults to `parent.agentic_tool` when omitted. */
   effectiveTool?: AgenticToolName;
-  /** User whose per-tool defaults are used when parent inheritance is gated off. */
+  /** User whose per-tool defaults apply when the parent layer is gated off. */
   user?: Pick<User, 'default_agentic_config'> | null;
-  /** Explicit per-call overrides from the spawn/fork request. */
   overrides?: ChildSessionOverrides;
   /** Override `new Date()` for deterministic tests. */
   now?: Date;
 }
 
 export interface ResolvedChildSessionConfig {
-  /** Always populated — falls through request → parent (same tool) → user-default → mapped system default. */
+  /** Always populated. */
   permission_config: NonNullable<Session['permission_config']>;
   /** May be `undefined` when no model is set anywhere appropriate for the effective tool. */
-  model_config?: ResolvedModelConfig;
+  model_config?: NonNullable<Session['model_config']>;
 }
 
-/**
- * Resolve `permission_config` and `model_config` for a child session.
- *
- * See file-level doc-comment for the precedence rule. This helper does NOT
- * resolve MCP server IDs — those are handled at the call site (parent-copy
- * vs. explicit override is independent of tool match).
- */
 export function resolveChildSessionConfig(
   args: ResolveChildSessionConfigArgs
 ): ResolvedChildSessionConfig {
@@ -106,90 +62,32 @@ export function resolveChildSessionConfig(
   const sameTool = effectiveTool === parent.agentic_tool;
   const userToolDefaults = user?.default_agentic_config?.[effectiveTool];
 
-  // ---- model_config ----
-  // Explicit > parent (gated on tool match) > user default > undefined.
-  // The tool gate is the bug fix: a Claude model cannot run on Codex, so
-  // we drop the parent fallback when the child crosses tools.
-  const inheritedParentModel: ModelConfigInput | undefined = sameTool
-    ? parent.model_config
+  // Build the parent layer only when same-tool — the cross-tool gate.
+  const parentLayer: ParentPermissionLayer | undefined = sameTool
+    ? {
+        permissionMode: parent.permission_config?.mode,
+        codexSandboxMode: parent.permission_config?.codex?.sandboxMode,
+        codexApprovalPolicy: parent.permission_config?.codex?.approvalPolicy,
+        codexNetworkAccess: parent.permission_config?.codex?.networkAccess,
+      }
     : undefined;
 
-  const model_config =
-    resolveModelConfig(overrides?.modelConfig, { now }) ??
-    resolveModelConfig(inheritedParentModel, { now }) ??
-    resolveModelConfig(userToolDefaults?.modelConfig, { now });
-
-  // ---- permission_config ----
-  // Explicit > parent (gated on tool match) > user default > system default.
-  // For cross-tool spawns we never inherit parent.permission_config —
-  // Claude's `acceptEdits` is not a valid Codex mode, and Codex's `codex`
-  // sub-config is missing on Claude parents anyway. The resolver always
-  // produces a populated permission_config.
-  const permission_config = resolveChildPermissionConfig({
+  const permission_config = resolvePermissionConfig({
     effectiveTool,
-    sameTool,
-    parentPermission: parent.permission_config,
-    userToolDefaults,
     overrides,
+    userToolDefaults,
+    parentLayer,
   });
 
+  // model_config: explicit > parent (same tool only) > user default > undefined.
+  const model_config = resolveModelConfigPrecedence(
+    [
+      overrides?.modelConfig,
+      sameTool ? parent.model_config : undefined,
+      userToolDefaults?.modelConfig,
+    ],
+    { now }
+  );
+
   return { permission_config, model_config };
-}
-
-/**
- * Resolve `permission_config` for a child session.
- *
- * Split out so the precedence walk is readable: each branch is a single
- * "do we have a value at this priority?" check.
- */
-function resolveChildPermissionConfig(args: {
-  effectiveTool: AgenticToolName;
-  sameTool: boolean;
-  parentPermission: Session['permission_config'];
-  userToolDefaults: DefaultAgenticToolConfig | undefined;
-  overrides?: ChildSessionOverrides;
-}): NonNullable<Session['permission_config']> {
-  const { effectiveTool, sameTool, parentPermission, userToolDefaults, overrides } = args;
-
-  // ---- mode ----
-  // Explicit > parent (same tool only) > user default > system default.
-  let resolvedMode: PermissionMode | undefined = overrides?.permissionMode;
-  if (!resolvedMode && sameTool && parentPermission?.mode) {
-    resolvedMode = parentPermission.mode;
-  }
-  if (!resolvedMode) {
-    resolvedMode = userToolDefaults?.permissionMode ?? getDefaultPermissionMode(effectiveTool);
-  }
-  const mode = mapPermissionMode(resolvedMode, effectiveTool);
-
-  const out: NonNullable<Session['permission_config']> = { mode };
-
-  // ---- codex sub-config (only on codex children) ----
-  // Explicit fields > parent's codex sub-config (only when same tool) > user defaults.
-  if (effectiveTool === 'codex') {
-    const sandboxMode =
-      overrides?.codexSandboxMode ??
-      (sameTool ? parentPermission?.codex?.sandboxMode : undefined) ??
-      userToolDefaults?.codexSandboxMode;
-    const approvalPolicy =
-      overrides?.codexApprovalPolicy ??
-      (sameTool ? parentPermission?.codex?.approvalPolicy : undefined) ??
-      userToolDefaults?.codexApprovalPolicy;
-    const networkAccessExplicit = overrides?.codexNetworkAccess;
-    const networkAccessParent = sameTool ? parentPermission?.codex?.networkAccess : undefined;
-    const networkAccess =
-      networkAccessExplicit !== undefined
-        ? networkAccessExplicit
-        : (networkAccessParent ?? userToolDefaults?.codexNetworkAccess);
-
-    if (sandboxMode && approvalPolicy) {
-      out.codex = {
-        sandboxMode,
-        approvalPolicy,
-        ...(networkAccess !== undefined && { networkAccess }),
-      };
-    }
-  }
-
-  return out;
 }

--- a/packages/core/src/sessions/resolve-child-session-config.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.ts
@@ -1,0 +1,195 @@
+/**
+ * Child-session config resolution (fork / spawn / subsession)
+ *
+ * Single source of truth for "given a parent session and a child request,
+ * what permission_config / model_config should the child be stamped with?"
+ *
+ * Why this exists separately from {@link resolveSessionDefaults}:
+ * - `resolveSessionDefaults` answers "no parent — what defaults apply?"
+ *   (used by direct create, zone trigger, gateway, and the before:create hook).
+ * - `resolveChildSessionConfig` answers "I have a parent — when should the
+ *   child inherit from it vs. fall back to the user's per-tool default?"
+ *
+ * The resolution rule, in one place
+ * ---------------------------------
+ * Each config field is resolved independently:
+ *
+ *   model_config:
+ *     1. explicit request override                         (always wins)
+ *     2. parent.model_config IF parent.agentic_tool === effectiveTool
+ *     3. user.default_agentic_config[effectiveTool].modelConfig
+ *     4. undefined                                          (system has no model fallback)
+ *
+ *   permission_config:
+ *     1. explicit request override (incl. codex sub-config)
+ *     2. parent.permission_config IF parent.agentic_tool === effectiveTool
+ *     3. user.default_agentic_config[effectiveTool].permissionMode (mapped)
+ *     4. getDefaultPermissionMode(effectiveTool) (mapped)
+ *
+ * The cross-tool gate at step 2 is the bug fix: if the child's tool differs
+ * from the parent's, parent config is *meaningless* — a Claude model name
+ * cannot run on Codex, and Claude's `acceptEdits` mode does not exist for
+ * Codex. The old code carried `parent.model_config` through as a fallback
+ * when the user had no per-tool default, so Codex children spawned from
+ * Claude parents inherited a Claude model and the SDK errored.
+ *
+ * MCP server inheritance is a separate axis and lives at the call site —
+ * MCPs are tool-agnostic and the existing "explicit list > copy from parent"
+ * behavior is correct regardless of tool match.
+ */
+
+import {
+  type ModelConfigInput,
+  type ResolvedModelConfig,
+  resolveModelConfig,
+} from '../models/resolve-config.js';
+import type {
+  AgenticToolName,
+  CodexApprovalPolicy,
+  CodexNetworkAccess,
+  CodexSandboxMode,
+  DefaultAgenticToolConfig,
+  PermissionMode,
+  Session,
+  User,
+} from '../types/index.js';
+import { getDefaultPermissionMode } from '../types/session.js';
+import { mapPermissionMode } from '../utils/permission-mode-mapper.js';
+
+/** Explicit overrides from the spawn/fork request. */
+export interface ChildSessionOverrides {
+  permissionMode?: PermissionMode;
+  modelConfig?: ModelConfigInput;
+  codexSandboxMode?: CodexSandboxMode;
+  codexApprovalPolicy?: CodexApprovalPolicy;
+  codexNetworkAccess?: CodexNetworkAccess;
+}
+
+/** Minimal parent shape this resolver reads — keeps tests free of full Session fixtures. */
+export type ChildResolverParent = Pick<
+  Session,
+  'agentic_tool' | 'permission_config' | 'model_config'
+>;
+
+export interface ResolveChildSessionConfigArgs {
+  /** Required — the parent session this child is forking/spawning from. */
+  parent: ChildResolverParent;
+  /** The child's agentic tool. Defaults to `parent.agentic_tool` when omitted. */
+  effectiveTool?: AgenticToolName;
+  /** User whose per-tool defaults are used when parent inheritance is gated off. */
+  user?: Pick<User, 'default_agentic_config'> | null;
+  /** Explicit per-call overrides from the spawn/fork request. */
+  overrides?: ChildSessionOverrides;
+  /** Override `new Date()` for deterministic tests. */
+  now?: Date;
+}
+
+export interface ResolvedChildSessionConfig {
+  /** Always populated — falls through request → parent (same tool) → user-default → mapped system default. */
+  permission_config: NonNullable<Session['permission_config']>;
+  /** May be `undefined` when no model is set anywhere appropriate for the effective tool. */
+  model_config?: ResolvedModelConfig;
+}
+
+/**
+ * Resolve `permission_config` and `model_config` for a child session.
+ *
+ * See file-level doc-comment for the precedence rule. This helper does NOT
+ * resolve MCP server IDs — those are handled at the call site (parent-copy
+ * vs. explicit override is independent of tool match).
+ */
+export function resolveChildSessionConfig(
+  args: ResolveChildSessionConfigArgs
+): ResolvedChildSessionConfig {
+  const { parent, user, overrides, now } = args;
+  const effectiveTool: AgenticToolName = args.effectiveTool ?? parent.agentic_tool;
+  const sameTool = effectiveTool === parent.agentic_tool;
+  const userToolDefaults = user?.default_agentic_config?.[effectiveTool];
+
+  // ---- model_config ----
+  // Explicit > parent (gated on tool match) > user default > undefined.
+  // The tool gate is the bug fix: a Claude model cannot run on Codex, so
+  // we drop the parent fallback when the child crosses tools.
+  const inheritedParentModel: ModelConfigInput | undefined = sameTool
+    ? parent.model_config
+    : undefined;
+
+  const model_config =
+    resolveModelConfig(overrides?.modelConfig, { now }) ??
+    resolveModelConfig(inheritedParentModel, { now }) ??
+    resolveModelConfig(userToolDefaults?.modelConfig, { now });
+
+  // ---- permission_config ----
+  // Explicit > parent (gated on tool match) > user default > system default.
+  // For cross-tool spawns we never inherit parent.permission_config —
+  // Claude's `acceptEdits` is not a valid Codex mode, and Codex's `codex`
+  // sub-config is missing on Claude parents anyway. The resolver always
+  // produces a populated permission_config.
+  const permission_config = resolveChildPermissionConfig({
+    effectiveTool,
+    sameTool,
+    parentPermission: parent.permission_config,
+    userToolDefaults,
+    overrides,
+  });
+
+  return { permission_config, model_config };
+}
+
+/**
+ * Resolve `permission_config` for a child session.
+ *
+ * Split out so the precedence walk is readable: each branch is a single
+ * "do we have a value at this priority?" check.
+ */
+function resolveChildPermissionConfig(args: {
+  effectiveTool: AgenticToolName;
+  sameTool: boolean;
+  parentPermission: Session['permission_config'];
+  userToolDefaults: DefaultAgenticToolConfig | undefined;
+  overrides?: ChildSessionOverrides;
+}): NonNullable<Session['permission_config']> {
+  const { effectiveTool, sameTool, parentPermission, userToolDefaults, overrides } = args;
+
+  // ---- mode ----
+  // Explicit > parent (same tool only) > user default > system default.
+  let resolvedMode: PermissionMode | undefined = overrides?.permissionMode;
+  if (!resolvedMode && sameTool && parentPermission?.mode) {
+    resolvedMode = parentPermission.mode;
+  }
+  if (!resolvedMode) {
+    resolvedMode = userToolDefaults?.permissionMode ?? getDefaultPermissionMode(effectiveTool);
+  }
+  const mode = mapPermissionMode(resolvedMode, effectiveTool);
+
+  const out: NonNullable<Session['permission_config']> = { mode };
+
+  // ---- codex sub-config (only on codex children) ----
+  // Explicit fields > parent's codex sub-config (only when same tool) > user defaults.
+  if (effectiveTool === 'codex') {
+    const sandboxMode =
+      overrides?.codexSandboxMode ??
+      (sameTool ? parentPermission?.codex?.sandboxMode : undefined) ??
+      userToolDefaults?.codexSandboxMode;
+    const approvalPolicy =
+      overrides?.codexApprovalPolicy ??
+      (sameTool ? parentPermission?.codex?.approvalPolicy : undefined) ??
+      userToolDefaults?.codexApprovalPolicy;
+    const networkAccessExplicit = overrides?.codexNetworkAccess;
+    const networkAccessParent = sameTool ? parentPermission?.codex?.networkAccess : undefined;
+    const networkAccess =
+      networkAccessExplicit !== undefined
+        ? networkAccessExplicit
+        : (networkAccessParent ?? userToolDefaults?.codexNetworkAccess);
+
+    if (sandboxMode && approvalPolicy) {
+      out.codex = {
+        sandboxMode,
+        approvalPolicy,
+        ...(networkAccess !== undefined && { networkAccess }),
+      };
+    }
+  }
+
+  return out;
+}

--- a/packages/core/src/sessions/resolve-permission-config.ts
+++ b/packages/core/src/sessions/resolve-permission-config.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared permission_config resolver used by `resolveSessionDefaults` (no
+ * parent) and `resolveChildSessionConfig` (with parent).
+ *
+ * Both helpers walk the same precedence: request → (parent — only when the
+ * caller passes one) → user default → mapped system default. The only
+ * difference is whether a "parent layer" is interposed between the explicit
+ * override and the user default. This module collapses that walk so the two
+ * public resolvers don't drift on the codex sub-config edge cases.
+ */
+
+import type { ModelConfigInput } from '../models/resolve-config.js';
+import type {
+  AgenticToolName,
+  CodexApprovalPolicy,
+  CodexNetworkAccess,
+  CodexSandboxMode,
+  DefaultAgenticToolConfig,
+  PermissionMode,
+  Session,
+} from '../types/index.js';
+import { getDefaultPermissionMode } from '../types/session.js';
+import { mapPermissionMode } from '../utils/permission-mode-mapper.js';
+
+/**
+ * Common runtime overrides shared by every session-creation flow. Per-flow
+ * extensions (e.g. `SessionDefaultsOverrides` adds `mcpServerIds`) extend
+ * this base.
+ */
+export interface SessionRuntimeOverrides {
+  permissionMode?: PermissionMode;
+  modelConfig?: ModelConfigInput;
+  codexSandboxMode?: CodexSandboxMode;
+  codexApprovalPolicy?: CodexApprovalPolicy;
+  codexNetworkAccess?: CodexNetworkAccess;
+}
+
+/**
+ * Optional "parent layer" interposed between explicit overrides and user
+ * defaults. Only the fields a parent can carry forward are present. The
+ * caller (the child-session resolver) is responsible for gating this on
+ * tool match — passing `undefined` means "no parent layer applies."
+ */
+export interface ParentPermissionLayer {
+  permissionMode?: PermissionMode;
+  codexSandboxMode?: CodexSandboxMode;
+  codexApprovalPolicy?: CodexApprovalPolicy;
+  codexNetworkAccess?: CodexNetworkAccess;
+}
+
+export interface ResolvePermissionConfigArgs {
+  effectiveTool: AgenticToolName;
+  overrides?: SessionRuntimeOverrides;
+  userToolDefaults?: DefaultAgenticToolConfig;
+  /** When present, layered between explicit override and user default. */
+  parentLayer?: ParentPermissionLayer;
+}
+
+/**
+ * Resolve `permission_config` for a session being created, with consistent
+ * precedence whether or not a parent layer is supplied. Always returns a
+ * populated object — the system default mapped through `mapPermissionMode`
+ * is the final fallback.
+ *
+ * Codex's dual sub-config (`sandboxMode` + `approvalPolicy` + `networkAccess`)
+ * is emitted only on `codex` sessions, and only when both required fields
+ * resolve to a value.
+ */
+export function resolvePermissionConfig(
+  args: ResolvePermissionConfigArgs
+): NonNullable<Session['permission_config']> {
+  const { effectiveTool, overrides, userToolDefaults, parentLayer } = args;
+
+  const requestedMode: PermissionMode =
+    overrides?.permissionMode ??
+    parentLayer?.permissionMode ??
+    userToolDefaults?.permissionMode ??
+    getDefaultPermissionMode(effectiveTool);
+
+  const out: NonNullable<Session['permission_config']> = {
+    mode: mapPermissionMode(requestedMode, effectiveTool),
+  };
+
+  if (effectiveTool === 'codex') {
+    const sandboxMode =
+      overrides?.codexSandboxMode ??
+      parentLayer?.codexSandboxMode ??
+      userToolDefaults?.codexSandboxMode;
+    const approvalPolicy =
+      overrides?.codexApprovalPolicy ??
+      parentLayer?.codexApprovalPolicy ??
+      userToolDefaults?.codexApprovalPolicy;
+    const networkAccess =
+      overrides?.codexNetworkAccess !== undefined
+        ? overrides.codexNetworkAccess
+        : parentLayer?.codexNetworkAccess !== undefined
+          ? parentLayer.codexNetworkAccess
+          : userToolDefaults?.codexNetworkAccess;
+
+    if (sandboxMode && approvalPolicy) {
+      out.codex = {
+        sandboxMode,
+        approvalPolicy,
+        ...(networkAccess !== undefined && { networkAccess }),
+      };
+    }
+  }
+
+  return out;
+}

--- a/packages/core/src/sessions/resolve-session-defaults.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.ts
@@ -1,56 +1,36 @@
 /**
- * Session creation config resolution
+ * Session creation config resolution (no parent — fresh sessions).
  *
  * Single source of truth for "given a user (and optional overrides), what
  * permission_config / model_config / mcp_server_ids should this new session
- * be stamped with?"
- *
- * This collapses the resolution dance that was duplicated across:
+ * be stamped with?" Used by:
  * - `apps/agor-daemon/src/mcp/tools/sessions.ts`   (`agor_sessions_create`)
- * - `apps/agor-daemon/src/mcp/tools/worktrees.ts`  (`agor_worktrees_set_zone`)
+ * - `apps/agor-daemon/src/services/zone-trigger.ts` (`fireAlwaysNewZoneTrigger`)
  * - `apps/agor-daemon/src/services/gateway.ts`     (gateway session creation)
- * - `apps/agor-daemon/src/services/sessions.ts`    (cross-tool spawn fallback)
  * - `apps/agor-daemon/src/utils/apply-session-config-defaults.ts` (the
- *   `before:create` hook, which applies these defaults to ANY caller — UI
- *   drag-into-zone, raw REST, etc. — that omits permission/model config)
+ *   `before:create` hook for any UI/REST caller that omits config)
  *
- * Resolution order (highest priority first):
- *   1. `overrides.*`         — explicit caller intent
- *   2. `user.default_agentic_config[tool].*`  — user's saved default for this tool
- *   3. Hardcoded `getDefaultPermissionMode(tool)` (permission only) /
- *      `undefined` (model)
+ * Resolution order:
+ *   permission_config: overrides → user default → mapped system default
+ *                      (algorithm shared with the child resolver via
+ *                      {@link resolvePermissionConfig})
+ *   model_config:      overrides → user default → undefined
+ *   mcp_server_ids:    overrides → worktree → user default → []
  *
- * MCP server inheritance (separate axis):
- *   1. `overrides.mcpServerIds`  — explicit (incl. empty array = "no MCPs")
- *   2. `worktree.mcp_server_ids` — worktree-level override
- *   3. `user.default_agentic_config[tool].mcpServerIds`
- *   4. `[]`
+ * The child-session variant ({@link resolveChildSessionConfig}) layers a
+ * tool-gated parent source between overrides and user defaults; both
+ * resolvers share the same permission/model walk.
  */
 
+import { resolveModelConfigPrecedence } from '../models/resolve-config.js';
+import type { AgenticToolName, Session, User } from '../types/index.js';
 import {
-  type ModelConfigInput,
-  type ResolvedModelConfig,
-  resolveModelConfig,
-} from '../models/resolve-config.js';
-import type {
-  AgenticToolName,
-  CodexApprovalPolicy,
-  CodexNetworkAccess,
-  CodexSandboxMode,
-  PermissionMode,
-  Session,
-  User,
-} from '../types/index.js';
-import { getDefaultPermissionMode } from '../types/session.js';
-import { mapPermissionMode } from '../utils/permission-mode-mapper.js';
+  resolvePermissionConfig,
+  type SessionRuntimeOverrides,
+} from './resolve-permission-config.js';
 
 /** Explicit per-call overrides. Each field, when defined, wins over user defaults. */
-export interface SessionDefaultsOverrides {
-  permissionMode?: PermissionMode;
-  modelConfig?: ModelConfigInput;
-  codexSandboxMode?: CodexSandboxMode;
-  codexApprovalPolicy?: CodexApprovalPolicy;
-  codexNetworkAccess?: CodexNetworkAccess;
+export interface SessionDefaultsOverrides extends SessionRuntimeOverrides {
   /**
    * Explicit MCP server ID list. An empty array means "no MCPs" — does NOT
    * fall through to worktree/user defaults. Pass `undefined` to fall through.
@@ -70,60 +50,32 @@ export interface ResolveSessionDefaultsArgs {
 }
 
 export interface ResolvedSessionDefaults {
-  /** Always populated — falls back to `getDefaultPermissionMode(tool)` mapped through `mapPermissionMode`. */
+  /** Always populated — falls back to mapped `getDefaultPermissionMode(tool)`. */
   permission_config: NonNullable<Session['permission_config']>;
   /** Optional — `undefined` when neither overrides nor user defaults specify a model. */
-  model_config?: ResolvedModelConfig;
+  model_config?: NonNullable<Session['model_config']>;
   /** Resolved MCP server list. Empty array means "no MCPs". */
   mcp_server_ids: string[];
 }
 
-/**
- * Resolve session creation defaults from caller overrides + user defaults.
- *
- * The returned `permission_config` is always populated (using the system
- * fallback when nothing else applies), so callers can persist it directly.
- * `model_config` may be `undefined` when no model has been chosen anywhere.
- */
 export function resolveSessionDefaults(args: ResolveSessionDefaultsArgs): ResolvedSessionDefaults {
   const { agenticTool, user, worktree, overrides, now } = args;
   const userToolDefaults = user?.default_agentic_config?.[agenticTool];
 
-  // ---- permission_config ----
-  // Walk: explicit override → user default → hardcoded fallback.
-  const requestedMode: PermissionMode =
-    overrides?.permissionMode ??
-    userToolDefaults?.permissionMode ??
-    getDefaultPermissionMode(agenticTool);
-  const permissionMode = mapPermissionMode(requestedMode, agenticTool);
+  const permission_config = resolvePermissionConfig({
+    effectiveTool: agenticTool,
+    overrides,
+    userToolDefaults,
+    // No parent layer for fresh-session defaults.
+  });
 
-  const permission_config: NonNullable<Session['permission_config']> = {
-    mode: permissionMode,
-  };
+  const model_config = resolveModelConfigPrecedence(
+    [overrides?.modelConfig, userToolDefaults?.modelConfig],
+    { now }
+  );
 
-  // Codex's dual permission config: explicit overrides win as a unit; otherwise
-  // copy user defaults if both required fields are present (legacy behavior).
-  if (agenticTool === 'codex') {
-    const sandboxMode = overrides?.codexSandboxMode ?? userToolDefaults?.codexSandboxMode;
-    const approvalPolicy = overrides?.codexApprovalPolicy ?? userToolDefaults?.codexApprovalPolicy;
-    const networkAccess = overrides?.codexNetworkAccess ?? userToolDefaults?.codexNetworkAccess;
-    if (sandboxMode && approvalPolicy) {
-      permission_config.codex = {
-        sandboxMode,
-        approvalPolicy,
-        ...(networkAccess !== undefined && { networkAccess }),
-      };
-    }
-  }
-
-  // ---- model_config ----
-  const model_config =
-    resolveModelConfig(overrides?.modelConfig, { now }) ??
-    resolveModelConfig(userToolDefaults?.modelConfig, { now });
-
-  // ---- mcp_server_ids ----
-  // Explicit override wins (incl. empty array = "no MCPs"). Otherwise:
-  // worktree config > user defaults > [].
+  // mcp_server_ids: explicit override wins (incl. empty array = "no MCPs"),
+  // then worktree config, then user defaults, then [].
   let mcp_server_ids: string[];
   if (overrides?.mcpServerIds !== undefined) {
     mcp_server_ids = overrides.mcpServerIds;


### PR DESCRIPTION
## Summary

A Codex subsession spawned from a Claude parent received `claude-opus-4-7` as its `model_config.model`, because `SessionsService.spawn` ended its cross-tool fallback with `userResolved.model_config ?? parentModel`. The Codex executor then got a Claude model ID and the SDK errored.

This PR centralizes the resolution rule, gates parent inheritance on tool match, and adds soft validation so the same class of bug shows up loudly next time.

## What changed

**New `resolveChildSessionConfig` helper** — `packages/core/src/sessions/resolve-child-session-config.ts`. Single source of truth for child-session config, field-by-field:

```
model_config:      request → parent (same tool only) → user default → undefined
permission_config: request → parent (same tool only) → user default → mapped system default
```

The "same tool only" gate is the fix. For cross-tool spawns the helper drops parent fallback (a Claude model can't run on Codex; Claude's `acceptEdits` mode is meaningless to Codex; Codex's `codex` sub-config is missing from a Claude parent anyway). MCP server inheritance is intentionally *not* in this helper — MCPs are tool-agnostic and the existing "explicit list > copy from parent" rule is correct regardless of tool match.

**`SessionsService.spawn` refactor** — collapsed from a bespoke precedence dance into a single call into the helper. Doc comment at the method spells out the rule and points at the helper.

**Soft validator** — `packages/core/src/models/lint-model-tool-match.ts`. Data-driven from a `TOOL_MODEL_PREFIXES` const map; never blocks, just logs a warning when a resolved model ID looks like it belongs to a different tool. Custom model strings, internal aliases, BYOK proxies, and Copilot (multi-provider routing) pass silently. Wired into `spawn()` post-resolution.

## Inheritance map (pre-PR audit)

| Code path | model_config | permission_config | mcp_servers |
|---|---|---|---|
| `agor_sessions_create` | request → user default → undef | request → user default → system | request → worktree → user default → [] |
| `fork()` (always same-tool) | parent | parent | parent (copied) |
| `spawn()` same-tool, no overrides | parent | parent | parent (copied) |
| **`spawn()` cross-tool, no overrides** | **user default ?? parent** ← bug | user default → system | parent (copied) |
| `spawn()` w/ explicit override | override | override | override → parent |
| `fireAlwaysNewZoneTrigger` | user default → undef | user default → system | worktree → user default → [] |
| `before:create` hook | user default if missing | user default → system if missing | n/a |
| Gateway create | channel → user default → system | (same) | channel → worktree → user default → [] |

After this PR, the only asymmetric row (cross-tool spawn) is gone — `spawn()` resolves through the helper alongside the others.

## Test plan

- [x] `packages/core/src/sessions/resolve-child-session-config.test.ts` — 21 unit tests covering the cross-tool regression, same-tool inheritance preservation, explicit-override precedence, codex sub-config gating, and permission-mode mapping.
- [x] `packages/core/src/models/lint-model-tool-match.test.ts` — 10 unit tests covering match / mismatch / unknown branches plus the warning formatter.
- [x] Specific regression test: `parent claude-code (model: claude-opus-4-7) → child codex with empty user defaults ⇒ child.model_config === undefined` (was `claude-opus-4-7`).
- [x] `pnpm check` clean (typecheck + lint + build).
- [x] Full `@agor/core` suite (2174 tests) and `@agor/daemon` suite (520 tests) pass.
- [ ] Live repro: spawn a codex subsession from a claude-code parent in a running daemon and confirm it doesn't get a Claude model. Deferred to reviewer with the watch-mode dev daemon.

## Hard rules (from the task brief)

- ✅ Custom model strings still accepted — the validator only warns.
- ✅ Inheritance logic is centralized in one helper.
- ✅ Unit test for the cross-tool spawn case is included.
- ✅ Resolver rule documented at the top of `resolve-child-session-config.ts`.
- ✅ Soft validation is data-driven (`TOOL_MODEL_PREFIXES` const map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)