### PR TITLE
fix(agor-ui): resolve @agor/core/types imports in vite/vitest configs

### DIFF
--- a/apps/agor-ui/vite.config.ts
+++ b/apps/agor-ui/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@agor/core/types': path.resolve(__dirname, '../../packages/core/src/types/index.ts'),
     },
   },
 

--- a/apps/agor-ui/vitest.config.ts
+++ b/apps/agor-ui/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@agor/core/types': path.resolve(__dirname, '../../packages/core/src/types/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Two-line addition to `apps/agor-ui/vite.config.ts` and `apps/agor-ui/vitest.config.ts` resolve aliases, mapping `@agor/core/types` to the in-repo source so vite/vitest can load the deep subpath import without going through the package's built `dist/`.

Without this alias, agor-ui code that does \`import { ... } from '@agor/core/types'\` fails to resolve under vite dev/build and vitest when \`packages/core/dist\` isn't pre-built — a common case on a clean checkout or after \`pnpm clean\`.

## Test plan

- [ ] \`pnpm --filter @agor/ui test\` succeeds on a clean checkout (no prior \`packages/core\` build)
- [ ] \`pnpm --filter @agor/ui dev\` resolves \`@agor/core/types\` imports without \`Cannot find module\` errors