### PR TITLE
[codex] Add JetBrains Junie agent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ yarn-error.log*
 
 # Agor specific
 .agor/
+.agor-local/
 apps/agor-desktop/out/

--- a/apps/agor-cli/src/commands/session/list.ts
+++ b/apps/agor-cli/src/commands/session/list.ts
@@ -43,7 +43,7 @@ export default class SessionList extends BaseCommand {
     agent: Flags.string({
       char: 'a',
       description: 'Filter by agent',
-      options: ['claude-code', 'codex', 'gemini', 'opencode', 'copilot'],
+      options: ['claude-code', 'codex', 'gemini', 'opencode', 'copilot', 'junie'],
     }),
     board: Flags.string({
       char: 'b',

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3119,6 +3119,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             ),
             OPENAI_API_KEY: !!(config.credentials?.OPENAI_API_KEY || process.env.OPENAI_API_KEY),
             GEMINI_API_KEY: !!(config.credentials?.GEMINI_API_KEY || process.env.GEMINI_API_KEY),
+            COPILOT_GITHUB_TOKEN: !!(
+              config.credentials?.COPILOT_GITHUB_TOKEN || process.env.COPILOT_GITHUB_TOKEN
+            ),
+            JUNIE_OPENAI_COMPATIBLE_API_KEY: !!(
+              config.credentials?.JUNIE_OPENAI_COMPATIBLE_API_KEY ||
+              process.env.JUNIE_OPENAI_COMPATIBLE_API_KEY
+            ),
           },
         },
         services: servicesConfig,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -373,6 +373,13 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   app.use('/copilot-models', createCopilotModelsService(db));
   app.service('/copilot-models').hooks({ before: { find: [ctx.requireAuth] } });
 
+  app.use('/config/junie-models', {
+    // biome-ignore lint/suspicious/noExplicitAny: Feathers service payload is validated by config service
+    async create(data: any) {
+      return await configService.loadJunieModels(data);
+    },
+  });
+
   const worktreeRepository = new WorktreeRepository(db);
   const { UsersRepository, SessionRepository } = await import('@agor/core/db');
   const usersRepository = new UsersRepository(db);
@@ -738,7 +745,7 @@ function createExecuteHandler(
         sessionId,
         taskId,
         prompt: data.prompt,
-        tool: session.agentic_tool as 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot',
+        tool: session.agentic_tool as import('@agor/core/types').AgenticToolName,
         permissionMode: permissionModeForPayload as 'ask' | 'auto' | 'allow-all' | undefined,
         cwd,
         messageSource: data.messageSource,

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchJunieModels } from './config';
+
+describe('fetchJunieModels', () => {
+  it('loads model IDs from an OpenAI-compatible models endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ id: 'qwen-3.6-27b' }, { id: 'qwen-3.5-35b-a3b' }, { object: 'model' }],
+        }),
+        { status: 200 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchJunieModels('https://llm.bitp.cz', 'sk-test')).resolves.toEqual([
+      'qwen-3.6-27b',
+      'qwen-3.5-35b-a3b',
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://llm.bitp.cz/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-test',
+        }),
+      })
+    );
+  });
+
+  it('normalizes endpoint URLs when users paste a completion endpoint', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [{ id: 'model-a' }] }), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchJunieModels('https://llm.bitp.cz/v1/chat/completions', 'sk-test');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://llm.bitp.cz/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+  });
+
+  it('throws a clean error when the gateway rejects the request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('unauthorized', { status: 401, statusText: 'Unauthorized' })
+        )
+    );
+
+    await expect(fetchJunieModels('https://llm.bitp.cz', 'bad-key')).rejects.toThrow(
+      'Failed to load Junie models: 401 Unauthorized'
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -39,8 +39,53 @@ function maskCredentials(config: AgorConfig): AgorConfig {
       ANTHROPIC_BASE_URL: config.credentials.ANTHROPIC_BASE_URL,
       OPENAI_API_KEY: maskApiKey(config.credentials.OPENAI_API_KEY),
       GEMINI_API_KEY: maskApiKey(config.credentials.GEMINI_API_KEY),
+      COPILOT_GITHUB_TOKEN: maskApiKey(config.credentials.COPILOT_GITHUB_TOKEN),
+      JUNIE_OPENAI_COMPATIBLE_API_KEY: maskApiKey(
+        config.credentials.JUNIE_OPENAI_COMPATIBLE_API_KEY
+      ),
     },
   };
