### PR TITLE
feat(codex): enable session forking via App Server thread/fork

### DIFF
--- a/apps/agor-docs/pages/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/pages/guide/sdk-comparison.mdx
@@ -14,7 +14,7 @@ Agor integrates with multiple AI coding agents. Each SDK has different capabilit
 | **Streaming responses**     | ✅ Text + tools     | ⚠️ Tools only             | ✅ Text + tools     | ✅ Text + tools           | ✅ Text + tools           | Claude, Gemini, Copilot & OpenCode stream text token-by-token; Codex streams tool events only |
 | **Stop mid-execution**      | ✅ Yes              | ⚠️ Limited                | ⚠️ Limited          | ⚠️ Limited                | ⚠️ Limited                | Claude has `interrupt()`, others may lose partial work                                      |
 | **Session import/export**   | ✅ Yes              | ❌ No                     | ❌ No               | ❌ No                     | ❌ No                     | Only Claude Code stores sessions as JSONL transcripts                                       |
-| **Session forkable**        | ✅ Yes (via replay) | ✅ Yes (via replay)       | ✅ Yes (via replay) | ✅ Yes (via replay)       | ❌ Not yet                | Agor emulates forking by replaying messages to new session                                  |
+| **Session forkable**        | ✅ SDK-native       | ✅ App Server fork        | ❌ Not yet          | ❌ Not yet                | ❌ Not yet                | Claude uses Agent SDK's `forkSession`; Codex uses `codex app-server` `thread/fork` sidecar  |
 | **MCP integration**         | ✅ Native           | ✅ Native                  | ✅ Native           | ✅ Native                 | ✅ Native                 | All agents support MCP with Agor's built-in self-access server                              |
 | **Permission requests**     | ✅ Rich             | ⚠️ Basic                  | ⚠️ Basic            | ✅ Interactive             | ⚠️ Auto-granted          | OpenCode permissions auto-granted by Agor to prevent session hangs                          |
 | **Project instructions**    | ✅ CLAUDE.md        | ✅ AGENTS.md               | ⚠️ Manual           | ⚠️ Manual                 | ✅ opencode.json          | OpenCode reads project config from `opencode.json`; Claude auto-loads CLAUDE.md             |
@@ -151,15 +151,25 @@ Agor integrates with multiple AI coding agents. Each SDK has different capabilit
 
 ### 4. Session Forking
 
-**All agents support forking via Agor's replay mechanism:**
+Forking creates a sibling session that inherits the parent's full conversation history at the fork point, then diverges. The mechanism is SDK-native where the agent supports it.
 
-1. User requests fork at specific message
-2. Agor creates new session
-3. Replays messages up to fork point
-4. New prompts diverge from original
-5. Full genealogy tracking in database
+**Claude Code:** ✅ **SDK-native fork**
 
