### PR TITLE
fix(daemon): resolve user.env templates in MCP test connection

### DIFF
--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -54,4 +54,22 @@ describe('register-services /mcp-servers/discover wiring', () => {
     // unresolved {{ user.env.X }} strings.
     expect(probeIdx).toBeLessThan(headersIdx);
   });
+
+  it('skips pre-resolution URL validation for templated URLs', () => {
+    // `new URL("https://{{ user.env.HOST }}/mcp")` throws because of the
+    // whitespace inside `{{ }}`, and `new URL("{{ user.env.MCP_URL }}")`
+    // throws because there is no scheme. So pre-resolution `validateUrl()`
+    // calls MUST be guarded by an `isTemplated` check, otherwise URL
+    // templates get rejected before they can be resolved (the original
+    // shape of the bug this PR is fixing, but for the URL field).
+    expect(discoverBlock).toMatch(/\bconst\s+isTemplated\s*=/);
+
+    // Both pre-resolution validation sites (inline `data.url` and saved
+    // `server.url`) must be inside an `!isTemplated(...)` guard.
+    expect(discoverBlock).toMatch(/!isTemplated\(\s*data\.url/);
+    expect(discoverBlock).toMatch(/!isTemplated\(\s*server\.url/);
+
+    // The post-resolution recheck still runs for templated URLs.
+    expect(discoverBlock).toMatch(/isTemplated\(\s*serverConfig\.url/);
+  });
 });

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -3,42 +3,32 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * Regression tests for the `/mcp-servers/discover` endpoint's template
- * resolution.
+ * Structural regression check for the `/mcp-servers/discover` endpoint.
  *
- * Background: a previous bug had the discover endpoint passing
- * `serverConfig.auth` straight to `resolveMCPAuthHeaders`, with no
- * Handlebars resolution. Servers configured with the recommended
- * `{{ user.env.X }}` syntax for bearer/JWT tokens had the literal
- * template string sent as the Authorization header, the upstream MCP
- * server returned 401, and the UI surfaced "Connection failed" — even
- * though the same servers worked fine in real sessions (the executor
- * resolves these templates via process.env + AGOR_USER_ENV_KEYS).
+ * Behavior of the template resolution itself is covered in
+ * `utils/mcp-probe-templates.test.ts` (real input/output assertions).
+ * This file only protects the *wiring*: the discover endpoint MUST call
+ * `resolveProbeServerTemplates`, and it MUST do so before
+ * `resolveMCPAuthHeaders` consumes the auth config (otherwise the
+ * resolution is dead code that runs after the headers are built).
  *
- * The fix loads the caller's user env vars from the DB, builds the same
- * template context the executor uses, and runs `resolveMcpServerTemplates`
- * over the probe before `resolveMCPAuthHeaders` runs.
- *
- * These structural assertions intentionally operate on a window scoped to
- * the discover endpoint: they prevent removing or reordering the resolver
- * call without flagging unrelated changes elsewhere in `register-services.ts`.
+ * Same source-level pattern as `register-services.oauth-callback.test.ts`:
+ * cheap, no Feathers/DB scaffolding, scoped to the discover block so
+ * unrelated edits elsewhere in `register-services.ts` don't trigger it.
  */
-describe('register-services /mcp-servers/discover template resolution', () => {
+describe('register-services /mcp-servers/discover wiring', () => {
   const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
 
-  // Strip block + line comments so prose mentioning the old buggy behavior
-  // can't satisfy or fool the assertions below. Keep `://` so URLs survive.
+  // Strip block + line comments so prose explaining the bug can't satisfy
+  // or fool the structural checks. Keep `://` so URLs survive.
   const codeOnly = rawSource
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/(^|[^:])\/\/.*$/gm, '$1');
 
-  /**
-   * Slice the discover endpoint body. We anchor on the unique
-   * `app.use('/mcp-servers/discover'` registration and stop at the next
-   * top-level `app.use(` or `app.service(` registration so refactors
-   * inside the endpoint stay covered while unrelated surrounding code
-   * doesn't leak in.
-   */
+  // Slice the discover endpoint body. We anchor on the unique
+  // `app.use('/mcp-servers/discover'` registration and stop at the next
+  // top-level `app.use(` or `app.service(` so the assertions stay scoped
+  // to the endpoint and don't drift into unrelated code.
   const discoverStart = codeOnly.indexOf("app.use('/mcp-servers/discover'");
   const afterDiscover = codeOnly.slice(discoverStart + 1);
   const nextAppUse = afterDiscover.search(/app\.(use|service)\s*\(/);
@@ -54,32 +44,16 @@ describe('register-services /mcp-servers/discover template resolution', () => {
     expect(discoverBlock.length).toBeGreaterThan(0);
   });
 
-  it('resolves Handlebars templates before building auth headers', () => {
-    // Without resolveMcpServerTemplates, the literal `{{ user.env.X }}`
-    // string is sent as the Authorization header → 401.
-    expect(discoverBlock).toMatch(/\bresolveMcpServerTemplates\s*\(/);
-
-    // The probe must resolve templates BEFORE handing the auth config to
-    // resolveMCPAuthHeaders — otherwise the resolution is dead code.
-    const resolveIdx = discoverBlock.search(/\bresolveMcpServerTemplates\s*\(/);
+  it('calls resolveProbeServerTemplates before resolveMCPAuthHeaders', () => {
+    const probeIdx = discoverBlock.search(/\bresolveProbeServerTemplates\s*\(/);
     const headersIdx = discoverBlock.search(/\bresolveMCPAuthHeaders\s*\(/);
-    expect(resolveIdx).toBeGreaterThan(-1);
+
+    // Both must be present.
+    expect(probeIdx).toBeGreaterThan(-1);
     expect(headersIdx).toBeGreaterThan(-1);
-    expect(resolveIdx).toBeLessThan(headersIdx);
-  });
 
-  it("loads the caller's user env vars from the DB to build the template context", () => {
-    // The daemon's process.env never holds user secrets — they live
-    // encrypted in the users table. Without resolveUserEnvironment the
-    // template context is empty and every {{ user.env.X }} resolves to
-    // undefined, masking the original bug as a different error.
-    expect(discoverBlock).toMatch(/\bresolveUserEnvironment\s*\(/);
-
-    // buildMCPTemplateContextFromEnv keys off AGOR_USER_ENV_KEYS to
-    // decide which keys are user-scoped. The synthetic env we construct
-    // here MUST include that tag — forgetting it produces an empty
-    // context even when user vars are loaded.
-    expect(discoverBlock).toMatch(/\bbuildMCPTemplateContextFromEnv\s*\(/);
-    expect(discoverBlock).toMatch(/\bAGOR_USER_ENV_KEYS_VAR\b/);
+    // Resolution must happen first — otherwise the headers are built from
+    // unresolved {{ user.env.X }} strings.
+    expect(probeIdx).toBeLessThan(headersIdx);
   });
 });

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -21,9 +21,7 @@ describe('register-services /mcp-servers/discover wiring', () => {
 
   // Strip block + line comments so prose explaining the bug can't satisfy
   // or fool the structural checks. Keep `://` so URLs survive.
-  const codeOnly = rawSource
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  const codeOnly = rawSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
   // Slice the discover endpoint body. We anchor on the unique
   // `app.use('/mcp-servers/discover'` registration and stop at the next

--- a/apps/agor-daemon/src/register-services.mcp-discover.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression tests for the `/mcp-servers/discover` endpoint's template
+ * resolution.
+ *
+ * Background: a previous bug had the discover endpoint passing
+ * `serverConfig.auth` straight to `resolveMCPAuthHeaders`, with no
+ * Handlebars resolution. Servers configured with the recommended
+ * `{{ user.env.X }}` syntax for bearer/JWT tokens had the literal
+ * template string sent as the Authorization header, the upstream MCP
+ * server returned 401, and the UI surfaced "Connection failed" — even
+ * though the same servers worked fine in real sessions (the executor
+ * resolves these templates via process.env + AGOR_USER_ENV_KEYS).
+ *
+ * The fix loads the caller's user env vars from the DB, builds the same
+ * template context the executor uses, and runs `resolveMcpServerTemplates`
+ * over the probe before `resolveMCPAuthHeaders` runs.
+ *
+ * These structural assertions intentionally operate on a window scoped to
+ * the discover endpoint: they prevent removing or reordering the resolver
+ * call without flagging unrelated changes elsewhere in `register-services.ts`.
+ */
+describe('register-services /mcp-servers/discover template resolution', () => {
+  const rawSource = readFileSync(join(__dirname, 'register-services.ts'), 'utf8');
+
+  // Strip block + line comments so prose mentioning the old buggy behavior
+  // can't satisfy or fool the assertions below. Keep `://` so URLs survive.
+  const codeOnly = rawSource
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  /**
+   * Slice the discover endpoint body. We anchor on the unique
+   * `app.use('/mcp-servers/discover'` registration and stop at the next
+   * top-level `app.use(` or `app.service(` registration so refactors
+   * inside the endpoint stay covered while unrelated surrounding code
+   * doesn't leak in.
+   */
+  const discoverStart = codeOnly.indexOf("app.use('/mcp-servers/discover'");
+  const afterDiscover = codeOnly.slice(discoverStart + 1);
+  const nextAppUse = afterDiscover.search(/app\.(use|service)\s*\(/);
+  const discoverBlock =
+    discoverStart === -1
+      ? ''
+      : nextAppUse === -1
+        ? afterDiscover
+        : afterDiscover.slice(0, nextAppUse);
+
+  it('registers the discover endpoint (sanity)', () => {
+    expect(discoverStart).toBeGreaterThan(-1);
+    expect(discoverBlock.length).toBeGreaterThan(0);
+  });
+
+  it('resolves Handlebars templates before building auth headers', () => {
+    // Without resolveMcpServerTemplates, the literal `{{ user.env.X }}`
+    // string is sent as the Authorization header → 401.
+    expect(discoverBlock).toMatch(/\bresolveMcpServerTemplates\s*\(/);
+
+    // The probe must resolve templates BEFORE handing the auth config to
+    // resolveMCPAuthHeaders — otherwise the resolution is dead code.
+    const resolveIdx = discoverBlock.search(/\bresolveMcpServerTemplates\s*\(/);
+    const headersIdx = discoverBlock.search(/\bresolveMCPAuthHeaders\s*\(/);
+    expect(resolveIdx).toBeGreaterThan(-1);
+    expect(headersIdx).toBeGreaterThan(-1);
+    expect(resolveIdx).toBeLessThan(headersIdx);
+  });
+
+  it("loads the caller's user env vars from the DB to build the template context", () => {
+    // The daemon's process.env never holds user secrets — they live
+    // encrypted in the users table. Without resolveUserEnvironment the
+    // template context is empty and every {{ user.env.X }} resolves to
+    // undefined, masking the original bug as a different error.
+    expect(discoverBlock).toMatch(/\bresolveUserEnvironment\s*\(/);
+
+    // buildMCPTemplateContextFromEnv keys off AGOR_USER_ENV_KEYS to
+    // decide which keys are user-scoped. The synthetic env we construct
+    // here MUST include that tag — forgetting it produces an empty
+    // context even when user vars are loaded.
+    expect(discoverBlock).toMatch(/\bbuildMCPTemplateContextFromEnv\s*\(/);
+    expect(discoverBlock).toMatch(/\bAGOR_USER_ENV_KEYS_VAR\b/);
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2264,38 +2264,45 @@ async function registerMCPServices(
         // this, Test Connection sends the literal `Bearer {{ user.env.X }}`
         // string and the MCP server returns 401, even though the server works
         // fine in real sessions.
+        //
+        // The endpoint is gated by `requireAuth` (see hook registration
+        // below), so a missing user_id here means the auth contract was
+        // bypassed somewhere upstream — fail loud rather than silently
+        // skip resolution and ship literal templates upstream.
         const userId = params?.user?.user_id as UserID | undefined;
-        if (userId) {
-          const { resolveUserEnvironment } = await import('@agor/core/config');
-          const { resolveProbeServerTemplates } = await import('./utils/mcp-probe-templates.js');
+        if (!userId) {
+          throw new NotAuthenticated('MCP discover requires an authenticated user');
+        }
 
-          const userEnv = await resolveUserEnvironment(userId, db);
-          const resolution = resolveProbeServerTemplates(
-            {
-              url: serverConfig.url,
-              transport: serverConfig.transport,
-              auth: serverConfig.auth as MCPAuth | undefined,
-              name: serverConfig.name,
-              mcpServerId: serverId,
-            },
-            userEnv
-          );
+        const { resolveUserEnvironment } = await import('@agor/core/config');
+        const { resolveProbeServerTemplates } = await import('./utils/mcp-probe-templates.js');
 
-          if (!resolution.ok) {
-            return { success: false, error: resolution.error };
-          }
+        const userEnv = await resolveUserEnvironment(userId, db);
+        const resolution = resolveProbeServerTemplates(
+          {
+            url: serverConfig.url,
+            transport: serverConfig.transport,
+            auth: serverConfig.auth as MCPAuth | undefined,
+            name: serverConfig.name,
+            mcpServerId: serverId,
+          },
+          userEnv
+        );
 
-          serverConfig.auth = resolution.resolved.auth as typeof serverConfig.auth;
-          // Re-validate whenever the input URL was templated, even if the
-          // resolved string happens to match the input (e.g., a user env
-          // value that itself looks like the template). Pre-resolution
-          // validation is skipped for templated URLs, so this is the only
-          // gate that runs for them.
-          if (resolution.resolved.url !== serverConfig.url || isTemplated(serverConfig.url)) {
-            const recheck = validateUrl(resolution.resolved.url);
-            if (!recheck.valid) return { success: false, error: recheck.error };
-            serverConfig.url = resolution.resolved.url;
-          }
+        if (!resolution.ok) {
+          return { success: false, error: resolution.error };
+        }
+
+        serverConfig.auth = resolution.resolved.auth as typeof serverConfig.auth;
+        // Re-validate whenever the input URL was templated, even if the
+        // resolved string happens to match the input (e.g., a user env
+        // value that itself looks like the template). Pre-resolution
+        // validation is skipped for templated URLs, so this is the only
+        // gate that runs for them.
+        if (resolution.resolved.url !== serverConfig.url || isTemplated(serverConfig.url)) {
+          const recheck = validateUrl(resolution.resolved.url);
+          if (!recheck.valid) return { success: false, error: recheck.error };
+          serverConfig.url = resolution.resolved.url;
         }
 
         console.log('[MCP Discovery] Starting test for:', serverConfig.name || 'inline-config');

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -28,6 +28,8 @@ import { NotAuthenticated } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   HookContext,
+  MCPAuth,
+  MCPServer,
   MCPServerID,
   MessageSource,
   SessionID,
@@ -2245,6 +2247,65 @@ async function registerMCPServices(
             success: false,
             error: `Connection test not supported for stdio servers (requires active session)`,
           };
+        }
+
+        // Resolve {{ user.env.X }} templates in url/auth using the caller's
+        // user env vars. The executor does this at session runtime via
+        // process.env + AGOR_USER_ENV_KEYS, but the daemon's process.env
+        // never holds user secrets — so we pull them from the DB here. Without
+        // this, Test Connection sends the literal `Bearer {{ user.env.X }}`
+        // string and the MCP server returns 401, even though the server works
+        // fine in real sessions.
+        const userId = (params as AuthenticatedParams).user?.user_id as UserID | undefined;
+        if (userId) {
+          const { resolveUserEnvironment, AGOR_USER_ENV_KEYS_VAR } = await import(
+            '@agor/core/config'
+          );
+          const { resolveMcpServerTemplates, buildMCPTemplateContextFromEnv } = await import(
+            '@agor/core/mcp'
+          );
+
+          const userEnv = await resolveUserEnvironment(userId, db);
+          const templateContext = buildMCPTemplateContextFromEnv({
+            ...userEnv,
+            [AGOR_USER_ENV_KEYS_VAR]: Object.keys(userEnv).join(','),
+          });
+
+          const now = new Date();
+          const probeServer: MCPServer = {
+            mcp_server_id: ((serverId as string | undefined) ?? 'inline-test') as MCPServerID,
+            name: serverConfig.name || 'inline-test',
+            transport: serverConfig.transport,
+            url: serverConfig.url,
+            auth: serverConfig.auth as MCPAuth | undefined,
+            scope: 'global',
+            source: 'user',
+            enabled: true,
+            created_at: now,
+            updated_at: now,
+          };
+          const result = resolveMcpServerTemplates(probeServer, templateContext);
+
+          if (!result.isValid) {
+            return { success: false, error: result.errorMessage };
+          }
+          // Surface unresolved auth templates as a clear error — otherwise the
+          // probe sends an empty/literal Authorization header and the 401 hides
+          // the real cause from the user.
+          const unresolvedAuth = result.unresolvedFields.filter((f) => f.startsWith('auth.'));
+          if (unresolvedAuth.length > 0) {
+            return {
+              success: false,
+              error: `Unresolved env var template(s): ${unresolvedAuth.join(', ')}. Define the matching variables in Settings → Environment Variables.`,
+            };
+          }
+
+          serverConfig.auth = result.server.auth as typeof serverConfig.auth;
+          if (result.server.url) {
+            const recheck = validateUrl(result.server.url);
+            if (!recheck.valid) return { success: false, error: recheck.error };
+            serverConfig.url = result.server.url;
+          }
         }
 
         console.log('[MCP Discovery] Starting test for:', serverConfig.name || 'inline-config');

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2172,10 +2172,13 @@ async function registerMCPServices(
         const isTemplated = (url: string): boolean => url.includes('{{');
 
         const hasInlineConfig = !!data.url;
+        // `auth` is typed as the canonical MCPAuth (rather than narrowing to
+        // `typeof data.auth`) so the resolved auth from
+        // `resolveProbeServerTemplates` flows back in without casts.
         let serverConfig: {
           url: string;
           transport: 'http' | 'sse' | 'stdio';
-          auth?: typeof data.auth;
+          auth?: MCPAuth;
           name?: string;
           scope?: string;
           owner_user_id?: string;
@@ -2282,7 +2285,7 @@ async function registerMCPServices(
           {
             url: serverConfig.url,
             transport: serverConfig.transport,
-            auth: serverConfig.auth as MCPAuth | undefined,
+            auth: serverConfig.auth,
             name: serverConfig.name,
             mcpServerId: serverId,
           },
@@ -2293,7 +2296,7 @@ async function registerMCPServices(
           return { success: false, error: resolution.error };
         }
 
-        serverConfig.auth = resolution.resolved.auth as typeof serverConfig.auth;
+        serverConfig.auth = resolution.resolved.auth;
         // Re-validate whenever the input URL was templated, even if the
         // resolved string happens to match the input (e.g., a user env
         // value that itself looks like the template). Pre-resolution

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2256,7 +2256,7 @@ async function registerMCPServices(
         // this, Test Connection sends the literal `Bearer {{ user.env.X }}`
         // string and the MCP server returns 401, even though the server works
         // fine in real sessions.
-        const userId = (params as AuthenticatedParams).user?.user_id as UserID | undefined;
+        const userId = params?.user?.user_id as UserID | undefined;
         if (userId) {
           const { resolveUserEnvironment, AGOR_USER_ENV_KEYS_VAR } = await import(
             '@agor/core/config'

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2164,6 +2164,13 @@ async function registerMCPServices(
           }
         };
 
+        // Skip pre-resolution URL validation for templated URLs — `new URL()`
+        // rejects whitespace inside `{{ user.env.X }}` (and full-URL templates
+        // like `{{ user.env.MCP_URL }}` have no scheme yet), so validating
+        // pre-resolution would block legitimate templates from ever reaching
+        // the resolver. The resolved URL is re-validated below before use.
+        const isTemplated = (url: string): boolean => url.includes('{{');
+
         const hasInlineConfig = !!data.url;
         let serverConfig: {
           url: string;
@@ -2176,8 +2183,10 @@ async function registerMCPServices(
         let serverId: string | undefined;
 
         if (hasInlineConfig) {
-          const urlValidation = validateUrl(data.url!);
-          if (!urlValidation.valid) return { success: false, error: urlValidation.error };
+          if (!isTemplated(data.url!)) {
+            const urlValidation = validateUrl(data.url!);
+            if (!urlValidation.valid) return { success: false, error: urlValidation.error };
+          }
           serverConfig = {
             url: data.url!,
             transport: data.transport || 'http',
@@ -2224,7 +2233,7 @@ async function registerMCPServices(
                 error: 'Access denied: admin role required to discover session-scoped MCP servers',
               };
           }
-          if (server.url) {
+          if (server.url && !isTemplated(server.url)) {
             const urlValidation = validateUrl(server.url);
             if (!urlValidation.valid) return { success: false, error: urlValidation.error };
           }
@@ -2277,7 +2286,12 @@ async function registerMCPServices(
           }
 
           serverConfig.auth = resolution.resolved.auth as typeof serverConfig.auth;
-          if (resolution.resolved.url !== serverConfig.url) {
+          // Re-validate whenever the input URL was templated, even if the
+          // resolved string happens to match the input (e.g., a user env
+          // value that itself looks like the template). Pre-resolution
+          // validation is skipped for templated URLs, so this is the only
+          // gate that runs for them.
+          if (resolution.resolved.url !== serverConfig.url || isTemplated(serverConfig.url)) {
             const recheck = validateUrl(resolution.resolved.url);
             if (!recheck.valid) return { success: false, error: recheck.error };
             serverConfig.url = resolution.resolved.url;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -29,7 +29,6 @@ import type {
   AuthenticatedParams,
   HookContext,
   MCPAuth,
-  MCPServer,
   MCPServerID,
   MessageSource,
   SessionID,
@@ -2258,53 +2257,30 @@ async function registerMCPServices(
         // fine in real sessions.
         const userId = params?.user?.user_id as UserID | undefined;
         if (userId) {
-          const { resolveUserEnvironment, AGOR_USER_ENV_KEYS_VAR } = await import(
-            '@agor/core/config'
-          );
-          const { resolveMcpServerTemplates, buildMCPTemplateContextFromEnv } = await import(
-            '@agor/core/mcp'
-          );
+          const { resolveUserEnvironment } = await import('@agor/core/config');
+          const { resolveProbeServerTemplates } = await import('./utils/mcp-probe-templates.js');
 
           const userEnv = await resolveUserEnvironment(userId, db);
-          const templateContext = buildMCPTemplateContextFromEnv({
-            ...userEnv,
-            [AGOR_USER_ENV_KEYS_VAR]: Object.keys(userEnv).join(','),
-          });
+          const resolution = resolveProbeServerTemplates(
+            {
+              url: serverConfig.url,
+              transport: serverConfig.transport,
+              auth: serverConfig.auth as MCPAuth | undefined,
+              name: serverConfig.name,
+              mcpServerId: serverId,
+            },
+            userEnv
+          );
 
-          const now = new Date();
-          const probeServer: MCPServer = {
-            mcp_server_id: ((serverId as string | undefined) ?? 'inline-test') as MCPServerID,
-            name: serverConfig.name || 'inline-test',
-            transport: serverConfig.transport,
-            url: serverConfig.url,
-            auth: serverConfig.auth as MCPAuth | undefined,
-            scope: 'global',
-            source: 'user',
-            enabled: true,
-            created_at: now,
-            updated_at: now,
-          };
-          const result = resolveMcpServerTemplates(probeServer, templateContext);
-
-          if (!result.isValid) {
-            return { success: false, error: result.errorMessage };
-          }
-          // Surface unresolved auth templates as a clear error — otherwise the
-          // probe sends an empty/literal Authorization header and the 401 hides
-          // the real cause from the user.
-          const unresolvedAuth = result.unresolvedFields.filter((f) => f.startsWith('auth.'));
-          if (unresolvedAuth.length > 0) {
-            return {
-              success: false,
-              error: `Unresolved env var template(s): ${unresolvedAuth.join(', ')}. Define the matching variables in Settings → Environment Variables.`,
-            };
+          if (!resolution.ok) {
+            return { success: false, error: resolution.error };
           }
 
-          serverConfig.auth = result.server.auth as typeof serverConfig.auth;
-          if (result.server.url) {
-            const recheck = validateUrl(result.server.url);
+          serverConfig.auth = resolution.resolved.auth as typeof serverConfig.auth;
+          if (resolution.resolved.url !== serverConfig.url) {
+            const recheck = validateUrl(resolution.resolved.url);
             if (!recheck.valid) return { success: false, error: recheck.error };
-            serverConfig.url = result.server.url;
+            serverConfig.url = resolution.resolved.url;
           }
         }
 

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { resolveProbeServerTemplates } from './mcp-probe-templates';
+
+/**
+ * Behavior tests for the MCP discover-endpoint template resolution helper.
+ *
+ * Direct exercise of the recipe used by `/mcp-servers/discover`: synthetic
+ * env tagged with AGOR_USER_ENV_KEYS → buildMCPTemplateContextFromEnv →
+ * resolveMcpServerTemplates → typed result. The bug this PR fixed (literal
+ * `{{ user.env.X }}` strings reaching the upstream MCP server) regresses
+ * here if any of those steps stops composing correctly.
+ */
+describe('resolveProbeServerTemplates', () => {
+  it('resolves {{ user.env.X }} in bearer tokens to the actual value', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: { type: 'bearer', token: '{{ user.env.GARMIN_TOKEN }}' },
+        name: 'garmin',
+      },
+      { GARMIN_TOKEN: 'real-secret-abc123' }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved.auth?.token).toBe('real-secret-abc123');
+    }
+  });
+
+  it('passes plain (non-templated) bearer tokens through unchanged', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: { type: 'bearer', token: 'pasted-raw-token' },
+        name: 'plain',
+      },
+      {}
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved.auth?.token).toBe('pasted-raw-token');
+    }
+  });
+
+  it('returns an actionable error when an auth template references a missing var', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: { type: 'bearer', token: '{{ user.env.MISSING }}' },
+        name: 'garmin',
+      },
+      {} // no env vars defined
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Error must point at the failing field AND tell the user where to fix it.
+      expect(result.error).toContain('auth.token');
+      expect(result.error).toContain('Settings');
+    }
+  });
+
+  it('returns an actionable error when only some auth templates resolve', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: {
+          type: 'jwt',
+          api_url: 'https://auth.example.com/jwt',
+          api_token: '{{ user.env.JWT_KEY }}',
+          api_secret: '{{ user.env.JWT_SECRET_MISSING }}',
+        },
+        name: 'jwt-server',
+      },
+      { JWT_KEY: 'present' } // JWT_SECRET_MISSING absent
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('auth.api_secret');
+      // Resolved fields should NOT be mentioned in the error.
+      expect(result.error).not.toContain('auth.api_token');
+    }
+  });
+
+  it('resolves URL templates and returns the expanded URL', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://{{ user.env.HOST }}/mcp',
+        transport: 'http',
+        auth: { type: 'none' },
+        name: 'host-templated',
+      },
+      { HOST: 'api.example.com' }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.resolved.url).toBe('https://api.example.com/mcp');
+    }
+  });
+
+  it('resolves all templated JWT fields together', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: {
+          type: 'jwt',
+          api_url: 'https://auth.example.com/jwt',
+          api_token: '{{ user.env.JWT_KEY }}',
+          api_secret: '{{ user.env.JWT_SECRET }}',
+        },
+        name: 'jwt-server',
+      },
+      { JWT_KEY: 'key-value', JWT_SECRET: 'secret-value' }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok && result.resolved.auth?.type === 'jwt') {
+      expect(result.resolved.auth.api_token).toBe('key-value');
+      expect(result.resolved.auth.api_secret).toBe('secret-value');
+    }
+  });
+
+  it('handles an empty userEnv when there are no templates to resolve', () => {
+    // Realistic scenario: user with no env vars set, server uses pasted raw token.
+    // Must not error out — many users never need the templating feature.
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: { type: 'bearer', token: 'literal' },
+        name: 'no-user-env',
+      },
+      {}
+    );
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
@@ -16,10 +16,10 @@ describe('resolveProbeServerTemplates', () => {
       {
         url: 'https://api.example.com/mcp',
         transport: 'http',
-        auth: { type: 'bearer', token: '{{ user.env.GARMIN_TOKEN }}' },
-        name: 'garmin',
+        auth: { type: 'bearer', token: '{{ user.env.MY_API_TOKEN }}' },
+        name: 'example',
       },
-      { GARMIN_TOKEN: 'real-secret-abc123' }
+      { MY_API_TOKEN: 'real-secret-abc123' }
     );
 
     expect(result.ok).toBe(true);
@@ -51,7 +51,7 @@ describe('resolveProbeServerTemplates', () => {
         url: 'https://api.example.com/mcp',
         transport: 'http',
         auth: { type: 'bearer', token: '{{ user.env.MISSING }}' },
-        name: 'garmin',
+        name: 'example',
       },
       {} // no env vars defined
     );

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
@@ -143,4 +143,89 @@ describe('resolveProbeServerTemplates', () => {
 
     expect(result.ok).toBe(true);
   });
+
+  it('surfaces missing OAuth template variables that the core resolver would silently drop', () => {
+    // The shared resolver treats OAuth fields as optional and does not add
+    // them to `unresolvedFields` (template-resolver.ts:287-335). For Test
+    // Connection that's the wrong call: a templated `oauth_client_secret`
+    // resolving to empty leads to a confusing upstream OAuth failure
+    // instead of a local "set the env var" message. The helper compensates.
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: {
+          type: 'oauth',
+          oauth_token_url: 'https://auth.example.com/token',
+          oauth_client_id: 'public-id',
+          oauth_client_secret: '{{ user.env.OAUTH_SECRET_MISSING }}',
+        },
+        name: 'oauth-server',
+      },
+      {} // no env vars defined
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('auth.oauth_client_secret');
+      expect(result.error).toContain('Settings');
+      // Resolved fields must NOT appear in the error.
+      expect(result.error).not.toContain('auth.oauth_client_id');
+      expect(result.error).not.toContain('auth.oauth_token_url');
+    }
+  });
+
+  it('resolves OAuth templates to actual values when env vars are present', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: {
+          type: 'oauth',
+          oauth_token_url: '{{ user.env.OAUTH_TOKEN_URL }}',
+          oauth_client_id: '{{ user.env.OAUTH_CLIENT_ID }}',
+          oauth_client_secret: '{{ user.env.OAUTH_CLIENT_SECRET }}',
+          oauth_scope: '{{ user.env.OAUTH_SCOPE }}',
+        },
+        name: 'oauth-templated',
+      },
+      {
+        OAUTH_TOKEN_URL: 'https://auth.example.com/token',
+        OAUTH_CLIENT_ID: 'client-abc',
+        OAUTH_CLIENT_SECRET: 'secret-xyz',
+        OAUTH_SCOPE: 'read write',
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok && result.resolved.auth?.type === 'oauth') {
+      expect(result.resolved.auth.oauth_token_url).toBe('https://auth.example.com/token');
+      expect(result.resolved.auth.oauth_client_id).toBe('client-abc');
+      expect(result.resolved.auth.oauth_client_secret).toBe('secret-xyz');
+      expect(result.resolved.auth.oauth_scope).toBe('read write');
+    }
+  });
+
+  it('lists multiple missing OAuth fields together', () => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        auth: {
+          type: 'oauth',
+          oauth_token_url: '{{ user.env.OAUTH_TOKEN_URL_MISSING }}',
+          oauth_client_id: 'public-id',
+          oauth_client_secret: '{{ user.env.OAUTH_SECRET_MISSING }}',
+        },
+        name: 'oauth-server',
+      },
+      {}
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('auth.oauth_token_url');
+      expect(result.error).toContain('auth.oauth_client_secret');
+    }
+  });
 });

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.ts
@@ -1,0 +1,97 @@
+/**
+ * MCP probe template resolution.
+ *
+ * The `/mcp-servers/discover` endpoint runs in the daemon process, whose
+ * `process.env` never holds user secrets — those live encrypted in the
+ * users table. So the daemon can't reuse the executor's "read process.env
+ * tagged with AGOR_USER_ENV_KEYS" path verbatim. Instead, callers load the
+ * user's env vars from the DB and hand them to this helper, which builds
+ * the same template context the executor uses (synthesizing the
+ * AGOR_USER_ENV_KEYS tag so `buildMCPTemplateContextFromEnv` exposes the
+ * right keys) and runs the resolver.
+ *
+ * Returning a discriminated union with a human-readable error keeps the
+ * endpoint flow straightforward: on `ok: false` the caller returns the
+ * error string to the UI; on `ok: true` it uses `resolved` for the probe.
+ */
+
+import { AGOR_USER_ENV_KEYS_VAR } from '@agor/core/config';
+import { buildMCPTemplateContextFromEnv, resolveMcpServerTemplates } from '@agor/core/mcp';
+import type { MCPAuth, MCPServer, MCPServerID, MCPTransport } from '@agor/core/types';
+
+export interface ProbeServerConfig {
+  url: string;
+  transport: MCPTransport;
+  auth?: MCPAuth;
+  name?: string;
+  /** Optional MCP server id (when probing an existing saved server). */
+  mcpServerId?: string;
+}
+
+export type ProbeTemplateResult =
+  | { ok: true; resolved: ProbeServerConfig }
+  | { ok: false; error: string };
+
+/**
+ * Resolve `{{ user.env.X }}` templates in a probe MCP server config.
+ *
+ * @param serverConfig - probe target (url + auth + transport)
+ * @param userEnv      - decrypted user env vars (Record<key, value>); usually
+ *                       the result of `resolveUserEnvironment(userId, db)`
+ * @returns ok+resolved when all templates resolved cleanly, or ok:false with
+ *          an actionable error string otherwise.
+ */
+export function resolveProbeServerTemplates(
+  serverConfig: ProbeServerConfig,
+  userEnv: Record<string, string>
+): ProbeTemplateResult {
+  // Tag the synthetic env with AGOR_USER_ENV_KEYS so
+  // buildMCPTemplateContextFromEnv knows which keys to expose. Without
+  // this tag the resulting context.user.env is empty and every template
+  // silently resolves to undefined.
+  const templateContext = buildMCPTemplateContextFromEnv({
+    ...userEnv,
+    [AGOR_USER_ENV_KEYS_VAR]: Object.keys(userEnv).join(','),
+  });
+
+  const now = new Date();
+  const probeServer: MCPServer = {
+    mcp_server_id: ((serverConfig.mcpServerId as string | undefined) ??
+      'inline-test') as MCPServerID,
+    name: serverConfig.name || 'inline-test',
+    transport: serverConfig.transport,
+    url: serverConfig.url,
+    auth: serverConfig.auth,
+    scope: 'global',
+    source: 'user',
+    enabled: true,
+    created_at: now,
+    updated_at: now,
+  };
+
+  const result = resolveMcpServerTemplates(probeServer, templateContext);
+
+  if (!result.isValid) {
+    return { ok: false, error: result.errorMessage ?? 'Template resolution failed' };
+  }
+
+  // Surface unresolved auth templates as a clear error — otherwise the
+  // probe sends an empty/literal Authorization header and the upstream
+  // 401 hides the real cause from the user.
+  const unresolvedAuth = result.unresolvedFields.filter((f) => f.startsWith('auth.'));
+  if (unresolvedAuth.length > 0) {
+    return {
+      ok: false,
+      error: `Unresolved env var template(s): ${unresolvedAuth.join(', ')}. Define the matching variables in Settings → Environment Variables.`,
+    };
+  }
+
+  return {
+    ok: true,
+    resolved: {
+      ...serverConfig,
+      auth: result.server.auth,
+      url: result.server.url ?? serverConfig.url,
+    },
+  };
+}

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.ts
@@ -78,7 +78,29 @@ export function resolveProbeServerTemplates(
   // Surface unresolved auth templates as a clear error — otherwise the
   // probe sends an empty/literal Authorization header and the upstream
   // 401 hides the real cause from the user.
-  const unresolvedAuth = result.unresolvedFields.filter((f) => f.startsWith('auth.'));
+  //
+  // The core resolver intentionally omits OAuth fields from
+  // `unresolvedFields` (template-resolver.ts treats them as optional at
+  // session runtime, where missing values just skip OAuth behavior). For
+  // Test Connection a templated `oauth_client_secret` that resolves to
+  // empty still means the OAuth flow is about to fail upstream with a
+  // confusing error, so detect those locally and add them to the list.
+  const unresolvedAuth = [...result.unresolvedFields.filter((f) => f.startsWith('auth.'))];
+  if (serverConfig.auth?.type === 'oauth') {
+    const oauthTemplatedFields = [
+      'oauth_token_url',
+      'oauth_client_id',
+      'oauth_client_secret',
+      'oauth_scope',
+    ] as const;
+    for (const field of oauthTemplatedFields) {
+      const original = serverConfig.auth[field];
+      if (original && original.includes('{{') && !result.server.auth?.[field]) {
+        unresolvedAuth.push(`auth.${field}`);
+      }
+    }
+  }
+
   if (unresolvedAuth.length > 0) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

- The `/mcp-servers/discover` endpoint (powering the **Test Connection** button on the MCP server form) was passing `serverConfig.auth` directly to `resolveMCPAuthHeaders`, with no template resolution. A bearer token configured as `{{ user.env.TOKEN }}` was sent literally to the upstream server, which returned 401.
- The executor already resolves these templates correctly at session runtime (via `process.env` + `AGOR_USER_ENV_KEYS`, populated by `createUserProcessEnvironment` when the daemon spawns the executor), so the same MCP servers worked fine in actual sessions — only Test Connection was broken.
- Fix: in the discover endpoint, load the caller's user env vars from the DB via `resolveUserEnvironment`, build the same template context the executor uses, and run `resolveMcpServerTemplates` over the probe's auth/url before calling `resolveMCPAuthHeaders`. Unresolved auth templates now surface as a clear error pointing at Settings → Environment Variables instead of a generic 401.

## Test plan

- [ ] Configure an HTTP MCP server with bearer auth set to `{{ user.env.SOME_TOKEN }}` where `SOME_TOKEN` is set as a global-scope user env var. Click **Test Connection** — should succeed (previously: "Connection failed … unauthorized").
- [ ] Same config but with `SOME_TOKEN` *not* defined in user env vars. Click **Test Connection** — should return a clear error like `Unresolved env var template(s): auth.token. Define the matching variables in Settings → Environment Variables.` (previously: generic 401).
- [ ] Pasted-raw token continues to work unchanged.
- [ ] Sanity-check that real sessions using the templated server still work (this path was already correct and shouldn't be affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)