### PR TITLE
feat(ui): friendly global error boundary with copy-paste crash report

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -23,6 +23,7 @@ import { useEffect, useState } from 'react';
 import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AVAILABLE_AGENTS } from './components/AgentSelectionGrid';
 import { App as AgorApp } from './components/App';
+import { ErrorBoundary, setCrashContext } from './components/ErrorBoundary';
 import { ForcePasswordChangeModal } from './components/ForcePasswordChangeModal';
 import { InitialLoadingScreen } from './components/InitialLoadingScreen';
 import { LoginPage } from './components/LoginPage';
@@ -219,6 +220,17 @@ function AppContent() {
   // This ensures we get the latest onboarding_completed status
   // Fall back to user from auth if users Map hasn't loaded yet
   const currentUser = user ? userById.get(user.user_id) || user : null;
+
+  // Keep the global ErrorBoundary's crash context populated so a render
+  // crash anywhere below us can produce a useful report (build SHA + signed-in
+  // user). The boundary is a class component that lives ABOVE this tree, so
+  // it can't read hooks — a module-level setter is the bridge.
+  useEffect(() => {
+    setCrashContext({
+      buildSha: capturedSha,
+      userEmail: currentUser?.email ?? null,
+    });
+  }, [capturedSha, currentUser?.email]);
 
   // Onboarding wizard state
   const [onboardingWizardOpen, setOnboardingWizardOpen] = useState(false);
@@ -1637,7 +1649,9 @@ function AppWrapper() {
   return (
     <ConfigProvider theme={getCurrentThemeConfig()}>
       <AntApp>
-        <AppContent />
+        <ErrorBoundary variant="global">
+          <AppContent />
+        </ErrorBoundary>
       </AntApp>
     </ConfigProvider>
   );

--- a/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/agor-ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,22 +1,36 @@
 import { Alert } from 'antd';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { GlobalCrashScreen } from './GlobalCrashScreen';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
+  // Visual mode for the fallback.
+  //   'scoped' (default): small inline antd <Alert> — good for section-level
+  //     boundaries that wrap one piece of UI (e.g. the logs modal).
+  //   'global': full-screen friendly crash screen with a copy-paste markdown
+  //     report and GitHub issue link — for the top-level boundary around the
+  //     entire app.
+  variant?: 'scoped' | 'global';
   fallbackTitle?: ReactNode;
   // When this value changes, the boundary clears its error state and re-renders
   // children. Useful when fresh data may unblock the failed render (e.g. a
-  // logs refresh after a transient bad payload).
+  // logs refresh after a transient bad payload). The global variant doesn't
+  // typically use this — the user reloads instead.
   resetKey?: unknown;
 }
 
 interface ErrorBoundaryState {
   error: Error | null;
+  errorInfo: ErrorInfo | null;
   resetKey: unknown;
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null, resetKey: this.props.resetKey };
+  state: ErrorBoundaryState = {
+    error: null,
+    errorInfo: null,
+    resetKey: this.props.resetKey,
+  };
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { error };
@@ -27,27 +41,33 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     state: ErrorBoundaryState
   ): Partial<ErrorBoundaryState> | null {
     if (props.resetKey !== state.resetKey) {
-      return { error: null, resetKey: props.resetKey };
+      return { error: null, errorInfo: null, resetKey: props.resetKey };
     }
     return null;
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('ErrorBoundary caught render error:', error, info.componentStack);
+    this.setState({ errorInfo: info });
   }
 
   render() {
-    const { error } = this.state;
+    const { error, errorInfo } = this.state;
+    const { variant = 'scoped', fallbackTitle, children } = this.props;
+
     if (error) {
+      if (variant === 'global') {
+        return <GlobalCrashScreen error={error} errorInfo={errorInfo} />;
+      }
       return (
         <Alert
           type="error"
           showIcon
-          title={this.props.fallbackTitle ?? 'Something went wrong rendering this view.'}
+          title={fallbackTitle ?? 'Something went wrong rendering this view.'}
           description={error.message || String(error)}
         />
       );
     }
-    return this.props.children;
+    return children;
   }
 }

