### PR TITLE
fix(daemon): clear error when executor cwd is gone + K8s persistence docs (#1109)

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -316,6 +316,32 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   console.log(`${logPrefix} Spawning executor at: ${executorPath}`);
   console.log(`${logPrefix} Command: ${payload.command}`);
 
+  // Detect missing-cwd up front (issue #1109). Without this, node's
+  // child_process surfaces `spawn /usr/local/bin/node ENOENT` — reported
+  // against the executable path, not the cwd that's actually gone — and
+  // operators end up debugging the wrong layer. The most common cause is
+  // running with a persistent database while `$HOME` is on an ephemeral
+  // volume (e.g. Kubernetes emptyDir): on pod redeploy the DB still
+  // references worktree/repo paths that no longer exist on disk. We
+  // surface that clearly here; recovery is left to the operator
+  // (restore the volume, or use the worktree/repo lifecycle commands to
+  // remove the orphan rows).
+  if (cwd && !existsSync(cwd)) {
+    console.error(
+      `${logPrefix} Refusing to spawn: cwd does not exist on disk: ${cwd}. ` +
+        `This usually means the worktree or repo directory was deleted ` +
+        `out-of-band — for example a Kubernetes pod redeploy with an ` +
+        `ephemeral $HOME but a persistent database. Verify that the volume ` +
+        `backing $HOME persists across restarts. See issue #1109.`
+    );
+    // Surface failure through the normal exit-code path so onExit handlers
+    // (e.g. the clone-safety-net in repos.ts) run as expected. 127 is the
+    // conventional "command not found" exit code; close enough semantically
+    // for "the cwd is gone" without inventing a new one.
+    options.onExit?.(127);
+    return;
+  }
+
   const executorProcess = spawn(cmd, args, {
     cwd,
     env: asUser ? undefined : { ...envWithDaemonUrl }, // When impersonating, env is in the command; otherwise pass to spawn

--- a/apps/agor-docs/pages/guide/containerized-execution.mdx
+++ b/apps/agor-docs/pages/guide/containerized-execution.mdx
@@ -186,6 +186,36 @@ For production Agor deployments with containerized execution, we recommend:
 
 ## Shared Filesystem Setup
 
+### Persistence Must Match the Database
+
+This is the single most common deployment foot-gun and worth calling out
+before the rest of the storage discussion.
+
+**If the Agor database is persistent, then `$HOME` (or whichever directory
+holds `repos/` and `worktrees/`) MUST also be persistent.** The database
+stores absolute paths to every repository clone and every worktree on
+disk. If the database survives a pod restart but the filesystem does not
+— for example, the database is backed by a `PersistentVolumeClaim` while
+`$HOME` is an `emptyDir` — then on redeploy the daemon will reference
+paths that no longer exist. Opening a terminal or running a session will
+fail when the executor tries to `chdir` into a directory that's gone.
+
+The daemon will surface a clear error in this state (`cwd does not exist
+on disk: ...` — see [issue
+\#1109](https://github.com/preset-io/agor/issues/1109)), but the only
+real fix is to restore the volume or, if the volume is unrecoverable,
+clean up the orphan database rows using
+`agor worktree remove` / `agor repo remove` before re-cloning.
+
+Safe configurations:
+
+- **Both persistent**: Database on PVC, `$HOME` (or `data_home`) on
+  PVC/EFS/NFS. Recommended for production.
+- **Both ephemeral**: Database on `emptyDir`, `$HOME` on `emptyDir`. Fine
+  for short-lived test pods — everything resets together.
+- **Avoid mixing**: Persistent database + ephemeral filesystem is the
+  broken state described above.
+
 ### Why Shared Storage?
 
 Agor's development model requires:


### PR DESCRIPTION
## Summary

Tiny, focused replacement for #1183 (now closed). The literal user complaint in #1109 is that the daemon dies with `spawn /usr/local/bin/node ENOENT` (or `chdir(2) failed`) when the worktree directory has disappeared from disk — a typical Kubernetes deployment foot-gun where Postgres is persistent but `$HOME` is an `emptyDir`. Node's ENOENT is reported against the executable path, not the missing cwd, which sent the reporter down a long debugging rabbit hole.

Two changes, ~50 lines total:

- `apps/agor-daemon/src/utils/spawn-executor.ts` — `existsSync(cwd)` check before handing the spawn to node-child-process. If the cwd is gone, log a clear error pointing at the actual problem and call `onExit(127)` so existing handlers (e.g. the clone safety-net in `repos.ts`) run as expected.
- `apps/agor-docs/pages/guide/containerized-execution.mdx` — new "Persistence Must Match the Database" section in the deployment guide, listing the three valid persistence configurations and explicitly calling out the broken-mix case.

Recovery (restoring the volume, or cleaning up orphan rows with `agor worktree remove` / `agor repo remove`) is intentionally left to the operator. Building automated "rebuild from git remote" tooling into the daemon is a separate conversation — see #1183's closing comment for the rationale.

## What this does NOT do (deliberately)

The closed PR #1183 also added a `filesystem_status` column on both tables, a startup reconciliation pass, `recreateFilesystem` service methods, REST + MCP recreate surfaces, a `MissingPathError` envelope, and a UI banner. After a fresh maintainer pass, that was over-built for what #1109 actually reports — it's disaster-recovery tooling, not a bug fix, and the premise of "rebuild from git remote" is lossy by design (walks past uncommitted work, ignored files, env state, node_modules). That belongs in an explicit `agor admin repair` CLI command — opt-in, last-resort, with a clear "your data is gone" disclaimer — and deserves its own design conversation independent of #1109.

## Test plan

- [x] `pnpm check` (typecheck + lint + build) — green
- [x] `@agor/daemon` 631 tests — green
- [ ] Manual: `rm -rf` a worktree's directory, attempt to open a terminal or run a session → daemon logs `Refusing to spawn: cwd does not exist on disk: <path>` with the K8s hint, no misleading ENOENT

Closes #1109.

Thanks @poberherr for the well-documented reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)