### PR TITLE
fix(gateway): inject created_by when creating gateway channels

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1125,6 +1125,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [requireAuth],
       create: [
         requireMinimumRole(ROLES.ADMIN, 'create gateway channels'),
+        injectCreatedBy(),
         // Encrypt env var values at rest (same pattern as user env vars / API keys)
         async (context: HookContext) => {
           const data = context.data as Record<string, unknown> | undefined;

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -1,0 +1,66 @@
+/**
+ * GatewayChannelRepository Tests
+ *
+ * Covers the created_by requirement — the contract that the
+ * injectCreatedBy() hook must satisfy before calling create().
+ */
+
+import type { UUID, WorktreeID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { GatewayChannelRepository } from './gateway-channels';
+import { RepoRepository } from './repos';
+import { WorktreeRepository } from './worktrees';
+
+async function seedWorktree(db: Database) {
+  const repoRepo = new RepoRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId() as UUID,
+    slug: 'test/repo',
+    name: 'test-repo',
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: '/home/user/.agor/repos/test-repo',
+    default_branch: 'main',
+  });
+
+  const worktreeRepo = new WorktreeRepository(db);
+  const worktree = await worktreeRepo.create({
+    worktree_id: generateId() as WorktreeID,
+    repo_id: repo.repo_id as UUID,
+    name: 'main',
+    ref: 'refs/heads/main',
+    worktree_unique_id: 1,
+    path: '/home/user/.agor/worktrees/test/repo/main',
+    created_by: generateId() as UUID,
+  });
+
+  return worktree;
+}
+
+describe('GatewayChannelRepository', () => {
+  dbTest('create throws when created_by is missing', async ({ db }) => {
+    const repo = new GatewayChannelRepository(db);
+    await expect(repo.create({ name: 'Test Channel' })).rejects.toThrow(
+      'GatewayChannel must have a created_by'
+    );
+  });
+
+  dbTest('create stamps created_by on the returned channel', async ({ db }) => {
+    const worktree = await seedWorktree(db);
+    const repo = new GatewayChannelRepository(db);
+    const userId = generateId() as UUID;
+
+    const channel = await repo.create({
+      name: 'Test Channel',
+      created_by: userId,
+      target_worktree_id: worktree.worktree_id as UUID,
+    });
+
+    expect(channel.created_by).toBe(userId);
+    expect(channel.name).toBe('Test Channel');
+    expect(channel.id).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `GatewayChannelRepository.channelToInsert()` validates that `created_by` is present and throws if it's not, but the `gateway-channels` create hook was never calling `injectCreatedBy()` — unlike every other service (cards, artifacts, boards, sessions, board-comments)
- This caused every channel creation attempt to fail with `"GatewayChannel must have a created_by"`
- Fix: add `injectCreatedBy()` to the gateway-channels `before.create` hook in `register-hooks.ts`

## Test plan

- [ ] New unit tests in `packages/core/src/db/repositories/gateway-channels.test.ts`:
  - Creating a channel without `created_by` throws the expected error
  - Creating a channel with `created_by` succeeds and stamps it on the returned record
- [ ] Manually create a gateway channel in the UI — should succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)