### PR TITLE
feat(ui): paste screenshot from clipboard into session input

### DIFF
--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -741,6 +741,32 @@ export const AutocompleteTextarea = React.forwardRef<
       [onFilesDrop]
     );
 
+    const handlePaste = useCallback(
+      (e: React.ClipboardEvent) => {
+        if (!onFilesDrop) return;
+
+        const imageFiles: File[] = [];
+        for (const item of Array.from(e.clipboardData.items)) {
+          if (item.kind === 'file' && item.type.startsWith('image/')) {
+            const file = item.getAsFile();
+            if (file) {
+              const ext = item.type.split('/')[1] || 'png';
+              const niceName = `pasted-screenshot-${new Date()
+                .toISOString()
+                .replace(/[:.]/g, '-')}.${ext}`;
+              imageFiles.push(new File([file], niceName, { type: file.type }));
+            }
+          }
+        }
+
+        if (imageFiles.length === 0) return;
+
+        e.preventDefault();
+        onFilesDrop(imageFiles);
+      },
+      [onFilesDrop]
+    );
+
     /**
      * Render popover content
      */
@@ -917,6 +943,7 @@ export const AutocompleteTextarea = React.forwardRef<
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
+          onPaste={handlePaste}
         >
           {/* Drag-over overlay */}
           {isDragOver && (


### PR DESCRIPTION
## Summary

Pasting an image (e.g. a screenshot from the OS clipboard) into the session prompt textarea now opens the existing FileUpload modal with the image pre-filled. Skips the previous save-to-disk → paperclip → pick-file flow.

**Before:** Save screenshot to disk → click paperclip → pick `temp` destination → select the file.

**After:** ⌘V / Ctrl+V into the prompt textarea → FileUpload modal opens with the image pre-populated → pick destination → Upload.

## Implementation

- Single file: `apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx`
- New `onPaste` handler on the same wrapper `<div>` that already handles drag-and-drop. Iterates `clipboardData.items`, collects files where `kind === 'file'` and `type.startsWith('image/')`, renames them to `pasted-screenshot-<ISO>.<ext>`, and hands them to the existing `onFilesDrop` callback.
- Text paste is untouched: `preventDefault()` only fires when image files are actually present.
- Reuses the existing FileUpload modal's `initialFiles` flow — zero changes on the parent (`SessionPanel`) or daemon side.

Mobile prompt input (`MobilePromptInput.tsx`) is unchanged — it doesn't wire `onFilesDrop` and isn't a priority surface for this feature.

## Test plan

- [ ] Copy a screenshot to clipboard, focus the session prompt textarea, paste → FileUpload modal opens with the image queued
- [ ] Paste plain text → text is inserted normally, no modal
- [ ] Drag-and-drop a file → still works (existing behavior unchanged)
- [ ] Typecheck passes (`tsc -b --pretty false` in `apps/agor-ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)