### PR TITLE
fix(onboarding): unbreak SSH-configured users + surface clone failures

### DIFF
--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -7,7 +7,7 @@
  */
 
 import { type Database, SessionRepository, WorktreeRepository } from '@agor/core/db';
-import { simpleGit } from '@agor/core/git';
+import { createGit } from '@agor/core/git';
 import type { SessionID } from '@agor/core/types';
 
 // Constants for file search
@@ -66,8 +66,11 @@ export class FilesService {
         return [];
       }
 
-      // Run git ls-files
-      const git = simpleGit(worktree.path);
+      // Run git ls-files. Use the shared factory so the unsafe-ops scanner
+      // is opt-in here too — otherwise a daemon env that happens to carry
+      // `GIT_SSH_COMMAND` (or similar) trips the scanner before the command
+      // ever reaches git.
+      const { git } = createGit(worktree.path);
       let result: string;
 
       try {

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -26,6 +26,7 @@ import { type Database, RepoRepository, WorktreeRepository } from '@agor/core/db
 import { autoAssignWorktreeUniqueId } from '@agor/core/environment/variable-resolver';
 import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
+  createGit,
   extractRepoName,
   getDefaultBranch,
   getRemoteUrl,
@@ -33,7 +34,6 @@ import {
   getWorktreePath,
   isValidGitRepo,
   listWorktrees,
-  simpleGit,
 } from '@agor/core/git';
 import type {
   AuthenticatedParams,
@@ -592,7 +592,10 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // This gives the user immediate feedback instead of a silent fire-and-forget failure
     if (repo.local_path) {
       try {
-        const git = simpleGit(repo.local_path);
+        // Use the shared factory so the unsafe-ops scanner is opt-in
+        // (otherwise a daemon env carrying GIT_SSH_COMMAND or similar
+        // would throw before the fetch even ran).
+        const { git } = createGit(repo.local_path);
 
         // Check 1: Validate sourceBranch exists on remote (if specified)
         // Skip for tags — tags are validated differently (they don't have origin/ prefix)

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -184,10 +184,38 @@ const AGENT_LABELS: Record<AgenticToolName, string> = {
 };
 
 /**
+ * A repo is "usable" once its clone has actually completed. After PR #1126
+ * the daemon pre-creates a placeholder row with `clone_status: 'cloning'`
+ * before the executor runs — matching it as if it were finished caused the
+ * wizard to auto-advance off the `'clone'` step within ~50ms, which then
+ * dropped the subsequent `repo:cloneError` event (its listener filters on
+ * `currentStep === 'clone'`). Legacy rows have no `clone_status`; treat
+ * those as ready too so existing repos still match.
+ */
+function isRepoReady(repo: Repo): boolean {
+  return repo.clone_status === 'ready' || repo.clone_status === undefined;
+}
+
+/**
+ * Find the framework repo only when it's actually usable. Wraps
+ * `findFrameworkRepo` (which intentionally returns placeholders so
+ * AssistantTab / AssistantsTable can detect "exists") with the wizard's
+ * stricter "clone finished" filter.
+ */
+function findReadyFrameworkRepo(repoById: Map<string, Repo>): [string, Repo] | undefined {
+  const found = findFrameworkRepo(repoById);
+  return found && isRepoReady(found[1]) ? found : undefined;
+}
+
+/**
  * Find a repo in the wizard's in-memory map that matches the user's input.
  * Used by both the clone-complete auto-advance effect and the board/worktree
  * safety-net effect — centralised here so the match criteria cannot drift
  * between the two.
+ *
+ * Placeholder rows (`clone_status: 'cloning' | 'failed'`) are skipped — the
+ * caller asked "is the clone done yet?", and the answer for a placeholder
+ * is no.
  */
 function findMatchingRepoId(
   repoById: Map<string, Repo>,
@@ -195,6 +223,7 @@ function findMatchingRepoId(
 ): string | null {
   const normalizedInput = criteria.remoteUrl ? normalizeRepoUrl(criteria.remoteUrl) : '';
   for (const [id, repo] of repoById) {
+    if (!isRepoReady(repo)) continue;
     if (
       (normalizedInput &&
         repo.remote_url &&
@@ -361,8 +390,11 @@ export function OnboardingWizard({
       // Board exists — go to worktree creation
       setCurrentStep('worktree');
     } else if (resumedPath === 'assistant') {
-      // Check if the framework repo already exists
-      const found = findFrameworkRepo(repoById);
+      // Check if the framework repo is registered AND finished cloning.
+      // A placeholder (`clone_status: 'cloning'`) or `'failed'` row means
+      // the previous clone is still in flight or stuck — resume on the
+      // clone step so the user can wait it out or hit Retry.
+      const found = findReadyFrameworkRepo(repoById);
       if (found) {
         setCreatedRepoId(found[0]);
       }
@@ -393,8 +425,11 @@ export function OnboardingWizard({
     if (currentStep !== 'clone' || !loading) return;
 
     if (path === 'assistant') {
-      // Look for framework repo
-      const found = findFrameworkRepo(repoById);
+      // Only advance once the framework repo is actually cloned. Matching
+      // the pre-created placeholder (`clone_status: 'cloning'`) would push
+      // us off the clone step before `repo:cloneError` arrives, so a real
+      // failure would never reach `handleCloneError`. See `isRepoReady`.
+      const found = findReadyFrameworkRepo(repoById);
       if (found) {
         setCreatedRepoId(found[0]);
         setLoading(false);
@@ -438,9 +473,10 @@ export function OnboardingWizard({
       setCreatedRepoId(matchId);
       return;
     }
-    // For assistant path, find framework repo
+    // For assistant path, find framework repo (placeholders excluded —
+    // `createdRepoId` should point at a real, cloned repo).
     if (path === 'assistant') {
-      const found = findFrameworkRepo(repoById);
+      const found = findReadyFrameworkRepo(repoById);
       if (found) {
         setCreatedRepoId(found[0]);
       }
@@ -476,31 +512,57 @@ export function OnboardingWizard({
   }, [currentStep, loading, worktreeById, createdWorktreeId]);
 
   // ─── Listen for clone error events from backend ──
+  // Two redundant channels because event ordering is not guaranteed and we
+  // want whichever lands first to break the spinner:
+  //
+  //  1. `repo:cloneError` (WebSocket broadcast from `cloneRepository`'s
+  //     onExit safety net) — fires only when the executor exits non-zero
+  //     and carries a generic, branch-aware message.
+  //  2. `repos.patched` (Feathers service event) — fires whenever the
+  //     placeholder row transitions to `clone_status: 'failed'`. The patch
+  //     payload includes `clone_error.message` (the first line of git's
+  //     stderr) which is far more useful than the generic WS message —
+  //     e.g. "configuring core.sshCommand is not permitted…" surfaces
+  //     verbatim instead of being swallowed into "Clone failed (exit 1)".
   useEffect(() => {
     if (!client?.io) return;
 
-    const handleCloneError = (data: { slug: string; url: string; error: string }) => {
-      // Only handle if we're on the clone step and loading
+    const isOurCloneByIdentity = (slug: string | undefined, url: string | undefined) =>
+      (path === 'assistant' && slug === FRAMEWORK_REPO_SLUG) ||
+      (path === 'own-repo' && ((url && url === repoUrl) || (slug && slug === repoSlug)));
+
+    const surfaceError = (message: string) => {
+      // Only handle if we're on the clone step and loading. If the user has
+      // moved on (or the wizard never reached `'clone'`), don't yank state.
       if (currentStep !== 'clone' || !loading) return;
-
-      // Check if the error is for our clone operation
-      const isOurClone =
-        (path === 'assistant' && data.slug === FRAMEWORK_REPO_SLUG) ||
-        (path === 'own-repo' && (data.url === repoUrl || data.slug === repoSlug));
-
-      if (isOurClone) {
-        setLoading(false);
-        setError(data.error);
-        if (cloneTimeoutRef.current) {
-          clearTimeout(cloneTimeoutRef.current);
-          cloneTimeoutRef.current = null;
-        }
+      setLoading(false);
+      setError(message);
+      if (cloneTimeoutRef.current) {
+        clearTimeout(cloneTimeoutRef.current);
+        cloneTimeoutRef.current = null;
       }
     };
 
+    const handleCloneError = (data: { slug: string; url: string; error: string }) => {
+      if (!isOurCloneByIdentity(data.slug, data.url)) return;
+      surfaceError(data.error);
+    };
+
+    const handleRepoPatched = (repo: Repo) => {
+      if (repo.clone_status !== 'failed') return;
+      if (!isOurCloneByIdentity(repo.slug, repo.remote_url)) return;
+      // Prefer the row's specific error; fall back to a generic message.
+      const message =
+        repo.clone_error?.message ?? `Clone failed (exit ${repo.clone_error?.exit_code ?? '?'}).`;
+      surfaceError(message);
+    };
+
+    const reposService = client.service('repos');
     client.io.on('repo:cloneError', handleCloneError);
+    reposService.on('patched', handleRepoPatched);
     return () => {
       client.io.off('repo:cloneError', handleCloneError);
+      reposService.removeListener('patched', handleRepoPatched);
     };
   }, [client, currentStep, loading, path, repoUrl, repoSlug]);
 
@@ -552,8 +614,11 @@ export function OnboardingWizard({
       saveOnboardingProgress({ path: selectedPath });
 
       if (selectedPath === 'assistant') {
-        // Check if framework repo already exists
-        const found = findFrameworkRepo(repoById);
+        // Check if framework repo already exists AND is cloned. A leftover
+        // placeholder/failed row means the previous attempt didn't finish —
+        // route the user to the clone step so they see the spinner (or
+        // error + Retry) instead of being sent on with no usable repo.
+        const found = findReadyFrameworkRepo(repoById);
         if (found) {
           setCreatedRepoId(found[0]);
           setCurrentStep('board');

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -291,6 +291,10 @@ export function OnboardingWizard({
   // Elapsed time for clone progress
   const [cloneElapsedSeconds, setCloneElapsedSeconds] = useState(0);
   const cloneIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Repo IDs that were already failed when the current clone attempt started.
+  // The failure watcher ignores these so a stale row from a prior attempt never
+  // immediately cancels a new retry before the daemon has a chance to replace it.
+  const knownFailedRepoIdsRef = useRef<Set<string>>(new Set());
 
   // ─── Derived ──────────────────────────────────────
   const steps = useMemo(() => getStepsForPath(path), [path]);
@@ -522,6 +526,9 @@ export function OnboardingWizard({
     let failedRepo: Repo | undefined;
     for (const [, repo] of repoById) {
       if (repo.clone_status !== 'failed') continue;
+      // Skip rows that were already failed when this attempt started — those are
+      // stale from a prior attempt and will be replaced by the daemon shortly.
+      if (knownFailedRepoIdsRef.current.has(repo.repo_id)) continue;
       if (
         (path === 'assistant' &&
           (repo.slug === FRAMEWORK_REPO_SLUG || repo.remote_url?.includes('agor-assistant'))) ||
@@ -671,6 +678,15 @@ export function OnboardingWizard({
   );
 
   const handleStartClone = useCallback(async () => {
+    // Snapshot which repos are already failed before this attempt starts.
+    // The repoById failure watcher ignores these IDs so a stale row from a
+    // previous attempt never immediately cancels the new clone.
+    const snapshot = new Set<string>();
+    for (const [id, repo] of repoById) {
+      if (repo.clone_status === 'failed') snapshot.add(id);
+    }
+    knownFailedRepoIdsRef.current = snapshot;
+
     setError(null);
     setLoading(true);
     setCloneElapsedSeconds(0);
@@ -744,6 +760,7 @@ export function OnboardingWizard({
     repoUrl,
     repoSlug,
     localRepoPath,
+    repoById,
     onCreateRepo,
     onCreateLocalRepo,
   ]);

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -197,14 +197,12 @@ function isRepoReady(repo: Repo): boolean {
 }
 
 /**
- * Find the framework repo only when it's actually usable. Wraps
- * `findFrameworkRepo` (which intentionally returns placeholders so
- * AssistantTab / AssistantsTable can detect "exists") with the wizard's
- * stricter "clone finished" filter.
+ * Find the framework repo only when it's actually usable. Uses `readyOnly`
+ * so non-ready candidates are excluded **before** priority selection —
+ * a stale failed/cloning private fork never hides a ready public repo.
  */
 function findReadyFrameworkRepo(repoById: Map<string, Repo>): [string, Repo] | undefined {
-  const found = findFrameworkRepo(repoById);
-  return found && isRepoReady(found[1]) ? found : undefined;
+  return findFrameworkRepo(repoById, { readyOnly: true });
 }
 
 /**
@@ -510,6 +508,46 @@ export function OnboardingWizard({
       }
     }
   }, [currentStep, loading, worktreeById, createdWorktreeId]);
+
+  // ─── Watch repoById for clone failure (state-driven, race-free) ──
+  // Events can arrive while the listener closure still has `loading=false`
+  // (between handleStartClone() setting loading=true and the next React render
+  // re-registering the effect). Reading failure from authoritative repoById
+  // state covers that race AND durable failure on remount (if the event was
+  // already missed). Logic mirrors the auto-advance effect above, but for
+  // clone_status: 'failed' rather than 'ready'.
+  useEffect(() => {
+    if (currentStep !== 'clone' || !loading) return;
+
+    let failedRepo: Repo | undefined;
+    for (const [, repo] of repoById) {
+      if (repo.clone_status !== 'failed') continue;
+      if (
+        (path === 'assistant' &&
+          (repo.slug === FRAMEWORK_REPO_SLUG || repo.remote_url?.includes('agor-assistant'))) ||
+        (path === 'own-repo' &&
+          ((repoUrl &&
+            repo.remote_url &&
+            normalizeRepoUrl(repo.remote_url) === normalizeRepoUrl(repoUrl)) ||
+            (repoSlug && repo.slug === repoSlug) ||
+            (localRepoPath && repo.local_path === localRepoPath)))
+      ) {
+        failedRepo = repo;
+        break;
+      }
+    }
+
+    if (!failedRepo) return;
+    const message =
+      failedRepo.clone_error?.message ??
+      `Clone failed (exit ${failedRepo.clone_error?.exit_code ?? '?'}).`;
+    setLoading(false);
+    setError(message);
+    if (cloneTimeoutRef.current) {
+      clearTimeout(cloneTimeoutRef.current);
+      cloneTimeoutRef.current = null;
+    }
+  }, [currentStep, loading, path, repoById, repoUrl, repoSlug, localRepoPath]);
 
   // ─── Listen for clone error events from backend ──
   // Two redundant channels because event ordering is not guaranteed and we

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -516,10 +516,10 @@ export function OnboardingWizard({
   // ─── Watch repoById for clone failure (state-driven, race-free) ──
   // Events can arrive while the listener closure still has `loading=false`
   // (between handleStartClone() setting loading=true and the next React render
-  // re-registering the effect). Reading failure from authoritative repoById
-  // state covers that race AND durable failure on remount (if the event was
-  // already missed). Logic mirrors the auto-advance effect above, but for
-  // clone_status: 'failed' rather than 'ready'.
+  // re-registering the effect). Reading from authoritative repoById covers that
+  // race without relying on event delivery. Pre-existing failed rows (stale from
+  // prior attempts) are excluded via knownFailedRepoIdsRef — see handleStartClone.
+  // Logic mirrors the auto-advance effect above, but for clone_status: 'failed'.
   useEffect(() => {
     if (currentStep !== 'clone' || !loading) return;
 

--- a/apps/agor-ui/src/hooks/useFrameworkRepo.ts
+++ b/apps/agor-ui/src/hooks/useFrameworkRepo.ts
@@ -50,14 +50,25 @@ export function useFrameworkRepo(repos: Repo[]): Repo | undefined {
 
 /**
  * Non-hook version for use in loops / imperative code (e.g., OnboardingWizard effects).
+ *
+ * When `readyOnly` is true, non-ready repos (`clone_status: 'cloning' | 'failed'`) are
+ * excluded **before** priority selection, so a stale/failed higher-priority match (e.g.
+ * an abandoned `agor-assistant-private` clone) never hides a ready lower-priority repo.
  */
-export function findFrameworkRepo(repos: Iterable<[string, Repo]>): [string, Repo] | undefined {
+export function findFrameworkRepo(
+  repos: Iterable<[string, Repo]>,
+  options?: { readyOnly?: boolean }
+): [string, Repo] | undefined {
   const repoArray: Repo[] = [];
   const entryMap = new Map<string, [string, Repo]>();
 
   for (const entry of repos) {
-    repoArray.push(entry[1]);
-    entryMap.set(entry[1].repo_id, entry);
+    const repo = entry[1];
+    if (options?.readyOnly && repo.clone_status !== 'ready' && repo.clone_status !== undefined) {
+      continue;
+    }
+    repoArray.push(repo);
+    entryMap.set(repo.repo_id, entry);
   }
 
   const best = findBestFrameworkRepo(repoArray);

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -366,6 +366,12 @@ export function redactGitEnv(env: Record<string, string | undefined>): Record<st
  * `/etc/gitconfig` is intentionally NOT killed — admin policy territory
  * (CA bundles, proxies, safe.directory).
  *
+ * **env isolation**: `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_TERMINAL_PROMPT=0` are
+ * only set when `env` is provided (or an auth token is found in it). Callers
+ * that omit `env` (e.g. `createGit(worktreePath)`) intentionally inherit the
+ * daemon process environment so they can read `/etc/gitconfig`, `safe.directory`,
+ * and other admin-policy config. They still get the `unsafe.*` scanner opt-ins.
+ *
  * @param authHost - Host to scope the auth header to. When omitted, falls back
  *                   to github.com; callers should derive this via
  *                   {@link parseHostFromGitUrl} or {@link resolveAuthHost}.
@@ -580,7 +586,10 @@ export async function cloneRepo(options: CloneOptions): Promise<CloneResult> {
     }
   }
 
-  // Create git instance with user env vars (SSH host key checking is always disabled).
+  // Create git instance with user env vars. Auth headers are injected via
+  // http.extraheader; GIT_CONFIG_GLOBAL isolation is active only when env is
+  // provided (intentional — callers without env inherit the daemon process
+  // environment so they can read /etc/gitconfig, safe.directory, etc.).
   // Derive the auth-header host from the clone URL so GitHub Enterprise and
   // self-hosted GitLab work without per-deployment configuration. (Bitbucket
   // Cloud needs a different username shape — see buildAuthHeaderEnv comments.)
@@ -1411,7 +1420,8 @@ export async function deleteBranch(repoPath: string, branchName: string): Promis
 }
 
 /**
- * Re-export simpleGit for use in services
- * Allows other packages to use simple-git through @agor/core dependency
+ * Re-export for test helpers only.
+ * Production service code must use createGit() to get the unsafe-ops flags,
+ * env hardening, and consistent git binary selection.
  */
 export { simpleGit };

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -58,8 +58,12 @@ export async function validateGitRef(ref: unknown): Promise<void> {
   // fails outside a git worktree — breaking callers like the seed script
   // that validate refs before a repo exists. The non-`--branch` form is
   // pure syntactic validation and needs no git context.
-  const gitBinary = getGitBinary();
-  const git = simpleGit({ binary: gitBinary });
+  //
+  // Route through `createGit` so the unsafe-ops scanner is opt-in here too
+  // — otherwise a daemon env carrying `GIT_SSH_COMMAND` (or similar) would
+  // throw a confusing "not permitted without enabling allowUnsafeSshCommand"
+  // out of what is meant to be a pure syntactic check.
+  const { git } = createGit();
   try {
     await git.raw(['check-ref-format', `refs/heads/${ref}`]);
   } catch {
@@ -373,11 +377,18 @@ export function createGit(
 ): { git: ReturnType<typeof simpleGit> } {
   const gitBinary = getGitBinary();
 
-  // Non-secret config stays in `config:` (becomes `-c key=value` on argv,
-  // which is fine for these values).
-  const config = [
-    'core.sshCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null',
-  ];
+  // No `-c core.sshCommand=...` injection. PR #786 added one to skip the
+  // first-time-host SSH prompt in Docker — but it silently overrode the
+  // user's intentional `core.sshCommand` from `~/.gitconfig` on every
+  // daemon-issued op AND was the argv that tripped simple-git's bundled
+  // `@simple-git/argv-parser` ("Configuring core.sshCommand is not
+  // permitted…"). `GIT_CONFIG_GLOBAL=/dev/null` (set below) is the correct
+  // way to neutralize the user gitconfig for token-carrying ops; the
+  // `unsafe.allowUnsafeSshCommand` flag below remains as defense-in-depth
+  // for anything else that injects `core.sshCommand` (e.g. an SSH-origin
+  // pull whose existing `.git/config` carries one). Agor's daemon-issued
+  // ops are HTTPS+token regardless (`clone-redesign.md`).
+  const config: string[] = [];
 
   // Auth header config goes through env vars so the token never lands on
   // argv. buildAuthHeaderEnv returns [] when no usable token is supplied.


### PR DESCRIPTION
## Summary

- **Bug A (SSH guard fires for users with `core.sshCommand` in `~/.gitconfig`)**: Remove the unconditional `-c core.sshCommand=...` arg injection from `createGit()` that was added in PR #786 for Docker SSH host verification. The injection was redundant (`GIT_CONFIG_GLOBAL=/dev/null` already neutralises `~/.gitconfig` during daemon ops) and caused simple-git's unsafe-ops scanner to throw for users with their own `core.sshCommand`. Also routes all three bare `simpleGit()` callers (`files.ts`, `repos.ts`, `validateGitRef`) through `createGit()` so they inherit the unsafe flags and env hardening.
- **Bug B (spinner hangs forever on clone failure)**: The wizard auto-advanced the moment a placeholder repo row appeared with `clone_status:'cloning'` (PR #1126's land-and-advance pattern), and the clone error arrived later via WebSocket to a step the wizard had already left. Fix: gate all four `findFrameworkRepo()` lookups on `isRepoReady()` (only advances when `clone_status` is `'ready'` or `undefined`). Also adds a `repos.patched` listener as a second error-surfacing channel with the richer `clone_error.message` (actual git stderr).

## Changed files

- `packages/core/src/git/index.ts` — remove `-c core.sshCommand=...` injection; route `validateGitRef` through `createGit()`
- `apps/agor-daemon/src/services/files.ts` — route `simpleGit()` → `createGit()`
- `apps/agor-daemon/src/services/repos.ts` — route `simpleGit()` → `createGit()`
- `apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx` — `isRepoReady()` guard + `repos.patched` error listener

## Test plan

- [ ] User with `core.sshCommand` in `~/.gitconfig` can complete the onboarding clone step without error
- [ ] Clone failure (bad URL, auth error) shows an error message in the wizard instead of a spinning loader
- [ ] Clone success still auto-advances the wizard to the next step
- [ ] `git ls-files` in the files autocomplete service still works when daemon env has `GIT_SSH_COMMAND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)