-**Note:** This is an Agor feature, not SDK-native. Works identically across all agents.
+- On the fork's first prompt, Agor sets `resume: <parent_sdk_session_id>` and `forkSession: true` on the Agent SDK query
+- The SDK assigns a fresh session id derived from the parent's history; subsequent prompts resume that id normally
+- Atomic with the first prompt — no separate replay step
+
+**Codex:** ✅ **App Server `thread/fork`**
+
+- The public `@openai/codex-sdk` does not expose `fork()`, but the local `codex app-server` does via the `thread/fork` JSON-RPC method
+- On the fork's first prompt, Agor spawns `codex app-server` as a short-lived sidecar, calls `thread/fork` with the parent's thread id, and persists the returned thread id on the child session
+- All subsequent prompts go through the normal SDK `resumeThread(...).runStreamed(...)` path — the sidecar is only touched once
+
+**Gemini, Copilot, OpenCode:** ❌ **Not supported yet**
+
+- These SDKs don't expose a fork primitive. Use **spawn subsession** to delegate a fresh-context child instead.
+
+In every case Agor tracks `genealogy.forked_from_session_id` and `fork_point_message_index` in its own database so the UI can render the parent ↔ child relationship. The "Ask a side question" (`btw`) action is built on the same fork primitive and therefore lights up wherever fork is supported.
 
 ---
 

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -198,7 +198,7 @@ export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapab
     supportsStatelessFsMode: true,
   },
   codex: {
-    supportsSessionFork: false,
+    supportsSessionFork: true,
     supportsChildSpawn: true,
     supportsSessionImport: false,
     supportsStatelessFsMode: true,

--- a/packages/executor/src/sdk-handlers/codex/app-server-client.ts
+++ b/packages/executor/src/sdk-handlers/codex/app-server-client.ts
@@ -1,0 +1,219 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+interface JsonRpcResponse<T = unknown> {
+  id: number;
+  result?: T;
+  error?: { message?: string; code?: number; data?: unknown };
+}
+
+interface ThreadForkResult {
+  thread?: { id?: string };
+}
+
+export interface CodexAppServerClientOptions {
+  /** Extra env values to pass to the spawned `codex app-server` process. */
+  env?: NodeJS.ProcessEnv;
+  /** Request timeout for initialize/fork calls. Defaults to 10s. */
+  timeoutMs?: number;
+  /** Override executable for tests or non-standard installs. Defaults to `codex`. */
+  command?: string;
+}
+
+/**
+ * Minimal JSONL client for Codex's local App Server.
+ *
+ * This intentionally implements only the `thread/fork` sidecar operation so
+ * Agor can keep using `@openai/codex-sdk` for normal streaming execution. The
+ * App Server is spawned, initialized, asked to fork one stored thread, then
+ * torn down immediately.
+ */
+export class CodexAppServerClient {
+  private readonly timeoutMs: number;
+  private readonly command: string;
+  private child?: ChildProcessWithoutNullStreams;
+  private nextId = 0;
+  private readonly pending = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (error: Error) => void;
+      timer: NodeJS.Timeout;
+    }
+  >();
+  private stderr = '';
+  private startPromise?: Promise<void>;
+
+  constructor(private readonly options: CodexAppServerClientOptions = {}) {
+    this.timeoutMs = options.timeoutMs ?? 10_000;
+    this.command = options.command ?? 'codex';
+  }
+
+  async forkThread(threadId: string): Promise<string> {
+    await this.start();
+    await this.request('initialize', {
+      clientInfo: { name: 'agor', title: 'Agor', version: '0.0.0' },
+    });
+    this.sendNotification('initialized', {});
+
+    const result = await this.request<ThreadForkResult>('thread/fork', { threadId });
+    const forkedThreadId = result.thread?.id;
+    if (!forkedThreadId) {
+      throw new Error(
+        `Codex app-server thread/fork returned no thread id: ${JSON.stringify(result)}`
+      );
+    }
+    return forkedThreadId;
+  }
+
+  async close(): Promise<void> {
+    const child = this.child;
+    if (!child) return;
+
+    this.child = undefined;
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(`Codex app-server closed before response ${id}`));
+    }
+    this.pending.clear();
+
+    const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+    const timedOut = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+        resolve();
+      }, 1_000).unref();
+    });
+    await Promise.race([exited, timedOut]);
+  }
+
+  private async start(): Promise<void> {
+    if (this.startPromise) return this.startPromise;
+
+    this.startPromise = new Promise<void>((resolve, reject) => {
+      const child = spawn(this.command, ['app-server'], {
+        env: { ...process.env, ...this.options.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      this.child = child;
+
+      const rejectStartup = (error: Error) => {
+        this.rejectAll(error);
+        reject(error);
+      };
+
+      child.once('error', (error) => {
+        rejectStartup(new Error(`Failed to start Codex app-server: ${error.message}`));
+      });
+
+      child.once('spawn', () => resolve());
+
+      child.stderr.on('data', (chunk: Buffer) => {
+        this.stderr += chunk.toString('utf8');
+        // Keep error payloads useful without unbounded memory growth.
+        if (this.stderr.length > 20_000) this.stderr = this.stderr.slice(-20_000);
+      });
+
+      child.once('exit', (code, signal) => {
+        this.rejectAll(
+          new Error(
+            `Codex app-server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}).${
+              this.stderr ? ` stderr: ${this.stderr}` : ''
+            }`
+          )
+        );
+      });
+
+      const rl = createInterface({ input: child.stdout });
+      rl.on('line', (line) => this.handleLine(line));
+    });
+
+    return this.startPromise;
+  }
+
+  private request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const id = this.nextId++;
+    const child = this.child;
+    if (!child) throw new Error('Codex app-server is not running');
+
+    const promise = new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(
+          new Error(
+            `Timed out waiting for Codex app-server response to ${method}.${
+              this.stderr ? ` stderr: ${this.stderr}` : ''
+            }`
+          )
+        );
+      }, this.timeoutMs);
+      timer.unref();
+
+      this.pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject,
+        timer,
+      });
+    });
+
+    child.stdin.write(`${JSON.stringify({ method, id, params })}\n`);
+    return promise;
+  }
+
+  private sendNotification(method: string, params: Record<string, unknown>): void {
+    const child = this.child;
+    if (!child) throw new Error('Codex app-server is not running');
+    child.stdin.write(`${JSON.stringify({ method, params })}\n`);
+  }
+
+  private handleLine(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (!parsed || typeof parsed !== 'object' || !('id' in parsed)) return;
+    const response = parsed as JsonRpcResponse;
+    const pending = this.pending.get(response.id);
+    if (!pending) return;
+
+    this.pending.delete(response.id);
+    clearTimeout(pending.timer);
+
+    if (response.error) {
+      pending.reject(
+        new Error(
+          `Codex app-server request failed: ${
+            response.error.message ?? JSON.stringify(response.error)
+          }`
+        )
+      );
+      return;
+    }
+
+    pending.resolve(response.result);
+  }
+
+  private rejectAll(error: Error): void {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export async function forkCodexThreadViaAppServer(
+  threadId: string,
+  options?: CodexAppServerClientOptions
+): Promise<string> {
+  const client = new CodexAppServerClient(options);
+  try {
+    return await client.forkThread(threadId);
+  } finally {
+    await client.close();
+  }
+}

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -114,7 +114,7 @@ export class CodexTool implements ITool {
       supportsSessionImport: false, // ❌ Deferred until we have real JSONL format
       supportsSessionCreate: false, // ❌ Not exposed (handled via executeTask)
       supportsLiveExecution: true, // ✅ Via Codex SDK
-      supportsSessionFork: false,
+      supportsSessionFork: true,
       supportsChildSpawn: false,
       supportsGitState: false, // Agor manages git state
       supportsStreaming: true, // ✅ Via runStreamed()

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -16,6 +16,11 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const appServerMocks = vi.hoisted(() => ({
+  forkCodexThreadViaAppServer: vi.fn(),
+}));
+
 import { CodexPromptService } from './prompt-service.js';
 
 // Track how many Codex instances were created (module-level state)
@@ -32,6 +37,8 @@ async function* streamMockEvents() {
 }
 
 // Mock @agor/core/sdk to avoid spawning real Codex CLI processes
+vi.mock('./app-server-client.js', () => appServerMocks);
+
 vi.mock('@agor/core/sdk', () => {
   class MockCodexClient {
     apiKey: string;
@@ -73,6 +80,7 @@ vi.mock('@agor/core/sdk', () => {
 const mockMessagesRepo = {} as any;
 const mockSessionsRepo = {
   findById: vi.fn(),
+  update: vi.fn(),
 } as any;
 const mockSessionMCPServerRepo = {
   listServers: vi.fn().mockResolvedValue([]),
@@ -89,6 +97,7 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     mockStreamEvents = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
+    appServerMocks.forkCodexThreadViaAppServer.mockReset();
   });
 
   it('should create exactly one Codex instance on initialization', () => {
@@ -241,6 +250,94 @@ describe('CodexPromptService - OPENAI_BASE_URL handling', () => {
     (service as any).refreshClient('stable-key');
     expect(mockInstanceCount).toBe(countAfterInit + 2);
     expect(mockInstanceBaseUrls.at(-1)).toBeUndefined();
+  });
+});
+
+describe('CodexPromptService - forked sessions', () => {
+  beforeEach(() => {
+    mockInstanceCount = 0;
+    mockInstanceBaseUrls = [];
+    mockStreamEvents = [];
+    delete process.env.OPENAI_BASE_URL;
+    vi.clearAllMocks();
+    appServerMocks.forkCodexThreadViaAppServer.mockReset();
+  });
+
+  it('forks the parent Codex thread via app-server before resuming the child thread', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockWorktreesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-child.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    const childSession = {
+      session_id: 'child-session',
+      worktree_id: 'worktree-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      genealogy: { forked_from_session_id: 'parent-session' },
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    };
+    const parentSession = {
+      session_id: 'parent-session',
+      worktree_id: 'worktree-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: 'parent-thread-id',
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    };
+
+    mockSessionsRepo.findById.mockImplementation(async (id: string) => {
+      if (id === 'child-session') return childSession;
+      if (id === 'parent-session') return parentSession;
+      return null;
+    });
+    mockSessionsRepo.update.mockResolvedValue(undefined);
+    mockWorktreesRepo.findById.mockResolvedValue({
+      worktree_id: 'worktree-1',
+      path: process.cwd(),
+    });
+    appServerMocks.forkCodexThreadViaAppServer.mockResolvedValue('forked-thread-id');
+
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('child-session' as any, 'continue')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    expect(appServerMocks.forkCodexThreadViaAppServer).toHaveBeenCalledWith(
+      'parent-thread-id',
+      expect.objectContaining({ env: expect.any(Object) })
+    );
+    expect(mockSessionsRepo.update).toHaveBeenCalledWith('child-session', {
+      sdk_session_id: 'forked-thread-id',
+    });
+    expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
+      threadId: 'forked-thread-id',
+    });
   });
 });
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -44,6 +44,7 @@ import type {
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
+import { forkCodexThreadViaAppServer } from './app-server-client.js';
 import { DEFAULT_CODEX_MODEL } from './models.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
 
@@ -746,6 +747,57 @@ export class CodexPromptService {
   }
 
   /**
+   * Fork a Codex thread for an Agor forked session.
+   *
+   * The public TypeScript Codex SDK does not currently expose fork(), but the
+   * local Codex App Server does expose `thread/fork`. Keep this as a tiny
+   * sidecar: create the forked thread id, persist it to Agor, then continue
+   * through the normal SDK `resumeThread(...).runStreamed(...)` path.
+   */
+  private async ensureForkedCodexThread(
+    sessionId: SessionID,
+    session: {
+      genealogy?: { forked_from_session_id?: SessionID };
+      sdk_session_id?: string | null;
+    }
+  ): Promise<void> {
+    if (session.sdk_session_id) return;
+
+    const parentSessionId = session.genealogy?.forked_from_session_id;
+    if (!parentSessionId) return;
+
+    const parentSession = await this.sessionsRepo.findById(parentSessionId);
+    if (!parentSession?.sdk_session_id) {
+      console.warn(
+        `⚠️  [Codex] Fork requested from parent ${parentSessionId.substring(0, 8)}, but parent has no Codex thread id; starting fresh`
+      );
+      return;
+    }
+
+    console.log(
+      `🍴 [Codex] Forking from parent thread ${parentSession.sdk_session_id.substring(0, 8)} via app-server thread/fork`
+    );
+
+    const appServerEnv: NodeJS.ProcessEnv = { ...process.env };
+    if (this.useNativeAuth && !this.apiKey) {
+      delete appServerEnv.OPENAI_API_KEY;
+      delete appServerEnv.CODEX_API_KEY;
+    } else if (this.apiKey) {
+      appServerEnv.CODEX_API_KEY = this.apiKey;
+    }
+
+    const forkedThreadId = await forkCodexThreadViaAppServer(parentSession.sdk_session_id, {
+      env: appServerEnv,
+    });
+    await this.sessionsRepo.update(sessionId, { sdk_session_id: forkedThreadId });
+    session.sdk_session_id = forkedThreadId;
+
+    console.log(
+      `✅ [Codex] Forked thread ${parentSession.sdk_session_id.substring(0, 8)} → ${forkedThreadId.substring(0, 8)}`
+    );
+  }
+
+  /**
    * Execute prompt with streaming support
    *
    * Uses Codex SDK's runStreamed() method for real-time event streaming.
@@ -843,6 +895,8 @@ export class CodexPromptService {
     }
 
     console.log(`   Working directory: ${worktree.path}`);
+
+    await this.ensureForkedCodexThread(sessionId, session);
 
     // Build thread options. approvalPolicy + networkAccessEnabled flow through
     // here (not config.toml); ThreadOptions override matching `--config` keys.


### PR DESCRIPTION
## Summary

- Enables session **fork** for Codex sessions. The public `@openai/codex-sdk` does not expose `fork()`, but the local `codex app-server` exposes `thread/fork` over JSON-RPC. This PR adds a minimal JSONL sidecar that spawns app-server, calls `thread/fork`, and tears down — then continues through the normal SDK `resumeThread(...).runStreamed(...)` path.
- Flips `supportsSessionFork: true` for codex in both the static `AGENTIC_TOOL_CAPABILITIES` map (`packages/core`) and the runtime `CodexTool`. The UI fork affordance (`SessionPanel`) and the MCP fork gate (`apps/agor-daemon/src/mcp/tools/sessions.ts`) both read this flag, so flipping it is enough to surface the action everywhere.
- Adds a unit test that mocks the app-server sidecar and asserts: parent thread id is forwarded, the forked thread id is persisted to the child session, and the streaming `complete` event carries the new id.

### Implementation notes
- The sidecar (`app-server-client.ts`) only implements `thread/fork`; everything else still flows through the SDK so we don't fork the streaming codepath.
- `ensureForkedCodexThread()` only fires when the child has no `sdk_session_id` *and* `genealogy.forked_from_session_id` is set — i.e. only for Agor-forked sessions on their first prompt. It logs and falls back to a fresh thread if the parent never got a Codex thread id.
- Subscription-mode (`useNativeAuth && !apiKey`) env scrubbing is mirrored when spawning app-server so the CLI still picks up `auth.json`.

## Test plan
- [x] `pnpm check` clean (typecheck + lint + build)
- [x] `pnpm exec vitest run src/sdk-handlers/codex/` → 45 passed (incl. new fork test)
- [x] Daemon session tests → 17 passed
- [ ] Manual: fork a running Codex session via UI; confirm child resumes parent context

🤖 Generated with [Claude Code](https://claude.com/claude-code)