### PR TITLE
fix(ui): stop duplicate "User updated" toast on onboarding skip

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -633,7 +633,6 @@ function AppContent() {
     }
   };
 
-  // Handle update user (`silent` suppresses the success toast; errors always show)
   const handleUpdateUser = async (
     userId: string,
     updates: UpdateUserInput,

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -231,19 +231,23 @@ function AppContent() {
 
     if (!currentUser) return;
 
-    // Mark onboarding complete and store result in preferences
-    handleUpdateUser(currentUser.user_id, {
-      onboarding_completed: true,
-      preferences: {
-        ...currentUser.preferences,
-        mainBoardId: result.boardId || currentUser.preferences?.mainBoardId,
-        onboarding: {
-          path: result.path,
-          worktreeId: result.worktreeId,
-          boardId: result.boardId,
+    // Silent: the wizard closing + navigation is the confirmation here.
+    handleUpdateUser(
+      currentUser.user_id,
+      {
+        onboarding_completed: true,
+        preferences: {
+          ...currentUser.preferences,
+          mainBoardId: result.boardId || currentUser.preferences?.mainBoardId,
+          onboarding: {
+            path: result.path,
+            worktreeId: result.worktreeId,
+            boardId: result.boardId,
+          },
         },
       },
-    });
+      { silent: true }
+    );
 
     // Clear the assistant pending flag if applicable
     if (result.path === 'assistant' && client) {
@@ -629,13 +633,19 @@ function AppContent() {
     }
   };
 
-  // Handle update user
-  const handleUpdateUser = async (userId: string, updates: UpdateUserInput) => {
+  // Handle update user (`silent` suppresses the success toast; errors always show)
+  const handleUpdateUser = async (
+    userId: string,
+    updates: UpdateUserInput,
+    options: { silent?: boolean } = {}
+  ) => {
     if (!client) return;
     try {
       // Cast UpdateUserInput to Partial<User> - backend handles encryption/conversion
       await client.service('users').patch(userId, updates as Partial<User>);
-      showSuccess('User updated successfully!');
+      if (!options.silent) {
+        showSuccess('User updated successfully!');
+      }
     } catch (error) {
       showError(`Failed to update user: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -817,15 +817,14 @@ export function OnboardingWizard({
 
   const handleSkip = useCallback(() => {
     if (!user) return;
-    onUpdateUser(user.user_id, { onboarding_completed: true });
-    // Close immediately - the parent will handle setting the state
+    // onComplete sets onboarding_completed; updating it here too would double-PATCH.
     onComplete({
       worktreeId: '',
       sessionId: '',
       boardId: '',
       path: 'assistant',
     });
-  }, [user, onUpdateUser, onComplete]);
+  }, [user, onComplete]);
 
   const handleBack = useCallback(() => {
     setError(null);


### PR DESCRIPTION
## Summary

Clicking **Skip** on the onboarding wizard fired **two** PATCH `/users` requests, each producing a `User updated successfully!` toast.

Root cause: redundant update.

- `OnboardingWizard.handleSkip` called `onUpdateUser(user, { onboarding_completed: true })` directly, then called `onComplete(...)`.
- `onComplete` resolves to `App.handleOnboardingComplete`, which **also** calls `handleUpdateUser` with `onboarding_completed: true` (plus preferences).
- Two PATCHes → two toasts.

## Fix

- **`OnboardingWizard.tsx` — `handleSkip`**: drop the redundant `onUpdateUser` call. `onComplete` already marks onboarding complete.
- **`App.tsx` — `handleUpdateUser`**: accept an optional `{ silent?: boolean }` argument.
- **`App.tsx` — `handleOnboardingComplete`**: pass `silent: true`. Per the bug report's lean ("both are unnecessary"), the wizard closing + navigation is sufficient feedback for the onboarding milestone.

Explicit settings-page saves (and other `handleUpdateUser` callers) keep the toast — `silent` defaults to `false`.

## Test plan

- [ ] Fresh user, click **Skip** in onboarding wizard → wizard closes, **zero toasts** appear.
- [ ] Fresh user, complete the wizard via the **Finish** button → still zero toasts (consistent with skip; navigation is the confirmation).
- [ ] Settings page: change a user field and save → exactly one `User updated successfully!` toast (unchanged).
- [ ] DevTools Network tab on Skip: only **one** `PATCH /users/:id`, not two.
- [ ] React StrictMode (dev): no double-fire.

## Adjacent / out of scope

While in the area I noticed `OnboardingWizard.saveOnboardingProgress` and the API-key save step also call `onUpdateUser` mid-wizard, which surface "User updated successfully!" toasts during the flow (noisy UX). Filing separately rather than expanding scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)