+}
+
+function resolveJunieModelsUrl(baseUrl: string): string {
+  const normalized = baseUrl.trim().replace(/\/+$/, '');
+  if (!normalized) {
+    throw new Error('Junie OpenAI-compatible base URL is required');
+  }
+
+  if (normalized.endsWith('/v1/models')) return normalized;
+  if (normalized.endsWith('/v1/chat/completions')) {
+    return `${normalized.slice(0, -'/chat/completions'.length)}/models`;
+  }
+  if (normalized.endsWith('/v1/responses')) {
+    return `${normalized.slice(0, -'/responses'.length)}/models`;
+  }
+  if (normalized.endsWith('/v1')) return `${normalized}/models`;
+  return `${normalized}/v1/models`;
+}
+
+export async function fetchJunieModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  const response = await fetch(resolveJunieModelsUrl(baseUrl), {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load Junie models: ${response.status} ${response.statusText}`);
+  }
+
+  const body = (await response.json()) as { data?: unknown };
+  if (!Array.isArray(body.data)) {
+    throw new Error('Failed to load Junie models: gateway response did not contain a data array');
+  }
+
+  return body.data
+    .map((model) => (model && typeof model === 'object' ? (model as { id?: unknown }).id : null))
+    .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
 }
 
 /**
@@ -138,6 +183,31 @@ export class ConfigService {
     };
   }
 
+  async loadJunieModels(data: { openaiCompatibleBaseUrl?: string; apiKey?: string }): Promise<{
+    models: string[];
+  }> {
+    const config = await loadConfig();
+    const openaiCompatibleBaseUrl =
+      data.openaiCompatibleBaseUrl?.trim() || config.junie?.openaiCompatibleBaseUrl?.trim();
+    if (!openaiCompatibleBaseUrl) {
+      throw new Error('Junie OpenAI-compatible base URL is required');
+    }
+
+    const keyResult = data.apiKey?.trim()
+      ? { apiKey: data.apiKey.trim() }
+      : await resolveApiKey('JUNIE_OPENAI_COMPATIBLE_API_KEY', {
+          db: this.db,
+        });
+    const apiKey = keyResult.apiKey;
+    if (!apiKey) {
+      throw new Error('Junie OpenAI-compatible API key is not configured');
+    }
+
+    return {
+      models: await fetchJunieModels(openaiCompatibleBaseUrl, apiKey),
+    };
+  }
+
   /**
    * Update config values
    *
@@ -184,6 +254,66 @@ export class ConfigService {
       }
       if (data.opencode.serverUrl !== undefined) {
         config.opencode.serverUrl = data.opencode.serverUrl;
+      }
+    }
+
+    // Allow updating Junie configuration
+    if (data.junie) {
+      if (!config.junie) {
+        config.junie = {};
+      }
+      const juniePatch = data.junie as Record<string, unknown>;
+
+      if (juniePatch.executable !== undefined) {
+        if (juniePatch.executable === null || juniePatch.executable === '') {
+          delete config.junie.executable;
+        } else if (typeof juniePatch.executable === 'string') {
+          config.junie.executable = juniePatch.executable;
+        } else {
+          throw new Error('junie.executable must be a string');
+        }
+      }
+      if (juniePatch.openaiCompatibleBaseUrl !== undefined) {
+        if (
+          juniePatch.openaiCompatibleBaseUrl === null ||
+          juniePatch.openaiCompatibleBaseUrl === ''
+        ) {
+          delete config.junie.openaiCompatibleBaseUrl;
+        } else if (typeof juniePatch.openaiCompatibleBaseUrl === 'string') {
+          config.junie.openaiCompatibleBaseUrl = juniePatch.openaiCompatibleBaseUrl;
+        } else {
+          throw new Error('junie.openaiCompatibleBaseUrl must be a string');
+        }
+      }
+      if (juniePatch.defaultModel !== undefined) {
+        if (juniePatch.defaultModel === null || juniePatch.defaultModel === '') {
+          delete config.junie.defaultModel;
+        } else if (typeof juniePatch.defaultModel === 'string') {
+          config.junie.defaultModel = juniePatch.defaultModel;
+        } else {
+          throw new Error('junie.defaultModel must be a string');
+        }
+      }
+      if (juniePatch.fasterModel !== undefined) {
+        if (juniePatch.fasterModel === null || juniePatch.fasterModel === '') {
+          delete config.junie.fasterModel;
+        } else if (typeof juniePatch.fasterModel === 'string') {
+          config.junie.fasterModel = juniePatch.fasterModel;
+        } else {
+          throw new Error('junie.fasterModel must be a string');
+        }
+      }
+      if (juniePatch.apiType !== undefined) {
+        if (juniePatch.apiType === null || juniePatch.apiType === '') {
+          delete config.junie.apiType;
+        } else if (
+          juniePatch.apiType === 'OpenAIResponses' ||
+          juniePatch.apiType === 'OpenAICompletion'
+        ) {
+          config.junie.apiType = juniePatch.apiType;
+        } else {
+          throw new Error('junie.apiType must be OpenAIResponses or OpenAICompletion');
+        }
       }
     }
 

--- a/apps/agor-daemon/src/services/users.security.test.ts
+++ b/apps/agor-daemon/src/services/users.security.test.ts
@@ -81,3 +81,25 @@ describe('UsersService — git token env var hardening', () => {
     ).resolves.toBeDefined();
   });
 });
+
+describe('UsersService — Junie API keys', () => {
+  dbTest(
+    'stores Junie OpenAI-compatible API key encrypted and exposes status only',
+    async ({ db }) => {
+      const service = new UsersService(db);
+      const id = await makeUser(service);
+
+      const patched = await service.patch(id, {
+        agentic_tools: {
+          junie: { JUNIE_OPENAI_COMPATIBLE_API_KEY: 'sk-junie-openai-compatible' },
+        },
+      });
+
+      expect(patched.agentic_tools?.junie?.JUNIE_OPENAI_COMPATIBLE_API_KEY).toBe(true);
+      expect(JSON.stringify(patched)).not.toContain('sk-junie-openai-compatible');
+      await expect(
+        service.getToolConfigField(id, 'junie', 'JUNIE_OPENAI_COMPATIBLE_API_KEY')
+      ).resolves.toBe('sk-junie-openai-compatible');
+    }
+  );
+});

--- a/apps/agor-daemon/src/setup/credentials.ts
+++ b/apps/agor-daemon/src/setup/credentials.ts
@@ -19,6 +19,7 @@ export interface InitializedCredentials {
   anthropicBaseUrl?: string;
   geminiApiKey?: string;
   copilotGithubToken?: string;
+  junieOpenAICompatibleApiKey?: string;
 }
 
 /**
@@ -82,7 +83,7 @@ export function initializeAnthropicAuthToken(
  * Initialize Anthropic base URL for proxy/custom endpoint support
  *
  * Priority: config.yaml > env var
- * Used for LiteLLM proxies, AWS Bedrock, Claude Enterprise, or compatible APIs.
+ * Used for proxies, AWS Bedrock, Claude Enterprise, or compatible APIs.
  *
  * @param config - Application config object with credentials
  * @param envBaseUrl - ANTHROPIC_BASE_URL from process.env
@@ -171,6 +172,35 @@ export function initializeCopilotGithubToken(
 }
 
 /**
+ * Initialize Junie OpenAI-compatible API key
+ *
+ * Priority: config.yaml > env var.
+ */
+export function initializeJunieOpenAICompatibleApiKey(
+  config: { credentials?: CredentialsConfig },
+  envApiKey: string | undefined
+): string | undefined {
+  if (config.credentials?.JUNIE_OPENAI_COMPATIBLE_API_KEY && !envApiKey) {
+    process.env.JUNIE_OPENAI_COMPATIBLE_API_KEY =
+      config.credentials.JUNIE_OPENAI_COMPATIBLE_API_KEY;
+    console.log('✅ Set JUNIE_OPENAI_COMPATIBLE_API_KEY from config for Junie');
+  }
+
+  const apiKey = config.credentials?.JUNIE_OPENAI_COMPATIBLE_API_KEY || envApiKey;
+  if (!apiKey) {
+    console.log(
+      'ℹ️  No JUNIE_OPENAI_COMPATIBLE_API_KEY found - Junie agent will require BYOK setup'
+    );
+    console.log(
+      '   To use Junie: agor config set credentials.JUNIE_OPENAI_COMPATIBLE_API_KEY <token>'
+    );
+    console.log('   Or set JUNIE_OPENAI_COMPATIBLE_API_KEY environment variable');
+  }
+
+  return apiKey;
+}
+
+/**
  * Initialize all AI service credentials
  *
  * Convenience function to initialize all supported API keys at once.
@@ -191,6 +221,10 @@ export function initializeCredentials(config: {
       process.env.COPILOT_GITHUB_TOKEN,
       process.env.GH_TOKEN,
       process.env.GITHUB_TOKEN
+    ),
+    junieOpenAICompatibleApiKey: initializeJunieOpenAICompatibleApiKey(
+      config,
+      process.env.JUNIE_OPENAI_COMPATIBLE_API_KEY
     ),
   };
 }

--- a/apps/agor-daemon/src/utils/spawn-executor.secrets.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.secrets.test.ts
@@ -74,6 +74,7 @@ describe('isSecretEnvKey matches the keys spawn-executor cares about', () => {
     'OPENAI_API_KEY',
     'GEMINI_API_KEY',
     'GOOGLE_API_KEY',
+    'JUNIE_OPENAI_COMPATIBLE_API_KEY',
   ];
 
   for (const key of relevantKeys) {

--- a/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
@@ -40,4 +40,11 @@ export const AVAILABLE_AGENTS: AgenticToolOption[] = [
     description: 'GitHub Copilot agentic runtime',
     beta: true,
   },
+  {
+    id: 'junie',
+    name: 'Junie',
+    icon: 'J',
+    description: 'JetBrains Junie via OpenAI-compatible BYOK',
+    beta: true,
+  },
 ];

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -62,6 +62,7 @@ const MODEL_LABELS: Record<string, string> = {
   gemini: 'Gemini Model',
   opencode: 'OpenCode LLM Provider',
   copilot: 'Copilot Model',
+  junie: 'Junie OpenAI-compatible Model',
 };
 
 export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -104,6 +104,15 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       docUrl: 'https://github.com/settings/tokens',
     },
   ],
+  junie: [
+    {
+      field: 'JUNIE_OPENAI_COMPATIBLE_API_KEY',
+      label: 'Junie OpenAI-compatible API Key',
+      description: '(Junie)',
+      placeholder: 'sk-...',
+      docUrl: 'https://junie.jetbrains.com/docs/parameters.html',
+    },
+  ],
   opencode: [],
 };
 

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -23,8 +23,8 @@ export interface ModelConfig {
 export interface ModelSelectorProps {
   value?: ModelConfig;
   onChange?: (config: ModelConfig) => void;
-  agent?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot'; // Kept as 'agent' for backwards compat in prop name
-  agentic_tool?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+  agent?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie'; // Kept as 'agent' for backwards compat in prop name
+  agentic_tool?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
   /**
    * Optional Feathers client. When provided AND the agentic tool is Copilot,
    * the picker fetches the live model list from /copilot-models (which calls
@@ -169,6 +169,17 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             });
           }
         }}
+      />
+    );
+  }
+
+  if (effectiveTool === 'junie') {
+    return (
+      <Input
+        value={value?.model}
+        onChange={(e) => onChange?.({ mode: 'exact', model: e.target.value })}
+        placeholder="e.g., qwen-3.5-35b-a3b"
+        style={{ width: '100%', minWidth: 400 }}
       />
     );
   }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -110,6 +110,8 @@ export interface OnboardingWizardProps {
     ANTHROPIC_API_KEY?: boolean;
     OPENAI_API_KEY?: boolean;
     GEMINI_API_KEY?: boolean;
+    COPILOT_GITHUB_TOKEN?: boolean;
+    JUNIE_OPENAI_COMPATIBLE_API_KEY?: boolean;
   };
 }
 
@@ -153,6 +155,8 @@ function apiKeyNameForAgent(agent: AgenticToolName): string {
       return 'GEMINI_API_KEY';
     case 'copilot':
       return 'COPILOT_GITHUB_TOKEN';
+    case 'junie':
+      return 'JUNIE_OPENAI_COMPATIBLE_API_KEY';
     case 'opencode':
       return 'ANTHROPIC_API_KEY';
     default:
@@ -170,6 +174,8 @@ function apiKeyPlaceholder(agent: AgenticToolName): string {
       return 'AIza...';
     case 'copilot':
       return 'ghp_...';
+    case 'junie':
+      return 'sk-...';
     default:
       return 'sk-ant-...';
   }
@@ -181,6 +187,7 @@ const AGENT_LABELS: Record<AgenticToolName, string> = {
   gemini: 'Gemini',
   opencode: 'OpenCode',
   copilot: 'GitHub Copilot',
+  junie: 'Junie',
 };
 
 /**
@@ -213,6 +220,10 @@ const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string }
   codex: { label: 'platform.openai.com', url: 'https://platform.openai.com/api-keys' },
   gemini: { label: 'aistudio.google.com', url: 'https://aistudio.google.com/apikey' },
   copilot: { label: 'github.com/features/copilot', url: 'https://github.com/features/copilot' },
+  junie: {
+    label: 'Junie parameters docs',
+    url: 'https://junie.jetbrains.com/docs/parameters.html',
+  },
   opencode: null,
 };
 
@@ -279,6 +290,7 @@ export function OnboardingWizard({
   const codexFields = user?.agentic_tools?.codex;
   const geminiFields = user?.agentic_tools?.gemini;
   const copilotFields = user?.agentic_tools?.copilot;
+  const junieFields = user?.agentic_tools?.junie;
   const hasAnthropicKey = !!(
     claudeFields?.ANTHROPIC_API_KEY ||
     claudeFields?.CLAUDE_CODE_OAUTH_TOKEN ||
@@ -301,6 +313,11 @@ export function OnboardingWizard({
     user?.env_vars?.COPILOT_GITHUB_TOKEN ||
     (systemCredentials as Record<string, unknown>)?.COPILOT_GITHUB_TOKEN
   );
+  const hasJunieOpenAICompatibleKey = !!(
+    junieFields?.JUNIE_OPENAI_COMPATIBLE_API_KEY ||
+    user?.env_vars?.JUNIE_OPENAI_COMPATIBLE_API_KEY ||
+    (systemCredentials as Record<string, unknown>)?.JUNIE_OPENAI_COMPATIBLE_API_KEY
+  );
 
   const hasKeyForAgent = (agent: AgenticToolName): boolean => {
     switch (agent) {
@@ -312,6 +329,8 @@ export function OnboardingWizard({
         return hasGeminiKey;
       case 'copilot':
         return hasCopilotToken;
+      case 'junie':
+        return hasJunieOpenAICompatibleKey;
       case 'opencode':
         return hasAnthropicKey || hasOpenAIKey || hasGeminiKey;
       default:
@@ -1116,6 +1135,7 @@ export function OnboardingWizard({
               { value: 'gemini', label: 'Gemini' },
               { value: 'copilot', label: 'GitHub Copilot' },
               { value: 'opencode', label: 'OpenCode' },
+              { value: 'junie', label: 'Junie' },
             ]}
             style={{ width: '100%' }}
           />

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -19,7 +19,7 @@ interface ModeOption {
 export interface PermissionModeSelectorProps {
   value?: PermissionMode;
   onChange?: (value: PermissionMode) => void;
-  agentic_tool?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+  agentic_tool?: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
   /** If true, renders as a compact Select dropdown instead of Radio buttons */
   compact?: boolean;
   /**
@@ -179,6 +179,16 @@ const OPENCODE_MODES: ModeOption[] = [
   },
 ];
 
+const JUNIE_MODES: ModeOption[] = [
+  {
+    mode: 'default',
+    label: 'default',
+    description: 'Junie-managed approvals and behavior',
+    icon: <SafetyOutlined />,
+    color: '#1677ff',
+  },
+];
+
 // Codex sandbox mode options
 export const CODEX_SANDBOX_MODES = [
   {
@@ -233,6 +243,8 @@ const getModesForTool = (tool: PermissionModeSelectorProps['agentic_tool']): Mod
       return OPENCODE_MODES;
     case 'copilot':
       return COPILOT_MODES;
+    case 'junie':
+      return JUNIE_MODES;
     default:
       return CLAUDE_CODE_MODES;
   }
@@ -246,6 +258,8 @@ const getDefaultMode = (tool: PermissionModeSelectorProps['agentic_tool']): Perm
     case 'gemini':
     case 'opencode':
       return 'autoEdit';
+    case 'junie':
+      return 'default';
     default:
       return 'acceptEdits';
   }

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -13,7 +13,20 @@ import {
   LoadingOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Form, Input, Space, Spin, Switch, Tabs, Tooltip, theme } from 'antd';
+import {
+  Alert,
+  AutoComplete,
+  Button,
+  Form,
+  Input,
+  Select,
+  Space,
+  Spin,
+  Switch,
+  Tabs,
+  Tooltip,
+  theme,
+} from 'antd';
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '../../utils/message';
 import {
@@ -43,8 +56,26 @@ const GLOBAL_TOOL_FIELDS: Record<AgenticToolName, AgenticToolFieldConfig[]> = {
   codex: TOOL_FIELD_CONFIGS.codex.filter((f) => f.field !== 'OPENAI_BASE_URL'),
   gemini: TOOL_FIELD_CONFIGS.gemini,
   copilot: TOOL_FIELD_CONFIGS.copilot,
+  junie: TOOL_FIELD_CONFIGS.junie,
   opencode: TOOL_FIELD_CONFIGS.opencode,
 };
+
+type JunieModelsResponse = {
+  models?: string[];
+};
+
+function buildJunieModelOptions(models: string[], selectedModels: string[]) {
+  const values = new Set<string>();
+  for (const model of selectedModels) {
+    const trimmed = model.trim();
+    if (trimmed) values.add(trimmed);
+  }
+  for (const model of models) {
+    const trimmed = model.trim();
+    if (trimmed) values.add(trimmed);
+  }
+  return [...values].map((model) => ({ value: model, label: model }));
+}
 
 /** Per-tool global-config tab body. */
 const ApiKeyTabContent: React.FC<{
@@ -122,6 +153,17 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
   const [opencodeConnected, setOpencodeConnected] = useState<boolean | null>(null);
   const [opencodeTesting, setOpencodeTesting] = useState(false);
   const [loadingOpencode, setLoadingOpencode] = useState(true);
+  const [loadingJunieConfig, setLoadingJunieConfig] = useState(true);
+  const [savingJunieConfig, setSavingJunieConfig] = useState(false);
+  const [junieExecutable, setJunieExecutable] = useState('junie');
+  const [junieOpenAICompatibleBaseUrl, setJunieOpenAICompatibleBaseUrl] = useState('');
+  const [junieDefaultModel, setJunieDefaultModel] = useState('');
+  const [junieFasterModel, setJunieFasterModel] = useState('');
+  const [junieModels, setJunieModels] = useState<string[]>([]);
+  const [loadingJunieModels, setLoadingJunieModels] = useState(false);
+  const [junieApiType, setJunieApiType] = useState<'OpenAIResponses' | 'OpenAICompletion'>(
+    'OpenAICompletion'
+  );
 
   // Load API keys configuration
   useEffect(() => {
@@ -156,6 +198,41 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     };
 
     loadKeys();
+  }, [client]);
+
+  // Load Junie configuration
+  useEffect(() => {
+    if (!client) return;
+
+    const loadJunie = async () => {
+      try {
+        setLoadingJunieConfig(true);
+        const config = (await client.service('config').get('junie')) as {
+          executable?: string;
+          openaiCompatibleBaseUrl?: string;
+          defaultModel?: string;
+          fasterModel?: string;
+          apiType?: 'OpenAIResponses' | 'OpenAICompletion';
+        } | null;
+
+        setJunieExecutable(config?.executable || 'junie');
+        setJunieOpenAICompatibleBaseUrl(config?.openaiCompatibleBaseUrl || '');
+        setJunieDefaultModel(config?.defaultModel || '');
+        setJunieFasterModel(config?.fasterModel || '');
+        setJunieApiType(config?.apiType || 'OpenAICompletion');
+      } catch (err) {
+        console.error('Failed to load Junie config:', err);
+        setJunieExecutable('junie');
+        setJunieOpenAICompatibleBaseUrl('');
+        setJunieDefaultModel('');
+        setJunieFasterModel('');
+        setJunieApiType('OpenAICompletion');
+      } finally {
+        setLoadingJunieConfig(false);
+      }
+    };
+
+    loadJunie();
   }, [client]);
 
   // Load OpenCode configuration
@@ -272,7 +349,75 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
     }
   };
 
-  const loading = loadingKeys || loadingOpencode;
+  const handleSaveJunieConfig = async () => {
+    if (!client) return;
+
+    const openaiCompatibleBaseUrl = junieOpenAICompatibleBaseUrl.trim();
+    const defaultModel = junieDefaultModel.trim();
+
+    if (!openaiCompatibleBaseUrl) {
+      showError('Junie OpenAI-compatible base URL cannot be empty');
+      return;
+    }
+    if (!defaultModel) {
+      showError('Junie default model cannot be empty');
+      return;
+    }
+
+    try {
+      setSavingJunieConfig(true);
+      await client.service('config').patch(null, {
+        junie: {
+          executable: junieExecutable.trim() || 'junie',
+          openaiCompatibleBaseUrl,
+          defaultModel,
+          fasterModel: junieFasterModel.trim() || null,
+          apiType: junieApiType,
+        },
+      });
+      showSuccess('Junie settings saved');
+    } catch (err) {
+      console.error('Failed to save Junie config:', err);
+      showError(err instanceof Error ? err.message : 'Failed to save Junie settings');
+    } finally {
+      setSavingJunieConfig(false);
+    }
+  };
+
+  const handleLoadJunieModels = async () => {
+    if (!client) return;
+
+    const openaiCompatibleBaseUrl = junieOpenAICompatibleBaseUrl.trim();
+    if (!openaiCompatibleBaseUrl) {
+      showError('Junie OpenAI-compatible base URL cannot be empty');
+      return;
+    }
+
+    try {
+      setLoadingJunieModels(true);
+      const result = (await client.service('config/junie-models').create({
+        openaiCompatibleBaseUrl,
+      })) as JunieModelsResponse;
+      const models = Array.isArray(result.models) ? result.models : [];
+      setJunieModels(models);
+      if (models.length === 0) {
+        showError('Gateway returned no models');
+      } else {
+        showSuccess(`Loaded ${models.length} Junie models`);
+      }
+    } catch (err) {
+      console.error('Failed to load Junie models:', err);
+      showError(err instanceof Error ? err.message : 'Failed to load Junie models');
+    } finally {
+      setLoadingJunieModels(false);
+    }
+  };
+
+  const loading = loadingKeys || loadingOpencode || loadingJunieConfig;
+  const junieModelOptions = buildJunieModelOptions(junieModels, [
+    junieDefaultModel,
+    junieFasterModel,
+  ]);
 
   if (loading) {
     return (
@@ -346,6 +491,92 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                 onClear={handleClearKey}
                 onClearError={() => setKeysError(null)}
               />
+            ),
+          },
+          {
+            key: 'junie',
+            label: 'Junie',
+            children: (
+              <div
+                style={{
+                  paddingTop: token.paddingMD,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: token.marginXL,
+                }}
+              >
+                <ApiKeyTabContent
+                  tool="junie"
+                  fieldStatus={fieldStatus}
+                  keysError={keysError}
+                  savingKeys={savingKeys}
+                  onSave={handleSaveKey}
+                  onClear={handleClearKey}
+                  onClearError={() => setKeysError(null)}
+                />
+
+                <Form layout="vertical">
+                  <Form.Item
+                    label="Junie executable"
+                    extra="Command Agor runs for Junie headless sessions."
+                  >
+                    <Input
+                      value={junieExecutable}
+                      onChange={(event) => setJunieExecutable(event.target.value)}
+                      placeholder="junie"
+                    />
+                  </Form.Item>
+                  <Form.Item
+                    label="OpenAI-compatible base URL"
+                    extra="Gateway root URL. Agor appends the Junie profile endpoint for the selected API type."
+                    required
+                  >
+                    <Space.Compact style={{ width: '100%' }}>
+                      <Input
+                        value={junieOpenAICompatibleBaseUrl}
+                        onChange={(event) => setJunieOpenAICompatibleBaseUrl(event.target.value)}
+                        placeholder="https://openai-compatible.example.com"
+                      />
+                      <Button onClick={handleLoadJunieModels} loading={loadingJunieModels}>
+                        Load models
+                      </Button>
+                    </Space.Compact>
+                  </Form.Item>
+                  <Form.Item label="Default model" required>
+                    <AutoComplete
+                      options={junieModelOptions}
+                      value={junieDefaultModel}
+                      onChange={setJunieDefaultModel}
+                      placeholder="gpt-5.2"
+                      filterOption={false}
+                    />
+                  </Form.Item>
+                  <Form.Item label="Faster model">
+                    <AutoComplete
+                      options={junieModelOptions}
+                      value={junieFasterModel}
+                      onChange={setJunieFasterModel}
+                      placeholder="gpt-5.4-mini"
+                      filterOption={false}
+                    />
+                  </Form.Item>
+                  <Form.Item label="OpenAI-compatible API type">
+                    <Select value={junieApiType} onChange={setJunieApiType}>
+                      <Select.Option value="OpenAICompletion">
+                        OpenAI Chat Completions
+                      </Select.Option>
+                      <Select.Option value="OpenAIResponses">OpenAI Responses</Select.Option>
+                    </Select>
+                  </Form.Item>
+                  <Button
+                    type="primary"
+                    onClick={handleSaveJunieConfig}
+                    loading={savingJunieConfig}
+                  >
+                    Save Junie settings
+                  </Button>
+                </Form>
+              </div>
             ),
           },
           {

--- a/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
@@ -38,6 +38,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
   const [geminiForm] = Form.useForm();
   const [opencodeForm] = Form.useForm();
   const [copilotForm] = Form.useForm();
+  const [junieForm] = Form.useForm();
 
   const [saving, setSaving] = useState<Record<AgenticToolName, boolean>>({
     'claude-code': false,
@@ -45,6 +46,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
     gemini: false,
     opencode: false,
     copilot: false,
+    junie: false,
   });
   const [activeTab, setActiveTab] = useState<AgenticToolName>('claude-code');
 
@@ -63,6 +65,8 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
         return opencodeForm;
       case 'copilot':
         return copilotForm;
+      case 'junie':
+        return junieForm;
     }
   };
 
@@ -124,6 +128,12 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
       label: 'GitHub Copilot',
       tool: 'copilot',
       form: copilotForm,
+    },
+    {
+      key: 'junie',
+      label: 'Junie',
+      tool: 'junie',
+      form: junieForm,
     },
   ];
 

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -79,6 +79,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [geminiForm] = Form.useForm();
   const [opencodeForm] = Form.useForm();
   const [copilotForm] = Form.useForm();
+  const [junieForm] = Form.useForm();
   const [audioForm] = Form.useForm();
 
   // Per-tool credential presence state, keyed `${tool}.${field}` for spinner
@@ -90,6 +91,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     gemini: {},
     opencode: {},
     copilot: {},
+    junie: {},
   });
   const [savingToolField, setSavingToolField] = useState<Record<string, boolean>>({});
 
@@ -104,6 +106,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     gemini: false,
     opencode: false,
     copilot: false,
+    junie: false,
   });
 
   // Initialize forms when user changes or modal opens
@@ -126,6 +129,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       claudeForm.setFieldsValue(getFormValuesFromConfig('claude-code', defaults?.['claude-code']));
       codexForm.setFieldsValue(getFormValuesFromConfig('codex', defaults?.codex));
       geminiForm.setFieldsValue(getFormValuesFromConfig('gemini', defaults?.gemini));
+      junieForm.setFieldsValue(getFormValuesFromConfig('junie', defaults?.junie));
 
       // Initialize audio form with user's preferences
       const audioPrefs = userData.preferences?.audio;
@@ -137,7 +141,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           audioPrefs?.minDurationSeconds ?? DEFAULT_AUDIO_PREFERENCES.minDurationSeconds,
       });
     },
-    [form, claudeForm, codexForm, geminiForm, audioForm]
+    [form, claudeForm, codexForm, geminiForm, junieForm, audioForm]
   );
 
   // Initialize when modal opens with user data
@@ -158,6 +162,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: {},
       opencode: {},
       copilot: {},
+      junie: {},
     };
     const stored = user?.agentic_tools;
     if (stored) {
@@ -183,6 +188,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     claudeForm.resetFields();
     codexForm.resetFields();
     geminiForm.resetFields();
+    junieForm.resetFields();
     setActiveTab('general');
     onClose();
   };
@@ -354,6 +360,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: geminiForm,
       opencode: opencodeForm,
       copilot: copilotForm,
+      junie: junieForm,
     };
 
     try {
@@ -386,6 +393,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: geminiForm,
       opencode: opencodeForm,
       copilot: copilotForm,
+      junie: junieForm,
     };
 
     formMap[tool].setFieldsValue(getClearedFormValues(tool));
@@ -437,6 +445,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'gemini':
       case 'opencode':
       case 'copilot':
+      case 'junie':
         await handleAgenticConfigSave(activeTab as AgenticToolName);
         break;
     }
@@ -501,6 +510,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         {
           key: 'copilot',
           label: 'GitHub Copilot',
+          icon: <RobotOutlined />,
+        },
+        {
+          key: 'junie',
+          label: 'Junie',
           icon: <RobotOutlined />,
         },
       ],
@@ -644,7 +658,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'codex':
       case 'gemini':
       case 'opencode':
-      case 'copilot': {
+      case 'copilot':
+      case 'junie': {
         const toolName = activeTab as AgenticToolName;
         const formMap = {
           'claude-code': claudeForm,
@@ -652,6 +667,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           gemini: geminiForm,
           opencode: opencodeForm,
           copilot: copilotForm,
+          junie: junieForm,
         };
         const currentForm = formMap[toolName];
         const displayNames: Record<AgenticToolName, string> = {
@@ -660,6 +676,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           gemini: 'Gemini',
           opencode: 'OpenCode',
           copilot: 'Copilot',
+          junie: 'Junie',
         };
         // Field set is owned by ApiKeyFields' `TOOL_FIELD_CONFIGS`. Per-field
         // saving spinners are tracked in `savingToolField` keyed by `${tool}.${field}`.
@@ -738,6 +755,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: 'Gemini',
       opencode: 'OpenCode',
       copilot: 'GitHub Copilot',
+      junie: 'Junie',
     };
     return titles[activeTab] || 'User Settings';
   };

--- a/apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx
+++ b/apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx
@@ -41,6 +41,7 @@ export const ToolIcon: React.FC<ToolIconProps> = ({ tool, size = 32, className =
     gemini: '💎',
     opencode: '🌐',
     copilot: '✈️',
+    junie: 'J',
   };
 
   if (!logoSrc) {

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/ScheduleTab.tsx
@@ -121,7 +121,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
       const scheduleConfig = {
         timezone: 'UTC',
         prompt_template: promptTemplate,
-        agentic_tool: agenticTool as 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot',
+        agentic_tool: agenticTool as AgenticToolName,
         retention: retention,
         allow_concurrent_runs: allowConcurrentRuns,
         permission_mode: formValues.permissionMode,

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -22,6 +22,8 @@ interface SystemCredentials {
   ANTHROPIC_API_KEY?: boolean;
   OPENAI_API_KEY?: boolean;
   GEMINI_API_KEY?: boolean;
+  COPILOT_GITHUB_TOKEN?: boolean;
+  JUNIE_OPENAI_COMPATIBLE_API_KEY?: boolean;
 }
 
 interface OnboardingConfig {

--- a/docs/superpowers/plans/2026-05-12-junie-integration.md
+++ b/docs/superpowers/plans/2026-05-12-junie-integration.md
@@ -1,0 +1,214 @@
+# Junie Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add JetBrains Junie as a BYOK-only Agor agent backed by an OpenAI-compatible custom model profile.
+
+**Architecture:** The integration extends Agor's existing agent enum/config surfaces, then adds a process-backed executor adapter for Junie's headless CLI. Junie uses a separate `JUNIE_OPENAI_COMPATIBLE_API_KEY`, session-scoped temp profile/config files, and `session.sdk_session_id` for continuity.
+
+**Tech Stack:** TypeScript, Vitest, Feathers-backed executor repositories, React/Ant Design UI.
+
+---
+
+## File Structure
+
+- Modify `packages/core/src/types/agentic-tool.ts`: add `junie` and capabilities.
+- Modify `packages/core/src/config/types.ts`: add Junie settings and `JUNIE_OPENAI_COMPATIBLE_API_KEY`.
+- Modify `packages/core/src/config/key-resolver.ts`: resolve Junie key through the generic resolver.
+- Modify `packages/core/src/config/config-manager.ts`: expose Junie credential lookup.
+- Modify `packages/core/src/types/user.ts`: add Junie API key status/update fields.
+- Modify `packages/core/src/db/schema.sqlite.ts` and `packages/core/src/db/schema.postgres.ts`: extend encrypted user key JSON type.
+- Modify `packages/core/src/db/repositories/users.ts` and `apps/agor-daemon/src/services/users.ts`: encrypt, decrypt, and expose Junie key status.
+- Modify `apps/agor-daemon/src/services/config.ts`: mask and hot-reload Junie credentials, allow Junie settings.
+- Modify `apps/agor-daemon/src/utils/spawn-executor.ts`: include Junie secret in impersonated executor env.
+- Modify `packages/executor/src/payload-types.ts`, `packages/executor/src/cli.ts`, and `packages/executor/src/index.ts`: accept `junie`.
+- Modify `packages/executor/src/handlers/sdk/tool-registry.ts`: register Junie.
+- Create `packages/executor/src/handlers/sdk/junie.ts`: executor entrypoint.
+- Create `packages/executor/src/sdk-handlers/junie/profile.ts`: generate Junie model profiles.
+- Create `packages/executor/src/sdk-handlers/junie/normalizer.ts`: parse Junie JSON/stdout fallback.
+- Create `packages/executor/src/sdk-handlers/junie/junie-tool.ts`: command construction and process execution helpers.
+- Create `packages/executor/src/sdk-handlers/junie/index.ts` and `types.ts`: exports and local types.
+- Modify `packages/executor/src/sdk-handlers/normalizer-factory.ts` and `models.ts`: include Junie.
+- Modify UI agent selectors, model selector, permission selector, key fields, settings, onboarding, and tool icon fallback.
+
+## Task 1: Core Credential and Agent Types
+
+**Files:**
+- Modify: `packages/core/src/types/agentic-tool.ts`
+- Modify: `packages/core/src/config/types.ts`
+- Modify: `packages/core/src/config/key-resolver.ts`
+- Modify: `packages/core/src/config/config-manager.ts`
+- Modify: `packages/core/src/types/user.ts`
+- Modify: `packages/core/src/utils/permission-mode-mapper.ts`
+- Test: `packages/core/src/utils/permission-mode-mapper.test.ts`
+- Test: `packages/core/src/config/config-manager.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that expect:
+
+```ts
+expect(mapPermissionMode('allow-all', 'junie')).toBe('default');
+expect(mapPermissionMode('acceptEdits', 'junie')).toBe('default');
+```
+
+Add config-manager type coverage for `getCredential('JUNIE_OPENAI_COMPATIBLE_API_KEY')`.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+pnpm --filter @agor/core test src/utils/permission-mode-mapper.test.ts src/config/config-manager.test.ts
+```
+
+Expected: fail because `junie` and `JUNIE_OPENAI_COMPATIBLE_API_KEY` are not recognized.
+
+- [ ] **Step 3: Implement minimal core changes**
+
+Add `junie` to agent unions/capabilities. Add `JUNIE_OPENAI_COMPATIBLE_API_KEY` and `AgorJunieSettings` to config types and credential lookup unions. Add Junie user API key status/update fields. Map all Junie permission modes to `default`.
+
+- [ ] **Step 4: Run green tests**
+
+Run the same command. Expected: all selected tests pass.
+
+## Task 2: Daemon Credential Plumbing
+
+**Files:**
+- Modify: `packages/core/src/db/schema.sqlite.ts`
+- Modify: `packages/core/src/db/schema.postgres.ts`
+- Modify: `packages/core/src/db/repositories/users.ts`
+- Modify: `apps/agor-daemon/src/services/users.ts`
+- Modify: `apps/agor-daemon/src/services/config.ts`
+- Modify: `apps/agor-daemon/src/setup/credentials.ts`
+- Modify: `apps/agor-daemon/src/utils/spawn-executor.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Extend existing user/config/spawn tests to assert Junie key status is masked, encrypted, and included in impersonated secret env.
+
+- [ ] **Step 2: Run red tests**
+
+Run focused daemon/core tests that cover those files.
+
+- [ ] **Step 3: Implement credential plumbing**
+
+Thread `JUNIE_OPENAI_COMPATIBLE_API_KEY` through user encrypted storage, config masking/hot-reload, config patching, setup logging, and executor env handoff.
+
+- [ ] **Step 4: Run green tests**
+
+Run the same focused tests. Expected: all selected tests pass.
+
+## Task 3: Junie Executor Adapter
+
+**Files:**
+- Modify: `packages/executor/src/payload-types.ts`
+- Modify: `packages/executor/src/cli.ts`
+- Modify: `packages/executor/src/index.ts`
+- Modify: `packages/executor/src/handlers/sdk/tool-registry.ts`
+- Modify: `packages/executor/src/sdk-handlers/normalizer-factory.ts`
+- Modify: `packages/executor/src/sdk-handlers/models.ts`
+- Create: `packages/executor/src/handlers/sdk/junie.ts`
+- Create: `packages/executor/src/sdk-handlers/junie/index.ts`
+- Create: `packages/executor/src/sdk-handlers/junie/types.ts`
+- Create: `packages/executor/src/sdk-handlers/junie/profile.ts`
+- Create: `packages/executor/src/sdk-handlers/junie/normalizer.ts`
+- Create: `packages/executor/src/sdk-handlers/junie/junie-tool.ts`
+- Test: `packages/executor/src/payload-types.test.ts`
+- Test: `packages/executor/src/sdk-handlers/junie/profile.test.ts`
+- Test: `packages/executor/src/sdk-handlers/junie/normalizer.test.ts`
+- Test: `packages/executor/src/sdk-handlers/junie/junie-tool.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Tests should assert:
+
+```ts
+PromptPayloadSchema.parse({ command: 'prompt', sessionToken: 'jwt', params: { sessionId, taskId, prompt: 'hi', tool: 'junie', cwd: '/tmp/repo' } });
+```
+
+Profile generation produces `OpenAIResponses` with `/v1/responses`; command args include `--model custom:agor-openai-compatible` and do not include the API key; normalizer extracts assistant text from known JSON shapes and falls back to stdout.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+pnpm --filter @agor/executor test src/payload-types.test.ts src/sdk-handlers/junie/profile.test.ts src/sdk-handlers/junie/normalizer.test.ts src/sdk-handlers/junie/junie-tool.test.ts
+```
+
+Expected: fail because Junie files and schema support do not exist.
+
+- [ ] **Step 3: Implement adapter**
+
+Add schema/tool registry support. Implement pure profile, normalizer, and command construction helpers first. Implement process execution wrapper with `node:child_process` and Feathers-backed message/task updates after pure helpers pass.
+
+- [ ] **Step 4: Run green tests**
+
+Run the same executor tests. Expected: all selected tests pass.
+
+## Task 4: UI Exposure
+
+**Files:**
+- Modify: `apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts`
+- Modify: `apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx`
+- Modify: `apps/agor-ui/src/components/ApiKeyFields.tsx`
+- Modify: `apps/agor-ui/src/components/SettingsModal/AgenticToolsTab.tsx`
+- Modify: `apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx`
+- Modify: `apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx`
+- Modify: `apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx`
+- Modify: `apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx`
+
+- [ ] **Step 1: Write failing UI/type tests where existing coverage exists**
+
+Add or update lightweight tests for agent option lists if present. If no local tests exist, rely on TypeScript for UI coverage.
+
+- [ ] **Step 2: Implement UI changes**
+
+Add Junie labels, key fields, settings fields for OpenAI-compatible URL/default models/API type/executable, model selector support, permission selector default-only behavior, and `J` icon fallback.
+
+- [ ] **Step 3: Run UI typecheck**
+
+Run:
+
+```bash
+pnpm --filter agor-ui typecheck
+```
+
+Expected: typecheck passes.
+
+## Task 5: Final Verification
+
+**Files:**
+- Review all changed files.
+
+- [ ] **Step 1: Run targeted verification**
+
+Run:
+
+```bash
+pnpm --filter @agor/core test src/utils/permission-mode-mapper.test.ts src/config/config-manager.test.ts
+pnpm --filter @agor/executor test src/payload-types.test.ts src/sdk-handlers/junie/profile.test.ts src/sdk-handlers/junie/normalizer.test.ts src/sdk-handlers/junie/junie-tool.test.ts
+pnpm --filter agor-ui typecheck
+```
+
+- [ ] **Step 2: Manual install probe if Junie exists**
+
+Run:
+
+```bash
+junie --version
+```
+
+Expected: version is printed if Junie is installed; if absent, report that smoke testing was skipped.
+
+- [ ] **Step 3: Final diff review**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+```
+
+Expected: no whitespace errors; changes match the approved design.

--- a/docs/superpowers/specs/2026-05-12-junie-integration-design.md
+++ b/docs/superpowers/specs/2026-05-12-junie-integration-design.md
@@ -1,0 +1,373 @@
+# Junie Agent Integration Design
+
+## Summary
+
+Add JetBrains Junie as a first-class Agor agentic tool using Junie's headless CLI.
+The initial integration is BYOK-only and targets the user's OpenAI-compatible gateway through a
+Junie custom model profile. Agor will not support JetBrains account login or Junie
+API tokens in this first version.
+
+## Goals
+
+- Add `junie` anywhere Agor enumerates supported agentic tools.
+- Run Junie against Agor worktrees from the executor process.
+- Use a separate OpenAI-compatible credential path so Junie does not reuse Codex's
+  `OPENAI_API_KEY`.
+- Default Junie to an OpenAI-compatible endpoint.
+- Preserve Agor session continuity by storing Junie's CLI session id in
+  `session.sdk_session_id`.
+- Surface Junie in the UI with model/gateway configuration and basic execution
+  status.
+- Keep the first implementation narrow: normal prompt execution only.
+
+## Non-Goals
+
+- Do not implement JetBrains account login, Junie API token auth, or browser-based
+  auth flows.
+- Do not implement ACP mode in the first pass.
+- Do not treat Junie as an SDK integration unless JetBrains exposes a stable SDK
+  later.
+- Do not expose Junie's merge/rebase task modes in the first UI pass.
+- Do not add session import from Junie's local storage in the first pass.
+- Do not run project builds during implementation unless the user asks or watch mode
+  reports a compilation problem.
+
+## External Behavior
+
+Users can select Junie when creating a session, choose an OpenAI-compatible model profile, and
+send prompts the same way they do for Claude Code, Codex, Gemini, OpenCode, and
+Copilot. Junie runs in the selected worktree and writes changes directly to that
+worktree.
+
+Junie uses:
+
+- `JUNIE_OPENAI_COMPATIBLE_API_KEY` for the OpenAI-compatible bearer token.
+- `junie.openaiCompatibleBaseUrl` for the OpenAI-compatible gateway URL.
+- `junie.defaultModel` for the primary OpenAI-compatible model.
+- `junie.fasterModel` for Junie's helper/internal model, when configured.
+- `junie.apiType`, defaulting to `OpenAIResponses`, with `OpenAICompletion` as an
+  escape hatch.
+- `junie.executable`, defaulting to `junie`, for non-standard installations.
+
+The generated Junie custom model profile should default to:
+
+```json
+{
+  "apiType": "OpenAIResponses",
+  "baseUrl": "<openai-compatible-base-url>/v1/responses",
+  "apiKey": "<resolved JUNIE_OPENAI_COMPATIBLE_API_KEY>",
+  "id": "<junie.defaultModel>",
+  "primaryModel": {
+    "id": "<junie.defaultModel>"
+  },
+  "fasterModel": {
+    "id": "<junie.fasterModel>"
+  }
+}
+```
+
+When `junie.fasterModel` is absent, omit `fasterModel` and let Junie inherit the
+top-level model settings.
+
+## Architecture
+
+### Core Type and Config Layer
+
+Add `junie` to the canonical `AgenticToolName` union and related static
+capability maps in `packages/core/src/types/agentic-tool.ts`.
+
+Add Junie configuration to `packages/core/src/config/types.ts`:
+
+```ts
+export interface AgorJunieSettings {
+  executable?: string;
+  openaiCompatibleBaseUrl?: string;
+  defaultModel?: string;
+  fasterModel?: string;
+  apiType?: 'OpenAIResponses' | 'OpenAICompletion';
+}
+```
+
+Add `JUNIE_OPENAI_COMPATIBLE_API_KEY` to:
+
+- `CredentialKey`
+- `AgorCredentials`
+- `ApiKeyName`
+- key resolver tests
+- config masking
+- config hot-reload to `process.env`
+- user API key status/update types
+- user repository/service encryption paths
+- executor secret environment handoff
+
+The resolver precedence remains:
+
+1. Per-user encrypted key.
+2. Global `~/.agor/config.yaml`.
+3. Process environment.
+4. No native auth fallback for Junie.
+
+For Junie specifically, an unresolved key should produce a clear user-facing failure
+that asks for `JUNIE_OPENAI_COMPATIBLE_API_KEY`; it should not attempt JetBrains native auth.
+
+### Executor Integration
+
+Add `junie` to:
+
+- `packages/executor/src/payload-types.ts`
+- `packages/executor/src/handlers/sdk/tool-registry.ts`
+- executor CLI tool choices
+- normalizer factory
+
+Create `packages/executor/src/handlers/sdk/junie.ts`. Junie is process-backed
+rather than SDK-backed, so implement a Junie-specific executor helper instead of
+forcing it through `executeToolTask`.
+
+Create `packages/executor/src/sdk-handlers/junie/`:
+
+- `index.ts` exports Junie handler pieces.
+- `junie-tool.ts` checks installation, builds command args, spawns Junie, streams
+  stdout/stderr progress, stores messages, and updates tasks.
+- `profile.ts` creates the temp custom model profile.
+- `config.ts` creates the temp Junie config file.
+- `mcp-config.ts` creates the temp MCP config folder and `mcp.json`.
+- `normalizer.ts` converts Junie JSON/stdout/stderr into Agor's normalized raw
+  response shape.
+- `types.ts` defines Junie-specific output and config types.
+
+The command should be built without putting secrets in argv. The API key belongs in
+the generated profile file or an env file owned by the target Unix user, not in
+command-line flags.
+
+Expected command shape:
+
+```bash
+junie \
+  --project <worktree-path> \
+  --session-id <sdk-session-id> \
+  --model custom:<profile-id> \
+  --model-location <temp-model-dir> \
+  --mcp-location <temp-mcp-dir> \
+  --config-location <temp-config.json> \
+  --output-format json \
+  --json-output-file <temp-output.json> \
+  --skip-update-check \
+  --task <prompt>
+```
+
+For a new Agor session with no `sdk_session_id`, generate a deterministic Junie
+session id from the Agor session id, store it on the Agor session before execution,
+and pass it to Junie. This avoids needing to infer Junie's generated id from output.
+
+Use this exact format:
+
+```ts
+const junieSessionId = `agor-${agorSessionId}`;
+```
+
+### Filesystem and Isolation
+
+Use a per-session temp root under Agor's data home or OS temp directory:
+
+```text
+<tmp>/agor-junie-<session-id>/
+  config.json
+  models/
+    agor-openai-compatible.json
+  mcp/
+    mcp.json
+  output/
+    task-<task-id>.json
+  cache/
+```
+
+Files containing secrets must be mode `0600`, and directories must be mode `0700`.
+When Unix impersonation is active, files must be owned or readable by the executor
+user.
+
+### Message and Streaming Behavior
+
+Junie CLI output should be treated as process progress, not token streaming, until
+its JSON output format proves stable enough for finer-grained events.
+
+Execution should:
+
+1. Create the Agor user message.
+2. Broadcast a streaming/progress assistant placeholder.
+3. Append useful stdout/stderr chunks as progress events.
+4. Read `--json-output-file` on process exit.
+5. Create the final assistant message from Junie's JSON result, or from stdout
+   fallback if JSON is missing or invalid.
+6. Store raw Junie output on the task response metadata for later debugging.
+7. Capture git state at task end.
+
+Token usage is unknown in the first pass unless Junie's JSON file exposes stable
+usage fields. If usage is absent, leave token fields undefined rather than storing
+zero.
+
+### MCP Handling
+
+Junie supports MCP config discovery through MCP folders. Agor should generate a
+session-scoped `.junie`-compatible `mcp.json` from the MCP servers selected for the
+Agor session.
+
+The generated file should use Junie's documented structure:
+
+```json
+{
+  "mcpServers": {
+    "ServerName": {
+      "command": "command",
+      "args": ["arg"],
+      "env": {}
+    }
+  }
+}
+```
+
+Remote MCP servers should use:
+
+```json
+{
+  "mcpServers": {
+    "RemoteServer": {
+      "url": "https://example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer token"
+      }
+    }
+  }
+}
+```
+
+Secrets resolved from Agor templates must be injected at runtime into the temp MCP
+file and never written to project-scoped `.junie/` files.
+
+### Permission Model
+
+Junie docs do not expose an Agor-style approval policy matrix. The first version
+should expose a simple permission state:
+
+- `default`: Junie-managed approvals and behavior.
+
+Map other incoming Agor permission modes to `default` for Junie. The UI should avoid
+offering misleading auto/allow-all controls until Junie documents equivalent
+headless flags.
+
+### Version-Control Modes
+
+Junie documents:
+
+- `--review`
+- `--merge <branch-or-commit>`
+- `--rebase <branch-or-commit>`
+
+First pass:
+
+- Expose normal prompt execution.
+- Do not expose `review`, `merge`, or `rebase` in the UI yet.
+- Keep the adapter internals structured so `--review` can be added later without
+  changing the normal prompt path.
+- Keep merge and rebase hidden for a later follow-up, because they require more
+  UI shape and clearer failure handling.
+
+### UI Scope
+
+Add Junie to:
+
+- Agent selection grid and New Session modal.
+- Tool icon map with a `J` text fallback in the first pass. A checked-in Junie logo
+  asset can be added later.
+- Settings > Agentic Tools credential UI.
+- Per-user API key UI.
+- Onboarding wizard.
+- Model selector.
+- Permission selector.
+- Session panel metadata and controls.
+- Zone trigger agent selector.
+
+The Junie model selector should collect:
+
+- Primary model.
+- Optional faster model.
+- API type, default `OpenAIResponses`.
+
+Settings > Agentic Tools should collect:
+
+- OpenAI-compatible base URL.
+- Default primary model.
+- Optional default faster model.
+- API type, default `OpenAIResponses`.
+- Optional Junie executable path.
+
+The secret should remain in API key fields, not in the model selector. The model
+selector should only override session-level `model_config` values and should not
+edit global `junie.*` settings.
+
+### Error Handling
+
+Installation errors should say:
+
+```text
+Junie CLI was not found. Install it with Homebrew, npm, or JetBrains' install script,
+then set junie.executable if it is not on PATH.
+```
+
+Missing OpenAI-compatible key should say:
+
+```text
+Junie requires JUNIE_OPENAI_COMPATIBLE_API_KEY. Add it in Settings > Agentic Tools or your
+user profile API keys.
+```
+
+Missing OpenAI-compatible URL should say:
+
+```text
+Junie requires junie.openaiCompatibleBaseUrl. Add your OpenAI-compatible gateway URL in Settings.
+```
+
+If Junie exits non-zero, store stdout/stderr previews on the failed task and create
+a concise assistant/system failure message.
+
+If JSON output parsing fails but the process exits successfully, store the stdout
+fallback and mark the task completed with a warning in metadata.
+
+Temp Junie files should be retained on failure for debugging and cleaned up after
+successful execution unless debug logging is enabled.
+
+### Testing
+
+Add focused unit tests rather than broad builds:
+
+- Core type/config tests for `JUNIE_OPENAI_COMPATIBLE_API_KEY` resolution.
+- User service/repository tests for encrypted Junie key status and update.
+- Executor payload schema tests accepting `junie`.
+- Tool registry tests registering Junie.
+- Junie profile generation tests for `OpenAIResponses` and `OpenAICompletion`.
+- Junie command construction tests ensuring secrets are not in argv.
+- Junie normalizer tests for JSON output and stdout fallback.
+- UI tests or type coverage for agent lists/model selector where existing tests
+  already cover similar agents.
+
+Manual smoke test after implementation:
+
+```bash
+junie --version
+```
+
+Then create a Junie session against a tiny worktree and prompt:
+
+```text
+Read the README and summarize the project in one paragraph. Do not edit files.
+```
+
+This should verify installation, OpenAI-compatible profile generation, BYOK auth, task
+storage, and session continuity without creating code changes.
+
+## References
+
+- Junie headless mode: https://junie.jetbrains.com/docs/junie-headless.html
+- Junie CLI reference: https://junie.jetbrains.com/docs/parameters.html
+- Junie custom LLM models: https://junie.jetbrains.com/docs/custom-llm-models.html
+- Junie MCP configuration: https://junie.jetbrains.com/docs/junie-cli-mcp-configuration.html
+- Junie custom model parameters: https://junie.jetbrains.com/docs/parameters.html

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Agor development, test, and release workflows";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        agor = pkgs.lib.evalModules {
+          specialArgs = { inherit pkgs system; };
+          modules = [ ./nix/agor-flake-module.nix ];
+        };
+        cfg = agor.config.agor;
+      in
+      {
+        inherit (cfg)
+          apps
+          checks
+          formatter
+          packages
+          ;
+
+        devShells.default = cfg.devShell;
+      }
+    );
+}

--- a/nix/agor-flake-module.nix
+++ b/nix/agor-flake-module.nix
@@ -1,0 +1,688 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkOption types;
+  cfg = config.agor;
+  pkgConfigPath = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
+    pkgs.glib
+    pkgs.libsecret
+    pkgs.openssl
+    pkgs.sqlite
+  ];
+  libraryPath = lib.makeLibraryPath [
+    pkgs.glib
+    pkgs.libsecret
+    pkgs.openssl
+    pkgs.sqlite
+    pkgs.stdenv.cc.cc.lib
+  ];
+  nativeBuildEnv = ''
+    export npm_config_python="${pkgs.python3}/bin/python3"
+    export npm_config_node_gyp="${pkgs.node-gyp}/bin/node-gyp"
+    export PKG_CONFIG_PATH="${pkgConfigPath}:''${PKG_CONFIG_PATH:-}"
+    export LD_LIBRARY_PATH="${libraryPath}:''${LD_LIBRARY_PATH:-}"
+  '';
+
+  mkScript =
+    name: text:
+    pkgs.writeShellApplication {
+      inherit name;
+      runtimeInputs = cfg.runtimeInputs;
+      text = ''
+        ${nativeBuildEnv}
+        ${text}
+      '';
+    };
+
+  buildAgorLive = mkScript "build-agor-live" ''
+    set -euo pipefail
+
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    PKG_DIR="$ROOT/${cfg.agorLivePackageDir}"
+
+    if [ ! -d "$PKG_DIR" ]; then
+      echo "Could not find ${cfg.agorLivePackageDir} from: $ROOT"
+      exit 1
+    fi
+
+    echo "Building agor-live bundle..."
+    (cd "$PKG_DIR" && ./build.sh)
+  '';
+
+  runAgorLive = mkScript "run-agor-live" ''
+    set -euo pipefail
+
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    PKG_DIR="$ROOT/${cfg.agorLivePackageDir}"
+
+    if [ ! -d "$PKG_DIR" ]; then
+      echo "Could not find ${cfg.agorLivePackageDir} from: $ROOT"
+      exit 1
+    fi
+
+    (cd "$PKG_DIR" && ./build.sh)
+
+    if [ ! -f "$PKG_DIR/bin/agor.js" ]; then
+      echo "Missing agor executable at $PKG_DIR/bin/agor.js"
+      exit 1
+    fi
+
+    cd "$PKG_DIR"
+    node ./bin/agor.js "$@"
+  '';
+
+  publishAgorLive = mkScript "publish-agor-live" ''
+    set -euo pipefail
+
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    PKG_DIR="$ROOT/${cfg.agorLivePackageDir}"
+
+    if [ ! -d "$PKG_DIR" ]; then
+      echo "Could not find ${cfg.agorLivePackageDir} from: $ROOT"
+      exit 1
+    fi
+
+    if [ -z "''${NPM_TOKEN:-}" ]; then
+      echo "NPM_TOKEN is not set."
+      echo "Export your token first, e.g.:"
+      echo "  export NPM_TOKEN=..."
+      exit 1
+    fi
+
+    echo "Building agor-live bundle..."
+    (cd "$PKG_DIR" && ./build.sh)
+
+    TMP_NPMRC="$(mktemp)"
+    cleanup() {
+      rm -f "$TMP_NPMRC"
+    }
+    trap cleanup EXIT
+
+    cat > "$TMP_NPMRC" <<NPMRC
+    //registry.npmjs.org/:_authToken=''${NPM_TOKEN}
+    always-auth=true
+    NPMRC
+
+    echo "Verifying npm identity..."
+    NPM_CONFIG_USERCONFIG="$TMP_NPMRC" npm whoami
+
+    echo "Publishing agor-live..."
+    (
+      cd "$PKG_DIR"
+      NPM_CONFIG_USERCONFIG="$TMP_NPMRC" npm publish --access public
+    )
+
+    echo "Publish completed."
+  '';
+
+  agorTestEnv = mkScript "agor-test-env" ''
+    set -euo pipefail
+
+    usage() {
+      cat <<'EOF'
+    agor-test-env
+
+    Run an isolated local Agor instance for human testing branch changes.
+
+    Usage:
+      nix run .#agor-test-env -- [options]
+
+    Options:
+      --state-dir DIR       Runtime state root (default: ./.agor-local)
+      --daemon-port PORT    Daemon port (default: 3031)
+      --ui-port PORT        UI dev server port (default: 5174)
+      --no-install          Skip pnpm install bootstrap
+      -h, --help            Show this help
+
+    Environment overrides:
+      AGOR_TEST_STATE_DIR
+      AGOR_TEST_DAEMON_PORT
+      AGOR_TEST_UI_PORT
+      JUNIE_OPENAI_COMPATIBLE_API_KEY
+      JUNIE_OPENAI_COMPATIBLE_BASE_URL
+      JUNIE_DEFAULT_MODEL
+      JUNIE_FASTER_MODEL
+
+    The wrapper sets HOME, AGOR_DATA_HOME, AGOR_DB_PATH, PORT, UI_PORT,
+    VITE_DAEMON_URL, and VITE_DAEMON_PORT to keep this instance separate
+    from ~/.agor and from the normal dev ports.
+    EOF
+    }
+
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    STATE_DIR="''${AGOR_TEST_STATE_DIR:-$ROOT/${cfg.localTest.stateDir}}"
+    DAEMON_PORT="''${AGOR_TEST_DAEMON_PORT:-${toString cfg.localTest.daemonPort}}"
+    UI_PORT="''${AGOR_TEST_UI_PORT:-${toString cfg.localTest.uiPort}}"
+    INSTALL=1
+
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --state-dir)
+          if [ "$#" -lt 2 ]; then
+            echo "--state-dir requires a value" >&2
+            exit 2
+          fi
+          STATE_DIR="$2"
+          shift 2
+          ;;
+        --daemon-port)
+          if [ "$#" -lt 2 ]; then
+            echo "--daemon-port requires a value" >&2
+            exit 2
+          fi
+          DAEMON_PORT="$2"
+          shift 2
+          ;;
+        --ui-port)
+          if [ "$#" -lt 2 ]; then
+            echo "--ui-port requires a value" >&2
+            exit 2
+          fi
+          UI_PORT="$2"
+          shift 2
+          ;;
+        --no-install)
+          INSTALL=0
+          shift
+          ;;
+        -h|--help)
+          usage
+          exit 0
+          ;;
+        *)
+          echo "Unknown option: $1" >&2
+          usage >&2
+          exit 2
+          ;;
+      esac
+    done
+
+    STATE_DIR="$(mkdir -p "$STATE_DIR" && cd "$STATE_DIR" && pwd)"
+    TEST_HOME="$STATE_DIR/home"
+    AGOR_HOME_DIR="$TEST_HOME/.agor"
+    DATA_HOME="$STATE_DIR/data"
+    LOG_DIR="$STATE_DIR/logs"
+    CONFIG_PATH="$AGOR_HOME_DIR/config.yaml"
+    DB_FILE="$STATE_DIR/agor.db"
+    SEEDED_REPO_SLUG="${cfg.localTest.seededRepoSlug}"
+    SEEDED_WORKTREE_NAME="${cfg.localTest.seededWorktreeName}"
+    SEEDED_WORKTREE_BRANCH="${cfg.localTest.seededWorktreeBranch}"
+
+    mkdir -p "$AGOR_HOME_DIR" "$DATA_HOME" "$LOG_DIR" "$STATE_DIR/codex-home"
+
+    CONFIG_JWT_SECRET=""
+    CONFIG_MASTER_SECRET=""
+    if [ -f "$CONFIG_PATH" ]; then
+      CONFIG_JWT_SECRET="$(awk '/^[[:space:]]+jwtSecret:/ { print $2; exit }' "$CONFIG_PATH")"
+      CONFIG_MASTER_SECRET="$(awk '/^[[:space:]]+masterSecret:/ { print $2; exit }' "$CONFIG_PATH")"
+    fi
+    if [ -z "$CONFIG_JWT_SECRET" ]; then
+      CONFIG_JWT_SECRET="$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")"
+    fi
+    if [ -z "$CONFIG_MASTER_SECRET" ]; then
+      CONFIG_MASTER_SECRET="$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")"
+    fi
+    if [ -f "$ROOT/.env" ]; then
+      set -a
+      # shellcheck disable=SC1091
+      . "$ROOT/.env"
+      set +a
+    fi
+    JUNIE_OPENAI_COMPATIBLE_BASE_URL="''${JUNIE_OPENAI_COMPATIBLE_BASE_URL:-${cfg.localTest.junie.openaiCompatibleBaseUrl}}"
+    JUNIE_DEFAULT_MODEL="''${JUNIE_DEFAULT_MODEL:-${cfg.localTest.junie.defaultModel}}"
+    JUNIE_FASTER_MODEL="''${JUNIE_FASTER_MODEL:-${cfg.localTest.junie.fasterModel}}"
+
+    cat > "$CONFIG_PATH" <<EOF
+    daemon:
+      host: 127.0.0.1
+      port: $DAEMON_PORT
+      public_url: http://127.0.0.1:$DAEMON_PORT
+      base_url: http://127.0.0.1:$DAEMON_PORT
+      allowAnonymous: false
+      requireAuth: true
+      instanceLabel: Local Test
+      instanceDescription: Isolated flake test environment at $STATE_DIR
+      jwtSecret: $CONFIG_JWT_SECRET
+      masterSecret: $CONFIG_MASTER_SECRET
+    ui:
+      host: 127.0.0.1
+      port: $UI_PORT
+    database:
+      dialect: sqlite
+      sqlite:
+        path: $DB_FILE
+    paths:
+      data_home: $DATA_HOME
+    security:
+      cors:
+        origins:
+          - http://127.0.0.1:$UI_PORT
+          - http://localhost:$UI_PORT
+    execution:
+      worktree_rbac: false
+      unix_user_mode: simple
+      allow_web_terminal: true
+    codex:
+      home: $STATE_DIR/codex-home
+    credentials:
+      JUNIE_OPENAI_COMPATIBLE_API_KEY: ''${JUNIE_OPENAI_COMPATIBLE_API_KEY:-}
+    junie:
+      openaiCompatibleBaseUrl: $JUNIE_OPENAI_COMPATIBLE_BASE_URL
+      defaultModel: $JUNIE_DEFAULT_MODEL
+      fasterModel: $JUNIE_FASTER_MODEL
+      apiType: OpenAICompletion
+    EOF
+
+    cd "$ROOT"
+
+    if [ "$INSTALL" = 1 ] && [ ! -d "$ROOT/node_modules" ]; then
+      echo "Installing workspace dependencies with pnpm..."
+      pnpm install --frozen-lockfile
+    fi
+
+    export HOME="$TEST_HOME"
+    export AGOR_DATA_HOME="$DATA_HOME"
+    export AGOR_DB_DIALECT=sqlite
+    export AGOR_DB_PATH="file:$DB_FILE"
+    export DATABASE_URL="file:$DB_FILE"
+    export PORT="$DAEMON_PORT"
+    export UI_PORT="$UI_PORT"
+    export VITE_DAEMON_URL="http://127.0.0.1:$DAEMON_PORT"
+    export VITE_DAEMON_PORT="$DAEMON_PORT"
+    export CODEX_HOME="$STATE_DIR/codex-home"
+    export NODE_ENV=development
+
+    echo "Agor local test environment"
+    echo "  State:  $STATE_DIR"
+    echo "  Config: $CONFIG_PATH"
+    echo "  DB:     $DB_FILE"
+    echo "  Daemon: http://127.0.0.1:$DAEMON_PORT"
+    echo "  UI:     http://127.0.0.1:$UI_PORT"
+    echo "  Seed:   $SEEDED_REPO_SLUG / $SEEDED_WORKTREE_NAME"
+    echo ""
+
+    echo "Building executor for local worktree and agent runs..."
+    pnpm --filter @agor/executor build
+    echo ""
+
+    echo "Applying database migrations for isolated test DB..."
+    pnpm agor db migrate --yes
+    echo ""
+
+    echo "Ensuring default local admin exists..."
+    pnpm agor user create-admin
+    echo ""
+
+    if curl -fsS "http://127.0.0.1:$DAEMON_PORT/health" >/dev/null 2>&1; then
+      echo "Port $DAEMON_PORT already has an Agor daemon responding. Pick another --daemon-port." >&2
+      exit 1
+    fi
+
+    if curl -fsS "http://127.0.0.1:$UI_PORT" >/dev/null 2>&1; then
+      echo "Port $UI_PORT already has an HTTP server responding. Pick another --ui-port." >&2
+      exit 1
+    fi
+
+    daemon_pid=""
+    ui_pid=""
+    cleanup() {
+      status="$?"
+      trap - EXIT INT TERM
+      if [ -n "$daemon_pid" ]; then kill "$daemon_pid" 2>/dev/null || true; fi
+      if [ -n "$ui_pid" ]; then kill "$ui_pid" 2>/dev/null || true; fi
+      wait "$daemon_pid" "$ui_pid" 2>/dev/null || true
+      exit "$status"
+    }
+    trap cleanup EXIT INT TERM
+
+    pnpm --filter @agor/daemon dev:daemon-only > "$LOG_DIR/daemon.log" 2>&1 &
+    daemon_pid="$!"
+
+    for _ in $(seq 1 60); do
+      if curl -fsS "http://127.0.0.1:$DAEMON_PORT/health" >/dev/null 2>&1; then
+        break
+      fi
+      if ! kill -0 "$daemon_pid" 2>/dev/null; then
+        echo "Daemon exited early. Log:"
+        tail -100 "$LOG_DIR/daemon.log" || true
+        exit 1
+      fi
+      sleep 1
+    done
+
+    if ! curl -fsS "http://127.0.0.1:$DAEMON_PORT/health" >/dev/null 2>&1; then
+      echo "Daemon did not become healthy within 60 seconds. Log:"
+      tail -100 "$LOG_DIR/daemon.log" || true
+      exit 1
+    fi
+
+    echo "Seeding local Agor repository..."
+    auth_json="$(curl -fsS \
+      -H 'Content-Type: application/json' \
+      -d '{"strategy":"local","email":"admin@agor.live","password":"admin"}' \
+      "http://127.0.0.1:$DAEMON_PORT/authentication")"
+    access_token="$(printf '%s' "$auth_json" | jq -r '.accessToken')"
+    if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+      echo "Failed to authenticate default local admin for seed setup" >&2
+      exit 1
+    fi
+
+    auth_curl() {
+      curl -fsS \
+        -H "Authorization: Bearer $access_token" \
+        -H 'Content-Type: application/json' \
+        "$@"
+    }
+
+    repo_json="$(auth_curl "http://127.0.0.1:$DAEMON_PORT/repos?slug=local%2Fagor")"
+    repo_id="$(printf '%s' "$repo_json" | jq -r '.data[0].repo_id // empty')"
+    if [ -z "$repo_id" ]; then
+      repo_json="$(auth_curl \
+        -d "{\"path\":\"$ROOT\",\"slug\":\"$SEEDED_REPO_SLUG\"}" \
+        "http://127.0.0.1:$DAEMON_PORT/repos/local")"
+      repo_id="$(printf '%s' "$repo_json" | jq -r '.repo_id')"
+      echo "  Registered repo $SEEDED_REPO_SLUG"
+    else
+      echo "  Repo $SEEDED_REPO_SLUG already registered"
+    fi
+
+    board_json="$(auth_curl "http://127.0.0.1:$DAEMON_PORT/boards?slug=default")"
+    board_id="$(printf '%s' "$board_json" | jq -r '.data[0].board_id // empty')"
+    if [ -z "$board_id" ]; then
+      echo "Default board not found after seed initialization" >&2
+      exit 1
+    fi
+
+    worktree_json="$(auth_curl "http://127.0.0.1:$DAEMON_PORT/worktrees?repo_id=$repo_id&name=$SEEDED_WORKTREE_NAME")"
+    worktree_id="$(printf '%s' "$worktree_json" | jq -r '.data[0].worktree_id // empty')"
+    if [ -n "$worktree_id" ]; then
+      seed_status="$(printf '%s' "$worktree_json" | jq -r '.data[0].filesystem_status // "unknown"')"
+      if [ "$seed_status" != "ready" ]; then
+        echo "  Removing stale worktree $SEEDED_WORKTREE_NAME (status: $seed_status)"
+        auth_curl -X DELETE "http://127.0.0.1:$DAEMON_PORT/worktrees/$worktree_id?deleteFromFilesystem=true" >/dev/null
+        worktree_id=""
+      fi
+    fi
+
+    if [ -z "$worktree_id" ]; then
+      source_branch="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
+      if [ -z "$source_branch" ]; then
+        source_branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD)"
+      fi
+      worktree_payload="$(jq -nc \
+        --arg name "$SEEDED_WORKTREE_NAME" \
+        --arg ref "$SEEDED_WORKTREE_BRANCH" \
+        --arg sourceBranch "$source_branch" \
+        --arg boardId "$board_id" \
+        '{name:$name, ref:$ref, createBranch:true, sourceBranch:$sourceBranch, boardId:$boardId}')"
+      worktree_json="$(auth_curl \
+        -d "$worktree_payload" \
+        "http://127.0.0.1:$DAEMON_PORT/repos/$repo_id/worktrees")"
+      worktree_id="$(printf '%s' "$worktree_json" | jq -r '.worktree_id')"
+      echo "  Created worktree $SEEDED_WORKTREE_NAME from $source_branch"
+    else
+      echo "  Worktree $SEEDED_WORKTREE_NAME already exists"
+    fi
+
+    for _ in $(seq 1 60); do
+      worktree_json="$(auth_curl "http://127.0.0.1:$DAEMON_PORT/worktrees/$worktree_id")"
+      status="$(printf '%s' "$worktree_json" | jq -r '.filesystem_status // "unknown"')"
+      if [ "$status" = "ready" ]; then
+        break
+      fi
+      if [ "$status" = "failed" ]; then
+        printf '%s\n' "$worktree_json" | jq .
+        echo "Seeded worktree failed to become ready" >&2
+        exit 1
+      fi
+      sleep 1
+    done
+
+    worktree_json="$(auth_curl "http://127.0.0.1:$DAEMON_PORT/worktrees/$worktree_id")"
+    status="$(printf '%s' "$worktree_json" | jq -r '.filesystem_status // "unknown"')"
+    worktree_path="$(printf '%s' "$worktree_json" | jq -r '.path // empty')"
+    if [ "$status" != "ready" ]; then
+      echo "Seeded worktree did not become ready within 60 seconds (status: $status)" >&2
+      exit 1
+    fi
+    echo "  Worktree ready at $worktree_path"
+    echo ""
+
+    pnpm --filter agor-ui exec vite --host 127.0.0.1 --port "$UI_PORT" --strictPort > "$LOG_DIR/ui.log" 2>&1 &
+    ui_pid="$!"
+
+    for _ in $(seq 1 60); do
+      if curl -fsS "http://127.0.0.1:$UI_PORT" >/dev/null 2>&1; then
+        break
+      fi
+      if ! kill -0 "$ui_pid" 2>/dev/null; then
+        echo "UI exited early. Log:"
+        tail -100 "$LOG_DIR/ui.log" || true
+        exit 1
+      fi
+      sleep 1
+    done
+
+    if ! curl -fsS "http://127.0.0.1:$UI_PORT" >/dev/null 2>&1; then
+      echo "UI did not become reachable within 60 seconds. Log:"
+      tail -100 "$LOG_DIR/ui.log" || true
+      exit 1
+    fi
+
+    echo "Ready."
+    echo "  Open: http://127.0.0.1:$UI_PORT"
+    echo "  Logs: tail -f $LOG_DIR/daemon.log $LOG_DIR/ui.log"
+    echo ""
+    echo "Press Ctrl-C to stop both processes."
+
+    wait -n "$daemon_pid" "$ui_pid"
+  '';
+
+  agorTestChecks = mkScript "agor-test-checks" ''
+    set -euo pipefail
+
+    ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    cd "$ROOT"
+
+    if [ ! -d "$ROOT/node_modules" ]; then
+      echo "Installing workspace dependencies with pnpm..."
+      pnpm install --frozen-lockfile
+    fi
+
+    echo "Running workspace typecheck..."
+    pnpm typecheck
+
+    echo "Running focused Junie/core checks..."
+    pnpm --filter @agor/core test src/types/session.test.ts src/utils/permission-mode-mapper.test.ts src/config/config-manager.test.ts
+    pnpm --filter @agor/executor test src/payload-types.test.ts src/sdk-handlers/junie/profile.test.ts src/sdk-handlers/junie/normalizer.test.ts src/sdk-handlers/junie/junie-tool.test.ts
+    pnpm --filter @agor/daemon test src/utils/spawn-executor.secrets.test.ts src/services/config.test.ts
+    pnpm --filter agor-ui typecheck
+
+    echo "Running repo lint..."
+    pnpm lint
+  '';
+
+  scripts = {
+    inherit
+      agorTestChecks
+      agorTestEnv
+      buildAgorLive
+      publishAgorLive
+      runAgorLive
+      ;
+  };
+
+  appFor = scriptName: programName: description: {
+    type = "app";
+    program = "${scripts.${scriptName}}/bin/${programName}";
+    meta.description = description;
+  };
+in
+{
+  options.agor = {
+    agorLivePackageDir = mkOption {
+      type = types.str;
+      default = "packages/agor-live";
+      description = "Repository-relative directory containing the published agor-live package.";
+    };
+
+    runtimeInputs = mkOption {
+      type = types.listOf types.package;
+      default = with pkgs; [
+        bash
+        cacert
+        coreutils
+        curl
+        findutils
+        git
+        glib
+        gnugrep
+        gnused
+        gnumake
+        jq
+        libsecret
+        node-gyp
+        nodejs_22
+        openssh
+        openssl
+        pkg-config
+        pnpm
+        python3
+        sqlite
+        stdenv.cc
+      ];
+      description = "Runtime and native build tools needed by Agor's Node workspace.";
+    };
+
+    localTest = {
+      stateDir = mkOption {
+        type = types.str;
+        default = ".agor-local";
+        description = "Repository-relative default state directory for nix run .#agor-test-env.";
+      };
+
+      daemonPort = mkOption {
+        type = types.port;
+        default = 3031;
+        description = "Default daemon port for the isolated test environment.";
+      };
+
+      uiPort = mkOption {
+        type = types.port;
+        default = 5174;
+        description = "Default UI port for the isolated test environment.";
+      };
+
+      seededRepoSlug = mkOption {
+        type = types.str;
+        default = "local/agor";
+        description = "Repo slug used when preseeding the local checkout.";
+      };
+
+      seededWorktreeName = mkOption {
+        type = types.str;
+        default = "junie-smoke-test";
+        description = "Worktree name created for local Junie smoke testing.";
+      };
+
+      seededWorktreeBranch = mkOption {
+        type = types.str;
+        default = "junie-smoke-test";
+        description = "Branch name created for the seeded local test worktree.";
+      };
+
+      junie = {
+        openaiCompatibleBaseUrl = mkOption {
+          type = types.str;
+          default = "https://llm.bitp.cz";
+          description = "Default OpenAI-compatible endpoint URL for local Junie testing.";
+        };
+
+        defaultModel = mkOption {
+          type = types.str;
+          default = "qwen-3.6-27b";
+          description = "Default Junie model for local testing.";
+        };
+
+        fasterModel = mkOption {
+          type = types.str;
+          default = "qwen-3.5-35b-a3b";
+          description = "Default Junie faster/helper model for local testing.";
+        };
+      };
+    };
+
+    devShell = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = "Default Agor development shell.";
+    };
+
+    packages = mkOption {
+      type = types.attrsOf types.package;
+      readOnly = true;
+      description = "Flake packages generated from the Agor module.";
+    };
+
+    apps = mkOption {
+      type = types.attrs;
+      readOnly = true;
+      description = "Flake apps generated from the Agor module.";
+    };
+
+    checks = mkOption {
+      type = types.attrsOf types.package;
+      readOnly = true;
+      description = "Build-time flake checks.";
+    };
+
+    formatter = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = "Nix formatter used by nix fmt.";
+    };
+  };
+
+  config.agor = {
+    devShell = pkgs.mkShell {
+      packages = cfg.runtimeInputs;
+      shellHook = ''
+        ${nativeBuildEnv}
+        echo "Agor dev shell: node $(node --version), pnpm $(pnpm --version)"
+      '';
+    };
+
+    packages = {
+      build-agor-live-wrapper = buildAgorLive;
+      run-agor-live-wrapper = runAgorLive;
+      publish-agor-live-wrapper = publishAgorLive;
+      agor-test-env-wrapper = agorTestEnv;
+      agor-test-checks-wrapper = agorTestChecks;
+      default = runAgorLive;
+    };
+
+    apps = {
+      build-agor-live = appFor "buildAgorLive" "build-agor-live" "Build the agor-live bundle.";
+      run-agor-live = appFor "runAgorLive" "run-agor-live" "Build and run agor-live.";
+      publish-agor-live =
+        appFor "publishAgorLive" "publish-agor-live"
+          "Build and publish agor-live to npm.";
+      agor-test-env = appFor "agorTestEnv" "agor-test-env" "Run an isolated local Agor test environment.";
+      agor-test-checks = appFor "agorTestChecks" "agor-test-checks" "Run local Agor validation checks.";
+      default = appFor "runAgorLive" "run-agor-live" "Build and run agor-live.";
+    };
+
+    checks = {
+      build-agor-live-wrapper = buildAgorLive;
+      agor-test-env-wrapper = agorTestEnv;
+      agor-test-checks-wrapper = agorTestChecks;
+    };
+
+    formatter = pkgs.nixfmt;
+  };
+}

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -416,6 +416,18 @@ describe('getConfigValue', () => {
     expect(apiKey).toBe('test-key-123');
   });
 
+  it('should handle Junie OpenAI-compatible credentials key', async () => {
+    const config = createConfigData({
+      credentials: {
+        JUNIE_OPENAI_COMPATIBLE_API_KEY: 'junie-openai-compatible-key',
+      },
+    });
+    await saveConfig(config);
+
+    const apiKey = await getConfigValue('credentials.JUNIE_OPENAI_COMPATIBLE_API_KEY');
+    expect(apiKey).toBe('junie-openai-compatible-key');
+  });
+
   it('should handle boolean values', async () => {
     const config = createConfigData();
     await saveConfig(config);

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -444,15 +444,16 @@ export function loadConfigSync(): AgorConfig {
  * Credential keys that are valid in `config.yaml`'s `credentials` section
  * (i.e., keys that have a meaningful global / app-level value). User-only
  * tokens like `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max subscription) and
