### PR TITLE
fix(ui): always render artifact card header + add delete confirm

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -53,7 +53,18 @@ import {
   useSandpack,
   useSandpackConsole,
 } from '@codesandbox/sandpack-react';
-import { Alert, Badge, Button, Card, Spin, Tag, Tooltip, Typography, theme } from 'antd';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Popconfirm,
+  Spin,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import { compressToBase64 } from 'lz-string';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
@@ -557,59 +568,214 @@ export const ArtifactNode = ({
     window.dispatchEvent(new CustomEvent(`agor:export-codesandbox-${data.artifactId}`));
   }, [data.artifactId]);
 
-  // Loading state
+  // Title bar — always rendered, regardless of load state. When the
+  // payload hasn't come back yet (initial fetch in flight, or the row's
+  // files column got corrupted and getPayload threw), the user still
+  // needs to see which card is which on the board so they can hit the
+  // reload or delete button. We fall back to a short-id placeholder
+  // until `payload.name` is available.
+  //
+  // The action buttons split into two groups: the ones that need a
+  // valid payload to do anything useful (export, interact, consent)
+  // only render when `payload` exists; reload and delete are always
+  // available so a stuck artifact can be retried or removed.
+  const fallbackName = `Artifact ${data.artifactId.slice(0, 8)}`;
+  const headerBadgeStatus: 'processing' | 'error' | 'success' = error
+    ? 'error'
+    : loading
+      ? 'processing'
+      : 'success';
+  const headerBadgeTitle = error ? 'Failed to load' : loading ? 'Reloading...' : 'Live';
+  const trustBadge = payload ? renderTrustBadge(payload) : null;
+  const showConsentAffordance =
+    payload?.trust_state === 'untrusted' &&
+    (((payload.required_env_vars && payload.required_env_vars.length > 0) ||
+      (payload.agor_grants && Object.keys(payload.agor_grants).length > 0)) ??
+      false);
+
+  const cardTitle = (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+        <Badge status={headerBadgeStatus} title={headerBadgeTitle} />
+        <Typography.Text
+          style={{ fontSize: 12, fontWeight: 600, maxWidth: data.width - 200 }}
+          ellipsis
+        >
+          {payload?.name ?? fallbackName}
+        </Typography.Text>
+        {trustBadge}
+      </div>
+      <div style={{ display: 'flex', gap: 2 }}>
+        {showConsentAffordance && (
+          <Tooltip title="Trust this artifact to inject secrets">
+            <Button
+              type="text"
+              size="small"
+              // `danger` themes the icon via Ant's colorError token —
+              // signals "this artifact won't render with secrets until
+              // you grant trust" without us hardcoding a hex.
+              danger
+              icon={<LockOutlined />}
+              onClick={(e) => {
+                e.stopPropagation();
+                setConsentOpen(true);
+              }}
+            />
+          </Tooltip>
+        )}
+        {payload && (
+          <Tooltip title="Open in CodeSandbox (eject — daemon-injected env vars/AGOR_TOKEN won't carry over)">
+            <Button
+              type="text"
+              size="small"
+              icon={<ExportOutlined />}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleOpenInCodeSandbox();
+              }}
+            />
+          </Tooltip>
+        )}
+        <Tooltip title="Reload">
+          <Button
+            type="text"
+            size="small"
+            icon={<ReloadOutlined spin={loading} />}
+            onClick={(e) => {
+              e.stopPropagation();
+              fetchPayload();
+            }}
+          />
+        </Tooltip>
+        {payload && (
+          <Tooltip title={interactMode ? 'Exit interact mode' : 'Interact with app'}>
+            <Button
+              type={interactMode ? 'primary' : 'text'}
+              size="small"
+              icon={interactMode ? <CheckCircleOutlined /> : <EyeOutlined />}
+              onClick={(e) => {
+                e.stopPropagation();
+                setInteractMode((prev) => !prev);
+              }}
+            />
+          </Tooltip>
+        )}
+        {data.onDeleteArtifact && (
+          <Popconfirm
+            title="Delete artifact?"
+            description={`This will remove "${payload?.name ?? fallbackName}" from the board.`}
+            onConfirm={(e) => {
+              e?.stopPropagation();
+              data.onDeleteArtifact?.(data.objectId, data.artifactId);
+            }}
+            onCancel={(e) => e?.stopPropagation()}
+            okText="Delete"
+            cancelText="Cancel"
+            okButtonProps={{ danger: true }}
+          >
+            <Tooltip title="Delete artifact">
+              <Button
+                type="text"
+                size="small"
+                danger
+                icon={<DeleteOutlined />}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </Tooltip>
+          </Popconfirm>
+        )}
+      </div>
+    </div>
+  );
+
+  // Shared Card chrome — body content swaps based on load state but the
+  // title bar stays put so the user always knows which artifact this is.
+  const cardOuterStyle = {
+    width: data.width,
+    height: data.height,
+    background: token.colorBgContainer,
+    border: `2px solid ${error ? token.colorErrorBorder : selected ? token.colorPrimary : token.colorBorder}`,
+    borderRadius: 8,
+    boxShadow: token.boxShadowSecondary,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  } as const;
+
+  // Loading state — title bar is still visible (with reload + delete) so
+  // a stuck loader can be retried or pruned.
   if (loading && !payload) {
     return (
-      <Card
-        style={{
-          width: data.width,
-          height: data.height,
-          background: token.colorBgContainer,
-          border: `2px solid ${token.colorBorder}`,
-          borderRadius: 8,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-        styles={{
-          body: { display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' },
-        }}
-      >
-        <Spin indicator={<LoadingOutlined />} description="Loading artifact..." />
-      </Card>
+      <>
+        <NodeResizer
+          isVisible={selected}
+          minWidth={MIN_WIDTH}
+          minHeight={MIN_HEIGHT}
+          onResize={handleResize}
+          lineStyle={{ borderColor: token.colorPrimary }}
+          handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
+        />
+        <Card
+          style={cardOuterStyle}
+          styles={{
+            body: {
+              padding: 0,
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+          }}
+          size="small"
+          title={cardTitle}
+        >
+          <Spin indicator={<LoadingOutlined />} description="Loading artifact..." />
+        </Card>
+      </>
     );
   }
 
-  // Error state
+  // Error state — title bar visible so the user can see which artifact
+  // failed and act on it (Retry / Delete) without guessing.
   if (error) {
     return (
-      <Card
-        style={{
-          width: data.width,
-          height: data.height,
-          background: token.colorBgContainer,
-          border: `2px solid ${token.colorErrorBorder}`,
-          borderRadius: 8,
-        }}
-        styles={{
-          body: {
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            height: '100%',
-            gap: 8,
-          },
-        }}
-      >
-        <CloseCircleOutlined style={{ fontSize: 24, color: token.colorError }} />
-        <Typography.Text type="danger" style={{ fontSize: 12, textAlign: 'center' }}>
-          {error}
-        </Typography.Text>
-        <Button size="small" icon={<ReloadOutlined />} onClick={fetchPayload}>
-          Retry
-        </Button>
-      </Card>
+      <>
+        <NodeResizer
+          isVisible={selected}
+          minWidth={MIN_WIDTH}
+          minHeight={MIN_HEIGHT}
+          onResize={handleResize}
+          lineStyle={{ borderColor: token.colorPrimary }}
+          handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
+        />
+        <Card
+          style={cardOuterStyle}
+          styles={{
+            body: {
+              padding: 0,
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+            },
+          }}
+          size="small"
+          title={cardTitle}
+        >
+          <CloseCircleOutlined style={{ fontSize: 24, color: token.colorError }} />
+          <Typography.Text
+            type="danger"
+            style={{ fontSize: 12, textAlign: 'center', padding: '0 16px' }}
+          >
+            {error}
+          </Typography.Text>
+          <Button size="small" icon={<ReloadOutlined />} onClick={fetchPayload}>
+            Retry
+          </Button>
+        </Card>
+      </>
     );
   }
 
@@ -624,11 +790,6 @@ export const ArtifactNode = ({
       : {}),
   };
   const sandpackTemplate = (sandpackConfig.template ?? payload.template) as 'react';
-  const trustBadge = renderTrustBadge(payload);
-  const showConsentAffordance =
-    payload.trust_state === 'untrusted' &&
-    ((payload.required_env_vars && payload.required_env_vars.length > 0) ||
-      (payload.agor_grants && Object.keys(payload.agor_grants).length > 0));
   const legacyBanner = payload.legacy?.is_legacy ? (
     <LegacyBanner upgradeInstructions={payload.legacy.upgrade_instructions} />
   ) : null;
@@ -644,17 +805,7 @@ export const ArtifactNode = ({
         handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
       />
       <Card
-        style={{
-          width: data.width,
-          height: data.height,
-          background: token.colorBgContainer,
-          border: `2px solid ${selected ? token.colorPrimary : token.colorBorder}`,
-          borderRadius: 8,
-          boxShadow: token.boxShadowSecondary,
-          overflow: 'hidden',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
+        style={cardOuterStyle}
         styles={{
           body: {
             padding: 0,
@@ -665,87 +816,7 @@ export const ArtifactNode = ({
           },
         }}
         size="small"
-        title={
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
-              <Badge
-                status={loading ? 'processing' : 'success'}
-                title={loading ? 'Reloading...' : 'Live'}
-              />
-              <Typography.Text
-                style={{ fontSize: 12, fontWeight: 600, maxWidth: data.width - 200 }}
-                ellipsis
-              >
-                {payload.name}
-              </Typography.Text>
-              {trustBadge}
-            </div>
-            <div style={{ display: 'flex', gap: 2 }}>
-              {showConsentAffordance && (
-                <Tooltip title="Trust this artifact to inject secrets">
-                  <Button
-                    type="text"
-                    size="small"
-                    // `danger` themes the icon via Ant's colorError token —
-                    // signals "this artifact won't render with secrets until
-                    // you grant trust" without us hardcoding a hex.
-                    danger
-                    icon={<LockOutlined />}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setConsentOpen(true);
-                    }}
-                  />
-                </Tooltip>
-              )}
-              <Tooltip title="Open in CodeSandbox (eject — daemon-injected env vars/AGOR_TOKEN won't carry over)">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<ExportOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleOpenInCodeSandbox();
-                  }}
-                />
-              </Tooltip>
-              <Tooltip title="Reload">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<ReloadOutlined spin={loading} />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    fetchPayload();
-                  }}
-                />
-              </Tooltip>
-              <Tooltip title={interactMode ? 'Exit interact mode' : 'Interact with app'}>
-                <Button
-                  type={interactMode ? 'primary' : 'text'}
-                  size="small"
-                  icon={interactMode ? <CheckCircleOutlined /> : <EyeOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setInteractMode((prev) => !prev);
-                  }}
-                />
-              </Tooltip>
-              {data.onDeleteArtifact && (
-                <Button
-                  type="text"
-                  size="small"
-                  danger
-                  icon={<DeleteOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    data.onDeleteArtifact?.(data.objectId, data.artifactId);
-                  }}
-                />
-              )}
-            </div>
-          </div>
-        }
+        title={cardTitle}
       >
         {/* Force Sandpack internal containers to fill available height */}
         <style>{`

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -587,11 +587,18 @@ export const ArtifactNode = ({
       : 'success';
   const headerBadgeTitle = error ? 'Failed to load' : loading ? 'Reloading...' : 'Live';
   const trustBadge = payload ? renderTrustBadge(payload) : null;
+  // A loaded payload that's also in the error state is stale — the body
+  // renders the error placeholder, so the header shouldn't expose
+  // payload-acting controls (Export / Interact / Consent) that operate
+  // on the stale data. Keep the title + Reload + Delete though, since
+  // those still help the user act on the broken state.
+  const hasUsablePayload = !!payload && !error;
+  const hasRequiredEnvVars = (payload?.required_env_vars?.length ?? 0) > 0;
+  const hasConsentGrants = Object.keys(payload?.agor_grants ?? {}).length > 0;
   const showConsentAffordance =
+    hasUsablePayload &&
     payload?.trust_state === 'untrusted' &&
-    (((payload.required_env_vars && payload.required_env_vars.length > 0) ||
-      (payload.agor_grants && Object.keys(payload.agor_grants).length > 0)) ??
-      false);
+    (hasRequiredEnvVars || hasConsentGrants);
 
   const cardTitle = (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -605,7 +612,12 @@ export const ArtifactNode = ({
         </Typography.Text>
         {trustBadge}
       </div>
-      <div style={{ display: 'flex', gap: 2 }}>
+      {/* `nodrag nopan` — React Flow's escape hatch. Without it the canvas
+          interprets a mousedown on these controls as the start of a node
+          drag (stopPropagation on click is too late, by then the drag
+          handler has already armed). Same pattern used elsewhere in this
+          file for the interact-mode iframe wrapper. */}
+      <div className="nodrag nopan" style={{ display: 'flex', gap: 2 }}>
         {showConsentAffordance && (
           <Tooltip title="Trust this artifact to inject secrets">
             <Button
@@ -623,7 +635,7 @@ export const ArtifactNode = ({
             />
           </Tooltip>
         )}
-        {payload && (
+        {hasUsablePayload && (
           <Tooltip title="Open in CodeSandbox (eject — daemon-injected env vars/AGOR_TOKEN won't carry over)">
             <Button
               type="text"
@@ -647,7 +659,7 @@ export const ArtifactNode = ({
             }}
           />
         </Tooltip>
-        {payload && (
+        {hasUsablePayload && (
           <Tooltip title={interactMode ? 'Exit interact mode' : 'Interact with app'}>
             <Button
               type={interactMode ? 'primary' : 'text'}
@@ -663,7 +675,7 @@ export const ArtifactNode = ({
         {data.onDeleteArtifact && (
           <Popconfirm
             title="Delete artifact?"
-            description={`This will remove "${payload?.name ?? fallbackName}" from the board.`}
+            description={`This will delete "${payload?.name ?? fallbackName}" and its files.`}
             onConfirm={(e) => {
               e?.stopPropagation();
               data.onDeleteArtifact?.(data.objectId, data.artifactId);
@@ -702,19 +714,24 @@ export const ArtifactNode = ({
     flexDirection: 'column',
   } as const;
 
+  // Shared resizer — same across loading / error / normal states.
+  const resizer = (
+    <NodeResizer
+      isVisible={selected}
+      minWidth={MIN_WIDTH}
+      minHeight={MIN_HEIGHT}
+      onResize={handleResize}
+      lineStyle={{ borderColor: token.colorPrimary }}
+      handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
+    />
+  );
+
   // Loading state — title bar is still visible (with reload + delete) so
   // a stuck loader can be retried or pruned.
   if (loading && !payload) {
     return (
       <>
-        <NodeResizer
-          isVisible={selected}
-          minWidth={MIN_WIDTH}
-          minHeight={MIN_HEIGHT}
-          onResize={handleResize}
-          lineStyle={{ borderColor: token.colorPrimary }}
-          handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
-        />
+        {resizer}
         <Card
           style={cardOuterStyle}
           styles={{
@@ -740,14 +757,7 @@ export const ArtifactNode = ({
   if (error) {
     return (
       <>
-        <NodeResizer
-          isVisible={selected}
-          minWidth={MIN_WIDTH}
-          minHeight={MIN_HEIGHT}
-          onResize={handleResize}
-          lineStyle={{ borderColor: token.colorPrimary }}
-          handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
-        />
+        {resizer}
         <Card
           style={cardOuterStyle}
           styles={{
@@ -771,7 +781,15 @@ export const ArtifactNode = ({
           >
             {error}
           </Typography.Text>
-          <Button size="small" icon={<ReloadOutlined />} onClick={fetchPayload}>
+          <Button
+            className="nodrag nopan"
+            size="small"
+            icon={<ReloadOutlined />}
+            onClick={(e) => {
+              e.stopPropagation();
+              fetchPayload();
+            }}
+          >
             Retry
           </Button>
         </Card>
@@ -796,14 +814,7 @@ export const ArtifactNode = ({
 
   return (
     <>
-      <NodeResizer
-        isVisible={selected}
-        minWidth={MIN_WIDTH}
-        minHeight={MIN_HEIGHT}
-        onResize={handleResize}
-        lineStyle={{ borderColor: token.colorPrimary }}
-        handleStyle={{ backgroundColor: token.colorPrimary, width: 8, height: 8 }}
-      />
+      {resizer}
       <Card
         style={cardOuterStyle}
         styles={{


### PR DESCRIPTION
## Summary

Two UX papercuts on the board's artifact cards, both spotted on the live Artifacts board.

**1. Card header was missing in loading / error states.** When an artifact failed to load (e.g. its \`files\` column was empty in the DB after a botched publish, so \`getPayload\` threw), the card painted a bare error state with no title — the user couldn't tell which artifact was broken without inspecting the React Flow node id. Same blind spot during initial load: just a spinner, no title.

Refactored the three return branches (loading / error / normal) to share a single Card chrome with one canonical title bar. When \`payload\` isn't available yet, the title falls back to \`Artifact <short-id>\` so there's always something to identify the card by. **Reload and Delete stay visible in every state** so a stuck or broken artifact can still be retried or pruned without leaving the board. Buttons that need payload data (Export, Interact, Trust) only render when payload is loaded.

**2. Delete was a one-tap destructive op.** Wrapped the trash icon in an Ant Design \`Popconfirm\` matching the pattern used in \`ArtifactsTable.tsx\` and elsewhere in the app (worktree / card / board / mcp-server deletes all use the same): "Delete artifact? This will remove '<name>' from the board." with a danger Delete button and Cancel.

## Test plan

- [x] \`pnpm i\` + \`pnpm check\` (typecheck + lint + build) clean
- [ ] On the board UI:
  - Existing artifact: title + all buttons render as before; clicking Delete now shows the confirm
  - Broken artifact (empty files): card now shows the title + reload + delete instead of a no-title error state
  - Initial load: spinner now shown alongside the title bar
- [ ] Confirm clicking outside the Popconfirm dismisses cleanly (doesn't trigger a node-drag on the canvas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)