### PR TITLE
feat(mcp): personal API keys + SSE transport + sessionless access

### DIFF
--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -66,9 +66,16 @@ describe('coerceJsonRecord', () => {
  */
 function captureMcpHandler() {
   let handler: ((req: Request, res: Response) => Promise<unknown> | unknown) | null = null;
+  const register = (_path: string, fn: typeof handler) => {
+    handler = fn;
+  };
   const app = {
-    post: (_path: string, fn: typeof handler) => {
-      handler = fn;
+    post: register,
+    get: register,
+    delete: register,
+    service: (name: string) => {
+      if (name !== 'users') throw new Error(`Unexpected service lookup: ${name}`);
+      return {};
     },
   } as unknown as Parameters<typeof setupMCPRoutes>[0];
   setupMCPRoutes(app, {} as never, /* toolSearchEnabled */ false);

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -13,7 +13,9 @@
  * JSON across requests, which is critical for client-side KV prefix caching.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { Database } from '@agor/core/db';
+import { UserApiKeysRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { DaemonServicesConfig, ServiceGroupName, SessionID, UserID } from '@agor/core/types';
 import { getServiceTier, SERVICE_GROUP_TO_MCP_DOMAINS, SERVICE_TIER_RANK } from '@agor/core/types';
@@ -23,6 +25,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { Request, Response } from 'express';
 import { toJSONSchema } from 'zod/v4-mini';
+import { ApiKeyStrategy } from '../auth/api-key-strategy.js';
 import type { AuthenticatedParams, AuthenticatedUser } from '../declarations.js';
 import { validateSessionToken } from './tokens.js';
 import { ToolRegistry } from './tool-registry.js';
@@ -42,6 +45,15 @@ import { registerTaskTools } from './tools/tasks.js';
 import { registerUserTools } from './tools/users.js';
 import { registerWorktreeTools } from './tools/worktrees.js';
 
+export {
+  coerceJsonRecord,
+  coerceString,
+  sessionContextRequiredResult,
+  textResult,
+} from './utils.js';
+
+import { coerceString } from './utils.js';
+
 /**
  * Shared context passed to every tool handler.
  */
@@ -49,43 +61,9 @@ export interface McpContext {
   app: Application;
   db: Database;
   userId: UserID;
-  sessionId: SessionID;
+  sessionId: SessionID | undefined;
   authenticatedUser: AuthenticatedUser;
   baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider'>;
-}
-
-/**
- * Helper: coerce unknown value to trimmed non-empty string or undefined.
- */
-export function coerceString(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-/**
- * Helper: coerce a possibly-stringified JSON value to a Record, or return as-is.
- *
- * Some MCP clients double-serialize nested objects as JSON strings (especially
- * with large or complex content). This helper transparently parses those back.
- * Returns the original value unchanged if it's not a string or not valid JSON.
- */
-export function coerceJsonRecord(value: unknown): unknown {
-  if (typeof value !== 'string') return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}
-
-/**
- * Helper: format a value as MCP text content response.
- */
-export function textResult(data: unknown) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
-  };
 }
 
 /** Server instructions shown to agents when tool search is enabled. */
@@ -433,6 +411,26 @@ export function setupMCPRoutes(
     console.log(`✅ MCP tool registry built (${cachedRegistry!.size} tools cached)`);
   }
 
+  // Stateful transports for streamable HTTP sessions (enables GET SSE + DELETE).
+  const transports = new Map<
+    string,
+    {
+      transport: StreamableHTTPServerTransport;
+      server: McpServer;
+      userId: UserID;
+    }
+  >();
+
+  const apiKeysRepo = new UserApiKeysRepository(db);
+  const apiKeyStrategy = new ApiKeyStrategy();
+  apiKeyStrategy.setDependencies(apiKeysRepo, app.service('users'));
+
+  const isInitializeRequest = (body: unknown): boolean => {
+    if (!body || typeof body !== 'object') return false;
+    const maybeRequest = body as { method?: unknown };
+    return maybeRequest.method === 'initialize';
+  };
+
   const handler = async (req: Request, res: Response) => {
     try {
       console.log(`🔌 Incoming MCP request: ${req.method} /mcp`);
@@ -457,50 +455,71 @@ export function setupMCPRoutes(
         });
       }
 
-      // Extract session token from Authorization header only
-      let sessionToken: string | undefined;
+      // Accept MCP credentials via Authorization bearer token or X-API-Key.
+      // Bearer tokens may be either short-lived session tokens or personal API keys.
+      let credential: string | undefined;
       const authHeader = req.headers.authorization;
       if (authHeader?.startsWith('Bearer ')) {
-        sessionToken = authHeader.slice(7);
+        credential = authHeader.slice(7);
+      }
+      if (!credential) {
+        const xApiKey = req.headers['x-api-key'];
+        if (typeof xApiKey === 'string' && xApiKey.startsWith('agor_sk_')) {
+          credential = xApiKey;
+        }
       }
 
-      if (!sessionToken) {
-        console.warn('⚠️  MCP request missing Authorization header');
+      if (!credential) {
+        console.warn('⚠️  MCP request missing credentials');
         return res.status(401).json({
           jsonrpc: '2.0',
           id: (req.body as { id?: unknown })?.id,
           error: {
             code: -32001,
             message:
-              'Authentication required: session token must be provided via Authorization: Bearer header',
+              'Authentication required: provide an Authorization: Bearer token or X-API-Key header',
           },
         });
       }
 
-      // Validate token and extract context
-      const context = await validateSessionToken(app, sessionToken);
-      if (!context) {
-        console.warn('⚠️  Invalid MCP session token');
-        return res.status(401).json({
-          jsonrpc: '2.0',
-          id: (req.body as { id?: unknown })?.id,
-          error: {
-            code: -32001,
-            message: 'Invalid or expired session token',
-          },
-        });
-      }
-
-      console.log(
-        `🔌 MCP request authenticated (user: ${context.userId.substring(0, 8)}, session: ${context.sessionId.substring(0, 8)})`
-      );
-
-      // Fetch the authenticated user
+      // Support long-lived personal API keys for external orchestrators (Hermes, etc.).
       let authenticatedUser: AuthenticatedUser;
-      try {
-        authenticatedUser = await app.service('users').get(context.userId);
-      } catch (error) {
-        if (error instanceof NotFoundError) {
+      let userId: UserID;
+      let sessionId: SessionID | undefined;
+
+      if (credential.startsWith('agor_sk_')) {
+        try {
+          const result = await apiKeyStrategy.authenticate({ apiKey: credential }, {});
+          authenticatedUser = result.user;
+          userId = authenticatedUser.user_id as UserID;
+        } catch {
+          console.warn('⚠️  Invalid MCP API key');
+          return res.status(401).json({
+            jsonrpc: '2.0',
+            id: (req.body as { id?: unknown })?.id,
+            error: {
+              code: -32001,
+              message: 'Invalid API key',
+            },
+          });
+        }
+
+        // Session context for tools like agor_sessions_get_current/agor_sessions_spawn.
+        // In API key mode, allow explicit session selection via query/header.
+        const requestedSessionId =
+          coerceString(req.query.sessionId as string | undefined) ||
+          coerceString(
+            typeof req.headers['x-agor-session-id'] === 'string'
+              ? req.headers['x-agor-session-id']
+              : undefined
+          );
+
+        sessionId = requestedSessionId as SessionID | undefined;
+      } else {
+        // Existing deterministic MCP session-token flow.
+        const context = await validateSessionToken(app, credential);
+        if (!context) {
+          console.warn('⚠️  Invalid MCP session token');
           return res.status(401).json({
             jsonrpc: '2.0',
             id: (req.body as { id?: unknown })?.id,
@@ -510,8 +529,34 @@ export function setupMCPRoutes(
             },
           });
         }
-        throw error;
+
+        userId = context.userId;
+        sessionId = context.sessionId;
+
+        try {
+          authenticatedUser = await app.service('users').get(userId);
+        } catch (error) {
+          if (error instanceof NotFoundError) {
+            return res.status(401).json({
+              jsonrpc: '2.0',
+              id: (req.body as { id?: unknown })?.id,
+              error: {
+                code: -32001,
+                message: 'Invalid or expired session token',
+              },
+            });
+          }
+          throw error;
+        }
       }
+
+      console.log(
+        `🔌 MCP request authenticated (user: ${userId.substring(0, 8)}, session: ${sessionId?.substring(0, 8) || 'none'})`
+      );
+
+      // Sessionless access is permitted for personal API keys. Tools that need
+      // a current session (e.g. agor_sessions_get_current, spawn) will surface
+      // their own error if called without ?sessionId=/X-Agor-Session-Id set.
 
       const baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider'> = {
         user: {
@@ -523,33 +568,106 @@ export function setupMCPRoutes(
         provider: 'mcp',
       };
 
-      // Create a per-request McpServer with tools registered per service tier
-      const mcpServer = createMcpServer(
-        {
-          app,
-          db,
-          userId: context.userId,
-          sessionId: context.sessionId,
-          authenticatedUser,
-          baseServiceParams,
+      const mcpContext: McpContext = {
+        app,
+        db,
+        userId,
+        sessionId,
+        authenticatedUser,
+        baseServiceParams,
+      };
+
+      const mcpSessionId = coerceString(req.headers['mcp-session-id']);
+
+      // ─────────────────────────────────────────────────────────────────────────────
+      // Stateful mode (streamable HTTP sessions): supports GET /mcp SSE + DELETE /mcp
+      // ─────────────────────────────────────────────────────────────────────────────
+      if (req.method === 'GET' || req.method === 'DELETE' || mcpSessionId) {
+        if (!mcpSessionId || !transports.has(mcpSessionId)) {
+          return res.status(400).json({
+            jsonrpc: '2.0',
+            id: (req.body as { id?: unknown })?.id,
+            error: {
+              code: -32000,
+              message: 'Bad Request: Invalid or missing MCP session ID',
+            },
+          });
+        }
+
+        const existing = transports.get(mcpSessionId)!;
+        if (existing.userId !== userId) {
+          return res.status(403).json({
+            jsonrpc: '2.0',
+            id: (req.body as { id?: unknown })?.id,
+            error: {
+              code: -32003,
+              message: 'Forbidden: MCP session belongs to a different user',
+            },
+          });
+        }
+
+        if (req.method === 'GET') {
+          let closed = false;
+          req.on('close', () => {
+            if (closed) return;
+            closed = true;
+            existing.transport.close().catch(() => {});
+          });
+        }
+
+        await existing.transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      // Initialize a new stateful streamable HTTP session
+      if (req.method === 'POST' && isInitializeRequest(req.body)) {
+        const mcpServer = createMcpServer(mcpContext, toolSearchEnabled, servicesConfig);
+
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (newSessionId) => {
+            transports.set(newSessionId, { transport, server: mcpServer, userId });
+          },
+        });
+
+        transport.onclose = () => {
+          const sid = transport.sessionId;
+          if (sid) transports.delete(sid);
+          mcpServer.close().catch(() => {});
+        };
+
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      // ─────────────────────────────────────────────────────────────────────────────
+      // Stateless fallback mode: preserves legacy behavior for direct POST usage
+      // ─────────────────────────────────────────────────────────────────────────────
+      if (req.method === 'POST') {
+        const mcpServer = createMcpServer(mcpContext, toolSearchEnabled, servicesConfig);
+
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+        });
+
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+
+        res.on('close', () => {
+          transport.close().catch(() => {});
+          mcpServer.close().catch(() => {});
+        });
+        return;
+      }
+
+      return res.status(405).json({
+        jsonrpc: '2.0',
+        id: (req.body as { id?: unknown })?.id,
+        error: {
+          code: -32005,
+          message: `Method ${req.method} not allowed on /mcp`,
         },
-        toolSearchEnabled,
-        servicesConfig
-      );
-
-      // Create stateless transport (one per request, no session tracking)
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
-
-      // Connect and handle the request
-      await mcpServer.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-
-      // Clean up after response is done
-      res.on('close', () => {
-        transport.close().catch(() => {});
-        mcpServer.close().catch(() => {});
       });
     } catch (error) {
       console.error('❌ MCP request failed:', error);
@@ -565,6 +683,12 @@ export function setupMCPRoutes(
   // Register as Express POST route
   // @ts-expect-error - FeathersJS app extends Express
   app.post('/mcp', handler);
+  // GET supports SSE stream in streamable HTTP transport
+  // @ts-expect-error - FeathersJS app extends Express
+  app.get('/mcp', handler);
+  // DELETE supports streamable HTTP session termination
+  // @ts-expect-error - FeathersJS app extends Express
+  app.delete('/mcp', handler);
 
-  console.log('✅ MCP routes registered at POST /mcp');
+  console.log('✅ MCP routes registered at /mcp (POST + GET + DELETE)');
 }

--- a/apps/agor-daemon/src/mcp/tools/analytics.ts
+++ b/apps/agor-daemon/src/mcp/tools/analytics.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { resolveRepoId, resolveUserId, resolveWorktreeId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { textResult } from '../utils.js';
 
 export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_analytics_leaderboard

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -28,7 +28,7 @@ import type { ArtifactsService } from '../../services/artifacts.js';
 import { hasWorktreePermission } from '../../utils/worktree-authorization.js';
 import { resolveArtifactId, resolveBoardId, resolveWorktreeId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 const SANDPACK_TEMPLATES = [
   'react',

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BoardsServiceImpl } from '../../declarations.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 export function registerBoardTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_boards_get

--- a/apps/agor-daemon/src/mcp/tools/card-types.ts
+++ b/apps/agor-daemon/src/mcp/tools/card-types.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 export function registerCardTypeTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_card_types_create

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import type { CardsService } from '../../services/cards.js';
 import { resolveBoardId, resolveCardId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 export function registerCardTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_cards_create

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ReposServiceImpl, WorktreesServiceImpl } from '../../declarations.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 import { assertValidVariant } from './_environment-helpers.js';
 
 export function registerEnvironmentTools(server: McpServer, ctx: McpContext): void {

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -2,7 +2,7 @@ import type { MCPServer } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { textResult } from '../utils.js';
 
 /**
  * Standard MCP-server payload returned by the MCP tools. Shared by the catalog

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { isSuperAdmin } from '../../utils/worktree-authorization.js';
 import { resolveSessionId, resolveTaskId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 export function registerMessageTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_messages_list

--- a/apps/agor-daemon/src/mcp/tools/proxies.ts
+++ b/apps/agor-daemon/src/mcp/tools/proxies.ts
@@ -16,7 +16,7 @@ import { getBaseUrl, loadConfig, type ResolvedProxy, resolveProxies } from '@ago
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 interface ProxyDescriptor {
   vendor: string;

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -3,7 +3,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ReposServiceImpl } from '../../declarations.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, textResult } from '../utils.js';
 
 export function registerRepoTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_repos_list

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { coerceJsonRecord, textResult } from '../server.js';
 import { ToolRegistry } from '../tool-registry.js';
+import { coerceJsonRecord, textResult } from '../utils.js';
 
 /**
  * Registered tool entry from the SDK's internal _registeredTools map.

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -60,7 +60,7 @@ async function registerAndCaptureTools(
   ctx: {
     app: unknown;
     userId: string;
-    sessionId: string;
+    sessionId?: string;
   },
   toolNames: string[]
 ): Promise<Record<string, CapturedTool>> {
@@ -90,12 +90,56 @@ async function registerAndCaptureTools(
 }
 
 async function registerAndCaptureHandlers(
-  ctx: { app: unknown; userId: string; sessionId: string },
+  ctx: { app: unknown; userId: string; sessionId?: string },
   toolNames: string[]
 ): Promise<Record<string, ToolHandler>> {
   const tools = await registerAndCaptureTools(ctx, toolNames);
   return Object.fromEntries(Object.entries(tools).map(([name, { cb }]) => [name, cb]));
 }
+
+describe('sessionless API-key context', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('agor_sessions_get_current returns a clean session-context error', async () => {
+    const sessionsGet = vi.fn();
+    const app = makeFakeApp({
+      sessions: { get: sessionsGet },
+    });
+    const { agor_sessions_get_current } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: undefined },
+      ['agor_sessions_get_current']
+    );
+
+    const result = await agor_sessions_get_current({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toMatch(/requires session context/i);
+    expect(parsed.error).toMatch(/X-Agor-Session-Id/);
+    expect(sessionsGet).not.toHaveBeenCalled();
+  });
+
+  it('agor_sessions_spawn returns a clean session-context error', async () => {
+    const spawn = vi.fn();
+    const app = makeFakeApp({
+      sessions: { spawn },
+      '/sessions/:id/prompt': { create: vi.fn() },
+    });
+    const { agor_sessions_spawn } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: undefined },
+      ['agor_sessions_spawn']
+    );
+
+    const result = await agor_sessions_spawn({ prompt: 'delegate this' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toMatch(/requires session context/i);
+    expect(parsed.error).toMatch(/X-Agor-Session-Id/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});
 
 describe('agor_sessions_create', () => {
   const baseWorktree = {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -16,6 +16,7 @@ import {
   type Board,
   getSessionType,
   type Session,
+  type SessionID,
   type SessionType,
   type ZoneBoardObject,
 } from '@agor/core/types';
@@ -31,7 +32,7 @@ import {
   resolveWorktreeId,
 } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { sessionContextRequiredResult, textResult } from '../utils.js';
 import { listAttachedMcpServers } from './mcp-servers.js';
 
 /**
@@ -212,6 +213,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       inputSchema: z.object({}),
     },
     async () => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       const currentSessionParams: SessionParams = {
         ...ctx.baseServiceParams,
         _include_last_message: true,
@@ -219,7 +222,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       };
       const session = await ctx.app
         .service('sessions')
-        .get(ctx.sessionId, currentSessionParams as Parameters<SessionsServiceImpl['get']>[1]);
+        .get(currentSessionId, currentSessionParams as Parameters<SessionsServiceImpl['get']>[1]);
 
       // Denormalize worktree, repo, and board context
       let worktree: Record<string, unknown> | null = null;
@@ -270,7 +273,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         }
       }
 
-      const attached_mcp_servers = await listAttachedMcpServers(ctx, ctx.sessionId);
+      const attached_mcp_servers = await listAttachedMcpServers(ctx, currentSessionId);
 
       return textResult({
         session,
@@ -301,11 +304,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       const includeSiblings = args.includeSiblings !== false;
 
       // Fetch session and user in parallel (no dependencies)
       const [session, user] = await Promise.all([
-        ctx.app.service('sessions').get(ctx.sessionId, ctx.baseServiceParams),
+        ctx.app.service('sessions').get(currentSessionId, ctx.baseServiceParams),
         ctx.app.service('users').get(ctx.userId, ctx.baseServiceParams),
       ]);
 
@@ -504,6 +509,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       const spawnData: Partial<import('@agor/core/types').SpawnConfig> = {
         prompt: args.prompt,
         title: args.title,
@@ -519,7 +526,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       const childSession = await (
         ctx.app.service('sessions') as unknown as SessionsServiceImpl
-      ).spawn(ctx.sessionId, spawnData, ctx.baseServiceParams);
+      ).spawn(currentSessionId, spawnData, ctx.baseServiceParams);
 
       const task = await ctx.app.service('/sessions/:id/prompt').create(
         {
@@ -614,6 +621,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             error: `${targetSession.agentic_tool} does not support session forking. Use mode "subsession" instead to delegate work to a fresh session.`,
           });
         }
+        if (mode === 'btw' && !ctx.sessionId) return sessionContextRequiredResult();
 
         // Shared fork+prompt flow for both "fork" and "btw" modes
         const forkData: { prompt: string; task_id?: string } = { prompt: args.prompt };
@@ -631,7 +639,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           forkPatch.fork_origin = 'btw';
           forkPatch.callback_config = {
             enabled: true,
-            callback_session_id: ctx.sessionId,
+            callback_session_id: ctx.sessionId as SessionID,
             callback_created_by: ctx.userId,
             callback_mode: 'once',
           };
@@ -814,6 +822,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // Determine the effective callback target session ID
       const effectiveCallbackSessionId = args.callbackSessionId || ctx.sessionId;
       const wantsCallback = args.enableCallback || args.callbackSessionId;
+      if (wantsCallback && !effectiveCallbackSessionId) return sessionContextRequiredResult();
 
       // Validate user has prompt permission on the callback target session's worktree
       if (wantsCallback && args.callbackSessionId) {

--- a/apps/agor-daemon/src/mcp/tools/tasks.ts
+++ b/apps/agor-daemon/src/mcp/tools/tasks.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { resolveSessionId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { textResult } from '../utils.js';
 
 export function registerTaskTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_tasks_list

--- a/apps/agor-daemon/src/mcp/tools/users.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.ts
@@ -2,7 +2,7 @@ import { ROLES } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { textResult } from '../utils.js';
 
 export function registerUserTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_users_list

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -24,7 +24,7 @@ import {
   resolveWorktreeId,
 } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, sessionContextRequiredResult, textResult } from '../utils.js';
 import { assertValidVariant } from './_environment-helpers.js';
 
 const WORKTREE_NAME_PATTERN = /^[a-z0-9-]+$/;
@@ -445,6 +445,7 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
       if (coerceString(args.worktreeId)) {
         resolvedWorktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
       } else {
+        if (!ctx.sessionId) return sessionContextRequiredResult();
         const currentSession = await ctx.app.service('sessions').get(ctx.sessionId);
         const sessionWorktreeId = currentSession.worktree_id;
         if (!sessionWorktreeId)

--- a/apps/agor-daemon/src/mcp/utils.ts
+++ b/apps/agor-daemon/src/mcp/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Helper: coerce unknown value to trimmed non-empty string or undefined.
+ */
+export function coerceString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Helper: coerce a possibly-stringified JSON value to a Record, or return as-is.
+ *
+ * Some MCP clients double-serialize nested objects as JSON strings (especially
+ * with large or complex content). This helper transparently parses those back.
+ * Returns the original value unchanged if it's not a string or not valid JSON.
+ */
+export function coerceJsonRecord(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Helper: format a value as MCP text content response.
+ */
+export function textResult(data: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+export const SESSION_CONTEXT_REQUIRED_MESSAGE =
+  'This tool requires session context. Pass X-Agor-Session-Id or ?sessionId= to scope the request.';
+
+export function sessionContextRequiredResult() {
+  return textResult({ error: SESSION_CONTEXT_REQUIRED_MESSAGE });
+}


### PR DESCRIPTION
## Summary

Three-commit series that makes the Agor MCP endpoint usable by **external orchestrators** (Hermes and similar long-running agent harnesses) without binding every request to a specific session.

1. **\`feat(ui): expose Personal API Keys in main settings\`**
   Adds a Personal API Keys panel to the main Settings modal so a user can mint long-lived \`agor_sk_*\` keys for off-session use (Hermes, CLI tooling, IDE extensions, etc.). The keys already existed at the daemon layer; this exposes them in a normal place to manage.

2. **\`feat(mcp): add SSE-capable /mcp session transport\`**
   Adds streamable-HTTP / SSE support to \`POST /mcp\` so clients that want a persistent session (GET /mcp for the stream, DELETE /mcp to terminate) can use it alongside the existing stateless POST path. The server keeps a per-\`mcp-session-id\` transport map and enforces that the session belongs to the authenticated user.

3. **\`feat(mcp): allow sessionless access with personal API keys\`**
   Drops the hard \`sessionId\` requirement on every MCP request. Personal API keys exist to call MCP without picking a specific Agor session up front. Tools that genuinely need a current session (e.g. \`agor_sessions_get_current_context\`, spawn) still surface their own error when \`ctx.sessionId\` is undefined; everything else (search, list, get-by-id, board/worktree ops) just works.

## Motivation

External orchestrators want to discover and invoke MCP tools before they know which Agor session a given task belongs to (or to invoke tools that aren't session-scoped at all). The current gate forces \`?sessionId=\` / \`X-Agor-Session-Id\` on every call, which breaks tool discovery and any sessionless workflow.

## Notes

- Session tokens (the in-UI flow) are unchanged.
- The auth boundary is unchanged: every request still authenticates via session JWT or personal API key; only the orthogonal session-context gate is relaxed.
- SSE transport is opt-in per request via the standard MCP \`mcp-session-id\` header; existing stateless POST callers see no change.

## Test plan

- [ ] Mint a personal API key in Settings → Personal API Keys
- [ ] \`curl -X POST http://localhost:3030/mcp -H 'Authorization: Bearer agor_sk_...' -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}'\` — returns the tool list without \`?sessionId=\`
- [ ] Initialize a streamable HTTP session (POST with \`initialize\`), then GET /mcp with the returned \`mcp-session-id\` — server streams events back
- [ ] DELETE /mcp with the \`mcp-session-id\` cleanly tears down the transport
- [ ] Call a session-scoped tool (e.g. \`agor_sessions_get_current_context\`) without session context — returns a clear error pointing at \`X-Agor-Session-Id\` / \`?sessionId\`
- [ ] Existing session-token flow from the UI continues to work unchanged