### PR TITLE
fix(daemon): add missing injectCreatedBy() for gateway channel

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1125,6 +1125,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [requireAuth],
       create: [
         requireMinimumRole(ROLES.ADMIN, 'create gateway channels'),
+        injectCreatedBy(),
         // Encrypt env var values at rest (same pattern as user env vars / API keys)
         async (context: HookContext) => {
           const data = context.data as Record<string, unknown> | undefined;


### PR DESCRIPTION
without this I got `{"message":"GatewayChannel must have a created_by","name":"RepositoryError"}` when creating a channel.