### PR TITLE
chore(release): bump agor-live and client minor

### DIFF
--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.17.4",
+  "version": "0.18.0",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.17.4",
+  "version": "0.18.0",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Bump both publish-facing packages by one minor version ahead of the next release.

| Package | Before | After |
|---|---|---|
| `agor-live` | 0.17.4 | 0.18.0 |
| `@agor-live/client` | 0.17.4 | 0.18.0 |

Both packages move in lockstep. Workspace consumers use `workspace:*` so no fixed-version refs need updating, and `pnpm-lock.yaml` is unchanged.

### Notable changes since 0.17.4

- #1145 — `POST /tasks/:id/run` for pure-REST harnesses (client surface change)
- #1146 — `agor_environment_set` MCP tool + worktree-create variant
- #1142 — fix cross-tool spawn inheriting parent's model
- #1144 — daemon: skip sudo wrap for git ops in simple/no-RBAC mode
- #1141 — `asUser=undefined` for repo.clone and worktree.add

### Publish

Mechanical version bump only — no code changes. Publish to npm is handled separately via `./build.sh --publish` (no auto-publish workflow exists yet); this PR just updates the manifest so a subsequent publish picks up the new version. The `agor-live publish smoke-test` workflow will run on this PR and exercise the packed tarball end-to-end.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (warnings only, pre-existing)
- [x] `pnpm test` clean (all 8 turbo tasks pass)
- [x] `pnpm install` produced no lockfile diff (workspace:* resolves dynamically)
- [ ] `agor-live publish smoke-test` CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)