### PR TITLE
fix(daemon,ui): unbreak Quick Start (solo mode + /ui mount) (#1150)

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -182,23 +182,6 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   const getReadAuthHooks = () => (allowAnonymous ? [] : [requireAuth]);
 
   // --------------------------------------------------------------------------
-  // Security: block anonymous in public deployments
-  // --------------------------------------------------------------------------
-  const isPublicDeployment =
-    process.env.NODE_ENV === 'production' ||
-    process.env.RAILWAY_ENVIRONMENT !== undefined ||
-    process.env.RENDER !== undefined;
-
-  if (isPublicDeployment && allowAnonymous) {
-    console.error('');
-    console.error('❌ SECURITY ERROR: Anonymous authentication is enabled in a public deployment');
-    console.error('   This would allow unauthorized access to your Agor instance.');
-    console.error('   Set daemon.allowAnonymous=false in config or unset it (defaults to false)');
-    console.error('');
-    process.exit(1);
-  }
-
-  // --------------------------------------------------------------------------
   // Ports, daemon URL, credentials
   // --------------------------------------------------------------------------
   const envPort = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : undefined;
@@ -207,6 +190,39 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
 
   const envUiPort = process.env.UI_PORT ? Number.parseInt(process.env.UI_PORT, 10) : undefined;
   const UI_PORT = envUiPort || config.ui?.port || 5173;
+
+  // --------------------------------------------------------------------------
+  // Security: block anonymous when the daemon is reachable from outside the host
+  // --------------------------------------------------------------------------
+  // The risk is "unauthenticated requests from the network", which is a
+  // function of the bind interface — not NODE_ENV. Localhost-bound daemons
+  // (the default, including the solo Quick Start path) are safe with
+  // allowAnonymous=true; only loopback can reach them. Railway/Render set
+  // their own env vars and always expose to the public internet, so we keep
+  // those signals as well.
+  const isLoopbackBind =
+    DAEMON_HOST === 'localhost' || DAEMON_HOST === '127.0.0.1' || DAEMON_HOST === '::1';
+  const isPublicDeployment =
+    !isLoopbackBind ||
+    process.env.RAILWAY_ENVIRONMENT !== undefined ||
+    process.env.RENDER !== undefined;
+
+  if (isPublicDeployment && allowAnonymous) {
+    console.error('');
+    console.error(
+      '❌ SECURITY ERROR: Anonymous authentication is enabled on a network-reachable daemon'
+    );
+    console.error(
+      `   Bind host: ${DAEMON_HOST} (anyone who can reach this address gets full access)`
+    );
+    console.error('   Fix one of:');
+    console.error('     • Bind to localhost: set daemon.host: localhost in ~/.agor/config.yaml');
+    console.error(
+      '     • Require auth:      set daemon.allowAnonymous: false (or unset; default is false)'
+    );
+    console.error('');
+    process.exit(1);
+  }
 
   // Handle INSTANCE_LABEL env var override (for Docker deployments)
   if (process.env.INSTANCE_LABEL) {
@@ -398,11 +414,17 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
   // --------------------------------------------------------------------------
-  // Static file serving (production only)
+  // Static file serving — serve the bundled UI when it exists alongside
+  // the daemon (i.e., installed-package layout: dist/daemon + dist/ui).
+  // Previously gated on NODE_ENV=production, which made the UI 404 in
+  // foreground mode (where NODE_ENV is unset) — see issue #1150. The actual
+  // signal is "do we have a built UI bundle to serve?", which existsSync
+  // already answers correctly for both dev (no, vite serves on its own port)
+  // and installed (yes, it sits at ../ui).
   // --------------------------------------------------------------------------
-  const isProduction = process.env.NODE_ENV === 'production';
   const serveStaticFiles = servicesConfig.static_files !== 'off';
-  if (isProduction && serveStaticFiles) {
+  let bundledUiAvailable = false;
+  if (serveStaticFiles) {
     const path = await import('node:path');
     const { fileURLToPath } = await import('node:url');
     const { existsSync } = await import('node:fs');
@@ -412,6 +434,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     const uiPath = path.resolve(dirname, '../ui');
 
     if (existsSync(uiPath)) {
+      bundledUiAvailable = true;
       console.log(`📂 Serving UI from: ${uiPath}`);
 
       app.use(
@@ -433,7 +456,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
         }
       }) as never);
     } else {
-      console.warn(`⚠️  UI directory not found at ${uiPath} - UI will not be served`);
+      console.warn(`⚠️  UI bundle not found at ${uiPath} - UI will not be served`);
       console.warn(`   This is expected in development mode (UI runs on port ${UI_PORT})`);
     }
   }
