### PR TITLE
doc(message-gateway): make App-Level Token Scope explicit

### DIFF
--- a/apps/agor-docs/pages/guide/message-gateway.mdx
+++ b/apps/agor-docs/pages/guide/message-gateway.mdx
@@ -96,8 +96,9 @@ The outbound routing is a lightweight after-hook on message creation. For sessio
 2. Under **OAuth & Permissions**, add the `chat:write` bot scope.
 3. Under **App Home**, enable the **Messages Tab** and check "Allow users to send Slash commands and messages from the messages tab."
 4. Under **Event Subscriptions**, subscribe to the `message.im` bot event.
-5. Under **Socket Mode**, enable Socket Mode and generate an **App-Level Token** (`xapp-...`).
-6. Install the app to your workspace and note the **Bot User OAuth Token** (`xoxb-...`).
+5. Under **Socket Mode**, enable Socket Mode
+6. Under **Basic Information**, generate an **App-Level Token** (`xapp-...`) with `connections:write` scope.
+7. Install the app to your workspace and note the **Bot User OAuth Token** (`xoxb-...`).
 
 ### 2. Create a Channel in Agor
 


### PR DESCRIPTION
Add the permission scope required for Slack gateway to work. 

To be fair Slack do have a description for the scope. But it was only meaningful to me after I inspected the error without it. This should save other's time. 