- * `COPILOT_GITHUB_TOKEN` are intentionally excluded — they don't make sense
- * as a global default.
+ * `COPILOT_GITHUB_TOKEN` is intentionally excluded — it doesn't make sense as
+ * a global default.
  */
 export type ConfigCredentialKey =
   | 'ANTHROPIC_API_KEY'
   | 'ANTHROPIC_AUTH_TOKEN'
   | 'ANTHROPIC_BASE_URL'
   | 'OPENAI_API_KEY'
-  | 'GEMINI_API_KEY';
+  | 'GEMINI_API_KEY'
+  | 'JUNIE_OPENAI_COMPATIBLE_API_KEY';
 
 const CONFIG_CREDENTIAL_KEYS: ReadonlySet<string> = new Set<ConfigCredentialKey>([
   'ANTHROPIC_API_KEY',
@@ -460,6 +461,7 @@ const CONFIG_CREDENTIAL_KEYS: ReadonlySet<string> = new Set<ConfigCredentialKey>
   'ANTHROPIC_BASE_URL',
   'OPENAI_API_KEY',
   'GEMINI_API_KEY',
+  'JUNIE_OPENAI_COMPATIBLE_API_KEY',
 ]);
 
 export function isConfigCredentialKey(key: string): key is ConfigCredentialKey {

--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -93,6 +93,7 @@ export const ALLOWED_ENV_VARS = new Set([
   'OPENAI_BASE_URL',
   'GEMINI_API_KEY',
   'GOOGLE_API_KEY',
+  'JUNIE_OPENAI_COMPATIBLE_API_KEY',
 
   // Vertex AI (Claude Code on GCP)
   'CLAUDE_CODE_USE_VERTEX',

--- a/packages/core/src/config/key-resolver.ts
+++ b/packages/core/src/config/key-resolver.ts
@@ -19,7 +19,8 @@ export type ApiKeyName =
   | 'CLAUDE_CODE_OAUTH_TOKEN'
   | 'OPENAI_API_KEY'
   | 'GEMINI_API_KEY'
-  | 'COPILOT_GITHUB_TOKEN';
+  | 'COPILOT_GITHUB_TOKEN'
+  | 'JUNIE_OPENAI_COMPATIBLE_API_KEY';
 
 export interface KeyResolutionContext {
   /** User ID for per-user key lookup */

--- a/packages/core/src/config/resource-schemas.ts
+++ b/packages/core/src/config/resource-schemas.ts
@@ -28,7 +28,9 @@ const repoSlugSchema = z
 // ---------------------------------------------------------------------------
 
 export const enforcedAgentConfigSchema = z.object({
-  agentic_tool: z.enum(['claude-code', 'codex', 'gemini', 'opencode', 'copilot']).optional(),
+  agentic_tool: z
+    .enum(['claude-code', 'codex', 'gemini', 'opencode', 'copilot', 'junie'])
+    .optional(),
   permission_mode: z.string().optional(),
   model: z.string().optional(),
   mcp_server_ids: z.array(z.string()).optional(),

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -644,6 +644,7 @@ export enum CredentialKey {
   OPENAI_API_KEY = 'OPENAI_API_KEY',
   GEMINI_API_KEY = 'GEMINI_API_KEY',
   COPILOT_GITHUB_TOKEN = 'COPILOT_GITHUB_TOKEN',
+  JUNIE_OPENAI_COMPATIBLE_API_KEY = 'JUNIE_OPENAI_COMPATIBLE_API_KEY',
 }
 
 /**
@@ -669,6 +670,29 @@ export interface AgorCredentials {
 
   /** GitHub token for Copilot */
   COPILOT_GITHUB_TOKEN?: string;
+
+  /** OpenAI-compatible API key for Junie */
+  JUNIE_OPENAI_COMPATIBLE_API_KEY?: string;
+}
+
+/**
+ * JetBrains Junie headless integration settings.
+ */
+export interface AgorJunieSettings {
+  /** Junie executable path or command (default: junie) */
+  executable?: string;
+
+  /** OpenAI-compatible gateway root URL */
+  openaiCompatibleBaseUrl?: string;
+
+  /** Primary model ID used by Junie */
+  defaultModel?: string;
+
+  /** Optional faster/helper model for Junie internal tasks */
+  fasterModel?: string;
+
+  /** Junie custom model API type (default: OpenAICompletion) */
+  apiType?: 'OpenAIResponses' | 'OpenAICompletion';
 }
 
 /**
@@ -775,6 +799,9 @@ export interface AgorConfig {
   /** OpenCode.ai integration settings */
   opencode?: AgorOpenCodeSettings;
 
+  /** JetBrains Junie integration settings */
+  junie?: AgorJunieSettings;
+
   /** Execution isolation settings */
   execution?: AgorExecutionSettings;
 
@@ -836,6 +863,7 @@ export type ConfigKey =
   | `ui.${keyof AgorUISettings}`
   | `database.${keyof AgorDatabaseSettings}`
   | `opencode.${keyof AgorOpenCodeSettings}`
+  | `junie.${keyof AgorJunieSettings}`
   | `execution.${keyof AgorExecutionSettings}`
   | `security.${keyof AgorSecuritySettings}`
   | `worktrees.${keyof AgorWorktreesSettings}`

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -86,7 +86,7 @@ export const sessions = pgTable(
       ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
-      enum: ['claude-code', 'codex', 'gemini', 'opencode', 'copilot'],
+      enum: ['claude-code', 'codex', 'gemini', 'opencode', 'copilot', 'junie'],
     }).notNull(),
     board_id: varchar('board_id', { length: 36 }), // NULL = no board
 
@@ -636,7 +636,7 @@ export const worktrees = pgTable(
         schedule?: {
           timezone: string; // IANA timezone (default: 'UTC')
           prompt_template: string; // Handlebars template
-          agentic_tool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+          agentic_tool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
           retention: number; // How many sessions to keep (0 = keep forever)
           permission_mode?: string; // Permission mode for spawned sessions
           model_config?: {
@@ -763,6 +763,9 @@ export const users = pgTable(
           copilot?: {
             COPILOT_GITHUB_TOKEN?: string;
           };
+          junie?: {
+            JUNIE_OPENAI_COMPATIBLE_API_KEY?: string;
+          };
           opencode?: Record<string, never>;
         };
         // Encrypted environment variables with scope metadata.
@@ -825,6 +828,15 @@ export const users = pgTable(
             serverUrl?: string;
           };
           copilot?: {
+            modelConfig?: {
+              mode?: 'alias' | 'exact';
+              model?: string;
+              effort?: EffortLevel;
+            };
+            permissionMode?: string;
+            mcpServerIds?: string[];
+          };
+          junie?: {
             modelConfig?: {
               mode?: 'alias' | 'exact';
               model?: string;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -74,7 +74,7 @@ export const sessions = sqliteTable(
       ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
-      enum: ['claude-code', 'codex', 'gemini', 'opencode', 'copilot'],
+      enum: ['claude-code', 'codex', 'gemini', 'opencode', 'copilot', 'junie'],
     }).notNull(),
     board_id: text('board_id', { length: 36 }), // NULL = no board
 
@@ -632,7 +632,7 @@ export const worktrees = sqliteTable(
         schedule?: {
           timezone: string; // IANA timezone (default: 'UTC')
           prompt_template: string; // Handlebars template
-          agentic_tool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+          agentic_tool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
           retention: number; // How many sessions to keep (0 = keep forever)
           permission_mode?: string; // Permission mode for spawned sessions
           model_config?: {
@@ -761,6 +761,9 @@ export const users = sqliteTable(
           copilot?: {
             COPILOT_GITHUB_TOKEN?: string;
           };
+          junie?: {
+            JUNIE_OPENAI_COMPATIBLE_API_KEY?: string;
+          };
           opencode?: Record<string, never>;
         };
         // Encrypted environment variables with scope metadata.
@@ -825,6 +828,15 @@ export const users = sqliteTable(
             serverUrl?: string;
           };
           copilot?: {
+            modelConfig?: {
+              mode?: 'alias' | 'exact';
+              model?: string;
+              effort?: EffortLevel;
+            };
+            permissionMode?: string;
+            mcpServerIds?: string[];
+          };
+          junie?: {
             modelConfig?: {
               mode?: 'alias' | 'exact';
               model?: string;

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -11,11 +11,12 @@ import type { AgenticToolID } from './id';
  * - gemini: Google's Gemini Code Assist
  * - opencode: Open-source terminal-based AI assistant with 75+ LLM providers
  * - copilot: GitHub Copilot's agentic runtime via @github/copilot-sdk
+ * - junie: JetBrains Junie CLI backed by a BYOK OpenAI-compatible endpoint
  *
  * Not to be confused with "execution tools" (Bash, Write, Read, etc.)
  * which are the primitives that agentic tools use to perform work.
  */
-export type AgenticToolName = 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+export type AgenticToolName = 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
 
 /**
  * Agentic tool metadata for UI display
@@ -128,6 +129,14 @@ export type CodexNetworkAccess = boolean;
  */
 export type CopilotPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
 
+/**
+ * Junie permission modes
+ *
+ * Junie headless docs do not expose an Agor-style permission policy matrix yet.
+ * Agor therefore treats permissions as Junie-managed in the first integration.
+ */
+export type JuniePermissionMode = 'default';
+
 // ============================================================================
 // Tool Capabilities (static, shared between backend and UI)
 // ============================================================================
@@ -179,6 +188,12 @@ export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapab
     supportsStatelessFsMode: false,
   },
   copilot: {
+    supportsSessionFork: false,
+    supportsChildSpawn: true,
+    supportsSessionImport: false,
+    supportsStatelessFsMode: false,
+  },
+  junie: {
     supportsSessionFork: false,
     supportsChildSpawn: true,
     supportsSessionImport: false,

--- a/packages/core/src/types/session.test.ts
+++ b/packages/core/src/types/session.test.ts
@@ -5,6 +5,7 @@
  * - Claude Code: acceptEdits (auto-accept file edits)
  * - Gemini: autoEdit (native SDK mode)
  * - Codex: auto (auto-approve safe ops)
+ * - Junie: default (Junie-managed)
  */
 
 import { describe, expect, it } from 'vitest';
@@ -26,6 +27,10 @@ describe('getDefaultPermissionMode', () => {
 
   it('returns "autoEdit" for opencode (uses Gemini-like modes)', () => {
     expect(getDefaultPermissionMode('opencode')).toBe('autoEdit');
+  });
+
+  it('returns "default" for junie (Junie-managed)', () => {
+    expect(getDefaultPermissionMode('junie')).toBe('default');
   });
 
   it('returns "acceptEdits" for any unknown tool (default case)', () => {
@@ -65,7 +70,14 @@ describe('getDefaultPermissionMode', () => {
 
   describe('all agentic tools coverage', () => {
     it('handles all valid AgenticToolName values', () => {
-      const allTools: AgenticToolName[] = ['claude-code', 'codex', 'gemini', 'opencode'];
+      const allTools: AgenticToolName[] = [
+        'claude-code',
+        'codex',
+        'gemini',
+        'opencode',
+        'copilot',
+        'junie',
+      ];
       const results: Record<string, string> = {};
 
       for (const tool of allTools) {
@@ -77,10 +89,19 @@ describe('getDefaultPermissionMode', () => {
       expect(results.codex).toBe('auto');
       expect(results.gemini).toBe('autoEdit');
       expect(results.opencode).toBe('autoEdit');
+      expect(results.copilot).toBe('acceptEdits');
+      expect(results.junie).toBe('default');
     });
 
     it('returns valid PermissionMode values', () => {
-      const allTools: AgenticToolName[] = ['claude-code', 'codex', 'gemini', 'opencode'];
+      const allTools: AgenticToolName[] = [
+        'claude-code',
+        'codex',
+        'gemini',
+        'opencode',
+        'copilot',
+        'junie',
+      ];
       const validModes = [
         // Claude Code native modes
         'default',

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -89,6 +89,7 @@ export type {
  * - Gemini: 'autoEdit' (native ApprovalMode.AUTO_EDIT - auto-approve file edits)
  * - Codex: 'auto' (auto-approve safe operations, ask for dangerous ones)
  * - OpenCode: 'autoEdit' (auto-approve, similar to Gemini)
+ * - Junie: 'default' (Junie-managed behavior)
  */
 export function getDefaultPermissionMode(agenticTool: AgenticToolName): PermissionMode {
   switch (agenticTool) {
@@ -100,6 +101,8 @@ export function getDefaultPermissionMode(agenticTool: AgenticToolName): Permissi
       return 'autoEdit'; // OpenCode auto-approves, similar to Gemini
     case 'copilot':
       return 'acceptEdits'; // Copilot uses same semantics as Claude Code
+    case 'junie':
+      return 'default'; // Junie-managed behavior
     default:
       return 'acceptEdits'; // Claude Code native mode
   }

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -92,6 +92,7 @@ export interface DefaultAgenticConfig {
   gemini?: DefaultAgenticToolConfig;
   opencode?: DefaultAgenticToolConfig;
   copilot?: DefaultAgenticToolConfig;
+  junie?: DefaultAgenticToolConfig;
 }
 
 /**
@@ -121,6 +122,10 @@ export interface CopilotConfig {
   COPILOT_GITHUB_TOKEN?: string;
 }
 
+export interface JunieConfig {
+  JUNIE_OPENAI_COMPATIBLE_API_KEY?: string;
+}
+
 /**
  * Per-tool credential map. Each tool's config is independent and
  * scoped to its own SDK at session-spawn time.
@@ -130,6 +135,7 @@ export interface AgenticToolsConfig {
   codex?: CodexConfig;
   gemini?: GeminiConfig;
   copilot?: CopilotConfig;
+  junie?: JunieConfig;
   opencode?: Record<string, never>;
 }
 
@@ -138,7 +144,8 @@ export type AgenticToolConfigField =
   | keyof ClaudeCodeConfig
   | keyof CodexConfig
   | keyof GeminiConfig
-  | keyof CopilotConfig;
+  | keyof CopilotConfig
+  | keyof JunieConfig;
 
 /**
  * Public DTO shape: per-tool credential presence flags.

--- a/packages/core/src/types/worktree.ts
+++ b/packages/core/src/types/worktree.ts
@@ -454,7 +454,7 @@ export interface WorktreeScheduleConfig {
   /**
    * Agent to use for scheduled sessions
    */
-  agentic_tool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+  agentic_tool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
 
   /**
    * How many scheduled sessions to keep

--- a/packages/core/src/utils/permission-mode-mapper.test.ts
+++ b/packages/core/src/utils/permission-mode-mapper.test.ts
@@ -79,6 +79,22 @@ describe('mapPermissionMode', () => {
       expect(mapPermissionMode('yolo', 'codex')).toBe('allow-all');
     });
   });
+
+  describe('Junie', () => {
+    it('maps all supported modes to Junie-managed default behavior', () => {
+      expect(mapPermissionMode('default', 'junie')).toBe('default');
+      expect(mapPermissionMode('acceptEdits', 'junie')).toBe('default');
+      expect(mapPermissionMode('bypassPermissions', 'junie')).toBe('default');
+      expect(mapPermissionMode('plan', 'junie')).toBe('default');
+      expect(mapPermissionMode('dontAsk', 'junie')).toBe('default');
+      expect(mapPermissionMode('autoEdit', 'junie')).toBe('default');
+      expect(mapPermissionMode('yolo', 'junie')).toBe('default');
+      expect(mapPermissionMode('ask', 'junie')).toBe('default');
+      expect(mapPermissionMode('auto', 'junie')).toBe('default');
+      expect(mapPermissionMode('on-failure', 'junie')).toBe('default');
+      expect(mapPermissionMode('allow-all', 'junie')).toBe('default');
+    });
+  });
 });
 
 describe('mapToCodexPermissionConfig', () => {

--- a/packages/core/src/utils/permission-mode-mapper.ts
+++ b/packages/core/src/utils/permission-mode-mapper.ts
@@ -9,6 +9,7 @@
  * - Claude Code: default, acceptEdits, bypassPermissions, plan, dontAsk
  * - Gemini: default, autoEdit, yolo
  * - Codex: ask, auto, on-failure, allow-all
+ * - Junie: default
  */
 
 import type { AgenticToolName, PermissionMode } from '../types';
@@ -114,6 +115,10 @@ export function mapPermissionMode(
         default:
           return 'auto'; // Safe default
       }
+
+    case 'junie':
+      // Junie exposes no permission-mode CLI surface; let Junie manage behavior.
+      return 'default';
 
     default:
       // Unknown tool - return mode as-is

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -218,7 +218,7 @@ async function handleLegacyMode(values: {
     sessionId: values['session-id'] as string,
     taskId: values['task-id'] as string,
     prompt: values.prompt as string,
-    tool: values.tool as 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot',
+    tool: values.tool as 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'junie',
     permissionMode: (values['permission-mode'] as 'ask' | 'auto' | 'allow-all') || undefined,
     daemonUrl: (values['daemon-url'] as string) || 'http://localhost:3030',
   });
@@ -246,7 +246,7 @@ function printUsage(): void {
   console.error('  --task-id <id>           Task ID created by daemon');
   console.error('  --prompt <text>          User prompt to execute');
   console.error(
-    '  --tool <name>            SDK tool (claude-code, gemini, codex, opencode, copilot)'
+    '  --tool <name>            SDK tool (claude-code, gemini, codex, opencode, copilot, junie)'
   );
   console.error('  --permission-mode <mode> Permission mode (ask, auto, allow-all)');
   console.error('  --daemon-url <url>       Daemon WebSocket URL (default: http://localhost:3030)');

--- a/packages/executor/src/handlers/sdk/junie.test.ts
+++ b/packages/executor/src/handlers/sdk/junie.test.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock('@agor/core/git', () => ({
+  getGitState: vi.fn().mockResolvedValue('test-sha'),
+}));
+
+function makeChildProcess(stdoutText: string, stderrText = '', exitCode = 0) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+
+  setTimeout(() => {
+    if (stdoutText) child.stdout.emit('data', Buffer.from(stdoutText));
+    if (stderrText) child.stderr.emit('data', Buffer.from(stderrText));
+    child.emit('close', exitCode);
+  }, 0);
+
+  return child;
+}
+
+describe('executeJunieTask', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockImplementation((_command: string, args: string[]) => {
+      const outputPath = args[args.indexOf('--json-output-file') + 1];
+      fs.writeFileSync(outputPath, JSON.stringify({ result: 'JUNIE_OK', sessionId: 'junie-123' }));
+      return makeChildProcess('');
+    });
+  });
+
+  it('does not duplicate the daemon-written user message', async () => {
+    const { executeJunieTask } = await import('./junie.js');
+    const messagesCreate = vi.fn().mockResolvedValue({});
+    const tasksPatch = vi.fn().mockResolvedValue({});
+    const sessionsPatch = vi.fn().mockResolvedValue({});
+    const resolveApiKeyCreate = vi.fn().mockResolvedValue({ apiKey: 'sk-test' });
+
+    const client = {
+      service: (name: string) => {
+        switch (name) {
+          case 'sessions':
+            return {
+              get: vi.fn().mockResolvedValue({
+                session_id: 'session-1',
+                worktree_id: 'worktree-1',
+                agentic_tool: 'junie',
+                model_config: {},
+              }),
+              patch: sessionsPatch,
+            };
+          case 'worktrees':
+            return {
+              get: vi.fn().mockResolvedValue({
+                worktree_id: 'worktree-1',
+                path: '/tmp',
+              }),
+            };
+          case 'config':
+            return {
+              get: vi.fn().mockResolvedValue({
+                openaiCompatibleBaseUrl: 'https://openai-compatible.example.com',
+                defaultModel: 'qwen',
+              }),
+            };
+          case 'config/resolve-api-key':
+            return {
+              create: resolveApiKeyCreate,
+            };
+          case 'messages':
+            return {
+              find: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    type: 'user',
+                    role: 'user',
+                    task_id: 'task-1',
+                    content: 'already written by daemon',
+                  },
+                ],
+              }),
+              create: messagesCreate,
+            };
+          case 'tasks':
+            return {
+              get: vi.fn().mockResolvedValue({ task_id: 'task-1' }),
+              patch: tasksPatch,
+            };
+          default:
+            throw new Error(`Unexpected service: ${name}`);
+        }
+      },
+    };
+
+    await executeJunieTask({
+      client: client as never,
+      sessionId: 'session-1' as never,
+      taskId: 'task-1' as never,
+      prompt: 'Reply exactly JUNIE_OK',
+      abortController: new AbortController(),
+    });
+
+    expect(resolveApiKeyCreate).toHaveBeenCalledWith({
+      taskId: 'task-1',
+      keyName: 'JUNIE_OPENAI_COMPATIBLE_API_KEY',
+      tool: 'junie',
+    });
+    expect(messagesCreate).toHaveBeenCalledTimes(1);
+    expect(messagesCreate.mock.calls[0][0]).toMatchObject({
+      type: 'assistant',
+      role: 'assistant',
+      index: 1,
+      content: 'JUNIE_OK',
+    });
+    expect(sessionsPatch).toHaveBeenCalledWith('session-1', { sdk_session_id: 'junie-123' });
+  });
+});

--- a/packages/executor/src/handlers/sdk/junie.ts
+++ b/packages/executor/src/handlers/sdk/junie.ts
@@ -1,0 +1,320 @@
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateId } from '@agor/core';
+import { getGitState } from '@agor/core/git';
+import type { MessageID, MessageSource, PermissionMode, SessionID, TaskID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import {
+  buildJunieArgs,
+  buildJunieModelProfile,
+  extractJunieAssistantText,
+  getJunieSessionId,
+  JUNIE_PROFILE_ID,
+  type JunieApiType,
+  type JunieRawResponse,
+} from '../../sdk-handlers/junie/index.js';
+import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
+import type { AgorClient } from '../../services/feathers-client.js';
+
+interface JunieSettings {
+  executable?: string;
+  openaiCompatibleBaseUrl?: string;
+  defaultModel?: string;
+  fasterModel?: string;
+  apiType?: JunieApiType;
+}
+
+async function resolveJunieApiKey(client: AgorClient, taskId: TaskID): Promise<string> {
+  const result = (await client.service('config/resolve-api-key').create({
+    taskId,
+    keyName: 'JUNIE_OPENAI_COMPATIBLE_API_KEY',
+    tool: 'junie',
+  })) as { apiKey?: string | null; decryptionFailed?: boolean };
+
+  if (result.decryptionFailed) {
+    throw new Error(
+      'Junie OpenAI-compatible API key could not be decrypted. Re-enter JUNIE_OPENAI_COMPATIBLE_API_KEY in Settings.'
+    );
+  }
+
+  if (!result.apiKey) {
+    throw new Error(
+      'Junie requires JUNIE_OPENAI_COMPATIBLE_API_KEY. Add it in Settings > Agentic Tools or your user profile API keys.'
+    );
+  }
+
+  return result.apiKey;
+}
+
+async function getMessageState(
+  client: AgorClient,
+  sessionId: SessionID,
+  taskId: TaskID
+): Promise<{ nextIndex: number; hasUserMessageForTask: boolean }> {
+  const existingMessages = await client.service('messages').find({
+    query: {
+      session_id: sessionId,
+      $sort: { index: 1 },
+    },
+  });
+  const messages = Array.isArray(existingMessages) ? existingMessages : existingMessages.data;
+  return {
+    nextIndex: messages?.length || 0,
+    hasUserMessageForTask:
+      messages?.some((message) => {
+        const candidate = message as {
+          task_id?: string | null;
+          type?: string | null;
+          role?: string | null;
+        };
+        return (
+          candidate.task_id === taskId &&
+          (candidate.type === 'user' || candidate.type === 'system') &&
+          candidate.role === 'user'
+        );
+      }) ?? false,
+  };
+}
+
+async function writeJsonFile(filePath: string, value: unknown, mode = 0o600): Promise<void> {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, { mode });
+  await fs.chmod(filePath, mode).catch(() => undefined);
+}
+
+async function prepareJunieFiles(params: {
+  sessionId: SessionID;
+  taskId: TaskID;
+  apiKey: string;
+  settings: JunieSettings;
+  model: string;
+  fasterModel?: string;
+}): Promise<{
+  rootDir: string;
+  modelDir: string;
+  mcpDir: string;
+  configPath: string;
+  cacheDir: string;
+  outputPath: string;
+}> {
+  const rootDir = path.join(os.tmpdir(), `agor-junie-${params.sessionId}-${params.taskId}`);
+  const modelDir = path.join(rootDir, 'models');
+  const mcpDir = path.join(rootDir, 'mcp');
+  const outputDir = path.join(rootDir, 'output');
+  const cacheDir = path.join(rootDir, 'cache');
+  await fs.mkdir(modelDir, { recursive: true, mode: 0o700 });
+  await fs.mkdir(mcpDir, { recursive: true, mode: 0o700 });
+  await fs.mkdir(outputDir, { recursive: true, mode: 0o700 });
+  await fs.mkdir(cacheDir, { recursive: true, mode: 0o700 });
+
+  await writeJsonFile(
+    path.join(modelDir, `${JUNIE_PROFILE_ID}.json`),
+    buildJunieModelProfile({
+      apiKey: params.apiKey,
+      baseUrl: params.settings.openaiCompatibleBaseUrl || '',
+      model: params.model,
+      fasterModel: params.fasterModel,
+      apiType: params.settings.apiType,
+    })
+  );
+  await writeJsonFile(path.join(mcpDir, 'mcp.json'), { mcpServers: {} });
+  const configPath = path.join(rootDir, 'config.json');
+  await writeJsonFile(configPath, {});
+
+  return {
+    rootDir,
+    modelDir,
+    mcpDir,
+    configPath,
+    cacheDir,
+    outputPath: path.join(outputDir, `task-${params.taskId}.json`),
+  };
+}
+
+function runJunieProcess(
+  command: string,
+  args: string[],
+  cwd: string,
+  signal: AbortSignal
+): Promise<{
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+      signal,
+    });
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (exitCode) => resolve({ exitCode, stdout, stderr }));
+  });
+}
+
+async function readJunieOutput(outputPath: string): Promise<unknown | undefined> {
+  try {
+    return JSON.parse(await fs.readFile(outputPath, 'utf8')) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function executeJunieTask(params: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  prompt: string;
+  permissionMode?: PermissionMode;
+  abortController: AbortController;
+  messageSource?: MessageSource;
+}): Promise<void> {
+  const { client, sessionId, taskId, prompt } = params;
+  const session = await client.service('sessions').get(sessionId);
+  const worktree = await client.service('worktrees').get(session.worktree_id);
+  const settings = ((await client.service('config').get('junie')) || {}) as JunieSettings;
+  const apiKey = await resolveJunieApiKey(client, taskId);
+  const openaiCompatibleBaseUrl = settings.openaiCompatibleBaseUrl?.trim();
+  const sessionModelConfig = session.model_config as
+    | { model?: string; fasterModel?: string }
+    | undefined;
+
+  if (!openaiCompatibleBaseUrl) {
+    throw new Error(
+      'Junie requires junie.openaiCompatibleBaseUrl. Add your OpenAI-compatible endpoint URL in Settings.'
+    );
+  }
+
+  const sessionModel =
+    sessionModelConfig?.model && sessionModelConfig.model !== 'default'
+      ? sessionModelConfig.model
+      : undefined;
+  const model = sessionModel || settings.defaultModel;
+  if (!model) {
+    throw new Error(
+      'Junie requires a model. Configure junie.defaultModel or select a session model.'
+    );
+  }
+
+  const junieSessionId = session.sdk_session_id
+    ? getJunieSessionId(sessionId, session.sdk_session_id)
+    : undefined;
+
+  const files = await prepareJunieFiles({
+    sessionId,
+    taskId,
+    apiKey,
+    settings: { ...settings, openaiCompatibleBaseUrl },
+    model,
+    fasterModel: sessionModelConfig?.fasterModel || settings.fasterModel,
+  });
+
+  try {
+    const messageState = await getMessageState(client, sessionId, taskId);
+    let nextIndex = messageState.nextIndex;
+    if (!messageState.hasUserMessageForTask) {
+      await client.service('messages').create({
+        message_id: generateId() as MessageID,
+        session_id: sessionId,
+        task_id: taskId,
+        type: 'user',
+        role: MessageRole.USER,
+        index: nextIndex,
+        timestamp: new Date().toISOString(),
+        content_preview: prompt.substring(0, 200),
+        content: prompt,
+        metadata: params.messageSource ? { source: params.messageSource } : undefined,
+      });
+      nextIndex += 1;
+    }
+
+    const executable = settings.executable?.trim() || 'junie';
+    const args = buildJunieArgs({
+      projectPath: worktree.path,
+      sessionId: junieSessionId,
+      profileId: JUNIE_PROFILE_ID,
+      modelDir: files.modelDir,
+      mcpDir: files.mcpDir,
+      configPath: files.configPath,
+      cacheDir: files.cacheDir,
+      outputPath: files.outputPath,
+      prompt,
+    });
+
+    const processResult = await runJunieProcess(
+      executable,
+      args,
+      worktree.path,
+      params.abortController.signal
+    );
+    const parsedOutput = await readJunieOutput(files.outputPath);
+    const rawSdkResponse: JunieRawResponse = {
+      ...((parsedOutput && typeof parsedOutput === 'object' ? parsedOutput : {}) as Record<
+        string,
+        unknown
+      >),
+      stdout: processResult.stdout,
+      stderr: processResult.stderr,
+      exitCode: processResult.exitCode,
+      model: `custom:${JUNIE_PROFILE_ID}`,
+    };
+    const returnedSessionId =
+      typeof rawSdkResponse.sessionId === 'string' ? rawSdkResponse.sessionId.trim() : '';
+    if (!session.sdk_session_id && returnedSessionId) {
+      await client.service('sessions').patch(sessionId, { sdk_session_id: returnedSessionId });
+    }
+
+    if (processResult.exitCode !== 0) {
+      const message = processResult.stderr.trim() || processResult.stdout.trim() || 'Junie failed';
+      throw new Error(message);
+    }
+
+    const assistantText = extractJunieAssistantText(rawSdkResponse, processResult.stdout);
+    await client.service('messages').create({
+      message_id: generateId() as MessageID,
+      session_id: sessionId,
+      task_id: taskId,
+      type: 'assistant',
+      role: MessageRole.ASSISTANT,
+      index: nextIndex,
+      timestamp: new Date().toISOString(),
+      content_preview: assistantText.substring(0, 200),
+      content: assistantText,
+    });
+
+    const shaAtEnd = await getGitState(worktree.path).catch(() => undefined);
+    const normalized = normalizeRawSdkResponse('junie', rawSdkResponse);
+    const currentTask = await client.service('tasks').get(taskId);
+    const gitState = shaAtEnd
+      ? currentTask.git_state
+        ? { ...currentTask.git_state, sha_at_end: shaAtEnd }
+        : undefined
+      : undefined;
+
+    await client.service('tasks').patch(taskId, {
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      raw_sdk_response: rawSdkResponse,
+      normalized_sdk_response: normalized,
+      model: normalized?.primaryModel || `custom:${JUNIE_PROFILE_ID}`,
+      ...(gitState
+        ? {
+            git_state: gitState,
+          }
+        : {}),
+    });
+  } finally {
+    await fs.rm(files.rootDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}

--- a/packages/executor/src/handlers/sdk/tool-registry.ts
+++ b/packages/executor/src/handlers/sdk/tool-registry.ts
@@ -11,7 +11,7 @@ import type { AgorClient } from '../../services/feathers-client.js';
 /**
  * Tool identifier
  */
-export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot';
+export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'junie';
 
 /**
  * Tool runner function - executes via Feathers WebSocket
@@ -114,12 +114,13 @@ export class ToolRegistry {
  */
 export async function initializeToolRegistry(): Promise<void> {
   // Import all tool handlers
-  const [claude, codex, gemini, opencode, copilot] = await Promise.all([
+  const [claude, codex, gemini, opencode, copilot, junie] = await Promise.all([
     import('./claude.js'),
     import('./codex.js'),
     import('./gemini.js'),
     import('./opencode.js'),
     import('./copilot.js'),
+    import('./junie.js'),
   ]);
 
   // Register Claude Code
@@ -160,5 +161,12 @@ export async function initializeToolRegistry(): Promise<void> {
     name: 'GitHub Copilot',
     apiKeyEnvVar: 'COPILOT_GITHUB_TOKEN', // or GH_TOKEN / GITHUB_TOKEN
     runner: copilot.executeCopilotTask,
+  });
+
+  ToolRegistry.register({
+    tool: 'junie',
+    name: 'Junie',
+    apiKeyEnvVar: 'JUNIE_OPENAI_COMPATIBLE_API_KEY',
+    runner: junie.executeJunieTask,
   });
 }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -24,7 +24,7 @@ export interface ExecutorConfig {
   sessionId: string;
   taskId: string;
   prompt: string;
-  tool: 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot';
+  tool: 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'junie';
   permissionMode?: PermissionMode;
   daemonUrl: string;
   messageSource?: MessageSource;

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -80,6 +80,23 @@ describe('PromptPayloadSchema', () => {
     expect(() => PromptPayloadSchema.parse(payload)).toThrow();
   });
 
+  it('should parse prompt payload for Junie', () => {
+    const payload = {
+      command: 'prompt',
+      sessionToken: 'jwt-token-here',
+      params: {
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        taskId: '550e8400-e29b-41d4-a716-446655440001',
+        prompt: 'Hello Junie!',
+        tool: 'junie',
+        cwd: '/home/user/project',
+      },
+    };
+
+    const result = PromptPayloadSchema.parse(payload);
+    expect(result.params.tool).toBe('junie');
+  });
+
   it('should reject missing required fields', () => {
     const payload = {
       command: 'prompt',

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -65,7 +65,14 @@ const GitUrlSchema = z.string().refine(isGitUrl, {
 /**
  * Tool types supported by the prompt command
  */
-export const ToolTypeSchema = z.enum(['claude-code', 'gemini', 'codex', 'opencode', 'copilot']);
+export const ToolTypeSchema = z.enum([
+  'claude-code',
+  'gemini',
+  'codex',
+  'opencode',
+  'copilot',
+  'junie',
+]);
 export type ToolType = z.infer<typeof ToolTypeSchema>;
 
 /**

--- a/packages/executor/src/sdk-handlers/base/types.ts
+++ b/packages/executor/src/sdk-handlers/base/types.ts
@@ -10,7 +10,7 @@ import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
 /**
  * Supported tool types
  */
-export type ToolType = 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+export type ToolType = 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie';
 
 /**
  * Streaming callback interface for agents that support real-time streaming

--- a/packages/executor/src/sdk-handlers/junie/index.ts
+++ b/packages/executor/src/sdk-handlers/junie/index.ts
@@ -1,0 +1,4 @@
+export * from './junie-tool.js';
+export * from './normalizer.js';
+export * from './profile.js';
+export * from './types.js';

--- a/packages/executor/src/sdk-handlers/junie/junie-tool.test.ts
+++ b/packages/executor/src/sdk-handlers/junie/junie-tool.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { buildJunieArgs, getJunieSessionId } from './junie-tool.js';
+
+describe('getJunieSessionId', () => {
+  it('reuses existing SDK session id and generates deterministic ids otherwise', () => {
+    expect(getJunieSessionId('agor-session-id', 'existing-junie-id')).toBe('existing-junie-id');
+    expect(getJunieSessionId('550e8400-e29b-41d4-a716-446655440000')).toBe(
+      'agor-550e8400-e29b-41d4-a716-446655440000'
+    );
+  });
+});
+
+describe('buildJunieArgs', () => {
+  it('does not pass --session-id for a first Junie prompt', () => {
+    const args = buildJunieArgs({
+      projectPath: '/repo',
+      profileId: 'agor-openai-compatible',
+      modelDir: '/tmp/models',
+      mcpDir: '/tmp/mcp',
+      configPath: '/tmp/config.json',
+      cacheDir: '/tmp/cache',
+      outputPath: '/tmp/output.json',
+      prompt: 'Do the thing',
+    });
+
+    expect(args).toEqual([
+      '--project',
+      '/repo',
+      '--model',
+      'custom:agor-openai-compatible',
+      '--model-default-locations',
+      'false',
+      '--model-location',
+      '/tmp/models',
+      '--mcp-default-locations',
+      'false',
+      '--mcp-location',
+      '/tmp/mcp',
+      '--config-default-locations',
+      'false',
+      '--config-location',
+      '/tmp/config.json',
+      '--cache-dir',
+      '/tmp/cache',
+      '--output-format',
+      'json',
+      '--json-output-file',
+      '/tmp/output.json',
+      '--skip-update-check',
+      '--task',
+      'Do the thing',
+    ]);
+    expect(args.join(' ')).not.toContain('sk-junie');
+  });
+
+  it('passes --session-id only when resuming an existing Junie session', () => {
+    const args = buildJunieArgs({
+      projectPath: '/repo',
+      sessionId: 'junie-session-123',
+      profileId: 'agor-openai-compatible',
+      modelDir: '/tmp/models',
+      mcpDir: '/tmp/mcp',
+      configPath: '/tmp/config.json',
+      cacheDir: '/tmp/cache',
+      outputPath: '/tmp/output.json',
+      prompt: 'Follow up',
+    });
+
+    expect(args.slice(0, 6)).toEqual([
+      '--project',
+      '/repo',
+      '--session-id',
+      'junie-session-123',
+      '--model',
+      'custom:agor-openai-compatible',
+    ]);
+  });
+});

--- a/packages/executor/src/sdk-handlers/junie/junie-tool.ts
+++ b/packages/executor/src/sdk-handlers/junie/junie-tool.ts
@@ -1,0 +1,41 @@
+import type { JunieArgsOptions } from './types.js';
+
+export function getJunieSessionId(agorSessionId: string, sdkSessionId?: string | null): string {
+  return sdkSessionId?.trim() || `agor-${agorSessionId}`;
+}
+
+export function buildJunieArgs(options: JunieArgsOptions): string[] {
+  const args = [
+    '--project',
+    options.projectPath,
+    '--model',
+    `custom:${options.profileId}`,
+    '--model-default-locations',
+    'false',
+    '--model-location',
+    options.modelDir,
+    '--mcp-default-locations',
+    'false',
+    '--mcp-location',
+    options.mcpDir,
+    '--config-default-locations',
+    'false',
+    '--config-location',
+    options.configPath,
+    '--cache-dir',
+    options.cacheDir,
+    '--output-format',
+    'json',
+    '--json-output-file',
+    options.outputPath,
+    '--skip-update-check',
+    '--task',
+    options.prompt,
+  ];
+
+  if (options.sessionId?.trim()) {
+    args.splice(2, 0, '--session-id', options.sessionId.trim());
+  }
+
+  return args;
+}

--- a/packages/executor/src/sdk-handlers/junie/normalizer.test.ts
+++ b/packages/executor/src/sdk-handlers/junie/normalizer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { extractJunieAssistantText, normalizeJunieRawResponse } from './normalizer.js';
+
+describe('extractJunieAssistantText', () => {
+  it('extracts text from common Junie JSON result shapes', () => {
+    expect(extractJunieAssistantText({ result: 'Done from result' })).toBe('Done from result');
+    expect(extractJunieAssistantText({ message: 'Done from message' })).toBe('Done from message');
+    expect(
+      extractJunieAssistantText({ content: [{ type: 'text', text: 'Done from content' }] })
+    ).toBe('Done from content');
+  });
+
+  it('falls back to stdout when JSON does not contain assistant text', () => {
+    expect(extractJunieAssistantText({ status: 'ok' }, 'stdout text')).toBe('stdout text');
+  });
+});
+
+describe('normalizeJunieRawResponse', () => {
+  it('normalizes usage and model when present', () => {
+    const normalized = normalizeJunieRawResponse({
+      model: 'custom:agor-openai-compatible',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+      },
+    });
+
+    expect(normalized?.primaryModel).toBe('custom:agor-openai-compatible');
+    expect(normalized?.tokenUsage.totalTokens).toBe(15);
+  });
+});

--- a/packages/executor/src/sdk-handlers/junie/normalizer.ts
+++ b/packages/executor/src/sdk-handlers/junie/normalizer.ts
@@ -1,0 +1,79 @@
+import type {
+  INormalizer,
+  NormalizedSdkData,
+  NormalizedTokenUsage,
+} from '../base/normalizer.interface.js';
+import type { JunieRawResponse } from './types.js';
+
+function asText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+export function extractJunieAssistantText(raw: unknown, stdoutFallback?: string): string {
+  if (!raw || typeof raw !== 'object') {
+    return stdoutFallback?.trim() ?? '';
+  }
+
+  const response = raw as JunieRawResponse;
+  const direct =
+    asText(response.result) ??
+    asText(response.message) ??
+    asText(response.text) ??
+    asText(response.content);
+  if (direct) return direct;
+
+  if (Array.isArray(response.content)) {
+    const text = response.content
+      .map((part) => (part.type === undefined || part.type === 'text' ? part.text : undefined))
+      .filter((part): part is string => !!part?.trim())
+      .join('\n')
+      .trim();
+    if (text) return text;
+  }
+
+  return stdoutFallback?.trim() ?? asText(response.stdout) ?? '';
+}
+
+export function normalizeJunieRawResponse(raw: unknown): NormalizedSdkData | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+
+  const response = raw as JunieRawResponse;
+  if (response.normalized) {
+    return response.normalized;
+  }
+
+  const inputTokens = response.usage?.input_tokens ?? response.usage?.inputTokens ?? 0;
+  const outputTokens = response.usage?.output_tokens ?? response.usage?.outputTokens ?? 0;
+  const tokenUsage: NormalizedTokenUsage = {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+  };
+
+  return {
+    tokenUsage,
+    contextWindowLimit: 0,
+    primaryModel: response.model,
+  };
+}
+
+export class JunieNormalizer implements INormalizer<JunieRawResponse> {
+  normalize(raw: JunieRawResponse): NormalizedSdkData {
+    return (
+      normalizeJunieRawResponse(raw) ?? {
+        tokenUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+        contextWindowLimit: 0,
+      }
+    );
+  }
+}

--- a/packages/executor/src/sdk-handlers/junie/profile.test.ts
+++ b/packages/executor/src/sdk-handlers/junie/profile.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildJunieModelProfile, resolveJunieBaseUrl } from './profile.js';
+
+describe('buildJunieModelProfile', () => {
+  it('builds a Chat Completions profile for an OpenAI-compatible endpoint by default', () => {
+    const profile = buildJunieModelProfile({
+      apiKey: 'sk-junie',
+      baseUrl: 'https://llm.example.com',
+      model: 'gpt-5.4',
+      fasterModel: 'gpt-5.4-mini',
+    });
+
+    expect(profile).toEqual({
+      apiType: 'OpenAICompletion',
+      baseUrl: 'https://llm.example.com/v1/chat/completions',
+      apiKey: 'sk-junie',
+      id: 'gpt-5.4',
+      primaryModel: { id: 'gpt-5.4' },
+      fasterModel: { id: 'gpt-5.4-mini' },
+    });
+  });
+
+  it('builds a Chat Completions profile when requested', () => {
+    const profile = buildJunieModelProfile({
+      apiKey: 'sk-junie',
+      apiType: 'OpenAICompletion',
+      baseUrl: 'https://llm.example.com/v1',
+      model: 'gpt-5.4',
+    });
+
+    expect(profile.baseUrl).toBe('https://llm.example.com/v1/chat/completions');
+    expect(profile.apiType).toBe('OpenAICompletion');
+    expect(profile).not.toHaveProperty('fasterModel');
+  });
+});
+
+describe('resolveJunieBaseUrl', () => {
+  it('does not duplicate endpoint suffixes', () => {
+    expect(resolveJunieBaseUrl('https://llm.example.com/v1/responses', 'OpenAIResponses')).toBe(
+      'https://llm.example.com/v1/responses'
+    );
+    expect(
+      resolveJunieBaseUrl('https://llm.example.com/v1/chat/completions', 'OpenAICompletion')
+    ).toBe('https://llm.example.com/v1/chat/completions');
+  });
+});

--- a/packages/executor/src/sdk-handlers/junie/profile.ts
+++ b/packages/executor/src/sdk-handlers/junie/profile.ts
@@ -1,0 +1,44 @@
+import type { JunieApiType, JunieModelProfile, JunieModelProfileOptions } from './types.js';
+
+export const JUNIE_PROFILE_ID = 'agor-openai-compatible';
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+export function resolveJunieBaseUrl(
+  baseUrl: string,
+  apiType: JunieApiType = 'OpenAICompletion'
+): string {
+  const normalized = stripTrailingSlash(baseUrl.trim());
+  if (apiType === 'OpenAIResponses') {
+    if (normalized.endsWith('/v1/responses')) return normalized;
+    if (normalized.endsWith('/v1')) return `${normalized}/responses`;
+    return `${normalized}/v1/responses`;
+  }
+
+  if (normalized.endsWith('/v1/chat/completions')) return normalized;
+  if (normalized.endsWith('/v1')) return `${normalized}/chat/completions`;
+  return `${normalized}/v1/chat/completions`;
+}
+
+export function buildJunieModelProfile(options: JunieModelProfileOptions): JunieModelProfile {
+  const apiType = options.apiType ?? 'OpenAICompletion';
+  const profile: JunieModelProfile = {
+    apiType,
+    baseUrl: resolveJunieBaseUrl(options.baseUrl, apiType),
+    apiKey: options.apiKey,
+    id: options.model,
+    primaryModel: {
+      id: options.model,
+    },
+  };
+
+  if (options.fasterModel?.trim()) {
+    profile.fasterModel = {
+      id: options.fasterModel.trim(),
+    };
+  }
+
+  return profile;
+}

--- a/packages/executor/src/sdk-handlers/junie/types.ts
+++ b/packages/executor/src/sdk-handlers/junie/types.ts
@@ -1,0 +1,55 @@
+import type { NormalizedSdkData } from '../base/normalizer.interface.js';
+
+export type JunieApiType = 'OpenAIResponses' | 'OpenAICompletion';
+
+export interface JunieModelProfileOptions {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  fasterModel?: string;
+  apiType?: JunieApiType;
+}
+
+export interface JunieModelProfile {
+  apiType: JunieApiType;
+  baseUrl: string;
+  apiKey: string;
+  id: string;
+  primaryModel: {
+    id: string;
+  };
+  fasterModel?: {
+    id: string;
+  };
+}
+
+export interface JunieRawResponse {
+  result?: string;
+  message?: string;
+  text?: string;
+  content?: string | Array<{ type?: string; text?: string }>;
+  model?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+  };
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  normalized?: NormalizedSdkData;
+  [key: string]: unknown;
+}
+
+export interface JunieArgsOptions {
+  projectPath: string;
+  sessionId?: string;
+  profileId: string;
+  modelDir: string;
+  mcpDir: string;
+  configPath: string;
+  cacheDir: string;
+  outputPath: string;
+  prompt: string;
+}

--- a/packages/executor/src/sdk-handlers/normalizer-factory.ts
+++ b/packages/executor/src/sdk-handlers/normalizer-factory.ts
@@ -14,12 +14,14 @@ import { ClaudeCodeNormalizer } from './claude/normalizer.js';
 import { CodexNormalizer } from './codex/normalizer.js';
 import { CopilotNormalizer } from './copilot/normalizer.js';
 import { GeminiNormalizer } from './gemini/normalizer.js';
+import { JunieNormalizer } from './junie/normalizer.js';
 
 // Singleton instances (normalizers are stateless, so one instance is fine)
 const claudeNormalizer = new ClaudeCodeNormalizer();
 const codexNormalizer = new CodexNormalizer();
 const copilotNormalizer = new CopilotNormalizer();
 const geminiNormalizer = new GeminiNormalizer();
+const junieNormalizer = new JunieNormalizer();
 
 /**
  * Normalize raw SDK response to common format
@@ -29,7 +31,7 @@ const geminiNormalizer = new GeminiNormalizer();
  * @returns Normalized data with consistent structure, or undefined if normalization fails
  */
 export function normalizeRawSdkResponse(
-  agenticTool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | string,
+  agenticTool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'junie' | string,
   rawSdkResponse: unknown
 ): NormalizedSdkData | undefined {
   if (!rawSdkResponse) {
@@ -62,6 +64,11 @@ export function normalizeRawSdkResponse(
         // OpenCode doesn't have a normalizer yet - return undefined
         console.debug('[Normalizer] OpenCode normalizer not implemented yet');
         return undefined;
+
+      case 'junie':
+        return junieNormalizer.normalize(
+          rawSdkResponse as Parameters<typeof junieNormalizer.normalize>[0]
+        );
 
       default:
         console.warn(`[Normalizer] Unknown agentic tool: ${agenticTool}`);

--- a/packages/executor/src/types/sdk-response.ts
+++ b/packages/executor/src/types/sdk-response.ts
@@ -102,6 +102,15 @@ export type CopilotSdkResponse = import('../sdk-handlers/copilot/normalizer.js')
 export type OpenCodeSdkResponse = unknown;
 
 // ============================================================================
+// Junie CLI Response
+// ============================================================================
+
+/**
+ * Junie CLI Response - JSON output plus process metadata
+ */
+export type JunieSdkResponse = import('../sdk-handlers/junie/types.js').JunieRawResponse;
+
+// ============================================================================
 // Union Type - All Raw SDK Responses
 // ============================================================================
 
@@ -114,7 +123,8 @@ export type RawSdkResponse =
   | CodexSdkResponse
   | GeminiSdkResponse
   | CopilotSdkResponse
-  | OpenCodeSdkResponse;
+  | OpenCodeSdkResponse
+  | JunieSdkResponse;
 
 // ============================================================================
 // Legacy/Deprecated Types (for backward compatibility)


### PR DESCRIPTION
## Summary

Adds JetBrains Junie as a supported Agor agentic tool, focused on BYOK against any OpenAI-compatible endpoint.

- Adds Junie executor support using the Junie headless CLI, including temporary custom model/MCP config generation, session id persistence, and prompt/result normalization.
- Adds Junie settings in the UI with OpenAI-compatible base URL, API key, default model, faster model, executable path, and dynamic model loading from the configured endpoint.
- Adds local runnable test environment support via Nix flake apps/checks, with Agor repo preseeding for end-to-end local validation.
- Documents the Junie integration design and OpenAI-compatible endpoint assumptions.

## Validation

- Pre-commit workspace typecheck/build passed for all scoped packages.
- Pre-commit Biome check completed with warnings only; warnings are existing unrelated warnings.
- `nix develop -c pnpm --filter @agor/executor test src/handlers/sdk/junie.test.ts src/sdk-handlers/junie/profile.test.ts src/sdk-handlers/junie/normalizer.test.ts src/sdk-handlers/junie/junie-tool.test.ts`
  - Passed: 4 test files, 10 tests.
- `nix develop -c pnpm --filter @agor/daemon test src/services/config.test.ts src/services/users.security.test.ts src/utils/spawn-executor.secrets.test.ts`
  - Passed: 3 test files, 25 tests.
- `nix develop -c pnpm --filter @agor/core test src/config/config-manager.test.ts src/config/key-resolver.test.ts`
  - Passed: 2 test files, 73 tests.

## Notes

This PR intentionally keeps Junie auth to BYOK for OpenAI-compatible custom model endpoints. It does not add JetBrains account login or native Junie auth flows.