### PR TITLE
perf(ui): cut conversation pane re-renders during active streaming

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -12,6 +12,7 @@
 
 import type {
   AgorClient,
+  Message,
   MessageID,
   PermissionScope,
   SessionID,
@@ -28,6 +29,10 @@ import { TaskBlock } from '../TaskBlock';
 
 const { Text } = Typography;
 const EMPTY_STREAMING_MESSAGES = new Map();
+// Shared empty-array sentinel so TaskBlock's `taskMessages` prop keeps a stable
+// reference for tasks whose messages haven't been loaded — otherwise `|| []`
+// would mint a fresh array on every render and thrash TaskBlock's React.memo.
+const EMPTY_MESSAGES: Message[] = [];
 
 /**
  * Check if two Maps are equal (same keys and same content)
@@ -210,7 +215,15 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // haven't run yet — there's no message_range, no user-message row, no
     // assistant output to render — so showing them here as TaskBlocks just
     // duplicates what the queue panel already shows.
-    const tasks = (reactiveState?.tasks || []).filter((t) => t.status !== TaskStatus.QUEUED);
+    //
+    // Memoized so the filtered array's identity is stable across re-renders
+    // when the underlying reactive `tasks` list hasn't changed. Without this,
+    // every streaming chunk produced a fresh array → every downstream useMemo
+    // depending on `tasks` would invalidate and rebuild.
+    const tasks = useMemo(
+      () => (reactiveState?.tasks || []).filter((t) => t.status !== TaskStatus.QUEUED),
+      [reactiveState?.tasks]
+    );
     const allStreamingMessages = reactiveState?.streamingMessages || EMPTY_STREAMING_MESSAGES;
     const loading = reactiveState ? reactiveState.loading : !!sessionId;
     const error = reactiveState?.error || null;
@@ -268,8 +281,10 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // When a new task arrives (i.e. the *last* task id changes), collapse
     // whatever was open and expand the new one. We deliberately depend on
     // `lastTaskId` rather than `tasks` so that:
-    //   1. unrelated re-renders don't fire this effect (tasks array gets a
-    //      new reference on every render thanks to the QUEUED filter), and
+    //   1. unrelated re-renders don't fire this effect (`tasks` still gets
+    //      a new reference whenever any task patch lands — the useMemo bails
+    //      out only when the *upstream* `reactiveState.tasks` array is
+    //      identity-stable), and
     //   2. if the user collapses the current last task, we don't immediately
     //      re-open it — that "auto re-expand on empty" behavior fought the
     //      user and showed up as a flicker.
@@ -285,7 +300,10 @@ export const ConversationView = React.memo<ConversationViewProps>(
       });
     }, [lastTaskId, scrollToBottom]);
 
-    // Handle task expand/collapse
+    // Handle task expand/collapse. Single stable callback shared by every
+    // TaskBlock — the callback takes `taskId` so we don't need to mint a
+    // per-task closure (which previously rebuilt on every render and broke
+    // TaskBlock's React.memo for the entire task list).
     const handleTaskExpandChange = useCallback((taskId: string, expanded: boolean) => {
       setExpandedTaskIds((prev) => {
         const next = new Set(prev);
@@ -298,16 +316,25 @@ export const ConversationView = React.memo<ConversationViewProps>(
       });
     }, []);
 
-    // Memoize expand handlers per task to keep stable references
-    const expandHandlers = useMemo(() => {
-      const handlerMap = new Map<string, (expanded: boolean) => void>();
-      for (const task of tasks) {
-        handlerMap.set(task.task_id, (expanded: boolean) =>
-          handleTaskExpandChange(task.task_id, expanded)
-        );
-      }
-      return handlerMap;
-    }, [tasks, handleTaskExpandChange]);
+    // Stable load/unload callbacks. The previous inline arrows were minted on
+    // every ConversationView render → every TaskBlock saw new `onLoadTaskMessages`
+    // / `onUnloadTaskMessages` refs → memo bailout failed for every TaskBlock,
+    // including ones whose messages weren't changing.
+    const handleLoadTaskMessages = useCallback(
+      (taskId: string) => {
+        if (!reactiveSession) return;
+        return reactiveSession.loadTaskMessages(taskId).then(() => undefined);
+      },
+      [reactiveSession]
+    );
+
+    const handleUnloadTaskMessages = useCallback(
+      (taskId: string) => {
+        if (!reactiveSession) return;
+        reactiveSession.unloadTaskMessages(taskId);
+      },
+      [reactiveSession]
+    );
 
     // Auto-scroll to bottom when streaming messages arrive (only if user is already at bottom)
     // biome-ignore lint/correctness/useExhaustiveDependencies: We want to scroll on streaming change
@@ -477,7 +504,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
             userById={userById}
             currentUserId={currentUserId}
             isExpanded={expandedTaskIds.has(task.task_id)}
-            onExpandChange={expandHandlers.get(task.task_id)!}
+            onExpandChange={handleTaskExpandChange}
             sessionId={sessionId}
             onPermissionDecision={onPermissionDecision}
             onInputResponse={onInputResponse}
@@ -485,16 +512,10 @@ export const ConversationView = React.memo<ConversationViewProps>(
             scheduledFromWorktree={scheduledFromWorktree}
             scheduledRunAt={scheduledRunAt}
             streamingMessages={streamingMessagesByTask.get(task.task_id)}
-            taskMessages={reactiveState?.messagesByTask.get(task.task_id) || []}
+            taskMessages={reactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES}
             taskMessagesLoaded={!!reactiveState?.loadedTaskIds.has(task.task_id)}
-            onLoadTaskMessages={(taskId: string) => {
-              if (!reactiveSession) return;
-              return reactiveSession.loadTaskMessages(taskId).then(() => undefined);
-            }}
-            onUnloadTaskMessages={(taskId: string) => {
-              if (!reactiveSession) return;
-              reactiveSession.unloadTaskMessages(taskId);
-            }}
+            onLoadTaskMessages={handleLoadTaskMessages}
+            onUnloadTaskMessages={handleUnloadTaskMessages}
             assistantEmoji={assistantEmoji}
             isLatestTask={taskIndex === tasks.length - 1}
           />

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Typography, theme } from 'antd';
-import type React from 'react';
+import React from 'react';
 import { Streamdown } from 'streamdown';
 import { highlightMentionsInMarkdown } from '../../utils/highlightMentions';
 import { isDarkTheme } from '../../utils/theme';
@@ -48,7 +48,14 @@ interface MarkdownRendererProps {
   showControls?: boolean;
 }
 
-export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+// Memoized: Streamdown does meaningful per-render work (syntax highlighting,
+// Mermaid, KaTeX) and this component is rendered once per text block in every
+// message. During streaming, the conversation pane's parent re-renders on
+// every chunk; without memo, every prior message's MarkdownRenderer re-ran
+// even though its `content` was unchanged. Default shallow compare is fine —
+// all props are primitives or stable refs at call sites in the conversation
+// pane (MessageBlock, ThinkingBlock, CollapsibleMarkdown).
+const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   content,
   inline = false,
   style,
@@ -104,3 +111,6 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     </Typography>
   );
 };
+
+export const MarkdownRenderer = React.memo(MarkdownRendererInner);
+MarkdownRenderer.displayName = 'MarkdownRenderer';

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -24,7 +24,7 @@ import { RobotOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons'
 import { Bubble } from '@ant-design/x';
 import { Tooltip, theme } from 'antd';
 
-import type React from 'react';
+import React from 'react';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
 import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
@@ -86,7 +86,6 @@ interface MessageBlockProps {
   isFirstPendingPermission?: boolean; // For sequencing permission requests
   isFirstPendingInput?: boolean; // For sequencing input requests
   isLatestMessage?: boolean; // Whether this is the most recent message (don't collapse by default)
-  allMessages?: Message[]; // All messages for aggregation (e.g., finding matching compaction events)
   assistantEmoji?: string; // Emoji override for assistant avatar (replaces tool icon)
   onPermissionDecision?: (
     sessionId: string,
@@ -236,7 +235,20 @@ function getAgentAvatar({
   );
 }
 
-export const MessageBlock: React.FC<MessageBlockProps> = ({
+// Memoized: every text block / tool block of every message in the conversation
+// re-rendered on every streaming chunk because TaskBlock's `messages` array
+// gets a fresh reference each tick. Default shallow compare is sufficient
+// here because callers pass:
+//   - `message`: stable per message_id (only the actively streaming message
+//     gets a new ref each chunk — correct: it should re-render)
+//   - `userById`: from AppEntityDataContext (PR #1095 — stable across session
+//     patches)
+//   - `currentUserId`, `agentic_tool`, `sessionId`, `taskId`, `assistantEmoji`,
+//     `isTaskRunning`, `isLatestMessage`, `isFirstPending*`: primitives or
+//     stable derived values
+//   - `onPermissionDecision`, `onInputResponse`: useCallback-wrapped in App.tsx
+//     and passed through useMemo'd AppActionsContext
+const MessageBlockInner: React.FC<MessageBlockProps> = ({
   message,
   userById = new Map(),
   currentUserId,
@@ -247,7 +259,6 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
   isFirstPendingPermission = false,
   isFirstPendingInput = false,
   isLatestMessage = false,
-  allMessages = [],
   onPermissionDecision,
   onInputResponse,
   assistantEmoji,
@@ -795,3 +806,6 @@ export const MessageBlock: React.FC<MessageBlockProps> = ({
     </>
   );
 };
+
+export const MessageBlock = React.memo(MessageBlockInner);
+MessageBlock.displayName = 'MessageBlock';

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -75,7 +75,12 @@ interface TaskBlockProps {
   userById?: Map<string, User>;
   currentUserId?: string;
   isExpanded: boolean;
-  onExpandChange: (expanded: boolean) => void;
+  /**
+   * Called when the user toggles this task's expand state. Receives the
+   * `taskId` so the parent can use a single stable callback shared across
+   * every TaskBlock — see ConversationView's `handleTaskExpandChange`.
+   */
+  onExpandChange: (taskId: string, expanded: boolean) => void;
   sessionId?: SessionID | null;
   onPermissionDecision?: (
     sessionId: string,
@@ -575,7 +580,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     return (
       <Collapse
         activeKey={isExpanded ? ['task-content'] : []}
-        onChange={(keys) => onExpandChange(keys.length > 0)}
+        onChange={(keys) => onExpandChange(task.task_id, keys.length > 0)}
         expandIcon={() => null}
         style={{ background: 'transparent', margin: `${token.sizeUnit * 3}px 0` }}
         items={[
@@ -679,7 +684,6 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           isFirstPendingInput={isFirstPendingInput}
                           isLatestMessage={isLatestMessage}
                           taskId={task.task_id}
-                          allMessages={messages}
                           assistantEmoji={assistantEmoji}
                         />
                       );


### PR DESCRIPTION
## Summary

Sibling to #1095 (board-canvas re-render audit) — same playbook applied to the conversation pane. During active streaming, leaf components inside the pane were re-rendering on every chunk because (a) several were not memoized, and (b) `ConversationView` was passing referentially-unstable props that broke the existing memo bailouts on `TaskBlock` / its children.

> **Status:** drafted because the changes are based on **static analysis informed by #1095's patterns** — caller-side ref stability was verified for every memoized component, but I haven't been able to capture before/after render counts with the React DevTools Profiler in this environment. Validation steps below.

## Findings (confirmed Max's hypotheses)

- ✅ The board canvas is a **sibling** of `SessionPanel` (`apps/agor-ui/src/components/App/App.tsx:907`), not a parent/child. Conversation-pane churn cannot directly trigger canvas re-renders — the zoom jitter during streaming is consistent with main-thread starvation from heavy conversation work, not coupling.
- ✅ Tasks / Messages live in the per-session `ReactiveSessionHandle` (via `useSharedReactiveSession`), **not** in any global store/context. `AppLiveDataContext` does not carry messages.
- ✅ `ConversationView`, `TaskBlock`, `AgentChain` are already wrapped in `React.memo` (#1095 / earlier work).
- ❌ But `TaskBlock`'s memo bailout was being broken on every streaming chunk by unstable props minted in `ConversationView`'s render body — every TaskBlock re-rendered, every MessageBlock re-rendered, every MarkdownRenderer (Streamdown: syntax highlighting + Mermaid + KaTeX) re-rendered.

## Fixes

1. **`ConversationView`: memoize the `tasks` filter.** Previously `.filter()` minted a fresh array on every render, invalidating every downstream `useMemo` depending on `tasks`.
2. **`ConversationView`: shared `EMPTY_MESSAGES` sentinel.** Replaces `|| []` fallback so TaskBlocks for un-loaded tasks keep a stable prop ref.
3. **`ConversationView`: replace per-task `expandHandlers` Map with a single stable callback.** The map was rebuilt every render — every TaskBlock got a fresh `onExpandChange` closure even though the only changing piece was the `taskId`. New API: `onExpandChange(taskId, expanded)` so the parent shares one `useCallback`'d handler. Same pattern applied to `onLoadTaskMessages` / `onUnloadTaskMessages` (previously inline arrows in JSX).
4. **`MarkdownRenderer` → `React.memo`.** Streamdown does meaningful per-render work, and there's one per text block per message. Default shallow compare is safe — all props are primitives or stable at conversation-pane call sites.
5. **`MessageBlock` → `React.memo`.** Default shallow compare is safe; caller-side stability traced:
   - `message`: stable per `message_id` (only the actively streaming message gets a new ref each chunk — correct behavior)
   - `userById`: from `AppEntityDataContext` (#1095 — doesn't churn on session patches)
   - `onPermissionDecision` / `onInputResponse`: `useCallback`-wrapped in `App.tsx`, passed through a `useMemo`'d `AppActionsContext`
   - Other props: primitives or stable derived values
   - **Removed** an unused `allMessages` prop that was passing `messages` on every render and would have broken the shallow compare.

## Expected effect

During streaming of an active task with N prior tasks containing M messages each: only the actively streaming message's `MessageBlock` and its `MarkdownRenderer` should re-render per chunk, instead of every TaskBlock × every MessageBlock × every text block.

## Deliberately deferred (follow-ups)

- `ToolBlock` `React.memo` — less critical once `MessageBlock` bails out, and `children` prop instability would need a custom `areEqual`.
- List virtualization (`react-window` / `tanstack-virtual`) for very long conversations — out of scope.
- Further `AppLiveDataContext` splits to keep the canvas quiet during session-status patches — already partially handled by #1095, remaining gain is small.

## Test plan

- [x] `pnpm check` (typecheck + lint + build, excluding docs) — green
- [x] `pnpm --filter agor-ui test` — 19 files / 126 tests passing
- [ ] **React DevTools Profiler validation (manual, blocking ready-status):**
  - [ ] Open a session with several prior tasks; send a prompt; record while the agent streams 5+ tool calls. Compare render counts on `MessageBlock` / `MarkdownRenderer` / `TaskBlock` before/after.
  - [ ] Zoom in/out on the canvas mid-stream — should be noticeably smoother than `main`.
  - [ ] Long conversation worst-case: open a session with 100+ messages, scroll around mid-stream — verify scroll position is preserved, no input lag.
- [ ] Regression checks:
  - [ ] Tool blocks still expand/collapse correctly
  - [ ] Permission / `AskUserQuestion` request flows still interactive (first-pending sequencing)
  - [ ] Code-block syntax highlighting still renders (Streamdown memo'd, but `content` changes correctly)
  - [ ] Auto-scroll on streaming still works (scroll-near-bottom heuristic)
  - [ ] Fork / spawn navigation works (genealogy banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)