### PR TITLE
feat(defaults): relax Codex/Claude permission defaults for Agor's MCP-heavy model

### DIFF
--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -119,9 +119,9 @@ describe('applySessionConfigDefaults', () => {
       users: { [ALICE]: { user_id: ALICE } },
     });
     await hook(ctx);
-    // System default for claude-code is 'acceptEdits'
+    // System default for claude-code is 'bypassPermissions'
     expect((ctx.data as { permission_config: { mode: string } }).permission_config.mode).toBe(
-      'acceptEdits'
+      'bypassPermissions'
     );
   });
 
@@ -174,7 +174,7 @@ describe('applySessionConfigDefaults', () => {
     await hook(ctx);
     // System default for claude-code
     expect((ctx.data as { permission_config: { mode: string } }).permission_config.mode).toBe(
-      'acceptEdits'
+      'bypassPermissions'
     );
   });
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1377,50 +1377,87 @@ export function OnboardingWizard({
     // e.g. the user already ran `claude auth login` outside the wizard.
     const isAuthenticated = hasKey || !!testAuthResult?.authenticated;
 
+    // Surfaces Agor's relaxed permission defaults so users see what they're
+    // agreeing to during onboarding instead of discovering it via behavior.
+    // Defense-in-depth comes from the worktree sandbox + (optional) Unix
+    // impersonation, not from per-call prompts in an MCP-heavy session.
+    const renderSecurityDefaultsNote = (tool: 'claude-code' | 'codex') => {
+      const description =
+        tool === 'claude-code' ? (
+          <span>
+            New sessions run in <Text strong>bypassPermissions</Text> mode — Claude won't prompt for
+            each file edit or tool call. Safety comes from Agor's worktree sandbox; you can tighten
+            per session in <Text strong>Session Settings</Text>.
+          </span>
+        ) : (
+          <span>
+            New sessions run as <Text strong>workspace-write</Text> + approval{' '}
+            <Text strong>never</Text> with network access on — Codex won't prompt for each action.
+            Safety comes from Agor's worktree sandbox; you can tighten per session in{' '}
+            <Text strong>Session Settings</Text>.
+          </span>
+        );
+      return (
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: 16, textAlign: 'left' }}
+          message="Permission defaults"
+          description={description}
+        />
+      );
+    };
+
     const renderAuthHint = () => {
       if (selectedAgent === 'claude-code') {
         return (
-          <Alert
-            type="info"
-            showIcon
-            style={{ marginBottom: 16, textAlign: 'left' }}
-            description={
-              <span>
-                You have three ways to authenticate Claude Code: paste an{' '}
-                <Text code style={{ fontSize: 12 }}>
-                  ANTHROPIC_API_KEY
-                </Text>{' '}
-                below, run{' '}
-                <Text code style={{ fontSize: 12 }}>
-                  claude auth login
-                </Text>{' '}
-                in the terminal Agor runs as, or set up a Pro/Max session token from{' '}
-                <Text strong>User Settings → Claude Code</Text> (best for Claude subscribers).
-              </span>
-            }
-          />
+          <>
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16, textAlign: 'left' }}
+              description={
+                <span>
+                  You have three ways to authenticate Claude Code: paste an{' '}
+                  <Text code style={{ fontSize: 12 }}>
+                    ANTHROPIC_API_KEY
+                  </Text>{' '}
+                  below, run{' '}
+                  <Text code style={{ fontSize: 12 }}>
+                    claude auth login
+                  </Text>{' '}
+                  in the terminal Agor runs as, or set up a Pro/Max session token from{' '}
+                  <Text strong>User Settings → Claude Code</Text> (best for Claude subscribers).
+                </span>
+              }
+            />
+            {renderSecurityDefaultsNote('claude-code')}
+          </>
         );
       }
       if (selectedAgent === 'codex') {
         return (
-          <Alert
-            type="info"
-            showIcon
-            style={{ marginBottom: 16, textAlign: 'left' }}
-            description={
-              <span>
-                Paste an{' '}
-                <Text code style={{ fontSize: 12 }}>
-                  OPENAI_API_KEY
-                </Text>{' '}
-                below, or authenticate via{' '}
-                <Text code style={{ fontSize: 12 }}>
-                  codex
-                </Text>{' '}
-                in the terminal Agor runs as.
-              </span>
-            }
-          />
+          <>
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16, textAlign: 'left' }}
+              description={
+                <span>
+                  Paste an{' '}
+                  <Text code style={{ fontSize: 12 }}>
+                    OPENAI_API_KEY
+                  </Text>{' '}
+                  below, or authenticate via{' '}
+                  <Text code style={{ fontSize: 12 }}>
+                    codex
+                  </Text>{' '}
+                  in the terminal Agor runs as.
+                </span>
+              }
+            />
+            {renderSecurityDefaultsNote('codex')}
+          </>
         );
       }
       if (AGENT_KEY_CONSOLES[selectedAgent]) {

--- a/packages/core/src/sessions/resolve-child-session-config.test.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.test.ts
@@ -65,14 +65,14 @@ describe('resolveChildSessionConfig', () => {
       expect(r.model_config?.model).toBe('gpt-5.4');
     });
 
-    it('uses mapped codex permission default (auto), not parent acceptEdits', () => {
+    it('uses mapped codex permission default (allow-all), not parent acceptEdits', () => {
       const r = resolveChildSessionConfig({
         parent,
         effectiveTool: 'codex',
         user: makeUser({}),
         now,
       });
-      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.mode).toBe('allow-all');
     });
 
     it('explicit override wins even on cross-tool spawn', () => {
@@ -182,7 +182,7 @@ describe('resolveChildSessionConfig', () => {
         user: null,
         now,
       });
-      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.mode).toBe('allow-all');
     });
   });
 
