### PR TITLE
fix(ui): require confirmation on nuke environment + unify the dialog

### DIFF
--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -10,7 +10,8 @@ import {
   StopOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { App, Button, Space, Spin, Tooltip, theme } from 'antd';
+import { Button, Space, Spin, Tooltip, theme } from 'antd';
+import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
@@ -37,7 +38,7 @@ export function EnvironmentPill({
   connectionDisabled = false,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
-  const { modal } = App.useApp();
+  const confirmNuke = useConfirmNukeEnvironment();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = worktree.environment_instance;
@@ -324,18 +325,11 @@ export function EnvironmentPill({
                   type="text"
                   size="small"
                   danger
+                  aria-label="Nuke environment"
                   icon={<FireOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
-                    modal.confirm({
-                      title: 'Nuke environment?',
-                      content:
-                        'This will stop the environment and DELETE all its volumes. Any data not committed/pushed will be lost.',
-                      okText: 'Nuke',
-                      okType: 'danger',
-                      cancelText: 'Cancel',
-                      onOk: () => onNukeEnvironment(worktree.worktree_id),
-                    });
+                    confirmNuke(() => onNukeEnvironment(worktree.worktree_id));
                   }}
                   disabled={connectionDisabled}
                   style={{

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -10,7 +10,7 @@ import {
   StopOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Space, Spin, Tooltip, theme } from 'antd';
+import { App, Button, Space, Spin, Tooltip, theme } from 'antd';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
@@ -37,6 +37,7 @@ export function EnvironmentPill({
   connectionDisabled = false,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
+  const { modal } = App.useApp();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = worktree.environment_instance;
@@ -326,7 +327,15 @@ export function EnvironmentPill({
                   icon={<FireOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
-                    onNukeEnvironment(worktree.worktree_id);
+                    modal.confirm({
+                      title: 'Nuke environment?',
+                      content:
+                        'This will stop the environment and DELETE all its volumes. Any data not committed/pushed will be lost.',
+                      okText: 'Nuke',
+                      okType: 'danger',
+                      cancelText: 'Cancel',
+                      onOk: () => onNukeEnvironment(worktree.worktree_id),
+                    });
                   }}
                   disabled={connectionDisabled}
                   style={{

--- a/apps/agor-ui/src/components/WorktreeHeaderPill/WorktreeHeaderPill.tsx
+++ b/apps/agor-ui/src/components/WorktreeHeaderPill/WorktreeHeaderPill.tsx
@@ -15,7 +15,8 @@ import {
   TeamOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { App, Button, Spin, Tooltip, theme } from 'antd';
+import { Button, Spin, Tooltip, theme } from 'antd';
+import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
@@ -54,7 +55,7 @@ export function WorktreeHeaderPill({
   connectionDisabled = false,
 }: WorktreeHeaderPillProps) {
   const { token } = theme.useToken();
-  const { modal } = App.useApp();
+  const confirmNuke = useConfirmNukeEnvironment();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = worktree.environment_instance;
@@ -318,15 +319,7 @@ export function WorktreeHeaderPill({
                   icon={<FireOutlined />}
                   onClick={(e) => {
                     e.stopPropagation();
-                    modal.confirm({
-                      title: 'Nuke environment?',
-                      content:
-                        'This will stop the environment and DELETE all its volumes. Any data not committed/pushed will be lost.',
-                      okText: 'Nuke',
-                      okType: 'danger',
-                      cancelText: 'Cancel',
-                      onOk: () => onNukeEnvironment(worktree.worktree_id),
-                    });
+                    confirmNuke(() => onNukeEnvironment(worktree.worktree_id));
                   }}
                   disabled={connectionDisabled}
                   style={iconButtonStyle}

--- a/apps/agor-ui/src/components/WorktreeHeaderPill/WorktreeHeaderPill.tsx
+++ b/apps/agor-ui/src/components/WorktreeHeaderPill/WorktreeHeaderPill.tsx
@@ -15,7 +15,7 @@ import {
   TeamOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Spin, Tooltip, theme } from 'antd';
+import { App, Button, Spin, Tooltip, theme } from 'antd';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
@@ -54,6 +54,7 @@ export function WorktreeHeaderPill({
   connectionDisabled = false,
 }: WorktreeHeaderPillProps) {
   const { token } = theme.useToken();
+  const { modal } = App.useApp();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = worktree.environment_instance;
@@ -317,7 +318,15 @@ export function WorktreeHeaderPill({
                   icon={<FireOutlined />}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onNukeEnvironment(worktree.worktree_id);
+                    modal.confirm({
+                      title: 'Nuke environment?',
+                      content:
+                        'This will stop the environment and DELETE all its volumes. Any data not committed/pushed will be lost.',
+                      okText: 'Nuke',
+                      okType: 'danger',
+                      cancelText: 'Cancel',
+                      onOk: () => onNukeEnvironment(worktree.worktree_id),
+                    });
                   }}
                   disabled={connectionDisabled}
                   style={iconButtonStyle}

--- a/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/WorktreeModal/tabs/EnvironmentTab.tsx
@@ -42,6 +42,7 @@ import {
 import { Alert, Button, Card, Select, Space, Spin, Tag, Tooltip, Typography, theme } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAuthConfig } from '../../../hooks/useAuthConfig';
+import { useConfirmNukeEnvironment } from '../../../hooks/useConfirmNukeEnvironment';
 import { usePermissions } from '../../../hooks/usePermissions';
 import {
   getEnvironmentState,
@@ -105,6 +106,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
   const { confirm } = useThemedModal();
+  const confirmNuke = useConfirmNukeEnvironment();
   const { isAdmin, hasRole } = usePermissions();
   const { featuresConfig } = useAuthConfig();
 
@@ -244,32 +246,16 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
   };
   const handleNuke = () => {
     if (!client) return;
-    confirm({
-      title: 'Nuke Environment?',
-      icon: <FireOutlined style={{ color: '#ff4d4f' }} />,
-      content: (
-        <div>
-          <p>
-            <strong>This is a destructive operation!</strong>
-          </p>
-          <p>This will typically remove all volumes, data, and state for this environment.</p>
-          <p>Are you sure you want to proceed?</p>
-        </div>
-      ),
-      okText: 'Yes, Nuke It',
-      okType: 'danger',
-      cancelText: 'Cancel',
-      onOk: async () => {
-        setIsNuking(true);
-        try {
-          await client.service(`worktrees/${worktree.worktree_id}/nuke`).create({});
-          showSuccess('Environment nuked successfully');
-        } catch (error) {
-          showError(error instanceof Error ? error.message : 'Failed to nuke environment');
-        } finally {
-          setIsNuking(false);
-        }
-      },
+    confirmNuke(async () => {
+      setIsNuking(true);
+      try {
+        await client.service(`worktrees/${worktree.worktree_id}/nuke`).create({});
+        showSuccess('Environment nuked successfully');
+      } catch (error) {
+        showError(error instanceof Error ? error.message : 'Failed to nuke environment');
+      } finally {
+        setIsNuking(false);
+      }
     });
   };
 

--- a/apps/agor-ui/src/hooks/index.ts
+++ b/apps/agor-ui/src/hooks/index.ts
@@ -11,6 +11,7 @@ export * from './useAgorData';
 export * from './useAuth';
 export * from './useAuthConfig';
 export * from './useBoardActions';
+export * from './useConfirmNukeEnvironment';
 export * from './useInitialLoaderPhase';
 export * from './useLocalStorage';
 export * from './useMessages';

--- a/apps/agor-ui/src/hooks/useConfirmNukeEnvironment.tsx
+++ b/apps/agor-ui/src/hooks/useConfirmNukeEnvironment.tsx
@@ -1,0 +1,35 @@
+import { FireOutlined } from '@ant-design/icons';
+import { theme } from 'antd';
+import { useThemedModal } from '../utils/modal';
+
+/**
+ * Single source of truth for the "nuke environment" confirmation dialog.
+ * Callers (EnvironmentPill, WorktreeHeaderPill, EnvironmentTab) must use
+ * this so the destructive copy and button styling stay consistent.
+ */
+export function useConfirmNukeEnvironment() {
+  const { confirm } = useThemedModal();
+  const { token } = theme.useToken();
+
+  return (onConfirm: () => void | Promise<void>) =>
+    confirm({
+      title: 'Nuke environment?',
+      icon: <FireOutlined style={{ color: token.colorError }} />,
+      content: (
+        <>
+          <p>
+            <strong>This is a destructive operation.</strong>
+          </p>
+          <p>
+            This typically removes all Docker volumes, databases, and other environment state.
+            Source files in the worktree are not deleted, but anything stored inside containers or
+            volumes may be lost.
+          </p>
+        </>
+      ),
+      okText: 'Nuke environment',
+      okType: 'danger',
+      cancelText: 'Cancel',
+      onOk: onConfirm,
+    });
+}


### PR DESCRIPTION
## Summary

The nuke button on `EnvironmentPill` and `WorktreeHeaderPill` previously fired the destructive action on a single click — one mis-click wiped the environment and all its volumes.

Initial fix: wrapped both onClick handlers in `Modal.confirm`.

After review (thanks Codex subsession), expanded scope to address an existing DRY issue: a **third** nuke-confirm already lived in `EnvironmentTab.tsx` with drifted copy ("Yes, Nuke It" vs "Nuke", different titles, different body text). Extracted everything into one `useConfirmNukeEnvironment()` hook so the destructive copy lives in exactly one place. Also:
- fixed misleading body copy that implied source-file loss (nuke only wipes Docker volumes, not the worktree files)
- routed the hook through the canonical `useThemedModal()` helper
- added the missing `aria-label="Nuke environment"` on `EnvironmentPill`'s nuke button (`WorktreeHeaderPill` already had one)

### Before
- Click 🔥 → environment nuked immediately (pills)
- Three drifted dialog implementations across pills + EnvironmentTab

### After
- Click 🔥 → identical themed modal everywhere:
  - Title: *"Nuke environment?"*
  - Body: *"This is a destructive operation. This typically removes all Docker volumes, databases, and other environment state. Source files in the worktree are not deleted, but anything stored inside containers or volumes may be lost."*
  - Buttons: `[Cancel]` `[Nuke environment]` (danger/red)
  - Esc cancels, Enter confirms

## Test plan
- [ ] Click nuke on a worktree card env pill → dialog appears, Cancel does nothing
- [ ] Click nuke → Confirm → env nukes as before
- [ ] Same on the worktree header pill (WorktreeModal)
- [ ] Same on the Environment tab inside WorktreeModal
- [ ] Dialog renders correctly in both light and dark themes (uses `token.colorError`)
- [ ] Other destructive actions (archive session, archive/delete worktree) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
