### PR TITLE
docs(changelog): backfill 0.16.2–0.19.0 + style consistency pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,340 @@
 # Changelog
 
+This project follows [Keep a Changelog](https://keepachangelog.com/) conventions.
+Version numbers track `packages/agor-live` releases. Each entry links to its PR via `(#NNNN)`.
+
+## Style
+
+Section labels:
+- **Features** — user-visible new capabilities
+- **Fixes** — bug fixes
+- **Security** — security-relevant changes (called out separately to make audit easier)
+- **Breaking** — backwards-incompatible changes (call out migration steps)
+- **Chores** — build, deps, infra, refactors (only when user-visible or substantial)
+
+Entry pattern:
+
+```
+- **Short headline** — one to two sentences of context (#NNNN)
+```
+
+If an entry needs more than two sentences, break it into sub-bullets rather than a wall of text:
+
+```
+- **Headline** — high-level summary (#NNNN)
+  - Detail 1
+  - Detail 2
+```
+
+The reader's first pass is the headline only; sub-bullets are for the curious. Keep headlines crisp; skip dependabot/CI churn unless user-visible.
+
 ## Unreleased
 
+_No user-visible changes yet._
+
+## 0.19.0 (2026-05-14)
+
+### Features
+- **Codex session forking** — enable fork/spawn for Codex via the App Server thread/fork API; reaches parity with Claude on session genealogy (#1188)
+- **Friendly global error boundary** — when the UI crashes, show a recoverable screen with a one-click copy-paste crash report (#1191)
+- **Quick callback toggle in footer** — surface the session callback toggle in the session footer; show the active target in settings (#1187)
+- **Onboarding wizard streamlining** — restructure the five-ask flow for clarity and fewer dead-ends (#1168)
+- **Granular loading progress** — parallel spinners with checkmarks during initial load instead of a single opaque spinner (#1170)
+- **In-transcript daemon-restart message** — when the daemon restarts mid-session, inject a system message into the transcript so the gap is visible (#1166)
+
 ### Fixes
-- **Stop AskUserQuestion from hanging gateway sessions (#1177)** — disallow `AskUserQuestion`, `ExitPlanMode`, `EnterWorktree`, and `ExitWorktree` at the SDK layer via `disallowedTools` so the model never invokes them. The interactive question widget previously blocked the executor waiting for a UI response that never arrives in Slack/gateway channels; the agent now inlines its choices in normal text and the user replies as a regular turn. Removes the `InputRequestService`/`InputRequestManager`/`InputRequestBlock` machinery, the `/sessions/:id/input-response` daemon route, the `input_resolved` Feathers event, and the `execution.input_request_timeout_ms` config option. Disallowed tools are unioned with whatever `~/.claude/settings.json`'s `permissions.deny` already contains.
+- **Stop AskUserQuestion from hanging gateway sessions** — disallow `AskUserQuestion`, `ExitPlanMode`, `EnterWorktree`, and `ExitWorktree` at the SDK layer via `disallowedTools` so the model never invokes them in Slack/gateway channels (#1181)
+  - Previously the interactive question widget blocked the executor waiting for a UI response that never arrives in non-UI channels
+  - Removes the `InputRequestService`/`InputRequestManager`/`InputRequestBlock` machinery, the `/sessions/:id/input-response` daemon route, the `input_resolved` Feathers event, and the `execution.input_request_timeout_ms` config option
+  - Disallowed tools are unioned with whatever `~/.claude/settings.json`'s `permissions.deny` already contains
+- **Expand Edit and other diff-bearing tool cards by default** — collapsed-by-default hid the actual change from view (#1193)
+- **Clear stuck error when executor cwd is gone** — detect missing worktree/repo FS paths and surface an actionable repair flow; adds K8s persistence docs (#1189)
+- **Truncate long worktree names + reserve action button space** — long names no longer push action buttons off the card (#1184)
+- **Centralize RBAC gate in git impersonation** — fixes a class of bugs where the gate was only enforced at some call sites (closes #1143) (#1180)
+- **Inject `created_by` when creating gateway channels** — previously gateway-created channels lacked an owner attribution (#1178)
+- **Suppress `system/task_updated` lifecycle events** — follow-up to #1116 to silence remaining noisy SDK lifecycle chatter (#1172)
+- **Source conditional exports in `@agor/core`** — vite/vitest now resolve `@agor/core` without a prior build (#1171)
+- **Fix `agor-ui` tests resolving `@agor/core/types`** — unblocks UI test suite (#1162)
+- **OpenCode reasoning-only responses** — render reasoning-only outputs as messages instead of dropping them as "thoughts" (#1163)
+- **Always render artifact card header + add delete confirm** — prevents accidental deletes and keeps the header visible during state transitions (#1167)
+
+### Security
+- **Harden git config via `GIT_CONFIG_PARAMETERS`** — inject `transfer.credentialsInUrl=die`, block `file://`/`ext::` protocol RCE families, enable HFS/NTFS path-traversal protection on every git invocation; tunable via `security.git_config_parameters` (#1157)
+
+### Breaking
+- **Anonymous mode removed** — `agor daemon` now always requires authentication; configs that relied on anonymous access must add a user/API key (#1154)
+
+### Chores / Performance
+- **Split `AppEntityDataContext` into Repo/User/Mcp contexts** — cuts re-renders across the UI when any one entity stream updates (#1186)
+- **Cut conversation pane re-renders during active streaming** — large transcripts stream noticeably faster (#1185)
+- **Sweep AntD v6 deprecation warnings** (Space/Alert/Modal) (#1175)
+- **Make `App-Level Token Scope` explicit in gateway docs** (#1174)
+- **Remove assistant-setup step from `agor init`** — handled by the UI onboarding wizard now (#1169)
+
+## 0.18.0 (2026-05-12)
+
+### Features
+- **Declarative artifact format + TOFU consent flow** — artifacts now use a versioned declarative schema with a Trust-On-First-Use prompt on first run (#1147)
+  - Replaces ad-hoc artifact JSON with a typed config
+  - Adds a `agor_artifacts_*` review surface before code runs
+- **`POST /tasks/:id/run` REST endpoint** — pure-REST trigger for harnesses that don't want to manage WebSocket lifecycle (#1145)
+- **MCP `agor_environment_set` + `variant` on `agor_worktrees_create`** — agents can now set env command variants from `.agor.yml` and pick variants at worktree creation (#1146)
+- **Modifier-scroll canvas zoom** — Cmd/Ctrl-scroll zooms the board canvas (#1124)
+- **Promote MCP servers to first-class field in NewSessionModal** — pick MCP servers when creating a session, not after (#1120)
+- **Session drawer improvements** — sort, timestamps, repo pill, status column (#1112)
+- **Admin edit shortcut on MCP pill + restructured edit modal** — faster admin path to fix MCP config (#1123)
+- **Copilot model picker** — static + dynamic `listModels`, bumps the `AskUserQuestion` timeout to match (#1137)
+- **`agor_repos_update` MCP tool + surface clone failures** (#1155)
+- **Onboarding wizard "all five asks"** — covers repo, env, MCP, model, and assistant in one pass (precursor to the 0.19 streamlining) (#1168)
+
+### Fixes
+- **Stop cross-tool spawn from inheriting parent's model** — spawning Codex from a Claude session no longer attempts to use a Claude model id (#1142)
+- **Skip sudo wrap for git ops in simple/no-RBAC mode** — eliminates sudo prompts when isolation is off (closes #1140) (#1144)
+- **Pin user-supplied `default_branch` end-to-end** — typed `sourceBranch` no longer reset by incoming WebSocket events (#1127)
+- **Unbreak ChatGPT subscription auth for Codex** — remove per-session `CODEX_HOME` so the SDK can find the existing auth (#1136)
+- **`Session Archived` toast theme + normalize toast patterns** (#1139)
+- **Stop pinned worktrees from piling at origin on board load** (#1121)
+- **Permission mode label in session settings** — formalizes the `iconOnly` prop on the picker (#1108)
+- **Suppress noisy SDK `system/status: requesting` lifecycle messages** (#1116)
+- **`use asUser=undefined` for `repo.clone` and `worktree.add`** — avoid impersonation for executor lifecycle operations that need daemon identity (#1141)
+- **Onboarding: unbreak SSH-configured users + surface clone failures** (#1165)
+- **Quick Start regressions** — fix solo mode and `/ui` mount (#1153)
+- **Stop duplicate "User updated" toast on onboarding skip** (#1149)
+- **MCP test connection** — resolve `user.env` templates before testing (#1151)
+- **Logs modal React #130 crash** — unwrap the `ansi-to-react` double-default (#1152)
+- **Artifacts on Postgres** — persist `files`/`deps` via canonical `t.json<T>` (#1160)
+- **Artifacts on Vite** — use the `REACT_APP_` prefix for sandpack-react's CRA templates (#1161)
+
+### Security
+- **Move Handlebars rendering to the daemon, drop `unsafe-eval`** — the UI's CSP no longer needs the `unsafe-eval` escape hatch (#1115)
+
+### Breaking
+- **Anonymous mode deprecated** — config warnings now fire when anonymous-mode keys are present (precursor to the 0.19 removal)
+
+### Chores
+- **Remove Codespaces / devcontainer support** — unused; reduces surface area (#1113)
+- **Bump Claude Code + Codex SDKs and CLIs to latest** (#1114)
+- **Migrate off deprecated AntD `<List>`** (#1117)
+- **Expand `agor_proxies_list` description** for artifact-authoring agents (#1110)
+- **Dependabot consolidation** — `pnpm/action-setup` 4→6 (#1130), `actions/checkout` 4→6 (#1129), `actions/upload-pages-artifact` 3→5 (#1128), `next` 14→15 (#959), core-runtime group bump (#1131)
+
+## 0.17.4 (2026-05-06)
+
+### Fixes
+- **Repair WebSocket reconnect** — fixes a regression where the UI got stuck in a disconnected state after the daemon restarted; adds an `agor-live` publish smoke-test in CI (#1107)
+- **Allow daemon port in CORS localhost allow-list** — fixes browser-iframe CORS for non-default daemon ports (commit `481b19d1`)
+- **MCP server pill stays "connected" after OAuth revocation** — surface revoked state immediately (#1101)
+- **Clear DCR cache on disconnect + optimistic UI token strip** — fixes ghost-authenticated MCP servers (#1102)
+- **Strip `accept-encoding` from proxy** — stops double-handling of gzip when the daemon proxies an upstream (#1104)
+- **Zone trigger dialog renders interpolated template** — was showing raw `{{ }}` placeholders to users (#1090, #1096)
+- **MCP OAuth token expiry resolution cascade** + research doc capturing the bug (#1092)
+- **Register custom client RPC methods on Socket.io proxy** — methods declared on the client SDK now actually reach the daemon (#1091)
+- **Per-user impersonated clone & credential plumbing in strict mode** (#1088)
+- **Refresh MCP auth state in real-time after OAuth re-auth** (#1086)
+
+### Features
+- **YAML-driven API proxy for artifacts** — artifacts can declare upstream APIs in `.agor.yml` and call them without CORS hassles (#1089)
+- **Render `{{ agor.token }}` for artifact daemon auth** — artifacts can authenticate to the daemon using a templated token (#1100)
+
+### Security / Internal
+- **Replace `credential.helper` with env-var `http.extraheader` for impersonated clone** — avoids writing credentials to disk during cloning (#1103)
+- **Allow simple-git `credential.helper` for impersonated clone** — companion fix for the above transition (#1099)
+- **Use base URL origin for artifact proxy template var** (#1098)
+
+### Chores / Performance
+- **Cut board re-renders on socket traffic** (#1095)
+- **Re-enable `@agor/core` tests in CI** (#1094)
+- **Bump vite 7.3.2 → 8.0.10 (and plugin-react 5 → 6)** (#1105)
+- **Bump uuid 11 → 14** (#1097)
+
+## 0.17.3 (2026-05-04)
+
+### Features
+- **Per-user custom OpenAI-compatible Codex endpoint** — each user can point Codex at their own OpenAI-compatible endpoint (#1087)
+- **Per-tool credential storage** — UI for storing per-SDK credentials separately, with runtime scoping; lays groundwork for tighter credential isolation (#1077)
+- **MCP OAuth 2.1 full discovery** — `.well-known` discovery + Dynamic Client Registration (#1078)
+- **Disconnected-state UX chokepoint** — single, friendly screen when the daemon socket drops, instead of scattered error states (#1070)
+- **`agor_models_list` MCP tool + accept `model` as string in `sessions.create`** (#1066)
+- **Daemon-owned user-message + task-centric queue** — "never lose a prompt": typed prompts persist server-side and reattach across reconnects (#1068)
+
+### Fixes
+- **`fix(scheduler): stop clobbering saved permission_mode on mount`** (#1085)
+- **Correct MCP OAuth status display for expired tokens** (#1084)
+- **Centralize session config defaults so dragged sessions don't hang** (closes #1064) (#1082)
+- **Restore `AskUserQuestion` widget rendering in chat pane** (#1073) — later superseded by the 0.19 disable, but kept the widget functional in 0.17.3
+- **Password-change-required redirect flow + dev-env UID/GID pin** (#1074)
+- **Prevent OOM during build** (closes #932) (#1075)
+
+### Chores
+- **Support Node 24 LTS / 25** (closes #278) (#1076)
+- **Big-bang deps bump** (consolidates dependabot PRs) (#1083)
+- **Audit and trim stale `context/` docs** (#1081)
+- **Consolidate AntD `ConfigProvider` to single root** (#1071)
+- **Restructure guide IA around features-first navigation** (#1072)
+- **Messaging & positioning doc** (#1080)
+
+## 0.17.2 (2026-04-24)
+
+### Fixes
+- **Repair `agor-live@0.17.1` publishing** — rewrite `workspace:*` refs at publish time so the npm-published `agor-live` resolves correctly (#1067)
+- **Harden auth reconnect + token-refresh state machine** — fixes recurring `jwt expired` errors and reconnect deadlocks (#1065)
+- **Onboarding wizard infinite spinner + repo matching bugs** (#1062)
+
+### Chores
+- **Drop `pnpm-pack` workspace:* guard** (commit `a52527ea`) — companion to the publish-time rewrite above
+
+## 0.17.1 (2026-04-23)
+
+### Features
+- **Frontend/backend version-sync banner** — warn users when the served UI and daemon disagree on version (#1060)
+- **GPT-5.5 support** — bump Codex CLI + OpenAI SDK + model list (#1059)
+
+### Fixes
+- **Audio settings** — minimum duration persists, chimes play again after settings save (#1061)
+- **Recurring `jwt expired` errors** — dynamic refresh + 401 retry on the UI's auth fetch layer (#1058)
+- **Accept `modelConfig` at session create/spawn + surface MCP attach errors** (#1056)
+
+## 0.17.0 (2026-04-23)
+
+### Features
+- **Effort level replaces thinking mode + 1M-context models** — exposes Claude's `output_config.effort` (`low`/`medium`/`high`/`max`) and the `[1m]` model suffix that opts into the 1M-token context window (#985)
+- **`stateless_fs_mode` for headless k8s deployments** — daemon can run with no persistent FS state for ephemeral container deployments (#982)
+- **Env command variants (`.agor.yml` v2)** — define multiple named environment variants per repo and pick one at worktree creation (#1042)
+- **Per-session env-var scope selection** (v0.5 env-var-access model) (#1032)
+- **Configurable CSP + CORS** — with sandpack-friendly defaults; tunable from `security.csp` / `security.cors` in `config.yaml` (#1031)
+- **Scheduler "execute now" trigger + `allow_concurrent_runs`** (#1030, closes #999)
+- **Leaderboard model/tool dimensions** — split tokens, time bucketing, per-model breakdown (#1024)
+- **Capture Sandpack bundler/runtime errors in artifact status** — bundler errors surface in the artifact card instead of failing silently (#1011)
+- **Allow members to use the web terminal via config flag** (`execution.allow_web_terminal`) (#1006)
+- **Custom CSS animations support on boards** (#997)
+- **MCP `agor_artifacts_update` and `agor_artifacts_land`** (#1052)
+- **OAuth 2.1 MCP token refresh** — just-in-time refresh + UI force-refresh (#1047)
+- **POST `/authentication/impersonate` endpoint** — superadmin impersonation for support workflows (#983)
+- **Improved sync-unix admin command** — restore, cleanup, status-fix, plus `--worktree-id` flag (#993, #994)
+- **Show command in Bash tool header + expanded code block** (#991)
+
+### Fixes
+- **Inherit `permission_config` and `model_config` in session fork/btw** (#989, #1004)
+- **Fail fast on worktree name collisions** — surface clear creation errors (#998)
+- **`btw` ephemeral tag** no longer wraps onto multiple lines (#1003)
+- **Worktree directory** — fully remove on archive-delete and recreate on unarchive (#986)
+- **Use `realpathSync` in delete-directory safety checks** — follow symlinks (#988)
+- **Grant superadmins full worktree access** (#992)
+- **Skip user impersonation for worktree lifecycle executor operations** (#990)
+- **CSS-in-JS style loss on archive** — eliminate two-phase unmount (#1007)
+- **Custom CSS clearing, specificity, and form state** (#1002, #995)
+- **Worktree list filter dropdown** loading forever for `All`/`Archived` (#996)
+- **Confirmation modal when archiving session** from hover button (#1000)
+- **Prevent duplicate queued prompts in conversation panel** (#984)
+- **Prevent expensive re-renders on prompt input keystrokes** (#981)
+- **Prevent CSS breakage when closing the session panel** (#980)
+- **Handle archived object state + unarchive board placement recovery** (#979)
+- **Add Vertex AI and Bedrock env vars to executor allowlist** (#1005)
+- **Native emoji style so picker works under default CSP** (#1055)
+- **Cramped inline edit in Settings → Env Vars** (#1054)
+- **Bump session/board URL short IDs from 8 to 16 chars** — reduces collision risk for long-running deployments (#1053)
+- **`.agor.yml` import**: replace (not merge) environment to avoid stale leftover keys (#1051)
+- **CodePreviewModal YAML staircase rendering** (#1050)
+- **Preserve typed prompt on fork/spawn failure + surface executor errors** (#1048)
+- **Require public base URL for OAuth callback** — no localhost fallback in production (#1045)
+- **`agor daemon start` fails fast on pending migrations** (#1044)
+- **`@agor-live/client` pack validation false positives** on JSDoc `@agor/core` mentions (#1043)
+- **Show stopped/unknown todo items when parent task is no longer running** (#1033)
+- **Collapse tool bodies by default, keep Write expanded** (#1028)
+- **Bash ToolBlock command overflow** (#1021)
+- **Make all ToolBlocks expanded by default** (#1013)
+- **Upload uses worktree RBAC instead of session ownership** (#1010)
+- **Deterministic sync-unix with repo-root perms and error surfacing** (#1008)
+
+### Security
+- **Web-hardening pack** — CORS, CSP, upload limits, JWT, trust-proxy (#1027)
+- **Auth/route hardening** — GitHub setup state-nonce + MCP header-only auth (#1026)
+- **Harden executor/git/unix input validation** (#1025)
+- **Scope `find()` queries by worktree RBAC** (#1016)
+- **Stop leaking secrets via sudo argv and startup logs** (#1015)
+- **Pin transitive CVEs via pnpm.overrides + CI audit gate** (#1014)
+- **Session-identity hardening** — Chain D + `created_by` trust (#1037)
+- **Authenticate `terminal:*` WebSocket events** (#1036)
+- **Internal MCP session tokens** — add `jti` + `exp` (#1039)
+- **Env command hardening** — deny-list, audit log, role gate, shell-mode fix (#1034)
+
+### Chores
+- **Bump Claude Code CLI to 2.1.112 / Agent SDK to 0.2.112** (#1012)
+- **Parallelize CI workflow into independent jobs** (#1009)
+- **Un-hide `@agor/core` + `@agor/executor` in CI** and fix pre-existing rot (#1035)
+
+## 0.16.5 (2026-04-12)
+
+### Fixes
+- **Correct Codex context-window computation** — was undercounting tokens (#970)
+- **Build `@agor-live/client` before CLI** to resolve DTS errors during install (#971)
+- **Restore standalone `@agor-live/client` packaging** — fixes a regression in 0.16.4's published artifact (#972)
+
+### Chores
+- **Bulk-bump core deps + rework dependabot config** (#973)
+
+## 0.16.4 (2026-04-12)
+
+### Features
+- **Config-aware `agor daemon start` CLI command** — reads `config.yaml` for daemon port/host (#961)
+- **Reactive session API dogfooding** in `@agor-live/client` — public API for streaming session state (#968)
+
+### Fixes
+- **Codex `edit_files` diff** — use per-invocation pre/post snapshots so concurrent edits don't pollute each other (#965)
+- **`ERR_STRING_TOO_LONG` in agor daemon logs** — avoid concatenating gigantic strings into the logger (#967)
+
+### Chores
+- **Migrate `agor-ui` to `@agor-live/client` daemon surface** — UI now consumes the published client package instead of a direct daemon import (#969)
+
+## 0.16.3 (2026-04-11)
+
+### Features
+- **Codex event visibility + tool telemetry parity** — Codex sessions now surface the same per-tool telemetry events as Claude (#964)
+- **API client quick wins** — typed `prompt` helper, `findAll`, auth user typing, UUID input ergonomics (#962)
+
+### Fixes
+- **Codex `edit_files` diff mapping** — show true before/after instead of cumulative state (#963)
+
+## 0.16.2 (2026-04-11)
+
+### Features
+- **Decouple artifacts from worktrees + DB serialization** — artifacts become first-class entities, persisted directly to the database rather than tied to a worktree's filesystem (#918)
+- **Rich diff viewer for Edit/Write tool results** — Monaco-style diff rendering with collapse/expand (#917)
+- **Self-hosted Sandpack bundler** — point artifacts at a private-network bundler for air-gapped deployments (#914)
+- **CORS for Sandpack / CodeSandbox artifact origins** (#926)
+- **`btw` ephemeral fork mode + fork-while-running + `callbackMode`** — spawn a "by-the-way" exploratory fork without disturbing the parent, with optional callback when it completes (#953)
+- **Gateway context injection for Slack and GitHub** — pass channel/issue context into the agent prompt automatically (#931)
+- **Environment variables in gateway channel config** — per-channel env vars for gateway-spawned sessions (#929)
+- **`session` tier in worktree RBAC `others_can`** — safe default that lets collaborators create their own sessions without impersonating other users' OS identity (#951)
+- **Pre-registered OAuth client support** (e.g. Figma) — works with MCP servers that don't do DCR (#943)
+- **Four-tier service config + conditional registration + UI gating** — feature flags now drive both daemon service registration and UI affordances (#958)
+- **Declarative daemon resources config + sync command** — config-as-code for users, repos, boards, etc. (#957)
+- **Tool block UX improvements** — better headers, copy buttons, collapse states (#919)
+- **MCP `agor_artifacts_get`** (#920)
+- **MCP `agor_sessions_stop`** (#956)
+- **Expose RBAC fields in MCP worktree create/update tools** (#937)
+
+### Fixes
+- **Concurrent tool calls incorrectly shown as timed out** — timeout state was applied to the wrong invocation (#925)
+- **Force Sandpack remount on artifact content change** — stale iframe state (#928)
+- **Persist artifact position on board after drag** (#924)
+- **Artifact delete emits removed event + throttle console reporter** (#923)
+- **Artifacts settings table crash on null `worktree_id`** (#922)
+- **Expose `use_local_bundler` option on the publish MCP tool** (#921)
+- **Sandpack build yarn collision + Parcel asset paths** (#915)
+- **Smart default worktree placement** — use median of existing entities instead of a fixed offset (#916)
+- **Blockquote syntax for gateway context** — fixes Slack markdown rendering (#934)
+- **Thinking-block collapsed preview** — full-content ellipsis instead of mid-word cut (#935)
+- **Short-ID prefixes resolved consistently across all MCP tools** (#944)
+- **Handle double-serialized arguments in `agor_execute_tool`** — MCP clients that double-encode JSON now work (#940)
+- **MCP OAuth: resource metadata** — handle servers that omit `resource_metadata` in `WWW-Authenticate` (#938)
+- **MCP OAuth: don't pass resource-metadata scopes for pre-registered clients** (#945)
+- **MCP OAuth: remove automatic prompt interception** — explicit user action only (#942)
+- **MCP auth status lookup uses exact case-insensitive match** (#952)
+- **Perf: optimize attention-glow effect on worktree cards** — measurable frame-time win on busy boards (#955)
+
+### Chores
+- **Bump Codex to GPT-5.4 and Codex SDK to 0.118.0** (#941)
 
 ## 0.16.1 (2026-04-04)
 


### PR DESCRIPTION
## Summary

The root `CHANGELOG.md` was six weeks stale (last entry: `0.16.1`, 2026-04-04) and the single `Unreleased` bullet describing the `AskUserQuestion` fix was a ~250-word wall of text. This PR:

- **Backfills every missing version** from PR history: `0.16.2`, `0.16.3`, `0.16.4`, `0.16.5`, `0.17.0`, `0.17.1`, `0.17.2`, `0.17.3`, `0.17.4`, `0.18.0`, and `0.19.0`. Each section dated by the first appearance of that version on `origin/main`.
- **Documents the style at the top** so future maintainers (and agents) follow the same pattern — section labels (Features / Fixes / Security / Breaking / Chores), bold-headline entry pattern, sub-bullet rule for entries needing more than two sentences.
- **Reformats the `Unreleased` wall-of-text** into a crisp headline + three sub-bullets, and moves it into `0.19.0` since it shipped in #1181.
- **Preserves `0.16.1` and below** substantively per the task's hard rule (only the top-level structure changed; older entries untouched).

PR numbers were sourced from merged-commit messages on `origin/main`, and a sample of 11 (#1188, #1147, #1107, #1087, #1067, #1056, #985, #918, #953, #1157, #1154) were spot-checked against `gh pr view`. Dependabot version-bump PRs and trivial CI tweaks were skipped unless user-visible.

## Coordination

`0.19.0` shipped earlier today (#1190), so this changelog includes a `0.19.0` section. The `Unreleased` section is now empty.

## Test plan
- [ ] Render the top of `CHANGELOG.md` on GitHub and confirm the Style section + the first two version sections read cleanly
- [ ] Spot-check 5+ PR numbers in older backfilled sections against the merged PRs
- [ ] Confirm sections are in descending semver order with consistent date format

🤖 Generated with [Claude Code](https://claude.com/claude-code)