### PR TITLE
chore(release): bump agor-live and client to 0.19.0

### DIFF
--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git worktrees, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Minor version bump for both `agor-live` and `@agor-live/client` ahead of the next release. Follows the cadence set by #1148 (0.17.4 → 0.18.0).

| Package | Before | After |
|---|---|---|
| `agor-live` | 0.18.0 | 0.19.0 |
| `@agor-live/client` | 0.18.0 | 0.19.0 |

Workspace consumers (`apps/agor-ui`, `apps/agor-cli`, `packages/agor-live`) use `workspace:*` refs, so no fixed-version updates and no lockfile churn. Publishing is handled by release CI on merge.

## Test plan

- [x] Both `package.json` files at 0.19.0
- [x] No `0.18.0` references remain in `pnpm-lock.yaml` (workspace deps not version-pinned in lockfile)
- [x] No fixed-version consumer refs to update (all use `workspace:*`)
- [x] Diff shape matches merged PR #1148 (2 files, 2 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)