### PR TITLE
fix(ui): stop Conversation panel from reopening itself after close

### DIFF
--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -199,19 +199,21 @@ export function useUrlState(options: UseUrlStateOptions) {
       lastUrlSessionParamRef.current = urlSessionParam;
     }
 
-    // Skip if URL hasn't changed AND we've already resolved everything AND state
-    // still matches the URL. The `stateMatchesUrl` clause is the self-healing
-    // bit: if some upstream effect ever clears `currentBoardId` / `currentSessionId`
-    // (e.g. a stale wipe-on-disconnect regression), we re-resolve and restore
-    // state from the URL on the next data tick instead of letting the state→URL
-    // effect collapse `/b/<id>` to `/`. The `boardChanged`/`sessionChanged`
-    // checks below keep this idempotent on stable state.
+    // Skip if URL hasn't changed AND we've already resolved everything.
+    //
+    // We intentionally do NOT self-heal state from a stale URL here. An earlier
+    // revision added a `stateMatchesUrl` clause that re-asserted state when
+    // state was null but the URL still had params — meant as belt-and-suspenders
+    // against wipe-on-disconnect. The problem is the same shape applies to an
+    // intentional close: user clicks ✕ → `selectedSessionId` flips to null, URL
+    // hasn't been rewritten yet, self-heal fires and re-sets state from URL →
+    // panel reopens. Wipe-on-disconnect is now prevented at source (App.tsx
+    // passes `client` directly, the missing-board fallback is connected-gated),
+    // so the self-heal is unnecessary and was conflating intentional clears
+    // with accidental wipes.
     const fullyResolved =
       urlParamsResolvedRef.current.board && urlParamsResolvedRef.current.session;
-    const stateMatchesUrl =
-      (!urlBoardParam || !!currentBoardIdRef.current) &&
-      (!urlSessionParam || !!currentSessionIdRef.current);
-    if (!urlParamsChanged && fullyResolved && stateMatchesUrl) {
+    if (!urlParamsChanged && fullyResolved) {
       return;
     }
 

--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -201,16 +201,12 @@ export function useUrlState(options: UseUrlStateOptions) {
 
     // Skip if URL hasn't changed AND we've already resolved everything.
     //
-    // We intentionally do NOT self-heal state from a stale URL here. An earlier
-    // revision added a `stateMatchesUrl` clause that re-asserted state when
-    // state was null but the URL still had params — meant as belt-and-suspenders
-    // against wipe-on-disconnect. The problem is the same shape applies to an
-    // intentional close: user clicks ✕ → `selectedSessionId` flips to null, URL
-    // hasn't been rewritten yet, self-heal fires and re-sets state from URL →
-    // panel reopens. Wipe-on-disconnect is now prevented at source (App.tsx
-    // passes `client` directly, the missing-board fallback is connected-gated),
-    // so the self-heal is unnecessary and was conflating intentional clears
-    // with accidental wipes.
+    // Invariant: URL→State only re-asserts state when the URL itself changes.
+    // State clears (e.g. user closes panel → `selectedSessionId = null`) are
+    // intentional until State→URL catches up — do NOT "self-heal" state from
+    // a stale URL param here, or you'll fight intentional clears and the panel
+    // will reopen itself. Wipe-on-disconnect is prevented at source (App.tsx
+    // passes `client` directly; missing-board fallback is `connected`-gated).
     const fullyResolved =
       urlParamsResolvedRef.current.board && urlParamsResolvedRef.current.session;
     if (!urlParamsChanged && fullyResolved) {


### PR DESCRIPTION
## Summary

- Closing the Conversation panel briefly disappeared then **flickered back open**.
- Root cause: PR #1207 added a `stateMatchesUrl` self-heal clause to `useUrlState`'s URL→State sync. When state goes null but URL still has params, it re-asserts state from the URL — exactly the shape of an intentional close.
- Removed the clause. URL→State now only re-asserts state when the URL itself changes; State→URL still writes the URL when state changes (incl. intentional close).

## Why the self-heal isn't needed

Wipe-on-disconnect — the scenario it was guarding — is already prevented at source by the other changes in #1207:
- `App.tsx` passes `client` directly (no more `connected ? client : null` wiping data)
- The missing-board fallback is `connected`-gated

The self-heal was belt-and-suspenders that couldn't distinguish "state was accidentally wiped, URL is truth" from "user intentionally cleared state, URL hasn't caught up yet" — and the bug we're fixing is exactly the latter case.

## Trace

**Before (with self-heal):**
1. Click ✕ → `setSelectedSessionId(null)`
2. Re-render: URL→State runs first. `stateMatchesUrl=false` → don't bail → re-resolves session from URL → `onSessionChange(sessionId)` → state set back. Panel reopens.

**After:**
1. Click ✕ → `setSelectedSessionId(null)`
2. URL→State: `!urlParamsChanged && fullyResolved` → bail.
3. State→URL: navigates to `/b/<board>/`.
4. URL change re-triggers URL→State: `sessionChanged=false` (both null), no-op. Panel stays closed.

## Test plan

- [ ] Open a session panel; click ✕; panel closes and stays closed (no flicker).
- [ ] Reopen by clicking a session card; URL updates to `/b/<board>/<session>/`.
- [ ] Browser back/forward through `/b/<board>/<session>/` ↔ `/b/<board>/` works.
- [ ] Deep link `/b/<board>/<session>/` on first load opens the panel.
- [ ] Disconnect/reconnect (covered by #1207): URL and board state survive, panel state isn't accidentally re-asserted.
- [ ] Light + dark theme — nothing visual changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)