### PR TITLE
chore(ui): sweep antd v6 deprecation warnings (Space/Alert/Modal)

### DIFF
--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -137,7 +137,7 @@ export function ArtifactConsentModal({
         showIcon
         icon={<WarningOutlined />}
         style={{ marginBottom: 16 }}
-        message="Read the source before granting trust"
+        title="Read the source before granting trust"
         description="Granting trust injects your env-var values and any requested daemon capabilities into this artifact's runtime. The artifact's JS can read those values. Secrets never enter LLM context — but the artifact iframe can still exfiltrate them via fetch()."
       />
 
@@ -221,7 +221,7 @@ export function ArtifactConsentModal({
             type="info"
             showIcon
             style={{ marginTop: 8 }}
-            message="agor_token is artifact-scoped only"
+            title="agor_token is artifact-scoped only"
             description="Author and instance grants do NOT cover agor_token — granting it here only affects this artifact, regardless of the scope you pick below."
           />
         )}

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -130,7 +130,7 @@ export function ArtifactConsentModal({
       onCancel={onClose}
       width={920}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
     >
       <Alert
         type="warning"

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -232,7 +232,7 @@ export function ArtifactConsentModal({
           Trust scope
         </Typography.Title>
         <Radio.Group value={scope} onChange={(e) => setScope(e.target.value)}>
-          <Space direction="vertical">
+          <Space orientation="vertical">
             <Radio value="session">Just once (in-memory; cleared when daemon restarts)</Radio>
             <Radio value="artifact">This artifact only</Radio>
             <Radio value="author" disabled={requestsAgorToken}>

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -161,7 +161,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
               </Text>
               {logs.truncated && (
                 <Alert
-                  message="Logs truncated (showing last 500 lines)"
+                  title="Logs truncated (showing last 500 lines)"
                   type="warning"
                   showIcon
                   style={{ marginTop: 8 }}
@@ -174,7 +174,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
           {/* Error state */}
           {logs?.error && (
             <Alert
-              message="Error fetching logs"
+              title="Error fetching logs"
               description={
                 <div>
                   <div>{logs.error}</div>

--- a/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
+++ b/apps/agor-ui/src/components/EnvironmentLogsModal/EnvironmentLogsModal.tsx
@@ -152,7 +152,7 @@ export const EnvironmentLogsModal: React.FC<EnvironmentLogsModalProps> = ({
       ]}
     >
       <ErrorBoundary fallbackTitle="Couldn't render the logs viewer." resetKey={logs?.timestamp}>
-        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
           {/* Timestamp and truncation warning */}
           {logs && !logs.error && (
             <div>

--- a/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -43,7 +43,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         <Alert
           type="error"
           showIcon
-          message={this.props.fallbackTitle ?? 'Something went wrong rendering this view.'}
+          title={this.props.fallbackTitle ?? 'Something went wrong rendering this view.'}
           description={error.message || String(error)}
         />
       );


### PR DESCRIPTION
## Summary

Three antd v6 deprecation warnings slipped past the prior sweep in 8b6751d3 (new code added since 2026-05-07). Each is a pure prop rename with identical semantics.

- **Commit 1** — `<Space direction>` → `orientation` (ArtifactConsentModal, EnvironmentLogsModal)
- **Commit 2** — `<Alert message>` → `title` (ArtifactConsentModal ×2, EnvironmentLogsModal ×2, ErrorBoundary)
- **Commit 3** — Modal `destroyOnClose` → `destroyOnHidden` (ArtifactConsentModal)

Triggered by Max reporting the `<Space direction>` warning in the OnboardingWizard render path. The wizard's own `<Space>` was already migrated; the warning came from descendants (ArtifactConsentModal etc).

Also swept the repo for related deprecations and confirmed clean: `<TabPane>`, `<Dropdown overlay>`, `Tooltip/Popover visible`, `dropdownClassName`, `<Input.Group>`, `<Card bordered={false}>`, `<Spin tip>`, `bodyStyle`/`headStyle`, `dropdownRender`.

## Test plan

- [x] `pnpm check` (typecheck + lint + build) — green
- [x] `pnpm --filter agor-ui test` — 126 passed
- [ ] Visual smoke: open the artifact TOFU consent modal, the environment logs modal, and trigger an ErrorBoundary fallback — console should be deprecation-free for these surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)