### PR TITLE
fix(ui): truncate long worktree names + reserve action button space on worktree cards

### DIFF
--- a/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
+++ b/apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx
@@ -763,9 +763,18 @@ const WorktreeCardComponent = ({
           justifyContent: 'space-between',
           alignItems: 'center',
           marginBottom: 12,
+          gap: 8,
         }}
       >
-        <Space size={8} align="center">
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
           {!inPopover && (
             <div
               className="drag-handle"
@@ -776,6 +785,7 @@ const WorktreeCardComponent = ({
                 width: 32,
                 height: 32,
                 justifyContent: 'center',
+                flexShrink: 0,
               }}
             >
               {isCreating || hasRunningSession ? (
@@ -799,17 +809,27 @@ const WorktreeCardComponent = ({
               )}
             </div>
           )}
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography.Text strong className="nodrag">
+          <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+            <Typography.Text
+              strong
+              className="nodrag"
+              ellipsis={{ tooltip: assistantConfig?.displayName ?? worktree.name }}
+            >
               {assistantConfig?.displayName ?? worktree.name}
             </Typography.Text>
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            <Typography.Text
+              type="secondary"
+              style={{ fontSize: 12 }}
+              ellipsis={{
+                tooltip: assistantConfig ? `${repo.slug} / ${worktree.name}` : repo.slug,
+              }}
+            >
               {assistantConfig ? `${repo.slug} / ${worktree.name}` : repo.slug}
             </Typography.Text>
           </div>
-        </Space>
+        </div>
 
-        <Space size={4}>
+        <Space size={4} style={{ flexShrink: 0 }}>
           {!inPopover && isPinned && (
             <Tooltip
               title={


### PR DESCRIPTION
## Summary

Worktree cards with long names (e.g. `fix-issue-1143-impersonation-resolver-and-worktree-remove`) wrapped the worktree name onto two lines AND pushed the action button column (terminal / schedule-now / edit / drag / trash) onto a second row.

## What changed

`apps/agor-ui/src/components/WorktreeCard/WorktreeCard.tsx` — header layout only:

- Title-side `<Space>` → `<div>` flex container with `flex: 1, minWidth: 0` so it can shrink
- Inner column also gets `flex: 1, minWidth: 0` so its `Typography.Text` children can apply ellipsis
- Both `Typography.Text` lines (display name + repo/worktree subtitle) use antd's `ellipsis={{ tooltip: ... }}` → single-line truncation with a native hover tooltip showing the full string
- Action `<Space>` gets `flexShrink: 0` so it never wraps
- Drag-handle icon container also gets `flexShrink: 0` (defensive)
- Header outer flex gains `gap: 8` so title and actions don't touch when truncated

26 added / 6 removed in a single file. No behavioral changes to other parts of the card (sessions, scheduled runs, gateway, notes, pills).

## Test plan

- [ ] Open a board with a worktree named `fix-issue-1143-impersonation-resolver-and-worktree-remove` (or similar 50+ char name) and confirm the name truncates with `…` on one line
- [ ] Action buttons stay on a single row in their fixed position on the right
- [ ] Hover the truncated name — native tooltip shows the full name
- [ ] Same with an assistant worktree (the repo/name string moves to subtitle and should also truncate)
- [ ] Try light + dark theme
- [ ] Try board zoom out / popover mode (`inPopover`) — layout still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)