### PR TITLE
chore(cli): remove assistant-setup step from agor init (handled in UI wizard)

### DIFF
--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -367,11 +367,6 @@ export default class Init extends Command {
       }
     }
 
-    // Prompt for assistant setup (unless --force or skipped prompts)
-    if (!skipPrompts) {
-      await this.promptAssistantSetup();
-    }
-
     // Success summary
     this.log('');
     this.log(chalk.green.bold('✅ Agor initialized successfully!'));
@@ -495,56 +490,6 @@ export default class Init extends Command {
     });
 
     this.log(`${chalk.green('   ✓')} Admin user created (${chalk.gray(email)})`);
-  }
-
-  /**
-   * Prompt user for assistant setup
-   *
-   * Stores intent in config.yaml for the UI wizard to pick up.
-   * The framework repo is public, so HTTPS always works.
-   */
-  private async promptAssistantSetup(): Promise<void> {
-    this.log('');
-    this.log(chalk.bold('🤖 Assistant'));
-    this.log('');
-    this.log(
-      chalk.gray('An assistant is a persistent AI companion that manages your Agor instance.')
-    );
-    this.log(
-      chalk.gray(
-        'It maintains memory across sessions, orchestrates work, and learns your preferences.'
-      )
-    );
-    this.log('');
-
-    const { setupAssistant } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'setupAssistant',
-        message: 'Set up your assistant?',
-        default: true,
-      },
-    ]);
-
-    if (setupAssistant) {
-      const frameworkRepoUrl = 'https://github.com/preset-io/agor-assistant.git';
-      await setConfigValue('onboarding.assistantPending', true);
-      await setConfigValue('onboarding.frameworkRepoUrl', frameworkRepoUrl);
-      this.log(`${chalk.green('   ✓')} Assistant setup queued for the UI wizard`);
-
-      // Check for ANTHROPIC_API_KEY
-      if (!process.env.ANTHROPIC_API_KEY) {
-        this.log('');
-        this.log(
-          chalk.yellow(
-            '   💡 Tip: Set ANTHROPIC_API_KEY in your environment for Claude Code sessions'
-          )
-        );
-        this.log(chalk.gray('   You can also configure API keys in the UI after setup'));
-      }
-    } else {
-      this.log(chalk.gray('   Skipped. You can set this up later from the UI.'));
-    }
   }
 
   /**

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -359,7 +359,7 @@ export function OnboardingWizard({
     const mainBoardId = user.preferences?.mainBoardId;
 
     if (!onboarding?.path) {
-      // No prior state — check if CLI set the assistant flag
+      // No prior state — auto-select assistant path if flag was set (e.g. by existing installs)
       if (assistantPending && !path) {
         setPath('assistant');
       }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -672,10 +672,10 @@ export interface AgorCredentials {
 }
 
 /**
- * Onboarding settings (stored by CLI init, consumed by UI wizard)
+ * Onboarding settings (consumed by UI wizard; may be set by existing installs)
  */
 export interface AgorOnboardingSettings {
-  /** Whether assistant setup was requested during init */
+  /** Whether assistant setup is pending (set by existing installs, consumed by UI wizard) */
   assistantPending?: boolean;
   /** @deprecated Use assistantPending instead */
   persistedAgentPending?: boolean;


### PR DESCRIPTION
## Summary

- Removes the `promptAssistantSetup()` method and its call site from `agor init`
- The step asked "Set up your assistant?", then wrote `onboarding.assistantPending=true` + `onboarding.frameworkRepoUrl` to config.yaml if the user said Yes

## Why this is safe

The UI onboarding wizard **always** shows the "Set up your assistant" button on its welcome step — it doesn't gate on `assistantPending`. The flag only auto-selected that path as a convenience shortcut. Without it, users land on the same welcome step and click the button themselves. The wizard also has a hardcoded `FRAMEWORK_REPO_URL` fallback (`useFrameworkRepo.ts`), so the clone URL is unaffected.

## Before / after

**Before** — `agor init` output included:
```
🤖 Assistant

An assistant is a persistent AI companion that manages your Agor instance.
It maintains memory across sessions, orchestrates work, and learns your preferences.

✔ Set up your assistant? Yes
   ✓ Assistant setup queued for the UI wizard
```

**After** — `agor init` goes straight to the success summary after creating the admin user.

## Validation

- UI wizard (`OnboardingWizard.tsx:363-365`) still auto-selects the assistant path for any existing configs that have `assistantPending=true`
- New installs: wizard welcome step shows "Set up your assistant" button (unchanged)
- `frameworkRepoUrl` config field preserved for back-compat with any existing config.yaml that has it set

## Coordination

- **`streamline-onboarding-wizard`** (in flight) — improves the UI wizard side that takes over this responsibility. Cross-link.
- **`analyze-rip-out-anonymous-mode`** (in flight) — also touches `agor init`. Heads up: assistant prompt is gone.
- **`fix-quickstart-daemon-and-ui-404`** (#1150) — Quick Start flow touches. No conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)