### PR TITLE
fix(ui): expand Edit (and other diff-bearing) tool cards by default

### DIFF
--- a/apps/agor-ui/src/components/ToolBlock/defaultExpansion.ts
+++ b/apps/agor-ui/src/components/ToolBlock/defaultExpansion.ts
@@ -10,13 +10,20 @@
 
 /**
  * Tool names whose ToolBlock body is the primary payload of the call
- * (i.e. you almost always want to see it without a click).
+ * (i.e. you almost always want to see it without a click). In practice
+ * that's file writes / edits, where the diff IS the content.
  *
  * Includes cross-agent equivalents:
- * - Claude Code: `Write`
+ * - Claude Code: `Write`, `Edit`, `MultiEdit`, `NotebookEdit`
  * - Codex: `edit_files`
  */
-const TOOLS_EXPANDED_BY_DEFAULT = new Set<string>(['Write', 'edit_files']);
+const TOOLS_EXPANDED_BY_DEFAULT = new Set<string>([
+  'Write',
+  'Edit',
+  'MultiEdit',
+  'NotebookEdit',
+  'edit_files',
+]);
 
 /**
  * Whether a tool call should render its ToolBlock body expanded by default.


### PR DESCRIPTION
## Summary

- **Regression:** [#1028](https://github.com/preset-io/agor/pull/1028) (commit `87f8e943`) flipped `ToolBlock.expandedByDefault` to `false` and only re-promoted `Write`/`edit_files`. That dropped `Edit` into the same bucket as `Bash`/`Read` — collapsed by default. But `Edit`'s body IS a diff; hiding it behind a click is the whole reason the regression was noticeable.
- **Fix:** add `Edit`, `MultiEdit`, `NotebookEdit` to `TOOLS_EXPANDED_BY_DEFAULT` in `apps/agor-ui/src/components/ToolBlock/defaultExpansion.ts`. Data-driven, one file, no scattered conditionals — both call sites (`AgentChain`, `MessageBlock`) already route through `shouldExpandToolByDefault`.
- The user toggle still works (you can collapse manually); diff-renderer side (`DiffBlock`'s `forceExpanded`) is unchanged. Non-diff tools (`Bash`, `Read`, `Grep`, etc.) still collapse by default — the original scannable-chain intent is preserved.

## Test plan

- [x] `pnpm check` (typecheck + lint + build) passes
- [x] `pnpm --filter agor-ui test` — 132 / 132 pass
- [ ] In a live session, an `Edit` tool card lands expanded showing the diff
- [ ] `Write`/`MultiEdit`/`NotebookEdit` likewise expanded
- [ ] `Read`/`Bash`/`Grep` still collapsed by default
- [ ] Clicking the chevron still toggles collapse/expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)