### PR TITLE
fix(repos): surface clone failures + add agor_repos_update (#1126)

### DIFF
--- a/apps/agor-cli/src/commands/repo/add.ts
+++ b/apps/agor-cli/src/commands/repo/add.ts
@@ -4,10 +4,15 @@
  * Clones the repo to ~/.agor/repos/<name> and registers it with the daemon.
  */
 
+import type { CloneRepositoryResult, Repo } from '@agor-live/client';
 import { extractSlugFromUrl, isValidGitUrl, isValidSlug } from '@agor-live/client';
 import { Args, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import { BaseCommand } from '../../base-command';
+
+/** How long to wait for the async clone to land on the placeholder row. */
+const CLONE_POLL_TIMEOUT_MS = 2 * 60 * 1000;
+const CLONE_POLL_INTERVAL_MS = 1000;
 
 export default class RepoAdd extends BaseCommand {
   static description = 'Clone a remote git repository and register it with Agor';
@@ -83,12 +88,68 @@ export default class RepoAdd extends BaseCommand {
       this.log(chalk.dim(`URL: ${args.url}`));
       this.log('');
 
-      // Call daemon API to clone repo
-      const repo = await client.service('repos').clone({
+      // Daemon returns `{ status, slug, repo_id }` immediately while the
+      // clone runs in the background; the placeholder row carries
+      // `clone_status: 'cloning'` and is patched to `'ready'`/`'failed'`
+      // when the executor finishes. Use the route exposed at `/repos/clone`
+      // (same path the UI calls) — there is no client method shortcut for it.
+      const result = (await client.service('repos/clone').create({
         url: args.url,
         name: slug,
         slug,
-      });
+      })) as CloneRepositoryResult;
+
+      if (result.status === 'exists') {
+        this.log(`${chalk.yellow('⚠')} Repository '${slug}' is already registered`);
+        this.log(chalk.dim(`Use ${chalk.cyan('agor repo list')} to see registered repos.`));
+        this.log('');
+        await this.cleanupClient(client);
+        return;
+      }
+
+      if (!result.repo_id) {
+        // Defensive: pre-create path always returns repo_id, but if the
+        // daemon ever stops including it we don't want the CLI to silently
+        // hang on a missing target.
+        this.log(chalk.yellow('⚠ Clone started but daemon did not return a repo_id.'));
+        this.log(chalk.dim(`Run ${chalk.cyan('agor repo list')} to check progress.`));
+        await this.cleanupClient(client);
+        return;
+      }
+
+      // Poll `agor_repos_get` (via the standard Feathers get) until the
+      // executor patches the placeholder. Bounded to CLONE_POLL_TIMEOUT_MS
+      // so a hung executor cannot wedge the CLI indefinitely.
+      const reposService = client.service('repos');
+      const deadline = Date.now() + CLONE_POLL_TIMEOUT_MS;
+      let repo: Repo | undefined;
+      while (Date.now() < deadline) {
+        const fetched = (await reposService.get(result.repo_id)) as Repo;
+        if (fetched.clone_status === 'ready' || fetched.clone_status === undefined) {
+          repo = fetched;
+          break;
+        }
+        if (fetched.clone_status === 'failed') {
+          const err = fetched.clone_error;
+          const hint =
+            err?.category === 'auth_failed'
+              ? '\nConfigure GITHUB_TOKEN in Settings → API Keys for private repos.'
+              : '';
+          await this.cleanupClient(client);
+          this.log('');
+          this.log(chalk.red(`✗ Clone failed: ${err?.message ?? 'unknown error'}${hint}`));
+          this.log('');
+          this.exit(1);
+        }
+        await new Promise((resolve) => setTimeout(resolve, CLONE_POLL_INTERVAL_MS));
+      }
+
+      if (!repo) {
+        await this.cleanupClient(client);
+        this.log(chalk.red(`✗ Clone timed out after ${CLONE_POLL_TIMEOUT_MS / 1000}s.`));
+        this.log(chalk.dim('Check daemon logs or run `agor repo list` to see current state.'));
+        this.exit(1);
+      }
 
       this.log(`${chalk.green('✓')} Repository cloned and registered`);
       this.log(chalk.dim(`  Path: ${repo.local_path}`));

--- a/apps/agor-cli/src/commands/repo/add.ts
+++ b/apps/agor-cli/src/commands/repo/add.ts
@@ -4,7 +4,7 @@
  * Clones the repo to ~/.agor/repos/<name> and registers it with the daemon.
  */
 
-import type { CloneRepositoryResult, Repo } from '@agor-live/client';
+import type { Repo } from '@agor-live/client';
 import { extractSlugFromUrl, isValidGitUrl, isValidSlug } from '@agor-live/client';
 import { Args, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -93,11 +93,11 @@ export default class RepoAdd extends BaseCommand {
       // `clone_status: 'cloning'` and is patched to `'ready'`/`'failed'`
       // when the executor finishes. Use the route exposed at `/repos/clone`
       // (same path the UI calls) — there is no client method shortcut for it.
-      const result = (await client.service('repos/clone').create({
+      const result = await client.service('repos/clone').create({
         url: args.url,
         name: slug,
         slug,
-      })) as CloneRepositoryResult;
+      });
 
       if (result.status === 'exists') {
         this.log(`${chalk.yellow('⚠')} Repository '${slug}' is already registered`);

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -116,10 +116,11 @@ export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersP
  */
 export interface ReposServiceImpl extends Service<Repo, Partial<Repo>, FeathersParams> {
   addLocalRepository(data: { path: string; slug?: string }, params?: FeathersParams): Promise<Repo>;
+  findBySlug(slug: string, params?: FeathersParams): Promise<Repo | null>;
   cloneRepository(
-    data: { url: string; name?: string; slug?: string; destination?: string },
+    data: { url: string; name?: string; slug?: string; default_branch?: string },
     params?: FeathersParams
-  ): Promise<Repo>;
+  ): Promise<{ status: 'pending' | 'exists'; slug: string; repo_id?: string }>;
   createWorktree(
     id: string,
     data: {

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -10,6 +10,7 @@
 import type { ExpressApplication, Service } from '@agor/core/feathers';
 import type {
   Board,
+  CloneRepositoryResult,
   AuthenticatedParams as CoreAuthenticatedParams,
   AuthenticatedUser as CoreAuthenticatedUser,
   CreateHookContext as CoreCreateHookContext,
@@ -116,11 +117,21 @@ export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersP
  */
 export interface ReposServiceImpl extends Service<Repo, Partial<Repo>, FeathersParams> {
   addLocalRepository(data: { path: string; slug?: string }, params?: FeathersParams): Promise<Repo>;
-  findBySlug(slug: string, params?: FeathersParams): Promise<Repo | null>;
   cloneRepository(
     data: { url: string; name?: string; slug?: string; default_branch?: string },
     params?: FeathersParams
-  ): Promise<{ status: 'pending' | 'exists'; slug: string; repo_id?: string }>;
+  ): Promise<CloneRepositoryResult>;
+  updateMetadata(
+    id: string,
+    patch: {
+      name?: string;
+      slug?: string;
+      repo_type?: 'remote' | 'local';
+      remote_url?: string;
+      default_branch?: string;
+    },
+    params?: FeathersParams
+  ): Promise<Repo>;
   createWorktree(
     id: string,
     data: {

--- a/apps/agor-daemon/src/mcp/routes.test.ts
+++ b/apps/agor-daemon/src/mcp/routes.test.ts
@@ -89,6 +89,7 @@ describeIntegration('MCP Tools - Session Tools', () => {
     expect(toolNames).toContain('agor_repos_get');
     expect(toolNames).toContain('agor_repos_create_remote');
     expect(toolNames).toContain('agor_repos_create_local');
+    expect(toolNames).toContain('agor_repos_update');
     expect(toolNames).toContain('agor_worktrees_get');
     expect(toolNames).toContain('agor_worktrees_list');
     expect(toolNames).toContain('agor_worktrees_update');

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -30,7 +30,13 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
     'agor_repos_get',
     {
-      description: 'Get detailed information about a specific repository',
+      description:
+        'Get detailed information about a specific repository, including async clone state. ' +
+        'For repos created via agor_repos_create_remote, check `clone_status` ' +
+        '(`cloning` | `ready` | `failed`). On `failed`, `clone_error.category` ' +
+        '(`auth_failed` | `not_found` | `network` | `unknown`) tells you what went wrong; ' +
+        '`auth_failed` usually means the calling user has not configured a `GITHUB_TOKEN` ' +
+        'in Settings → API Keys (or it has expired/lost access).',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         repoId: z.string().describe('Repository ID (UUIDv7 or short ID)'),
@@ -47,7 +53,13 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
     'agor_repos_create_remote',
     {
       description:
-        'Clone a remote repository into Agor. Returns immediately with pending status - repository will be created asynchronously.',
+        'Clone a remote repository into Agor. Returns immediately with `{ status: "pending", ' +
+        'slug, repo_id }` while the clone runs in the background. Poll `agor_repos_get(repo_id)` ' +
+        'until `clone_status` is `ready` (success) or `failed` (see `clone_error` for details). ' +
+        'Private repos require the calling user to have `GITHUB_TOKEN` configured in ' +
+        'Settings → API Keys; without it, the clone will fail with `clone_error.category: ' +
+        '"auth_failed"`. Retrying after a failed clone is supported — the previous failed row ' +
+        'is replaced.',
       inputSchema: z.object({
         url: z
           .string()
@@ -114,6 +126,115 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
       const repo = await reposService.addLocalRepository({ path, slug }, ctx.baseServiceParams);
       return textResult(repo);
+    }
+  );
+
+  // Tool 5: agor_repos_update
+  //
+  // Patch repo metadata after creation. The original use case (issue #1126):
+  // a user worked around a broken `create_remote` by manually `git clone`ing
+  // and registering with `create_local`, then needed to flip `repo_type` to
+  // `'remote'` so subsequent flows treated it as a managed clone.
+  //
+  // Slug renames are DB-only — the on-disk directory under ~/.agor/repos is
+  // not moved (existing worktrees and running sessions hold absolute paths
+  // into that directory). For a directory move, delete + re-clone instead.
+  server.registerTool(
+    'agor_repos_update',
+    {
+      description:
+        "Patch a repository's metadata (name, slug, repo_type, remote_url, default_branch). " +
+        'Useful for correcting metadata after a `create_local` workaround — e.g. flipping ' +
+        '`repo_type: "local" → "remote"` so the repo is treated as a managed clone. ' +
+        'Note: changing `slug` updates the DB only; the on-disk directory at ' +
+        '~/.agor/repos/<slug> is NOT moved.',
+      inputSchema: z.object({
+        repoId: z.string().describe('Repository ID (UUIDv7 or short ID)'),
+        name: z.string().optional().describe('Human-readable name'),
+        slug: z
+          .string()
+          .optional()
+          .describe('URL-friendly slug in org/name format. Must be unique across all repos.'),
+        repo_type: z
+          .enum(['remote', 'local'])
+          .optional()
+          .describe(
+            'Repository management type. Switching to "remote" requires `remote_url` (in this patch or already set on the repo).'
+          ),
+        remote_url: z
+          .string()
+          .optional()
+          .describe('Git remote URL. Required when `repo_type` is "remote".'),
+        default_branch: z
+          .string()
+          .optional()
+          .describe(
+            'Default branch name used as the source for new worktrees that do not specify a sourceBranch.'
+          ),
+      }),
+    },
+    async (args) => {
+      const repoId = coerceString(args.repoId);
+      if (!repoId) throw new Error('repoId is required');
+
+      const reposService = ctx.app.service('repos');
+      const current = await reposService.get(repoId, ctx.baseServiceParams);
+
+      const patch: Record<string, unknown> = {};
+      const name = coerceString(args.name);
+      if (name !== undefined) patch.name = name;
+
+      const slug = coerceString(args.slug);
+      if (slug !== undefined) {
+        if (!isValidSlug(slug)) {
+          throw new Error('slug must be in org/name format');
+        }
+        if (slug !== current.slug) {
+          // Uniqueness pre-check — Feathers patch would otherwise surface a
+          // raw UNIQUE-constraint error from the DB driver.
+          const reposServiceImpl = reposService as unknown as ReposServiceImpl;
+          const collision = await reposServiceImpl.findBySlug(slug);
+          if (collision && collision.repo_id !== current.repo_id) {
+            throw new Error(`A repository with slug '${slug}' already exists`);
+          }
+        }
+        patch.slug = slug;
+      }
+
+      const repoType = coerceString(args.repo_type);
+      if (repoType !== undefined) {
+        if (repoType !== 'remote' && repoType !== 'local') {
+          throw new Error('repo_type must be "remote" or "local"');
+        }
+        patch.repo_type = repoType;
+      }
+
+      const remoteUrl = coerceString(args.remote_url);
+      if (remoteUrl !== undefined) {
+        if (remoteUrl && !isValidGitUrl(remoteUrl)) {
+          throw new Error('remote_url must be a valid git URL (https:// or git@)');
+        }
+        patch.remote_url = remoteUrl;
+      }
+
+      const defaultBranch = coerceString(args.default_branch);
+      if (defaultBranch !== undefined) patch.default_branch = defaultBranch;
+
+      // Effective post-patch shape — required so we catch
+      // `repo_type: 'remote'` without a `remote_url` regardless of whether
+      // the URL is in the patch or already on the row.
+      const effectiveType = patch.repo_type ?? current.repo_type;
+      const effectiveRemoteUrl = 'remote_url' in patch ? patch.remote_url : current.remote_url;
+      if (effectiveType === 'remote' && !effectiveRemoteUrl) {
+        throw new Error('repo_type "remote" requires a remote_url');
+      }
+
+      if (Object.keys(patch).length === 0) {
+        throw new Error('At least one field must be provided to update');
+      }
+
+      const updated = await reposService.patch(repoId, patch, ctx.baseServiceParams);
+      return textResult(updated);
     }
   );
 }

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -78,6 +78,14 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Human-readable name for the repository. If not provided, defaults to the slug.'
           ),
+        default_branch: z
+          .string()
+          .optional()
+          .describe(
+            "Pin a non-default branch as the repo's default (overrides origin/HEAD). " +
+              'Used when the repository\'s "default" should be a long-lived feature branch ' +
+              "rather than whatever the remote's HEAD points at."
+          ),
       }),
     },
     async (args) => {
@@ -96,8 +104,12 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       if (!isValidSlug(slug)) throw new Error('slug must be in org/name format');
 
       const name = coerceString(args.name);
+      const defaultBranch = coerceString(args.default_branch);
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-      const result = await reposService.cloneRepository({ url, slug, name }, ctx.baseServiceParams);
+      const result = await reposService.cloneRepository(
+        { url, slug, name, ...(defaultBranch ? { default_branch: defaultBranch } : {}) },
+        ctx.baseServiceParams
+      );
       return textResult(result);
     }
   );
@@ -131,14 +143,9 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
 
   // Tool 5: agor_repos_update
   //
-  // Patch repo metadata after creation. The original use case (issue #1126):
-  // a user worked around a broken `create_remote` by manually `git clone`ing
-  // and registering with `create_local`, then needed to flip `repo_type` to
-  // `'remote'` so subsequent flows treated it as a managed clone.
-  //
-  // Slug renames are DB-only — the on-disk directory under ~/.agor/repos is
-  // not moved (existing worktrees and running sessions hold absolute paths
-  // into that directory). For a directory move, delete + re-clone instead.
+  // Patch repo metadata after creation. Validation + uniqueness checks live
+  // on the service (`ReposService.updateMetadata`) so REST / UI / direct
+  // callers can't drift from this surface.
   server.registerTool(
     'agor_repos_update',
     {
@@ -177,63 +184,20 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       const repoId = coerceString(args.repoId);
       if (!repoId) throw new Error('repoId is required');
 
-      const reposService = ctx.app.service('repos');
-      const current = await reposService.get(repoId, ctx.baseServiceParams);
-
-      const patch: Record<string, unknown> = {};
+      const patch: Parameters<ReposServiceImpl['updateMetadata']>[1] = {};
       const name = coerceString(args.name);
       if (name !== undefined) patch.name = name;
-
       const slug = coerceString(args.slug);
-      if (slug !== undefined) {
-        if (!isValidSlug(slug)) {
-          throw new Error('slug must be in org/name format');
-        }
-        if (slug !== current.slug) {
-          // Uniqueness pre-check — Feathers patch would otherwise surface a
-          // raw UNIQUE-constraint error from the DB driver.
-          const reposServiceImpl = reposService as unknown as ReposServiceImpl;
-          const collision = await reposServiceImpl.findBySlug(slug);
-          if (collision && collision.repo_id !== current.repo_id) {
-            throw new Error(`A repository with slug '${slug}' already exists`);
-          }
-        }
-        patch.slug = slug;
-      }
-
+      if (slug !== undefined) patch.slug = slug;
       const repoType = coerceString(args.repo_type);
-      if (repoType !== undefined) {
-        if (repoType !== 'remote' && repoType !== 'local') {
-          throw new Error('repo_type must be "remote" or "local"');
-        }
-        patch.repo_type = repoType;
-      }
-
+      if (repoType === 'remote' || repoType === 'local') patch.repo_type = repoType;
       const remoteUrl = coerceString(args.remote_url);
-      if (remoteUrl !== undefined) {
-        if (remoteUrl && !isValidGitUrl(remoteUrl)) {
-          throw new Error('remote_url must be a valid git URL (https:// or git@)');
-        }
-        patch.remote_url = remoteUrl;
-      }
-
+      if (remoteUrl !== undefined) patch.remote_url = remoteUrl;
       const defaultBranch = coerceString(args.default_branch);
       if (defaultBranch !== undefined) patch.default_branch = defaultBranch;
 
-      // Effective post-patch shape — required so we catch
-      // `repo_type: 'remote'` without a `remote_url` regardless of whether
-      // the URL is in the patch or already on the row.
-      const effectiveType = patch.repo_type ?? current.repo_type;
-      const effectiveRemoteUrl = 'remote_url' in patch ? patch.remote_url : current.remote_url;
-      if (effectiveType === 'remote' && !effectiveRemoteUrl) {
-        throw new Error('repo_type "remote" requires a remote_url');
-      }
-
-      if (Object.keys(patch).length === 0) {
-        throw new Error('At least one field must be provided to update');
-      }
-
-      const updated = await reposService.patch(repoId, patch, ctx.baseServiceParams);
+      const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
+      const updated = await reposService.updateMetadata(repoId, patch, ctx.baseServiceParams);
       return textResult(updated);
     }
   );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2267,7 +2267,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     '/repos/clone',
     {
       async create(
-        data: { url: string; name?: string; destination?: string; default_branch?: string },
+        data: { url: string; name?: string; slug?: string; default_branch?: string },
         params: RouteParams
       ) {
         return reposService.cloneRepository(data, params);

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -181,15 +181,21 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Go through `this.remove` (the Feathers service) — NOT `repoRepo.delete`
     // directly — so the standard `repos.removed` WebSocket event fires and
     // connected UIs drop the failed row from their state before we create
-    // the replacement placeholder. `cleanup` defaults to false, so the
-    // (probably-missing) filesystem isn't touched.
+    // the replacement placeholder.
+    //
+    // CRITICAL: do NOT forward the caller's `params.query` into the retry
+    // remove. A REST caller hitting `/repos/clone?cleanup=true` would
+    // otherwise trip the filesystem-cleanup branch on the placeholder
+    // (which doesn't exist on disk anyway, but the side-effects matter for
+    // worktrees that may have been pre-created). Pass an explicitly empty
+    // query so retry is always a DB-only tombstone removal.
     const existing = await this.repoRepo.findBySlug(slug);
     if (existing) {
       if (existing.clone_status === 'failed') {
         console.log(
           `[clone ${slug}] Found previous failed clone (${existing.repo_id.substring(0, 8)}); deleting to retry`
         );
-        await this.remove(existing.repo_id, params);
+        await this.remove(existing.repo_id, { ...params, query: {} });
       } else {
         return { status: 'exists', slug, repo_id: existing.repo_id };
       }

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -26,8 +26,10 @@ import { type Database, RepoRepository, WorktreeRepository } from '@agor/core/db
 import { autoAssignWorktreeUniqueId } from '@agor/core/environment/variable-resolver';
 import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
+  extractRepoName,
   getDefaultBranch,
   getRemoteUrl,
+  getReposDir,
   getWorktreePath,
   isValidGitRepo,
   listWorktrees,
@@ -134,19 +136,27 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   /**
    * Custom method: Clone repository (fire-and-forget)
    *
-   * Spawns executor to handle everything:
+   * The DB row is created EARLY (here) with `clone_status: 'cloning'` so
+   * MCP / UI callers can discover the outcome via `agor_repos_get(repoId)`
+   * even when the clone fails — fixes #1126's "silent pending forever"
+   * symptom. The executor then handles:
    * - Git clone
    * - Parse .agor.yml
-   * - Create DB record via Feathers
+   * - Patch the existing row to `'ready'` (with parsed env, default branch)
+   *   or `'failed'` (with categorized clone_error)
    * - Initialize Unix group
    *
-   * Returns immediately with { status: 'pending' }.
-   * Client receives 'repos.created' WebSocket event when complete.
+   * Returns immediately with `{ status: 'pending', slug, repo_id }`.
+   * Clients see a `repos.created` event for the placeholder row, then a
+   * `repos.patched` event when the clone finishes.
+   *
+   * Slug-collision policy: a previous `clone_status: 'failed'` row is
+   * deleted to allow seamless retry; any other state surfaces `'exists'`.
    */
   async cloneRepository(
     data: { url: string; slug?: string; name?: string; default_branch?: string },
     params?: RepoParams
-  ): Promise<{ status: 'pending' | 'exists'; slug: string }> {
+  ): Promise<{ status: 'pending' | 'exists'; slug: string; repo_id?: string }> {
     // Note: `||` (not `??`) is intentional — we want an empty `data.slug`
     // to fall through to derivation rather than be treated as "explicit".
     let slug = data.slug || data.name;
@@ -159,22 +169,31 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       throw new Error('Could not derive a valid slug from URL. Please provide a slug.');
     }
 
-    // If repo with this slug already exists, this is a no-op but we surface
-    // it as `status: 'exists'` (rather than `pending`) so callers can give
-    // users immediate feedback — otherwise the UI would wait indefinitely
-    // for a `repos.created` event that will never fire.
+    // Slug-collision policy:
+    // - `clone_status: 'failed'` → previous attempt left a tombstone row;
+    //   delete it so the user can retry without manually cleaning up.
+    //   Cascades to any half-initialized worktree rows (FK onDelete: cascade).
+    // - any other state (ready / cloning / undefined-legacy) → surface
+    //   `'exists'` so callers don't unintentionally clobber a working repo
+    //   or interrupt an in-flight clone.
     const existing = await this.repoRepo.findBySlug(slug);
     if (existing) {
-      return { status: 'exists', slug };
+      if (existing.clone_status === 'failed') {
+        console.log(
+          `[clone ${slug}] Found previous failed clone (${existing.repo_id.substring(0, 8)}); deleting to retry`
+        );
+        await this.repoRepo.delete(existing.repo_id);
+      } else {
+        return { status: 'exists', slug, repo_id: existing.repo_id };
+      }
     }
 
     const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined;
 
     // Generate service JWT for executor authentication. The executor talks back
-    // to the daemon to create the repo record (which may include
-    // environment_config from .agor.yml) and patch status — operations that
-    // materialize admin-defined templates rather than user edits. Using a
-    // service token ensures hooks like requireAdminForEnvConfig bypass via
+    // to the daemon to patch the pre-created repo row to 'ready'/'failed' (and
+    // surface the parsed `.agor.yml` environment on success). Using a service
+    // token ensures hooks like requireAdminForEnvConfig bypass via
     // _isServiceAccount. Executor fetches per-user credentials via Feathers
     // RPC (users.getGitEnvironment) using the same service JWT.
     const sessionToken = generateSessionToken(
@@ -188,11 +207,41 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const asUser =
       rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
 
+    // Pre-create the repo row with `clone_status: 'cloning'` so failures stay
+    // queryable via `agor_repos_get(repoId)`. Pre-#1126 the row was only
+    // created on success by the executor — a failed clone left zero state and
+    // MCP callers had no way to discover the outcome (issue #1126 bug B).
+    //
+    // Use the Feathers service `create` (not `repoRepo.create`) so the
+    // standard `repos.created` WebSocket event fires and the UI can render
+    // a "cloning" card immediately, then transition to ready/failed when the
+    // executor patches the row.
+    //
+    // local_path is computed best-effort (mirrors what the executor will use
+    // inside `cloneRepo`); the executor patches it to the actual on-disk path
+    // on success.
+    const expectedRepoName = extractRepoName(data.url);
+    const expectedLocalPath = path.join(getReposDir(), expectedRepoName);
+    const placeholder = (await this.create(
+      {
+        slug: slug as RepoSlug,
+        name: data.name || slug,
+        repo_type: 'remote',
+        remote_url: data.url,
+        local_path: expectedLocalPath,
+        ...(data.default_branch ? { default_branch: data.default_branch } : {}),
+        clone_status: 'cloning',
+      },
+      params
+    )) as Repo;
+    const repoId = placeholder.repo_id;
+
     // Fire and forget - spawn executor and return immediately.
-    // Executor handles: git clone, .agor.yml parsing, DB record creation.
+    // Executor handles: git clone, .agor.yml parsing, repo row patching.
     // Executor fetches per-user credentials via Feathers RPC (users.getGitEnvironment).
     // Unix group init (groupadd/chgrp/setfacl) runs daemon-side via repos.initializeUnixGroup RPC.
     const app = this.app;
+    const repoRepo = this.repoRepo;
     spawnExecutorFireAndForget(
       {
         command: 'git.clone',
@@ -201,6 +250,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         params: {
           url: data.url,
           slug,
+          repoId,
           // Forward the user-supplied default_branch so the executor
           // persists what the operator typed in "Add Repository" instead
           // of silently overwriting it with origin/HEAD.
@@ -215,7 +265,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         asUser, // Run as resolved user (fresh groups via sudo -u)
         onExit: (code) => {
           if (code !== 0 && code !== null) {
-            // Broadcast clone failure to all connected clients
+            // Broadcast clone failure to all connected clients (the existing
+            // toast UX). Persistent failure state lives on the repo row.
             console.error(
               `[clone ${slug}] Clone failed with exit code ${code}, broadcasting error`
             );
@@ -236,15 +287,43 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
                 slug,
                 url: data.url,
                 error: `Clone failed (exit code ${code}). Check that the repository URL is correct and accessible.${branchHint}`,
+                repo_id: repoId,
               });
             }
+
+            // Safety net: if the executor crashed before it could patch the
+            // row (e.g. lost daemon connection), the repo would be stuck in
+            // `'cloning'` forever. Force it to `'failed'` here, but only if
+            // it's still 'cloning' (don't clobber a 'failed' write the
+            // executor already made with a richer category/message).
+            void (async () => {
+              try {
+                const current = await repoRepo.findById(repoId);
+                if (current && current.clone_status === 'cloning') {
+                  await repoRepo.update(repoId, {
+                    clone_status: 'failed',
+                    clone_error: {
+                      exit_code: code,
+                      category: 'unknown',
+                      message: `Clone exited with code ${code} before reporting an error.`,
+                    },
+                  });
+                }
+              } catch (err) {
+                console.error(
+                  `[clone ${slug}] Failed to mark repo as failed in onExit safety net:`,
+                  err instanceof Error ? err.message : String(err)
+                );
+              }
+            })();
           }
         },
       }
     );
 
-    // Return immediately - client will receive WebSocket event when repo is created
-    return { status: 'pending', slug };
+    // Return immediately - callers can poll `agor_repos_get(repoId)` for
+    // `clone_status: 'ready' | 'failed'` to discover the final outcome.
+    return { status: 'pending', slug, repo_id: repoId };
   }
 
   /**

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -37,6 +37,7 @@ import {
 } from '@agor/core/git';
 import type {
   AuthenticatedParams,
+  CloneRepositoryResult,
   QueryParams,
   Repo,
   RepoEnvironment,
@@ -156,7 +157,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   async cloneRepository(
     data: { url: string; slug?: string; name?: string; default_branch?: string },
     params?: RepoParams
-  ): Promise<{ status: 'pending' | 'exists'; slug: string; repo_id?: string }> {
+  ): Promise<CloneRepositoryResult> {
     // Note: `||` (not `??`) is intentional — we want an empty `data.slug`
     // to fall through to derivation rather than be treated as "explicit".
     let slug = data.slug || data.name;
@@ -176,13 +177,19 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // - any other state (ready / cloning / undefined-legacy) → surface
     //   `'exists'` so callers don't unintentionally clobber a working repo
     //   or interrupt an in-flight clone.
+    //
+    // Go through `this.remove` (the Feathers service) — NOT `repoRepo.delete`
+    // directly — so the standard `repos.removed` WebSocket event fires and
+    // connected UIs drop the failed row from their state before we create
+    // the replacement placeholder. `cleanup` defaults to false, so the
+    // (probably-missing) filesystem isn't touched.
     const existing = await this.repoRepo.findBySlug(slug);
     if (existing) {
       if (existing.clone_status === 'failed') {
         console.log(
           `[clone ${slug}] Found previous failed clone (${existing.repo_id.substring(0, 8)}); deleting to retry`
         );
-        await this.repoRepo.delete(existing.repo_id);
+        await this.remove(existing.repo_id, params);
       } else {
         return { status: 'exists', slug, repo_id: existing.repo_id };
       }
@@ -241,7 +248,10 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Executor fetches per-user credentials via Feathers RPC (users.getGitEnvironment).
     // Unix group init (groupadd/chgrp/setfacl) runs daemon-side via repos.initializeUnixGroup RPC.
     const app = this.app;
-    const repoRepo = this.repoRepo;
+    // Capture the Feathers service so the `onExit` safety net (below) writes
+    // through the same service layer the executor uses — that way clients
+    // receive `repos.patched` regardless of which path declares failure.
+    const reposService = this.app.service('repos');
     spawnExecutorFireAndForget(
       {
         command: 'git.clone',
@@ -296,11 +306,15 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             // `'cloning'` forever. Force it to `'failed'` here, but only if
             // it's still 'cloning' (don't clobber a 'failed' write the
             // executor already made with a richer category/message).
+            //
+            // Use the service (no `params` → internal call, bypasses auth
+            // hooks) so the patched event fires for any client that joined
+            // after the initial broadcast above.
             void (async () => {
               try {
-                const current = await repoRepo.findById(repoId);
-                if (current && current.clone_status === 'cloning') {
-                  await repoRepo.update(repoId, {
+                const current = (await reposService.get(repoId)) as Repo;
+                if (current.clone_status === 'cloning') {
+                  await reposService.patch(repoId, {
                     clone_status: 'failed',
                     clone_error: {
                       exit_code: code,
@@ -354,6 +368,87 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const { initializeRepoUnixGroup } = await import('../utils/unix-group-init.js');
     const unixGroup = await initializeRepoUnixGroup(this.db, this.app, data.repoId, data.userId);
     return { unixGroup };
+  }
+
+  /**
+   * Custom method: Patch repo metadata with validation.
+   *
+   * Centralizes the rules that wrap the bare Feathers `patch` so callers
+   * (MCP, REST, UI, internal) can't drift:
+   * - `slug` must match `isValidSlug` and be unique across all repos.
+   * - `remote_url`, when provided, must be a valid git URL.
+   * - Resulting `repo_type: 'remote'` requires a `remote_url` (the patch's
+   *   own field or the existing row's).
+   *
+   * Slug renames are DB-only — `local_path` on disk is not moved. Worktrees
+   * and running sessions hold absolute paths into the old directory, so a
+   * directory move is intentionally out of scope (do delete + re-clone).
+   */
+  async updateMetadata(
+    id: string,
+    patch: {
+      name?: string;
+      slug?: string;
+      repo_type?: 'remote' | 'local';
+      remote_url?: string;
+      default_branch?: string;
+    },
+    params?: RepoParams
+  ): Promise<Repo> {
+    const cleanPatch: Partial<Repo> = {};
+    if (patch.name !== undefined) cleanPatch.name = patch.name;
+
+    if (patch.slug !== undefined) {
+      if (!isValidSlug(patch.slug)) {
+        throw new Error('slug must be in org/name format');
+      }
+      cleanPatch.slug = patch.slug as RepoSlug;
+    }
+
+    if (patch.repo_type !== undefined) {
+      if (patch.repo_type !== 'remote' && patch.repo_type !== 'local') {
+        throw new Error('repo_type must be "remote" or "local"');
+      }
+      cleanPatch.repo_type = patch.repo_type;
+    }
+
+    if (patch.remote_url !== undefined) {
+      if (patch.remote_url && !isValidGitUrl(patch.remote_url)) {
+        throw new Error('remote_url must be a valid git URL (https:// or git@)');
+      }
+      cleanPatch.remote_url = patch.remote_url;
+    }
+
+    if (patch.default_branch !== undefined) cleanPatch.default_branch = patch.default_branch;
+
+    if (Object.keys(cleanPatch).length === 0) {
+      throw new Error('At least one field must be provided to update');
+    }
+
+    const current = (await this.get(id, params)) as Repo;
+
+    // Slug uniqueness — pre-check for a clean error message, but the DB
+    // uniqueness constraint remains authoritative for concurrent writes.
+    if (cleanPatch.slug && cleanPatch.slug !== current.slug) {
+      const collision = await this.repoRepo.findBySlug(cleanPatch.slug);
+      if (collision && collision.repo_id !== current.repo_id) {
+        throw new Error(`A repository with slug '${cleanPatch.slug}' already exists`);
+      }
+    }
+
+    // Resulting `remote` repos must have a remote_url. Evaluate against the
+    // post-patch shape so we catch both "URL provided in patch" and
+    // "URL already on the row".
+    const effectiveType = cleanPatch.repo_type ?? current.repo_type;
+    const effectiveRemoteUrl =
+      'remote_url' in cleanPatch ? cleanPatch.remote_url : current.remote_url;
+    if (effectiveType === 'remote' && !effectiveRemoteUrl) {
+      throw new Error('repo_type "remote" requires a remote_url');
+    }
+
+    // Use the Feathers service `patch` (not `repoRepo.update`) so the standard
+    // `patched` WebSocket event fires and the existing patch hooks run.
+    return (await this.patch(id, cleanPatch, params)) as Repo;
   }
 
   /**

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -795,11 +795,11 @@ function AppContent() {
     client.io.on('repo:cloneError', handleCloneError);
 
     try {
-      const result = (await client.service('repos/clone').create({
+      const result = await client.service('repos/clone').create({
         url: data.url,
         slug: data.slug,
         default_branch: data.default_branch,
-      })) as { status?: 'pending' | 'exists'; slug?: string; repo_id?: string };
+      });
 
       // Daemon short-circuits with `status: 'exists'` when a repo with this
       // slug is already registered — no `repos.created` event will fire, so

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -720,10 +720,13 @@ function AppContent() {
       return;
     }
 
-    // POST /repos/clone returns { status: 'pending' } immediately; the actual
-    // clone runs asynchronously in the executor. Show a persistent loading
-    // toast and wire one-shot listeners to resolve it on success or failure,
-    // with a safety timeout so the toast doesn't linger if events get lost.
+    // POST /repos/clone returns `{ status: 'pending', repo_id }` immediately;
+    // the daemon pre-creates the repo row with `clone_status: 'cloning'` and
+    // the executor patches it to `'ready'`/`'failed'`. Listen for `patched`
+    // (the durable outcome) — `created` only fires for the placeholder now,
+    // unless the row is a legacy `create_local` (no `clone_status`).
+    // `repo:cloneError` is kept as a belt-and-suspenders fallback so older
+    // executors that don't patch still surface failures.
     const toastKey = `clone-repo-${data.slug}`;
     const CLONE_TIMEOUT_MS = 120_000;
     showLoading(`Cloning ${data.slug}...`, { key: toastKey });
@@ -733,14 +736,41 @@ function AppContent() {
 
     const cleanup = () => {
       reposService.removeListener('created', handleCreated);
+      reposService.removeListener('patched', handlePatched);
       client.io.off('repo:cloneError', handleCloneError);
       clearTimeout(timeoutHandle);
     };
     const handleCreated = (repo: Repo) => {
       if (settled || repo.slug !== data.slug) return;
+      // Skip the `'cloning'` placeholder — `handlePatched` will declare the
+      // outcome once the executor finishes. `undefined` covers legacy rows
+      // and any direct executor-path that bypasses the placeholder.
+      if (repo.clone_status === 'cloning') return;
       settled = true;
       showSuccess(`Cloned ${data.slug}`, { key: toastKey });
       cleanup();
+    };
+    const handlePatched = (repo: Repo) => {
+      if (settled || repo.slug !== data.slug) return;
+      if (repo.clone_status === 'ready') {
+        settled = true;
+        showSuccess(`Cloned ${data.slug}`, { key: toastKey });
+        cleanup();
+      } else if (repo.clone_status === 'failed') {
+        settled = true;
+        const err = repo.clone_error;
+        // Authoring-failed clones almost always mean the user has no
+        // `GITHUB_TOKEN` configured (or it expired). Surface that hint
+        // alongside the raw git message so the recovery path is one click.
+        const hint =
+          err?.category === 'auth_failed'
+            ? ' — configure GITHUB_TOKEN in Settings → API Keys for private repos'
+            : '';
+        showError(`Failed to clone ${data.slug}: ${err?.message ?? 'unknown error'}${hint}`, {
+          key: toastKey,
+        });
+        cleanup();
+      }
     };
     const handleCloneError = (payload: { slug?: string; url?: string; error?: string }) => {
       if (settled) return;
@@ -761,6 +791,7 @@ function AppContent() {
     }, CLONE_TIMEOUT_MS);
 
     reposService.on('created', handleCreated);
+    reposService.on('patched', handlePatched);
     client.io.on('repo:cloneError', handleCloneError);
 
     try {
@@ -768,7 +799,7 @@ function AppContent() {
         url: data.url,
         slug: data.slug,
         default_branch: data.default_branch,
-      })) as { status?: 'pending' | 'exists'; slug?: string };
+      })) as { status?: 'pending' | 'exists'; slug?: string; repo_id?: string };
 
       // Daemon short-circuits with `status: 'exists'` when a repo with this
       // slug is already registered — no `repos.created` event will fire, so

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -35,6 +35,7 @@ export type {
   AgorService,
   BoardsService,
   MessagesService,
+  ReposCloneService,
   ReposLocalService,
   ReposService,
   ServiceTypes,

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -271,11 +271,6 @@ export interface MessagesService extends AgorService<Message> {
  */
 export interface ReposService extends AgorService<Repo> {
   /**
-   * Clone a repository and register it
-   */
-  clone(data: { url: string; name?: string; slug?: string }, params?: Params): Promise<Repo>;
-
-  /**
    * Initialize Unix group for a repo (daemon-side privileged operation).
    * Called by executor after cloning.
    */

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -11,6 +11,7 @@ import type {
   BoardExportBlob,
   CardType,
   CardWithType,
+  CloneRepositoryResult,
   ContextFileDetail,
   ContextFileListItem,
   MCPServer,
@@ -158,6 +159,7 @@ export interface ServiceTypes {
   tasks: Task;
   boards: Board;
   repos: Repo;
+  'repos/clone': Repo;
   'repos/local': Repo;
   worktrees: Worktree;
   users: User;
@@ -302,6 +304,22 @@ export interface ReposService extends AgorService<Repo> {
 
 export interface ReposLocalService extends AgorService<Repo> {
   create(data: { path: string; slug?: string }, params?: Params): Promise<Repo>;
+}
+
+/**
+ * `POST /repos/clone` returns the async `CloneRepositoryResult` envelope
+ * (status + repo_id for polling), not a fully-materialized `Repo`. Declared
+ * as a minimal standalone interface (not `AgorService<Repo>`) because
+ * overriding `create()` with a non-`Repo` return type would be a structural
+ * mismatch on the base service. Callers should fetch the full `Repo` via
+ * `client.service('repos').get(repo_id)` once polling shows `clone_status:
+ * 'ready'`.
+ */
+export interface ReposCloneService {
+  create(
+    data: { url: string; name?: string; slug?: string; default_branch?: string },
+    params?: Params
+  ): Promise<CloneRepositoryResult>;
 }
 
 /**
@@ -451,6 +469,7 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'tasks'): TasksService;
   service(path: 'messages'): MessagesService;
   service(path: 'repos'): ReposService;
+  service(path: 'repos/clone'): ReposCloneService;
   service(path: 'repos/local'): ReposLocalService;
   service(path: 'worktrees'): WorktreesService;
   service(path: 'boards'): BoardsService;

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -12,6 +12,7 @@ export type {
   AgorService,
   BoardsService,
   MessagesService,
+  ReposCloneService,
   ReposLocalService,
   ReposService,
   ServiceTypes,

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -194,6 +194,41 @@ describe('RepoRepository.create', () => {
     expect(fetched?.clone_status).toBe('failed');
     expect(fetched?.clone_error?.category).toBe('auth_failed');
   });
+
+  // The executor's success patch sends `clone_error: null` to drop the prior
+  // failure shape from the row. `repoToInsert` coerces null → undefined so
+  // the stored value matches the `clone_error?: RepoCloneError` invariant
+  // (set only when failed). Without that coercion, the type would lie about
+  // the shape of `repo.clone_error` after a recovery patch.
+  dbTest(
+    'should clear clone_error when success patch sends null (via deepMerge + repoToInsert)',
+    async ({ db }) => {
+      const repo = new RepoRepository(db);
+      const placeholder = await repo.create({
+        ...createRepoData({ slug: 'test/recovers' }),
+        clone_status: 'failed',
+        clone_error: {
+          exit_code: 128,
+          category: 'auth_failed',
+          message: 'fatal: Authentication failed',
+        },
+      });
+      expect(placeholder.clone_error?.category).toBe('auth_failed');
+
+      // `null` is the explicit-clear signal honored by `deepMerge`. Cast to
+      // mirror the executor's call site (Feathers' `Partial<Repo>` rejects
+      // null on optional fields even when the merger handles it).
+      const cleared = await repo.update(placeholder.repo_id, {
+        clone_status: 'ready',
+        clone_error: null as unknown as undefined,
+      });
+      expect(cleared.clone_status).toBe('ready');
+      expect(cleared.clone_error).toBeUndefined();
+
+      const refetched = await repo.findById(placeholder.repo_id);
+      expect(refetched?.clone_error).toBeUndefined();
+    }
+  );
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -163,6 +163,37 @@ describe('RepoRepository.create', () => {
     expect(created.created_at).toBe(createdAt);
     expect(created.last_updated).toBe(lastUpdated);
   });
+
+  // Issue #1126 / Bug B: pre-#1126 a failed clone left zero state because the
+  // executor only wrote the row on success. Pre-create + patch lets MCP
+  // callers discover the outcome via `agor_repos_get(repoId)`.
+  dbTest('should round-trip clone_status and clone_error through data blob', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const placeholder = await repo.create({
+      ...createRepoData({ slug: 'test/cloning' }),
+      clone_status: 'cloning',
+    });
+    expect(placeholder.clone_status).toBe('cloning');
+    expect(placeholder.clone_error).toBeUndefined();
+
+    const failed = await repo.update(placeholder.repo_id, {
+      clone_status: 'failed',
+      clone_error: {
+        exit_code: 128,
+        category: 'auth_failed',
+        message: 'fatal: Authentication failed for github.com',
+      },
+    });
+    expect(failed.clone_status).toBe('failed');
+    expect(failed.clone_error?.category).toBe('auth_failed');
+    expect(failed.clone_error?.exit_code).toBe(128);
+
+    // findById must surface the same shape (catches a regression where
+    // `rowToRepo` forgot to forward the new fields).
+    const fetched = await repo.findById(placeholder.repo_id);
+    expect(fetched?.clone_status).toBe('failed');
+    expect(fetched?.clone_error?.category).toBe('auth_failed');
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -80,6 +80,8 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       ...data,
       environment,
       environment_config,
+      clone_status: data.clone_status,
+      clone_error: data.clone_error,
     };
   }
 
@@ -128,6 +130,8 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         default_branch: repo.default_branch,
         environment,
         environment_config,
+        clone_status: repo.clone_status,
+        clone_error: repo.clone_error,
       },
     };
   }

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -131,7 +131,11 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         environment,
         environment_config,
         clone_status: repo.clone_status,
-        clone_error: repo.clone_error,
+        // `|| undefined` (not `??`) — deepMerge writes explicit `null` to
+        // clear `clone_error` on the success patch from the executor; we
+        // coerce that to `undefined` here so the stored value matches the
+        // `clone_error?: RepoCloneError` invariant (set only when failed).
+        clone_error: repo.clone_error || undefined,
       },
     };
   }
@@ -299,7 +303,12 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
           .where(eq(repos.repo_id, fullId))
           .run();
 
-        // Return merged repo with refreshed timestamp (no need to re-fetch)
+        // Sync re-derived fields back onto `merged` so the returned object
+        // matches what was actually persisted. `repoToInsert` coerces
+        // explicit-clear sentinels (e.g. `clone_error: null` from deepMerge)
+        // to `undefined`; without this sync the caller sees the un-coerced
+        // null and the type invariant lies.
+        merged.clone_error = insertData.data.clone_error;
         merged.last_updated = newUpdatedAt.toISOString();
         return merged;
       });

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -449,6 +449,14 @@ export const repos = pgTable(
         remote_url?: string;
         local_path: string; // Absolute path to base repository
         default_branch?: string;
+        // Async clone lifecycle: 'cloning' → 'ready' | 'failed'. Undefined for
+        // legacy rows and for local-type repos. See packages/core/src/types/repo.ts.
+        clone_status?: 'cloning' | 'ready' | 'failed';
+        clone_error?: {
+          exit_code: number;
+          category: 'auth_failed' | 'not_found' | 'network' | 'unknown';
+          message: string;
+        };
         // v2 environment config — source of truth. Named variants + optional
         // deployment-local template_overrides. See RepoEnvironment in
         // packages/core/src/types/worktree.ts.

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -441,6 +441,14 @@ export const repos = sqliteTable(
         remote_url?: string;
         local_path: string; // Absolute path to base repository
         default_branch?: string;
+        // Async clone lifecycle: 'cloning' → 'ready' | 'failed'. Undefined for
+        // legacy rows and for local-type repos. See packages/core/src/types/repo.ts.
+        clone_status?: 'cloning' | 'ready' | 'failed';
+        clone_error?: {
+          exit_code: number;
+          category: 'auth_failed' | 'not_found' | 'network' | 'unknown';
+          message: string;
+        };
         // v2 environment config — source of truth. Named variants + optional
         // deployment-local template_overrides. See RepoEnvironment in
         // packages/core/src/types/worktree.ts.

--- a/packages/core/src/git/index.test.ts
+++ b/packages/core/src/git/index.test.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { simpleGit } from 'simple-git';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  categorizeGitError,
   cloneRepo,
   createWorktree,
   extractRepoName,
@@ -1231,5 +1232,38 @@ describe('cloneRepo', () => {
     await cloneRepo({ url: remoteDir });
 
     await expect(cloneRepo({ url: remoteDir, branch: 'does-not-exist' })).rejects.toThrow();
+  });
+});
+
+describe('categorizeGitError', () => {
+  // Issue #1126 / Bug B: clone failures need to bucket into categories so the
+  // UI / MCP can suggest the right next step. The auth_failed bucket is the
+  // important one — it's the path that points users at Settings → API Keys.
+  it('categorizes private-repo authentication failures as auth_failed', () => {
+    expect(
+      categorizeGitError('fatal: Authentication failed for https://github.com/foo/bar.git/')
+    ).toBe('auth_failed');
+    expect(categorizeGitError('remote: HTTP Basic: Access denied')).toBe('auth_failed');
+    expect(categorizeGitError('Permission denied (publickey).')).toBe('auth_failed');
+    expect(categorizeGitError('terminal prompts disabled')).toBe('auth_failed');
+  });
+
+  it('categorizes missing repos as not_found', () => {
+    expect(categorizeGitError('remote: Repository not found.')).toBe('not_found');
+    expect(categorizeGitError('error: 404 not found')).toBe('not_found');
+  });
+
+  it('categorizes connectivity issues as network', () => {
+    expect(categorizeGitError('fatal: unable to access: Could not resolve host: github.com')).toBe(
+      'network'
+    );
+    expect(
+      categorizeGitError('fatal: unable to connect to git.example.com: Connection refused')
+    ).toBe('network');
+  });
+
+  it('falls through to unknown for unrecognised stderr', () => {
+    expect(categorizeGitError('fatal: corrupted ref refs/heads/main')).toBe('unknown');
+    expect(categorizeGitError('')).toBe('unknown');
   });
 });

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -13,6 +13,7 @@ import { mkdir, stat } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { simpleGit } from 'simple-git';
 import { getReposDir, getWorktreesDir } from '../config/config-manager';
+import type { RepoCloneErrorCategory } from '../types/repo';
 
 /**
  * Validate a user-supplied git ref (branch name, tag) before it is passed to
@@ -263,17 +264,15 @@ export function buildAuthHeaderEnv(
  * Bucket a git error message into a coarse category so callers (UI, MCP) can
  * suggest the right next step.
  *
- * The buckets line up with `RepoCloneErrorCategory` in
- * `packages/core/src/types/repo.ts`. The matching is intentionally loose —
- * git's stderr varies across versions and remotes, and a false-positive
- * `auth_failed` is cheaper than `unknown` for the user trying to recover.
- *
- * `'auth_failed'` is the bucket whose copy points users at Settings → API
- * Keys (the most common reason private clones silently failed pre-#1126).
+ * Returns the canonical `RepoCloneErrorCategory` union from `@agor/core/types`
+ * so callers can persist it onto `Repo.clone_error.category` without redeclaring
+ * the values. The matching is intentionally loose — git's stderr varies across
+ * versions and remotes, and a false-positive `auth_failed` is cheaper than
+ * `unknown` for the user trying to recover. `'auth_failed'` is the bucket whose
+ * copy points users at Settings → API Keys (the most common reason private
+ * clones silently failed pre-#1126).
  */
-export type GitErrorCategory = 'auth_failed' | 'not_found' | 'network' | 'unknown';
-
-export function categorizeGitError(stderr: string): GitErrorCategory {
+export function categorizeGitError(stderr: string): RepoCloneErrorCategory {
   const s = stderr.toLowerCase();
   if (
     s.includes('authentication failed') ||

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -260,6 +260,55 @@ export function buildAuthHeaderEnv(
 }
 
 /**
+ * Bucket a git error message into a coarse category so callers (UI, MCP) can
+ * suggest the right next step.
+ *
+ * The buckets line up with `RepoCloneErrorCategory` in
+ * `packages/core/src/types/repo.ts`. The matching is intentionally loose —
+ * git's stderr varies across versions and remotes, and a false-positive
+ * `auth_failed` is cheaper than `unknown` for the user trying to recover.
+ *
+ * `'auth_failed'` is the bucket whose copy points users at Settings → API
+ * Keys (the most common reason private clones silently failed pre-#1126).
+ */
+export type GitErrorCategory = 'auth_failed' | 'not_found' | 'network' | 'unknown';
+
+export function categorizeGitError(stderr: string): GitErrorCategory {
+  const s = stderr.toLowerCase();
+  if (
+    s.includes('authentication failed') ||
+    s.includes('could not read username') ||
+    s.includes('could not read password') ||
+    s.includes('terminal prompts disabled') ||
+    s.includes('fatal: authentication') ||
+    s.includes('http basic') ||
+    s.includes('403 forbidden') ||
+    s.includes('permission denied (publickey)')
+  ) {
+    return 'auth_failed';
+  }
+  if (
+    s.includes('repository not found') ||
+    s.includes('not found') ||
+    s.includes('does not exist') ||
+    s.includes('404')
+  ) {
+    return 'not_found';
+  }
+  if (
+    s.includes('could not resolve host') ||
+    s.includes('connection refused') ||
+    s.includes('connection timed out') ||
+    s.includes('operation timed out') ||
+    s.includes('network is unreachable') ||
+    s.includes('network error')
+  ) {
+    return 'network';
+  }
+  return 'unknown';
+}
+
+/**
  * Mask `GIT_CONFIG_VALUE_<n>` entries carrying an `Authorization:` header.
  * Use before serialising env into logs / error reports. The match is loose
  * on purpose — a false-positive redaction is cheaper than a leaked token.

--- a/packages/core/src/types/repo.ts
+++ b/packages/core/src/types/repo.ts
@@ -128,9 +128,42 @@ export interface Repo {
    */
   unix_group?: string;
 
+  /**
+   * Async clone lifecycle status for `repo_type: 'remote'` repos.
+   *
+   * - `'cloning'`: row was pre-created by the daemon; executor is running `git clone`
+   * - `'ready'`: clone finished successfully (executor patched the row)
+   * - `'failed'`: clone exited non-zero — see `clone_error` for details
+   * - `undefined`: legacy row created before this field existed, or `repo_type: 'local'`
+   *
+   * Callers that need to know whether a remote clone succeeded should poll
+   * `agor_repos_get(repoId)` and treat anything other than `'ready'`/`undefined`
+   * as not-yet-usable.
+   */
+  clone_status?: RepoCloneStatus;
+
+  /**
+   * Populated when `clone_status === 'failed'`. Cleared on retry.
+   *
+   * `category` exists so a UI can suggest the right next step
+   * (e.g. `auth_failed` → "configure GITHUB_TOKEN in Settings → API Keys").
+   */
+  clone_error?: RepoCloneError;
+
   /** Repository metadata */
   created_at: string;
   last_updated: string;
+}
+
+export type RepoCloneStatus = 'cloning' | 'ready' | 'failed';
+
+export type RepoCloneErrorCategory = 'auth_failed' | 'not_found' | 'network' | 'unknown';
+
+export interface RepoCloneError {
+  exit_code: number;
+  category: RepoCloneErrorCategory;
+  /** Short, user-facing first-line message (stderr excerpt or wrapper message). */
+  message: string;
 }
 
 /**

--- a/packages/core/src/types/repo.ts
+++ b/packages/core/src/types/repo.ts
@@ -167,6 +167,22 @@ export interface RepoCloneError {
 }
 
 /**
+ * Return shape of `reposService.cloneRepository` (and the REST + MCP layers
+ * that wrap it).
+ *
+ * - `'pending'`: row pre-created with `clone_status: 'cloning'`. Callers should
+ *   poll `agor_repos_get(repo_id)` or listen for `repos.patched` until
+ *   `clone_status` is `'ready'` or `'failed'`.
+ * - `'exists'`: no-op — a row with the requested slug is already registered.
+ *   `repo_id` is included so callers can fetch the existing row.
+ */
+export interface CloneRepositoryResult {
+  status: 'pending' | 'exists';
+  slug: string;
+  repo_id?: string;
+}
+
+/**
  * Request shape for creating/cloning a remote repository from the UI.
  *
  * The UI validates and fills in `slug` and `default_branch` before dispatching,

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { parseAgorYml } from '@agor/core/config';
 import {
+  categorizeGitError,
   cleanWorktree,
   cloneRepo,
   createWorktree,
@@ -201,25 +202,44 @@ export async function handleGitClone(
       // some-feature-branch" actually persist into the DB record instead
       // of being silently overwritten by whatever GitHub's HEAD points at.
       const defaultBranch = payload.params.default_branch?.trim() || cloneResult.defaultBranch;
-      console.log(
-        `[git.clone] Creating repo record: slug=${slug} default_branch=${defaultBranch}` +
-          (payload.params.default_branch ? ' (user-supplied)' : ' (auto-detected)')
-      );
 
-      // Create repo via Feathers service
-      // The daemon's repos service handles validation and hooks
-      const repoRecord = await client.service('repos').create({
-        repo_type: 'remote',
-        slug,
-        name: repoName,
-        remote_url: payload.params.url,
-        local_path: cloneResult.path,
-        default_branch: defaultBranch,
-        ...(environment ? { environment } : {}),
-      });
-
-      repoId = repoRecord.repo_id;
-      console.log(`[git.clone] Repo record created: ${repoId}`);
+      if (payload.params.repoId) {
+        // Daemon pre-created the row in `cloneRepository` so failures stay
+        // queryable. Patch it to `ready` and fill in the post-clone fields.
+        repoId = payload.params.repoId;
+        console.log(
+          `[git.clone] Patching pre-created repo ${repoId.substring(0, 8)} to ready: ` +
+            `slug=${slug} default_branch=${defaultBranch}` +
+            (payload.params.default_branch ? ' (user-supplied)' : ' (auto-detected)')
+        );
+        await client.service('repos').patch(repoId, {
+          name: repoName,
+          local_path: cloneResult.path,
+          default_branch: defaultBranch,
+          clone_status: 'ready',
+          ...(environment ? { environment } : {}),
+        });
+      } else {
+        // Legacy fallback (no pre-created row): create the record now. Used
+        // when a caller invokes the executor directly without going through
+        // `reposService.cloneRepository` (e.g. ad-hoc tooling).
+        console.log(
+          `[git.clone] Creating repo record: slug=${slug} default_branch=${defaultBranch}` +
+            (payload.params.default_branch ? ' (user-supplied)' : ' (auto-detected)')
+        );
+        const repoRecord = await client.service('repos').create({
+          repo_type: 'remote',
+          slug,
+          name: repoName,
+          remote_url: payload.params.url,
+          local_path: cloneResult.path,
+          default_branch: defaultBranch,
+          clone_status: 'ready',
+          ...(environment ? { environment } : {}),
+        });
+        repoId = repoRecord.repo_id;
+        console.log(`[git.clone] Repo record created: ${repoId}`);
+      }
 
       // Initialize Unix group for repo isolation via daemon RPC (if requested).
       // Runs daemon-side so that groupadd/chgrp/setfacl execute with daemon
@@ -257,6 +277,40 @@ export async function handleGitClone(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('[git.clone] Failed:', errorMessage);
+
+    // Persist failure on the pre-created repo row so MCP / REST callers can
+    // discover the outcome via `agor_repos_get(repoId)` instead of polling
+    // `agor_repos_list` forever for a row that will never appear. The daemon
+    // also broadcasts WebSocket `repo:cloneError` independently — this row
+    // is the durable record for clients that connect later.
+    if (payload.params.repoId && client) {
+      try {
+        const category = categorizeGitError(errorMessage);
+        const firstLine = errorMessage.split('\n')[0]?.slice(0, 500) || errorMessage.slice(0, 500);
+        await client.service('repos').patch(payload.params.repoId, {
+          clone_status: 'failed',
+          clone_error: {
+            // simple-git wraps git's exit code in the message rather than
+            // surfacing it as a numeric field; default to 1 since the
+            // underlying call already failed.
+            exit_code: 1,
+            category,
+            message: firstLine,
+          },
+        });
+        console.log(
+          `[git.clone] Marked repo ${payload.params.repoId.substring(0, 8)} as failed (${category})`
+        );
+      } catch (patchError) {
+        // Best-effort: if the daemon-side patch fails, the daemon's `onExit`
+        // handler in `cloneRepository` is the safety net (it patches based on
+        // exit code alone) — log and move on.
+        console.error(
+          '[git.clone] Failed to mark repo as failed:',
+          patchError instanceof Error ? patchError.message : String(patchError)
+        );
+      }
+    }
 
     return {
       success: false,

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -217,6 +217,14 @@ export async function handleGitClone(
           local_path: cloneResult.path,
           default_branch: defaultBranch,
           clone_status: 'ready',
+          // Explicit null clears any prior `clone_error` (e.g. from a retry
+          // through the daemon's failed-row replace path). `deepMerge` in
+          // `RepoRepository.update` propagates the null; `repoToInsert`
+          // coerces it back to `undefined` so the stored shape stays
+          // aligned with the `clone_error?: RepoCloneError` invariant.
+          // Cast: Feathers' patch typing is `Partial<Repo>`, which forbids
+          // null on optional fields even when the merger explicitly handles it.
+          clone_error: null as unknown as undefined,
           ...(environment ? { environment } : {}),
         });
       } else {

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -191,6 +191,16 @@ export const GitClonePayloadSchema = BasePayloadSchema.extend({
     /** Create DB record after clone (default: true) */
     createDbRecord: z.boolean().optional().default(true),
 
+    /**
+     * Pre-existing repo row to patch with clone outcome. When set, the
+     * executor patches this row with `clone_status: 'ready'` (success) or
+     * `'failed'` (with `clone_error`) instead of creating a new row. The
+     * daemon pre-creates the row in `cloneRepository` so failures are
+     * persisted (and queryable) instead of vanishing into a dropped
+     * `{ status: 'pending' }` response.
+     */
+    repoId: z.string().optional(),
+
     /** User ID of the requesting user (for per-user credential resolution) */
     userId: z.string().uuid().optional(),
 


### PR DESCRIPTION
## Summary

Fixes the two real bugs in #1126 — Bug A's token-injection mechanism was already merged in #1088/#1103 two days before the issue was filed, so this PR focuses on the remaining gaps.

- **Bug B — silent clone failures.** The repo row is now pre-created with \`clone_status: 'cloning'\` (mirroring the existing worktrees \`filesystem_status: 'creating'\` pattern) so failures stay queryable via \`agor_repos_get(repoId)\` instead of vanishing into a dropped \`{ status: 'pending' }\`. The executor patches to \`'ready'\` on success or \`'failed'\` with a categorized \`clone_error\` (\`auth_failed | not_found | network | unknown\`) so the UI / MCP can suggest the right next step. \`auth_failed\` points users at Settings → API Keys, which is the most common reason private clones silently failed pre-#1126 (no \`GITHUB_TOKEN\` configured for the calling user).
- **Bug C — \`agor_repos_update\`.** New MCP tool patches \`name\` / \`slug\` / \`repo_type\` / \`remote_url\` / \`default_branch\` with validation. Original use case from the issue: a user worked around the silent-clone bug with \`create_local\` and needed to flip \`repo_type: 'local' → 'remote'\` afterward.

Storage uses the existing repos \`data\` JSON blob — no migration needed.

Slug-collision policy: a previous \`clone_status: 'failed'\` row is deleted on retry (FK cascade handles any half-initialized worktrees); other states still surface \`'exists'\`. Daemon's \`onExit\` callback also patches to \`'failed'\` as a safety net if the executor crashes before reporting.

Thanks to @poberherr for the well-written report.

Closes #1126

## Test plan

- [x] \`pnpm check\` (typecheck + lint + tests) passes
- [x] \`@agor/core\` repos + git suites: 177/177 pass (incl. new tests for \`categorizeGitError\` and \`clone_status\`/\`clone_error\` round-trip)
- [x] \`@agor/daemon\`: 569/569 pass (30 integration skipped as expected)
- [x] \`@agor/executor\`: 344/344 pass
- [ ] Manual: clone a private GitHub repo without \`GITHUB_TOKEN\` configured → expect \`agor_repos_get\` to return \`clone_status: 'failed'\` with \`clone_error.category: 'auth_failed'\`
- [ ] Manual: clone with valid \`GITHUB_TOKEN\` → expect \`clone_status: 'ready'\` with the parsed \`.agor.yml\` environment
- [ ] Manual: clone same slug twice after a failure → expect retry to succeed (placeholder gets deleted + recreated)
- [ ] Manual: \`agor_repos_update\` flipping a local repo to remote — verify subsequent worktree creation behaves like a remote repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)