### PR TITLE
fix(daemon): skip sudo wrap for git ops in simple/no-RBAC mode (closes #1140)

### DIFF
--- a/apps/agor-daemon/src/utils/git-impersonation.test.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression test for #1140 — `repo clone fails when user is not sudoer`.
+ *
+ * In the open-access default (`worktree_rbac: false`, `unix_user_mode:
+ * simple`) no supplemental Unix groups are ever created, so wrapping git
+ * operations in `sudo -u` is pure overhead. Worse: it breaks for users
+ * who never configured passwordless sudoers, with the daemon failing to
+ * clone repos against `user not in sudoers`.
+ *
+ * The resolver must return `undefined` in that case so callers spawn the
+ * git process directly. Sudo wrapping kicks in only when groups exist
+ * (RBAC enabled or non-simple unix_user_mode).
+ */
+
+import type { Database } from '@agor/core/db';
+import type { UserID, Worktree, WorktreeID } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsUnixGroupRefreshNeeded = vi.fn(() => false);
+const mockGetDaemonUser = vi.fn<() => string | undefined>(() => 'agorpg');
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@agor/core/config');
+  return {
+    ...actual,
+    isUnixGroupRefreshNeeded: () => mockIsUnixGroupRefreshNeeded(),
+    getDaemonUser: () => mockGetDaemonUser(),
+  };
+});
+
+// validateResolvedUnixUser hits the OS via getent/id; stub it out — the
+// resolver only validates after deciding to impersonate, so these tests
+// never need a real Unix user.
+vi.mock('@agor/core/unix', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@agor/core/unix');
+  return {
+    ...actual,
+    validateResolvedUnixUser: vi.fn(),
+  };
+});
+
+import {
+  resolveGitImpersonationForUser,
+  resolveGitImpersonationForWorktree,
+} from './git-impersonation';
+
+const fakeDb = {} as Database;
+const fakeUserId = 'user-123' as UserID;
+const fakeWorktree = {
+  worktree_id: 'wt-1' as WorktreeID,
+  created_by: fakeUserId,
+} as Worktree;
+
+beforeEach(() => {
+  mockIsUnixGroupRefreshNeeded.mockReset();
+  mockGetDaemonUser.mockReset();
+  mockGetDaemonUser.mockReturnValue('agorpg');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveGitImpersonationForUser', () => {
+  it('returns undefined in open-access default (no RBAC, simple mode) — #1140', async () => {
+    mockIsUnixGroupRefreshNeeded.mockReturnValue(false);
+    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns daemon user when group refresh is needed (RBAC or insulated/strict)', async () => {
+    mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
+    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
+    expect(result).toBe('agorpg');
+  });
+
+  it('returns undefined when group refresh is needed but daemon user not configured', async () => {
+    mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
+    mockGetDaemonUser.mockReturnValue(undefined);
+    const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('resolveGitImpersonationForWorktree', () => {
+  it('returns undefined in open-access default (no RBAC, simple mode) — #1140', async () => {
+    mockIsUnixGroupRefreshNeeded.mockReturnValue(false);
+    const result = await resolveGitImpersonationForWorktree(fakeDb, fakeWorktree);
+    expect(result).toBeUndefined();
+  });
+
+  it('delegates to resolveGitImpersonationForUser using worktree.created_by', async () => {
+    mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
+    const result = await resolveGitImpersonationForWorktree(fakeDb, fakeWorktree);
+    expect(result).toBe('agorpg');
+  });
+});

--- a/apps/agor-daemon/src/utils/git-impersonation.test.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.test.ts
@@ -28,9 +28,9 @@ vi.mock('@agor/core/config', async () => {
   };
 });
 
-// validateResolvedUnixUser hits the OS via getent/id; stub it out — the
-// resolver only validates after deciding to impersonate, so these tests
-// never need a real Unix user.
+// validateResolvedUnixUser is a no-op for `simple` mode (the resolver always
+// passes that), but stub it anyway so the test never depends on real Unix
+// user lookups via getent/id, even if the production call switches modes.
 vi.mock('@agor/core/unix', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@agor/core/unix');
   return {

--- a/apps/agor-daemon/src/utils/git-impersonation.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.ts
@@ -1,14 +1,15 @@
 /**
  * Git Impersonation Utilities
  *
- * Git operations (clone, worktree add/remove/clean) always run as the daemon user
- * to avoid permission issues with shared directories under /home/agorpg/.agor/.
+ * Git operations (clone, worktree add/remove/clean) always run as the daemon
+ * user. We may wrap them in `sudo -u` to force a fresh group membership read
+ * via `initgroups()` so the daemon can see `agor_wt_*` groups added at
+ * runtime — but only when supplemental groups actually exist.
  *
- * We still use sudo -u to force a fresh group membership read via initgroups(),
- * which ensures the executor process has current worktree groups (agor_wt_*).
- *
- * The daemon process has stale group memberships from startup, so without sudo -u,
- * git operations can't access worktree-owned files.
+ * In the open-access default (`worktree_rbac: false`, `unix_user_mode:
+ * simple`) no supplemental groups are ever created, so wrapping in sudo is
+ * pure overhead AND breaks for users who never configured passwordless
+ * sudoers (#1140). Return undefined in that case so callers spawn directly.
  */
 
 import type { Database } from '@agor/core/db';
@@ -16,42 +17,39 @@ import type { UserID, Worktree } from '@agor/core/types';
 import { validateResolvedUnixUser } from '@agor/core/unix';
 
 /**
- * Resolve Unix user for git operations
+ * Resolve Unix user for git operations.
  *
- * Git operations always run as the daemon user (agorpg) because:
- * 1. Parent directories (/home/agorpg/.agor/worktrees/) are owned by agorpg
- * 2. Running as another user causes permission errors when creating directories
- * 3. We still use sudo -u to get fresh group memberships via initgroups()
+ * Returns the daemon user when group refresh via `sudo -u` is needed
+ * (RBAC enabled or non-simple unix_user_mode). Returns `undefined` when
+ * no supplemental groups exist, signalling callers to skip sudo entirely.
  *
  * @param db - Database instance (unused, kept for API compatibility)
  * @param userId - User ID (unused, kept for API compatibility)
- * @returns Daemon username to force fresh group lookup via sudo -u
+ * @returns Daemon username when sudo wrap is needed, otherwise undefined
  */
 export async function resolveGitImpersonationForUser(
-  db: Database,
-  userId: UserID
+  _db: Database,
+  _userId: UserID
 ): Promise<string | undefined> {
-  const { getDaemonUser } = await import('@agor/core/config');
+  const { getDaemonUser, isUnixGroupRefreshNeeded } = await import('@agor/core/config');
 
-  // Always use daemon user for git operations
+  // No supplemental groups → no need for sudo. Avoids requiring sudoers
+  // for users on the default open-access setup. (#1140)
+  if (!isUnixGroupRefreshNeeded()) {
+    return undefined;
+  }
+
   const daemonUser = getDaemonUser();
-
-  // Validate user exists
   if (daemonUser) {
     validateResolvedUnixUser('simple', daemonUser);
   }
-
   return daemonUser;
 }
 
 /**
- * Resolve Unix user for git operations on a worktree
+ * Resolve Unix user for git operations on a worktree.
  *
- * Git operations always run as the daemon user (see resolveGitImpersonationForUser).
- *
- * @param db - Database instance (unused, kept for API compatibility)
- * @param worktree - Worktree (unused, kept for API compatibility)
- * @returns Daemon username to force fresh group lookup via sudo -u
+ * @see resolveGitImpersonationForUser
  */
 export async function resolveGitImpersonationForWorktree(
   db: Database,

--- a/apps/agor-daemon/src/utils/git-shell-capture.ts
+++ b/apps/agor-daemon/src/utils/git-shell-capture.ts
@@ -5,11 +5,11 @@
  * after daemon start are missing). This means in-process simple-git calls fail
  * for repos whose ACLs rely on recently-added groups.
  *
- * Solution: Use `sudo -u <daemonUser>` to run git commands, which calls
- * initgroups() and gets fresh group memberships from /etc/group.
- *
- * Falls back to direct shell execution (without sudo) when no daemon user
- * is configured (e.g., simple mode without Unix isolation).
+ * When supplemental groups exist (RBAC enabled, or `unix_user_mode` insulated/
+ * strict), we wrap git commands in `sudo -u <daemonUser>` so sudo calls
+ * initgroups() and gets fresh group memberships from /etc/group. In the open-
+ * access default (no RBAC, simple mode) no such groups exist, so we run the
+ * git command directly — this avoids requiring sudoers config (#1140).
  *
  * @see git-impersonation.ts for the same pattern used in git clone/worktree operations
  */

--- a/apps/agor-daemon/src/utils/git-shell-capture.ts
+++ b/apps/agor-daemon/src/utils/git-shell-capture.ts
@@ -19,13 +19,18 @@ import { runAsUser, validateResolvedUnixUser } from '@agor/core/unix';
 /**
  * Resolve and validate the daemon user for sudo -u impersonation.
  *
- * Uses getDaemonUser() from config and validates via validateResolvedUnixUser()
- * to prevent unvalidated strings from reaching shell commands.
+ * Returns `undefined` when no supplemental groups exist (no RBAC, simple
+ * unix mode), so `runAsUser` runs the command directly without sudo. This
+ * matches the gating in {@link ../utils/git-impersonation.ts} and avoids
+ * the "user not in sudoers" failure on default open-access setups (#1140).
  *
- * @returns Validated daemon username, or undefined if not configured
+ * @returns Validated daemon username, or undefined if no group refresh is needed
  */
 async function resolveValidatedDaemonUser(): Promise<string | undefined> {
-  const { getDaemonUser } = await import('@agor/core/config');
+  const { getDaemonUser, isUnixGroupRefreshNeeded } = await import('@agor/core/config');
+  if (!isUnixGroupRefreshNeeded()) {
+    return undefined;
+  }
   const daemonUser = getDaemonUser();
   if (daemonUser) {
     validateResolvedUnixUser('simple', daemonUser);

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -598,6 +598,26 @@ export function isUnixImpersonationEnabled(): boolean {
   }
 }
 
+/**
+ * Whether the daemon needs to wrap git operations in `sudo -u` to pick up
+ * supplemental Unix groups created after daemon startup.
+ *
+ * `sudo -u` is the only way to force a fresh `initgroups()` on a long-running
+ * daemon process — without it, `agor_wt_*` groups added at runtime are
+ * invisible and ACL-gated git operations fail with permission errors.
+ *
+ * Why: Issue #1140 — in the open-access default (no RBAC, simple unix mode)
+ * no supplemental groups are ever created, so wrapping in sudo is pure
+ * overhead AND breaks for users who never configured passwordless sudoers.
+ *
+ * Returns true when:
+ * - `worktree_rbac` is enabled (RBAC creates `agor_wt_*` groups), OR
+ * - `unix_user_mode` is `insulated` or `strict` (per-user impersonation)
+ */
+export function isUnixGroupRefreshNeeded(): boolean {
+  return isWorktreeRbacEnabled() || isUnixImpersonationEnabled();
+}
+
 // =============================================================================
 // Data Home Path Resolution
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #1140. Default open-access setups (`worktree_rbac: false`, `unix_user_mode: simple`) never create supplemental Unix groups, but the daemon was still wrapping every git operation in `sudo -n -u <daemon_user> bash -c …`. For users without passwordless sudoers, this broke cloning entirely with `user not in sudoers`.

- Add `isUnixGroupRefreshNeeded()` helper in `packages/core/src/config/config-manager.ts` — true only when `worktree_rbac` is on or `unix_user_mode` is `insulated`/`strict`
- Gate both git impersonation resolvers on it: `apps/agor-daemon/src/utils/git-impersonation.ts` (clone, worktree add/remove) and `apps/agor-daemon/src/utils/git-shell-capture.ts` (git state capture). Returning `undefined` makes `runAsUser`/`buildSpawnArgs` spawn directly with no sudo wrap.
- 5 regression tests in `apps/agor-daemon/src/utils/git-impersonation.test.ts` covering the simple-mode bug + the modes where sudo is still required.

## Impersonation audit (Phase 4 of the brief)

The brief asked whether we need a centralizing `runAsUser`-style helper to prevent the next regression. **The helper already exists and is solid** — `buildSpawnArgs` + `runAsUser` + `prepareImpersonationEnv` in `packages/core/src/unix/`. Every major call site (executor spawn, environment commands, terminals, zellij, git ops) routes through it. No raw `setuid`/`spawn({uid,gid})`/bare `sudo` invocations bypass it. Env-file routing keeps secrets out of `argv`. `GIT_CONFIG_GLOBAL=/dev/null` blocks daemon `~/.gitconfig` leakage.

Recent regressions (#1015, #1088, #1099, #1103, and now #1140) didn't break the spawn-layer abstraction. They all happened one layer up — at the **resolver layer** (the function that decides "should we impersonate, and as whom?"). #1140 is the same shape: the resolver returned the daemon user unconditionally, ignoring the mode flags.

A new lower-level helper would not have prevented this. Defensive measures belong at the resolver layer, not the spawn layer.

### Recommended follow-ups (separate PRs)

1. **Replace the hardcoded secret allowlist at `apps/agor-daemon/src/utils/spawn-executor.ts:277-281`** with `splitSecretEnv()`. Currently any new secret env var (e.g. a future `*_TOKEN`) silently leaks into argv when impersonating until the list is updated by hand. The `isSecretEnvKey()` regex already does the right detection — just need to use it.
2. **Document the resolver contract** in `context/guides/rbac-and-unix-isolation.md`: every `resolveXImpersonation(...)` must consult mode flags before returning a username, never hand back the daemon user unconditionally. Pair with a shared assertion helper for tests.

## Test plan

- [x] `pnpm check` passes (typecheck + lint + build, all packages)
- [x] New regression tests pass (5/5)
- [x] Daemon utils suite still passes (186/186)
- [x] Core config-manager suite still passes (69/69)
- [ ] Manual verify on a simple-mode setup without sudoers: `Add Repository` flow now succeeds where it previously failed with `user not in sudoers`
- [ ] Manual verify on a `worktree_rbac: true` or `unix_user_mode: insulated` setup: clone still wraps in `sudo -u` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)