--- a/apps/agor-ui/src/components/ErrorBoundary/GlobalCrashScreen.tsx
+++ b/apps/agor-ui/src/components/ErrorBoundary/GlobalCrashScreen.tsx
@@ -1,0 +1,125 @@
+import { CopyOutlined, FrownOutlined, GithubOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Collapse, Space, Typography, theme } from 'antd';
+import type { ErrorInfo } from 'react';
+import { useState } from 'react';
+import { copyToClipboard } from '../../utils/clipboard';
+import { buildGitHubIssueUrl, buildMarkdownReport, firstComponentFromStack } from './crashReport';
+
+const { Title, Paragraph, Text } = Typography;
+
+interface GlobalCrashScreenProps {
+  error: Error;
+  errorInfo: ErrorInfo | null;
+}
+
+export function GlobalCrashScreen({ error, errorInfo }: GlobalCrashScreenProps) {
+  const { token } = theme.useToken();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(buildMarkdownReport(error, errorInfo));
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleReload = () => {
+    window.location.reload();
+  };
+
+  const githubUrl = buildGitHubIssueUrl(error, errorInfo);
+  const component = firstComponentFromStack(errorInfo?.componentStack);
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+        backgroundColor: token.colorBgLayout,
+      }}
+    >
+      <Card
+        style={{
+          maxWidth: 640,
+          width: '100%',
+          textAlign: 'center',
+        }}
+        styles={{ body: { padding: '2.5rem 2rem' } }}
+      >
+        {/*
+          TODO(asset): swap this placeholder for a generated mascot at
+          /apps/agor-ui/public/error-mascot.svg. Drop the file in, then replace
+          this <FrownOutlined /> with <img src="/error-mascot.svg" ... />.
+        */}
+        <FrownOutlined
+          style={{
+            fontSize: 96,
+            color: token.colorTextTertiary,
+            marginBottom: token.marginLG,
+          }}
+        />
+
+        <Title level={2} style={{ marginTop: 0, marginBottom: token.marginXS }}>
+          Well, that wasn't supposed to happen.
+        </Title>
+        <Paragraph style={{ color: token.colorTextSecondary, marginBottom: token.marginLG }}>
+          The UI hit an unexpected error and couldn't finish rendering. Reloading usually gets you
+          going again. If it keeps happening, the report below will help us fix it.
+        </Paragraph>
+
+        <Space wrap style={{ justifyContent: 'center', marginBottom: token.marginLG }}>
+          <Button icon={<CopyOutlined />} onClick={handleCopy}>
+            {copied ? 'Copied!' : 'Copy error details'}
+          </Button>
+          <Button
+            icon={<GithubOutlined />}
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Report on GitHub
+          </Button>
+          <Button type="primary" icon={<ReloadOutlined />} onClick={handleReload}>
+            Reload page
+          </Button>
+        </Space>
+
+        <Collapse
+          ghost
+          items={[
+            {
+              key: 'details',
+              label: <Text type="secondary">Show technical details</Text>,
+              children: (
+                <div style={{ textAlign: 'left' }}>
+                  <Paragraph style={{ marginBottom: token.marginSM }}>
+                    <Text strong>Component:</Text> <Text code>{component}</Text>
+                    <br />
+                    <Text strong>Error:</Text> <Text code>{error.message || String(error)}</Text>
+                  </Paragraph>
+                  <pre
+                    style={{
+                      maxHeight: 240,
+                      overflow: 'auto',
+                      fontSize: 12,
+                      padding: token.paddingSM,
+                      backgroundColor: token.colorBgContainerDisabled,
+                      borderRadius: token.borderRadiusSM,
+                      margin: 0,
+                    }}
+                  >
+                    {(errorInfo?.componentStack ?? error.stack ?? '(no stack available)').trim()}
+                  </pre>
+                </div>
+              ),
+            },
+          ]}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/apps/agor-ui/src/components/ErrorBoundary/crashContext.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/crashContext.ts
@@ -1,0 +1,24 @@
+// Module-level snapshot of context the global ErrorBoundary wants to include
+// in crash reports (build SHA, signed-in user, etc.). Populated as a side
+// effect from <AppContent> via useEffect; read synchronously by the boundary
+// when a render crashes. We can't use hooks from a class component, and
+// React context is unavailable above the crash point — so a plain module
+// singleton is the simplest path.
+
+export interface CrashContext {
+  buildSha: string | null;
+  userEmail: string | null;
+}
+
+let current: CrashContext = {
+  buildSha: null,
+  userEmail: null,
+};
+
+export function setCrashContext(patch: Partial<CrashContext>): void {
+  current = { ...current, ...patch };
+}
+
+export function getCrashContext(): CrashContext {
+  return current;
+}

