### PR TITLE
feat(artifacts)!: declarative format + TOFU consent flow

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -12,7 +12,14 @@
  */
 
 import { WorktreeRepository } from '@agor/core/db';
-import type { AgorGrants, BoardID, SandpackConfig, UUID, WorktreeID } from '@agor/core/types';
+import type {
+  AgorGrants,
+  BoardID,
+  SandpackConfig,
+  UserRole,
+  UUID,
+  WorktreeID,
+} from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -249,11 +256,16 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const artifactId = coerceString(args.artifactId)!;
 
-      const artifact = await service.get(artifactId, ctx.baseServiceParams);
-      // role on AuthenticatedUser is loosely typed as `string`; the service
-      // takes the strict `UserRole` union but values flowing through here
-      // are always valid roles (auth strategies enforce on the way in).
-      await service.deleteArtifact(artifactId, ctx.userId, ctx.authenticatedUser.role as never);
+      // deleteArtifact loads the row, runs the owner/admin check, performs
+      // the delete, and returns the artifact so we can emit `removed`
+      // without a redundant pre-delete fetch. role on AuthenticatedUser is
+      // loosely typed as `string`; auth strategies enforce a valid value
+      // upstream so the cast to UserRole is honest.
+      const artifact = await service.deleteArtifact(
+        artifactId,
+        ctx.userId,
+        ctx.authenticatedUser.role as UserRole
+      );
       ctx.app.service('artifacts').emit('removed', artifact);
 
       return textResult({ success: true, artifactId });
@@ -355,7 +367,8 @@ Caller must own the artifact (or be an admin).`,
           required_env_vars: args.requiredEnvVars,
           agor_grants: args.agorGrants as AgorGrants | undefined,
         },
-        ctx.userId
+        ctx.userId,
+        ctx.authenticatedUser.role as UserRole
       );
 
       const { files: _files, ...artifactSummary } = updated;

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -109,7 +109,7 @@ DECLARATIVE CONFIG:
 CONSENT MODEL (TOFU): when the viewer is NOT the artifact author, the daemon does NOT inject env vars or grants without an explicit trust grant. Untrusted artifacts render with empty env values and a "Trust to render with secrets" badge.
 
 IMPORTANT:
-- Secrets never enter the LLM context. Env values are only injected into the served \`.env\` at view time.
+- Secret VALUES are never sent to the LLM as-is — they're only injected into the served \`.env\` at view time. CAVEAT: if your artifact renders a secret-derived value into the DOM (e.g. \`<div>API: {key}</div>\`), an agent calling \`agor_artifacts_query_dom\` against your own running render WILL see the rendered text. Treat any \`agor_artifacts_query_*\` reply as potentially carrying secret-derived output if the artifact renders one.
 - Missing user env vars render as "" — your app should detect that and surface a "configure SOMETHING in Settings" message rather than calling APIs with empty creds.
 - For node.js / static templates without a dotenv path, env vars are NOT injected; the daemon emits a warning if you declared any.`,
       inputSchema: z.object({

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -99,7 +99,7 @@ IMPORTANT:
           .string()
           .optional()
           .describe(
-            'Board to place the artifact on. REQUIRED when creating; on update (artifactId given) defaults to the artifact’s current board if omitted.'
+            'Board to place the artifact on. REQUIRED when creating. IGNORED when updating (artifactId given) — to move an artifact between boards use agor_artifacts_update.'
           ),
         name: z
           .string()
@@ -221,7 +221,7 @@ Fields:
 - sandpack_status: Sandpack bundler status ('idle', 'running', 'timeout', etc.)
 - console_logs: console.log/warn/error output from the running app
 
-NOTE: sandpack_error and console_logs require a browser to be viewing the artifact. If no browser is connected, these fields will be empty/null.`,
+NOTE: sandpack_error and console_logs require a browser to be viewing the artifact. They are scoped to the calling user's render — you only see your own console output, never another viewer's.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         artifactId: z.string().describe('Artifact ID'),
@@ -229,7 +229,7 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
     },
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
-      const status = await service.getStatus(coerceString(args.artifactId)!);
+      const status = await service.getStatus(coerceString(args.artifactId)!, ctx.userId);
       return textResult(status);
     }
   );
@@ -239,7 +239,7 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
     'agor_artifacts_delete',
     {
       description:
-        'Delete an artifact. Removes database record and board placement. Does not touch the filesystem.',
+        "Delete an artifact. Owner or admin only — calling as a different user returns 'Forbidden'. Removes database record and board placement. Does not touch the filesystem.",
       annotations: { destructiveHint: true },
       inputSchema: z.object({
         artifactId: z.string().describe('Artifact ID to delete'),
@@ -250,7 +250,10 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
       const artifactId = coerceString(args.artifactId)!;
 
       const artifact = await service.get(artifactId, ctx.baseServiceParams);
-      await service.deleteArtifact(artifactId);
+      // role on AuthenticatedUser is loosely typed as `string`; the service
+      // takes the strict `UserRole` union but values flowing through here
+      // are always valid roles (auth strategies enforce on the way in).
+      await service.deleteArtifact(artifactId, ctx.userId, ctx.authenticatedUser.role as never);
       ctx.app.service('artifacts').emit('removed', artifact);
 
       return textResult({ success: true, artifactId });

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -76,7 +76,7 @@ const AgorRuntimeSchema = z
       .boolean()
       .optional()
       .describe(
-        "Inject `agor-runtime.js` into the served file map. Default: true. Set false to opt the artifact out of agent DOM introspection (e.g. if the artifact's own code conflicts with our message listener)."
+        "Inject the daemon-side `agor-runtime.js` into the served bundle (as an iframe-level `<script>` via Sandpack's `externalResources`). Default: true. Set false to opt the artifact out of agent DOM introspection (e.g. if the artifact's own code conflicts with our message listener)."
       ),
   })
   .optional();

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -572,7 +572,7 @@ Caps: 50 nodes max, 50KB outerHTML per node, 5KB textContent per node. Tightened
 Use cases:
 - "Did my artifact actually render the new heading?" — \`{ selector: 'h1' }\`
 - "Inspect a list of cards" — \`{ selector: '.card', multiple: true }\`
-- "Get the full document" — use \`agor_artifacts_query_dom\` with \`selector: 'html'\` or call agor_artifacts_query_document_html (lower-level dump).`,
+- "Get the full document" — use \`{ selector: 'html' }\`, or call \`agor_artifacts_query_document_html\` for an unstructured dump of the entire \`document.documentElement.outerHTML\`.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
@@ -606,6 +606,44 @@ Use cases:
             multiple: args.multiple,
             maxNodes: args.maxNodes,
           },
+          timeoutMs: args.timeoutMs,
+        });
+        return textResult(result);
+      } catch (err) {
+        return textResult({
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+
+  // Tool 11: agor_artifacts_query_document_html
+  server.registerTool(
+    'agor_artifacts_query_document_html',
+    {
+      description: `Return the rendered artifact's full \`document.documentElement.outerHTML\` (unstructured dump).
+
+Same round-trip as agor_artifacts_query_dom: requires \`agor_runtime.enabled\` and a browser tab logged in as YOU currently viewing the artifact.
+
+Capped at 200KB. Truncated output ends with \`... [truncated]\`. For targeted queries prefer agor_artifacts_query_dom with a CSS selector — this tool is the "give me everything" escape hatch when you don't know what to look for yet.`,
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
+        timeoutMs: z
+          .number()
+          .optional()
+          .describe('How long to wait for the browser to answer (500-30000). Default: 5000.'),
+      }),
+    },
+    async (args) => {
+      const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
+      try {
+        const result = await service.queryArtifactRuntime({
+          artifactId,
+          userId: ctx.userId,
+          kind: 'document_html',
+          args: {},
           timeoutMs: args.timeoutMs,
         });
         return textResult(result);

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -95,8 +95,18 @@ IMPORTANT:
 - For node.js / static templates without a dotenv path, env vars are NOT injected; the daemon emits a warning if you declared any.`,
       inputSchema: z.object({
         folderPath: z.string().describe('Absolute path to folder containing artifact files'),
-        boardId: z.string().describe('Board to place the artifact on'),
-        name: z.string().describe('Artifact display name'),
+        boardId: z
+          .string()
+          .optional()
+          .describe(
+            'Board to place the artifact on. REQUIRED when creating; on update (artifactId given) defaults to the artifact’s current board if omitted.'
+          ),
+        name: z
+          .string()
+          .optional()
+          .describe(
+            'Artifact display name. REQUIRED when creating; on update (artifactId given) defaults to the existing name if omitted. PASSING A DIFFERENT NAME ON UPDATE WILL RENAME THE ARTIFACT.'
+          ),
         artifactId: z
           .string()
           .optional()
@@ -137,7 +147,8 @@ IMPORTANT:
     },
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
-      const resolvedBoardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
+      const boardIdRaw = coerceString(args.boardId);
+      const resolvedBoardId = boardIdRaw ? await resolveBoardId(ctx, boardIdRaw) : undefined;
       const resolvedArtifactId = coerceString(args.artifactId)
         ? await resolveArtifactId(ctx, coerceString(args.artifactId)!)
         : undefined;
@@ -145,7 +156,7 @@ IMPORTANT:
         {
           folderPath: coerceString(args.folderPath)!,
           board_id: resolvedBoardId,
-          name: coerceString(args.name)!,
+          name: coerceString(args.name),
           artifact_id: resolvedArtifactId,
           template: args.template,
           public: args.public,
@@ -185,7 +196,13 @@ IMPORTANT:
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const result = await service.checkBuildFromFolder(coerceString(args.folderPath)!);
-      return textResult(result);
+      // Mirror getStatus shape — `build_status` (not `status`) and `build_errors`
+      // (always an array, never undefined) so agents can parse one schema across
+      // both tools.
+      return textResult({
+        build_status: result.status,
+        build_errors: result.errors,
+      });
     }
   );
 
@@ -354,11 +371,11 @@ Caller must own the artifact (or be an admin).`,
 
 Use this when you want to tweak an artifact's code: land it into a worktree, edit the files locally, then call agor_artifacts_publish with the same artifactId to push the changes back.
 
-Writes a small \`agor.artifact.json\` sidecar alongside the source files. The sidecar carries metadata that doesn't fit in the file map (template, sandpack_config, required_env_vars, agor_grants) so a round-trip publish() can preserve it. Build tools (Vite/CRA/etc.) ignore the sidecar.
+Writes a small \`agor.artifact.json\` sidecar alongside the source files. The sidecar carries metadata that doesn't fit in the file map (template, sandpack_config, required_env_vars, agor_grants) so a round-trip publish() can preserve it. **Do not delete \`agor.artifact.json\`** — without it, a republish will reset \`required_env_vars\` and \`agor_grants\` to empty. Build tools (Vite/CRA/etc.) ignore the sidecar.
 
 Safety:
 - Destination must be inside the target worktree (cannot escape via ".." or absolute paths).
-- Default subpath is \`.agor/artifacts/<artifact-id>\` (inside the worktree). Pass a custom subpath if you want a different location.
+- Default subpath is \`.agor/artifacts/<slug>-<short-id>\` derived from the artifact's name (kebab-cased, ASCII-only). Pass a custom subpath if you want a different location.
 - Refuses to write to an existing destination unless overwrite=true is passed.
 - overwrite=true removes the destination directory first (symlinks are unlinked, not followed).
 
@@ -370,7 +387,7 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
           .string()
           .optional()
           .describe(
-            'Worktree-relative path for the destination folder. Default: .agor/artifacts/<artifact-id>. Must not be absolute or escape the worktree.'
+            'Worktree-relative path for the destination folder. Default: .agor/artifacts/<slug>-<short-id> derived from the artifact name. Must not be absolute or escape the worktree.'
           ),
         overwrite: z
           .boolean()
@@ -436,7 +453,7 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
         destinationPath: result.destinationPath,
         fileCount: result.fileCount,
         bytesWritten: result.bytesWritten,
-        instructions: `Artifact materialized to ${result.destinationPath}. Edit files there, then call agor_artifacts_publish with folderPath=${result.destinationPath} and artifactId=${artifactId} to push changes back.`,
+        instructions: `Artifact materialized to ${result.destinationPath}. The folder includes \`agor.artifact.json\` — keep it: it carries template/sandpack_config/required_env_vars/agor_grants for round-trip publishing. Edit source files there, then call agor_artifacts_publish with folderPath=${result.destinationPath} and artifactId=${artifactId} to push changes back.`,
       });
     }
   );
@@ -525,24 +542,51 @@ CAVEAT: daemon-supplied capabilities (\`AGOR_TOKEN\`, \`AGOR_PROXY_*\`, etc.) wo
         template: artifact.sandpack_config?.template ?? artifact.template,
       };
 
-      const res = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(definePayload),
-      });
-      if (!res.ok) {
-        const detail = await res.text();
+      let res: Response;
+      try {
+        res = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(definePayload),
+        });
+      } catch (err) {
         return textResult({
-          error: `CodeSandbox define API failed: ${res.status} ${res.statusText}`,
-          detail,
+          error: `CodeSandbox define API unreachable: ${err instanceof Error ? err.message : String(err)}`,
         });
       }
-      const body = (await res.json()) as { sandbox_id?: string };
+      if (!res.ok) {
+        // Bodies on failure are typically Cloudflare HTML challenge pages —
+        // dumping them as a string blows up the agent's context window with
+        // no actionable signal. Collapse to a one-liner.
+        const ct = res.headers.get('content-type') ?? '';
+        const looksJson = ct.includes('application/json');
+        let hint = '';
+        if (looksJson) {
+          try {
+            const body = (await res.json()) as { error?: string; message?: string };
+            const msg = body.error ?? body.message;
+            if (typeof msg === 'string' && msg.length > 0) {
+              hint = `: ${msg.slice(0, 200)}`;
+            }
+          } catch {}
+        }
+        return textResult({
+          error: `CodeSandbox define API failed (${res.status} ${res.statusText})${hint}. The endpoint is sometimes throttled by Cloudflare; retry or use a different export channel.`,
+        });
+      }
+      let body: { sandbox_id?: string };
+      try {
+        body = (await res.json()) as { sandbox_id?: string };
+      } catch (err) {
+        return textResult({
+          error:
+            `CodeSandbox returned a non-JSON 200 response (likely a Cloudflare interstitial). Try again later. ${err instanceof Error ? err.message : ''}`.trim(),
+        });
+      }
       const sandboxId = body.sandbox_id;
       if (!sandboxId) {
         return textResult({
           error: 'CodeSandbox returned a 200 with no sandbox_id',
-          response: body,
         });
       }
       const url = `https://codesandbox.io/s/${sandboxId}`;

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -3,10 +3,16 @@
  *
  * Agent-facing tools for publishing and managing Sandpack artifacts on boards.
  * Artifacts are DB-backed live web applications that render on the board canvas.
+ *
+ * The format is intentionally small: a file map plus declarative metadata
+ * (`required_env_vars`, `agor_grants`, `sandpack_config`). The daemon
+ * synthesizes a per-viewer `.env` and resolves daemon-supplied capabilities
+ * at render time. There is no Handlebars layer, no per-fetch JS rendering,
+ * and no `sandpack.json`/`agor.config.js` sidecar.
  */
 
 import { WorktreeRepository } from '@agor/core/db';
-import type { BoardID, UUID, WorktreeID } from '@agor/core/types';
+import type { AgorGrants, BoardID, SandpackConfig, UUID, WorktreeID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -16,45 +22,77 @@ import { resolveArtifactId, resolveBoardId, resolveWorktreeId } from '../resolve
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
+const SANDPACK_TEMPLATES = [
+  'react',
+  'react-ts',
+  'vanilla',
+  'vanilla-ts',
+  'vue',
+  'vue3',
+  'svelte',
+  'solid',
+  'angular',
+] as const;
+
+const SandpackConfigSchema = z
+  .object({
+    template: z.enum(SANDPACK_TEMPLATES).optional(),
+    customSetup: z
+      .object({
+        dependencies: z.record(z.string(), z.string()).optional(),
+        devDependencies: z.record(z.string(), z.string()).optional(),
+        entry: z.string().optional(),
+        environment: z.string().optional(),
+      })
+      .optional(),
+    theme: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
+    options: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough()
+  .optional();
+
+const AgorGrantsSchema = z
+  .object({
+    agor_token: z.boolean().optional(),
+    agor_api_url: z.boolean().optional(),
+    agor_user_email: z.boolean().optional(),
+    agor_artifact_id: z.boolean().optional(),
+    agor_board_id: z.boolean().optional(),
+    agor_proxies: z.array(z.string()).optional(),
+  })
+  .optional();
+
 export function registerArtifactTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_artifacts_publish
   server.registerTool(
     'agor_artifacts_publish',
     {
-      description: `Publish a folder as a live Sandpack artifact on a board. Reads all files from the given folder path, serializes them to the database, and places (or updates) the artifact on the board.
+      description: `Publish a folder as a live Sandpack artifact on a board. Reads files from the given folder, serializes them to the database, and places (or updates) the artifact on the board.
 
-If artifact_id is omitted, creates a new artifact.
-If artifact_id is provided, updates the existing artifact (must be owned by you).
+If artifactId is omitted, creates a new artifact.
+If artifactId is provided, updates the existing artifact (must be owned by you).
 
-The folder should contain source files and optionally a sandpack.json manifest. The agent decides where to create the folder — inside the worktree, a temp directory, etc. The folder is only read at publish time; after that, the artifact lives in the database.
+The folder should contain ordinary source files (no \`sandpack.json\`, no \`agor.config.js\`). The agent decides where to create the folder — inside the worktree, a temp directory, etc. The folder is only read at publish time; after that, the artifact lives in the database.
 
 Recommended: create the folder inside your worktree so files can be version-controlled.
 
-CONFIG CONVENTION (agor.config.js):
-If you include a file named "/agor.config.js", it is treated as a Handlebars template and rendered per-user at view time. This lets artifacts access API credentials and Agor context without hardcoding secrets.
+DECLARATIVE CONFIG:
+- \`requiredEnvVars\`: array of env var NAMES the artifact needs (e.g. ["OPENAI_KEY", "STRIPE_KEY"]). The daemon synthesizes a per-viewer \`.env\` at render time using values from the viewer's stored env vars (Settings → Environment Variables). Names are stored without prefix; the daemon prefixes per template (Vite → \`VITE_\`, CRA → \`REACT_APP_\`, etc.). Reference these in your code via \`import.meta.env.VITE_X\` (Vite) or \`process.env.X\` (Node).
+- \`agorGrants\`: declarative daemon capabilities. Each grant maps to a fixed env var:
+    \`agor_token: true\`     → mints a 15-min daemon JWT for the viewer; injected as \`AGOR_TOKEN\`. ARTIFACT-SCOPED CONSENT ONLY — author/instance grants don't auto-cover this.
+    \`agor_api_url: true\`   → injects the daemon URL as \`AGOR_API_URL\`.
+    \`agor_user_email: true\` → injects viewer's email as \`AGOR_USER_EMAIL\`.
+    \`agor_artifact_id: true\` → \`AGOR_ARTIFACT_ID\` (informational, no consent).
+    \`agor_board_id: true\`   → \`AGOR_BOARD_ID\` (informational, no consent).
+    \`agor_proxies: ["openai", ...]\` → injects \`AGOR_PROXY_OPENAI\` etc. for HTTP proxy URLs.
+- \`sandpackConfig\`: author-controlled SandpackProvider config (template, customSetup, theme, options). Sanitized on write — UI-affecting / private-account props are stripped.
 
-Available template variables:
-  {{ user.env.VAR_NAME }} - User's environment variable (configured in Settings > Environment Variables)
-  {{ user.id }}           - Current user's ID
-  {{ user.name }}         - Current user's display name
-  {{ user.email }}        - Current user's email
-  {{ agor.apiUrl }}       - Agor daemon URL
-  {{ artifact.id }}       - This artifact's ID
-  {{ artifact.boardId }}  - Board ID
-  {{ board.id }}          - Board ID (same as artifact.boardId)
-  {{ board.slug }}        - Board slug (for URL construction)
+CONSENT MODEL (TOFU): when the viewer is NOT the artifact author, the daemon does NOT inject env vars or grants without an explicit trust grant. Untrusted artifacts render with empty env values and a "Trust to render with secrets" badge.
 
 IMPORTANT:
-- Use {{ user.env.X }} for secrets (API keys, tokens). NEVER hardcode sensitive values.
-- All users can see the raw template file, but each user's rendered values are private.
-- Rendered secrets are injected into the artifact JS at view time. Artifact code CAN access these values, so only use this for artifacts you trust. The security guarantee is that secrets never enter the LLM context or conversation history.
-- Missing env vars render as empty string "". Your app should check for empty values and show a helpful message (e.g. "Please configure OPENAI_API_KEY in Settings > Environment Variables") instead of making API calls with empty credentials.
-
-Example /agor.config.js:
-  export const apiKey = "{{ user.env.OPENAI_API_KEY }}";
-  export const apiUrl = "{{ agor.apiUrl }}";
-
-Then in your app: import { apiKey, apiUrl } from '/agor.config.js';`,
+- Secrets never enter the LLM context. Env values are only injected into the served \`.env\` at view time.
+- Missing user env vars render as "" — your app should detect that and surface a "configure SOMETHING in Settings" message rather than calling APIs with empty creds.
+- For node.js / static templates without a dotenv path, env vars are NOT injected; the daemon emits a warning if you declared any.`,
       inputSchema: z.object({
         folderPath: z.string().describe('Absolute path to folder containing artifact files'),
         boardId: z.string().describe('Board to place the artifact on'),
@@ -64,23 +102,27 @@ Then in your app: import { apiKey, apiUrl } from '/agor.config.js';`,
           .optional()
           .describe('If provided, update existing artifact (must be owned by you)'),
         template: z
-          .enum([
-            'react',
-            'react-ts',
-            'vanilla',
-            'vanilla-ts',
-            'vue',
-            'vue3',
-            'svelte',
-            'solid',
-            'angular',
-          ])
+          .enum(SANDPACK_TEMPLATES)
           .optional()
-          .describe('Sandpack template (default: react)'),
+          .describe(
+            'Sandpack template (default: react). Also settable via sandpackConfig.template.'
+          ),
         public: z
           .boolean()
           .optional()
           .describe('Whether the artifact is visible to all board viewers (default: true)'),
+        sandpackConfig: SandpackConfigSchema.describe(
+          'Author-controlled Sandpack provider config (sanitized on write).'
+        ),
+        requiredEnvVars: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Env var NAMES (no prefix) the artifact needs. Daemon synthesizes a per-viewer .env at render time.'
+          ),
+        agorGrants: AgorGrantsSchema.describe(
+          'Daemon capabilities to inject. See tool description for the full list.'
+        ),
         x: z.number().optional().describe('X position on board (default: 0, only used on create)'),
         y: z.number().optional().describe('Y position on board (default: 0, only used on create)'),
         width: z
@@ -91,24 +133,6 @@ Then in your app: import { apiKey, apiUrl } from '/agor.config.js';`,
           .number()
           .optional()
           .describe('Height in pixels (default: 400, only used on create)'),
-        useLocalBundler: z
-          .boolean()
-          .optional()
-          .describe(
-            `Use the daemon's self-hosted Sandpack bundler at /static/sandpack/ instead of the default CodeSandbox hosted bundler. Default: false.
-
-When to set true:
-- Daemon is on a private network / VPN with no egress to codesandbox.io
-- Air-gapped deployments, compliance constraints, or fully offline demos
-
-REQUIRES the daemon to have been built with \`./build.sh --with-sandpack\`. If the local bundler is not available, artifact creation fails with a clear error.
-
-KNOWN LIMITATIONS of the local bundler (upstream sandpack-bundler v2):
-- CommonJS npm packages fail to resolve. Popular examples that break: recharts, lodash (use lodash-es instead), moment. Stick to ESM-only packages when this flag is true.
-- Fewer features and slower updates than the hosted bundler. Upstream issues: https://github.com/codesandbox/sandpack-bundler
-
-When in doubt, leave unset — the hosted bundler supports the widest range of packages and is the recommended default.`
-          ),
       }),
     },
     async (args) => {
@@ -125,7 +149,9 @@ When in doubt, leave unset — the hosted bundler supports the widest range of p
           artifact_id: resolvedArtifactId,
           template: args.template,
           public: args.public,
-          use_local_bundler: args.useLocalBundler,
+          sandpack_config: args.sandpackConfig as SandpackConfig | undefined,
+          required_env_vars: args.requiredEnvVars,
+          agor_grants: args.agorGrants as AgorGrants | undefined,
           x: args.x,
           y: args.y,
           width: args.width,
@@ -134,7 +160,6 @@ When in doubt, leave unset — the hosted bundler supports the widest range of p
         ctx.userId
       );
 
-      // Omit files blob from response to avoid context bloat for agents
       const { files: _files, ...artifactSummary } = artifact;
       return textResult({
         artifact: artifactSummary,
@@ -207,7 +232,6 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const artifactId = coerceString(args.artifactId)!;
 
-      // Get artifact before deletion for the emit
       const artifact = await service.get(artifactId, ctx.baseServiceParams);
       await service.deleteArtifact(artifactId);
       ctx.app.service('artifacts').emit('removed', artifact);
@@ -221,7 +245,7 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
     'agor_artifacts_get',
     {
       description:
-        'Get a single artifact by ID, including its full file map (path → content). Use this to read artifact source code from another worktree without filesystem access. Respects visibility: public artifacts are readable by anyone; private artifacts are only readable by their creator.',
+        'Get a single artifact by ID, including its full file map (path → content) and declarative metadata (sandpack_config, required_env_vars, agor_grants). Use this to read artifact source code from another worktree without filesystem access. Respects visibility: public artifacts are readable by anyone; private artifacts are only readable by their creator.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
@@ -231,7 +255,6 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const artifactId = coerceString(args.artifactId)!;
 
-      // Fetch the artifact via the Feathers get() method (inherited from DrizzleService)
       let artifact: Awaited<ReturnType<typeof service.get>>;
       try {
         artifact = await service.get(artifactId, ctx.baseServiceParams);
@@ -242,12 +265,10 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
         throw err;
       }
 
-      // Visibility check: private artifacts are only visible to their creator
       if (!service.isVisibleTo(artifact, ctx.userId)) {
         return textResult({ error: `Artifact ${artifactId} not found` });
       }
 
-      // Return metadata (without files blob) + full file map separately
       const { files, ...metadata } = artifact;
       return textResult({
         artifact: metadata,
@@ -260,13 +281,11 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
   server.registerTool(
     'agor_artifacts_update',
     {
-      description: `Update artifact metadata without re-reading files from disk. Use this to move an artifact to a different board, rename it, toggle visibility, archive it, or reposition its board placement.
-
-Primary use case: move an artifact to a different board via \`boardId\` when you no longer have the original source folder on disk.
+      description: `Update artifact metadata without re-reading files from disk. Use this to move an artifact to a different board, rename it, toggle visibility, archive it, reposition its board placement, or update its declarative config (requiredEnvVars / agorGrants / sandpackConfig).
 
 For file/content changes, use agor_artifacts_publish (which re-reads a folder and updates the stored files).
 
-Placement (x, y, width, height) is preserved across board moves unless you explicitly override it — so a cross-board move keeps the artifact in the same relative layout.
+Placement (x, y, width, height) is preserved across board moves unless you explicitly override it.
 
 Caller must own the artifact (or be an admin).`,
       inputSchema: z.object({
@@ -283,6 +302,14 @@ Caller must own the artifact (or be an admin).`,
         y: z.number().optional().describe('New Y position on board'),
         width: z.number().optional().describe('New width in pixels'),
         height: z.number().optional().describe('New height in pixels'),
+        sandpackConfig: SandpackConfigSchema.describe(
+          "Replace the artifact's sandpack_config (sanitized on write)."
+        ),
+        requiredEnvVars: z
+          .array(z.string())
+          .optional()
+          .describe("Replace the artifact's required_env_vars list."),
+        agorGrants: AgorGrantsSchema.describe("Replace the artifact's agor_grants object."),
       }),
     },
     async (args) => {
@@ -304,6 +331,9 @@ Caller must own the artifact (or be an admin).`,
           y: args.y,
           width: args.width,
           height: args.height,
+          sandpack_config: args.sandpackConfig as SandpackConfig | undefined,
+          required_env_vars: args.requiredEnvVars,
+          agor_grants: args.agorGrants as AgorGrants | undefined,
         },
         ctx.userId
       );
@@ -324,12 +354,12 @@ Caller must own the artifact (or be an admin).`,
 
 Use this when you want to tweak an artifact's code: land it into a worktree, edit the files locally, then call agor_artifacts_publish with the same artifactId to push the changes back.
 
-Writes a sandpack.json manifest alongside the files so agor_artifacts_publish can read the template/dependencies/entry back in a round-trip.
+Writes a small \`agor.artifact.json\` sidecar alongside the source files. The sidecar carries metadata that doesn't fit in the file map (template, sandpack_config, required_env_vars, agor_grants) so a round-trip publish() can preserve it. Build tools (Vite/CRA/etc.) ignore the sidecar.
 
 Safety:
 - Destination must be inside the target worktree (cannot escape via ".." or absolute paths).
 - Default subpath is \`.agor/artifacts/<artifact-id>\` (inside the worktree). Pass a custom subpath if you want a different location.
-- Refuses to write to an existing destination unless overwrite=true is passed (empty or not).
+- Refuses to write to an existing destination unless overwrite=true is passed.
 - overwrite=true removes the destination directory first (symlinks are unlinked, not followed).
 
 Visibility: public artifacts are readable by anyone; private artifacts are only landable by their owner.`,
@@ -353,7 +383,6 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
       const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
       const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
 
-      // Fetch artifact for visibility check.
       let artifact: Awaited<ReturnType<typeof service.get>>;
       try {
         artifact = await service.get(artifactId, ctx.baseServiceParams);
@@ -367,10 +396,6 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
         return textResult({ error: `Artifact ${artifactId} not found` });
       }
 
-      // Resolve worktree through the service layer (enforces `view` via RBAC
-      // hooks). Landing an artifact writes to disk, so `view` is not enough —
-      // require at least `session` (the same tier that lets a user create
-      // sessions that could themselves write files in the worktree).
       const worktree = (await ctx.app
         .service('worktrees')
         .get(worktreeId, ctx.baseServiceParams)) as {
@@ -441,13 +466,97 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
         artifactsList = await service.findVisible(ctx.userId, { limit });
       }
 
-      // Omit files blob from list results to avoid context bloat
       const stripped = (artifactsList as Record<string, unknown>[]).map(
         ({ files: _f, ...rest }) => rest
       );
       return textResult({
         total: stripped.length,
         data: stripped,
+      });
+    }
+  );
+
+  // Tool 9: agor_artifacts_export_codesandbox
+  server.registerTool(
+    'agor_artifacts_export_codesandbox',
+    {
+      description: `Export an artifact to CodeSandbox via their "define API". Returns a sandbox URL and ID. Useful for sharing or demoing — the artifact runs in CodeSandbox's standard environment, not Agor.
+
+CAVEAT: daemon-supplied capabilities (\`AGOR_TOKEN\`, \`AGOR_PROXY_*\`, etc.) won't work on CodeSandbox. The exported sandbox can read \`required_env_vars\` from CodeSandbox's "Secret Keys" UI — the names match because both sides use the same prefix-per-template convention (Vite → \`VITE_\`, CRA → \`REACT_APP_\`, etc.).`,
+      inputSchema: z.object({
+        artifactId: z.string().describe('Artifact ID to export (full UUID or short prefix)'),
+      }),
+    },
+    async (args) => {
+      const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
+
+      let artifact: Awaited<ReturnType<typeof service.get>>;
+      try {
+        artifact = await service.get(artifactId, ctx.baseServiceParams);
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return textResult({ error: `Artifact ${artifactId} not found` });
+        }
+        throw err;
+      }
+      if (!service.isVisibleTo(artifact, ctx.userId)) {
+        return textResult({ error: `Artifact ${artifactId} not found` });
+      }
+      if (!artifact.files || Object.keys(artifact.files).length === 0) {
+        return textResult({ error: `Artifact ${artifactId} has no files to export` });
+      }
+
+      // Build the CodeSandbox "define" payload. Strip leading slashes from
+      // file keys (CodeSandbox expects "src/index.js", not "/src/index.js").
+      // The agor.config.js / agor.artifact.json sidecars (if any made it
+      // into the file map for any reason) are dropped — they'd be broken
+      // outside Agor.
+      const filesPayload: Record<string, { content: string }> = {};
+      for (const [filePath, content] of Object.entries(artifact.files)) {
+        const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+        if (stripped === 'agor.config.js' || stripped === 'agor.artifact.json') continue;
+        if (stripped === '.env') continue;
+        filesPayload[stripped] = { content };
+      }
+
+      const definePayload = {
+        files: filesPayload,
+        template: artifact.sandpack_config?.template ?? artifact.template,
+      };
+
+      const res = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(definePayload),
+      });
+      if (!res.ok) {
+        const detail = await res.text();
+        return textResult({
+          error: `CodeSandbox define API failed: ${res.status} ${res.statusText}`,
+          detail,
+        });
+      }
+      const body = (await res.json()) as { sandbox_id?: string };
+      const sandboxId = body.sandbox_id;
+      if (!sandboxId) {
+        return textResult({
+          error: 'CodeSandbox returned a 200 with no sandbox_id',
+          response: body,
+        });
+      }
+      const url = `https://codesandbox.io/s/${sandboxId}`;
+
+      const requiredVars = artifact.required_env_vars ?? [];
+      const note = requiredVars.length
+        ? `This artifact declares required_env_vars=${JSON.stringify(requiredVars)}. Set the prefixed names (VITE_${requiredVars[0]}, etc.) in CodeSandbox → Settings → Secret Keys to make them available at runtime.`
+        : 'No required env vars to configure.';
+
+      return textResult({
+        artifactId,
+        sandboxId,
+        url,
+        note,
       });
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -174,7 +174,7 @@ IMPORTANT:
       const resolvedArtifactId = coerceString(args.artifactId)
         ? await resolveArtifactId(ctx, coerceString(args.artifactId)!)
         : undefined;
-      const artifact = await service.publish(
+      const artifact = await service.publishArtifact(
         {
           folderPath: coerceString(args.folderPath)!,
           board_id: resolvedBoardId,

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -507,101 +507,14 @@ CAVEAT: daemon-supplied capabilities (\`AGOR_TOKEN\`, \`AGOR_PROXY_*\`, etc.) wo
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
-
-      let artifact: Awaited<ReturnType<typeof service.get>>;
       try {
-        artifact = await service.get(artifactId, ctx.baseServiceParams);
-      } catch (err) {
-        if (err instanceof NotFoundError) {
-          return textResult({ error: `Artifact ${artifactId} not found` });
-        }
-        throw err;
-      }
-      if (!service.isVisibleTo(artifact, ctx.userId)) {
-        return textResult({ error: `Artifact ${artifactId} not found` });
-      }
-      if (!artifact.files || Object.keys(artifact.files).length === 0) {
-        return textResult({ error: `Artifact ${artifactId} has no files to export` });
-      }
-
-      // Build the CodeSandbox "define" payload. Strip leading slashes from
-      // file keys (CodeSandbox expects "src/index.js", not "/src/index.js").
-      // The agor.config.js / agor.artifact.json sidecars (if any made it
-      // into the file map for any reason) are dropped — they'd be broken
-      // outside Agor.
-      const filesPayload: Record<string, { content: string }> = {};
-      for (const [filePath, content] of Object.entries(artifact.files)) {
-        const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
-        if (stripped === 'agor.config.js' || stripped === 'agor.artifact.json') continue;
-        if (stripped === '.env') continue;
-        filesPayload[stripped] = { content };
-      }
-
-      const definePayload = {
-        files: filesPayload,
-        template: artifact.sandpack_config?.template ?? artifact.template,
-      };
-
-      let res: Response;
-      try {
-        res = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(definePayload),
-        });
+        const result = await service.exportToCodeSandbox(artifactId, ctx.userId);
+        return textResult(result);
       } catch (err) {
         return textResult({
-          error: `CodeSandbox define API unreachable: ${err instanceof Error ? err.message : String(err)}`,
+          error: err instanceof Error ? err.message : String(err),
         });
       }
-      if (!res.ok) {
-        // Bodies on failure are typically Cloudflare HTML challenge pages —
-        // dumping them as a string blows up the agent's context window with
-        // no actionable signal. Collapse to a one-liner.
-        const ct = res.headers.get('content-type') ?? '';
-        const looksJson = ct.includes('application/json');
-        let hint = '';
-        if (looksJson) {
-          try {
-            const body = (await res.json()) as { error?: string; message?: string };
-            const msg = body.error ?? body.message;
-            if (typeof msg === 'string' && msg.length > 0) {
-              hint = `: ${msg.slice(0, 200)}`;
-            }
-          } catch {}
-        }
-        return textResult({
-          error: `CodeSandbox define API failed (${res.status} ${res.statusText})${hint}. The endpoint is sometimes throttled by Cloudflare; retry or use a different export channel.`,
-        });
-      }
-      let body: { sandbox_id?: string };
-      try {
-        body = (await res.json()) as { sandbox_id?: string };
-      } catch (err) {
-        return textResult({
-          error:
-            `CodeSandbox returned a non-JSON 200 response (likely a Cloudflare interstitial). Try again later. ${err instanceof Error ? err.message : ''}`.trim(),
-        });
-      }
-      const sandboxId = body.sandbox_id;
-      if (!sandboxId) {
-        return textResult({
-          error: 'CodeSandbox returned a 200 with no sandbox_id',
-        });
-      }
-      const url = `https://codesandbox.io/s/${sandboxId}`;
-
-      const requiredVars = artifact.required_env_vars ?? [];
-      const note = requiredVars.length
-        ? `This artifact declares required_env_vars=${JSON.stringify(requiredVars)}. Set the prefixed names (VITE_${requiredVars[0]}, etc.) in CodeSandbox → Settings → Secret Keys to make them available at runtime.`
-        : 'No required env vars to configure.';
-
-      return textResult({
-        artifactId,
-        sandboxId,
-        url,
-        note,
-      });
     }
   );
 }

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -14,6 +14,7 @@
 import { WorktreeRepository } from '@agor/core/db';
 import type {
   AgorGrants,
+  AgorRuntimeConfig,
   BoardID,
   SandpackConfig,
   UserRole,
@@ -66,6 +67,17 @@ const AgorGrantsSchema = z
     agor_artifact_id: z.boolean().optional(),
     agor_board_id: z.boolean().optional(),
     agor_proxies: z.array(z.string()).optional(),
+  })
+  .optional();
+
+const AgorRuntimeSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .optional()
+      .describe(
+        "Inject `agor-runtime.js` into the served file map. Default: true. Set false to opt the artifact out of agent DOM introspection (e.g. if the artifact's own code conflicts with our message listener)."
+      ),
   })
   .optional();
 
@@ -140,6 +152,9 @@ IMPORTANT:
         agorGrants: AgorGrantsSchema.describe(
           'Daemon capabilities to inject. See tool description for the full list.'
         ),
+        agorRuntime: AgorRuntimeSchema.describe(
+          'Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via agor_artifacts_query_dom). Default: enabled.'
+        ),
         x: z.number().optional().describe('X position on board (default: 0, only used on create)'),
         y: z.number().optional().describe('Y position on board (default: 0, only used on create)'),
         width: z
@@ -170,6 +185,7 @@ IMPORTANT:
           sandpack_config: args.sandpackConfig as SandpackConfig | undefined,
           required_env_vars: args.requiredEnvVars,
           agor_grants: args.agorGrants as AgorGrants | undefined,
+          agor_runtime: args.agorRuntime as AgorRuntimeConfig | undefined,
           x: args.x,
           y: args.y,
           width: args.width,
@@ -342,6 +358,9 @@ Caller must own the artifact (or be an admin).`,
           .optional()
           .describe("Replace the artifact's required_env_vars list."),
         agorGrants: AgorGrantsSchema.describe("Replace the artifact's agor_grants object."),
+        agorRuntime: AgorRuntimeSchema.describe(
+          "Replace the artifact's agor_runtime config (controls agor-runtime.js injection)."
+        ),
       }),
     },
     async (args) => {
@@ -366,6 +385,7 @@ Caller must own the artifact (or be an admin).`,
           sandpack_config: args.sandpackConfig as SandpackConfig | undefined,
           required_env_vars: args.requiredEnvVars,
           agor_grants: args.agorGrants as AgorGrants | undefined,
+          agor_runtime: args.agorRuntime as AgorRuntimeConfig | undefined,
         },
         ctx.userId,
         ctx.authenticatedUser.role as UserRole
@@ -525,6 +545,69 @@ CAVEAT: daemon-supplied capabilities (\`AGOR_TOKEN\`, \`AGOR_PROXY_*\`, etc.) wo
       const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
       try {
         const result = await service.exportToCodeSandbox(artifactId, ctx.userId);
+        return textResult(result);
+      } catch (err) {
+        return textResult({
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  );
+
+  // Tool 10: agor_artifacts_query_dom
+  server.registerTool(
+    'agor_artifacts_query_dom',
+    {
+      description: `Query the rendered DOM of a running artifact via CSS selector.
+
+Round-trip: this MCP call → daemon → WebSocket → your own browser tab(s) viewing the artifact → Sandpack iframe → \`agor-runtime.js\` (auto-injected at render time) → response back up the chain. Replies carry serialized matches: tag, attributes, textContent, outerHTML.
+
+REQUIREMENTS:
+- The artifact must have \`agor_runtime.enabled !== false\` (default is enabled). If the author disabled introspection, the call returns a clean error.
+- A browser tab logged in as YOU must be currently viewing the artifact. The daemon scopes responses to the requesting user — another viewer's browser cannot answer your query (and so cannot leak their secret-bearing render).
+- If no qualifying tab is open, the call times out (default 5s) with an error suggesting you open the artifact and retry.
+
+Caps: 50 nodes max, 50KB outerHTML per node, 5KB textContent per node. Tightened for context budget.
+
+Use cases:
+- "Did my artifact actually render the new heading?" — \`{ selector: 'h1' }\`
+- "Inspect a list of cards" — \`{ selector: '.card', multiple: true }\`
+- "Get the full document" — use \`agor_artifacts_query_dom\` with \`selector: 'html'\` or call agor_artifacts_query_document_html (lower-level dump).`,
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
+        selector: z
+          .string()
+          .describe('CSS selector to match (e.g. "h1", ".card", "[data-test=\'submit\']")'),
+        multiple: z
+          .boolean()
+          .optional()
+          .describe('querySelectorAll vs querySelector. Default: false (single match).'),
+        maxNodes: z
+          .number()
+          .optional()
+          .describe('Max nodes to return (capped at 50 by the runtime). Default: 50.'),
+        timeoutMs: z
+          .number()
+          .optional()
+          .describe('How long to wait for the browser to answer (500-30000). Default: 5000.'),
+      }),
+    },
+    async (args) => {
+      const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const artifactId = await resolveArtifactId(ctx, coerceString(args.artifactId)!);
+      try {
+        const result = await service.queryArtifactRuntime({
+          artifactId,
+          userId: ctx.userId,
+          kind: 'query_dom',
+          args: {
+            selector: coerceString(args.selector),
+            multiple: args.multiple,
+            maxNodes: args.maxNodes,
+          },
+          timeoutMs: args.timeoutMs,
+        });
         return textResult(result);
       } catch (err) {
         return textResult({

--- a/apps/agor-daemon/src/mcp/tools/proxies.ts
+++ b/apps/agor-daemon/src/mcp/tools/proxies.ts
@@ -53,24 +53,26 @@ Each proxy forwards requests from /proxies/<vendor>/X to <upstream>/X so Sandpac
 
 EVERY request to a proxy needs TWO credentials, in the same headers object:
 
-  1. Authorization: Bearer <agor.token>     ← daemon JWT, protects the proxy from being an open relay
+  1. Authorization: Bearer <AGOR_TOKEN>     ← daemon JWT (15-min TTL), protects the proxy from being an open relay
   2. <Vendor's auth header>                  ← whatever the upstream API actually wants
 
-Both render via Handlebars in /agor.config.js — the daemon mints {{ agor.token }} per-user at view time (15-min TTL). Vendor secrets come from {{ user.env.NAME }} (configured by the user in Settings → Environment Variables).
+Both come from the synthesized .env. Declare what your artifact needs at publish time:
+  agor_artifacts_publish(..., agorGrants={ agor_token: true, agor_proxies: ["shortcut"] },
+                          requiredEnvVars=["SHORTCUT_API_TOKEN"])
 
-# Canonical example
+The daemon resolves consent (TOFU) and writes a per-viewer .env with the prefixed names:
+  VITE_AGOR_TOKEN, VITE_AGOR_PROXY_SHORTCUT, VITE_SHORTCUT_API_TOKEN  (Vite templates)
+  REACT_APP_AGOR_TOKEN, REACT_APP_AGOR_PROXY_SHORTCUT, ...            (CRA templates)
 
-  // /agor.config.js
-  export const shortcutUrl = "{{ agor.proxies.shortcut.url }}";
-  export const agorToken   = "{{ agor.token }}";
-  export const scToken     = "{{ user.env.SHORTCUT_API_TOKEN }}";
+# Canonical example (Vite)
 
-  // App.js
-  import { shortcutUrl, agorToken, scToken } from "./agor.config.js";
+  // App.tsx
+  const shortcutUrl = import.meta.env.VITE_AGOR_PROXY_SHORTCUT;
+  const agorToken   = import.meta.env.VITE_AGOR_TOKEN;
+  const scToken     = import.meta.env.VITE_SHORTCUT_API_TOKEN;
 
   if (!scToken) {
-    // Render a "configure SHORTCUT_API_TOKEN in Settings" prompt — missing
-    // env vars render as empty string, not undefined.
+    // Empty string when the user hasn't configured it — show a prompt.
     return <ConfigurePrompt name="SHORTCUT_API_TOKEN" />;
   }
 
@@ -90,7 +92,7 @@ Both render via Handlebars in /agor.config.js — the daemon mints {{ agor.token
 
 # Error envelope to handle in fetch wrappers
 
-  401 {error:"unauthorized"}          ← missing/expired agor.token (refresh by reloading the artifact)
+  401 {error:"unauthorized"}          ← missing/expired AGOR_TOKEN (refresh by reloading the artifact)
   404 {error:"unknown_vendor"}        ← vendor not configured on this daemon
   405 {error:"method_not_allowed"}    ← method not in allowed_methods
   413 {error:"request_too_large"}     ← request body > 5 MB
@@ -102,7 +104,7 @@ Always check r.ok before JSON.parse, and surface the error JSON to the user — 
 
 # What the proxy does NOT do
 
-  - No auth injection: the daemon does not read {{ user.env.X }} for you and does not add vendor headers. You forward them yourself on every request.
+  - No auth injection: the daemon doesn't add vendor headers automatically. You forward them yourself from .env on every request.
   - No transformation: bytes pass through unchanged. No JSON re-encoding, no schema validation.
   - No caching, no retries.
   - No 'pageThrough' helper for pagination.
@@ -115,9 +117,9 @@ Always check r.ok before JSON.parse, and surface the error JSON to the user — 
 # Discovery flow for an agent building an artifact
 
   1. Call agor_proxies_list to see what vendors are configured.
-  2. For each vendor you'll use, write its url, the daemon Authorization header, and the vendor-specific auth header into /agor.config.js as Handlebars references (never hardcode secrets).
-  3. Wire up a fetch wrapper that includes both headers on every call and renders the error envelope above on !r.ok.
-  4. If the user hasn't configured the env var, the secret renders as "" — detect this and prompt them, don't make the API call.`,
+  2. Declare the vendors you'll use in agor_artifacts_publish via agorGrants={ agor_token: true, agor_proxies: ["..."] } and the user-side secrets via requiredEnvVars=["VENDOR_API_TOKEN", ...].
+  3. Wire a fetch wrapper that reads import.meta.env.VITE_AGOR_TOKEN, VITE_AGOR_PROXY_<VENDOR>, VITE_<USER_KEY> and includes the two headers on every call.
+  4. If a user hasn't configured the env var, the value renders as "" — detect this and prompt them, don't make the API call.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({}),
     },

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -174,6 +174,7 @@ interface RouteParams extends Params {
     id?: string;
     messageId?: string;
     mcpId?: string;
+    requestId?: string;
   };
   user?: User;
 }
@@ -567,6 +568,40 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       },
       {
         create: { role: ROLES.MEMBER, action: 'post artifact sandpack error' },
+      },
+      requireAuth
+    );
+
+    // ── Runtime query responses ────────────────────────────────────────────
+    // Browser POSTs the iframe's `agor:result` payload here. Path encodes
+    // the request id so the daemon can correlate to a pending query in
+    // memory. The caller must be the same user that issued the original
+    // query — the service-side check rejects mismatches silently.
+    registerAuthenticatedRoute(
+      app,
+      '/artifacts/:id/runtime-response/:requestId',
+      {
+        async create(
+          data: { ok: boolean; result?: unknown; error?: string },
+          _params: RouteParams
+        ) {
+          const requestId = _params.route?.requestId;
+          if (!requestId) throw new Error('Request ID required');
+          const userId = _params.user?.user_id;
+          if (!userId) throw new Error('Authenticated user required');
+          const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
+          artifactsService.resolveRuntimeQuery({
+            requestId,
+            responderUserId: userId,
+            ok: data.ok,
+            result: data.result,
+            error: data.error,
+          });
+          return { received: true };
+        },
+      },
+      {
+        create: { role: ROLES.MEMBER, action: 'post artifact runtime response' },
       },
       requireAuth
     );

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -555,6 +555,69 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       },
       requireAuth
     );
+
+    // ── Trust grants (TOFU consent flow) ───────────────────────────────────
+    // Per-artifact: POST creates a grant covering the artifact's currently-
+    // requested env vars and grants. Caller MUST be authenticated; the grant
+    // is attributed to the calling user.
+    registerAuthenticatedRoute(
+      app,
+      '/artifacts/:id/trust',
+      {
+        async create(
+          data: {
+            scopeType: import('@agor/core/types').ArtifactTrustScopeType;
+            envVars?: string[];
+            grants?: import('@agor/core/types').AgorGrants;
+          },
+          _params: RouteParams
+        ) {
+          const artifactId = _params.route?.id;
+          if (!artifactId) throw new Error('Artifact ID required');
+          const userId = _params.user?.user_id;
+          if (!userId) throw new Error('Authenticated user required');
+          const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
+          return artifactsService.grantTrust({
+            userId,
+            artifactId,
+            scopeType: data.scopeType,
+            envVars: data.envVars ?? [],
+            grants: data.grants ?? {},
+          });
+        },
+      },
+      {
+        create: { role: ROLES.MEMBER, action: 'create artifact trust grant' },
+      },
+      requireAuth
+    );
+
+    // List the calling user's active trust grants. Used by the settings page.
+    registerAuthenticatedRoute(
+      app,
+      '/me/artifact-trust-grants',
+      {
+        async find(params: RouteParams) {
+          const userId = params.user?.user_id;
+          if (!userId) throw new Error('Authenticated user required');
+          const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
+          return artifactsService.listTrustGrants(userId);
+        },
+        async remove(id: unknown, params: RouteParams) {
+          const userId = params.user?.user_id;
+          if (!userId) throw new Error('Authenticated user required');
+          const grantId = String(id);
+          const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
+          await artifactsService.revokeTrustGrant(userId, grantId);
+          return { revoked: true, grantId };
+        },
+      },
+      {
+        find: { role: ROLES.VIEWER, action: 'list artifact trust grants' },
+        remove: { role: ROLES.MEMBER, action: 'revoke artifact trust grant' },
+      },
+      requireAuth
+    );
   }
 
   // ============================================================================

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1602,14 +1602,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : '',
         `channels: ${app.channel('authenticated').length}`
       );
-    } else if (!context.method && context.path) {
-      // Custom event (no method on the fake-hook the channel mixin builds —
-      // see @feathersjs/transport-commons channels/index.ts:67-71). This is
-      // the path agor-query takes; log to diagnose silent drops.
-      console.log(
-        `📡 [Publish] custom event path=${context.path} event=${context.event ?? '?'} ` +
-          `channels=${app.channel('authenticated').length}`
-      );
     }
     // Broadcast only to authenticated clients (joined to channel on login)
     return app.channel('authenticated');

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -521,8 +521,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ) {
           const artifactId = _params.route?.id;
           if (!artifactId) throw new Error('Artifact ID required');
+          const userId = _params.user?.user_id;
+          if (!userId) throw new Error('Authenticated user required');
           const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
-          artifactsService.appendConsoleLogs(artifactId, data.entries as never);
+          // Visibility check: only viewers who can see the artifact may
+          // append to its console buffer. Without this any member could
+          // write spam into another artifact's logs.
+          const artifact = await artifactsService.get(artifactId);
+          if (!artifactsService.isVisibleTo(artifact, userId)) {
+            throw new Error(`Artifact ${artifactId} not found`);
+          }
+          artifactsService.appendConsoleLogs(artifactId, userId, data.entries as never);
           return { success: true };
         },
       },
@@ -545,8 +554,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ) {
           const artifactId = _params.route?.id;
           if (!artifactId) throw new Error('Artifact ID required');
+          const userId = _params.user?.user_id;
+          if (!userId) throw new Error('Authenticated user required');
           const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
-          artifactsService.setSandpackError(artifactId, data.error, data.status);
+          const artifact = await artifactsService.get(artifactId);
+          if (!artifactsService.isVisibleTo(artifact, userId)) {
+            throw new Error(`Artifact ${artifactId} not found`);
+          }
+          artifactsService.setSandpackError(artifactId, userId, data.error, data.status);
           return { success: true };
         },
       },

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -591,32 +591,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       requireAuth
     );
 
-    // Export artifact to CodeSandbox via their define API. The "Open in
-    // CodeSandbox" button on the artifact card calls this; the same path is
-    // exposed to agents via the agor_artifacts_export_codesandbox MCP tool.
-    // Returns { url, sandboxId, note } on success or { error } on failure.
-    registerAuthenticatedRoute(
-      app,
-      '/artifacts/:id/export/codesandbox',
-      {
-        async create(_data: unknown, params: RouteParams) {
-          const artifactId = params.route?.id;
-          if (!artifactId) throw new Error('Artifact ID required');
-          const userId = params.user?.user_id;
-          const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
-          try {
-            return await artifactsService.exportToCodeSandbox(artifactId, userId);
-          } catch (err) {
-            return { error: err instanceof Error ? err.message : String(err) };
-          }
-        },
-      },
-      {
-        create: { role: ROLES.MEMBER, action: 'export artifact to codesandbox' },
-      },
-      requireAuth
-    );
-
     // List the calling user's active trust grants. Used by the settings page.
     registerAuthenticatedRoute(
       app,

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -565,11 +565,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       '/artifacts/:id/trust',
       {
         async create(
-          data: {
-            scopeType: import('@agor/core/types').ArtifactTrustScopeType;
-            envVars?: string[];
-            grants?: import('@agor/core/types').AgorGrants;
-          },
+          data: { scopeType: import('@agor/core/types').ArtifactTrustScopeType },
           _params: RouteParams
         ) {
           const artifactId = _params.route?.id;
@@ -577,12 +573,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           const userId = _params.user?.user_id;
           if (!userId) throw new Error('Authenticated user required');
           const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
+          // The consent surface (env vars + grants) is derived server-side
+          // from the artifact's current request. The client only nominates
+          // the scope; the server decides what the grant covers. This stops
+          // a confused/malicious client from persisting a grant whose
+          // covered set diverges from what the server will actually inject.
           return artifactsService.grantTrust({
             userId,
             artifactId,
             scopeType: data.scopeType,
-            envVars: data.envVars ?? [],
-            grants: data.grants ?? {},
           });
         },
       },

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -591,6 +591,32 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       requireAuth
     );
 
+    // Export artifact to CodeSandbox via their define API. The "Open in
+    // CodeSandbox" button on the artifact card calls this; the same path is
+    // exposed to agents via the agor_artifacts_export_codesandbox MCP tool.
+    // Returns { url, sandboxId, note } on success or { error } on failure.
+    registerAuthenticatedRoute(
+      app,
+      '/artifacts/:id/export/codesandbox',
+      {
+        async create(_data: unknown, params: RouteParams) {
+          const artifactId = params.route?.id;
+          if (!artifactId) throw new Error('Artifact ID required');
+          const userId = params.user?.user_id;
+          const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
+          try {
+            return await artifactsService.exportToCodeSandbox(artifactId, userId);
+          } catch (err) {
+            return { error: err instanceof Error ? err.message : String(err) };
+          }
+        },
+      },
+      {
+        create: { role: ROLES.MEMBER, action: 'export artifact to codesandbox' },
+      },
+      requireAuth
+    );
+
     // List the calling user's active trust grants. Used by the settings page.
     registerAuthenticatedRoute(
       app,

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1602,6 +1602,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : '',
         `channels: ${app.channel('authenticated').length}`
       );
+    } else if (!context.method && context.path) {
+      // Custom event (no method on the fake-hook the channel mixin builds —
+      // see @feathersjs/transport-commons channels/index.ts:67-71). This is
+      // the path agor-query takes; log to diagnose silent drops.
+      console.log(
+        `📡 [Publish] custom event path=${context.path} event=${context.event ?? '?'} ` +
+          `channels=${app.channel('authenticated').length}`
+      );
     }
     // Broadcast only to authenticated clients (joined to channel on login)
     return app.channel('authenticated');

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -577,6 +577,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     // the request id so the daemon can correlate to a pending query in
     // memory. The caller must be the same user that issued the original
     // query — the service-side check rejects mismatches silently.
+    //
+    // The injected agor-runtime.js caps replies (200KB document HTML, 50
+    // nodes per query, 50KB outerHTML per node), but a malicious or buggy
+    // browser could bypass the runtime and POST a much larger body. Cap
+    // here too so a wrongly-sized payload doesn't bloat the daemon's
+    // pending-query map or the agent's MCP context.
+    const RUNTIME_RESPONSE_BYTE_CAP = 512 * 1024;
     registerAuthenticatedRoute(
       app,
       '/artifacts/:id/runtime-response/:requestId',
@@ -589,13 +596,34 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           if (!requestId) throw new Error('Request ID required');
           const userId = _params.user?.user_id;
           if (!userId) throw new Error('Authenticated user required');
+
+          // Defensive size cap. JSON.stringify is the cheapest faithful
+          // measurement of "how big is this payload going to be when we
+          // hand it to the agent." Round trips through the runtime stay
+          // well under this in practice.
+          let payloadOk = data.ok;
+          let payloadResult = data.result;
+          let payloadError = data.error;
+          try {
+            const measured = JSON.stringify(payloadResult ?? null);
+            if (measured.length > RUNTIME_RESPONSE_BYTE_CAP) {
+              payloadOk = false;
+              payloadResult = undefined;
+              payloadError = `Runtime response exceeded ${RUNTIME_RESPONSE_BYTE_CAP} bytes (got ${measured.length}). Reduce maxNodes or use a more specific selector.`;
+            }
+          } catch (err) {
+            payloadOk = false;
+            payloadResult = undefined;
+            payloadError = `Runtime response was not JSON-serializable: ${err instanceof Error ? err.message : String(err)}`;
+          }
+
           const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
           artifactsService.resolveRuntimeQuery({
             requestId,
             responderUserId: userId,
-            ok: data.ok,
-            result: data.result,
-            error: data.error,
+            ok: payloadOk,
+            result: payloadResult,
+            error: payloadError,
           });
           return { received: true };
         },

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3141,6 +3141,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // Value: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin'.
           // Defaults to 'member' when unset.
           managedEnvsMinimumRole: config.execution?.managed_envs_minimum_role ?? 'member',
+          // True when the daemon runs in a multi-user Unix isolation mode
+          // (insulated/strict). UI hides "trust everyone on this instance"
+          // surfaces when true. Server-side gates (e.g. ArtifactsService.
+          // grantTrust) are the source of truth and reject regardless.
+          multiUser: (config.execution?.unix_user_mode ?? 'simple') !== 'simple',
         },
       };
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -277,7 +277,12 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   }
 
   if (svcEnabled('artifacts')) {
-    app.use('/artifacts', createArtifactsService(db, app));
+    // `agor-query` is the runtime-introspection fan-out event (daemon →
+    // viewer's browser tab). Feathers' default `serviceEvents` is just
+    // ['created','updated','patched','removed'], so without this it
+    // fires locally on the server's EventEmitter and never reaches any
+    // socket. See queryArtifactRuntime in services/artifacts.ts.
+    app.use('/artifacts', createArtifactsService(db, app), { events: ['agor-query'] });
   }
 
   if (svcEnabled('boards')) {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -7,7 +7,6 @@
 
 import {
   type AgorConfig,
-  getBaseUrl,
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
 } from '@agor/core/config';
@@ -49,7 +48,6 @@ import {
   oauth21TokenCache,
   persistOAuthToken,
 } from './oauth-cache.js';
-import type { ArtifactsService } from './services/artifacts.js';
 import { createArtifactsService } from './services/artifacts.js';
 import { createBoardCommentsService } from './services/board-comments.js';
 import { createBoardObjectsService } from './services/board-objects.js';
@@ -280,24 +278,6 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
 
   if (svcEnabled('artifacts')) {
     app.use('/artifacts', createArtifactsService(db, app));
-
-    // Detect self-hosted Sandpack bundler
-    {
-      const pathMod = await import('node:path');
-      const { fileURLToPath: toPath } = await import('node:url');
-      const { existsSync: exists } = await import('node:fs');
-      const dir =
-        typeof __dirname !== 'undefined' ? __dirname : pathMod.dirname(toPath(import.meta.url));
-      const sandpackPath = pathMod.resolve(dir, '../static/sandpack');
-      if (exists(sandpackPath)) {
-        const baseUrl = await getBaseUrl();
-        const origin = new URL(baseUrl).origin;
-        const bundlerURL = `${origin}/static/sandpack/`;
-        const artifactsService = app.service('artifacts') as unknown as ArtifactsService;
-        artifactsService.selfHostedBundlerURL = bundlerURL;
-        console.log(`🧩 Self-hosted Sandpack bundler detected: ${bundlerURL}`);
-      }
-    }
   }
 
   if (svcEnabled('boards')) {

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -801,7 +801,7 @@ describe('ArtifactsService.getStatus + console isolation', () => {
 });
 
 describe('ArtifactsService.deleteArtifact authorization', () => {
-  dbTest('owner can delete', async ({ db }) => {
+  dbTest('owner can delete; returned artifact carries the deleted row', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
     const artifactRepo = new ArtifactRepository(db);
@@ -815,9 +815,8 @@ describe('ArtifactsService.deleteArtifact authorization', () => {
       created_by: 'user-owner',
     });
 
-    await expect(
-      service.deleteArtifact(created.artifact_id, 'user-owner', 'member')
-    ).resolves.toBeUndefined();
+    const deleted = await service.deleteArtifact(created.artifact_id, 'user-owner', 'member');
+    expect(deleted.artifact_id).toBe(created.artifact_id);
   });
 
   dbTest('non-owner non-admin is rejected', async ({ db }) => {
@@ -855,6 +854,99 @@ describe('ArtifactsService.deleteArtifact authorization', () => {
 
     await expect(
       service.deleteArtifact(created.artifact_id, 'admin-user', 'admin')
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ artifact_id: created.artifact_id });
+  });
+
+  // REST DELETE /artifacts/:id arrives via service.remove(id, params); regression
+  // guard that it threads params.user through to the auth-checked deleteArtifact.
+  dbTest('service.remove() threads params.user → owner deletes successfully', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const removed = await service.remove(created.artifact_id, {
+      user: { user_id: 'user-owner', role: 'member' },
+    });
+    expect(removed.artifact_id).toBe(created.artifact_id);
+  });
+
+  dbTest('service.remove() rejects when params.user is missing or wrong', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(service.remove(created.artifact_id)).rejects.toThrow(/Forbidden/i);
+    await expect(
+      service.remove(created.artifact_id, {
+        user: { user_id: 'user-stranger', role: 'member' },
+      })
+    ).rejects.toThrow(/Forbidden/i);
+  });
+});
+
+describe('ArtifactsService.updateMetadata authorization', () => {
+  dbTest('admin can update someone else’s artifact', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const updated = await service.updateMetadata(
+      created.artifact_id,
+      { name: 'admin-renamed' },
+      'admin-user',
+      'admin'
+    );
+    expect(updated.name).toBe('admin-renamed');
+  });
+
+  dbTest('non-owner non-admin is rejected', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.updateMetadata(
+        created.artifact_id,
+        { name: 'stranger-renamed' },
+        'user-stranger',
+        'member'
+      )
+    ).rejects.toThrow(/Forbidden/i);
   });
 });

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -9,7 +9,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { generateId } from '@agor/core';
-import { ArtifactRepository, BoardRepository, type Database } from '@agor/core/db';
+import { ArtifactRepository, BoardRepository, type Database, UsersRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Artifact, BoardID } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect } from 'vitest';
@@ -35,6 +35,42 @@ async function seedBoard(db: Database) {
     name: 'Test Board',
     created_by: 'user-owner',
   });
+}
+
+/**
+ * Insert a row into `users` so FK-bearing tables (like
+ * `artifact_trust_grants.user_id`) accept a grant for this user. The CI
+ * SQLite has `PRAGMA foreign_keys = ON`; tests that skip seeding hit
+ * SQLITE_CONSTRAINT_FOREIGNKEY.
+ */
+async function seedUser(db: Database, userId: string): Promise<void> {
+  const repo = new UsersRepository(db);
+  await repo.create({
+    user_id: userId as never,
+    email: `${userId}@test.local`,
+    display_name: userId,
+  });
+}
+
+/**
+ * Compute the same default land subpath that `defaultLandFolderName` in
+ * the service does. Tests that pre-create the default destination must
+ * stay in sync — duplicating the logic here is the lesser evil vs
+ * exporting an internal helper just for tests.
+ */
+function defaultLandDestForArtifact(
+  tmpRoot: string,
+  artifact: { name: string; artifact_id: string }
+): string {
+  const slug = artifact.name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  const shortId = artifact.artifact_id.replace(/-/g, '').slice(0, 8);
+  const folder = slug.length > 0 ? `${slug}-${shortId}` : artifact.artifact_id;
+  return path.join(tmpRoot, '.agor', 'artifacts', folder);
 }
 
 /** Seed an artifact with a known file map and a board placement. */
@@ -137,7 +173,7 @@ describe('ArtifactsService.updateMetadata', () => {
 
     await expect(
       service.updateMetadata(artifact.artifact_id, { name: 'Hijacked' }, 'user-stranger')
-    ).rejects.toThrow(/not the owner/i);
+    ).rejects.toThrow(/Forbidden/i);
   });
 
   dbTest('rejects move to a nonexistent board without mutating the row', async ({ db }) => {
@@ -309,7 +345,7 @@ describe('ArtifactsService.land', () => {
 
     const result = await service.land(artifact.artifact_id, tmpRoot);
 
-    const expectedDest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
+    const expectedDest = defaultLandDestForArtifact(tmpRoot, artifact);
     expect(result.destinationPath).toBe(expectedDest);
     expect(result.fileCount).toBe(3); // 2 source files + agor.artifact.json sidecar
     expect(readFileSync(path.join(expectedDest, 'app.js'), 'utf-8')).toBe('export const x = 1');
@@ -396,7 +432,7 @@ describe('ArtifactsService.land', () => {
     const artifact = await seedArtifact(db, board.board_id);
 
     // Pre-create the default destination with a file inside.
-    const dest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
+    const dest = defaultLandDestForArtifact(tmpRoot, artifact);
     const fs = await import('node:fs/promises');
     await fs.mkdir(dest, { recursive: true });
     writeFileSync(path.join(dest, 'pre-existing.txt'), 'preexisting');
@@ -411,7 +447,7 @@ describe('ArtifactsService.land', () => {
       files: { '/only.js': 'fresh' },
     });
 
-    const dest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
+    const dest = defaultLandDestForArtifact(tmpRoot, artifact);
     const fs = await import('node:fs/promises');
     await fs.mkdir(dest, { recursive: true });
     writeFileSync(path.join(dest, 'stale.txt'), 'stale');
@@ -599,6 +635,7 @@ describe('ArtifactsService.grantTrust', () => {
   dbTest('artifact-scope grant persists and authorizes future renders', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
+    await seedUser(db, 'user-stranger');
     const artifactRepo = new ArtifactRepository(db);
     const created = await artifactRepo.create({
       artifact_id: generateId(),
@@ -627,6 +664,7 @@ describe('ArtifactsService.grantTrust', () => {
     async ({ db }) => {
       const service = new ArtifactsService(db, makeFakeApp());
       const board = await seedBoard(db);
+      await seedUser(db, 'user-stranger');
       const artifactRepo = new ArtifactRepository(db);
       const created = await artifactRepo.create({
         artifact_id: generateId(),
@@ -685,6 +723,7 @@ describe('ArtifactsService.grantTrust', () => {
   dbTest('author-scope grant covers a different artifact by the same author', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
+    await seedUser(db, 'viewer-1');
     const artifactRepo = new ArtifactRepository(db);
     const a = await artifactRepo.create({
       artifact_id: generateId(),

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1017,6 +1017,33 @@ describe('ArtifactsService.getPayload agor-runtime injection', () => {
     expect(payload.files['/src/index.js']).toMatch(/^import '\.\.\/agor-runtime\.js';/);
   });
 
+  dbTest(
+    'detects /App.js as an injection target (most common React-template shape)',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      // Hello-world-style artifact: only /App.js, Sandpack synthesizes
+      // the rest. This is the shape the testing agent surfaced as a
+      // gap — none of the original /src/index.* candidates matched, so
+      // the runtime got silently dropped and queries timed out.
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'app-only',
+        template: 'react',
+        files: { '/App.js': 'export default function App() { return null; }' },
+        public: true,
+        created_by: 'user-owner',
+      });
+
+      const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+      expect(payload.files['/agor-runtime.js']).toBeDefined();
+      // Both files at root → relative specifier is './agor-runtime.js'.
+      expect(payload.files['/App.js']).toMatch(/^import '\.\/agor-runtime\.js';/);
+    }
+  );
+
   dbTest('opt-out: enabled=false skips injection entirely', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
@@ -1109,6 +1136,35 @@ describe('ArtifactsService.queryArtifactRuntime', () => {
         timeoutMs: 500,
       })
     ).rejects.toThrow(/not found/i);
+  });
+
+  dbTest('rejects with no-entry error rather than misleading timeout', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    // No /App.*, /index.*, /main.*, or /src/* — runtime can't attach.
+    // Without the pre-flight check the caller would see a generic
+    // "open the artifact in your browser" timeout, even though the
+    // browser IS open and the runtime simply wasn't injected.
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'no-entry',
+      template: 'react',
+      files: { '/some-utility.js': 'export const x = 1' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.queryArtifactRuntime({
+        artifactId: created.artifact_id,
+        userId: 'user-owner',
+        kind: 'query_dom',
+        args: { selector: 'h1' },
+        timeoutMs: 500,
+      })
+    ).rejects.toThrow(/no recognizable entry file/i);
   });
 
   dbTest('times out cleanly when no browser answers', async ({ db }) => {

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1025,8 +1025,58 @@ describe('ArtifactsService.getPayload agor-runtime injection', () => {
       const arr = resources as string[];
       expect(arr.length).toBeGreaterThan(0);
       expect(arr[0]).toMatch(/^data:text\/javascript;base64,/);
-      const decoded = Buffer.from(arr[0].split(',', 2)[1], 'base64').toString('utf-8');
+      // Critical: must end in `.js` so Sandpack's static client (which
+      // sniffs MIME via `/\.([^.]*)$/` on the URL) accepts it. A bare
+      // base64 data URL ends in base64 chars and gets silently rejected
+      // — see SandpackStatic.injectExternalResources.
+      expect(arr[0]).toMatch(/\.js$/);
+      const sandpackExtensionSniff = /\.([^.]*)$/;
+      expect(arr[0].match(sandpackExtensionSniff)?.[1]).toBe('js');
+      // The body before the `#` fragment is the actual base64 payload.
+      const body = arr[0].slice('data:text/javascript;base64,'.length).split('#', 1)[0];
+      const decoded = Buffer.from(body, 'base64').toString('utf-8');
       expect(decoded).toContain('agor:query');
+    }
+  );
+
+  dbTest(
+    'externalResources is daemon-owned: author-supplied entries are not preserved',
+    async ({ db }) => {
+      // sanitizeSandpackConfig strips externalResources on write, but a
+      // legacy/manually-edited row could still carry them. Render-time
+      // injection must NOT re-emit them — that would re-enable a prop
+      // the sanitizer explicitly blocked (XSS into the iframe).
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'author-resources',
+        template: 'react',
+        files: { '/App.js': 'export default () => null;' },
+        // Cast through `any` to simulate a row that escaped the
+        // sanitizer (legacy / manual edit). `SandpackConfig.options`
+        // doesn't expose `externalResources` because authors aren't
+        // allowed to set it; we want to prove the daemon doesn't honor
+        // it even when it slips into the persisted row anyway.
+        sandpack_config: {
+          options: { externalResources: ['https://attacker.example/xss.js'] },
+        } as any,
+        public: true,
+        created_by: 'user-owner',
+      });
+
+      const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+      const resources = (payload.sandpack_config?.options as Record<string, unknown> | undefined)
+        ?.externalResources;
+      expect(Array.isArray(resources)).toBe(true);
+      const arr = resources as string[];
+      // Exactly one entry: the daemon's runtime URL. The attacker entry
+      // is dropped.
+      expect(arr.length).toBe(1);
+      expect(arr[0]).toMatch(/^data:text\/javascript;base64,/);
+      expect(arr.some((r) => r.includes('attacker.example'))).toBe(false);
     }
   );
 

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1012,8 +1012,9 @@ describe('ArtifactsService.getPayload agor-runtime injection', () => {
     expect(payload.files['/agor-runtime.js']).toBeDefined();
     expect(payload.files['/agor-runtime.js']).toContain('agor:query');
     // The entry file got the import prepended (served only — the persisted
-    // row is unchanged).
-    expect(payload.files['/src/index.js']).toMatch(/^import '\/agor-runtime\.js';/);
+    // row is unchanged). Specifier is relative-from-entry, not root-
+    // absolute, so Sandpack resolves it across template variants.
+    expect(payload.files['/src/index.js']).toMatch(/^import '\.\.\/agor-runtime\.js';/);
   });
 
   dbTest('opt-out: enabled=false skips injection entirely', async ({ db }) => {

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -300,7 +300,7 @@ describe('ArtifactsService.land', () => {
     }
   });
 
-  dbTest('writes all files plus sandpack.json to default subpath', async ({ db }) => {
+  dbTest('writes all files plus agor.artifact.json to default subpath', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
     const artifact = await seedArtifact(db, board.board_id, {
@@ -311,13 +311,15 @@ describe('ArtifactsService.land', () => {
 
     const expectedDest = path.join(tmpRoot, '.agor', 'artifacts', artifact.artifact_id);
     expect(result.destinationPath).toBe(expectedDest);
-    expect(result.fileCount).toBe(3); // 2 source files + sandpack.json
+    expect(result.fileCount).toBe(3); // 2 source files + agor.artifact.json sidecar
     expect(readFileSync(path.join(expectedDest, 'app.js'), 'utf-8')).toBe('export const x = 1');
     expect(readFileSync(path.join(expectedDest, 'nested', 'deep.js'), 'utf-8')).toBe(
       'export const y = 2'
     );
 
-    const manifest = JSON.parse(readFileSync(path.join(expectedDest, 'sandpack.json'), 'utf-8'));
+    const manifest = JSON.parse(
+      readFileSync(path.join(expectedDest, 'agor.artifact.json'), 'utf-8')
+    );
     expect(manifest.template).toBe('react');
   });
 
@@ -416,7 +418,7 @@ describe('ArtifactsService.land', () => {
 
     const result = await service.land(artifact.artifact_id, tmpRoot, { overwrite: true });
 
-    expect(result.fileCount).toBe(2); // /only.js + sandpack.json
+    expect(result.fileCount).toBe(2); // /only.js + agor.artifact.json sidecar
     expect(readFileSync(path.join(dest, 'only.js'), 'utf-8')).toBe('fresh');
     // Stale file is gone.
     const fsSync = await import('node:fs');
@@ -485,5 +487,237 @@ describe('ArtifactsService.land', () => {
     });
 
     await expect(service.land(created.artifact_id, tmpRoot)).rejects.toThrow(/no stored files/i);
+  });
+});
+
+describe('ArtifactsService.getPayload trust + .env synthesis', () => {
+  // Seed an artifact whose `created_by` is the author. The payload's trust
+  // resolution should treat the author as 'self' and skip consent.
+  dbTest('viewer-is-author → trust_state=self, .env injected', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'self-render',
+      template: 'react',
+      files: { '/index.js': 'console.log("self")', '/package.json': '{}' },
+      required_env_vars: ['OPENAI_KEY'],
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+    expect(payload.trust_state).toBe('self');
+    expect(payload.trust_scope).toBe('self');
+    // .env is synthesized even though the user has no env var stored — value is empty.
+    expect(payload.files['/.env']).toMatch(/VITE_OPENAI_KEY=/);
+  });
+
+  dbTest(
+    'untrusted viewer → trust_state=untrusted, .env keys present with empty values',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'untrusted-render',
+        template: 'react',
+        files: { '/index.js': 'console.log("x")' },
+        required_env_vars: ['OPENAI_KEY', 'STRIPE_KEY'],
+        agor_grants: { agor_token: true },
+        public: true,
+        created_by: 'user-owner',
+      });
+
+      const payload = await service.getPayload(created.artifact_id, 'user-stranger' as never);
+      expect(payload.trust_state).toBe('untrusted');
+      // Empty values, but keys are present so the artifact can detect the state.
+      expect(payload.files['/.env']).toMatch(/VITE_OPENAI_KEY=/);
+      expect(payload.files['/.env']).toMatch(/VITE_STRIPE_KEY=/);
+      expect(payload.files['/.env']).toMatch(/VITE_AGOR_TOKEN=/);
+    }
+  );
+
+  dbTest('vanilla template skips .env synthesis entirely', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'vanilla',
+      template: 'vanilla',
+      files: { '/index.html': '<h1>hi</h1>' },
+      required_env_vars: ['SOMETHING'],
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+    expect(payload.files['/.env']).toBeUndefined();
+  });
+});
+
+describe('ArtifactsService.grantTrust', () => {
+  dbTest('session-scope grant is in-memory only and authorizes the next render', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'session-trust',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      required_env_vars: ['OPENAI_KEY'],
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    // First render — untrusted.
+    const before = await service.getPayload(created.artifact_id, 'user-stranger' as never);
+    expect(before.trust_state).toBe('untrusted');
+
+    // Grant session-scope trust.
+    const result = await service.grantTrust({
+      userId: 'user-stranger',
+      artifactId: created.artifact_id,
+      scopeType: 'session',
+      envVars: ['OPENAI_KEY'],
+      grants: {},
+    });
+    expect(result.persisted).toBe(false);
+
+    const after = await service.getPayload(created.artifact_id, 'user-stranger' as never);
+    expect(after.trust_state).toBe('trusted');
+    expect(after.trust_scope).toBe('session');
+  });
+
+  dbTest('artifact-scope grant persists and authorizes future renders', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'artifact-trust',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      required_env_vars: ['OPENAI_KEY'],
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await service.grantTrust({
+      userId: 'user-stranger',
+      artifactId: created.artifact_id,
+      scopeType: 'artifact',
+      envVars: ['OPENAI_KEY'],
+      grants: {},
+    });
+
+    const payload = await service.getPayload(created.artifact_id, 'user-stranger' as never);
+    expect(payload.trust_state).toBe('trusted');
+    expect(payload.trust_scope).toBe('artifact');
+  });
+
+  dbTest(
+    'strict subset: existing OPENAI_KEY grant does NOT cover OPENAI_KEY+STRIPE_KEY',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'expanding-needs',
+        template: 'react',
+        files: { '/index.js': 'console.log("x")' },
+        required_env_vars: ['OPENAI_KEY', 'STRIPE_KEY'],
+        public: true,
+        created_by: 'user-owner',
+      });
+
+      await service.grantTrust({
+        userId: 'user-stranger',
+        artifactId: created.artifact_id,
+        scopeType: 'artifact',
+        envVars: ['OPENAI_KEY'], // narrower than the artifact now requests
+        grants: {},
+      });
+
+      const payload = await service.getPayload(created.artifact_id, 'user-stranger' as never);
+      expect(payload.trust_state).toBe('untrusted');
+    }
+  );
+
+  dbTest('agor_token at author scope is rejected (artifact scope only)', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'token-author',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      agor_grants: { agor_token: true },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.grantTrust({
+        userId: 'user-stranger',
+        artifactId: created.artifact_id,
+        scopeType: 'author',
+        envVars: [],
+        grants: { agor_token: true },
+      })
+    ).rejects.toThrow(/agor_token/);
+  });
+
+  dbTest('author-scope grant covers a different artifact by the same author', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const a = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'a',
+      template: 'react',
+      files: { '/index.js': 'a' },
+      required_env_vars: ['OPENAI_KEY'],
+      public: true,
+      created_by: 'author-1',
+    });
+    const b = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'b',
+      template: 'react',
+      files: { '/index.js': 'b' },
+      required_env_vars: ['OPENAI_KEY'],
+      public: true,
+      created_by: 'author-1',
+    });
+
+    // Grant on artifact A at author scope.
+    await service.grantTrust({
+      userId: 'viewer-1',
+      artifactId: a.artifact_id,
+      scopeType: 'author',
+      envVars: ['OPENAI_KEY'],
+      grants: {},
+    });
+
+    // Artifact B (same author) should be trusted via the author grant.
+    const payload = await service.getPayload(b.artifact_id, 'viewer-1' as never);
+    expect(payload.trust_state).toBe('trusted');
+    expect(payload.trust_scope).toBe('author');
   });
 });

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -989,3 +989,258 @@ describe('ArtifactsService.updateMetadata authorization', () => {
     ).rejects.toThrow(/Forbidden/i);
   });
 });
+
+describe('ArtifactsService.getPayload agor-runtime injection', () => {
+  dbTest('default-on: injects /agor-runtime.js + prepends import to entry', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'runtime-default',
+      template: 'react',
+      files: {
+        '/src/index.js': 'console.log("user code")',
+      },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+
+    expect(payload.files['/agor-runtime.js']).toBeDefined();
+    expect(payload.files['/agor-runtime.js']).toContain('agor:query');
+    // The entry file got the import prepended (served only — the persisted
+    // row is unchanged).
+    expect(payload.files['/src/index.js']).toMatch(/^import '\/agor-runtime\.js';/);
+  });
+
+  dbTest('opt-out: enabled=false skips injection entirely', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'runtime-disabled',
+      template: 'react',
+      files: { '/src/index.js': 'console.log("user code")' },
+      agor_runtime: { enabled: false },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+    expect(payload.files['/agor-runtime.js']).toBeUndefined();
+    expect(payload.files['/src/index.js']).toBe('console.log("user code")');
+  });
+
+  dbTest('persistence: published rows do not carry the runtime file', async ({ db }) => {
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'runtime-persistence',
+      template: 'react',
+      files: { '/src/index.js': 'console.log("user code")' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    // The DB row's files map should never carry agor-runtime.js — it's a
+    // render-time injection only. Read directly from repo to bypass any
+    // per-render mutation in getPayload.
+    const stored = await artifactRepo.findById(created.artifact_id);
+    expect(stored?.files?.['/agor-runtime.js']).toBeUndefined();
+    expect(stored?.files?.['/src/index.js']).toBe('console.log("user code")');
+  });
+});
+
+describe('ArtifactsService.queryArtifactRuntime', () => {
+  dbTest('rejects when agor_runtime.enabled is false', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'runtime-disabled',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      agor_runtime: { enabled: false },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.queryArtifactRuntime({
+        artifactId: created.artifact_id,
+        userId: 'user-owner',
+        kind: 'query_dom',
+        args: { selector: 'h1' },
+        timeoutMs: 500,
+      })
+    ).rejects.toThrow(/disabled/i);
+  });
+
+  dbTest('rejects when artifact is not visible to caller', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'private',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: false,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.queryArtifactRuntime({
+        artifactId: created.artifact_id,
+        userId: 'user-stranger',
+        kind: 'query_dom',
+        args: { selector: 'h1' },
+        timeoutMs: 500,
+      })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  dbTest('times out cleanly when no browser answers', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'no-browser',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    // Floor-clamped to 500ms by queryArtifactRuntime; that's enough to
+    // verify the timeout path without dragging the test suite.
+    const start = Date.now();
+    await expect(
+      service.queryArtifactRuntime({
+        artifactId: created.artifact_id,
+        userId: 'user-owner',
+        kind: 'query_dom',
+        args: { selector: 'h1' },
+        timeoutMs: 500,
+      })
+    ).rejects.toThrow(/timed out/i);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(450);
+  });
+
+  dbTest('resolveRuntimeQuery delivers the iframe response', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'happy-path',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    let capturedRequestId: string | null = null;
+    // Mock the service.emit so we can grab the request_id and resolve the
+    // query before it times out. (Real production has an iframe round-trip
+    // do this; we short-circuit it here.)
+    const realApp = service as unknown as {
+      app: { service: (name: string) => { emit: (event: string, data: unknown) => void } };
+    };
+    const originalApp = realApp.app;
+    realApp.app = {
+      service: () => ({
+        emit: (event: string, data: unknown) => {
+          if (event === 'agor-query') {
+            capturedRequestId = (data as { request_id: string }).request_id;
+          }
+        },
+      }),
+    } as never;
+
+    const queryPromise = service.queryArtifactRuntime({
+      artifactId: created.artifact_id,
+      userId: 'user-owner',
+      kind: 'query_dom',
+      args: { selector: 'h1' },
+      timeoutMs: 5000,
+    });
+    // Flush the microtask queue so emit lands.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(capturedRequestId).not.toBeNull();
+    service.resolveRuntimeQuery({
+      requestId: capturedRequestId as string,
+      responderUserId: 'user-owner',
+      ok: true,
+      result: { matched: 1, nodes: [{ tag: 'h1', textContent: 'Hi' }] },
+    });
+
+    const result = await queryPromise;
+    expect(result).toEqual({ matched: 1, nodes: [{ tag: 'h1', textContent: 'Hi' }] });
+
+    realApp.app = originalApp;
+  });
+
+  dbTest('resolveRuntimeQuery silently ignores wrong-user responses', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'cross-user-block',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    let capturedRequestId: string | null = null;
+    const realApp = service as unknown as {
+      app: { service: (name: string) => { emit: (event: string, data: unknown) => void } };
+    };
+    const originalApp = realApp.app;
+    realApp.app = {
+      service: () => ({
+        emit: (event: string, data: unknown) => {
+          if (event === 'agor-query') {
+            capturedRequestId = (data as { request_id: string }).request_id;
+          }
+        },
+      }),
+    } as never;
+
+    const queryPromise = service.queryArtifactRuntime({
+      artifactId: created.artifact_id,
+      userId: 'user-owner',
+      kind: 'query_dom',
+      args: { selector: 'h1' },
+      timeoutMs: 600,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    // Different user (responder) tries to answer — should be silently
+    // dropped, query should still time out.
+    service.resolveRuntimeQuery({
+      requestId: capturedRequestId as string,
+      responderUserId: 'someone-else',
+      ok: true,
+      result: { i: 'should not be visible' },
+    });
+    await expect(queryPromise).rejects.toThrow(/timed out/i);
+
+    realApp.app = originalApp;
+  });
+});

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -582,13 +582,12 @@ describe('ArtifactsService.grantTrust', () => {
     const before = await service.getPayload(created.artifact_id, 'user-stranger' as never);
     expect(before.trust_state).toBe('untrusted');
 
-    // Grant session-scope trust.
+    // Grant session-scope trust. Server derives env vars + grants from the
+    // artifact's current request — caller only nominates the scope.
     const result = await service.grantTrust({
       userId: 'user-stranger',
       artifactId: created.artifact_id,
       scopeType: 'session',
-      envVars: ['OPENAI_KEY'],
-      grants: {},
     });
     expect(result.persisted).toBe(false);
 
@@ -616,8 +615,6 @@ describe('ArtifactsService.grantTrust', () => {
       userId: 'user-stranger',
       artifactId: created.artifact_id,
       scopeType: 'artifact',
-      envVars: ['OPENAI_KEY'],
-      grants: {},
     });
 
     const payload = await service.getPayload(created.artifact_id, 'user-stranger' as never);
@@ -626,7 +623,7 @@ describe('ArtifactsService.grantTrust', () => {
   });
 
   dbTest(
-    'strict subset: existing OPENAI_KEY grant does NOT cover OPENAI_KEY+STRIPE_KEY',
+    'strict subset: a grant predating an expansion of required_env_vars no longer covers',
     async ({ db }) => {
       const service = new ArtifactsService(db, makeFakeApp());
       const board = await seedBoard(db);
@@ -637,17 +634,23 @@ describe('ArtifactsService.grantTrust', () => {
         name: 'expanding-needs',
         template: 'react',
         files: { '/index.js': 'console.log("x")' },
-        required_env_vars: ['OPENAI_KEY', 'STRIPE_KEY'],
+        required_env_vars: ['OPENAI_KEY'],
         public: true,
         created_by: 'user-owner',
       });
 
+      // Grant covers the artifact at this point in time (just OPENAI_KEY).
       await service.grantTrust({
         userId: 'user-stranger',
         artifactId: created.artifact_id,
         scopeType: 'artifact',
-        envVars: ['OPENAI_KEY'], // narrower than the artifact now requests
-        grants: {},
+      });
+
+      // Author later expands the artifact's requested env vars. The grant is
+      // now strictly narrower than the request, so the user should be
+      // re-prompted on the next render.
+      await artifactRepo.update(created.artifact_id, {
+        required_env_vars: ['OPENAI_KEY', 'STRIPE_KEY'],
       });
 
       const payload = await service.getPayload(created.artifact_id, 'user-stranger' as never);
@@ -675,8 +678,6 @@ describe('ArtifactsService.grantTrust', () => {
         userId: 'user-stranger',
         artifactId: created.artifact_id,
         scopeType: 'author',
-        envVars: [],
-        grants: { agor_token: true },
       })
     ).rejects.toThrow(/agor_token/);
   });
@@ -711,8 +712,6 @@ describe('ArtifactsService.grantTrust', () => {
       userId: 'viewer-1',
       artifactId: a.artifact_id,
       scopeType: 'author',
-      envVars: ['OPENAI_KEY'],
-      grants: {},
     });
 
     // Artifact B (same author) should be trusted via the author grant.

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -991,46 +991,21 @@ describe('ArtifactsService.updateMetadata authorization', () => {
 });
 
 describe('ArtifactsService.getPayload agor-runtime injection', () => {
-  dbTest('default-on: injects /agor-runtime.js + prepends import to entry', async ({ db }) => {
-    const service = new ArtifactsService(db, makeFakeApp());
-    const board = await seedBoard(db);
-    const artifactRepo = new ArtifactRepository(db);
-    const created = await artifactRepo.create({
-      artifact_id: generateId(),
-      board_id: board.board_id,
-      name: 'runtime-default',
-      template: 'react',
-      files: {
-        '/src/index.js': 'console.log("user code")',
-      },
-      public: true,
-      created_by: 'user-owner',
-    });
-
-    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
-
-    expect(payload.files['/agor-runtime.js']).toBeDefined();
-    expect(payload.files['/agor-runtime.js']).toContain('agor:query');
-    // The entry file got the import prepended (served only — the persisted
-    // row is unchanged). Specifier is relative-from-entry, not root-
-    // absolute, so Sandpack resolves it across template variants.
-    expect(payload.files['/src/index.js']).toMatch(/^import '\.\.\/agor-runtime\.js';/);
-  });
-
   dbTest(
-    'detects /App.js as an injection target (most common React-template shape)',
+    'default-on: adds runtime data URL to sandpack_config.options.externalResources without touching files',
     async ({ db }) => {
       const service = new ArtifactsService(db, makeFakeApp());
       const board = await seedBoard(db);
       const artifactRepo = new ArtifactRepository(db);
-      // Hello-world-style artifact: only /App.js, Sandpack synthesizes
-      // the rest. This is the shape the testing agent surfaced as a
-      // gap — none of the original /src/index.* candidates matched, so
-      // the runtime got silently dropped and queries timed out.
+      // Hello-world-shape: /App.js only. The previous file-map injection
+      // approach silently dropped the runtime here (no /src/index.*
+      // entry to attach to). Under externalResources we don't need
+      // any user file at all — the runtime ships as an iframe-level
+      // <script src="..."> tag.
       const created = await artifactRepo.create({
         artifact_id: generateId(),
         board_id: board.board_id,
-        name: 'app-only',
+        name: 'runtime-default',
         template: 'react',
         files: { '/App.js': 'export default function App() { return null; }' },
         public: true,
@@ -1038,13 +1013,24 @@ describe('ArtifactsService.getPayload agor-runtime injection', () => {
       });
 
       const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
-      expect(payload.files['/agor-runtime.js']).toBeDefined();
-      // Both files at root → relative specifier is './agor-runtime.js'.
-      expect(payload.files['/App.js']).toMatch(/^import '\.\/agor-runtime\.js';/);
+
+      // User files are served verbatim — no import prepended, no synthesized
+      // runtime file in the map.
+      expect(payload.files['/App.js']).toBe('export default function App() { return null; }');
+      expect(payload.files['/agor-runtime.js']).toBeUndefined();
+
+      const resources = (payload.sandpack_config?.options as Record<string, unknown> | undefined)
+        ?.externalResources;
+      expect(Array.isArray(resources)).toBe(true);
+      const arr = resources as string[];
+      expect(arr.length).toBeGreaterThan(0);
+      expect(arr[0]).toMatch(/^data:text\/javascript;base64,/);
+      const decoded = Buffer.from(arr[0].split(',', 2)[1], 'base64').toString('utf-8');
+      expect(decoded).toContain('agor:query');
     }
   );
 
-  dbTest('opt-out: enabled=false skips injection entirely', async ({ db }) => {
+  dbTest('opt-out: enabled=false skips externalResources injection entirely', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
     const artifactRepo = new ArtifactRepository(db);
@@ -1062,28 +1048,55 @@ describe('ArtifactsService.getPayload agor-runtime injection', () => {
     const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
     expect(payload.files['/agor-runtime.js']).toBeUndefined();
     expect(payload.files['/src/index.js']).toBe('console.log("user code")');
+    const resources = (payload.sandpack_config?.options as Record<string, unknown> | undefined)
+      ?.externalResources;
+    // Either no externalResources at all, or an array that doesn't carry
+    // the runtime data URL. Both are acceptable opt-out shapes.
+    if (Array.isArray(resources)) {
+      expect((resources as string[]).every((r) => !r.startsWith('data:text/javascript'))).toBe(
+        true
+      );
+    } else {
+      expect(resources).toBeUndefined();
+    }
   });
 
-  dbTest('persistence: published rows do not carry the runtime file', async ({ db }) => {
-    const board = await seedBoard(db);
-    const artifactRepo = new ArtifactRepository(db);
-    const created = await artifactRepo.create({
-      artifact_id: generateId(),
-      board_id: board.board_id,
-      name: 'runtime-persistence',
-      template: 'react',
-      files: { '/src/index.js': 'console.log("user code")' },
-      public: true,
-      created_by: 'user-owner',
-    });
+  dbTest(
+    'persistence: published sandpack_config does not carry the runtime data URL',
+    async ({ db }) => {
+      const board = await seedBoard(db);
+      const artifactRepo = new ArtifactRepository(db);
+      const created = await artifactRepo.create({
+        artifact_id: generateId(),
+        board_id: board.board_id,
+        name: 'runtime-persistence',
+        template: 'react',
+        files: { '/src/index.js': 'console.log("user code")' },
+        public: true,
+        created_by: 'user-owner',
+      });
 
-    // The DB row's files map should never carry agor-runtime.js — it's a
-    // render-time injection only. Read directly from repo to bypass any
-    // per-render mutation in getPayload.
-    const stored = await artifactRepo.findById(created.artifact_id);
-    expect(stored?.files?.['/agor-runtime.js']).toBeUndefined();
-    expect(stored?.files?.['/src/index.js']).toBe('console.log("user code")');
-  });
+      // The persisted row should never carry the runtime injection — it's
+      // a render-time-only synthesis. Read directly from the repo to
+      // bypass any getPayload-level rewriting.
+      const stored = await artifactRepo.findById(created.artifact_id);
+      expect(stored?.files?.['/agor-runtime.js']).toBeUndefined();
+      expect(stored?.files?.['/src/index.js']).toBe('console.log("user code")');
+      const persistedResources = (
+        stored?.sandpack_config?.options as Record<string, unknown> | undefined
+      )?.externalResources;
+      // sanitizeSandpackConfig strips externalResources on write, so
+      // either nothing was persisted at all or any persisted array is
+      // empty / runtime-free.
+      if (Array.isArray(persistedResources)) {
+        expect(
+          (persistedResources as string[]).every((r) => !r.startsWith('data:text/javascript'))
+        ).toBe(true);
+      } else {
+        expect(persistedResources).toBeUndefined();
+      }
+    }
+  );
 });
 
 describe('ArtifactsService.queryArtifactRuntime', () => {
@@ -1136,35 +1149,6 @@ describe('ArtifactsService.queryArtifactRuntime', () => {
         timeoutMs: 500,
       })
     ).rejects.toThrow(/not found/i);
-  });
-
-  dbTest('rejects with no-entry error rather than misleading timeout', async ({ db }) => {
-    const service = new ArtifactsService(db, makeFakeApp());
-    const board = await seedBoard(db);
-    const artifactRepo = new ArtifactRepository(db);
-    // No /App.*, /index.*, /main.*, or /src/* — runtime can't attach.
-    // Without the pre-flight check the caller would see a generic
-    // "open the artifact in your browser" timeout, even though the
-    // browser IS open and the runtime simply wasn't injected.
-    const created = await artifactRepo.create({
-      artifact_id: generateId(),
-      board_id: board.board_id,
-      name: 'no-entry',
-      template: 'react',
-      files: { '/some-utility.js': 'export const x = 1' },
-      public: true,
-      created_by: 'user-owner',
-    });
-
-    await expect(
-      service.queryArtifactRuntime({
-        artifactId: created.artifact_id,
-        userId: 'user-owner',
-        kind: 'query_dom',
-        args: { selector: 'h1' },
-        timeoutMs: 500,
-      })
-    ).rejects.toThrow(/no recognizable entry file/i);
   });
 
   dbTest('times out cleanly when no browser answers', async ({ db }) => {

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -719,4 +719,142 @@ describe('ArtifactsService.grantTrust', () => {
     expect(payload.trust_state).toBe('trusted');
     expect(payload.trust_scope).toBe('author');
   });
+
+  dbTest('grantTrust rejects when artifact is not visible to caller', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'private',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      required_env_vars: ['OPENAI_KEY'],
+      public: false,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.grantTrust({
+        userId: 'user-stranger',
+        artifactId: created.artifact_id,
+        scopeType: 'artifact',
+      })
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+describe('ArtifactsService.getStatus + console isolation', () => {
+  dbTest('console logs and sandpack errors are scoped per viewer', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'console-isolation',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    // Two different viewers post console output. Viewer A's output may
+    // contain values derived from their own injected secrets — those must
+    // never leak into viewer B's status read.
+    service.appendConsoleLogs(created.artifact_id, 'viewer-A', [
+      { timestamp: 1, level: 'log', message: 'A_SECRET=alpha' },
+    ]);
+    service.appendConsoleLogs(created.artifact_id, 'viewer-B', [
+      { timestamp: 2, level: 'log', message: 'B_SECRET=bravo' },
+    ]);
+    service.setSandpackError(created.artifact_id, 'viewer-A', { message: 'A-only error' }, 'idle');
+
+    const statusA = await service.getStatus(created.artifact_id, 'viewer-A' as never);
+    expect(statusA.console_logs.map((l) => l.message)).toEqual(['A_SECRET=alpha']);
+    expect(statusA.sandpack_error?.message).toBe('A-only error');
+
+    const statusB = await service.getStatus(created.artifact_id, 'viewer-B' as never);
+    expect(statusB.console_logs.map((l) => l.message)).toEqual(['B_SECRET=bravo']);
+    expect(statusB.sandpack_error).toBeNull();
+  });
+
+  dbTest('getStatus rejects when artifact is not visible to caller', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'private',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      public: false,
+      created_by: 'user-owner',
+    });
+
+    await expect(service.getStatus(created.artifact_id, 'user-stranger' as never)).rejects.toThrow(
+      /not found/i
+    );
+  });
+});
+
+describe('ArtifactsService.deleteArtifact authorization', () => {
+  dbTest('owner can delete', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.deleteArtifact(created.artifact_id, 'user-owner', 'member')
+    ).resolves.toBeUndefined();
+  });
+
+  dbTest('non-owner non-admin is rejected', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.deleteArtifact(created.artifact_id, 'user-stranger', 'member')
+    ).rejects.toThrow(/Forbidden/i);
+  });
+
+  dbTest("admin can delete someone else's artifact", async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'owned',
+      template: 'react',
+      files: { '/index.js': 'x' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    await expect(
+      service.deleteArtifact(created.artifact_id, 'admin-user', 'admin')
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -1106,6 +1106,107 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     await this.trustRepo.revoke(grantId);
   }
 
+  // ── External "open in" / export ────────────────────────────────────────
+
+  /**
+   * Build a CodeSandbox define-API payload from the artifact's stored files
+   * and POST it. Returns the resulting sandbox URL on success.
+   *
+   * Caveats inherent to the eject path (caller should surface to users):
+   *  - daemon-supplied capabilities (AGOR_TOKEN / AGOR_PROXY_*) are stripped
+   *    server-side anyway and won't function on CodeSandbox;
+   *  - the synthesized `.env` and round-trip sidecars are dropped — they're
+   *    Agor-only artifacts;
+   *  - CodeSandbox's define endpoint is sometimes Cloudflare-throttled.
+   *
+   * Throws `Error` on every failure (visibility, missing files, network,
+   * non-JSON 200 — typically a Cloudflare interstitial). Callers should
+   * catch and present a friendly message.
+   */
+  async exportToCodeSandbox(
+    artifactId: string,
+    userId?: UserID
+  ): Promise<{ artifactId: string; sandboxId: string; url: string; note: string }> {
+    const artifact = await this.artifactRepo.findById(artifactId);
+    if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
+    if (!this.isVisibleTo(artifact, userId)) {
+      // Same shape as a hard-not-found — don't leak existence of private artifacts.
+      throw new Error(`Artifact ${artifactId} not found`);
+    }
+    if (!artifact.files || Object.keys(artifact.files).length === 0) {
+      throw new Error(`Artifact ${artifactId} has no files to export`);
+    }
+
+    // Strip Agor-only sidecars + the synthesized .env. CodeSandbox expects
+    // `src/index.js` keys, not `/src/index.js` (no leading slash).
+    const filesPayload: Record<string, { content: string }> = {};
+    for (const [filePath, content] of Object.entries(artifact.files)) {
+      const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+      if (
+        stripped === 'agor.config.js' ||
+        stripped === 'agor.artifact.json' ||
+        stripped === '.env'
+      ) {
+        continue;
+      }
+      filesPayload[stripped] = { content };
+    }
+
+    const definePayload = {
+      files: filesPayload,
+      template: artifact.sandpack_config?.template ?? artifact.template,
+    };
+
+    let res: Response;
+    try {
+      res = await fetch('https://codesandbox.io/api/v1/sandboxes/define?json=1', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(definePayload),
+      });
+    } catch (err) {
+      throw new Error(
+        `CodeSandbox define API unreachable: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    if (!res.ok) {
+      // Failure bodies are typically Cloudflare HTML interstitials. Don't
+      // dump them — they bloat logs/UIs without adding signal.
+      const ct = res.headers.get('content-type') ?? '';
+      let hint = '';
+      if (ct.includes('application/json')) {
+        try {
+          const body = (await res.json()) as { error?: string; message?: string };
+          const msg = body.error ?? body.message;
+          if (typeof msg === 'string' && msg.length > 0) hint = `: ${msg.slice(0, 200)}`;
+        } catch {}
+      }
+      throw new Error(
+        `CodeSandbox define API failed (${res.status} ${res.statusText})${hint}. The endpoint is sometimes throttled by Cloudflare; retry in a moment.`
+      );
+    }
+    let body: { sandbox_id?: string };
+    try {
+      body = (await res.json()) as { sandbox_id?: string };
+    } catch (err) {
+      throw new Error(
+        `CodeSandbox returned a non-JSON 200 response (likely a Cloudflare interstitial). Try again later. ${err instanceof Error ? err.message : ''}`.trim()
+      );
+    }
+    const sandboxId = body.sandbox_id;
+    if (!sandboxId) {
+      throw new Error('CodeSandbox returned a 200 with no sandbox_id');
+    }
+
+    const url = `https://codesandbox.io/s/${sandboxId}`;
+    const requiredVars = artifact.required_env_vars ?? [];
+    const note = requiredVars.length
+      ? `This artifact declares required_env_vars=${JSON.stringify(requiredVars)}. Set the prefixed names (e.g. VITE_${requiredVars[0]}) in CodeSandbox → Settings → Secret Keys to make them available at runtime.`
+      : 'No required env vars to configure.';
+
+    return { artifactId, sandboxId, url, note };
+  }
+
   // ── Build / status / console / find helpers (mostly unchanged) ──
 
   async checkBuildFromFolder(folderPath: string): Promise<{

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -1456,24 +1456,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     // Broadcast on the artifacts service. The client filters: only respond
     // if currently viewing this artifact AND logged in as the requester.
-    // The diagnostic log is best-effort — `channel`/`listenerCount` aren't
-    // present on the fake app used in tests, so we tolerate either missing.
-    const svc = this.app.service('artifacts') as unknown as {
-      listenerCount?: (e: string) => number;
-    };
-    const appWithChannel = this.app as unknown as {
-      channel?: (name: string) => { length: number };
-    };
-    const listenerCount =
-      typeof svc.listenerCount === 'function' ? svc.listenerCount('agor-query') : 'n/a';
-    const authChannelSize =
-      typeof appWithChannel.channel === 'function'
-        ? appWithChannel.channel('authenticated').length
-        : 'n/a';
-    console.log(
-      `[agor-query] emit requestId=${requestId} artifactId=${input.artifactId.slice(0, 8)} kind=${input.kind} ` +
-        `listenerCount=${listenerCount} authenticatedChannelSize=${authChannelSize}`
-    );
     this.app.service('artifacts').emit('agor-query', {
       request_id: requestId,
       artifact_id: input.artifactId,

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -125,19 +125,50 @@ function pickEntryForRuntimeInjection(
   if (artifact.sandpack_config?.customSetup?.entry) {
     candidates.push(artifact.sandpack_config.customSetup.entry);
   }
-  // Common Sandpack template entries, in roughly observed-frequency order.
+  // Common Sandpack template entries. Order matters — earlier entries win
+  // when multiple match. Each template family has its own conventions:
+  //
+  //   `react` (default): user code goes in /App.{js,tsx,…}; Sandpack
+  //     synthesizes the bundler `index.js` itself. Most artifacts hit
+  //     this case — agents publishing minimal projects often only
+  //     provide `/App.js`.
+  //   Vite-style React: /src/App.* + /src/main.*.
+  //   Vue/Svelte: /src/App.{vue,svelte} + /src/main.*.
+  //   Vanilla / static: /index.* at root.
+  //
+  // We inject into the FIRST matching user file. Module side-effect
+  // imports run synchronously the first time the bundler pulls them in,
+  // so the runtime's IIFE registers before the rest of the artifact
+  // boots regardless of whether the file is the bundler-level entry.
   candidates.push(
+    // React template — author's component file at root (the most common
+    // shape for agent-published artifacts).
+    '/App.tsx',
+    '/App.ts',
+    '/App.jsx',
+    '/App.js',
+    // React/Vite/Solid — author's component file under /src.
+    '/src/App.tsx',
+    '/src/App.ts',
+    '/src/App.jsx',
+    '/src/App.js',
+    // Standard bundler entries under /src.
     '/src/index.tsx',
     '/src/index.ts',
     '/src/index.jsx',
     '/src/index.js',
-    '/src/main.ts',
     '/src/main.tsx',
+    '/src/main.ts',
+    '/src/main.jsx',
     '/src/main.js',
+    // Bundler entries at root.
     '/index.tsx',
     '/index.ts',
     '/index.jsx',
-    '/index.js'
+    '/index.js',
+    '/main.tsx',
+    '/main.ts',
+    '/main.js'
   );
   for (const candidate of candidates) {
     if (typeof candidate !== 'string') continue;
@@ -1459,6 +1490,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     if (artifact.agor_runtime?.enabled === false) {
       throw new Error(
         `Runtime introspection is disabled for artifact ${input.artifactId} (agor_runtime.enabled = false). The artifact author can re-enable it via agor_artifacts_update.`
+      );
+    }
+    // Pre-flight entry check: the runtime is render-time-injected by
+    // prepending an `import` to the entry file. If we can't detect a
+    // user JS/TS file to inject into, the runtime is silently dropped at
+    // render time — and a vanilla "query timed out, open the artifact"
+    // error misleads the caller (the artifact IS open, it just has no
+    // runtime). Detect this up front and surface the actual cause.
+    if (artifact.files && !pickEntryForRuntimeInjection(artifact.files, artifact)) {
+      throw new Error(
+        `Runtime introspection is unavailable for artifact ${input.artifactId}: no recognizable entry file in the artifact's file map (looked for /App.{js,jsx,ts,tsx}, /src/App.{js,jsx,ts,tsx}, /index.* and /src/index.*, /main.* and /src/main.*). Add one of those to the file map and republish.`
       );
     }
 

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -1141,8 +1141,13 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
 
     // Strip Agor-only sidecars + the synthesized .env. CodeSandbox expects
-    // `src/index.js` keys, not `/src/index.js` (no leading slash).
+    // `src/index.js` keys, not `/src/index.js` (no leading slash). Hold the
+    // user's package.json aside so we can merge dependencies into it before
+    // adding it back — CSB infers the runtime (CRA / vue-cli / svelte / …)
+    // from the dependency graph in package.json, so getting this right is
+    // what makes the export validate.
     const filesPayload: Record<string, { content: string }> = {};
+    let userPackageJson: string | null = null;
     for (const [filePath, content] of Object.entries(artifact.files)) {
       const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
       if (
@@ -1152,13 +1157,47 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       ) {
         continue;
       }
+      if (stripped === 'package.json') {
+        userPackageJson = content;
+        continue;
+      }
       filesPayload[stripped] = { content };
     }
 
-    const definePayload = {
-      files: filesPayload,
-      template: artifact.sandpack_config?.template ?? artifact.template,
+    let userPkg: Record<string, unknown> = {};
+    if (userPackageJson) {
+      try {
+        const parsed = JSON.parse(userPackageJson);
+        if (typeof parsed === 'object' && parsed !== null) {
+          userPkg = parsed as Record<string, unknown>;
+        }
+      } catch {
+        // Forgive malformed user package.json — synthesize one from the
+        // dependency cache rather than failing the whole export.
+      }
+    }
+    const customSetupDeps = artifact.sandpack_config?.customSetup?.dependencies ?? {};
+    const cachedDeps = artifact.dependencies ?? {};
+    const mergedDeps: Record<string, string> = {
+      ...customSetupDeps,
+      ...cachedDeps,
+      ...((userPkg.dependencies as Record<string, string> | undefined) ?? {}),
     };
+    const finalPkg: Record<string, unknown> = {
+      name: 'artifact-export',
+      version: '0.0.0',
+      main: artifact.entry ?? userPkg.main ?? 'src/index.js',
+      ...userPkg,
+      dependencies: mergedDeps,
+    };
+    filesPayload['package.json'] = { content: JSON.stringify(finalPkg, null, 2) };
+
+    // Don't send a top-level `template` — Sandpack template names (`react`,
+    // `react-ts`, `vue3`, …) are NOT valid CSB template names (`create-
+    // react-app`, `vue-cli`, …). CSB returns "Unable to process params"
+    // when given a Sandpack name. Letting CSB infer from package.json deps
+    // is both simpler and more reliable.
+    const definePayload = { files: filesPayload };
 
     let res: Response;
     try {

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -494,7 +494,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     if (updates.public !== undefined) dbUpdates.public = updates.public;
     if (updates.archived !== undefined) {
       dbUpdates.archived = updates.archived;
-      dbUpdates.archived_at = updates.archived ? new Date().toISOString() : undefined;
+      // Explicit null on unarchive — `undefined` would be ignored by the
+      // repo's `!== undefined` gate, leaving the stale archive timestamp
+      // in place and confusing anything that reads it for archive history.
+      dbUpdates.archived_at = updates.archived ? new Date().toISOString() : null;
     }
     if (moving) dbUpdates.board_id = newBoardId;
     if (updates.required_env_vars !== undefined) {

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -1,13 +1,15 @@
 /**
  * Artifacts Service
  *
- * Provides REST + WebSocket API for artifact management.
- * Artifacts are board-scoped, DB-backed Sandpack applications.
+ * REST + WebSocket API for artifact management. Artifacts are board-scoped,
+ * DB-backed Sandpack apps. The format is deliberately small: a file map +
+ * declarative metadata (`required_env_vars`, `agor_grants`, `sandpack_config`).
+ * The daemon handles secret/grant injection at render time and never persists
+ * the synthesized values.
  *
- * Key behavior:
- * - Publish reads a folder from the filesystem, serializes contents into the DB `files` column
- * - getPayload reads from DB (with legacy filesystem fallback for un-migrated artifacts)
- * - Console logs stored in-memory ring buffer for agent debugging
+ * No backwards compatibility with the legacy `sandpack.json`/`agor.config.js`
+ * sidecar format — `detectLegacyFormat` flags old artifacts so the UI can
+ * surface a self-service upgrade prompt.
  */
 
 import { createHash } from 'node:crypto';
@@ -18,58 +20,47 @@ import { generateId } from '@agor/core';
 import { getBaseUrl, loadConfig, PAGINATION, resolveProxies } from '@agor/core/config';
 import {
   ArtifactRepository,
+  ArtifactTrustGrantRepository,
   BoardRepository,
   type Database,
   WorktreeRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
 import type {
+  AgorGrants,
   Artifact,
   ArtifactBuildStatus,
   ArtifactConsoleEntry,
   ArtifactPayload,
   ArtifactStatus,
+  ArtifactTrustScopeType,
   BoardID,
   QueryParams,
+  SandpackConfig,
   SandpackError,
-  SandpackManifest,
   SandpackTemplate,
   UserID,
   WorktreeID,
 } from '@agor/core/types';
-import Handlebars from 'handlebars';
+import {
+  ARTIFACT_SCOPED_ONLY_GRANT_KEYS,
+  GRANT_ENV_VAR_NAMES,
+  proxyGrantEnvName,
+} from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { DrizzleService } from '../adapters/drizzle.js';
+import {
+  detectLegacyFormat,
+  envVarPrefixForTemplate,
+  sanitizeSandpackConfig,
+} from '../utils/sandpack-config.js';
 import type { UsersService } from './users.js';
-
-/**
- * Convention: if an artifact contains a file named /agor.config.js,
- * the backend treats it as a Handlebars template and renders it per-user
- * at payload fetch time. Template variables:
- *   {{ user.env.VAR_NAME }} - User's encrypted env var
- *   {{ agor.token }}        - Short-lived (15m) daemon JWT for the viewing
- *                              user. Same shape as a regular access token —
- *                              attach as `Authorization: Bearer ...` to
- *                              authenticate against the daemon (e.g. when
- *                              calling `/proxies/<vendor>/...`). Trust model
- *                              matches `user.env.X`: rendered into artifact
- *                              JS at view time, never enters LLM context.
- *   {{ agor.apiUrl }}       - Daemon URL
- *   {{ artifact.id }}       - Artifact ID
- *   {{ artifact.boardId }}  - Board ID
- */
-const AGOR_CONFIG_FILE = '/agor.config.js';
 
 /**
  * Resolve a destination path by canonicalizing the longest existing prefix via
  * `realpath` and re-joining the still-nonexistent tail. Used by `land()` to
  * detect symlinked ancestors that would otherwise defeat a lexical
  * containment check.
- *
- * Example: if `/wt/.agor` is a symlink to `/etc` and the caller passes
- * `.agor/artifacts/x`, the canonicalized destination is `/etc/artifacts/x`,
- * which fails the worktree-root containment check.
  */
 async function canonicalizeExistingPrefix(target: string): Promise<string> {
   const segments = target.split(path.sep);
@@ -94,8 +85,12 @@ export type ArtifactParams = QueryParams<{
 
 const MAX_CONSOLE_ENTRIES = 100;
 
+/** Path the synthesized .env file lands at in the file map. */
+const SYNTHESIZED_ENV_PATH = '/.env';
+
 export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>, ArtifactParams> {
   private artifactRepo: ArtifactRepository;
+  private trustRepo: ArtifactTrustGrantRepository;
   private worktreeRepo: WorktreeRepository;
   private boardRepo: BoardRepository;
   private app: Application;
@@ -109,8 +104,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   /** In-memory Sandpack status per artifact (from browser iframe) */
   private sandpackStatuses: Map<string, string> = new Map();
 
-  /** URL of self-hosted Sandpack bundler (detected at startup, null if not available) */
-  selfHostedBundlerURL: string | null = null;
+  /**
+   * Just-once / session-scope grants live here only — never persisted.
+   * Keyed by `${userId}:${artifactId}`. Cleared when the daemon restarts.
+   */
+  private sessionGrants: Map<string, { envVars: Set<string>; grants: AgorGrants }> = new Map();
 
   constructor(db: Database, app: Application) {
     const artifactRepo = new ArtifactRepository(db);
@@ -123,16 +121,14 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       },
     });
     this.artifactRepo = artifactRepo;
+    this.trustRepo = new ArtifactTrustGrantRepository(db);
     this.worktreeRepo = new WorktreeRepository(db);
     this.boardRepo = new BoardRepository(db);
     this.app = app;
   }
 
-  // Override Feathers CRUD to enforce lifecycle-safe operations.
-  // Artifacts require publish semantics (serializing folder → DB).
-  // Raw Feathers create would skip these, causing incomplete state.
-  // Use publish() or the agor_artifacts_publish MCP tool instead.
-
+  // Direct Feathers create is intentionally rejected — artifacts require
+  // the publish() lifecycle (folder → DB).
   async create(_data: Partial<Artifact>, _params?: unknown): Promise<Artifact> {
     throw new Error(
       'Direct artifact creation not supported. Use publish() or agor_artifacts_publish MCP tool.'
@@ -140,14 +136,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }
 
   /**
-   * Feathers patch override: route board_id and placement changes through
+   * Patch override: route board_id and placement changes through
    * updateMetadata so the board_objects entry is moved/resized alongside the
-   * row update. Plain metadata patches (name, description, public, archived,
-   * build state, etc.) fall through to the default DrizzleService patch.
-   *
-   * Ownership is enforced by Feathers hooks (creator-or-admin); this method
-   * additionally forwards the caller's user_id into updateMetadata as a
-   * defence-in-depth check for direct internal callers.
+   * row update. Plain metadata patches fall through to the default
+   * DrizzleService patch.
    */
   async patch(id: string | number, data: Partial<Artifact>, params?: unknown): Promise<Artifact> {
     const d = data as Partial<Artifact> & {
@@ -161,15 +153,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     if (d.board_id !== undefined || placementFields) {
       const artifactId = String(id);
-      // Resolve short IDs to a full ID through the repository.
       const existing = await this.artifactRepo.findById(artifactId);
       if (!existing) throw new Error(`Artifact ${artifactId} not found`);
-
-      // Pass through the caller's user_id when available (external REST/MCP
-      // calls) so updateMetadata's owner check engages. Feathers hooks are
-      // the primary gate; this is defence-in-depth for internal callers that
-      // forward a user. Internal service-to-service calls without a user
-      // still bypass the inline check (matches existing publish() behavior).
       const callerUserId = (params as { user?: { user_id?: string } } | undefined)?.user?.user_id;
 
       return this.updateMetadata(
@@ -193,9 +178,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }
 
   /**
-   * Centralized visibility predicate.
-   * Private artifacts are only readable by their creator; public artifacts
-   * are readable by anyone. Used by MCP tools (get, land) to avoid drift.
+   * Centralized visibility predicate. Private artifacts are only readable
+   * by their creator; public artifacts are readable by anyone.
    */
   isVisibleTo(artifact: Pick<Artifact, 'public' | 'created_by'>, userId?: string): boolean {
     if (artifact.public) return true;
@@ -213,11 +197,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }
 
   /**
-   * Publish a folder as a live Sandpack artifact on a board.
-   *
-   * Reads all files from folderPath, serializes them into the DB `files` column.
-   * If artifactId is provided, updates an existing artifact (must be owned by userId).
-   * If artifactId is omitted, creates a new artifact and places it on the board.
+   * Publish a folder as a live Sandpack artifact on a board. Reads files from
+   * `folderPath`, serializes them into the DB, and places (or updates) the
+   * artifact on the board.
    */
   async publish(
     data: {
@@ -227,7 +209,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       artifact_id?: string;
       template?: SandpackTemplate;
       public?: boolean;
-      use_local_bundler?: boolean;
+      sandpack_config?: SandpackConfig;
+      required_env_vars?: string[];
+      agor_grants?: AgorGrants;
       x?: number;
       y?: number;
       width?: number;
@@ -236,66 +220,54 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     userId?: string
   ): Promise<Artifact> {
     const folderPath = path.resolve(data.folderPath);
-    const template = data.template ?? 'react';
     const isPublic = data.public ?? true;
 
-    // Path containment: only allow reading from worktree paths or temp directories
+    // Path containment: only allow reading from worktree paths or temp dirs.
     await this.validatePublishPath(folderPath);
 
     if (!fs.existsSync(folderPath)) {
       throw new Error(`Folder not found: ${folderPath}`);
     }
 
-    // Read all files from the folder
     const files = this.readFilesRecursive(folderPath, folderPath);
 
-    // Read sandpack.json manifest if present
-    const manifestPath = path.join(folderPath, 'sandpack.json');
-    let manifest: SandpackManifest = { template };
-    if (fs.existsSync(manifestPath)) {
-      manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-    }
+    // package.json#dependencies is the source of truth; cache it on the row
+    // for cheap list/list-friendly reads.
+    const cachedDeps = this.extractDependenciesFromPackageJson(files);
+    const sandpackConfig = sanitizeSandpackConfig(data.sandpack_config);
+    const template = (data.template ?? sandpackConfig.template ?? 'react') as SandpackTemplate;
+    if (!sandpackConfig.template) sandpackConfig.template = template;
+    const cachedEntry = sandpackConfig.customSetup?.entry;
+    const requiredEnvVars = sanitizeEnvVarNames(data.required_env_vars);
+    const agorGrants = sanitizeAgorGrants(data.agor_grants);
 
-    // Allow explicit parameter to override manifest
-    if (data.use_local_bundler !== undefined) {
-      manifest.use_local_bundler = data.use_local_bundler;
-    }
-
-    // Validate use_local_bundler opt-in
-    if (manifest.use_local_bundler && !this.selfHostedBundlerURL) {
-      throw new Error(
-        'Cannot publish artifact with use_local_bundler=true: this daemon was not built with --with-sandpack, so no self-hosted Sandpack bundler is available. Either rebuild the daemon with `./build.sh --with-sandpack`, or omit use_local_bundler to use the default CodeSandbox hosted bundler.'
-      );
-    }
-
-    // Compute content hash from serialized files
     const contentHash = this.computeHashFromFiles(files);
 
     if (data.artifact_id) {
-      // ── UPDATE existing artifact ──
       const existing = await this.artifactRepo.findById(data.artifact_id);
       if (!existing) throw new Error(`Artifact ${data.artifact_id} not found`);
       if (userId && existing.created_by && existing.created_by !== userId) {
         throw new Error('Cannot update artifact: not the owner');
       }
 
-      // Auto-check build status from the files we just read
       const buildResult = this.validateFiles(files);
 
       const updated = await this.artifactRepo.update(data.artifact_id, {
         name: data.name,
         files,
-        dependencies: manifest.dependencies,
-        entry: manifest.entry,
-        template: manifest.template ?? template,
+        dependencies: cachedDeps,
+        entry: cachedEntry,
+        template,
+        sandpack_config: sandpackConfig,
+        required_env_vars: requiredEnvVars,
+        agor_grants: agorGrants,
         content_hash: contentHash,
-        use_local_bundler: manifest.use_local_bundler,
         public: isPublic,
         build_status: buildResult.status,
         build_errors: buildResult.errors.length > 0 ? buildResult.errors : undefined,
       });
 
-      // Clear stale in-memory Sandpack state — new content will produce fresh state from the browser
+      // Stale Sandpack state — new content will produce fresh state from the browser.
       this.sandpackErrors.delete(data.artifact_id);
       this.sandpackStatuses.delete(data.artifact_id);
 
@@ -303,10 +275,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       return updated;
     }
 
-    // ── CREATE new artifact ──
     const artifactId = generateId();
-
-    // Auto-check build status from the files we just read
     const buildResult = this.validateFiles(files);
 
     const artifact = await this.artifactRepo.create({
@@ -314,11 +283,13 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       board_id: data.board_id as BoardID,
       name: data.name,
       path: folderPath,
-      template: manifest.template ?? template,
+      template,
       files,
-      dependencies: manifest.dependencies,
-      entry: manifest.entry,
-      use_local_bundler: manifest.use_local_bundler,
+      dependencies: cachedDeps,
+      entry: cachedEntry,
+      sandpack_config: sandpackConfig,
+      required_env_vars: requiredEnvVars,
+      agor_grants: agorGrants,
       content_hash: contentHash,
       build_status: buildResult.status,
       build_errors: buildResult.errors.length > 0 ? buildResult.errors : undefined,
@@ -326,7 +297,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       created_by: userId,
     });
 
-    // Place on board as a thin reference
     const objectId = `artifact-${artifactId}`;
     try {
       const updatedBoard = await this.boardRepo.upsertBoardObject(data.board_id, objectId, {
@@ -342,7 +312,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         this.app.service('boards').emit('patched', updatedBoard);
       }
     } catch (boardError) {
-      // Compensate: remove DB record if board placement fails
+      // Compensate: remove DB record if board placement fails.
       try {
         await this.artifactRepo.delete(artifactId);
       } catch (deleteError) {
@@ -359,17 +329,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }
 
   /**
-   * Update artifact metadata without touching file contents.
-   *
-   * Supports: name, description, public, archived flag, board move,
-   * and board placement (x/y/width/height).
-   *
-   * When moving between boards, the old board object is removed and a new one
-   * is created on the destination board. Placement (x/y/width/height) is
-   * preserved unless caller explicitly overrides — this makes cross-board
-   * moves layout-preserving by default.
-   *
-   * For file/content updates use publish() instead.
+   * Update artifact metadata without touching files.
+   * For file/content changes use publish().
    */
   async updateMetadata(
     artifactId: string,
@@ -383,6 +344,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       y?: number;
       width?: number;
       height?: number;
+      required_env_vars?: string[];
+      agor_grants?: AgorGrants;
+      sandpack_config?: SandpackConfig;
     },
     userId?: string
   ): Promise<Artifact> {
@@ -398,9 +362,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const newBoardId = updates.board_id ?? oldBoardId;
     const moving = newBoardId !== oldBoardId;
 
-    // Pre-validate destination board exists when moving. This avoids persisting
-    // a dangling `artifact.board_id` with no matching board_objects entry if
-    // the upsert would fail.
     if (moving) {
       const destBoard = await this.boardRepo.findById(newBoardId);
       if (!destBoard) {
@@ -408,8 +369,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       }
     }
 
-    // Read the current board object (if present) so we can preserve placement
-    // when moving or when only some placement fields are provided.
     let currentPlacement: { x: number; y: number; width: number; height: number } | null = null;
     try {
       const oldBoard = await this.boardRepo.findById(oldBoardId);
@@ -418,11 +377,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         currentPlacement = { x: obj.x, y: obj.y, width: obj.width, height: obj.height };
       }
     } catch {
-      // Board may have been deleted out from under the artifact — placement
-      // falls back to defaults below.
+      // Old board may have been deleted.
     }
 
-    // Apply DB updates (metadata + board_id).
     const dbUpdates: Partial<Artifact> = {};
     if (updates.name !== undefined) dbUpdates.name = updates.name;
     if (updates.description !== undefined) dbUpdates.description = updates.description;
@@ -432,13 +389,21 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       dbUpdates.archived_at = updates.archived ? new Date().toISOString() : undefined;
     }
     if (moving) dbUpdates.board_id = newBoardId;
+    if (updates.required_env_vars !== undefined) {
+      dbUpdates.required_env_vars = sanitizeEnvVarNames(updates.required_env_vars);
+    }
+    if (updates.agor_grants !== undefined) {
+      dbUpdates.agor_grants = sanitizeAgorGrants(updates.agor_grants);
+    }
+    if (updates.sandpack_config !== undefined) {
+      dbUpdates.sandpack_config = sanitizeSandpackConfig(updates.sandpack_config);
+    }
 
     let updated = existing;
     if (Object.keys(dbUpdates).length > 0) {
       updated = await this.artifactRepo.update(fullArtifactId, dbUpdates);
     }
 
-    // Sync board_objects if moving OR if placement fields were supplied.
     const placementChanged =
       updates.x !== undefined ||
       updates.y !== undefined ||
@@ -455,17 +420,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         height: updates.height ?? currentPlacement?.height ?? 400,
       };
 
-      // Upsert the destination board object FIRST. Only once the new placement
-      // is safely in place do we remove the old one — this way, a failing
-      // upsert leaves the old board object intact (we only have to roll back
-      // the DB row), rather than leaving the artifact orphaned on both boards.
       try {
         const targetBoard = await this.boardRepo.upsertBoardObject(newBoardId, objectId, placement);
         this.app.service('boards').emit('patched', targetBoard);
       } catch (upsertError) {
-        // Compensate: if we already updated the DB row (in particular, moved
-        // `board_id` to newBoardId), roll it back so the artifact row and
-        // board_objects stay consistent.
         if (Object.keys(dbUpdates).length > 0) {
           try {
             const rollback: Partial<Artifact> = {};
@@ -495,9 +453,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           const cleaned = await this.boardRepo.removeBoardObject(oldBoardId, objectId);
           this.app.service('boards').emit('patched', cleaned);
         } catch {
-          // Old board may not have this object (e.g. was already cleaned up),
-          // or the old board was deleted. The destination upsert already
-          // succeeded, so the artifact is reachable on its new board.
+          // Old board may not have this object.
         }
       }
     }
@@ -508,14 +464,14 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /**
    * Materialize an artifact's stored file map to a destination under a worktree.
-   * Inverse of publish().
+   * Inverse of publish(). Sandpack metadata is reconstructed as a sidecar
+   * `agor.artifact.json` so a round-trip via publish() round-trips the
+   * metadata that doesn't live in the file map.
    *
    * Security:
-   * - destination must resolve strictly inside the worktree (not equal to the
-   *   worktree root) — prevents overwriting random files via `subpath`.
-   * - per-file paths from the artifact's `files` map are re-validated to block
-   *   traversal keys like `../../etc/passwd` that could have been snuck into
-   *   the serialized file map.
+   * - destination must resolve strictly inside the worktree root.
+   * - per-file paths from the artifact's `files` map are re-validated to
+   *   block traversal keys.
    * - when overwriting, uses `fs.rm` which removes symlinks rather than
    *   following them.
    */
@@ -533,34 +489,20 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     if (!fs.existsSync(worktreePath)) {
       throw new Error(`Worktree path does not exist: ${worktreePath}`);
     }
-    // Canonicalize the worktree root so a symlinked root (e.g. a worktree
-    // whose `path` column is a symlink into $HOME) cannot be used to defeat
-    // the containment check below. Mirrors the pattern in
-    // apps/agor-daemon/src/services/file.ts and
-    // packages/core/src/git/index.ts.
     const worktreeRoot = await realpath(worktreePath);
 
-    // Default destination: .agor/artifacts/<artifact-id>
     const rawSubpath =
       options?.subpath && options.subpath.trim().length > 0
         ? options.subpath
         : path.join('.agor', 'artifacts', artifact.artifact_id);
 
-    // Absolute subpath is always rejected — caller must pass a worktree-relative path.
     if (path.isAbsolute(rawSubpath)) {
       throw new Error(`subpath must be relative to the worktree root: ${rawSubpath}`);
     }
 
     const destination = path.resolve(worktreeRoot, rawSubpath);
-
-    // Canonicalize any existing portion of the destination path (a
-    // pre-existing symlinked parent directory must not lift the write outside
-    // the worktree root).
     const canonicalDestination = await canonicalizeExistingPrefix(destination);
 
-    // Path-escape check: destination must be strictly inside the worktree.
-    // Equal to worktree root is refused — writing the artifact at the worktree
-    // root would stomp user code.
     const assertInsideRoot = (candidate: string, reason: string): void => {
       if (candidate === worktreeRoot) {
         throw new Error(`${reason}: must not resolve to the worktree root`);
@@ -573,9 +515,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     assertInsideRoot(destination, `subpath ${rawSubpath}`);
     assertInsideRoot(canonicalDestination, `subpath ${rawSubpath} (canonical)`);
 
-    // Validate file-map keys for traversal. Artifact file keys are stored as
-    // `/path/to/file` (leading slash, forward slashes). Strip leading slash,
-    // resolve inside destination, and verify containment.
     for (const filePath of Object.keys(artifact.files)) {
       const key = filePath.startsWith('/') ? filePath.slice(1) : filePath;
       if (path.isAbsolute(key)) {
@@ -588,20 +527,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       }
     }
 
-    // Handle existing destination.
     if (fs.existsSync(destination)) {
       if (!options?.overwrite) {
         throw new Error(
           `Destination already exists: ${destination} (pass overwrite=true to replace)`
         );
       }
-      // fs.rm with recursive unlinks symlinks rather than following them.
       await rm(destination, { recursive: true, force: true });
     }
 
     await mkdir(destination, { recursive: true });
 
-    // Write the file map.
     let bytesWritten = 0;
     let fileCount = 0;
     for (const [filePath, content] of Object.entries(artifact.files)) {
@@ -613,16 +549,24 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       fileCount += 1;
     }
 
-    // Reconstruct sandpack.json for round-trip with publish() (publish skips
-    // sandpack.json when reading, and reconstitutes manifest state from DB
-    // columns).
-    const manifest: SandpackManifest = { template: artifact.template };
-    if (artifact.dependencies) manifest.dependencies = artifact.dependencies;
-    if (artifact.entry) manifest.entry = artifact.entry;
-    if (artifact.use_local_bundler) manifest.use_local_bundler = artifact.use_local_bundler;
-    const manifestJson = `${JSON.stringify(manifest, null, 2)}\n`;
-    await writeFile(path.join(destination, 'sandpack.json'), manifestJson, 'utf-8');
-    bytesWritten += Buffer.byteLength(manifestJson, 'utf-8');
+    // Round-trip sidecar: persist artifact-level metadata that has no place in
+    // a normal file tree (template, sandpack_config, required_env_vars,
+    // agor_grants). publish() reads agor.artifact.json back if present;
+    // ordinary builds/Vite/CRA never look at it.
+    const sidecar: Record<string, unknown> = {
+      $schema: 'https://agor.live/schemas/artifact/2026-05-09.json',
+      template: artifact.template,
+    };
+    if (artifact.sandpack_config) sidecar.sandpack_config = artifact.sandpack_config;
+    if (artifact.required_env_vars && artifact.required_env_vars.length > 0) {
+      sidecar.required_env_vars = artifact.required_env_vars;
+    }
+    if (artifact.agor_grants && Object.keys(artifact.agor_grants).length > 0) {
+      sidecar.agor_grants = artifact.agor_grants;
+    }
+    const sidecarJson = `${JSON.stringify(sidecar, null, 2)}\n`;
+    await writeFile(path.join(destination, 'agor.artifact.json'), sidecarJson, 'utf-8');
+    bytesWritten += Buffer.byteLength(sidecarJson, 'utf-8');
     fileCount += 1;
 
     return { destinationPath: destination, fileCount, bytesWritten };
@@ -630,10 +574,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /**
    * Read artifact payload for the frontend.
-   * Primary path: reads from DB `files` column.
-   * Legacy fallback: reads from filesystem if `files` is null (un-migrated artifacts).
-   * If the artifact contains an /agor.config.js file, it is treated as a
-   * Handlebars template and rendered with the requesting user's context.
+   *
+   * Resolves trust state, synthesizes a per-viewer `.env` (when consent
+   * permits), runs legacy detection, and returns everything the renderer
+   * needs.
    */
   async getPayload(artifactId: string, userId?: UserID): Promise<ArtifactPayload> {
     const artifact = await this.artifactRepo.findById(artifactId);
@@ -650,68 +594,372 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       throw new Error(`Artifact ${artifactId} has no files in DB — cannot serve payload`);
     }
 
-    const files: Record<string, string> = { ...artifact.files };
-    const manifest: SandpackManifest = {
-      template: artifact.template as SandpackTemplate,
-      dependencies: artifact.dependencies,
-      entry: artifact.entry,
-      use_local_bundler: artifact.use_local_bundler,
-    };
+    const filesOut: Record<string, string> = { ...artifact.files };
+    const requiredEnvVars = artifact.required_env_vars ?? [];
+    const grants = artifact.agor_grants ?? {};
+    const consentRelevantGrants = pickConsentRelevantGrants(grants);
 
-    // Compute hash from files
-    const contentHash = this.computeHashFromFiles(files);
+    const needsConsent =
+      requiredEnvVars.length > 0 || Object.keys(consentRelevantGrants).length > 0;
 
-    // Render agor.config.js template if present
-    let missingEnvVars: string[] | undefined;
-    if (files[AGOR_CONFIG_FILE]) {
-      const result = await this.renderAgorConfig(files[AGOR_CONFIG_FILE], artifact, userId);
-      files[AGOR_CONFIG_FILE] = result.rendered;
-      if (result.missingEnvVars.length > 0) {
-        missingEnvVars = result.missingEnvVars;
+    let trustState: ArtifactPayload['trust_state'] = 'no_secrets_needed';
+    let trustScope: ArtifactPayload['trust_scope'] | undefined;
+    let envValues: Record<string, string> = {};
+
+    if (needsConsent) {
+      const decision = await this.resolveTrust({
+        artifact,
+        userId,
+        requiredEnvVars,
+        grants,
+      });
+      trustState = decision.state;
+      trustScope = decision.scope;
+      if (decision.state === 'self' || decision.state === 'trusted') {
+        envValues = await this.resolveEnvVarValues(userId, requiredEnvVars);
       }
     }
 
-    // Resolve bundlerURL
-    let bundlerURL: string | undefined;
-    if (manifest.use_local_bundler) {
-      if (this.selfHostedBundlerURL) {
-        bundlerURL = this.selfHostedBundlerURL;
-      } else {
-        console.warn(
-          `[artifacts] Artifact ${artifactId} opted into local bundler but no self-hosted bundler is available on this daemon. Falling back to CodeSandbox hosted bundler. Rebuild with --with-sandpack to restore local bundling.`
-        );
-      }
+    if (needsConsent) {
+      const envFile = await this.synthesizeEnvFile({
+        template: artifact.template,
+        requiredEnvVars,
+        envValues,
+        grants,
+        artifact,
+        userId,
+        injectGrants: trustState === 'self' || trustState === 'trusted',
+      });
+      // Only emit a .env if we have something meaningful to put in it OR if
+      // the artifact's bundler can read it. For vanilla/static templates the
+      // file is irrelevant.
+      if (envFile !== null) filesOut[SYNTHESIZED_ENV_PATH] = envFile;
     }
 
-    return {
+    const contentHash = this.computeHashFromFiles(filesOut);
+    const legacy = detectLegacyFormat(artifact);
+
+    const payload: ArtifactPayload = {
       artifact_id: artifact.artifact_id,
       name: artifact.name,
       description: artifact.description,
-      template: manifest.template ?? (artifact.template as SandpackTemplate),
-      files,
-      dependencies: manifest.dependencies,
-      entry: manifest.entry,
+      template: artifact.template,
+      files: filesOut,
+      sandpack_config: artifact.sandpack_config,
+      dependencies: artifact.dependencies,
+      entry: artifact.entry,
       content_hash: contentHash,
-      ...(missingEnvVars ? { missing_env_vars: missingEnvVars } : {}),
-      ...(bundlerURL ? { bundlerURL } : {}),
+      required_env_vars: requiredEnvVars.length > 0 ? requiredEnvVars : undefined,
+      agor_grants: Object.keys(grants).length > 0 ? grants : undefined,
+      trust_state: trustState,
+      ...(trustScope ? { trust_scope: trustScope } : {}),
+      ...(legacy.is_legacy ? { legacy } : {}),
     };
+    return payload;
   }
 
   /**
-   * Check build: verify artifact files exist and are non-empty.
-   * Reads from a folder path (pre-publish check) or from DB (post-publish check).
+   * Resolve consent for an artifact's requested env vars + grants.
+   * Returns the trust state and (when applicable) the scope of the matching grant.
+   *
+   * Resolution order matches the roadmap:
+   *   1. Author is the viewer → 'self'.
+   *   2. agor_token requested → ONLY artifact-scoped grants apply.
+   *   3. instance > author > artifact > session — first matching wins.
    */
+  private async resolveTrust(input: {
+    artifact: Artifact;
+    userId?: UserID;
+    requiredEnvVars: string[];
+    grants: AgorGrants;
+  }): Promise<{ state: ArtifactPayload['trust_state']; scope?: ArtifactTrustScopeType }> {
+    const { artifact, userId, requiredEnvVars, grants } = input;
+    if (userId && artifact.created_by && artifact.created_by === userId) {
+      return { state: 'self', scope: 'self' };
+    }
+    if (!userId) return { state: 'untrusted' };
+
+    const wantsAgorToken = !!grants.agor_token;
+    const consentRelevantGrants = pickConsentRelevantGrants(grants);
+
+    // agor_token is artifact-scoped only — author/instance grants do NOT cover it.
+    if (wantsAgorToken) {
+      const artifactGrants = await this.trustRepo.findActiveForScope({
+        userId,
+        scopeType: 'artifact',
+        scopeValue: artifact.artifact_id,
+      });
+      if (artifactGrants.some((g) => coversRequest(g, requiredEnvVars, consentRelevantGrants))) {
+        return { state: 'trusted', scope: 'artifact' };
+      }
+      // Even if a non-token grant covers, agor_token requires artifact scope.
+      // Fall through to untrusted unless a session grant matches (below).
+    } else {
+      const tryScopes: {
+        type: Exclude<ArtifactTrustScopeType, 'session' | 'self'>;
+        value: string | null;
+      }[] = [
+        { type: 'instance', value: null },
+        { type: 'author', value: artifact.created_by ?? null },
+        { type: 'artifact', value: artifact.artifact_id },
+      ];
+      for (const sc of tryScopes) {
+        if (sc.type === 'author' && !sc.value) continue;
+        const matches = await this.trustRepo.findActiveForScope({
+          userId,
+          scopeType: sc.type,
+          scopeValue: sc.value,
+        });
+        if (matches.some((g) => coversRequest(g, requiredEnvVars, consentRelevantGrants))) {
+          return { state: 'trusted', scope: sc.type };
+        }
+      }
+    }
+
+    const sessionKey = `${userId}:${artifact.artifact_id}`;
+    const sessionGrant = this.sessionGrants.get(sessionKey);
+    if (sessionGrant) {
+      const envCovered = requiredEnvVars.every((v) => sessionGrant.envVars.has(v));
+      const grantsCovered = grantsAreSubset(consentRelevantGrants, sessionGrant.grants);
+      // agor_token is artifact-scoped only; for the session-scope path we
+      // additionally require that the grant explicitly listed agor_token.
+      const tokenCovered = !wantsAgorToken || sessionGrant.grants.agor_token === true;
+      if (envCovered && grantsCovered && tokenCovered) {
+        return { state: 'trusted', scope: 'session' };
+      }
+    }
+
+    return { state: 'untrusted' };
+  }
+
+  /**
+   * Build the synthesized `.env` body. Returns null for templates without a
+   * dotenv path (vanilla/static), in which case nothing is injected.
+   */
+  private async synthesizeEnvFile(input: {
+    template: SandpackTemplate;
+    requiredEnvVars: string[];
+    envValues: Record<string, string>;
+    grants: AgorGrants;
+    artifact: Artifact;
+    userId?: UserID;
+    injectGrants: boolean;
+  }): Promise<string | null> {
+    const prefix = envVarPrefixForTemplate(input.template);
+    if (prefix === null) {
+      // No dotenv path. Warn loudly if the artifact wanted env vars or grants.
+      if (input.requiredEnvVars.length > 0 || Object.keys(input.grants).length > 0) {
+        console.warn(
+          `[artifacts] Artifact ${input.artifact.artifact_id} (template=${input.template}) requests env vars/grants but the template has no dotenv path. Nothing was injected.`
+        );
+      }
+      return null;
+    }
+
+    const lines: string[] = [];
+    for (const name of input.requiredEnvVars) {
+      const value = input.envValues[name] ?? '';
+      lines.push(`${prefix}${name}=${escapeEnvValue(value)}`);
+    }
+
+    if (input.injectGrants) {
+      const injectedGrants = await this.resolveGrantValues({
+        grants: input.grants,
+        artifact: input.artifact,
+        userId: input.userId,
+      });
+      for (const [name, value] of Object.entries(injectedGrants)) {
+        lines.push(`${prefix}${name}=${escapeEnvValue(value)}`);
+      }
+    } else {
+      // Empty values for grants — keeps the env keys present so the artifact
+      // can detect "untrusted" rather than "ReferenceError on missing key".
+      for (const [grantName, fixedEnvName] of Object.entries(GRANT_ENV_VAR_NAMES)) {
+        if ((input.grants as Record<string, unknown>)[grantName]) {
+          lines.push(`${prefix}${fixedEnvName}=`);
+        }
+      }
+      if (input.grants.agor_proxies) {
+        for (const vendor of input.grants.agor_proxies) {
+          lines.push(`${prefix}${proxyGrantEnvName(vendor)}=`);
+        }
+      }
+    }
+
+    return lines.length > 0 ? `${lines.join('\n')}\n` : null;
+  }
+
+  /**
+   * Resolve the runtime values for each granted capability. Mints a JWT for
+   * `agor_token`, looks up the daemon URL for `agor_api_url`, etc.
+   */
+  private async resolveGrantValues(input: {
+    grants: AgorGrants;
+    artifact: Artifact;
+    userId?: UserID;
+  }): Promise<Record<string, string>> {
+    const out: Record<string, string> = {};
+    const { grants, artifact, userId } = input;
+
+    if (grants.agor_token && userId) {
+      out[GRANT_ENV_VAR_NAMES.agor_token] = await this.mintViewerJwt(userId);
+    }
+    if (grants.agor_api_url) {
+      out[GRANT_ENV_VAR_NAMES.agor_api_url] = await getBaseUrl();
+    }
+    if (grants.agor_user_email && userId) {
+      try {
+        const usersService = this.app.service('users') as unknown as UsersService;
+        const user = await usersService.get(userId);
+        if (user?.email) out[GRANT_ENV_VAR_NAMES.agor_user_email] = user.email;
+      } catch {
+        // Fall through — leave the variable empty.
+      }
+    }
+    if (grants.agor_artifact_id) {
+      out[GRANT_ENV_VAR_NAMES.agor_artifact_id] = artifact.artifact_id;
+    }
+    if (grants.agor_board_id) {
+      out[GRANT_ENV_VAR_NAMES.agor_board_id] = artifact.board_id;
+    }
+
+    if (grants.agor_proxies && grants.agor_proxies.length > 0) {
+      try {
+        const config = await loadConfig();
+        const proxies = resolveProxies(config);
+        const baseUrl = await getBaseUrl();
+        const origin = new URL(baseUrl).origin;
+        const configuredVendors = new Set(proxies.map((p) => p.vendor));
+        for (const vendor of grants.agor_proxies) {
+          if (!configuredVendors.has(vendor)) continue;
+          out[proxyGrantEnvName(vendor)] = `${origin}/proxies/${vendor}`;
+        }
+      } catch (err) {
+        console.warn('[artifacts] failed to resolve proxy URLs for grant injection:', err);
+      }
+    }
+
+    return out;
+  }
+
+  private async mintViewerJwt(userId: string): Promise<string> {
+    const authConfig = this.app.get('authentication') as { secret?: string } | undefined;
+    const jwtSecret = authConfig?.secret;
+    if (!jwtSecret) {
+      console.warn('[artifacts] no auth.secret set — AGOR_TOKEN will render empty');
+      return '';
+    }
+    return jwt.sign({ sub: userId, type: 'access' }, jwtSecret, {
+      expiresIn: '15m',
+      issuer: 'agor',
+      audience: 'https://agor.dev',
+    });
+  }
+
+  private async resolveEnvVarValues(
+    userId: UserID | undefined,
+    names: string[]
+  ): Promise<Record<string, string>> {
+    if (!userId || names.length === 0) return {};
+    try {
+      const usersService = this.app.service('users') as unknown as UsersService;
+      const all = await usersService.getEnvironmentVariables(userId);
+      const out: Record<string, string> = {};
+      for (const n of names) {
+        if (all[n] !== undefined) out[n] = all[n];
+      }
+      return out;
+    } catch (err) {
+      console.error(`[artifacts] failed to resolve env vars for user ${userId}:`, err);
+      return {};
+    }
+  }
+
+  // ── Trust grants management (called from REST routes / consent modal) ──
+
+  /**
+   * Persist a trust grant for `(viewer, scope_type, scope_value)`. For
+   * `session`-scope grants the value lives in-process only.
+   */
+  async grantTrust(input: {
+    userId: string;
+    artifactId: string;
+    scopeType: ArtifactTrustScopeType;
+    envVars: string[];
+    grants: AgorGrants;
+  }): Promise<{ scope: ArtifactTrustScopeType; persisted: boolean }> {
+    const sanitizedEnv = sanitizeEnvVarNames(input.envVars);
+    const sanitizedGrants = sanitizeAgorGrants(input.grants);
+
+    if (input.scopeType === 'session') {
+      const key = `${input.userId}:${input.artifactId}`;
+      this.sessionGrants.set(key, {
+        envVars: new Set(sanitizedEnv),
+        grants: sanitizedGrants,
+      });
+      return { scope: 'session', persisted: false };
+    }
+
+    if (input.scopeType === 'self') {
+      throw new Error("'self' grants are implicit and cannot be persisted");
+    }
+
+    // Resolve scope_value from artifact when needed.
+    let scopeValue: string | null = null;
+    if (input.scopeType === 'artifact') {
+      scopeValue = input.artifactId;
+    } else if (input.scopeType === 'author') {
+      const artifact = await this.artifactRepo.findById(input.artifactId);
+      if (!artifact?.created_by) {
+        throw new Error('Cannot grant author-scope trust: artifact has no recorded author');
+      }
+      scopeValue = artifact.created_by;
+    } else if (input.scopeType === 'instance') {
+      scopeValue = null;
+    }
+
+    // agor_token must be artifact-scoped only.
+    const wantsAgorToken = !!sanitizedGrants.agor_token;
+    if (wantsAgorToken && input.scopeType !== 'artifact') {
+      throw new Error(
+        `Cannot grant agor_token at scope '${input.scopeType}' — agor_token requires artifact-scoped consent`
+      );
+    }
+
+    await this.trustRepo.create({
+      user_id: input.userId,
+      scope_type: input.scopeType,
+      scope_value: scopeValue,
+      env_vars_set: sanitizedEnv,
+      agor_grants_set: sanitizedGrants,
+    });
+    return { scope: input.scopeType, persisted: true };
+  }
+
+  async listTrustGrants(userId: string) {
+    return this.trustRepo.findActiveByUser(userId);
+  }
+
+  async revokeTrustGrant(userId: string, grantId: string): Promise<void> {
+    const grant = await this.trustRepo.findById(grantId);
+    if (!grant) throw new Error(`Trust grant ${grantId} not found`);
+    if (grant.user_id !== userId) {
+      throw new Error('Cannot revoke a trust grant owned by another user');
+    }
+    await this.trustRepo.revoke(grantId);
+  }
+
+  // ── Build / status / console / find helpers (mostly unchanged) ──
+
   async checkBuildFromFolder(folderPath: string): Promise<{
     status: ArtifactBuildStatus;
     errors: string[];
   }> {
     const resolved = path.resolve(folderPath);
     await this.validatePublishPath(resolved);
-
     if (!fs.existsSync(resolved)) {
       return { status: 'error', errors: [`Folder not found: ${folderPath}`] };
     }
-
     const files = this.readFilesRecursive(resolved, resolved);
     return this.validateFiles(files);
   }
@@ -722,25 +970,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }> {
     const payload = await this.getPayload(artifactId);
     const result = this.validateFiles(payload.files);
-
-    // Update DB
     await this.artifactRepo.updateBuildStatus(
       artifactId,
       result.status,
       result.errors.length > 0 ? result.errors : undefined
     );
-
     return result;
   }
 
-  /**
-   * Store console log entries from frontend
-   */
   appendConsoleLogs(artifactId: string, entries: ArtifactConsoleEntry[]): void {
     const existing = this.consoleLogs.get(artifactId) ?? [];
     const combined = [...existing, ...entries];
-
-    // Ring buffer: keep last MAX_CONSOLE_ENTRIES
     if (combined.length > MAX_CONSOLE_ENTRIES) {
       this.consoleLogs.set(artifactId, combined.slice(-MAX_CONSOLE_ENTRIES));
     } else {
@@ -748,10 +988,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
   }
 
-  /**
-   * Store Sandpack error state from the browser frontend.
-   * Called when useSandpack() reports an error change in the iframe.
-   */
   setSandpackError(artifactId: string, error: SandpackError | null, status?: string): void {
     this.sandpackErrors.set(artifactId, error);
     if (status !== undefined) {
@@ -759,12 +995,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
   }
 
-  /**
-   * Get artifact status (build + console logs + Sandpack state) for agent debugging.
-   *
-   * build_status reflects the worst state: if Sandpack reports an error,
-   * it overrides the file-validation status even if files are structurally valid.
-   */
   async getStatus(artifactId: string): Promise<ArtifactStatus> {
     const artifact = await this.artifactRepo.findById(artifactId);
     if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
@@ -772,13 +1002,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const sandpackError = this.sandpackErrors.get(artifactId) ?? null;
     const sandpackStatus = this.sandpackStatuses.get(artifactId);
 
-    // Override build_status if Sandpack reports an error
     let buildStatus = artifact.build_status;
     let buildErrors = artifact.build_errors;
 
     if (sandpackError) {
       buildStatus = 'error';
-      // Merge Sandpack error into build_errors so agents see it in one place
       const sandpackMsg = `[Sandpack] ${sandpackError.message}`;
       buildErrors = [...(buildErrors ?? []), sandpackMsg];
     }
@@ -794,15 +1022,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     };
   }
 
-  /**
-   * Delete artifact: remove board object and DB record.
-   * No filesystem cleanup — files aren't ours to manage.
-   */
   async deleteArtifact(artifactId: string): Promise<void> {
     const artifact = await this.artifactRepo.findById(artifactId);
     if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
 
-    // Remove board object reference
     const objectId = `artifact-${artifactId}`;
     try {
       const updatedBoard = await this.boardRepo.removeBoardObject(artifact.board_id, objectId);
@@ -810,31 +1033,20 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         this.app.service('boards').emit('patched', updatedBoard);
       }
     } catch {
-      // Board object may not exist or board may be deleted
+      // Board object may not exist or board may be deleted.
     }
 
-    // Clear in-memory state
     this.consoleLogs.delete(artifactId);
     this.sandpackErrors.delete(artifactId);
     this.sandpackStatuses.delete(artifactId);
 
-    // Delete DB record
     await this.artifactRepo.delete(artifactId);
   }
 
-  /**
-   * Find artifacts by board ID with visibility filtering.
-   * Always enforces visibility: public artifacts + private artifacts owned by userId.
-   * Anonymous callers (no userId) see only public artifacts.
-   */
   async findByBoardId(boardId: BoardID, userId?: string): Promise<Artifact[]> {
     return this.artifactRepo.findByBoardId(boardId, { userId: userId ?? '__anonymous__' });
   }
 
-  /**
-   * Find all visible artifacts (across boards) for a user.
-   * Anonymous callers see only public artifacts.
-   */
   async findVisible(userId?: string, options?: { limit?: number }): Promise<Artifact[]> {
     return this.artifactRepo.findVisible(userId ?? '__anonymous__', { limit: options?.limit });
   }
@@ -842,20 +1054,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   // ── Private helpers ──
 
   /**
-   * Validate that a publish folder path is inside an allowed root directory.
-   * Allowed roots: any registered worktree path, /tmp, /var/tmp.
-   * Prevents reading arbitrary filesystem paths through the publish API.
+   * Restrict publish folder paths to known-safe roots: any registered
+   * worktree path, or /tmp / /var/tmp.
    */
   private async validatePublishPath(folderPath: string): Promise<void> {
     const resolved = path.resolve(folderPath);
 
-    // Allow temp directories
     const allowedTempRoots = ['/tmp', '/var/tmp'];
     for (const root of allowedTempRoots) {
       if (resolved.startsWith(root + path.sep) || resolved === root) return;
     }
 
-    // Allow any registered worktree path
     const worktrees = await this.worktreeRepo.findAll();
     for (const wt of worktrees) {
       const wtPath = path.resolve(wt.path);
@@ -867,9 +1076,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     );
   }
 
-  /**
-   * Validate files: check that source files exist and are non-empty
-   */
   private validateFiles(files: Record<string, string>): {
     status: ArtifactBuildStatus;
     errors: string[];
@@ -893,169 +1099,27 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     return { status: errors.length > 0 ? 'error' : 'success', errors };
   }
 
-  /**
-   * Render an agor.config.js Handlebars template with user-specific context.
-   * Returns the rendered string and a list of user.env.* vars that are missing.
-   */
-  private async renderAgorConfig(
-    rawTemplate: string,
-    artifact: Artifact,
-    userId?: UserID
-  ): Promise<{ rendered: string; missingEnvVars: string[] }> {
-    // Extract all user.env.* references from the template AST
-    const requiredEnvVars = this.extractUserEnvPaths(rawTemplate);
-
-    // Build template context. Use the canonical base URL resolver so the
-    // proxy URLs surfaced to artifacts (`agor.proxies.<vendor>.url`) match
-    // what `agor_proxies_list` returns and respect AGOR_BASE_URL /
-    // daemon.base_url overrides for deployed instances.
-    //
-    // Take the .origin only (scheme + host + port) — the proxy mount lives
-    // at /proxies/<vendor> on the daemon root, NOT under whatever path the
-    // configured base URL points at (e.g. AGOR_BASE_URL=https://host/ui
-    // would otherwise produce https://host/ui/proxies/<vendor>, which hits
-    // the SPA shell instead of the proxy). Mirrors mcp/tools/proxies.ts.
-    const daemonUrl = await getBaseUrl();
-    const daemonOrigin = new URL(daemonUrl).origin;
-
-    // Resolve board slug for template context
-    const board = await this.boardRepo.findById(artifact.board_id);
-
-    // Resolve configured HTTP proxies so artifacts can reference
-    // {{ agor.proxies.<vendor>.url }} without hardcoding the daemon host.
-    // Failure here must not break artifact rendering — fall back to an empty
-    // map so missing-proxy lookups render as "" the same way missing env
-    // vars do.
-    const proxiesContext: Record<
-      string,
-      { url: string; upstream: string; allowed_methods: string[] }
-    > = {};
+  private extractDependenciesFromPackageJson(
+    files: Record<string, string>
+  ): Record<string, string> | undefined {
+    const pkg = files['/package.json'] ?? files['package.json'];
+    if (!pkg) return undefined;
     try {
-      const config = await loadConfig();
-      const proxies = resolveProxies(config);
-      for (const p of proxies) {
-        proxiesContext[p.vendor] = {
-          url: `${daemonOrigin}/proxies/${p.vendor}`,
-          upstream: p.upstream,
-          allowed_methods: [...p.allowed_methods],
-        };
-      }
-    } catch (err) {
-      console.warn('[artifacts] failed to resolve proxies for template context:', err);
-    }
-
-    // Mint a short-lived daemon JWT for the viewing user so artifacts can
-    // authenticate to the daemon's own routes (notably `/proxies/<vendor>`).
-    // Shape matches the regular access token issued at login — `sub`,
-    // `type:'access'`, `iss:'agor'`, `aud:'https://agor.dev'` — so the same
-    // verification path accepts it. 15-minute TTL is intentional: the
-    // payload is re-rendered on every viewer load, so a fresh token is
-    // always within reach. No new token type/scope is introduced —
-    // exposing this is the same trust decision as exposing
-    // `{{ user.env.SHORTCUT_API_TOKEN }}` (rendered into artifact JS, never
-    // enters LLM context, scoped to the viewing user only).
-    let agorToken = '';
-    if (userId) {
-      const authConfig = this.app.get('authentication') as { secret?: string } | undefined;
-      const jwtSecret = authConfig?.secret;
-      if (jwtSecret) {
-        agorToken = jwt.sign({ sub: userId, type: 'access' }, jwtSecret, {
-          expiresIn: '15m',
-          issuer: 'agor',
-          audience: 'https://agor.dev',
-        });
-      } else {
-        console.warn('[artifacts] no auth.secret set — {{ agor.token }} will render empty');
-      }
-    }
-
-    const context: Record<string, unknown> = {
-      artifact: { id: artifact.artifact_id, boardId: artifact.board_id },
-      agor: { apiUrl: daemonUrl, proxies: proxiesContext, token: agorToken },
-      board: { id: artifact.board_id, slug: board?.slug ?? '' },
-    };
-
-    let missingEnvVars: string[] = requiredEnvVars; // all missing if no user
-
-    if (userId) {
-      try {
-        const usersService = this.app.service('users') as unknown as UsersService;
-        const [envVars, user] = await Promise.all([
-          usersService.getEnvironmentVariables(userId),
-          usersService.get(userId),
-        ]);
-        context.user = { id: userId, name: user.name ?? '', email: user.email, env: envVars };
-        missingEnvVars = requiredEnvVars.filter((v) => !envVars[v]);
-      } catch (error) {
-        console.error(
-          `Failed to resolve env vars for artifact ${artifact.artifact_id}, user ${userId}:`,
-          error
-        );
-        context.user = { id: userId, env: {} };
-      }
-    }
-
-    // Render template using shared core helper (missing values become "").
-    // renderTemplate returns "" on render error (default onError behavior);
-    // fall back to the raw template so the user sees something rather than
-    // a silently-empty artifact body.
-    const rendered = renderTemplate(rawTemplate, context);
-    return { rendered: rendered || rawTemplate, missingEnvVars };
-  }
-
-  /**
-   * Parse a Handlebars template and extract all user.env.* variable names.
-   * Performs a full AST traversal to catch references in any position
-   * (mustache statements, block params, subexpressions, helpers, etc.).
-   */
-  private extractUserEnvPaths(templateString: string): string[] {
-    try {
-      const ast = Handlebars.parse(templateString);
-      const paths: string[] = [];
-
-      function collectPathExpression(node: Record<string, unknown>): void {
-        if (node.type === 'PathExpression' && typeof node.original === 'string') {
-          if (node.original.startsWith('user.env.')) {
-            paths.push(node.original.replace('user.env.', ''));
-          }
-        }
-      }
-
-      function walk(node: unknown): void {
-        if (!node || typeof node !== 'object') return;
-        const n = node as Record<string, unknown>;
-
-        // Check this node itself for PathExpression
-        collectPathExpression(n);
-
-        // Traverse all known AST child properties
-        for (const key of ['body', 'params', 'hash', 'pairs']) {
-          const child = n[key];
-          if (Array.isArray(child)) child.forEach(walk);
-        }
-        for (const key of ['path', 'program', 'inverse', 'value']) {
-          if (n[key] && typeof n[key] === 'object') walk(n[key]);
-        }
-      }
-
-      walk(ast);
-      return [...new Set(paths)];
+      const parsed = JSON.parse(pkg) as { dependencies?: Record<string, string> };
+      return parsed.dependencies && Object.keys(parsed.dependencies).length > 0
+        ? parsed.dependencies
+        : undefined;
     } catch {
-      return [];
+      return undefined;
     }
   }
 
-  /**
-   * Compute content hash from in-memory file map
-   */
   private computeHashFromFiles(files: Record<string, string>): string {
     const hash = createHash('md5');
     const sortedKeys = Object.keys(files).sort();
-
     for (const key of sortedKeys) {
       hash.update(`${key}:${files[key]}`);
     }
-
     return hash.digest('hex');
   }
 
@@ -1066,16 +1130,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry.name);
-
-      // Skip symlinks to prevent escape outside artifact directory
       if (entry.isSymbolicLink()) continue;
-
-      // Verify resolved path stays within root directory
       const resolved = path.resolve(fullPath);
       if (!resolved.startsWith(path.resolve(root) + path.sep) && resolved !== path.resolve(root)) {
         continue;
       }
-
       if (entry.isDirectory()) {
         if (entry.name !== 'node_modules' && entry.name !== '.git') {
           files.push(...this.getFileList(fullPath, root));
@@ -1094,15 +1153,109 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     for (const file of fileList) {
       const relativePath = path.relative(rootDir, file);
-      // Skip sandpack.json (it's the manifest, not a source file)
-      if (relativePath === 'sandpack.json') continue;
-      // Use forward slashes and prefix with /
+      // The `agor.artifact.json` sidecar is land()'s round-trip carrier for
+      // metadata that doesn't fit in the file map. publish() consumes it
+      // separately (callers pass the parsed values via the publish args).
+      // Either way it doesn't belong in the served file map.
+      if (relativePath === 'agor.artifact.json') continue;
+      // Skip the synthesized .env so a round-trip via land() → publish()
+      // doesn't accidentally bake the viewer's secrets into the next publish.
+      if (relativePath === '.env') continue;
       const normalizedPath = `/${relativePath.replace(/\\/g, '/')}`;
       files[normalizedPath] = fs.readFileSync(file, 'utf-8');
     }
 
     return files;
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers (testable; no service state)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+export function sanitizeEnvVarNames(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  for (const v of input) {
+    if (typeof v !== 'string') continue;
+    if (!ENV_VAR_NAME_RE.test(v)) continue;
+    seen.add(v);
+  }
+  return [...seen];
+}
+
+export function sanitizeAgorGrants(input: unknown): AgorGrants {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+  const src = input as Record<string, unknown>;
+  const out: AgorGrants = {};
+  for (const key of Object.keys(GRANT_ENV_VAR_NAMES)) {
+    if (src[key] === true) (out as Record<string, unknown>)[key] = true;
+  }
+  if (Array.isArray(src.agor_proxies)) {
+    out.agor_proxies = (src.agor_proxies as unknown[])
+      .filter((v): v is string => typeof v === 'string' && v.length > 0)
+      .map((v) => v.toLowerCase().replace(/[^a-z0-9-_]+/g, ''));
+  }
+  return out;
+}
+
+/** Strip informational grants that don't need consent. */
+export function pickConsentRelevantGrants(grants: AgorGrants): AgorGrants {
+  const out: AgorGrants = { ...grants };
+  // agor_artifact_id and agor_board_id are pure metadata — no consent.
+  delete out.agor_artifact_id;
+  delete out.agor_board_id;
+  return out;
+}
+
+/**
+ * Strict subset check: the existing grant must cover every requested env var
+ * AND every requested non-informational grant.
+ */
+function coversRequest(
+  grant: { env_vars_set: string[]; agor_grants_set: AgorGrants },
+  requiredEnvVars: string[],
+  requestedGrants: AgorGrants
+): boolean {
+  const env = new Set(grant.env_vars_set);
+  for (const v of requiredEnvVars) {
+    if (!env.has(v)) return false;
+  }
+  if (!grantsAreSubset(requestedGrants, grant.agor_grants_set)) return false;
+  // agor_token specifically must already be in the existing grant if requested.
+  for (const k of ARTIFACT_SCOPED_ONLY_GRANT_KEYS) {
+    if (
+      (requestedGrants as Record<string, unknown>)[k] === true &&
+      (grant.agor_grants_set as Record<string, unknown>)[k] !== true
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function grantsAreSubset(needs: AgorGrants, has: AgorGrants): boolean {
+  for (const key of Object.keys(GRANT_ENV_VAR_NAMES) as (keyof typeof GRANT_ENV_VAR_NAMES)[]) {
+    if ((needs as Record<string, unknown>)[key] && !(has as Record<string, unknown>)[key]) {
+      return false;
+    }
+  }
+  if (needs.agor_proxies && needs.agor_proxies.length > 0) {
+    const hasSet = new Set(has.agor_proxies ?? []);
+    for (const v of needs.agor_proxies) {
+      if (!hasSet.has(v)) return false;
+    }
+  }
+  return true;
+}
+
+/** Escape a `.env` value: quote, escape backslashes/quotes/newlines. */
+function escapeEnvValue(value: string): string {
+  if (!value) return '';
+  // Always quote — covers spaces, `#`, `=` in the value, etc.
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
 }
 
 export function createArtifactsService(db: Database, app: Application): ArtifactsService {

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -1456,6 +1456,24 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     // Broadcast on the artifacts service. The client filters: only respond
     // if currently viewing this artifact AND logged in as the requester.
+    // The diagnostic log is best-effort — `channel`/`listenerCount` aren't
+    // present on the fake app used in tests, so we tolerate either missing.
+    const svc = this.app.service('artifacts') as unknown as {
+      listenerCount?: (e: string) => number;
+    };
+    const appWithChannel = this.app as unknown as {
+      channel?: (name: string) => { length: number };
+    };
+    const listenerCount =
+      typeof svc.listenerCount === 'function' ? svc.listenerCount('agor-query') : 'n/a';
+    const authChannelSize =
+      typeof appWithChannel.channel === 'function'
+        ? appWithChannel.channel('authenticated').length
+        : 'n/a';
+    console.log(
+      `[agor-query] emit requestId=${requestId} artifactId=${input.artifactId.slice(0, 8)} kind=${input.kind} ` +
+        `listenerCount=${listenerCount} authenticatedChannelSize=${authChannelSize}`
+    );
     this.app.service('artifacts').emit('agor-query', {
       request_id: requestId,
       artifact_id: input.artifactId,

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -46,13 +46,16 @@ import type {
   SandpackError,
   SandpackTemplate,
   UserID,
+  UserRole,
   WorktreeID,
 } from '@agor/core/types';
 import {
   ARTIFACT_SCOPED_ONLY_GRANT_KEYS,
   GRANT_ENV_VAR_NAMES,
+  hasMinimumRole,
   NO_CONSENT_GRANT_KEYS,
   proxyGrantEnvName,
+  ROLES,
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { DrizzleService } from '../adapters/drizzle.js';
@@ -165,13 +168,22 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   /** Held for `resolveUserEnvironment` (scope-aware env-var resolution). */
   private dbRef: Database;
 
-  /** In-memory ring buffer for console logs per artifact */
+  /**
+   * In-memory ring buffer for console logs.
+   *
+   * Keyed by `${artifactId}:${userId}` — NOT just artifactId. After a viewer
+   * grants trust, the daemon injects their secrets into the artifact's
+   * runtime; an artifact that does `console.log(import.meta.env.VITE_X)`
+   * would otherwise leak that secret into a global-per-artifact buffer
+   * readable by anyone via agor_artifacts_status. Per-viewer keying
+   * isolates each viewer's render output.
+   */
   private consoleLogs: Map<string, ArtifactConsoleEntry[]> = new Map();
 
-  /** In-memory Sandpack error state per artifact (from browser iframe) */
+  /** In-memory Sandpack error state, keyed by `${artifactId}:${userId}`. */
   private sandpackErrors: Map<string, SandpackError | null> = new Map();
 
-  /** In-memory Sandpack status per artifact (from browser iframe) */
+  /** In-memory Sandpack status, keyed by `${artifactId}:${userId}`. */
   private sandpackStatuses: Map<string, string> = new Map();
 
   /**
@@ -1043,6 +1055,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     // Server-derive the consent surface from the artifact's current request.
     const artifact = await this.artifactRepo.findById(input.artifactId);
     if (!artifact) throw new Error(`Artifact ${input.artifactId} not found`);
+    if (!this.isVisibleTo(artifact, input.userId)) {
+      // Mirror getPayload's privacy guarantee — don't leak existence of a
+      // private artifact via the trust endpoint.
+      throw new Error(`Artifact ${input.artifactId} not found`);
+    }
     const sanitizedEnv = sanitizeEnvVarNames(artifact.required_env_vars ?? []);
     const sanitizedGrants = sanitizeAgorGrants(artifact.agor_grants ?? {});
 
@@ -1278,29 +1295,66 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     return result;
   }
 
-  appendConsoleLogs(artifactId: string, entries: ArtifactConsoleEntry[]): void {
-    const existing = this.consoleLogs.get(artifactId) ?? [];
+  /** Compose the per-viewer key for the in-memory console/error/status maps. */
+  private viewerKey(artifactId: string, userId: string): string {
+    return `${artifactId}:${userId}`;
+  }
+
+  /** Drop every per-viewer buffer entry for an artifact (called on delete). */
+  private clearAllViewerBuffersFor(artifactId: string): void {
+    const prefix = `${artifactId}:`;
+    for (const key of this.consoleLogs.keys()) {
+      if (key.startsWith(prefix)) this.consoleLogs.delete(key);
+    }
+    for (const key of this.sandpackErrors.keys()) {
+      if (key.startsWith(prefix)) this.sandpackErrors.delete(key);
+    }
+    for (const key of this.sandpackStatuses.keys()) {
+      if (key.startsWith(prefix)) this.sandpackStatuses.delete(key);
+    }
+  }
+
+  appendConsoleLogs(artifactId: string, userId: string, entries: ArtifactConsoleEntry[]): void {
+    const key = this.viewerKey(artifactId, userId);
+    const existing = this.consoleLogs.get(key) ?? [];
     const combined = [...existing, ...entries];
     if (combined.length > MAX_CONSOLE_ENTRIES) {
-      this.consoleLogs.set(artifactId, combined.slice(-MAX_CONSOLE_ENTRIES));
+      this.consoleLogs.set(key, combined.slice(-MAX_CONSOLE_ENTRIES));
     } else {
-      this.consoleLogs.set(artifactId, combined);
+      this.consoleLogs.set(key, combined);
     }
   }
 
-  setSandpackError(artifactId: string, error: SandpackError | null, status?: string): void {
-    this.sandpackErrors.set(artifactId, error);
+  setSandpackError(
+    artifactId: string,
+    userId: string,
+    error: SandpackError | null,
+    status?: string
+  ): void {
+    const key = this.viewerKey(artifactId, userId);
+    this.sandpackErrors.set(key, error);
     if (status !== undefined) {
-      this.sandpackStatuses.set(artifactId, status);
+      this.sandpackStatuses.set(key, status);
     }
   }
 
-  async getStatus(artifactId: string): Promise<ArtifactStatus> {
+  /**
+   * Returns the artifact's runtime status — visibility-checked. The console
+   * logs and Sandpack-error fields are scoped to the calling user's render
+   * (see `viewerKey`); other viewers' captured output is never returned.
+   */
+  async getStatus(artifactId: string, userId?: UserID): Promise<ArtifactStatus> {
     const artifact = await this.artifactRepo.findById(artifactId);
     if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
+    if (!this.isVisibleTo(artifact, userId)) {
+      // Don't leak existence of private artifacts.
+      throw new Error(`Artifact ${artifactId} not found`);
+    }
 
-    const sandpackError = this.sandpackErrors.get(artifactId) ?? null;
-    const sandpackStatus = this.sandpackStatuses.get(artifactId);
+    const key = userId ? this.viewerKey(artifactId, userId) : null;
+    const sandpackError = key ? (this.sandpackErrors.get(key) ?? null) : null;
+    const sandpackStatus = key ? this.sandpackStatuses.get(key) : undefined;
+    const consoleLogs = key ? (this.consoleLogs.get(key) ?? []) : [];
 
     let buildStatus = artifact.build_status;
     let buildErrors = artifact.build_errors;
@@ -1317,14 +1371,27 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       build_errors: buildErrors ?? [],
       sandpack_error: sandpackError,
       sandpack_status: sandpackStatus,
-      console_logs: this.consoleLogs.get(artifactId) ?? [],
+      console_logs: consoleLogs,
       content_hash: artifact.content_hash,
     };
   }
 
-  async deleteArtifact(artifactId: string): Promise<void> {
+  /**
+   * Delete an artifact, its board placement, and its in-memory buffers.
+   * Owner-or-admin only — agent-facing tools must pass `userId` and the
+   * caller's role. The Feathers REST hook chain enforces the same rule for
+   * direct PATCH/REMOVE; this method is what the MCP tool calls and used
+   * to be unchecked.
+   */
+  async deleteArtifact(artifactId: string, userId?: string, userRole?: UserRole): Promise<void> {
     const artifact = await this.artifactRepo.findById(artifactId);
     if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
+
+    const isOwner = !!userId && artifact.created_by === userId;
+    const isAdmin = !!userRole && hasMinimumRole(userRole, ROLES.ADMIN);
+    if (!isOwner && !isAdmin) {
+      throw new Error("Forbidden: only the artifact's creator or an admin may delete it");
+    }
 
     const objectId = `artifact-${artifactId}`;
     try {
@@ -1336,10 +1403,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // Board object may not exist or board may be deleted.
     }
 
-    this.consoleLogs.delete(artifactId);
-    this.sandpackErrors.delete(artifactId);
-    this.sandpackStatuses.delete(artifactId);
-
+    this.clearAllViewerBuffersFor(artifactId);
     await this.artifactRepo.delete(artifactId);
   }
 

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -90,6 +90,22 @@ async function canonicalizeExistingPrefix(target: string): Promise<string> {
 }
 
 /**
+ * Compute a relative ES-module specifier from `fromFile` to `toFile`. Both
+ * are root-absolute paths in the served file map (e.g. `/src/index.js`,
+ * `/agor-runtime.js`). Returns the kind of specifier Sandpack's bundler
+ * resolves reliably across templates: `./agor-runtime.js` when the two
+ * are siblings, `../agor-runtime.js` when the target is one or more
+ * levels up.
+ */
+function relativeImportSpecifier(fromFile: string, toFile: string): string {
+  const fromDir = path.posix.dirname(fromFile);
+  const targetPath = toFile.startsWith('/') ? toFile : `/${toFile}`;
+  let rel = path.posix.relative(fromDir, targetPath);
+  if (!rel.startsWith('.')) rel = `./${rel}`;
+  return rel;
+}
+
+/**
  * Pick which file to prepend the `import './agor-runtime.js';` line into.
  *
  * Priority: artifact's recorded `entry` column → `customSetup.entry` from
@@ -480,9 +496,13 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         build_errors: buildResult.errors.length > 0 ? buildResult.errors : undefined,
       });
 
-      // Stale Sandpack state — new content will produce fresh state from the browser.
-      this.sandpackErrors.delete(existing.artifact_id);
-      this.sandpackStatuses.delete(existing.artifact_id);
+      // Stale Sandpack state — new content will produce fresh state from
+      // the browser. Use the helper to clear ALL per-viewer entries; bare
+      // `delete(artifact_id)` no longer matches the keys (which are now
+      // `${artifactId}:${userId}` after the per-viewer console isolation
+      // fix), so without this every viewer kept their stale error/status
+      // across republishes.
+      this.clearAllViewerBuffersFor(existing.artifact_id);
 
       this.app.service('artifacts').emit('patched', updated);
       return updated;
@@ -878,10 +898,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // Prepend an import to the entry file so the runtime registers its
       // message listener before user code starts emitting events. We modify
       // the served file map only — the persisted entry is untouched.
+      //
+      // Use a relative specifier rather than the root-absolute
+      // `/agor-runtime.js`. Sandpack's bundler resolves relative imports
+      // reliably across templates; root-absolute paths work in some
+      // bundler configurations and fail in others (e.g. Parcel-based
+      // templates resolve them against a different root).
       const entryPath = pickEntryForRuntimeInjection(filesOut, artifact);
       if (entryPath) {
         const original = filesOut[entryPath] ?? '';
-        filesOut[entryPath] = `import '${AGOR_RUNTIME_PATH}';\n${original}`;
+        const importSpec = relativeImportSpecifier(entryPath, AGOR_RUNTIME_PATH);
+        filesOut[entryPath] = `import '${importSpec}';\n${original}`;
       } else {
         // No discoverable entry — drop the runtime file rather than ship
         // it dead weight, and warn loudly so we notice if a template's

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -95,36 +95,40 @@ async function canonicalizeExistingPrefix(target: string): Promise<string> {
  * iframe HTML, so a `data:text/javascript;base64,…` URL avoids any extra
  * HTTP round-trip and any cross-origin coupling. Built once per process —
  * the source is a static constant.
+ *
+ * The `#agor-runtime.js` fragment is necessary because Sandpack's static
+ * client infers content type from the URL's last extension via
+ * `/\.([^.]*)$/` and rejects anything that isn't `.js` or `.css` (see
+ * `@codesandbox/sandpack-client/dist/index-*.mjs` -> `injectExternalResources`).
+ * A bare `data:text/javascript;base64,…` ends in base64 chars, which would
+ * be silently rejected. Browsers strip the fragment when fetching, so the
+ * decoded body runs identically.
  */
 let cachedAgorRuntimeDataUrl: string | null = null;
 function agorRuntimeDataUrl(): string {
   if (cachedAgorRuntimeDataUrl !== null) return cachedAgorRuntimeDataUrl;
   const b64 = Buffer.from(AGOR_RUNTIME_SOURCE, 'utf-8').toString('base64');
-  cachedAgorRuntimeDataUrl = `data:text/javascript;base64,${b64}`;
+  cachedAgorRuntimeDataUrl = `data:text/javascript;base64,${b64}#agor-runtime.js`;
   return cachedAgorRuntimeDataUrl;
 }
 
 /**
- * Return a copy of `cfg` with the agor-runtime data URL prepended to
- * `options.externalResources`. The persisted `sandpack_config` is never
- * mutated — this builds a new object for the served payload only.
+ * Return a copy of `cfg` with the agor-runtime data URL set as the sole
+ * entry in `options.externalResources`. The persisted `sandpack_config`
+ * is never mutated — this builds a new object for the served payload only.
  *
- * Prepending (rather than appending) means the runtime's message listener
- * is registered before any author-supplied external scripts run, so the
- * order is deterministic across artifacts.
+ * `externalResources` is daemon-owned: `sanitizeSandpackConfig` deliberately
+ * strips it on write (XSS into the iframe), so we don't preserve any
+ * author-supplied entries here even though `SandpackConfig` allows the
+ * shape — re-emitting them would re-enable a prop the sanitizer blocked.
  */
 function withInjectedAgorRuntime(cfg: SandpackConfig | undefined): SandpackConfig {
   const dataUrl = agorRuntimeDataUrl();
-  const existingResources = (cfg?.options as Record<string, unknown> | undefined)
-    ?.externalResources;
-  const existingArr = Array.isArray(existingResources)
-    ? (existingResources as unknown[]).filter((v): v is string => typeof v === 'string')
-    : [];
   return {
     ...(cfg ?? {}),
     options: {
       ...(cfg?.options ?? {}),
-      externalResources: [dataUrl, ...existingArr],
+      externalResources: [dataUrl],
     },
   };
 }

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -17,7 +17,13 @@ import * as fs from 'node:fs';
 import { mkdir, realpath, rm, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { generateId } from '@agor/core';
-import { getBaseUrl, loadConfig, PAGINATION, resolveProxies } from '@agor/core/config';
+import {
+  getBaseUrl,
+  loadConfig,
+  PAGINATION,
+  resolveProxies,
+  resolveUserEnvironment,
+} from '@agor/core/config';
 import {
   ArtifactRepository,
   ArtifactTrustGrantRepository,
@@ -45,6 +51,7 @@ import type {
 import {
   ARTIFACT_SCOPED_ONLY_GRANT_KEYS,
   GRANT_ENV_VAR_NAMES,
+  NO_CONSENT_GRANT_KEYS,
   proxyGrantEnvName,
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
@@ -77,6 +84,67 @@ async function canonicalizeExistingPrefix(target: string): Promise<string> {
   return target;
 }
 
+/**
+ * Build the default `.agor/artifacts/<folder>` name used when `land()` is
+ * called without a custom subpath. Combines a slugified artifact name with
+ * the first 8 chars of the UUID — readable AND collision-resistant — so the
+ * folder is easy to navigate while still uniquely identifying the artifact.
+ */
+function defaultLandFolderName(artifact: { name: string; artifact_id: string }): string {
+  const slug = artifact.name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  const shortId = artifact.artifact_id.replace(/-/g, '').slice(0, 8);
+  return slug.length > 0 ? `${slug}-${shortId}` : artifact.artifact_id;
+}
+
+/**
+ * Round-trip sidecar shape written by `land()` and read back by `publish()`.
+ * Carries metadata that doesn't fit into the file map (template, sandpack
+ * config, declarative consent surface).
+ */
+interface ArtifactSidecar {
+  template?: SandpackTemplate;
+  sandpack_config?: SandpackConfig;
+  required_env_vars?: string[];
+  agor_grants?: AgorGrants;
+}
+
+/**
+ * Read `agor.artifact.json` from a folder if present. Returns null when the
+ * file is missing or unparseable — the caller treats absence and corruption
+ * the same way (fall through to other defaults).
+ */
+function readArtifactSidecar(folderPath: string): ArtifactSidecar | null {
+  const sidecarPath = path.join(folderPath, 'agor.artifact.json');
+  if (!fs.existsSync(sidecarPath)) return null;
+  try {
+    const raw = fs.readFileSync(sidecarPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<ArtifactSidecar>;
+    return {
+      template:
+        typeof parsed.template === 'string' ? (parsed.template as SandpackTemplate) : undefined,
+      sandpack_config:
+        parsed.sandpack_config && typeof parsed.sandpack_config === 'object'
+          ? (parsed.sandpack_config as SandpackConfig)
+          : undefined,
+      required_env_vars: Array.isArray(parsed.required_env_vars)
+        ? parsed.required_env_vars
+        : undefined,
+      agor_grants:
+        parsed.agor_grants && typeof parsed.agor_grants === 'object'
+          ? (parsed.agor_grants as AgorGrants)
+          : undefined,
+    };
+  } catch (err) {
+    console.warn(`[artifacts] Failed to parse agor.artifact.json in ${folderPath}:`, err);
+    return null;
+  }
+}
+
 export type ArtifactParams = QueryParams<{
   board_id?: BoardID;
   worktree_id?: WorktreeID;
@@ -94,6 +162,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   private worktreeRepo: WorktreeRepository;
   private boardRepo: BoardRepository;
   private app: Application;
+  /** Held for `resolveUserEnvironment` (scope-aware env-var resolution). */
+  private dbRef: Database;
 
   /** In-memory ring buffer for console logs per artifact */
   private consoleLogs: Map<string, ArtifactConsoleEntry[]> = new Map();
@@ -125,6 +195,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     this.worktreeRepo = new WorktreeRepository(db);
     this.boardRepo = new BoardRepository(db);
     this.app = app;
+    this.dbRef = db;
   }
 
   // Direct Feathers create is intentionally rejected — artifacts require
@@ -204,8 +275,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   async publish(
     data: {
       folderPath: string;
-      board_id: string;
-      name: string;
+      board_id?: string;
+      name?: string;
       artifact_id?: string;
       template?: SandpackTemplate;
       public?: boolean;
@@ -220,45 +291,81 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     userId?: string
   ): Promise<Artifact> {
     const folderPath = path.resolve(data.folderPath);
-    const isPublic = data.public ?? true;
 
     // Path containment: only allow reading from worktree paths or temp dirs.
-    await this.validatePublishPath(folderPath);
+    // The matching worktree id (if any) is stored on the row for provenance
+    // + future "list artifacts I published from worktree X" filtering.
+    const matchedWorktreeId = await this.validatePublishPath(folderPath);
 
     if (!fs.existsSync(folderPath)) {
       throw new Error(`Folder not found: ${folderPath}`);
     }
 
-    const files = this.readFilesRecursive(folderPath, folderPath);
+    // Round-trip metadata: read agor.artifact.json (written by land()). Acts
+    // as a fallback for fields the caller didn't supply explicitly.
+    const sidecar = readArtifactSidecar(folderPath);
 
-    // package.json#dependencies is the source of truth; cache it on the row
-    // for cheap list/list-friendly reads.
-    const cachedDeps = this.extractDependenciesFromPackageJson(files);
-    const sandpackConfig = sanitizeSandpackConfig(data.sandpack_config);
-    const template = (data.template ?? sandpackConfig.template ?? 'react') as SandpackTemplate;
-    if (!sandpackConfig.template) sandpackConfig.template = template;
-    const cachedEntry = sandpackConfig.customSetup?.entry;
-    const requiredEnvVars = sanitizeEnvVarNames(data.required_env_vars);
-    const agorGrants = sanitizeAgorGrants(data.agor_grants);
-
-    const contentHash = this.computeHashFromFiles(files);
-
+    // For updates, load the existing row up-front so it can serve as the
+    // bottom of the fallback chain (data > sidecar > existing > default).
+    let existing: Artifact | null = null;
     if (data.artifact_id) {
-      const existing = await this.artifactRepo.findById(data.artifact_id);
+      existing = await this.artifactRepo.findById(data.artifact_id);
       if (!existing) throw new Error(`Artifact ${data.artifact_id} not found`);
       if (userId && existing.created_by && existing.created_by !== userId) {
         throw new Error('Cannot update artifact: not the owner');
       }
+    }
 
+    const files = this.readFilesRecursive(folderPath, folderPath);
+
+    // Resolution chain for each field: explicit data > sidecar > existing > default.
+    const resolvedSandpackConfig = sanitizeSandpackConfig(
+      data.sandpack_config ?? sidecar?.sandpack_config ?? existing?.sandpack_config
+    );
+    const template = (data.template ??
+      resolvedSandpackConfig.template ??
+      sidecar?.template ??
+      existing?.template ??
+      'react') as SandpackTemplate;
+    if (!resolvedSandpackConfig.template) resolvedSandpackConfig.template = template;
+    const requiredEnvVars = sanitizeEnvVarNames(
+      data.required_env_vars ?? sidecar?.required_env_vars ?? existing?.required_env_vars
+    );
+    const agorGrants = sanitizeAgorGrants(
+      data.agor_grants ?? sidecar?.agor_grants ?? existing?.agor_grants
+    );
+
+    // Name and board are required on create; on update they default to the
+    // existing row so a routine republish doesn't have to know them.
+    const resolvedName = data.name ?? existing?.name;
+    if (!resolvedName) {
+      throw new Error('name is required when creating a new artifact');
+    }
+    const resolvedBoardId = (data.board_id ?? existing?.board_id) as BoardID | undefined;
+    if (!resolvedBoardId) {
+      throw new Error('boardId is required when creating a new artifact');
+    }
+
+    const isPublic = data.public ?? existing?.public ?? true;
+
+    // package.json#dependencies is the source of truth; cache it on the row
+    // for cheap list-friendly reads.
+    const cachedDeps = this.extractDependenciesFromPackageJson(files);
+    const cachedEntry = resolvedSandpackConfig.customSetup?.entry;
+
+    const contentHash = this.computeHashFromFiles(files);
+
+    if (existing) {
       const buildResult = this.validateFiles(files);
 
-      const updated = await this.artifactRepo.update(data.artifact_id, {
-        name: data.name,
+      const updated = await this.artifactRepo.update(existing.artifact_id, {
+        name: resolvedName,
+        worktree_id: matchedWorktreeId ?? existing.worktree_id ?? null,
         files,
         dependencies: cachedDeps,
         entry: cachedEntry,
         template,
-        sandpack_config: sandpackConfig,
+        sandpack_config: resolvedSandpackConfig,
         required_env_vars: requiredEnvVars,
         agor_grants: agorGrants,
         content_hash: contentHash,
@@ -268,8 +375,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       });
 
       // Stale Sandpack state — new content will produce fresh state from the browser.
-      this.sandpackErrors.delete(data.artifact_id);
-      this.sandpackStatuses.delete(data.artifact_id);
+      this.sandpackErrors.delete(existing.artifact_id);
+      this.sandpackStatuses.delete(existing.artifact_id);
 
       this.app.service('artifacts').emit('patched', updated);
       return updated;
@@ -280,14 +387,15 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     const artifact = await this.artifactRepo.create({
       artifact_id: artifactId,
-      board_id: data.board_id as BoardID,
-      name: data.name,
+      board_id: resolvedBoardId,
+      worktree_id: matchedWorktreeId,
+      name: resolvedName,
       path: folderPath,
       template,
       files,
       dependencies: cachedDeps,
       entry: cachedEntry,
-      sandpack_config: sandpackConfig,
+      sandpack_config: resolvedSandpackConfig,
       required_env_vars: requiredEnvVars,
       agor_grants: agorGrants,
       content_hash: contentHash,
@@ -299,7 +407,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     const objectId = `artifact-${artifactId}`;
     try {
-      const updatedBoard = await this.boardRepo.upsertBoardObject(data.board_id, objectId, {
+      const updatedBoard = await this.boardRepo.upsertBoardObject(resolvedBoardId, objectId, {
         type: 'artifact',
         artifact_id: artifactId,
         x: data.x ?? 0,
@@ -494,7 +602,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const rawSubpath =
       options?.subpath && options.subpath.trim().length > 0
         ? options.subpath
-        : path.join('.agor', 'artifacts', artifact.artifact_id);
+        : path.join('.agor', 'artifacts', defaultLandFolderName(artifact));
 
     if (path.isAbsolute(rawSubpath)) {
       throw new Error(`subpath must be relative to the worktree root: ${rawSubpath}`);
@@ -553,17 +661,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     // a normal file tree (template, sandpack_config, required_env_vars,
     // agor_grants). publish() reads agor.artifact.json back if present;
     // ordinary builds/Vite/CRA never look at it.
-    const sidecar: Record<string, unknown> = {
+    //
+    // Always emit every field — even when empty — so the sidecar is
+    // self-documenting: an agent reading it knows the artifact's full
+    // declarative contract without inferring from absence.
+    const sidecar = {
       $schema: 'https://agor.live/schemas/artifact/2026-05-09.json',
       template: artifact.template,
+      sandpack_config: artifact.sandpack_config ?? {},
+      required_env_vars: artifact.required_env_vars ?? [],
+      agor_grants: artifact.agor_grants ?? {},
     };
-    if (artifact.sandpack_config) sidecar.sandpack_config = artifact.sandpack_config;
-    if (artifact.required_env_vars && artifact.required_env_vars.length > 0) {
-      sidecar.required_env_vars = artifact.required_env_vars;
-    }
-    if (artifact.agor_grants && Object.keys(artifact.agor_grants).length > 0) {
-      sidecar.agor_grants = artifact.agor_grants;
-    }
     const sidecarJson = `${JSON.stringify(sidecar, null, 2)}\n`;
     await writeFile(path.join(destination, 'agor.artifact.json'), sidecarJson, 'utf-8');
     bytesWritten += Buffer.byteLength(sidecarJson, 'utf-8');
@@ -599,8 +707,12 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const grants = artifact.agor_grants ?? {};
     const consentRelevantGrants = pickConsentRelevantGrants(grants);
 
+    // "Needs consent" gates the trust prompt. "Has injectables" gates the
+    // .env synthesis — no-consent grants (artifact_id, board_id) still want
+    // values written even when the artifact is otherwise untrusted.
     const needsConsent =
       requiredEnvVars.length > 0 || Object.keys(consentRelevantGrants).length > 0;
+    const hasInjectables = requiredEnvVars.length > 0 || Object.keys(grants).length > 0;
 
     let trustState: ArtifactPayload['trust_state'] = 'no_secrets_needed';
     let trustScope: ArtifactPayload['trust_scope'] | undefined;
@@ -620,7 +732,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       }
     }
 
-    if (needsConsent) {
+    if (hasInjectables) {
       const envFile = await this.synthesizeEnvFile({
         template: artifact.template,
         requiredEnvVars,
@@ -628,11 +740,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         grants,
         artifact,
         userId,
-        injectGrants: trustState === 'self' || trustState === 'trusted',
+        injectConsentGated: trustState === 'self' || trustState === 'trusted',
       });
-      // Only emit a .env if we have something meaningful to put in it OR if
+      // Only emit a .env if we have something meaningful to put in it AND
       // the artifact's bundler can read it. For vanilla/static templates the
-      // file is irrelevant.
+      // file is irrelevant (synthesizeEnvFile returns null).
       if (envFile !== null) filesOut[SYNTHESIZED_ENV_PATH] = envFile;
     }
 
@@ -735,6 +847,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   /**
    * Build the synthesized `.env` body. Returns null for templates without a
    * dotenv path (vanilla/static), in which case nothing is injected.
+   *
+   * Injection rules:
+   *   - `requiredEnvVars`: emitted with the consented value when trusted,
+   *     empty string otherwise.
+   *   - No-consent grants (artifact_id, board_id): always emitted with their
+   *     real values regardless of trust state — they are pure metadata.
+   *   - Consent-gated grants (agor_token, agor_api_url, agor_user_email,
+   *     agor_proxies): emitted with real values when trusted, empty when not.
+   *     Empty keys are still emitted so the artifact can detect "untrusted"
+   *     rather than crash on a ReferenceError.
    */
   private async synthesizeEnvFile(input: {
     template: SandpackTemplate;
@@ -743,11 +865,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     grants: AgorGrants;
     artifact: Artifact;
     userId?: UserID;
-    injectGrants: boolean;
+    injectConsentGated: boolean;
   }): Promise<string | null> {
     const prefix = envVarPrefixForTemplate(input.template);
     if (prefix === null) {
-      // No dotenv path. Warn loudly if the artifact wanted env vars or grants.
       if (input.requiredEnvVars.length > 0 || Object.keys(input.grants).length > 0) {
         console.warn(
           `[artifacts] Artifact ${input.artifact.artifact_id} (template=${input.template}) requests env vars/grants but the template has no dotenv path. Nothing was injected.`
@@ -757,30 +878,45 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
 
     const lines: string[] = [];
+
     for (const name of input.requiredEnvVars) {
       const value = input.envValues[name] ?? '';
       lines.push(`${prefix}${name}=${escapeEnvValue(value)}`);
     }
 
-    if (input.injectGrants) {
-      const injectedGrants = await this.resolveGrantValues({
-        grants: input.grants,
+    // No-consent grants: always inject with real values.
+    const noConsentGrants = pickNoConsentGrants(input.grants);
+    if (Object.keys(noConsentGrants).length > 0) {
+      const noConsentValues = await this.resolveGrantValues({
+        grants: noConsentGrants,
         artifact: input.artifact,
         userId: input.userId,
       });
-      for (const [name, value] of Object.entries(injectedGrants)) {
+      for (const [name, value] of Object.entries(noConsentValues)) {
+        lines.push(`${prefix}${name}=${escapeEnvValue(value)}`);
+      }
+    }
+
+    // Consent-gated grants: real values when trusted, empty otherwise.
+    const consentGated = pickConsentRelevantGrants(input.grants);
+    if (input.injectConsentGated) {
+      const injected = await this.resolveGrantValues({
+        grants: consentGated,
+        artifact: input.artifact,
+        userId: input.userId,
+      });
+      for (const [name, value] of Object.entries(injected)) {
         lines.push(`${prefix}${name}=${escapeEnvValue(value)}`);
       }
     } else {
-      // Empty values for grants — keeps the env keys present so the artifact
-      // can detect "untrusted" rather than "ReferenceError on missing key".
       for (const [grantName, fixedEnvName] of Object.entries(GRANT_ENV_VAR_NAMES)) {
-        if ((input.grants as Record<string, unknown>)[grantName]) {
+        if (NO_CONSENT_GRANT_KEYS.includes(grantName as never)) continue;
+        if ((consentGated as Record<string, unknown>)[grantName]) {
           lines.push(`${prefix}${fixedEnvName}=`);
         }
       }
-      if (input.grants.agor_proxies) {
-        for (const vendor of input.grants.agor_proxies) {
+      if (consentGated.agor_proxies) {
+        for (const vendor of consentGated.agor_proxies) {
           lines.push(`${prefix}${proxyGrantEnvName(vendor)}=`);
         }
       }
@@ -862,8 +998,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   ): Promise<Record<string, string>> {
     if (!userId || names.length === 0) return {};
     try {
-      const usersService = this.app.service('users') as unknown as UsersService;
-      const all = await usersService.getEnvironmentVariables(userId);
+      // Scope-aware resolution: artifact rendering must NOT receive vars the
+      // user scoped to specific sessions (`scope: 'session'`) — those only
+      // unlock when a matching `sessionId` is passed. With no sessionId here,
+      // session-scoped vars are skipped (see env-resolver.ts:179-183, 220-232).
+      const all = await resolveUserEnvironment(userId, this.dbRef, {});
       const out: Record<string, string> = {};
       for (const n of names) {
         if (all[n] !== undefined) out[n] = all[n];
@@ -878,18 +1017,31 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   // ── Trust grants management (called from REST routes / consent modal) ──
 
   /**
-   * Persist a trust grant for `(viewer, scope_type, scope_value)`. For
-   * `session`-scope grants the value lives in-process only.
+   * Persist a trust grant for `(viewer, scope_type, scope_value)`. The
+   * consent surface (env vars + grants) is derived server-side from the
+   * artifact's CURRENT request — the client never gets to nominate what it
+   * is consenting to. This is intentional: the grant must reflect "what the
+   * server will inject" at the moment of consent, not whatever the client
+   * thinks should be covered. If the artifact later expands its requested
+   * set, the grant becomes insufficient via `coversRequest`'s subset check
+   * and the user is re-prompted.
+   *
+   * `session`-scope grants live in-process only (no DB write).
    */
   async grantTrust(input: {
     userId: string;
     artifactId: string;
     scopeType: ArtifactTrustScopeType;
-    envVars: string[];
-    grants: AgorGrants;
   }): Promise<{ scope: ArtifactTrustScopeType; persisted: boolean }> {
-    const sanitizedEnv = sanitizeEnvVarNames(input.envVars);
-    const sanitizedGrants = sanitizeAgorGrants(input.grants);
+    if (input.scopeType === 'self') {
+      throw new Error("'self' grants are implicit and cannot be persisted");
+    }
+
+    // Server-derive the consent surface from the artifact's current request.
+    const artifact = await this.artifactRepo.findById(input.artifactId);
+    if (!artifact) throw new Error(`Artifact ${input.artifactId} not found`);
+    const sanitizedEnv = sanitizeEnvVarNames(artifact.required_env_vars ?? []);
+    const sanitizedGrants = sanitizeAgorGrants(artifact.agor_grants ?? {});
 
     if (input.scopeType === 'session') {
       const key = `${input.userId}:${input.artifactId}`;
@@ -900,22 +1052,27 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       return { scope: 'session', persisted: false };
     }
 
-    if (input.scopeType === 'self') {
-      throw new Error("'self' grants are implicit and cannot be persisted");
-    }
-
     // Resolve scope_value from artifact when needed.
     let scopeValue: string | null = null;
     if (input.scopeType === 'artifact') {
       scopeValue = input.artifactId;
     } else if (input.scopeType === 'author') {
-      const artifact = await this.artifactRepo.findById(input.artifactId);
-      if (!artifact?.created_by) {
+      if (!artifact.created_by) {
         throw new Error('Cannot grant author-scope trust: artifact has no recorded author');
       }
       scopeValue = artifact.created_by;
     } else if (input.scopeType === 'instance') {
       scopeValue = null;
+      // Instance-wide trust is meaningful only on single-user instances. On
+      // multi-user setups it would mean "trust any artifact published by any
+      // user on this server with my secrets" — too broad. Reject.
+      const config = await loadConfig();
+      const unixMode = config.execution?.unix_user_mode ?? 'simple';
+      if (unixMode !== 'simple') {
+        throw new Error(
+          "'instance'-scope trust grants are disabled when execution.unix_user_mode is not 'simple' (multi-user instance)"
+        );
+      }
     }
 
     // agor_token must be artifact-scoped only.
@@ -1014,7 +1171,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     return {
       artifact_id: artifact.artifact_id,
       build_status: buildStatus,
-      build_errors: buildErrors,
+      build_errors: buildErrors ?? [],
       sandpack_error: sandpackError,
       sandpack_status: sandpackStatus,
       console_logs: this.consoleLogs.get(artifactId) ?? [],
@@ -1055,20 +1212,25 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /**
    * Restrict publish folder paths to known-safe roots: any registered
-   * worktree path, or /tmp / /var/tmp.
+   * worktree path, or /tmp / /var/tmp. Returns the matching worktree's id
+   * when the path is inside a worktree (caller persists this on the
+   * artifact row for provenance + by-worktree filtering); returns null for
+   * temp-dir paths.
    */
-  private async validatePublishPath(folderPath: string): Promise<void> {
+  private async validatePublishPath(folderPath: string): Promise<WorktreeID | null> {
     const resolved = path.resolve(folderPath);
 
     const allowedTempRoots = ['/tmp', '/var/tmp'];
     for (const root of allowedTempRoots) {
-      if (resolved.startsWith(root + path.sep) || resolved === root) return;
+      if (resolved.startsWith(root + path.sep) || resolved === root) return null;
     }
 
     const worktrees = await this.worktreeRepo.findAll();
     for (const wt of worktrees) {
       const wtPath = path.resolve(wt.path);
-      if (resolved.startsWith(wtPath + path.sep) || resolved === wtPath) return;
+      if (resolved.startsWith(wtPath + path.sep) || resolved === wtPath) {
+        return wt.worktree_id as WorktreeID;
+      }
     }
 
     throw new Error(
@@ -1196,7 +1358,9 @@ export function sanitizeAgorGrants(input: unknown): AgorGrants {
   if (Array.isArray(src.agor_proxies)) {
     out.agor_proxies = (src.agor_proxies as unknown[])
       .filter((v): v is string => typeof v === 'string' && v.length > 0)
-      .map((v) => v.toLowerCase().replace(/[^a-z0-9-_]+/g, ''));
+      .map((v) => v.toLowerCase().replace(/[^a-z0-9-_]+/g, ''))
+      // Re-filter post-normalisation: strings like "!!!" reduce to "" above.
+      .filter((v) => v.length > 0);
   }
   return out;
 }
@@ -1207,6 +1371,15 @@ export function pickConsentRelevantGrants(grants: AgorGrants): AgorGrants {
   // agor_artifact_id and agor_board_id are pure metadata — no consent.
   delete out.agor_artifact_id;
   delete out.agor_board_id;
+  return out;
+}
+
+/** Inverse of `pickConsentRelevantGrants`: only the no-consent metadata keys. */
+export function pickNoConsentGrants(grants: AgorGrants): AgorGrants {
+  const out: AgorGrants = {};
+  for (const key of NO_CONSENT_GRANT_KEYS) {
+    if (grants[key]) out[key] = true;
+  }
   return out;
 }
 

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -34,6 +34,7 @@ import {
 import type { Application } from '@agor/core/feathers';
 import type {
   AgorGrants,
+  AgorRuntimeConfig,
   Artifact,
   ArtifactBuildStatus,
   ArtifactConsoleEntry,
@@ -59,6 +60,7 @@ import {
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { DrizzleService } from '../adapters/drizzle.js';
+import { AGOR_RUNTIME_PATH, AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
 import {
   detectLegacyFormat,
   envVarPrefixForTemplate,
@@ -88,6 +90,52 @@ async function canonicalizeExistingPrefix(target: string): Promise<string> {
 }
 
 /**
+ * Pick which file to prepend the `import './agor-runtime.js';` line into.
+ *
+ * Priority: artifact's recorded `entry` column → `customSetup.entry` from
+ * the sandpack config → common Sandpack template entry conventions. Files
+ * are matched against `filesOut` (the about-to-be-served file map) rather
+ * than the canonical artifact files, so any leading-slash variants the
+ * map happens to use are accepted.
+ *
+ * Returns null if nothing matches — caller skips runtime injection.
+ */
+function pickEntryForRuntimeInjection(
+  filesOut: Record<string, string>,
+  artifact: { entry?: string; sandpack_config?: SandpackConfig }
+): string | null {
+  const candidates: string[] = [];
+  if (artifact.entry) candidates.push(artifact.entry);
+  if (artifact.sandpack_config?.customSetup?.entry) {
+    candidates.push(artifact.sandpack_config.customSetup.entry);
+  }
+  // Common Sandpack template entries, in roughly observed-frequency order.
+  candidates.push(
+    '/src/index.tsx',
+    '/src/index.ts',
+    '/src/index.jsx',
+    '/src/index.js',
+    '/src/main.ts',
+    '/src/main.tsx',
+    '/src/main.js',
+    '/index.tsx',
+    '/index.ts',
+    '/index.jsx',
+    '/index.js'
+  );
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue;
+    // Match either with or without the leading slash — file-map convention
+    // varies between persisted shapes.
+    const variants = [candidate, candidate.startsWith('/') ? candidate.slice(1) : `/${candidate}`];
+    for (const v of variants) {
+      if (typeof filesOut[v] === 'string') return v;
+    }
+  }
+  return null;
+}
+
+/**
  * Build the default `.agor/artifacts/<folder>` name used when `land()` is
  * called without a custom subpath. Combines a slugified artifact name with
  * the first 8 chars of the UUID — readable AND collision-resistant — so the
@@ -114,6 +162,7 @@ interface ArtifactSidecar {
   sandpack_config?: SandpackConfig;
   required_env_vars?: string[];
   agor_grants?: AgorGrants;
+  agor_runtime?: AgorRuntimeConfig;
 }
 
 /**
@@ -140,6 +189,10 @@ function readArtifactSidecar(folderPath: string): ArtifactSidecar | null {
       agor_grants:
         parsed.agor_grants && typeof parsed.agor_grants === 'object'
           ? (parsed.agor_grants as AgorGrants)
+          : undefined,
+      agor_runtime:
+        parsed.agor_runtime && typeof parsed.agor_runtime === 'object'
+          ? (parsed.agor_runtime as AgorRuntimeConfig)
           : undefined,
     };
   } catch (err) {
@@ -191,6 +244,28 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * Keyed by `${userId}:${artifactId}`. Cleared when the daemon restarts.
    */
   private sessionGrants: Map<string, { envVars: Set<string>; grants: AgorGrants }> = new Map();
+
+  /**
+   * In-flight runtime queries keyed by request_id.
+   *
+   * When an agent calls `agor_artifacts_query_dom`, the daemon emits a
+   * service event a viewer's browser picks up, dispatches into the
+   * Sandpack iframe via postMessage, and POSTs the iframe's reply back.
+   * That POST resolves the pending entry here. Cleaned up on timeout.
+   *
+   * `requesterId` is checked against the response endpoint's authenticated
+   * user — only the original requester can fulfill their own query, so a
+   * different viewer's browser tab can't return that user's rendered DOM.
+   */
+  private pendingRuntimeQueries: Map<
+    string,
+    {
+      resolve: (result: unknown) => void;
+      reject: (err: Error) => void;
+      timeout: ReturnType<typeof setTimeout>;
+      requesterId: string;
+    }
+  > = new Map();
 
   constructor(db: Database, app: Application) {
     const artifactRepo = new ArtifactRepository(db);
@@ -307,6 +382,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       sandpack_config?: SandpackConfig;
       required_env_vars?: string[];
       agor_grants?: AgorGrants;
+      agor_runtime?: AgorRuntimeConfig;
       x?: number;
       y?: number;
       width?: number;
@@ -358,6 +434,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const agorGrants = sanitizeAgorGrants(
       data.agor_grants ?? sidecar?.agor_grants ?? existing?.agor_grants
     );
+    // agor_runtime is a small flag bag (currently just `enabled`). Same
+    // explicit-data > sidecar > existing > default chain. Default is
+    // implicit-enabled (i.e. `undefined` reads as enabled at render time).
+    const agorRuntime: AgorRuntimeConfig | undefined =
+      data.agor_runtime ?? sidecar?.agor_runtime ?? existing?.agor_runtime ?? undefined;
 
     // Name and board are required on create; on update they default to the
     // existing row so a routine republish doesn't have to know them.
@@ -392,6 +473,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         sandpack_config: resolvedSandpackConfig,
         required_env_vars: requiredEnvVars,
         agor_grants: agorGrants,
+        agor_runtime: agorRuntime,
         content_hash: contentHash,
         public: isPublic,
         build_status: buildResult.status,
@@ -422,6 +504,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       sandpack_config: resolvedSandpackConfig,
       required_env_vars: requiredEnvVars,
       agor_grants: agorGrants,
+      agor_runtime: agorRuntime,
       content_hash: contentHash,
       build_status: buildResult.status,
       build_errors: buildResult.errors.length > 0 ? buildResult.errors : undefined,
@@ -478,6 +561,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       height?: number;
       required_env_vars?: string[];
       agor_grants?: AgorGrants;
+      agor_runtime?: AgorRuntimeConfig;
       sandpack_config?: SandpackConfig;
     },
     userId?: string,
@@ -535,6 +619,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
     if (updates.agor_grants !== undefined) {
       dbUpdates.agor_grants = sanitizeAgorGrants(updates.agor_grants);
+    }
+    if (updates.agor_runtime !== undefined) {
+      dbUpdates.agor_runtime = updates.agor_runtime;
     }
     if (updates.sandpack_config !== undefined) {
       dbUpdates.sandpack_config = sanitizeSandpackConfig(updates.sandpack_config);
@@ -704,6 +791,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       sandpack_config: artifact.sandpack_config ?? {},
       required_env_vars: artifact.required_env_vars ?? [],
       agor_grants: artifact.agor_grants ?? {},
+      agor_runtime: artifact.agor_runtime ?? {},
     };
     const sidecarJson = `${JSON.stringify(sidecar, null, 2)}\n`;
     await writeFile(path.join(destination, 'agor.artifact.json'), sidecarJson, 'utf-8');
@@ -779,6 +867,30 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // the artifact's bundler can read it. For vanilla/static templates the
       // file is irrelevant (synthesizeEnvFile returns null).
       if (envFile !== null) filesOut[SYNTHESIZED_ENV_PATH] = envFile;
+    }
+
+    // Inject the iframe-side runtime that powers agent-driven introspection
+    // (DOM queries, etc.). Default-on; authors can opt out via
+    // `agor_runtime.enabled = false`. Render-time only — never persisted.
+    const runtimeEnabled = artifact.agor_runtime?.enabled !== false;
+    if (runtimeEnabled) {
+      filesOut[AGOR_RUNTIME_PATH] = AGOR_RUNTIME_SOURCE;
+      // Prepend an import to the entry file so the runtime registers its
+      // message listener before user code starts emitting events. We modify
+      // the served file map only — the persisted entry is untouched.
+      const entryPath = pickEntryForRuntimeInjection(filesOut, artifact);
+      if (entryPath) {
+        const original = filesOut[entryPath] ?? '';
+        filesOut[entryPath] = `import '${AGOR_RUNTIME_PATH}';\n${original}`;
+      } else {
+        // No discoverable entry — drop the runtime file rather than ship
+        // it dead weight, and warn loudly so we notice if a template's
+        // entry detection grows stale.
+        delete filesOut[AGOR_RUNTIME_PATH];
+        console.warn(
+          `[artifacts] Could not find an entry file for ${artifact.artifact_id} (template=${artifact.template}); skipping agor-runtime.js injection.`
+        );
+      }
     }
 
     const contentHash = this.computeHashFromFiles(filesOut);
@@ -1188,7 +1300,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       if (
         stripped === 'agor.config.js' ||
         stripped === 'agor.artifact.json' ||
-        stripped === '.env'
+        stripped === '.env' ||
+        stripped === 'agor-runtime.js'
       ) {
         continue;
       }
@@ -1282,6 +1395,107 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       : 'No required env vars to configure.';
 
     return { artifactId, sandboxId, url, note };
+  }
+
+  // ── Runtime queries (DOM introspection from agent → viewer's iframe) ──
+
+  /**
+   * Send a query to the requester's own browser tab(s) viewing this
+   * artifact. The browser dispatches into the Sandpack iframe via
+   * postMessage; agor-runtime.js (auto-injected at render time) replies;
+   * the browser POSTs the reply to `/artifacts/:id/runtime-response/...`,
+   * which calls `resolveRuntimeQuery` to complete this promise.
+   *
+   * Visibility-checked. Rejects if:
+   * - the artifact is private and the caller can't see it,
+   * - the artifact has `agor_runtime.enabled === false`,
+   * - or no browser tab fulfilled the query within `timeoutMs`.
+   *
+   * Scope: the response endpoint requires the responding user to match
+   * `requesterId`. So even though the dispatch event is broadcast, only
+   * the requester's own browser can complete the round-trip with their
+   * own (potentially secret-bearing) DOM. Cross-user introspection of
+   * a third party's render is structurally prevented.
+   */
+  async queryArtifactRuntime(input: {
+    artifactId: string;
+    userId: string;
+    kind: 'query_dom' | 'document_html';
+    args: Record<string, unknown>;
+    timeoutMs?: number;
+  }): Promise<unknown> {
+    const artifact = await this.artifactRepo.findById(input.artifactId);
+    if (!artifact) throw new Error(`Artifact ${input.artifactId} not found`);
+    if (!this.isVisibleTo(artifact, input.userId)) {
+      throw new Error(`Artifact ${input.artifactId} not found`);
+    }
+    if (artifact.agor_runtime?.enabled === false) {
+      throw new Error(
+        `Runtime introspection is disabled for artifact ${input.artifactId} (agor_runtime.enabled = false). The artifact author can re-enable it via agor_artifacts_update.`
+      );
+    }
+
+    const requestId = generateId();
+    const timeoutMs = Math.min(Math.max(input.timeoutMs ?? 5000, 500), 30000);
+
+    const promise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRuntimeQueries.delete(requestId);
+        reject(
+          new Error(
+            `Runtime query timed out after ${timeoutMs}ms. Open the artifact in your browser (so the runtime can answer), then retry.`
+          )
+        );
+      }, timeoutMs);
+
+      this.pendingRuntimeQueries.set(requestId, {
+        resolve,
+        reject,
+        timeout,
+        requesterId: input.userId,
+      });
+    });
+
+    // Broadcast on the artifacts service. The client filters: only respond
+    // if currently viewing this artifact AND logged in as the requester.
+    this.app.service('artifacts').emit('agor-query', {
+      request_id: requestId,
+      artifact_id: input.artifactId,
+      requested_by_user_id: input.userId,
+      kind: input.kind,
+      args: input.args,
+    });
+
+    return promise;
+  }
+
+  /**
+   * Called by the response REST endpoint when a viewer's browser POSTs
+   * the iframe's reply. The auth boundary already authenticated the
+   * caller; we additionally check that the responder matches the original
+   * requester so a different user can't fulfill someone else's query.
+   *
+   * Silently no-op when the request id is unknown (timed out, never
+   * existed, or already completed). Stale POSTs are common — multiple
+   * tabs may answer the same query and only the first wins.
+   */
+  resolveRuntimeQuery(input: {
+    requestId: string;
+    responderUserId: string;
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+  }): void {
+    const pending = this.pendingRuntimeQueries.get(input.requestId);
+    if (!pending) return;
+    if (pending.requesterId !== input.responderUserId) return;
+    clearTimeout(pending.timeout);
+    this.pendingRuntimeQueries.delete(input.requestId);
+    if (input.ok) {
+      pending.resolve(input.result);
+    } else {
+      pending.reject(new Error(input.error || 'Runtime query failed (no error provided)'));
+    }
   }
 
   // ── Build / status / console / find helpers (mostly unchanged) ──
@@ -1555,6 +1769,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // Skip the synthesized .env so a round-trip via land() → publish()
       // doesn't accidentally bake the viewer's secrets into the next publish.
       if (relativePath === '.env') continue;
+      // Skip the daemon-injected runtime so a round-trip via land() →
+      // publish() doesn't persist a copy that then gets double-injected
+      // on next render. The runtime is render-time only.
+      if (relativePath === 'agor-runtime.js') continue;
       const normalizedPath = `/${relativePath.replace(/\\/g, '/')}`;
       files[normalizedPath] = fs.readFileSync(file, 'utf-8');
     }

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -60,7 +60,7 @@ import {
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { DrizzleService } from '../adapters/drizzle.js';
-import { AGOR_RUNTIME_PATH, AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
+import { AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
 import {
   detectLegacyFormat,
   envVarPrefixForTemplate,
@@ -90,96 +90,43 @@ async function canonicalizeExistingPrefix(target: string): Promise<string> {
 }
 
 /**
- * Compute a relative ES-module specifier from `fromFile` to `toFile`. Both
- * are root-absolute paths in the served file map (e.g. `/src/index.js`,
- * `/agor-runtime.js`). Returns the kind of specifier Sandpack's bundler
- * resolves reliably across templates: `./agor-runtime.js` when the two
- * are siblings, `../agor-runtime.js` when the target is one or more
- * levels up.
+ * Lazily-built data URL carrying the agor-runtime IIFE. Sandpack injects
+ * each `externalResources` entry as a `<script src="...">` tag in the
+ * iframe HTML, so a `data:text/javascript;base64,…` URL avoids any extra
+ * HTTP round-trip and any cross-origin coupling. Built once per process —
+ * the source is a static constant.
  */
-function relativeImportSpecifier(fromFile: string, toFile: string): string {
-  const fromDir = path.posix.dirname(fromFile);
-  const targetPath = toFile.startsWith('/') ? toFile : `/${toFile}`;
-  let rel = path.posix.relative(fromDir, targetPath);
-  if (!rel.startsWith('.')) rel = `./${rel}`;
-  return rel;
+let cachedAgorRuntimeDataUrl: string | null = null;
+function agorRuntimeDataUrl(): string {
+  if (cachedAgorRuntimeDataUrl !== null) return cachedAgorRuntimeDataUrl;
+  const b64 = Buffer.from(AGOR_RUNTIME_SOURCE, 'utf-8').toString('base64');
+  cachedAgorRuntimeDataUrl = `data:text/javascript;base64,${b64}`;
+  return cachedAgorRuntimeDataUrl;
 }
 
 /**
- * Pick which file to prepend the `import './agor-runtime.js';` line into.
+ * Return a copy of `cfg` with the agor-runtime data URL prepended to
+ * `options.externalResources`. The persisted `sandpack_config` is never
+ * mutated — this builds a new object for the served payload only.
  *
- * Priority: artifact's recorded `entry` column → `customSetup.entry` from
- * the sandpack config → common Sandpack template entry conventions. Files
- * are matched against `filesOut` (the about-to-be-served file map) rather
- * than the canonical artifact files, so any leading-slash variants the
- * map happens to use are accepted.
- *
- * Returns null if nothing matches — caller skips runtime injection.
+ * Prepending (rather than appending) means the runtime's message listener
+ * is registered before any author-supplied external scripts run, so the
+ * order is deterministic across artifacts.
  */
-function pickEntryForRuntimeInjection(
-  filesOut: Record<string, string>,
-  artifact: { entry?: string; sandpack_config?: SandpackConfig }
-): string | null {
-  const candidates: string[] = [];
-  if (artifact.entry) candidates.push(artifact.entry);
-  if (artifact.sandpack_config?.customSetup?.entry) {
-    candidates.push(artifact.sandpack_config.customSetup.entry);
-  }
-  // Common Sandpack template entries. Order matters — earlier entries win
-  // when multiple match. Each template family has its own conventions:
-  //
-  //   `react` (default): user code goes in /App.{js,tsx,…}; Sandpack
-  //     synthesizes the bundler `index.js` itself. Most artifacts hit
-  //     this case — agents publishing minimal projects often only
-  //     provide `/App.js`.
-  //   Vite-style React: /src/App.* + /src/main.*.
-  //   Vue/Svelte: /src/App.{vue,svelte} + /src/main.*.
-  //   Vanilla / static: /index.* at root.
-  //
-  // We inject into the FIRST matching user file. Module side-effect
-  // imports run synchronously the first time the bundler pulls them in,
-  // so the runtime's IIFE registers before the rest of the artifact
-  // boots regardless of whether the file is the bundler-level entry.
-  candidates.push(
-    // React template — author's component file at root (the most common
-    // shape for agent-published artifacts).
-    '/App.tsx',
-    '/App.ts',
-    '/App.jsx',
-    '/App.js',
-    // React/Vite/Solid — author's component file under /src.
-    '/src/App.tsx',
-    '/src/App.ts',
-    '/src/App.jsx',
-    '/src/App.js',
-    // Standard bundler entries under /src.
-    '/src/index.tsx',
-    '/src/index.ts',
-    '/src/index.jsx',
-    '/src/index.js',
-    '/src/main.tsx',
-    '/src/main.ts',
-    '/src/main.jsx',
-    '/src/main.js',
-    // Bundler entries at root.
-    '/index.tsx',
-    '/index.ts',
-    '/index.jsx',
-    '/index.js',
-    '/main.tsx',
-    '/main.ts',
-    '/main.js'
-  );
-  for (const candidate of candidates) {
-    if (typeof candidate !== 'string') continue;
-    // Match either with or without the leading slash — file-map convention
-    // varies between persisted shapes.
-    const variants = [candidate, candidate.startsWith('/') ? candidate.slice(1) : `/${candidate}`];
-    for (const v of variants) {
-      if (typeof filesOut[v] === 'string') return v;
-    }
-  }
-  return null;
+function withInjectedAgorRuntime(cfg: SandpackConfig | undefined): SandpackConfig {
+  const dataUrl = agorRuntimeDataUrl();
+  const existingResources = (cfg?.options as Record<string, unknown> | undefined)
+    ?.externalResources;
+  const existingArr = Array.isArray(existingResources)
+    ? (existingResources as unknown[]).filter((v): v is string => typeof v === 'string')
+    : [];
+  return {
+    ...(cfg ?? {}),
+    options: {
+      ...(cfg?.options ?? {}),
+      externalResources: [dataUrl, ...existingArr],
+    },
+  };
 }
 
 /**
@@ -921,35 +868,17 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
 
     // Inject the iframe-side runtime that powers agent-driven introspection
-    // (DOM queries, etc.). Default-on; authors can opt out via
-    // `agor_runtime.enabled = false`. Render-time only — never persisted.
+    // (DOM queries, etc.) via `sandpack_config.options.externalResources` —
+    // Sandpack adds the resulting `<script src="...">` to the iframe HTML
+    // before any user code runs. We use a `data:` URL so no extra HTTP
+    // round-trip is required and no daemon-served origin needs to be
+    // CORS-allowed by the bundler. Default-on; authors can opt out via
+    // `agor_runtime.enabled = false`. Render-time only — never persisted,
+    // never touches user files.
     const runtimeEnabled = artifact.agor_runtime?.enabled !== false;
-    if (runtimeEnabled) {
-      filesOut[AGOR_RUNTIME_PATH] = AGOR_RUNTIME_SOURCE;
-      // Prepend an import to the entry file so the runtime registers its
-      // message listener before user code starts emitting events. We modify
-      // the served file map only — the persisted entry is untouched.
-      //
-      // Use a relative specifier rather than the root-absolute
-      // `/agor-runtime.js`. Sandpack's bundler resolves relative imports
-      // reliably across templates; root-absolute paths work in some
-      // bundler configurations and fail in others (e.g. Parcel-based
-      // templates resolve them against a different root).
-      const entryPath = pickEntryForRuntimeInjection(filesOut, artifact);
-      if (entryPath) {
-        const original = filesOut[entryPath] ?? '';
-        const importSpec = relativeImportSpecifier(entryPath, AGOR_RUNTIME_PATH);
-        filesOut[entryPath] = `import '${importSpec}';\n${original}`;
-      } else {
-        // No discoverable entry — drop the runtime file rather than ship
-        // it dead weight, and warn loudly so we notice if a template's
-        // entry detection grows stale.
-        delete filesOut[AGOR_RUNTIME_PATH];
-        console.warn(
-          `[artifacts] Could not find an entry file for ${artifact.artifact_id} (template=${artifact.template}); skipping agor-runtime.js injection.`
-        );
-      }
-    }
+    const servedSandpackConfig = runtimeEnabled
+      ? withInjectedAgorRuntime(artifact.sandpack_config)
+      : artifact.sandpack_config;
 
     const contentHash = this.computeHashFromFiles(filesOut);
     const legacy = detectLegacyFormat(artifact);
@@ -960,7 +889,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       description: artifact.description,
       template: artifact.template,
       files: filesOut,
-      sandpack_config: artifact.sandpack_config,
+      sandpack_config: servedSandpackConfig,
       dependencies: artifact.dependencies,
       entry: artifact.entry,
       content_hash: contentHash,
@@ -1358,8 +1287,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       if (
         stripped === 'agor.config.js' ||
         stripped === 'agor.artifact.json' ||
-        stripped === '.env' ||
-        stripped === 'agor-runtime.js'
+        stripped === '.env'
       ) {
         continue;
       }
@@ -1490,17 +1418,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     if (artifact.agor_runtime?.enabled === false) {
       throw new Error(
         `Runtime introspection is disabled for artifact ${input.artifactId} (agor_runtime.enabled = false). The artifact author can re-enable it via agor_artifacts_update.`
-      );
-    }
-    // Pre-flight entry check: the runtime is render-time-injected by
-    // prepending an `import` to the entry file. If we can't detect a
-    // user JS/TS file to inject into, the runtime is silently dropped at
-    // render time — and a vanilla "query timed out, open the artifact"
-    // error misleads the caller (the artifact IS open, it just has no
-    // runtime). Detect this up front and surface the actual cause.
-    if (artifact.files && !pickEntryForRuntimeInjection(artifact.files, artifact)) {
-      throw new Error(
-        `Runtime introspection is unavailable for artifact ${input.artifactId}: no recognizable entry file in the artifact's file map (looked for /App.{js,jsx,ts,tsx}, /src/App.{js,jsx,ts,tsx}, /index.* and /src/index.*, /main.* and /src/main.*). Add one of those to the file map and republish.`
       );
     }
 
@@ -1838,10 +1755,6 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // Skip the synthesized .env so a round-trip via land() → publish()
       // doesn't accidentally bake the viewer's secrets into the next publish.
       if (relativePath === '.env') continue;
-      // Skip the daemon-injected runtime so a round-trip via land() →
-      // publish() doesn't persist a copy that then gets double-injected
-      // on next render. The runtime is render-time only.
-      if (relativePath === 'agor-runtime.js') continue;
       const normalizedPath = `/${relativePath.replace(/\\/g, '/')}`;
       files[normalizedPath] = fs.readFileSync(file, 'utf-8');
     }

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -238,7 +238,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       const artifactId = String(id);
       const existing = await this.artifactRepo.findById(artifactId);
       if (!existing) throw new Error(`Artifact ${artifactId} not found`);
-      const callerUserId = (params as { user?: { user_id?: string } } | undefined)?.user?.user_id;
+      const callerParams = params as { user?: { user_id?: string; role?: UserRole } } | undefined;
+      const callerUserId = callerParams?.user?.user_id;
+      const callerRole = callerParams?.user?.role;
 
       return this.updateMetadata(
         existing.artifact_id,
@@ -253,7 +255,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           width: d.width,
           height: d.height,
         },
-        callerUserId
+        callerUserId,
+        callerRole
       );
     }
 
@@ -270,11 +273,20 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     return artifact.created_by === userId;
   }
 
-  async remove(id: string | number, _params?: unknown): Promise<Artifact> {
+  async remove(id: string | number, params?: unknown): Promise<Artifact> {
     const artifactId = String(id);
-    const artifact = await this.artifactRepo.findById(artifactId);
-    if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
-    await this.deleteArtifact(artifactId);
+    const callerParams = params as { user?: { user_id?: string; role?: UserRole } } | undefined;
+    // Thread the authenticated caller through so deleteArtifact() can run
+    // its owner/admin check. The Feathers REST hook chain has already
+    // gated this call (see ensureArtifactOwnerOrAdmin in register-hooks),
+    // so the inline check is redundant for REST callers — but it stays as
+    // a defense-in-depth and as the single auth point for non-Feathers
+    // callers (e.g. internal lifecycle code).
+    const artifact = await this.deleteArtifact(
+      artifactId,
+      callerParams?.user?.user_id,
+      callerParams?.user?.role
+    );
     this.app.service('artifacts').emit('removed', artifact);
     return artifact;
   }
@@ -468,12 +480,18 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       agor_grants?: AgorGrants;
       sandpack_config?: SandpackConfig;
     },
-    userId?: string
+    userId?: string,
+    userRole?: UserRole
   ): Promise<Artifact> {
     const existing = await this.artifactRepo.findById(artifactId);
     if (!existing) throw new Error(`Artifact ${artifactId} not found`);
-    if (userId && existing.created_by && existing.created_by !== userId) {
-      throw new Error('Cannot update artifact: not the owner');
+    // Owner-or-admin: matches the Feathers REST hook (ensureArtifactOwner-
+    // OrAdmin) and the agor_artifacts_update tool description. Without the
+    // role check, an admin authorized by the hook still got rejected here.
+    const isOwner = !!userId && existing.created_by === userId;
+    const isAdmin = !!userRole && hasMinimumRole(userRole, ROLES.ADMIN);
+    if (userId && !isOwner && !isAdmin) {
+      throw new Error("Forbidden: only the artifact's creator or an admin may update it");
     }
 
     const fullArtifactId = existing.artifact_id;
@@ -1383,7 +1401,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * direct PATCH/REMOVE; this method is what the MCP tool calls and used
    * to be unchecked.
    */
-  async deleteArtifact(artifactId: string, userId?: string, userRole?: UserRole): Promise<void> {
+  async deleteArtifact(
+    artifactId: string,
+    userId?: string,
+    userRole?: UserRole
+  ): Promise<Artifact> {
     const artifact = await this.artifactRepo.findById(artifactId);
     if (!artifact) throw new Error(`Artifact ${artifactId} not found`);
 
@@ -1405,6 +1427,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     this.clearAllViewerBuffersFor(artifactId);
     await this.artifactRepo.delete(artifactId);
+    // Returned so callers can emit `removed` events without a redundant
+    // pre-delete fetch.
+    return artifact;
   }
 
   async findByBoardId(boardId: BoardID, userId?: string): Promise<Artifact[]> {

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -151,7 +151,7 @@ function defaultLandFolderName(artifact: { name: string; artifact_id: string }):
 }
 
 /**
- * Round-trip sidecar shape written by `land()` and read back by `publish()`.
+ * Round-trip sidecar shape written by `land()` and read back by `publishArtifact()`.
  * Carries metadata that doesn't fit into the file map (template, sandpack
  * config, declarative consent surface).
  */
@@ -284,10 +284,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }
 
   // Direct Feathers create is intentionally rejected — artifacts require
-  // the publish() lifecycle (folder → DB).
+  // the publishArtifact() lifecycle (folder → DB).
   async create(_data: Partial<Artifact>, _params?: unknown): Promise<Artifact> {
     throw new Error(
-      'Direct artifact creation not supported. Use publish() or agor_artifacts_publish MCP tool.'
+      'Direct artifact creation not supported. Use publishArtifact() or agor_artifacts_publish MCP tool.'
     );
   }
 
@@ -368,8 +368,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * Publish a folder as a live Sandpack artifact on a board. Reads files from
    * `folderPath`, serializes them into the DB, and places (or updates) the
    * artifact on the board.
+   *
+   * Named `publishArtifact` (not `publish`) on purpose: `service.publish`
+   * is a reserved Feathers channel-mixin hook — if a service defines a
+   * `publish()` method, the mixin assumes custom channel routing and
+   * skips all event subscriptions, including the default
+   * `created`/`patched`/`removed` and custom events like `agor-query`.
+   * That breaks every WebSocket fan-out from this service. See
+   * `@feathersjs/transport-commons` channels/index.ts.
    */
-  async publish(
+  async publishArtifact(
     data: {
       folderPath: string;
       board_id?: string;
@@ -547,7 +555,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /**
    * Update artifact metadata without touching files.
-   * For file/content changes use publish().
+   * For file/content changes use publishArtifact().
    */
   async updateMetadata(
     artifactId: string,
@@ -694,8 +702,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /**
    * Materialize an artifact's stored file map to a destination under a worktree.
-   * Inverse of publish(). Sandpack metadata is reconstructed as a sidecar
-   * `agor.artifact.json` so a round-trip via publish() round-trips the
+   * Inverse of publishArtifact(). Sandpack metadata is reconstructed as a sidecar
+   * `agor.artifact.json` so a round-trip via publishArtifact() round-trips the
    * metadata that doesn't live in the file map.
    *
    * Security:
@@ -781,7 +789,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     // Round-trip sidecar: persist artifact-level metadata that has no place in
     // a normal file tree (template, sandpack_config, required_env_vars,
-    // agor_grants). publish() reads agor.artifact.json back if present;
+    // agor_grants). publishArtifact() reads agor.artifact.json back if present;
     // ordinary builds/Vite/CRA never look at it.
     //
     // Always emit every field — even when empty — so the sidecar is
@@ -1752,11 +1760,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     for (const file of fileList) {
       const relativePath = path.relative(rootDir, file);
       // The `agor.artifact.json` sidecar is land()'s round-trip carrier for
-      // metadata that doesn't fit in the file map. publish() consumes it
+      // metadata that doesn't fit in the file map. publishArtifact() consumes it
       // separately (callers pass the parsed values via the publish args).
       // Either way it doesn't belong in the served file map.
       if (relativePath === 'agor.artifact.json') continue;
-      // Skip the synthesized .env so a round-trip via land() → publish()
+      // Skip the synthesized .env so a round-trip via land() → publishArtifact()
       // doesn't accidentally bake the viewer's secrets into the next publish.
       if (relativePath === '.env') continue;
       const normalizedPath = `/${relativePath.replace(/\\/g, '/')}`;

--- a/apps/agor-daemon/src/setup/proxies.ts
+++ b/apps/agor-daemon/src/setup/proxies.ts
@@ -18,9 +18,11 @@
  *   2. No vendor library — yaml-driven only, no built-in vendor presets.
  *   3. Read-only default — `allowed_methods` defaults to `[GET]`.
  *   4. Off by default — no `proxies:` block = no route mounted at all.
- *   5. No auth injection — daemon does not read user env vars or set auth
- *      headers. Auth stays in the artifact via the existing Handlebars
- *      convention (`agor.config.js`).
+ *   5. No auth injection — daemon does not set vendor auth headers on
+ *      forwarded requests. Auth stays in the artifact: declare
+ *      `agor_grants.agor_token: true` and `requiredEnvVars: [...]` at
+ *      publish time and the daemon synthesizes the values into a
+ *      per-viewer `.env`.
  */
 
 import type { AgorConfig } from '@agor/core/config';

--- a/apps/agor-daemon/src/utils/agor-runtime-source.ts
+++ b/apps/agor-daemon/src/utils/agor-runtime-source.ts
@@ -1,0 +1,137 @@
+/**
+ * Iframe-side runtime injected into every artifact's bundle at render time.
+ *
+ * Listens for `postMessage` queries from the Agor parent page and replies
+ * with serialized data from the iframe's DOM. Standard browser APIs only —
+ * no Sandpack-internal coupling. The parent uses
+ * `useSandpackClient().iframe.current.contentWindow.postMessage(...)` to
+ * dispatch; the daemon WebSocket-fans-out the request and correlates the
+ * reply.
+ *
+ * Wire format:
+ *   parent → iframe: { type: 'agor:query', requestId, kind, args }
+ *   iframe → parent: { type: 'agor:result', requestId, ok: bool, result?, error? }
+ *
+ * Supported `kind`:
+ *   - `query_dom` — args: { selector, multiple?, maxNodes? }
+ *   - `document_html` — args: {}
+ *
+ * Caps everything (per-element HTML, total HTML, node count) so an
+ * artifact with a giant DOM can't blow up the wire / agent context.
+ *
+ * NOT persisted — generated and injected per-render in `getPayload()`.
+ * Stripped from CodeSandbox exports and round-trip `land()` output.
+ */
+export const AGOR_RUNTIME_SOURCE = `// agor-runtime.js — injected by Agor at render time. Do not edit.
+// Source: apps/agor-daemon/src/utils/agor-runtime-source.ts
+(function () {
+  if (typeof window === 'undefined') return;
+  if (window.__agor_runtime_installed__) return;
+  window.__agor_runtime_installed__ = true;
+
+  var MAX_NODES = 50;
+  var MAX_HTML_PER_NODE = 50000;
+  var MAX_TEXT_PER_NODE = 5000;
+  var MAX_DOC_HTML = 200000;
+
+  function serializeEl(el) {
+    var attrs = {};
+    for (var i = 0; i < el.attributes.length; i++) {
+      var a = el.attributes[i];
+      attrs[a.name] = a.value;
+    }
+    var html = el.outerHTML || '';
+    if (html.length > MAX_HTML_PER_NODE) {
+      html = html.slice(0, MAX_HTML_PER_NODE) + '... [truncated]';
+    }
+    var text = (el.textContent || '');
+    if (text.length > MAX_TEXT_PER_NODE) {
+      text = text.slice(0, MAX_TEXT_PER_NODE) + '... [truncated]';
+    }
+    return {
+      tag: el.tagName ? el.tagName.toLowerCase() : '',
+      attributes: attrs,
+      textContent: text,
+      outerHTML: html,
+    };
+  }
+
+  window.addEventListener('message', function (event) {
+    var data = event.data;
+    if (!data || typeof data !== 'object' || data.type !== 'agor:query') return;
+    var requestId = data.requestId;
+    var kind = data.kind;
+    var args = data.args || {};
+
+    function reply(payload) {
+      try {
+        var msg = { type: 'agor:result', requestId: requestId };
+        for (var k in payload) {
+          if (Object.prototype.hasOwnProperty.call(payload, k)) msg[k] = payload[k];
+        }
+        msg.ok = !payload.error;
+        // event.source is the parent window. '*' targetOrigin because the
+        // iframe runs cross-origin from a Sandpack bundler URL we don't
+        // control. Replies carry no secrets — only whatever the iframe's
+        // DOM already contains, which the parent rendered itself.
+        if (event.source && typeof event.source.postMessage === 'function') {
+          event.source.postMessage(msg, '*');
+        }
+      } catch (e) {
+        // Source closed or throwed; nothing to do.
+      }
+    }
+
+    try {
+      if (kind === 'query_dom') {
+        var selector = args.selector;
+        if (typeof selector !== 'string' || selector.length === 0) {
+          return reply({ error: 'selector required (CSS selector string)' });
+        }
+        var multiple = args.multiple === true;
+        var requestedMax = typeof args.maxNodes === 'number' ? args.maxNodes : MAX_NODES;
+        var maxNodes = Math.max(1, Math.min(requestedMax, MAX_NODES));
+
+        var nodes;
+        if (multiple) {
+          nodes = Array.prototype.slice.call(document.querySelectorAll(selector), 0, maxNodes);
+        } else {
+          var single = document.querySelector(selector);
+          nodes = single ? [single] : [];
+        }
+        var serialized = [];
+        for (var i = 0; i < nodes.length; i++) serialized.push(serializeEl(nodes[i]));
+        return reply({ result: { matched: serialized.length, nodes: serialized } });
+      }
+
+      if (kind === 'document_html') {
+        var html = (document.documentElement && document.documentElement.outerHTML) || '';
+        if (html.length > MAX_DOC_HTML) {
+          html = html.slice(0, MAX_DOC_HTML) + '... [truncated]';
+        }
+        return reply({ result: { html: html, length: html.length } });
+      }
+
+      return reply({ error: 'unknown query kind: ' + String(kind) });
+    } catch (err) {
+      return reply({ error: (err && err.message) ? err.message : String(err) });
+    }
+  });
+
+  // Announce readiness to the parent so it knows the iframe is wired up
+  // before sending any queries (avoids a race on first-paint).
+  try {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ type: 'agor:ready' }, '*');
+    }
+  } catch (e) {
+    /* parent closed */
+  }
+})();
+`;
+
+/**
+ * Path the runtime lands at in the file map. Stable so the parent-side
+ * filename detection (export strip, land() round-trip) can match it.
+ */
+export const AGOR_RUNTIME_PATH = '/agor-runtime.js';

--- a/apps/agor-daemon/src/utils/agor-runtime-source.ts
+++ b/apps/agor-daemon/src/utils/agor-runtime-source.ts
@@ -8,6 +8,13 @@
  * dispatch; the daemon WebSocket-fans-out the request and correlates the
  * reply.
  *
+ * Injection: served as a `data:text/javascript;base64,…` URL in
+ * `sandpack_config.options.externalResources`. Sandpack adds the resulting
+ * `<script src="…">` tag to the iframe HTML before any user code runs, so
+ * the listener is registered before the bundle boots and we don't have to
+ * mutate any user files (no entry-file detection, no `import` prepended,
+ * no template-specific resolver issues).
+ *
  * Wire format:
  *   parent → iframe: { type: 'agor:query', requestId, kind, args }
  *   iframe → parent: { type: 'agor:result', requestId, ok: bool, result?, error? }
@@ -19,8 +26,8 @@
  * Caps everything (per-element HTML, total HTML, node count) so an
  * artifact with a giant DOM can't blow up the wire / agent context.
  *
- * NOT persisted — generated and injected per-render in `getPayload()`.
- * Stripped from CodeSandbox exports and round-trip `land()` output.
+ * NOT persisted — generated and injected per-render in `getPayload()`,
+ * never enters the file map or the persisted `sandpack_config`.
  */
 export const AGOR_RUNTIME_SOURCE = `// agor-runtime.js — injected by Agor at render time. Do not edit.
 // Source: apps/agor-daemon/src/utils/agor-runtime-source.ts
@@ -129,9 +136,3 @@ export const AGOR_RUNTIME_SOURCE = `// agor-runtime.js — injected by Agor at r
   }
 })();
 `;
-
-/**
- * Path the runtime lands at in the file map. Stable so the parent-side
- * filename detection (export strip, land() round-trip) can match it.
- */
-export const AGOR_RUNTIME_PATH = '/agor-runtime.js';

--- a/apps/agor-daemon/src/utils/sandpack-config.test.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.test.ts
@@ -12,7 +12,6 @@ import { describe, expect, it } from 'vitest';
 import {
   detectLegacyFormat,
   envVarPrefixForTemplate,
-  mergeWithDefaults,
   sanitizeSandpackConfig,
 } from './sandpack-config';
 
@@ -88,20 +87,6 @@ describe('envVarPrefixForTemplate', () => {
   it('other templates default to no prefix (process.env.X)', () => {
     expect(envVarPrefixForTemplate('vue')).toBe('');
     expect(envVarPrefixForTemplate('angular')).toBe('');
-  });
-});
-
-describe('mergeWithDefaults', () => {
-  it('merges defaults under the author config', () => {
-    const merged = mergeWithDefaults({
-      template: 'react-ts',
-      options: { showInlineErrors: false, autorun: false },
-    });
-    // Default initMode survives when author didn't override it.
-    expect(merged.options?.initMode).toBe('user-visible');
-    // Author override wins.
-    expect(merged.options?.showInlineErrors).toBe(false);
-    expect(merged.options?.autorun).toBe(false);
   });
 });
 

--- a/apps/agor-daemon/src/utils/sandpack-config.test.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the sandpack-config helpers.
+ *
+ * Coverage:
+ * - sanitizeSandpackConfig blocks the unsafe prop list
+ * - envVarPrefixForTemplate returns the right prefix per template family
+ * - detectLegacyFormat catches sandpack.json + Handlebars and emits a useful
+ *   upgrade prompt with the parsed env vars and grant keys interpolated
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  detectLegacyFormat,
+  envVarPrefixForTemplate,
+  mergeWithDefaults,
+  sanitizeSandpackConfig,
+} from './sandpack-config';
+
+describe('sanitizeSandpackConfig', () => {
+  it('strips block-listed top-level props', () => {
+    const out = sanitizeSandpackConfig({
+      template: 'react',
+      teamId: 'cs-team-1',
+      sandboxId: 'cs-box-1',
+    });
+    expect(out.template).toBe('react');
+    expect((out as Record<string, unknown>).teamId).toBeUndefined();
+    expect((out as Record<string, unknown>).sandboxId).toBeUndefined();
+  });
+
+  it('strips bundlerURL / externalResources / npmRegistries / exportOptions', () => {
+    const out = sanitizeSandpackConfig({
+      options: {
+        bundlerURL: 'https://attacker.example/sandpack/',
+        externalResources: ['https://attacker.example/xss.js'],
+        showLineNumbers: true,
+      },
+      customSetup: {
+        dependencies: { react: '18.0.0' },
+        npmRegistries: [{ enabledScopes: [] }],
+        exportOptions: { secret: 'x' },
+        entry: '/index.js',
+      },
+    });
+    expect(out.options?.bundlerURL).toBeUndefined();
+    expect((out.options as Record<string, unknown>).externalResources).toBeUndefined();
+    expect(out.options?.showLineNumbers).toBe(true);
+    expect((out.customSetup as Record<string, unknown>).npmRegistries).toBeUndefined();
+    expect((out.customSetup as Record<string, unknown>).exportOptions).toBeUndefined();
+    expect(out.customSetup?.entry).toBe('/index.js');
+    expect(out.customSetup?.dependencies?.react).toBe('18.0.0');
+  });
+
+  it("drops options.classes values that don't match the safe regex", () => {
+    const out = sanitizeSandpackConfig({
+      options: {
+        classes: {
+          ok: 'safe-class',
+          bad: 'agor-internal-css "><script>',
+        },
+      },
+    });
+    expect(out.options?.classes?.ok).toBe('safe-class');
+    expect(out.options?.classes?.bad).toBeUndefined();
+  });
+
+  it('returns {} for non-object input', () => {
+    expect(sanitizeSandpackConfig(null)).toEqual({});
+    expect(sanitizeSandpackConfig('not a config')).toEqual({});
+    expect(sanitizeSandpackConfig(['array'])).toEqual({});
+  });
+});
+
+describe('envVarPrefixForTemplate', () => {
+  it('vite-family templates get VITE_', () => {
+    expect(envVarPrefixForTemplate('react')).toBe('VITE_');
+    expect(envVarPrefixForTemplate('react-ts')).toBe('VITE_');
+    expect(envVarPrefixForTemplate('vue3')).toBe('VITE_');
+    expect(envVarPrefixForTemplate('svelte')).toBe('VITE_');
+    expect(envVarPrefixForTemplate('solid')).toBe('VITE_');
+  });
+
+  it('vanilla / static templates get null (no env path)', () => {
+    expect(envVarPrefixForTemplate('vanilla')).toBeNull();
+    expect(envVarPrefixForTemplate('vanilla-ts')).toBeNull();
+  });
+
+  it('other templates default to no prefix (process.env.X)', () => {
+    expect(envVarPrefixForTemplate('vue')).toBe('');
+    expect(envVarPrefixForTemplate('angular')).toBe('');
+  });
+});
+
+describe('mergeWithDefaults', () => {
+  it('merges defaults under the author config', () => {
+    const merged = mergeWithDefaults({
+      template: 'react-ts',
+      options: { showInlineErrors: false, autorun: false },
+    });
+    // Default initMode survives when author didn't override it.
+    expect(merged.options?.initMode).toBe('user-visible');
+    // Author override wins.
+    expect(merged.options?.showInlineErrors).toBe(false);
+    expect(merged.options?.autorun).toBe(false);
+  });
+});
+
+describe('detectLegacyFormat', () => {
+  it('flags sandpack.json + agor.config.js in the file map', () => {
+    const result = detectLegacyFormat({
+      files: {
+        '/sandpack.json': '{"template": "react"}',
+        '/agor.config.js': 'export const x = "{{ user.env.OPENAI_KEY }}"',
+        '/App.js': 'export default function App() { return null; }',
+      },
+    });
+    expect(result.is_legacy).toBe(true);
+    expect(result.signals).toContain('has_sandpack_json');
+    expect(result.signals).toContain('has_agor_config_js');
+    expect(result.signals).toContain('has_handlebars_user_env');
+    expect(result.detected_env_vars).toContain('OPENAI_KEY');
+    expect(result.upgrade_instructions).toContain('OPENAI_KEY');
+    expect(result.upgrade_instructions).toContain('sandpack.json');
+    expect(result.upgrade_instructions).toContain('agor.config.js');
+  });
+
+  it('extracts grant keys from {{ agor.* }} references', () => {
+    const result = detectLegacyFormat({
+      files: {
+        '/agor.config.js': [
+          'export const t = "{{ agor.token }}";',
+          'export const u = "{{ agor.apiUrl }}";',
+          'export const p = "{{ agor.proxies.openai.url }}";',
+        ].join('\n'),
+      },
+    });
+    expect(result.detected_grants).toContain('agor_token');
+    expect(result.detected_grants).toContain('agor_api_url');
+    expect(result.detected_grants.some((g) => g.startsWith('agor_proxies:openai'))).toBe(true);
+    expect(result.upgrade_instructions).toMatch(/agor_proxies/);
+  });
+
+  it('returns is_legacy=false for a clean new-format artifact', () => {
+    const result = detectLegacyFormat({
+      files: { '/index.js': 'console.log("hi")', '/package.json': '{}' },
+      sandpack_config: { template: 'react' },
+      required_env_vars: ['OPENAI_KEY'],
+    });
+    expect(result.is_legacy).toBe(false);
+    expect(result.signals).toEqual([]);
+  });
+});

--- a/apps/agor-daemon/src/utils/sandpack-config.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.ts
@@ -1,0 +1,311 @@
+/**
+ * Sandpack config helpers
+ *
+ * Centralizes:
+ *  - The allow-list of `SandpackConfig` properties authors may persist.
+ *  - The template → env-var-prefix mapping used when synthesizing `.env`.
+ *  - Default merging at render time.
+ *  - Legacy-format detection so the UI can offer an agentic upgrade.
+ *
+ * The artifact runtime is arbitrary-JS-by-design — most "unsafe" Sandpack
+ * props don't grant new capability beyond what the file map already allows.
+ * The block list is deliberately minimal: anything that affects the parent
+ * UI, the daemon-controlled bundler, or per-user CodeSandbox accounts.
+ *
+ * See `docs/internal/artifacts-roadmap-2026-05-09.md` (sanitizeSandpackConfig
+ * allow list) for the rationale for each prop.
+ */
+
+import type {
+  AgorGrants,
+  ArtifactLegacyFormatReport,
+  ArtifactLegacySignal,
+  SandpackConfig,
+  SandpackTemplate,
+} from '@agor/core/types';
+
+/** Defaults merged underneath the artifact's `sandpack_config` at render time. */
+export const DEFAULT_SANDPACK_CONFIG: SandpackConfig = {
+  options: {
+    initMode: 'user-visible',
+    showLineNumbers: true,
+    showInlineErrors: true,
+    showTabs: true,
+  },
+};
+
+/**
+ * Templates whose Sandpack runtime uses Vite. The synthesized `.env` keys
+ * must be prefixed with `VITE_` so `import.meta.env.VITE_*` picks them up.
+ */
+const VITE_TEMPLATES = new Set<SandpackTemplate>(['react', 'react-ts', 'vue3', 'svelte', 'solid']);
+
+/**
+ * Templates that don't have a working dotenv path at all. The daemon emits
+ * a warning if such an artifact has a non-empty `required_env_vars`.
+ */
+const NO_ENV_TEMPLATES = new Set<SandpackTemplate>(['vanilla', 'vanilla-ts']);
+
+/**
+ * Returns the prefix the daemon should apply when synthesizing `.env` for
+ * the given template, or `null` if the template doesn't support a dotenv
+ * path (the artifact will need to find another way to consume secrets).
+ */
+export function envVarPrefixForTemplate(template: SandpackTemplate): string | null {
+  if (NO_ENV_TEMPLATES.has(template)) return null;
+  if (VITE_TEMPLATES.has(template)) return 'VITE_';
+  // CRA isn't a separate template in the current type — it ships as a
+  // forked `react` build that consumers opt into. We default to `VITE_`
+  // for `react` since the upstream Sandpack template is now Vite-based.
+  // `vue` (Vue CLI), `angular` (Angular CLI), etc. consume plain
+  // `process.env.X`.
+  return '';
+}
+
+/**
+ * Sanitize a `SandpackConfig` blob before persisting. Strips block-listed
+ * props (with no error — silently dropping is friendlier than rejecting on
+ * publish). Pass-through structure is preserved so authors get back
+ * something close to what they sent.
+ */
+export function sanitizeSandpackConfig(input: unknown): SandpackConfig {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+  const src = input as Record<string, unknown>;
+  const out: SandpackConfig = {};
+
+  if (typeof src.template === 'string') {
+    out.template = src.template as SandpackTemplate;
+  }
+
+  if (src.customSetup && typeof src.customSetup === 'object') {
+    const cs = src.customSetup as Record<string, unknown>;
+    const customSetup: NonNullable<SandpackConfig['customSetup']> = {};
+    if (cs.dependencies && typeof cs.dependencies === 'object') {
+      customSetup.dependencies = sanitizeStringMap(cs.dependencies);
+    }
+    if (cs.devDependencies && typeof cs.devDependencies === 'object') {
+      customSetup.devDependencies = sanitizeStringMap(cs.devDependencies);
+    }
+    if (typeof cs.entry === 'string') customSetup.entry = cs.entry;
+    if (typeof cs.environment === 'string') customSetup.environment = cs.environment;
+    // Block: customSetup.npmRegistries (private-registry confusion),
+    //        customSetup.exportOptions (per-user CodeSandbox API token).
+    out.customSetup = customSetup;
+  }
+
+  if (typeof src.theme === 'string' || (src.theme && typeof src.theme === 'object')) {
+    out.theme = src.theme as SandpackConfig['theme'];
+  }
+
+  if (src.options && typeof src.options === 'object') {
+    out.options = sanitizeOptions(src.options as Record<string, unknown>);
+  }
+
+  // Block: top-level teamId / sandboxId — bind to a CodeSandbox account.
+  return out;
+}
+
+const ALLOWED_OPTION_KEYS = new Set<string>([
+  'activeFile',
+  'visibleFiles',
+  'layout',
+  'recompileMode',
+  'recompileDelay',
+  'initMode',
+  'autorun',
+  'autoReload',
+  'showNavigator',
+  'showLineNumbers',
+  'showInlineErrors',
+  'showRefreshButton',
+  'showTabs',
+  'showConsole',
+  'showConsoleButton',
+  'closableTabs',
+  'startRoute',
+  'codeEditor',
+  'classes',
+]);
+
+const SAFE_CLASS_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+function sanitizeOptions(options: Record<string, unknown>): SandpackConfig['options'] {
+  const out: NonNullable<SandpackConfig['options']> = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (!ALLOWED_OPTION_KEYS.has(key)) continue;
+    if (key === 'classes') {
+      out.classes = sanitizeClassMap(value);
+      continue;
+    }
+    if (key === 'visibleFiles' && Array.isArray(value)) {
+      out.visibleFiles = value.filter((v): v is string => typeof v === 'string');
+      continue;
+    }
+    out[key as keyof typeof out] = value as never;
+  }
+  return out;
+}
+
+function sanitizeClassMap(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v !== 'string') continue;
+    // Defence in depth: classes are applied to parent UI components, so block
+    // arbitrary class names that might collide with Agor's own styling. Only
+    // allow plain identifier-like names.
+    if (!SAFE_CLASS_NAME_RE.test(v)) continue;
+    out[key] = v;
+  }
+  return out;
+}
+
+function sanitizeStringMap(input: unknown): Record<string, string> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Merge defaults underneath the author's config. Used at render time so the
+ * artifact gets sensible Sandpack defaults without forcing every author to
+ * spell them out.
+ */
+export function mergeWithDefaults(config: SandpackConfig | undefined): SandpackConfig {
+  const merged: SandpackConfig = {
+    ...DEFAULT_SANDPACK_CONFIG,
+    ...(config ?? {}),
+  };
+  merged.options = { ...DEFAULT_SANDPACK_CONFIG.options, ...(config?.options ?? {}) };
+  if (config?.customSetup || DEFAULT_SANDPACK_CONFIG.customSetup) {
+    merged.customSetup = {
+      ...(DEFAULT_SANDPACK_CONFIG.customSetup ?? {}),
+      ...(config?.customSetup ?? {}),
+    };
+  }
+  return merged;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Legacy format detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HANDLEBARS_TOKEN_RE = /\{\{\s*agor\.(token|apiUrl|proxies\.([\w-]+)|user\w*)/g;
+const HANDLEBARS_USER_ENV_RE = /\{\{\s*user\.env\.([A-Z_][A-Z0-9_]*)/g;
+
+/**
+ * Inspect an artifact's file map + config columns and report which legacy-format
+ * signals are present. Used to render the safe-degraded warning banner with
+ * an interpolated upgrade prompt.
+ */
+export function detectLegacyFormat(artifact: {
+  files?: Record<string, string>;
+  sandpack_config?: SandpackConfig;
+  required_env_vars?: string[];
+  agor_grants?: AgorGrants;
+}): ArtifactLegacyFormatReport {
+  const files = artifact.files ?? {};
+  const signals = new Set<ArtifactLegacySignal>();
+  const detectedEnvVars = new Set<string>();
+  const detectedGrants = new Set<string>();
+
+  if (files['/sandpack.json'] || files['sandpack.json']) {
+    signals.add('has_sandpack_json');
+  }
+
+  const hasAgorConfig = files['/agor.config.js'] || files['agor.config.js'];
+  if (hasAgorConfig) signals.add('has_agor_config_js');
+
+  if (!artifact.sandpack_config || Object.keys(artifact.sandpack_config).length === 0) {
+    // Only flag missing sandpack_config if there's another legacy signal —
+    // a brand-new artifact with sensible defaults is fine.
+    if (signals.size > 0) signals.add('no_sandpack_config');
+  }
+
+  for (const [, content] of Object.entries(files)) {
+    if (typeof content !== 'string') continue;
+    for (const m of content.matchAll(HANDLEBARS_TOKEN_RE)) {
+      signals.add('has_handlebars_token');
+      const which = m[1];
+      if (which === 'token') detectedGrants.add('agor_token');
+      else if (which === 'apiUrl') detectedGrants.add('agor_api_url');
+      else if (which.startsWith('proxies.')) {
+        // matched group 2 is the vendor name
+        if (m[2]) detectedGrants.add(`agor_proxies:${m[2]}`);
+      } else if (which === 'userEmail' || which === 'user') {
+        detectedGrants.add('agor_user_email');
+      }
+    }
+    for (const m of content.matchAll(HANDLEBARS_USER_ENV_RE)) {
+      signals.add('has_handlebars_user_env');
+      detectedEnvVars.add(m[1]);
+    }
+  }
+
+  const isLegacy = signals.size > 0;
+  const detectedEnvVarsArr = [...detectedEnvVars].sort();
+  const detectedGrantsArr = [...detectedGrants].sort();
+  const upgradeInstructions = renderUpgradeInstructions({
+    detectedEnvVars: detectedEnvVarsArr,
+    detectedGrants: detectedGrantsArr,
+    signals: [...signals],
+  });
+
+  return {
+    is_legacy: isLegacy,
+    signals: [...signals],
+    detected_env_vars: detectedEnvVarsArr,
+    detected_grants: detectedGrantsArr,
+    upgrade_instructions: upgradeInstructions,
+  };
+}
+
+function renderUpgradeInstructions(input: {
+  detectedEnvVars: string[];
+  detectedGrants: string[];
+  signals: ArtifactLegacySignal[];
+}): string {
+  // Translate the parsed detection result back into the new-format vocab.
+  const proxyVendors: string[] = [];
+  const grantsObj: Record<string, true | string[]> = {};
+  for (const g of input.detectedGrants) {
+    if (g.startsWith('agor_proxies:')) {
+      proxyVendors.push(g.slice('agor_proxies:'.length));
+    } else {
+      grantsObj[g] = true;
+    }
+  }
+  if (proxyVendors.length > 0) {
+    grantsObj.agor_proxies = proxyVendors.sort();
+  }
+
+  const envVarsLine =
+    input.detectedEnvVars.length > 0
+      ? `[${input.detectedEnvVars.map((v) => `"${v}"`).join(', ')}]`
+      : '[]';
+  const grantsLine = Object.keys(grantsObj).length > 0 ? JSON.stringify(grantsObj) : '{}';
+
+  const removals: string[] = [];
+  if (input.signals.includes('has_sandpack_json')) removals.push('sandpack.json');
+  if (input.signals.includes('has_agor_config_js')) removals.push('agor.config.js');
+  const removalsLine = removals.length > 0 ? removals.join(' and ') : '(none)';
+
+  return [
+    'Use the agor_artifacts_get tool to read the current artifact files.',
+    'Then use agor_artifacts_publish to republish with the new format:',
+    '  - Drop these legacy files from the file map: ' + removalsLine,
+    '  - Set sandpack_config (template, customSetup.entry, customSetup.dependencies)',
+    '    so the artifact still renders correctly.',
+    '  - Set required_env_vars: ' + envVarsLine,
+    '  - Set agor_grants: ' + grantsLine,
+    '  - Update source files to read env vars via the bundler convention',
+    '    (Vite: import.meta.env.VITE_*, CRA: process.env.REACT_APP_*,',
+    '    Node: process.env.*) instead of {{ user.env.* }} or',
+    '    {{ agor.* }} Handlebars tokens.',
+    '',
+    'Use agor_search_tools for the full publish/get tool schemas.',
+  ].join('\n');
+}

--- a/apps/agor-daemon/src/utils/sandpack-config.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.ts
@@ -188,6 +188,7 @@ const HANDLEBARS_ARTIFACT_BOARD_ID_RE = /\{\{\s*artifact\.boardId\s*\}\}/;
  * an interpolated upgrade prompt.
  */
 export function detectLegacyFormat(artifact: {
+  artifact_id?: string;
   files?: Record<string, string>;
   sandpack_config?: SandpackConfig;
   required_env_vars?: string[];
@@ -247,6 +248,7 @@ export function detectLegacyFormat(artifact: {
   const detectedEnvVarsArr = [...detectedEnvVars].sort();
   const detectedGrantsArr = [...detectedGrants].sort();
   const upgradeInstructions = renderUpgradeInstructions({
+    artifactId: artifact.artifact_id,
     detectedEnvVars: detectedEnvVarsArr,
     detectedGrants: detectedGrantsArr,
     signals: [...signals],
@@ -262,6 +264,7 @@ export function detectLegacyFormat(artifact: {
 }
 
 function renderUpgradeInstructions(input: {
+  artifactId?: string;
   detectedEnvVars: string[];
   detectedGrants: string[];
   signals: ArtifactLegacySignal[];
@@ -291,18 +294,29 @@ function renderUpgradeInstructions(input: {
   if (input.signals.includes('has_agor_config_js')) removals.push('agor.config.js');
   const removalsLine = removals.length > 0 ? removals.join(' and ') : '(none)';
 
+  // Pin the artifact id into the prompt so an agent given this string knows
+  // exactly which row to migrate. Without it the agent has to guess (or
+  // worse, batch-migrate every legacy artifact it can find).
+  const artifactRef = input.artifactId ? `"${input.artifactId}"` : '<this artifact id>';
+
   return [
-    'Use the agor_artifacts_get tool to read the current artifact files.',
-    'Then use agor_artifacts_publish to republish with the new format:',
-    `  - Drop these legacy files from the file map: ${removalsLine}`,
-    '  - Set sandpack_config (template, customSetup.entry, customSetup.dependencies)',
-    '    so the artifact still renders correctly.',
-    `  - Set required_env_vars: ${envVarsLine}`,
-    `  - Set agor_grants: ${grantsLine}`,
+    `Migrate ONLY this artifact: ${artifactRef}. Do not touch any other artifacts.`,
+    '',
+    `1. Read the current files: agor_artifacts_get(artifactId=${artifactRef}).`,
+    `2. Republish with the new format: agor_artifacts_publish(folderPath=<tmp folder you write the rewritten files to>, artifactId=${artifactRef}, …).`,
+    '',
+    'In the rewritten file map:',
+    `  - Drop these legacy files: ${removalsLine}`,
     '  - Update source files to read env vars via the bundler convention',
     '    (Vite: import.meta.env.VITE_*, CRA: process.env.REACT_APP_*,',
     '    Node: process.env.*) instead of {{ user.env.* }} or',
     '    {{ agor.* }} Handlebars tokens.',
+    '',
+    'In the publish call, set:',
+    '  - sandpack_config (template, customSetup.entry, customSetup.dependencies)',
+    '    so the artifact still renders correctly.',
+    `  - required_env_vars: ${envVarsLine}`,
+    `  - agor_grants: ${grantsLine}`,
     '',
     'Use agor_search_tools for the full publish/get tool schemas.',
   ].join('\n');

--- a/apps/agor-daemon/src/utils/sandpack-config.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.ts
@@ -169,32 +169,18 @@ function sanitizeStringMap(input: unknown): Record<string, string> {
   return out;
 }
 
-/**
- * Merge defaults underneath the author's config. Used at render time so the
- * artifact gets sensible Sandpack defaults without forcing every author to
- * spell them out.
- */
-export function mergeWithDefaults(config: SandpackConfig | undefined): SandpackConfig {
-  const merged: SandpackConfig = {
-    ...DEFAULT_SANDPACK_CONFIG,
-    ...(config ?? {}),
-  };
-  merged.options = { ...DEFAULT_SANDPACK_CONFIG.options, ...(config?.options ?? {}) };
-  if (config?.customSetup || DEFAULT_SANDPACK_CONFIG.customSetup) {
-    merged.customSetup = {
-      ...(DEFAULT_SANDPACK_CONFIG.customSetup ?? {}),
-      ...(config?.customSetup ?? {}),
-    };
-  }
-  return merged;
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Legacy format detection
 // ─────────────────────────────────────────────────────────────────────────────
 
 const HANDLEBARS_TOKEN_RE = /\{\{\s*agor\.(token|apiUrl|proxies\.([\w-]+)|user\w*)/g;
 const HANDLEBARS_USER_ENV_RE = /\{\{\s*user\.env\.([A-Z_][A-Z0-9_]*)/g;
+// Old format also rendered top-level `{{user.email}}` (note: NOT `agor.user…`)
+// and `{{artifact.id}}` / `{{artifact.boardId}}`. Presence-only — no /g flag
+// because we only care whether the variable appears, not where.
+const HANDLEBARS_USER_EMAIL_RE = /\{\{\s*user\.email\s*\}\}/;
+const HANDLEBARS_ARTIFACT_ID_RE = /\{\{\s*artifact\.id\s*\}\}/;
+const HANDLEBARS_ARTIFACT_BOARD_ID_RE = /\{\{\s*artifact\.boardId\s*\}\}/;
 
 /**
  * Inspect an artifact's file map + config columns and report which legacy-format
@@ -242,6 +228,18 @@ export function detectLegacyFormat(artifact: {
     for (const m of content.matchAll(HANDLEBARS_USER_ENV_RE)) {
       signals.add('has_handlebars_user_env');
       detectedEnvVars.add(m[1]);
+    }
+    if (HANDLEBARS_USER_EMAIL_RE.test(content)) {
+      signals.add('has_handlebars_user_email');
+      detectedGrants.add('agor_user_email');
+    }
+    if (HANDLEBARS_ARTIFACT_ID_RE.test(content)) {
+      signals.add('has_handlebars_artifact_ref');
+      detectedGrants.add('agor_artifact_id');
+    }
+    if (HANDLEBARS_ARTIFACT_BOARD_ID_RE.test(content)) {
+      signals.add('has_handlebars_artifact_ref');
+      detectedGrants.add('agor_board_id');
     }
   }
 
@@ -296,11 +294,11 @@ function renderUpgradeInstructions(input: {
   return [
     'Use the agor_artifacts_get tool to read the current artifact files.',
     'Then use agor_artifacts_publish to republish with the new format:',
-    '  - Drop these legacy files from the file map: ' + removalsLine,
+    `  - Drop these legacy files from the file map: ${removalsLine}`,
     '  - Set sandpack_config (template, customSetup.entry, customSetup.dependencies)',
     '    so the artifact still renders correctly.',
-    '  - Set required_env_vars: ' + envVarsLine,
-    '  - Set agor_grants: ' + grantsLine,
+    `  - Set required_env_vars: ${envVarsLine}`,
+    `  - Set agor_grants: ${grantsLine}`,
     '  - Update source files to read env vars via the bundler convention',
     '    (Vite: import.meta.env.VITE_*, CRA: process.env.REACT_APP_*,',
     '    Node: process.env.*) instead of {{ user.env.* }} or',

--- a/apps/agor-daemon/src/utils/sandpack-config.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.ts
@@ -24,16 +24,6 @@ import type {
   SandpackTemplate,
 } from '@agor/core/types';
 
-/** Defaults merged underneath the artifact's `sandpack_config` at render time. */
-export const DEFAULT_SANDPACK_CONFIG: SandpackConfig = {
-  options: {
-    initMode: 'user-visible',
-    showLineNumbers: true,
-    showInlineErrors: true,
-    showTabs: true,
-  },
-};
-
 /**
  * Templates whose Sandpack runtime uses Vite. The synthesized `.env` keys
  * must be prefixed with `VITE_` so `import.meta.env.VITE_*` picks them up.

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -44,7 +44,7 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 - `sandpack_config` — Author-controlled SandpackProvider props (template, customSetup, options). Sanitized on write.
 - `required_env_vars` — Names of env vars the artifact needs (e.g. `["OPENAI_KEY"]`). The daemon synthesizes a per-viewer `.env` at render time.
 - `agor_grants` — Declarative daemon capabilities (`agor_token`, `agor_api_url`, `agor_proxies`, …).
-- `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`. The runtime needs a JS/TS entry file to attach to — pure-HTML/`vanilla`-static artifacts skip injection silently and `agor_artifacts_query_dom` will time out against them.
+- `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`. The runtime ships as an iframe-level `<script>` tag via Sandpack's `externalResources`, so it works regardless of which user files exist (no entry-file detection, no file mutation, no template-specific gotchas).
 
 **On the board:**
 - **Header** — Artifact name with a trust badge (`Yours`/`Trusted`/`Untrusted`), an interact toggle (eye icon), and a 🔒 lock affordance to open the consent modal when the artifact is untrusted.

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -44,6 +44,7 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 - `sandpack_config` — Author-controlled SandpackProvider props (template, customSetup, options). Sanitized on write.
 - `required_env_vars` — Names of env vars the artifact needs (e.g. `["OPENAI_KEY"]`). The daemon synthesizes a per-viewer `.env` at render time.
 - `agor_grants` — Declarative daemon capabilities (`agor_token`, `agor_api_url`, `agor_proxies`, …).
+- `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`.
 
 **On the board:**
 - **Header** — Artifact name with a trust badge (`Yours`/`Trusted`/`Untrusted`), an interact toggle (eye icon), and a 🔒 lock affordance to open the consent modal when the artifact is untrusted.
@@ -132,6 +133,7 @@ Agents manage artifacts through Agor's [MCP tools](/guide/internal-mcp):
 | `agor_artifacts_list` | List visible artifacts (optionally filtered by board) |
 | `agor_artifacts_delete` | Remove an artifact (DB record + board placement) |
 | `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys |
+| `agor_artifacts_query_dom` | Query the rendered DOM via CSS selector. Round-trips through the viewer's open tab (no headless browser). Requires `agor_runtime.enabled !== false` and a browser tab logged in as you currently viewing the artifact |
 
 The typical agent workflow: **publish** the folder, **iterate** by editing files locally and republishing with the same `artifactId`. To pick up where you left off from another worktree, **land** the artifact back to disk first.
 

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -44,7 +44,7 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 - `sandpack_config` — Author-controlled SandpackProvider props (template, customSetup, options). Sanitized on write.
 - `required_env_vars` — Names of env vars the artifact needs (e.g. `["OPENAI_KEY"]`). The daemon synthesizes a per-viewer `.env` at render time.
 - `agor_grants` — Declarative daemon capabilities (`agor_token`, `agor_api_url`, `agor_proxies`, …).
-- `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`.
+- `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`. The runtime needs a JS/TS entry file to attach to — pure-HTML/`vanilla`-static artifacts skip injection silently and `agor_artifacts_query_dom` will time out against them.
 
 **On the board:**
 - **Header** — Artifact name with a trust badge (`Yours`/`Trusted`/`Untrusted`), an interact toggle (eye icon), and a 🔒 lock affordance to open the consent modal when the artifact is untrusted.

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -19,31 +19,36 @@ Under the hood, artifacts are powered by [Sandpack](https://sandpack.codesandbox
 
 ## How it works
 
-1. **Agent creates an artifact** via `agor_artifacts_create` — picks a template (React, vanilla JS, etc.), names it, and optionally provides initial files
-2. **Agor scaffolds the directory** at `.agor/artifacts/<id>/` inside the worktree, writes a `sandpack.json` manifest and source files
-3. **The artifact appears on the board** as an interactive node with a live Sandpack preview
-4. **Agent edits files** using normal file tools, then calls `agor_artifacts_refresh` to push changes to the board
-5. **You interact with the running app** directly on the canvas — click buttons, fill forms, see state updates
+1. **Agent writes a folder** of ordinary source files (a regular `package.json`, `App.tsx`, etc.) — typically inside the worktree so the code is version-controlled.
+2. **Agent calls `agor_artifacts_publish`** with the folder path, the board, the Sandpack template, and (optionally) declarative metadata: `requiredEnvVars`, `agorGrants`, `sandpackConfig`. The daemon serializes the file map into the database.
+3. **The artifact appears on the board** as an interactive node with a live Sandpack preview.
+4. **Agent edits files and republishes** with the same `artifactId`. The board hot-reloads via WebSocket.
+5. **You interact with the running app** directly on the canvas — click buttons, fill forms, see state updates.
 
 ---
 
 ## Artifact anatomy
 
-Each artifact is a filesystem directory plus a database record:
+Each artifact is a stored file map plus a small set of declarative metadata columns. The folder on disk is just the staging area an agent writes before calling `publish` — no Agor-specific sidecars required.
 
-**On disk** (inside the worktree):
+**File map** (shipped to the browser):
 ```
-.agor/artifacts/<artifact-id>/
-  sandpack.json        # Manifest: template, dependencies, entry point
-  App.tsx              # Source files (varies by template)
-  styles.css
-  ...
+/package.json          # Standard package.json — dependencies live here
+/App.tsx               # Source files (varies by template)
+/styles.css
+/.env                  # Synthesized at view time; never persisted (see below)
 ```
+
+**Stored metadata** (DB columns; not in the file map):
+- `template` — Sandpack template (`react`, `react-ts`, `vue3`, …).
+- `sandpack_config` — Author-controlled SandpackProvider props (template, customSetup, options). Sanitized on write.
+- `required_env_vars` — Names of env vars the artifact needs (e.g. `["OPENAI_KEY"]`). The daemon synthesizes a per-viewer `.env` at render time.
+- `agor_grants` — Declarative daemon capabilities (`agor_token`, `agor_api_url`, `agor_proxies`, …).
 
 **On the board:**
-- **Header** — Artifact name with an interact toggle (eye icon)
-- **Preview** — Live Sandpack renderer showing the running application
-- **Interact mode** — Toggle to interact with the app (click buttons, type inputs) vs. normal canvas navigation
+- **Header** — Artifact name with a trust badge (`Yours`/`Trusted`/`Untrusted`), an interact toggle (eye icon), and a 🔒 lock affordance to open the consent modal when the artifact is untrusted.
+- **Preview** — Live Sandpack renderer showing the running application.
+- **Legacy banner** — Old-format artifacts (those still carrying `sandpack.json` / `agor.config.js`) render in safe-degraded mode with an inline upgrade prompt you can hand to an agent.
 
 ---
 
@@ -118,13 +123,17 @@ Agents manage artifacts through Agor's [MCP tools](/guide/internal-mcp):
 
 | Tool | Purpose |
 |------|---------|
-| `agor_artifacts_create` | Scaffold a new artifact with template, files, and board placement |
+| `agor_artifacts_publish` | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId` |
+| `agor_artifacts_get` | Read an artifact's full file map + declarative metadata |
+| `agor_artifacts_land` | Materialize an artifact's stored files back into a worktree (round-trip with publish) |
+| `agor_artifacts_update` | Patch metadata only (board move, name, `requiredEnvVars`, `agorGrants`, `sandpackConfig`) |
 | `agor_artifacts_check_build` | Verify source files exist and are non-empty |
-| `agor_artifacts_refresh` | Re-read filesystem and push updates to connected clients |
-| `agor_artifacts_get_status` | Get build status + console logs for debugging |
-| `agor_artifacts_console_log` | Append runtime console entries (for agent debugging) |
+| `agor_artifacts_status` | Get build status + Sandpack errors + console logs for debugging |
+| `agor_artifacts_list` | List visible artifacts (optionally filtered by board) |
+| `agor_artifacts_delete` | Remove an artifact (DB record + board placement) |
+| `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys |
 
-The typical agent workflow: **create** the artifact, **edit files** with standard file tools, **check build** to verify structure, then **refresh** to push changes live.
+The typical agent workflow: **publish** the folder, **iterate** by editing files locally and republishing with the same `artifactId`. To pick up where you left off from another worktree, **land** the artifact back to disk first.
 
 ---
 
@@ -159,62 +168,86 @@ For anything that needs a real backend, the artifact is still a great starting p
 
 ---
 
-## Secrets and API credentials (`agor.config.js`)
+## Secrets and daemon capabilities
 
-Artifacts can securely access API keys and credentials through a **convention-based config file**. If an artifact contains a file named `/agor.config.js`, Agor treats it as a [Handlebars](https://handlebarsjs.com/) template and renders it **per-user** at view time. This means each user's secrets are injected privately — the raw template on disk only contains placeholders, never actual values.
+Artifacts get secrets and daemon capabilities through two declarative fields on the artifact row, with a **TOFU consent flow** for non-self artifacts:
 
-### How it works
+- `requiredEnvVars` — names of env vars the artifact needs.
+- `agorGrants` — capabilities the daemon will inject (JWT, daemon URL, vendor proxy URLs, etc.).
 
-The agent writes an `agor.config.js` file with template variables:
+At render time the daemon resolves consent, looks up the **viewing user's** values, and synthesizes a `.env` file into the served file map (never persisted). Apps read the values via the standard bundler convention.
 
-```js
-// agor.config.js — template on disk (no secrets here)
-export const apiKey = "{{user.env.OPENAI_API_KEY}}";
-export const apiUrl = "{{agor.apiUrl}}";
-```
+### Declaring what an artifact needs
 
-When you view the artifact, Agor renders the template with **your** environment variables. The artifact code imports from it like any JS module:
-
-```js
-import { apiKey, apiUrl } from '/agor.config.js';
-
-// apiKey is your personal key, resolved at view time
-const res = await fetch('https://api.openai.com/v1/chat/completions', {
-  headers: { Authorization: `Bearer ${apiKey}` },
-  // ...
+```ts
+agor_artifacts_publish({
+  folderPath: ".agor/artifacts/staging/openai-chat",
+  boardId: "01924f3b-...",
+  name: "OpenAI Chat",
+  template: "react-ts",
+  requiredEnvVars: ["OPENAI_KEY"],
+  agorGrants: { agor_token: true, agor_proxies: ["openai"] },
 });
 ```
 
-### Available template variables
+### Reading injected values in app code
 
-| Variable | Source | Example |
-|----------|--------|---------|
-| `{{user.env.VAR_NAME}}` | Your environment variables (Settings > Environment Variables) | `{{user.env.OPENAI_API_KEY}}` |
-| `{{user.id}}` | Current user's ID | `6544d0ab-...` |
-| `{{user.name}}` | Current user's display name | `Max` |
-| `{{user.email}}` | Current user's email | `max@example.com` |
-| `{{agor.apiUrl}}` | Agor daemon URL | `http://localhost:3030` |
-| `{{artifact.id}}` | Current artifact's ID | `01924f3a-...` |
-| `{{artifact.boardId}}` | Board the artifact lives on | `01924f3b-...` |
-| `{{board.id}}` | Board ID | `01924f3b-...` |
-| `{{board.slug}}` | Board slug (for URL construction) | `my-board` |
+The daemon prefixes the synthesized `.env` keys per template, so apps use the standard idiom:
 
-### Setting up your environment variables
+| Template family | Bundler | `.env` prefix | Read from |
+|---|---|---|---|
+| `react`, `react-ts`, `vue3`, `svelte`, `solid` | Vite | `VITE_` | `import.meta.env.VITE_X` |
+| `vue`, `angular` | Vue/Angular CLI | (none) | `process.env.X` |
+| `vanilla`, `vanilla-ts` | Static | n/a | not supported |
 
-1. Go to **Settings > Environment Variables**
-2. Add the keys your artifacts need (e.g., `OPENAI_API_KEY`, `GITHUB_TOKEN`)
-3. Values are encrypted at rest with AES-256-GCM — they're only decrypted when rendering your config
+```ts
+const apiKey = import.meta.env.VITE_OPENAI_KEY;
+const agorToken = import.meta.env.VITE_AGOR_TOKEN;
+const proxyUrl = import.meta.env.VITE_AGOR_PROXY_OPENAI;
 
-If a referenced variable isn't set, it renders as an empty string. Well-written artifacts check for this and show a helpful message instead of failing silently.
+if (!apiKey) {
+  return <ConfigurePrompt name="OPENAI_KEY" />;
+}
+```
+
+### Available `agor_grants`
+
+| Grant | Env var name | Behavior |
+|---|---|---|
+| `agor_token: true` | `AGOR_TOKEN` | Mints a 15-min daemon JWT for the viewer. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
+| `agor_api_url: true` | `AGOR_API_URL` | Daemon base URL. |
+| `agor_proxies: ["openai", ...]` | `AGOR_PROXY_OPENAI`, … | HTTP proxy URLs for listed vendors (see [API Proxies](/guide/api-proxies)). |
+| `agor_user_email: true` | `AGOR_USER_EMAIL` | Viewer's email. |
+| `agor_artifact_id: true` | `AGOR_ARTIFACT_ID` | Pure metadata — no consent. |
+| `agor_board_id: true` | `AGOR_BOARD_ID` | Pure metadata — no consent. |
+
+### TOFU consent
+
+When the viewer is **not** the artifact's author, the daemon won't inject secrets or grants without an explicit trust grant:
+
+1. **Untrusted state** — The artifact renders with empty `.env` values and shows a `Untrusted` badge in the header.
+2. **The viewer clicks 🔒 to open the consent modal.** The modal displays the artifact's source files (with an inline preview pane), the requested env var names, and the requested grants.
+3. **The viewer picks a trust scope** — just-once / this-artifact / this-author / instance-wide.
+4. **The grant is persisted** in `artifact_trust_grants` (or held in-memory for "just-once") and the daemon re-renders with secrets injected.
+
+The matching check is a **strict subset**: if the artifact later adds a new required env var or grant, the existing grant doesn't cover it and the consent modal re-prompts. `agor_token` is treated stricter still — only artifact-scoped grants cover it; author or instance scopes don't.
+
+You can review and revoke grants from **Settings > Trusted Artifacts**.
+
+### Setting up your env vars
+
+1. Go to **Settings > Environment Variables**.
+2. Add the keys your artifacts need (e.g., `OPENAI_KEY`, `GITHUB_TOKEN`).
+3. Values are encrypted at rest with AES-256-GCM — they're only decrypted when rendering.
+
+Missing values render as empty string, not undefined. Check for that and surface a "configure X in Settings" prompt rather than calling APIs with empty creds.
 
 ### Security properties
 
-This design has a meaningful security advantage over tools like Claude Desktop artifacts, where secrets are typically pasted into the conversation and become part of the LLM context:
-
-- **Secrets never hit the LLM** — The agent writes `{{user.env.OPENAI_API_KEY}}` as a placeholder. Your actual API key is resolved server-side at view time and never appears in conversation history or model context
-- **Per-user isolation** — Two users viewing the same artifact each get their own rendered config with their own keys
-- **Template is transparent** — The raw `agor.config.js` on disk only contains placeholders, so anyone reviewing the artifact code sees *which* credentials are needed without seeing the actual values
-- **Encrypted at rest** — User environment variables are stored with AES-256-GCM encryption
+- **Secrets never hit the LLM.** Agents only see env var **names**; values are resolved at view time on the daemon and injected into the served file map.
+- **Per-viewer rendering.** Two users viewing the same artifact get their own `.env` with their own values.
+- **Encrypted at rest** with AES-256-GCM.
+- **No cross-author injection without consent** — the TOFU flow blocks accidental secret leaks into someone else's code.
 
 <div style={{
   marginTop: '12px',
@@ -224,8 +257,12 @@ This design has a meaningful security advantage over tools like Claude Desktop a
   backgroundColor: 'rgba(212, 148, 10, 0.08)',
   fontSize: '14px'
 }}>
-**Trust boundary:** Rendered secrets are injected into the artifact's JavaScript and execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values (e.g., via `fetch` to an external URL). Only open artifacts from sources you trust — the same principle as running any untrusted code. The security guarantee is that **your secrets stay out of the LLM context and conversation history**, not that they're hidden from the artifact code itself.
+**Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via `fetch()`. Only grant trust to artifacts you've reviewed — the consent modal includes a code-preview pane for exactly that reason. The guarantee is that **your secrets stay out of the LLM context and that no daemon-side injection happens without your explicit consent**, not that the artifact JS can't read them once you opt in.
 </div>
+
+### Legacy format (`agor.config.js`)
+
+Older artifacts used a `/agor.config.js` Handlebars sidecar. That format is no longer rendered. Artifacts still carrying it render in safe-degraded mode (no env vars or grants injected) and the board node displays a warning banner with an interpolated upgrade prompt — copy it into a new conversation with an agent that has `agor_artifacts_get` and `agor_artifacts_publish` tools, and the agent can do the migration mechanically.
 
 ---
 
@@ -236,7 +273,9 @@ Artifacts are designed for rapid prototyping, not permanent hosting. When you're
 1. **The code is already on disk** — artifact source files live at `.agor/artifacts/<id>/` inside your worktree. They're standard source files, not a proprietary format
 2. **Ask your agent to scaffold a real project** — "Take this artifact and set it up as a Next.js app" or "Create a Vite project from this prototype"
 3. **Pick your hosting** — Vercel, Netlify, Cloudflare Pages, a Docker container — the agent can set up deployment config for whatever platform you choose
-4. **Graduate your secrets** — Move `agor.config.js` template variables to your hosting platform's environment variable system (Vercel env vars, `.env` files, etc.)
+4. **Graduate your secrets** — Move `requiredEnvVars` to your hosting platform's environment variable system. The bundler convention is the same on the other side (Vite reads `import.meta.env.VITE_*`, etc.) — only the prefix and the source of values change.
+
+You can also one-click eject to CodeSandbox (`agor_artifacts_export_codesandbox`) if you want a quick share link — note that daemon-supplied capabilities (`AGOR_TOKEN`, `AGOR_PROXY_*`) won't work there.
 
 The artifact gets you from idea to working UI in minutes. The agent gets you from prototype to deployed app when you're ready.
 

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -246,7 +246,7 @@ Missing values render as empty string, not undefined. Check for that and surface
 
 ### Security properties
 
-- **Secrets never hit the LLM.** Agents only see env var **names**; values are resolved at view time on the daemon and injected into the served file map.
+- **Raw secret values never enter agent prompts.** Agents see env var **names**; values are resolved at view time on the daemon and injected into the served file map — they're not in any payload an agent reads via the artifacts MCP tools. **Caveat:** `agor_artifacts_query_dom` and `agor_artifacts_query_document_html` return whatever the iframe rendered, so an artifact that prints (or otherwise reflects) a secret-derived value into the DOM will surface that into the calling agent's context. Opt out with `agor_runtime: { enabled: false }` for artifacts that intentionally render sensitive output.
 - **Per-viewer rendering.** Two users viewing the same artifact get their own `.env` with their own values.
 - **Encrypted at rest** with AES-256-GCM.
 - **No cross-author injection without consent** — the TOFU flow blocks accidental secret leaks into someone else's code.
@@ -259,7 +259,7 @@ Missing values render as empty string, not undefined. Check for that and surface
   backgroundColor: 'rgba(212, 148, 10, 0.08)',
   fontSize: '14px'
 }}>
-**Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via `fetch()`. Only grant trust to artifacts you've reviewed — the consent modal includes a code-preview pane for exactly that reason. The guarantee is that **your secrets stay out of the LLM context and that no daemon-side injection happens without your explicit consent**, not that the artifact JS can't read them once you opt in.
+**Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via `fetch()`, or render them into the DOM where `agor_artifacts_query_dom` would surface them to a calling agent. Only grant trust to artifacts you've reviewed — the consent modal includes a code-preview pane for exactly that reason. The guarantee is that **no daemon-side secret injection happens without your explicit consent**, not that the artifact JS can't read or expose those values once you opt in.
 </div>
 
 ### Legacy format (`agor.config.js`)

--- a/apps/agor-ui/package.json
+++ b/apps/agor-ui/package.json
@@ -41,6 +41,7 @@
     "emoji-picker-react": "^4.18.0",
     "emojibase": "^17.0.0",
     "emojibase-data": "^17.0.0",
+    "lz-string": "1.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-js-cron": "^5.2.0",

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -26,6 +26,7 @@ import { Alert, Button, Card, Modal, message, Radio, Space, Tag, Typography } fr
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
+import { useAuthConfig } from '@/hooks/useAuthConfig';
 import { FileCollection, type FileItem } from '../FileCollection/FileCollection';
 
 interface ArtifactConsentModalProps {
@@ -35,7 +36,11 @@ interface ArtifactConsentModalProps {
   files: Record<string, string>;
   requiredEnvVars: string[];
   grants: AgorGrants;
-  /** Hide the "instance-wide" scope option (default: hidden in multi-user mode). */
+  /**
+   * Force-hide the "instance-wide" scope option. Defaults to undefined; when
+   * left unset, the modal hides instance scope automatically on multi-user
+   * Unix isolation modes (read from `/health` features.multiUser).
+   */
   hideInstanceScope?: boolean;
   onClose: () => void;
   onGranted: () => void;
@@ -62,10 +67,14 @@ export function ArtifactConsentModal({
   onClose,
   onGranted,
 }: ArtifactConsentModalProps) {
+  const { featuresConfig } = useAuthConfig();
   const [scope, setScope] = useState<Exclude<ArtifactTrustScopeType, 'self'>>('artifact');
   const [activeFile, setActiveFile] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const requestsAgorToken = !!grants.agor_token;
+  // Auto-hide the instance scope when the daemon is in multi-user Unix
+  // isolation mode, unless the caller explicitly forces a value via prop.
+  const effectivelyHideInstanceScope = hideInstanceScope ?? featuresConfig?.multiUser === true;
 
   const fileItems: FileItem[] = useMemo(
     () =>
@@ -87,11 +96,9 @@ export function ArtifactConsentModal({
       const res = await fetch(`${getDaemonUrl()}/artifacts/${artifactId}/trust`, {
         method: 'POST',
         headers: getAuthHeaders(),
-        body: JSON.stringify({
-          scopeType: scope,
-          envVars: requiredEnvVars,
-          grants,
-        }),
+        // The server derives the consent surface (env vars + grants) from
+        // the artifact itself; the client only nominates the scope.
+        body: JSON.stringify({ scopeType: scope }),
       });
       if (!res.ok) {
         const detail = await res.text().catch(() => '');
@@ -208,7 +215,7 @@ export function ArtifactConsentModal({
               Anything published by this author
               {requestsAgorToken ? ' (disabled — agor_token requires artifact scope)' : ''}
             </Radio>
-            {!hideInstanceScope && (
+            {!effectivelyHideInstanceScope && (
               <Radio value="instance" disabled={requestsAgorToken}>
                 Anything on this Agor instance
                 {requestsAgorToken ? ' (disabled — agor_token requires artifact scope)' : ''}

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -25,8 +25,10 @@ import { LockOutlined, SafetyCertificateOutlined, WarningOutlined } from '@ant-d
 import { Alert, Button, Card, Modal, Radio, Space, Tag, Typography } from 'antd';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
+import { ThemedSyntaxHighlighter } from '@/components/ThemedSyntaxHighlighter';
 import { getDaemonUrl } from '@/config/daemon';
 import { useAuthConfig } from '@/hooks/useAuthConfig';
+import { getLanguageFromPath } from '@/utils/language';
 import { useThemedMessage } from '@/utils/message';
 import { FileCollection, type FileItem } from '../FileCollection/FileCollection';
 
@@ -139,7 +141,13 @@ export function ArtifactConsentModal({
         description="Granting trust injects your env-var values and any requested daemon capabilities into this artifact's runtime. The artifact's JS can read those values. Secrets never enter LLM context — but the artifact iframe can still exfiltrate them via fetch()."
       />
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 2fr)',
+          gap: 16,
+        }}
+      >
         <Card size="small" title="Files in this artifact" styles={{ body: { padding: 0 } }}>
           <div style={{ maxHeight: 360, overflow: 'auto' }}>
             <FileCollection
@@ -153,20 +161,34 @@ export function ArtifactConsentModal({
         <Card
           size="small"
           title={activeFile ? `Preview: ${activeFile}` : 'Pick a file to preview'}
-          styles={{ body: { padding: 0 } }}
+          // The Card is in a 1fr-2fr grid, so it claims its share of the
+          // 920px modal even when the file's longest line is wider; the
+          // `minmax(0, …)` columns above + the inner `minWidth: 0` here
+          // are what stop a long source line from blowing out the grid.
+          styles={{ body: { padding: 0, minWidth: 0 } }}
         >
-          <pre
-            style={{
-              margin: 0,
-              maxHeight: 360,
-              overflow: 'auto',
-              padding: 12,
-              fontSize: 11,
-              lineHeight: 1.5,
-            }}
-          >
-            {activeFile ? (files[activeFile] ?? '(file is empty)') : ''}
-          </pre>
+          <div style={{ maxHeight: 360, overflow: 'auto' }}>
+            {activeFile ? (
+              <ThemedSyntaxHighlighter
+                language={getLanguageFromPath(activeFile)}
+                showLineNumbers
+                customStyle={{
+                  margin: 0,
+                  borderRadius: 0,
+                  fontSize: 12,
+                  // The outer wrapper handles vertical scroll — let the
+                  // highlighter scroll horizontally on its own line.
+                  maxHeight: 'none',
+                }}
+              >
+                {files[activeFile] ?? '(file is empty)'}
+              </ThemedSyntaxHighlighter>
+            ) : (
+              <div style={{ padding: 12, fontSize: 12, opacity: 0.6 }}>
+                Click a file on the left to preview it.
+              </div>
+            )}
+          </div>
         </Card>
       </div>
 

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -22,11 +22,12 @@
 
 import type { AgorGrants, ArtifactTrustScopeType } from '@agor-live/client';
 import { LockOutlined, SafetyCertificateOutlined, WarningOutlined } from '@ant-design/icons';
-import { Alert, Button, Card, Modal, message, Radio, Space, Tag, Typography } from 'antd';
+import { Alert, Button, Card, Modal, Radio, Space, Tag, Typography } from 'antd';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
 import { useAuthConfig } from '@/hooks/useAuthConfig';
+import { useThemedMessage } from '@/utils/message';
 import { FileCollection, type FileItem } from '../FileCollection/FileCollection';
 
 interface ArtifactConsentModalProps {
@@ -68,6 +69,7 @@ export function ArtifactConsentModal({
   onGranted,
 }: ArtifactConsentModalProps) {
   const { featuresConfig } = useAuthConfig();
+  const { showSuccess, showError } = useThemedMessage();
   const [scope, setScope] = useState<Exclude<ArtifactTrustScopeType, 'self'>>('artifact');
   const [activeFile, setActiveFile] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -102,13 +104,13 @@ export function ArtifactConsentModal({
       });
       if (!res.ok) {
         const detail = await res.text().catch(() => '');
-        message.error(`Failed to grant trust: ${res.statusText} ${detail}`);
+        showError(`Failed to grant trust: ${res.statusText} ${detail}`);
         return;
       }
-      message.success('Trust granted');
+      showSuccess('Trust granted');
       onGranted();
     } catch (err) {
-      message.error(`Failed to grant trust: ${err instanceof Error ? err.message : String(err)}`);
+      showError(`Failed to grant trust: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setSubmitting(false);
     }

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -1,0 +1,258 @@
+/**
+ * ArtifactConsentModal — TOFU consent flow for artifact secret/grant injection.
+ *
+ * Surfaces when the viewer clicks "Render with secrets" on an untrusted
+ * artifact. Reuses `FileCollection` for source-code review (so the user can
+ * read what they're about to feed secrets to) and presents the requested
+ * env vars + grants with severity coding before they choose a trust scope.
+ *
+ * Scopes:
+ *  - just-once     → in-memory session grant (cleared on daemon restart)
+ *  - this-artifact → DB-backed; only this artifact ID
+ *  - this-author   → DB-backed; every artifact this author publishes
+ *  - instance-wide → DB-backed; every artifact on this Agor instance
+ *
+ * `instance-wide` is hidden when the daemon is in multi-user mode
+ * (`unix_user_mode !== 'simple'`). The roadmap's reasoning: a "trust everyone"
+ * button on a shared instance is too sharp.
+ *
+ * agor_token is treated stricter — author/instance scopes are disabled when
+ * the artifact requests it; only artifact-scoped or just-once grants apply.
+ */
+
+import type { AgorGrants, ArtifactTrustScopeType } from '@agor-live/client';
+import { LockOutlined, SafetyCertificateOutlined, WarningOutlined } from '@ant-design/icons';
+import { Alert, Button, Card, Modal, message, Radio, Space, Tag, Typography } from 'antd';
+import type { ReactNode } from 'react';
+import { useMemo, useState } from 'react';
+import { getDaemonUrl } from '@/config/daemon';
+import { FileCollection, type FileItem } from '../FileCollection/FileCollection';
+
+interface ArtifactConsentModalProps {
+  open: boolean;
+  artifactId: string;
+  name: string;
+  files: Record<string, string>;
+  requiredEnvVars: string[];
+  grants: AgorGrants;
+  /** Hide the "instance-wide" scope option (default: hidden in multi-user mode). */
+  hideInstanceScope?: boolean;
+  onClose: () => void;
+  onGranted: () => void;
+}
+
+const HIGH_POWER_GRANT_KEYS = new Set<keyof AgorGrants>(['agor_token']);
+
+function getAuthHeaders(): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export function ArtifactConsentModal({
+  open,
+  artifactId,
+  name,
+  files,
+  requiredEnvVars,
+  grants,
+  hideInstanceScope,
+  onClose,
+  onGranted,
+}: ArtifactConsentModalProps) {
+  const [scope, setScope] = useState<Exclude<ArtifactTrustScopeType, 'self'>>('artifact');
+  const [activeFile, setActiveFile] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const requestsAgorToken = !!grants.agor_token;
+
+  const fileItems: FileItem[] = useMemo(
+    () =>
+      Object.entries(files).map(([path, content]) => ({
+        path: path.startsWith('/') ? path.slice(1) : path,
+        title: path.split('/').pop() ?? path,
+        size: content.length,
+        lastModified: new Date(0).toISOString(),
+        isText: true,
+      })),
+    [files]
+  );
+
+  const grantBadges = renderGrantBadges(grants);
+
+  const submit = async () => {
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${getDaemonUrl()}/artifacts/${artifactId}/trust`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({
+          scopeType: scope,
+          envVars: requiredEnvVars,
+          grants,
+        }),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        message.error(`Failed to grant trust: ${res.statusText} ${detail}`);
+        return;
+      }
+      message.success('Trust granted');
+      onGranted();
+    } catch (err) {
+      message.error(`Failed to grant trust: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={
+        <span>
+          <SafetyCertificateOutlined style={{ marginRight: 8 }} />
+          Trust “{name}” to render with secrets
+        </span>
+      }
+      open={open}
+      onCancel={onClose}
+      width={920}
+      footer={null}
+      destroyOnClose
+    >
+      <Alert
+        type="warning"
+        showIcon
+        icon={<WarningOutlined />}
+        style={{ marginBottom: 16 }}
+        message="Read the source before granting trust"
+        description="Granting trust injects your env-var values and any requested daemon capabilities into this artifact's runtime. The artifact's JS can read those values. Secrets never enter LLM context — but the artifact iframe can still exfiltrate them via fetch()."
+      />
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        <Card size="small" title="Files in this artifact" styles={{ body: { padding: 0 } }}>
+          <div style={{ maxHeight: 360, overflow: 'auto' }}>
+            <FileCollection
+              files={fileItems}
+              onFileClick={(file) => setActiveFile(`/${file.path}`)}
+              emptyMessage="No files in this artifact"
+            />
+          </div>
+        </Card>
+
+        <Card
+          size="small"
+          title={activeFile ? `Preview: ${activeFile}` : 'Pick a file to preview'}
+          styles={{ body: { padding: 0 } }}
+        >
+          <pre
+            style={{
+              margin: 0,
+              maxHeight: 360,
+              overflow: 'auto',
+              padding: 12,
+              fontSize: 11,
+              lineHeight: 1.5,
+            }}
+          >
+            {activeFile ? (files[activeFile] ?? '(file is empty)') : ''}
+          </pre>
+        </Card>
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <Typography.Title level={5} style={{ marginBottom: 8 }}>
+          Requested env vars
+        </Typography.Title>
+        <Space size={[4, 4]} wrap>
+          {requiredEnvVars.length === 0 && (
+            <Typography.Text type="secondary">(none)</Typography.Text>
+          )}
+          {requiredEnvVars.map((v) => (
+            <Tag key={v} icon={<LockOutlined />} color="gold">
+              {v}
+            </Tag>
+          ))}
+        </Space>
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <Typography.Title level={5} style={{ marginBottom: 8 }}>
+          Daemon capabilities
+        </Typography.Title>
+        <Space size={[4, 4]} wrap>
+          {grantBadges.length === 0 && <Typography.Text type="secondary">(none)</Typography.Text>}
+          {grantBadges}
+        </Space>
+        {requestsAgorToken && (
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginTop: 8 }}
+            message="agor_token is artifact-scoped only"
+            description="Author and instance grants do NOT cover agor_token — granting it here only affects this artifact, regardless of the scope you pick below."
+          />
+        )}
+      </div>
+
+      <div style={{ marginTop: 16 }}>
+        <Typography.Title level={5} style={{ marginBottom: 8 }}>
+          Trust scope
+        </Typography.Title>
+        <Radio.Group value={scope} onChange={(e) => setScope(e.target.value)}>
+          <Space direction="vertical">
+            <Radio value="session">Just once (in-memory; cleared when daemon restarts)</Radio>
+            <Radio value="artifact">This artifact only</Radio>
+            <Radio value="author" disabled={requestsAgorToken}>
+              Anything published by this author
+              {requestsAgorToken ? ' (disabled — agor_token requires artifact scope)' : ''}
+            </Radio>
+            {!hideInstanceScope && (
+              <Radio value="instance" disabled={requestsAgorToken}>
+                Anything on this Agor instance
+                {requestsAgorToken ? ' (disabled — agor_token requires artifact scope)' : ''}
+              </Radio>
+            )}
+          </Space>
+        </Radio.Group>
+      </div>
+
+      <div style={{ marginTop: 24, display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <Button onClick={onClose}>Render without secrets</Button>
+        <Button type="primary" loading={submitting} onClick={submit}>
+          Render with secrets
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+function renderGrantBadges(grants: AgorGrants): ReactNode[] {
+  const out: ReactNode[] = [];
+  for (const [key, value] of Object.entries(grants)) {
+    if (key === 'agor_proxies') {
+      const list = (value as string[] | undefined) ?? [];
+      for (const vendor of list) {
+        out.push(
+          <Tag key={`proxy:${vendor}`} color="purple">
+            agor_proxies:{vendor}
+          </Tag>
+        );
+      }
+      continue;
+    }
+    if (!value) continue;
+    const isHighPower = HIGH_POWER_GRANT_KEYS.has(key as keyof AgorGrants);
+    out.push(
+      <Tag
+        key={key}
+        color={isHighPower ? 'red' : 'blue'}
+        icon={isHighPower ? <WarningOutlined /> : undefined}
+      >
+        {key}
+      </Tag>
+    );
+  }
+  return out;
+}

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
@@ -3,6 +3,7 @@ import { CopyOutlined } from '@ant-design/icons';
 import { Button, Modal } from 'antd';
 import { ThemedSyntaxHighlighter } from '@/components/ThemedSyntaxHighlighter';
 import { copyToClipboard } from '@/utils/clipboard';
+import { getLanguageFromPath } from '@/utils/language';
 import { useThemedMessage } from '@/utils/message';
 
 export interface CodePreviewModalProps {
@@ -11,40 +12,6 @@ export interface CodePreviewModalProps {
   onClose: () => void;
   loading?: boolean;
 }
-
-const getLanguageFromPath = (path: string): string => {
-  const ext = path.split('.').pop()?.toLowerCase();
-  const languageMap: Record<string, string> = {
-    js: 'javascript',
-    ts: 'typescript',
-    jsx: 'jsx',
-    tsx: 'tsx',
-    py: 'python',
-    rb: 'ruby',
-    go: 'go',
-    rs: 'rust',
-    java: 'java',
-    c: 'c',
-    cpp: 'cpp',
-    h: 'c',
-    css: 'css',
-    scss: 'scss',
-    html: 'html',
-    xml: 'xml',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    sh: 'bash',
-    bash: 'bash',
-    sql: 'sql',
-    graphql: 'graphql',
-    proto: 'protobuf',
-    toml: 'toml',
-    vue: 'vue',
-    svelte: 'svelte',
-  };
-  return languageMap[ext || ''] || 'text';
-};
 
 export const CodePreviewModal = ({ file, open, onClose, loading }: CodePreviewModalProps) => {
   const { showSuccess } = useThemedMessage();

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
@@ -129,6 +129,13 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
       >
         <div
           ref={iframeContainerRef}
+          // In interact mode, React Flow's node-drag / canvas-pan / wheel-zoom
+          // listeners would otherwise capture every mousedown and wheel event
+          // before the iframe sees them — text selection (and therefore
+          // copy/paste) breaks, and scrolling zooms the canvas. The
+          // `nodrag nopan nowheel` classes are React Flow's documented
+          // escape hatch.
+          className={interactMode ? 'nodrag nopan nowheel' : undefined}
           style={{
             flex: 1,
             position: 'relative',

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -37,6 +37,7 @@ import {
   CheckCircleOutlined,
   CloseCircleOutlined,
   DeleteOutlined,
+  ExportOutlined,
   EyeOutlined,
   LoadingOutlined,
   LockOutlined,
@@ -51,7 +52,7 @@ import {
   useSandpack,
   useSandpackConsole,
 } from '@codesandbox/sandpack-react';
-import { Alert, Badge, Button, Card, Spin, Tag, Tooltip, Typography, theme } from 'antd';
+import { Alert, Badge, Button, Card, message, Spin, Tag, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import { getDaemonUrl } from '@/config/daemon';
@@ -291,6 +292,34 @@ export const ArtifactNode = ({
     [data]
   );
 
+  // Eject the artifact to a fresh CodeSandbox sandbox in a new tab.
+  // Open the tab synchronously on click, then redirect it after the daemon
+  // returns the URL — async window.open() is blocked by most popup blockers.
+  const handleOpenInCodeSandbox = useCallback(() => {
+    const newTab = window.open('about:blank', '_blank');
+    void (async () => {
+      try {
+        const res = await fetch(
+          `${getDaemonUrl()}/artifacts/${data.artifactId}/export/codesandbox`,
+          { method: 'POST', headers: getAuthHeaders() }
+        );
+        const body = (await res.json()) as { url?: string; error?: string };
+        if (!res.ok || body.error || !body.url) {
+          newTab?.close();
+          message.error(`Open in CodeSandbox failed: ${body.error ?? res.statusText}`);
+          return;
+        }
+        if (newTab) newTab.location.href = body.url;
+        else window.open(body.url, '_blank');
+      } catch (err) {
+        newTab?.close();
+        message.error(
+          `Open in CodeSandbox failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    })();
+  }, [data.artifactId]);
+
   // Loading state
   if (loading && !payload) {
     return (
@@ -428,6 +457,17 @@ export const ArtifactNode = ({
                   />
                 </Tooltip>
               )}
+              <Tooltip title="Open in CodeSandbox (eject — daemon-injected env vars/AGOR_TOKEN won't carry over)">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<ExportOutlined />}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleOpenInCodeSandbox();
+                  }}
+                />
+              </Tooltip>
               <Tooltip title="Reload">
                 <Button
                   type="text"

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -218,7 +218,17 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
         kind: string;
         args: Record<string, unknown>;
       };
-      if (!detail || detail.artifact_id !== artifactId) return;
+      if (!detail) return;
+      if (detail.artifact_id !== artifactId) {
+        console.log(
+          `[agor-query] bridge skip (wrong artifact): mine=${artifactId.slice(0, 8)} event=${detail.artifact_id?.slice(0, 8)} requestId=${detail.request_id}`
+        );
+        return;
+      }
+      console.log(
+        `[agor-query] bridge received requestId=${detail.request_id} kind=${detail.kind} ` +
+          `iframeAttached=${!!iframe.current?.contentWindow}`
+      );
 
       // Requester filter: the daemon's `agor-query` event broadcasts on
       // the global authenticated channel, so EVERY logged-in tab receives
@@ -231,12 +241,21 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       // prevent.
       if (detail.requested_by_user_id) {
         const currentUserId = getCurrentUserIdFromJwt();
-        if (!currentUserId || currentUserId !== detail.requested_by_user_id) return;
+        if (!currentUserId || currentUserId !== detail.requested_by_user_id) {
+          console.log(
+            `[agor-query] bridge skip (wrong user): requestId=${detail.request_id} ` +
+              `mine=${currentUserId?.slice(0, 8) ?? 'null'} requestedBy=${detail.requested_by_user_id.slice(0, 8)}`
+          );
+          return;
+        }
       }
 
       const requestId = detail.request_id;
       const target = iframe.current?.contentWindow;
       if (!target) {
+        console.log(
+          `[agor-query] bridge no iframe contentWindow requestId=${requestId} — query will time out`
+        );
         // Iframe not yet attached; can't answer this query. The daemon's
         // pending entry will time out and surface a clean error to the
         // agent. No need to POST a synthetic failure here.
@@ -251,6 +270,9 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
         // iframe we just dispatched to, not from any other postMessage
         // source that happens to know our requestId.
         if (msgEvent.source !== target) return;
+        console.log(
+          `[agor-query] iframe replied requestId=${requestId} ok=${!!data.ok} ${data.error ? `error=${data.error}` : ''}`
+        );
         cleanup();
         void postResult({ ok: !!data.ok, result: data.result, error: data.error });
       };
@@ -280,6 +302,9 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       };
 
       window.addEventListener('message', messageHandler);
+      console.log(
+        `[agor-query] bridge postMessage requestId=${requestId} kind=${detail.kind} -> iframe`
+      );
       // Forward to the iframe. Cross-origin so target origin is '*';
       // payload carries no secrets, just a query for the iframe to run.
       target.postMessage(
@@ -869,7 +894,7 @@ function LegacyBanner({ upgradeInstructions }: { upgradeInstructions: string }) 
       // prompt text to copy it.
       className="nodrag nopan"
       style={{ borderRadius: 0, fontSize: 11, padding: '10px 14px' }}
-      message="Legacy artifact — won't render correctly"
+      title="Legacy artifact — won't render correctly"
       description={
         <details style={{ marginTop: 4 }}>
           <summary style={{ cursor: 'pointer', color: token.colorTextSecondary }}>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -546,7 +546,15 @@ export const ArtifactNode = ({
           }
         `}</style>
         <div
-          className="artifact-sandpack-wrapper"
+          // React Flow's node-drag, canvas-pan, and wheel-zoom listeners all
+          // attach at the node level and would otherwise fire on every
+          // mousedown/wheel inside the iframe. The `nodrag nopan nowheel`
+          // classes are React Flow's documented escape hatch — without them,
+          // dragging to text-select inside the artifact starts a node drag
+          // (so copy/paste / selection breaks), and scrolling a long page
+          // zooms the canvas. Only apply in interact mode so the card
+          // remains draggable when the iframe is overlay-blocked.
+          className={`artifact-sandpack-wrapper${interactMode ? ' nodrag nopan nowheel' : ''}`}
           style={{
             flex: 1,
             position: 'relative',

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -51,6 +51,7 @@ import {
   SandpackProvider,
   type SandpackSetup,
   useSandpack,
+  useSandpackClient,
   useSandpackConsole,
 } from '@codesandbox/sandpack-react';
 import { Alert, Badge, Button, Card, Spin, Tag, Tooltip, Typography, theme } from 'antd';
@@ -158,6 +159,88 @@ function ConsoleReporter({ artifactId }: { artifactId: string }) {
  * Must be inside SandpackProvider.
  */
 const SANDPACK_ERROR_THROTTLE_MS = 1000;
+
+/**
+ * Bridges agent-driven runtime queries: WS event from the daemon → postMessage
+ * to the iframe → reply postMessage from `agor-runtime.js` → POST back to
+ * the daemon's `/artifacts/:id/runtime-response/:requestId`. Must be inside
+ * `<SandpackProvider>` so it can grab the iframe ref via `useSandpackClient`.
+ *
+ * Multiple ArtifactNode instances can be on the same board. Each registers
+ * its own bridge; the one whose `artifactId` matches the incoming event
+ * answers, the rest ignore. Server-side correlation also enforces that
+ * the responding user matches the requester, so even if multiple tabs
+ * answered the same query (one per ArtifactNode for the same artifact),
+ * only the first response wins.
+ */
+const RUNTIME_QUERY_DEFAULT_TIMEOUT_MS = 6000;
+function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
+  const { iframe } = useSandpackClient();
+
+  useEffect(() => {
+    const handleQuery = (event: Event) => {
+      const detail = (event as CustomEvent).detail as {
+        request_id: string;
+        artifact_id: string;
+        kind: string;
+        args: Record<string, unknown>;
+      };
+      if (!detail || detail.artifact_id !== artifactId) return;
+      const requestId = detail.request_id;
+      const target = iframe.current?.contentWindow;
+      if (!target) {
+        // Iframe not yet attached; can't answer this query. The daemon's
+        // pending entry will time out and surface a clean error to the
+        // agent. No need to POST a synthetic failure here.
+        return;
+      }
+
+      const messageHandler = (msgEvent: MessageEvent) => {
+        const data = msgEvent.data;
+        if (!data || typeof data !== 'object') return;
+        if (data.type !== 'agor:result' || data.requestId !== requestId) return;
+        cleanup();
+        void postResult({ ok: !!data.ok, result: data.result, error: data.error });
+      };
+      const timeout = setTimeout(() => {
+        cleanup();
+        void postResult({
+          ok: false,
+          error: 'Iframe did not respond before timeout (agor-runtime.js may be missing).',
+        });
+      }, RUNTIME_QUERY_DEFAULT_TIMEOUT_MS);
+      const cleanup = () => {
+        window.removeEventListener('message', messageHandler);
+        clearTimeout(timeout);
+      };
+
+      const postResult = async (body: { ok: boolean; result?: unknown; error?: string }) => {
+        try {
+          await fetch(`${getDaemonUrl()}/artifacts/${artifactId}/runtime-response/${requestId}`, {
+            method: 'POST',
+            headers: getAuthHeaders(),
+            body: JSON.stringify(body),
+          });
+        } catch {
+          // The daemon's pending entry will time out on its own — nothing
+          // we can do client-side if the response POST itself fails.
+        }
+      };
+
+      window.addEventListener('message', messageHandler);
+      // Forward to the iframe. Cross-origin so target origin is '*';
+      // payload carries no secrets, just a query for the iframe to run.
+      target.postMessage(
+        { type: 'agor:query', requestId, kind: detail.kind, args: detail.args },
+        '*'
+      );
+    };
+    window.addEventListener('agor:artifact-runtime-query', handleQuery);
+    return () => window.removeEventListener('agor:artifact-runtime-query', handleQuery);
+  }, [artifactId, iframe]);
+
+  return null;
+}
 
 function SandpackErrorReporter({ artifactId }: { artifactId: string }) {
   const { sandpack } = useSandpack();
@@ -656,6 +739,7 @@ export const ArtifactNode = ({
             />
             <ConsoleReporter artifactId={data.artifactId} />
             <SandpackErrorReporter artifactId={data.artifactId} />
+            <ArtifactRuntimeBridge artifactId={data.artifactId} />
           </SandpackProvider>
         </div>
       </Card>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -105,8 +105,13 @@ function getCurrentUserIdFromJwt(): string | null {
   try {
     const parts = token.split('.');
     if (parts.length < 2) return null;
-    const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const payload = JSON.parse(atob(padded));
+    // base64url → base64. atob requires `=` padding to a multiple of 4;
+    // base64url payloads are usually unpadded, so add it back before
+    // decoding. Without this, decode can throw on perfectly valid JWTs
+    // and we'd fail open (see the bridge's requester filter).
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) b64 += '=';
+    const payload = JSON.parse(atob(b64));
     return typeof payload.sub === 'string' ? payload.sub : null;
   } catch {
     return null;
@@ -220,15 +225,13 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       // it. Without this client-side check, every tab would run the DOM
       // query against its own (possibly secret-bearing) render — the
       // server would later drop the wrong-user response, but the query
-      // would have already executed. Skipping here means non-requesters
-      // never run the selector at all.
-      const currentUserId = getCurrentUserIdFromJwt();
-      if (
-        detail.requested_by_user_id &&
-        currentUserId &&
-        detail.requested_by_user_id !== currentUserId
-      ) {
-        return;
+      // would have already executed. Fail closed (skip the query) if we
+      // can't establish the viewer's identity — falling open here would
+      // re-introduce the cross-user privacy leak this filter exists to
+      // prevent.
+      if (detail.requested_by_user_id) {
+        const currentUserId = getCurrentUserIdFromJwt();
+        if (!currentUserId || currentUserId !== detail.requested_by_user_id) return;
       }
 
       const requestId = detail.request_id;

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -51,7 +51,6 @@ import {
   SandpackProvider,
   type SandpackSetup,
   useSandpack,
-  useSandpackClient,
   useSandpackConsole,
 } from '@codesandbox/sandpack-react';
 import { Alert, Badge, Button, Card, Spin, Tag, Tooltip, Typography, theme } from 'antd';
@@ -207,7 +206,20 @@ const SANDPACK_ERROR_THROTTLE_MS = 1000;
  */
 const RUNTIME_QUERY_DEFAULT_TIMEOUT_MS = 6000;
 function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
-  const { iframe } = useSandpackClient();
+  // CRITICAL: must be `useSandpack` (read existing clients) rather than
+  // `useSandpackClient` — the latter "registers a new sandpack client"
+  // and expects the caller to render its own <iframe> and pass the ref;
+  // because we don't render one, the ref stays null forever and the
+  // bridge can never postMessage to the actual preview iframe. By going
+  // through `sandpack.clients`, we grab the iframe the sibling
+  // <SandpackPreview> already registered with the provider.
+  const { sandpack } = useSandpack();
+  // Park the current sandpack state in a ref so the window-event handler
+  // can read the latest `clients` without re-attaching on every Sandpack
+  // re-render (status ticks, file updates, etc). Re-attaching would
+  // leave a brief gap where a daemon emit could miss the listener.
+  const sandpackRef = useRef(sandpack);
+  sandpackRef.current = sandpack;
 
   useEffect(() => {
     const handleQuery = (event: Event) => {
@@ -221,13 +233,14 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       if (!detail) return;
       if (detail.artifact_id !== artifactId) {
         console.log(
-          `[agor-query] bridge skip (wrong artifact): mine=${artifactId.slice(0, 8)} event=${detail.artifact_id?.slice(0, 8)} requestId=${detail.request_id}`
+          `[agor-query] bridge skip (wrong artifact): mine=${artifactId.slice(0, 16)} event=${detail.artifact_id?.slice(0, 16)} requestId=${detail.request_id}`
         );
         return;
       }
+      const currentSandpack = sandpackRef.current;
       console.log(
         `[agor-query] bridge received requestId=${detail.request_id} kind=${detail.kind} ` +
-          `iframeAttached=${!!iframe.current?.contentWindow}`
+          `clientCount=${Object.keys(currentSandpack.clients).length}`
       );
 
       // Requester filter: the daemon's `agor-query` event broadcasts on
@@ -244,21 +257,29 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
         if (!currentUserId || currentUserId !== detail.requested_by_user_id) {
           console.log(
             `[agor-query] bridge skip (wrong user): requestId=${detail.request_id} ` +
-              `mine=${currentUserId?.slice(0, 8) ?? 'null'} requestedBy=${detail.requested_by_user_id.slice(0, 8)}`
+              `mine=${currentUserId?.slice(0, 16) ?? 'null'} requestedBy=${detail.requested_by_user_id.slice(0, 16)}`
           );
           return;
         }
       }
 
       const requestId = detail.request_id;
-      const target = iframe.current?.contentWindow;
+      // Pick the first registered Sandpack client's iframe. In practice
+      // each ArtifactNode has one preview (one client). If multiple
+      // existed we'd target the first; the agor-runtime listener is
+      // identical across them so the choice is arbitrary.
+      const clientIds = Object.keys(currentSandpack.clients);
+      const firstClient = clientIds.length > 0 ? currentSandpack.clients[clientIds[0]] : null;
+      const target = firstClient?.iframe?.contentWindow ?? null;
       if (!target) {
         console.log(
-          `[agor-query] bridge no iframe contentWindow requestId=${requestId} — query will time out`
+          `[agor-query] bridge no client iframe requestId=${requestId} clients=${clientIds.length} ` +
+            `firstHasIframe=${!!firstClient?.iframe} — query will time out`
         );
-        // Iframe not yet attached; can't answer this query. The daemon's
-        // pending entry will time out and surface a clean error to the
-        // agent. No need to POST a synthetic failure here.
+        // Sandpack hasn't registered a client yet (still booting, or
+        // initMode='user-visible' is waiting for visibility). The
+        // daemon's pending entry will time out cleanly. The agent's
+        // retry will land after Sandpack is ready.
         return;
       }
 
@@ -314,7 +335,10 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
     };
     window.addEventListener('agor:artifact-runtime-query', handleQuery);
     return () => window.removeEventListener('agor:artifact-runtime-query', handleQuery);
-  }, [artifactId, iframe]);
+    // `sandpack` is read via sandpackRef at query time, so we don't need
+    // it in deps — the handler attaches once per artifact and keeps
+    // working as Sandpack re-renders.
+  }, [artifactId]);
 
   return null;
 }

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -230,18 +230,7 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
         kind: string;
         args: Record<string, unknown>;
       };
-      if (!detail) return;
-      if (detail.artifact_id !== artifactId) {
-        console.log(
-          `[agor-query] bridge skip (wrong artifact): mine=${artifactId.slice(0, 16)} event=${detail.artifact_id?.slice(0, 16)} requestId=${detail.request_id}`
-        );
-        return;
-      }
-      const currentSandpack = sandpackRef.current;
-      console.log(
-        `[agor-query] bridge received requestId=${detail.request_id} kind=${detail.kind} ` +
-          `clientCount=${Object.keys(currentSandpack.clients).length}`
-      );
+      if (!detail || detail.artifact_id !== artifactId) return;
 
       // Requester filter: the daemon's `agor-query` event broadcasts on
       // the global authenticated channel, so EVERY logged-in tab receives
@@ -254,13 +243,7 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       // prevent.
       if (detail.requested_by_user_id) {
         const currentUserId = getCurrentUserIdFromJwt();
-        if (!currentUserId || currentUserId !== detail.requested_by_user_id) {
-          console.log(
-            `[agor-query] bridge skip (wrong user): requestId=${detail.request_id} ` +
-              `mine=${currentUserId?.slice(0, 16) ?? 'null'} requestedBy=${detail.requested_by_user_id.slice(0, 16)}`
-          );
-          return;
-        }
+        if (!currentUserId || currentUserId !== detail.requested_by_user_id) return;
       }
 
       const requestId = detail.request_id;
@@ -268,14 +251,11 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       // each ArtifactNode has one preview (one client). If multiple
       // existed we'd target the first; the agor-runtime listener is
       // identical across them so the choice is arbitrary.
+      const currentSandpack = sandpackRef.current;
       const clientIds = Object.keys(currentSandpack.clients);
       const firstClient = clientIds.length > 0 ? currentSandpack.clients[clientIds[0]] : null;
       const target = firstClient?.iframe?.contentWindow ?? null;
       if (!target) {
-        console.log(
-          `[agor-query] bridge no client iframe requestId=${requestId} clients=${clientIds.length} ` +
-            `firstHasIframe=${!!firstClient?.iframe} — query will time out`
-        );
         // Sandpack hasn't registered a client yet (still booting, or
         // initMode='user-visible' is waiting for visibility). The
         // daemon's pending entry will time out cleanly. The agent's
@@ -291,9 +271,6 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
         // iframe we just dispatched to, not from any other postMessage
         // source that happens to know our requestId.
         if (msgEvent.source !== target) return;
-        console.log(
-          `[agor-query] iframe replied requestId=${requestId} ok=${!!data.ok} ${data.error ? `error=${data.error}` : ''}`
-        );
         cleanup();
         void postResult({ ok: !!data.ok, result: data.result, error: data.error });
       };
@@ -323,9 +300,6 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       };
 
       window.addEventListener('message', messageHandler);
-      console.log(
-        `[agor-query] bridge postMessage requestId=${requestId} kind=${detail.kind} -> iframe`
-      );
       // Forward to the iframe. Cross-origin so target origin is '*';
       // payload carries no secrets, just a query for the iframe to run.
       target.postMessage(

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -722,6 +722,10 @@ function renderLegacyBanner(
       type="warning"
       showIcon
       icon={<WarningOutlined />}
+      // `nodrag nopan` so clicking on the banner doesn't start a React
+      // Flow node drag — without these, the user can't select the upgrade
+      // prompt text to copy it.
+      className="nodrag nopan"
       style={{ borderRadius: 0, fontSize: 11, padding: '4px 12px' }}
       message="Legacy artifact — won't render correctly"
       description={
@@ -739,6 +743,11 @@ function renderLegacyBanner(
               borderRadius: 4,
               maxHeight: 180,
               overflow: 'auto',
+              // React Flow nodes default to `user-select: none` to keep
+              // drag clean — opt this <pre> back into text selection so
+              // users can copy the upgrade prompt.
+              userSelect: 'text',
+              cursor: 'text',
             }}
           >
             {upgradeInstructions}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -52,10 +52,12 @@ import {
   useSandpack,
   useSandpackConsole,
 } from '@codesandbox/sandpack-react';
-import { Alert, Badge, Button, Card, message, Spin, Tag, Tooltip, Typography, theme } from 'antd';
+import { Alert, Badge, Button, Card, Spin, Tag, Tooltip, Typography, theme } from 'antd';
+import { compressToBase64 } from 'lz-string';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import { getDaemonUrl } from '@/config/daemon';
+import { useThemedMessage } from '@/utils/message';
 import { ArtifactConsentModal } from '../../ArtifactConsentModal/ArtifactConsentModal';
 import { withBodyReset } from './utils/sandpackDefaults';
 
@@ -232,6 +234,7 @@ export const ArtifactNode = ({
   selected?: boolean;
 }) => {
   const { token } = theme.useToken();
+  const { showError } = useThemedMessage();
   const [interactMode, setInteractMode] = useState(false);
   const [payload, setPayload] = useState<ArtifactPayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -293,32 +296,58 @@ export const ArtifactNode = ({
   );
 
   // Eject the artifact to a fresh CodeSandbox sandbox in a new tab.
-  // Open the tab synchronously on click, then redirect it after the daemon
-  // returns the URL — async window.open() is blocked by most popup blockers.
+  //
+  // Browser-side form-POST instead of a daemon round-trip — the daemon's
+  // outbound IP is consistently blocked by Cloudflare on CodeSandbox's
+  // define endpoint, but real browser submissions go through. This is also
+  // what AntD/Storybook do for their "Open in CodeSandbox" buttons.
+  //
+  // Implementation matches @codesandbox/sandpack-client's `getParameters`:
+  // LZString.compressToBase64 with URL-safe character substitution.
   const handleOpenInCodeSandbox = useCallback(() => {
-    const newTab = window.open('about:blank', '_blank');
-    void (async () => {
-      try {
-        const res = await fetch(
-          `${getDaemonUrl()}/artifacts/${data.artifactId}/export/codesandbox`,
-          { method: 'POST', headers: getAuthHeaders() }
-        );
-        const body = (await res.json()) as { url?: string; error?: string };
-        if (!res.ok || body.error || !body.url) {
-          newTab?.close();
-          message.error(`Open in CodeSandbox failed: ${body.error ?? res.statusText}`);
-          return;
-        }
-        if (newTab) newTab.location.href = body.url;
-        else window.open(body.url, '_blank');
-      } catch (err) {
-        newTab?.close();
-        message.error(
-          `Open in CodeSandbox failed: ${err instanceof Error ? err.message : String(err)}`
-        );
+    if (!payload) return;
+    const filesPayload: Record<string, { content: string }> = {};
+    for (const [filePath, content] of Object.entries(payload.files)) {
+      const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+      // Strip Agor-only sidecars + the synthesized .env — they'd be inert
+      // (or broken) outside Agor. The synthesized .env carries the viewer's
+      // secrets; never ship it to a third party.
+      if (
+        stripped === 'agor.config.js' ||
+        stripped === 'agor.artifact.json' ||
+        stripped === '.env'
+      ) {
+        continue;
       }
-    })();
-  }, [data.artifactId]);
+      filesPayload[stripped] = { content };
+    }
+    const definePayload = {
+      files: filesPayload,
+      template: payload.sandpack_config?.template ?? payload.template,
+    };
+    const parameters = compressToBase64(JSON.stringify(definePayload))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = 'https://codesandbox.io/api/v1/sandboxes/define';
+    form.target = '_blank';
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'parameters';
+    input.value = parameters;
+    form.appendChild(input);
+    document.body.appendChild(form);
+    try {
+      form.submit();
+    } catch (err) {
+      showError(`Open in CodeSandbox failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      form.remove();
+    }
+  }, [payload, showError]);
 
   // Loading state
   if (loading && !payload) {

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -732,7 +732,7 @@ function LegacyBanner({ upgradeInstructions }: { upgradeInstructions: string }) 
       // Flow node drag — without these, the user can't select the upgrade
       // prompt text to copy it.
       className="nodrag nopan"
-      style={{ borderRadius: 0, fontSize: 11, padding: '4px 12px' }}
+      style={{ borderRadius: 0, fontSize: 11, padding: '10px 14px' }}
       message="Legacy artifact — won't render correctly"
       description={
         <details style={{ marginTop: 4 }}>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -478,6 +478,10 @@ export const ArtifactNode = ({
                   <Button
                     type="text"
                     size="small"
+                    // `danger` themes the icon via Ant's colorError token —
+                    // signals "this artifact won't render with secrets until
+                    // you grant trust" without us hardcoding a hex.
+                    danger
                     icon={<LockOutlined />}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -87,6 +87,33 @@ function getAuthHeaders(): HeadersInit {
 }
 
 /**
+ * Decode the current user's id from the Feathers JWT in localStorage.
+ *
+ * Used by the runtime-query bridge to filter out queries the daemon emits
+ * for OTHER users — without this, every authenticated browser tab would
+ * run the agent's selector against its own (potentially secret-bearing)
+ * render. The server-side correlation already drops cross-user response
+ * POSTs, but the actual DOM query still ran in the wrong tab. Filtering
+ * client-side prevents the query from executing at all.
+ *
+ * Returns null on any parse failure — callers should treat that as
+ * "don't run this query" (safe default).
+ */
+function getCurrentUserIdFromJwt(): string | null {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
+  if (!token) return null;
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const payload = JSON.parse(atob(padded));
+    return typeof payload.sub === 'string' ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Inner component that captures Sandpack console events and forwards them to the daemon.
  * Must be inside SandpackProvider.
  */
@@ -182,10 +209,28 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
       const detail = (event as CustomEvent).detail as {
         request_id: string;
         artifact_id: string;
+        requested_by_user_id?: string;
         kind: string;
         args: Record<string, unknown>;
       };
       if (!detail || detail.artifact_id !== artifactId) return;
+
+      // Requester filter: the daemon's `agor-query` event broadcasts on
+      // the global authenticated channel, so EVERY logged-in tab receives
+      // it. Without this client-side check, every tab would run the DOM
+      // query against its own (possibly secret-bearing) render — the
+      // server would later drop the wrong-user response, but the query
+      // would have already executed. Skipping here means non-requesters
+      // never run the selector at all.
+      const currentUserId = getCurrentUserIdFromJwt();
+      if (
+        detail.requested_by_user_id &&
+        currentUserId &&
+        detail.requested_by_user_id !== currentUserId
+      ) {
+        return;
+      }
+
       const requestId = detail.request_id;
       const target = iframe.current?.contentWindow;
       if (!target) {
@@ -199,6 +244,10 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
         const data = msgEvent.data;
         if (!data || typeof data !== 'object') return;
         if (data.type !== 'agor:result' || data.requestId !== requestId) return;
+        // Source check (defense in depth): only accept replies from the
+        // iframe we just dispatched to, not from any other postMessage
+        // source that happens to know our requestId.
+        if (msgEvent.source !== target) return;
         cleanup();
         void postResult({ ok: !!data.ok, result: data.result, error: data.error });
       };

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -317,6 +317,98 @@ function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
   return null;
 }
 
+/**
+ * Eject the rendered artifact to a fresh CodeSandbox sandbox in a new tab.
+ *
+ * Sits inside `<SandpackProvider>` so it can read `useSandpack().sandpack` —
+ * specifically `sandpack.files` (the *resolved* bundler file map, which
+ * includes the template scaffolding files Sandpack synthesizes) and
+ * `sandpack.environment` (the CSB-compatible runtime name like
+ * `create-react-app` / `parcel` / `vue-cli`). Building the payload from
+ * the daemon's raw `payload.files` skipped both — without scaffolding,
+ * CSB has no entry point to render and no DOM root to mount on, so the
+ * resulting sandbox boots empty.
+ *
+ * Triggered by a window event the outer header button dispatches; we
+ * can't move the button itself inside the provider because it lives in
+ * the React-Flow node header (outside the Sandpack subtree).
+ *
+ * Browser-side form-POST instead of a daemon round-trip — the daemon's
+ * outbound IP is consistently blocked by Cloudflare on CodeSandbox's
+ * define endpoint, but real browser submissions go through.
+ */
+const STRIPPED_FROM_EXPORT = new Set([
+  // Agor-only sidecars — inert/broken outside Agor.
+  'agor.config.js',
+  'agor.artifact.json',
+  // The synthesized .env carries the *viewer's* secrets — never ship to a
+  // third party even though Sandpack happens to have it in the file map.
+  '.env',
+]);
+function CodeSandboxExporter({ artifactId }: { artifactId: string }) {
+  const { sandpack } = useSandpack();
+  const { showError } = useThemedMessage();
+  // Park the sandpack state in a ref so the window-event handler reads
+  // the latest resolved file map without re-attaching on every tick.
+  const sandpackRef = useRef(sandpack);
+  sandpackRef.current = sandpack;
+
+  useEffect(() => {
+    const handler = () => {
+      const current = sandpackRef.current;
+      const normalizedFiles: Record<string, { content: string; isBinary: boolean }> = {};
+      for (const [filePath, file] of Object.entries(current.files)) {
+        const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
+        if (STRIPPED_FROM_EXPORT.has(stripped)) continue;
+        normalizedFiles[stripped] = { content: file.code, isBinary: false };
+      }
+      // Mirror Sandpack's `getFileParameters`: include `template:
+      // environment` inside the compressed parameters so CSB picks the
+      // right runtime (without it, the sandbox renders nothing).
+      const definePayload: Record<string, unknown> = { files: normalizedFiles };
+      if (current.environment) definePayload.template = current.environment;
+      const parameters = compressToBase64(JSON.stringify(definePayload))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.action = 'https://codesandbox.io/api/v1/sandboxes/define';
+      form.target = '_blank';
+      const paramsInput = document.createElement('input');
+      paramsInput.type = 'hidden';
+      paramsInput.name = 'parameters';
+      paramsInput.value = parameters;
+      form.appendChild(paramsInput);
+      // Sandpack sends `environment` as a separate top-level input too,
+      // not just inside `parameters` — keep parity to be safe.
+      if (current.environment) {
+        const envInput = document.createElement('input');
+        envInput.type = 'hidden';
+        envInput.name = 'environment';
+        envInput.value = current.environment;
+        form.appendChild(envInput);
+      }
+      document.body.appendChild(form);
+      try {
+        form.submit();
+      } catch (err) {
+        showError(
+          `Open in CodeSandbox failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      } finally {
+        form.remove();
+      }
+    };
+    const eventName = `agor:export-codesandbox-${artifactId}`;
+    window.addEventListener(eventName, handler);
+    return () => window.removeEventListener(eventName, handler);
+  }, [artifactId, showError]);
+
+  return null;
+}
+
 function SandpackErrorReporter({ artifactId }: { artifactId: string }) {
   const { sandpack } = useSandpack();
   const lastSentRef = useRef<string | null>(null);
@@ -386,20 +478,6 @@ function SandpackErrorReporter({ artifactId }: { artifactId: string }) {
   return null;
 }
 
-/** Forgiving JSON parse — used when reading a user's package.json which may
- *  be malformed; we'd rather export with a synthesized package.json than
- *  fail the whole flow. */
-function safeJsonParse(input: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(input);
-    return typeof parsed === 'object' && parsed !== null
-      ? (parsed as Record<string, unknown>)
-      : null;
-  } catch {
-    return null;
-  }
-}
-
 export const ArtifactNode = ({
   data,
   selected,
@@ -408,7 +486,6 @@ export const ArtifactNode = ({
   selected?: boolean;
 }) => {
   const { token } = theme.useToken();
-  const { showError } = useThemedMessage();
   const [interactMode, setInteractMode] = useState(false);
   const [payload, setPayload] = useState<ArtifactPayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -469,94 +546,16 @@ export const ArtifactNode = ({
     [data]
   );
 
-  // Eject the artifact to a fresh CodeSandbox sandbox in a new tab.
-  // (helper used inside the handler to forgive parse errors on user pkg.json)
-  //
-  // Browser-side form-POST instead of a daemon round-trip — the daemon's
-  // outbound IP is consistently blocked by Cloudflare on CodeSandbox's
-  // define endpoint, but real browser submissions go through. This is also
-  // what AntD/Storybook do for their "Open in CodeSandbox" buttons.
-  //
-  // Implementation matches @codesandbox/sandpack-client's `getParameters`:
-  // LZString.compressToBase64 with URL-safe character substitution.
+  // The actual form-POST work happens inside <CodeSandboxExporter/>, which
+  // lives inside SandpackProvider so it can use `useSandpack()` to read the
+  // *resolved* file map and runtime environment. Trying to build the
+  // payload from `payload.files` outside the provider misses the template
+  // scaffolding files (`index.html`, `index.js`, `package.json`, etc.) that
+  // Sandpack synthesizes per template — without those the destination
+  // sandbox boots empty (no entry, no DOM root).
   const handleOpenInCodeSandbox = useCallback(() => {
-    if (!payload) return;
-    const filesPayload: Record<string, { content: string }> = {};
-    let userPackageJson: string | null = null;
-    for (const [filePath, content] of Object.entries(payload.files)) {
-      const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
-      // Strip Agor-only sidecars + the synthesized .env — they'd be inert
-      // (or broken) outside Agor. The synthesized .env carries the viewer's
-      // secrets; never ship it to a third party.
-      if (
-        stripped === 'agor.config.js' ||
-        stripped === 'agor.artifact.json' ||
-        stripped === '.env'
-      ) {
-        continue;
-      }
-      // Hold onto the user's package.json (if any) — we merge it below to
-      // make sure CSB sees the artifact's dependencies even when the
-      // author kept them in `sandpack_config.customSetup` rather than the
-      // package.json itself.
-      if (stripped === 'package.json') {
-        userPackageJson = content;
-        continue;
-      }
-      filesPayload[stripped] = { content };
-    }
-
-    // Merge dependencies: user's package.json > artifact.dependencies cache
-    // > sandpack_config.customSetup.dependencies. CSB infers the runtime
-    // (CRA / vue-cli / svelte / parcel / …) from the dependency graph in
-    // `package.json`, so getting this right is what makes the export work.
-    const userPkg: Record<string, unknown> =
-      (userPackageJson ? safeJsonParse(userPackageJson) : null) ?? {};
-    const customSetupDeps = payload.sandpack_config?.customSetup?.dependencies ?? {};
-    const cachedDeps = payload.dependencies ?? {};
-    const mergedDeps: Record<string, string> = {
-      ...customSetupDeps,
-      ...cachedDeps,
-      ...((userPkg.dependencies as Record<string, string> | undefined) ?? {}),
-    };
-    const finalPkg: Record<string, unknown> = {
-      name: 'artifact-export',
-      version: '0.0.0',
-      main: payload.entry ?? userPkg.main ?? 'src/index.js',
-      ...userPkg,
-      dependencies: mergedDeps,
-    };
-    filesPayload['package.json'] = { content: JSON.stringify(finalPkg, null, 2) };
-
-    // Don't send a top-level `template` — Sandpack template names (`react`,
-    // `react-ts`, `vue3`, …) are NOT valid CSB template names (`create-
-    // react-app`, `vue-cli`, …). Letting CSB infer from package.json deps
-    // is both simpler and more reliable than maintaining a translation
-    // table.
-    const definePayload = { files: filesPayload };
-    const parameters = compressToBase64(JSON.stringify(definePayload))
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/, '');
-
-    const form = document.createElement('form');
-    form.method = 'POST';
-    form.action = 'https://codesandbox.io/api/v1/sandboxes/define';
-    form.target = '_blank';
-    const input = document.createElement('input');
-    input.type = 'hidden';
-    input.name = 'parameters';
-    input.value = parameters;
-    form.appendChild(input);
-    document.body.appendChild(form);
-    try {
-      form.submit();
-    } catch (err) {
-      showError(`Open in CodeSandbox failed: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      form.remove();
-    }
-  }, [payload, showError]);
+    window.dispatchEvent(new CustomEvent(`agor:export-codesandbox-${data.artifactId}`));
+  }, [data.artifactId]);
 
   // Loading state
   if (loading && !payload) {
@@ -815,6 +814,7 @@ export const ArtifactNode = ({
             <ConsoleReporter artifactId={data.artifactId} />
             <SandpackErrorReporter artifactId={data.artifactId} />
             <ArtifactRuntimeBridge artifactId={data.artifactId} />
+            <CodeSandboxExporter artifactId={data.artifactId} />
           </SandpackProvider>
         </div>
       </Card>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -36,6 +36,7 @@ import type {
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
+  CopyOutlined,
   DeleteOutlined,
   ExportOutlined,
   EyeOutlined,
@@ -57,6 +58,7 @@ import { compressToBase64 } from 'lz-string';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import { getDaemonUrl } from '@/config/daemon';
+import { copyToClipboard } from '@/utils/clipboard';
 import { useThemedMessage } from '@/utils/message';
 import { ArtifactConsentModal } from '../../ArtifactConsentModal/ArtifactConsentModal';
 import { withBodyReset } from './utils/sandpackDefaults';
@@ -470,9 +472,9 @@ export const ArtifactNode = ({
     payload.trust_state === 'untrusted' &&
     ((payload.required_env_vars && payload.required_env_vars.length > 0) ||
       (payload.agor_grants && Object.keys(payload.agor_grants).length > 0));
-  const legacyBanner = payload.legacy?.is_legacy
-    ? renderLegacyBanner(payload.legacy.upgrade_instructions, token)
-    : null;
+  const legacyBanner = payload.legacy?.is_legacy ? (
+    <LegacyBanner upgradeInstructions={payload.legacy.upgrade_instructions} />
+  ) : null;
 
   return (
     <>
@@ -713,10 +715,14 @@ function renderTrustBadge(payload: ArtifactPayload) {
   );
 }
 
-function renderLegacyBanner(
-  upgradeInstructions: string,
-  token: ReturnType<typeof theme.useToken>['token']
-) {
+function LegacyBanner({ upgradeInstructions }: { upgradeInstructions: string }) {
+  const { token } = theme.useToken();
+  const { showSuccess, showError } = useThemedMessage();
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(upgradeInstructions);
+    if (ok) showSuccess('Upgrade prompt copied — paste it to an agent');
+    else showError('Failed to copy — select the text manually and copy with the keyboard');
+  };
   return (
     <Alert
       type="warning"
@@ -733,25 +739,43 @@ function renderLegacyBanner(
           <summary style={{ cursor: 'pointer', color: token.colorTextSecondary }}>
             Show upgrade prompt for an agent
           </summary>
-          <pre
-            style={{
-              whiteSpace: 'pre-wrap',
-              fontSize: 10,
-              marginTop: 6,
-              padding: 8,
-              background: token.colorFillTertiary,
-              borderRadius: 4,
-              maxHeight: 180,
-              overflow: 'auto',
-              // React Flow nodes default to `user-select: none` to keep
-              // drag clean — opt this <pre> back into text selection so
-              // users can copy the upgrade prompt.
-              userSelect: 'text',
-              cursor: 'text',
-            }}
-          >
-            {upgradeInstructions}
-          </pre>
+          <div style={{ position: 'relative', marginTop: 6 }}>
+            <Button
+              type="text"
+              size="small"
+              icon={<CopyOutlined />}
+              onClick={handleCopy}
+              style={{
+                position: 'absolute',
+                top: 4,
+                right: 4,
+                zIndex: 1,
+                fontSize: 11,
+              }}
+            >
+              Copy
+            </Button>
+            <pre
+              style={{
+                whiteSpace: 'pre-wrap',
+                fontSize: 10,
+                margin: 0,
+                padding: 8,
+                paddingRight: 64, // leave room for the absolute-positioned copy button
+                background: token.colorFillTertiary,
+                borderRadius: 4,
+                maxHeight: 180,
+                overflow: 'auto',
+                // React Flow nodes default to `user-select: none` to keep
+                // drag clean — opt this <pre> back into text selection so
+                // users can copy the upgrade prompt manually too.
+                userSelect: 'text',
+                cursor: 'text',
+              }}
+            >
+              {upgradeInstructions}
+            </pre>
+          </div>
         </details>
       }
     />

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -39,18 +39,23 @@ import {
   DeleteOutlined,
   EyeOutlined,
   LoadingOutlined,
+  LockOutlined,
   ReloadOutlined,
+  SafetyOutlined,
+  WarningOutlined,
 } from '@ant-design/icons';
 import {
   SandpackPreview,
   SandpackProvider,
+  type SandpackSetup,
   useSandpack,
   useSandpackConsole,
 } from '@codesandbox/sandpack-react';
-import { Badge, Button, Card, Spin, Tooltip, Typography, theme } from 'antd';
+import { Alert, Badge, Button, Card, Spin, Tag, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import { getDaemonUrl } from '@/config/daemon';
+import { ArtifactConsentModal } from '../../ArtifactConsentModal/ArtifactConsentModal';
 import { withBodyReset } from './utils/sandpackDefaults';
 
 interface ArtifactNodeData {
@@ -230,6 +235,7 @@ export const ArtifactNode = ({
   const [payload, setPayload] = useState<ArtifactPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [consentOpen, setConsentOpen] = useState(false);
   const lastHashRef = useRef<string | null>(null);
 
   // Fetch artifact payload from daemon
@@ -343,6 +349,24 @@ export const ArtifactNode = ({
 
   if (!payload) return null;
 
+  const sandpackConfig = payload.sandpack_config ?? {};
+  const sandpackOptions = sandpackConfig.options ?? {};
+  const customSetup = {
+    ...(sandpackConfig.customSetup ?? {}),
+    ...(payload.dependencies && !sandpackConfig.customSetup?.dependencies
+      ? { dependencies: payload.dependencies }
+      : {}),
+  };
+  const sandpackTemplate = (sandpackConfig.template ?? payload.template) as 'react';
+  const trustBadge = renderTrustBadge(payload);
+  const showConsentAffordance =
+    payload.trust_state === 'untrusted' &&
+    ((payload.required_env_vars && payload.required_env_vars.length > 0) ||
+      (payload.agor_grants && Object.keys(payload.agor_grants).length > 0));
+  const legacyBanner = payload.legacy?.is_legacy
+    ? renderLegacyBanner(payload.legacy.upgrade_instructions, token)
+    : null;
+
   return (
     <>
       <NodeResizer
@@ -377,19 +401,33 @@ export const ArtifactNode = ({
         size="small"
         title={
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
               <Badge
                 status={loading ? 'processing' : 'success'}
                 title={loading ? 'Reloading...' : 'Live'}
               />
               <Typography.Text
-                style={{ fontSize: 12, fontWeight: 600, maxWidth: data.width - 160 }}
+                style={{ fontSize: 12, fontWeight: 600, maxWidth: data.width - 200 }}
                 ellipsis
               >
                 {payload.name}
               </Typography.Text>
+              {trustBadge}
             </div>
             <div style={{ display: 'flex', gap: 2 }}>
+              {showConsentAffordance && (
+                <Tooltip title="Trust this artifact to inject secrets">
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<LockOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setConsentOpen(true);
+                    }}
+                  />
+                </Tooltip>
+              )}
               <Tooltip title="Reload">
                 <Button
                   type="text"
@@ -443,8 +481,11 @@ export const ArtifactNode = ({
           style={{
             flex: 1,
             position: 'relative',
+            display: 'flex',
+            flexDirection: 'column',
           }}
         >
+          {legacyBanner}
           {/* Transparent overlay blocks iframe from capturing mouse events (zoom/pan/drag)
               when not in interact mode. Iframes ignore pointer-events:none on ancestors. */}
           {!interactMode && (
@@ -458,13 +499,18 @@ export const ArtifactNode = ({
           )}
           <SandpackProvider
             key={payload.content_hash}
-            template={payload.template as 'react'}
+            template={sandpackTemplate}
             files={withBodyReset(payload.files)}
-            customSetup={payload.dependencies ? { dependencies: payload.dependencies } : undefined}
+            customSetup={
+              Object.keys(customSetup).length > 0 ? (customSetup as SandpackSetup) : undefined
+            }
+            theme={sandpackConfig.theme as never}
             options={{
               initMode: 'user-visible',
-              ...(payload.entry ? { activeFile: payload.entry } : {}),
-              ...(payload.bundlerURL ? { bundlerURL: payload.bundlerURL } : {}),
+              ...sandpackOptions,
+              ...(payload.entry && !sandpackOptions.activeFile
+                ? { activeFile: payload.entry }
+                : {}),
             }}
           >
             <SandpackPreview
@@ -475,21 +521,100 @@ export const ArtifactNode = ({
               showNavigator={false}
               showOpenInCodeSandbox={false}
               showRefreshButton={interactMode}
-              // When self-hosting the bundler at a subpath (e.g. /static/sandpack/),
-              // Sandpack's default startRoute "/" resolves via `new URL("/", bundlerURL)`
-              // to the origin root per the WHATWG URL spec, wiping out the subpath and
-              // loading the wrong page into the iframe. Use "./" so it resolves to the
-              // bundler's own directory. NOTE: this MUST be passed as a prop directly
-              // on SandpackPreview — setting it via SandpackProvider.options is silently
-              // overridden because SandpackPreview's own prop default ("/") is always
-              // forwarded as clientPropsOverride, which wins over options.startRoute.
-              {...(payload.bundlerURL ? { startRoute: './' } : {})}
             />
             <ConsoleReporter artifactId={data.artifactId} />
             <SandpackErrorReporter artifactId={data.artifactId} />
           </SandpackProvider>
         </div>
       </Card>
+      {consentOpen && (
+        <ArtifactConsentModal
+          open={consentOpen}
+          artifactId={payload.artifact_id}
+          name={payload.name}
+          files={payload.files}
+          requiredEnvVars={payload.required_env_vars ?? []}
+          grants={payload.agor_grants ?? {}}
+          onClose={() => setConsentOpen(false)}
+          onGranted={() => {
+            setConsentOpen(false);
+            fetchPayload();
+          }}
+        />
+      )}
     </>
   );
 };
+
+function renderTrustBadge(payload: ArtifactPayload) {
+  const state = payload.trust_state;
+  if (state === 'no_secrets_needed') return null;
+  if (state === 'self') {
+    return (
+      <Tag color="blue" icon={<SafetyOutlined />} style={{ fontSize: 10, marginLeft: 4 }}>
+        Yours
+      </Tag>
+    );
+  }
+  if (state === 'trusted') {
+    const scopeLabel =
+      payload.trust_scope === 'instance'
+        ? 'instance-wide'
+        : payload.trust_scope === 'author'
+          ? 'this author'
+          : payload.trust_scope === 'session'
+            ? 'just-once'
+            : 'this artifact';
+    return (
+      <Tooltip title={`Secrets injected — trust granted for ${scopeLabel}`}>
+        <Tag color="green" icon={<SafetyOutlined />} style={{ fontSize: 10, marginLeft: 4 }}>
+          Trusted
+        </Tag>
+      </Tooltip>
+    );
+  }
+  // 'untrusted'
+  return (
+    <Tooltip title="Render is missing secrets — click the lock icon to grant trust">
+      <Tag color="orange" icon={<LockOutlined />} style={{ fontSize: 10, marginLeft: 4 }}>
+        Untrusted
+      </Tag>
+    </Tooltip>
+  );
+}
+
+function renderLegacyBanner(
+  upgradeInstructions: string,
+  token: ReturnType<typeof theme.useToken>['token']
+) {
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      icon={<WarningOutlined />}
+      style={{ borderRadius: 0, fontSize: 11, padding: '4px 12px' }}
+      message="Legacy artifact — won't render correctly"
+      description={
+        <details style={{ marginTop: 4 }}>
+          <summary style={{ cursor: 'pointer', color: token.colorTextSecondary }}>
+            Show upgrade prompt for an agent
+          </summary>
+          <pre
+            style={{
+              whiteSpace: 'pre-wrap',
+              fontSize: 10,
+              marginTop: 6,
+              padding: 8,
+              background: token.colorFillTertiary,
+              borderRadius: 4,
+              maxHeight: 180,
+              overflow: 'auto',
+            }}
+          >
+            {upgradeInstructions}
+          </pre>
+        </details>
+      }
+    />
+  );
+}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -226,6 +226,20 @@ function SandpackErrorReporter({ artifactId }: { artifactId: string }) {
   return null;
 }
 
+/** Forgiving JSON parse — used when reading a user's package.json which may
+ *  be malformed; we'd rather export with a synthesized package.json than
+ *  fail the whole flow. */
+function safeJsonParse(input: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(input);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export const ArtifactNode = ({
   data,
   selected,
@@ -296,6 +310,7 @@ export const ArtifactNode = ({
   );
 
   // Eject the artifact to a fresh CodeSandbox sandbox in a new tab.
+  // (helper used inside the handler to forgive parse errors on user pkg.json)
   //
   // Browser-side form-POST instead of a daemon round-trip — the daemon's
   // outbound IP is consistently blocked by Cloudflare on CodeSandbox's
@@ -307,6 +322,7 @@ export const ArtifactNode = ({
   const handleOpenInCodeSandbox = useCallback(() => {
     if (!payload) return;
     const filesPayload: Record<string, { content: string }> = {};
+    let userPackageJson: string | null = null;
     for (const [filePath, content] of Object.entries(payload.files)) {
       const stripped = filePath.startsWith('/') ? filePath.slice(1) : filePath;
       // Strip Agor-only sidecars + the synthesized .env — they'd be inert
@@ -319,12 +335,45 @@ export const ArtifactNode = ({
       ) {
         continue;
       }
+      // Hold onto the user's package.json (if any) — we merge it below to
+      // make sure CSB sees the artifact's dependencies even when the
+      // author kept them in `sandpack_config.customSetup` rather than the
+      // package.json itself.
+      if (stripped === 'package.json') {
+        userPackageJson = content;
+        continue;
+      }
       filesPayload[stripped] = { content };
     }
-    const definePayload = {
-      files: filesPayload,
-      template: payload.sandpack_config?.template ?? payload.template,
+
+    // Merge dependencies: user's package.json > artifact.dependencies cache
+    // > sandpack_config.customSetup.dependencies. CSB infers the runtime
+    // (CRA / vue-cli / svelte / parcel / …) from the dependency graph in
+    // `package.json`, so getting this right is what makes the export work.
+    const userPkg: Record<string, unknown> =
+      (userPackageJson ? safeJsonParse(userPackageJson) : null) ?? {};
+    const customSetupDeps = payload.sandpack_config?.customSetup?.dependencies ?? {};
+    const cachedDeps = payload.dependencies ?? {};
+    const mergedDeps: Record<string, string> = {
+      ...customSetupDeps,
+      ...cachedDeps,
+      ...((userPkg.dependencies as Record<string, string> | undefined) ?? {}),
     };
+    const finalPkg: Record<string, unknown> = {
+      name: 'artifact-export',
+      version: '0.0.0',
+      main: payload.entry ?? userPkg.main ?? 'src/index.js',
+      ...userPkg,
+      dependencies: mergedDeps,
+    };
+    filesPayload['package.json'] = { content: JSON.stringify(finalPkg, null, 2) };
+
+    // Don't send a top-level `template` — Sandpack template names (`react`,
+    // `react-ts`, `vue3`, …) are NOT valid CSB template names (`create-
+    // react-app`, `vue-cli`, …). Letting CSB infer from package.json deps
+    // is both simpler and more reliable than maintaining a translation
+    // table.
+    const definePayload = { files: filesPayload };
     const parameters = compressToBase64(JSON.stringify(definePayload))
       .replace(/\+/g, '-')
       .replace(/\//g, '_')

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -816,6 +816,21 @@ export function useAgorData(
     artifactsService.on('updated', handleArtifactPatched);
     artifactsService.on('removed', handleArtifactRemoved);
 
+    // Agent-driven runtime queries: daemon emits when an MCP tool wants to
+    // introspect the iframe DOM. ArtifactNode components listen for the
+    // re-dispatched window event and filter by artifactId — the only one
+    // currently rendering this artifact answers, anyone else ignores.
+    const handleAgorQuery = (event: {
+      request_id: string;
+      artifact_id: string;
+      requested_by_user_id: string;
+      kind: string;
+      args: Record<string, unknown>;
+    }) => {
+      window.dispatchEvent(new CustomEvent('agor:artifact-runtime-query', { detail: event }));
+    };
+    artifactsService.on('agor-query', handleAgorQuery);
+
     // Subscribe to session-MCP server relationship events
     const sessionMcpService = client.service('session-mcp-servers');
     const handleSessionMcpCreated = (relationship: {
@@ -1089,6 +1104,7 @@ export function useAgorData(
       artifactsService.removeListener('patched', handleArtifactPatched);
       artifactsService.removeListener('updated', handleArtifactPatched);
       artifactsService.removeListener('removed', handleArtifactRemoved);
+      artifactsService.removeListener('agor-query', handleAgorQuery);
     };
   }, [client, enabled, fetchData, hasInitiallyFetched]);
 

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -827,10 +827,6 @@ export function useAgorData(
       kind: string;
       args: Record<string, unknown>;
     }) => {
-      console.log(
-        `[agor-query] WS received requestId=${event.request_id} artifactId=${event.artifact_id?.slice(0, 8)} ` +
-          `kind=${event.kind} requestedBy=${event.requested_by_user_id?.slice(0, 8)}`
-      );
       window.dispatchEvent(new CustomEvent('agor:artifact-runtime-query', { detail: event }));
     };
     artifactsService.on('agor-query', handleAgorQuery);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -827,6 +827,10 @@ export function useAgorData(
       kind: string;
       args: Record<string, unknown>;
     }) => {
+      console.log(
+        `[agor-query] WS received requestId=${event.request_id} artifactId=${event.artifact_id?.slice(0, 8)} ` +
+          `kind=${event.kind} requestedBy=${event.requested_by_user_id?.slice(0, 8)}`
+      );
       window.dispatchEvent(new CustomEvent('agor:artifact-runtime-query', { detail: event }));
     };
     artifactsService.on('agor-query', handleAgorQuery);

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -47,6 +47,13 @@ interface FeaturesConfig {
    * services/worktrees.ts is the source of truth. Defaults to 'member'.
    */
   managedEnvsMinimumRole?: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin';
+  /**
+   * True when the daemon runs in a multi-user Unix isolation mode
+   * (insulated/strict). The UI uses this to hide "trust everyone on this
+   * instance" surfaces (e.g. the `instance` scope option in the artifact
+   * consent modal). Server-side gates are the source of truth.
+   */
+  multiUser?: boolean;
 }
 
 interface HealthResponse {

--- a/apps/agor-ui/src/utils/language.ts
+++ b/apps/agor-ui/src/utils/language.ts
@@ -1,0 +1,45 @@
+/**
+ * Map a file path's extension to a Prism language id used by
+ * `ThemedSyntaxHighlighter`. Returns `'text'` for unknown extensions so
+ * the highlighter still renders (just without coloring).
+ */
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  js: 'javascript',
+  cjs: 'javascript',
+  mjs: 'javascript',
+  ts: 'typescript',
+  jsx: 'jsx',
+  tsx: 'tsx',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  c: 'c',
+  cpp: 'cpp',
+  h: 'c',
+  hpp: 'cpp',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  xml: 'xml',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  sh: 'bash',
+  bash: 'bash',
+  sql: 'sql',
+  graphql: 'graphql',
+  proto: 'protobuf',
+  toml: 'toml',
+  vue: 'vue',
+  svelte: 'svelte',
+  md: 'markdown',
+  markdown: 'markdown',
+  env: 'bash',
+};
+
+export function getLanguageFromPath(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase();
+  return LANGUAGE_BY_EXT[ext ?? ''] ?? 'text';
+}

--- a/context/guides/creating-database-migrations.md
+++ b/context/guides/creating-database-migrations.md
@@ -1,458 +1,85 @@
 # How to Create Database Migrations
 
 **Status:** ✅ Guide
-**Related:** [[database-migrations]], [[postgres-support]], [[architecture]]
+**Related:** [[postgres-support]], [[architecture]]
 
 ---
 
 ## Overview
 
-Agor uses **Drizzle ORM** to manage database schema migrations for both SQLite and PostgreSQL. This guide shows you how to create new migrations when you modify the database schema.
-
-## Prerequisites
-
-- Understanding of Drizzle ORM basics
-- Familiarity with both `schema.sqlite.ts` and `schema.postgres.ts`
-- Docker environment running (for generating migrations)
+Agor uses **Drizzle ORM** for schema migrations against both SQLite and PostgreSQL. Schemas live in two parallel files; migrations are generated locally with `pnpm` and applied via `agor db migrate`. No Docker is required for the dev loop.
 
 ---
 
-## The Dual-Schema Pattern
+## The dual-schema pattern
 
-Agor maintains **two separate schema files** to support both SQLite and PostgreSQL:
+Two schema files, kept in lockstep:
 
 ```
 packages/core/src/db/
 ├── schema.sqlite.ts    # SQLite-specific schema
 ├── schema.postgres.ts  # PostgreSQL-specific schema
-└── schema-factory.ts   # (Dead code - kept for reference)
+└── schema-factory.ts   # Runtime dialect detection helpers
+                        # (getDatabaseDialect / detectDialectFromUrl).
+                        # Type-helper factory pattern was abandoned —
+                        # type helpers are inlined in each schema.
 ```
 
-### Why Two Schemas?
+**Golden rule: when you modify one schema, you modify the other to match.**
 
-TypeScript type inference doesn't work well with a factory pattern for Drizzle schemas. The `schema-factory.ts` file exists but is **not actually used** in production. Instead, both schemas define type helpers **inline**:
+Only **3 column types** legitimately differ between dialects:
 
-```typescript
-// In both schema files:
-const t = {
-  timestamp: (name: string) => ...,  // Dialect-specific
-  bool: (name: string) => ...,       // Dialect-specific
-  json: <T>(name: string) => ...,    // Dialect-specific
-} as const;
-```
+| Concept | SQLite | Postgres |
+|---|---|---|
+| Timestamp | `integer` | `timestamp` |
+| Boolean | `integer` | `boolean` |
+| JSON | `text` | `jsonb` |
 
-### Keeping Schemas in Sync
-
-**The golden rule:** When you modify one schema, you must modify the other to match.
-
-**Only 3 types differ between dialects:**
-
-1. **Timestamps:** `integer` (SQLite) vs `timestamp` (Postgres)
-2. **Booleans:** `integer` (SQLite) vs `boolean` (Postgres)
-3. **JSON:** `text` (SQLite) vs `jsonb` (Postgres)
-
-**Everything else is identical:**
-
-- Table structure
-- Column names
-- Indexes
-- Foreign keys
-- Constraints
+Everything else — table names, columns, indexes, foreign keys — should be identical.
 
 ---
 
-## Step-by-Step: Creating a Migration
-
-### Step 1: Modify Both Schema Files
-
-When adding/removing/changing columns, update **both** `schema.sqlite.ts` and `schema.postgres.ts`.
-
-**Example:** Removing unused columns from `mcp_servers` table
-
-```typescript
-// schema.sqlite.ts
-export const mcpServers = sqliteTable(
-  'mcp_servers',
-  {
-    // ... other columns ...
-
-    scope: text('scope', {
-      enum: ['global', 'session'], // ← Changed from 4 to 2 values
-    }).notNull(),
-
-    // Scope foreign key
-    owner_user_id: text('owner_user_id', { length: 36 }),
-    // ❌ REMOVED: team_id, repo_id, session_id
-
-    // ... other columns ...
-  },
-  table => ({
-    nameIdx: index('mcp_servers_name_idx').on(table.name),
-    scopeIdx: index('mcp_servers_scope_idx').on(table.scope),
-    ownerIdx: index('mcp_servers_owner_idx').on(table.owner_user_id),
-    // ❌ REMOVED: teamIdx, repoIdx, sessionIdx
-    enabledIdx: index('mcp_servers_enabled_idx').on(table.enabled),
-  })
-);
-```
-
-```typescript
-// schema.postgres.ts
-export const mcpServers = pgTable(
-  'mcp_servers',
-  {
-    // ... other columns ...
-
-    scope: text('scope', {
-      enum: ['global', 'session'], // ← Same change
-    }).notNull(),
-
-    // Scope foreign key
-    owner_user_id: varchar('owner_user_id', { length: 36 }),
-    // ❌ REMOVED: team_id, repo_id, session_id
-
-    // ... other columns ...
-  },
-  table => ({
-    nameIdx: index('mcp_servers_name_idx').on(table.name),
-    scopeIdx: index('mcp_servers_scope_idx').on(table.scope),
-    ownerIdx: index('mcp_servers_owner_idx').on(table.owner_user_id),
-    // ❌ REMOVED: teamIdx, repoIdx, sessionIdx
-    enabledIdx: index('mcp_servers_enabled_idx').on(table.enabled),
-  })
-);
-```
-
-**Notice:** The only difference is `text()` vs `varchar()` - everything else is identical.
-
-### Step 2: Generate Migrations
-
-Migrations must be generated **inside the Docker environment** where the dependencies are installed.
+## Workflow
 
 ```bash
-# Generate SQLite migration
-docker exec <container-name> sh -c "cd /app/packages/core && pnpm db:generate:sqlite"
+# 1. Edit packages/core/src/db/schema.sqlite.ts AND schema.postgres.ts.
 
-# Generate PostgreSQL migration
-docker exec <container-name> sh -c "cd /app/packages/core && pnpm db:generate:postgres"
+# 2. Generate migrations (host-side; drizzle-kit is in node_modules).
+cd packages/core
+pnpm db:generate:sqlite
+pnpm db:generate:postgres
+
+# 3. Review the generated SQL — drizzle usually gets it right but verify.
+cat drizzle/sqlite/<NEW_FILE>.sql
+cat drizzle/postgres/<NEW_FILE>.sql
+
+# 4. Apply to your local dev database.
+pnpm agor db migrate
+
+# 5. (Optional) Test against a live agor-managed env.
+#    The container's docker-entrypoint.sh runs `pnpm agor db migrate --yes`
+#    on boot, so a worktree restart applies pending migrations automatically.
+
+# 6. Commit schema files + new SQL + the meta/_journal.json updates.
+git add packages/core/src/db/schema.{sqlite,postgres}.ts
+git add packages/core/drizzle/sqlite/<NEW_FILE>.sql packages/core/drizzle/sqlite/meta/
+git add packages/core/drizzle/postgres/<NEW_FILE>.sql packages/core/drizzle/postgres/meta/
 ```
 
-**Example output:**
-
-```
-[✓] Your SQL migration file ➜ drizzle/sqlite/0014_graceful_ben_grimm.sql 🚀
-[✓] Your SQL migration file ➜ drizzle/postgres/0004_nervous_imperial_guard.sql 🚀
-```
-
-### Step 3: Copy Migrations to Host
-
-The migration files are generated inside Docker. Copy them to your host filesystem:
-
-```bash
-# Copy SQLite migration
-docker cp <container-name>:/app/packages/core/drizzle/sqlite/0014_*.sql \
-  packages/core/drizzle/sqlite/
-
-# Copy Postgres migration
-docker cp <container-name>:/app/packages/core/drizzle/postgres/0004_*.sql \
-  packages/core/drizzle/postgres/
-
-# Copy updated metadata (important!)
-docker cp <container-name>:/app/packages/core/drizzle/sqlite/meta/ \
-  packages/core/drizzle/sqlite/
-
-docker cp <container-name>:/app/packages/core/drizzle/postgres/meta/ \
-  packages/core/drizzle/postgres/
-```
-
-### Step 4: Review Generated SQL
-
-**Always review the generated migrations** before committing!
-
-```bash
-# Review SQLite migration
-cat packages/core/drizzle/sqlite/0014_graceful_ben_grimm.sql
-
-# Review Postgres migration
-cat packages/core/drizzle/postgres/0004_nervous_imperial_guard.sql
-```
-
-**Common patterns to look for:**
-
-- **Column additions:** Should use `ALTER TABLE ADD COLUMN`
-- **Column removals:** SQLite recreates table, Postgres drops column
-- **Type changes:** SQLite recreates table, Postgres alters type
-- **Index changes:** Dropped before table changes, recreated after
-
-### Step 5: Test in Docker Environment
-
-Restart the Docker environment to apply migrations:
-
-```bash
-# Via Agor MCP
-mcp__agor__agor_environment_stop(worktreeId)
-mcp__agor__agor_environment_start(worktreeId)
-
-# Or via docker compose
-docker compose -p <project-name> restart
-```
-
-**Check the logs** to verify migrations ran successfully:
-
-```bash
-docker compose -p <project-name> logs | grep -i migration
-```
-
-Expected output:
-
-```
-✅ Migrations complete
-✅ Database is up to date
-```
-
-### Step 6: Verify Schema in Database
-
-Connect to the Docker database and verify the schema changes:
-
-```bash
-# SQLite
-docker exec <container-name> sqlite3 /home/agor/.agor/agor.db \
-  "PRAGMA table_info(mcp_servers);"
-
-# Postgres (if using Postgres)
-docker exec <container-name> psql $DATABASE_URL \
-  -c "\d mcp_servers"
-```
-
-### Step 7: Commit to Git
-
-Once verified, commit the migration files:
-
-```bash
-git add packages/core/drizzle/sqlite/0014_*.sql
-git add packages/core/drizzle/sqlite/meta/
-git add packages/core/drizzle/postgres/0004_*.sql
-git add packages/core/drizzle/postgres/meta/
-git add packages/core/src/db/schema.sqlite.ts
-git add packages/core/src/db/schema.postgres.ts
-
-git commit -m "feat: remove unused MCP server scope columns
-
-- Simplified MCPScope from 4 values to 2 (global, session)
-- Removed team_id, repo_id, session_id columns from mcp_servers
-- Removed corresponding foreign keys and indexes
-- Generated migrations for both SQLite (0014) and Postgres (0004)"
-```
+If `drizzle-kit` prompts you to disambiguate a rename, answer in the terminal — those prompts only show up when the diff is genuinely ambiguous.
 
 ---
 
-## Common Migration Scenarios
+## Common scenarios
 
-### Adding a New Column
+| Change | Drizzle output |
+|---|---|
+| Add column | `ALTER TABLE … ADD COLUMN` (both dialects) |
+| Remove column | SQLite recreates the table (`__new_<table>` dance); Postgres `DROP COLUMN` |
+| Change column type | SQLite recreates table; Postgres `ALTER COLUMN … TYPE` |
+| Add index | `CREATE INDEX` (both dialects) |
 
-**1. Update both schemas:**
-
-```typescript
-// schema.sqlite.ts
-export const myTable = sqliteTable('my_table', {
-  // ... existing columns ...
-  new_column: text('new_column'), // ← Add new column
-});
-
-// schema.postgres.ts
-export const myTable = pgTable('my_table', {
-  // ... existing columns ...
-  new_column: text('new_column'), // ← Same change
-});
-```
-
-**2. Generate migrations** (as described above)
-
-**Result:**
-
-```sql
--- SQLite
-ALTER TABLE `my_table` ADD `new_column` text;
-
--- Postgres
-ALTER TABLE "my_table" ADD COLUMN "new_column" text;
-```
-
-### Removing a Column
-
-**1. Update both schemas** (remove the column)
-
-**2. Generate migrations**
-
-**Result:**
-
-```sql
--- SQLite (recreates table)
-CREATE TABLE `__new_my_table` (...);  -- Without removed column
-INSERT INTO `__new_my_table` SELECT ... FROM `my_table`;
-DROP TABLE `my_table`;
-ALTER TABLE `__new_my_table` RENAME TO `my_table`;
-
--- Postgres (direct drop)
-ALTER TABLE "my_table" DROP COLUMN "old_column";
-```
-
-### Changing a Column Type
-
-**1. Update both schemas** (change the type)
-
-**2. Generate migrations**
-
-**Result:**
-
-- **SQLite:** Recreates table with new type
-- **Postgres:** Uses `ALTER COLUMN ... TYPE`
-
-### Adding an Index
-
-**1. Update both schemas** (add to the index section)
-
-```typescript
-table => ({
-  // ... existing indexes ...
-  newIdx: index('my_table_new_idx').on(table.new_column),
-});
-```
-
-**2. Generate migrations**
-
-**Result:**
-
-```sql
-CREATE INDEX "my_table_new_idx" ON "my_table" ("new_column");
-```
-
----
-
-## Migration File Structure
-
-### Drizzle Migration Folders
-
-```
-packages/core/drizzle/
-├── sqlite/
-│   ├── 0000_pretty_mac_gargan.sql      # Baseline
-│   ├── 0001_organic_stick.sql
-│   ├── ...
-│   ├── 0014_graceful_ben_grimm.sql     # Your new migration
-│   └── meta/
-│       ├── _journal.json                # Migration manifest
-│       ├── 0000_snapshot.json           # Schema snapshots
-│       └── 0014_snapshot.json
-└── postgres/
-    ├── 0000_loud_loki.sql
-    ├── ...
-    ├── 0004_nervous_imperial_guard.sql  # Your new migration
-    └── meta/
-        ├── _journal.json
-        └── 0004_snapshot.json
-```
-
-### Journal File Format
-
-`drizzle/sqlite/meta/_journal.json`:
-
-```json
-{
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1234567890,
-      "tag": "0000_pretty_mac_gargan",
-      "breakpoints": false
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1732590180,
-      "tag": "0014_graceful_ben_grimm",
-      "breakpoints": true
-    }
-  ]
-}
-```
-
----
-
-## Troubleshooting
-
-### "drizzle-kit: not found"
-
-**Problem:** drizzle-kit is not installed in your host environment
-
-**Solution:** Always generate migrations **inside Docker** where dependencies are installed
-
-```bash
-docker exec <container-name> sh -c "cd /app/packages/core && pnpm db:generate:sqlite"
-```
-
-### "No schema changes, nothing to migrate"
-
-**Problem:** The schema file wasn't updated, or changes were already migrated
-
-**Solutions:**
-
-1. Verify you updated **both** schema files
-2. Check if a migration already exists for your changes
-3. Ensure Docker picked up your schema changes (rebuild if needed)
-
-### Migration Fails to Apply
-
-**Problem:** SQL syntax error or constraint violation
-
-**Steps:**
-
-1. Review the generated SQL in `drizzle/*/XXXX.sql`
-2. Check for breaking changes (e.g., removing a column with data)
-3. Test the SQL manually in a test database
-4. Consider a data migration script if needed
-
-### Schemas Out of Sync
-
-**Problem:** SQLite and Postgres schemas have different structures
-
-**Prevention:**
-
-- Always update both schemas together
-- Use the same column names and types (except for the 3 dialect-specific types)
-- Generate migrations for both dialects
-
-**Detection:**
-
-```bash
-# Compare table definitions
-docker exec <container-name> sqlite3 /home/agor/.agor/agor.db ".schema mcp_servers"
-docker exec <container-name> psql $DATABASE_URL -c "\d mcp_servers"
-```
-
----
-
-## Best Practices
-
-### ✅ Do:
-
-- **Always update both schemas** - Never update just SQLite or Postgres alone
-- **Generate both migrations** - Even if you're only using one database now
-- **Review generated SQL** - Drizzle usually gets it right, but verify
-- **Test in Docker first** - Don't apply migrations to production databases directly
-- **Commit migrations with code** - Schema and code should be in sync
-- **Use meaningful commit messages** - Explain what changed and why
-
-### ❌ Don't:
-
-- **Don't skip Postgres** - Even if you only use SQLite today, maintain both
-- **Don't edit migrations manually** - Let Drizzle generate them (unless absolutely necessary)
-- **Don't run migrations on production without backup** - Always backup first
-- **Don't bypass migrations** - Use `drizzle-kit push` only for local development
-- **Don't forget metadata** - Always copy the `meta/` folder along with SQL files
+For removals/type changes on tables with data, **review the recreation SQL carefully** — Drizzle does an `INSERT INTO __new_x SELECT … FROM x` which loses data if the column list doesn't match.
 
 ---
 
@@ -472,103 +99,37 @@ Don't use `CHECK(col IN ('a', 'b', 'c'))` on a SQLite column. When a new value i
 
 Validate enum values at the application layer instead — Drizzle schema `enum` option, Zod, or service hooks. The TypeScript types are the source of truth; the DB just stores text.
 
+### Schemas drifting
+
+If you only update one schema, generation succeeds for that dialect and silently leaves the other one stale. Catch it before merge:
+
+```bash
+sqlite3 ~/.agor/agor.db ".schema <table>"
+# vs the postgres equivalent if you have a Postgres dev DB
+```
+
 ---
 
 ## Reference
 
-### Drizzle Kit Commands
-
 ```bash
-# Generate migration from schema diff
-pnpm db:generate:sqlite
-pnpm db:generate:postgres
+# From packages/core:
+pnpm db:generate:sqlite      # generate SQLite migration from schema diff
+pnpm db:generate:postgres    # generate Postgres migration from schema diff
+pnpm db:push                 # push schema directly (dev only — skips migrations)
+pnpm db:studio               # open Drizzle Studio
 
-# Push schema directly (dev only - skips migrations)
-pnpm db:push:sqlite
-pnpm db:push:postgres
-
-# View pending migrations
-agor db status
-
-# Apply pending migrations
-agor db migrate
+# From repo root:
+pnpm agor db status          # show pending migrations
+pnpm agor db migrate         # apply pending migrations to local DB
 ```
 
-### File Locations
+**File locations:**
 
-- **Schemas:** `packages/core/src/db/schema.{sqlite,postgres}.ts`
-- **Migrations:** `packages/core/drizzle/{sqlite,postgres}/`
-- **Configs:** `packages/core/drizzle.{sqlite,postgres}.config.ts`
-- **Runtime:** `packages/core/src/db/migrate.ts`
+- Schemas: `packages/core/src/db/schema.{sqlite,postgres}.ts`
+- Migrations: `packages/core/drizzle/{sqlite,postgres}/*.sql` + `meta/_journal.json`
+- Configs: `packages/core/drizzle.{sqlite,postgres}.config.ts`
+- Migrate runtime: `packages/core/src/db/migrate.ts`
+- Auto-apply on container boot: `docker/docker-entrypoint.sh` (calls `pnpm agor db migrate --yes`)
 
-### Related Documentation
-
-- [`context/concepts/architecture.md`](../concepts/architecture.md) — System design
-- [Drizzle Migrations Docs](https://orm.drizzle.team/docs/migrations)
-
----
-
-## Real Example: MCP Server Scope Simplification
-
-This guide was created while implementing the MCP server scoping fix. Here's the full workflow that was followed:
-
-### Changes Made
-
-**Goal:** Remove unused `team`, `repo` scopes and their associated columns
-
-**Files Modified:**
-
-1. `packages/core/src/db/schema.sqlite.ts` - Updated `mcpServers` table
-2. `packages/core/src/db/schema.postgres.ts` - Updated `mcpServers` table
-3. `packages/core/src/types/mcp.ts` - Updated `MCPScope` type
-4. `packages/core/src/db/repositories/mcp-servers.ts` - Removed scope logic
-
-**Schema Changes:**
-
-- Changed `scope` enum from `['global', 'team', 'repo', 'session']` to `['global', 'session']`
-- Removed columns: `team_id`, `repo_id`, `session_id`
-- Removed foreign key references
-- Removed indexes: `teamIdx`, `repoIdx`, `sessionIdx`
-
-**Commands Run:**
-
-```bash
-# 1. Generate migrations
-docker exec agor-session-scoped-mcp2-agor-dev-1 sh -c \
-  "cd /app/packages/core && pnpm db:generate:sqlite"
-
-docker exec agor-session-scoped-mcp2-agor-dev-1 sh -c \
-  "cd /app/packages/core && pnpm db:generate:postgres"
-
-# 2. Copy to host
-docker cp agor-session-scoped-mcp2-agor-dev-1:/app/packages/core/drizzle/sqlite/0014_graceful_ben_grimm.sql \
-  packages/core/drizzle/sqlite/
-
-docker cp agor-session-scoped-mcp2-agor-dev-1:/app/packages/core/drizzle/postgres/0004_nervous_imperial_guard.sql \
-  packages/core/drizzle/postgres/
-
-docker cp agor-session-scoped-mcp2-agor-dev-1:/app/packages/core/drizzle/sqlite/meta/ \
-  packages/core/drizzle/sqlite/
-
-docker cp agor-session-scoped-mcp2-agor-dev-1:/app/packages/core/drizzle/postgres/meta/ \
-  packages/core/drizzle/postgres/
-
-# 3. Restart Docker to apply
-mcp__agor__agor_environment_stop("586d2110-0ec0-436d-86f9-b6c9a8ebcfe9")
-mcp__agor__agor_environment_start("586d2110-0ec0-436d-86f9-b6c9a8ebcfe9")
-
-# 4. Verify
-docker exec agor-session-scoped-mcp2-agor-dev-1 \
-  sqlite3 /home/agor/.agor/agor.db "PRAGMA table_info(mcp_servers);"
-```
-
-**Result:**
-
-- ✅ SQLite migration: 0014_graceful_ben_grimm.sql (recreates table)
-- ✅ Postgres migration: 0004_nervous_imperial_guard.sql (drops columns/indexes)
-- ✅ Both applied successfully in Docker environment
-- ✅ Schema validated - unused columns removed
-
----
-
-_This guide was created on 2025-11-26 during the MCP scoping fix implementation._
+**External:** [Drizzle migrations docs](https://orm.drizzle.team/docs/migrations).

--- a/docs/internal/artifacts-roadmap-2026-05-09.md
+++ b/docs/internal/artifacts-roadmap-2026-05-09.md
@@ -1,0 +1,312 @@
+# Artifacts Format Refactor — 2026-05-09
+
+Single-PR refactor consolidating artifact format, env var injection, daemon capabilities, and a TOFU consent flow. Backwards compatibility intentionally **not preserved** — old artifacts get a clear upgrade prompt that points at the MCP tool surface for self-service migration.
+
+The original branch goal (build a "deserialize artifact → folder" MCP tool) was a no-op: `agor_artifacts_land` already shipped in PR #1052. This branch was repurposed for the refactor below.
+
+---
+
+## Goals
+
+1. **One canonical format.** Files map + DB metadata. No `sandpack.json` sidecar, no `dependencies` column-as-truth, no Agor-only manifest fields scattered across the file tree.
+2. **Standard JS env-var idiom.** `required_env_vars` declared on the artifact; daemon injects a per-viewer `.env` at render time. Apps read `import.meta.env.VITE_*` (Vite) or `process.env.*` (other bundlers). No more Handlebars-as-JS.
+3. **Explicit daemon capabilities.** `agor_grants` metadata enumerates what the daemon will inject (JWT, API URL, proxy URLs, etc.). Each grant maps to a well-known env var name. Auditable and stricter consent treatment for high-power grants.
+4. **TOFU consent for non-self artifacts.** The daemon won't inject secrets or capabilities into someone else's artifact without an explicit trust grant from the viewing user.
+5. **One-shot agent review** as a consent-time aide.
+6. **Clean port to CodeSandbox** as a side benefit — once artifacts are standard JS projects, "Open in CodeSandbox" is trivial.
+
+---
+
+## What gets ripped
+
+### 1. `use_local_bundler` everywhere
+
+The self-hosted Sandpack bundler had two flawed versions and the original VPN-driven motivation was solved at the Chrome-config layer. Dead-end.
+
+- Drop `use_local_bundler` field from `SandpackManifest` (`packages/core/src/types/artifact.ts:96`) and `Artifact` type.
+- Drop the column from SQLite + Postgres schemas (migration: drop column).
+- Drop `selfHostedBundlerURL` resolution in `ArtifactsService` (`apps/agor-daemon/src/services/artifacts.ts:113`).
+- Drop the `--with-sandpack` build path's hosting plumbing (CLI flag, daemon route, UI bundler URL plumbing). Verify build script + docker still work.
+- Drop the publish-time validation that rejected `use_local_bundler=true` when the bundler wasn't built (`services/artifacts.ts:265-268`).
+- Drop `payload.bundlerURL` plumbing in the render path (`apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx:467,486`). The CodeSandbox-hosted bundler is the only path.
+
+### 2. `sandpack.json` as a serialized file format
+
+- `readFilesRecursive` no longer special-cases `sandpack.json` (`services/artifacts.ts:1098`) — it's just a regular file if a user happens to have one, but Agor doesn't read or write it.
+- `land()` no longer reconstructs a `sandpack.json` on disk (`services/artifacts.ts:616-626`).
+- `publish()` no longer parses one (`services/artifacts.ts:252-262`).
+- `package.json#dependencies` becomes the source of truth for runtime deps. If absent at publish time, synthesize a minimal one from the `dependencies` field on the publish call.
+
+### 3. `agor.config.js` Handlebars rendering
+
+- Remove the per-fetch Handlebars rendering layer (`services/artifacts.ts:46-62, 664, 897-987`).
+- Anything that today relied on `{{user.env.X}}`, `{{agor.token}}`, `{{agor.apiUrl}}`, `{{agor.proxies.X.url}}`, `{{user.email}}`, `{{artifact.id}}`, `{{artifact.boardId}}` migrates to the new `required_env_vars` + `agor_grants` system below.
+
+### 4. `dependencies` and `entry` columns as the source of truth
+
+Keep the columns as a denormalized read cache (cheap), but `package.json` is canonical. On publish, parse `package.json` into the cache columns; on read, prefer the file-map's `package.json`.
+
+---
+
+## What gets added
+
+### 1. `sandpack_config` jsonb column
+
+A single object spread directly into `<SandpackProvider {...config} />` at render time:
+
+```ts
+sandpack_config: {
+  template?: SandpackTemplate
+  customSetup?: { dependencies?, devDependencies?, entry?, environment? }
+  theme?: SandpackThemeProp
+  options?: { activeFile?, visibleFiles?, layout?, recompileMode?,
+              showConsole?, showLineNumbers?, showInlineErrors?, ... }
+}
+```
+
+Shape mirrors `SandpackProviderProps` (`@codesandbox/sandpack-react`'s `types.ts`). On read, merge under defaults (`DEFAULT_SANDPACK_CONFIG`); on write, run through `sanitizeSandpackConfig` (allowlist below).
+
+#### `sanitizeSandpackConfig` allowlist
+
+Light. The artifact runtime is arbitrary-JS-by-design, so most "unsafe" Sandpack props don't grant new capability beyond what the file map already allows. Block only what affects the parent UI or daemon-controlled rendering:
+
+**Allow:**
+- `template`
+- `customSetup.dependencies`, `customSetup.devDependencies`, `customSetup.entry`, `customSetup.environment`
+- `theme`
+- `options.activeFile`, `options.visibleFiles`, `options.layout`, `options.recompileMode`, `options.recompileDelay`, `options.initMode`, `options.autorun`, `options.autoReload`, `options.showNavigator`, `options.showLineNumbers`, `options.showInlineErrors`, `options.showRefreshButton`, `options.showTabs`, `options.showConsole`, `options.showConsoleButton`, `options.closableTabs`, `options.startRoute`, `options.codeEditor`
+
+**Block (Agor-controlled or unsafe):**
+- `options.bundlerURL` — Agor sets this.
+- `options.externalResources` — XSS into the iframe (defense in depth, since the file map can already do this).
+- `customSetup.npmRegistries` — defense in depth against confused users assuming "private registry = trusted."
+- `customSetup.exportOptions` — has API token; per-user, not per-artifact.
+- `teamId`, `sandboxId` — bind to a CodeSandbox account; not the artifact author's call.
+- `options.fileResolver` — function-valued; can't survive JSON anyway.
+- `options.classes` — applied to parent UI components. Allow only if values match a known-safe class regex (`^[a-zA-Z0-9_-]+$`), otherwise drop.
+
+### 2. `required_env_vars` text[] column
+
+Array of plain var names (no prefix). Examples: `["OPENAI_KEY", "GITHUB_TOKEN"]`.
+
+At payload-fetch time, the daemon looks up the **viewing user's** encrypted `user.env.X` for each name and synthesizes a `.env` file injected into the file map on the way out (never persisted). Prefix per template:
+
+| Template family | Bundler | Prefix written to `.env` | App reads as |
+|---|---|---|---|
+| `vite-*`, `react-ts`, `react`, `vue3`, `svelte`, `solid` | Vite | `VITE_` | `import.meta.env.VITE_X` |
+| `create-react-app`, legacy `react`-CRA | Webpack/CRA | `REACT_APP_` | `process.env.REACT_APP_X` |
+| `node` | Node | none | `process.env.X` |
+| `vanilla`, `static` | none | n/a (skip injection) | n/a |
+| Other (`vue`, `angular-cli`, `parcel`-based) | Parcel/Vue-CLI | none | `process.env.X` |
+
+Prefix logic lives in a single helper: `envVarPrefixForTemplate(template: SandpackTemplate): string`. Templates without a working dotenv path (`vanilla`, `static`) skip env injection entirely; the daemon emits a warning if such an artifact has a non-empty `required_env_vars`.
+
+### 3. `agor_grants` jsonb column
+
+Discrete capability flags for daemon-supplied values. Each grant maps to a fixed env var name (with the template-appropriate prefix applied):
+
+| Grant key | Env var name | Behavior |
+|---|---|---|
+| `agor_token: true` | `AGOR_TOKEN` | Mint a 15-min daemon JWT for the **viewer**, inject. |
+| `agor_api_url: true` | `AGOR_API_URL` | Inject the daemon's base URL. |
+| `agor_proxies: ["openai", "anthropic"]` | `AGOR_PROXY_OPENAI`, `AGOR_PROXY_ANTHROPIC` | Inject proxy URLs for listed vendors. |
+| `agor_user_email: true` | `AGOR_USER_EMAIL` | Inject viewer's email. |
+| `agor_artifact_id: true` | `AGOR_ARTIFACT_ID` | Inject this artifact's ID. |
+| `agor_board_id: true` | `AGOR_BOARD_ID` | Inject the artifact's board ID. |
+
+Conventional name + explicit declaration. Grants are part of the consent surface; consent rules below treat `agor_token` stricter than informational ones (`agor_artifact_id`, `agor_board_id`) which need no consent at all.
+
+### 4. `artifact_trust_grants` table + TOFU consent flow
+
+```
+artifact_trust_grants
+  grant_id          UUID PK
+  user_id           — viewer who granted
+  scope_type        — 'artifact' | 'author' | 'instance' | 'session'
+  scope_value       — artifact_id | author_user_id | NULL | session_id
+  env_vars_set      — JSON array of var names this grant covers
+  agor_grants_set   — JSON object of grants this grant covers
+  granted_at        — timestamp
+  revoked_at        — timestamp (nullable; soft delete for audit)
+```
+
+**Consent resolution at render time** (in priority order):
+1. Author is the viewer → no consent needed.
+2. `agor_grants.agor_token` is requested → require artifact-scoped grant (never author/instance scoped — the JWT is too high-power).
+3. `instance` grant covering the requested set → grant applies.
+4. `author` grant covering the requested set → applies.
+5. `artifact` grant covering the requested set → applies.
+6. `session` grant (in-memory only) covering the requested set → applies.
+7. None of the above → render iframe with **empty values** (artifact will likely error; that's fine and visible). Show "Trust to render with secrets" badge in the card header.
+
+**Required env var or grant set is a strict subset check.** If Alice silently adds `STRIPE_KEY` to her artifact's `required_env_vars`, the existing grant doesn't cover it; re-prompt.
+
+### 5. Consent modal
+
+Single dialog, renders when the user clicks "Render with secrets" on a not-yet-trusted artifact.
+
+- Reuses `FileCollection` (`apps/agor-ui/src/components/FileCollection/FileCollection.tsx`) — adapter from `Record<string, string>` files map to `FileItem[]`.
+- Inline file viewer pane (no separate `CodePreviewModal` round-trip — the consent buttons must stay visible while reading code).
+- Shows env vars (with ⚠ icon) and grants (with ⚠ icon, distinct color for high-power ones like `agor_token`).
+- Trust scope radios: just-once, this-artifact, this-author, instance-wide. The instance option is hidden when `unix_user_mode !== 'simple'` (multi-user instances should not have a "trust everyone" button).
+- Action buttons: "Render with secrets" (commits the chosen scope), "Render without" (proceed with empty values, no grant created), "Ask agent to review" (opens the review pane below).
+
+### 6. One-shot agent review endpoint
+
+`POST /artifacts/:id/review` → `{ summary: string, concerns: Array<{severity: 'low'|'med'|'high', file: string, line?: number, note: string}> }`
+
+Synchronous one-shot LLM call. No DB session, no worktree, no genealogy. Uses the executor SDK plumbing already in `packages/executor/`. Hardcoded review prompt focused on: secret exfiltration patterns, suspicious `fetch()` destinations, obfuscation, unusual external resource loads.
+
+The endpoint *informs* — it does **not** auto-grant. Concerns surface as inline badges on the file tree in the consent modal. User reads them and decides.
+
+### 7. Settings: trusted artifacts & authors page
+
+New section under user settings. Lists every active grant: scope, env vars covered, grants covered, granted_at, last-used. Revoke button on each. Audit-log entry on revoke. Soft-deletes (`revoked_at`) preserve history.
+
+### 8. UI surfaces
+
+- **Artifact card header**: badge indicating consent state — "Trusted (this artifact)", "Trusted (Alice)", "Untrusted — render without secrets to view," etc.
+- **Render without secrets** is a valid, common state. The card shows a small "🔓 trust to inject secrets" affordance that opens the consent modal.
+- **`required_env_vars` editor** in the artifact settings panel: chip list of var names with add/remove. Hint text reminds about the prefix-per-template convention.
+- **`agor_grants` editor** in the artifact settings panel: checkboxes for each grant key, multi-select for `agor_proxies`. Author-only (other viewers can't edit).
+
+---
+
+## Migration: backwards-compat is not preserved; old format gets a self-service upgrade prompt
+
+Existing artifacts will have:
+- `sandpack.json` files in their `files` map (an Agor-specific sidecar that's no longer parsed).
+- `dependencies` / `entry` populated in DB columns (still readable as cache).
+- `agor.config.js` files with Handlebars syntax (`{{user.env.X}}`, `{{agor.token}}`).
+- No `required_env_vars`, no `agor_grants`, no `sandpack_config`.
+
+### Detection
+
+On artifact read, run a one-time `detectLegacyFormat(artifact)` that returns:
+
+```ts
+{
+  isLegacy: boolean
+  signals: ('has_sandpack_json' | 'has_agor_config_js' | 'no_sandpack_config' | 'has_handlebars_token' | 'has_handlebars_user_env')[]
+  detectedEnvVars: string[]      // names parsed out of {{user.env.X}}
+  detectedGrants: string[]       // grant keys parsed out of {{agor.X}}
+}
+```
+
+### Render behavior for legacy artifacts
+
+Render in **safe-degraded mode**: no env vars or grants injected (the old Handlebars rendering is gone, so `{{user.env.X}}` literals will show up in the bundle if the author didn't migrate). Show a banner on the artifact card:
+
+> ⚠ This artifact uses the old format and won't render correctly. Ask your agent to upgrade it:
+> ```
+> Use the agor_artifacts_get tool to read artifact <id>'s files and current
+> required_env_vars. Then use agor_artifacts_publish to republish with:
+>   - sandpack_config populated (template, dependencies, entry from package.json)
+>   - required_env_vars: [<detected var names>]
+>   - agor_grants: { <detected grants> }
+>   - sandpack.json and agor.config.js removed from the file map
+>   - Source files updated to read from import.meta.env.VITE_* instead of {{user.env.*}}
+> See agor_search_tools for full schemas.
+> ```
+
+The instruction text is generated dynamically from `detectLegacyFormat()` output — it interpolates the actual detected vars and grants for that specific artifact.
+
+Rationale: MCP tools are self-documenting. The upgrade is mechanical enough for an agent to do correctly given the tool descriptions. We don't need to ship migration code that we'll delete in a month.
+
+### Schema migration
+
+Drizzle migration:
+- ADD `sandpack_config jsonb DEFAULT '{}'`
+- ADD `required_env_vars jsonb DEFAULT '[]'`  (use jsonb on Postgres, text on SQLite)
+- ADD `agor_grants jsonb DEFAULT '{}'`
+- DROP `use_local_bundler`
+- KEEP `dependencies` and `entry` columns (denormalized cache)
+- CREATE TABLE `artifact_trust_grants`
+
+Data backfill: not attempted. Old rows get default empty values for new fields. Render path detects + warns.
+
+---
+
+## "Open in CodeSandbox" — bonus tool
+
+Trivial after the refactor. New MCP tool:
+
+```
+agor_artifacts_export_codesandbox(artifactId)
+  → { url: string, sandboxId: string }
+```
+
+Implementation:
+1. Fetch artifact files map.
+2. Strip leading slash from keys, wrap each value in `{ content }`.
+3. Drop `agor.config.js` if present (will be Handlebars literals, broken on CodeSandbox).
+4. POST to `https://codesandbox.io/api/v1/sandboxes/define?json=1` with `{ files, template: artifact.sandpack_config.template }`.
+5. Return sandbox URL and instructions to set `required_env_vars` / `agor_grants` values via CodeSandbox's Secret Keys UI (the names will already match because the export uses the same prefix-per-template convention).
+
+A small caveat in the tool description: `AGOR_TOKEN` and other daemon capabilities won't work on CodeSandbox — that artifact's daemon-dependent features will fail there. This is acceptable; the eject button is for share/demo, not full equivalence.
+
+UI: parallel "Open in CodeSandbox" button on the artifact card.
+
+---
+
+## Future, not in this PR
+
+- **Ephemeral sessions** (sessions not bound to a worktree). The artifact review endpoint is synchronous one-shot for now. When ephemeral sessions land, the same button can upgrade to a real session-backed flow without UI churn. Likely implementation: scratch worktree per user (option 3 from the conversation).
+- **`preset-io/agor-artifact-examples` repo.** Curated examples consumable via `git clone + agor_artifacts_publish`. Empty repo + seed examples + PR template + CI to validate. Optional `agor_artifacts_publish_from_examples_repo` helper later.
+- **Static MCP tool reference page on agor.live.** The artifact tools (and others) live only in code; a guide page would help human discoverability when the examples repo lands.
+- **Per-env-var consent granularity.** Today's design groups all env vars in a grant. Could split if friction proves real.
+- **StackBlitz export.** Browser-only SDK; UI button only, no MCP tool.
+
+---
+
+## Test plan (high-level)
+
+- **Round-trip**: publish → land → publish (modified) → land. Diff matches except for explicit edits.
+- **Migration**: legacy artifact (with `sandpack.json` + `agor.config.js`) renders in safe-degraded mode, banner appears with correct interpolated upgrade instructions.
+- **Sanitize**: blocked Sandpack props are stripped on publish (`bundlerURL`, `externalResources`, `npmRegistries`, `teamId`, etc.).
+- **Env injection**: per-template prefix is applied correctly (Vite → `VITE_`, CRA → `REACT_APP_`, etc.). Empty values injected when no consent.
+- **Consent**: artifact requires `OPENAI_KEY` + `agor_token`; first render shows modal; granting "this author" persists; second render of same author's artifact requesting same set is silent; second render with new `STRIPE_KEY` re-prompts. Revocation removes grant; next render re-prompts.
+- **`agor_token` is artifact-scoped only**: granting "this author" doesn't auto-cover JWT; re-prompt for it.
+- **Strict subset on grant matching**: existing grant for `[OPENAI_KEY]` doesn't cover artifact requesting `[OPENAI_KEY, STRIPE_KEY]`.
+- **CodeSandbox export**: round-trips a simple React artifact; sandbox URL is reachable; deps install; app builds.
+- **Review endpoint**: returns concerns for an obviously malicious artifact (literal `fetch(EXFIL, body=KEY)`); returns empty concerns for a benign one.
+
+---
+
+## File-level scope (rough)
+
+**Schema + types:**
+- `packages/core/src/db/schema.{sqlite,postgres}.ts` — column changes + `artifact_trust_grants` table
+- `packages/core/src/db/migrations/` — new migration
+- `packages/core/src/types/artifact.ts` — drop `SandpackManifest`, add `SandpackConfig`, `AgorGrants`, `ArtifactTrustGrant`
+- `packages/core/src/db/repositories/artifact.ts` — new fields
+- `packages/core/src/db/repositories/artifact-trust.ts` — new repo
+
+**Daemon:**
+- `apps/agor-daemon/src/services/artifacts.ts` — rip `agor.config.js` rendering, rip `sandpack.json` handling, rip `use_local_bundler`, add `.env` synthesis with prefix logic, add `agor_grants` injection, add legacy detection
+- `apps/agor-daemon/src/services/artifact-trust.ts` — new service for grants
+- `apps/agor-daemon/src/mcp/tools/artifacts.ts` — update `publish` + `get` schemas, add `export_codesandbox`, add `review` (or expose via REST)
+- `apps/agor-daemon/src/services/artifact-review.ts` — new one-shot review endpoint
+- `apps/agor-daemon/src/utils/sandpack-config.ts` — `sanitizeSandpackConfig`, `envVarPrefixForTemplate`, defaults
+
+**UI:**
+- `apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx` — render path uses `sandpack_config` blob, drops `bundlerURL`, shows trust state badge
+- `apps/agor-ui/src/components/ArtifactConsentModal/` — new component (single modal w/ inline file viewer, reuses `FileCollection`)
+- `apps/agor-ui/src/components/SettingsModal/TrustedArtifactsTab.tsx` — new settings tab
+- `apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx` — add `required_env_vars` / `agor_grants` editors
+- Storybook stories for the consent modal
+
+**Docs:**
+- `apps/agor-docs/pages/guide/artifacts.mdx` — rewrite for new format
+- `CLAUDE.md` — update artifact section
+- `context/concepts/` — possibly a new `artifacts.md`
+
+---
+
+## Notes for the implementing agent
+
+- The user runs `pnpm dev` in watch mode; do **not** run `pnpm build`.
+- Use `simple-git` for any git ops, never `execSync`.
+- Pre-commit hooks (typecheck, lint) must pass; do not use `--no-verify`.
+- `agor_artifacts_land` already exists and stays. Round-trip via land → edit → publish should still work post-refactor, just with the new format.
+- This is intentionally not split into multiple PRs. The pieces are interlocking enough that a half-shipped state would be worse than the full refactor.

--- a/packages/core/drizzle/postgres/0032_artifacts_format_refactor.sql
+++ b/packages/core/drizzle/postgres/0032_artifacts_format_refactor.sql
@@ -1,0 +1,27 @@
+-- Artifacts format refactor (2026-05-09).
+--
+-- See the matching sqlite migration and
+-- `docs/internal/artifacts-roadmap-2026-05-09.md` for the rationale.
+-- Backwards compatibility is intentionally NOT preserved; old rows get
+-- empty defaults and the daemon surfaces a self-service upgrade prompt.
+
+ALTER TABLE "artifacts" DROP COLUMN IF EXISTS "use_local_bundler";--> statement-breakpoint
+ALTER TABLE "artifacts" ADD COLUMN "sandpack_config" jsonb DEFAULT '{}'::jsonb;--> statement-breakpoint
+ALTER TABLE "artifacts" ADD COLUMN "required_env_vars" jsonb DEFAULT '[]'::jsonb;--> statement-breakpoint
+ALTER TABLE "artifacts" ADD COLUMN "agor_grants" jsonb DEFAULT '{}'::jsonb;--> statement-breakpoint
+
+CREATE TABLE "artifact_trust_grants" (
+	"grant_id" varchar(36) PRIMARY KEY NOT NULL,
+	"user_id" varchar(36) NOT NULL,
+	"scope_type" text NOT NULL,
+	"scope_value" text,
+	"env_vars_set" jsonb NOT NULL,
+	"agor_grants_set" jsonb NOT NULL,
+	"granted_at" timestamp with time zone NOT NULL,
+	"revoked_at" timestamp with time zone
+);--> statement-breakpoint
+
+ALTER TABLE "artifact_trust_grants" ADD CONSTRAINT "artifact_trust_grants_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("user_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+
+CREATE INDEX "artifact_trust_grants_user_idx" ON "artifact_trust_grants" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "artifact_trust_grants_scope_idx" ON "artifact_trust_grants" USING btree ("scope_type", "scope_value");

--- a/packages/core/drizzle/postgres/0033_artifacts_agor_runtime.sql
+++ b/packages/core/drizzle/postgres/0033_artifacts_agor_runtime.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "artifacts" ADD COLUMN "agor_runtime" jsonb;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1777300000000,
       "tag": "0031_restructure_agentic_tool_config",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1777400000000,
+      "tag": "0032_artifacts_format_refactor",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1777400000000,
       "tag": "0032_artifacts_format_refactor",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778500000000,
+      "tag": "0033_artifacts_agor_runtime",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0042_artifacts_format_refactor.sql
+++ b/packages/core/drizzle/sqlite/0042_artifacts_format_refactor.sql
@@ -1,0 +1,79 @@
+-- Artifacts format refactor (2026-05-09).
+--
+-- - Drop `use_local_bundler` (the self-hosted Sandpack bundler is gone).
+-- - Add `sandpack_config` (JSON) — author-controlled SandpackProvider props.
+-- - Add `required_env_vars` (JSON array) — env var NAMES the artifact needs.
+-- - Add `agor_grants` (JSON object) — declarative daemon capabilities.
+-- - Add `artifact_trust_grants` table for the TOFU consent flow.
+--
+-- Backwards compatibility is intentionally NOT preserved. Old artifacts get
+-- empty defaults; the daemon detects the legacy format on read and surfaces a
+-- self-service upgrade prompt to the user. See
+-- `docs/internal/artifacts-roadmap-2026-05-09.md`.
+
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+
+CREATE TABLE `__new_artifacts` (
+	`artifact_id` text(36) PRIMARY KEY NOT NULL,
+	`worktree_id` text(36),
+	`board_id` text(36) NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`path` text,
+	`template` text DEFAULT 'react' NOT NULL,
+	`build_status` text DEFAULT 'unknown' NOT NULL,
+	`build_errors` text,
+	`content_hash` text,
+	`files` text,
+	`dependencies` text,
+	`entry` text,
+	`sandpack_config` text,
+	`required_env_vars` text,
+	`agor_grants` text,
+	`public` integer DEFAULT true NOT NULL,
+	`created_by` text(36),
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`archived` integer DEFAULT false NOT NULL,
+	`archived_at` integer,
+	FOREIGN KEY (`worktree_id`) REFERENCES `worktrees`(`worktree_id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`board_id`) REFERENCES `boards`(`board_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+
+INSERT INTO `__new_artifacts`(
+	"artifact_id", "worktree_id", "board_id", "name", "description", "path",
+	"template", "build_status", "build_errors", "content_hash", "files",
+	"dependencies", "entry", "public", "created_by", "created_at",
+	"updated_at", "archived", "archived_at"
+)
+SELECT
+	"artifact_id", "worktree_id", "board_id", "name", "description", "path",
+	"template", "build_status", "build_errors", "content_hash", "files",
+	"dependencies", "entry", "public", "created_by", "created_at",
+	"updated_at", "archived", "archived_at"
+FROM `artifacts`;--> statement-breakpoint
+
+DROP TABLE `artifacts`;--> statement-breakpoint
+ALTER TABLE `__new_artifacts` RENAME TO `artifacts`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+
+CREATE INDEX `artifacts_worktree_idx` ON `artifacts` (`worktree_id`);--> statement-breakpoint
+CREATE INDEX `artifacts_board_idx` ON `artifacts` (`board_id`);--> statement-breakpoint
+CREATE INDEX `artifacts_archived_idx` ON `artifacts` (`archived`);--> statement-breakpoint
+CREATE INDEX `artifacts_public_idx` ON `artifacts` (`public`);--> statement-breakpoint
+
+CREATE TABLE `artifact_trust_grants` (
+	`grant_id` text(36) PRIMARY KEY NOT NULL,
+	`user_id` text(36) NOT NULL,
+	`scope_type` text NOT NULL,
+	`scope_value` text,
+	`env_vars_set` text NOT NULL,
+	`agor_grants_set` text NOT NULL,
+	`granted_at` integer NOT NULL,
+	`revoked_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`user_id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+
+CREATE INDEX `artifact_trust_grants_user_idx` ON `artifact_trust_grants` (`user_id`);--> statement-breakpoint
+CREATE INDEX `artifact_trust_grants_scope_idx` ON `artifact_trust_grants` (`scope_type`, `scope_value`);

--- a/packages/core/drizzle/sqlite/0043_artifacts_agor_runtime.sql
+++ b/packages/core/drizzle/sqlite/0043_artifacts_agor_runtime.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `artifacts` ADD `agor_runtime` text;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1777300000000,
       "tag": "0041_restructure_agentic_tool_config",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1777400000000,
+      "tag": "0042_artifacts_format_refactor",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1777400000000,
       "tag": "0042_artifacts_format_refactor",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1778500000000,
+      "tag": "0043_artifacts_agor_runtime",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/artifact-trust.ts
+++ b/packages/core/src/db/repositories/artifact-trust.ts
@@ -1,0 +1,162 @@
+/**
+ * Artifact Trust Grants Repository
+ *
+ * Stores per-viewer TOFU consent for injecting env vars and daemon grants
+ * into artifacts they didn't author. The viewer is `user_id`. The grant
+ * matches an artifact via `(scope_type, scope_value)`:
+ *
+ * - 'artifact'  → scope_value = artifact_id
+ * - 'author'    → scope_value = author user_id
+ * - 'instance'  → scope_value = null (covers every artifact on this Agor instance)
+ * - 'session'   → in-memory only; the service layer keeps these out of the DB.
+ *
+ * Soft-deletion: `revoked_at` is set instead of DELETE so the audit log
+ * stays intact. Active grants are filtered by `revoked_at IS NULL`.
+ */
+
+import type { AgorGrants, ArtifactTrustGrant, ArtifactTrustScopeType } from '@agor/core/types';
+import { and, eq, isNull } from 'drizzle-orm';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
+import {
+  type ArtifactTrustGrantInsert,
+  type ArtifactTrustGrantRow,
+  artifactTrustGrants,
+} from '../schema';
+
+function readJson<T>(value: unknown, fallback: T): T {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return fallback;
+    }
+  }
+  return value as T;
+}
+
+function writeJson(db: Database, value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (isPostgresDatabase(db)) return value;
+  return JSON.stringify(value);
+}
+
+export class ArtifactTrustGrantRepository {
+  constructor(private db: Database) {}
+
+  private rowToGrant(row: ArtifactTrustGrantRow): ArtifactTrustGrant {
+    return {
+      grant_id: row.grant_id as never,
+      user_id: row.user_id as never,
+      scope_type: row.scope_type as ArtifactTrustScopeType,
+      scope_value: row.scope_value ?? null,
+      env_vars_set: readJson<string[]>(row.env_vars_set, []),
+      agor_grants_set: readJson<AgorGrants>(row.agor_grants_set, {}),
+      granted_at: new Date(row.granted_at).toISOString(),
+      revoked_at: row.revoked_at ? new Date(row.revoked_at).toISOString() : undefined,
+    };
+  }
+
+  /**
+   * Persist a new trust grant.
+   *
+   * Note: `session`-scope grants are intentionally NOT stored here — they're
+   * the caller's responsibility to keep in-memory only.
+   */
+  async create(input: {
+    user_id: string;
+    scope_type: Exclude<ArtifactTrustScopeType, 'session' | 'self'>;
+    scope_value: string | null;
+    env_vars_set: string[];
+    agor_grants_set: AgorGrants;
+  }): Promise<ArtifactTrustGrant> {
+    const grantId = generateId();
+    const now = new Date();
+
+    const insertData: ArtifactTrustGrantInsert = {
+      grant_id: grantId,
+      user_id: input.user_id,
+      scope_type: input.scope_type,
+      scope_value: input.scope_value,
+      env_vars_set: writeJson(this.db, input.env_vars_set) as never,
+      agor_grants_set: writeJson(this.db, input.agor_grants_set) as never,
+      granted_at: now,
+      revoked_at: null,
+    };
+
+    await insert(this.db, artifactTrustGrants).values(insertData).run();
+
+    const row = await select(this.db)
+      .from(artifactTrustGrants)
+      .where(eq(artifactTrustGrants.grant_id, grantId))
+      .one();
+    if (!row) throw new Error('Failed to retrieve created trust grant');
+    return this.rowToGrant(row);
+  }
+
+  /**
+   * Active (non-revoked) grants for a viewer.
+   */
+  async findActiveByUser(userId: string): Promise<ArtifactTrustGrant[]> {
+    const rows = await select(this.db)
+      .from(artifactTrustGrants)
+      .where(and(eq(artifactTrustGrants.user_id, userId), isNull(artifactTrustGrants.revoked_at)))
+      .all();
+    return rows.map((r: ArtifactTrustGrantRow) => this.rowToGrant(r));
+  }
+
+  /**
+   * Active grants for a viewer that match a specific scope. Used when
+   * resolving consent for a single artifact.
+   */
+  async findActiveForScope(input: {
+    userId: string;
+    scopeType: Exclude<ArtifactTrustScopeType, 'session' | 'self'>;
+    scopeValue: string | null;
+  }): Promise<ArtifactTrustGrant[]> {
+    const conditions = [
+      eq(artifactTrustGrants.user_id, input.userId),
+      eq(artifactTrustGrants.scope_type, input.scopeType),
+      isNull(artifactTrustGrants.revoked_at),
+    ];
+    if (input.scopeValue === null) {
+      conditions.push(isNull(artifactTrustGrants.scope_value));
+    } else {
+      conditions.push(eq(artifactTrustGrants.scope_value, input.scopeValue));
+    }
+    const rows = await select(this.db)
+      .from(artifactTrustGrants)
+      .where(and(...conditions))
+      .all();
+    return rows.map((r: ArtifactTrustGrantRow) => this.rowToGrant(r));
+  }
+
+  async findById(grantId: string): Promise<ArtifactTrustGrant | null> {
+    const row = await select(this.db)
+      .from(artifactTrustGrants)
+      .where(eq(artifactTrustGrants.grant_id, grantId))
+      .one();
+    return row ? this.rowToGrant(row) : null;
+  }
+
+  /**
+   * Soft-delete: set revoked_at. The row is kept for audit history.
+   */
+  async revoke(grantId: string): Promise<void> {
+    await update(this.db, artifactTrustGrants)
+      .set({ revoked_at: new Date() })
+      .where(eq(artifactTrustGrants.grant_id, grantId))
+      .run();
+  }
+
+  /**
+   * Hard delete — for tests/admin only. Production code should use revoke().
+   */
+  async delete(grantId: string): Promise<void> {
+    await deleteFrom(this.db, artifactTrustGrants)
+      .where(eq(artifactTrustGrants.grant_id, grantId))
+      .run();
+  }
+}

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -1,14 +1,17 @@
 /**
  * Artifact Repository
  *
- * Type-safe CRUD operations for artifacts with short ID support.
- * Artifacts are live web applications rendered via Sandpack on board canvases.
+ * Type-safe CRUD for artifacts. Artifacts are live web applications rendered
+ * via Sandpack on board canvases. JSON columns are de/serialised here so the
+ * service layer can deal in plain objects.
  */
 
 import type {
+  AgorGrants,
   Artifact,
   ArtifactBuildStatus,
   BoardID,
+  SandpackConfig,
   SandpackTemplate,
   UUID,
   WorktreeID,
@@ -16,7 +19,7 @@ import type {
 import { and, eq, like, or } from 'drizzle-orm';
 import { formatShortId, generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
 import { type ArtifactInsert, type ArtifactRow, artifacts } from '../schema';
 import {
   AmbiguousIdError,
@@ -24,6 +27,35 @@ import {
   EntityNotFoundError,
   RepositoryError,
 } from './base';
+
+/**
+ * JSON columns differ between SQLite (text) and Postgres (jsonb). On
+ * Postgres the driver hands us a parsed value; on SQLite we get a string and
+ * must JSON.parse. This helper hides the difference from the rest of the
+ * repo.
+ */
+function readJson<T>(value: unknown): T | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string') {
+    if (value.length === 0) return undefined;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return undefined;
+    }
+  }
+  return value as T;
+}
+
+/**
+ * Mirror of `readJson` for writes. Postgres takes the value as-is (the
+ * jsonb driver serialises); SQLite needs a string.
+ */
+function writeJson(db: Database, value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (isPostgresDatabase(db)) return value;
+  return JSON.stringify(value);
+}
 
 export class ArtifactRepository implements BaseRepository<Artifact, Partial<Artifact>> {
   constructor(private db: Database) {}
@@ -38,12 +70,14 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       path: row.path ?? null,
       template: (row.template ?? 'react') as SandpackTemplate,
       build_status: (row.build_status ?? 'unknown') as ArtifactBuildStatus,
-      build_errors: row.build_errors ? JSON.parse(row.build_errors) : undefined,
+      build_errors: readJson<string[]>(row.build_errors),
       content_hash: row.content_hash ?? undefined,
-      files: row.files ? JSON.parse(row.files as string) : undefined,
-      dependencies: row.dependencies ? JSON.parse(row.dependencies as string) : undefined,
+      files: readJson<Record<string, string>>(row.files),
+      dependencies: readJson<Record<string, string>>(row.dependencies),
       entry: row.entry ?? undefined,
-      use_local_bundler: Boolean(row.use_local_bundler),
+      sandpack_config: readJson<SandpackConfig>(row.sandpack_config),
+      required_env_vars: readJson<string[]>(row.required_env_vars),
+      agor_grants: readJson<AgorGrants>(row.agor_grants),
       public: row.public !== undefined ? Boolean(row.public) : true,
       created_by: row.created_by ?? undefined,
       created_at: new Date(row.created_at).toISOString(),
@@ -88,12 +122,14 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
         path: data.path ?? null,
         template: data.template ?? 'react',
         build_status: data.build_status ?? 'unknown',
-        build_errors: data.build_errors ? JSON.stringify(data.build_errors) : null,
+        build_errors: writeJson(this.db, data.build_errors) as never,
         content_hash: data.content_hash ?? null,
-        files: data.files ? JSON.stringify(data.files) : null,
-        dependencies: data.dependencies ? JSON.stringify(data.dependencies) : null,
+        files: writeJson(this.db, data.files) as never,
+        dependencies: writeJson(this.db, data.dependencies) as never,
         entry: data.entry ?? null,
-        use_local_bundler: data.use_local_bundler ?? false,
+        sandpack_config: writeJson(this.db, data.sandpack_config) as never,
+        required_env_vars: writeJson(this.db, data.required_env_vars) as never,
+        agor_grants: writeJson(this.db, data.agor_grants) as never,
         public: data.public ?? true,
         created_by: data.created_by ?? null,
         created_at: now,
@@ -235,18 +271,25 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       if (updates.template !== undefined) setData.template = updates.template;
       if (updates.build_status !== undefined) setData.build_status = updates.build_status;
       if (updates.build_errors !== undefined) {
-        setData.build_errors = updates.build_errors ? JSON.stringify(updates.build_errors) : null;
+        setData.build_errors = writeJson(this.db, updates.build_errors);
       }
       if (updates.content_hash !== undefined) setData.content_hash = updates.content_hash ?? null;
       if (updates.files !== undefined) {
-        setData.files = updates.files ? JSON.stringify(updates.files) : null;
+        setData.files = writeJson(this.db, updates.files);
       }
       if (updates.dependencies !== undefined) {
-        setData.dependencies = updates.dependencies ? JSON.stringify(updates.dependencies) : null;
+        setData.dependencies = writeJson(this.db, updates.dependencies);
       }
       if (updates.entry !== undefined) setData.entry = updates.entry ?? null;
-      if (updates.use_local_bundler !== undefined)
-        setData.use_local_bundler = updates.use_local_bundler;
+      if (updates.sandpack_config !== undefined) {
+        setData.sandpack_config = writeJson(this.db, updates.sandpack_config);
+      }
+      if (updates.required_env_vars !== undefined) {
+        setData.required_env_vars = writeJson(this.db, updates.required_env_vars);
+      }
+      if (updates.agor_grants !== undefined) {
+        setData.agor_grants = writeJson(this.db, updates.agor_grants);
+      }
       if (updates.public !== undefined) setData.public = updates.public;
       if (updates.archived !== undefined) setData.archived = updates.archived;
       if (updates.archived_at !== undefined) {

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -295,6 +295,12 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       if (updates.archived_at !== undefined) {
         setData.archived_at = updates.archived_at ? new Date(updates.archived_at) : null;
       }
+      // worktree_id: passing null clears the FK; passing undefined leaves it
+      // alone. Required so a republish from a worktree path backfills the FK
+      // for artifacts that were created before the column was populated.
+      if (updates.worktree_id !== undefined) {
+        setData.worktree_id = updates.worktree_id ?? null;
+      }
 
       await update(this.db, artifacts).set(setData).where(eq(artifacts.artifact_id, fullId)).run();
 

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -17,6 +17,7 @@ import type {
   UUID,
   WorktreeID,
 } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { and, eq, like, or } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -92,8 +93,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
   async resolveId(id: string): Promise<string> {
     if (id.length === 36 && id.includes('-')) return id;
 
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
     const results = await select(this.db)
       .from(artifacts)
       .where(like(artifacts.artifact_id, pattern))

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -8,6 +8,7 @@
 
 import type {
   AgorGrants,
+  AgorRuntimeConfig,
   Artifact,
   ArtifactBuildStatus,
   BoardID,
@@ -78,6 +79,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       sandpack_config: readJson<SandpackConfig>(row.sandpack_config),
       required_env_vars: readJson<string[]>(row.required_env_vars),
       agor_grants: readJson<AgorGrants>(row.agor_grants),
+      agor_runtime: readJson<AgorRuntimeConfig>(row.agor_runtime),
       public: row.public !== undefined ? Boolean(row.public) : true,
       created_by: row.created_by ?? undefined,
       created_at: new Date(row.created_at).toISOString(),
@@ -130,6 +132,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
         sandpack_config: writeJson(this.db, data.sandpack_config) as never,
         required_env_vars: writeJson(this.db, data.required_env_vars) as never,
         agor_grants: writeJson(this.db, data.agor_grants) as never,
+        agor_runtime: writeJson(this.db, data.agor_runtime) as never,
         public: data.public ?? true,
         created_by: data.created_by ?? null,
         created_at: now,
@@ -286,6 +289,9 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       }
       if (updates.required_env_vars !== undefined) {
         setData.required_env_vars = writeJson(this.db, updates.required_env_vars);
+      }
+      if (updates.agor_runtime !== undefined) {
+        setData.agor_runtime = writeJson(this.db, updates.agor_runtime);
       }
       if (updates.agor_grants !== undefined) {
         setData.agor_grants = writeJson(this.db, updates.agor_grants);

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -17,7 +17,7 @@ import type {
   WorktreeID,
 } from '@agor/core/types';
 import { and, eq, like, or } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
 import { type ArtifactInsert, type ArtifactRow, artifacts } from '../schema';
@@ -102,7 +102,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       throw new AmbiguousIdError(
         'Artifact',
         id,
-        results.map((r: { artifact_id: string }) => formatShortId(r.artifact_id as UUID))
+        results.map((r: { artifact_id: string }) => r.artifact_id)
       );
     }
     return results[0].artifact_id;

--- a/packages/core/src/db/repositories/board-comments.ts
+++ b/packages/core/src/db/repositories/board-comments.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BoardComment, CommentID, UUID } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { and, eq, isNull, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -114,8 +115,7 @@ export class BoardCommentsRepository
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db)
       .from(boardComments)

--- a/packages/core/src/db/repositories/board-comments.ts
+++ b/packages/core/src/db/repositories/board-comments.ts
@@ -7,7 +7,7 @@
 
 import type { BoardComment, CommentID, UUID } from '@agor/core/types';
 import { and, eq, isNull, like } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type BoardCommentInsert, type BoardCommentRow, boardComments } from '../schema';
@@ -130,7 +130,7 @@ export class BoardCommentsRepository
       throw new AmbiguousIdError(
         'BoardComment',
         id,
-        results.map((r: { comment_id: string }) => formatShortId(r.comment_id as UUID))
+        results.map((r: { comment_id: string }) => r.comment_id)
       );
     }
 

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -9,7 +9,7 @@ import { WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
 import { and, eq, exists, inArray, isNotNull, like, ne, or, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import { generateSlug } from '../../lib/slugs';
 import { getBoardUrl } from '../../utils/url';
 import type { Database } from '../client';
@@ -115,7 +115,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       throw new AmbiguousIdError(
         'Board',
         id,
-        results.map((r: { board_id: string }) => formatShortId(r.board_id as UUID))
+        results.map((r: { board_id: string }) => r.board_id)
       );
     }
 

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Board, BoardExportBlob, BoardObject, UUID } from '@agor/core/types';
-import { WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
+import { prefixToLikePattern, WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
 import { and, eq, exists, inArray, isNotNull, like, ne, or, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
@@ -102,8 +102,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db).from(boards).where(like(boards.board_id, pattern)).all();
 

--- a/packages/core/src/db/repositories/card-types.ts
+++ b/packages/core/src/db/repositories/card-types.ts
@@ -6,7 +6,7 @@
 
 import type { CardType, UUID } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type CardTypeInsert, type CardTypeRow, cardTypes } from '../schema';
@@ -48,7 +48,7 @@ export class CardTypeRepository implements BaseRepository<CardType, Partial<Card
       throw new AmbiguousIdError(
         'CardType',
         id,
-        results.map((r: { card_type_id: string }) => formatShortId(r.card_type_id as UUID))
+        results.map((r: { card_type_id: string }) => r.card_type_id)
       );
     }
     return results[0].card_type_id;

--- a/packages/core/src/db/repositories/card-types.ts
+++ b/packages/core/src/db/repositories/card-types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CardType, UUID } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -36,8 +37,7 @@ export class CardTypeRepository implements BaseRepository<CardType, Partial<Card
   private async resolveId(id: string): Promise<string> {
     if (id.length === 36 && id.includes('-')) return id;
 
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
     const results = await select(this.db)
       .from(cardTypes)
       .where(like(cardTypes.card_type_id, pattern))

--- a/packages/core/src/db/repositories/cards.ts
+++ b/packages/core/src/db/repositories/cards.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BoardID, Card, CardType, CardTypeID, CardWithType, UUID } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { and, eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -57,8 +58,7 @@ export class CardRepository implements BaseRepository<Card, Partial<Card>> {
   private async resolveId(id: string): Promise<string> {
     if (id.length === 36 && id.includes('-')) return id;
 
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
     const results = await select(this.db).from(cards).where(like(cards.card_id, pattern)).all();
 
     if (results.length === 0) throw new EntityNotFoundError('Card', id);

--- a/packages/core/src/db/repositories/cards.ts
+++ b/packages/core/src/db/repositories/cards.ts
@@ -7,7 +7,7 @@
 
 import type { BoardID, Card, CardType, CardTypeID, CardWithType, UUID } from '@agor/core/types';
 import { and, eq, like } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { boardObjects, type CardInsert, type CardRow, cards, cardTypes } from '../schema';
@@ -66,7 +66,7 @@ export class CardRepository implements BaseRepository<Card, Partial<Card>> {
       throw new AmbiguousIdError(
         'Card',
         id,
-        results.map((r: { card_id: string }) => formatShortId(r.card_id as UUID))
+        results.map((r: { card_id: string }) => r.card_id)
       );
     }
     return results[0].card_id;

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -14,7 +14,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { decryptApiKey, encryptApiKey } from '../encryption';
@@ -223,7 +223,7 @@ export class GatewayChannelRepository
       throw new AmbiguousIdError(
         'GatewayChannel',
         id,
-        results.map((r: { id: string }) => formatShortId(r.id as UUID))
+        results.map((r: { id: string }) => r.id)
       );
     }
 

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -13,6 +13,7 @@ import type {
   GatewayEnvVar,
   UUID,
 } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -207,8 +208,7 @@ export class GatewayChannelRepository
       return id;
     }
 
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db)
       .from(gatewayChannels)

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -2,6 +2,7 @@
  * Repository Exports
  */
 
+export * from './artifact-trust';
 export * from './artifacts';
 export * from './base';
 export * from './board-comments';

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -15,7 +15,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { and, eq, like } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type MCPServerInsert, type MCPServerRow, mcpServers } from '../schema';
@@ -142,7 +142,7 @@ export class MCPServerRepository
       throw new AmbiguousIdError(
         'MCPServer',
         id,
-        results.map((r: { mcp_server_id: string }) => formatShortId(r.mcp_server_id as UUID))
+        results.map((r: { mcp_server_id: string }) => r.mcp_server_id)
       );
     }
 

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -14,6 +14,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { and, eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -126,8 +127,7 @@ export class MCPServerRepository
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db)
       .from(mcpServers)

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -276,9 +276,10 @@ describe('RepoRepository.findById', () => {
       expect(error).toBeInstanceOf(AmbiguousIdError);
       const ambiguousError = error as AmbiguousIdError;
       expect(ambiguousError.matches).toHaveLength(2);
-      // formatShortId returns 8 chars by default
-      expect(ambiguousError.matches[0]).toBe('01933e4a');
-      expect(ambiguousError.matches[1]).toBe('01933e4a');
+      // AmbiguousIdError carries full UUIDs so the user can disambiguate by
+      // pasting one back — short forms collapse to the same string when the
+      // prefix collides (which is exactly when the error fires).
+      expect(ambiguousError.matches).toEqual(expect.arrayContaining([id1, id2]));
     }
   });
 });

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -7,7 +7,7 @@
 import type { Repo, RepoEnvironment, RepoEnvironmentConfigV1, UUID } from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
 import { resolveVariant, wrapV1AsV2 } from '../../config/variant-resolver.js';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
 import { type RepoInsert, type RepoRow, repos } from '../schema';
@@ -155,7 +155,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       throw new AmbiguousIdError(
         'Repo',
         id,
-        results.map((r: { repo_id: string }) => formatShortId(r.repo_id as UUID))
+        results.map((r: { repo_id: string }) => r.repo_id)
       );
     }
 

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Repo, RepoEnvironment, RepoEnvironmentConfigV1, UUID } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
 import { resolveVariant, wrapV1AsV2 } from '../../config/variant-resolver.js';
 import { generateId } from '../../lib/ids';
@@ -142,8 +143,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db).from(repos).where(like(repos.repo_id, pattern)).all();
 

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -8,7 +8,7 @@ import type { Session, UUID } from '@agor/core/types';
 import { SessionStatus, WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
 import { and, desc, eq, inArray, isNotNull, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import { getSessionUrl } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
@@ -181,7 +181,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       throw new AmbiguousIdError(
         'Session',
         id,
-        results.map((r: { session_id: string }) => formatShortId(r.session_id as UUID))
+        results.map((r: { session_id: string }) => r.session_id)
       );
     }
 

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Session, UUID } from '@agor/core/types';
-import { SessionStatus, WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
+import { prefixToLikePattern, SessionStatus, WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
 import { and, desc, eq, inArray, isNotNull, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
@@ -165,8 +165,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db)
       .from(sessions)

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -5,7 +5,7 @@
  */
 
 import type { SessionID, Task, TaskMetadata, UUID } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { prefixToLikePattern, TaskStatus } from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -101,8 +101,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db).from(tasks).where(like(tasks.task_id, pattern)).all();
 

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -7,7 +7,7 @@
 import type { SessionID, Task, TaskMetadata, UUID } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
 import { eq, like, sql } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
 import { type TaskInsert, type TaskRow, tasks } from '../schema';
@@ -114,7 +114,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       throw new AmbiguousIdError(
         'Task',
         id,
-        results.map((r: { task_id: string }) => formatShortId(r.task_id as UUID))
+        results.map((r: { task_id: string }) => r.task_id)
       );
     }
 

--- a/packages/core/src/db/repositories/thread-session-map.ts
+++ b/packages/core/src/db/repositories/thread-session-map.ts
@@ -14,7 +14,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { and, eq, like, lt } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type ThreadSessionMapInsert, type ThreadSessionMapRow, threadSessionMap } from '../schema';
@@ -94,7 +94,7 @@ export class ThreadSessionMapRepository
       throw new AmbiguousIdError(
         'ThreadSessionMap',
         id,
-        results.map((r: { id: string }) => formatShortId(r.id as UUID))
+        results.map((r: { id: string }) => r.id)
       );
     }
 

--- a/packages/core/src/db/repositories/thread-session-map.ts
+++ b/packages/core/src/db/repositories/thread-session-map.ts
@@ -13,6 +13,7 @@ import type {
   ThreadStatus,
   UUID,
 } from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
 import { and, eq, like, lt } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -78,8 +79,7 @@ export class ThreadSessionMapRepository
       return id;
     }
 
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db)
       .from(threadSessionMap)

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -14,7 +14,7 @@ import type {
   User,
   UUID,
 } from '@agor/core/types';
-import { toAgenticToolsStatus } from '@agor/core/types';
+import { prefixToLikePattern, toAgenticToolsStatus } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
 import { normalizeStoredEnvMap, type RawStoredEnvVar } from '../../config/env-vars';
 import { generateId } from '../../lib/ids';
@@ -133,8 +133,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
     }
 
     // Short ID - need to resolve
-    const normalized = id.replace(/-/g, '').toLowerCase();
-    const pattern = `${normalized}%`;
+    const pattern = prefixToLikePattern(id);
 
     const results = await select(this.db).from(users).where(like(users.user_id, pattern)).all();
 

--- a/packages/core/src/db/repositories/worktrees.test.ts
+++ b/packages/core/src/db/repositories/worktrees.test.ts
@@ -268,8 +268,10 @@ describe('WorktreeRepository.findById', () => {
       expect(error).toBeInstanceOf(AmbiguousIdError);
       const ambiguousError = error as AmbiguousIdError;
       expect(ambiguousError.matches).toHaveLength(2);
-      expect(ambiguousError.matches[0]).toBe('01933e4a');
-      expect(ambiguousError.matches[1]).toBe('01933e4a');
+      // AmbiguousIdError carries full UUIDs so the user can disambiguate by
+      // pasting one back — short forms collapse to the same string when the
+      // prefix collides (which is exactly when the error fires).
+      expect(ambiguousError.matches).toEqual(expect.arrayContaining([id1, id2]));
     }
   });
 });

--- a/packages/core/src/db/repositories/worktrees.ts
+++ b/packages/core/src/db/repositories/worktrees.ts
@@ -7,7 +7,7 @@
 import type { AgenticToolName, SessionStatus, UUID, Worktree, WorktreeID } from '@agor/core/types';
 import { WORKTREE_PERMISSION_LEVELS } from '@agor/core/types';
 import { and, desc, eq, getTableColumns, inArray, isNotNull, like, or, sql } from 'drizzle-orm';
-import { formatShortId, generateId } from '../../lib/ids';
+import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
 import { type WorktreeInsert, type WorktreeRow, worktreeOwners, worktrees } from '../schema';
@@ -208,7 +208,7 @@ export class WorktreeRepository implements BaseRepository<Worktree, Partial<Work
       throw new AmbiguousIdError(
         'Worktree',
         prefix,
-        matches.map((m: { worktree_id: string }) => formatShortId(m.worktree_id as UUID))
+        matches.map((m: { worktree_id: string }) => m.worktree_id)
       );
     }
 

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1051,6 +1051,7 @@ export const artifacts = pgTable(
     sandpack_config: jsonb('sandpack_config'),
     required_env_vars: jsonb('required_env_vars'),
     agor_grants: jsonb('agor_grants'),
+    agor_runtime: jsonb('agor_runtime'),
     public: t.bool('public').notNull().default(true),
     created_by: varchar('created_by', { length: 36 }),
     created_at: t.timestamp('created_at').notNull(),

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1046,9 +1046,11 @@ export const artifacts = pgTable(
     build_errors: text('build_errors'), // JSON array of error strings
     content_hash: text('content_hash'),
     files: text('files'), // JSON: Record<string, string> — serialized file contents
-    dependencies: text('dependencies'), // JSON: Record<string, string> — npm deps
-    entry: text('entry'), // entry file from manifest
-    use_local_bundler: t.bool('use_local_bundler').notNull().default(false),
+    dependencies: text('dependencies'), // JSON: Record<string, string> — denormalized cache of package.json
+    entry: text('entry'), // denormalized cache of the Sandpack entry file
+    sandpack_config: jsonb('sandpack_config'),
+    required_env_vars: jsonb('required_env_vars'),
+    agor_grants: jsonb('agor_grants'),
     public: t.bool('public').notNull().default(true),
     created_by: varchar('created_by', { length: 36 }),
     created_at: t.timestamp('created_at').notNull(),
@@ -1066,6 +1068,31 @@ export const artifacts = pgTable(
 
 export type ArtifactRow = typeof artifacts.$inferSelect;
 export type ArtifactInsert = typeof artifacts.$inferInsert;
+
+/**
+ * Per-viewer trust grants for artifact secret/grant injection.
+ * See the matching SQLite definition for full docs.
+ */
+export const artifactTrustGrants = pgTable(
+  'artifact_trust_grants',
+  {
+    grant_id: varchar('grant_id', { length: 36 }).primaryKey(),
+    user_id: varchar('user_id', { length: 36 }).notNull(),
+    scope_type: text('scope_type').notNull(),
+    scope_value: text('scope_value'),
+    env_vars_set: jsonb('env_vars_set').notNull(),
+    agor_grants_set: jsonb('agor_grants_set').notNull(),
+    granted_at: t.timestamp('granted_at').notNull(),
+    revoked_at: t.timestamp('revoked_at'),
+  },
+  (table) => ({
+    userIdx: index('artifact_trust_grants_user_idx').on(table.user_id),
+    scopeIdx: index('artifact_trust_grants_scope_idx').on(table.scope_type, table.scope_value),
+  })
+);
+
+export type ArtifactTrustGrantRow = typeof artifactTrustGrants.$inferSelect;
+export type ArtifactTrustGrantInsert = typeof artifactTrustGrants.$inferInsert;
 
 /**
  * Board Objects table - Positioned entities (worktrees and cards) on boards

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1053,6 +1053,7 @@ export const artifacts = sqliteTable(
     sandpack_config: text('sandpack_config'), // JSON: SandpackConfig (author-controlled, sanitized on write)
     required_env_vars: text('required_env_vars'), // JSON: string[] of env var NAMES (no prefix)
     agor_grants: text('agor_grants'), // JSON: AgorGrants (declarative daemon capabilities)
+    agor_runtime: text('agor_runtime'), // JSON: AgorRuntimeConfig (controls daemon-injected agor-runtime.js)
     public: t.bool('public').notNull().default(true),
     created_by: text('created_by', { length: 36 }),
     created_at: t.timestamp('created_at').notNull(),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1048,9 +1048,11 @@ export const artifacts = sqliteTable(
     build_errors: text('build_errors'), // JSON array of error strings
     content_hash: text('content_hash'),
     files: text('files'), // JSON: Record<string, string> — serialized file contents
-    dependencies: text('dependencies'), // JSON: Record<string, string> — npm deps
-    entry: text('entry'), // entry file from manifest
-    use_local_bundler: t.bool('use_local_bundler').notNull().default(false),
+    dependencies: text('dependencies'), // JSON: Record<string, string> — denormalized cache of package.json
+    entry: text('entry'), // denormalized cache of the Sandpack entry file
+    sandpack_config: text('sandpack_config'), // JSON: SandpackConfig (author-controlled, sanitized on write)
+    required_env_vars: text('required_env_vars'), // JSON: string[] of env var NAMES (no prefix)
+    agor_grants: text('agor_grants'), // JSON: AgorGrants (declarative daemon capabilities)
     public: t.bool('public').notNull().default(true),
     created_by: text('created_by', { length: 36 }),
     created_at: t.timestamp('created_at').notNull(),
@@ -1068,6 +1070,35 @@ export const artifacts = sqliteTable(
 
 export type ArtifactRow = typeof artifacts.$inferSelect;
 export type ArtifactInsert = typeof artifacts.$inferInsert;
+
+/**
+ * Per-viewer trust grants for artifact secret/grant injection. The viewer
+ * (`user_id`) consented to inject the listed `env_vars_set` and
+ * `agor_grants_set` into one or more artifacts matching `scope_type` +
+ * `scope_value`. Soft-deleted via `revoked_at` for audit history.
+ */
+export const artifactTrustGrants = sqliteTable(
+  'artifact_trust_grants',
+  {
+    grant_id: text('grant_id', { length: 36 }).primaryKey(),
+    user_id: text('user_id', { length: 36 }).notNull(),
+    // CHECK constraint omitted — service-layer enforcement only, so adding new
+    // scope_types in the future doesn't require a SQLite table-recreate.
+    scope_type: text('scope_type').notNull(),
+    scope_value: text('scope_value'),
+    env_vars_set: text('env_vars_set').notNull(),
+    agor_grants_set: text('agor_grants_set').notNull(),
+    granted_at: t.timestamp('granted_at').notNull(),
+    revoked_at: t.timestamp('revoked_at'),
+  },
+  (table) => ({
+    userIdx: index('artifact_trust_grants_user_idx').on(table.user_id),
+    scopeIdx: index('artifact_trust_grants_scope_idx').on(table.scope_type, table.scope_value),
+  })
+);
+
+export type ArtifactTrustGrantRow = typeof artifactTrustGrants.$inferSelect;
+export type ArtifactTrustGrantInsert = typeof artifactTrustGrants.$inferInsert;
 
 /**
  * Board Objects table - Positioned entities (worktrees and cards) on boards

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -32,6 +32,7 @@ export const mcpServers = schema.mcpServers;
 export const cardTypes = schema.cardTypes;
 export const cards = schema.cards;
 export const artifacts = schema.artifacts;
+export const artifactTrustGrants = schema.artifactTrustGrants;
 export const boardObjects = schema.boardObjects;
 export const sessionMcpServers = schema.sessionMcpServers;
 export const sessionEnvSelections = schema.sessionEnvSelections;

--- a/packages/core/src/gateway/context.ts
+++ b/packages/core/src/gateway/context.ts
@@ -95,5 +95,5 @@ export function formatGatewayContext(ctx: GatewayContext): string {
     return '';
   }
 
-  return lines.join('\n') + '\n\n';
+  return `${lines.join('\n')}\n\n`;
 }

--- a/packages/core/src/git/security.test.ts
+++ b/packages/core/src/git/security.test.ts
@@ -196,8 +196,8 @@ describe('isLikelyGitToken — credential helper shape check', () => {
   });
 
   it('accepts well-formed GitHub-style PATs', () => {
-    expect(isLikelyGitToken('ghp_' + 'a'.repeat(36))).toBe(true);
-    expect(isLikelyGitToken('github_pat_' + 'A'.repeat(40))).toBe(true);
+    expect(isLikelyGitToken(`ghp_${'a'.repeat(36)}`)).toBe(true);
+    expect(isLikelyGitToken(`github_pat_${'A'.repeat(40)}`)).toBe(true);
     expect(isLikelyGitToken('a'.repeat(40))).toBe(true);
   });
 });

--- a/packages/core/src/lib/ids.test.ts
+++ b/packages/core/src/lib/ids.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { prefixToLikePattern } from '../types/id';
 import {
   expandPrefix,
   findByShortIdPrefix,
@@ -318,6 +319,48 @@ describe('findByShortIdPrefix', () => {
     const iter = new Set(entities);
     const matches = findByShortIdPrefix('0193', iter);
     expect(matches).toHaveLength(3);
+  });
+});
+
+describe('prefixToLikePattern', () => {
+  // The whole point: stored IDs are hyphenated UUIDs, so the LIKE pattern
+  // must match that format. A bare-hex prefix that spans a hyphen
+  // boundary used to silently match nothing.
+  it('passes through a sub-8 prefix unchanged (no hyphen yet)', () => {
+    expect(prefixToLikePattern('019e0eca')).toBe('019e0eca%');
+    expect(prefixToLikePattern('019')).toBe('019%');
+  });
+
+  it('inserts a hyphen at position 8 for prefixes that cross it', () => {
+    expect(prefixToLikePattern('019e0eca0d2d')).toBe('019e0eca-0d2d%');
+    expect(prefixToLikePattern('019e0eca0d')).toBe('019e0eca-0d%');
+  });
+
+  it('inserts hyphens at the canonical positions 8, 12, 16, 20', () => {
+    expect(prefixToLikePattern('019e0eca0d2d7000')).toBe('019e0eca-0d2d-7000%');
+    expect(prefixToLikePattern('019e0eca0d2d70008000')).toBe('019e0eca-0d2d-7000-8000%');
+    expect(prefixToLikePattern('019e0eca0d2d7000800000000000')).toBe(
+      '019e0eca-0d2d-7000-8000-00000000%'
+    );
+  });
+
+  it('accepts already-hyphenated prefixes and re-emits canonical form', () => {
+    expect(prefixToLikePattern('019e0eca-0d2d')).toBe('019e0eca-0d2d%');
+    // Even malformed-but-equivalent hyphen placement normalizes correctly.
+    expect(prefixToLikePattern('019e0-eca0d2d')).toBe('019e0eca-0d2d%');
+  });
+
+  it('lowercases the prefix', () => {
+    expect(prefixToLikePattern('019E0ECA-0D2D')).toBe('019e0eca-0d2d%');
+  });
+
+  it('handles the full 32/36-char canonical UUID', () => {
+    expect(prefixToLikePattern('019e0eca0d2d7000800000000000abcd')).toBe(
+      '019e0eca-0d2d-7000-8000-00000000abcd%'
+    );
+    expect(prefixToLikePattern('019e0eca-0d2d-7000-8000-00000000abcd')).toBe(
+      '019e0eca-0d2d-7000-8000-00000000abcd%'
+    );
   });
 });
 

--- a/packages/core/src/types/artifact-grants.ts
+++ b/packages/core/src/types/artifact-grants.ts
@@ -1,0 +1,40 @@
+/**
+ * Mapping from `agor_grants.<key>` to the canonical env var name the daemon
+ * synthesizes into `.env`. The template-appropriate prefix
+ * (`VITE_` / `REACT_APP_` / none) is applied separately by
+ * `envVarPrefixForTemplate` in apps/agor-daemon/src/utils/sandpack-config.ts.
+ */
+import type { AgorGrants } from './artifact';
+
+export const GRANT_ENV_VAR_NAMES = {
+  agor_token: 'AGOR_TOKEN',
+  agor_api_url: 'AGOR_API_URL',
+  agor_user_email: 'AGOR_USER_EMAIL',
+  agor_artifact_id: 'AGOR_ARTIFACT_ID',
+  agor_board_id: 'AGOR_BOARD_ID',
+} as const satisfies Record<keyof Omit<AgorGrants, 'agor_proxies'>, string>;
+
+/**
+ * Vendor name → AGOR_PROXY_<VENDOR> env var name.
+ * Vendor is uppercased, dashes/spaces normalised to underscores.
+ */
+export function proxyGrantEnvName(vendor: string): string {
+  return `AGOR_PROXY_${vendor.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}`;
+}
+
+/**
+ * Grants the daemon will inject without prompting for consent. These are
+ * pure metadata — no secrets, no capability beyond "knowing your own
+ * coordinates".
+ */
+export const NO_CONSENT_GRANT_KEYS = ['agor_artifact_id', 'agor_board_id'] as const;
+
+/**
+ * Grants that REQUIRE artifact-scoped consent and cannot be satisfied by an
+ * author- or instance-wide grant. The JWT (`agor_token`) is the canonical
+ * example: handing a 15-minute daemon JWT to "everything Alice ever
+ * publishes" is too broad.
+ */
+export const ARTIFACT_SCOPED_ONLY_GRANT_KEYS = ['agor_token'] as const;
+
+export type ConsentRelevantGrantKey = Exclude<keyof AgorGrants, 'agor_proxies'>;

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -170,7 +170,11 @@ export interface Artifact {
 
   /** Whether this artifact is archived */
   archived: boolean;
-  archived_at?: string;
+  /**
+   * When the artifact was archived. Null/undefined when not archived; a
+   * timestamp when archived. Always cleared on unarchive (NULL in DB).
+   */
+  archived_at?: string | null;
 }
 
 /**

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -4,15 +4,93 @@
  * Artifacts are board-scoped, DB-backed live web applications rendered via Sandpack.
  * The filesystem folder is a transient staging area; on publish, the daemon serializes
  * folder contents into the DB `files` column. Serving reads from DB only.
+ *
+ * Format: standard JS file map + DB metadata. No `sandpack.json` sidecar, no
+ * `agor.config.js` Handlebars sidecar. Env vars are declared on the artifact row
+ * (`required_env_vars`) and synthesized into `.env` at render time. Daemon
+ * capabilities are declared explicitly via `agor_grants`. See
+ * `apps/agor-docs/pages/guide/artifacts.mdx` and
+ * `docs/internal/artifacts-roadmap-2026-05-09.md`.
  */
 
 import type { SandpackTemplate } from './board';
-import type { ArtifactID, BoardID, WorktreeID } from './id';
+import type { ArtifactID, BoardID, UserID, UUID, WorktreeID } from './id';
 
 /**
  * Build status for artifacts
  */
 export type ArtifactBuildStatus = 'unknown' | 'checking' | 'success' | 'error';
+
+/**
+ * Allow-listed Sandpack provider config that authors can persist on an artifact.
+ *
+ * The shape mirrors a subset of `SandpackProviderProps` from
+ * `@codesandbox/sandpack-react`. Anything outside the allow list is stripped
+ * by `sanitizeSandpackConfig` before persistence — see
+ * `apps/agor-daemon/src/utils/sandpack-config.ts` for the canonical allow list
+ * and the rationale for each block.
+ *
+ * `customSetup.dependencies` lives here as a denormalized convenience. The
+ * authoritative source for runtime deps is `package.json#dependencies` in the
+ * file map.
+ */
+export interface SandpackConfig {
+  template?: SandpackTemplate;
+  customSetup?: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    entry?: string;
+    environment?: string;
+  };
+  theme?: 'light' | 'dark' | 'auto' | Record<string, unknown>;
+  options?: {
+    activeFile?: string;
+    visibleFiles?: string[];
+    layout?: 'preview' | 'tests' | 'console';
+    recompileMode?: 'immediate' | 'delayed';
+    recompileDelay?: number;
+    initMode?: 'lazy' | 'immediate' | 'user-visible';
+    autorun?: boolean;
+    autoReload?: boolean;
+    showNavigator?: boolean;
+    showLineNumbers?: boolean;
+    showInlineErrors?: boolean;
+    showRefreshButton?: boolean;
+    showTabs?: boolean;
+    showConsole?: boolean;
+    showConsoleButton?: boolean;
+    closableTabs?: boolean;
+    startRoute?: string;
+    classes?: Record<string, string>;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Discrete daemon-supplied capabilities granted to an artifact.
+ *
+ * Each grant maps to a fixed env var name (see GRANT_ENV_VAR_NAMES in
+ * `packages/core/src/types/artifact-grants.ts`). Grants are part of the
+ * consent surface — `agor_token` in particular is treated stricter than
+ * informational grants like `agor_artifact_id`.
+ */
+export interface AgorGrants {
+  /** Mint a 15-min daemon JWT for the viewer; injected as AGOR_TOKEN. */
+  agor_token?: boolean;
+  /** Inject the daemon's base URL as AGOR_API_URL. */
+  agor_api_url?: boolean;
+  /** Inject viewer's email as AGOR_USER_EMAIL. */
+  agor_user_email?: boolean;
+  /** Inject this artifact's ID as AGOR_ARTIFACT_ID (informational, no consent). */
+  agor_artifact_id?: boolean;
+  /** Inject the artifact's board ID as AGOR_BOARD_ID (informational, no consent). */
+  agor_board_id?: boolean;
+  /**
+   * Inject proxy URLs for listed vendors as AGOR_PROXY_<VENDOR> env vars.
+   * e.g. `["openai", "anthropic"]` → AGOR_PROXY_OPENAI, AGOR_PROXY_ANTHROPIC.
+   */
+  agor_proxies?: string[];
+}
 
 /**
  * Artifact - Live web application rendered via Sandpack on the board canvas
@@ -53,14 +131,33 @@ export interface Artifact {
   /** Serialized file contents: path -> code. Null for legacy records not yet re-published. */
   files?: Record<string, string>;
 
-  /** NPM dependencies from manifest */
+  /**
+   * Denormalized cache of `package.json#dependencies`. The file-map's
+   * `package.json` is canonical; this column is rebuilt from it on publish.
+   */
   dependencies?: Record<string, string>;
 
-  /** Entry file from manifest */
+  /** Denormalized cache of the Sandpack entry file (e.g. `/index.js`). */
   entry?: string;
 
-  /** Use self-hosted Sandpack bundler */
-  use_local_bundler?: boolean;
+  /**
+   * Author-controlled Sandpack provider config. Spread into `<SandpackProvider>`
+   * at render time, after defaults are merged. Sanitized on write (see
+   * `sanitizeSandpackConfig`).
+   */
+  sandpack_config?: SandpackConfig;
+
+  /**
+   * Names of env vars this artifact needs. The daemon synthesizes a `.env` file
+   * with the viewer's values at payload-fetch time, prefixed per the
+   * template's bundler convention (Vite → `VITE_`, CRA → `REACT_APP_`, etc.).
+   *
+   * Names are stored without prefix (e.g. `["OPENAI_KEY", "STRIPE_KEY"]`).
+   */
+  required_env_vars?: string[];
+
+  /** Daemon capabilities the artifact wants the daemon to inject. */
+  agor_grants?: AgorGrants;
 
   /** Whether this artifact is visible to all board viewers */
   public: boolean;
@@ -77,44 +174,61 @@ export interface Artifact {
 }
 
 /**
- * The sandpack.json manifest format
- * Maps directly to SandpackProvider props
- */
-export interface SandpackManifest {
-  template: SandpackTemplate;
-  /** NPM dependencies beyond template defaults */
-  dependencies?: Record<string, string>;
-  /** Entry file path */
-  entry?: string;
-  /**
-   * Opt into the daemon's self-hosted Sandpack bundler instead of CodeSandbox's
-   * default hosted bundler. Stores intent rather than a concrete URL so the
-   * artifact keeps working if the daemon's origin changes. Resolved to the
-   * daemon's selfHostedBundlerURL at payload read time. If the local bundler
-   * is not available at read time, falls back silently to the hosted bundler.
-   */
-  use_local_bundler?: boolean;
-}
-
-/**
- * Artifact payload served to frontend via REST
- * Contains everything needed to render the Sandpack preview
+ * Artifact payload served to frontend via REST.
+ *
+ * Contains everything needed to render the Sandpack preview. The daemon
+ * resolves consent and synthesizes the `.env` file before returning. The
+ * `trust_state` field tells the UI whether secrets were actually injected.
  */
 export interface ArtifactPayload {
   artifact_id: ArtifactID;
   name: string;
   description?: string;
   template: SandpackTemplate;
-  /** File map: path -> code content */
+  /** File map: path -> code content. May include a synthesized `/.env`. */
   files: Record<string, string>;
+  /** Author-controlled Sandpack config (spread into `<SandpackProvider>`). */
+  sandpack_config?: SandpackConfig;
   dependencies?: Record<string, string>;
   entry?: string;
   content_hash: string;
-  /** Env vars referenced in agor.config.js that the requesting user hasn't configured */
-  missing_env_vars?: string[];
-  /** Custom Sandpack bundler URL. Set when self-hosted bundler is available or specified in manifest. */
-  bundlerURL?: string;
+  /** Names of env vars the artifact requires (without prefix). */
+  required_env_vars?: string[];
+  /** Grants the artifact requested. */
+  agor_grants?: AgorGrants;
+  /**
+   * Whether the daemon injected secrets into this payload.
+   *
+   * - 'self' — viewer is the author; secrets always injected.
+   * - 'trusted' — an active trust grant matched the requested set.
+   * - 'untrusted' — empty values injected; UI should offer the consent flow.
+   * - 'no_secrets_needed' — artifact requested no env vars or grants.
+   */
+  trust_state: ArtifactTrustState;
+  /**
+   * Where the matching grant was found (only set when trust_state==='trusted').
+   * Useful for the UI to render a precise badge ("Trusted (Alice)" vs
+   * "Trusted (this artifact)").
+   */
+  trust_scope?: ArtifactTrustScopeType;
+  /**
+   * Legacy-format detection result. Present when the artifact was published
+   * with the pre-2026-05 format (sandpack.json sidecar / agor.config.js
+   * Handlebars). The UI surfaces `legacy.upgrade_instructions` as a banner
+   * with copyable agent prompt.
+   */
+  legacy?: ArtifactLegacyFormatReport;
 }
+
+/**
+ * Where the daemon found the trust grant that authorized injection.
+ */
+export type ArtifactTrustScopeType = 'self' | 'instance' | 'author' | 'artifact' | 'session';
+
+/**
+ * Trust state attached to a payload.
+ */
+export type ArtifactTrustState = 'self' | 'trusted' | 'untrusted' | 'no_secrets_needed';
 
 /**
  * Console log entry from Sandpack runtime (captured in browser, sent to daemon)
@@ -155,4 +269,70 @@ export interface ArtifactStatus {
   sandpack_status?: string;
   console_logs: ArtifactConsoleEntry[];
   content_hash?: string;
+}
+
+/**
+ * A persisted trust grant. The viewer (`user_id`) consented to inject the
+ * listed `env_vars_set` and `agor_grants_set` into one or more artifacts
+ * matching `scope_type` + `scope_value`.
+ *
+ * Soft-deleted via `revoked_at` for audit history.
+ */
+export interface ArtifactTrustGrant {
+  grant_id: UUID;
+  user_id: UserID;
+  scope_type: ArtifactTrustScopeType;
+  /**
+   * Resolves per scope_type:
+   * - 'artifact'  → ArtifactID
+   * - 'author'    → UserID (artifact author)
+   * - 'instance'  → null
+   * - 'session'   → in-memory only; never persisted with this row shape
+   * - 'self'      → never persisted (viewer-is-author bypass)
+   */
+  scope_value: string | null;
+  env_vars_set: string[];
+  agor_grants_set: AgorGrants;
+  granted_at: string;
+  revoked_at?: string;
+}
+
+/**
+ * Result of `detectLegacyFormat()`. Surfaces in the artifact payload so the
+ * UI can render the upgrade banner. The `upgrade_instructions` string is
+ * fully interpolated for this specific artifact and ready to hand to an
+ * agent.
+ */
+export interface ArtifactLegacyFormatReport {
+  is_legacy: boolean;
+  signals: ArtifactLegacySignal[];
+  /** Env var names parsed out of `{{ user.env.X }}` references. */
+  detected_env_vars: string[];
+  /** Grant keys parsed out of `{{ agor.X }}` references. */
+  detected_grants: string[];
+  /** Pre-formatted prompt the user can hand to an agent for self-service upgrade. */
+  upgrade_instructions: string;
+}
+
+export type ArtifactLegacySignal =
+  | 'has_sandpack_json'
+  | 'has_agor_config_js'
+  | 'no_sandpack_config'
+  | 'has_handlebars_token'
+  | 'has_handlebars_user_env';
+
+/**
+ * Output of the one-shot artifact review LLM call. Surfaces inline as inline
+ * badges on the file tree in the consent modal.
+ */
+export interface ArtifactReviewReport {
+  summary: string;
+  concerns: ArtifactReviewConcern[];
+}
+
+export interface ArtifactReviewConcern {
+  severity: 'low' | 'med' | 'high';
+  file: string;
+  line?: number;
+  note: string;
 }

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -319,7 +319,9 @@ export type ArtifactLegacySignal =
   | 'has_agor_config_js'
   | 'no_sandpack_config'
   | 'has_handlebars_token'
-  | 'has_handlebars_user_env';
+  | 'has_handlebars_user_env'
+  | 'has_handlebars_user_email'
+  | 'has_handlebars_artifact_ref';
 
 /**
  * Output of the one-shot artifact review LLM call. Surfaces inline as inline

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -93,6 +93,30 @@ export interface AgorGrants {
 }
 
 /**
+ * Per-artifact configuration for the daemon-injected `agor-runtime.js`.
+ *
+ * The runtime is a small (~30 lines) iframe-side script that listens for
+ * `postMessage` queries from the Agor parent page (e.g. `agor:query` with
+ * a CSS selector) and replies with serialized DOM snapshots. Agents call
+ * the matching MCP tools (e.g. `agor_artifacts_query_dom`) which fan out
+ * to the active viewer's browser, dispatch to the iframe, and return the
+ * iframe's reply.
+ *
+ * Injected at render time (in `getPayload`), parallel to `.env` synthesis
+ * — never persisted in the artifact's `files` column. Stripped from
+ * CodeSandbox exports for the same reason: it talks to an Agor parent
+ * that doesn't exist outside Agor.
+ *
+ * Defaults to enabled. Authors can opt out (`enabled: false`) for
+ * artifacts that should not be introspectable, or for artifacts whose
+ * own code conflicts with our message listener.
+ */
+export interface AgorRuntimeConfig {
+  /** Inject `agor-runtime.js` into the served file map. Defaults to `true`. */
+  enabled?: boolean;
+}
+
+/**
  * Artifact - Live web application rendered via Sandpack on the board canvas
  *
  * Artifacts are board-scoped, DB-backed objects. The `files` column holds the
@@ -155,6 +179,14 @@ export interface Artifact {
    * Names are stored without prefix (e.g. `["OPENAI_KEY", "STRIPE_KEY"]`).
    */
   required_env_vars?: string[];
+
+  /**
+   * Daemon-injected `agor-runtime.js` config. Default behavior (when this
+   * field is null/undefined) is enabled — agents calling
+   * `agor_artifacts_query_dom` etc. will get responses from any browser
+   * currently viewing the artifact. Set `enabled: false` to opt out.
+   */
+  agor_runtime?: AgorRuntimeConfig;
 
   /** Daemon capabilities the artifact wants the daemon to inject. */
   agor_grants?: AgorGrants;

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -102,9 +102,10 @@ export interface AgorGrants {
  * to the active viewer's browser, dispatch to the iframe, and return the
  * iframe's reply.
  *
- * Injected at render time (in `getPayload`), parallel to `.env` synthesis
- * — never persisted in the artifact's `files` column. Stripped from
- * CodeSandbox exports for the same reason: it talks to an Agor parent
+ * Injected at render time (in `getPayload`) as a `data:text/javascript`
+ * URL added to `sandpack_config.options.externalResources`. The persisted
+ * `files` column and `sandpack_config` are never mutated. Doesn't show up
+ * in CodeSandbox exports for the same reason: it talks to an Agor parent
  * that doesn't exist outside Agor.
  *
  * Defaults to enabled. Authors can opt out (`enabled: false`) for
@@ -112,7 +113,11 @@ export interface AgorGrants {
  * own code conflicts with our message listener.
  */
 export interface AgorRuntimeConfig {
-  /** Inject `agor-runtime.js` into the served file map. Defaults to `true`. */
+  /**
+   * Inject the daemon-side `agor-runtime.js` into the served bundle (as an
+   * iframe-level `<script>` via Sandpack's `externalResources`). Defaults
+   * to `true`.
+   */
   enabled?: boolean;
 }
 

--- a/packages/core/src/types/id.ts
+++ b/packages/core/src/types/id.ts
@@ -105,6 +105,45 @@ export function toShortId(id: AnyShortId, length: number = 8): ShortID {
 }
 
 /**
+ * Convert a (possibly-hyphenated) short-ID prefix into a SQL `LIKE`-friendly
+ * pattern that matches the canonical hyphenated UUID storage format.
+ *
+ * Repositories store IDs as full hyphenated UUIDs (e.g. `019e0eca-0d2d-7…`).
+ * Users pass prefixes in mixed forms — bare hex (`019e0eca0d2d`), partial
+ * hyphenated (`019e0eca-0d2d`), or copy-pasted from `AmbiguousIdError`
+ * (which prints the full hyphenated UUID, so a prefix-truncation often
+ * lands on a hyphen boundary). Without normalization, `LIKE '019e0eca0d2d%'`
+ * can never match a row whose ID is `019e0eca-0d2d-7XXX-…` because of the
+ * hyphen at position 8.
+ *
+ * This strips any hyphens from the input and re-inserts them at the
+ * canonical UUID positions (8, 12, 16, 20 hex chars) so the resulting
+ * pattern matches the stored format. Non-hex / empty inputs pass through
+ * to a pattern that will naturally not match any UUID column.
+ *
+ * @example
+ *   prefixToLikePattern('019e0eca')        === '019e0eca%'
+ *   prefixToLikePattern('019e0eca0d2d')    === '019e0eca-0d2d%'
+ *   prefixToLikePattern('019e0eca-0d2d')   === '019e0eca-0d2d%'
+ *   prefixToLikePattern('019E0ECA')        === '019e0eca%' // lowercased
+ */
+export function prefixToLikePattern(prefix: string): string {
+  const clean = prefix.replace(/-/g, '').toLowerCase();
+  // Hyphens land at hex positions 8, 12, 16, 20 in a canonical UUID.
+  const breaks = [8, 12, 16, 20];
+  let out = '';
+  let cursor = 0;
+  for (const b of breaks) {
+    if (b >= clean.length) {
+      return `${out}${clean.slice(cursor)}%`;
+    }
+    out += `${clean.slice(cursor, b)}-`;
+    cursor = b;
+  }
+  return `${out}${clean.slice(cursor)}%`;
+}
+
+/**
  * Find all entities whose ID starts with the given short-ID prefix.
  *
  * This is the shared short-ID matching primitive used by both core

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -3,6 +3,7 @@
 export type { PermissionDecision, PermissionRequest } from '../permissions';
 export * from './agentic-tool';
 export * from './artifact';
+export * from './artifact-grants';
 export * from './board';
 export * from './board-comment';
 export * from './card';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       emojibase-data:
         specifier: ^17.0.0
         version: 17.0.0(emojibase@17.0.0)
+      lz-string:
+        specifier: 1.5.0
+        version: 1.5.0
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Summary

Refactors the artifact format to be portable, auditable, and standards-aligned. Backwards compatibility is **intentionally not preserved** — legacy artifacts render in safe-degraded mode with an interpolated agentic upgrade prompt that points at existing MCP tools (\`agor_artifacts_get\` / \`agor_artifacts_publish\`) for self-service migration.

Design doc: \`docs/internal/artifacts-roadmap-2026-05-09.md\`.

## Why

- The old format had three sources of truth for the same data (DB columns, \`sandpack.json\` sidecar, \`package.json\`), an Agor-only \`agor.config.js\` Handlebars convention that didn't run on any other IDE, and a self-hosted Sandpack bundler path (\`use_local_bundler\`) that was a dead-end.
- Daemon-injected secrets (env vars, JWTs) were silently rendered into any artifact a viewer opened — viewing implied trusting the author with whatever \`{{user.env.X}}\` they referenced.

## What's added

- **\`sandpack_config\` jsonb column** — spread directly into \`<SandpackProvider>\`, gated by \`sanitizeSandpackConfig\` allow-list (drops \`bundlerURL\`, \`externalResources\`, \`npmRegistries\`, \`exportOptions\`, \`teamId\`, etc.)
- **\`required_env_vars\`** — list of plain var names; daemon synthesizes a per-viewer \`.env\` with template-aware prefix (\`VITE_\` / \`REACT_APP_\` / none)
- **\`agor_grants\`** — discrete daemon capabilities (\`agor_token\`, \`agor_api_url\`, \`agor_proxies\`, \`agor_user_email\`, \`agor_artifact_id\`, \`agor_board_id\`), each mapped to a well-known env var name
- **\`artifact_trust_grants\` table + TOFU consent flow** — scopes: session / artifact / author / instance, with strict-subset matching on env vars and \`agor_token\` consent locked to artifact-scope only
- **\`ArtifactConsentModal\`** — single dialog, inline \`FileCollection\` review pane, render-without-secrets is a valid degraded state
- **\`agor_artifacts_export_codesandbox\` MCP tool** — trivial post-refactor since the files map is now a portable JS project
- **\`agor.artifact.json\` sidecar** for round-tripping via \`agor_artifacts_land\`

## What's ripped

- \`use_local_bundler\` everywhere (build flag, payload, render path, types). Original VPN-blocked-CDN motivation was solved at the Chrome-config layer; the bundler had two flawed versions and was a dead-end. \`build.sh --with-sandpack\` left intact for follow-up.
- \`agor.config.js\` Handlebars rendering — replaced by \`required_env_vars\` + \`agor_grants\`. \`detectLegacyFormat()\` parses old Handlebars to produce the upgrade prompt.
- \`sandpack.json\` file-format sidecar — replaced by \`agor.artifact.json\`; \`package.json#dependencies\` is canonical for runtime deps.

## Breaking changes

- \`Artifact.use_local_bundler\` removed; \`ArtifactPayload.bundlerURL\` removed.
- Old \`agor.config.js\` artifacts render with empty values; banner shows agentic upgrade instructions interpolated from the legacy parse.
- \`agor_artifacts_publish\` MCP signature: \`useLocalBundler\` dropped; \`sandpackConfig\`, \`requiredEnvVars\`, \`agorGrants\` added.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm check\` (build for all packages except docs) green
- [ ] Round-trip: publish → land → publish (modified) → land. Diff matches except explicit edits.
- [ ] Migration: legacy artifact (with \`sandpack.json\` + \`agor.config.js\`) renders in safe-degraded mode, banner appears with correct interpolated upgrade instructions.
- [ ] Sanitize: blocked Sandpack props are stripped on publish (\`bundlerURL\`, \`externalResources\`, \`npmRegistries\`, \`teamId\`, etc.).
- [ ] Env injection: per-template prefix is applied correctly (Vite → \`VITE_\`, CRA → \`REACT_APP_\`, etc.). Empty values injected when no consent.
- [ ] Consent: artifact requires \`OPENAI_KEY\` + \`agor_token\`; first render shows modal; granting "this author" persists; second render of same author's artifact requesting same set is silent; second render with new \`STRIPE_KEY\` re-prompts. Revocation removes grant; next render re-prompts.
- [ ] \`agor_token\` is artifact-scoped only: granting "this author" doesn't auto-cover JWT; re-prompt for it.
- [ ] Strict subset on grant matching: existing grant for \`[OPENAI_KEY]\` doesn't cover artifact requesting \`[OPENAI_KEY, STRIPE_KEY]\`.
- [ ] CodeSandbox export: round-trips a simple React artifact; sandbox URL is reachable; deps install; app builds.

Daemon-side service tests for sanitize / legacy detection / trust resolution / strict-subset / agor_token-author-rejection / sibling-author-coverage / land round-trip are committed in \`utils/sandpack-config.test.ts\` and \`services/artifacts.test.ts\`. Manual UI verification (consent modal, legacy banner, trust-state badge) not yet performed.

## Known follow-ups (not in this PR)

- \`Settings → Trusted Artifacts\` revocation page (backend ready).
- \`POST /artifacts/:id/review\` one-shot agent endpoint + "Ask agent to review" affordance in the consent modal.
- "Open in CodeSandbox" UI button on the artifact card (MCP export tool ships here).
- \`build.sh --with-sandpack\` flag cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)