@@ -530,7 +553,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     svcEnabled,
     jwtSecret,
     daemonUrl,
-    isProduction,
+    bundledUiAvailable,
     DAEMON_PORT,
     UI_PORT,
     worktreeRbacEnabled,

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -41,6 +41,7 @@ import expressStaticGzip from 'express-static-gzip';
 import { registerHooks } from './register-hooks.js';
 import { registerRoutes } from './register-routes.js';
 import { registerServices } from './register-services.js';
+import { isLoopbackBindHost, isLoopbackUrl } from './setup/bind-host.js';
 import { loadBuildInfo } from './setup/build-info.js';
 import { buildCorsConfig, isSandpackOrigin } from './setup/cors.js';
 import {
@@ -194,16 +195,24 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // --------------------------------------------------------------------------
   // Security: block anonymous when the daemon is reachable from outside the host
   // --------------------------------------------------------------------------
-  // The risk is "unauthenticated requests from the network", which is a
-  // function of the bind interface — not NODE_ENV. Localhost-bound daemons
-  // (the default, including the solo Quick Start path) are safe with
-  // allowAnonymous=true; only loopback can reach them. Railway/Render set
-  // their own env vars and always expose to the public internet, so we keep
-  // those signals as well.
-  const isLoopbackBind =
-    DAEMON_HOST === 'localhost' || DAEMON_HOST === '127.0.0.1' || DAEMON_HOST === '::1';
+  // The risk is "unauthenticated requests from the network", which has three
+  // independent signals:
+  //   1. bind interface — non-loopback bind means the kernel itself accepts
+  //      remote traffic (most direct exposure).
+  //   2. configured public base URL (`AGOR_BASE_URL` / `daemon.base_url`) —
+  //      operator declared the daemon is reachable at a non-loopback URL,
+  //      typically because it sits behind a reverse proxy that publishes a
+  //      localhost-bound daemon to the internet.
+  //   3. Railway / Render env vars — those PaaS platforms always expose
+  //      services publicly.
+  // NODE_ENV is intentionally NOT consulted: the CLI sets it to 'production'
+  // for Express/library perf optimizations even on solo localhost installs,
+  // so it carries no signal about exposure.
+  const declaredPublicBaseUrl = process.env.AGOR_BASE_URL ?? config.daemon?.base_url;
+  const baseUrlIsPublic = isLoopbackUrl(declaredPublicBaseUrl) === false;
   const isPublicDeployment =
-    !isLoopbackBind ||
+    !isLoopbackBindHost(DAEMON_HOST) ||
+    baseUrlIsPublic ||
     process.env.RAILWAY_ENVIRONMENT !== undefined ||
     process.env.RENDER !== undefined;
 
@@ -212,11 +221,18 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     console.error(
       '❌ SECURITY ERROR: Anonymous authentication is enabled on a network-reachable daemon'
     );
-    console.error(
-      `   Bind host: ${DAEMON_HOST} (anyone who can reach this address gets full access)`
-    );
+    console.error(`   Bind host: ${DAEMON_HOST}`);
+    if (baseUrlIsPublic) {
+      console.error(`   Public base URL: ${declaredPublicBaseUrl}`);
+    }
+    console.error('   Anyone who can reach this address gets full access.');
     console.error('   Fix one of:');
     console.error('     • Bind to localhost: set daemon.host: localhost in ~/.agor/config.yaml');
+    if (baseUrlIsPublic) {
+      console.error(
+        '     • Unset the public base URL (daemon.base_url / AGOR_BASE_URL) if the daemon is not actually reachable there'
+      );
+    }
     console.error(
       '     • Require auth:      set daemon.allowAnonymous: false (or unset; default is false)'
     );

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -99,7 +99,8 @@ export interface RegisterServicesContext {
   svcEnabled: (group: string) => boolean;
   jwtSecret: string;
   daemonUrl: string;
-  isProduction: boolean;
+  /** True when the daemon is serving the bundled UI itself at /ui (installed agor-live). */
+  bundledUiAvailable: boolean;
   DAEMON_PORT: number;
   UI_PORT: number;
   worktreeRbacEnabled: boolean;
@@ -360,8 +361,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
       methods: ['create', 'routeMessage'],
     });
 
