### PR TITLE
fix(daemon): detect missing worktree/repo FS paths + actionable repair (#1109 partial)

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -161,6 +161,11 @@ export interface ReposServiceImpl extends Service<Repo, Partial<Repo>, FeathersP
     data: { worktree_id: string },
     params?: FeathersParams
   ): Promise<{ path: string }>;
+  /** Reclone a remote repo's on-disk directory after FS drift (issue #1109). */
+  recreateFilesystem(
+    id: string,
+    params?: FeathersParams
+  ): Promise<{ status: 'pending' | 'noop'; repo_id: string; slug: string }>;
 }
 
 /**
@@ -246,4 +251,6 @@ export interface WorktreesServiceImpl extends Service<Worktree, Partial<Worktree
     options?: { boardId?: import('@agor/core/types').BoardID },
     params?: FeathersParams
   ): Promise<Worktree>;
+  /** Recreate a worktree's on-disk directory after FS drift (issue #1109). */
+  recreateFilesystem(id: WorktreeID, params?: FeathersParams): Promise<Worktree>;
 }

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -201,4 +201,34 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       return textResult(updated);
     }
   );
+
+  // Tool 6: agor_repos_recreate_filesystem (issue #1109)
+  //
+  // Recovery action when a repo's on-disk directory is missing — typical in
+  // K8s with persistent DB + ephemeral $HOME. Reruns `git clone` and then
+  // cascades to recreate every worktree of this repo that's also missing.
+  server.registerTool(
+    'agor_repos_recreate_filesystem',
+    {
+      description:
+        'Reclone a remote repository whose on-disk directory has disappeared ' +
+        '(typical K8s drift: persistent DB + ephemeral $HOME). Only works for ' +
+        '`repo_type: "remote"` repos — local-type repos point at user-managed ' +
+        'paths and must be restored manually. Returns immediately with ' +
+        '`{ status: "pending" | "noop", repo_id, slug }`. On clone success, ' +
+        "cascades to recreate every non-archived worktree of this repo that's " +
+        "also marked `filesystem_status: 'missing'`. Poll `agor_repos_get(repo_id)` " +
+        "for `clone_status: 'ready'` (then `filesystem_status: 'ready'`).",
+      inputSchema: z.object({
+        repoId: z.string().describe('Repository ID (UUIDv7 or short ID)'),
+      }),
+    },
+    async (args) => {
+      const repoId = coerceString(args.repoId);
+      if (!repoId) throw new Error('repoId is required');
+      const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
+      const result = await reposService.recreateFilesystem(repoId, ctx.baseServiceParams);
+      return textResult(result);
+    }
+  );
 }

--- a/apps/agor-daemon/src/mcp/tools/worktrees.ts
+++ b/apps/agor-daemon/src/mcp/tools/worktrees.ts
@@ -925,6 +925,32 @@ export function registerWorktreeTools(server: McpServer, ctx: McpContext): void 
     }
   );
 