@@ -236,7 +236,7 @@ describe('resolveChildSessionConfig', () => {
 
     it('cross-tool spawn TO codex with no user default emits no codex sub-config', () => {
       // User has no codex defaults → no sandboxMode + approvalPolicy pair → no sub-config.
-      // The mapped permission mode still resolves (to 'auto').
+      // The mapped permission mode still resolves (to 'allow-all').
       const parent = makeParent({ agentic_tool: 'claude-code' });
       const r = resolveChildSessionConfig({
         parent,
@@ -244,7 +244,7 @@ describe('resolveChildSessionConfig', () => {
         user: makeUser({}),
         now,
       });
-      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.mode).toBe('allow-all');
       expect(r.permission_config.codex).toBeUndefined();
     });
 

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -21,7 +21,7 @@ describe('resolveSessionDefaults', () => {
   describe('permission_config', () => {
     it('falls back to system default when nothing else is set', () => {
       const r = resolveSessionDefaults({ agenticTool: 'claude-code' });
-      expect(r.permission_config).toEqual({ mode: 'acceptEdits' });
+      expect(r.permission_config).toEqual({ mode: 'bypassPermissions' });
     });
 
     it("uses the user's tool default when present", () => {
@@ -190,12 +190,12 @@ describe('resolveSessionDefaults', () => {
     it('cross-tool spawn with no user default for target tool: returns mapped system default permission mode', () => {
       // User has Claude defaults but is spawning a Codex child. There's no
       // codex entry in default_agentic_config, so we should fall back to
-      // codex's system default ('auto'), not to whatever the parent had.
+      // codex's system default ('allow-all'), not to whatever the parent had.
       const r = resolveSessionDefaults({
         agenticTool: 'codex',
         user: makeUser({ 'claude-code': { permissionMode: 'bypassPermissions' } }),
       });
-      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.mode).toBe('allow-all');
     });
 
     it('cross-tool spawn from Claude → Gemini with no user default: returns gemini system default', () => {
@@ -211,7 +211,7 @@ describe('resolveSessionDefaults', () => {
       // lookup fails. Ensure it still returns a populated permission_config.
       const r = resolveSessionDefaults({ agenticTool: 'codex' });
       expect(r.permission_config).toBeDefined();
-      expect(r.permission_config.mode).toBe('auto');
+      expect(r.permission_config.mode).toBe('allow-all');
     });
   });
 

--- a/packages/core/src/types/session.test.ts
+++ b/packages/core/src/types/session.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests for session.ts runtime behavior
  *
- * Each agent now uses its native permission modes:
- * - Claude Code: acceptEdits (auto-accept file edits)
- * - Gemini: autoEdit (native SDK mode)
- * - Codex: auto (auto-approve safe ops)
+ * Defaults are tuned for Agor's MCP-heavy model — the environment-level
+ * sandbox is the defense, not per-call prompts:
+ * - Claude Code: bypassPermissions (no per-call prompts)
+ * - Codex: allow-all (maps to sandbox workspace-write + approval never)
+ * - Gemini: autoEdit (unchanged — pending separate audit)
+ * - OpenCode: autoEdit (unchanged — pending separate audit)
  */
 
 import { describe, expect, it } from 'vitest';
@@ -12,12 +14,12 @@ import type { AgenticToolName } from './agentic-tool';
 import { getDefaultPermissionMode } from './session';
 
 describe('getDefaultPermissionMode', () => {
-  it('returns "auto" for codex (native Codex mode)', () => {
-    expect(getDefaultPermissionMode('codex')).toBe('auto');
+  it('returns "allow-all" for codex (Agor MCP-heavy default)', () => {
+    expect(getDefaultPermissionMode('codex')).toBe('allow-all');
   });
 
-  it('returns "acceptEdits" for claude-code (native Claude mode)', () => {
-    expect(getDefaultPermissionMode('claude-code')).toBe('acceptEdits');
+  it('returns "bypassPermissions" for claude-code (Agor MCP-heavy default)', () => {
+    expect(getDefaultPermissionMode('claude-code')).toBe('bypassPermissions');
   });
 
   it('returns "autoEdit" for gemini (native Gemini mode)', () => {
@@ -28,22 +30,21 @@ describe('getDefaultPermissionMode', () => {
     expect(getDefaultPermissionMode('opencode')).toBe('autoEdit');
   });
 
-  it('returns "acceptEdits" for any unknown tool (default case)', () => {
+  it('returns "bypassPermissions" for any unknown tool (default case)', () => {
     // Type assertion to test default behavior with invalid input
     const unknownTool = 'unknown-tool' as AgenticToolName;
-    expect(getDefaultPermissionMode(unknownTool)).toBe('acceptEdits');
+    expect(getDefaultPermissionMode(unknownTool)).toBe('bypassPermissions');
   });
 
   describe('permission mode characteristics', () => {
-    it('codex uses auto-approve safe operations mode', () => {
-      // Codex-specific behavior: auto-approve safe operations, ask for dangerous ones
+    it('codex maps to sandbox workspace-write + approval never', () => {
       const mode = getDefaultPermissionMode('codex');
-      expect(mode).toBe('auto');
+      expect(mode).toBe('allow-all');
     });
 
-    it('claude-code uses Claude native mode', () => {
+    it('claude-code uses bypass mode for MCP-heavy sessions', () => {
       const mode = getDefaultPermissionMode('claude-code');
-      expect(mode).toBe('acceptEdits');
+      expect(mode).toBe('bypassPermissions');
     });
 
     it('gemini uses native Gemini SDK mode', () => {
@@ -72,9 +73,8 @@ describe('getDefaultPermissionMode', () => {
         results[tool] = getDefaultPermissionMode(tool);
       }
 
-      // Verify expected mappings - each uses its native SDK mode
-      expect(results['claude-code']).toBe('acceptEdits');
-      expect(results.codex).toBe('auto');
+      expect(results['claude-code']).toBe('bypassPermissions');
+      expect(results.codex).toBe('allow-all');
       expect(results.gemini).toBe('autoEdit');
       expect(results.opencode).toBe('autoEdit');
     });

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -84,24 +84,31 @@ export type {
 /**
  * Get the default permission mode for a given agentic tool
  *
- * Returns the native SDK default for each tool:
- * - Claude Code: 'acceptEdits' (auto-accept file edits, prompt for other tools)
- * - Gemini: 'autoEdit' (native ApprovalMode.AUTO_EDIT - auto-approve file edits)
- * - Codex: 'auto' (auto-approve safe operations, ask for dangerous ones)
- * - OpenCode: 'autoEdit' (auto-approve, similar to Gemini)
+ * Claude Code / Codex defaults assume Agor's environment-level sandbox
+ * (worktree FS scoping, Unix impersonation in insulated/strict modes,
+ * executor process isolation) is the actual defense — per-call approval
+ * prompts are friction without benefit in an MCP-heavy session where
+ * every Agor self-call would otherwise gate. Users / parent sessions /
+ * per-session overrides still trump these defaults via resolvePermissionConfig.
+ *
+ * Per tool:
+ * - Claude Code: 'bypassPermissions' (no per-call prompts; sandbox is the defense)
+ * - Codex: 'allow-all' — maps to sandbox `workspace-write` + approval `never`
+ * - Gemini: 'autoEdit' (unchanged — pending separate audit)
+ * - OpenCode: 'autoEdit' (unchanged — pending separate audit)
  */
 export function getDefaultPermissionMode(agenticTool: AgenticToolName): PermissionMode {
   switch (agenticTool) {
     case 'gemini':
       return 'autoEdit'; // Native Gemini SDK mode
     case 'codex':
-      return 'auto'; // Native Codex SDK mode
+      return 'allow-all'; // Maps to Codex sandbox=workspace-write + approval=never
     case 'opencode':
       return 'autoEdit'; // OpenCode auto-approves, similar to Gemini
     case 'copilot':
-      return 'acceptEdits'; // Copilot uses same semantics as Claude Code
+      return 'bypassPermissions'; // Copilot uses same semantics as Claude Code
     default:
-      return 'acceptEdits'; // Claude Code native mode
+      return 'bypassPermissions'; // Claude Code
   }
 }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -841,10 +841,18 @@ export class CodexPromptService {
     // - MCP servers + model_instructions_file: per-Codex-instance via CodexOptions.config
     // ThreadOptions are emitted AFTER `--config` flags, so for keys that overlap
     // (approval_policy, sandbox_workspace_write.network_access) ThreadOptions win.
+    //
+    // System defaults (`never` + `workspace-write` + network on) assume Agor's
+    // environment-level sandbox (worktree FS scoping, Unix impersonation in
+    // insulated/strict modes, executor process isolation) is the actual
+    // defense — per-call approval prompts are friction without benefit in
+    // an MCP-heavy session where every Agor self-call would otherwise gate.
+    // Users / parent sessions / per-session overrides still flow through
+    // resolvePermissionConfig and trump these defaults.
     const codexConfig = session.permission_config?.codex;
     const sandboxMode = codexConfig?.sandboxMode || 'workspace-write';
-    const approvalPolicy = codexConfig?.approvalPolicy || 'on-request';
-    const networkAccess = codexConfig?.networkAccess ?? false;
+    const approvalPolicy = codexConfig?.approvalPolicy || 'never';
+    const networkAccess = codexConfig?.networkAccess ?? true;
 
     console.log(
       `   Using Codex permissions: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}`


### PR DESCRIPTION
## Summary

Agor sessions are MCP-heavy — every session calls Agor's own MCP tools to introspect worktrees, sessions, and boards. Under the conservative SDK defaults, onboarding hit **death-by-modal** (Codex `on-request` gates every Agor MCP call; Claude `acceptEdits` still prompts on Bash + MCP).

This relaxes the system defaults so new users get a working out-of-the-box experience. **Defense-in-depth comes from Agor's environment-level sandbox** (worktree FS scoping, Unix impersonation in `insulated` / `strict` modes, executor process isolation) — not from per-call approval prompts.

## New system defaults

| Tool | Setting | Before | After |
|---|---|---|---|
| Codex | `approvalPolicy` | `on-request` | `never` |
| Codex | `networkAccess` | `false` | `true` |
| Codex | `sandboxMode` | `workspace-write` | `workspace-write` *(unchanged)* |
| Claude Code | `permission_config.mode` | `acceptEdits` | `bypassPermissions` |
| Copilot | `permission_config.mode` | `acceptEdits` | `bypassPermissions` |
| Gemini | — | `autoEdit` | unchanged *(pending separate audit)* |
| OpenCode | — | `autoEdit` | unchanged *(pending separate audit)* |

Note: `getDefaultPermissionMode('codex')` returns `'allow-all'`, which `mapToCodexPermissionConfig` materializes as `sandbox=workspace-write` + `approval=never` — consistent with the executor-level fallback.

## Existing-user behavior

- ✅ **Existing sessions** are snapshotted at creation time → unchanged.
- ✅ **Users with `default_agentic_config.*.permissionMode`** explicitly set → resolver respects their choice before the new system default.
- ✅ **Users with both `codexSandboxMode` + `codexApprovalPolicy`** → resolver emits `out.codex` and executor uses those, never reaches the relaxed fallback.
- ✅ **Per-session overrides** (Session Settings UI) still trump everything.

### Pre-existing edge case worth flagging

A user who set ONLY ONE of the three Codex sub-config fields (e.g. `codexApprovalPolicy: 'untrusted'` alone, without `codexSandboxMode`) has *always* been silently ignored — the resolver gate at `resolve-permission-config.ts:100` requires both. Under old defaults the executor fell back to `'on-request'`; now it falls back to `'never'`. Narrow scenario but worth fixing separately by having the resolver fill partial sub-configs from system defaults.

## Onboarding wizard

Adds a "Permission defaults" info card under the Claude Code / Codex auth hint:

> New sessions run in **bypassPermissions** mode — Claude won't prompt for each file edit or tool call. Safety comes from Agor's worktree sandbox; you can tighten per session in **Session Settings**.

No hidden behavior — users see what they're agreeing to during onboarding.

## Test plan

- [x] `pnpm install && pnpm check` (typecheck + lint + build) — green
- [x] `@agor/core` test suite — 2265 passed, 1 skipped (updated 3 test files for new defaults)
- [x] `@agor/executor` test suite — 361 passed
- [x] `@agor/daemon` test suite — 651 passed, 30 skipped (updated 1 test file for new claude default)
- [x] `agor-ui` test suite — 132 passed
- [ ] Manual smoke: spin up fresh Codex session → log line should print `approvalPolicy=never, networkAccess=true`
- [ ] Manual smoke: spin up fresh Claude Code session → confirm MCP calls don't prompt
- [ ] Manual smoke: onboarding wizard → confirm new "Permission defaults" alert renders for Claude Code + Codex
- [ ] Manual smoke: existing user with custom `permissionMode: 'plan'` → confirm their setting is preserved

## Coordination

Did not collide with in-flight Codex worktrees (`audit-codex-permission-flow`, `codex-permission-flow`, #1136 / `improve-codex-subscription-auth-ux`) — those are about **auth**, not permission defaults. Quick rebase check before merge recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)