### PR TITLE
fix(ui): clicking 'Untrusted' artifact badge opens consent modal

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -586,7 +586,9 @@ export const ArtifactNode = ({
       ? 'processing'
       : 'success';
   const headerBadgeTitle = error ? 'Failed to load' : loading ? 'Reloading...' : 'Live';
-  const trustBadge = payload ? renderTrustBadge(payload) : null;
+  const trustBadge = payload
+    ? renderTrustBadge(payload, () => setConsentOpen(true))
+    : null;
   // A loaded payload that's also in the error state is stale — the body
   // renders the error placeholder, so the header shouldn't expose
   // payload-acting controls (Export / Interact / Consent) that operate
@@ -919,7 +921,7 @@ export const ArtifactNode = ({
   );
 };
 
-function renderTrustBadge(payload: ArtifactPayload) {
+function renderTrustBadge(payload: ArtifactPayload, onTrustClick?: () => void) {
   const state = payload.trust_state;
   if (state === 'no_secrets_needed') return null;
   if (state === 'self') {
@@ -946,10 +948,31 @@ function renderTrustBadge(payload: ArtifactPayload) {
       </Tooltip>
     );
   }
-  // 'untrusted'
+  // 'untrusted' — the badge itself is the affordance. `nodrag nopan` is
+  // required because React Flow's drag handler arms on mousedown at the
+  // parent node level, which would swallow the click before onClick fires
+  // (stopPropagation on click is too late, same gotcha as the controls
+  // row above).
   return (
-    <Tooltip title="Render is missing secrets — click the lock icon to grant trust">
-      <Tag color="orange" icon={<LockOutlined />} style={{ fontSize: 10, marginLeft: 4 }}>
+    <Tooltip title="Click to review and grant trust so secrets are injected">
+      <Tag
+        color="orange"
+        icon={<LockOutlined />}
+        className={onTrustClick ? 'nodrag nopan' : undefined}
+        style={{
+          fontSize: 10,
+          marginLeft: 4,
+          cursor: onTrustClick ? 'pointer' : undefined,
+        }}
+        onClick={
+          onTrustClick
+            ? (e) => {
+                e.stopPropagation();
+                onTrustClick();
+              }
+            : undefined
+        }
+      >
         Untrusted
       </Tag>
     </Tooltip>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -586,9 +586,7 @@ export const ArtifactNode = ({
       ? 'processing'
       : 'success';
   const headerBadgeTitle = error ? 'Failed to load' : loading ? 'Reloading...' : 'Live';
-  const trustBadge = payload
-    ? renderTrustBadge(payload, () => setConsentOpen(true))
-    : null;
+  const trustBadge = payload ? renderTrustBadge(payload, () => setConsentOpen(true)) : null;
   // A loaded payload that's also in the error state is stale — the body
   // renders the error placeholder, so the header shouldn't expose
   // payload-acting controls (Export / Interact / Consent) that operate


### PR DESCRIPTION
## Summary

The orange **Untrusted** badge in the artifact card header advertised *"click the lock icon to grant trust"* but the `<Tag>` itself had no `onClick`. Users naturally clicked the prominent badge and nothing happened. The actual clickable lock `<Button>` lives in the controls row to the right and is easy to miss — and the badge sits in the title area, outside the `nodrag nopan` wrapper, so even adding a handler would lose mousedown to React Flow's canvas-drag.

This PR makes the badge itself the affordance:

- `renderTrustBadge` now takes an optional `onTrustClick` callback
- The `'untrusted'` Tag gets `onClick`, `cursor: pointer`, and `className="nodrag nopan"`
- Tooltip simplified to "Click to review and grant trust so secrets are injected"
- The existing standalone lock `<Button>` in the controls row is left untouched (redundancy is harmless and removing it would be a bigger UX change)
- No data-model or API changes

## Out of scope (originally bundled, now split out)

The branch was originally scoped for three changes; the other two are deferred to follow-ups because they need design decisions:

1. **CodeSandbox VM/Devbox export** — turns out CodeSandbox's [Define API](https://codesandbox.io/docs/learn/browser-sandboxes/cli-api) (the form-POST endpoint we use) only creates browser sandboxes. VM/Devbox creation needs the [CodeSandbox SDK](https://codesandbox.io/sdk) server-side with an API token, which is a daemon-layer refactor — not a one-parameter swap. See [discussion #8454](https://github.com/codesandbox/codesandbox-client/discussions/8454).
2. **Generic export dropdown (StackBlitz / .zip / Gist)** — the data model (`files` + `package.json` deps + `required_env_vars`) is already destination-neutral. Only the `template` name needs per-destination translation. Worth doing as its own PR with its own UI iteration.

## Test plan

- [ ] Open a board with an untrusted artifact (one that declares `required_env_vars` or `agor_grants` and was published by another user)
- [ ] Click the orange **Untrusted** badge in the card header → consent modal opens
- [ ] Grant trust → modal closes, payload refetches, badge becomes green **Trusted**
- [ ] Drag the artifact card by an empty area of the header → card still drags (no regression from the `nodrag nopan` class on the badge)
- [ ] Click the standalone lock `<Button>` in the controls row → still opens the modal (existing path)
- [ ] Verify the `'self'`, `'trusted'`, `'no_secrets_needed'` badge states render unchanged (no click affordance — only `'untrusted'` is interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)