+  // Tool 8b: agor_worktrees_recreate_filesystem (issue #1109)
+  server.registerTool(
+    'agor_worktrees_recreate_filesystem',
+    {
+      description:
+        "Recreate a worktree's on-disk directory after filesystem drift (e.g., K8s pod redeploy with ephemeral $HOME but persistent DB). Reruns `git.worktree.add` so the directory comes back on the same branch. Use when `filesystem_status` is `'missing'`. If the parent repo's directory is also missing, recreate the repo first via `agor_repos_recreate_filesystem`.",
+      inputSchema: z.object({
+        worktreeId: z.string().describe('Worktree ID to recreate (UUIDv7 or short ID)'),
+      }),
+    },
+    async (args) => {
+      const worktreeId = await resolveWorktreeId(ctx, coerceString(args.worktreeId)!);
+      const worktreesService = ctx.app.service('worktrees') as unknown as WorktreesServiceImpl;
+      const result = await worktreesService.recreateFilesystem(
+        worktreeId as WorktreeID,
+        ctx.baseServiceParams
+      );
+      return textResult({
+        success: true,
+        worktree: result,
+        message:
+          'Worktree filesystem recreation triggered. Poll `agor_worktrees_get` for `filesystem_status: "ready"` (or `"failed"` with `error_message`).',
+      });
+    }
+  );
+
   // Tool 9: agor_assistants_list
   server.registerTool(
     'agor_assistants_list',

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2309,6 +2309,26 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
+  // Recreate a remote repo's on-disk filesystem after drift (issue #1109).
+  // Same role gate as cloning: a member who could clone the repo originally
+  // can re-clone it after the directory has been lost (typical K8s redeploy
+  // with ephemeral $HOME).
+  registerAuthenticatedRoute(
+    app,
+    '/repos/:id/recreate-filesystem',
+    {
+      async create(_data: unknown, params: RouteParams) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Repo ID required');
+        return reposService.recreateFilesystem(id, params);
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'recreate repository filesystem' },
+    },
+    requireAuth
+  );
+
   registerAuthenticatedRoute(
     app,
     '/repos/:id/worktrees/:name',
@@ -2714,6 +2734,66 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               if (!isOwner && !hasMinimumRole(userRole, ROLES.ADMIN)) {
                 throw new Forbidden(
                   'You must be the worktree owner or a global admin to unarchive worktrees'
+                );
+              }
+              return context;
+            },
+      ],
+    },
+  });
+
+  // ============================================================================
+  // Recreate worktree filesystem (issue #1109)
+  // ============================================================================
+  // Rerun `git.worktree.add` for a worktree whose directory has disappeared
+  // from disk (typically because $HOME was ephemeral in K8s). Auth tier
+  // matches archive/delete — operators with 'all' on the worktree.
+  app.use('/worktrees/:id/recreate-filesystem', {
+    async create(_data: unknown, params: RouteParams) {
+      const id = params.route?.id;
+      if (!id) throw new BadRequest('Worktree ID required');
+      return worktreesService.recreateFilesystem(
+        id as import('@agor/core/types').WorktreeID,
+        params
+      );
+    },
+  });
+
+  app.service('/worktrees/:id/recreate-filesystem').hooks({
+    before: {
+      create: [
+        requireAuth,
+        requireMinimumRole(ROLES.MEMBER, 'recreate worktree filesystem'),
+        async (context: HookContext) => {
+          const id = context.params.route?.id;
+          if (!id) throw new Error('Worktree ID required');
+
+          const worktree = await worktreeRepository.findById(id);
+          if (!worktree) {
+            throw new Forbidden(`Worktree not found: ${id}`);
+          }
+
+          const userId = context.params.user?.user_id as
+            | import('@agor/core/types').UUID
+            | undefined;
+          const isOwner = userId
+            ? await worktreeRepository.isOwner(worktree.worktree_id, userId)
+            : false;
+
+          context.params.worktree = worktree;
+          context.params.isWorktreeOwner = isOwner;
+
+          return context;
+        },
+        worktreeRbacEnabled
+          ? ensureWorktreePermission('all', 'recreate worktree filesystem', superadminOpts)
+          : (context: HookContext) => {
+              const isOwner = context.params.isWorktreeOwner;
+              const userRole = context.params.user?.role;
+
+              if (!isOwner && !hasMinimumRole(userRole, ROLES.ADMIN)) {
+                throw new Forbidden(
+                  'You must be the worktree owner or a global admin to recreate the worktree filesystem'
                 );
               }
               return context;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -593,31 +593,10 @@ function createExecuteHandler(
       try {
         assertWorktreeFsAvailable({ worktree, repo });
       } catch (err) {
-        // Persist drift state on the worktree (and repo, if it was the miss)
+        // Persist drift state on the worktree (or repo, if it was the miss)
         // so subsequent UI reads can surface the banner without re-spawning.
-        const { isMissingPathError } = await import('@agor/core/fs');
-        if (isMissingPathError(err)) {
-          try {
-            if (err.data.subject === 'worktree') {
-              await app
-                .service('worktrees')
-                .patch(
-                  worktree.worktree_id,
-                  { filesystem_status: 'missing' },
-                  { provider: undefined }
-                );
-            } else if (err.data.subject === 'repo' && repo) {
-              await app
-                .service('repos')
-                .patch(repo.repo_id, { filesystem_status: 'missing' }, { provider: undefined });
-            }
-          } catch (patchErr) {
-            console.warn(
-              `[prompt] Failed to mark ${err.data.subject} as missing in DB:`,
-              patchErr instanceof Error ? patchErr.message : String(patchErr)
-            );
-          }
-        }
+        const { markMissingPathDrift } = await import('./utils/mark-fs-drift.js');
+        await markMissingPathDrift(app, err, repo, '[prompt]');
         throw err;
       }
       cwd = worktree.path;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -24,6 +24,7 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { NotAuthenticated } from '@agor/core/feathers';
+import { assertWorktreeFsAvailable } from '@agor/core/fs';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -570,14 +571,56 @@ function createExecuteHandler(
     const taskId = data.taskId;
 
     // Get worktree path
+    // Pre-flight FS check (issue #1109): if the worktree row exists but its
+    // path is gone (typical K8s drift — ephemeral $HOME, persistent DB), throw
+    // a structured MissingPathError so the UI can render a Reclone/Delete
+    // card instead of letting node-child-process die with a misleading
+    // `spawn /usr/local/bin/node ENOENT`.
     let cwd = process.cwd();
     if (session.worktree_id) {
+      const worktree = await app.service('worktrees').get(session.worktree_id, params);
+      let repo: import('@agor/core/types').Repo | null = null;
       try {
-        const worktree = await app.service('worktrees').get(session.worktree_id, params);
-        cwd = worktree.path;
-      } catch (error) {
-        console.warn(`Could not get worktree path for ${session.worktree_id}:`, error);
+        repo = (await app.service('repos').get(worktree.repo_id, params)) as
+          | import('@agor/core/types').Repo
+          | null;
+      } catch (err) {
+        console.warn(
+          `[prompt] Could not load parent repo ${worktree.repo_id} for FS pre-flight check:`,
+          err instanceof Error ? err.message : String(err)
+        );
       }
+      try {
+        assertWorktreeFsAvailable({ worktree, repo });
+      } catch (err) {
+        // Persist drift state on the worktree (and repo, if it was the miss)
+        // so subsequent UI reads can surface the banner without re-spawning.
+        const { isMissingPathError } = await import('@agor/core/fs');
+        if (isMissingPathError(err)) {
+          try {
+            if (err.data.subject === 'worktree') {
+              await app
+                .service('worktrees')
+                .patch(
+                  worktree.worktree_id,
+                  { filesystem_status: 'missing' },
+                  { provider: undefined }
+                );
+            } else if (err.data.subject === 'repo' && repo) {
+              await app
+                .service('repos')
+                .patch(repo.repo_id, { filesystem_status: 'missing' }, { provider: undefined });
+            }
+          } catch (patchErr) {
+            console.warn(
+              `[prompt] Failed to mark ${err.data.subject} as missing in DB:`,
+              patchErr instanceof Error ? patchErr.message : String(patchErr)
+            );
+          }
+        }
+        throw err;
+      }
+      cwd = worktree.path;
     }
 
     // Find executor binary

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -347,6 +347,173 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
   }
 
   /**
+   * Custom method: Recreate a repo's on-disk filesystem (issue #1109).
+   *
+   * Reruns `git clone` for a `remote`-type repo whose `local_path` has
+   * disappeared from disk (typical K8s drift: `$HOME` is ephemeral, the DB
+   * row persists). Local-type repos are user-managed paths and cannot be
+   * recreated by Agor — those throw an explicit error so the operator
+   * understands they need to restore the directory themselves.
+   *
+   * On clone success, cascades into every non-archived worktree of this repo
+   * that is also `filesystem_status: 'missing'`, recreating each by calling
+   * `worktrees.recreateFilesystem`.
+   *
+   * Returns immediately (fire-and-forget). Callers poll the row's
+   * `clone_status` / `filesystem_status` to discover the outcome.
+   */
+  async recreateFilesystem(
+    id: string,
+    params?: RepoParams
+  ): Promise<{ status: 'pending' | 'noop'; repo_id: string; slug: string }> {
+    const repo = (await this.get(id, params)) as Repo;
+
+    if (repo.repo_type !== 'remote' || !repo.remote_url) {
+      throw new Error(
+        `Cannot recreate filesystem for ${repo.slug}: only remote repositories can be recloned. ` +
+          `Restore the directory at ${repo.local_path} manually for local-type repos.`
+      );
+    }
+
+    if (existsSync(repo.local_path)) {
+      // Idempotent: nothing to recreate. Clear the 'missing' marker so the
+      // UI banner disappears.
+      if (repo.filesystem_status === 'missing') {
+        await this.patch(repo.repo_id, { filesystem_status: 'ready' }, { provider: undefined });
+      }
+      return { status: 'noop', repo_id: repo.repo_id, slug: repo.slug };
+    }
+
+    console.log(
+      `📂 [repos.recreateFilesystem] Reclone requested for ${repo.slug} (${repo.repo_id.slice(0, 8)}): ${repo.local_path}`
+    );
+
+    // Mark the row as cloning so the UI shows a spinner instead of the
+    // missing-banner during the operation. Clear filesystem_status so the
+    // missing-banner goes away; the executor will set clone_status -> 'ready'
+    // on success and our onExit handler will stamp filesystem_status: 'ready'
+    // to keep the two fields in sync.
+    await this.patch(
+      repo.repo_id,
+      {
+        clone_status: 'cloning',
+        clone_error: undefined,
+        filesystem_status: undefined,
+      },
+      { provider: undefined }
+    );
+
+    const userId = (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined;
+    const rbacEnabled = isWorktreeRbacEnabled();
+    const asUser =
+      rbacEnabled && userId ? await resolveGitImpersonationForUser(this.db, userId) : undefined;
+
+    const sessionToken = generateSessionToken(
+      this.app as unknown as { settings: { authentication?: { secret?: string } } }
+    );
+
+    const app = this.app;
+    const reposService = this.app.service('repos');
+    const slug = repo.slug;
+    const repoId = repo.repo_id;
+    const remoteUrl = repo.remote_url;
+
+    spawnExecutorFireAndForget(
+      {
+        command: 'git.clone',
+        sessionToken,
+        daemonUrl: getDaemonUrl(),
+        params: {
+          url: remoteUrl,
+          slug,
+          repoId,
+          ...(repo.default_branch ? { default_branch: repo.default_branch } : {}),
+          createDbRecord: true,
+          userId: userId as string | undefined,
+          initUnixGroup: rbacEnabled,
+        },
+      },
+      {
+        logPrefix: `[recreate ${slug}]`,
+        asUser,
+        onExit: (code) => {
+          if (code === 0) {
+            // Clone succeeded: stamp filesystem_status: 'ready' and cascade
+            // recreation to every missing worktree of this repo. Use the
+            // service layer (no params → internal) so the patched event fires.
+            void (async () => {
+              try {
+                await reposService.patch(repoId, { filesystem_status: 'ready' });
+                console.log(`[recreate ${slug}] Repo reclone succeeded; cascading to worktrees`);
+
+                const worktreesService = app.service(
+                  'worktrees'
+                ) as unknown as import('../declarations.js').WorktreesServiceImpl;
+                // `paginate: false` always returns an array.
+                const worktreeRows = (await worktreesService.find({
+                  query: { repo_id: repoId, archived: false, $limit: 1000 },
+                  paginate: false,
+                })) as unknown as Worktree[];
+                const missingWorktrees = worktreeRows.filter(
+                  (w) => w.filesystem_status === 'missing' || !existsSync(w.path)
+                );
+                if (missingWorktrees.length > 0) {
+                  console.log(
+                    `[recreate ${slug}] Recreating ${missingWorktrees.length} missing worktree(s)`
+                  );
+                }
+                for (const wt of missingWorktrees) {
+                  try {
+                    await worktreesService.recreateFilesystem(wt.worktree_id);
+                  } catch (err) {
+                    console.warn(
+                      `[recreate ${slug}] Failed to recreate worktree ${wt.name}:`,
+                      err instanceof Error ? err.message : String(err)
+                    );
+                  }
+                }
+              } catch (err) {
+                console.warn(
+                  `[recreate ${slug}] Failed cascading worktree recreation:`,
+                  err instanceof Error ? err.message : String(err)
+                );
+              }
+            })();
+            return;
+          }
+
+          // Clone failed: the executor itself patches `clone_status: 'failed'`
+          // on errors it catches. The safety net here covers crash-without-
+          // patch (lost daemon connection) — mirror the cloneRepository
+          // pattern.
+          void (async () => {
+            try {
+              const current = (await reposService.get(repoId)) as Repo;
+              if (current.clone_status === 'cloning') {
+                await reposService.patch(repoId, {
+                  clone_status: 'failed',
+                  clone_error: {
+                    exit_code: code ?? 1,
+                    category: 'unknown',
+                    message: `Reclone exited with code ${code} before reporting an error.`,
+                  },
+                });
+              }
+            } catch (err) {
+              console.error(
+                `[recreate ${slug}] Failed to mark repo as failed in onExit safety net:`,
+                err instanceof Error ? err.message : String(err)
+              );
+            }
+          })();
+        },
+      }
+    );
+
+    return { status: 'pending', repo_id: repoId, slug };
+  }
+
+  /**
    * Custom method: Initialize Unix group for a repo (daemon-side privileged operation).
    *
    * Called by the executor via Feathers RPC after cloning a repo, so that

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -375,6 +375,17 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       );
     }
 
+    // Idempotency guard: a clone already in flight (initial create, or a
+    // previous recreate that hasn't finished) wins. Reporting 'noop' is
+    // honest — we did not start a new clone — and the caller can keep
+    // polling `clone_status` for the in-flight executor's outcome.
+    if (repo.clone_status === 'cloning') {
+      console.log(
+        `📂 [repos.recreateFilesystem] Clone already in flight for ${repo.slug}; skipping`
+      );
+      return { status: 'noop', repo_id: repo.repo_id, slug: repo.slug };
+    }
+
     if (existsSync(repo.local_path)) {
       // Idempotent: nothing to recreate. Clear the 'missing' marker so the
       // UI banner disappears.

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -30,6 +30,7 @@ import {
 import { type Database, formatShortId, UsersRepository, WorktreeRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { Forbidden } from '@agor/core/feathers';
+import { assertWorktreeFsAvailable, isMissingPathError } from '@agor/core/fs';
 import type { AuthenticatedParams, UserID, WorktreeID } from '@agor/core/types';
 import {
   resolveUnixUserForImpersonation,
@@ -366,6 +367,51 @@ export class TerminalsService {
       const worktree = await worktreeRepo.findById(data.worktreeId);
       if (worktree) {
         worktreeName = worktree.name;
+
+        // Pre-flight FS check (issue #1109): refuse to spawn Zellij into a
+        // missing cwd. Without this the executor dies with `chdir(2) failed:
+        // No such file or directory` and the user sees a generic "terminal
+        // failed to open" error. We surface a structured MissingPathError so
+        // the UI can render a Reclone/Delete card.
+        let repo: import('@agor/core/types').Repo | null = null;
+        try {
+          repo = (await this.app.service('repos').get(worktree.repo_id, { provider: undefined })) as
+            | import('@agor/core/types').Repo
+            | null;
+        } catch (err) {
+          console.warn(
+            `[terminals] Could not load parent repo ${worktree.repo_id} for FS pre-flight check:`,
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+        try {
+          assertWorktreeFsAvailable({ worktree, repo });
+        } catch (err) {
+          if (isMissingPathError(err)) {
+            try {
+              if (err.data.subject === 'worktree') {
+                await this.app
+                  .service('worktrees')
+                  .patch(
+                    worktree.worktree_id,
+                    { filesystem_status: 'missing' },
+                    { provider: undefined }
+                  );
+              } else if (err.data.subject === 'repo' && repo) {
+                await this.app
+                  .service('repos')
+                  .patch(repo.repo_id, { filesystem_status: 'missing' }, { provider: undefined });
+              }
+            } catch (patchErr) {
+              console.warn(
+                `[terminals] Failed to mark ${err.data.subject} as missing in DB:`,
+                patchErr instanceof Error ? patchErr.message : String(patchErr)
+              );
+            }
+          }
+          throw err;
+        }
+
         if (finalUnixUser) {
           const symlinkPath = `/home/${finalUnixUser}/agor/worktrees/${worktree.name}`;
           cwd = fs.existsSync(symlinkPath) ? symlinkPath : worktree.path;

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -30,7 +30,7 @@ import {
 import { type Database, formatShortId, UsersRepository, WorktreeRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { Forbidden } from '@agor/core/feathers';
-import { assertWorktreeFsAvailable, isMissingPathError } from '@agor/core/fs';
+import { assertWorktreeFsAvailable } from '@agor/core/fs';
 import type { AuthenticatedParams, UserID, WorktreeID } from '@agor/core/types';
 import {
   resolveUnixUserForImpersonation,
@@ -38,6 +38,7 @@ import {
   UnixUserNotFoundError,
   validateResolvedUnixUser,
 } from '@agor/core/unix';
+import { markMissingPathDrift } from '../utils/mark-fs-drift.js';
 import { generateSessionToken, spawnExecutorFireAndForget } from '../utils/spawn-executor.js';
 import { hasWorktreePermission } from '../utils/worktree-authorization.js';
 
@@ -387,28 +388,7 @@ export class TerminalsService {
         try {
           assertWorktreeFsAvailable({ worktree, repo });
         } catch (err) {
-          if (isMissingPathError(err)) {
-            try {
-              if (err.data.subject === 'worktree') {
-                await this.app
-                  .service('worktrees')
-                  .patch(
-                    worktree.worktree_id,
-                    { filesystem_status: 'missing' },
-                    { provider: undefined }
-                  );
-              } else if (err.data.subject === 'repo' && repo) {
-                await this.app
-                  .service('repos')
-                  .patch(repo.repo_id, { filesystem_status: 'missing' }, { provider: undefined });
-              }
-            } catch (patchErr) {
-              console.warn(
-                `[terminals] Failed to mark ${err.data.subject} as missing in DB:`,
-                patchErr instanceof Error ? patchErr.message : String(patchErr)
-              );
-            }
-          }
+          await markMissingPathDrift(this.app, err, repo, '[terminals]');
           throw err;
         }
 

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -852,6 +852,132 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
   }
 
   /**
+   * Custom method: Recreate the worktree's filesystem directory (issue #1109).
+   *
+   * Use case: a deployment lost its $HOME (typical K8s emptyDir behaviour
+   * combined with persistent Postgres). The DB row is still valid; the
+   * directory is gone. We rerun `git.worktree.add` with `restoreMode: true`
+   * so it checks the remote for an existing branch and either checks it out
+   * or creates a fresh one from `base_ref` — the same logic the unarchive
+   * flow uses for `filesystemAction: 'deleted'` worktrees.
+   *
+   * Pre-conditions checked:
+   * - Worktree row exists and is not archived (recreating an archived
+   *   worktree should go through unarchive instead).
+   * - Parent repo's `local_path` exists on disk. If the repo's filesystem is
+   *   also gone, the caller must `agor_repos_recreate(repo_id)` first —
+   *   we throw a `MissingPathError` pointing at the repo in that case.
+   *
+   * Side effects:
+   * - Patches `filesystem_status: 'creating'` synchronously so the UI sees
+   *   the transition.
+   * - Spawns the executor fire-and-forget; the executor patches the row to
+   *   `'ready'` (or `'failed'` with an error_message) on completion.
+   */
+  async recreateFilesystem(
+    id: WorktreeID,
+    params?: WorktreeParams
+  ): Promise<WorktreeWithZoneAndSessions> {
+    const worktree = await this.get(id, params);
+
+    if (worktree.archived) {
+      throw new Error(
+        `Cannot recreate filesystem for archived worktree ${worktree.name}. Unarchive first.`
+      );
+    }
+
+    const reposService = this.app.service('repos');
+    const repo = (await reposService.get(worktree.repo_id, { provider: undefined })) as Repo;
+
+    // Repo missing → caller must recreate the repo first. Surface a
+    // MissingPathError so the UI offers the right action.
+    if (!existsSync(repo.local_path)) {
+      const { MissingPathError } = await import('@agor/core/fs');
+      throw new MissingPathError({
+        code: 'REPO_PATH_MISSING',
+        subject: 'repo',
+        message:
+          `Cannot recreate worktree ${worktree.name}: its repository ${repo.slug} is also missing ` +
+          `from disk (${repo.local_path}). Recreate the repository first.`,
+        path: repo.local_path,
+        action: 'reclone_or_delete',
+        repo_id: repo.repo_id,
+        worktree_id: worktree.worktree_id,
+      });
+    }
+
+    if (existsSync(worktree.path)) {
+      // Idempotent: nothing to recreate. Clear the 'missing' marker if it was
+      // set so the UI banner disappears.
+      if (worktree.filesystem_status === 'missing') {
+        await this.patch(
+          id,
+          { filesystem_status: 'ready', error_message: undefined },
+          { provider: undefined }
+        );
+      }
+      return this.get(id, params);
+    }
+
+    console.log(`📂 Recreating worktree filesystem: ${worktree.path}`);
+    await this.patch(
+      id,
+      { filesystem_status: 'creating', error_message: undefined },
+      { provider: undefined }
+    );
+
+    const rbacEnabled = isWorktreeRbacEnabled();
+    const { getDaemonUser } = await import('@agor/core/config');
+    const daemonUser = getDaemonUser();
+
+    try {
+      const sessionToken = generateSessionToken(
+        this.app as unknown as { settings: { authentication?: { secret?: string } } }
+      );
+      spawnExecutor(
+        {
+          command: 'git.worktree.add',
+          sessionToken,
+          daemonUrl: getDaemonUrl(),
+          params: {
+            worktreeId: worktree.worktree_id,
+            repoId: repo.repo_id,
+            repoPath: repo.local_path,
+            worktreeName: worktree.name,
+            worktreePath: worktree.path,
+            branch: worktree.ref,
+            refType: worktree.ref_type || 'branch',
+            createBranch: false,
+            restoreMode: true,
+            sourceBranch: worktree.base_ref || repo.default_branch || 'main',
+            initUnixGroup: rbacEnabled,
+            othersAccess: worktree.others_fs_access || 'read',
+            daemonUser,
+            repoUnixGroup: repo.unix_group,
+          },
+        },
+        {
+          logPrefix: `[WorktreesService.recreate ${worktree.name}]`,
+        }
+      );
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(`⚠️  Failed to spawn executor for worktree recreation:`, errMsg);
+      await this.patch(
+        id,
+        {
+          filesystem_status: 'failed',
+          error_message: `Failed to spawn executor: ${errMsg}`,
+        },
+        { provider: undefined }
+      );
+      throw error;
+    }
+
+    return this.get(id, params);
+  }
+
+  /**
    * Custom method: Find worktree by repo_id and name
    */
   async findByRepoAndName(

--- a/apps/agor-daemon/src/services/worktrees.ts
+++ b/apps/agor-daemon/src/services/worktrees.ts
@@ -725,73 +725,15 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
     // (e.g., it was archived with filesystemAction: 'deleted')
     if (!existsSync(worktree.path)) {
       console.log(`📂 Worktree directory missing, spawning executor to recreate: ${worktree.path}`);
-
-      // Set filesystem_status to 'creating' while we rebuild
       await this.patch(id, { filesystem_status: 'creating' }, { provider: undefined });
-
-      // Look up repo to get local_path
-      const reposService = this.app.service('repos');
-      const repo = (await reposService.get(worktree.repo_id)) as Repo;
-
-      const rbacEnabled = isWorktreeRbacEnabled();
-      const { getDaemonUser } = await import('@agor/core/config');
-      const daemonUser = getDaemonUser();
-
-      // No user impersonation for infrastructure operations — the daemon user
-      // owns all worktrees and impersonation would resolve getWorktreesDir()
-      // to the wrong home directory, causing safety check failures.
-
-      try {
-        // Use a service JWT so the executor can patch rendered env command
-        // templates without tripping requireAdminForEnvConfig when unarchive
-        // is performed by a non-admin user.
-        const sessionToken = generateSessionToken(
-          this.app as unknown as { settings: { authentication?: { secret?: string } } }
-        );
-        spawnExecutor(
-          {
-            command: 'git.worktree.add',
-            sessionToken,
-            daemonUrl: getDaemonUrl(),
-            params: {
-              worktreeId: worktree.worktree_id,
-              repoId: repo.repo_id,
-              repoPath: repo.local_path,
-              worktreeName: worktree.name,
-              worktreePath: worktree.path,
-              branch: worktree.ref,
-              refType: worktree.ref_type || 'branch',
-              // Use restore mode: checks if branch exists on remote via ls-remote,
-              // checks out existing branch if found, otherwise creates new branch from base_ref.
-              // This is safe because it only creates a new branch when ls-remote confirms
-              // the branch doesn't exist on the remote (no risk of force-deleting existing branches).
-              createBranch: false,
-              restoreMode: true,
-              sourceBranch: worktree.base_ref || repo.default_branch || 'main',
-              // Unix group isolation
-              initUnixGroup: rbacEnabled,
-              othersAccess: worktree.others_fs_access || 'read',
-              daemonUser,
-              repoUnixGroup: repo.unix_group,
-            },
-          },
-          {
-            logPrefix: `[WorktreesService.unarchive ${worktree.name}]`,
-          }
-        );
-      } catch (error) {
-        console.error(
-          `⚠️  Failed to spawn executor for worktree recreation:`,
-          error instanceof Error ? error.message : String(error)
-        );
-        // Mark as failed so the UI can show the error state
-        const errMsg = error instanceof Error ? error.message : String(error);
-        await this.patch(
-          id,
-          { filesystem_status: 'failed', error_message: `Failed to spawn executor: ${errMsg}` },
-          { provider: undefined }
-        );
-      }
+      const repo = (await this.app.service('repos').get(worktree.repo_id)) as Repo;
+      // unarchive-fired spawn failures are non-fatal: don't rethrow, the
+      // worktree row stays as 'failed' and the user can retry via the UI.
+      await this.spawnRestoreWorktree(
+        worktree,
+        repo,
+        `[WorktreesService.unarchive ${worktree.name}]`
+      ).catch(() => {});
     }
 
     // Ensure a board object exists when unarchiving to a board.
@@ -852,6 +794,83 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
   }
 
   /**
+   * Spawn `git.worktree.add` in restore mode for an existing worktree row.
+   *
+   * Used by `unarchive` (when the operator chose `filesystemAction: 'deleted'`)
+   * and `recreateFilesystem` (issue #1109 — directory gone, row still
+   * valid). Both paths walk the same "remote ls-remote, checkout-or-create"
+   * dance, set `filesystem_status: 'creating'`, and rely on the executor to
+   * patch the row to `'ready'` / `'failed'` on completion.
+   *
+   * Marks `filesystem_status: 'failed'` if the executor itself fails to
+   * launch (the only error visible from the daemon side — runtime failures
+   * are surfaced by the executor patching the row directly).
+   */
+  private async spawnRestoreWorktree(
+    worktree: Worktree,
+    repo: Repo,
+    logPrefix: string
+  ): Promise<void> {
+    const rbacEnabled = isWorktreeRbacEnabled();
+    const { getDaemonUser } = await import('@agor/core/config');
+    const daemonUser = getDaemonUser();
+
+    // No user impersonation for infrastructure operations — the daemon user
+    // owns all worktrees and impersonation would resolve getWorktreesDir()
+    // to the wrong home directory, causing safety check failures.
+
+    try {
+      // Use a service JWT so the executor can patch rendered env command
+      // templates without tripping requireAdminForEnvConfig when restore
+      // is performed by a non-admin user.
+      const sessionToken = generateSessionToken(
+        this.app as unknown as { settings: { authentication?: { secret?: string } } }
+      );
+      spawnExecutor(
+        {
+          command: 'git.worktree.add',
+          sessionToken,
+          daemonUrl: getDaemonUrl(),
+          params: {
+            worktreeId: worktree.worktree_id,
+            repoId: repo.repo_id,
+            repoPath: repo.local_path,
+            worktreeName: worktree.name,
+            worktreePath: worktree.path,
+            branch: worktree.ref,
+            refType: worktree.ref_type || 'branch',
+            // restoreMode: checks if the branch exists on remote via
+            // ls-remote, checks out existing branch if found, otherwise
+            // creates a new branch from base_ref. Safe because it only
+            // creates when ls-remote confirms absence (no risk of
+            // force-deleting existing branches).
+            createBranch: false,
+            restoreMode: true,
+            sourceBranch: worktree.base_ref || repo.default_branch || 'main',
+            initUnixGroup: rbacEnabled,
+            othersAccess: worktree.others_fs_access || 'read',
+            daemonUser,
+            repoUnixGroup: repo.unix_group,
+          },
+        },
+        { logPrefix }
+      );
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(`${logPrefix} Failed to spawn executor for worktree restore:`, errMsg);
+      await this.patch(
+        worktree.worktree_id,
+        {
+          filesystem_status: 'failed',
+          error_message: `Failed to spawn executor: ${errMsg}`,
+        },
+        { provider: undefined }
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Custom method: Recreate the worktree's filesystem directory (issue #1109).
    *
    * Use case: a deployment lost its $HOME (typical K8s emptyDir behaviour
@@ -865,7 +884,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
    * - Worktree row exists and is not archived (recreating an archived
    *   worktree should go through unarchive instead).
    * - Parent repo's `local_path` exists on disk. If the repo's filesystem is
-   *   also gone, the caller must `agor_repos_recreate(repo_id)` first —
+   *   also gone, the caller must `agor_repos_recreate_filesystem(repo_id)` first —
    *   we throw a `MissingPathError` pointing at the repo in that case.
    *
    * Side effects:
@@ -886,6 +905,17 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       );
     }
 
+    // Idempotency guard: if a recreate is already in flight (double-click,
+    // MCP retry, or repo-recreate cascade racing a manual worktree
+    // recreate), don't spawn a second `git.worktree.add` against the same
+    // path. The in-flight executor will patch the row on completion.
+    if (worktree.filesystem_status === 'creating') {
+      console.log(
+        `📂 [WorktreesService.recreate ${worktree.name}] Recreation already in flight; skipping`
+      );
+      return worktree;
+    }
+
     const reposService = this.app.service('repos');
     const repo = (await reposService.get(worktree.repo_id, { provider: undefined })) as Repo;
 
@@ -893,17 +923,18 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
     // MissingPathError so the UI offers the right action.
     if (!existsSync(repo.local_path)) {
       const { MissingPathError } = await import('@agor/core/fs');
-      throw new MissingPathError({
-        code: 'REPO_PATH_MISSING',
-        subject: 'repo',
-        message:
-          `Cannot recreate worktree ${worktree.name}: its repository ${repo.slug} is also missing ` +
+      throw new MissingPathError(
+        `Cannot recreate worktree ${worktree.name}: its repository ${repo.slug} is also missing ` +
           `from disk (${repo.local_path}). Recreate the repository first.`,
-        path: repo.local_path,
-        action: 'reclone_or_delete',
-        repo_id: repo.repo_id,
-        worktree_id: worktree.worktree_id,
-      });
+        {
+          code: 'REPO_PATH_MISSING',
+          subject: 'repo',
+          path: repo.local_path,
+          action: 'reclone_or_delete',
+          repo_id: repo.repo_id,
+          worktree_id: worktree.worktree_id,
+        }
+      );
     }
 
     if (existsSync(worktree.path)) {
@@ -926,53 +957,7 @@ export class WorktreesService extends DrizzleService<Worktree, Partial<Worktree>
       { provider: undefined }
     );
 
-    const rbacEnabled = isWorktreeRbacEnabled();
-    const { getDaemonUser } = await import('@agor/core/config');
-    const daemonUser = getDaemonUser();
-
-    try {
-      const sessionToken = generateSessionToken(
-        this.app as unknown as { settings: { authentication?: { secret?: string } } }
-      );
-      spawnExecutor(
-        {
-          command: 'git.worktree.add',
-          sessionToken,
-          daemonUrl: getDaemonUrl(),
-          params: {
-            worktreeId: worktree.worktree_id,
-            repoId: repo.repo_id,
-            repoPath: repo.local_path,
-            worktreeName: worktree.name,
-            worktreePath: worktree.path,
-            branch: worktree.ref,
-            refType: worktree.ref_type || 'branch',
-            createBranch: false,
-            restoreMode: true,
-            sourceBranch: worktree.base_ref || repo.default_branch || 'main',
-            initUnixGroup: rbacEnabled,
-            othersAccess: worktree.others_fs_access || 'read',
-            daemonUser,
-            repoUnixGroup: repo.unix_group,
-          },
-        },
-        {
-          logPrefix: `[WorktreesService.recreate ${worktree.name}]`,
-        }
-      );
-    } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      console.error(`⚠️  Failed to spawn executor for worktree recreation:`, errMsg);
-      await this.patch(
-        id,
-        {
-          filesystem_status: 'failed',
-          error_message: `Failed to spawn executor: ${errMsg}`,
-        },
-        { provider: undefined }
-      );
-      throw error;
-    }
+    await this.spawnRestoreWorktree(worktree, repo, `[WorktreesService.recreate ${worktree.name}]`);
 
     return this.get(id, params);
   }

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -19,6 +19,7 @@ import { createHealthMonitor } from './services/health-monitor.js';
 import { SchedulerService } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
+import { reconcileFilesystemStatus } from './utils/fs-reconciliation.js';
 
 // ---------------------------------------------------------------------------
 // Context
@@ -356,6 +357,36 @@ export async function startup(ctx: StartupContext): Promise<void> {
 
   // 1. Cleanup orphaned tasks/sessions from previous daemon instance
   await cleanupOrphans(ctx);
+
+  // 1b. Reconcile filesystem drift (issue #1109)
+  // K8s deployments with persistent DB + ephemeral $HOME leave the DB pointing
+  // at repo/worktree paths that no longer exist. Mark them as
+  // `filesystem_status: 'missing'` here so the UI can render a Reclone/Delete
+  // banner before the user tries to open a terminal or run a prompt and hits
+  // a misleading `spawn ... ENOENT` from node-child-process.
+  try {
+    const stats = await reconcileFilesystemStatus(db);
+    if (
+      stats.worktrees_marked_missing > 0 ||
+      stats.repos_marked_missing > 0 ||
+      stats.worktrees_restored > 0 ||
+      stats.repos_restored > 0
+    ) {
+      console.log(
+        `📂 FS reconciliation: ` +
+          `${stats.repos_marked_missing} repo(s) missing, ` +
+          `${stats.repos_restored} repo(s) restored; ` +
+          `${stats.worktrees_marked_missing} worktree(s) missing, ` +
+          `${stats.worktrees_restored} worktree(s) restored ` +
+          `(checked ${stats.repos_checked} repo(s), ${stats.worktrees_checked} worktree(s))`
+      );
+    }
+  } catch (err) {
+    console.warn(
+      '⚠️  FS reconciliation pass failed (non-fatal):',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
 
   // 2. Initialize Health Monitor for periodic environment health checks
   const healthMonitor = await createHealthMonitor(app);

--- a/apps/agor-daemon/src/utils/fs-reconciliation.ts
+++ b/apps/agor-daemon/src/utils/fs-reconciliation.ts
@@ -21,10 +21,9 @@
  * (`preserved` / `cleaned` / `deleted`) — those have their own lifecycle and
  * a missing path is expected/intentional for them.
  */
-import { existsSync } from 'node:fs';
-
 import type { Database } from '@agor/core/db';
 import { RepoRepository, WorktreeRepository } from '@agor/core/db';
+import { detectRepoFsDrift, detectWorktreeFsDrift } from '@agor/core/fs';
 import type { Repo, Worktree } from '@agor/core/types';
 
 export interface ReconciliationStats {
@@ -87,17 +86,17 @@ async function reconcileRepo(repo: Repo, repoRepo: RepoRepository): Promise<Reco
     return 'skipped';
   }
 
-  const onDisk = existsSync(repo.local_path);
+  const drift = detectRepoFsDrift(repo);
   const wasMissing = repo.filesystem_status === 'missing';
 
-  if (!onDisk && !wasMissing) {
+  if (drift && !wasMissing) {
     await repoRepo.update(repo.repo_id, { filesystem_status: 'missing' });
     console.warn(
-      `[fs-reconciliation] Repo ${repo.slug} (${repo.repo_id.slice(0, 8)}) marked 'missing': ${repo.local_path}`
+      `[fs-reconciliation] Repo ${repo.slug} (${repo.repo_id.slice(0, 8)}) marked 'missing': ${drift.path}`
     );
     return 'newly_missing';
   }
-  if (onDisk && wasMissing) {
+  if (!drift && wasMissing) {
     await repoRepo.update(repo.repo_id, { filesystem_status: 'ready' });
     console.log(
       `[fs-reconciliation] Repo ${repo.slug} (${repo.repo_id.slice(0, 8)}) restored: ${repo.local_path}`
@@ -118,17 +117,23 @@ async function reconcileWorktree(
     return 'skipped';
   }
 
-  const onDisk = existsSync(worktree.path);
+  // Reconciliation runs the worktree pass independently of the repo pass;
+  // both call sites use `detectWorktreeFsDrift` / `detectRepoFsDrift` from
+  // `@agor/core/fs` to keep the predicate honest in exactly one place.
+  // (We don't pass `repo` here because repo drift is handled in its own pass
+  // — checking parent-repo presence again would be a wasted lookup per
+  // worktree.)
+  const drift = detectWorktreeFsDrift({ worktree });
   const wasMissing = worktree.filesystem_status === 'missing';
 
-  if (!onDisk && !wasMissing) {
+  if (drift && !wasMissing) {
     await worktreeRepo.update(worktree.worktree_id, { filesystem_status: 'missing' });
     console.warn(
-      `[fs-reconciliation] Worktree ${worktree.name} (${worktree.worktree_id.slice(0, 8)}) marked 'missing': ${worktree.path}`
+      `[fs-reconciliation] Worktree ${worktree.name} (${worktree.worktree_id.slice(0, 8)}) marked 'missing': ${drift.path}`
     );
     return 'newly_missing';
   }
-  if (onDisk && wasMissing) {
+  if (!drift && wasMissing) {
     await worktreeRepo.update(worktree.worktree_id, { filesystem_status: 'ready' });
     console.log(
       `[fs-reconciliation] Worktree ${worktree.name} (${worktree.worktree_id.slice(0, 8)}) restored: ${worktree.path}`

--- a/apps/agor-daemon/src/utils/fs-reconciliation.ts
+++ b/apps/agor-daemon/src/utils/fs-reconciliation.ts
@@ -1,0 +1,139 @@
+/**
+ * Startup filesystem reconciliation (issue #1109).
+ *
+ * Iterates every repo + worktree in the database and checks whether its
+ * recorded `local_path` / `path` still exists on disk. Drift gets persisted
+ * as `filesystem_status: 'missing'` so the UI can surface a Reclone / Delete
+ * banner BEFORE the user tries to open a terminal or run a prompt.
+ *
+ * Why this matters: in K8s where `$HOME` is an `emptyDir` but Postgres lives
+ * on a persistent volume, a pod redeploy leaves the DB pointing at paths
+ * that no longer exist. Without this pass, the user only discovers the
+ * problem when they hit "Open Terminal" and the executor dies with a
+ * misleading `spawn /usr/local/bin/node ENOENT`.
+ *
+ * Idempotent and lossy in one direction only: it writes `'missing'` when
+ * the FS is gone, and it clears `'missing'` back to `'ready'` when the FS
+ * has reappeared (e.g. operator restored from backup). It NEVER deletes any
+ * rows — recovery is gated on an explicit user action (recreate or remove).
+ *
+ * Skips in-flight rows (`creating` / `cloning`) and archive states
+ * (`preserved` / `cleaned` / `deleted`) — those have their own lifecycle and
+ * a missing path is expected/intentional for them.
+ */
+import { existsSync } from 'node:fs';
+
+import type { Database } from '@agor/core/db';
+import { RepoRepository, WorktreeRepository } from '@agor/core/db';
+import type { Repo, Worktree } from '@agor/core/types';
+
+export interface ReconciliationStats {
+  worktrees_checked: number;
+  worktrees_marked_missing: number;
+  worktrees_restored: number;
+  repos_checked: number;
+  repos_marked_missing: number;
+  repos_restored: number;
+}
+
+const WORKTREE_FS_RECONCILIATION_SKIP_STATES = new Set<NonNullable<Worktree['filesystem_status']>>([
+  'creating',
+  'preserved',
+  'cleaned',
+  'deleted',
+]);
+
+export async function reconcileFilesystemStatus(db: Database): Promise<ReconciliationStats> {
+  const stats: ReconciliationStats = {
+    worktrees_checked: 0,
+    worktrees_marked_missing: 0,
+    worktrees_restored: 0,
+    repos_checked: 0,
+    repos_marked_missing: 0,
+    repos_restored: 0,
+  };
+
+  const repoRepo = new RepoRepository(db);
+  const worktreeRepo = new WorktreeRepository(db);
+
+  // Reconcile repos first — a missing repo cascades drift detection downward,
+  // but we still want to record per-worktree status so the UI can offer the
+  // right recovery action at the row the user is looking at.
+  const repos = await repoRepo.findAll();
+  for (const repo of repos) {
+    stats.repos_checked++;
+    const status = await reconcileRepo(repo, repoRepo);
+    if (status === 'newly_missing') stats.repos_marked_missing++;
+    else if (status === 'restored') stats.repos_restored++;
+  }
+
+  const worktreesList = await worktreeRepo.findAll({ includeArchived: false });
+  for (const worktree of worktreesList) {
+    stats.worktrees_checked++;
+    const status = await reconcileWorktree(worktree, worktreeRepo);
+    if (status === 'newly_missing') stats.worktrees_marked_missing++;
+    else if (status === 'restored') stats.worktrees_restored++;
+  }
+
+  return stats;
+}
+
+type ReconcileOutcome = 'ok' | 'newly_missing' | 'restored' | 'skipped';
+
+async function reconcileRepo(repo: Repo, repoRepo: RepoRepository): Promise<ReconcileOutcome> {
+  // Don't touch repos still being cloned — their executor controls clone_status,
+  // and stamping filesystem_status while clone is racing would be confusing.
+  if (repo.clone_status === 'cloning') {
+    return 'skipped';
+  }
+
+  const onDisk = existsSync(repo.local_path);
+  const wasMissing = repo.filesystem_status === 'missing';
+
+  if (!onDisk && !wasMissing) {
+    await repoRepo.update(repo.repo_id, { filesystem_status: 'missing' });
+    console.warn(
+      `[fs-reconciliation] Repo ${repo.slug} (${repo.repo_id.slice(0, 8)}) marked 'missing': ${repo.local_path}`
+    );
+    return 'newly_missing';
+  }
+  if (onDisk && wasMissing) {
+    await repoRepo.update(repo.repo_id, { filesystem_status: 'ready' });
+    console.log(
+      `[fs-reconciliation] Repo ${repo.slug} (${repo.repo_id.slice(0, 8)}) restored: ${repo.local_path}`
+    );
+    return 'restored';
+  }
+  return 'ok';
+}
+
+async function reconcileWorktree(
+  worktree: Worktree,
+  worktreeRepo: WorktreeRepository
+): Promise<ReconcileOutcome> {
+  if (
+    worktree.filesystem_status &&
+    WORKTREE_FS_RECONCILIATION_SKIP_STATES.has(worktree.filesystem_status)
+  ) {
+    return 'skipped';
+  }
+
+  const onDisk = existsSync(worktree.path);
+  const wasMissing = worktree.filesystem_status === 'missing';
+
+  if (!onDisk && !wasMissing) {
+    await worktreeRepo.update(worktree.worktree_id, { filesystem_status: 'missing' });
+    console.warn(
+      `[fs-reconciliation] Worktree ${worktree.name} (${worktree.worktree_id.slice(0, 8)}) marked 'missing': ${worktree.path}`
+    );
+    return 'newly_missing';
+  }
+  if (onDisk && wasMissing) {
+    await worktreeRepo.update(worktree.worktree_id, { filesystem_status: 'ready' });
+    console.log(
+      `[fs-reconciliation] Worktree ${worktree.name} (${worktree.worktree_id.slice(0, 8)}) restored: ${worktree.path}`
+    );
+    return 'restored';
+  }
+  return 'ok';
+}

--- a/apps/agor-daemon/src/utils/mark-fs-drift.ts
+++ b/apps/agor-daemon/src/utils/mark-fs-drift.ts
@@ -1,0 +1,41 @@
+/**
+ * Persist filesystem-drift state after a spawn-time pre-flight check throws
+ * a `MissingPathError` (issue #1109).
+ *
+ * Lives daemon-side because the work is service-layer DB patching, which we
+ * never push into `@agor/core`. The drift detection itself is core
+ * (`assertWorktreeFsAvailable`); persisting the result is app glue.
+ *
+ * Swallows patch failures (non-fatal — the structured error is what the
+ * caller cares about; the marker is best-effort UX so the next reader sees
+ * the banner without needing to re-spawn).
+ */
+import type { Application } from '@agor/core/feathers';
+import { isMissingPathError } from '@agor/core/fs';
+import type { Repo } from '@agor/core/types';
+
+export async function markMissingPathDrift(
+  app: Application,
+  err: unknown,
+  repo: Repo | null,
+  logPrefix: string
+): Promise<void> {
+  if (!isMissingPathError(err)) return;
+  const { subject, worktree_id } = err.payload;
+  try {
+    if (subject === 'worktree' && worktree_id) {
+      await app
+        .service('worktrees')
+        .patch(worktree_id, { filesystem_status: 'missing' }, { provider: undefined });
+    } else if (subject === 'repo' && repo) {
+      await app
+        .service('repos')
+        .patch(repo.repo_id, { filesystem_status: 'missing' }, { provider: undefined });
+    }
+  } catch (patchErr) {
+    console.warn(
+      `${logPrefix} Failed to mark ${subject} as missing in DB:`,
+      patchErr instanceof Error ? patchErr.message : String(patchErr)
+    );
+  }
+}

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -316,6 +316,28 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   console.log(`${logPrefix} Spawning executor at: ${executorPath}`);
   console.log(`${logPrefix} Command: ${payload.command}`);
 
+  // Replace the OS-level `spawn /usr/local/bin/node ENOENT` (which reports
+  // against the executable path, even when the real culprit is a missing
+  // cwd) with a clear log line. Issue #1109: caller paths that resolve a
+  // worktree's `cwd` to a directory that no longer exists shouldn't make
+  // node-child-process die with a misleading error. Pre-flight callers
+  // (`assertWorktreeFsAvailable`) catch the common cases earlier and throw
+  // a structured error — this is the belt-and-braces log for any spawn we
+  // didn't pre-check, plus a defence against race conditions where the
+  // directory vanishes between the check and the spawn.
+  if (cwd && !existsSync(cwd)) {
+    console.error(
+      `${logPrefix} Refusing to spawn: cwd does not exist on disk: ${cwd}. ` +
+        `This usually means a worktree or repo's filesystem path was deleted ` +
+        `out-of-band (e.g. K8s pod redeploy with ephemeral $HOME). ` +
+        `See issue #1109.`
+    );
+    // Surface the failure through the normal exit-code path so onExit
+    // handlers (e.g. clone-safety-net in repos.ts) run as expected.
+    options.onExit?.(127);
+    return;
+  }
+
   const executorProcess = spawn(cmd, args, {
     cwd,
     env: asUser ? undefined : { ...envWithDaemonUrl }, // When impersonating, env is in the command; otherwise pass to spawn

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -32,6 +32,7 @@ import {
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import {
+  Alert,
   App,
   Badge,
   Button,
@@ -331,6 +332,39 @@ const WorktreeCardComponent = ({
   // Check if worktree is still being created on filesystem
   const isCreating = worktree.filesystem_status === 'creating';
   const isFailed = worktree.filesystem_status === 'failed';
+  // FS drift state (issue #1109). 'missing' means the DB row references a
+  // path that no longer exists on disk — typically a K8s ephemeral $HOME
+  // combined with a persistent DB. Recovery is either reclone or delete.
+  const isWorktreeMissing = worktree.filesystem_status === 'missing';
+  const isRepoMissing = repo?.filesystem_status === 'missing';
+  const isMissing = isWorktreeMissing || isRepoMissing;
+  const [recreating, setRecreating] = useState(false);
+  const handleRecreateFilesystem = useCallback(async () => {
+    if (!client) return;
+    setRecreating(true);
+    try {
+      if (isRepoMissing) {
+        await client.service(`repos/${worktree.repo_id}/recreate-filesystem`).create({});
+        showSuccess(`Reclone of ${repo?.slug ?? 'repository'} started.`);
+      } else {
+        await client.service(`worktrees/${worktree.worktree_id}/recreate-filesystem`).create({});
+        showSuccess(`Recreating worktree ${worktree.name}...`);
+      }
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to trigger filesystem recreation.');
+    } finally {
+      setRecreating(false);
+    }
+  }, [
+    client,
+    isRepoMissing,
+    worktree.repo_id,
+    worktree.worktree_id,
+    worktree.name,
+    repo?.slug,
+    showSuccess,
+    showError,
+  ]);
 
   // Check if this worktree is a persisted agent
   const assistantConfig = useMemo(() => getAssistantConfig(worktree), [worktree]);
@@ -975,6 +1009,67 @@ const WorktreeCardComponent = ({
               {notesExpanded ? 'See less' : 'See more'}
             </Button>
           )}
+        </div>
+      )}
+
+      {/* Filesystem-missing banner (issue #1109).
+          Renders above the sessions list so it's visible regardless of whether
+          the worktree has active sessions. Two flavours:
+          - Repo path missing: must reclone the repo first; worktrees will
+            cascade automatically.
+          - Worktree path missing (repo present): recreate the worktree
+            directly. */}
+      {isMissing && (
+        <div className="nodrag" style={{ marginBottom: 8 }}>
+          <Alert
+            type="warning"
+            showIcon
+            message={
+              isRepoMissing
+                ? `Repository ${repo?.slug ?? worktree.repo_id.substring(0, 8)} is missing on disk`
+                : `Worktree ${worktree.name} is missing on disk`
+            }
+            description={
+              isRepoMissing
+                ? 'The repository directory no longer exists on disk (common after K8s redeploys with ephemeral $HOME). Reclone to restore it — worktrees will be recreated automatically.'
+                : 'The worktree directory no longer exists on disk (common after K8s redeploys with ephemeral $HOME). Recreate to restore it, or archive/delete the record if it is no longer needed.'
+            }
+            action={
+              <Space direction="vertical" size="small">
+                <Button
+                  size="small"
+                  type="primary"
+                  loading={recreating}
+                  disabled={!client || connectionDisabled}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRecreateFilesystem();
+                  }}
+                >
+                  {isRepoMissing ? 'Reclone repository' : 'Recreate worktree'}
+                </Button>
+                {onArchiveOrDelete && !isRepoMissing && (
+                  <Button
+                    size="small"
+                    danger
+                    icon={<DeleteOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      // FS is already gone, so 'preserved' is the only sane
+                      // filesystemAction — there's nothing on disk to clean
+                      // or re-delete.
+                      onArchiveOrDelete(worktree.worktree_id, {
+                        metadataAction: 'delete',
+                        filesystemAction: 'preserved',
+                      });
+                    }}
+                  >
+                    Delete record
+                  </Button>
+                )}
+              </Space>
+            }
+          />
         </div>
       )}
 

--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -1118,7 +1118,11 @@ const WorktreeCardComponent = ({
               <Button
                 type="primary"
                 icon={<PlusOutlined />}
-                disabled={connectionDisabled}
+                // Disable when the worktree (or its repo) is missing on disk:
+                // the spawn-time pre-flight check would reject the resulting
+                // prompt anyway, and the banner above already offers the
+                // recovery action.
+                disabled={connectionDisabled || isMissing}
                 onClick={(e) => {
                   e.stopPropagation();
                   onCreateSession(worktree.worktree_id);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -280,6 +280,12 @@
       "import": "./dist/unix/index.js",
       "require": "./dist/unix/index.cjs"
     },
+    "./fs": {
+      "source": "./src/fs/index.ts",
+      "types": "./dist/fs/index.d.ts",
+      "import": "./dist/fs/index.js",
+      "require": "./dist/fs/index.cjs"
+    },
     "./mcp": {
       "source": "./src/mcp/index.ts",
       "types": "./dist/mcp/index.d.ts",

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -83,6 +83,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       environment_config,
       clone_status: data.clone_status,
       clone_error: data.clone_error,
+      filesystem_status: data.filesystem_status,
     };
   }
 
@@ -137,6 +138,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         // coerce that to `undefined` here so the stored value matches the
         // `clone_error?: RepoCloneError` invariant (set only when failed).
         clone_error: repo.clone_error || undefined,
+        filesystem_status: repo.filesystem_status,
       },
     };
   }

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -462,6 +462,11 @@ export const repos = pgTable(
           category: 'auth_failed' | 'not_found' | 'network' | 'unknown';
           message: string;
         };
+        // FS drift state (issue #1109). 'missing' when local_path doesn't exist
+        // on disk despite the row existing. Set by the startup reconciliation
+        // pass or the spawn-time pre-flight check; recovered via
+        // agor_repos_recreate. Undefined ≡ not-yet-reconciled.
+        filesystem_status?: 'ready' | 'missing';
         // v2 environment config — source of truth. Named variants + optional
         // deployment-local template_overrides. See RepoEnvironment in
         // packages/core/src/types/worktree.ts.
@@ -564,7 +569,7 @@ export const worktrees = pgTable(
     archived_at: t.timestamp('archived_at'),
     archived_by: varchar('archived_by', { length: 36 }),
     filesystem_status: text('filesystem_status', {
-      enum: ['creating', 'ready', 'failed', 'preserved', 'cleaned', 'deleted'],
+      enum: ['creating', 'ready', 'failed', 'missing', 'preserved', 'cleaned', 'deleted'],
     }),
 
     // RBAC: App-layer permissions (rbac.md)

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -465,7 +465,7 @@ export const repos = pgTable(
         // FS drift state (issue #1109). 'missing' when local_path doesn't exist
         // on disk despite the row existing. Set by the startup reconciliation
         // pass or the spawn-time pre-flight check; recovered via
-        // agor_repos_recreate. Undefined ≡ not-yet-reconciled.
+        // agor_repos_recreate_filesystem. Undefined ≡ not-yet-reconciled.
         filesystem_status?: 'ready' | 'missing';
         // v2 environment config — source of truth. Named variants + optional
         // deployment-local template_overrides. See RepoEnvironment in

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -454,6 +454,11 @@ export const repos = sqliteTable(
           category: 'auth_failed' | 'not_found' | 'network' | 'unknown';
           message: string;
         };
+        // FS drift state (issue #1109). 'missing' when local_path doesn't exist
+        // on disk despite the row existing. Set by the startup reconciliation
+        // pass or the spawn-time pre-flight check; recovered via
+        // agor_repos_recreate. Undefined ≡ not-yet-reconciled.
+        filesystem_status?: 'ready' | 'missing';
         // v2 environment config — source of truth. Named variants + optional
         // deployment-local template_overrides. See RepoEnvironment in
         // packages/core/src/types/worktree.ts.
@@ -556,7 +561,7 @@ export const worktrees = sqliteTable(
     archived_at: t.timestamp('archived_at'),
     archived_by: text('archived_by', { length: 36 }),
     filesystem_status: text('filesystem_status', {
-      enum: ['creating', 'ready', 'failed', 'preserved', 'cleaned', 'deleted'],
+      enum: ['creating', 'ready', 'failed', 'missing', 'preserved', 'cleaned', 'deleted'],
     }),
 
     // RBAC: App-layer permissions (rbac.md)

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -457,7 +457,7 @@ export const repos = sqliteTable(
         // FS drift state (issue #1109). 'missing' when local_path doesn't exist
         // on disk despite the row existing. Set by the startup reconciliation
         // pass or the spawn-time pre-flight check; recovered via
-        // agor_repos_recreate. Undefined ≡ not-yet-reconciled.
+        // agor_repos_recreate_filesystem. Undefined ≡ not-yet-reconciled.
         filesystem_status?: 'ready' | 'missing';
         // v2 environment config — source of truth. Named variants + optional
         // deployment-local template_overrides. See RepoEnvironment in

--- a/packages/core/src/feathers/index.ts
+++ b/packages/core/src/feathers/index.ts
@@ -23,10 +23,12 @@ export { LocalStrategy } from '@feathersjs/authentication-local';
 export {
   BadRequest,
   Conflict,
+  FeathersError,
   Forbidden,
   NotAuthenticated,
   NotFound,
   TooManyRequests,
+  Unprocessable,
 } from '@feathersjs/errors';
 export type { Application as ExpressApplication } from '@feathersjs/express';
 // Express Integration

--- a/packages/core/src/fs/check-worktree-path.test.ts
+++ b/packages/core/src/fs/check-worktree-path.test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { Repo, Worktree } from '../types';
+import {
+  assertWorktreeFsAvailable,
+  detectWorktreeFsDrift,
+  isMissingPathError,
+  MissingPathError,
+} from './index';
+
+const fakeWorktree = (overrides: Partial<Worktree> & { path: string }): Worktree =>
+  ({
+    worktree_id: 'wt_00000000-0000-0000-0000-000000000001' as Worktree['worktree_id'],
+    repo_id: 'rp_00000000-0000-0000-0000-000000000002' as Worktree['repo_id'],
+    name: 'feat-fix',
+    ...overrides,
+  }) as Worktree;
+
+const fakeRepo = (overrides: Partial<Repo> & { local_path: string }): Repo =>
+  ({
+    repo_id: 'rp_00000000-0000-0000-0000-000000000002' as Repo['repo_id'],
+    slug: 'preset-io/agor',
+    name: 'agor',
+    ...overrides,
+  }) as Repo;
+
+describe('assertWorktreeFsAvailable', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-fs-check-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('passes when both repo and worktree paths exist', () => {
+    const worktree = fakeWorktree({ path: tmpDir });
+    const repo = fakeRepo({ local_path: tmpDir });
+    expect(() => assertWorktreeFsAvailable({ worktree, repo })).not.toThrow();
+  });
+
+  it('throws REPO_PATH_MISSING with priority when repo path is gone', () => {
+    const worktree = fakeWorktree({ path: tmpDir }); // worktree path exists
+    const repo = fakeRepo({ local_path: path.join(tmpDir, 'gone-repo') });
+    // even though the worktree path is present, the repo miss must surface
+    // first since recovery requires recloning the repo before recreating
+    // worktrees
+    let thrown: unknown;
+    try {
+      assertWorktreeFsAvailable({ worktree, repo });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(isMissingPathError(thrown)).toBe(true);
+    const e = thrown as MissingPathError;
+    expect(e.data.code).toBe('REPO_PATH_MISSING');
+    expect(e.data.subject).toBe('repo');
+    expect(e.data.path).toBe(repo.local_path);
+    expect(e.data.action).toBe('reclone_or_delete');
+    expect(e.data.repo_id).toBe(repo.repo_id);
+    expect(e.data.worktree_id).toBe(worktree.worktree_id);
+    // surfaceable through Feathers as 422
+    expect(e.code).toBe(422);
+  });
+
+  it('throws WORKTREE_PATH_MISSING when only the worktree path is gone', () => {
+    const worktree = fakeWorktree({ path: path.join(tmpDir, 'gone-wt') });
+    const repo = fakeRepo({ local_path: tmpDir });
+    let thrown: unknown;
+    try {
+      assertWorktreeFsAvailable({ worktree, repo });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(isMissingPathError(thrown)).toBe(true);
+    const e = thrown as MissingPathError;
+    expect(e.data.code).toBe('WORKTREE_PATH_MISSING');
+    expect(e.data.subject).toBe('worktree');
+    expect(e.data.path).toBe(worktree.path);
+    expect(e.data.worktree_id).toBe(worktree.worktree_id);
+    expect(e.data.repo_id).toBe(worktree.repo_id);
+  });
+
+  it('throws WORKTREE_PATH_MISSING when repo is unknown but worktree is gone', () => {
+    const worktree = fakeWorktree({ path: path.join(tmpDir, 'gone-wt') });
+    expect(() => assertWorktreeFsAvailable({ worktree })).toThrow(MissingPathError);
+  });
+
+  it('error message references the missing path and the standard K8s drift hint', () => {
+    const worktree = fakeWorktree({ path: path.join(tmpDir, 'gone-wt') });
+    let thrown: unknown;
+    try {
+      assertWorktreeFsAvailable({ worktree });
+    } catch (err) {
+      thrown = err;
+    }
+    const e = thrown as MissingPathError;
+    expect(e.message).toContain(worktree.path);
+    expect(e.message).toContain('Kubernetes');
+  });
+});
+
+describe('detectWorktreeFsDrift', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-fs-check-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when everything is present', () => {
+    const worktree = fakeWorktree({ path: tmpDir });
+    const repo = fakeRepo({ local_path: tmpDir });
+    expect(detectWorktreeFsDrift({ worktree, repo })).toBeNull();
+  });
+
+  it('reports repo drift before worktree drift', () => {
+    const worktree = fakeWorktree({ path: path.join(tmpDir, 'gone-wt') });
+    const repo = fakeRepo({ local_path: path.join(tmpDir, 'gone-repo') });
+    expect(detectWorktreeFsDrift({ worktree, repo })).toEqual({
+      subject: 'repo',
+      path: repo.local_path,
+    });
+  });
+
+  it('reports worktree drift when repo is present', () => {
+    const worktree = fakeWorktree({ path: path.join(tmpDir, 'gone-wt') });
+    const repo = fakeRepo({ local_path: tmpDir });
+    expect(detectWorktreeFsDrift({ worktree, repo })).toEqual({
+      subject: 'worktree',
+      path: worktree.path,
+    });
+  });
+});

--- a/packages/core/src/fs/check-worktree-path.test.ts
+++ b/packages/core/src/fs/check-worktree-path.test.ts
@@ -59,12 +59,12 @@ describe('assertWorktreeFsAvailable', () => {
     }
     expect(isMissingPathError(thrown)).toBe(true);
     const e = thrown as MissingPathError;
-    expect(e.data.code).toBe('REPO_PATH_MISSING');
-    expect(e.data.subject).toBe('repo');
-    expect(e.data.path).toBe(repo.local_path);
-    expect(e.data.action).toBe('reclone_or_delete');
-    expect(e.data.repo_id).toBe(repo.repo_id);
-    expect(e.data.worktree_id).toBe(worktree.worktree_id);
+    expect(e.payload.code).toBe('REPO_PATH_MISSING');
+    expect(e.payload.subject).toBe('repo');
+    expect(e.payload.path).toBe(repo.local_path);
+    expect(e.payload.action).toBe('reclone_or_delete');
+    expect(e.payload.repo_id).toBe(repo.repo_id);
+    expect(e.payload.worktree_id).toBe(worktree.worktree_id);
     // surfaceable through Feathers as 422
     expect(e.code).toBe(422);
   });
@@ -80,11 +80,11 @@ describe('assertWorktreeFsAvailable', () => {
     }
     expect(isMissingPathError(thrown)).toBe(true);
     const e = thrown as MissingPathError;
-    expect(e.data.code).toBe('WORKTREE_PATH_MISSING');
-    expect(e.data.subject).toBe('worktree');
-    expect(e.data.path).toBe(worktree.path);
-    expect(e.data.worktree_id).toBe(worktree.worktree_id);
-    expect(e.data.repo_id).toBe(worktree.repo_id);
+    expect(e.payload.code).toBe('WORKTREE_PATH_MISSING');
+    expect(e.payload.subject).toBe('worktree');
+    expect(e.payload.path).toBe(worktree.path);
+    expect(e.payload.worktree_id).toBe(worktree.worktree_id);
+    expect(e.payload.repo_id).toBe(worktree.repo_id);
   });
 
   it('throws WORKTREE_PATH_MISSING when repo is unknown but worktree is gone', () => {

--- a/packages/core/src/fs/check-worktree-path.ts
+++ b/packages/core/src/fs/check-worktree-path.ts
@@ -1,0 +1,94 @@
+/**
+ * Spawn-time pre-flight check (issue #1109).
+ *
+ * Before the daemon spawns anything that takes a worktree path as `cwd`
+ * (terminal / AI executor / git op), call `assertWorktreeFsAvailable` so we
+ * fail with a clear, structured `MissingPathError` instead of letting the
+ * child process die with `chdir(2) failed: No such file or directory` (or
+ * the even-more-misleading `spawn /usr/local/bin/node ENOENT`, which reports
+ * against the executable path despite the cwd being the real culprit).
+ *
+ * Typical K8s failure mode: pod redeploy with `$HOME` as `emptyDir` but
+ * Postgres on a persistent volume — DB has a worktree row, the directory is
+ * gone.
+ */
+import { existsSync } from 'node:fs';
+
+import type { Repo } from '../types/repo';
+import type { Worktree } from '../types/worktree';
+import { MissingPathError } from './missing-path-error';
+
+export interface AssertWorktreeFsAvailableInput {
+  worktree: Pick<Worktree, 'worktree_id' | 'repo_id' | 'path' | 'name'>;
+  /** Parent repo if known. When provided, the repo's own `local_path` is also
+   * checked — if it's gone too, the thrown error points at the repo first
+   * (recovery requires re-cloning the repo before recreating worktrees). */
+  repo?: Pick<Repo, 'repo_id' | 'local_path' | 'name' | 'slug'> | null;
+}
+
+/**
+ * Throws `MissingPathError` if either the worktree's path or its parent
+ * repo's path is missing on disk. Repo-missing takes precedence because
+ * recovery requires re-cloning the repo first.
+ *
+ * Returns `void` on success; the caller proceeds to spawn.
+ */
+export function assertWorktreeFsAvailable({
+  worktree,
+  repo,
+}: AssertWorktreeFsAvailableInput): void {
+  if (repo && repo.local_path && !existsSync(repo.local_path)) {
+    throw new MissingPathError({
+      code: 'REPO_PATH_MISSING',
+      subject: 'repo',
+      message:
+        `Repository ${repo.slug || repo.name || repo.repo_id.slice(0, 8)} is registered ` +
+        `in the database but its directory ${repo.local_path} no longer exists on disk. ` +
+        `This typically happens in Kubernetes when $HOME is ephemeral but the database ` +
+        `persists across restarts. Reclone the repository or delete the database record ` +
+        `to recover.`,
+      path: repo.local_path,
+      action: 'reclone_or_delete',
+      repo_id: repo.repo_id,
+      worktree_id: worktree.worktree_id,
+    });
+  }
+
+  if (!existsSync(worktree.path)) {
+    throw new MissingPathError({
+      code: 'WORKTREE_PATH_MISSING',
+      subject: 'worktree',
+      message:
+        `Worktree ${worktree.name || worktree.worktree_id.slice(0, 8)} is registered ` +
+        `in the database but its directory ${worktree.path} no longer exists on disk. ` +
+        `This typically happens in Kubernetes when $HOME is ephemeral but the database ` +
+        `persists across restarts. Recreate the worktree or delete the database record ` +
+        `to recover.`,
+      path: worktree.path,
+      action: 'reclone_or_delete',
+      worktree_id: worktree.worktree_id,
+      repo_id: worktree.repo_id,
+    });
+  }
+}
+
+/**
+ * Non-throwing variant used by the startup reconciliation pass.
+ *
+ * Returns the first missing-path payload it would have thrown, or `null` if
+ * everything is on disk. Callers persist the result onto the row's
+ * `filesystem_status` so the UI can surface the drift before the user
+ * triggers a spawn.
+ */
+export function detectWorktreeFsDrift({
+  worktree,
+  repo,
+}: AssertWorktreeFsAvailableInput): { subject: 'worktree' | 'repo'; path: string } | null {
+  if (repo && repo.local_path && !existsSync(repo.local_path)) {
+    return { subject: 'repo', path: repo.local_path };
+  }
+  if (!existsSync(worktree.path)) {
+    return { subject: 'worktree', path: worktree.path };
+  }
+  return null;
+}

--- a/packages/core/src/fs/check-worktree-path.ts
+++ b/packages/core/src/fs/check-worktree-path.ts
@@ -38,37 +38,39 @@ export function assertWorktreeFsAvailable({
   repo,
 }: AssertWorktreeFsAvailableInput): void {
   if (repo && repo.local_path && !existsSync(repo.local_path)) {
-    throw new MissingPathError({
-      code: 'REPO_PATH_MISSING',
-      subject: 'repo',
-      message:
-        `Repository ${repo.slug || repo.name || repo.repo_id.slice(0, 8)} is registered ` +
+    throw new MissingPathError(
+      `Repository ${repo.slug || repo.name || repo.repo_id.slice(0, 8)} is registered ` +
         `in the database but its directory ${repo.local_path} no longer exists on disk. ` +
         `This typically happens in Kubernetes when $HOME is ephemeral but the database ` +
         `persists across restarts. Reclone the repository or delete the database record ` +
         `to recover.`,
-      path: repo.local_path,
-      action: 'reclone_or_delete',
-      repo_id: repo.repo_id,
-      worktree_id: worktree.worktree_id,
-    });
+      {
+        code: 'REPO_PATH_MISSING',
+        subject: 'repo',
+        path: repo.local_path,
+        action: 'reclone_or_delete',
+        repo_id: repo.repo_id,
+        worktree_id: worktree.worktree_id,
+      }
+    );
   }
 
   if (!existsSync(worktree.path)) {
-    throw new MissingPathError({
-      code: 'WORKTREE_PATH_MISSING',
-      subject: 'worktree',
-      message:
-        `Worktree ${worktree.name || worktree.worktree_id.slice(0, 8)} is registered ` +
+    throw new MissingPathError(
+      `Worktree ${worktree.name || worktree.worktree_id.slice(0, 8)} is registered ` +
         `in the database but its directory ${worktree.path} no longer exists on disk. ` +
         `This typically happens in Kubernetes when $HOME is ephemeral but the database ` +
         `persists across restarts. Recreate the worktree or delete the database record ` +
         `to recover.`,
-      path: worktree.path,
-      action: 'reclone_or_delete',
-      worktree_id: worktree.worktree_id,
-      repo_id: worktree.repo_id,
-    });
+      {
+        code: 'WORKTREE_PATH_MISSING',
+        subject: 'worktree',
+        path: worktree.path,
+        action: 'reclone_or_delete',
+        worktree_id: worktree.worktree_id,
+        repo_id: worktree.repo_id,
+      }
+    );
   }
 }
 
@@ -84,11 +86,25 @@ export function detectWorktreeFsDrift({
   worktree,
   repo,
 }: AssertWorktreeFsAvailableInput): { subject: 'worktree' | 'repo'; path: string } | null {
-  if (repo && repo.local_path && !existsSync(repo.local_path)) {
-    return { subject: 'repo', path: repo.local_path };
+  const repoDrift = repo ? detectRepoFsDrift(repo) : null;
+  if (repoDrift) {
+    return { subject: 'repo', path: repoDrift.path };
   }
   if (!existsSync(worktree.path)) {
     return { subject: 'worktree', path: worktree.path };
   }
   return null;
+}
+
+/**
+ * Pure predicate for repo-level FS drift. Returns `{ path }` of the missing
+ * directory, or `null` when the repo is present on disk.
+ *
+ * Used by the startup reconciliation pass to mark `Repo.filesystem_status`
+ * independently of any worktree context, and composed inside
+ * `detectWorktreeFsDrift` so both call sites resolve drift the same way.
+ */
+export function detectRepoFsDrift(repo: Pick<Repo, 'local_path'>): { path: string } | null {
+  if (!repo.local_path) return null;
+  return existsSync(repo.local_path) ? null : { path: repo.local_path };
 }

--- a/packages/core/src/fs/index.ts
+++ b/packages/core/src/fs/index.ts
@@ -1,0 +1,2 @@
+export * from './check-worktree-path';
+export * from './missing-path-error';

--- a/packages/core/src/fs/missing-path-error.ts
+++ b/packages/core/src/fs/missing-path-error.ts
@@ -9,10 +9,16 @@
  * directory` with an actionable message + machine-readable code so the UI can
  * render a "Reclone / Delete record" card.
  *
- * The shape mirrors the `clone_error` / `repo:cloneError` precedent from PR
- * #1126: `code` + `message` for humans, plus IDs/path so the UI knows which
- * record to act on.
+ * Extends Feathers' `Unprocessable` (HTTP 422) so it propagates through the
+ * standard error middleware unchanged: the `data` payload is serialised onto
+ * the wire response — which is how the UI gets the structured envelope —
+ * and `name` / `code` / `className` follow Feathers conventions for free.
+ * 422 (Unprocessable Entity) is the right status: the request itself is
+ * well-formed, the precondition just isn't satisfied. 404 would imply "no
+ * such session/worktree", which is misleading — the row exists, the on-disk
+ * artefact does not.
  */
+import { Unprocessable } from '../feathers';
 import type { RepoID, WorktreeID } from '../types/id';
 
 export type MissingPathSubject = 'worktree' | 'repo';
@@ -24,8 +30,6 @@ export interface MissingPathErrorPayload {
   code: 'WORKTREE_PATH_MISSING' | 'REPO_PATH_MISSING';
   /** Subject ("worktree" or "repo"). Convenience for UI routing. */
   subject: MissingPathSubject;
-  /** Human-readable message safe to surface in the UI. */
-  message: string;
   /** Absolute path that was expected to exist but doesn't. */
   path: string;
   /** Suggested user action. Currently only one value, but kept open for future. */
@@ -40,30 +44,32 @@ export interface MissingPathErrorPayload {
 
 /**
  * Thrown when the daemon refuses to spawn (terminal / executor / git op)
- * because the resolved filesystem path is gone.
- *
- * Subclass of `Error` so it propagates through FeathersJS error handling
- * unchanged; the `data` property is serialised onto the wire response, which
- * is how the UI gets at the structured envelope.
+ * because the resolved filesystem path is gone. See module docstring for
+ * rationale.
  */
-export class MissingPathError extends Error {
-  readonly name = 'MissingPathError' as const;
-  readonly data: MissingPathErrorPayload;
-  /**
-   * Feathers' error middleware copies `error.code` (numeric HTTP-ish status)
-   * onto the response. We use 422 (Unprocessable Entity) because the request
-   * itself is well-formed — the precondition just isn't satisfied. 404 would
-   * imply "no such session/worktree", which is misleading; the row exists,
-   * the on-disk artefact does not.
-   */
-  readonly code = 422;
+export class MissingPathError extends Unprocessable {
+  // Sentinel for `isMissingPathError` — Feathers' error middleware
+  // serializes own-properties onto the wire response, so callers that only
+  // see the serialized envelope can still discriminate.
+  readonly _missingPath = true as const;
 
-  constructor(payload: MissingPathErrorPayload) {
-    super(payload.message);
-    this.data = payload;
+  constructor(message: string, data: MissingPathErrorPayload) {
+    super(message, data);
+    // Override Feathers' default name so error.name reflects the structured
+    // semantics instead of the generic 'Unprocessable'.
+    this.name = 'MissingPathError';
+  }
+
+  get payload(): MissingPathErrorPayload {
+    return this.data as MissingPathErrorPayload;
   }
 }
 
 export function isMissingPathError(err: unknown): err is MissingPathError {
-  return err instanceof MissingPathError;
+  return (
+    err instanceof MissingPathError ||
+    (typeof err === 'object' &&
+      err !== null &&
+      (err as { _missingPath?: unknown })._missingPath === true)
+  );
 }

--- a/packages/core/src/fs/missing-path-error.ts
+++ b/packages/core/src/fs/missing-path-error.ts
@@ -1,0 +1,69 @@
+/**
+ * Structured error envelope for "DB row exists but filesystem path is gone"
+ * (issue #1109).
+ *
+ * Thrown by the spawn-time pre-flight check before the daemon hands a missing
+ * `cwd` to `child_process.spawn` — replaces the misleading
+ * `spawn /usr/local/bin/node ENOENT` (which is reported against the executable,
+ * not the cwd) and the equally-misleading `chdir(2) failed: No such file or
+ * directory` with an actionable message + machine-readable code so the UI can
+ * render a "Reclone / Delete record" card.
+ *
+ * The shape mirrors the `clone_error` / `repo:cloneError` precedent from PR
+ * #1126: `code` + `message` for humans, plus IDs/path so the UI knows which
+ * record to act on.
+ */
+import type { RepoID, WorktreeID } from '../types/id';
+
+export type MissingPathSubject = 'worktree' | 'repo';
+
+export type MissingPathAction = 'reclone_or_delete';
+
+export interface MissingPathErrorPayload {
+  /** Machine-readable code. */
+  code: 'WORKTREE_PATH_MISSING' | 'REPO_PATH_MISSING';
+  /** Subject ("worktree" or "repo"). Convenience for UI routing. */
+  subject: MissingPathSubject;
+  /** Human-readable message safe to surface in the UI. */
+  message: string;
+  /** Absolute path that was expected to exist but doesn't. */
+  path: string;
+  /** Suggested user action. Currently only one value, but kept open for future. */
+  action: MissingPathAction;
+  /** Worktree this references (always set for worktree-missing; set when the
+   * miss was discovered while resolving a worktree-anchored operation). */
+  worktree_id?: WorktreeID;
+  /** Repo this references (always set for repo-missing; set when the miss
+   * was discovered while resolving a worktree whose repo is also missing). */
+  repo_id?: RepoID;
+}
+
+/**
+ * Thrown when the daemon refuses to spawn (terminal / executor / git op)
+ * because the resolved filesystem path is gone.
+ *
+ * Subclass of `Error` so it propagates through FeathersJS error handling
+ * unchanged; the `data` property is serialised onto the wire response, which
+ * is how the UI gets at the structured envelope.
+ */
+export class MissingPathError extends Error {
+  readonly name = 'MissingPathError' as const;
+  readonly data: MissingPathErrorPayload;
+  /**
+   * Feathers' error middleware copies `error.code` (numeric HTTP-ish status)
+   * onto the response. We use 422 (Unprocessable Entity) because the request
+   * itself is well-formed — the precondition just isn't satisfied. 404 would
+   * imply "no such session/worktree", which is misleading; the row exists,
+   * the on-disk artefact does not.
+   */
+  readonly code = 422;
+
+  constructor(payload: MissingPathErrorPayload) {
+    super(payload.message);
+    this.data = payload;
+  }
+}
+
+export function isMissingPathError(err: unknown): err is MissingPathError {
+  return err instanceof MissingPathError;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from './api/index.js';
 export * from './config/index.js';
 export * from './db/index.js';
 export * from './environment/render-snapshot.js';
+export * from './fs/index.js';
 export * from './git/index.js';
 export * from './lib/validation.js';
 export * from './mcp/index.js';

--- a/packages/core/src/types/repo.ts
+++ b/packages/core/src/types/repo.ts
@@ -158,7 +158,7 @@ export interface Repo {
    * - `'missing'`: DB row exists but `local_path` no longer exists on disk.
    *   Typical in K8s when `$HOME` is ephemeral but the DB persists across
    *   pod restarts. Set by the startup reconciliation pass or by the
-   *   spawn-time pre-flight check. Recovery: `agor_repos_recreate` re-runs
+   *   spawn-time pre-flight check. Recovery: `agor_repos_recreate_filesystem` re-runs
    *   `git clone` and cascades worktree recreation.
    *
    * Distinct from `clone_status`, which describes the original clone

--- a/packages/core/src/types/repo.ts
+++ b/packages/core/src/types/repo.ts
@@ -150,12 +150,30 @@ export interface Repo {
    */
   clone_error?: RepoCloneError;
 
+  /**
+   * Filesystem drift status (issue #1109).
+   *
+   * - `'ready'` / `undefined`: `local_path` exists on disk (or hasn't been
+   *   reconciled yet — legacy rows).
+   * - `'missing'`: DB row exists but `local_path` no longer exists on disk.
+   *   Typical in K8s when `$HOME` is ephemeral but the DB persists across
+   *   pod restarts. Set by the startup reconciliation pass or by the
+   *   spawn-time pre-flight check. Recovery: `agor_repos_recreate` re-runs
+   *   `git clone` and cascades worktree recreation.
+   *
+   * Distinct from `clone_status`, which describes the original clone
+   * lifecycle and is set only at row-creation time.
+   */
+  filesystem_status?: RepoFilesystemStatus;
+
   /** Repository metadata */
   created_at: string;
   last_updated: string;
 }
 
 export type RepoCloneStatus = 'cloning' | 'ready' | 'failed';
+
+export type RepoFilesystemStatus = 'ready' | 'missing';
 
 export type RepoCloneErrorCategory = 'auth_failed' | 'not_found' | 'network' | 'unknown';
 

--- a/packages/core/src/types/worktree.ts
+++ b/packages/core/src/types/worktree.ts
@@ -328,6 +328,13 @@ export interface Worktree {
    * - 'ready': Worktree fully created and ready to use
    * - 'failed': Worktree creation failed (git worktree add error)
    *
+   * Drift state (issue #1109):
+   * - 'missing': DB row exists but `path` no longer exists on disk
+   *   (typical in K8s where `$HOME` is ephemeral but the DB persists).
+   *   Set by the startup reconciliation pass or the spawn-time pre-flight
+   *   check. The recreate action (`agor_worktrees_recreate`) reruns
+   *   `git.worktree.add` and transitions back to 'ready'.
+   *
    * Archive states (set when worktree is archived):
    * - 'preserved': Filesystem left untouched
    * - 'cleaned': git clean -fdx run (removes node_modules, build artifacts)
@@ -335,7 +342,14 @@ export interface Worktree {
    *
    * Note: null/undefined means 'ready' for backward compatibility
    */
-  filesystem_status?: 'creating' | 'ready' | 'failed' | 'preserved' | 'cleaned' | 'deleted';
+  filesystem_status?:
+    | 'creating'
+    | 'ready'
+    | 'failed'
+    | 'missing'
+    | 'preserved'
+    | 'cleaned'
+    | 'deleted';
 
   /**
    * Error message when filesystem_status is 'failed'

--- a/packages/core/src/types/worktree.ts
+++ b/packages/core/src/types/worktree.ts
@@ -332,7 +332,7 @@ export interface Worktree {
    * - 'missing': DB row exists but `path` no longer exists on disk
    *   (typical in K8s where `$HOME` is ephemeral but the DB persists).
    *   Set by the startup reconciliation pass or the spawn-time pre-flight
-   *   check. The recreate action (`agor_worktrees_recreate`) reruns
+   *   check. The recreate action (`agor_worktrees_recreate_filesystem`) reruns
    *   `git.worktree.add` and transitions back to 'ready'.
    *
    * Archive states (set when worktree is archived):

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
     'tools/mcp/oauth-refresh': 'src/tools/mcp/oauth-refresh.ts', // MCP OAuth refresh_token persistence + mutex
     'tools/mcp/oauth-token-expiry': 'src/tools/mcp/oauth-token-expiry.ts', // MCP OAuth token expiry resolution cascade
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for worktree isolation
+    'fs/index': 'src/fs/index.ts', // Filesystem reconciliation helpers (issue #1109)
     'mcp/index': 'src/mcp/index.ts', // MCP template resolution utilities
     'gateway/index': 'src/gateway/index.ts', // Gateway platform connectors (Slack, etc.)
     'yaml/index': 'src/yaml/index.ts', // Browser-safe js-yaml re-export


### PR DESCRIPTION
## Summary

The actionable, app-side slice of #1109. When a deployment loses its `$HOME` — the typical K8s pattern with persistent Postgres + `emptyDir` for `$HOME` — the database ends up referencing repo/worktree paths that no longer exist on disk. Opening a terminal or running a prompt currently crashes the executor with `chdir(2) failed: No such file or directory` or the misleading `spawn /usr/local/bin/node ENOENT` (reported against the executable, not the cwd that's actually missing).

This PR detects the drift, surfaces it as a structured error, and gives the operator an actionable repair path — exactly what @poberherr asked for in the issue.

## What changes

- **Type/schema:** `Worktree.filesystem_status` gains `'missing'`; `Repo` gets a parallel `filesystem_status?: 'ready' | 'missing'`. Both live in existing TEXT/JSON columns — no migration.
- **`@agor/core/fs`:** new `MissingPathError` + `assertWorktreeFsAvailable` / `detectWorktreeFsDrift` helpers, modelled on the structured `clone_error` envelope from #1126.
- **Spawn-time pre-flight:** check fires before every cwd-dependent spawn (session prompt in `register-services.ts`, terminal launch in `terminals.ts`). On miss, the row is marked `filesystem_status: 'missing'` and a 422 is thrown with `{ code, subject, path, action, repo_id, worktree_id }`.
- **Startup reconciliation:** `reconcileFilesystemStatus` walks repos + worktrees and stamps drift before the user even tries to open them. Clears the flag if paths reappear (operator restored from backup). Idempotent, never deletes rows.
- **Recreate actions:** `WorktreesService.recreateFilesystem` (reruns `git.worktree.add` with `restoreMode: true`) + `ReposService.recreateFilesystem` (reruns `git clone`, then cascades to every missing worktree of the repo).
- **REST + MCP surface:** `POST /worktrees/:id/recreate-filesystem`, `POST /repos/:id/recreate-filesystem`, plus `agor_worktrees_recreate_filesystem` and `agor_repos_recreate_filesystem` MCP tools so external orchestrators / CLI can repair too.
- **UI:** `Alert`-style missing-on-disk banner in `WorktreeCard` with **Recreate worktree** / **Reclone repository** primary action and **Delete record** secondary (delete is hidden when the repo itself is the miss — recovery must start there).
- **Belt-and-braces guard** in `spawn-executor.ts` replaces the OS-level ENOENT with a clear `cwd does not exist on disk` log when a caller bypasses the pre-flight or races against directory removal.

## Out of scope (issue #1109's other parts)

These are separate from this PR but linked here so the issue isn't lost:

- **K8s docs / Helm chart** documenting that `$HOME` needs a PV when the DB does — infra concern, related to #751.
- **Multi-arch Zellij** (`arm64` t4g nodes loading an x86_64 binary) — image-build / packaging concern.
- **sudo shim** — in flight as #1140/#1141/#1143 (worktree `fix-issue-1143-impersonation-resolver-and-worktree-remove`).

## Test plan

- [x] `pnpm check` (typecheck + lint + build) — green
- [x] `@agor/core` 2262 tests + 8 new tests (`check-worktree-path.test.ts`) — green
- [x] `@agor/daemon` 630 tests — green
- [x] `agor-ui` 126 tests — green
- [x] `@agor/executor` 350 tests — green
- [ ] Manual: `rm -rf` a worktree's directory, refresh UI → banner appears, click Recreate → directory comes back, sessions can prompt again
- [ ] Manual: `rm -rf` a repo's directory, refresh UI → repo card shows missing banner with Reclone action (delete hidden); click Reclone → repo + every missing worktree of it are recreated
- [ ] Manual: daemon restart with a stale row whose path is gone → reconciliation log line fires, row is stamped `'missing'` before any UI fetches it

Thanks @poberherr for the well-documented reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)