### PR TITLE
fix(api-keys): allow revoking personal keys

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2484,32 +2484,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       async create(data: { name: string }, params: AuthenticatedParams) {
         return userApiKeysService.create(data, params);
       },
+      async patch(id: string, data: { name?: string }, params: AuthenticatedParams) {
+        if (!id) throw new BadRequest('API key ID required');
+        return userApiKeysService.patch(id, data, params);
+      },
+      async remove(id: string, params: AuthenticatedParams) {
+        if (!id) throw new BadRequest('API key ID required');
+        return userApiKeysService.remove(id, params);
+      },
     },
     {
       find: { role: ROLES.MEMBER, action: 'list API keys' },
       create: { role: ROLES.MEMBER, action: 'create API keys' },
-    },
-    requireAuth
-  );
-
-  registerAuthenticatedRoute(
-    app,
-    '/api/v1/user/api-keys/:id',
-    {
-      // biome-ignore lint/suspicious/noExplicitAny: Feathers service type
-      async patch(data: { name?: string }, params: any) {
-        const id = params.route?.id;
-        if (!id) throw new BadRequest('API key ID required');
-        return userApiKeysService.patch(id, data, params);
-      },
-      // biome-ignore lint/suspicious/noExplicitAny: Feathers service type
-      async remove(_id: unknown, params: any) {
-        const keyId = params.route?.id;
-        if (!keyId) throw new BadRequest('API key ID required');
-        return userApiKeysService.remove(keyId, params);
-      },
-    },
-    {
       patch: { role: ROLES.MEMBER, action: 'update API keys' },
       remove: { role: ROLES.MEMBER, action: 'delete API keys' },
     },


### PR DESCRIPTION
## Summary
- move personal API key patch/remove handlers onto the base Feathers service path used by the client
- remove the duplicate /api/v1/user/api-keys/:id service registration
- keep existing member authorization for list/create/update/delete API key actions

## Verification
- pnpm build
- pnpm --filter @agor/daemon typecheck
- pnpm biome check apps/agor-daemon/src/register-routes.ts
- pnpm --filter @agor/daemon test

Note: full pnpm test was attempted on the fork worktree, but unrelated @agor/executor tests failed in this local environment due missing Claude Code executable and existing diff-enrichment failures.