--- a/apps/agor-ui/src/components/ErrorBoundary/crashReport.test.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/crashReport.test.ts
@@ -1,0 +1,90 @@
+import type { ErrorInfo } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setCrashContext } from './crashContext';
+import {
+  buildGitHubIssueUrl,
+  buildMarkdownReport,
+  firstComponentFromStack,
+  GITHUB_NEW_ISSUE_URL,
+  MAX_GITHUB_BODY_CHARS,
+} from './crashReport';
+
+const sampleStack = `
+    in BoardCanvas (at BoardCanvas.tsx:42)
+    in Suspense
+    in AppContent (at App.tsx:96)
+`;
+const env = {
+  now: new Date('2026-05-15T05:18:00Z'),
+  href: 'http://localhost:5173/b/abc/sess1/',
+  userAgent: 'Mozilla/5.0 (test)',
+};
+
+beforeEach(() => {
+  setCrashContext({ buildSha: 'cace77e4', userEmail: 'max@preset.io' });
+});
+
+describe('firstComponentFromStack', () => {
+  it('returns the first component name from a React component stack', () => {
+    expect(firstComponentFromStack(sampleStack)).toBe('BoardCanvas');
+  });
+
+  it('falls back to a placeholder for empty / missing stacks', () => {
+    expect(firstComponentFromStack(null)).toBe('unknown component');
+    expect(firstComponentFromStack(undefined)).toBe('unknown component');
+    expect(firstComponentFromStack('')).toBe('unknown component');
+    expect(firstComponentFromStack('garbage with no in-token')).toBe('unknown component');
+  });
+});
+
+describe('buildMarkdownReport', () => {
+  it('includes timestamp, location, user, build, browser, and message', () => {
+    const error = new Error('boom');
+    const info: ErrorInfo = { componentStack: sampleStack, digest: null };
+    const md = buildMarkdownReport(error, info, env);
+
+    expect(md).toContain('## UI crash report');
+    expect(md).toContain('**When:** 2026-05-15T05:18:00.000Z');
+    expect(md).toContain('**Where:** http://localhost:5173/b/abc/sess1/');
+    expect(md).toContain('**Component:** BoardCanvas');
+    expect(md).toContain('**User:** max@preset.io');
+    expect(md).toContain('**Build:** cace77e4');
+    expect(md).toContain('**Browser:** Mozilla/5.0 (test)');
+    expect(md).toContain('**Error:** boom');
+    expect(md).toContain('### Component stack');
+    expect(md).toContain('### Error stack');
+  });
+
+  it('uses placeholders when crash context is unset', () => {
+    setCrashContext({ buildSha: null, userEmail: null });
+    const md = buildMarkdownReport(new Error('x'), null, env);
+    expect(md).toContain('**User:** (not signed in)');
+    expect(md).toContain('**Build:** unknown');
+    expect(md).toContain('**Component:** unknown component');
+  });
+});
+
+describe('buildGitHubIssueUrl', () => {
+  it('points at preset-io/agor with title, body, and bug label', () => {
+    const url = buildGitHubIssueUrl(
+      new Error('boom'),
+      { componentStack: sampleStack, digest: null },
+      env
+    );
+    expect(url.startsWith(`${GITHUB_NEW_ISSUE_URL}?`)).toBe(true);
+
+    const params = new URL(url).searchParams;
+    expect(params.get('title')).toBe('UI crash: BoardCanvas — boom');
+    expect(params.get('labels')).toBe('bug');
+    expect(params.get('body')).toContain('## UI crash report');
+  });
+
+  it('truncates oversized bodies and notes the truncation', () => {
+    const huge = 'x'.repeat(20_000);
+    const error = new Error(huge);
+    const url = buildGitHubIssueUrl(error, { componentStack: sampleStack, digest: null }, env);
+    const body = new URL(url).searchParams.get('body') ?? '';
+    expect(body.length).toBeLessThanOrEqual(MAX_GITHUB_BODY_CHARS + 100);
+    expect(body).toContain('truncated');
+  });
+});

