### PR TITLE
fix(executor): suppress system/task_updated lifecycle events (follow-up to #1116)

### DIFF
--- a/apps/agor-ui/package.json
+++ b/apps/agor-ui/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@agor-live/client": "workspace:*",
+    "@agor/core": "workspace:*",
     "@ant-design/icons": "^6.1.1",
     "@ant-design/x": "^2.5.0",
     "@codemirror/lang-json": "^6.0.2",

--- a/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
+++ b/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
@@ -7,6 +7,7 @@
  * - sdk_event → Shows unhandled SDK events (blacklist approach: surface by default)
  */
 
+import { shouldHidePersistedClaudeSdkEvent } from '@agor/core/sdk/claude-system-suppression';
 import type { Message } from '@agor-live/client';
 import { ClockCircleOutlined, InfoCircleOutlined, WarningOutlined } from '@ant-design/icons';
 import { Space, Typography, theme } from 'antd';
@@ -32,29 +33,11 @@ export const RateLimitBlock: React.FC<RateLimitBlockProps> = ({ message, agentic
   const block = rateLimitBlock || apiWaitBlock || sdkEventBlock;
   if (!block) return null;
 
-  // Defensive filter: hide already-persisted noisy SDK lifecycle events.
-  // The server-side filter in message-processor.ts drops these going forward;
-  // this catches noise already in the DB from sessions created before each fix.
-  //   - system/status (status='requesting'): PR #1116, fires on every API call
-  //   - system/task_updated (follow-up to #1116): fires on every task state patch
-  if (
-    block.type === 'sdk_event' &&
-    'sdkType' in block &&
-    block.sdkType === 'system' &&
-    'sdkSubtype' in block
-  ) {
-    if (
-      block.sdkSubtype === 'status' &&
-      'metadata' in block &&
-      typeof block.metadata === 'object' &&
-      block.metadata !== null &&
-      (block.metadata as { status?: unknown }).status === 'requesting'
-    ) {
-      return null;
-    }
-    if (block.sdkSubtype === 'task_updated') {
-      return null;
-    }
+  // Defensive filter for sdk_event rows already in the DB. The server-side
+  // suppression in message-processor.ts is forward-only; the shared helper
+  // keeps both sides honest. See @agor/core/sdk/claude-system-suppression.
+  if (shouldHidePersistedClaudeSdkEvent(block)) {
+    return null;
   }
 
   const text = ('text' in block ? block.text : '') as string;

--- a/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
+++ b/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
@@ -35,7 +35,7 @@ export const RateLimitBlock: React.FC<RateLimitBlockProps> = ({ message, agentic
 
   // Defensive filter for sdk_event rows already in the DB. The server-side
   // suppression in message-processor.ts is forward-only; the shared helper
-  // keeps both sides honest. See @agor/core/sdk/claude-system-suppression.
+  // keeps both sides honest. See @agor/core/client/claude-system-suppression.
   if (shouldHidePersistedClaudeSdkEvent(block)) {
     return null;
   }

--- a/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
+++ b/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
@@ -7,7 +7,7 @@
  * - sdk_event → Shows unhandled SDK events (blacklist approach: surface by default)
  */
 
-import { shouldHidePersistedClaudeSdkEvent } from '@agor/core/sdk/claude-system-suppression';
+import { shouldHidePersistedClaudeSdkEvent } from '@agor/core/client/claude-system-suppression';
 import type { Message } from '@agor-live/client';
 import { ClockCircleOutlined, InfoCircleOutlined, WarningOutlined } from '@ant-design/icons';
 import { Space, Typography, theme } from 'antd';

--- a/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
+++ b/apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx
@@ -32,21 +32,29 @@ export const RateLimitBlock: React.FC<RateLimitBlockProps> = ({ message, agentic
   const block = rateLimitBlock || apiWaitBlock || sdkEventBlock;
   if (!block) return null;
 
-  // Defensive filter: hide already-persisted system/status messages with status='requesting'.
-  // Server-side filter in message-processor.ts drops these going forward; this catches noise
-  // already in the DB from sessions created between the SDK bump and this fix.
+  // Defensive filter: hide already-persisted noisy SDK lifecycle events.
+  // The server-side filter in message-processor.ts drops these going forward;
+  // this catches noise already in the DB from sessions created before each fix.
+  //   - system/status (status='requesting'): PR #1116, fires on every API call
+  //   - system/task_updated (follow-up to #1116): fires on every task state patch
   if (
     block.type === 'sdk_event' &&
     'sdkType' in block &&
     block.sdkType === 'system' &&
-    'sdkSubtype' in block &&
-    block.sdkSubtype === 'status' &&
-    'metadata' in block &&
-    typeof block.metadata === 'object' &&
-    block.metadata !== null &&
-    (block.metadata as { status?: unknown }).status === 'requesting'
+    'sdkSubtype' in block
   ) {
-    return null;
+    if (
+      block.sdkSubtype === 'status' &&
+      'metadata' in block &&
+      typeof block.metadata === 'object' &&
+      block.metadata !== null &&
+      (block.metadata as { status?: unknown }).status === 'requesting'
+    ) {
+      return null;
+    }
+    if (block.sdkSubtype === 'task_updated') {
+      return null;
+    }
   }
 
   const text = ('text' in block ? block.text : '') as string;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -238,6 +238,12 @@
       "import": "./dist/sdk/index.js",
       "require": "./dist/sdk/index.cjs"
     },
+    "./sdk/claude-system-suppression": {
+      "source": "./src/sdk/claude-system-suppression.ts",
+      "types": "./dist/sdk/claude-system-suppression.d.ts",
+      "import": "./dist/sdk/claude-system-suppression.js",
+      "require": "./dist/sdk/claude-system-suppression.cjs"
+    },
     "./tools/mcp/jwt-auth": {
       "source": "./src/tools/mcp/jwt-auth.ts",
       "types": "./dist/tools/mcp/jwt-auth.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -238,11 +238,11 @@
       "import": "./dist/sdk/index.js",
       "require": "./dist/sdk/index.cjs"
     },
-    "./sdk/claude-system-suppression": {
-      "source": "./src/sdk/claude-system-suppression.ts",
-      "types": "./dist/sdk/claude-system-suppression.d.ts",
-      "import": "./dist/sdk/claude-system-suppression.js",
-      "require": "./dist/sdk/claude-system-suppression.cjs"
+    "./client/claude-system-suppression": {
+      "source": "./src/client/claude-system-suppression.ts",
+      "types": "./dist/client/claude-system-suppression.d.ts",
+      "import": "./dist/client/claude-system-suppression.js",
+      "require": "./dist/client/claude-system-suppression.cjs"
     },
     "./tools/mcp/jwt-auth": {
       "source": "./src/tools/mcp/jwt-auth.ts",

--- a/packages/core/src/client/claude-system-suppression.test.ts
+++ b/packages/core/src/client/claude-system-suppression.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { shouldHidePersistedClaudeSdkEvent } from './claude-system-suppression';
+
+describe('shouldHidePersistedClaudeSdkEvent', () => {
+  it('hides task_updated rows (including ones with patch.error)', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'task_updated',
+        metadata: { subtype: 'task_updated', patch: { status: 'failed', error: 'boom' } },
+      })
+    ).toBe(true);
+  });
+
+  it('hides status=requesting rows via the metadata path', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'status',
+        metadata: { subtype: 'status', status: 'requesting' },
+      })
+    ).toBe(true);
+  });
+
+  it('lets user-meaningful subtypes through (e.g. mirror_error)', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'mirror_error',
+        metadata: { subtype: 'mirror_error', error: 'disk full' },
+      })
+    ).toBe(false);
+  });
+
+  it('lets status=compacting fall through (the executor renders it as a real SYSTEM message)', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'status',
+        metadata: { subtype: 'status', status: 'compacting' },
+      })
+    ).toBe(false);
+  });
+
+  it('does not match non-system sdkType', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'tool_progress',
+        sdkSubtype: 'task_updated',
+      })
+    ).toBe(false);
+  });
+
+  it('does not match non-sdk_event blocks', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'rate_limit',
+        sdkType: 'system',
+        sdkSubtype: 'task_updated',
+      })
+    ).toBe(false);
+  });
+
+  it('tolerates missing metadata on status rows', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'status',
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/client/claude-system-suppression.ts
+++ b/packages/core/src/client/claude-system-suppression.ts
@@ -31,6 +31,15 @@ import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 export type ClaudeSystemSubtype = Extract<SDKMessage, { type: 'system' }>['subtype'];
 
 /**
+ * The `status` values an `SDKStatusMessage` can carry, again derived from the
+ * SDK union so an upstream rename trips typecheck instead of silently leaking.
+ */
+export type ClaudeSystemStatus = Extract<
+  SDKMessage,
+  { type: 'system'; subtype: 'status' }
+>['status'];
+
+/**
  * System subtypes we suppress on sight — pure lifecycle telemetry that has no
  * user-meaningful content on its own.
  *
@@ -52,11 +61,14 @@ export const SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES: ReadonlySet<ClaudeSystemSubtype>
 /**
  * `SDKStatusMessage.status` values we suppress. `requesting` fires on every
  * API call; `compacting` is handled separately in the executor (it renders as
- * a real SYSTEM "Compacting…" message). Other status values — including
- * `null`, which carries permissionMode/compact_result transitions — are
- * intentionally allowed to fall through to the generic sdk_event surfacer.
+ * a real SYSTEM "Compacting…" message). Other status values — `null` (the SDK's
+ * "no active status" sentinel, often co-occurring with `permissionMode` or
+ * `compact_result` fields) and any future additions — are intentionally allowed
+ * to fall through to the generic sdk_event surfacer.
  */
-export const SUPPRESSED_CLAUDE_STATUSES: ReadonlySet<string> = new Set(['requesting']);
+export const SUPPRESSED_CLAUDE_STATUSES: ReadonlySet<NonNullable<ClaudeSystemStatus>> = new Set([
+  'requesting',
+] as const);
 
 /**
  * Block shape persisted on `sdk_event` content blocks. Loose by design: this
@@ -89,7 +101,10 @@ export function shouldHidePersistedClaudeSdkEvent(block: PersistedSdkEventBlock)
       typeof block.metadata === 'object' && block.metadata !== null
         ? (block.metadata as { status?: unknown }).status
         : undefined;
-    if (typeof status === 'string' && SUPPRESSED_CLAUDE_STATUSES.has(status)) {
+    if (
+      typeof status === 'string' &&
+      (SUPPRESSED_CLAUDE_STATUSES as ReadonlySet<string>).has(status)
+    ) {
       return true;
     }
   }

--- a/packages/core/src/sdk/claude-system-suppression.ts
+++ b/packages/core/src/sdk/claude-system-suppression.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared suppression rules for noisy Claude Agent SDK `type:'system'` events.
+ *
+ * Blacklist philosophy: surface unknown subtypes by default so newly added
+ * SDK events (e.g. `mirror_error`, `notification`, `api_retry`, `memory_recall`,
+ * `plugin_install`) reach users without code changes. Only entries we have
+ * confirmed are pure lifecycle telemetry belong in the suppress set.
+ *
+ * Two consumers:
+ *   - executor (`message-processor.ts`): drops these before they ever become
+ *     persisted sdk_event blocks. Forward-only.
+ *   - UI (`RateLimitBlock`): defensive filter for sdk_event rows already in the
+ *     DB from sessions created before a given suppression entry was added.
+ *
+ * History:
+ *   - PR #1116 added `status='requesting'`.
+ *   - PR #1172 added `task_updated` and lifted both rules into this shared
+ *     module so the executor + UI no longer hardcode the same literals.
+ *
+ * This module is browser-safe: it imports types only from
+ * `@anthropic-ai/claude-agent-sdk` (erased at runtime).
+ */
+
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+
+/**
+ * The exhaustive set of `subtype` values for SDK messages with `type:'system'`,
+ * pulled from the SDK's discriminated union. A rename in the SDK turns into a
+ * type error at the call site, rather than a silent miss.
+ */
+export type ClaudeSystemSubtype = Extract<SDKMessage, { type: 'system' }>['subtype'];
+
+/**
+ * System subtypes we suppress on sight — pure lifecycle telemetry that has no
+ * user-meaningful content on its own.
+ *
+ * Task failure visibility note: `task_*` events are suppressed wholesale,
+ * including `task_updated` rows where `patch.error` is set. The Task tool's
+ * own `tool_result` block (with `is_error: true`) is the authoritative surface
+ * for subagent task failures; the parallel `task_*` telemetry stream is
+ * redundant. If that invariant ever breaks, revisit this set.
+ */
+export const SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES: ReadonlySet<ClaudeSystemSubtype> = new Set([
+  'files_persisted',
+  'session_state_changed',
+  'task_started',
+  'task_progress',
+  'task_updated',
+  'task_notification',
+] as const);
+
+/**
+ * `SDKStatusMessage.status` values we suppress. `requesting` fires on every
+ * API call; `compacting` is handled separately in the executor (it renders as
+ * a real SYSTEM "Compacting…" message). Other status values — including
+ * `null`, which carries permissionMode/compact_result transitions — are
+ * intentionally allowed to fall through to the generic sdk_event surfacer.
+ */
+export const SUPPRESSED_CLAUDE_STATUSES: ReadonlySet<string> = new Set(['requesting']);
+
+/**
+ * Block shape persisted on `sdk_event` content blocks. Loose by design: this
+ * helper is consumed by the UI from message rows that may predate any given
+ * schema revision.
+ */
+interface PersistedSdkEventBlock {
+  type?: string;
+  sdkType?: string;
+  sdkSubtype?: string;
+  metadata?: unknown;
+}
+
+/**
+ * Defensive UI filter: returns true when an already-persisted `sdk_event`
+ * block matches one of our suppression rules and should be hidden from the
+ * transcript. Catches rows written before the executor learned to drop them.
+ */
+export function shouldHidePersistedClaudeSdkEvent(block: PersistedSdkEventBlock): boolean {
+  if (block.type !== 'sdk_event') return false;
+  if (block.sdkType !== 'system') return false;
+  if (!block.sdkSubtype) return false;
+
+  if ((SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES as ReadonlySet<string>).has(block.sdkSubtype)) {
+    return true;
+  }
+
+  if (block.sdkSubtype === 'status') {
+    const status =
+      typeof block.metadata === 'object' && block.metadata !== null
+        ? (block.metadata as { status?: unknown }).status
+        : undefined;
+    if (typeof status === 'string' && SUPPRESSED_CLAUDE_STATUSES.has(status)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     'models/index': 'src/models/index.ts', // Model metadata (browser-safe)
     'sessions/index': 'src/sessions/index.ts', // Session config defaults resolution
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
+    'sdk/claude-system-suppression': 'src/sdk/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     'models/index': 'src/models/index.ts', // Model metadata (browser-safe)
     'sessions/index': 'src/sessions/index.ts', // Session config defaults resolution
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
-    'sdk/claude-system-suppression': 'src/sdk/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
+    'client/claude-system-suppression': 'src/client/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -12,6 +12,52 @@ function rateLimitMsg(info: Record<string, unknown>) {
   return { type: 'rate_limit_event', rate_limit_info: info } as never;
 }
 
+function systemMsg(payload: Record<string, unknown>) {
+  return { type: 'system', ...payload } as never;
+}
+
+describe('SDKMessageProcessor system event suppression', () => {
+  it('suppresses status=requesting (PR #1116)', async () => {
+    const processor = createProcessor();
+    const events = await processor.process(
+      systemMsg({ subtype: 'status', status: 'requesting', session_id: 's', uuid: 'u' })
+    );
+    expect(events.filter((e) => e.type === 'sdk_event')).toHaveLength(0);
+  });
+
+  it('suppresses task_updated, including patches with an error field', async () => {
+    const processor = createProcessor();
+    const events = await processor.process(
+      systemMsg({
+        subtype: 'task_updated',
+        task_id: 't1',
+        patch: { status: 'failed', error: 'boom' },
+        session_id: 's',
+        uuid: 'u',
+      })
+    );
+    expect(events.filter((e) => e.type === 'sdk_event')).toHaveLength(0);
+  });
+
+  it('surfaces user-meaningful system subtypes (e.g. mirror_error)', async () => {
+    const processor = createProcessor();
+    const events = await processor.process(
+      systemMsg({
+        subtype: 'mirror_error',
+        error: 'disk full',
+        key: { projectKey: 'p', sessionId: 's' },
+        session_id: 's',
+        uuid: 'u',
+      })
+    );
+    const sdkEvents = events.filter((e) => e.type === 'sdk_event');
+    expect(sdkEvents).toHaveLength(1);
+    const event = sdkEvents[0] as Extract<ProcessedEvent, { type: 'sdk_event' }>;
+    expect(event.sdkType).toBe('system');
+    expect(event.sdkSubtype).toBe('mirror_error');
+  });
+});
+
 describe('SDKMessageProcessor rate_limit_event handling', () => {
   it('suppresses allowed status with no overage concern', async () => {
     const processor = createProcessor();

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -815,13 +815,26 @@ export class SDKMessageProcessor {
 
   /**
    * System message subtypes to suppress (log-only, don't surface to users).
-   * Everything NOT in this set (and not already handled) is surfaced by default.
+   *
+   * Blacklist philosophy: surface unknown subtypes by default so newly added
+   * SDK events (e.g. `mirror_error`, `notification`, `api_retry`, `memory_recall`,
+   * `plugin_install`) reach users without code changes. Only entries we have
+   * confirmed are pure lifecycle telemetry belong here. The fall-through path
+   * at L741 logs every unhandled subtype, which is how we'd notice a new one.
+   *
+   * History:
+   *   - PR #1116 added the `status='requesting'` predicate (handled separately
+   *     above, since `status` is a value, not a subtype).
+   *   - Follow-up to #1116 added `task_updated`, completing the `task_*` family
+   *     after it started leaking through and rendering as
+   *     "SDK event: system/task_updated" blurbs in transcripts.
    */
   private static readonly SUPPRESSED_SYSTEM_SUBTYPES = new Set([
     'files_persisted', // Internal SDK bookkeeping
     'session_state_changed', // Internal SDK state transitions
     'task_started', // SDK task lifecycle — no user-facing value
     'task_progress', // SDK task lifecycle — fires repeatedly, very noisy
+    'task_updated', // SDK task lifecycle — fires on every task state patch
     'task_notification', // SDK task lifecycle notification
   ]);
 

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -21,6 +21,10 @@ import type {
   SDKUserMessage,
   SDKUserMessageReplay,
 } from '@agor/core/sdk';
+import {
+  SUPPRESSED_CLAUDE_STATUSES,
+  SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES,
+} from '@agor/core/sdk/claude-system-suppression';
 import type { SessionID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 
@@ -683,10 +687,14 @@ export class SDKMessageProcessor {
       ];
     }
 
-    // Suppress status='requesting' — pure API-call lifecycle telemetry, fires on every request.
-    // Other status subtype variants (null, permissionMode change, compact_result/error) still flow
-    // through and get surfaced as generic sdk_event messages below.
-    if ('status' in msg && msg.status === 'requesting') {
+    // Suppress noisy status values (e.g. 'requesting' — fires on every API call).
+    // Other status variants (null, permissionMode change, compact_result/error) still
+    // flow through and get surfaced as generic sdk_event messages below.
+    if (
+      'status' in msg &&
+      typeof msg.status === 'string' &&
+      SUPPRESSED_CLAUDE_STATUSES.has(msg.status)
+    ) {
       return [];
     }
 
@@ -733,7 +741,7 @@ export class SDKMessageProcessor {
     const subtype =
       ('subtype' in msg ? (msg as { subtype?: string }).subtype : undefined) || 'unknown';
 
-    if (SDKMessageProcessor.SUPPRESSED_SYSTEM_SUBTYPES.has(subtype)) {
+    if ((SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES as ReadonlySet<string>).has(subtype)) {
       console.debug(`🔇 Suppressed system subtype: ${subtype}`);
       return [];
     }
@@ -811,31 +819,6 @@ export class SDKMessageProcessor {
   private static readonly SUPPRESSED_MESSAGE_TYPES = new Set([
     'tool_progress', // Fires constantly during tool execution — extremely noisy
     'prompt_suggestion', // End-of-conversation suggestions, not relevant in Agor
-  ]);
-
-  /**
-   * System message subtypes to suppress (log-only, don't surface to users).
-   *
-   * Blacklist philosophy: surface unknown subtypes by default so newly added
-   * SDK events (e.g. `mirror_error`, `notification`, `api_retry`, `memory_recall`,
-   * `plugin_install`) reach users without code changes. Only entries we have
-   * confirmed are pure lifecycle telemetry belong here. The fall-through path
-   * at L741 logs every unhandled subtype, which is how we'd notice a new one.
-   *
-   * History:
-   *   - PR #1116 added the `status='requesting'` predicate (handled separately
-   *     above, since `status` is a value, not a subtype).
-   *   - Follow-up to #1116 added `task_updated`, completing the `task_*` family
-   *     after it started leaking through and rendering as
-   *     "SDK event: system/task_updated" blurbs in transcripts.
-   */
-  private static readonly SUPPRESSED_SYSTEM_SUBTYPES = new Set([
-    'files_persisted', // Internal SDK bookkeeping
-    'session_state_changed', // Internal SDK state transitions
-    'task_started', // SDK task lifecycle — no user-facing value
-    'task_progress', // SDK task lifecycle — fires repeatedly, very noisy
-    'task_updated', // SDK task lifecycle — fires on every task state patch
-    'task_notification', // SDK task lifecycle notification
   ]);
 
   /**

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -11,6 +11,10 @@
  * - Yield structured events for database persistence
  */
 
+import {
+  SUPPRESSED_CLAUDE_STATUSES,
+  SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES,
+} from '@agor/core/client/claude-system-suppression';
 import type {
   SDKAssistantMessage,
   SDKCompactBoundaryMessage,
@@ -21,10 +25,6 @@ import type {
   SDKUserMessage,
   SDKUserMessageReplay,
 } from '@agor/core/sdk';
-import {
-  SUPPRESSED_CLAUDE_STATUSES,
-  SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES,
-} from '@agor/core/sdk/claude-system-suppression';
 import type { SessionID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 
@@ -693,7 +693,7 @@ export class SDKMessageProcessor {
     if (
       'status' in msg &&
       typeof msg.status === 'string' &&
-      SUPPRESSED_CLAUDE_STATUSES.has(msg.status)
+      (SUPPRESSED_CLAUDE_STATUSES as ReadonlySet<string>).has(msg.status)
     ) {
       return [];
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@agor-live/client':
         specifier: workspace:*
         version: link:../../packages/client
+      '@agor/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@ant-design/icons':
         specifier: ^6.1.1
         version: 6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6928,7 +6931,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6931,6 +6931,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:


### PR DESCRIPTION
## Summary

PR #1116 silenced one noisy SDK lifecycle event (`system/status` with `status='requesting'`). It was scoped to that single value and didn't audit the broader space of `type:'system'` subtypes. A sibling subtype — `system/task_updated` (fires on every task state patch) — slipped past and started rendering as "SDK event: system/task_updated" blurbs in session transcripts.

This PR fixes that, audits the full space, and (after two code-review passes) lifts the suppression rules into a typed, shared, browser-safe module so the executor and UI no longer drift on the same literals.

### Audit

Enumerated every `type:'system'` subtype emitted by claude-agent-sdk 0.2.132 against current handling:

- **Surfaced (user-meaningful)**: `init`, `compact_boundary`, `status:'compacting'`, `api_retry`, `local_command_output`, `mirror_error`, `notification`, `plugin_install`, `memory_recall`, `elicitation_complete`, hook events.
- **Suppressed**: `files_persisted`, `session_state_changed`, the full `task_*` family (`task_started`, `task_progress`, `task_updated`, `task_notification`), and `status:'requesting'`.

### Philosophy: blacklist, hardened

Considered allowlist vs blacklist. Stayed with **blacklist** because roughly half the SDK's system subtypes are user-meaningful — an allowlist would silently swallow new useful events (`mirror_error`, `notification`, `api_retry`, etc.) when the SDK adds them. The fall-through path logs every unhandled subtype (`Surfacing unhandled system subtype: …`), which is how the next addition will surface.

### Changes

**New shared module** `packages/core/src/client/claude-system-suppression.ts` (browser-safe — type-only SDK import, erased at runtime):
- `SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES` typed against `Extract<SDKMessage, { type:'system' }>['subtype']` so SDK renames trip typecheck instead of silently leaking.
- `SUPPRESSED_CLAUDE_STATUSES` typed against `Extract<SDKMessage, { type:'system'; subtype:'status' }>['status']` (same discipline).
- `shouldHidePersistedClaudeSdkEvent(block)` helper consumed by the UI's defensive filter.

**Executor** (`packages/executor/src/sdk-handlers/claude/message-processor.ts`):
- Consumes the shared sets. Private static `SUPPRESSED_SYSTEM_SUBTYPES` removed.
- `status` predicate now uses the typed set; doc comment no longer references brittle line numbers.

**UI** (`apps/agor-ui/src/components/RateLimitBlock/RateLimitBlock.tsx`):
- Inline ~20-line predicate replaced with a single `shouldHidePersistedClaudeSdkEvent(block)` call.
- `apps/agor-ui` gains `@agor/core` as a `workspace:*` dep (peer with agor-cli/agor-daemon for direct core access; the helper sits in the browser-safe `client/` namespace).

**Tests**:
- `packages/executor/src/sdk-handlers/claude/message-processor.test.ts` — 3 new cases (suppression of `status='requesting'`, `task_updated` including `patch.error` variant, and pass-through of `mirror_error` as a kept subtype).
- `packages/core/src/client/claude-system-suppression.test.ts` — 7 cases on the shared helper directly (`task_updated`/`patch.error`, `status='requesting'`, `mirror_error` pass-through, `compacting` pass-through, non-system sdkType skip, non-sdk_event skip, missing-metadata tolerance).

### Failure visibility invariant (documented in code)

`task_*` events are suppressed wholesale, including `task_updated` rows where `patch.error` is set. The Task tool's own `tool_result` block (with `is_error: true`) is the authoritative surface for subagent task failures; the parallel `task_*` telemetry stream is redundant. If that invariant ever breaks, revisit the set.

### Non-goals / follow-ups

- **Codex SDK telemetry**: `SDKTaskUpdatedMessage` is Claude-specific. Worth a separate pass to audit whether Codex emits analogous lifecycle events.
- **Notification system (PR #1135 design doc)**: if `task_*` events ever feed a session-header status indicator, this suppression is still correct — they stay out of the transcript while a separate consumer can subscribe.
- **`status: null` policy**: currently falls through to the generic surfacer. Could be tightened later if it proves noisy in practice.
- **`RateLimitBlock` rename to `SdkEventBlock`**: the component is now miscast for its content (rate limits + api waits + generic sdk events). Out of scope here.

## Test plan

- [x] `pnpm check` (typecheck + lint + build) — clean
- [x] `pnpm --filter @agor/executor test message-processor.test` — 9/9 (was 6/6; +3 suppression cases)
- [x] `pnpm --filter @agor/core test claude-system-suppression` — 7/7 (new file)
- [x] `pnpm --filter agor-ui test` — 126/126
- [ ] Fresh Claude Code session in dev: run several tool calls, confirm no `system/task_updated` or `system/status: requesting` rows in transcript
- [ ] Force an SDK error and confirm `system/error` / `mirror_error` / similar still surface
- [ ] Confirm tool calls themselves still render normally (they're not `system/*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
