### PR TITLE
fix(artifacts): persist files to text columns on Postgres

### DIFF
--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -321,6 +321,126 @@ describe('ArtifactsService.patch (board move routing)', () => {
   });
 });
 
+describe('ArtifactsService.publishArtifact', () => {
+  let tmpFolder: string;
+
+  beforeEach(() => {
+    tmpFolder = mkdtempSync(path.join(tmpdir(), 'agor-publish-test-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpFolder, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  dbTest('persists files to DB so land() can read them back', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+
+    writeFileSync(path.join(tmpFolder, 'App.js'), 'export default function App() { return null; }');
+    writeFileSync(
+      path.join(tmpFolder, 'index.js'),
+      'import { createRoot } from "react-dom/client";\n'
+    );
+
+    const published = await service.publishArtifact(
+      {
+        folderPath: tmpFolder,
+        board_id: board.board_id,
+        name: 'Publish Roundtrip Test',
+        template: 'react',
+      },
+      'user-owner'
+    );
+
+    expect(published.build_status).toBe('success');
+    expect(published.content_hash).toBeDefined();
+    expect(published.files).toBeDefined();
+    expect(Object.keys(published.files ?? {})).toEqual(
+      expect.arrayContaining(['/App.js', '/index.js'])
+    );
+
+    // The bug: the row that lands in the DB has no `files` value, so a
+    // subsequent read can't materialize the artifact.
+    const reloaded = await artifactRepo.findById(published.artifact_id);
+    expect(reloaded?.files).toBeDefined();
+    expect(Object.keys(reloaded?.files ?? {})).toEqual(
+      expect.arrayContaining(['/App.js', '/index.js'])
+    );
+
+    // End-to-end: land() pulls files back to disk via the persisted row.
+    const landRoot = mkdtempSync(path.join(tmpdir(), 'agor-publish-land-'));
+    try {
+      const result = await service.land(published.artifact_id, landRoot);
+      expect(result.fileCount).toBeGreaterThanOrEqual(2);
+      expect(readFileSync(path.join(result.destinationPath, 'App.js'), 'utf-8')).toBe(
+        'export default function App() { return null; }'
+      );
+    } finally {
+      rmSync(landRoot, { recursive: true, force: true });
+    }
+  });
+
+  // Regression for the post-Artifacts-2.0 publish bug: on Postgres the
+  // `files`/`dependencies`/`build_errors` columns are still `text` (not
+  // jsonb), so the repo MUST stringify objects before insert. Otherwise
+  // postgres-js coerces JS objects via `Object.prototype.toString()` into
+  // the literal string "[object Object]", which JSON.parse rejects on
+  // read — leaving every fresh artifact with files=undefined and breaking
+  // land() / the viewer iframe.
+  //
+  // dbTest runs on SQLite so we can't trip the postgres-js coercion
+  // directly. Instead, peek at the raw libsql column to confirm we wrote
+  // a JSON string (the shape both dialects need); if a future refactor
+  // stops stringifying for one dialect, this assertion will fail loudly.
+  dbTest('stores files as a JSON string in the text column', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+
+    writeFileSync(path.join(tmpFolder, 'App.js'), 'export default () => null;');
+
+    const published = await service.publishArtifact(
+      {
+        folderPath: tmpFolder,
+        board_id: board.board_id,
+        name: 'JSON String Shape',
+        template: 'react',
+      },
+      'user-owner'
+    );
+
+    // dbTest gives us a LibSQLDatabase — go behind the repo's row mapper
+    // to see what actually landed in the column. Postgres-side this would
+    // use db.execute(sql`...`); both wrappers are exposed under one API
+    // by `executeRaw` in database-wrapper.ts, but importing it adds the
+    // drizzle-orm dep to the daemon and isn't worth it for one test.
+    const libsql = (
+      db as unknown as {
+        $client: {
+          execute(args: { sql: string; args: unknown[] }): Promise<{
+            rows: Array<Record<string, unknown>>;
+          }>;
+        };
+      }
+    ).$client;
+    const raw = await libsql.execute({
+      sql: 'SELECT files, dependencies, build_errors FROM artifacts WHERE artifact_id = ?',
+      args: [published.artifact_id],
+    });
+    const row = raw.rows[0];
+    expect(row).toBeDefined();
+    expect(typeof row.files).toBe('string');
+    expect(row.files).not.toBe('[object Object]');
+    expect(JSON.parse(row.files as string)).toMatchObject({
+      '/App.js': 'export default () => null;',
+    });
+  });
+});
+
 describe('ArtifactsService.land', () => {
   let tmpRoot: string;
 

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -31,10 +31,12 @@ import {
 } from './base';
 
 /**
- * JSON columns differ between SQLite (text) and Postgres (jsonb). On
- * Postgres the driver hands us a parsed value; on SQLite we get a string and
- * must JSON.parse. This helper hides the difference from the rest of the
- * repo.
+ * JSON columns differ between SQLite (text) and Postgres (mixed: some
+ * `jsonb`, some `text` for historical reasons — see `schema.postgres.ts`
+ * around `files`/`dependencies`/`build_errors`). On Postgres the jsonb
+ * driver hands us a parsed value; on SQLite (and on Postgres text columns
+ * that carry serialized JSON) we get a string and must JSON.parse. This
+ * helper hides the difference.
  */
 function readJson<T>(value: unknown): T | undefined {
   if (value === null || value === undefined) return undefined;
@@ -50,12 +52,29 @@ function readJson<T>(value: unknown): T | undefined {
 }
 
 /**
- * Mirror of `readJson` for writes. Postgres takes the value as-is (the
- * jsonb driver serialises); SQLite needs a string.
+ * Write helper for `jsonb` columns. On Postgres, drizzle's jsonb column
+ * stringifies the value via its own `mapToDriverValue`, so we pass the
+ * raw object. On SQLite (where the same logical column is `text`), we
+ * stringify ourselves.
  */
-function writeJson(db: Database, value: unknown): unknown {
+function writeJsonb(db: Database, value: unknown): unknown {
   if (value === undefined || value === null) return null;
   if (isPostgresDatabase(db)) return value;
+  return JSON.stringify(value);
+}
+
+/**
+ * Write helper for columns that are `text` on BOTH dialects but carry a
+ * serialized JSON payload — `files`, `dependencies`, `build_errors` on the
+ * artifacts row. These pre-date the jsonb columns and never got migrated
+ * (changing a `text` to `jsonb` requires a data rewrite). Always
+ * stringify so postgres-js doesn't coerce a JS object via
+ * `Object.prototype.toString()` into the string `"[object Object]"` —
+ * which is exactly how the post-Artifacts-2.0 publish path silently
+ * dropped every file map on Postgres deployments.
+ */
+function writeJsonText(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
   return JSON.stringify(value);
 }
 
@@ -124,15 +143,15 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
         path: data.path ?? null,
         template: data.template ?? 'react',
         build_status: data.build_status ?? 'unknown',
-        build_errors: writeJson(this.db, data.build_errors) as never,
+        build_errors: writeJsonText(data.build_errors) as never,
         content_hash: data.content_hash ?? null,
-        files: writeJson(this.db, data.files) as never,
-        dependencies: writeJson(this.db, data.dependencies) as never,
+        files: writeJsonText(data.files) as never,
+        dependencies: writeJsonText(data.dependencies) as never,
         entry: data.entry ?? null,
-        sandpack_config: writeJson(this.db, data.sandpack_config) as never,
-        required_env_vars: writeJson(this.db, data.required_env_vars) as never,
-        agor_grants: writeJson(this.db, data.agor_grants) as never,
-        agor_runtime: writeJson(this.db, data.agor_runtime) as never,
+        sandpack_config: writeJsonb(this.db, data.sandpack_config) as never,
+        required_env_vars: writeJsonb(this.db, data.required_env_vars) as never,
+        agor_grants: writeJsonb(this.db, data.agor_grants) as never,
+        agor_runtime: writeJsonb(this.db, data.agor_runtime) as never,
         public: data.public ?? true,
         created_by: data.created_by ?? null,
         created_at: now,
@@ -274,27 +293,27 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       if (updates.template !== undefined) setData.template = updates.template;
       if (updates.build_status !== undefined) setData.build_status = updates.build_status;
       if (updates.build_errors !== undefined) {
-        setData.build_errors = writeJson(this.db, updates.build_errors);
+        setData.build_errors = writeJsonText(updates.build_errors);
       }
       if (updates.content_hash !== undefined) setData.content_hash = updates.content_hash ?? null;
       if (updates.files !== undefined) {
-        setData.files = writeJson(this.db, updates.files);
+        setData.files = writeJsonText(updates.files);
       }
       if (updates.dependencies !== undefined) {
-        setData.dependencies = writeJson(this.db, updates.dependencies);
+        setData.dependencies = writeJsonText(updates.dependencies);
       }
       if (updates.entry !== undefined) setData.entry = updates.entry ?? null;
       if (updates.sandpack_config !== undefined) {
-        setData.sandpack_config = writeJson(this.db, updates.sandpack_config);
+        setData.sandpack_config = writeJsonb(this.db, updates.sandpack_config);
       }
       if (updates.required_env_vars !== undefined) {
-        setData.required_env_vars = writeJson(this.db, updates.required_env_vars);
+        setData.required_env_vars = writeJsonb(this.db, updates.required_env_vars);
       }
       if (updates.agor_runtime !== undefined) {
-        setData.agor_runtime = writeJson(this.db, updates.agor_runtime);
+        setData.agor_runtime = writeJsonb(this.db, updates.agor_runtime);
       }
       if (updates.agor_grants !== undefined) {
-        setData.agor_grants = writeJson(this.db, updates.agor_grants);
+        setData.agor_grants = writeJsonb(this.db, updates.agor_grants);
       }
       if (updates.public !== undefined) setData.public = updates.public;
       if (updates.archived !== undefined) setData.archived = updates.archived;


### PR DESCRIPTION
## The bug

After #1147 (Artifacts 2.0) shipped on 2026-05-09/10, every fresh
`agor_artifacts_publish` on Postgres deployments returned
`build_status: success` with a `content_hash` set, but stored no files:

- `agor_artifacts_land <id>` → `"Artifact <id> has no stored files to land"`
- Viewer iframe → `Failed to load artifact:` (empty error string) + Retry
- `agor_artifacts_get <id>` → `files: {}` despite a non-empty hash

Reproduced against the live daemon at 2026-05-12 with the brief's recipe:

```
mkdir -p /tmp/artifact-test && cat > .../App.js && cat > .../index.js
agor_artifacts_publish(folderPath=/tmp/artifact-test, ...)
  → build_status:success, content_hash:f82837d96fe970fb07c9b51c73efbb11
agor_artifacts_land(artifactId=<id>, worktreeId=<wt>)
  → "Artifact 019e1c71-e130-... has no stored files to land"
```

## Root cause

The artifacts repo's `writeJson(db, value)` returns the raw object for
Postgres, on the assumption that every JSON column on the row is `jsonb`.
That's true for the new declarative columns (`sandpack_config`,
`required_env_vars`, `agor_grants`, `agor_runtime`) — but `files`,
`dependencies`, and `build_errors` were never migrated and are still
`text` columns:

```ts
// packages/core/src/db/schema.postgres.ts
build_errors:      text('build_errors'),
files:             text('files'),       // ← still text
dependencies:      text('dependencies'),
sandpack_config:   jsonb('sandpack_config'),
required_env_vars: jsonb('required_env_vars'),
```

Sending a JS object to a Postgres `text` column trips
`Object.prototype.toString()`, so the column actually stored
`"[object Object]"`. `readJson` then runs `JSON.parse` against that,
catches the syntax error, and returns `undefined` — which `land()`
treats as "no stored files."

SQLite deployments were unaffected: that branch of `writeJson` always
stringified anyway, which is why no test caught the regression — the
test fixture uses SQLite.

## Fix

Split the helper:

- `writeJsonb(db, value)` — for true `jsonb` columns. Drizzle owns
  serialization, so we pass the raw object on Postgres and stringify on
  SQLite (where the same logical column is `text`).
- `writeJsonText(value)` — for `text` columns carrying serialized JSON.
  Always stringifies. Both dialects need this.

The three text-JSON columns (`files`, `dependencies`, `build_errors`)
now use `writeJsonText`; the four jsonb columns stay on `writeJsonb`.

## Tests

Adds `ArtifactsService.publishArtifact` test block:

1. **End-to-end roundtrip**: `publishArtifact` → `findById` → `land`.
   Asserts the persisted row has files and `land` materializes them.
2. **Raw-column shape**: peeks behind the row mapper at the LibSQL
   client and asserts the column holds a JSON string (not
   `"[object Object]"`). Codifies the storage contract both dialects
   need; a future change that stops stringifying for one dialect will
   fail this loudly.

`pnpm test src/services/artifacts.test.ts` → 49/49 passing.
`pnpm typecheck` and `pnpm lint` clean.

## What's NOT in this PR

- **Data fixup**: every Postgres artifact published since 2026-05-09/10
  has lost its file map. They can't be recovered from the DB; they need
  to be re-published from a folder or a land sidecar. Worth deciding
  whether to surface a `legacy.broken_files: true` flag on read or to
  let users self-heal via `agor_artifacts_publish` republish. Happy to
  follow up separately.
- **Schema migration to jsonb for `files`/`dependencies`/`build_errors`**:
  cleaner long-term but requires an `ALTER COLUMN … USING …::jsonb`
  rewrite. Out of scope for the hotfix.

## Test plan

- [x] Bug reproduces on prod daemon (publish → success+hash, land → no files)
- [x] `pnpm test src/services/artifacts.test.ts` — 49/49 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new errors/warnings)
- [ ] Manual smoke test on a Postgres deploy after merge

cc @mistercrunch — owns Artifacts 2.0, please skim the helper split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)