--- a/apps/agor-ui/src/components/ErrorBoundary/crashReport.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/crashReport.ts
@@ -1,0 +1,77 @@
+// Pure helpers that assemble a UI-crash report from an Error + React
+// ErrorInfo. Split out from the component so they're easy to unit test
+// without rendering anything.
+
+import type { ErrorInfo } from 'react';
+import { getCrashContext } from './crashContext';
+
+export const GITHUB_NEW_ISSUE_URL = 'https://github.com/preset-io/agor/issues/new';
+
+// Keep the GitHub issue URL well under common ~8KB browser limits — GitHub
+// silently truncates very long URLs. URL-encoding roughly triples raw size,
+// so we cap the markdown body around 4KB before encoding.
+export const MAX_GITHUB_BODY_CHARS = 4000;
+
+export function firstComponentFromStack(componentStack: string | null | undefined): string {
+  if (!componentStack) return 'unknown component';
+  // componentStack lines look like "    in MyComponent (at file.tsx:42)" —
+  // pull the first identifier following "in ".
+  const match = componentStack.match(/in\s+([A-Za-z0-9_$.]+)/);
+  return match?.[1] ?? 'unknown component';
+}
+
+interface BuildReportEnv {
+  now?: Date;
+  href?: string;
+  userAgent?: string;
+}
+
+export function buildMarkdownReport(
+  error: Error,
+  errorInfo: ErrorInfo | null,
+  env: BuildReportEnv = {}
+): string {
+  const { buildSha, userEmail } = getCrashContext();
+  const when = (env.now ?? new Date()).toISOString();
+  const where = env.href ?? (typeof window !== 'undefined' ? window.location.href : 'unknown');
+  const ua = env.userAgent ?? (typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown');
+  const component = firstComponentFromStack(errorInfo?.componentStack);
+
+  return [
+    '## UI crash report',
+    '',
+    `- **When:** ${when}`,
+    `- **Where:** ${where}`,
+    `- **Component:** ${component}`,
+    `- **User:** ${userEmail ?? '(not signed in)'}`,
+    `- **Build:** ${buildSha ?? 'unknown'}`,
+    `- **Browser:** ${ua}`,
+    `- **Error:** ${error.message || String(error)}`,
+    '',
+    '### Component stack',
+    '```',
+    (errorInfo?.componentStack ?? '(unavailable)').trim(),
+    '```',
+    '',
+    '### Error stack',
+    '```',
+    (error.stack ?? '(unavailable)').trim(),
+    '```',
+    '',
+  ].join('\n');
+}
+
+export function buildGitHubIssueUrl(
+  error: Error,
+  errorInfo: ErrorInfo | null,
+  env: BuildReportEnv = {}
+): string {
+  const component = firstComponentFromStack(errorInfo?.componentStack);
+  const title = `UI crash: ${component} — ${error.message?.slice(0, 80) ?? 'unknown error'}`;
+  let body = buildMarkdownReport(error, errorInfo, env);
+  if (body.length > MAX_GITHUB_BODY_CHARS) {
+    body = `${body.slice(0, MAX_GITHUB_BODY_CHARS)}\n\n_(truncated — see full report copied to clipboard)_`;
+  }
+  const params = new URLSearchParams({ title, body, labels: 'bug' });
+  return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`;
+}

--- a/apps/agor-ui/src/components/ErrorBoundary/index.ts
+++ b/apps/agor-ui/src/components/ErrorBoundary/index.ts
@@ -1,1 +1,3 @@
+export { getCrashContext, setCrashContext } from './crashContext';
 export { ErrorBoundary } from './ErrorBoundary';
+export { GlobalCrashScreen } from './GlobalCrashScreen';

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { AgorClient, UnixUserMode } from '@agor-live/client';
-import { Card, Descriptions, Space, Tag, Tooltip, Typography } from 'antd';
+import { Button, Card, Descriptions, Space, Tag, Tooltip, Typography } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useConnectionState } from '../../contexts/ConnectionContext';
@@ -25,6 +25,19 @@ export interface AboutTabProps {
 
 interface WindowWithAgorConfig extends Window {
   AGOR_DAEMON_URL?: string;
+}
+
+// Renders nothing — just throws on mount. Used by the admin Crash Test
+// button to verify the global ErrorBoundary catches render-phase crashes
+// and renders the friendly crash screen. React error boundaries do NOT
+// catch errors thrown from event handlers, which is why we flip a state
+// flag and let this component throw during the next render instead of
+// throwing from the button's onClick directly.
+function CrashTestBomb(): never {
+  throw new Error(
+    'Crash test: this is a synthetic render-phase error from About → Crash Test. ' +
+      "If you're seeing the friendly crash screen, the global ErrorBoundary works."
+  );
 }
 
 interface HealthInfo {
@@ -76,6 +89,9 @@ export const AboutTab: React.FC<AboutTabProps> = ({
   const daemonUrl = getDaemonUrl();
   const [detectionMethod, setDetectionMethod] = useState<string>('');
   const [healthInfo, setHealthInfo] = useState<HealthInfo | null>(null);
+  // Admin-only crash-test toggle: flipping this true makes <CrashTestBomb />
+  // mount and throw on the next render, which trips the global ErrorBoundary.
+  const [crashTest, setCrashTest] = useState(false);
   // SHA captured at tab-load time (resets on hard reload). Provider-owned in
   // App.tsx via useServerVersion so this and the banner stay in lockstep.
   const { capturedSha } = useConnectionState();
@@ -356,6 +372,17 @@ export const AboutTab: React.FC<AboutTabProps> = ({
                   </Descriptions.Item>
                   <Descriptions.Item label="Path">
                     <code>{window.location.pathname}</code>
+                  </Descriptions.Item>
+                  <Descriptions.Item label="Crash Test">
+                    <Space>
+                      <Button danger size="small" onClick={() => setCrashTest(true)}>
+                        Trigger render crash
+                      </Button>
+                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                        Throws during render to verify the global error boundary. Reload to recover.
+                      </Typography.Text>
+                    </Space>
+                    {crashTest && <CrashTestBomb />}
                   </Descriptions.Item>
                 </Descriptions>
               </Card>


### PR DESCRIPTION
## Summary
- Wraps `<AppContent />` in a top-level `ErrorBoundary` (variant=`"global"`) so unhandled render crashes (React #130 family, etc.) no longer white-screen the app.
- Friendly fallback: mascot placeholder (`<FrownOutlined />`), light-humor headline ("Well, that wasn't supposed to happen."), three actions — **Copy error details** (markdown report to clipboard), **Report on GitHub** (deep link with title + body pre-filled, URL-truncated to stay under GitHub's silent limit), **Reload page**.
- Preserves the existing scoped `<ErrorBoundary>` API used by `EnvironmentLogsModal` — same antd `<Alert>` fallback, same `fallbackTitle` / `resetKey` props. Global vs scoped is a single `variant` prop.
- Crash context (build SHA, signed-in user) is piped from `App.tsx` into a module-level setter the class boundary can read on crash (hooks aren't reachable from a class component above the crash point).
- Admin-only **Crash Test** button in *Settings → About → System Debug Info* mounts a `<CrashTestBomb />` that throws on render, so the boundary can be exercised without faking errors. State-toggle pattern is deliberate — React error boundaries don't catch event-handler throws.
- Unit tests for the report builders: 6 new tests covering markdown shape, fallback defaults, GitHub URL params, and body-truncation behavior.

## Asset follow-up
The mascot is `<FrownOutlined />` with a `TODO(asset)` pointing at `/apps/agor-ui/public/error-mascot.svg`. Drop a Nano-Banana-generated PNG/SVG in that path and swap the JSX line — no other changes needed.

## Telemetry
`console.error` only via `componentDidCatch` — no new dependency, no new daemon endpoint. Future wiring (Sentry or `/client-errors`) is a separate concern.

## Test plan
- [ ] Open Settings → About (admin) → System Debug Info → click **Trigger render crash**. Friendly screen renders.
- [ ] Click **Copy error details** → paste somewhere → confirm markdown report has timestamp, location, user, build SHA, component (`CrashTestBomb`), browser, error, component stack, error stack.
- [ ] Click **Report on GitHub** → confirm new-issue page opens with title `UI crash: CrashTestBomb — ...` and body pre-filled with the report.
- [ ] Click **Reload page** → recovers cleanly.
- [ ] Light + dark theme both render correctly.
- [ ] Existing logs-modal scoped boundary still shows an inline `<Alert>` (no regression to scoped path).
- [ ] `pnpm --filter agor-ui test src/components/ErrorBoundary/` — 6 tests pass.
- [ ] `pnpm check` — typecheck + lint + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)