### PR TITLE
perf(ui): split AppEntityDataContext into Repo/User/Mcp granular contexts

### DIFF
--- a/apps/agor-ui/src/components/EventStreamPanel/EventStreamPanel.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventStreamPanel.tsx
@@ -15,7 +15,7 @@ import {
 import { Badge, Button, Checkbox, Empty, Select, Space, Typography, theme } from 'antd';
 import { useMemo, useState } from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
-import { useAppEntityData, useAppLiveData } from '../../contexts/AppDataContext';
+import { useAppLiveData, useAppRepoData, useAppUserData } from '../../contexts/AppDataContext';
 import type { SocketEvent } from '../../hooks/useEventStream';
 import { Tag } from '../Tag';
 import { EventItem, type WorktreeActions } from './EventItem';
@@ -51,10 +51,11 @@ export const EventStreamPanel: React.FC<EventStreamPanelProps> = ({
 
   // EventStreamPanel inherently shows live socket activity, so subscribing
   // to AppLiveDataContext is correct — we *want* re-renders on session /
-  // worktree mutations. Entity data is split off so user/repo edits alone
-  // don't cause unnecessary churn.
+  // worktree mutations. Repo/user data are split so edits in one entity
+  // family don't invalidate the other.
   const { worktreeById, sessionById, sessionsByWorktree } = useAppLiveData();
-  const { repoById, userById } = useAppEntityData();
+  const { repoById } = useAppRepoData();
+  const { userById } = useAppUserData();
   const repos = useMemo(() => Array.from(repoById.values()), [repoById]);
 
   // Get actions from context

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -230,8 +230,7 @@ function getAgentAvatar({
 // here because callers pass:
 //   - `message`: stable per message_id (only the actively streaming message
 //     gets a new ref each chunk — correct: it should re-render)
-//   - `userById`: from AppEntityDataContext (PR #1095 — stable across session
-//     patches)
+//   - `userById`: from AppUserDataContext (stable across session patches)
 //   - `currentUserId`, `agentic_tool`, `sessionId`, `taskId`, `assistantEmoji`,
 //     `isTaskRunning`, `isLatestMessage`, `isFirstPending*`: primitives or
 //     stable derived values

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -32,7 +32,7 @@ import { Alert, App, Badge, Button, Space, Spin, Tooltip, Typography, theme } fr
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
-import { useAppEntityData } from '../../contexts/AppDataContext';
+import { useAppMcpData, useAppUserData } from '../../contexts/AppDataContext';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { getContextWindowGradient } from '../../utils/contextWindow';
@@ -227,10 +227,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const { showSuccess, showInfo, showError } = useThemedMessage();
   const connectionDisabled = useConnectionDisabled();
 
-  // Get data from entity context only — SessionPanel intentionally does NOT
-  // subscribe to live (sessions / worktrees / boards) data here, so streaming
-  // session patches don't trigger re-renders of this panel through context.
-  const { userById, mcpServerById, userAuthenticatedMcpServerIds } = useAppEntityData();
+  // Subscribe only to the entity families this panel needs. SessionPanel
+  // intentionally does NOT subscribe to live (sessions / worktrees / boards)
+  // data here, so streaming session patches don't trigger re-renders through
+  // context; user and MCP updates are also isolated from repo edits.
+  const { userById } = useAppUserData();
+  const { mcpServerById, userAuthenticatedMcpServerIds } = useAppMcpData();
 
   // Get actions from context
   const {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -9,7 +9,7 @@ import {
 import { Button, Divider, Space, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
-import { useAppEntityData } from '../../contexts/AppDataContext';
+import { useAppMcpData, useAppRepoData, useAppUserData } from '../../contexts/AppDataContext';
 import { copyToClipboard } from '../../utils/clipboard';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -60,9 +60,12 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     const { token } = theme.useToken();
     const { showSuccess, showError } = useThemedMessage();
 
-    // Get data from entity context only — keeps this panel insulated from
-    // session/worktree/board patches flowing through AppLiveDataContext.
-    const { userById, repoById, mcpServerById, userAuthenticatedMcpServerIds } = useAppEntityData();
+    // Subscribe only to the entity families this panel needs. This keeps the
+    // panel insulated from session/worktree/board patches and avoids unrelated
+    // entity churn (e.g. repo edits invalidating user/MCP consumers).
+    const { userById } = useAppUserData();
+    const { repoById } = useAppRepoData();
+    const { mcpServerById, userAuthenticatedMcpServerIds } = useAppMcpData();
 
     // Get actions from context
     const {

--- a/apps/agor-ui/src/contexts/AppDataContext.tsx
+++ b/apps/agor-ui/src/contexts/AppDataContext.tsx
@@ -1,22 +1,23 @@
 import type { MCPServer, Repo, Session, User, Worktree } from '@agor-live/client';
 import type React from 'react';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 /**
- * App data is split into TWO contexts so that high-frequency mutations
+ * App data is split into granular contexts so that high-frequency mutations
  * (sessions / worktrees) don't force re-renders of consumers that only
- * care about slow-moving entity data (users, repos, MCP servers, OAuth
- * status).
+ * care about slow-moving entity data, and slow-moving entity updates don't
+ * invalidate unrelated entity consumers.
  *
  * Before the split, a single `session:patched` event would mutate
  * `sessionById`, change the merged `appDataValue` reference, and cascade
  * a re-render through every `useAppData()` consumer — including
  * SessionPanel, which doesn't read sessions/worktrees from context at all.
- * With the split, SessionPanel subscribes only to the entity context and
- * is insulated from streaming-driven session churn.
+ * With the split, SessionPanel subscribes only to the specific entity
+ * contexts it needs and is insulated from streaming-driven session churn.
  *
- * - **AppEntityDataContext**: low-frequency, mostly user/admin-driven
- *   changes (users, repos, MCP servers).
+ * - **AppRepoDataContext**: repositories (rarely changes).
+ * - **AppUserDataContext**: users (registration / profile edits).
+ * - **AppMcpDataContext**: MCP servers + per-user OAuth status.
  * - **AppLiveDataContext**: high-frequency, socket-driven changes
  *   (sessions, worktrees).
  *
@@ -27,17 +28,26 @@ import { createContext, useContext } from 'react';
  * exposes (per code review feedback: don't ship unused fields).
  */
 
-export interface AppEntityDataContextValue {
+export interface AppRepoDataContextValue {
   // Repositories (config-level, rarely changes)
   repoById: Map<string, Repo>;
+}
 
+export interface AppUserDataContextValue {
   // Users (rarely changes — registration / profile edits)
   userById: Map<string, User>;
+}
 
+export interface AppMcpDataContextValue {
   // MCP servers + per-user auth state (admin / OAuth flows)
   mcpServerById: Map<string, MCPServer>;
   userAuthenticatedMcpServerIds: Set<string>; // MCP server IDs where current user has valid per-user OAuth tokens
 }
+
+export interface AppEntityDataContextValue
+  extends AppRepoDataContextValue,
+    AppUserDataContextValue,
+    AppMcpDataContextValue {}
 
 export interface AppLiveDataContextValue {
   // Sessions and worktrees — patched on every status flip / activity tick
@@ -46,8 +56,25 @@ export interface AppLiveDataContextValue {
   sessionsByWorktree: Map<string, Session[]>; // Indexed for quick filtering
 }
 
-const AppEntityDataContext = createContext<AppEntityDataContextValue | undefined>(undefined);
+const AppRepoDataContext = createContext<AppRepoDataContextValue | undefined>(undefined);
+const AppUserDataContext = createContext<AppUserDataContextValue | undefined>(undefined);
+const AppMcpDataContext = createContext<AppMcpDataContextValue | undefined>(undefined);
 const AppLiveDataContext = createContext<AppLiveDataContextValue | undefined>(undefined);
+
+interface AppRepoDataProviderProps {
+  children: React.ReactNode;
+  value: AppRepoDataContextValue;
+}
+
+interface AppUserDataProviderProps {
+  children: React.ReactNode;
+  value: AppUserDataContextValue;
+}
+
+interface AppMcpDataProviderProps {
+  children: React.ReactNode;
+  value: AppMcpDataContextValue;
+}
 
 interface AppEntityDataProviderProps {
   children: React.ReactNode;
@@ -59,11 +86,16 @@ interface AppLiveDataProviderProps {
   value: AppLiveDataContextValue;
 }
 
-export const AppEntityDataProvider: React.FC<AppEntityDataProviderProps> = ({
-  children,
-  value,
-}) => {
-  return <AppEntityDataContext.Provider value={value}>{children}</AppEntityDataContext.Provider>;
+export const AppRepoDataProvider: React.FC<AppRepoDataProviderProps> = ({ children, value }) => {
+  return <AppRepoDataContext.Provider value={value}>{children}</AppRepoDataContext.Provider>;
+};
+
+export const AppUserDataProvider: React.FC<AppUserDataProviderProps> = ({ children, value }) => {
+  return <AppUserDataContext.Provider value={value}>{children}</AppUserDataContext.Provider>;
+};
+
+export const AppMcpDataProvider: React.FC<AppMcpDataProviderProps> = ({ children, value }) => {
+  return <AppMcpDataContext.Provider value={value}>{children}</AppMcpDataContext.Provider>;
 };
 
 export const AppLiveDataProvider: React.FC<AppLiveDataProviderProps> = ({ children, value }) => {
@@ -71,13 +103,66 @@ export const AppLiveDataProvider: React.FC<AppLiveDataProviderProps> = ({ childr
 };
 
 /**
- * Slow-moving entity data (users, repos, MCP). Subscribing to this hook
- * does NOT trigger re-renders when sessions / worktrees / boards mutate.
+ * Back-compat composite provider used by App.tsx. It accepts the same combined
+ * value shape the old entity provider used, then fans it out into narrower
+ * providers with separately memoized values so an update to one entity family
+ * does not notify consumers of the others.
  */
-export const useAppEntityData = (): AppEntityDataContextValue => {
-  const context = useContext(AppEntityDataContext);
+export const AppEntityDataProvider: React.FC<AppEntityDataProviderProps> = ({
+  children,
+  value,
+}) => {
+  const repoValue = useMemo(() => ({ repoById: value.repoById }), [value.repoById]);
+  const userValue = useMemo(() => ({ userById: value.userById }), [value.userById]);
+  const mcpValue = useMemo(
+    () => ({
+      mcpServerById: value.mcpServerById,
+      userAuthenticatedMcpServerIds: value.userAuthenticatedMcpServerIds,
+    }),
+    [value.mcpServerById, value.userAuthenticatedMcpServerIds]
+  );
+
+  return (
+    <AppRepoDataProvider value={repoValue}>
+      <AppUserDataProvider value={userValue}>
+        <AppMcpDataProvider value={mcpValue}>{children}</AppMcpDataProvider>
+      </AppUserDataProvider>
+    </AppRepoDataProvider>
+  );
+};
+
+/**
+ * Repo data (rarely changes). Subscribing to this hook does NOT trigger
+ * re-renders when users, MCP servers, sessions, worktrees, or boards mutate.
+ */
+export const useAppRepoData = (): AppRepoDataContextValue => {
+  const context = useContext(AppRepoDataContext);
   if (!context) {
-    throw new Error('useAppEntityData must be used within an AppEntityDataProvider');
+    throw new Error('useAppRepoData must be used within an AppRepoDataProvider');
+  }
+  return context;
+};
+
+/**
+ * User data (registration / profile edits). Subscribing to this hook does NOT
+ * trigger re-renders when repos, MCP servers, sessions, worktrees, or boards mutate.
+ */
+export const useAppUserData = (): AppUserDataContextValue => {
+  const context = useContext(AppUserDataContext);
+  if (!context) {
+    throw new Error('useAppUserData must be used within an AppUserDataProvider');
+  }
+  return context;
+};
+
+/**
+ * MCP server data + per-user OAuth status. Subscribing to this hook does NOT
+ * trigger re-renders when users, repos, sessions, worktrees, or boards mutate.
+ */
+export const useAppMcpData = (): AppMcpDataContextValue => {
+  const context = useContext(AppMcpDataContext);
+  if (!context) {
+    throw new Error('useAppMcpData must be used within an AppMcpDataProvider');
   }
   return context;
 };


### PR DESCRIPTION
## Summary

Follow-up to #1185 — the conversation-pane work eliminated wasted leaf re-renders during streaming. This PR addresses the next tier of waste identified in the multi-user audit (run jointly with the Codex sibling session that started this branch): the entity-context bag was still coarse enough that an unrelated entity update (e.g. some other user editing their profile emoji) invalidated *every* entity consumer in the app, even ones that didn't read `userById`.

## What changed

- Split `AppEntityDataContext` into three narrower contexts:
  - `AppRepoDataContext` — repos (rarely changes)
  - `AppUserDataContext` — users (registration / profile edits)
  - `AppMcpDataContext` — MCP servers + per-user OAuth status
- Each context has its own Provider + `useApp{Repo,User,Mcp}Data()` hook.
- `AppEntityDataProvider` kept as a **back-compat composite** — accepts the same combined value shape `App.tsx` already passes in, then fans it out into the three narrower providers with separately memoized sub-values. This avoids a noisy reindent in `App.tsx`.
- `useAppEntityData()` removed; the three callers (`EventStreamPanel`, `SessionPanel`, `SessionPanelContent`) now subscribe only to the families they actually read.

## Effect by scenario (multi-user instance)

| Event | Before | After |
|---|---|---|
| Another user edits profile emoji (`users:patched`) | All 3 entity consumers re-render (SessionPanel re-renders even though it may not use users for an MCP-only path) | Only `useAppUserData()` consumers re-render |
| Another user adds an MCP server (`mcp-servers:created`) | All entity consumers re-render | Only `useAppMcpData()` consumers |
| Repo metadata edit | All entity consumers re-render | Only `useAppRepoData()` consumers |

## Audit lineage (deferred for separate PRs)

The full multi-user re-render audit identified three more leverage points beyond this PR:

1. **`AppLiveDataContext` provider-bag** — same problem as the entity bag, but higher-volume events (`sessionById`, `worktreeById`, `sessionsByWorktree`). Would need similar per-family splits OR a selector-based store (`useSyncExternalStore`) so consumers can subscribe to specific entries (e.g. `sessionsByWorktree.get(myWorktreeId)`).
2. **Daemon broadcast scope** — every Feathers event publishes to the global `'authenticated'` channel (`apps/agor-daemon/src/register-hooks.ts:1593-1609`); no per-worktree / per-session / per-user filtering. Multi-user instances receive ~all events from all other users. This is the biggest remaining win, addressed daemon-side.
3. **`useAgorData` patch handlers** — always do `new Map(prev).set(id, v)` which flips the Map ref even on no-op patches. The existing `if (existing === incoming) return prev` identity bailout never fires because Feathers JSON-unmarshals every payload. A value-equality bailout would skip the Map ref flip when no fields actually changed.

## Background — the Codex sibling

Originally drafted by Codex GPT-5.2 in session [`019e29f0`](https://agor.sandbox.preset.zone/ui/b/agor-claw-experiment/019e29f0a3bd71fe) which hit a token limit before commit. Claude Opus 4.7 in session [`019e29cc`](https://agor.sandbox.preset.zone/ui/b/agor-claw-experiment/019e29cc15c1769a) (the one that landed #1185) picked it up, reviewed the diff, ran full checks, and shipped the PR.

## Test plan

- [x] `pnpm check` (typecheck + lint + build excl docs) — green
- [x] `pnpm --filter agor-ui test` — 19 files / 126 tests green
- [ ] Manual smoke test: SessionPanel open, edit a repo's metadata in another tab — only `useAppRepoData` consumers should flash in React DevTools Profiler.
- [ ] Manual smoke test: same as above but edit a user profile — only `useAppUserData` consumers should flash, SessionPanel's MCP pills shouldn't redraw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)