### PR TITLE
fix(ui): unwrap ansi-to-react double-default to stop logs modal React #130 crash

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2816,16 +2816,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     '/worktrees/logs',
     {
       async find(params: Params) {
-        console.log('📋 Logs endpoint called');
-
         const id = params?.query?.worktree_id;
 
         if (!id) {
-          console.error('❌ No worktree_id in query params');
           throw new Error('worktree_id query parameter required');
         }
 
-        console.log('✅ Found worktree ID:', id);
         return worktreesService.getLogs(id as import('@agor/core/types').WorktreeID, params);
       },
       // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express

--- a/apps/agor-ui/src/components/AnsiText/AnsiText.tsx
+++ b/apps/agor-ui/src/components/AnsiText/AnsiText.tsx
@@ -1,5 +1,5 @@
-import Ansi from 'ansi-to-react';
 import type React from 'react';
+import { Ansi } from './ansiImport';
 
 export interface AnsiTextProps {
   children: string;

--- a/apps/agor-ui/src/components/AnsiText/ansiImport.test.ts
+++ b/apps/agor-ui/src/components/AnsiText/ansiImport.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Direct regression test for the `Ansi` import shim.
+ *
+ * Pins the failure mode that caused React error #130 in production builds:
+ * `ansi-to-react` ships as CJS with `__esModule: true` and `exports.default
+ * = Component`, and under some bundler interop paths the default import gets
+ * double-wrapped — `import Ansi from 'ansi-to-react'` resolves to
+ * `{ default: Component }` instead of the function itself. The shim
+ * (`./ansiImport.ts`) must unwrap that and hand back a callable, otherwise
+ * every `<Ansi>` in the app is a #130 timebomb.
+ *
+ * `vi.mock` is hoisted, so `ansi-to-react` is replaced at module-init time —
+ * exactly mirroring what the bundler interop did.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const FakeAnsi = (props: { children?: unknown }) => null as unknown;
+
+vi.mock('ansi-to-react', () => ({
+  // Reproduce the broken interop shape: the consumer's default import
+  // resolves to this object, *not* the function inside it.
+  default: { default: FakeAnsi },
+}));
+
+describe('Ansi import shim', () => {
+  it('unwraps the double-wrapped default export to a callable component', async () => {
+    const { Ansi } = await import('./ansiImport');
+    expect(typeof Ansi).toBe('function');
+    expect(Ansi).toBe(FakeAnsi);
+  });
+});

--- a/apps/agor-ui/src/components/AnsiText/ansiImport.ts
+++ b/apps/agor-ui/src/components/AnsiText/ansiImport.ts
@@ -1,0 +1,14 @@
+// `ansi-to-react` ships as CJS with `__esModule: true` and `exports.default =
+// Component`. Under some bundler interop paths (most notably Rollup's commonjs
+// plugin in Vite production builds) the namespace gets double-wrapped, so
+// `import Ansi from 'ansi-to-react'` yields `{ default: Component }` instead
+// of `Component`. Rendering `<Ansi>` in that state passes an object as the
+// element type and triggers React error #130 ("got: object"). Unwrap once
+// here so all callers get a real component reference.
+import AnsiDefault from 'ansi-to-react';
+
+type AnsiComponent = typeof AnsiDefault;
+
+const nested = (AnsiDefault as unknown as { default?: AnsiComponent }).default;
+export const Ansi: AnsiComponent =
+  typeof AnsiDefault === 'function' ? AnsiDefault : (nested ?? AnsiDefault);

--- a/apps/agor-ui/src/components/AnsiText/index.ts
+++ b/apps/agor-ui/src/components/AnsiText/index.ts
@@ -1,2 +1,3 @@
 export type { AnsiTextProps } from './AnsiText';
 export { AnsiText } from './AnsiText';
+export { Ansi } from './ansiImport';

--- a/apps/agor-ui/src/components/CollapsibleText/CollapsibleAnsiText.tsx
+++ b/apps/agor-ui/src/components/CollapsibleText/CollapsibleAnsiText.tsx
@@ -1,8 +1,8 @@
-import Ansi from 'ansi-to-react';
 import { theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
 import { TEXT_TRUNCATION } from '../../constants/ui';
+import { Ansi } from '../AnsiText/ansiImport';
 
 interface CollapsibleAnsiTextProps {
   children: string;

--- a/apps/agor-ui/src/components/CollapsibleText/CollapsibleAnsiText.tsx
+++ b/apps/agor-ui/src/components/CollapsibleText/CollapsibleAnsiText.tsx
@@ -2,7 +2,7 @@ import { theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
 import { TEXT_TRUNCATION } from '../../constants/ui';
-import { Ansi } from '../AnsiText/ansiImport';
+import { Ansi } from '../AnsiText';
 
 interface CollapsibleAnsiTextProps {
   children: string;

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Regression tests for EnvironmentLogsModal.
+ *
+ * Bug: opening the logs modal with non-empty log content sometimes crashed
+ * the entire app with "Minified React error #130" ("Element type is invalid:
+ * ... got: object"). Root cause was the `ansi-to-react` default export
+ * resolving to `{ default: Component }` (double-wrapped) under bundler CJS
+ * interop, so `<Ansi>` was rendered with an object as its element type.
+ *
+ * Empty-log worktrees never tripped the bug because `<Ansi>` is only mounted
+ * when `logs.logs` is non-empty; the conditional was the only thing keeping
+ * the modal alive on a fresh worktree.
+ */
+
+import type { AgorClient, Worktree } from '@agor-live/client';
+import { render, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Ansi } from '../AnsiText/ansiImport';
+import { EnvironmentLogsModal } from './EnvironmentLogsModal';
+
+const mockWorktree: Partial<Worktree> = {
+  worktree_id: 'wt-test' as Worktree['worktree_id'],
+  name: 'test-worktree',
+};
+
+function makeClient(response: unknown): AgorClient {
+  return {
+    service: () => ({
+      find: vi.fn().mockResolvedValue(response),
+    }),
+  } as unknown as AgorClient;
+}
+
+describe('EnvironmentLogsModal', () => {
+  it('safe Ansi import resolves to a callable component (defends against CJS double-default)', () => {
+    // Direct unit assertion: even if ansi-to-react ever ships a double-wrapped
+    // default again, the wrapper unwraps it. If this fails, every <Ansi>
+    // render in the app is a React #130 timebomb.
+    expect(typeof Ansi).toBe('function');
+  });
+
+  it('renders non-empty log content without crashing', async () => {
+    const client = makeClient({
+      logs: 'Server started on port 3000\nReady to accept connections',
+      timestamp: new Date('2026-05-10T12:00:00Z').toISOString(),
+      truncated: false,
+    });
+
+    const { findByText } = render(
+      <EnvironmentLogsModal
+        open
+        onClose={() => {}}
+        worktree={mockWorktree as Worktree}
+        client={client}
+      />
+    );
+
+    // The log body is rendered inside an antd Modal portal, so query against
+    // the document and assert the content (and importantly, no crash).
+    await waitFor(async () => {
+      const node = await findByText(/Server started on port 3000/);
+      expect(node).toBeInTheDocument();
+    });
+  });
+
+  it('renders ANSI-coloured log content without crashing', async () => {
+    // Real-world reproduction: process output with ANSI escape codes routed
+    // through the `<Ansi>` component is the exact path the original crash
+    // took. With the broken import this throws React #130 at mount time.
+    const client = makeClient({
+      logs: '[32mINFO[0m server up\n[31mERROR[0m oh no',
+      timestamp: new Date('2026-05-10T12:00:00Z').toISOString(),
+      truncated: false,
+    });
+
+    const { findByText } = render(
+      <EnvironmentLogsModal
+        open
+        onClose={() => {}}
+        worktree={mockWorktree as Worktree}
+        client={client}
+      />
+    );
+
+    await waitFor(async () => {
+      const info = await findByText(/INFO/);
+      expect(info).toBeInTheDocument();
+    });
+  });
+
+  it('renders the empty-logs placeholder when logs string is empty', async () => {
+    const client = makeClient({
+      logs: '',
+      timestamp: new Date('2026-05-10T12:00:00Z').toISOString(),
+    });
+
+    const { findByText } = render(
+      <EnvironmentLogsModal
+        open
+        onClose={() => {}}
+        worktree={mockWorktree as Worktree}
+        client={client}
+      />
+    );
+
+    await waitFor(async () => {
+      const node = await findByText(/\(no logs\)/);
+      expect(node).toBeInTheDocument();
+    });
+  });
+
+  it('renders error state with the daemon-supplied error message', async () => {
+    const client = makeClient({
+      logs: '',
+      timestamp: new Date('2026-05-10T12:00:00Z').toISOString(),
+      error: 'No logs command configured',
+    });
+
+    const { findByRole } = render(
+      <EnvironmentLogsModal
+        open
+        onClose={() => {}}
+        worktree={mockWorktree as Worktree}
+        client={client}
+      />
+    );
+
+    // Assert the antd Alert is rendered with the message (regression on the
+    // earlier `title` typo, which made the alert empty).
+    const alert = await findByRole('alert');
+    expect(within(alert).getByText('Error fetching logs')).toBeInTheDocument();
+    expect(within(alert).getByText(/No logs command configured/)).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.test.tsx
@@ -15,7 +15,7 @@
 import type { AgorClient, Worktree } from '@agor-live/client';
 import { render, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { Ansi } from '../AnsiText/ansiImport';
+import { Ansi } from '../AnsiText';
 import { EnvironmentLogsModal } from './EnvironmentLogsModal';
 
 const mockWorktree: Partial<Worktree> = {

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -1,8 +1,9 @@
 import type { AgorClient, Worktree } from '@agor-live/client';
 import { ReloadOutlined } from '@ant-design/icons';
-import Ansi from 'ansi-to-react';
 import { Alert, Button, Checkbox, Modal, Space, Typography, theme } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Ansi } from '../AnsiText/ansiImport';
+import { ErrorBoundary } from '../ErrorBoundary';
 
 const { Text } = Typography;
 
@@ -150,83 +151,85 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
         </Button>,
       ]}
     >
-      <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
-        {/* Timestamp and truncation warning */}
-        {logs && !logs.error && (
-          <div>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              Fetched at: {formatTimestamp(logs.timestamp)}
-            </Text>
-            {logs.truncated && (
-              <Alert
-                title="Logs truncated (showing last 500 lines)"
-                type="warning"
-                showIcon
-                style={{ marginTop: 8 }}
-                banner
-              />
-            )}
-          </div>
-        )}
+      <ErrorBoundary fallbackTitle="Couldn't render the logs viewer.">
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          {/* Timestamp and truncation warning */}
+          {logs && !logs.error && (
+            <div>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                Fetched at: {formatTimestamp(logs.timestamp)}
+              </Text>
+              {logs.truncated && (
+                <Alert
+                  message="Logs truncated (showing last 500 lines)"
+                  type="warning"
+                  showIcon
+                  style={{ marginTop: 8 }}
+                  banner
+                />
+              )}
+            </div>
+          )}
 
-        {/* Error state */}
-        {logs?.error && (
-          <Alert
-            title="Error fetching logs"
-            description={
-              <div>
-                <div>{logs.error}</div>
-                {logs.error.includes('No logs command') && (
-                  <div style={{ marginTop: 8, fontSize: 12 }}>
-                    Configure a 'logs' command in .env-config.yaml to view logs.
-                  </div>
-                )}
-              </div>
-            }
-            type="error"
-            showIcon
-          />
-        )}
+          {/* Error state */}
+          {logs?.error && (
+            <Alert
+              message="Error fetching logs"
+              description={
+                <div>
+                  <div>{logs.error}</div>
+                  {logs.error.includes('No logs command') && (
+                    <div style={{ marginTop: 8, fontSize: 12 }}>
+                      Configure a 'logs' command in .env-config.yaml to view logs.
+                    </div>
+                  )}
+                </div>
+              }
+              type="error"
+              showIcon
+            />
+          )}
 
-        {/* Logs display */}
-        {logs && !logs.error && (
-          <div
-            ref={logsContainerRef}
-            style={{
-              backgroundColor: '#000',
-              border: `1px solid ${token.colorBorder}`,
-              borderRadius: token.borderRadius,
-              padding: 16,
-              height: '60vh',
-              overflowY: 'auto',
-              fontFamily: 'monospace',
-              fontSize: 12,
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-word',
-              color: '#fff',
-            }}
-          >
-            {logs.logs ? <Ansi>{logs.logs}</Ansi> : '(no logs)'}
-          </div>
-        )}
+          {/* Logs display */}
+          {logs && !logs.error && (
+            <div
+              ref={logsContainerRef}
+              style={{
+                backgroundColor: '#000',
+                border: `1px solid ${token.colorBorder}`,
+                borderRadius: token.borderRadius,
+                padding: 16,
+                height: '60vh',
+                overflowY: 'auto',
+                fontFamily: 'monospace',
+                fontSize: 12,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                color: '#fff',
+              }}
+            >
+              {logs.logs ? <Ansi>{String(logs.logs)}</Ansi> : '(no logs)'}
+            </div>
+          )}
 
-        {/* Loading state */}
-        {loading && !logs && (
-          <div
-            style={{
-              textAlign: 'center',
-              padding: 40,
-              color: token.colorTextSecondary,
-              height: '60vh',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            Loading logs...
-          </div>
-        )}
-      </Space>
+          {/* Loading state */}
+          {loading && !logs && (
+            <div
+              style={{
+                textAlign: 'center',
+                padding: 40,
+                color: token.colorTextSecondary,
+                height: '60vh',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              Loading logs...
+            </div>
+          )}
+        </Space>
+      </ErrorBoundary>
     </Modal>
   );
 };

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -2,7 +2,7 @@ import type { AgorClient, Worktree } from '@agor-live/client';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Alert, Button, Checkbox, Modal, Space, Typography, theme } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Ansi } from '../AnsiText/ansiImport';
+import { Ansi } from '../AnsiText';
 import { ErrorBoundary } from '../ErrorBoundary';
 
 const { Text } = Typography;
@@ -151,7 +151,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
         </Button>,
       ]}
     >
-      <ErrorBoundary fallbackTitle="Couldn't render the logs viewer.">
+      <ErrorBoundary fallbackTitle="Couldn't render the logs viewer." resetKey={logs?.timestamp}>
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
           {/* Timestamp and truncation warning */}
           {logs && !logs.error && (

--- a/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -3,18 +3,33 @@ import { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
-  fallbackTitle?: string;
+  fallbackTitle?: ReactNode;
+  // When this value changes, the boundary clears its error state and re-renders
+  // children. Useful when fresh data may unblock the failed render (e.g. a
+  // logs refresh after a transient bad payload).
+  resetKey?: unknown;
 }
 
 interface ErrorBoundaryState {
   error: Error | null;
+  resetKey: unknown;
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null };
+  state: ErrorBoundaryState = { error: null, resetKey: this.props.resetKey };
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { error };
+  }
+
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState
+  ): Partial<ErrorBoundaryState> | null {
+    if (props.resetKey !== state.resetKey) {
+      return { error: null, resetKey: props.resetKey };
+    }
+    return null;
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {

--- a/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import { Alert } from 'antd';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallbackTitle?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught render error:', error, info.componentStack);
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          message={this.props.fallbackTitle ?? 'Something went wrong rendering this view.'}
+          description={error.message || String(error)}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/agor-ui/src/components/ErrorBoundary/index.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Summary

- **Root cause:** `import Ansi from 'ansi-to-react'` resolves to `{ default: Component }` (the namespace object) under bundler CJS interop in production builds, so `<Ansi>` was passing an object as its JSX element type → React error #130 ("got: object"). Verified by reproducing the same double-default unwrap in Node ESM. The package is unmaintained, has React 16/17 peer deps, and no `exports`/`module` field.
- **Why "sometimes":** the modal guards `<Ansi>` behind `logs.logs ? <Ansi>{logs.logs}</Ansi> : '(no logs)'`. Worktrees with empty log output never instantiated `<Ansi>`, so the crash only fired when logs actually arrived. Same shape as the cascade fixed in #1115 (an unrenderable value reaching JSX from a different code path).
- **Fix:** centralized `Ansi` resolution behind a tiny `AnsiText/ansiImport.ts` shim that unwraps the double-default once. Pointed all three call sites at it (`EnvironmentLogsModal`, `AnsiText`, `CollapsibleAnsiText` — the latter two were latent React #130 timebombs as well, just less frequently mounted).
- **Defense in depth:** added a small reusable `ErrorBoundary` and wrapped the logs modal body in it so any future render failure shows a friendly antd `Alert` fallback instead of crashing the whole app. Also defensively coerce `logs.logs` to a string at the `<Ansi>` boundary.
- **Sister cleanups in the same modal** (silent UX bugs found during the audit): `<Space orientation="vertical">` → `direction="vertical"`, and `<Alert title="…" />` → `<Alert message="…" />` in two places (antd 5 API — previously the alerts rendered with no title text).
- **Sister case (echo of #1115):** stripped three leftover debug `console.log/error` lines from the `/worktrees/logs` route in `register-routes.ts`.

## Test plan

- [x] New `EnvironmentLogsModal.test.tsx` (5 cases): safe `Ansi` is callable, modal mounts with non-empty plain logs, mounts with ANSI-coloured logs, shows `(no logs)` placeholder when empty, renders the error-state `Alert` with the daemon-supplied message.
- [x] `pnpm test` in `apps/agor-ui`: 17 files / 124 tests pass.
- [x] `pnpm check` (workspace typecheck + lint + build): all 6 tasks pass.
- [ ] Manual smoke: open the env logs modal on a worktree with active log output and confirm it renders without a hard crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)