-    const isProduction = ctx.isProduction;
-    const uiUrl = isProduction ? `${daemonUrl}/ui` : `http://localhost:${ctx.UI_PORT}`;
+    const uiUrl = ctx.bundledUiAvailable ? `${daemonUrl}/ui` : `http://localhost:${ctx.UI_PORT}`;
     registerGitHubAppSetupRoutes(app, { uiUrl, daemonUrl, db });
   }
 

--- a/apps/agor-daemon/src/setup/bind-host.test.ts
+++ b/apps/agor-daemon/src/setup/bind-host.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { isLoopbackBindHost, isLoopbackUrl } from './bind-host.js';
+
+describe('isLoopbackBindHost', () => {
+  it.each([
+    'localhost',
+    'LocalHost',
+    'LOCALHOST',
+    'localhost.',
+    '  localhost  ',
+    '127.0.0.1',
+    '127.1.2.3',
+    '127.255.255.255',
+    '::1',
+    '::ffff:127.0.0.1',
+    '::ffff:127.1.2.3',
+  ])('treats %s as loopback', (host) => {
+    expect(isLoopbackBindHost(host)).toBe(true);
+  });
+
+  it.each([
+    '0.0.0.0',
+    '::',
+    '::0',
+    '192.168.1.10',
+    '10.0.0.1',
+    'mybox.local',
+    'agor.example.com',
+    '::ffff:192.168.1.1',
+    '128.0.0.1',
+    '126.255.255.255',
+  ])('treats %s as non-loopback', (host) => {
+    expect(isLoopbackBindHost(host)).toBe(false);
+  });
+});
+
+describe('isLoopbackUrl', () => {
+  it('returns null for empty / undefined / null input', () => {
+    expect(isLoopbackUrl(undefined)).toBeNull();
+    expect(isLoopbackUrl(null)).toBeNull();
+    expect(isLoopbackUrl('')).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(isLoopbackUrl('not a url')).toBeNull();
+    expect(isLoopbackUrl('://broken')).toBeNull();
+  });
+
+  it.each([
+    'http://localhost',
+    'http://localhost:3030',
+    'https://127.0.0.1',
+    'http://[::1]:3030',
+    'http://[::ffff:127.0.0.1]/path',
+  ])('returns true for loopback URL %s', (url) => {
+    expect(isLoopbackUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'https://agor.example.com',
+    'http://192.168.1.10:3030',
+    'http://0.0.0.0:3030',
+    'http://[::]:3030',
+  ])('returns false for public URL %s', (url) => {
+    expect(isLoopbackUrl(url)).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/setup/bind-host.ts
+++ b/apps/agor-daemon/src/setup/bind-host.ts
@@ -1,0 +1,56 @@
+/**
+ * Bind-host classification.
+ *
+ * Helpers for deciding whether the daemon is reachable only from the local
+ * machine (loopback) or also from the network. Used by the startup security
+ * check that gates anonymous-auth on whether unauthenticated traffic could
+ * arrive from outside the host.
+ *
+ * Loopback forms recognised:
+ *   - 'localhost' (case-insensitive, optional trailing dot)
+ *   - any IPv4 in 127.0.0.0/8
+ *   - '::1' (IPv6 loopback)
+ *   - '::ffff:127.x.x.x' (IPv4-mapped IPv6 loopback, on dual-stack hosts)
+ *
+ * Non-loopback forms (NOT loopback): '0.0.0.0', '::', '192.168.x.y',
+ * 'mybox.local', any external hostname.
+ */
+
+const IPV4_LOOPBACK_RE = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+// IPv4-mapped IPv6 loopback as written by the user: '::ffff:127.x.y.z'.
+const IPV4_MAPPED_LOOPBACK_RE = /^::ffff:127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+// IPv4-mapped IPv6 loopback after WHATWG URL canonicalization, e.g.
+// 'http://[::ffff:127.0.0.1]' → hostname '::ffff:7f00:1'. The IPv4 octets get
+// repacked into two hex words, the high one always starting with '7f'.
+const IPV4_MAPPED_COMPRESSED_LOOPBACK_RE = /^::ffff:7f[0-9a-f]{0,2}:[0-9a-f]{1,4}$/;
+
+export function isLoopbackBindHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase().replace(/\.$/, '');
+  if (normalized === 'localhost') return true;
+  if (normalized === '::1') return true;
+  if (IPV4_LOOPBACK_RE.test(normalized)) return true;
+  if (IPV4_MAPPED_LOOPBACK_RE.test(normalized)) return true;
+  if (IPV4_MAPPED_COMPRESSED_LOOPBACK_RE.test(normalized)) return true;
+  return false;
+}
+
+/**
+ * Classify a configured base URL as loopback or network-reachable.
+ *
+ * Returns `null` for empty/invalid input so callers can distinguish "not
+ * configured" from "configured to a public host". This matches the security
+ * check's intent: only flag a *configured* public URL, not the absence of one.
+ */
+export function isLoopbackUrl(url: string | undefined | null): boolean | null {
+  if (!url) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  // WHATWG URL wraps IPv6 hostnames in brackets ('[::1]'); the bind-host
+  // classifier expects the bare form.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  return isLoopbackBindHost(hostname);
+}


### PR DESCRIPTION
## Summary

Fixes the broken README Quick Start reported in #1150. Two distinct bugs, same root cause: `NODE_ENV=production` was overloaded as a stand-in for two unrelated things.

**Bug A — `agor daemon start` (background) crashed with a SECURITY ERROR**
The CLI's daemon-manager spawns the background daemon with `NODE_ENV=production` (correct, for Express/library perf). The "is this exposed publicly?" check in `index.ts` treated `NODE_ENV=production` as a public-deployment marker and refused to start, even on the default `localhost` bind. Foreground (`--foreground`) worked because it doesn't go through the spawn path.

**Bug B — `agor daemon start --foreground` started but `/ui` returned 404**
The static-file mount that serves the bundled UI was also gated on `NODE_ENV=production`. In foreground mode `NODE_ENV` is unset, so the mount block was skipped and `/ui` 404'd.

## Fixes

**Commit 1 — `apps/agor-daemon/src/{index.ts,register-services.ts}`**

- **Security check** now gates on **bind address** instead of `NODE_ENV`. Localhost / `127.0.0.1` / `::1` are safe with `allowAnonymous=true` regardless of `NODE_ENV`. Only non-loopback binds (or `RAILWAY_ENVIRONMENT` / `RENDER` env vars) trigger the error.
- **UI mount** now keys on `existsSync(uiPath)` only — the same check that already handled the "no UI bundle in dev" case. Foreground and background now behave identically.
- Renamed the `isProduction` flag plumbed into `registerServices` to `bundledUiAvailable` so the GitHub-app callback URL picks `daemonUrl/ui` vs `localhost:UI_PORT` based on actual UI availability rather than `NODE_ENV`.

**Commit 2 — `apps/agor-daemon/src/setup/bind-host.{ts,test.ts}` + `index.ts`** (Codex review feedback)

- Extracted the inline loopback check to `isLoopbackBindHost(host)` + `isLoopbackUrl(url)` in `setup/bind-host.ts`. The original inline check missed: 127.x.x.x (whole 127.0.0.0/8 range), case variants, trailing-dot DNS form, IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`), and WHATWG-canonicalized IPv6 (`::ffff:7f00:1`). 32 unit tests in `bind-host.test.ts`.
- Added `daemon.base_url` / `AGOR_BASE_URL` as a third public-deployment signal alongside non-loopback bind and Railway/Render. Closes the reverse-proxy hole: a localhost-bound daemon with `daemon.base_url: https://agor.example.com` is reachable from the network even though the bind interface alone says otherwise. Reuses the existing `daemon.base_url` config field.
- Error message now lists the public base URL when it's the trigger, and offers a third remediation (unset the public base URL).

`NODE_ENV=production` injection in `daemon-manager.ts` is **kept** — it's the right signal for Express/library perf optimization. The fix is just to stop the security check and UI mount from misreading it.

## Before / after (issue #1150 repro)

```
~/.agor/config.yaml: daemon.allowAnonymous: true, daemon.host: localhost
```

|                              | Before                    | After                  |
| ---                          | ---                       | ---                    |
| `agor daemon start` (bg)     | ❌ SECURITY ERROR exit 1  | ✅ Daemon started      |
| `curl /ui/` (bg)             | n/a (daemon dead)         | ✅ HTTP 200, real UI   |
| `agor daemon start --foreground` | ✅ starts             | ✅ starts              |
| `curl /ui/` (fg)             | ❌ 404                    | ✅ HTTP 200, real UI   |
| `daemon.host: 0.0.0.0` + anon | ❌ SECURITY ERROR (right reason but stale message) | ❌ SECURITY ERROR (correct, with new clearer message) |
| `daemon.base_url: https://…` + anon (localhost-bound, behind proxy) | ✅ silently exposed | ❌ SECURITY ERROR (new in commit 2) |

## Test plan

End-to-end Quick Start via a built `agor-live` tarball (`HOME=/tmp/qs-test`):

- [x] `agor init --force` then flip config to anon mode (matches issue's "No to auth" wizard outcome)
- [x] `agor daemon start` (background) → clean start, no security error
- [x] `curl http://localhost:3030/ui/` → HTTP 200, 803 bytes, real UI HTML
- [x] `curl http://localhost:3030/health` → HTTP 200
- [x] `curl http://localhost:3030/` → 302 → `/ui/`
- [x] `agor daemon stop` → clean stop
- [x] `agor daemon start --foreground` → same `/ui/` works (now matches background)
- [x] `daemon.host: 0.0.0.0` + anon → security error fires
- [x] `daemon.base_url: https://agor.example.com` (localhost-bound, anon) → security error fires with new message naming both bind host and public base URL
- [x] `daemon.base_url: http://localhost:3030` (localhost-bound, anon) → starts cleanly (loopback URL doesn't trigger)
- [x] `pnpm --filter @agor/daemon typecheck` passes
- [x] `pnpm --filter @agor/daemon test` — 588 passed / 30 skipped (32 new bind-host tests)
- [x] `pnpm check` — typecheck + lint + build all green

## Review

Reviewed by a Codex subsession (verdict: **approve-with-nits**). Both should-fix items addressed in commit 2. Nice-to-have follow-ups left out of this PR to keep scope tight:

- **`/ui` and `/static` mount-block dedup.** Both blocks duplicate dynamic-import and `dirname` boilerplate. Pure cleanup, no behavior change. Worth a separate PR if anyone wants to tackle it.
- **`DEBUG_UPLOAD = process.env.NODE_ENV !== 'production'` duplication.** Defined identically in `apps/agor-daemon/src/utils/upload.ts:56` and `apps/agor-daemon/src/register-routes.ts:1498`. Pre-existing in the repo (not introduced by this PR). Should be centralized or replaced with `LOG_LEVEL`.

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)