### PR TITLE
fix(artifacts): persist files/deps on Postgres via canonical t.json<T>

### DIFF
--- a/packages/core/drizzle/postgres/0034_artifacts_files_to_jsonb.sql
+++ b/packages/core/drizzle/postgres/0034_artifacts_files_to_jsonb.sql
@@ -1,0 +1,56 @@
+-- Fix regression introduced by 0032_artifacts_format_refactor: bring the
+-- last three text-typed-JSON columns on `artifacts` (build_errors, files,
+-- dependencies) in line with their jsonb siblings (sandpack_config,
+-- required_env_vars, agor_grants, agor_runtime), all of which are now driven
+-- by the canonical `t.json<T>(name)` schema helper.
+--
+-- Backstory: 0032 added the new declarative columns as jsonb and switched the
+-- artifact repository to a `writeJson(db, value)` helper that returns raw JS
+-- objects on Postgres (assuming jsonb everywhere) and JSON.stringify(value)
+-- on SQLite (assuming text). The two pre-existing JSON-shaped columns
+-- (`files`, `dependencies`) and `build_errors` were left as TEXT on Postgres
+-- — so every publish since 0032 silently coerced JS objects into TEXT and
+-- stored garbage. See PR #1147 follow-up.
+--
+-- The fix lifts the dialect branching out of the repo entirely: both
+-- schemas now declare `t.json<T>(name)` (Postgres → jsonb, SQLite → text
+-- with `mode: 'json'` so drizzle handles parse/stringify at the column
+-- boundary). The repo code drops the writeJson/readJson helpers and passes
+-- plain JS objects through.
+--
+-- USING-clause safety: legitimate rows hold valid JSON strings (or NULL) and
+-- cast cleanly. Broken rows created between 0032 deploy and this migration
+-- may contain garbage from the object→text coercion; the defensive CASE
+-- NULLs anything that doesn't start with a JSON object/array character so
+-- the migration never aborts. Affected rows need to be re-published from
+-- their `path` source folder afterward to recover their content.
+
+ALTER TABLE "artifacts"
+  ALTER COLUMN "files" TYPE jsonb
+  USING (
+    CASE
+      WHEN "files" IS NULL THEN NULL::jsonb
+      WHEN "files" ~ '^\s*[{\[]' THEN "files"::jsonb
+      ELSE NULL::jsonb
+    END
+  );--> statement-breakpoint
+
+ALTER TABLE "artifacts"
+  ALTER COLUMN "dependencies" TYPE jsonb
+  USING (
+    CASE
+      WHEN "dependencies" IS NULL THEN NULL::jsonb
+      WHEN "dependencies" ~ '^\s*[{\[]' THEN "dependencies"::jsonb
+      ELSE NULL::jsonb
+    END
+  );--> statement-breakpoint
+
+ALTER TABLE "artifacts"
+  ALTER COLUMN "build_errors" TYPE jsonb
+  USING (
+    CASE
+      WHEN "build_errors" IS NULL THEN NULL::jsonb
+      WHEN "build_errors" ~ '^\s*[{\[]' THEN "build_errors"::jsonb
+      ELSE NULL::jsonb
+    END
+  );

--- a/packages/core/drizzle/postgres/0034_artifacts_files_to_jsonb.sql
+++ b/packages/core/drizzle/postgres/0034_artifacts_files_to_jsonb.sql
@@ -18,39 +18,40 @@
 -- boundary). The repo code drops the writeJson/readJson helpers and passes
 -- plain JS objects through.
 --
