### PR TITLE
fix(ui): spinner overlay on zone-trigger template render

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -22,7 +22,7 @@ import type {
 // shape.
 import { buildZoneTriggerContext } from '@agor-live/client';
 import { DownOutlined } from '@ant-design/icons';
-import { Alert, Collapse, Form, Input, Modal, Radio, Select, Space, Typography } from 'antd';
+import { Alert, Collapse, Form, Input, Modal, Radio, Select, Space, Spin, Typography } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import type { AgenticToolOption } from '../../../types';
 import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
@@ -93,6 +93,11 @@ export const ZoneTriggerModal = ({
 
   // Editable rendered template (user can modify before executing)
   const [editableTemplate, setEditableTemplate] = useState<string>('');
+
+  // True while the daemon is rendering the template. Drives a Spin overlay
+  // on the textarea so the user doesn't see the raw `{{...}}` source flash
+  // before the final rendered content arrives.
+  const [isRendering, setIsRendering] = useState<boolean>(true);
 
   // Explicit state for session config (survives form mount/unmount cycles)
   const [sessionConfig, setSessionConfig] = useState<{
@@ -206,6 +211,7 @@ export const ZoneTriggerModal = ({
     let cancelled = false;
     if (!client) {
       setEditableTemplate(trigger.template);
+      setIsRendering(false);
       return;
     }
     const selectedSessionForCtx =
@@ -228,8 +234,12 @@ export const ZoneTriggerModal = ({
         : undefined,
     });
 
+    setIsRendering(true);
     renderTemplate(client, trigger.template, context, 'raw').then((rendered) => {
-      if (!cancelled) setEditableTemplate(rendered);
+      if (!cancelled) {
+        setEditableTemplate(rendered);
+        setIsRendering(false);
+      }
     });
 
     return () => {
@@ -440,17 +450,20 @@ export const ZoneTriggerModal = ({
           <Typography.Text strong style={{ display: 'block', marginBottom: 8 }}>
             Prompt (editable)
           </Typography.Text>
-          <Input.TextArea
-            value={editableTemplate}
-            onChange={(e) => setEditableTemplate(e.target.value)}
-            rows={8}
-            style={{
-              fontFamily: 'monospace',
-              fontSize: '13px',
-              lineHeight: '1.5',
-            }}
-            placeholder="Edit the rendered prompt before executing..."
-          />
+          {/* `delay` so the spinner doesn't flash on sub-perceptible renders. */}
+          <Spin spinning={isRendering} delay={200} tip="Rendering template…">
+            <Input.TextArea
+              value={editableTemplate}
+              onChange={(e) => setEditableTemplate(e.target.value)}
+              rows={8}
+              style={{
+                fontFamily: 'monospace',
+                fontSize: '13px',
+                lineHeight: '1.5',
+              }}
+              placeholder="Edit the rendered prompt before executing..."
+            />
+          </Spin>
         </div>
       </Space>
     </Modal>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -94,9 +94,8 @@ export const ZoneTriggerModal = ({
   // Editable rendered template (user can modify before executing)
   const [editableTemplate, setEditableTemplate] = useState<string>('');
 
-  // True while the daemon is rendering the template. Drives a Spin overlay
-  // on the textarea so the user doesn't see the raw `{{...}}` source flash
-  // before the final rendered content arrives.
+  // Drives a Spin overlay so the user doesn't see the raw `{{...}}` flash
+  // before the daemon's rendered content arrives.
   const [isRendering, setIsRendering] = useState<boolean>(true);
 
   // Explicit state for session config (survives form mount/unmount cycles)
@@ -303,6 +302,7 @@ export const ZoneTriggerModal = ({
       onCancel={onCancel}
       onOk={handleExecute}
       okText="Execute Trigger"
+      okButtonProps={{ disabled: isRendering }}
       cancelText="Cancel"
       width={700}
     >
@@ -450,8 +450,7 @@ export const ZoneTriggerModal = ({
           <Typography.Text strong style={{ display: 'block', marginBottom: 8 }}>
             Prompt (editable)
           </Typography.Text>
-          {/* `delay` so the spinner doesn't flash on sub-perceptible renders. */}
-          <Spin spinning={isRendering} delay={200} tip="Rendering template…">
+          <Spin spinning={isRendering} delay={200} description="Rendering template…">
             <Input.TextArea
               value={editableTemplate}
               onChange={(e) => setEditableTemplate(e.target.value)}


### PR DESCRIPTION
## Summary
- Opening the **Zone Trigger modal** triggered a server-side Handlebars render via the daemon (post-#1115). During that round-trip the textarea flashed the raw `{{...}}` template source before snapping to the rendered content.
- Wrap the textarea in an antd `<Spin>` overlay driven by an `isRendering` flag. The textarea keeps its fixed `rows={8}` height so the modal layout stays stable.
- `delay={200}` so sub-perceptible renders don't flash a spinner.
- Error path is unchanged: `renderTemplate(..., 'raw')` still falls back to the raw template on transport failure — the spinner clears either way.

Complements:
- #1096 — prior fix on this same template path
- #1115 — moved Handlebars rendering to the daemon (made it async); this PR is the natural UX complement

## Test plan
- [ ] Drag a worktree into a zone with a trigger template — spinner appears while daemon renders, then textarea shows final content
- [ ] Modal width/height stays stable through render (no jitter)
- [ ] Throttle network to Slow 3G — spinner is clearly visible during the longer render
- [ ] Render error path — daemon failure shows raw template (no stuck spinner)
- [ ] Fast render — no spinner flash (delay suppresses sub-200ms loads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)