### PR TITLE
fix(defaults): make mapToCodexPermissionConfig the single source of truth (follow-up to #1215)

### DIFF
--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -9,7 +9,7 @@ import type {
   User,
   Worktree,
 } from '@agor-live/client';
-import { getDefaultPermissionMode } from '@agor-live/client';
+import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live/client';
 import { DownOutlined } from '@ant-design/icons';
 import { Alert, Collapse, Form, Input, Modal, Typography } from 'antd';
 import { useEffect, useState } from 'react';
@@ -141,6 +141,11 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
       const fallbackMcpServerIds =
         worktreeMcpIds && worktreeMcpIds.length > 0 ? worktreeMcpIds : agentDefaults?.mcpServerIds;
 
+      const permissionMode: PermissionMode =
+        (values.permissionMode as PermissionMode | undefined) ??
+        agentDefaults?.permissionMode ??
+        getDefaultPermissionMode(selectedAgent as AgenticToolName);
+
       const config: NewSessionConfig = {
         worktree_id: worktreeId,
         agent: selectedAgent,
@@ -150,24 +155,24 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
         modelConfig: values.modelConfig ?? agentDefaults?.modelConfig,
         effort: (values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort,
         mcpServerIds: values.mcpServerIds ?? fallbackMcpServerIds,
-        permissionMode:
-          (values.permissionMode as PermissionMode | undefined) ??
-          agentDefaults?.permissionMode ??
-          getDefaultPermissionMode(selectedAgent as AgenticToolName),
+        permissionMode,
         envVarNames: envVarNames.length > 0 ? envVarNames : undefined,
       };
 
       if (selectedAgent === 'codex') {
+        const codexDefaults = mapToCodexPermissionConfig(permissionMode);
         config.codexSandboxMode =
           (values.codexSandboxMode as CodexSandboxMode | undefined) ??
           agentDefaults?.codexSandboxMode ??
-          ('workspace-write' as CodexSandboxMode);
+          codexDefaults.sandboxMode;
         config.codexApprovalPolicy =
           (values.codexApprovalPolicy as CodexApprovalPolicy | undefined) ??
           agentDefaults?.codexApprovalPolicy ??
-          ('on-request' as CodexApprovalPolicy);
+          codexDefaults.approvalPolicy;
         config.codexNetworkAccess =
-          values.codexNetworkAccess ?? agentDefaults?.codexNetworkAccess ?? false;
+          values.codexNetworkAccess ??
+          agentDefaults?.codexNetworkAccess ??
+          codexDefaults.networkAccess;
       }
 
       onCreate(config);

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1382,18 +1382,27 @@ export function OnboardingWizard({
     // Defense-in-depth comes from the worktree sandbox + (optional) Unix
     // impersonation, not from per-call prompts in an MCP-heavy session.
     const renderSecurityDefaultsNote = (tool: 'claude-code' | 'codex') => {
+      const sandboxLink = (
+        <Typography.Link
+          href="https://agor.live/guide/multiplayer-unix-isolation"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Agor's worktree sandbox
+        </Typography.Link>
+      );
       const description =
         tool === 'claude-code' ? (
           <span>
             New sessions run in <Text strong>bypassPermissions</Text> mode — Claude won't prompt for
-            each file edit or tool call. Safety comes from Agor's worktree sandbox; you can tighten
-            per session in <Text strong>Session Settings</Text>.
+            each file edit or tool call. Safety comes from {sandboxLink}; you can tighten per
+            session in <Text strong>Session Settings</Text>.
           </span>
         ) : (
           <span>
             New sessions run as <Text strong>workspace-write</Text> + approval{' '}
             <Text strong>never</Text> with network access on — Codex won't prompt for each action.
-            Safety comes from Agor's worktree sandbox; you can tighten per session in{' '}
+            Safety comes from {sandboxLink}; you can tighten per session in{' '}
             <Text strong>Session Settings</Text>.
           </span>
         );

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -1,4 +1,5 @@
 import type { CodexApprovalPolicy, CodexSandboxMode, PermissionMode } from '@agor-live/client';
+import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live/client';
 import {
   EditOutlined,
   ExperimentOutlined,
@@ -238,19 +239,6 @@ const getModesForTool = (tool: PermissionModeSelectorProps['agentic_tool']): Mod
   }
 };
 
-/** Get the default permission mode for a given agentic tool */
-const getDefaultMode = (tool: PermissionModeSelectorProps['agentic_tool']): PermissionMode => {
-  switch (tool) {
-    case 'codex':
-      return 'auto';
-    case 'gemini':
-    case 'opencode':
-      return 'autoEdit';
-    default:
-      return 'acceptEdits';
-  }
-};
-
 export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
   value,
   onChange,
@@ -258,13 +246,19 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
   compact = false,
   iconOnly = false,
   size = 'middle',
-  codexSandboxMode = 'workspace-write',
-  codexApprovalPolicy = 'on-request',
+  codexSandboxMode,
+  codexApprovalPolicy,
   onCodexChange,
 }) => {
   const { token } = theme.useToken();
   const modes = getModesForTool(agentic_tool);
-  const effectiveValue = value || getDefaultMode(agentic_tool);
+  const effectiveValue = value || getDefaultPermissionMode(agentic_tool);
+  // Fill Codex prop defaults from the resolved mode so the dropdown shows
+  // the same values the executor will actually run with for a session
+  // missing explicit sub-config.
+  const codexDefaults = mapToCodexPermissionConfig(effectiveValue);
+  const effectiveCodexSandboxMode = codexSandboxMode ?? codexDefaults.sandboxMode;
+  const effectiveCodexApprovalPolicy = codexApprovalPolicy ?? codexDefaults.approvalPolicy;
 
   // Compact mode: render as Select dropdown(s)
   if (compact) {
@@ -274,8 +268,8 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
       return (
         <Space size={4}>
           <Select
-            value={codexSandboxMode}
-            onChange={(val) => onCodexChange(val, codexApprovalPolicy)}
+            value={effectiveCodexSandboxMode}
+            onChange={(val) => onCodexChange(val, effectiveCodexApprovalPolicy)}
             size={size}
             placeholder="Sandbox"
             popupMatchSelectWidth={false}
@@ -296,8 +290,8 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
             )}
           />
           <Select
-            value={codexApprovalPolicy}
-            onChange={(val) => onCodexChange(codexSandboxMode, val)}
+            value={effectiveCodexApprovalPolicy}
+            onChange={(val) => onCodexChange(effectiveCodexSandboxMode, val)}
             size={size}
             placeholder="Approval"
             popupMatchSelectWidth={false}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -14,6 +14,7 @@ import type {
 import {
   AGENTIC_TOOL_CAPABILITIES,
   getDefaultPermissionMode,
+  mapToCodexPermissionConfig,
   SessionStatus,
   TaskStatus,
 } from '@agor-live/client';
@@ -300,15 +301,18 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // shadow that used to live here was stale (missing gemini/opencode/copilot)
   // and silently drifted from the core definition.
 
-  const [permissionMode, setPermissionMode] = React.useState<PermissionMode>(
-    session?.permission_config?.mode ||
-      (session?.agentic_tool ? getDefaultPermissionMode(session.agentic_tool) : 'acceptEdits')
-  );
+  const initialPermissionMode: PermissionMode =
+    session?.permission_config?.mode ??
+    (session?.agentic_tool
+      ? getDefaultPermissionMode(session.agentic_tool)
+      : getDefaultPermissionMode('claude-code'));
+  const initialCodexDefaults = mapToCodexPermissionConfig(initialPermissionMode);
+  const [permissionMode, setPermissionMode] = React.useState<PermissionMode>(initialPermissionMode);
   const [codexSandboxMode, setCodexSandboxMode] = React.useState<CodexSandboxMode>(
-    session?.permission_config?.codex?.sandboxMode || 'workspace-write'
+    session?.permission_config?.codex?.sandboxMode ?? initialCodexDefaults.sandboxMode
   );
   const [codexApprovalPolicy, setCodexApprovalPolicy] = React.useState<CodexApprovalPolicy>(
-    session?.permission_config?.codex?.approvalPolicy || 'on-request'
+    session?.permission_config?.codex?.approvalPolicy ?? initialCodexDefaults.approvalPolicy
   );
   const [effortLevel, setEffortLevel] = React.useState<EffortLevel>(
     session?.model_config?.effort || 'high'

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -24,6 +24,7 @@ import type {
   Session,
   User,
 } from '@agor-live/client';
+import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live/client';
 import { DownOutlined, KeyOutlined, SettingOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import type { CollapseProps } from 'antd';
 import { Collapse, Divider, Form, Modal, Typography } from 'antd';
@@ -74,21 +75,20 @@ interface FormValues {
 }
 
 function buildInitialValues(session: Session, sessionMcpServerIds: string[]): FormValues {
-  const defaultPermissionMode: PermissionMode =
-    session.agentic_tool === 'codex'
-      ? 'auto'
-      : session.agentic_tool === 'gemini' || session.agentic_tool === 'opencode'
-        ? 'autoEdit'
-        : 'acceptEdits';
+  const permissionMode: PermissionMode =
+    session.permission_config?.mode ?? getDefaultPermissionMode(session.agentic_tool);
+  const codexDefaults = mapToCodexPermissionConfig(permissionMode);
 
   return {
     title: session.title || '',
     mcpServerIds: sessionMcpServerIds,
     modelConfig: session.model_config,
-    permissionMode: session.permission_config?.mode || defaultPermissionMode,
-    codexSandboxMode: session.permission_config?.codex?.sandboxMode || 'workspace-write',
-    codexApprovalPolicy: session.permission_config?.codex?.approvalPolicy || 'on-request',
-    codexNetworkAccess: session.permission_config?.codex?.networkAccess ?? false,
+    permissionMode,
+    codexSandboxMode: session.permission_config?.codex?.sandboxMode ?? codexDefaults.sandboxMode,
+    codexApprovalPolicy:
+      session.permission_config?.codex?.approvalPolicy ?? codexDefaults.approvalPolicy,
+    codexNetworkAccess:
+      session.permission_config?.codex?.networkAccess ?? codexDefaults.networkAccess,
     custom_context: session.custom_context ? JSON.stringify(session.custom_context, null, 2) : '',
     callbackConfig: {
       enabled: session.callback_config?.enabled ?? true,

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -12,7 +12,11 @@ import type {
   SessionID,
   SpawnConfig,
 } from '@agor-live/client';
-import { getDefaultPermissionMode, SessionStatus } from '@agor-live/client';
+import {
+  getDefaultPermissionMode,
+  mapToCodexPermissionConfig,
+  SessionStatus,
+} from '@agor-live/client';
 import { useState } from 'react';
 import type { NewSessionConfig } from '../components/NewSessionModal';
 
@@ -67,10 +71,14 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
       };
 
       if (agenticTool === 'codex') {
+        // Fill any missing field from the mode-derived defaults so the UI
+        // doesn't silently restore the old `on-request` / network-off
+        // behavior when advanced fields aren't expanded.
+        const codexDefaults = mapToCodexPermissionConfig(permissionMode);
         permissionConfig.codex = {
-          sandboxMode: config.codexSandboxMode || 'workspace-write',
-          approvalPolicy: config.codexApprovalPolicy || 'on-request',
-          networkAccess: config.codexNetworkAccess ?? false,
+          sandboxMode: config.codexSandboxMode ?? codexDefaults.sandboxMode,
+          approvalPolicy: config.codexApprovalPolicy ?? codexDefaults.approvalPolicy,
+          networkAccess: config.codexNetworkAccess ?? codexDefaults.networkAccess,
         };
       }
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -44,3 +44,10 @@ export {
   buildZoneTriggerContext,
 } from '../templates/zone-trigger-context.js';
 export * from '../types/index.js';
+// Permission-mode helpers — pure functions, browser-safe.
+export {
+  type CodexPermissionDefaults,
+  getDefaultCodexPermissionConfig,
+  mapPermissionMode,
+  mapToCodexPermissionConfig,
+} from '../utils/permission-mode-mapper.js';

--- a/packages/core/src/sessions/resolve-child-session-config.test.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.test.ts
@@ -234,9 +234,12 @@ describe('resolveChildSessionConfig', () => {
       });
     });
 
-    it('cross-tool spawn TO codex with no user default emits no codex sub-config', () => {
-      // User has no codex defaults → no sandboxMode + approvalPolicy pair → no sub-config.
-      // The mapped permission mode still resolves (to 'allow-all').
+    it('cross-tool spawn TO codex with no user default fills sub-config from the mapped mode', () => {
+      // User has no codex defaults → resolver fills sub-config from
+      // mapToCodexPermissionConfig(getDefaultPermissionMode('codex')).
+      // This used to emit `undefined`, which made the executor's fallback
+      // the de facto source of truth — kept here as a regression to ensure
+      // the daemon-side resolver stays authoritative.
       const parent = makeParent({ agentic_tool: 'claude-code' });
       const r = resolveChildSessionConfig({
         parent,
@@ -244,8 +247,14 @@ describe('resolveChildSessionConfig', () => {
         user: makeUser({}),
         now,
       });
-      expect(r.permission_config.mode).toBe('allow-all');
-      expect(r.permission_config.codex).toBeUndefined();
+      expect(r.permission_config).toEqual({
+        mode: 'allow-all',
+        codex: {
+          sandboxMode: 'workspace-write',
+          approvalPolicy: 'never',
+          networkAccess: true,
+        },
+      });
     });
 
     it('cross-tool spawn TO codex with user codex defaults includes sub-config', () => {

--- a/packages/core/src/sessions/resolve-permission-config.ts
+++ b/packages/core/src/sessions/resolve-permission-config.ts
@@ -20,7 +20,7 @@ import type {
   Session,
 } from '../types/index.js';
 import { getDefaultPermissionMode } from '../types/session.js';
-import { mapPermissionMode } from '../utils/permission-mode-mapper.js';
+import { mapPermissionMode, mapToCodexPermissionConfig } from '../utils/permission-mode-mapper.js';
 
 /**
  * Common runtime overrides shared by every session-creation flow. Per-flow
@@ -62,9 +62,13 @@ export interface ResolvePermissionConfigArgs {
  * populated object — the system default mapped through `mapPermissionMode`
  * is the final fallback.
  *
- * Codex's dual sub-config (`sandboxMode` + `approvalPolicy` + `networkAccess`)
- * is emitted only on `codex` sessions, and only when both required fields
- * resolve to a value.
+ * For `codex` sessions, the sub-config (`sandboxMode` + `approvalPolicy` +
+ * `networkAccess`) is ALWAYS emitted. Any field not provided by the
+ * override / parent / user layers is filled from `mapToCodexPermissionConfig`
+ * keyed off the resolved permission mode. This prevents partial user
+ * overrides (e.g. just `codexApprovalPolicy: 'untrusted'`) from being
+ * silently dropped and then escalated to the relaxed system default by the
+ * executor's last-line fallback.
  */
 export function resolvePermissionConfig(
   args: ResolvePermissionConfigArgs
@@ -77,9 +81,8 @@ export function resolvePermissionConfig(
     userToolDefaults?.permissionMode ??
     getDefaultPermissionMode(effectiveTool);
 
-  const out: NonNullable<Session['permission_config']> = {
-    mode: mapPermissionMode(requestedMode, effectiveTool),
-  };
+  const effectiveMode: PermissionMode = mapPermissionMode(requestedMode, effectiveTool);
+  const out: NonNullable<Session['permission_config']> = { mode: effectiveMode };
 
   if (effectiveTool === 'codex') {
     const sandboxMode =
@@ -97,13 +100,12 @@ export function resolvePermissionConfig(
           ? parentLayer.codexNetworkAccess
           : userToolDefaults?.codexNetworkAccess;
 
-    if (sandboxMode && approvalPolicy) {
-      out.codex = {
-        sandboxMode,
-        approvalPolicy,
-        ...(networkAccess !== undefined && { networkAccess }),
-      };
-    }
+    const defaults = mapToCodexPermissionConfig(effectiveMode);
+    out.codex = {
+      sandboxMode: sandboxMode ?? defaults.sandboxMode,
+      approvalPolicy: approvalPolicy ?? defaults.approvalPolicy,
+      networkAccess: networkAccess ?? defaults.networkAccess,
+    };
   }
 
   return out;

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -50,7 +50,7 @@ describe('resolveSessionDefaults', () => {
       expect(r.permission_config.mode).toBe('yolo');
     });
 
-    it('emits codex sub-config when sandboxMode + approvalPolicy both present (user defaults)', () => {
+    it('emits full codex sub-config from user defaults', () => {
       const r = resolveSessionDefaults({
         agenticTool: 'codex',
         user: makeUser({
@@ -66,6 +66,55 @@ describe('resolveSessionDefaults', () => {
         sandboxMode: 'workspace-write',
         approvalPolicy: 'on-request',
         networkAccess: false,
+      });
+    });
+
+    it('always emits codex sub-config for codex sessions, filling missing fields from the mapped mode', () => {
+      // No user defaults — sub-config should be filled from
+      // mapToCodexPermissionConfig(getDefaultPermissionMode('codex')).
+      const r = resolveSessionDefaults({ agenticTool: 'codex' });
+      expect(r.permission_config).toEqual({
+        mode: 'allow-all',
+        codex: {
+          sandboxMode: 'workspace-write',
+          approvalPolicy: 'never',
+          networkAccess: true,
+        },
+      });
+    });
+
+    it("partial user defaults are preserved; missing fields fill from the user's mode (regression: don't escalate to system default)", () => {
+      // User explicitly chose a stricter approval policy but didn't set
+      // sandboxMode or networkAccess. Pre-fix this dropped the sub-config
+      // entirely and the executor fallback escalated approval to 'never'.
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        user: makeUser({
+          codex: { permissionMode: 'ask', codexApprovalPolicy: 'untrusted' },
+        }),
+      });
+      expect(r.permission_config).toEqual({
+        mode: 'ask',
+        codex: {
+          // sandboxMode + networkAccess fill from mapToCodexPermissionConfig('ask')
+          sandboxMode: 'read-only',
+          approvalPolicy: 'untrusted',
+          networkAccess: false,
+        },
+      });
+    });
+
+    it('partial user defaults (only sandboxMode) — approvalPolicy + networkAccess fill from mode', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'codex',
+        user: makeUser({
+          codex: { codexSandboxMode: 'read-only' },
+        }),
+      });
+      expect(r.permission_config.codex).toEqual({
+        sandboxMode: 'read-only',
+        approvalPolicy: 'never', // from default mode 'allow-all'
+        networkAccess: true, // from default mode 'allow-all'
       });
     });
 

--- a/packages/core/src/utils/permission-mode-mapper.test.ts
+++ b/packages/core/src/utils/permission-mode-mapper.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { mapPermissionMode, mapToCodexPermissionConfig } from './permission-mode-mapper';
+import {
+  getDefaultCodexPermissionConfig,
+  mapPermissionMode,
+  mapToCodexPermissionConfig,
+} from './permission-mode-mapper';
 
 describe('mapPermissionMode', () => {
   describe('Claude Code', () => {
@@ -82,56 +86,78 @@ describe('mapPermissionMode', () => {
 });
 
 describe('mapToCodexPermissionConfig', () => {
-  it('maps ask mode to read-only + untrusted', () => {
-    const config = mapToCodexPermissionConfig('ask');
-    expect(config.sandboxMode).toBe('read-only');
-    expect(config.approvalPolicy).toBe('untrusted');
+  it('maps ask mode to read-only + untrusted + network off', () => {
+    expect(mapToCodexPermissionConfig('ask')).toEqual({
+      sandboxMode: 'read-only',
+      approvalPolicy: 'untrusted',
+      networkAccess: false,
+    });
   });
 
-  it('maps auto mode to workspace-write + on-request', () => {
-    const config = mapToCodexPermissionConfig('auto');
-    expect(config.sandboxMode).toBe('workspace-write');
-    expect(config.approvalPolicy).toBe('on-request');
+  it('maps auto mode to workspace-write + on-request + network off', () => {
+    expect(mapToCodexPermissionConfig('auto')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'on-request',
+      networkAccess: false,
+    });
   });
 
-  it('maps on-failure mode to workspace-write + on-failure', () => {
-    const config = mapToCodexPermissionConfig('on-failure');
-    expect(config.sandboxMode).toBe('workspace-write');
-    expect(config.approvalPolicy).toBe('on-failure');
+  it('maps on-failure mode to workspace-write + on-failure + network off', () => {
+    expect(mapToCodexPermissionConfig('on-failure')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'on-failure',
+      networkAccess: false,
+    });
   });
 
-  it('maps allow-all mode to workspace-write + never', () => {
-    const config = mapToCodexPermissionConfig('allow-all');
-    expect(config.sandboxMode).toBe('workspace-write');
-    expect(config.approvalPolicy).toBe('never');
+  it('maps allow-all mode to workspace-write + never + network on', () => {
+    // The only "sandbox is the defense" mode that gets network on by default.
+    expect(mapToCodexPermissionConfig('allow-all')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'never',
+      networkAccess: true,
+    });
   });
 
   it('maps Claude modes through conversion', () => {
-    // default → ask → read-only + untrusted
-    const defaultConfig = mapToCodexPermissionConfig('default');
-    expect(defaultConfig.sandboxMode).toBe('read-only');
-    expect(defaultConfig.approvalPolicy).toBe('untrusted');
-
-    // acceptEdits → auto → workspace-write + on-request
-    const acceptEditsConfig = mapToCodexPermissionConfig('acceptEdits');
-    expect(acceptEditsConfig.sandboxMode).toBe('workspace-write');
-    expect(acceptEditsConfig.approvalPolicy).toBe('on-request');
-
-    // bypassPermissions → allow-all → workspace-write + never
-    const bypassConfig = mapToCodexPermissionConfig('bypassPermissions');
-    expect(bypassConfig.sandboxMode).toBe('workspace-write');
-    expect(bypassConfig.approvalPolicy).toBe('never');
+    expect(mapToCodexPermissionConfig('default')).toEqual({
+      sandboxMode: 'read-only',
+      approvalPolicy: 'untrusted',
+      networkAccess: false,
+    });
+    expect(mapToCodexPermissionConfig('acceptEdits')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'on-request',
+      networkAccess: false,
+    });
+    expect(mapToCodexPermissionConfig('bypassPermissions')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'never',
+      networkAccess: true,
+    });
   });
 
   it('maps Gemini modes through conversion', () => {
-    // autoEdit → auto → workspace-write + on-request
-    const autoEditConfig = mapToCodexPermissionConfig('autoEdit');
-    expect(autoEditConfig.sandboxMode).toBe('workspace-write');
-    expect(autoEditConfig.approvalPolicy).toBe('on-request');
+    expect(mapToCodexPermissionConfig('autoEdit')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'on-request',
+      networkAccess: false,
+    });
+    expect(mapToCodexPermissionConfig('yolo')).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'never',
+      networkAccess: true,
+    });
+  });
+});
 
-    // yolo → allow-all → workspace-write + never
-    const yoloConfig = mapToCodexPermissionConfig('yolo');
-    expect(yoloConfig.sandboxMode).toBe('workspace-write');
-    expect(yoloConfig.approvalPolicy).toBe('never');
+describe('getDefaultCodexPermissionConfig', () => {
+  it('returns the codex sub-config for the system default mode', () => {
+    // System default is currently 'allow-all' — should track that source of truth.
+    expect(getDefaultCodexPermissionConfig()).toEqual({
+      sandboxMode: 'workspace-write',
+      approvalPolicy: 'never',
+      networkAccess: true,
+    });
   });
 });

--- a/packages/core/src/utils/permission-mode-mapper.ts
+++ b/packages/core/src/utils/permission-mode-mapper.ts
@@ -11,7 +11,13 @@
  * - Codex: ask, auto, on-failure, allow-all
  */
 
-import type { AgenticToolName, PermissionMode } from '../types';
+import type {
+  AgenticToolName,
+  CodexApprovalPolicy,
+  CodexSandboxMode,
+  PermissionMode,
+} from '../types';
+import { getDefaultPermissionMode } from '../types/session.js';
 
 /**
  * Maps a permission mode when spawning a child session of a different agent type.
@@ -122,48 +128,50 @@ export function mapPermissionMode(
 }
 
 /**
- * Converts a unified PermissionMode to Codex-specific dual configuration.
+ * Codex sub-config derived from a unified PermissionMode. Used as the
+ * single source of truth for default sandbox / approval / network
+ * settings across the daemon resolver, executor fallback, and UI flows.
  *
- * Codex uses a two-part permission system:
- * - sandboxMode: Controls WHERE Codex can write (filesystem boundaries)
- * - approvalPolicy: Controls WHETHER Codex asks before executing
- *
- * @param mode - The unified permission mode
- * @returns Codex-specific config { sandboxMode, approvalPolicy }
+ * `networkAccess` is yoked to `approvalPolicy === 'never'`: the "trust the
+ * sandbox" mode is the only one we treat as permissive enough to enable
+ * outbound network by default. Restrictive / asking modes keep it off so
+ * users who intentionally tighten approvals don't get network on top.
  */
-export function mapToCodexPermissionConfig(mode: PermissionMode): {
-  sandboxMode: 'read-only' | 'workspace-write';
-  approvalPolicy: 'untrusted' | 'on-request' | 'on-failure' | 'never';
-} {
+export interface CodexPermissionDefaults {
+  sandboxMode: CodexSandboxMode;
+  approvalPolicy: CodexApprovalPolicy;
+  networkAccess: boolean;
+}
+
+/**
+ * Convert a unified PermissionMode to a Codex sub-config (sandbox + approval
+ * + network). The mapping table lives here so the daemon resolver, executor
+ * fallback, and every UI surface that needs to display "what would happen
+ * if this session ran now" all agree on the answer.
+ */
+export function mapToCodexPermissionConfig(mode: PermissionMode): CodexPermissionDefaults {
   // First map to Codex-compatible mode
   const codexMode = mapPermissionMode(mode, 'codex');
 
   switch (codexMode) {
     case 'ask':
-      return {
-        sandboxMode: 'read-only',
-        approvalPolicy: 'untrusted', // Ask for everything
-      };
+      return { sandboxMode: 'read-only', approvalPolicy: 'untrusted', networkAccess: false };
     case 'auto':
-      return {
-        sandboxMode: 'workspace-write',
-        approvalPolicy: 'on-request', // Auto-approve safe ops, ask for dangerous
-      };
+      return { sandboxMode: 'workspace-write', approvalPolicy: 'on-request', networkAccess: false };
     case 'on-failure':
-      return {
-        sandboxMode: 'workspace-write',
-        approvalPolicy: 'on-failure', // Ask only when tools fail
-      };
+      return { sandboxMode: 'workspace-write', approvalPolicy: 'on-failure', networkAccess: false };
     case 'allow-all':
-      return {
-        sandboxMode: 'workspace-write',
-        approvalPolicy: 'never', // Never ask
-      };
+      return { sandboxMode: 'workspace-write', approvalPolicy: 'never', networkAccess: true };
     default:
-      // Fallback to safe default (ask for everything)
-      return {
-        sandboxMode: 'read-only',
-        approvalPolicy: 'untrusted',
-      };
+      return { sandboxMode: 'read-only', approvalPolicy: 'untrusted', networkAccess: false };
   }
+}
+
+/**
+ * Codex sub-config for the system default permission mode. Convenience
+ * wrapper for the common "I have no source mode in hand — give me what a
+ * brand-new session would get" case.
+ */
+export function getDefaultCodexPermissionConfig(): CodexPermissionDefaults {
+  return mapToCodexPermissionConfig(getDefaultPermissionMode('codex'));
 }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -31,6 +31,7 @@ import { Codex } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { EffortLevel } from '@agor/core/types';
+import { getDefaultCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
 import { getDaemonUrl } from '../../config.js';
 import type {
   MCPServerRepository,
@@ -842,17 +843,16 @@ export class CodexPromptService {
     // ThreadOptions are emitted AFTER `--config` flags, so for keys that overlap
     // (approval_policy, sandbox_workspace_write.network_access) ThreadOptions win.
     //
-    // System defaults (`never` + `workspace-write` + network on) assume Agor's
-    // environment-level sandbox (worktree FS scoping, Unix impersonation in
-    // insulated/strict modes, executor process isolation) is the actual
-    // defense — per-call approval prompts are friction without benefit in
-    // an MCP-heavy session where every Agor self-call would otherwise gate.
-    // Users / parent sessions / per-session overrides still flow through
-    // resolvePermissionConfig and trump these defaults.
+    // The daemon resolver (`resolvePermissionConfig`) always emits a full
+    // codex sub-config for new sessions, so this fallback only fires for
+    // legacy sessions in the DB with a partial / missing `permission_config`.
+    // It delegates to `getDefaultCodexPermissionConfig` so we have one source
+    // of truth for what "system default" means across daemon + executor.
     const codexConfig = session.permission_config?.codex;
-    const sandboxMode = codexConfig?.sandboxMode || 'workspace-write';
-    const approvalPolicy = codexConfig?.approvalPolicy || 'never';
-    const networkAccess = codexConfig?.networkAccess ?? true;
+    const defaults = getDefaultCodexPermissionConfig();
+    const sandboxMode = codexConfig?.sandboxMode ?? defaults.sandboxMode;
+    const approvalPolicy = codexConfig?.approvalPolicy ?? defaults.approvalPolicy;
+    const networkAccess = codexConfig?.networkAccess ?? defaults.networkAccess;
 
     console.log(
       `   Using Codex permissions: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}`


### PR DESCRIPTION
Follow-up to #1215 (merged). Code-review pass caught two real bugs the first cut missed.

## Summary

1. **UI was still writing the old restrictive Codex defaults.** `useSessionActions.createSession` and `NewSessionModal.handleCreate` materialized `permission_config.codex` with hardcoded `workspace-write / on-request / networkAccess=false` whenever the user didn't expand the advanced form. So onboarding for Codex *appeared* relaxed (the executor's `||` fallback was flipped in #1215) but actually still wrote the old values — and the executor never reached its fallback because the UI-supplied sub-config won. Fixed by deriving missing fields from `mapToCodexPermissionConfig(permissionMode)` instead.

2. **`resolvePermissionConfig` silently escalated partial Codex user-defaults.** The old gate at `if (sandboxMode && approvalPolicy)` dropped the entire codex sub-config when a user had set only one of the three fields (e.g. `codexApprovalPolicy: 'untrusted'` alone). Pre-#1215 the executor fell back to `on-request`; post-#1215 to `never`. So a user who explicitly tightened approvals got their choice silently inverted. Fixed by always emitting the sub-config for Codex sessions and filling missing fields from `mapToCodexPermissionConfig(effectiveMode)`.

## The DRY-up

`mapToCodexPermissionConfig` is now the single source of truth for Codex sub-config defaults across the entire stack:

- Extended its return type to include `networkAccess` (`true` only for `allow-all`, `false` for `ask`/`auto`/`on-failure`).
- Added `getDefaultCodexPermissionConfig()` for the common "system default codex sub-config" case.
- Exposed both helpers via the browser-safe `@agor-live/client` surface.
- Daemon resolver, executor fallback, UI new-session paths (`useSessionActions`, `NewSessionModal`), and UI display-layer reads (`SessionSettingsModal`, `PermissionModeSelector`, `SessionPanel`) all delegate to the helper.
- Removed `PermissionModeSelector.getDefaultMode` — its switch/case duplicated `getDefaultPermissionMode`.

## Onboarding wizard

The "Permission defaults" alert now links to [`agor.live/guide/multiplayer-unix-isolation`](https://agor.live/guide/multiplayer-unix-isolation) so users can read what "Agor's worktree sandbox" actually means before consenting to the relaxed defaults.

## Tests

- `mapToCodexPermissionConfig` assertions updated to cover the new `networkAccess` field + new test for `getDefaultCodexPermissionConfig`.
- New regression tests in `resolve-session-defaults.test.ts`:
  - Partial user-defaults (approval-only): explicit `untrusted` preserved, `sandboxMode`/`networkAccess` filled from the mode.
  - Partial user-defaults (sandbox-only): explicit `read-only` preserved, rest filled.
  - No-defaults: full sub-config emitted from the system default mode.
- Updated the `resolve-child-session-config` test that pinned the old "no codex sub-config" behavior to assert the filled defaults.
- All test suites green: `@agor/core` 2269, `@agor/executor` 361, `@agor/daemon` 651, `agor-ui` 132.

## Files

```
apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
apps/agor-ui/src/hooks/useSessionActions.ts
packages/core/src/client/index.ts
packages/core/src/sessions/resolve-permission-config.ts
packages/core/src/utils/permission-mode-mapper.ts
packages/core/src/utils/permission-mode-mapper.test.ts
packages/core/src/sessions/resolve-session-defaults.test.ts
packages/core/src/sessions/resolve-child-session-config.test.ts
packages/executor/src/sdk-handlers/codex/prompt-service.ts
```

## Test plan

- [x] `pnpm check` (typecheck + lint + build) — green
- [x] All test suites green
- [ ] Manual smoke: spawn a fresh Codex session → executor log line prints `approvalPolicy=never, networkAccess=true` (now actually reachable from UI, not pre-empted by hardcoded UI defaults)
- [ ] Manual smoke: set `default_agentic_config.codex.codexApprovalPolicy = 'untrusted'` in user settings (only field), spawn Codex session → `permission_config.codex.approvalPolicy === 'untrusted'`, `sandboxMode === 'read-only'`, `networkAccess === false` (filled from mapped `ask` mode, not escalated to system relaxed default)
- [ ] Manual smoke: SessionSettingsModal for a legacy session missing `permission_config.codex` shows the mode-derived defaults instead of the old `auto`/`on-request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)