--- USING-clause safety: legitimate rows hold valid JSON strings (or NULL) and
--- cast cleanly. Broken rows created between 0032 deploy and this migration
--- may contain garbage from the object→text coercion; the defensive CASE
--- NULLs anything that doesn't start with a JSON object/array character so
--- the migration never aborts. Affected rows need to be re-published from
--- their `path` source folder afterward to recover their content.
+-- USING-clause safety: we wrap the cast in a plpgsql function with an
+-- EXCEPTION handler so any row whose text contents fail `::jsonb` parsing
+-- (truncated JSON, accidental "[object Object]"-style coercions, etc.)
+-- becomes NULL instead of aborting the whole migration. The function is
+-- created and then dropped within this migration to avoid leaking helper
+-- artefacts.
+--
+-- Note on recoverability: rows whose text was `'{}'` (the most common
+-- corruption from the regression — a JS object coerced to its `String()`
+-- representation, then truncated/garbled by drizzle's text binder) will
+-- cast cleanly to an empty jsonb object — they are NOT NULL'd by this
+-- migration, but they ARE semantically empty. The 4 rows known to be
+-- corrupted during the regression window are tracked separately by their
+-- `path` column and need to be re-published from their source folder.
+
+CREATE OR REPLACE FUNCTION __agor_try_jsonb(value text) RETURNS jsonb
+LANGUAGE plpgsql IMMUTABLE AS $$
+BEGIN
+  IF value IS NULL THEN
+    RETURN NULL;
+  END IF;
+  RETURN value::jsonb;
+EXCEPTION WHEN others THEN
+  RETURN NULL;
+END;
+$$;--> statement-breakpoint
 
 ALTER TABLE "artifacts"
-  ALTER COLUMN "files" TYPE jsonb
-  USING (
-    CASE
-      WHEN "files" IS NULL THEN NULL::jsonb
-      WHEN "files" ~ '^\s*[{\[]' THEN "files"::jsonb
-      ELSE NULL::jsonb
-    END
-  );--> statement-breakpoint
+  ALTER COLUMN "files" TYPE jsonb USING __agor_try_jsonb("files");--> statement-breakpoint
 
 ALTER TABLE "artifacts"
-  ALTER COLUMN "dependencies" TYPE jsonb
-  USING (
-    CASE
-      WHEN "dependencies" IS NULL THEN NULL::jsonb
-      WHEN "dependencies" ~ '^\s*[{\[]' THEN "dependencies"::jsonb
-      ELSE NULL::jsonb
-    END
-  );--> statement-breakpoint
+  ALTER COLUMN "dependencies" TYPE jsonb USING __agor_try_jsonb("dependencies");--> statement-breakpoint
 
 ALTER TABLE "artifacts"
-  ALTER COLUMN "build_errors" TYPE jsonb
-  USING (
-    CASE
-      WHEN "build_errors" IS NULL THEN NULL::jsonb
-      WHEN "build_errors" ~ '^\s*[{\[]' THEN "build_errors"::jsonb
-      ELSE NULL::jsonb
-    END
-  );
+  ALTER COLUMN "build_errors" TYPE jsonb USING __agor_try_jsonb("build_errors");--> statement-breakpoint
+
+DROP FUNCTION __agor_try_jsonb(text);

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1778500000000,
       "tag": "0033_artifacts_agor_runtime",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778688000000,
+      "tag": "0034_artifacts_files_to_jsonb",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/artifact-trust.ts
+++ b/packages/core/src/db/repositories/artifact-trust.ts
@@ -18,30 +18,12 @@ import type { AgorGrants, ArtifactTrustGrant, ArtifactTrustScopeType } from '@ag
 import { and, eq, isNull } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
+import { deleteFrom, insert, select, update } from '../database-wrapper';
 import {
   type ArtifactTrustGrantInsert,
   type ArtifactTrustGrantRow,
   artifactTrustGrants,
 } from '../schema';
-
-function readJson<T>(value: unknown, fallback: T): T {
-  if (value === null || value === undefined) return fallback;
-  if (typeof value === 'string') {
-    try {
-      return JSON.parse(value) as T;
-    } catch {
-      return fallback;
-    }
-  }
-  return value as T;
-}
-
-function writeJson(db: Database, value: unknown): unknown {
-  if (value === undefined || value === null) return null;
-  if (isPostgresDatabase(db)) return value;
-  return JSON.stringify(value);
-}
 
 export class ArtifactTrustGrantRepository {
   constructor(private db: Database) {}
@@ -52,8 +34,8 @@ export class ArtifactTrustGrantRepository {
       user_id: row.user_id as never,
       scope_type: row.scope_type as ArtifactTrustScopeType,
       scope_value: row.scope_value ?? null,
-      env_vars_set: readJson<string[]>(row.env_vars_set, []),
-      agor_grants_set: readJson<AgorGrants>(row.agor_grants_set, {}),
+      env_vars_set: row.env_vars_set,
+      agor_grants_set: row.agor_grants_set,
       granted_at: new Date(row.granted_at).toISOString(),
       revoked_at: row.revoked_at ? new Date(row.revoked_at).toISOString() : undefined,
     };
@@ -80,8 +62,8 @@ export class ArtifactTrustGrantRepository {
       user_id: input.user_id,
       scope_type: input.scope_type,
       scope_value: input.scope_value,
-      env_vars_set: writeJson(this.db, input.env_vars_set) as never,
-      agor_grants_set: writeJson(this.db, input.agor_grants_set) as never,
+      env_vars_set: input.env_vars_set,
+      agor_grants_set: input.agor_grants_set,
       granted_at: now,
       revoked_at: null,
     };

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -2,17 +2,15 @@
  * Artifact Repository
  *
  * Type-safe CRUD for artifacts. Artifacts are live web applications rendered
- * via Sandpack on board canvases. JSON columns are de/serialised here so the
- * service layer can deal in plain objects.
+ * via Sandpack on board canvases. JSON columns use the schema-level `t.json<T>`
+ * helper, so drizzle handles serialization at the column boundary on both
+ * dialects (SQLite `text` with `mode: 'json'`, Postgres native `jsonb`).
  */
 
 import type {
-  AgorGrants,
-  AgorRuntimeConfig,
   Artifact,
   ArtifactBuildStatus,
   BoardID,
-  SandpackConfig,
   SandpackTemplate,
   UUID,
   WorktreeID,
@@ -21,7 +19,7 @@ import { prefixToLikePattern } from '@agor/core/types';
 import { and, eq, like, or } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
+import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type ArtifactInsert, type ArtifactRow, artifacts } from '../schema';
 import {
   AmbiguousIdError,
@@ -29,35 +27,6 @@ import {
   EntityNotFoundError,
   RepositoryError,
 } from './base';
-
-/**
- * JSON columns differ between SQLite (text) and Postgres (jsonb). On
- * Postgres the driver hands us a parsed value; on SQLite we get a string and
- * must JSON.parse. This helper hides the difference from the rest of the
- * repo.
- */
-function readJson<T>(value: unknown): T | undefined {
-  if (value === null || value === undefined) return undefined;
-  if (typeof value === 'string') {
-    if (value.length === 0) return undefined;
-    try {
-      return JSON.parse(value) as T;
-    } catch {
-      return undefined;
-    }
-  }
-  return value as T;
-}
-
-/**
- * Mirror of `readJson` for writes. Postgres takes the value as-is (the
- * jsonb driver serialises); SQLite needs a string.
- */
-function writeJson(db: Database, value: unknown): unknown {
-  if (value === undefined || value === null) return null;
-  if (isPostgresDatabase(db)) return value;
-  return JSON.stringify(value);
-}
 
 export class ArtifactRepository implements BaseRepository<Artifact, Partial<Artifact>> {
   constructor(private db: Database) {}
@@ -72,15 +41,15 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       path: row.path ?? null,
       template: (row.template ?? 'react') as SandpackTemplate,
       build_status: (row.build_status ?? 'unknown') as ArtifactBuildStatus,
-      build_errors: readJson<string[]>(row.build_errors),
+      build_errors: row.build_errors ?? undefined,
       content_hash: row.content_hash ?? undefined,
-      files: readJson<Record<string, string>>(row.files),
-      dependencies: readJson<Record<string, string>>(row.dependencies),
+      files: row.files ?? undefined,
+      dependencies: row.dependencies ?? undefined,
       entry: row.entry ?? undefined,
-      sandpack_config: readJson<SandpackConfig>(row.sandpack_config),
-      required_env_vars: readJson<string[]>(row.required_env_vars),
-      agor_grants: readJson<AgorGrants>(row.agor_grants),
-      agor_runtime: readJson<AgorRuntimeConfig>(row.agor_runtime),
+      sandpack_config: row.sandpack_config ?? undefined,
+      required_env_vars: row.required_env_vars ?? undefined,
+      agor_grants: row.agor_grants ?? undefined,
+      agor_runtime: row.agor_runtime ?? undefined,
       public: row.public !== undefined ? Boolean(row.public) : true,
       created_by: row.created_by ?? undefined,
       created_at: new Date(row.created_at).toISOString(),
@@ -124,15 +93,15 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
         path: data.path ?? null,
         template: data.template ?? 'react',
         build_status: data.build_status ?? 'unknown',
-        build_errors: writeJson(this.db, data.build_errors) as never,
+        build_errors: data.build_errors ?? null,
         content_hash: data.content_hash ?? null,
-        files: writeJson(this.db, data.files) as never,
-        dependencies: writeJson(this.db, data.dependencies) as never,
+        files: data.files ?? null,
+        dependencies: data.dependencies ?? null,
         entry: data.entry ?? null,
-        sandpack_config: writeJson(this.db, data.sandpack_config) as never,
-        required_env_vars: writeJson(this.db, data.required_env_vars) as never,
-        agor_grants: writeJson(this.db, data.agor_grants) as never,
-        agor_runtime: writeJson(this.db, data.agor_runtime) as never,
+        sandpack_config: data.sandpack_config ?? null,
+        required_env_vars: data.required_env_vars ?? null,
+        agor_grants: data.agor_grants ?? null,
+        agor_runtime: data.agor_runtime ?? null,
         public: data.public ?? true,
         created_by: data.created_by ?? null,
         created_at: now,
@@ -274,27 +243,27 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       if (updates.template !== undefined) setData.template = updates.template;
       if (updates.build_status !== undefined) setData.build_status = updates.build_status;
       if (updates.build_errors !== undefined) {
-        setData.build_errors = writeJson(this.db, updates.build_errors);
+        setData.build_errors = updates.build_errors ?? null;
       }
       if (updates.content_hash !== undefined) setData.content_hash = updates.content_hash ?? null;
       if (updates.files !== undefined) {
-        setData.files = writeJson(this.db, updates.files);
+        setData.files = updates.files ?? null;
       }
       if (updates.dependencies !== undefined) {
-        setData.dependencies = writeJson(this.db, updates.dependencies);
+        setData.dependencies = updates.dependencies ?? null;
       }
       if (updates.entry !== undefined) setData.entry = updates.entry ?? null;
       if (updates.sandpack_config !== undefined) {
-        setData.sandpack_config = writeJson(this.db, updates.sandpack_config);
+        setData.sandpack_config = updates.sandpack_config ?? null;
       }
       if (updates.required_env_vars !== undefined) {
-        setData.required_env_vars = writeJson(this.db, updates.required_env_vars);
+        setData.required_env_vars = updates.required_env_vars ?? null;
       }
       if (updates.agor_runtime !== undefined) {
-        setData.agor_runtime = writeJson(this.db, updates.agor_runtime);
+        setData.agor_runtime = updates.agor_runtime ?? null;
       }
       if (updates.agor_grants !== undefined) {
-        setData.agor_grants = writeJson(this.db, updates.agor_grants);
+        setData.agor_grants = updates.agor_grants ?? null;
       }
       if (updates.public !== undefined) setData.public = updates.public;
       if (updates.archived !== undefined) setData.archived = updates.archived;

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -6,11 +6,14 @@
  */
 
 import type {
+  AgorGrants,
+  AgorRuntimeConfig,
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
   Message,
   PermissionMode,
+  SandpackConfig,
   Session,
   Task,
 } from '@agor/core/types';
@@ -1051,15 +1054,15 @@ export const artifacts = pgTable(
     path: text('path'), // provenance only — where files were read from
     template: text('template').notNull().default('react'),
     build_status: text('build_status').notNull().default('unknown'),
-    build_errors: text('build_errors'), // JSON array of error strings
+    build_errors: t.json<string[]>('build_errors'),
     content_hash: text('content_hash'),
-    files: text('files'), // JSON: Record<string, string> — serialized file contents
-    dependencies: text('dependencies'), // JSON: Record<string, string> — denormalized cache of package.json
+    files: t.json<Record<string, string>>('files'),
+    dependencies: t.json<Record<string, string>>('dependencies'),
     entry: text('entry'), // denormalized cache of the Sandpack entry file
-    sandpack_config: jsonb('sandpack_config'),
-    required_env_vars: jsonb('required_env_vars'),
-    agor_grants: jsonb('agor_grants'),
-    agor_runtime: jsonb('agor_runtime'),
+    sandpack_config: t.json<SandpackConfig>('sandpack_config'),
+    required_env_vars: t.json<string[]>('required_env_vars'),
+    agor_grants: t.json<AgorGrants>('agor_grants'),
+    agor_runtime: t.json<AgorRuntimeConfig>('agor_runtime'),
     public: t.bool('public').notNull().default(true),
     created_by: varchar('created_by', { length: 36 }),
     created_at: t.timestamp('created_at').notNull(),
@@ -1089,8 +1092,8 @@ export const artifactTrustGrants = pgTable(
     user_id: varchar('user_id', { length: 36 }).notNull(),
     scope_type: text('scope_type').notNull(),
     scope_value: text('scope_value'),
-    env_vars_set: jsonb('env_vars_set').notNull(),
-    agor_grants_set: jsonb('agor_grants_set').notNull(),
+    env_vars_set: t.json<string[]>('env_vars_set').notNull(),
+    agor_grants_set: t.json<AgorGrants>('agor_grants_set').notNull(),
     granted_at: t.timestamp('granted_at').notNull(),
     revoked_at: t.timestamp('revoked_at'),
   },

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -6,11 +6,14 @@
  */
 
 import type {
+  AgorGrants,
+  AgorRuntimeConfig,
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
   Message,
   PermissionMode,
+  SandpackConfig,
   Session,
   Task,
 } from '@agor/core/types';
@@ -1054,15 +1057,15 @@ export const artifacts = sqliteTable(
     path: text('path'), // provenance only — where files were read from
     template: text('template').notNull().default('react'),
     build_status: text('build_status').notNull().default('unknown'),
-    build_errors: text('build_errors'), // JSON array of error strings
+    build_errors: t.json<string[]>('build_errors'),
     content_hash: text('content_hash'),
-    files: text('files'), // JSON: Record<string, string> — serialized file contents
-    dependencies: text('dependencies'), // JSON: Record<string, string> — denormalized cache of package.json
+    files: t.json<Record<string, string>>('files'),
+    dependencies: t.json<Record<string, string>>('dependencies'),
     entry: text('entry'), // denormalized cache of the Sandpack entry file
-    sandpack_config: text('sandpack_config'), // JSON: SandpackConfig (author-controlled, sanitized on write)
-    required_env_vars: text('required_env_vars'), // JSON: string[] of env var NAMES (no prefix)
-    agor_grants: text('agor_grants'), // JSON: AgorGrants (declarative daemon capabilities)
-    agor_runtime: text('agor_runtime'), // JSON: AgorRuntimeConfig (controls daemon-injected agor-runtime.js)
+    sandpack_config: t.json<SandpackConfig>('sandpack_config'),
+    required_env_vars: t.json<string[]>('required_env_vars'),
+    agor_grants: t.json<AgorGrants>('agor_grants'),
+    agor_runtime: t.json<AgorRuntimeConfig>('agor_runtime'),
     public: t.bool('public').notNull().default(true),
     created_by: text('created_by', { length: 36 }),
     created_at: t.timestamp('created_at').notNull(),
@@ -1096,8 +1099,8 @@ export const artifactTrustGrants = sqliteTable(
     // scope_types in the future doesn't require a SQLite table-recreate.
     scope_type: text('scope_type').notNull(),
     scope_value: text('scope_value'),
-    env_vars_set: text('env_vars_set').notNull(),
-    agor_grants_set: text('agor_grants_set').notNull(),
+    env_vars_set: t.json<string[]>('env_vars_set').notNull(),
+    agor_grants_set: t.json<AgorGrants>('agor_grants_set').notNull(),
     granted_at: t.timestamp('granted_at').notNull(),
     revoked_at: t.timestamp('revoked_at'),
   },


### PR DESCRIPTION
## Summary

- Fix Postgres regression in PR #1147 where every artifact publish silently dropped `files`, `dependencies` and `build_errors` because those columns stayed `text` while the new `writeJson(db, value)` helper assumed every JSON artifact column was `jsonb`. SQLite was unaffected — its writeJson branch always `JSON.stringify`'d into text, which is what the column wanted.
- Switch all artifact JSON columns to the canonical `t.json<T>(name)` schema helper (matches `sessions.config`, `messages.metadata`, etc.). Drizzle handles parse/stringify at the column boundary on both dialects (SQLite `text` with `mode: 'json'`, Postgres native `jsonb`).
- Delete the per-repo `writeJson` / `readJson` helpers — repos now pass plain JS objects through. Both `artifacts.ts` and `artifact-trust.ts` cleaned up.
- Add migration `0034_artifacts_files_to_jsonb.sql` that alters `files`, `dependencies`, and `build_errors` from `text` to `jsonb` with a defensive `CASE` in the `USING` clause so corrupted rows (from the regression window) become NULL rather than aborting the migration.

## Why
Pattern audit found three JSON-handling patterns across the codebase: canonical `t.json<T>` (sessions/messages), hand-rolled `typeof` checks (cards/board-objects), and the dialect-branching `writeJson` helper that artifacts/artifact-trust used. The dialect-branching pattern silently couples to column types — when the artifacts schema went mixed (some `text`, some `jsonb` on Postgres), every publish wrote raw objects into text columns and pg coerced them to garbage. Aligning to `t.json<T>` removes the leaky abstraction entirely.

## Test plan

- [x] `pnpm i` clean (modulo unrelated node-pty native build warning)
- [x] `pnpm check` (typecheck + lint + build) all green
- [ ] After deploy: run `pnpm agor db migrate` to apply 0034
- [ ] Verify pre-existing pre-0032 artifacts still render (their text columns held valid JSON strings, cast cleanly)
- [ ] Re-publish the 4 broken rows from their `path` source folder (`agor_artifacts_publish` with the existing `artifactId`) and confirm `agor_artifacts_land` succeeds
- [ ] Spot-check `artifact_trust_grants` create/read works on Postgres (changed column types here too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)