### PR TITLE
feat(ui): quick callback toggle in footer + surface target in settings

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -708,6 +708,7 @@ export const App: React.FC<AppProps> = ({
       onNukeEnvironment,
       onViewLogs: (worktreeId: string) => setLogsModalWorktreeId(worktreeId),
       onOpenSettings: (sessionId: string) => setSessionSettingsId(sessionId),
+      onSessionClick: handleSessionClick,
       onOpenWorktree: (worktreeId: string, tab?: WorktreeModalTab) => {
         setWorktreeModalWorktreeId(worktreeId);
         setWorktreeModalTab(tab);
@@ -725,6 +726,7 @@ export const App: React.FC<AppProps> = ({
       onStartEnvironment,
       onStopEnvironment,
       onNukeEnvironment,
+      handleSessionClick,
       handleOpenTerminal,
       canOpenTerminal,
     ]

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
@@ -1,0 +1,112 @@
+import type { Session } from '@agor-live/client';
+import { LinkOutlined, PhoneOutlined } from '@ant-design/icons';
+import { Badge, Space, Typography, theme } from 'antd';
+import type React from 'react';
+import { useAppActions } from '../../contexts/AppActionsContext';
+import { useAppLiveData } from '../../contexts/AppDataContext';
+import { getSessionDisplayTitle } from '../../utils/sessionTitle';
+
+interface CallbackTargetDisplayProps {
+  session: Session;
+  /** Called after the user clicks the parent link, so the host modal can close. */
+  onNavigate?: () => void;
+}
+
+function statusBadgeStatus(
+  status: string
+): 'processing' | 'success' | 'error' | 'warning' | 'default' {
+  switch (status) {
+    case 'running':
+      return 'processing';
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'error';
+    case 'timed_out':
+      return 'warning';
+    default:
+      return 'default';
+  }
+}
+
+/**
+ * Inline display of a session's callback target (parent / explicit
+ * callback_session_id). Renders inside the Callbacks panel of the
+ * Session Settings modal. Hidden when there is no target at all.
+ */
+export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
+  session,
+  onNavigate,
+}) => {
+  const { token } = theme.useToken();
+  const { onSessionClick } = useAppActions();
+  const { sessionById } = useAppLiveData();
+
+  const targetId =
+    session.callback_config?.callback_session_id ?? session.genealogy?.parent_session_id;
+
+  if (!targetId) return null;
+
+  const target = sessionById.get(targetId);
+  // Mirror CallbackToggleButton's resolution: spawned sessions default to
+  // enabled unless explicitly disabled.
+  const enabled = session.callback_config?.enabled !== false;
+  const archived = target?.archived === true;
+
+  const targetTitle = target
+    ? getSessionDisplayTitle(target, { includeAgentFallback: true, includeIdFallback: true })
+    : `${targetId.substring(0, 8)} (not loaded)`;
+
+  const handleOpen = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!onSessionClick) return;
+    onSessionClick(targetId);
+    onNavigate?.();
+  };
+
+  const targetLink = onSessionClick ? (
+    <Typography.Link onClick={handleOpen}>
+      <LinkOutlined style={{ marginRight: 4 }} />
+      <strong>{targetTitle}</strong>
+    </Typography.Link>
+  ) : (
+    <strong>{targetTitle}</strong>
+  );
+
+  const statusText = archived ? 'archived' : target?.status;
+  const borderColor = enabled ? token.colorPrimaryBorder : token.colorBorder;
+  const bg = enabled ? token.colorPrimaryBg : token.colorFillTertiary;
+  const iconColor = enabled ? token.colorPrimary : token.colorTextSecondary;
+
+  return (
+    <div
+      style={{
+        marginBottom: 12,
+        padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 3}px`,
+        border: `1px solid ${borderColor}`,
+        background: bg,
+        borderRadius: token.borderRadius,
+      }}
+    >
+      <Space size={6} wrap>
+        <PhoneOutlined style={{ color: iconColor }} />
+        <Typography.Text strong style={{ color: iconColor }}>
+          Callbacks {enabled ? 'ON' : 'OFF'}
+        </Typography.Text>
+        <Typography.Text type="secondary">
+          {' — '}
+          {enabled ? 'notifying' : 'would notify'}
+        </Typography.Text>
+        {targetLink}
+        {target && (
+          <Space size={4}>
+            <Badge status={statusBadgeStatus(target.status)} />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              {statusText}
+            </Typography.Text>
+          </Space>
+        )}
+      </Space>
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
@@ -1,0 +1,102 @@
+import type { Session } from '@agor-live/client';
+import { PhoneOutlined } from '@ant-design/icons';
+import { Badge, Button, Tooltip, Typography, theme } from 'antd';
+import type React from 'react';
+import { useAppActions } from '../../contexts/AppActionsContext';
+import { useAppLiveData } from '../../contexts/AppDataContext';
+import { getSessionDisplayTitle } from '../../utils/sessionTitle';
+
+interface CallbackToggleButtonProps {
+  session: Session;
+}
+
+/**
+ * Phone-icon toggle in the conversation footer that shows ONLY when this
+ * session has callbacks enabled. Clicking disables callbacks (one click,
+ * no confirmation — re-enable lives in Session Settings).
+ *
+ * Lives in its own component so the `useAppLiveData()` subscription needed
+ * to look up the callback-target session's title doesn't pull SessionPanel
+ * into the live-data subscription graph (see AppDataContext docs).
+ */
+export const CallbackToggleButton: React.FC<CallbackToggleButtonProps> = ({ session }) => {
+  const { token } = theme.useToken();
+  const { onUpdateSession, onSessionClick } = useAppActions();
+  const { sessionById } = useAppLiveData();
+
+  const targetId =
+    session.callback_config?.callback_session_id ?? session.genealogy?.parent_session_id;
+  // Default in core: spawned sessions (have parent_session_id) have callbacks
+  // implicitly ON unless explicitly disabled. Only treat as enabled if there's
+  // an actual target — there's nothing to call back to otherwise.
+  const explicitlyDisabled = session.callback_config?.enabled === false;
+  const enabled = !explicitlyDisabled && !!targetId;
+
+  if (!enabled) return null;
+
+  const target = sessionById.get(targetId);
+  const targetTitle = target
+    ? getSessionDisplayTitle(target, { includeAgentFallback: true, includeIdFallback: true })
+    : `${targetId.substring(0, 8)}`;
+
+  const statusBadge = (() => {
+    if (!target) return null;
+    switch (target.status) {
+      case 'running':
+        return <Badge status="processing" />;
+      case 'completed':
+        return <Badge status="success" />;
+      case 'failed':
+        return <Badge status="error" />;
+      case 'timed_out':
+        return <Badge status="warning" />;
+      default:
+        return <Badge status="default" />;
+    }
+  })();
+
+  const handleDisable = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onUpdateSession?.(session.session_id, {
+      callback_config: {
+        ...session.callback_config,
+        enabled: false,
+      },
+    });
+  };
+
+  const handleOpenParent = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onSessionClick?.(targetId);
+  };
+
+  const tooltipContent = (
+    <span>
+      Callbacks on — will notify{' '}
+      {onSessionClick && target ? (
+        <Typography.Link
+          onClick={handleOpenParent}
+          style={{ color: token.colorTextLightSolid, textDecoration: 'underline' }}
+        >
+          <strong>{targetTitle}</strong>
+        </Typography.Link>
+      ) : (
+        <strong>{targetTitle}</strong>
+      )}{' '}
+      {statusBadge} on completion. Click to disable. Also accessible in session settings.
+    </span>
+  );
+
+  return (
+    <Tooltip title={tooltipContent} mouseLeaveDelay={0.2}>
+      <Button
+        size="small"
+        type="text"
+        icon={<PhoneOutlined style={{ color: token.colorPrimary }} />}
+        onClick={handleDisable}
+        aria-label="Callbacks on — click to disable"
+      />
+    </Tooltip>
+  );
+};

--- a/apps/agor-ui/src/components/CallbackToggleButton/index.ts
+++ b/apps/agor-ui/src/components/CallbackToggleButton/index.ts
@@ -1,0 +1,2 @@
+export { CallbackTargetDisplay } from './CallbackTargetDisplay';
+export { CallbackToggleButton } from './CallbackToggleButton';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -40,6 +40,7 @@ import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
+import { CallbackToggleButton } from '../CallbackToggleButton';
 import { EffortSelector } from '../EffortSelector';
 import { FileUpload, FileUploadButton } from '../FileUpload';
 import { MCPServerPill } from '../MCPServer';
@@ -833,6 +834,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               size="small"
             />
             {isRunning && <Spin size="small" />}
+            <CallbackToggleButton session={session} />
             <Space.Compact>
               <Tooltip
                 title={

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -31,7 +31,9 @@ import React from 'react';
 import { AdvancedSettingsForm } from '../AdvancedSettingsForm';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { CallbackConfigForm } from '../CallbackConfigForm';
+import { CallbackTargetDisplay } from '../CallbackToggleButton';
 import { CodexSettingsForm } from '../CodexSettingsForm';
+import { ErrorBoundary } from '../ErrorBoundary';
 import { SessionEnvVarsSelector } from '../SessionEnvVarsSelector';
 import { SessionMetadataForm } from '../SessionMetadataForm';
 
@@ -308,7 +310,12 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
         Callbacks
       </Typography.Text>
     ),
-    children: <CallbackConfigForm showHelpText />,
+    children: (
+      <>
+        <CallbackTargetDisplay session={session} onNavigate={onClose} />
+        <CallbackConfigForm showHelpText />
+      </>
+    ),
   });
 
   secondaryItems.push({
@@ -319,7 +326,14 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
         Advanced
       </Typography.Text>
     ),
-    children: <AdvancedSettingsForm showHelpText />,
+    children: (
+      <ErrorBoundary
+        fallbackTitle="Failed to load Advanced settings."
+        resetKey={session.session_id}
+      >
+        <AdvancedSettingsForm showHelpText />
+      </ErrorBoundary>
+    ),
   });
 
   return (

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -33,6 +33,8 @@ export interface AppActionsContextValue {
 
   // Navigation/UI actions
   onOpenSettings?: (sessionId: string) => void;
+  /** Open / select a session by id (cross-board navigation when needed). */
+  onSessionClick?: (sessionId: string) => void;
   onOpenWorktree?: (worktreeId: string, tab?: WorktreeModalTab) => void;
   onOpenTerminal?: (commands: string[], worktreeId?: string) => void;
 }


### PR DESCRIPTION
## Summary

Three small, related UI changes around the per-session callback system (where spawned child sessions notify their parent on completion):

- **Phone-icon callback toggle in the conversation footer.** Sits just left of the action-button group as its own button (not bundled). Renders only when callbacks are currently on — no icon = no visual noise. Tooltip names the parent session being called back to (with a deep link) and shows its status; one click disables. Re-enabling still lives in Session Settings.
- **Callback target surfaced in Session Settings.** The Callbacks panel now shows an inline pill: `Callbacks ON — notifying <parent title> [status]`, with the title as a clickable deep link that opens the parent (and closes the modal).
- **Bonus: error boundary around the Advanced section** of Session Settings. The Advanced panel renders a lazy-loaded CodeMirror chunk via `<JSONEditor>` — if that dynamic import ever fails (e.g. stale chunk after a deploy), the unwrapped Suspense was crashing the whole settings tree. Wrapped it in the existing `ErrorBoundary` (reset key bound to `session.session_id`) as defense-in-depth — nothing obvious in the component itself pointed at a deterministic crash.

## Implementation notes

- New small components live under `apps/agor-ui/src/components/CallbackToggleButton/` (`CallbackToggleButton` + `CallbackTargetDisplay`). Both use `useAppLiveData()` internally to look up the parent session — kept out of `SessionPanel` so the live-data subscription churn doesn't defeat the existing memoization in `SessionPanel`.
- Added `onSessionClick` to `AppActionsContext` so non-host components can route a session-id to the existing `handleSessionClick` (URL state + board switching).
- Enabled-detection mirrors the core default: callbacks for spawned sessions are implicitly on (only treated as off when `callback_config.enabled === false`).

## Test plan

- [ ] Open a spawned session — phone icon visible in footer; hover shows tooltip with parent title and status badge.
- [ ] Click the parent title in the tooltip → conversation switches to the parent session.
- [ ] Click the phone icon (not the link) → callbacks disabled, icon disappears, no errors.
- [ ] Open Session Settings → Callbacks panel → inline "Callbacks ON/OFF — notifying X" pill shows; click the link → opens parent, settings modal closes.
- [ ] Re-enable callbacks via the Settings toggle → footer phone icon returns.
- [ ] Top-level session (no parent / no `callback_session_id`) → phone icon never shows; Callbacks panel hides the pill.
- [ ] Toggle dark / light theme — pill styling reads correctly in both.
- [ ] Expand Advanced section (CodeMirror lazy-loaded) — still works; if a future chunk failure occurs, the error boundary catches it instead of crashing the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)