### PR TITLE
feat(widgets): in-conversation interactive widgets — primitive + env_vars

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -64,6 +64,7 @@ import { configureSwagger } from './setup/swagger.js';
 import { loadDaemonVersion } from './setup/version.js';
 import { startup } from './startup.js';
 import { configureDaemonUrl } from './utils/spawn-executor.js';
+import { registerAllWidgets } from './widgets/index.js';
 
 // Load daemon version at startup
 const DAEMON_VERSION = await loadDaemonVersion(import.meta.url);
@@ -126,6 +127,14 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // Initialize Handlebars helpers for template rendering
   registerHandlebarsHelpers();
   console.log('✅ Handlebars helpers registered');
+
+  // Populate the widget registry. Each concrete widget type (`env_vars`,
+  // future `confirmation`, `oauth`, ...) lives in its own subdir under
+  // `./widgets/` and side-effect-registers via this central call. The
+  // registry is consulted by `POST /widgets/:id/{submit,dismiss}` and by
+  // the `agor_widgets_request_*` MCP tools.
+  registerAllWidgets();
+  console.log('✅ Widget registry populated');
 
   // Configure Git to fail fast instead of prompting for credentials
   process.env.GIT_TERMINAL_PROMPT = '0';

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -41,6 +41,7 @@ import { registerSearchTools } from './tools/search.js';
 import { registerSessionTools } from './tools/sessions.js';
 import { registerTaskTools } from './tools/tasks.js';
 import { registerUserTools } from './tools/users.js';
+import { registerWidgetTools } from './tools/widgets.js';
 import { registerWorktreeTools } from './tools/worktrees.js';
 
 /**
@@ -107,6 +108,7 @@ Domains:
 - users: User accounts, profiles, preferences, and administration
 - analytics: Usage and cost tracking leaderboard
 - mcp-servers: External MCP server configuration and OAuth management
+- widgets: In-conversation interactive widgets (forms/buttons rendered inline; values never enter your context)
 
 Common workflows:
 
@@ -214,6 +216,11 @@ function buildRegistry(servicesConfig?: DaemonServicesConfig): ToolRegistry {
     registerSessionTools(tempServer, dummyCtx);
     registerTaskTools(tempServer, dummyCtx);
     registerMessageTools(tempServer, dummyCtx);
+  }
+
+  if (isDomainEnabled('widgets', servicesConfig)) {
+    registry.setCurrentDomain('widgets');
+    registerWidgetTools(tempServer, dummyCtx);
   }
 
   if (isDomainEnabled('repos', servicesConfig)) {
@@ -384,6 +391,7 @@ function createMcpServer(
     registerTaskTools(s, c);
     registerMessageTools(s, c);
   });
+  domainRegister('widgets', registerWidgetTools);
   domainRegister('repos', registerRepoTools);
   domainRegister('worktrees', (s, c) => {
     registerWorktreeTools(s, c);

--- a/apps/agor-daemon/src/mcp/tool-registry.ts
+++ b/apps/agor-daemon/src/mcp/tool-registry.ts
@@ -51,6 +51,8 @@ const DOMAIN_DESCRIPTIONS: Record<string, string> = {
   analytics: 'Usage and cost tracking leaderboard',
   'mcp-servers': 'External MCP server configuration and OAuth management',
   proxies: 'Configured HTTP proxies for third-party APIs (Shortcut, Linear, Jira, etc.)',
+  widgets:
+    'In-conversation interactive widgets — agents render small forms/buttons inline in the transcript to capture user input that never enters the LLM context',
 };
 
 /** Tools always visible in `tools/list` even when search mode is enabled. */

--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -21,9 +21,13 @@ vi.mock('../resolve-ids.js', () => ({
   resolveMcpServerId: async (_ctx: unknown, id: string) => id,
 }));
 
-vi.mock('@agor/core/config', () => ({
-  isWorktreeRbacEnabled: () => false,
-}));
+vi.mock('@agor/core/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/config')>();
+  return {
+    ...actual,
+    isWorktreeRbacEnabled: () => false,
+  };
+});
 
 vi.mock('@agor/core/db', () => ({
   WorktreeRepository: class FakeWorktreeRepository {

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -1,0 +1,296 @@
+/**
+ * agor_widgets_request_env_vars MCP tool — handler tests.
+ *
+ * Covers Part 2 §7 of the design doc:
+ *   - Normal path: creates a `widget_request` message with status 'pending',
+ *     returns `{ widget_id, status: 'requested' }`.
+ *   - `already_present` short-circuit: when the user already has all names
+ *     set in the chosen default_scope, marks the widget `already_present`
+ *     and queues an auto-resume task with a "values already configured"
+ *     prompt — without rendering a form.
+ *   - Negative short-circuit: missing one name → falls back to the normal
+ *     pending path.
+ *   - `auto_resume: false` + `already_present`: status flips but no task
+ *     creation.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/append-system-message.js', () => ({
+  appendSystemMessage: vi.fn(),
+}));
+
+import { appendSystemMessage } from '../../utils/append-system-message.js';
+import { registerWidgetTools } from './widgets.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+type CapturedTool = {
+  cfg: { description?: string; inputSchema?: { safeParse: (v: unknown) => unknown } };
+  cb: ToolHandler;
+};
+
+function registerAndCapture(ctx: {
+  app: unknown;
+  userId: string;
+  sessionId: string;
+}): Record<string, CapturedTool> {
+  const captured: Record<string, CapturedTool> = {};
+  const fakeServer = {
+    registerTool: (name: string, cfg: unknown, cb: ToolHandler) => {
+      captured[name] = { cfg: cfg as CapturedTool['cfg'], cb };
+    },
+  } as unknown as McpServer;
+
+  registerWidgetTools(fakeServer, {
+    app: ctx.app as unknown as Parameters<typeof registerWidgetTools>[1]['app'],
+    db: {} as unknown as Parameters<typeof registerWidgetTools>[1]['db'],
+    userId: ctx.userId as unknown as Parameters<typeof registerWidgetTools>[1]['userId'],
+    sessionId: ctx.sessionId as unknown as Parameters<typeof registerWidgetTools>[1]['sessionId'],
+    authenticatedUser: { user_id: ctx.userId, role: 'member' } as unknown as Parameters<
+      typeof registerWidgetTools
+    >[1]['authenticatedUser'],
+    baseServiceParams: {},
+  });
+  return captured;
+}
+
+interface ServiceCall {
+  service: string;
+  method: string;
+  args: unknown[];
+}
+
+function makeApp(opts: {
+  sessionCreator: string;
+  creatorEnvVars?: Record<string, { set: true; scope: 'global' | 'session' }>;
+}): {
+  app: unknown;
+  calls: ServiceCall[];
+  patchedMessage(): Record<string, unknown> | undefined;
+} {
+  const calls: ServiceCall[] = [];
+  let lastMessagePatch: Record<string, unknown> | undefined;
+  const services: Record<string, Record<string, (...args: unknown[]) => unknown>> = {
+    sessions: {
+      get: async (...args: unknown[]) => {
+        calls.push({ service: 'sessions', method: 'get', args });
+        return { session_id: 'sess-1', worktree_id: 'wt-1', created_by: opts.sessionCreator };
+      },
+    },
+    users: {
+      get: async (...args: unknown[]) => {
+        calls.push({ service: 'users', method: 'get', args });
+        return {
+          user_id: opts.sessionCreator,
+          env_vars: opts.creatorEnvVars ?? {},
+        };
+      },
+    },
+    messages: {
+      patch: async (...args: unknown[]) => {
+        calls.push({ service: 'messages', method: 'patch', args });
+        lastMessagePatch = args[1] as Record<string, unknown>;
+        return { message_id: args[0] };
+      },
+    },
+    '/sessions/:id/prompt': {
+      create: async (...args: unknown[]) => {
+        calls.push({ service: '/sessions/:id/prompt', method: 'create', args });
+        return { task_id: 'task-stub' };
+      },
+    },
+  };
+  return {
+    app: {
+      service(name: string) {
+        const svc = services[name];
+        if (!svc) throw new Error(`Unexpected service call: ${name}`);
+        return svc;
+      },
+    },
+    calls,
+    patchedMessage() {
+      return lastMessagePatch;
+    },
+  };
+}
+
+describe('agor_widgets_request_env_vars', () => {
+  const appendStub = appendSystemMessage as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    appendStub.mockReset();
+    // Default: return a freshly-created widget message row.
+    appendStub.mockImplementation(async (opts: { content: string }) => ({
+      message_id: 'widget-msg-1',
+      session_id: 'sess-1',
+      type: 'widget_request',
+      role: 'system',
+      index: 0,
+      timestamp: '2026-05-19T00:00:00.000Z',
+      content: opts.content,
+      content_preview: opts.content,
+      metadata: {},
+    }));
+  });
+
+  it('normal path: creates a pending widget_request and returns status "requested"', async () => {
+    const { app, calls } = makeApp({ sessionCreator: 'user-creator' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    const res = await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    expect(appendStub).toHaveBeenCalledTimes(1);
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.type).toBe('widget_request');
+    expect(appendArgs.metadata.widget.status).toBe('pending');
+    expect(appendArgs.metadata.widget.widget_type).toBe('env_vars');
+
+    // Returns the new widget_id + "requested"
+    const text = JSON.parse(res.content[0].text);
+    expect(text.status).toBe('requested');
+    expect(text.widget_id).toBe('widget-msg-1');
+
+    // No auto-resume task on the normal path — it fires only after the user
+    // submits/dismisses, via the resolve handler.
+    expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+  });
+
+  it('already_present short-circuit: status flips, auto-resume task queued, no form-render', async () => {
+    const { app, calls } = makeApp({
+      sessionCreator: 'user-creator',
+      creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    const res = await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    const text = JSON.parse(res.content[0].text);
+    expect(text.status).toBe('already_present');
+
+    // The created message must be marked already_present from the get-go.
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.metadata.widget.status).toBe('already_present');
+
+    // The auto-resume task must have been queued with a "already configured" prompt
+    const promptCall = calls.find(
+      (c) => c.service === '/sessions/:id/prompt' && c.method === 'create'
+    );
+    expect(promptCall).toBeDefined();
+    const promptData = promptCall?.args[0] as { prompt: string; metadata: Record<string, unknown> };
+    expect(promptData.prompt).toContain('HUBSPOT_API_KEY');
+    expect(promptData.prompt.toLowerCase()).toContain('already configured');
+    expect(promptData.metadata.system_authored).toBe(true);
+    expect(promptData.metadata.widget_id).toBe('widget-msg-1');
+  });
+
+  it('does NOT short-circuit when even one requested name is missing', async () => {
+    const { app, calls } = makeApp({
+      sessionCreator: 'user-creator',
+      creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    const res = await handler({
+      names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY'],
+      reason: 'two integrations',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    const text = JSON.parse(res.content[0].text);
+    expect(text.status).toBe('requested');
+    expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+  });
+
+  it('does NOT short-circuit when the name is set but in a different scope than default_scope', async () => {
+    const { app, calls } = makeApp({
+      sessionCreator: 'user-creator',
+      // Stored under session scope; agent asks for global.
+      creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'session' } },
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    const res = await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'why',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    const text = JSON.parse(res.content[0].text);
+    expect(text.status).toBe('requested');
+    expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+  });
+
+  it('already_present + auto_resume:false skips the task creation', async () => {
+    const { app, calls } = makeApp({
+      sessionCreator: 'user-creator',
+      creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    const res = await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'why',
+      default_scope: 'global',
+      auto_resume: false,
+    });
+
+    const text = JSON.parse(res.content[0].text);
+    expect(text.status).toBe('already_present');
+    expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+  });
+
+  it('tool description tells the agent this is fire-and-forget', () => {
+    const { app } = makeApp({ sessionCreator: 'u' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+    const desc = captured.agor_widgets_request_env_vars.cfg.description ?? '';
+    expect(desc.toLowerCase()).toContain('fire-and-forget');
+    expect(desc.toLowerCase()).toContain('end your turn');
+    expect(desc.toLowerCase()).toContain('never enter your context');
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -5,9 +5,9 @@
  *   - Normal path: creates a `widget_request` message with status 'pending',
  *     returns `{ widget_id, status: 'requested' }`.
  *   - `already_present` short-circuit: when the user already has all names
- *     set in the chosen default_scope, marks the widget `already_present`
- *     and queues an auto-resume task with a "values already configured"
- *     prompt — without rendering a form.
+ *     set in GLOBAL scope, marks the widget `already_present` and queues
+ *     an auto-resume task with a "values already configured" prompt —
+ *     without rendering a form.
  *   - Negative short-circuit: missing one name → falls back to the normal
  *     pending path.
  *   - `auto_resume: false` + `already_present`: status flips but no task
@@ -199,7 +199,6 @@ describe('agor_widgets_request_env_vars', () => {
     const res = await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'call hubspot',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -248,7 +247,6 @@ describe('agor_widgets_request_env_vars', () => {
     await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'call hubspot',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -295,7 +293,6 @@ describe('agor_widgets_request_env_vars', () => {
     await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'call hubspot',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -338,7 +335,6 @@ describe('agor_widgets_request_env_vars', () => {
     await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'call hubspot',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -361,7 +357,6 @@ describe('agor_widgets_request_env_vars', () => {
     const res = await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'call hubspot',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -399,7 +394,6 @@ describe('agor_widgets_request_env_vars', () => {
     const res = await handler({
       names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY'],
       reason: 'two integrations',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -408,10 +402,10 @@ describe('agor_widgets_request_env_vars', () => {
     expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
   });
 
-  it('does NOT short-circuit when the name is set but in a different scope than default_scope', async () => {
+  it('does NOT short-circuit when the name is set only in session scope (short-circuit is global-only)', async () => {
     const { app, calls } = makeApp({
       sessionCreator: 'user-creator',
-      // Stored under session scope; agent asks for global.
+      // Stored under session scope; short-circuit only fires for global.
       creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'session' } },
     });
     const captured = registerAndCapture({
@@ -424,7 +418,6 @@ describe('agor_widgets_request_env_vars', () => {
     const res = await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'why',
-      default_scope: 'global',
       auto_resume: true,
     });
 
@@ -448,7 +441,6 @@ describe('agor_widgets_request_env_vars', () => {
     const res = await handler({
       names: ['HUBSPOT_API_KEY'],
       reason: 'why',
-      default_scope: 'global',
       auto_resume: false,
     });
 

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -67,6 +67,12 @@ interface ServiceCall {
 function makeApp(opts: {
   sessionCreator: string;
   creatorEnvVars?: Record<string, { set: true; scope: 'global' | 'session' }>;
+  /** When omitted, the tasks service returns a single RUNNING task (default). */
+  hostTask?: {
+    task_id: string;
+    status?: string;
+    message_range?: { start_index: number; end_index: number };
+  } | null;
 }): {
   app: unknown;
   calls: ServiceCall[];
@@ -74,6 +80,12 @@ function makeApp(opts: {
 } {
   const calls: ServiceCall[] = [];
   let lastMessagePatch: Record<string, unknown> | undefined;
+  const defaultTask = {
+    task_id: 'task-host-1',
+    status: 'running',
+    message_range: { start_index: 0, end_index: 4 },
+  };
+  const hostTask = opts.hostTask === undefined ? defaultTask : opts.hostTask;
   const services: Record<string, Record<string, (...args: unknown[]) => unknown>> = {
     sessions: {
       get: async (...args: unknown[]) => {
@@ -88,6 +100,21 @@ function makeApp(opts: {
           user_id: opts.sessionCreator,
           env_vars: opts.creatorEnvVars ?? {},
         };
+      },
+    },
+    tasks: {
+      find: async (...args: unknown[]) => {
+        calls.push({ service: 'tasks', method: 'find', args });
+        return { data: hostTask ? [hostTask] : [], total: hostTask ? 1 : 0, limit: 1, skip: 0 };
+      },
+      get: async (...args: unknown[]) => {
+        calls.push({ service: 'tasks', method: 'get', args });
+        if (!hostTask) throw new Error('task not found');
+        return hostTask;
+      },
+      patch: async (...args: unknown[]) => {
+        calls.push({ service: 'tasks', method: 'patch', args });
+        return { ...hostTask, ...(args[1] as Record<string, unknown>) };
       },
     },
     messages: {
@@ -168,6 +195,45 @@ describe('agor_widgets_request_env_vars', () => {
     // No auto-resume task on the normal path — it fires only after the user
     // submits/dismisses, via the resolve handler.
     expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+
+    // Regression: the widget message MUST be bound to the host task — the
+    // transcript renderer loads messages by `task_id`, so an orphaned widget
+    // is invisible in the conversation pane.
+    expect(appendArgs.taskId).toBe('task-host-1');
+
+    // And the host task's message_range.end_index should be extended to cover
+    // the newly-inserted widget message.
+    const taskPatch = calls.find((c) => c.service === 'tasks' && c.method === 'patch');
+    expect(taskPatch).toBeDefined();
+    const patchBody = taskPatch?.args[1] as {
+      message_range: { end_index: number };
+    };
+    expect(patchBody.message_range.end_index).toBe(0); // index of the appended widget
+  });
+
+  it('gracefully omits taskId when no task exists yet (e.g. brand-new session)', async () => {
+    const { app, calls } = makeApp({
+      sessionCreator: 'user-creator',
+      hostTask: null,
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.taskId).toBeUndefined();
+    // No task to patch
+    expect(calls.find((c) => c.service === 'tasks' && c.method === 'patch')).toBeUndefined();
   });
 
   it('already_present short-circuit: status flips, auto-resume task queued, no form-render', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -64,15 +64,24 @@ interface ServiceCall {
   args: unknown[];
 }
 
+interface FakeTask {
+  task_id: string;
+  status: string;
+  created_at?: string;
+  started_at?: string;
+  message_range?: { start_index: number; end_index: number };
+}
+
 function makeApp(opts: {
   sessionCreator: string;
   creatorEnvVars?: Record<string, { set: true; scope: 'global' | 'session' }>;
-  /** When omitted, the tasks service returns a single RUNNING task (default). */
-  hostTask?: {
-    task_id: string;
-    status?: string;
-    message_range?: { start_index: number; end_index: number };
-  } | null;
+  /**
+   * The session's tasks. Mirrors how the real `TasksService.find({ session_id })`
+   * returns ALL session tasks (ASC by created_at) regardless of status / sort,
+   * because of the short-circuit at `services/tasks.ts:65-110`.
+   * When omitted, a single RUNNING task is returned.
+   */
+  sessionTasks?: FakeTask[] | null;
 }): {
   app: unknown;
   calls: ServiceCall[];
@@ -80,12 +89,16 @@ function makeApp(opts: {
 } {
   const calls: ServiceCall[] = [];
   let lastMessagePatch: Record<string, unknown> | undefined;
-  const defaultTask = {
-    task_id: 'task-host-1',
-    status: 'running',
-    message_range: { start_index: 0, end_index: 4 },
-  };
-  const hostTask = opts.hostTask === undefined ? defaultTask : opts.hostTask;
+  const defaultTasks: FakeTask[] = [
+    {
+      task_id: 'task-host-1',
+      status: 'running',
+      created_at: '2026-05-19T00:00:00.000Z',
+      message_range: { start_index: 0, end_index: 4 },
+    },
+  ];
+  const sessionTasks = opts.sessionTasks === undefined ? defaultTasks : (opts.sessionTasks ?? []);
+  const tasksById = new Map(sessionTasks.map((t) => [t.task_id, t]));
   const services: Record<string, Record<string, (...args: unknown[]) => unknown>> = {
     sessions: {
       get: async (...args: unknown[]) => {
@@ -105,16 +118,25 @@ function makeApp(opts: {
     tasks: {
       find: async (...args: unknown[]) => {
         calls.push({ service: 'tasks', method: 'find', args });
-        return { data: hostTask ? [hostTask] : [], total: hostTask ? 1 : 0, limit: 1, skip: 0 };
+        return {
+          data: sessionTasks,
+          total: sessionTasks.length,
+          limit: 1000,
+          skip: 0,
+        };
       },
       get: async (...args: unknown[]) => {
         calls.push({ service: 'tasks', method: 'get', args });
-        if (!hostTask) throw new Error('task not found');
-        return hostTask;
+        const id = args[0] as string;
+        const t = tasksById.get(id);
+        if (!t) throw new Error(`task not found: ${id}`);
+        return t;
       },
       patch: async (...args: unknown[]) => {
         calls.push({ service: 'tasks', method: 'patch', args });
-        return { ...hostTask, ...(args[1] as Record<string, unknown>) };
+        const id = args[0] as string;
+        const t = tasksById.get(id);
+        return { ...t, ...(args[1] as Record<string, unknown>) };
       },
     },
     messages: {
@@ -214,7 +236,7 @@ describe('agor_widgets_request_env_vars', () => {
   it('gracefully omits taskId when no task exists yet (e.g. brand-new session)', async () => {
     const { app, calls } = makeApp({
       sessionCreator: 'user-creator',
-      hostTask: null,
+      sessionTasks: [],
     });
     const captured = registerAndCapture({
       app,
@@ -234,6 +256,94 @@ describe('agor_widgets_request_env_vars', () => {
     expect(appendArgs.taskId).toBeUndefined();
     // No task to patch
     expect(calls.find((c) => c.service === 'tasks' && c.method === 'patch')).toBeUndefined();
+  });
+
+  it('binds to the RUNNING task, not the oldest, when several completed tasks exist', async () => {
+    // Repro for the bug from initial live test: TasksService.find short-circuits
+    // on session_id and returns ALL session tasks in created_at ASC, ignoring
+    // the status filter. The fix must filter to active statuses in-process.
+    const { app, calls } = makeApp({
+      sessionCreator: 'user-creator',
+      sessionTasks: [
+        {
+          task_id: 'task-bootstrap',
+          status: 'completed',
+          created_at: '2026-05-19T22:21:29.000Z',
+          message_range: { start_index: 0, end_index: 11 },
+        },
+        {
+          task_id: 'task-first-prompt',
+          status: 'completed',
+          created_at: '2026-05-20T01:58:10.000Z',
+          message_range: { start_index: 12, end_index: 16 },
+        },
+        {
+          task_id: 'task-current',
+          status: 'running',
+          created_at: '2026-05-20T02:12:35.000Z',
+          message_range: { start_index: 17, end_index: 18 },
+        },
+      ],
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.taskId).toBe('task-current'); // NOT 'task-bootstrap'
+
+    // And the patch extends the CURRENT task's range, not the bootstrap's.
+    const taskPatch = calls.find((c) => c.service === 'tasks' && c.method === 'patch');
+    expect(taskPatch?.args[0]).toBe('task-current');
+  });
+
+  it('falls back to most-recent task when no task is RUNNING', async () => {
+    // Defensive: the MCP tool is invoked by a running agent, so this shouldn't
+    // normally happen — but if all tasks are somehow non-active, pick the
+    // most recent so the widget still renders SOMEWHERE rather than nowhere.
+    const { app } = makeApp({
+      sessionCreator: 'user-creator',
+      sessionTasks: [
+        {
+          task_id: 'task-old',
+          status: 'completed',
+          created_at: '2026-05-19T22:21:29.000Z',
+          message_range: { start_index: 0, end_index: 11 },
+        },
+        {
+          task_id: 'task-newer',
+          status: 'completed',
+          created_at: '2026-05-20T02:12:35.000Z',
+          message_range: { start_index: 12, end_index: 18 },
+        },
+      ],
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    await handler({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+      default_scope: 'global',
+      auto_resume: true,
+    });
+
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.taskId).toBe('task-newer');
   });
 
   it('already_present short-circuit: status flips, auto-resume task queued, no form-render', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -139,12 +139,13 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
         .get(sessionCreatorId, ctx.baseServiceParams)) as User;
 
       // `already_present` short-circuit: if every requested name is already
-      // set in the chosen default scope, skip the form entirely and auto-
-      // resume the agent with a "use what you have" prompt.
+      // set globally for this user, skip the form entirely and auto-resume
+      // the agent. Global-only check is intentional — session-scoped values
+      // depend on session_env_selections which we don't read here.
       const presentEverywhere = allNamesPresentInScope(
         creator.env_vars,
         params.names,
-        params.default_scope as EnvVarScope
+        'global' as EnvVarScope
       );
 
       const requestedAt = new Date().toISOString();

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -19,18 +19,17 @@ import type {
   EnvVarMetadata,
   EnvVarScope,
   MessageID,
-  Paginated,
   Session,
   SessionID,
-  Task,
   TaskID,
   User,
   UserID,
   WidgetMessageMetadata,
 } from '@agor/core/types';
-import { MessageRole, TaskStatus } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { appendSystemMessage } from '../../utils/append-system-message.js';
+import { findHostTaskForSession } from '../../utils/session-tasks.js';
 import { type EnvVarsParams, envVarsParamsSchema } from '../../widgets/env-vars/index.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
@@ -45,52 +44,6 @@ function widgetContentPreview(params: EnvVarsParams): string {
   return params.names.length === 1
     ? `Please provide ${list}: ${params.reason}`
     : `Please provide ${list}: ${params.reason}`;
-}
-
-/**
- * Find the active task for the session, so the widget message can be bound
- * to it. The transcript renderer loads messages per-task (`messages where
- * task_id = X`), so a widget message without a `task_id` is invisible —
- * see `packages/client/src/reactive-session.ts:252`. Prefer the currently
- * active task (the one that invoked this MCP call); fall back to the most
- * recent task as a defensive measure.
- *
- * Implementation note: `TasksService.find()` short-circuits on `session_id`
- * BEFORE applying status / sort (see `services/tasks.ts:65-110`), so a
- * combined query like `{ session_id, status: RUNNING, $sort }` silently
- * returns ALL session tasks in created_at ASC. We work around that by
- * fetching the session's tasks once and doing the active-status filter +
- * recency sort in-process. Same workaround the stop-route uses
- * (`register-routes.ts:1990-2024`).
- */
-const ACTIVE_TASK_STATUSES = new Set<string>([
-  TaskStatus.RUNNING,
-  TaskStatus.AWAITING_PERMISSION,
-  TaskStatus.STOPPING,
-]);
-
-function recencyKey(t: Task): number {
-  return new Date(t.started_at || t.created_at).getTime();
-}
-
-async function findHostTaskId(ctx: McpContext, sessionId: SessionID): Promise<TaskID | undefined> {
-  const result = (await ctx.app.service('tasks').find({
-    query: { session_id: sessionId, $limit: 1000 },
-    ...ctx.baseServiceParams,
-  })) as Paginated<Task> | Task[];
-  const all = Array.isArray(result) ? result : result.data;
-  if (all.length === 0) return undefined;
-
-  // Active (RUNNING / AWAITING_PERMISSION / STOPPING) most-recent first.
-  const active = all
-    .filter((t) => ACTIVE_TASK_STATUSES.has(t.status))
-    .sort((a, b) => recencyKey(b) - recencyKey(a));
-  if (active[0]) return active[0].task_id as TaskID;
-
-  // Fallback: the session's most-recent task overall (defensive — the MCP
-  // tool is invoked by a running agent, so an active task should exist).
-  const recent = [...all].sort((a, b) => recencyKey(b) - recencyKey(a));
-  return recent[0]?.task_id as TaskID | undefined;
 }
 
 /**
@@ -162,7 +115,15 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       // Bind the widget message to the host task so the transcript renderer
       // picks it up — `loadTaskMessages(taskId)` queries by `task_id`, and a
       // message without one is orphaned (invisible in the conversation pane).
-      const hostTaskId = await findHostTaskId(ctx, ctx.sessionId as SessionID);
+      // The transcript renderer loads messages per-task; an unbound widget
+      // message is invisible. See `utils/session-tasks.ts` for the lookup
+      // semantics (active-first, recency-DESC fallback).
+      const hostTask = await findHostTaskForSession(
+        ctx.app,
+        ctx.sessionId as SessionID,
+        ctx.baseServiceParams
+      );
+      const hostTaskId = hostTask?.task_id as TaskID | undefined;
 
       const created = await appendSystemMessage({
         app: ctx.app,
@@ -187,23 +148,18 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       // Extend the host task's message_range.end_index so the widget is
       // counted within the task's window (mirrors the daemon-restart
       // injection path at `startup.ts:274`).
-      if (hostTaskId) {
+      if (hostTask?.message_range) {
         try {
-          const task = (await ctx.app
-            .service('tasks')
-            .get(hostTaskId, ctx.baseServiceParams)) as Task;
-          if (task.message_range) {
-            await ctx.app.service('tasks').patch(
-              hostTaskId,
-              {
-                message_range: {
-                  start_index: task.message_range.start_index,
-                  end_index: created.index,
-                },
+          await ctx.app.service('tasks').patch(
+            hostTask.task_id,
+            {
+              message_range: {
+                start_index: hostTask.message_range.start_index,
+                end_index: created.index,
               },
-              ctx.baseServiceParams
-            );
-          }
+            },
+            ctx.baseServiceParams
+          );
         } catch (err) {
           // Non-fatal — widget will still render via task_id lookup.
           console.warn(

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -52,28 +52,45 @@ function widgetContentPreview(params: EnvVarsParams): string {
  * to it. The transcript renderer loads messages per-task (`messages where
  * task_id = X`), so a widget message without a `task_id` is invisible —
  * see `packages/client/src/reactive-session.ts:252`. Prefer the currently
- * RUNNING task (the one that invoked this MCP call); fall back to the most
+ * active task (the one that invoked this MCP call); fall back to the most
  * recent task as a defensive measure.
+ *
+ * Implementation note: `TasksService.find()` short-circuits on `session_id`
+ * BEFORE applying status / sort (see `services/tasks.ts:65-110`), so a
+ * combined query like `{ session_id, status: RUNNING, $sort }` silently
+ * returns ALL session tasks in created_at ASC. We work around that by
+ * fetching the session's tasks once and doing the active-status filter +
+ * recency sort in-process. Same workaround the stop-route uses
+ * (`register-routes.ts:1990-2024`).
  */
-async function findHostTaskId(ctx: McpContext, sessionId: SessionID): Promise<TaskID | undefined> {
-  const running = (await ctx.app.service('tasks').find({
-    query: {
-      session_id: sessionId,
-      status: TaskStatus.RUNNING,
-      $limit: 1,
-      $sort: { created_at: -1 },
-    },
-    ...ctx.baseServiceParams,
-  })) as Paginated<Task> | Task[];
-  const runningList = Array.isArray(running) ? running : running.data;
-  if (runningList[0]) return runningList[0].task_id as TaskID;
+const ACTIVE_TASK_STATUSES = new Set<string>([
+  TaskStatus.RUNNING,
+  TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.STOPPING,
+]);
 
-  const recent = (await ctx.app.service('tasks').find({
-    query: { session_id: sessionId, $limit: 1, $sort: { created_at: -1 } },
+function recencyKey(t: Task): number {
+  return new Date(t.started_at || t.created_at).getTime();
+}
+
+async function findHostTaskId(ctx: McpContext, sessionId: SessionID): Promise<TaskID | undefined> {
+  const result = (await ctx.app.service('tasks').find({
+    query: { session_id: sessionId, $limit: 1000 },
     ...ctx.baseServiceParams,
   })) as Paginated<Task> | Task[];
-  const recentList = Array.isArray(recent) ? recent : recent.data;
-  return recentList[0]?.task_id as TaskID | undefined;
+  const all = Array.isArray(result) ? result : result.data;
+  if (all.length === 0) return undefined;
+
+  // Active (RUNNING / AWAITING_PERMISSION / STOPPING) most-recent first.
+  const active = all
+    .filter((t) => ACTIVE_TASK_STATUSES.has(t.status))
+    .sort((a, b) => recencyKey(b) - recencyKey(a));
+  if (active[0]) return active[0].task_id as TaskID;
+
+  // Fallback: the session's most-recent task overall (defensive — the MCP
+  // tool is invoked by a running agent, so an active task should exist).
+  const recent = [...all].sort((a, b) => recencyKey(b) - recencyKey(a));
+  return recent[0]?.task_id as TaskID | undefined;
 }
 
 /**

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -116,11 +116,10 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
     'agor_widgets_request_env_vars',
     {
       description:
-        'Ask the user to provide one or more environment variables via an in-conversation form. ' +
-        'This is a FIRE-AND-FORGET request: the widget is rendered inline in the transcript and the user fills it out asynchronously. ' +
-        'End your turn after this tool call — you will receive a new user-role message ("[Agor] User submitted ...") when the user responds, and can resume work then. ' +
-        'CRITICAL: the values never enter your context — the user types them directly into the UI, the form posts straight to the daemon, and you only ever see variable NAMES. ' +
-        'Use this when you need a secret/credential to proceed (e.g. an API key). Do NOT ask the user to paste the value into chat — that defeats the security guarantee.',
+        'Ask the user to provide one or more environment variables via a compact in-conversation form. ' +
+        'FIRE-AND-FORGET: the widget renders inline; end your turn after calling. You will receive a user-role message ("[Agor] User submitted ...") when the user responds. ' +
+        'Values never enter your context — only the variable NAMES do. Do NOT ask the user to paste values into chat. ' +
+        'Keep `reason` to ONE short sentence (≤200 chars) — it shows as a small muted line; do not restate what the widget does or describe the security contract (the UI handles that).',
       annotations: { destructiveHint: false, openWorldHint: false },
       inputSchema: envVarsParamsSchema,
     },

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -1,0 +1,170 @@
+/**
+ * Widgets MCP Tools — agent-facing tools for in-conversation widget primitives.
+ *
+ * v1 ships a single tool: `agor_widgets_request_env_vars`. The widget is
+ * fire-and-forget: this handler returns immediately with `{ widget_id, status }`
+ * and the agent ends its turn. When the user types values into the inline
+ * form and hits "Save & continue", the daemon writes them, queues a system-
+ * authored auto-resume prompt via the existing `/sessions/:id/prompt` route,
+ * and the agent picks up where it left off in its next turn.
+ *
+ * Security contract (§5.1 of the design doc): the agent never sees submitted
+ * values. The tool input only accepts variable NAMES; the values reach the
+ * daemon directly from the browser via `POST /widgets/:widget_id/submit`.
+ *
+ * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ */
+
+import type {
+  EnvVarMetadata,
+  EnvVarScope,
+  MessageID,
+  Session,
+  SessionID,
+  User,
+  UserID,
+  WidgetMessageMetadata,
+} from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { appendSystemMessage } from '../../utils/append-system-message.js';
+import { type EnvVarsParams, envVarsParamsSchema } from '../../widgets/env-vars/index.js';
+import type { McpContext } from '../server.js';
+import { textResult } from '../server.js';
+
+/**
+ * Build a short, user-visible message body for the widget transcript row.
+ * Falls back to a generic phrasing when there's only one or many names; agents
+ * rarely look at this string but it's what shows above the form.
+ */
+function widgetContentPreview(params: EnvVarsParams): string {
+  const list = params.names.join(', ');
+  return params.names.length === 1
+    ? `Please provide ${list}: ${params.reason}`
+    : `Please provide ${list}: ${params.reason}`;
+}
+
+/**
+ * Check whether the user already has ALL requested names set in the chosen
+ * scope. The `already_present` short-circuit (D4 in the design doc) fires
+ * when this returns true.
+ */
+function allNamesPresentInScope(
+  envVarsMeta: Record<string, EnvVarMetadata> | undefined,
+  names: string[],
+  scope: EnvVarScope
+): boolean {
+  if (!envVarsMeta) return false;
+  for (const name of names) {
+    const meta = envVarsMeta[name];
+    if (!meta || meta.scope !== scope) return false;
+  }
+  return true;
+}
+
+export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'agor_widgets_request_env_vars',
+    {
+      description:
+        'Ask the user to provide one or more environment variables via an in-conversation form. ' +
+        'This is a FIRE-AND-FORGET request: the widget is rendered inline in the transcript and the user fills it out asynchronously. ' +
+        'End your turn after this tool call — you will receive a new user-role message ("[Agor] User submitted ...") when the user responds, and can resume work then. ' +
+        'CRITICAL: the values never enter your context — the user types them directly into the UI, the form posts straight to the daemon, and you only ever see variable NAMES. ' +
+        'Use this when you need a secret/credential to proceed (e.g. an API key). Do NOT ask the user to paste the value into chat — that defeats the security guarantee.',
+      annotations: { destructiveHint: false, openWorldHint: false },
+      inputSchema: envVarsParamsSchema,
+    },
+    async (args) => {
+      // Validated by Zod via the SDK; `args` has Zod defaults applied.
+      const params: EnvVarsParams = args as EnvVarsParams;
+
+      // Look up the host session + its creator. The session creator is the
+      // identity whose env vars get written and read by the executor — this
+      // matches the `dangerously_allow_session_sharing: false` semantics.
+      const session = (await ctx.app
+        .service('sessions')
+        .get(ctx.sessionId, ctx.baseServiceParams)) as Session;
+      const sessionCreatorId = session.created_by as UserID;
+      const creator = (await ctx.app
+        .service('users')
+        .get(sessionCreatorId, ctx.baseServiceParams)) as User;
+
+      // `already_present` short-circuit: if every requested name is already
+      // set in the chosen default scope, skip the form entirely and auto-
+      // resume the agent with a "use what you have" prompt.
+      const presentEverywhere = allNamesPresentInScope(
+        creator.env_vars,
+        params.names,
+        params.default_scope as EnvVarScope
+      );
+
+      const requestedAt = new Date().toISOString();
+      const baseWidgetMeta: Omit<WidgetMessageMetadata, 'widget_id'> = {
+        widget_type: 'env_vars',
+        schema_version: 1,
+        params,
+        status: presentEverywhere ? 'already_present' : 'pending',
+        requested_at: requestedAt,
+        ...(presentEverywhere ? { resolved_at: requestedAt } : {}),
+        auto_resume: params.auto_resume,
+      };
+
+      const created = await appendSystemMessage({
+        app: ctx.app,
+        db: ctx.db,
+        sessionId: ctx.sessionId,
+        content: widgetContentPreview(params),
+        contentPreview: `Widget: env_vars (${params.names.join(', ')})`,
+        type: 'widget_request',
+        role: MessageRole.SYSTEM,
+        // widget_id is filled in once we know the new message_id (id == widget_id).
+        metadata: {
+          widget: {
+            ...baseWidgetMeta,
+            widget_id: 'pending' as MessageID,
+          },
+        },
+      });
+
+      const widgetId = created.message_id as MessageID;
+
+      // Stamp the actual widget_id onto the row (single source of truth =
+      // `metadata.widget.widget_id === message.message_id`).
+      await ctx.app.service('messages').patch(
+        widgetId,
+        {
+          metadata: {
+            ...(created.metadata ?? {}),
+            widget: { ...baseWidgetMeta, widget_id: widgetId },
+          },
+        },
+        ctx.baseServiceParams
+      );
+
+      if (presentEverywhere) {
+        // Short-circuit: no form render. Auto-queue a "values already
+        // configured" task (unless the agent opted out via auto_resume:false).
+        if (params.auto_resume) {
+          const namesList = params.names.join(', ');
+          const verb = params.names.length === 1 ? 'was' : 'were';
+          const prompt = `[Agor] ${namesList} ${verb} already configured. You can proceed.`;
+          await ctx.app.service('/sessions/:id/prompt').create(
+            {
+              prompt,
+              messageSource: 'agor',
+              metadata: {
+                system_authored: true,
+                widget_id: widgetId,
+              },
+            },
+            { ...ctx.baseServiceParams, route: { id: ctx.sessionId as SessionID } }
+          );
+        }
+        return textResult({ widget_id: widgetId, status: 'already_present' });
+      }
+
+      return textResult({ widget_id: widgetId, status: 'requested' });
+    }
+  );
+}

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -19,13 +19,16 @@ import type {
   EnvVarMetadata,
   EnvVarScope,
   MessageID,
+  Paginated,
   Session,
   SessionID,
+  Task,
+  TaskID,
   User,
   UserID,
   WidgetMessageMetadata,
 } from '@agor/core/types';
-import { MessageRole } from '@agor/core/types';
+import { MessageRole, TaskStatus } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { appendSystemMessage } from '../../utils/append-system-message.js';
 import { type EnvVarsParams, envVarsParamsSchema } from '../../widgets/env-vars/index.js';
@@ -42,6 +45,35 @@ function widgetContentPreview(params: EnvVarsParams): string {
   return params.names.length === 1
     ? `Please provide ${list}: ${params.reason}`
     : `Please provide ${list}: ${params.reason}`;
+}
+
+/**
+ * Find the active task for the session, so the widget message can be bound
+ * to it. The transcript renderer loads messages per-task (`messages where
+ * task_id = X`), so a widget message without a `task_id` is invisible —
+ * see `packages/client/src/reactive-session.ts:252`. Prefer the currently
+ * RUNNING task (the one that invoked this MCP call); fall back to the most
+ * recent task as a defensive measure.
+ */
+async function findHostTaskId(ctx: McpContext, sessionId: SessionID): Promise<TaskID | undefined> {
+  const running = (await ctx.app.service('tasks').find({
+    query: {
+      session_id: sessionId,
+      status: TaskStatus.RUNNING,
+      $limit: 1,
+      $sort: { created_at: -1 },
+    },
+    ...ctx.baseServiceParams,
+  })) as Paginated<Task> | Task[];
+  const runningList = Array.isArray(running) ? running : running.data;
+  if (runningList[0]) return runningList[0].task_id as TaskID;
+
+  const recent = (await ctx.app.service('tasks').find({
+    query: { session_id: sessionId, $limit: 1, $sort: { created_at: -1 } },
+    ...ctx.baseServiceParams,
+  })) as Paginated<Task> | Task[];
+  const recentList = Array.isArray(recent) ? recent : recent.data;
+  return recentList[0]?.task_id as TaskID | undefined;
 }
 
 /**
@@ -110,10 +142,16 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
         auto_resume: params.auto_resume,
       };
 
+      // Bind the widget message to the host task so the transcript renderer
+      // picks it up — `loadTaskMessages(taskId)` queries by `task_id`, and a
+      // message without one is orphaned (invisible in the conversation pane).
+      const hostTaskId = await findHostTaskId(ctx, ctx.sessionId as SessionID);
+
       const created = await appendSystemMessage({
         app: ctx.app,
         db: ctx.db,
         sessionId: ctx.sessionId,
+        taskId: hostTaskId,
         content: widgetContentPreview(params),
         contentPreview: `Widget: env_vars (${params.names.join(', ')})`,
         type: 'widget_request',
@@ -128,6 +166,35 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       });
 
       const widgetId = created.message_id as MessageID;
+
+      // Extend the host task's message_range.end_index so the widget is
+      // counted within the task's window (mirrors the daemon-restart
+      // injection path at `startup.ts:274`).
+      if (hostTaskId) {
+        try {
+          const task = (await ctx.app
+            .service('tasks')
+            .get(hostTaskId, ctx.baseServiceParams)) as Task;
+          if (task.message_range) {
+            await ctx.app.service('tasks').patch(
+              hostTaskId,
+              {
+                message_range: {
+                  start_index: task.message_range.start_index,
+                  end_index: created.index,
+                },
+              },
+              ctx.baseServiceParams
+            );
+          }
+        } catch (err) {
+          // Non-fatal — widget will still render via task_id lookup.
+          console.warn(
+            `[widgets] failed to extend task.message_range for widget ${widgetId}:`,
+            err
+          );
+        }
+      }
 
       // Stamp the actual widget_id onto the row (single source of truth =
       // `metadata.widget.widget_id === message.message_id`).

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1482,6 +1482,21 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return context;
           }
 
+          // Trusted internal-server-side write escape hatch. Set by code paths
+          // that have ALREADY authorized the caller against a different,
+          // narrower contract than the users.patch self-only hook — e.g. the
+          // widget submit endpoint, which authorizes via `canResolveWidget`
+          // (session-creator OR prompt-tier worktree RBAC) and then writes
+          // the resulting env-var values onto the session creator's profile.
+          //
+          // Field-level admin gates above (unix_username / role /
+          // must_change_password) are NOT bypassed — those run first.
+          //
+          // Grep for: trustedInternalWrite — to audit every site that sets it.
+          if ((params as { trustedInternalWrite?: boolean }).trustedInternalWrite === true) {
+            return context;
+          }
+
           // Otherwise forbidden
           throw new Forbidden('You can only update your own profile');
         },

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1482,18 +1482,27 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return context;
           }
 
-          // Trusted internal-server-side write escape hatch. Set by code paths
-          // that have ALREADY authorized the caller against a different,
-          // narrower contract than the users.patch self-only hook — e.g. the
-          // widget submit endpoint, which authorizes via `canResolveWidget`
-          // (session-creator OR prompt-tier worktree RBAC) and then writes
-          // the resulting env-var values onto the session creator's profile.
+          // Env-var-specific trusted write escape hatch. Set ONLY by the widget
+          // submit path, which has already authorized the caller via
+          // `canResolveWidget` (session-creator OR prompt-tier worktree RBAC)
+          // before calling users.patch on the session creator's behalf.
           //
-          // Field-level admin gates above (unix_username / role /
-          // must_change_password) are NOT bypassed — those run first.
+          // Deliberately narrow: only allows `env_vars` + `env_var_scopes`
+          // fields — any attempt to slip in other fields (e.g. role, unix_username)
+          // throws immediately. Field-level admin gates above run first and are
+          // NOT bypassed regardless.
           //
-          // Grep for: trustedInternalWrite — to audit every site that sets it.
-          if ((params as { trustedInternalWrite?: boolean }).trustedInternalWrite === true) {
+          // Grep for: trustedEnvVarWrite — to audit every site that sets it.
+          if (
+            !context.params.provider &&
+            (params as { trustedEnvVarWrite?: boolean }).trustedEnvVarWrite === true
+          ) {
+            const keys = Object.keys(context.data ?? {});
+            if (!keys.every((k) => k === 'env_vars' || k === 'env_var_scopes')) {
+              throw new Forbidden(
+                'trustedEnvVarWrite only permits env_vars and env_var_scopes updates'
+              );
+            }
             return context;
           }
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -103,6 +103,7 @@ import {
   PERMISSION_RANK,
   resolveWorktreePermission,
 } from './utils/worktree-authorization.js';
+import { resolveWidget } from './widgets/submissions.js';
 
 /**
  * Extended Params with route ID parameter.
@@ -1224,6 +1225,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           permissionMode?: import('@agor/core/types').PermissionMode;
           stream?: boolean;
           messageSource?: MessageSource;
+          /**
+           * Optional extra task metadata merged onto the queued/created task.
+           * Used by internal callers (e.g. widget submissions) to stamp
+           * traceability fields like `system_authored` / `widget_id`.
+           * External callers receive no validation on this field — it's
+           * trusted because the route is RBAC-gated.
+           */
+          metadata?: Partial<import('@agor/core/types').TaskMetadata>;
         },
         params: RouteParams
       ) {
@@ -1317,6 +1326,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               metadata: {
                 ...(params.user?.user_id ? { queued_by_user_id: params.user.user_id } : {}),
                 ...(messageSource ? { source: messageSource } : {}),
+                ...(data.metadata ?? {}),
               },
             });
 
@@ -1356,12 +1366,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // writes the user-message row, and spawns the executor. Both this
           // path and processNextQueuedTask go through that helper so behavior
           // stays in lockstep.
+          const idleTaskMetadata: import('@agor/core/types').TaskMetadata = {
+            ...(messageSource ? { source: messageSource } : {}),
+            ...(data.metadata ?? {}),
+          };
           const task = await taskRepo.createPending({
             session_id: id as SessionID,
             full_prompt: data.prompt,
             created_by: createdBy,
             status: TaskStatus.CREATED,
-            metadata: messageSource ? { source: messageSource } : undefined,
+            metadata: Object.keys(idleTaskMetadata).length > 0 ? idleTaskMetadata : undefined,
           });
           // Bypassing the service means no native 'created' emit; do it here
           // so reactive clients see the new task before the executor spawns.
@@ -2287,6 +2301,69 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     },
     {
       create: { role: ROLES.MEMBER, action: 'respond to permission requests' },
+    },
+    requireAuth
+  );
+
+  // ============================================================================
+  // Widget submission / dismissal endpoints
+  //
+  // See `docs/internal/in-conversation-widgets-design-2026-05-19.md`. The
+  // resolver handles auth, idempotency, registry dispatch, message patching,
+  // auto-resume task queueing, and the `widget:resolved` broadcast.
+  // ============================================================================
+
+  const widgetResolverDeps = {
+    // biome-ignore lint/suspicious/noExplicitAny: Feathers Application shape
+    app: app as any,
+    isWorktreeOwner: async (worktreeId: string, userId: UUID) =>
+      worktreeRepository.isOwner(worktreeId as import('@agor/core/types').WorktreeID, userId),
+  };
+
+  registerAuthenticatedRoute(
+    app,
+    '/widgets/:id/submit',
+    {
+      async create(data: Record<string, unknown>, params: RouteParams) {
+        const widgetId = params.route?.id;
+        if (!widgetId) throw new Error('Widget ID required');
+        if (!params.user?.user_id) {
+          throw new NotAuthenticated('Authentication required to submit a widget');
+        }
+        return resolveWidget(
+          widgetId,
+          { kind: 'submit', body: data ?? {} },
+          { user_id: params.user.user_id as UUID, role: params.user.role as string | undefined },
+          widgetResolverDeps
+        );
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'submit widgets' },
+    },
+    requireAuth
+  );
+
+  registerAuthenticatedRoute(
+    app,
+    '/widgets/:id/dismiss',
+    {
+      async create(_data: unknown, params: RouteParams) {
+        const widgetId = params.route?.id;
+        if (!widgetId) throw new Error('Widget ID required');
+        if (!params.user?.user_id) {
+          throw new NotAuthenticated('Authentication required to dismiss a widget');
+        }
+        return resolveWidget(
+          widgetId,
+          { kind: 'dismiss' },
+          { user_id: params.user.user_id as UUID, role: params.user.role as string | undefined },
+          widgetResolverDeps
+        );
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'dismiss widgets' },
     },
     requireAuth
   );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -90,6 +90,7 @@ import {
   requireMinimumRole,
 } from './utils/authorization.js';
 import { buildInitialUserMessage } from './utils/build-initial-user-message.js';
+import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import {
@@ -1980,20 +1981,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           };
         }
 
-        const targetTasksArray: Task[] = [];
-
-        for (const status of [
-          TaskStatus.RUNNING,
-          TaskStatus.AWAITING_PERMISSION,
-          TaskStatus.STOPPING,
-        ]) {
-          const result = await tasksService.find({
-            query: { session_id: id, status, $limit: 10 },
-          });
-          const findResult = result as Task[] | Paginated<Task>;
-          const tasks = isPaginated(findResult) ? findResult.data : findResult;
-          targetTasksArray.push(...tasks);
-        }
+        // `TasksService.find()` short-circuits on session_id and silently
+        // ignores the status filter; use the shared helper that filters in
+        // process. Already recency-DESC sorted.
+        const targetTasksArray = await findActiveTasksForSession(app as never, id as SessionID);
 
         if (targetTasksArray.length === 0) {
           console.warn(
@@ -2017,11 +2008,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           };
         }
 
-        targetTasksArray.sort((a, b) => {
-          const timeA = new Date(a.started_at || a.created_at).getTime();
-          const timeB = new Date(b.started_at || b.created_at).getTime();
-          return timeB - timeA;
-        });
         const latestTask = targetTasksArray[0];
 
         console.log(

--- a/apps/agor-daemon/src/utils/append-system-message.ts
+++ b/apps/agor-daemon/src/utils/append-system-message.ts
@@ -33,7 +33,7 @@ export interface AppendSystemMessageOptions {
   /** Falls back to the first 200 chars of string content when omitted */
   contentPreview?: string;
   /** Defaults to 'system' */
-  type?: Extract<MessageType, 'system' | 'daemon_restart' | 'daemon_crash'>;
+  type?: Extract<MessageType, 'system' | 'daemon_restart' | 'daemon_crash' | 'widget_request'>;
   /** Defaults to MessageRole.SYSTEM */
   role?: Message['role'];
   metadata?: Message['metadata'];

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -1,0 +1,79 @@
+/**
+ * Helpers for finding "active" tasks for a session — RUNNING /
+ * AWAITING_PERMISSION / STOPPING — sorted by recency.
+ *
+ * Background: `TasksService.find()` short-circuits on `session_id: string`
+ * (see `services/tasks.ts:65-110`) and returns ALL session tasks in
+ * `created_at` ASC, ignoring any `status` filter or `$sort` passed in the
+ * same query. So callers can't write `{ session_id, status: RUNNING }`
+ * and trust the result. We instead fetch the full session task list once
+ * and filter/sort in process.
+ *
+ * Without this helper, multiple sites (widget MCP tool, stop route,
+ * potentially more) end up with parallel hand-rolled workarounds that
+ * drift. Keep this as the single source.
+ */
+
+import type { Application } from '@agor/core/feathers';
+import type { Paginated, Params, SessionID, Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+
+/** Statuses considered "active" — an executor may still be doing work. */
+export const ACTIVE_TASK_STATUSES: ReadonlySet<string> = new Set<string>([
+  TaskStatus.RUNNING,
+  TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.STOPPING,
+]);
+
+function recencyKey(t: Task): number {
+  return new Date(t.started_at || t.created_at).getTime();
+}
+
+/**
+ * All tasks for the session, returned in recency-DESC order (most recently
+ * started/created first). Useful when callers want a fallback path.
+ */
+export async function findTasksForSession(
+  app: Application,
+  sessionId: SessionID,
+  params?: Params
+): Promise<Task[]> {
+  const result = (await app.service('tasks').find({
+    query: { session_id: sessionId, $limit: 1000 },
+    ...(params ?? {}),
+  })) as Paginated<Task> | Task[];
+  const tasks = Array.isArray(result) ? result : result.data;
+  return [...tasks].sort((a, b) => recencyKey(b) - recencyKey(a));
+}
+
+/**
+ * The session's active tasks (RUNNING / AWAITING_PERMISSION / STOPPING),
+ * recency-DESC. Empty when nothing is active.
+ */
+export async function findActiveTasksForSession(
+  app: Application,
+  sessionId: SessionID,
+  params?: Params
+): Promise<Task[]> {
+  const all = await findTasksForSession(app, sessionId, params);
+  return all.filter((t) => ACTIVE_TASK_STATUSES.has(t.status));
+}
+
+/**
+ * The single most-recent active task — preferred when callers want "the
+ * task that is driving this session right now." Falls back to the most-
+ * recent task of any status when nothing is active, so widget messages /
+ * system messages always land somewhere visible to the transcript renderer.
+ *
+ * Returns `undefined` when the session has no tasks at all (brand-new
+ * session).
+ */
+export async function findHostTaskForSession(
+  app: Application,
+  sessionId: SessionID,
+  params?: Params
+): Promise<Task | undefined> {
+  const all = await findTasksForSession(app, sessionId, params);
+  if (all.length === 0) return undefined;
+  return all.find((t) => ACTIVE_TASK_STATUSES.has(t.status)) ?? all[0];
+}

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -39,8 +39,14 @@ export async function findTasksForSession(
   params?: Params
 ): Promise<Task[]> {
   const result = (await app.service('tasks').find({
-    query: { session_id: sessionId, $limit: 1000 },
     ...(params ?? {}),
+    // Merge defensively: spread params first, then force session_id so a
+    // caller-supplied params.query can never silently overwrite the filter.
+    query: {
+      ...(params?.query as Record<string, unknown> | undefined),
+      session_id: sessionId,
+      $limit: (params?.query as Record<string, unknown> | undefined)?.$limit ?? 1000,
+    },
   })) as Paginated<Task> | Task[];
   const tasks = Array.isArray(result) ? result : result.data;
   return [...tasks].sort((a, b) => recencyKey(b) - recencyKey(a));

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -26,9 +26,11 @@ import {
   registerEnvVarsWidget,
 } from './index';
 
-function makeCtx(patch?: (id: string, data: unknown) => unknown | Promise<unknown>) {
-  const patchSpy = vi.fn(async (id: string, data: unknown) => {
-    return patch ? patch(id, data) : { user_id: id };
+function makeCtx(
+  patch?: (id: string, data: unknown, params: unknown) => unknown | Promise<unknown>
+) {
+  const patchSpy = vi.fn(async (id: string, data: unknown, params: unknown) => {
+    return patch ? patch(id, data, params) : { user_id: id };
   });
   const app = {
     service(name: string) {
@@ -42,6 +44,7 @@ function makeCtx(patch?: (id: string, data: unknown) => unknown | Promise<unknow
       app: app as any,
       sessionId: 'sess-1' as never,
       submitterUserId: 'user-creator' as UserID,
+      submitterRole: 'member' as string | undefined,
       sessionCreatorUserId: 'user-creator' as UserID,
     },
     patchSpy,
@@ -169,11 +172,38 @@ describe('env_vars widget — applySubmit', () => {
       scope: 'global',
     });
     expect(patchSpy).toHaveBeenCalledTimes(1);
-    const [id, data] = patchSpy.mock.calls[0];
+    const [id, data, params] = patchSpy.mock.calls[0];
     expect(id).toBe('user-creator');
     expect(data).toEqual({
       env_vars: { HUBSPOT_API_KEY: 'shh' },
       env_var_scopes: { HUBSPOT_API_KEY: 'global' },
+    });
+    // Regression: must pass auth params so the users.patch self-only hook
+    // (`register-hooks.ts:1481`) doesn't 403. Submitter context goes through.
+    expect(params).toEqual({
+      user: { user_id: 'user-creator', role: 'member' },
+      authenticated: true,
+    });
+  });
+
+  it('passes admin params through when submitter is admin (admin bypass path)', async () => {
+    const { ctx: baseCtx, patchSpy } = makeCtx();
+    const adminCtx = {
+      ...baseCtx,
+      submitterUserId: 'user-admin' as UserID,
+      submitterRole: 'admin',
+    };
+    await envVarsWidget.applySubmit(adminCtx, {
+      values: { HUBSPOT_API_KEY: 'shh' },
+      scope: 'global',
+    });
+    const [, , params] = patchSpy.mock.calls[0];
+    // Admin submitter → users.patch hook bypasses the self-check via
+    // role-based admin path. Target is still sessionCreatorUserId, but the
+    // auth params carry the ADMIN submitter's identity.
+    expect(params).toEqual({
+      user: { user_id: 'user-admin', role: 'admin' },
+      authenticated: true,
     });
   });
 

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -165,10 +165,11 @@ describe('env_vars widget — buildResultMeta', () => {
 describe('env_vars widget — applySubmit', () => {
   it('calls users.patch with { env_vars, env_var_scopes } for the session creator', async () => {
     const { ctx, patchSpy } = makeCtx();
-    await envVarsWidget.applySubmit(ctx, {
-      values: { HUBSPOT_API_KEY: 'shh' },
-      scope: 'global',
-    });
+    await envVarsWidget.applySubmit(
+      ctx,
+      { values: { HUBSPOT_API_KEY: 'shh' }, scope: 'global' },
+      { names: ['HUBSPOT_API_KEY'], reason: 'call hubspot', auto_resume: true }
+    );
     expect(patchSpy).toHaveBeenCalledTimes(1);
     const [id, data, params] = patchSpy.mock.calls[0];
     expect(id).toBe('user-creator');
@@ -176,14 +177,13 @@ describe('env_vars widget — applySubmit', () => {
       env_vars: { HUBSPOT_API_KEY: 'shh' },
       env_var_scopes: { HUBSPOT_API_KEY: 'global' },
     });
-    // Regression: must pass auth params so the users.patch hook (`register-
-    // hooks.ts:1490`) accepts a write to a user other than the caller via
-    // the `trustedInternalWrite` escape hatch (the widget endpoint already
-    // authorized this via `canResolveWidget`).
+    // Regression: must pass auth params so the users.patch hook accepts a
+    // write to a user other than the caller via the `trustedEnvVarWrite`
+    // escape hatch (the widget endpoint already authorized via canResolveWidget).
     expect(params).toEqual({
       user: { user_id: 'user-creator', role: 'member' },
       authenticated: true,
-      trustedInternalWrite: true,
+      trustedEnvVarWrite: true,
     });
   });
 
@@ -194,39 +194,68 @@ describe('env_vars widget — applySubmit', () => {
       submitterUserId: 'user-admin' as UserID,
       submitterRole: 'admin',
     };
-    await envVarsWidget.applySubmit(adminCtx, {
-      values: { HUBSPOT_API_KEY: 'shh' },
-      scope: 'global',
-    });
+    await envVarsWidget.applySubmit(
+      adminCtx,
+      { values: { HUBSPOT_API_KEY: 'shh' }, scope: 'global' },
+      { names: ['HUBSPOT_API_KEY'], reason: 'call hubspot', auto_resume: true }
+    );
     const [, , params] = patchSpy.mock.calls[0];
     // Auth params carry the SUBMITTER identity so the patch is attributable.
     expect(params).toEqual({
       user: { user_id: 'user-admin', role: 'admin' },
       authenticated: true,
-      trustedInternalWrite: true,
+      trustedEnvVarWrite: true,
     });
   });
 
   it('writes ALL submitted names in one patch call', async () => {
     const { ctx, patchSpy } = makeCtx();
-    await envVarsWidget.applySubmit(ctx, {
-      values: { A_KEY: 'a', B_KEY: 'b' },
-      scope: 'session',
-    });
+    await envVarsWidget.applySubmit(
+      ctx,
+      { values: { A_KEY: 'a', B_KEY: 'b' }, scope: 'session' },
+      { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
+    );
     expect(patchSpy).toHaveBeenCalledTimes(1);
     const [, data] = patchSpy.mock.calls[0] as [string, Record<string, unknown>];
     expect(data.env_vars).toEqual({ A_KEY: 'a', B_KEY: 'b' });
     expect(data.env_var_scopes).toEqual({ A_KEY: 'session', B_KEY: 'session' });
   });
 
+  it('rejects submitted names that do not exactly match params.names', async () => {
+    const { ctx, patchSpy } = makeCtx();
+    // Tampered client tries to write EXTRA_VAR that wasn't in the widget request.
+    await expect(
+      envVarsWidget.applySubmit(
+        ctx,
+        { values: { HUBSPOT_API_KEY: 'v', EXTRA_VAR: 'evil' }, scope: 'global' },
+        { names: ['HUBSPOT_API_KEY'], reason: 'why', auto_resume: true }
+      )
+    ).rejects.toThrow(/exactly match/i);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects submitted names that are a subset of params.names', async () => {
+    const { ctx, patchSpy } = makeCtx();
+    // Client only submits one of the two requested vars — not an exact match.
+    await expect(
+      envVarsWidget.applySubmit(
+        ctx,
+        { values: { A_KEY: 'v' }, scope: 'global' },
+        { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
+      )
+    ).rejects.toThrow(/exactly match/i);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
   it('rejects blocklisted names before patching', async () => {
     const { ctx, patchSpy } = makeCtx();
     // PATH is on the blocklist (system identity).
     await expect(
-      envVarsWidget.applySubmit(ctx, {
-        values: { PATH: '/tmp/evil' },
-        scope: 'global',
-      })
+      envVarsWidget.applySubmit(
+        ctx,
+        { values: { PATH: '/tmp/evil' }, scope: 'global' },
+        { names: ['PATH'], reason: 'why', auto_resume: true }
+      )
     ).rejects.toThrow(/blocked|cannot be set/i);
     expect(patchSpy).not.toHaveBeenCalled();
   });
@@ -236,10 +265,11 @@ describe('env_vars widget — applySubmit', () => {
       throw new Error('Invalid environment variable: value too long');
     });
     await expect(
-      envVarsWidget.applySubmit(ctx, {
-        values: { HUBSPOT_API_KEY: 'v' },
-        scope: 'global',
-      })
+      envVarsWidget.applySubmit(
+        ctx,
+        { values: { HUBSPOT_API_KEY: 'v' }, scope: 'global' },
+        { names: ['HUBSPOT_API_KEY'], reason: 'why', auto_resume: true }
+      )
     ).rejects.toThrow(/value too long/i);
   });
 
@@ -270,10 +300,11 @@ describe('env_vars widget — applySubmit', () => {
     ];
     try {
       const { ctx } = makeCtx();
-      await envVarsWidget.applySubmit(ctx, {
-        values: { HUBSPOT_API_KEY: secret },
-        scope: 'global',
-      });
+      await envVarsWidget.applySubmit(
+        ctx,
+        { values: { HUBSPOT_API_KEY: secret }, scope: 'global' },
+        { names: ['HUBSPOT_API_KEY'], reason: 'why', auto_resume: true }
+      );
       // Flatten every logged arg into a string and assert the secret is
       // nowhere in it. Covers stringified objects, error wrappers, etc.
       const allText = calls

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -78,8 +78,7 @@ describe('env_vars widget — paramsSchema', () => {
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      // default_scope and auto_resume defaults applied
-      expect(result.data.default_scope).toBe('global');
+      // auto_resume default applied (scope is a user-only UI choice)
       expect(result.data.auto_resume).toBe(true);
     }
   });
@@ -288,7 +287,6 @@ describe('env_vars widget — prompt builders', () => {
     const params = {
       names: ['HUBSPOT_API_KEY'],
       reason: 'why',
-      default_scope: 'global' as const,
       auto_resume: true,
     };
     const rm = { names_submitted: ['HUBSPOT_API_KEY'], scope: 'global' as const };
@@ -305,7 +303,6 @@ describe('env_vars widget — prompt builders', () => {
     const params = {
       names: ['A', 'B'],
       reason: 'why',
-      default_scope: 'session' as const,
       auto_resume: true,
     };
     const prompt = envVarsWidget.buildAutoResumePrompt(rm, params);
@@ -316,7 +313,6 @@ describe('env_vars widget — prompt builders', () => {
     const params = {
       names: ['HUBSPOT_API_KEY'],
       reason: 'why',
-      default_scope: 'global' as const,
       auto_resume: true,
     };
     const prompt = envVarsWidget.buildDismissedPrompt(params);

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -40,8 +40,7 @@ function makeCtx(
   };
   return {
     ctx: {
-      // biome-ignore lint/suspicious/noExplicitAny: Pass-through stub
-      app: app as any,
+      app: app as never,
       sessionId: 'sess-1' as never,
       submitterUserId: 'user-creator' as UserID,
       submitterRole: 'member' as string | undefined,
@@ -177,15 +176,18 @@ describe('env_vars widget — applySubmit', () => {
       env_vars: { HUBSPOT_API_KEY: 'shh' },
       env_var_scopes: { HUBSPOT_API_KEY: 'global' },
     });
-    // Regression: must pass auth params so the users.patch self-only hook
-    // (`register-hooks.ts:1481`) doesn't 403. Submitter context goes through.
+    // Regression: must pass auth params so the users.patch hook (`register-
+    // hooks.ts:1490`) accepts a write to a user other than the caller via
+    // the `trustedInternalWrite` escape hatch (the widget endpoint already
+    // authorized this via `canResolveWidget`).
     expect(params).toEqual({
       user: { user_id: 'user-creator', role: 'member' },
       authenticated: true,
+      trustedInternalWrite: true,
     });
   });
 
-  it('passes admin params through when submitter is admin (admin bypass path)', async () => {
+  it('passes submitter identity through for audit when an admin submits', async () => {
     const { ctx: baseCtx, patchSpy } = makeCtx();
     const adminCtx = {
       ...baseCtx,
@@ -197,12 +199,11 @@ describe('env_vars widget — applySubmit', () => {
       scope: 'global',
     });
     const [, , params] = patchSpy.mock.calls[0];
-    // Admin submitter → users.patch hook bypasses the self-check via
-    // role-based admin path. Target is still sessionCreatorUserId, but the
-    // auth params carry the ADMIN submitter's identity.
+    // Auth params carry the SUBMITTER identity so the patch is attributable.
     expect(params).toEqual({
       user: { user_id: 'user-admin', role: 'admin' },
       authenticated: true,
+      trustedInternalWrite: true,
     });
   });
 
@@ -242,8 +243,12 @@ describe('env_vars widget — applySubmit', () => {
     ).rejects.toThrow(/value too long/i);
   });
 
-  it('does NOT log the submitted value (R5)', async () => {
-    // R5 in the design doc: submit handler must not log values.
+  it('widget shim does not log the submitted value (R5 — daemon-widget surface only)', async () => {
+    // R5 in the design doc: submit handler must not log values. NOTE: this
+    // test covers ONLY the widget-side shim (env-vars/index.ts applySubmit
+    // + buildResultMeta). It stubs users.patch, so the users service's own
+    // log paths aren't exercised here — those are tested separately at the
+    // users-service level (it already only logs names, not values).
     const secret = 'super-leaky-secret-value-XYZ';
     const calls: unknown[][] = [];
     const spies = [

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -103,6 +103,12 @@ describe('env_vars widget — paramsSchema', () => {
   it('rejects empty reason', () => {
     expect(envVarsParamsSchema.safeParse({ names: ['X'], reason: '' }).success).toBe(false);
   });
+
+  it('rejects duplicate names', () => {
+    expect(
+      envVarsParamsSchema.safeParse({ names: ['A_KEY', 'A_KEY'], reason: 'why' }).success
+    ).toBe(false);
+  });
 });
 
 describe('env_vars widget — submitSchema', () => {

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -1,0 +1,297 @@
+/**
+ * env_vars widget — daemon-side tests.
+ *
+ * Mirrors `widgets/submissions.test.ts` patterns: pure-ish over a stubbed
+ * `app` surface, no FeathersJS bootstrap. Exercises the registry contract
+ * (paramsSchema / submitSchema / buildResultMeta / applySubmit /
+ * buildAutoResumePrompt / buildDismissedPrompt) and asserts the security
+ * invariant that submitted values never leak.
+ *
+ * Test surface aligned with §7 Part 2 + §8 R5 of the design doc:
+ *   - registry boot side-effect (`registerEnvVarsWidget` populates `getWidget`)
+ *   - `applySubmit` calls `users.patch` with the right shape
+ *   - bad names propagate as errors
+ *   - `buildResultMeta` returns ONLY `{ names_submitted, scope }`
+ *   - no submitted value ever appears in any logged or persisted payload
+ *   - prompt-builders shape
+ */
+
+import type { UserID } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetWidgetRegistryForTests, getWidget } from '../registry';
+import {
+  envVarsParamsSchema,
+  envVarsSubmitSchema,
+  envVarsWidget,
+  registerEnvVarsWidget,
+} from './index';
+
+function makeCtx(patch?: (id: string, data: unknown) => unknown | Promise<unknown>) {
+  const patchSpy = vi.fn(async (id: string, data: unknown) => {
+    return patch ? patch(id, data) : { user_id: id };
+  });
+  const app = {
+    service(name: string) {
+      if (name !== 'users') throw new Error(`Unexpected service call: ${name}`);
+      return { patch: patchSpy };
+    },
+  };
+  return {
+    ctx: {
+      // biome-ignore lint/suspicious/noExplicitAny: Pass-through stub
+      app: app as any,
+      sessionId: 'sess-1' as never,
+      submitterUserId: 'user-creator' as UserID,
+      sessionCreatorUserId: 'user-creator' as UserID,
+    },
+    patchSpy,
+  };
+}
+
+describe('env_vars widget — registry registration', () => {
+  beforeEach(() => {
+    _resetWidgetRegistryForTests();
+  });
+
+  it('registers under the env_vars type', () => {
+    registerEnvVarsWidget();
+    const entry = getWidget('env_vars');
+    expect(entry).toBeDefined();
+    expect(entry?.type).toBe('env_vars');
+    expect(entry?.schemaVersion).toBe(1);
+  });
+
+  it('is idempotent — repeated calls do not throw', () => {
+    registerEnvVarsWidget();
+    expect(() => registerEnvVarsWidget()).not.toThrow();
+  });
+});
+
+describe('env_vars widget — paramsSchema', () => {
+  it('accepts valid UPPER_SNAKE names + reason', () => {
+    const result = envVarsParamsSchema.safeParse({
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'call hubspot',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // default_scope and auto_resume defaults applied
+      expect(result.data.default_scope).toBe('global');
+      expect(result.data.auto_resume).toBe(true);
+    }
+  });
+
+  it('rejects lower-case env var names', () => {
+    expect(
+      envVarsParamsSchema.safeParse({
+        names: ['hubspot_api_key'],
+        reason: 'call hubspot',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty names array', () => {
+    expect(envVarsParamsSchema.safeParse({ names: [], reason: 'why' }).success).toBe(false);
+  });
+
+  it('rejects more than 10 names', () => {
+    const names = Array.from({ length: 11 }, (_, i) => `VAR_${i}`);
+    expect(envVarsParamsSchema.safeParse({ names, reason: 'why' }).success).toBe(false);
+  });
+
+  it('rejects empty reason', () => {
+    expect(envVarsParamsSchema.safeParse({ names: ['X'], reason: '' }).success).toBe(false);
+  });
+});
+
+describe('env_vars widget — submitSchema', () => {
+  it('accepts one value with global scope', () => {
+    expect(
+      envVarsSubmitSchema.safeParse({
+        values: { HUBSPOT_API_KEY: 'secret' },
+        scope: 'global',
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects empty values map', () => {
+    expect(envVarsSubmitSchema.safeParse({ values: {}, scope: 'global' }).success).toBe(false);
+  });
+
+  it('rejects invalid scope', () => {
+    expect(
+      envVarsSubmitSchema.safeParse({
+        values: { X: 'v' },
+        scope: 'invalid' as unknown as 'global',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects lowercase variable name in values', () => {
+    expect(
+      envVarsSubmitSchema.safeParse({
+        values: { lowercase_name: 'v' },
+        scope: 'global',
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('env_vars widget — buildResultMeta', () => {
+  it('returns ONLY { names_submitted, scope } — never values', () => {
+    const submit = {
+      values: { HUBSPOT_API_KEY: 'super-secret-value' },
+      scope: 'global' as const,
+    };
+    const rm = envVarsWidget.buildResultMeta(submit);
+    expect(Object.keys(rm).sort()).toEqual(['names_submitted', 'scope']);
+    expect(rm.names_submitted).toEqual(['HUBSPOT_API_KEY']);
+    expect(rm.scope).toBe('global');
+    expect(JSON.stringify(rm)).not.toContain('super-secret-value');
+  });
+
+  it('preserves submission order across multiple names', () => {
+    const submit = {
+      values: { A_KEY: 'a', B_KEY: 'b', C_KEY: 'c' },
+      scope: 'session' as const,
+    };
+    const rm = envVarsWidget.buildResultMeta(submit);
+    expect(rm.names_submitted).toEqual(['A_KEY', 'B_KEY', 'C_KEY']);
+    expect(rm.scope).toBe('session');
+  });
+});
+
+describe('env_vars widget — applySubmit', () => {
+  it('calls users.patch with { env_vars, env_var_scopes } for the session creator', async () => {
+    const { ctx, patchSpy } = makeCtx();
+    await envVarsWidget.applySubmit(ctx, {
+      values: { HUBSPOT_API_KEY: 'shh' },
+      scope: 'global',
+    });
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const [id, data] = patchSpy.mock.calls[0];
+    expect(id).toBe('user-creator');
+    expect(data).toEqual({
+      env_vars: { HUBSPOT_API_KEY: 'shh' },
+      env_var_scopes: { HUBSPOT_API_KEY: 'global' },
+    });
+  });
+
+  it('writes ALL submitted names in one patch call', async () => {
+    const { ctx, patchSpy } = makeCtx();
+    await envVarsWidget.applySubmit(ctx, {
+      values: { A_KEY: 'a', B_KEY: 'b' },
+      scope: 'session',
+    });
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const [, data] = patchSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(data.env_vars).toEqual({ A_KEY: 'a', B_KEY: 'b' });
+    expect(data.env_var_scopes).toEqual({ A_KEY: 'session', B_KEY: 'session' });
+  });
+
+  it('rejects blocklisted names before patching', async () => {
+    const { ctx, patchSpy } = makeCtx();
+    // PATH is on the blocklist (system identity).
+    await expect(
+      envVarsWidget.applySubmit(ctx, {
+        values: { PATH: '/tmp/evil' },
+        scope: 'global',
+      })
+    ).rejects.toThrow(/blocked|cannot be set/i);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces validation errors from the users-service patch', async () => {
+    const { ctx } = makeCtx(() => {
+      throw new Error('Invalid environment variable: value too long');
+    });
+    await expect(
+      envVarsWidget.applySubmit(ctx, {
+        values: { HUBSPOT_API_KEY: 'v' },
+        scope: 'global',
+      })
+    ).rejects.toThrow(/value too long/i);
+  });
+
+  it('does NOT log the submitted value (R5)', async () => {
+    // R5 in the design doc: submit handler must not log values.
+    const secret = 'super-leaky-secret-value-XYZ';
+    const calls: unknown[][] = [];
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation((...args) => {
+        calls.push(args);
+      }),
+      vi.spyOn(console, 'info').mockImplementation((...args) => {
+        calls.push(args);
+      }),
+      vi.spyOn(console, 'warn').mockImplementation((...args) => {
+        calls.push(args);
+      }),
+      vi.spyOn(console, 'error').mockImplementation((...args) => {
+        calls.push(args);
+      }),
+      vi.spyOn(console, 'debug').mockImplementation((...args) => {
+        calls.push(args);
+      }),
+    ];
+    try {
+      const { ctx } = makeCtx();
+      await envVarsWidget.applySubmit(ctx, {
+        values: { HUBSPOT_API_KEY: secret },
+        scope: 'global',
+      });
+      // Flatten every logged arg into a string and assert the secret is
+      // nowhere in it. Covers stringified objects, error wrappers, etc.
+      const allText = calls
+        .flat()
+        .map((v) => (typeof v === 'string' ? v : JSON.stringify(v)))
+        .join(' ');
+      expect(allText).not.toContain(secret);
+    } finally {
+      for (const s of spies) s.mockRestore();
+    }
+  });
+});
+
+describe('env_vars widget — prompt builders', () => {
+  it('buildAutoResumePrompt names variables + scope + a retry nudge (no values)', () => {
+    const params = {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'why',
+      default_scope: 'global' as const,
+      auto_resume: true,
+    };
+    const rm = { names_submitted: ['HUBSPOT_API_KEY'], scope: 'global' as const };
+    const prompt = envVarsWidget.buildAutoResumePrompt(rm, params);
+    expect(prompt).toContain('HUBSPOT_API_KEY');
+    expect(prompt).toContain('global');
+    expect(prompt.toLowerCase()).toMatch(/retry|proceed/);
+    // It MUST NOT contain any secret-looking value
+    expect(prompt).not.toMatch(/secret|value/i);
+  });
+
+  it('buildAutoResumePrompt uses "them" for multiple names', () => {
+    const rm = { names_submitted: ['A', 'B'], scope: 'session' as const };
+    const params = {
+      names: ['A', 'B'],
+      reason: 'why',
+      default_scope: 'session' as const,
+      auto_resume: true,
+    };
+    const prompt = envVarsWidget.buildAutoResumePrompt(rm, params);
+    expect(prompt).toContain('them');
+  });
+
+  it('buildDismissedPrompt says "do not re-request immediately"', () => {
+    const params = {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'why',
+      default_scope: 'global' as const,
+      auto_resume: true,
+    };
+    const prompt = envVarsWidget.buildDismissedPrompt(params);
+    expect(prompt).toContain('HUBSPOT_API_KEY');
+    expect(prompt).toContain('dismissed');
+    expect(prompt.toLowerCase()).toMatch(/do not re-request|don't re-request/);
+  });
+});

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -1,0 +1,147 @@
+/**
+ * env_vars widget — registry entry and registration.
+ *
+ * Concrete widget type: agent renders an inline form asking the user for one
+ * or more env vars (e.g. `HUBSPOT_API_KEY`). The values flow browser → daemon
+ * via `POST /widgets/:widget_id/submit` (NOT through the agent context) and
+ * land in the session creator's `users.data.env_vars` via the existing users
+ * service — encryption + blocklist + validation all reused.
+ *
+ * See §4 + §7 Part 2 of `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ */
+
+import { ENV_VAR_CONSTRAINTS, isEnvVarAllowed, validateEnvVar } from '@agor/core/config';
+import type { UserID } from '@agor/core/types';
+import { z } from 'zod';
+import { registerWidget, type WidgetRegistryEntry, type WidgetSubmitCtx } from '../registry.js';
+
+/** Mirror of the regex used by the users service. */
+const ENV_VAR_NAME_REGEX = ENV_VAR_CONSTRAINTS.NAME_PATTERN;
+
+/**
+ * Agent-provided params (validated when the MCP tool fires).
+ * Stored at `metadata.widget.params` on the widget message row.
+ */
+export const envVarsParamsSchema = z.object({
+  names: z
+    .array(z.string().regex(ENV_VAR_NAME_REGEX))
+    .min(1)
+    .max(10)
+    .describe('UPPER_SNAKE env var names (same validation as User Settings).'),
+  reason: z
+    .string()
+    .min(1)
+    .max(500)
+    .describe('Short explanation shown to the user — why these are needed.'),
+  instructions: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe('Optional markdown with extra context (e.g. where to obtain the key).'),
+  default_scope: z
+    .enum(['global', 'session'])
+    .default('global')
+    .describe('Suggested scope for the values. User can override in the form.'),
+  auto_resume: z
+    .boolean()
+    .default(true)
+    .describe(
+      'When true (default), a system-authored prompt is auto-queued back into the agent on submit/dismiss.'
+    ),
+});
+
+export type EnvVarsParams = z.infer<typeof envVarsParamsSchema>;
+
+/**
+ * Browser → daemon submit payload. Direct HTTP, never reaches the agent.
+ */
+export const envVarsSubmitSchema = z.object({
+  values: z
+    .record(
+      z.string().regex(ENV_VAR_NAME_REGEX),
+      z.string().min(1).max(ENV_VAR_CONSTRAINTS.MAX_VALUE_LENGTH)
+    )
+    .refine((v) => Object.keys(v).length >= 1 && Object.keys(v).length <= 10, {
+      message: 'Must submit between 1 and 10 env vars',
+    }),
+  scope: z.enum(['global', 'session']),
+});
+
+export type EnvVarsSubmit = z.infer<typeof envVarsSubmitSchema>;
+
+/**
+ * Result metadata: ONLY contains the names that were submitted + the scope.
+ * NEVER includes values. This is the data that flows back into the agent
+ * context via the auto-resume prompt.
+ */
+export interface EnvVarsResultMeta {
+  names_submitted: string[];
+  scope: 'global' | 'session';
+}
+
+/**
+ * Side-effect: persist the submitted values via the users service. Encryption,
+ * blocklist, regex, and value-length checks all live inside that service —
+ * we deliberately do NOT reimplement them here.
+ */
+async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): Promise<void> {
+  // Belt-and-braces: re-validate names against the same regex+blocklist
+  // the users service uses, surfacing a single combined error if anything
+  // fails. The users service would reject the same way, but doing it here
+  // up-front gives us a clearer error per name without partial writes.
+  for (const name of Object.keys(submit.values)) {
+    if (!isEnvVarAllowed(name)) {
+      throw new Error(`Cannot set environment variable "${name}": blocked by allow-list`);
+    }
+    const errors = validateEnvVar(name, submit.values[name]);
+    if (errors.length > 0) {
+      throw new Error(`Invalid env var ${name}: ${errors.map((e) => e.message).join('; ')}`);
+    }
+  }
+
+  const usersService = ctx.app.service('users') as unknown as {
+    patch(
+      id: UserID,
+      data: {
+        env_vars?: Record<string, string>;
+        env_var_scopes?: Record<string, 'global' | 'session'>;
+      }
+    ): Promise<unknown>;
+  };
+
+  const env_var_scopes: Record<string, 'global' | 'session'> = {};
+  for (const name of Object.keys(submit.values)) {
+    env_var_scopes[name] = submit.scope;
+  }
+
+  // Single patch: values are written first (encrypted in the service), then
+  // scopes applied in the same transaction.
+  await usersService.patch(ctx.sessionCreatorUserId, {
+    env_vars: submit.values,
+    env_var_scopes,
+  });
+}
+
+export const envVarsWidget: WidgetRegistryEntry<EnvVarsParams, EnvVarsSubmit, EnvVarsResultMeta> = {
+  type: 'env_vars',
+  schemaVersion: 1,
+  paramsSchema: envVarsParamsSchema,
+  submitSchema: envVarsSubmitSchema,
+  buildResultMeta: (submit) => ({
+    names_submitted: Object.keys(submit.values),
+    scope: submit.scope,
+  }),
+  applySubmit: applyEnvVarsSubmit,
+  buildAutoResumePrompt: (rm) =>
+    `[Agor] User submitted ${rm.names_submitted.join(', ')} (scope: ${rm.scope}). ` +
+    `You can now retry the operation that needed ` +
+    `${rm.names_submitted.length === 1 ? 'it' : 'them'}.`,
+  buildDismissedPrompt: (params) =>
+    `[Agor] User dismissed the request for ${params.names.join(', ')}. ` +
+    `Do not re-request immediately — ask whether to proceed without, or move on to other work.`,
+};
+
+/** Idempotent registration helper, safe to call at every daemon boot. */
+export function registerEnvVarsWidget(): void {
+  registerWidget(envVarsWidget);
+}

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -105,7 +105,8 @@ async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): 
       data: {
         env_vars?: Record<string, string>;
         env_var_scopes?: Record<string, 'global' | 'session'>;
-      }
+      },
+      params?: { user: { user_id: UserID; role: string | undefined }; authenticated: true }
     ): Promise<unknown>;
   };
 
@@ -116,10 +117,23 @@ async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): 
 
   // Single patch: values are written first (encrypted in the service), then
   // scopes applied in the same transaction.
-  await usersService.patch(ctx.sessionCreatorUserId, {
-    env_vars: submit.values,
-    env_var_scopes,
-  });
+  //
+  // Auth: the users.patch hook (`register-hooks.ts:1435-1487`) demands either
+  // (a) caller is admin, or (b) caller patches their own profile. Without
+  // params it sees `params.user = undefined` and throws 403. We pass the
+  // SUBMITTER's identity through — covers the common cases:
+  //   • submitter == session creator (default)  → self-patch path
+  //   • submitter is admin (any role >= admin)  → admin bypass path
+  // The cross-user collaborator case (non-admin submitter ≠ session creator)
+  // is a known limitation; see design doc §5.2.
+  await usersService.patch(
+    ctx.sessionCreatorUserId,
+    { env_vars: submit.values, env_var_scopes },
+    {
+      user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
+      authenticated: true,
+    }
+  );
 }
 
 export const envVarsWidget: WidgetRegistryEntry<EnvVarsParams, EnvVarsSubmit, EnvVarsResultMeta> = {

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -31,13 +31,10 @@ export const envVarsParamsSchema = z.object({
   reason: z
     .string()
     .min(1)
-    .max(500)
-    .describe('Short explanation shown to the user — why these are needed.'),
-  instructions: z
-    .string()
-    .max(2000)
-    .optional()
-    .describe('Optional markdown with extra context (e.g. where to obtain the key).'),
+    .max(200)
+    .describe(
+      'One sentence explaining why you need the value(s). Keep it tight — this renders in a small muted line under the input. NOT a place to restate what the widget does.'
+    ),
   default_scope: z
     .enum(['global', 'session'])
     .default('global')

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -11,6 +11,7 @@
  */
 
 import { ENV_VAR_CONSTRAINTS, isEnvVarAllowed, validateEnvVar } from '@agor/core/config';
+import { BadRequest } from '@agor/core/feathers';
 import type { UserID } from '@agor/core/types';
 import { z } from 'zod';
 import { registerWidget, type WidgetRegistryEntry, type WidgetSubmitCtx } from '../registry.js';
@@ -27,6 +28,9 @@ export const envVarsParamsSchema = z.object({
     .array(z.string().regex(ENV_VAR_NAME_REGEX))
     .min(1)
     .max(10)
+    .refine((names) => new Set(names).size === names.length, {
+      message: 'Env var names must be unique',
+    })
     .describe('UPPER_SNAKE env var names (same validation as User Settings).'),
   reason: z
     .string()
@@ -93,7 +97,7 @@ async function applyEnvVarsSubmit(
     submittedNames.length !== params.names.length ||
     submittedNames.some((name) => !requestedNames.has(name))
   ) {
-    throw new Error(
+    throw new BadRequest(
       'Submitted env var names must exactly match the widget request: expected ' +
         params.names.join(', ')
     );

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -77,12 +77,33 @@ export interface EnvVarsResultMeta {
  * blocklist, regex, and value-length checks all live inside that service —
  * we deliberately do NOT reimplement them here.
  */
-async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): Promise<void> {
+async function applyEnvVarsSubmit(
+  ctx: WidgetSubmitCtx,
+  submit: EnvVarsSubmit,
+  params: EnvVarsParams
+): Promise<void> {
+  // Enforce that the browser submitted exactly the names the agent requested
+  // (no more, no fewer). Without this, a tampered client could use the
+  // `trustedEnvVarWrite` escape hatch to write arbitrary env vars onto the
+  // session creator's profile — widening the attack surface far beyond what
+  // the agent (and the user reviewing the widget) intended.
+  const requestedNames = new Set(params.names);
+  const submittedNames = Object.keys(submit.values);
+  if (
+    submittedNames.length !== params.names.length ||
+    submittedNames.some((name) => !requestedNames.has(name))
+  ) {
+    throw new Error(
+      'Submitted env var names must exactly match the widget request: expected ' +
+        params.names.join(', ')
+    );
+  }
+
   // Belt-and-braces: re-validate names against the same regex+blocklist
   // the users service uses, surfacing a single combined error if anything
   // fails. The users service would reject the same way, but doing it here
   // up-front gives us a clearer error per name without partial writes.
-  for (const name of Object.keys(submit.values)) {
+  for (const name of submittedNames) {
     if (!isEnvVarAllowed(name)) {
       throw new Error(`Cannot set environment variable "${name}": blocked by allow-list`);
     }
@@ -102,32 +123,35 @@ async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): 
       params?: {
         user: { user_id: UserID; role: string | undefined };
         authenticated: true;
-        trustedInternalWrite?: boolean;
+        trustedEnvVarWrite?: boolean;
       }
     ): Promise<unknown>;
   };
 
   const env_var_scopes: Record<string, 'global' | 'session'> = {};
-  for (const name of Object.keys(submit.values)) {
+  for (const name of submittedNames) {
     env_var_scopes[name] = submit.scope;
   }
 
   // The widget submit endpoint already authorized the caller via
   // `canResolveWidget` (session-creator OR prompt-tier worktree RBAC), so
-  // we set `trustedInternalWrite` on the users.patch hook to bypass its
-  // self-only check (`register-hooks.ts:1490`). Field-level admin gates
-  // for unix_username/role/must_change_password run first and are NOT
-  // bypassed — env_vars / env_var_scopes are not gated.
+  // we set `trustedEnvVarWrite` on the users.patch hook to bypass its
+  // self-only check (`register-hooks.ts`). Field-level admin gates for
+  // unix_username/role/must_change_password run first and are NOT bypassed.
+  // The hook also enforces that only env_vars/env_var_scopes fields are
+  // written — this escape hatch cannot be used to patch other user fields.
   //
   // submitter identity is still threaded through for audit; the widget
   // submit handler records it separately as `metadata.widget.submitted_by`.
+  //
+  // Grep for: trustedEnvVarWrite — to audit every site that sets it.
   await usersService.patch(
     ctx.sessionCreatorUserId,
     { env_vars: submit.values, env_var_scopes },
     {
       user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
       authenticated: true,
-      trustedInternalWrite: true,
+      trustedEnvVarWrite: true,
     }
   );
 }

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -35,10 +35,6 @@ export const envVarsParamsSchema = z.object({
     .describe(
       'One sentence explaining why you need the value(s). Keep it tight — this renders in a small muted line under the input. NOT a place to restate what the widget does.'
     ),
-  default_scope: z
-    .enum(['global', 'session'])
-    .default('global')
-    .describe('Suggested scope for the values. User can override in the form.'),
   auto_resume: z
     .boolean()
     .default(true)

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -99,7 +99,11 @@ async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): 
         env_vars?: Record<string, string>;
         env_var_scopes?: Record<string, 'global' | 'session'>;
       },
-      params?: { user: { user_id: UserID; role: string | undefined }; authenticated: true }
+      params?: {
+        user: { user_id: UserID; role: string | undefined };
+        authenticated: true;
+        trustedInternalWrite?: boolean;
+      }
     ): Promise<unknown>;
   };
 
@@ -108,23 +112,22 @@ async function applyEnvVarsSubmit(ctx: WidgetSubmitCtx, submit: EnvVarsSubmit): 
     env_var_scopes[name] = submit.scope;
   }
 
-  // Single patch: values are written first (encrypted in the service), then
-  // scopes applied in the same transaction.
+  // The widget submit endpoint already authorized the caller via
+  // `canResolveWidget` (session-creator OR prompt-tier worktree RBAC), so
+  // we set `trustedInternalWrite` on the users.patch hook to bypass its
+  // self-only check (`register-hooks.ts:1490`). Field-level admin gates
+  // for unix_username/role/must_change_password run first and are NOT
+  // bypassed — env_vars / env_var_scopes are not gated.
   //
-  // Auth: the users.patch hook (`register-hooks.ts:1435-1487`) demands either
-  // (a) caller is admin, or (b) caller patches their own profile. Without
-  // params it sees `params.user = undefined` and throws 403. We pass the
-  // SUBMITTER's identity through — covers the common cases:
-  //   • submitter == session creator (default)  → self-patch path
-  //   • submitter is admin (any role >= admin)  → admin bypass path
-  // The cross-user collaborator case (non-admin submitter ≠ session creator)
-  // is a known limitation; see design doc §5.2.
+  // submitter identity is still threaded through for audit; the widget
+  // submit handler records it separately as `metadata.widget.submitted_by`.
   await usersService.patch(
     ctx.sessionCreatorUserId,
     { env_vars: submit.values, env_var_scopes },
     {
       user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
       authenticated: true,
+      trustedInternalWrite: true,
     }
   );
 }

--- a/apps/agor-daemon/src/widgets/index.ts
+++ b/apps/agor-daemon/src/widgets/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Widgets module barrel + central registration entry point.
+ *
+ * Each concrete widget type lives in its own subdirectory (e.g.
+ * `./env-vars/`) and exports a `register*Widget()` side-effect. Daemon
+ * startup calls `registerAllWidgets()` once at boot to populate the
+ * registry that the submit/dismiss routes (and any future internal
+ * callers) dispatch through.
+ *
+ * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ */
+
+import { registerEnvVarsWidget } from './env-vars/index.js';
+
+export type { WidgetRegistryEntry, WidgetSubmitCtx } from './registry.js';
+export { getWidget, listWidgetTypes, registerWidget } from './registry.js';
+export type {
+  AuthenticatedCaller,
+  WidgetResolutionAction,
+  WidgetResolutionResult,
+  WidgetResolverApp,
+  WidgetResolverDeps,
+} from './submissions.js';
+export { canResolveWidget, resolveWidget } from './submissions.js';
+
+/**
+ * Register every built-in widget type. Idempotent — safe to call multiple
+ * times (the registry no-ops on identical re-registration of the same entry).
+ */
+export function registerAllWidgets(): void {
+  registerEnvVarsWidget();
+}

--- a/apps/agor-daemon/src/widgets/registry.ts
+++ b/apps/agor-daemon/src/widgets/registry.ts
@@ -1,0 +1,121 @@
+/**
+ * Widget Registry — daemon-side dispatch map for in-conversation widgets.
+ *
+ * Each entry binds a `WidgetType` to its Zod schemas (for params + submit
+ * validation), its side-effect handler (`applySubmit`), and the two
+ * prompt-builder functions that produce the system-authored auto-resume /
+ * dismissal prompts.
+ *
+ * PR 1 lands the framework only — there are no registered entries yet.
+ * `env_vars`, `confirmation`, and `oauth` widgets each ship their own
+ * registration in a later PR (see §7 of the design doc).
+ *
+ * The registry is intentionally module-local rather than a runtime
+ * singleton — widget types register themselves via `registerWidget()` at
+ * daemon boot (called from each widget type's index file) and the submit
+ * handler looks them up via `getWidget()`. Empty in PR 1.
+ *
+ * Critical invariant: `buildAutoResumePrompt` receives only
+ * `(result_meta, params)` — never the raw submit body. This is what
+ * guarantees the secret-doesn't-enter-context property (§5.1).
+ */
+
+import type { Application } from '@agor/core/feathers';
+import type { SessionID, UserID, WidgetType } from '@agor/core/types';
+import type { z } from 'zod';
+
+/**
+ * Context passed to a widget's `applySubmit` handler. Contains just enough
+ * to perform the side-effect (write env vars, attach an MCP server, etc.)
+ * without exposing internals of the submit endpoint.
+ */
+export interface WidgetSubmitCtx {
+  app: Application;
+  /** The widget message's host session. */
+  sessionId: SessionID;
+  /** The user who submitted the widget (may differ from session creator). */
+  submitterUserId: UserID;
+  /** Session creator — credentials get written to this identity. */
+  sessionCreatorUserId: UserID;
+}
+
+/**
+ * One widget type's registration. Generic over its `params`, `submit`, and
+ * `result_meta` shapes so each registered widget gets compile-time type
+ * checking on the four hand-off boundaries (MCP tool → params, browser
+ * form → submit, daemon → result_meta, daemon → auto-resume prompt).
+ */
+export interface WidgetRegistryEntry<TParams, TSubmit, TResultMeta> {
+  /** Discriminant matching `metadata.widget.widget_type`. */
+  type: WidgetType;
+  /** Version of this widget's `params`/`submit`/`result_meta` contract. */
+  schemaVersion: number;
+  /** Validates the MCP tool's input (drives `metadata.widget.params`). */
+  paramsSchema: z.ZodType<TParams>;
+  /** Validates `POST /widgets/:widget_id/submit` body. */
+  submitSchema: z.ZodType<TSubmit>;
+  /**
+   * Build the sanitized `result_meta` written to the message row and fed
+   * into `buildAutoResumePrompt`. MUST NOT include secret values from the
+   * submit body — only names, scope, labels, etc.
+   */
+  buildResultMeta: (submit: TSubmit) => TResultMeta;
+  /**
+   * Apply the submission's side-effect (encrypt + write env var,
+   * attach MCP server, finalize OAuth, etc.). The submit endpoint runs
+   * this BEFORE patching the widget message status to 'submitted'.
+   */
+  applySubmit: (ctx: WidgetSubmitCtx, submit: TSubmit) => Promise<void>;
+  /**
+   * Build the user-role prompt auto-queued into the session's task queue
+   * on submit. Takes only `result_meta` + `params` — never the raw submit
+   * body — to keep submitted values out of the agent's context.
+   */
+  buildAutoResumePrompt: (resultMeta: TResultMeta, params: TParams) => string;
+  /**
+   * Build the user-role prompt auto-queued on dismissal. Should be
+   * explicit ("don't immediately re-ask") to avoid agent loops.
+   */
+  buildDismissedPrompt: (params: TParams) => string;
+}
+
+// Untyped variant used for storage / dispatch — the public API restores
+// generics via the registerWidget()/getWidget() helpers.
+type AnyWidgetEntry = WidgetRegistryEntry<unknown, unknown, unknown>;
+
+const widgetRegistry: Map<WidgetType, AnyWidgetEntry> = new Map();
+
+/**
+ * Register a widget type. Idempotent re-registration with the same shape is
+ * a no-op so test setup can re-register safely; conflicting re-registration
+ * throws to catch accidental duplicates.
+ */
+export function registerWidget<TParams, TSubmit, TResultMeta>(
+  entry: WidgetRegistryEntry<TParams, TSubmit, TResultMeta>
+): void {
+  const existing = widgetRegistry.get(entry.type);
+  if (existing && existing !== (entry as unknown as AnyWidgetEntry)) {
+    throw new Error(
+      `Widget type '${entry.type}' already registered with a different entry. ` +
+        `Each widget type may only be registered once.`
+    );
+  }
+  widgetRegistry.set(entry.type, entry as unknown as AnyWidgetEntry);
+}
+
+/** Look up a widget by type. Returns `undefined` for unknown types. */
+export function getWidget(type: WidgetType): AnyWidgetEntry | undefined {
+  return widgetRegistry.get(type);
+}
+
+/** All registered widget types (for diagnostics / tests). */
+export function listWidgetTypes(): WidgetType[] {
+  return Array.from(widgetRegistry.keys());
+}
+
+/**
+ * Clear the registry. ONLY for tests — production code must not call this.
+ */
+export function _resetWidgetRegistryForTests(): void {
+  widgetRegistry.clear();
+}

--- a/apps/agor-daemon/src/widgets/registry.ts
+++ b/apps/agor-daemon/src/widgets/registry.ts
@@ -35,6 +35,12 @@ export interface WidgetSubmitCtx {
   sessionId: SessionID;
   /** The user who submitted the widget (may differ from session creator). */
   submitterUserId: UserID;
+  /** The submitter's role, used to construct Feathers auth params for any
+   * internal service calls applySubmit makes. Service-layer hooks (e.g. the
+   * users.patch self-only check at `register-hooks.ts:1481`) read
+   * `params.user.role` to decide admin bypass — so applySubmit MUST pass these
+   * along when patching protected services, or it gets 403'd. */
+  submitterRole: string | undefined;
   /** Session creator — credentials get written to this identity. */
   sessionCreatorUserId: UserID;
 }

--- a/apps/agor-daemon/src/widgets/registry.ts
+++ b/apps/agor-daemon/src/widgets/registry.ts
@@ -70,8 +70,12 @@ export interface WidgetRegistryEntry<TParams, TSubmit, TResultMeta> {
    * Apply the submission's side-effect (encrypt + write env var,
    * attach MCP server, finalize OAuth, etc.). The submit endpoint runs
    * this BEFORE patching the widget message status to 'submitted'.
+   *
+   * `params` is the original agent-provided params stored on the widget row —
+   * available so the handler can cross-check the submit body against what was
+   * originally requested (e.g. env_vars validates names match exactly).
    */
-  applySubmit: (ctx: WidgetSubmitCtx, submit: TSubmit) => Promise<void>;
+  applySubmit: (ctx: WidgetSubmitCtx, submit: TSubmit, params: TParams) => Promise<void>;
   /**
    * Build the user-role prompt auto-queued into the session's task queue
    * on submit. Takes only `result_meta` + `params` — never the raw submit

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Unit tests for the widget resolution path.
+ *
+ * Tests the contract documented in §5 of the design doc:
+ *   - Auth gating (session creator passes, non-owner without prompt-tier
+ *     RBAC is rejected)
+ *   - Idempotency (double-submit on a `submitted` widget is rejected)
+ *   - Submit dispatches via the registry's applySubmit
+ *   - Auto-resume task is queued via `/sessions/:id/prompt`
+ *   - `auto_resume: false` skips the task creation
+ *   - Dismissal path uses `buildDismissedPrompt`
+ *   - WebSocket broadcast: `widget:resolved` fires
+ *
+ * No FeathersJS bootstrap — the resolver is pure-ish over a `deps.app`
+ * mock, so we exercise the full state machine with a hand-rolled stub.
+ */
+
+import type { Message, Session, UserID, Worktree } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { _resetWidgetRegistryForTests, registerWidget, type WidgetRegistryEntry } from './registry';
+import { canResolveWidget, resolveWidget } from './submissions';
+
+interface MockServiceCall {
+  service: string;
+  method: 'get' | 'patch' | 'create';
+  id?: string;
+  data?: unknown;
+  params?: unknown;
+}
+
+interface MockEvent {
+  service: string;
+  event: string;
+  payload: unknown;
+}
+
+function makeApp(records: { message: Message; session: Session; worktree: Worktree }) {
+  const calls: MockServiceCall[] = [];
+  const events: MockEvent[] = [];
+  let currentMessage = records.message;
+
+  const services = {
+    messages: {
+      async get(id: string) {
+        calls.push({ service: 'messages', method: 'get', id });
+        if (id !== currentMessage.message_id) {
+          throw new Error('Message not found');
+        }
+        return currentMessage;
+      },
+      async patch(id: string, data: Partial<Message>) {
+        calls.push({ service: 'messages', method: 'patch', id, data });
+        currentMessage = {
+          ...currentMessage,
+          metadata: { ...currentMessage.metadata, ...(data.metadata ?? {}) },
+        };
+        return currentMessage;
+      },
+      async create() {
+        throw new Error('messages.create should not be called');
+      },
+      emit(event: string, payload: unknown) {
+        events.push({ service: 'messages', event, payload });
+      },
+    },
+    sessions: {
+      async get() {
+        calls.push({ service: 'sessions', method: 'get' });
+        return records.session;
+      },
+      async patch() {
+        throw new Error('sessions.patch should not be called');
+      },
+      async create() {
+        throw new Error('sessions.create should not be called');
+      },
+    },
+    worktrees: {
+      async get() {
+        calls.push({ service: 'worktrees', method: 'get' });
+        return records.worktree;
+      },
+      async patch() {
+        throw new Error('worktrees.patch should not be called');
+      },
+      async create() {
+        throw new Error('worktrees.create should not be called');
+      },
+    },
+    '/sessions/:id/prompt': {
+      async get() {
+        throw new Error('prompt.get should not be called');
+      },
+      async patch() {
+        throw new Error('prompt.patch should not be called');
+      },
+      async create(data: unknown, params: unknown) {
+        calls.push({
+          service: '/sessions/:id/prompt',
+          method: 'create',
+          data,
+          params,
+        });
+        return { task_id: 'task-mock' };
+      },
+    },
+  };
+
+  const app = {
+    service(name: string) {
+      const svc = services[name as keyof typeof services];
+      if (!svc) throw new Error(`Mock app has no service '${name}'`);
+      return svc;
+    },
+  };
+
+  return {
+    app,
+    calls,
+    events,
+    get currentMessage() {
+      return currentMessage;
+    },
+  };
+}
+
+function makeFixtures(
+  opts: {
+    widgetStatus?: 'pending' | 'submitted' | 'dismissed';
+    widgetType?: string;
+    autoResume?: boolean;
+    sessionCreator?: UserID;
+    worktreeOthersCan?: Worktree['others_can'];
+  } = {}
+) {
+  const sessionCreator = (opts.sessionCreator ?? 'creator-user-id') as UserID;
+  const message: Message = {
+    message_id: 'widget-msg-1' as never,
+    session_id: 'sess-1' as never,
+    type: 'widget_request',
+    role: 'system' as never,
+    index: 5,
+    timestamp: '2026-05-19T00:00:00.000Z',
+    content_preview: 'Please provide HUBSPOT_API_KEY',
+    content: 'Please provide HUBSPOT_API_KEY',
+    metadata: {
+      widget: {
+        widget_id: 'widget-msg-1' as never,
+        widget_type: opts.widgetType ?? 'env_vars',
+        schema_version: 1,
+        params: { names: ['HUBSPOT_API_KEY'], reason: 'call Hubspot' },
+        status: opts.widgetStatus ?? 'pending',
+        requested_at: '2026-05-19T00:00:00.000Z',
+        ...(opts.autoResume !== undefined ? { auto_resume: opts.autoResume } : {}),
+      },
+    },
+  };
+  const session = {
+    session_id: 'sess-1',
+    worktree_id: 'wt-1',
+    created_by: sessionCreator,
+  } as unknown as Session;
+  const worktree = {
+    worktree_id: 'wt-1',
+    name: 'feat-x',
+    others_can: opts.worktreeOthersCan ?? 'session',
+  } as unknown as Worktree;
+  return { message, session, worktree };
+}
+
+function registerTestWidget(applySubmit = vi.fn(async () => {})) {
+  const entry: WidgetRegistryEntry<
+    { names: string[]; reason: string },
+    { value: string; scope: 'global' | 'session' },
+    { names_submitted: string[]; scope: string }
+  > = {
+    type: 'env_vars',
+    schemaVersion: 1,
+    paramsSchema: z.object({
+      names: z.array(z.string()),
+      reason: z.string(),
+    }),
+    submitSchema: z.object({
+      value: z.string(),
+      scope: z.enum(['global', 'session']),
+    }),
+    buildResultMeta: (submit) => ({
+      names_submitted: ['HUBSPOT_API_KEY'],
+      scope: submit.scope,
+    }),
+    applySubmit,
+    buildAutoResumePrompt: (rm) =>
+      `[Agor] User submitted ${rm.names_submitted.join(', ')} (scope: ${rm.scope}).`,
+    buildDismissedPrompt: (params) =>
+      `[Agor] User dismissed the request for ${params.names.join(', ')}.`,
+  };
+  registerWidget(entry);
+  return { entry, applySubmit };
+}
+
+describe('canResolveWidget', () => {
+  it('allows the session creator', () => {
+    const session = { created_by: 'alice' as UserID };
+    const worktree = { others_can: 'view' } as unknown as Worktree;
+    expect(canResolveWidget({ user_id: 'alice' as UserID }, session, worktree)).toBe(true);
+  });
+
+  it('rejects a non-creator with view-only RBAC', () => {
+    const session = { created_by: 'alice' as UserID };
+    const worktree = { others_can: 'view' } as unknown as Worktree;
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(false);
+  });
+
+  it('rejects a non-creator with session-tier RBAC (session tier is for own sessions only)', () => {
+    const session = { created_by: 'alice' as UserID };
+    const worktree = { others_can: 'session' } as unknown as Worktree;
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(false);
+  });
+
+  it('allows a non-creator with prompt-tier RBAC', () => {
+    const session = { created_by: 'alice' as UserID };
+    const worktree = { others_can: 'prompt' } as unknown as Worktree;
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(true);
+  });
+
+  it('allows a non-creator with all-tier RBAC', () => {
+    const session = { created_by: 'alice' as UserID };
+    const worktree = { others_can: 'all' } as unknown as Worktree;
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(true);
+  });
+});
+
+describe('resolveWidget', () => {
+  beforeEach(() => {
+    _resetWidgetRegistryForTests();
+  });
+
+  it('submits a pending widget: dispatches to applySubmit, patches status, queues auto-resume, broadcasts', async () => {
+    const { applySubmit } = registerTestWidget();
+    const fixtures = makeFixtures();
+    const { app, calls, events } = makeApp(fixtures);
+
+    const result = await resolveWidget(
+      'widget-msg-1',
+      { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
+      { user_id: 'creator-user-id' as UserID },
+      { app: app as never, isWorktreeOwner: async () => false }
+    );
+
+    expect(result).toEqual({
+      widget_id: 'widget-msg-1',
+      status: 'submitted',
+      auto_resume_queued: true,
+    });
+    expect(applySubmit).toHaveBeenCalledTimes(1);
+
+    // Message was patched with submitted status + result_meta + resolved_at +
+    // submitted_by. The secret value MUST NOT appear in the patch.
+    const messagePatch = calls.find((c) => c.service === 'messages' && c.method === 'patch');
+    expect(messagePatch).toBeDefined();
+    const patchedData = messagePatch?.data as {
+      metadata: {
+        widget: { status: string; result_meta: { scope: string }; submitted_by: string };
+      };
+    };
+    expect(patchedData.metadata.widget.status).toBe('submitted');
+    expect(patchedData.metadata.widget.submitted_by).toBe('creator-user-id');
+    expect(patchedData.metadata.widget.result_meta.scope).toBe('global');
+    expect(JSON.stringify(patchedData)).not.toContain('secret-key');
+
+    // Auto-resume task queued via /sessions/:id/prompt — same path as a
+    // user-typed prompt. Prompt body must derive from result_meta only,
+    // never the raw submit body.
+    const promptCall = calls.find(
+      (c) => c.service === '/sessions/:id/prompt' && c.method === 'create'
+    );
+    expect(promptCall).toBeDefined();
+    const promptData = promptCall?.data as {
+      prompt: string;
+      metadata: { system_authored: boolean; widget_id: string };
+    };
+    expect(promptData.prompt).toContain('HUBSPOT_API_KEY');
+    expect(promptData.prompt).toContain('global');
+    expect(promptData.prompt).not.toContain('secret-key');
+    expect(promptData.metadata.system_authored).toBe(true);
+    expect(promptData.metadata.widget_id).toBe('widget-msg-1');
+
+    // WebSocket event fired.
+    const event = events.find((e) => e.event === 'widget:resolved');
+    expect(event).toBeDefined();
+    expect((event?.payload as { status: string }).status).toBe('submitted');
+  });
+
+  it('rejects a submission from a non-creator without prompt-tier RBAC', async () => {
+    registerTestWidget();
+    const fixtures = makeFixtures({ worktreeOthersCan: 'session' });
+    const { app } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
+        { user_id: 'someone-else' as UserID },
+        { app: app as never, isWorktreeOwner: async () => false }
+      )
+    ).rejects.toThrow(/session creator|prompt/);
+  });
+
+  it('allows a submission from a non-creator with prompt-tier RBAC', async () => {
+    registerTestWidget();
+    const fixtures = makeFixtures({ worktreeOthersCan: 'prompt' });
+    const { app } = makeApp(fixtures);
+
+    const result = await resolveWidget(
+      'widget-msg-1',
+      { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
+      { user_id: 'someone-else' as UserID },
+      { app: app as never, isWorktreeOwner: async () => false }
+    );
+    expect(result.status).toBe('submitted');
+  });
+
+  it('rejects a double-submit (idempotency: status must be pending)', async () => {
+    registerTestWidget();
+    const fixtures = makeFixtures({ widgetStatus: 'submitted' });
+    const { app } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'k', scope: 'global' } },
+        { user_id: 'creator-user-id' as UserID },
+        { app: app as never, isWorktreeOwner: async () => false }
+      )
+    ).rejects.toThrow(/already submitted/);
+  });
+
+  it('rejects an unknown widget type on submit (registry miss)', async () => {
+    const fixtures = makeFixtures({ widgetType: 'unknown_type' });
+    const { app } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: {} },
+        { user_id: 'creator-user-id' as UserID },
+        { app: app as never, isWorktreeOwner: async () => false }
+      )
+    ).rejects.toThrow(/not registered/);
+  });
+
+  it('skips auto-resume task when auto_resume: false', async () => {
+    registerTestWidget();
+    const fixtures = makeFixtures({ autoResume: false });
+    const { app, calls } = makeApp(fixtures);
+
+    const result = await resolveWidget(
+      'widget-msg-1',
+      { kind: 'submit', body: { value: 'k', scope: 'global' } },
+      { user_id: 'creator-user-id' as UserID },
+      { app: app as never, isWorktreeOwner: async () => false }
+    );
+
+    expect(result.auto_resume_queued).toBe(false);
+    expect(calls.find((c) => c.service === '/sessions/:id/prompt')).toBeUndefined();
+  });
+
+  it('dismisses a pending widget: uses buildDismissedPrompt, no applySubmit', async () => {
+    const applySubmit = vi.fn(async () => {});
+    registerTestWidget(applySubmit);
+    const fixtures = makeFixtures();
+    const { app, calls } = makeApp(fixtures);
+
+    const result = await resolveWidget(
+      'widget-msg-1',
+      { kind: 'dismiss' },
+      { user_id: 'creator-user-id' as UserID },
+      { app: app as never, isWorktreeOwner: async () => false }
+    );
+
+    expect(result.status).toBe('dismissed');
+    expect(applySubmit).not.toHaveBeenCalled();
+
+    const promptCall = calls.find(
+      (c) => c.service === '/sessions/:id/prompt' && c.method === 'create'
+    );
+    expect(promptCall).toBeDefined();
+    const promptData = promptCall?.data as { prompt: string };
+    expect(promptData.prompt).toContain('dismissed');
+  });
+
+  it('dismissal works even for an unknown widget type (fallback prompt)', async () => {
+    const fixtures = makeFixtures({ widgetType: 'unknown_type' });
+    const { app, calls } = makeApp(fixtures);
+
+    const result = await resolveWidget(
+      'widget-msg-1',
+      { kind: 'dismiss' },
+      { user_id: 'creator-user-id' as UserID },
+      { app: app as never, isWorktreeOwner: async () => false }
+    );
+
+    expect(result.status).toBe('dismissed');
+    const promptCall = calls.find(
+      (c) => c.service === '/sessions/:id/prompt' && c.method === 'create'
+    );
+    const promptData = promptCall?.data as { prompt: string };
+    expect(promptData.prompt).toContain('dismissed');
+  });
+
+  it('throws NotAuthenticated when caller is undefined', async () => {
+    registerTestWidget();
+    const fixtures = makeFixtures();
+    const { app } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'k', scope: 'global' } },
+        undefined,
+        { app: app as never, isWorktreeOwner: async () => false }
+      )
+    ).rejects.toThrow(/Authentication/);
+  });
+
+  it('rejects an invalid submit body (Zod schema mismatch)', async () => {
+    registerTestWidget();
+    const fixtures = makeFixtures();
+    const { app } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { scope: 'invalid-scope' } },
+        { user_id: 'creator-user-id' as UserID },
+        { app: app as never, isWorktreeOwner: async () => false }
+      )
+    ).rejects.toThrow(/Invalid submit/);
+  });
+});
+
+describe('widget registry', () => {
+  beforeEach(() => {
+    _resetWidgetRegistryForTests();
+  });
+
+  it('starts empty in PR 1', async () => {
+    const { listWidgetTypes } = await import('./registry');
+    expect(listWidgetTypes()).toEqual([]);
+  });
+
+  it('refuses to register two widgets of the same type with different shapes', async () => {
+    const { registerWidget: register } = await import('./registry');
+    register({
+      type: 'foo',
+      schemaVersion: 1,
+      paramsSchema: z.unknown(),
+      submitSchema: z.unknown(),
+      buildResultMeta: () => ({}),
+      applySubmit: async () => {},
+      buildAutoResumePrompt: () => '',
+      buildDismissedPrompt: () => '',
+    });
+    expect(() =>
+      register({
+        type: 'foo',
+        schemaVersion: 2,
+        paramsSchema: z.unknown(),
+        submitSchema: z.unknown(),
+        buildResultMeta: () => ({}),
+        applySubmit: async () => {},
+        buildAutoResumePrompt: () => '',
+        buildDismissedPrompt: () => '',
+      })
+    ).toThrow(/already registered/);
+  });
+});

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -169,7 +169,9 @@ function makeFixtures(
   return { message, session, worktree };
 }
 
-function registerTestWidget(applySubmit = vi.fn(async () => {})) {
+function registerTestWidget(
+  applySubmit = vi.fn(async (_ctx: unknown, _submit: unknown, _params: unknown) => {})
+) {
   const entry: WidgetRegistryEntry<
     { names: string[]; reason: string },
     { value: string; scope: 'global' | 'session' },

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -203,31 +203,37 @@ describe('canResolveWidget', () => {
   it('allows the session creator', () => {
     const session = { created_by: 'alice' as UserID };
     const worktree = { others_can: 'view' } as unknown as Worktree;
-    expect(canResolveWidget({ user_id: 'alice' as UserID }, session, worktree)).toBe(true);
+    expect(canResolveWidget({ user_id: 'alice' as UserID }, session, worktree, false)).toBe(true);
   });
 
   it('rejects a non-creator with view-only RBAC', () => {
     const session = { created_by: 'alice' as UserID };
     const worktree = { others_can: 'view' } as unknown as Worktree;
-    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(false);
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree, false)).toBe(false);
   });
 
   it('rejects a non-creator with session-tier RBAC (session tier is for own sessions only)', () => {
     const session = { created_by: 'alice' as UserID };
     const worktree = { others_can: 'session' } as unknown as Worktree;
-    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(false);
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree, false)).toBe(false);
   });
 
   it('allows a non-creator with prompt-tier RBAC', () => {
     const session = { created_by: 'alice' as UserID };
     const worktree = { others_can: 'prompt' } as unknown as Worktree;
-    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(true);
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree, false)).toBe(true);
   });
 
   it('allows a non-creator with all-tier RBAC', () => {
     const session = { created_by: 'alice' as UserID };
     const worktree = { others_can: 'all' } as unknown as Worktree;
-    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree)).toBe(true);
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree, false)).toBe(true);
+  });
+
+  it('allows an explicit worktree owner even when others_can is view-only', () => {
+    const session = { created_by: 'alice' as UserID };
+    const worktree = { others_can: 'view' } as unknown as Worktree;
+    expect(canResolveWidget({ user_id: 'bob' as UserID }, session, worktree, true)).toBe(true);
   });
 });
 
@@ -437,6 +443,36 @@ describe('resolveWidget', () => {
         { app: app as never, isWorktreeOwner: async () => false }
       )
     ).rejects.toThrow(/Invalid submit/);
+  });
+
+  it('serializes concurrent resolutions on the same widget — only one applySubmit fires', async () => {
+    const { applySubmit } = registerTestWidget();
+    const fixtures = makeFixtures();
+    const { app } = makeApp(fixtures);
+
+    // Two callers hit submit in the same tick. The lock should let one
+    // through to terminal state; the second sees `status !== 'pending'` and
+    // rejects. applySubmit must only run ONCE.
+    const [first, second] = await Promise.allSettled([
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'one', scope: 'global' } },
+        { user_id: 'creator-user-id' as UserID },
+        { app: app as never, isWorktreeOwner: async () => false }
+      ),
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'two', scope: 'global' } },
+        { user_id: 'creator-user-id' as UserID },
+        { app: app as never, isWorktreeOwner: async () => false }
+      ),
+    ]);
+
+    expect(applySubmit).toHaveBeenCalledTimes(1);
+    const fulfilledCount = [first, second].filter((r) => r.status === 'fulfilled').length;
+    const rejectedCount = [first, second].filter((r) => r.status === 'rejected').length;
+    expect(fulfilledCount).toBe(1);
+    expect(rejectedCount).toBe(1);
   });
 });
 

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -170,6 +170,7 @@ export async function resolveWidget(
       app: deps.app as any,
       sessionId: message.session_id as SessionID,
       submitterUserId: caller.user_id,
+      submitterRole: caller.role,
       sessionCreatorUserId: session.created_by as UserID,
     };
     await entry.applySubmit(submitCtx, submit);

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -1,0 +1,246 @@
+/**
+ * Widget submission / dismissal route handlers.
+ *
+ * Two custom REST routes:
+ *   POST /widgets/:widget_id/submit
+ *   POST /widgets/:widget_id/dismiss
+ *
+ * Both follow the same resolution path:
+ *   1. Load the widget message row by `widget_id` (message_id == widget_id).
+ *   2. Authorize: caller is session creator OR has prompt-tier worktree RBAC.
+ *   3. Idempotency: status MUST be 'pending'.
+ *   4. Dispatch to the registry (`applySubmit` for submit; no side-effect
+ *      for dismiss).
+ *   5. Patch `metadata.widget.status` to 'submitted' / 'dismissed' along
+ *      with `result_meta` and `resolved_at`.
+ *   6. Queue a system-authored auto-resume task via the existing
+ *      `/sessions/:id/prompt` route (the "Never lose a prompt" #1068 path),
+ *      unless `auto_resume === false`.
+ *   7. Broadcast `widget:resolved` on the per-session Feathers room.
+ *
+ * Critical security invariant: the `applySubmit` handler is the ONLY place
+ * the raw submit body reaches; from `result_meta` onward, no
+ * caller-supplied values flow back into the agent context. See §5.1 of the
+ * design doc for the path-by-path enumeration.
+ */
+
+import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
+import type {
+  Message,
+  MessageID,
+  Session,
+  SessionID,
+  UserID,
+  WidgetMessageMetadata,
+  Worktree,
+} from '@agor/core/types';
+import { PERMISSION_RANK, resolveWorktreePermission } from '../utils/worktree-authorization.js';
+import { getWidget, type WidgetSubmitCtx } from './registry.js';
+
+/**
+ * Minimal Feathers-like surface the resolver needs. Typed against a subset
+ * so the resolver is trivially mockable in unit tests.
+ */
+export interface WidgetResolverApp {
+  service(name: string): {
+    get(id: string, params?: unknown): Promise<unknown>;
+    patch(id: string, data: unknown, params?: unknown): Promise<unknown>;
+    create(data: unknown, params?: unknown): Promise<unknown>;
+    emit?(event: string, payload: unknown): void;
+  };
+}
+
+export interface WidgetResolverDeps {
+  app: WidgetResolverApp;
+  /** Worktree ownership lookup — pulled out so tests can stub without RBAC plumbing. */
+  isWorktreeOwner(worktreeId: string, userId: UserID): Promise<boolean>;
+}
+
+export interface AuthenticatedCaller {
+  user_id: UserID;
+  role?: string;
+}
+
+export type WidgetResolutionAction =
+  | { kind: 'submit'; body: Record<string, unknown> }
+  | { kind: 'dismiss' };
+
+export interface WidgetResolutionResult {
+  widget_id: MessageID;
+  status: 'submitted' | 'dismissed';
+  auto_resume_queued: boolean;
+}
+
+/**
+ * Check whether the caller is allowed to resolve a widget for the given
+ * session+worktree. Mirrors the rule in §5.2 / R4: session creator always
+ * passes; non-creators need prompt-tier worktree RBAC.
+ */
+export function canResolveWidget(
+  caller: AuthenticatedCaller,
+  session: Pick<Session, 'created_by'>,
+  worktree: Worktree
+): boolean {
+  if (session.created_by === caller.user_id) return true;
+  const effective = resolveWorktreePermission(
+    worktree,
+    caller.user_id,
+    /* isOwner */ false,
+    caller.role
+  );
+  return PERMISSION_RANK[effective] >= PERMISSION_RANK.prompt;
+}
+
+/**
+ * Resolve a widget (submit or dismiss). Pure-ish: side effects all go
+ * through `deps.app` so tests can supply a mock surface. Throws Feathers
+ * standard errors (NotFound, Forbidden, NotAuthenticated) that the caller
+ * wraps into HTTP responses.
+ */
+export async function resolveWidget(
+  widgetId: string,
+  action: WidgetResolutionAction,
+  caller: AuthenticatedCaller | undefined,
+  deps: WidgetResolverDeps
+): Promise<WidgetResolutionResult> {
+  if (!caller) {
+    throw new NotAuthenticated('Authentication required to resolve a widget');
+  }
+
+  // 1. Load the widget message.
+  let message: Message;
+  try {
+    message = (await deps.app.service('messages').get(widgetId)) as Message;
+  } catch {
+    throw new NotFound(`Widget ${widgetId} not found`);
+  }
+
+  if (message.type !== 'widget_request') {
+    throw new NotFound(`Message ${widgetId} is not a widget request`);
+  }
+
+  const widget = message.metadata?.widget;
+  if (!widget) {
+    throw new NotFound(`Widget ${widgetId} has no widget metadata`);
+  }
+
+  // 2. Load the session + worktree for authz.
+  const session = (await deps.app.service('sessions').get(message.session_id)) as Session;
+  const worktree = (await deps.app.service('worktrees').get(session.worktree_id)) as Worktree;
+
+  if (!canResolveWidget(caller, session, worktree)) {
+    throw new Forbidden(
+      `You need to be the session creator or have 'prompt' permission on the worktree to resolve this widget.`
+    );
+  }
+
+  // 3. Idempotency: only 'pending' widgets can be resolved.
+  if (widget.status !== 'pending') {
+    throw new Forbidden(
+      `Widget ${widgetId} is already ${widget.status}; cannot ${action.kind} again.`
+    );
+  }
+
+  // 4. Dispatch to the registry. Unknown widget types fail loudly — the
+  //    client should know the daemon doesn't speak this widget type.
+  const entry = getWidget(widget.widget_type);
+  // (We tolerate a missing registry entry for the dismiss path because
+  // dismissal needs no side-effect — but we still need the entry for the
+  // dismissed-prompt builder. If no entry exists, fall back to a generic
+  // user-visible prompt.)
+
+  let resultMeta: unknown | undefined;
+  let autoResumePrompt: string | undefined;
+
+  if (action.kind === 'submit') {
+    if (!entry) {
+      throw new NotFound(
+        `Widget type '${widget.widget_type}' is not registered on this daemon. ` +
+          `Update the daemon or use a known widget type.`
+      );
+    }
+    const parsed = entry.submitSchema.safeParse(action.body);
+    if (!parsed.success) {
+      throw new Forbidden(`Invalid submit payload: ${parsed.error.message}`);
+    }
+    const submit = parsed.data;
+
+    const submitCtx: WidgetSubmitCtx = {
+      // biome-ignore lint/suspicious/noExplicitAny: Pass-through Feathers Application
+      app: deps.app as any,
+      sessionId: message.session_id as SessionID,
+      submitterUserId: caller.user_id,
+      sessionCreatorUserId: session.created_by as UserID,
+    };
+    await entry.applySubmit(submitCtx, submit);
+    resultMeta = entry.buildResultMeta(submit);
+    autoResumePrompt = entry.buildAutoResumePrompt(resultMeta, widget.params);
+  } else {
+    // dismiss
+    autoResumePrompt = entry
+      ? entry.buildDismissedPrompt(widget.params)
+      : `[Agor] User dismissed a widget request. Do not re-request immediately — ask whether to proceed without, or move on to other work.`;
+  }
+
+  // 5. Patch the widget message — flip status, stamp resolution.
+  const newStatus: WidgetMessageMetadata['status'] =
+    action.kind === 'submit' ? 'submitted' : 'dismissed';
+  const updatedWidget: WidgetMessageMetadata = {
+    ...widget,
+    status: newStatus,
+    resolved_at: new Date().toISOString(),
+    submitted_by: caller.user_id,
+    ...(resultMeta !== undefined ? { result_meta: resultMeta } : {}),
+  };
+  await deps.app.service('messages').patch(widgetId, {
+    metadata: {
+      ...(message.metadata ?? {}),
+      widget: updatedWidget,
+    },
+  });
+
+  // 6. Auto-resume task (skipped when the agent set auto_resume:false on
+  //    the original tool call). Goes through `/sessions/:id/prompt` so the
+  //    idle-vs-queued branching is identical to a user-typed prompt — the
+  //    "Never lose a prompt" #1068 path.
+  let autoResumeQueued = false;
+  if (widget.auto_resume !== false && autoResumePrompt) {
+    await deps.app.service('/sessions/:id/prompt').create(
+      {
+        prompt: autoResumePrompt,
+        messageSource: 'agor',
+        // Stamp traceability fields onto the queued task so the UI can
+        // distinguish system-authored auto-resume prompts from user-typed
+        // ones, and so the resulting task links back to its widget.
+        metadata: {
+          system_authored: true,
+          widget_id: widget.widget_id,
+        },
+      },
+      {
+        // Internal call — no `provider` so RBAC hooks bypass. Submitter is
+        // attributed (`created_by`) for audit; see §5.3 of the design.
+        user: { user_id: caller.user_id },
+        route: { id: message.session_id },
+      }
+    );
+    autoResumeQueued = true;
+  }
+
+  // 7. Broadcast on the messages service's room (per-session subscribers
+  //    are already wired up to that channel — see register-services.ts).
+  deps.app.service('messages').emit?.('widget:resolved', {
+    widget_id: widget.widget_id,
+    session_id: message.session_id,
+    status: newStatus,
+    result_meta: resultMeta,
+    resolved_at: updatedWidget.resolved_at,
+    submitted_by: caller.user_id,
+  });
+
+  return {
+    widget_id: widget.widget_id,
+    status: newStatus,
+    auto_resume_queued: autoResumeQueued,
+  };
+}

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -74,22 +74,32 @@ export interface WidgetResolutionResult {
 /**
  * Check whether the caller is allowed to resolve a widget for the given
  * session+worktree. Mirrors the rule in §5.2 / R4: session creator always
- * passes; non-creators need prompt-tier worktree RBAC.
+ * passes; worktree owners pass via the owner-bypass path; non-creators need
+ * prompt-tier worktree RBAC.
  */
 export function canResolveWidget(
   caller: AuthenticatedCaller,
   session: Pick<Session, 'created_by'>,
-  worktree: Worktree
+  worktree: Worktree,
+  isOwner: boolean
 ): boolean {
   if (session.created_by === caller.user_id) return true;
-  const effective = resolveWorktreePermission(
-    worktree,
-    caller.user_id,
-    /* isOwner */ false,
-    caller.role
-  );
+  const effective = resolveWorktreePermission(worktree, caller.user_id, isOwner, caller.role);
   return PERMISSION_RANK[effective] >= PERMISSION_RANK.prompt;
 }
+
+/**
+ * Per-widget in-process serialization. Two concurrent submits (e.g. two
+ * browser tabs both posting in the small window between the status check
+ * and the message.patch) would each pass the `status === 'pending'` gate
+ * and both run side effects: doubled auto-resume tasks, surprise writes.
+ *
+ * The lock guards the critical section (status check → applySubmit →
+ * message.patch → tasks.create). Sufficient for single-daemon deployments,
+ * which is the only deployment shape today. A multi-daemon setup would need
+ * a DB-level optimistic check; we accept that trade today.
+ */
+const inFlightResolutions = new Map<string, Promise<WidgetResolutionResult>>();
 
 /**
  * Resolve a widget (submit or dismiss). Pure-ish: side effects all go
@@ -107,6 +117,30 @@ export async function resolveWidget(
     throw new NotAuthenticated('Authentication required to resolve a widget');
   }
 
+  // Serialize concurrent resolutions for the same widget (see comment on
+  // `inFlightResolutions`). The second caller will await the first's
+  // outcome and then hit the `status !== 'pending'` rejection.
+  const existing = inFlightResolutions.get(widgetId);
+  if (existing) {
+    await existing.catch(() => {}); // swallow — we re-check status below
+  }
+  const promise = (async () => doResolveWidget(widgetId, action, caller, deps))();
+  inFlightResolutions.set(widgetId, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightResolutions.get(widgetId) === promise) {
+      inFlightResolutions.delete(widgetId);
+    }
+  }
+}
+
+async function doResolveWidget(
+  widgetId: string,
+  action: WidgetResolutionAction,
+  caller: AuthenticatedCaller,
+  deps: WidgetResolverDeps
+): Promise<WidgetResolutionResult> {
   // 1. Load the widget message.
   let message: Message;
   try {
@@ -127,10 +161,11 @@ export async function resolveWidget(
   // 2. Load the session + worktree for authz.
   const session = (await deps.app.service('sessions').get(message.session_id)) as Session;
   const worktree = (await deps.app.service('worktrees').get(session.worktree_id)) as Worktree;
+  const isOwner = await deps.isWorktreeOwner(worktree.worktree_id, caller.user_id);
 
-  if (!canResolveWidget(caller, session, worktree)) {
+  if (!canResolveWidget(caller, session, worktree, isOwner)) {
     throw new Forbidden(
-      `You need to be the session creator or have 'prompt' permission on the worktree to resolve this widget.`
+      `You need to be the session creator, a worktree owner, or have 'prompt' permission on the worktree to resolve this widget.`
     );
   }
 

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -208,7 +208,7 @@ async function doResolveWidget(
       submitterRole: caller.role,
       sessionCreatorUserId: session.created_by as UserID,
     };
-    await entry.applySubmit(submitCtx, submit);
+    await entry.applySubmit(submitCtx, submit, widget.params);
     resultMeta = entry.buildResultMeta(submit);
     autoResumePrompt = entry.buildAutoResumePrompt(resultMeta, widget.params);
   } else {

--- a/apps/agor-docs/pages/guide/_meta.ts
+++ b/apps/agor-docs/pages/guide/_meta.ts
@@ -13,6 +13,7 @@ export default {
   assistants: 'Assistants',
   'internal-mcp': 'Agor MCP Server',
   'rich-chat-ux': 'Rich Chat UX',
+  'in-conversation-widgets': 'In-Conversation Widgets',
   'multiplayer-social': 'Multiplayer & Social',
   'environment-configuration': 'Environments',
   scheduler: 'Scheduler',

--- a/apps/agor-docs/pages/guide/in-conversation-widgets.mdx
+++ b/apps/agor-docs/pages/guide/in-conversation-widgets.mdx
@@ -1,0 +1,130 @@
+---
+title: In-Conversation Widgets
+description: Agents can render small interactive UI inline in the transcript — a form, a button, a picker — that captures user input without that input ever entering the LLM's context. v1 ships the env_vars widget.
+---
+
+# In-Conversation Widgets
+
+**Agents sometimes need something from you mid-task** — an API key, a confirmation, a choice between options. Without widgets, the only way to get that input is for the agent to ask in chat and for you to paste a value back. That breaks two things at once: your flow (the agent now needs to wait, you need to context-switch) and the security guarantee (the value lands in the model's context window, in logs, in transcripts that survive).
+
+**Widgets fix that.** When the agent calls a widget tool, a small form renders inline in the transcript. You fill it out. The values flow **directly browser → daemon** — they never reach the agent. A sanitized "[Agor] User submitted X" prompt is auto-queued into the agent's next turn so it can pick up where it left off.
+
+Widgets are a primitive. v1 ships one widget type — `env_vars` — as the canonical example. Future widget types (confirmations, OAuth connect, MCP-server picker, file picker) use the same plumbing.
+
+---
+
+## The env_vars widget
+
+This is the widget the agent calls when it needs an environment variable it doesn't have. Typical use: an MCP integration needs `HUBSPOT_API_KEY` and the agent doesn't want to fail with "please go to Settings".
+
+### What the agent does
+
+The agent calls the MCP tool `agor_widgets_request_env_vars`:
+
+```json
+{
+  "names": ["HUBSPOT_API_KEY"],
+  "reason": "Needed to call the Hubspot Private Apps API.",
+  "instructions": "Get a key at https://app.hubspot.com/private-apps. Make sure the **CRM > contacts > read** scope is enabled.",
+  "default_scope": "global"
+}
+```
+
+The tool returns within milliseconds. The agent ends its turn voluntarily. **No HTTP timeout, no executor pause, no daemon-side await.**
+
+### What you see
+
+A small form renders inline in the transcript:
+
+- The variable name(s) the agent is asking for
+- A short reason
+- An optional instructions block (rendered as sanitized markdown — links and emphasis only, no scripts)
+- A password input per variable
+- A scope selector (Session / Global)
+- **Dismiss** and **Save & continue** buttons
+- A disclaimer: *"Type values here, never paste them into chat."*
+
+When you hit **Save & continue**, the value goes **directly from the form to the daemon** via `POST /widgets/:widget_id/submit`. It does not traverse the model. The daemon writes it through the same encrypted-at-rest path as `Settings → Environment Variables` (AES-256-GCM via the daemon's master secret).
+
+### What the agent sees next
+
+A new user-role message arrives in the agent's next turn:
+
+```
+[Agor] User submitted HUBSPOT_API_KEY (scope: global). You can now retry the operation that needed it.
+```
+
+The agent retries. **Only the name** appears in that prompt — the value is read from the encrypted store at executor spawn time, as if you had set it via the Settings panel.
+
+### The `already_present` short-circuit
+
+If you already have the requested variables set in the chosen scope, the widget skips the form entirely. The transcript shows a "✓ already configured" badge and the agent auto-resumes with:
+
+```
+[Agor] HUBSPOT_API_KEY was already configured. You can proceed.
+```
+
+One fewer click in the common "agent didn't know I had this" case.
+
+### Dismissal
+
+If you hit **Dismiss**, the widget marks itself dismissed and queues an explicit prompt into the agent so it doesn't loop:
+
+```
+[Agor] User dismissed the request for HUBSPOT_API_KEY. Do not re-request immediately — ask whether to proceed without, or move on to other work.
+```
+
+---
+
+## Security guarantees
+
+The widget primitive has one hard requirement: **submitted values never enter the LLM's context.** Triple-checked:
+
+| Path | Carries values? |
+|---|---|
+| Agent → MCP tool call | **No** — input schema only accepts names + reason + instructions |
+| Widget message row | **No** — the row stores params (names, reason, ...) and lifecycle state |
+| MCP tool return value | **No** — returns `{ widget_id, status }` only |
+| Browser → daemon submit | **Yes** — direct HTTP, authenticated, never traverses the agent |
+| Daemon → users service | **Yes** — encrypted at the boundary, never logged |
+| Auto-resume prompt to agent | **No** — built from sanitized `result_meta` (just names + scope) |
+| `widget:resolved` WebSocket event | **No** — same sanitized payload |
+| Transcript reload | **No** — the row never held values |
+
+The disclaimer text on the form (*"Type values here, never paste them into chat"*) is there for one specific reason: if the agent goes off-script and asks you to type a value into chat instead of into the widget, **don't**. The widget is the only path that preserves the no-LLM-context guarantee.
+
+For the full security analysis, see `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+
+---
+
+## Transcript persistence
+
+The widget message persists in the transcript with its final state:
+
+- `submitted` → ✅ + names + scope + timestamp
+- `dismissed` → ⊘ + names
+- `already_present` → ✓ + names + "already configured"
+
+The **names** of submitted variables are visible to anyone who can read the transcript. The **values** are not, and never were. This is the same surface as `Settings → Environment Variables`, which also shows names without values.
+
+If a particular request is sensitive enough that even the name shouldn't appear in the transcript, dismiss the widget and add the variable via Settings.
+
+---
+
+## Multi-user behavior
+
+When `worktree_rbac: true` and someone other than the session creator submits the widget (under `others_can: prompt`), the env var lands in **the session creator's** identity — that's whose env the agent will read at retry. The submitting user is recorded in `result_meta.submitted_by` for audit.
+
+This is consistent with `dangerously_allow_session_sharing: false` (the default-safe posture). For the full multi-user story see [Multiplayer Unix Isolation](./multiplayer-unix-isolation.mdx).
+
+---
+
+## Why widgets, not chat?
+
+Three reasons:
+
+1. **Secrets stay out of the model.** The values flow directly to the daemon's encrypted store. The agent never sees them.
+2. **No flow-breaking context switch.** You don't have to leave the conversation to go set up Settings → Env Vars.
+3. **Async-friendly.** The widget is durable. Submit it now, submit it in an hour, submit it tomorrow — the session picks up wherever it was, on whatever device. Slack and gateway sessions work the same way.
+
+This is the v1 instance of a broader primitive. Future widgets — confirmations, OAuth-connect, MCP-server picker — use the same machinery and the same security guarantees.

--- a/apps/agor-docs/pages/guide/sessions.mdx
+++ b/apps/agor-docs/pages/guide/sessions.mdx
@@ -225,4 +225,5 @@ _Session Settings modal — model, effort, permissions, MCP, env vars, callbacks
 - [Worktrees](/guide/worktrees) — The container for sessions
 - [Agor MCP Server](/guide/internal-mcp) — How agents introspect and spawn each other programmatically
 - [Rich Chat UX](/guide/rich-chat-ux) — Token accounting, context window viz, tool blocks, queueing
+- [In-Conversation Widgets](/guide/in-conversation-widgets) — Agent-rendered inline forms (env vars today, more soon) that capture input without it ever entering the model's context
 - [SDK Comparison](/guide/sdk-comparison) — What each agent SDK supports

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -505,6 +505,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
             onUnloadTaskMessages={handleUnloadTaskMessages}
             assistantEmoji={assistantEmoji}
             isLatestTask={taskIndex === tasks.length - 1}
+            client={client}
           />
         ))}
       </div>

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -44,6 +44,7 @@ import {
 } from '../ToolBlock';
 import { ToolIcon } from '../ToolIcon';
 import { ToolUseRenderer } from '../ToolUseRenderer';
+import { WidgetBlock } from './WidgetBlock';
 
 interface ToolUseBlock {
   type: 'tool_use';
@@ -298,6 +299,18 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   // surrounding agent text already carries the question/answer context.
   if (message.type === 'input_request') {
     return null;
+  }
+
+  // In-conversation interactive widgets. WidgetBlock looks up the registered
+  // component by `metadata.widget.widget_type` and falls back to an
+  // "Unknown widget type" placeholder for forward-compat with newer
+  // daemons. See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+  if (message.type === 'widget_request') {
+    return (
+      <div style={{ margin: `${token.sizeUnit * 1.5}px 0` }}>
+        <WidgetBlock message={message} />
+      </div>
+    );
   }
 
   // Check if this is a Task tool prompt or result (agent-generated, but has user role)

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -10,6 +10,7 @@
  */
 
 import {
+  type AgorClient,
   type ContentBlock as CoreContentBlock,
   type DiffEnrichment,
   type Message,
@@ -88,6 +89,8 @@ interface MessageBlockProps {
   isFirstPendingPermission?: boolean; // For sequencing permission requests
   isLatestMessage?: boolean; // Whether this is the most recent message (don't collapse by default)
   assistantEmoji?: string; // Emoji override for assistant avatar (replaces tool icon)
+  /** Authenticated Feathers client, forwarded to WidgetBlock for inline-form submission. */
+  client?: AgorClient | null;
   onPermissionDecision?: (
     sessionId: string,
     requestId: string,
@@ -253,6 +256,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   isLatestMessage = false,
   onPermissionDecision,
   assistantEmoji,
+  client = null,
 }) => {
   const { token } = theme.useToken();
 
@@ -311,7 +315,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   if (message.type === 'widget_request') {
     return (
       <div style={{ margin: `${token.sizeUnit * 1.5}px 0` }}>
-        <WidgetBlock message={message} />
+        <WidgetBlock message={message} client={client} />
       </div>
     );
   }

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -44,6 +44,9 @@ import {
 } from '../ToolBlock';
 import { ToolIcon } from '../ToolIcon';
 import { ToolUseRenderer } from '../ToolUseRenderer';
+// Side-effect import: registers every built-in widget component with the
+// `WidgetBlock` dispatcher (e.g. `env_vars`).
+import '../Widgets';
 import { WidgetBlock } from './WidgetBlock';
 
 interface ToolUseBlock {

--- a/apps/agor-ui/src/components/MessageBlock/WidgetBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/WidgetBlock.tsx
@@ -1,0 +1,123 @@
+/**
+ * WidgetBlock — in-conversation widget dispatcher.
+ *
+ * Switches on `message.metadata.widget.widget_type` and renders the matching
+ * widget component. In PR 1 the client-side widget registry is empty; the
+ * fallback renders an "Unknown widget type" placeholder so newer servers
+ * that ship widget types unknown to an older client degrade gracefully
+ * instead of crashing.
+ *
+ * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ */
+
+import type { Message, WidgetMessageMetadata, WidgetType } from '@agor-live/client';
+import {
+  CheckCircleOutlined,
+  ExclamationCircleOutlined,
+  MinusCircleOutlined,
+} from '@ant-design/icons';
+import { Card, Space, Typography, theme } from 'antd';
+import type React from 'react';
+
+const { Text } = Typography;
+
+export interface WidgetComponentProps {
+  message: Message;
+  widget: WidgetMessageMetadata;
+}
+
+/**
+ * Per-widget-type renderers. Each widget type registers itself via
+ * `registerWidgetComponent` at module load. PR 1 ships an empty registry;
+ * PR 2 (env_vars), PR 3 (confirmation), etc. populate it.
+ */
+const widgetComponents = new Map<WidgetType, React.FC<WidgetComponentProps>>();
+
+export function registerWidgetComponent(
+  type: WidgetType,
+  component: React.FC<WidgetComponentProps>
+): void {
+  widgetComponents.set(type, component);
+}
+
+interface WidgetBlockProps {
+  message: Message;
+}
+
+/**
+ * Render a `type === 'widget_request'` message. Looks up the registered
+ * component for `widget.widget_type`; falls back to a forward-compat
+ * placeholder.
+ */
+export const WidgetBlock: React.FC<WidgetBlockProps> = ({ message }) => {
+  const { token } = theme.useToken();
+  const widget = message.metadata?.widget;
+
+  if (!widget) {
+    // Defensive: a widget_request message should always have metadata.widget;
+    // if it doesn't, render nothing rather than crashing the transcript.
+    return null;
+  }
+
+  const Component = widgetComponents.get(widget.widget_type);
+
+  if (!Component) {
+    return (
+      <Card
+        size="small"
+        style={{
+          margin: `${token.sizeUnit * 1.5}px 0`,
+          background: token.colorBgContainer,
+          border: `1px dashed ${token.colorBorder}`,
+        }}
+      >
+        <Space>
+          <ExclamationCircleOutlined style={{ color: token.colorWarning }} />
+          <Space direction="vertical" size={0}>
+            <Text strong>Unknown widget type — update your client</Text>
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              The agent requested a <code>{widget.widget_type}</code> widget, but this client
+              doesn't know how to render it. Status: {renderStatusBadge(widget.status)}
+            </Text>
+          </Space>
+        </Space>
+      </Card>
+    );
+  }
+
+  return <Component message={message} widget={widget} />;
+};
+
+function renderStatusBadge(status: WidgetMessageMetadata['status']): React.ReactNode {
+  switch (status) {
+    case 'submitted':
+      return (
+        <>
+          <CheckCircleOutlined /> submitted
+        </>
+      );
+    case 'dismissed':
+      return (
+        <>
+          <MinusCircleOutlined /> dismissed
+        </>
+      );
+    case 'already_present':
+      return (
+        <>
+          <CheckCircleOutlined /> already configured
+        </>
+      );
+    default:
+      return <Text>pending</Text>;
+  }
+}
+
+/**
+ * Public helper used by tests / future PRs to inspect registry state. Not
+ * intended for use in production rendering — components should always
+ * dispatch through `WidgetBlock`.
+ */
+export function _listRegisteredWidgetTypes(): WidgetType[] {
+  return Array.from(widgetComponents.keys());
+}

--- a/apps/agor-ui/src/components/MessageBlock/WidgetBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/WidgetBlock.tsx
@@ -10,7 +10,7 @@
  * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
  */
 
-import type { Message, WidgetMessageMetadata, WidgetType } from '@agor-live/client';
+import type { AgorClient, Message, WidgetMessageMetadata, WidgetType } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   ExclamationCircleOutlined,
@@ -24,6 +24,13 @@ const { Text } = Typography;
 export interface WidgetComponentProps {
   message: Message;
   widget: WidgetMessageMetadata;
+  /**
+   * Authenticated Feathers client. Widget components MUST submit via
+   * `client.service(...).create(...)` rather than raw fetch so the
+   * built-in 401 refresh/retry hook applies and tokens stay in sync.
+   * `null` if no session is active.
+   */
+  client: AgorClient | null;
 }
 
 /**
@@ -42,6 +49,7 @@ export function registerWidgetComponent(
 
 interface WidgetBlockProps {
   message: Message;
+  client: AgorClient | null;
 }
 
 /**
@@ -49,7 +57,7 @@ interface WidgetBlockProps {
  * component for `widget.widget_type`; falls back to a forward-compat
  * placeholder.
  */
-export const WidgetBlock: React.FC<WidgetBlockProps> = ({ message }) => {
+export const WidgetBlock: React.FC<WidgetBlockProps> = ({ message, client }) => {
   const { token } = theme.useToken();
   const widget = message.metadata?.widget;
 
@@ -85,7 +93,7 @@ export const WidgetBlock: React.FC<WidgetBlockProps> = ({ message }) => {
     );
   }
 
-  return <Component message={message} widget={widget} />;
+  return <Component message={message} widget={widget} client={client} />;
 };
 
 function renderStatusBadge(status: WidgetMessageMetadata['status']): React.ReactNode {

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -9,7 +9,7 @@
  * - Groups 3+ sequential tool-only messages into ToolBlock
  */
 
-import type { StreamingMessageState } from '@agor-live/client';
+import type { AgorClient, StreamingMessageState } from '@agor-live/client';
 import {
   type Message,
   type MessageID,
@@ -96,6 +96,8 @@ interface TaskBlockProps {
   onLoadTaskMessages: (taskId: string) => Promise<void> | void;
   onUnloadTaskMessages: (taskId: string) => void;
   assistantEmoji?: string;
+  /** Authenticated Feathers client, forwarded to MessageBlock → WidgetBlock for inline submission. */
+  client?: AgorClient | null;
   /** Whether this is the most recent task in the session */
   isLatestTask?: boolean;
 }
@@ -367,6 +369,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     onUnloadTaskMessages,
     assistantEmoji,
     isLatestTask = false,
+    client = null,
   }) => {
     const { token } = theme.useToken();
 
@@ -656,6 +659,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           isLatestMessage={isLatestMessage}
                           taskId={task.task_id}
                           assistantEmoji={assistantEmoji}
+                          client={client}
                         />
                       );
                     }

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
@@ -31,7 +31,6 @@ function makeWidget(
     params: {
       names: ['HUBSPOT_API_KEY'],
       reason: 'Needed to call the Hubspot API.',
-      default_scope: 'global',
       ...(paramOverrides ?? {}),
     },
     ...rest,
@@ -70,7 +69,6 @@ export const PendingMultiple: Story = {
       params: {
         names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY', 'OPENAI_API_KEY'],
         reason: 'Needed to fan out to three downstream APIs in this task.',
-        default_scope: 'global',
       },
     });
     return { message: makeMessage(widget), widget };
@@ -83,7 +81,6 @@ export const PendingNoReason: Story = {
       params: {
         names: ['HUBSPOT_API_KEY'],
         reason: '',
-        default_scope: 'global',
       },
     });
     return { message: makeMessage(widget), widget };

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
@@ -1,7 +1,19 @@
-import type { Message, WidgetMessageMetadata } from '@agor-live/client';
+import type { AgorClient, Message, WidgetMessageMetadata } from '@agor-live/client';
 import type { Meta, StoryObj } from '@storybook/react';
 import { ConfigProvider, theme } from 'antd';
 import { EnvVarRequestWidget } from './EnvVarRequestWidget';
+
+// Stub client for stories — `service(path).create(body)` resolves to a
+// no-op so the form's Save/Dismiss buttons don't throw in the playground.
+const stubClient = {
+  service() {
+    return {
+      async create() {
+        return { widget_id: 'wid-storybook-1', status: 'submitted' };
+      },
+    };
+  },
+} as unknown as AgorClient;
 
 function makeMessage(widget: WidgetMessageMetadata): Message {
   return {
@@ -41,6 +53,7 @@ const meta = {
   title: 'Widgets/EnvVarRequestWidget',
   component: EnvVarRequestWidget,
   parameters: { layout: 'centered' },
+  args: { client: stubClient },
   decorators: [
     (Story) => (
       <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
@@ -1,0 +1,125 @@
+import type { Message, WidgetMessageMetadata } from '@agor-live/client';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ConfigProvider, theme } from 'antd';
+import { EnvVarRequestWidget } from './EnvVarRequestWidget';
+
+function makeMessage(widget: WidgetMessageMetadata): Message {
+  return {
+    message_id: widget.widget_id,
+    session_id: 'sess-storybook' as never,
+    type: 'widget_request',
+    role: 'system',
+    index: 0,
+    timestamp: '2026-05-19T12:00:00.000Z',
+    content: 'Please provide env vars',
+    content_preview: 'Please provide env vars',
+    metadata: { widget },
+  } as unknown as Message;
+}
+
+function makeWidget(
+  overrides: Partial<WidgetMessageMetadata> & { params?: Record<string, unknown> }
+): WidgetMessageMetadata {
+  const { params: paramOverrides, ...rest } = overrides;
+  return {
+    widget_id: 'wid-storybook-1' as never,
+    widget_type: 'env_vars',
+    schema_version: 1,
+    status: 'pending',
+    requested_at: '2026-05-19T12:00:00.000Z',
+    auto_resume: true,
+    params: {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'Needed to call the Hubspot API.',
+      default_scope: 'global',
+      ...(paramOverrides ?? {}),
+    },
+    ...rest,
+  } as WidgetMessageMetadata;
+}
+
+const meta = {
+  title: 'Widgets/EnvVarRequestWidget',
+  component: EnvVarRequestWidget,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
+        <div style={{ width: 560, padding: 24, background: '#141414' }}>
+          <Story />
+        </div>
+      </ConfigProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof EnvVarRequestWidget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PendingSingle: Story = {
+  args: {
+    message: makeMessage(makeWidget({})),
+    widget: makeWidget({}),
+  },
+};
+
+export const PendingMultiple: Story = {
+  args: (() => {
+    const widget = makeWidget({
+      params: {
+        names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY', 'OPENAI_API_KEY'],
+        reason: 'Needed to fan out to three downstream APIs in this task.',
+        default_scope: 'global',
+      },
+    });
+    return { message: makeMessage(widget), widget };
+  })(),
+};
+
+export const PendingWithInstructions: Story = {
+  args: (() => {
+    const widget = makeWidget({
+      params: {
+        names: ['HUBSPOT_API_KEY'],
+        reason: 'Needed to call the Hubspot Private Apps API.',
+        instructions:
+          'Get a key at [https://app.hubspot.com/private-apps](https://app.hubspot.com/private-apps).\n\nMake sure the **CRM > contacts > read** scope is enabled.',
+        default_scope: 'session',
+      },
+    });
+    return { message: makeMessage(widget), widget };
+  })(),
+};
+
+export const Submitted: Story = {
+  args: (() => {
+    const widget = makeWidget({
+      status: 'submitted',
+      resolved_at: '2026-05-19T12:34:56.000Z',
+      submitted_by: 'user-1' as never,
+      result_meta: { names_submitted: ['HUBSPOT_API_KEY'], scope: 'global' },
+    });
+    return { message: makeMessage(widget), widget };
+  })(),
+};
+
+export const Dismissed: Story = {
+  args: (() => {
+    const widget = makeWidget({
+      status: 'dismissed',
+      resolved_at: '2026-05-19T12:34:56.000Z',
+    });
+    return { message: makeMessage(widget), widget };
+  })(),
+};
+
+export const AlreadyPresent: Story = {
+  args: (() => {
+    const widget = makeWidget({
+      status: 'already_present',
+      resolved_at: '2026-05-19T12:00:00.001Z',
+    });
+    return { message: makeMessage(widget), widget };
+  })(),
+};

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.stories.tsx
@@ -77,15 +77,13 @@ export const PendingMultiple: Story = {
   })(),
 };
 
-export const PendingWithInstructions: Story = {
+export const PendingNoReason: Story = {
   args: (() => {
     const widget = makeWidget({
       params: {
         names: ['HUBSPOT_API_KEY'],
-        reason: 'Needed to call the Hubspot Private Apps API.',
-        instructions:
-          'Get a key at [https://app.hubspot.com/private-apps](https://app.hubspot.com/private-apps).\n\nMake sure the **CRM > contacts > read** scope is enabled.',
-        default_scope: 'session',
+        reason: '',
+        default_scope: 'global',
       },
     });
     return { message: makeMessage(widget), widget };

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
@@ -11,17 +11,46 @@
  *     read-only summary instead of the form.
  */
 
-import type { Message, WidgetMessageMetadata } from '@agor-live/client';
+import type { AgorClient, Message, WidgetMessageMetadata } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ReactElement } from 'react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { EnvVarRequestWidget } from './EnvVarRequestWidget';
 
 /** Wrap with Ant Design's App so `useThemedMessage` finds a message instance. */
 function renderWithApp(ui: ReactElement) {
   return render(<AntApp>{ui}</AntApp>);
+}
+
+interface StubServiceCall {
+  path: string;
+  body: unknown;
+}
+
+/**
+ * Minimal AgorClient stub — only the `service(path).create(body)` surface
+ * the widget uses. Returns a `calls` array for assertions and a `shouldFail`
+ * knob for negative tests.
+ */
+function makeStubClient(opts: { shouldFail?: boolean } = {}): {
+  client: AgorClient;
+  calls: StubServiceCall[];
+} {
+  const calls: StubServiceCall[] = [];
+  const client = {
+    service(path: string) {
+      return {
+        async create(body: unknown) {
+          calls.push({ path, body });
+          if (opts.shouldFail) throw new Error('Invalid env var');
+          return { widget_id: 'wid-1', status: 'submitted' };
+        },
+      };
+    },
+  } as unknown as AgorClient;
+  return { client, calls };
 }
 
 function makeMessage(widget: WidgetMessageMetadata): Message {
@@ -58,24 +87,6 @@ function makeWidget(
   } as WidgetMessageMetadata;
 }
 
-const originalFetch = global.fetch;
-let fetchMock: ReturnType<typeof vi.fn>;
-
-beforeEach(() => {
-  fetchMock = vi.fn(async () => ({
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    json: async () => ({ widget_id: 'wid-1', status: 'submitted' }),
-    text: async () => 'ok',
-  })) as unknown as ReturnType<typeof vi.fn>;
-  global.fetch = fetchMock as unknown as typeof fetch;
-});
-
-afterEach(() => {
-  global.fetch = originalFetch;
-});
-
 describe('EnvVarRequestWidget — pending state', () => {
   it('renders one password input per requested name', () => {
     const widget = makeWidget({
@@ -84,14 +95,20 @@ describe('EnvVarRequestWidget — pending state', () => {
         reason: 'two integrations',
       },
     });
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
     expect(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i)).toBeTruthy();
     expect(screen.getByLabelText(/Value for STRIPE_SECRET_KEY/i)).toBeTruthy();
   });
 
   it('disables Save until every field has a value', () => {
     const widget = makeWidget();
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
     const saveBtn = screen.getByRole('button', { name: 'Save' });
     expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
 
@@ -100,9 +117,12 @@ describe('EnvVarRequestWidget — pending state', () => {
     expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it('submits via POST /widgets/:id/submit with the typed values + chosen scope', async () => {
+  it('submits via widgets/:id/submit with the typed values + chosen scope', async () => {
     const widget = makeWidget();
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client, calls } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
 
     const input = screen.getByLabelText(/Value for HUBSPOT_API_KEY/i);
     fireEvent.change(input, { target: { value: 'secret-key' } });
@@ -110,43 +130,37 @@ describe('EnvVarRequestWidget — pending state', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(calls.length).toBe(1);
     });
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toMatch(/\/widgets\/wid-1\/submit$/);
-    expect(init.method).toBe('POST');
-    const body = JSON.parse(init.body as string);
-    expect(body).toEqual({
+    expect(calls[0].path).toBe('widgets/wid-1/submit');
+    expect(calls[0].body).toEqual({
       values: { HUBSPOT_API_KEY: 'secret-key' },
       scope: 'global', // UI always starts at Global; no scope change in this test
     });
   });
 
-  it('dismisses via POST /widgets/:id/dismiss with an empty body', async () => {
+  it('dismisses via widgets/:id/dismiss with an empty body', async () => {
     const widget = makeWidget();
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client, calls } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(calls.length).toBe(1);
     });
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toMatch(/\/widgets\/wid-1\/dismiss$/);
-    expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body as string)).toEqual({});
+    expect(calls[0].path).toBe('widgets/wid-1/dismiss');
+    expect(calls[0].body).toEqual({});
   });
 
   it('re-enables Save after a failed submit so the user can retry', async () => {
-    fetchMock.mockImplementation(async () => ({
-      ok: false,
-      status: 400,
-      statusText: 'Bad Request',
-      json: async () => ({ message: 'Invalid env var' }),
-      text: async () => 'Invalid env var',
-    }));
     const widget = makeWidget();
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client, calls } = makeStubClient({ shouldFail: true });
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
     fireEvent.change(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i), {
       target: { value: 'shh' },
     });
@@ -159,7 +173,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     await waitFor(() => {
       expect(saveBtn.disabled).toBe(false);
     });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(calls.length).toBe(1);
   });
 });
 
@@ -170,7 +184,10 @@ describe('EnvVarRequestWidget — terminal states', () => {
       resolved_at: '2026-05-19T12:34:56.000Z',
       result_meta: { names_submitted: ['HUBSPOT_API_KEY'], scope: 'global' },
     });
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
     expect(screen.getByText(/HUBSPOT_API_KEY/i)).toBeTruthy();
     expect(screen.getByText(/saved/i)).toBeTruthy();
     expect(screen.getByText(/global/i)).toBeTruthy();
@@ -179,14 +196,20 @@ describe('EnvVarRequestWidget — terminal states', () => {
 
   it('renders the dismissed summary', () => {
     const widget = makeWidget({ status: 'dismissed' });
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
     expect(screen.getByText(/dismissed/i)).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });
 
   it('renders the already_present summary', () => {
     const widget = makeWidget({ status: 'already_present' });
-    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
     expect(screen.getByText(/already configured/i)).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
@@ -17,13 +17,6 @@ import { App as AntApp } from 'antd';
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Streamdown (used by MarkdownRenderer) lazy-loads katex.min.css which jsdom
-// can't resolve — drops out as an unhandled rejection that fails the suite.
-// Swap the renderer for a plain text passthrough.
-vi.mock('@/components/MarkdownRenderer', () => ({
-  MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
-}));
-
 import { EnvVarRequestWidget } from './EnvVarRequestWidget';
 
 /** Wrap with Ant Design's App so `useThemedMessage` finds a message instance. */
@@ -101,7 +94,7 @@ describe('EnvVarRequestWidget — pending state', () => {
   it('disables Save until every field has a value', () => {
     const widget = makeWidget();
     renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
-    const saveBtn = screen.getByRole('button', { name: /Save & continue/i });
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
     expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
 
     const input = screen.getByLabelText(/Value for HUBSPOT_API_KEY/i) as HTMLInputElement;
@@ -116,11 +109,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     const input = screen.getByLabelText(/Value for HUBSPOT_API_KEY/i);
     fireEvent.change(input, { target: { value: 'secret-key' } });
 
-    // Switch scope to session to make sure the selection is carried.
-    fireEvent.click(screen.getByRole('radio', { name: /Session \(only this session\)/i }));
-
-    const saveBtn = screen.getByRole('button', { name: /Save & continue/i });
-    fireEvent.click(saveBtn);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -131,7 +120,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     const body = JSON.parse(init.body as string);
     expect(body).toEqual({
       values: { HUBSPOT_API_KEY: 'secret-key' },
-      scope: 'session',
+      scope: 'global', // default_scope was 'global'; no scope change in this test
     });
   });
 
@@ -139,7 +128,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     const widget = makeWidget();
     renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Dismiss/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -150,7 +139,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     expect(JSON.parse(init.body as string)).toEqual({});
   });
 
-  it('shows an inline error when the daemon rejects the submit', async () => {
+  it('re-enables Save after a failed submit so the user can retry', async () => {
     fetchMock.mockImplementation(async () => ({
       ok: false,
       status: 400,
@@ -163,11 +152,16 @@ describe('EnvVarRequestWidget — pending state', () => {
     fireEvent.change(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i), {
       target: { value: 'shh' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /Save & continue/i }));
+    const saveBtn = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    fireEvent.click(saveBtn);
 
+    // After the failed POST resolves, the button should NOT be stuck in
+    // loading/disabled — the user can fix and retry. (Error itself surfaces
+    // via the global toast, not an inline Alert.)
     await waitFor(() => {
-      expect(screen.getByText(/Invalid env var/i)).toBeTruthy();
+      expect(saveBtn.disabled).toBe(false);
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -179,22 +173,23 @@ describe('EnvVarRequestWidget — terminal states', () => {
       result_meta: { names_submitted: ['HUBSPOT_API_KEY'], scope: 'global' },
     });
     renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
-    expect(screen.getByText(/HUBSPOT_API_KEY saved/i)).toBeTruthy();
+    expect(screen.getByText(/HUBSPOT_API_KEY/i)).toBeTruthy();
+    expect(screen.getByText(/saved/i)).toBeTruthy();
     expect(screen.getByText(/global/i)).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /Save & continue/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });
 
   it('renders the dismissed summary', () => {
     const widget = makeWidget({ status: 'dismissed' });
     renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
     expect(screen.getByText(/dismissed/i)).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /Save & continue/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });
 
   it('renders the already_present summary', () => {
     const widget = makeWidget({ status: 'already_present' });
     renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
     expect(screen.getByText(/already configured/i)).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /Save & continue/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });
 });

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
@@ -52,7 +52,6 @@ function makeWidget(
     params: {
       names: ['HUBSPOT_API_KEY'],
       reason: 'Needed to call the Hubspot API.',
-      default_scope: 'global',
       ...(paramOverrides ?? {}),
     },
     ...rest,
@@ -83,7 +82,6 @@ describe('EnvVarRequestWidget — pending state', () => {
       params: {
         names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY'],
         reason: 'two integrations',
-        default_scope: 'global',
       },
     });
     renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
@@ -120,7 +118,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     const body = JSON.parse(init.body as string);
     expect(body).toEqual({
       values: { HUBSPOT_API_KEY: 'secret-key' },
-      scope: 'global', // default_scope was 'global'; no scope change in this test
+      scope: 'global', // UI always starts at Global; no scope change in this test
     });
   });
 

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * EnvVarRequestWidget — UI tests.
+ *
+ * Covers:
+ *   - Pending state renders one password input per name + a scope selector +
+ *     Save/Dismiss buttons.
+ *   - Submitting calls POST /widgets/:id/submit with the correct body shape
+ *     (values + scope).
+ *   - Dismissing calls POST /widgets/:id/dismiss.
+ *   - Terminal states (submitted / dismissed / already_present) render their
+ *     read-only summary instead of the form.
+ */
+
+import type { Message, WidgetMessageMetadata } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Streamdown (used by MarkdownRenderer) lazy-loads katex.min.css which jsdom
+// can't resolve — drops out as an unhandled rejection that fails the suite.
+// Swap the renderer for a plain text passthrough.
+vi.mock('@/components/MarkdownRenderer', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+import { EnvVarRequestWidget } from './EnvVarRequestWidget';
+
+/** Wrap with Ant Design's App so `useThemedMessage` finds a message instance. */
+function renderWithApp(ui: ReactElement) {
+  return render(<AntApp>{ui}</AntApp>);
+}
+
+function makeMessage(widget: WidgetMessageMetadata): Message {
+  return {
+    message_id: widget.widget_id,
+    session_id: 'sess-1' as never,
+    type: 'widget_request',
+    role: 'system',
+    index: 0,
+    timestamp: '2026-05-19T12:00:00.000Z',
+    content: 'Please provide env vars',
+    content_preview: 'Please provide env vars',
+    metadata: { widget },
+  } as unknown as Message;
+}
+
+function makeWidget(
+  overrides: Partial<WidgetMessageMetadata> & { params?: Record<string, unknown> } = {}
+): WidgetMessageMetadata {
+  const { params: paramOverrides, ...rest } = overrides;
+  return {
+    widget_id: 'wid-1' as never,
+    widget_type: 'env_vars',
+    schema_version: 1,
+    status: 'pending',
+    requested_at: '2026-05-19T12:00:00.000Z',
+    auto_resume: true,
+    params: {
+      names: ['HUBSPOT_API_KEY'],
+      reason: 'Needed to call the Hubspot API.',
+      default_scope: 'global',
+      ...(paramOverrides ?? {}),
+    },
+    ...rest,
+  } as WidgetMessageMetadata;
+}
+
+const originalFetch = global.fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ widget_id: 'wid-1', status: 'submitted' }),
+    text: async () => 'ok',
+  })) as unknown as ReturnType<typeof vi.fn>;
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('EnvVarRequestWidget — pending state', () => {
+  it('renders one password input per requested name', () => {
+    const widget = makeWidget({
+      params: {
+        names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY'],
+        reason: 'two integrations',
+        default_scope: 'global',
+      },
+    });
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    expect(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Value for STRIPE_SECRET_KEY/i)).toBeTruthy();
+  });
+
+  it('disables Save until every field has a value', () => {
+    const widget = makeWidget();
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    const saveBtn = screen.getByRole('button', { name: /Save & continue/i });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+
+    const input = screen.getByLabelText(/Value for HUBSPOT_API_KEY/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'shh' } });
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('submits via POST /widgets/:id/submit with the typed values + chosen scope', async () => {
+    const widget = makeWidget();
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+
+    const input = screen.getByLabelText(/Value for HUBSPOT_API_KEY/i);
+    fireEvent.change(input, { target: { value: 'secret-key' } });
+
+    // Switch scope to session to make sure the selection is carried.
+    fireEvent.click(screen.getByRole('radio', { name: /Session \(only this session\)/i }));
+
+    const saveBtn = screen.getByRole('button', { name: /Save & continue/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/widgets\/wid-1\/submit$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      values: { HUBSPOT_API_KEY: 'secret-key' },
+      scope: 'session',
+    });
+  });
+
+  it('dismisses via POST /widgets/:id/dismiss with an empty body', async () => {
+    const widget = makeWidget();
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Dismiss/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/widgets\/wid-1\/dismiss$/);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({});
+  });
+
+  it('shows an inline error when the daemon rejects the submit', async () => {
+    fetchMock.mockImplementation(async () => ({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ message: 'Invalid env var' }),
+      text: async () => 'Invalid env var',
+    }));
+    const widget = makeWidget();
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    fireEvent.change(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i), {
+      target: { value: 'shh' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Save & continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid env var/i)).toBeTruthy();
+    });
+  });
+});
+
+describe('EnvVarRequestWidget — terminal states', () => {
+  it('renders the submitted summary with names + scope', () => {
+    const widget = makeWidget({
+      status: 'submitted',
+      resolved_at: '2026-05-19T12:34:56.000Z',
+      result_meta: { names_submitted: ['HUBSPOT_API_KEY'], scope: 'global' },
+    });
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    expect(screen.getByText(/HUBSPOT_API_KEY saved/i)).toBeTruthy();
+    expect(screen.getByText(/global/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Save & continue/i })).toBeNull();
+  });
+
+  it('renders the dismissed summary', () => {
+    const widget = makeWidget({ status: 'dismissed' });
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    expect(screen.getByText(/dismissed/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Save & continue/i })).toBeNull();
+  });
+
+  it('renders the already_present summary', () => {
+    const widget = makeWidget({ status: 'already_present' });
+    renderWithApp(<EnvVarRequestWidget message={makeMessage(widget)} widget={widget} />);
+    expect(screen.getByText(/already configured/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Save & continue/i })).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -19,7 +19,12 @@
  */
 
 import type { EnvVarScope, Message, WidgetMessageMetadata } from '@agor-live/client';
-import { CheckCircleOutlined, LockOutlined, MinusCircleOutlined } from '@ant-design/icons';
+import {
+  CheckCircleOutlined,
+  LockOutlined,
+  MinusCircleOutlined,
+  SafetyCertificateOutlined,
+} from '@ant-design/icons';
 import { Button, Card, Input, Select, Space, Typography, theme } from 'antd';
 import { useMemo, useState } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
@@ -31,7 +36,6 @@ const { Text } = Typography;
 interface EnvVarsParams {
   names: string[];
   reason: string;
-  default_scope: EnvVarScope;
   auto_resume?: boolean;
 }
 
@@ -69,15 +73,22 @@ const VarRow: React.FC<VarRowProps> = ({ name, value, onChange, disabled }) => {
     <div>
       <Text
         strong
-        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginBottom: 4 }}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          marginBottom: 4,
+          fontFamily: token.fontFamilyCode,
+          fontSize: token.fontSizeSM,
+        }}
       >
         <LockOutlined style={{ color: token.colorTextSecondary }} />
-        <code style={{ fontSize: token.fontSize }}>{name}</code>
+        {name}
       </Text>
       <Input.Password
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Enter value"
+        placeholder={`Enter value for ${name}`}
         disabled={disabled}
         aria-label={`Value for ${name}`}
         autoComplete="off"
@@ -101,7 +112,11 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
     for (const name of params.names) initial[name] = '';
     return initial;
   });
-  const [scope, setScope] = useState<EnvVarScope>(params.default_scope ?? 'global');
+  // Scope is a user-only choice — agent doesn't get to suggest it. Default
+  // to global because the most common case is "credential I'll need across
+  // sessions" (API keys, tokens). User can downscope to Session if they
+  // want a one-off.
+  const [scope, setScope] = useState<EnvVarScope>('global');
   const [submitting, setSubmitting] = useState(false);
   const [dismissing, setDismissing] = useState(false);
 
@@ -157,6 +172,11 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
     }
   };
 
+  const title =
+    params.names.length === 1
+      ? 'Securely provide environment variable'
+      : `Securely provide ${params.names.length} environment variables`;
+
   return (
     <Card
       size="small"
@@ -164,6 +184,11 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
       styles={{ body: { padding: token.paddingSM } }}
     >
       <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+        <Space size="small" style={{ width: '100%' }}>
+          <SafetyCertificateOutlined style={{ color: token.colorPrimary }} />
+          <Text strong>{title}</Text>
+        </Space>
+
         {params.reason && (
           <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
             {params.reason}
@@ -181,17 +206,22 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
         ))}
 
         <Space style={{ width: '100%', justifyContent: 'space-between' }} size="small">
-          <Select
-            size="small"
-            value={scope}
-            onChange={(v) => setScope(v)}
-            disabled={submitting || dismissing}
-            style={{ width: 120 }}
-            options={[
-              { value: 'session', label: 'Session' },
-              { value: 'global', label: 'Global' },
-            ]}
-          />
+          <Space size="small">
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              Scope:
+            </Text>
+            <Select
+              size="small"
+              value={scope}
+              onChange={(v) => setScope(v)}
+              disabled={submitting || dismissing}
+              style={{ width: 110 }}
+              options={[
+                { value: 'global', label: 'Global' },
+                { value: 'session', label: 'Session' },
+              ]}
+            />
+          </Space>
           <Space size="small">
             <Button size="small" onClick={handleDismiss} loading={dismissing} disabled={submitting}>
               Dismiss
@@ -240,7 +270,7 @@ const SubmittedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget 
   const { token } = theme.useToken();
   const rm = readResultMeta(widget);
   const names = rm?.names_submitted ?? readParams(widget).names;
-  const scope = rm?.scope ?? readParams(widget).default_scope ?? 'global';
+  const scope = rm?.scope ?? 'global';
   return (
     <TerminalLine
       icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -2,31 +2,28 @@
  * EnvVarRequestWidget — env_vars in-conversation widget UI.
  *
  * Renders inline in the transcript when an agent calls
- * `agor_widgets_request_env_vars`. Captures one or more secret values via
- * password inputs and POSTs them DIRECTLY to the daemon
- * (`POST /widgets/:widget_id/submit`) — values never flow through the agent's
- * MCP transport.
+ * `agor_widgets_request_env_vars`. Captures secret value(s) via password
+ * inputs and POSTs them DIRECTLY to the daemon
+ * (`POST /widgets/:widget_id/submit`) — values never flow through the
+ * agent's MCP transport.
  *
- * Terminal states (read-only summaries):
- *   - submitted        ✅ names + scope + submitter timestamp
- *   - dismissed        ⊘ names + "request dismissed"
- *   - already_present  ✓ names + "already configured"
+ * Design intent: KISS. Single card, no title bar, no warning Alert, no
+ * instructions Alert. Lock icon + var name is the only mandatory chrome.
+ *
+ * Terminal states (one-line read-only summaries):
+ *   - submitted        ✅ NAME saved (scope)
+ *   - dismissed        ⊘ NAME dismissed
+ *   - already_present  ✓ NAME already configured
  *
  * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
  */
 
 import type { EnvVarScope, Message, WidgetMessageMetadata } from '@agor-live/client';
-import {
-  CheckCircleOutlined,
-  LockOutlined,
-  MinusCircleOutlined,
-  SafetyCertificateOutlined,
-} from '@ant-design/icons';
-import { Alert, Button, Card, Input, Radio, Space, Tag, Typography, theme } from 'antd';
+import { CheckCircleOutlined, LockOutlined, MinusCircleOutlined } from '@ant-design/icons';
+import { Button, Card, Input, Select, Space, Typography, theme } from 'antd';
 import { useMemo, useState } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
 import { useThemedMessage } from '@/utils/message';
-import { MarkdownRenderer } from '../MarkdownRenderer';
 import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
 
 const { Text } = Typography;
@@ -34,7 +31,6 @@ const { Text } = Typography;
 interface EnvVarsParams {
   names: string[];
   reason: string;
-  instructions?: string;
   default_scope: EnvVarScope;
   auto_resume?: boolean;
 }
@@ -52,11 +48,6 @@ function getAuthHeaders(): HeadersInit {
   };
 }
 
-/**
- * Coerce the widget's `params` (typed as `unknown` on the generic metadata) to
- * the env_vars-specific shape. The daemon validates with Zod before writing
- * the message row, so by the time this renders the shape is guaranteed.
- */
 function readParams(widget: WidgetMessageMetadata): EnvVarsParams {
   return widget.params as EnvVarsParams;
 }
@@ -64,6 +55,36 @@ function readParams(widget: WidgetMessageMetadata): EnvVarsParams {
 function readResultMeta(widget: WidgetMessageMetadata): EnvVarsResultMeta | undefined {
   return widget.result_meta as EnvVarsResultMeta | undefined;
 }
+
+interface VarRowProps {
+  name: string;
+  value: string;
+  onChange: (next: string) => void;
+  disabled: boolean;
+}
+
+const VarRow: React.FC<VarRowProps> = ({ name, value, onChange, disabled }) => {
+  const { token } = theme.useToken();
+  return (
+    <div>
+      <Text
+        strong
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginBottom: 4 }}
+      >
+        <LockOutlined style={{ color: token.colorTextSecondary }} />
+        <code style={{ fontSize: token.fontSize }}>{name}</code>
+      </Text>
+      <Input.Password
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Enter value"
+        disabled={disabled}
+        aria-label={`Value for ${name}`}
+        autoComplete="off"
+      />
+    </div>
+  );
+};
 
 interface PendingFormProps {
   widgetId: string;
@@ -83,7 +104,6 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
   const [scope, setScope] = useState<EnvVarScope>(params.default_scope ?? 'global');
   const [submitting, setSubmitting] = useState(false);
   const [dismissing, setDismissing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const allFilled = useMemo(
     () => params.names.every((name) => values[name]?.trim().length > 0),
@@ -106,11 +126,7 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
 
   const handleSubmit = async () => {
     if (!allFilled || submitting) return;
-    setError(null);
     setSubmitting(true);
-    // Build the submit payload from local state. Note: `values` never crosses
-    // into the message metadata or the daemon-broadcast event — only into the
-    // direct HTTP POST below.
     const submitBody = {
       values: Object.fromEntries(params.names.map((name) => [name, values[name]?.trim() ?? ''])),
       scope,
@@ -118,15 +134,12 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
     try {
       await post('submit', submitBody);
       showSuccess(
-        `Saved ${params.names.length === 1 ? params.names[0] : `${params.names.length} variables`} (${scope})`
+        params.names.length === 1
+          ? `Saved ${params.names[0]} (${scope})`
+          : `Saved ${params.names.length} variables (${scope})`
       );
-      // Don't manually flip local state — the daemon broadcasts a
-      // `widget:resolved` event that re-renders the row from the patched
-      // message metadata.
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setError(msg);
-      showError(`Failed to save: ${msg}`);
+      showError(`Save failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setSubmitting(false);
     }
@@ -134,14 +147,11 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
 
   const handleDismiss = async () => {
     if (dismissing) return;
-    setError(null);
     setDismissing(true);
     try {
       await post('dismiss', {});
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      setError(msg);
-      showError(`Failed to dismiss: ${msg}`);
+      showError(`Dismiss failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setDismissing(false);
     }
@@ -150,87 +160,77 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
   return (
     <Card
       size="small"
-      title={
-        <Space>
-          <SafetyCertificateOutlined style={{ color: token.colorPrimary }} />
-          <Text strong>
-            {params.names.length === 1
-              ? `Agent needs ${params.names[0]}`
-              : `Agent needs ${params.names.length} environment variables`}
-          </Text>
-        </Space>
-      }
       style={{ margin: `${token.sizeUnit * 1.5}px 0`, background: token.colorBgContainer }}
+      styles={{ body: { padding: token.paddingSM } }}
     >
-      <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
-        <MarkdownRenderer content={params.reason} compact />
-
-        {params.instructions && (
-          <Alert
-            type="info"
-            showIcon={false}
-            description={<MarkdownRenderer content={params.instructions} compact />}
-          />
+      <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+        {params.reason && (
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            {params.reason}
+          </Text>
         )}
 
-        <Space orientation="vertical" size="small" style={{ width: '100%' }}>
-          {params.names.map((name) => (
-            <div key={name}>
-              <Tag icon={<LockOutlined />} color="gold" style={{ marginBottom: 4 }}>
-                <code>{name}</code>
-              </Tag>
-              <Input.Password
-                value={values[name] ?? ''}
-                onChange={(e) => setValues((prev) => ({ ...prev, [name]: e.target.value }))}
-                placeholder={`Enter value for ${name}`}
-                disabled={submitting || dismissing}
-                aria-label={`Value for ${name}`}
-                autoComplete="off"
-              />
-            </div>
-          ))}
-        </Space>
-
-        <Space orientation="vertical" size={4}>
-          <Text strong style={{ fontSize: token.fontSizeSM }}>
-            Scope
-          </Text>
-          <Radio.Group
-            value={scope}
-            onChange={(e) => setScope(e.target.value as EnvVarScope)}
+        {params.names.map((name) => (
+          <VarRow
+            key={name}
+            name={name}
+            value={values[name] ?? ''}
+            onChange={(next) => setValues((prev) => ({ ...prev, [name]: next }))}
             disabled={submitting || dismissing}
-          >
-            <Radio value="session">Session (only this session)</Radio>
-            <Radio value="global">Global (every session you own)</Radio>
-          </Radio.Group>
+          />
+        ))}
+
+        <Space style={{ width: '100%', justifyContent: 'space-between' }} size="small">
+          <Select
+            size="small"
+            value={scope}
+            onChange={(v) => setScope(v)}
+            disabled={submitting || dismissing}
+            style={{ width: 120 }}
+            options={[
+              { value: 'session', label: 'Session' },
+              { value: 'global', label: 'Global' },
+            ]}
+          />
+          <Space size="small">
+            <Button size="small" onClick={handleDismiss} loading={dismissing} disabled={submitting}>
+              Dismiss
+            </Button>
+            <Button
+              size="small"
+              type="primary"
+              onClick={handleSubmit}
+              loading={submitting}
+              disabled={!allFilled || dismissing}
+            >
+              Save
+            </Button>
+          </Space>
         </Space>
+      </Space>
+    </Card>
+  );
+};
 
-        <Alert
-          type="warning"
-          showIcon
-          title={
-            <Text style={{ fontSize: token.fontSizeSM }}>
-              Type values here, never paste them into chat. Values are encrypted at rest and never
-              sent to the agent — only the variable names are.
-            </Text>
-          }
-        />
-
-        {error && <Alert type="error" showIcon title={error} />}
-
-        <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
-          <Button onClick={handleDismiss} loading={dismissing} disabled={submitting}>
-            Dismiss
-          </Button>
-          <Button
-            type="primary"
-            onClick={handleSubmit}
-            loading={submitting}
-            disabled={!allFilled || dismissing}
-          >
-            Save &amp; continue
-          </Button>
-        </Space>
+const TerminalLine: React.FC<{
+  icon: React.ReactNode;
+  borderColor: string;
+  text: React.ReactNode;
+}> = ({ icon, borderColor, text }) => {
+  const { token } = theme.useToken();
+  return (
+    <Card
+      size="small"
+      style={{
+        margin: `${token.sizeUnit * 1.5}px 0`,
+        background: token.colorBgContainer,
+        borderLeft: `3px solid ${borderColor}`,
+      }}
+      styles={{ body: { padding: `${token.paddingXS}px ${token.paddingSM}px` } }}
+    >
+      <Space size="small">
+        {icon}
+        {text}
       </Space>
     </Card>
   );
@@ -242,28 +242,16 @@ const SubmittedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget 
   const names = rm?.names_submitted ?? readParams(widget).names;
   const scope = rm?.scope ?? readParams(widget).default_scope ?? 'global';
   return (
-    <Card
-      size="small"
-      style={{
-        margin: `${token.sizeUnit * 1.5}px 0`,
-        background: token.colorBgContainer,
-        borderLeft: `3px solid ${token.colorSuccess}`,
-      }}
-    >
-      <Space>
-        <CheckCircleOutlined style={{ color: token.colorSuccess }} />
-        <Space orientation="vertical" size={0}>
-          <Text strong>
-            {names.length === 1 ? `${names[0]} saved` : `${names.length} variables saved`} ({scope})
-          </Text>
-          {widget.resolved_at && (
-            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-              Submitted at {new Date(widget.resolved_at).toLocaleString()}
-            </Text>
-          )}
-        </Space>
-      </Space>
-    </Card>
+    <TerminalLine
+      icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
+      borderColor={token.colorSuccess}
+      text={
+        <Text>
+          {names.length === 1 ? names[0] : `${names.length} variables`} saved
+          <Text type="secondary"> ({scope})</Text>
+        </Text>
+      }
+    />
   );
 };
 
@@ -271,19 +259,11 @@ const DismissedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget 
   const { token } = theme.useToken();
   const names = readParams(widget).names;
   return (
-    <Card
-      size="small"
-      style={{
-        margin: `${token.sizeUnit * 1.5}px 0`,
-        background: token.colorBgContainer,
-        borderLeft: `3px solid ${token.colorBorder}`,
-      }}
-    >
-      <Space>
-        <MinusCircleOutlined style={{ color: token.colorTextSecondary }} />
-        <Text type="secondary">Request for {names.join(', ')} dismissed</Text>
-      </Space>
-    </Card>
+    <TerminalLine
+      icon={<MinusCircleOutlined style={{ color: token.colorTextSecondary }} />}
+      borderColor={token.colorBorder}
+      text={<Text type="secondary">{names.join(', ')} dismissed</Text>}
+    />
   );
 };
 
@@ -291,28 +271,16 @@ const AlreadyPresentSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ wi
   const { token } = theme.useToken();
   const names = readParams(widget).names;
   return (
-    <Card
-      size="small"
-      style={{
-        margin: `${token.sizeUnit * 1.5}px 0`,
-        background: token.colorBgContainer,
-        borderLeft: `3px solid ${token.colorInfo}`,
-      }}
-    >
-      <Space>
-        <CheckCircleOutlined style={{ color: token.colorInfo }} />
-        <Space orientation="vertical" size={0}>
-          <Text strong>
-            {names.length === 1
-              ? `${names[0]} was already configured`
-              : `${names.join(', ')} were already configured`}
-          </Text>
-          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-            No action needed — the agent has resumed.
-          </Text>
-        </Space>
-      </Space>
-    </Card>
+    <TerminalLine
+      icon={<CheckCircleOutlined style={{ color: token.colorInfo }} />}
+      borderColor={token.colorInfo}
+      text={
+        <Text>
+          {names.length === 1 ? names[0] : names.join(', ')}{' '}
+          <Text type="secondary">already configured</Text>
+        </Text>
+      }
+    />
   );
 };
 
@@ -332,9 +300,7 @@ export const EnvVarRequestWidget: React.FC<WidgetComponentProps> = ({ message, w
   }
 };
 
-// Register on module load so `WidgetBlock` can dispatch to it. The
-// registration is a side-effect of importing this file (via the
-// `Widgets/index.ts` barrel imported from `MessageBlock.tsx`).
+// Side-effect: register with the WidgetBlock dispatcher on module load.
 registerWidgetComponent('env_vars', EnvVarRequestWidget);
 
 export const _EnvVarRequestWidgetForTests = {

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -18,7 +18,7 @@
  * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
  */
 
-import type { EnvVarScope, Message, WidgetMessageMetadata } from '@agor-live/client';
+import type { AgorClient, EnvVarScope, Message, WidgetMessageMetadata } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   LockOutlined,
@@ -27,7 +27,6 @@ import {
 } from '@ant-design/icons';
 import { Button, Card, Input, Select, Space, Typography, theme } from 'antd';
 import { useMemo, useState } from 'react';
-import { getDaemonUrl } from '@/config/daemon';
 import { useThemedMessage } from '@/utils/message';
 import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
 
@@ -42,14 +41,6 @@ interface EnvVarsParams {
 interface EnvVarsResultMeta {
   names_submitted: string[];
   scope: EnvVarScope;
-}
-
-function getAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
-  return {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
 }
 
 function readParams(widget: WidgetMessageMetadata): EnvVarsParams {
@@ -101,9 +92,15 @@ interface PendingFormProps {
   widgetId: string;
   message: Message;
   params: EnvVarsParams;
+  client: AgorClient | null;
 }
 
-const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, params }) => {
+const PendingForm: React.FC<PendingFormProps> = ({
+  widgetId,
+  message: _message,
+  params,
+  client,
+}) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
 
@@ -125,18 +122,13 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, 
     [params.names, values]
   );
 
+  // Use the Feathers client so the built-in 401 refresh/retry hook fires
+  // on token expiry rather than a raw 401 surfacing as a save failure.
   const post = async (path: 'submit' | 'dismiss', body: unknown) => {
-    const url = `${getDaemonUrl()}/widgets/${encodeURIComponent(widgetId)}/${path}`;
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: getAuthHeaders(),
-      body: JSON.stringify(body ?? {}),
-    });
-    if (!res.ok) {
-      const detail = await res.text().catch(() => '');
-      throw new Error(detail || `${res.statusText} (${res.status})`);
+    if (!client) {
+      throw new Error('No client available — refresh and try again');
     }
-    return res.json().catch(() => ({}));
+    return client.service(`widgets/${encodeURIComponent(widgetId)}/${path}`).create(body ?? {});
   };
 
   const handleSubmit = async () => {
@@ -314,7 +306,11 @@ const AlreadyPresentSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ wi
   );
 };
 
-export const EnvVarRequestWidget: React.FC<WidgetComponentProps> = ({ message, widget }) => {
+export const EnvVarRequestWidget: React.FC<WidgetComponentProps> = ({
+  message,
+  widget,
+  client,
+}) => {
   const params = readParams(widget);
   const widgetId = widget.widget_id as unknown as string;
 
@@ -326,7 +322,7 @@ export const EnvVarRequestWidget: React.FC<WidgetComponentProps> = ({ message, w
     case 'already_present':
       return <AlreadyPresentSummary widget={widget} />;
     default:
-      return <PendingForm widgetId={widgetId} message={message} params={params} />;
+      return <PendingForm widgetId={widgetId} message={message} params={params} client={client} />;
   }
 };
 

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -1,0 +1,347 @@
+/**
+ * EnvVarRequestWidget — env_vars in-conversation widget UI.
+ *
+ * Renders inline in the transcript when an agent calls
+ * `agor_widgets_request_env_vars`. Captures one or more secret values via
+ * password inputs and POSTs them DIRECTLY to the daemon
+ * (`POST /widgets/:widget_id/submit`) — values never flow through the agent's
+ * MCP transport.
+ *
+ * Terminal states (read-only summaries):
+ *   - submitted        ✅ names + scope + submitter timestamp
+ *   - dismissed        ⊘ names + "request dismissed"
+ *   - already_present  ✓ names + "already configured"
+ *
+ * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ */
+
+import type { EnvVarScope, Message, WidgetMessageMetadata } from '@agor-live/client';
+import {
+  CheckCircleOutlined,
+  LockOutlined,
+  MinusCircleOutlined,
+  SafetyCertificateOutlined,
+} from '@ant-design/icons';
+import { Alert, Button, Card, Input, Radio, Space, Tag, Typography, theme } from 'antd';
+import { useMemo, useState } from 'react';
+import { getDaemonUrl } from '@/config/daemon';
+import { useThemedMessage } from '@/utils/message';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
+
+const { Text } = Typography;
+
+interface EnvVarsParams {
+  names: string[];
+  reason: string;
+  instructions?: string;
+  default_scope: EnvVarScope;
+  auto_resume?: boolean;
+}
+
+interface EnvVarsResultMeta {
+  names_submitted: string[];
+  scope: EnvVarScope;
+}
+
+function getAuthHeaders(): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+/**
+ * Coerce the widget's `params` (typed as `unknown` on the generic metadata) to
+ * the env_vars-specific shape. The daemon validates with Zod before writing
+ * the message row, so by the time this renders the shape is guaranteed.
+ */
+function readParams(widget: WidgetMessageMetadata): EnvVarsParams {
+  return widget.params as EnvVarsParams;
+}
+
+function readResultMeta(widget: WidgetMessageMetadata): EnvVarsResultMeta | undefined {
+  return widget.result_meta as EnvVarsResultMeta | undefined;
+}
+
+interface PendingFormProps {
+  widgetId: string;
+  message: Message;
+  params: EnvVarsParams;
+}
+
+const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message: _message, params }) => {
+  const { token } = theme.useToken();
+  const { showSuccess, showError } = useThemedMessage();
+
+  const [values, setValues] = useState<Record<string, string>>(() => {
+    const initial: Record<string, string> = {};
+    for (const name of params.names) initial[name] = '';
+    return initial;
+  });
+  const [scope, setScope] = useState<EnvVarScope>(params.default_scope ?? 'global');
+  const [submitting, setSubmitting] = useState(false);
+  const [dismissing, setDismissing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const allFilled = useMemo(
+    () => params.names.every((name) => values[name]?.trim().length > 0),
+    [params.names, values]
+  );
+
+  const post = async (path: 'submit' | 'dismiss', body: unknown) => {
+    const url = `${getDaemonUrl()}/widgets/${encodeURIComponent(widgetId)}/${path}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(body ?? {}),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(detail || `${res.statusText} (${res.status})`);
+    }
+    return res.json().catch(() => ({}));
+  };
+
+  const handleSubmit = async () => {
+    if (!allFilled || submitting) return;
+    setError(null);
+    setSubmitting(true);
+    // Build the submit payload from local state. Note: `values` never crosses
+    // into the message metadata or the daemon-broadcast event — only into the
+    // direct HTTP POST below.
+    const submitBody = {
+      values: Object.fromEntries(params.names.map((name) => [name, values[name]?.trim() ?? ''])),
+      scope,
+    };
+    try {
+      await post('submit', submitBody);
+      showSuccess(
+        `Saved ${params.names.length === 1 ? params.names[0] : `${params.names.length} variables`} (${scope})`
+      );
+      // Don't manually flip local state — the daemon broadcasts a
+      // `widget:resolved` event that re-renders the row from the patched
+      // message metadata.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      showError(`Failed to save: ${msg}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDismiss = async () => {
+    if (dismissing) return;
+    setError(null);
+    setDismissing(true);
+    try {
+      await post('dismiss', {});
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      showError(`Failed to dismiss: ${msg}`);
+    } finally {
+      setDismissing(false);
+    }
+  };
+
+  return (
+    <Card
+      size="small"
+      title={
+        <Space>
+          <SafetyCertificateOutlined style={{ color: token.colorPrimary }} />
+          <Text strong>
+            {params.names.length === 1
+              ? `Agent needs ${params.names[0]}`
+              : `Agent needs ${params.names.length} environment variables`}
+          </Text>
+        </Space>
+      }
+      style={{ margin: `${token.sizeUnit * 1.5}px 0`, background: token.colorBgContainer }}
+    >
+      <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
+        <MarkdownRenderer content={params.reason} compact />
+
+        {params.instructions && (
+          <Alert
+            type="info"
+            showIcon={false}
+            description={<MarkdownRenderer content={params.instructions} compact />}
+          />
+        )}
+
+        <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+          {params.names.map((name) => (
+            <div key={name}>
+              <Tag icon={<LockOutlined />} color="gold" style={{ marginBottom: 4 }}>
+                <code>{name}</code>
+              </Tag>
+              <Input.Password
+                value={values[name] ?? ''}
+                onChange={(e) => setValues((prev) => ({ ...prev, [name]: e.target.value }))}
+                placeholder={`Enter value for ${name}`}
+                disabled={submitting || dismissing}
+                aria-label={`Value for ${name}`}
+                autoComplete="off"
+              />
+            </div>
+          ))}
+        </Space>
+
+        <Space orientation="vertical" size={4}>
+          <Text strong style={{ fontSize: token.fontSizeSM }}>
+            Scope
+          </Text>
+          <Radio.Group
+            value={scope}
+            onChange={(e) => setScope(e.target.value as EnvVarScope)}
+            disabled={submitting || dismissing}
+          >
+            <Radio value="session">Session (only this session)</Radio>
+            <Radio value="global">Global (every session you own)</Radio>
+          </Radio.Group>
+        </Space>
+
+        <Alert
+          type="warning"
+          showIcon
+          title={
+            <Text style={{ fontSize: token.fontSizeSM }}>
+              Type values here, never paste them into chat. Values are encrypted at rest and never
+              sent to the agent — only the variable names are.
+            </Text>
+          }
+        />
+
+        {error && <Alert type="error" showIcon title={error} />}
+
+        <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
+          <Button onClick={handleDismiss} loading={dismissing} disabled={submitting}>
+            Dismiss
+          </Button>
+          <Button
+            type="primary"
+            onClick={handleSubmit}
+            loading={submitting}
+            disabled={!allFilled || dismissing}
+          >
+            Save &amp; continue
+          </Button>
+        </Space>
+      </Space>
+    </Card>
+  );
+};
+
+const SubmittedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget }) => {
+  const { token } = theme.useToken();
+  const rm = readResultMeta(widget);
+  const names = rm?.names_submitted ?? readParams(widget).names;
+  const scope = rm?.scope ?? readParams(widget).default_scope ?? 'global';
+  return (
+    <Card
+      size="small"
+      style={{
+        margin: `${token.sizeUnit * 1.5}px 0`,
+        background: token.colorBgContainer,
+        borderLeft: `3px solid ${token.colorSuccess}`,
+      }}
+    >
+      <Space>
+        <CheckCircleOutlined style={{ color: token.colorSuccess }} />
+        <Space orientation="vertical" size={0}>
+          <Text strong>
+            {names.length === 1 ? `${names[0]} saved` : `${names.length} variables saved`} ({scope})
+          </Text>
+          {widget.resolved_at && (
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              Submitted at {new Date(widget.resolved_at).toLocaleString()}
+            </Text>
+          )}
+        </Space>
+      </Space>
+    </Card>
+  );
+};
+
+const DismissedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget }) => {
+  const { token } = theme.useToken();
+  const names = readParams(widget).names;
+  return (
+    <Card
+      size="small"
+      style={{
+        margin: `${token.sizeUnit * 1.5}px 0`,
+        background: token.colorBgContainer,
+        borderLeft: `3px solid ${token.colorBorder}`,
+      }}
+    >
+      <Space>
+        <MinusCircleOutlined style={{ color: token.colorTextSecondary }} />
+        <Text type="secondary">Request for {names.join(', ')} dismissed</Text>
+      </Space>
+    </Card>
+  );
+};
+
+const AlreadyPresentSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget }) => {
+  const { token } = theme.useToken();
+  const names = readParams(widget).names;
+  return (
+    <Card
+      size="small"
+      style={{
+        margin: `${token.sizeUnit * 1.5}px 0`,
+        background: token.colorBgContainer,
+        borderLeft: `3px solid ${token.colorInfo}`,
+      }}
+    >
+      <Space>
+        <CheckCircleOutlined style={{ color: token.colorInfo }} />
+        <Space orientation="vertical" size={0}>
+          <Text strong>
+            {names.length === 1
+              ? `${names[0]} was already configured`
+              : `${names.join(', ')} were already configured`}
+          </Text>
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            No action needed — the agent has resumed.
+          </Text>
+        </Space>
+      </Space>
+    </Card>
+  );
+};
+
+export const EnvVarRequestWidget: React.FC<WidgetComponentProps> = ({ message, widget }) => {
+  const params = readParams(widget);
+  const widgetId = widget.widget_id as unknown as string;
+
+  switch (widget.status) {
+    case 'submitted':
+      return <SubmittedSummary widget={widget} />;
+    case 'dismissed':
+      return <DismissedSummary widget={widget} />;
+    case 'already_present':
+      return <AlreadyPresentSummary widget={widget} />;
+    default:
+      return <PendingForm widgetId={widgetId} message={message} params={params} />;
+  }
+};
+
+// Register on module load so `WidgetBlock` can dispatch to it. The
+// registration is a side-effect of importing this file (via the
+// `Widgets/index.ts` barrel imported from `MessageBlock.tsx`).
+registerWidgetComponent('env_vars', EnvVarRequestWidget);
+
+export const _EnvVarRequestWidgetForTests = {
+  PendingForm,
+  SubmittedSummary,
+  DismissedSummary,
+  AlreadyPresentSummary,
+};
+
+export type { EnvVarsParams, EnvVarsResultMeta };

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -3,8 +3,8 @@
  *
  * Renders inline in the transcript when an agent calls
  * `agor_widgets_request_env_vars`. Captures secret value(s) via password
- * inputs and POSTs them DIRECTLY to the daemon
- * (`POST /widgets/:widget_id/submit`) — values never flow through the
+ * inputs and submits them DIRECTLY to the daemon via the Feathers client
+ * (`widgets/:widget_id/submit`) — values never flow through the
  * agent's MCP transport.
  *
  * Design intent: KISS. Single card, no title bar, no warning Alert, no

--- a/apps/agor-ui/src/components/Widgets/index.ts
+++ b/apps/agor-ui/src/components/Widgets/index.ts
@@ -1,0 +1,14 @@
+/**
+ * In-conversation widgets — UI barrel.
+ *
+ * Importing this module side-effect-registers every concrete widget
+ * component with the `WidgetBlock` dispatcher. Each component file calls
+ * `registerWidgetComponent(type, Component)` at module load.
+ *
+ * See `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ */
+
+// Side-effect imports — each file registers its widget component on load.
+import './EnvVarRequestWidget';
+
+export { EnvVarRequestWidget } from './EnvVarRequestWidget';

--- a/docs/internal/in-conversation-widgets-design-2026-05-19.md
+++ b/docs/internal/in-conversation-widgets-design-2026-05-19.md
@@ -10,14 +10,14 @@ Companion brief: `design-in-conversation-widget-primitive` worktree.
 
 Agor needs a way for agents to render small interactive UI inline in the conversation transcript — a form, a button, a picker — that captures user input **without that input ever entering the LLM's context**.
 
-**Motivating use case:** during onboarding (and beyond) the agent often needs an env var (`HUBSPOT_API_KEY`, `GITHUB_TOKEN`) before it can do its job. Today: "please go to User Settings → Env Vars and add X." User context-switches; flow breaks. **Wanted:** the agent calls `agor_widgets_request_env_vars({ names, reason })`, a form pops into the transcript, the user types and submits inline, the secret goes **directly from the React widget to the daemon** (not through the model), and the agent receives a sanitized confirmation event (`{ names, status }`, no values) and continues.
+**Motivating use case:** during onboarding (and beyond) the agent often needs an env var (`HUBSPOT_API_KEY`, `GITHUB_TOKEN`) before it can do its job. Today: "please go to User Settings → Env Vars and add X." User context-switches; flow breaks. **Wanted:** the agent calls `agor_widgets_request_env_vars({ names, reason })`, a form pops into the transcript, the user types and submits inline, the secret goes **directly from the React widget to the daemon** (not through the model), and a **sanitized system-authored prompt** is auto-queued into the agent's next turn (`[Agor] User submitted HUBSPOT_API_KEY (scope: global). Retry the operation that needed it.`) so it can continue.
 
 **This is the first instance of a broader primitive** — Agor Custom Widgets. v1 ships the framework + the env-var widget. The same primitive will host OAuth-connect, file picker, MCP-server selector, confirmation prompt, and similar agent-driven micro-interactions.
 
 **Three hard requirements drive the design:**
 
 1. **Secret never enters the LLM context.** Triple-checked across every code path. Value flows browser → daemon, never browser → agent → daemon.
-2. **Agent stays informed.** A sanitized confirmation event (`{ widget_id, widget_type, status, names, scope }`) reaches the agent so it can resume work.
+2. **Agent stays informed, asynchronously.** The MCP tool returns immediately (fire-and-forget). When the user submits, a sanitized system-authored task is **auto-queued** via the "Never lose a prompt" (#1068) infrastructure; the agent picks it up in its next turn — no executor pause, no HTTP timeout, works in Slack/gateway contexts unchanged.
 3. **Extensible.** v1 architecture supports 3+ future widget types without re-architecture (validated in §6).
 
 ---
@@ -26,10 +26,11 @@ Agor needs a way for agents to render small interactive UI inline in the convers
 
 | Pattern | PR | Verdict |
 |---|---|---|
-| `permission_request` messages + executor pause/resume (`canUseTool`) | merged | **Closest production reference.** Reuse the message-as-state, pause-the-tool-call, broadcast-via-Feathers shape. Differs only in *who initiates* (we initiate from an MCP tool, not a SDK hook). |
+| **"Never lose a prompt" — daemon-owned user-messages + task-centric queue** | #1068 | **Direct dependency.** Widget submissions inject a system-authored task into the existing prompt queue. The agent picks it up exactly as it would a user-typed message in an idle/busy session. This is what lets us be fully decoupled. |
+| `permission_request` messages + executor pause/resume (`canUseTool`) | merged | **Architecturally adjacent**, but we diverge on resolution. `permission_request` blocks the executor at `canUseTool`; widgets do **not** block — they fire, the tool returns, and the agent ends its turn. We share only the "message row as widget state" shape and the Feathers broadcast channel. |
 | `appendSystemMessage` helper + `MessageType` discriminant union | #1166 | **Reuse directly.** Add `'widget_request'` to `MessageType` and to the helper's `type` union (`apps/agor-daemon/src/utils/append-system-message.ts:36`). |
 | `ArtifactConsentModal` + `artifact_trust_grants` table + TOFU strict-subset matching | #1147 | **Mine for UX patterns, not architecture.** Artifact consent is a *modal* triggered from an artifact card; widgets render *inline in the transcript*. Reuse the scope-selector copy, the "submit just nominates scope" pattern, and the strict-subset principle. Do **not** reuse the table — widgets are per-session ephemera, not durable grants. |
-| `AskUserQuestion` SDK tool (`input_request` message type, `InputRequestService`, `InputRequestBlock`) | #658 → ripped in #1181 | **Dead.** The SDK tool is in `CLAUDE_CODE_DISALLOWED_TOOLS` (`packages/executor/src/sdk-handlers/claude/constants.ts:33`). The widget primitive is the long-term replacement; a `confirmation`/`question` widget closes the gap that disallowing left (see §6 and §7 PR 3). |
+| `AskUserQuestion` SDK tool (`input_request` message type, `InputRequestService`, `InputRequestBlock`) | #658 → ripped in #1181 | **Dead.** The SDK tool is in `CLAUDE_CODE_DISALLOWED_TOOLS` (`packages/executor/src/sdk-handlers/claude/constants.ts:33`). It was killed because pause/resume hangs in async contexts (Slack). The widget primitive's **decoupled** design is what makes it survivable; the confirmation widget (§7 PR 3) closes the gap that disallowing left. |
 | Env-var storage (`users.data.env_vars` JSON map, AES-256-GCM via `encryptApiKey`, scope enum, blocklist, `^[A-Z_][A-Z0-9_]*$` regex) | existing | **Reuse the existing users service.** The env-var widget submit handler is a thin shim that PATCHes `/users/:id` with a single-key `env_vars` patch. Validation, encryption, scope handling, blocklist enforcement all already live there. |
 | MCP tool registry (`apps/agor-daemon/src/mcp/tools/*.ts`, `registerTool(name, {description, inputSchema, annotations}, handler)`, `ctx.sessionId`, `textResult(...)`) | existing | **Slot a new `widgets.ts` file alongside other domains.** Standard pattern. |
 
@@ -107,63 +108,86 @@ Why per-widget tools (vs. one generic `agor_widgets_request(type, params)`):
 
 The handler logic is shared via a small helper (see §3.4) so adding a widget type ≈ defining its Zod schema, its React component, and its submit handler.
 
-### 3.3 Daemon flow (the pause/resume model)
+### 3.3 Daemon flow (decoupled fire-and-forget)
 
 ```
-┌──────────┐                ┌─────────────┐               ┌────────┐               ┌────────┐
-│  Agent   │                │ Daemon (MCP │               │   UI   │               │  User  │
-│ (Claude) │                │   server)   │               │ client │               │        │
-└────┬─────┘                └──────┬──────┘               └────┬───┘               └────┬───┘
-     │                             │                           │                        │
-     │ MCP: agor_widgets_request_  │                           │                        │
-     │  env_vars({names, reason})  │                           │                        │
-     │ ──────────────────────────► │                           │                        │
-     │                             │                           │                        │
-     │                             │ appendSystemMessage(      │                        │
-     │                             │   type='widget_request',  │                        │
-     │                             │   metadata.widget={...,   │                        │
-     │                             │     status:'pending'})    │                        │
-     │                             │                           │                        │
-     │                             │ Feathers 'messages         │                        │
-     │                             │  created' WS event ──────►│                        │
-     │                             │                           │ render WidgetBlock     │
-     │                             │                           │ ──────────────────────►│
-     │                             │                           │                        │
-     │                             │ await resolution          │ types HUBSPOT_API_KEY  │
-     │                             │ (long-poll, see §3.5)     │ ◄──────────────────────│
-     │                             │                           │                        │
-     │                             │ POST /widgets/:id/submit  │                        │
-     │                             │ {values, scope}           │                        │
-     │                             │ ◄─────────────────────────│                        │
-     │                             │                           │                        │
-     │                             │ users.patch              │                        │
-     │                             │  (encrypt, store)         │                        │
-     │                             │                           │                        │
-     │                             │ messages.patch           │                        │
-     │                             │  (widget.status =         │                        │
-     │                             │   'submitted',            │                        │
-     │                             │   result_meta = {names,   │                        │
-     │                             │   scope})                 │                        │
-     │                             │                           │                        │
-     │                             │ widget:resolved event ────┼───────────────────────►│
-     │                             │                           │ re-render badge       │
-     │                             │                           │                        │
-     │ MCP tool returns:           │                           │                        │
-     │  { widget_id,               │                           │                        │
-     │    status: 'submitted',     │                           │                        │
-     │    names: [...],            │                           │                        │
-     │    scope: 'global' }        │                           │                        │
-     │ ◄────────────────────────── │                           │                        │
-     │                             │                           │                        │
-     │ resumes — retries           │                           │                        │
-     │ original API call           │                           │                        │
+┌──────────┐         ┌─────────────┐         ┌────────┐         ┌────────┐
+│  Agent   │         │ Daemon (MCP │         │   UI   │         │  User  │
+│ (Claude) │         │   server)   │         │ client │         │        │
+└────┬─────┘         └──────┬──────┘         └────┬───┘         └────┬───┘
+     │ MCP call            │                      │                  │
+     │ agor_widgets_       │                      │                  │
+     │  request_env_vars   │                      │                  │
+     │ ──────────────────► │                      │                  │
+     │                     │ appendSystemMessage  │                  │
+     │                     │  type='widget_       │                  │
+     │                     │   request'           │                  │
+     │                     │  metadata.widget=    │                  │
+     │                     │   {…,status:         │                  │
+     │                     │   'pending'}         │                  │
+     │                     │                      │                  │
+     │                     │ 'messages created'   │                  │
+     │                     │  WS event ─────────► │ render           │
+     │                     │                      │  WidgetBlock ──► │
+     │                     │                      │                  │
+     │ tool returns        │                      │                  │
+     │ IMMEDIATELY:        │                      │                  │
+     │  { widget_id,       │                      │                  │
+     │    status:          │                      │                  │
+     │   'requested' }     │                      │                  │
+     │ ◄────────────────── │                      │                  │
+     │                     │                      │                  │
+     │ ends turn —         │                      │                  │
+     │ session goes IDLE   │                      │                  │
+     │                     │                      │                  │
+     │                     │   ⏱  (seconds, minutes, or hours later) │
+     │                     │                      │                  │
+     │                     │                      │ types value      │
+     │                     │                      │ ◄─────────────── │
+     │                     │ POST /widgets/:id/   │                  │
+     │                     │  submit              │                  │
+     │                     │  {values, scope}     │                  │
+     │                     │ ◄─────────────────── │                  │
+     │                     │                      │                  │
+     │                     │ users.patch          │                  │
+     │                     │  (encrypt, store)    │                  │
+     │                     │                      │                  │
+     │                     │ messages.patch       │                  │
+     │                     │  widget.status=      │                  │
+     │                     │   'submitted'        │                  │
+     │                     │                      │                  │
+     │                     │ tasks.create         │                  │
+     │                     │  (system-authored,   │                  │
+     │                     │   buildAutoResume    │                  │
+     │                     │   Prompt(            │                  │
+     │                     │    result_meta))     │                  │
+     │                     │                      │                  │
+     │                     │ 'widget:resolved' ─► │ re-render badge  │
+     │                     │                      │                  │
+     │ NEW TASK arrives    │                      │                  │
+     │ as user-role        │                      │                  │
+     │ message:            │                      │                  │
+     │ "[Agor] User        │                      │                  │
+     │  submitted          │                      │                  │
+     │  HUBSPOT_API_KEY    │                      │                  │
+     │  (scope: global).   │                      │                  │
+     │  Retry the          │                      │                  │
+     │  operation that     │                      │                  │
+     │  needed it."        │                      │                  │
+     │ ◄────────────────── │                      │                  │
+     │                     │                      │                  │
+     │ resumes —           │                      │                  │
+     │ retries original    │                      │                  │
+     │ API call            │                      │                  │
 ```
 
 Key properties:
 
-- **Executor doesn't exit.** It's blocked at the MCP tool call (HTTP request to the daemon, same shape as any other long-running tool). This is the same pause model that `permission_request` uses; the difference is the pause lives in the *daemon* (waiting on the human) rather than the *executor* (waiting on `canUseTool`).
-- **The MCP tool result carries names + status + scope, never values.**
-- **Transcript persistence is automatic** because the widget IS a message row.
+- **The MCP tool is fire-and-forget.** It inserts the widget message and returns within milliseconds. The agent reads the tool description and ends its turn voluntarily. No HTTP timeout, no executor pause, no daemon-side await.
+- **The widget message is the durable resolution surface.** It survives daemon restarts, executor exits, hours-long user gaps, page reloads. State lives entirely in `metadata.widget` on the row.
+- **Resolution arrives via the existing prompt queue.** When the user submits, the daemon writes the env var AND creates a system-authored task (`role: 'user'`, `created_by: 'system'`) using the same code path as a human-typed prompt (#1068's daemon-owned user-message infrastructure). Idle sessions kick off immediately; busy sessions queue it.
+- **The prompt is auto-built by the widget registry.** Each widget type contributes a `buildAutoResumePrompt(result_meta)` function (and a `buildDismissedPrompt(...)` for the dismissal path). The agent sees an ordinary user-role message; from its perspective there's no widget machinery to reason about.
+- **Async-context-friendly.** Slack/gateway sessions work unchanged — the user might respond hours later from their phone; the task just queues.
 
 ### 3.4 Widget registry
 
@@ -177,10 +201,14 @@ export interface WidgetRegistryEntry<TParams, TSubmit, TResultMeta> {
   paramsSchema: z.ZodType<TParams>;
   /** Zod schema validating POST /widgets/:id/submit body */
   submitSchema: z.ZodType<TSubmit>;
-  /** What goes back to the agent (and into result_meta on the message). NEVER includes secret values. */
+  /** What goes back into result_meta on the message + into the auto-resume prompt. NEVER includes secret values. */
   buildResultMeta: (submit: TSubmit) => TResultMeta;
   /** Side-effect: persist the submitted values to wherever they belong */
   applySubmit: (ctx: SubmitCtx, submit: TSubmit) => Promise<void>;
+  /** The user-role prompt auto-queued into the agent's next turn on submit. Plain text, no values. */
+  buildAutoResumePrompt: (result_meta: TResultMeta, params: TParams) => string;
+  /** The user-role prompt auto-queued on dismissal. Always explicit ("don't immediately re-ask") to avoid loops. */
+  buildDismissedPrompt: (params: TParams) => string;
 }
 
 // frontend mirror
@@ -189,26 +217,42 @@ export const widgetComponents: Record<WidgetType, React.FC<WidgetProps>> = {
 };
 ```
 
-A new widget type is three files: a Zod-typed registry entry on the daemon, a React component on the UI, a registration line on each side. No core changes needed.
+A new widget type is three files: a Zod-typed registry entry on the daemon (with the two prompt-builders), a React component on the UI, a registration line on each side. No core changes needed.
 
-### 3.5 Long-poll vs. event subscription
+**Example prompt builders for `env_vars`:**
 
-The MCP tool handler needs to block until the widget resolves (or times out). Two implementation options:
+```ts
+buildAutoResumePrompt: (rm) =>
+  `[Agor] User submitted ${rm.names_submitted.join(', ')} (scope: ${rm.scope}). ` +
+  `You can now retry the operation that needed ${rm.names_submitted.length === 1 ? 'it' : 'them'}.`,
 
-| Option | How | Trade-off |
-|---|---|---|
-| **Long-await on internal event bus** (recommended) | Handler subscribes to `widget:resolved:<widget_id>` on the FeathersJS app's event emitter; awaits with a 30-min timeout (configurable via `widgets.default_timeout_ms`). | Same in-process pattern `PermissionService.waitForDecision()` uses. Lives in daemon memory — survives WS disconnects from the UI but not daemon restart. |
-| **Poll the message row** | Handler polls every 2s for `widget.status !== 'pending'`. | Simpler but wastes cycles. Skip. |
+buildDismissedPrompt: (params) =>
+  `[Agor] User dismissed the request for ${params.names.join(', ')}. ` +
+  `Do not re-request immediately — ask whether to proceed without, or move on to other work.`,
+```
 
-**Daemon restart handling**: on startup, scan `messages WHERE metadata->widget.status='pending'` bound to running sessions; if executor is still alive (PID check / `awaiting_widget` task status), it's already disconnected from the in-process await — the executor sees an MCP error and retries, the user sees the widget either still pending or already submitted. **Simplest fix**: mark all pending widgets as `timed_out` on daemon restart, surface a follow-up system message ("The widget request for HUBSPOT_API_KEY was cancelled by a daemon restart — re-prompt the agent to ask again."). Same pattern PR #1166 uses for orphaned sessions.
+### 3.5 Task-queue integration (the resolution path)
 
-### 3.6 HTTP timeout for the MCP request
+When `POST /widgets/:widget_id/submit` succeeds, the submit handler does four things in one transaction:
 
-This is the **single biggest implementation risk** (see §8). MCP tool calls flow over HTTP; a 30-minute open request will hit infrastructure timeouts (reverse proxies, load balancers, browser-side fetch idle). Mitigations:
+1. **Persist values** — call `registry[widget_type].applySubmit(ctx, submit)`. For env-vars, this is `users.patch(userId, { env_vars: { [name]: { value, scope } } })`. Encryption + validation happen inside the existing users service.
+2. **Patch the widget message** — `messages.patch(widget_id, { metadata: { ..., widget: { status: 'submitted', result_meta, resolved_at } } })`. The transcript renderer flips to the "submitted" badge.
+3. **Queue the auto-resume task** (if `auto_resume !== false` was passed to the original tool call) — create a new task via the existing task-creation path with:
+   - `role: 'user'`
+   - `created_by_user_id: <submitter>` (audit) but `metadata.system_authored: true` and `metadata.widget_id` for traceability
+   - `content: registry[widget_type].buildAutoResumePrompt(result_meta, params)`
+   - The "Never lose a prompt" infrastructure handles queueing-vs-immediate-dispatch based on session busy state.
+4. **Emit `widget:resolved`** — broadcast on the per-session Feathers room so any other connected UI clients refresh.
 
-1. **Keep-alive heartbeats**: SSE-style chunked response that emits empty whitespace every 25s (the MCP transport already streams). Implementation lives in the MCP server framework, not per-tool.
-2. **Shorter default timeout** (configurable): start with 10 min — same as `permission_request` (`DEFAULT_PERMISSION_TIMEOUT_MS = 600_000`). Bump if friction proves real.
-3. **Polling fallback**: if a tool times out at the HTTP layer but the widget is still `pending`, the agent's natural retry semantics call it again with the same `widget_id` (idempotency key) — daemon resumes the await on the *same* widget row instead of creating a new one. Stretch goal; not blocking v1.
+Dismissal (`POST /widgets/:widget_id/dismiss`) follows the same path but skips step 1 and uses `buildDismissedPrompt` in step 3.
+
+**No daemon-side await. No long-running HTTP. No timeout on the widget itself.** The widget is durable in the messages table; it can sit `pending` for an hour or a day. The user, the session, or the worktree can move on freely.
+
+### 3.6 What happens if the agent doesn't end its turn?
+
+The MCP tool's `description` explicitly instructs: *"This is a fire-and-forget request. The widget is now visible to the user. End your turn after this tool call — you will receive a new user-role message when the user responds, and can resume work then."* If the agent ignores this and keeps reasoning, it just continues without the value (and will likely fail and retry on a later turn). The next-turn message arrives normally when the user submits — the queueing infrastructure doesn't care whether the session was idle or in the middle of something.
+
+We do **not** rely on tool description alone for correctness; ignoring the contract is annoying but not harmful, and the agent's standard "tool said it succeeded → I'll see results later" reasoning typically works without the explicit instruction.
 
 ---
 
@@ -217,13 +261,14 @@ This is the **single biggest implementation risk** (see §8). MCP tool calls flo
 | Piece | Path | Reuses |
 |---|---|---|
 | MCP tool | `apps/agor-daemon/src/mcp/tools/widgets.ts` (new) | `registerTool` pattern from `worktrees.ts` |
-| Daemon submit endpoint | `POST /widgets/:widget_id/submit` (new route) | FeathersJS service for `widget-submissions` |
+| MCP tool return | `{ widget_id, status: 'requested' }` — fires immediately, agent ends turn | `textResult()` |
+| Daemon submit endpoint | `POST /widgets/:widget_id/submit`, `POST /widgets/:widget_id/dismiss` (new routes) | FeathersJS service `widget-submissions` |
 | Persistence | Thin shim → `app.service('users').patch(userId, { env_vars: { [name]: { value, scope } } })` | existing users service, `encryptApiKey`, blocklist, regex |
-| Message update | `app.service('messages').patch(widget_id, { metadata.widget: {...} })` | existing messages service |
-| Event | `app.io.to(sessionRoomName(sessionId)).emit('widget:resolved', {...})` | existing per-session room |
+| Message update | `app.service('messages').patch(widget_id, { metadata.widget: { status, result_meta, resolved_at } })` | existing messages service |
+| **Auto-resume task** | `app.service('tasks').create({ session_id, role: 'user', content: buildAutoResumePrompt(rm), metadata: { system_authored: true, widget_id } })` — picks up via the existing prompt queue | "Never lose a prompt" #1068 |
+| Event broadcast | `widget:resolved` Feathers event on the session room | existing per-session room |
 | UI dispatch | `MessageBlock.tsx`: `if (message.type === 'widget_request') return <WidgetBlock message={message} />` | `PermissionRequestBlock` precedent at MessageBlock.tsx:256-294 |
 | Widget component | `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx` | form shape from `EnvVarEditor.tsx` |
-| Confirmation event for agent | MCP tool return: `{ widget_id, status, names, scope }` | `textResult()` |
 
 ### UI sketch
 
@@ -274,13 +319,14 @@ After dismissal:
 | Agent → MCP tool call (`agor_widgets_request_env_vars`) | **No** | Input schema accepts `names` (strings) + `reason`. No `values` field exists. Zod rejects extras. |
 | Daemon → `appendSystemMessage` → message row | **No** | `metadata.widget.params` is the agent-provided payload (names, reason, instructions); `content` is human-readable preview. Both are filled from the agent's tool args — agent had no values. |
 | Feathers `messages created` WebSocket event | **No** | Payload is the message row above. |
+| MCP tool return value → agent (synchronous) | **No** | Returns `{ widget_id, status: 'requested' }`. Fires immediately, before the user has even seen the widget. Cannot contain values by definition. |
 | UI → `POST /widgets/:id/submit` | **Yes** | Direct browser-to-daemon HTTP request. Auth via the user's session cookie / JWT. **This is the only place values exist on the wire**, and it never traverses the agent. |
 | Daemon submit handler → `users.patch` | **Yes (encrypted in transit at app layer)** | Standard env-var write path. `encryptApiKey()` is called inside the users service before DB write. |
-| Daemon → message status update (`messages.patch`) | **No** | Updates `metadata.widget.status` and `result_meta = { names, scope }`. Explicit allow-list — we patch by field, never spread the submit body. |
+| Daemon → message status update (`messages.patch`) | **No** | Updates `metadata.widget.status` and `result_meta` (e.g. `{ names_submitted, scope }`). Explicit allow-list — we patch by field, never spread the submit body. |
+| **Daemon → auto-resume task creation** (the prompt the agent next sees) | **No** | `tasks.create` content is `buildAutoResumePrompt(result_meta)`. The registry's prompt-builders take `result_meta` only — they have no access to the submit body. Add unit test: prompt-builder must accept `result_meta` only, not the raw submit payload (type system + runtime assertion). |
 | `widget:resolved` Feathers event | **No** | Payload is `{ widget_id, status, result_meta }`. |
-| MCP tool return value → agent | **No** | Returns `{ widget_id, status, names, scope }`. No `values` field. |
-| Transcript reload | **No** | Re-reads the message row; values were never stored on it. |
-| Logs | **No (must enforce)** | Submit handler MUST NOT log the request body. Add an explicit lint or test: `expect(logs).not.toContain(submittedValue)`. |
+| Transcript reload | **No** | Re-reads the message row; values were never stored on it. The auto-resume task is a normal task row containing only `result_meta`-derived text. |
+| Logs | **No (must enforce)** | Submit handler MUST NOT log the request body. Add an explicit test: `expect(logs).not.toContain(submittedValue)`. |
 
 The only access path to values after submission is the standard env-var read path (decrypt at runtime when launching an executor). That path is unchanged from today.
 
@@ -335,7 +381,7 @@ inputSchema: z.object({
 })
 // submit body: { option_id: string }
 // result_meta: { option_id, option_label }  // label is fine — it's agent-provided
-// MCP return: { widget_id, status, option_id, option_label }
+// auto-resume prompt: "[Agor] User chose: ${option_label}."
 ```
 
 **Fit check:**
@@ -352,18 +398,18 @@ inputSchema: z.object({
   scopes: z.array(z.string()).min(1),
   reason: z.string().max(500),
 })
-// submit body: empty — submission happens via OAuth callback, not user form
+// submit body: empty — resolution happens via OAuth callback, not user form
 // applySubmit: writes to existing OAuth tokens table
 // result_meta: { provider, granted_scopes: string[], account_label: string }
-// MCP return: { widget_id, status, provider, granted_scopes, account_label }
+// auto-resume prompt: "[Agor] User connected ${provider} (${account_label}). You can now retry."
 ```
 
 **Fit check:**
-- Widget renders a "Connect GitHub" button. Click → popup → OAuth callback hits a *separate* daemon endpoint (`/oauth/:provider/callback`) which then flips the widget status.
+- Widget renders a "Connect GitHub" button. Click → popup → OAuth callback hits a *separate* daemon endpoint (`/oauth/:provider/callback`) which then resolves the widget the same way `POST /widgets/:id/submit` would (write result_meta, queue auto-resume task, emit `widget:resolved`).
 - Token never goes anywhere near the agent. ✓
-- The submit endpoint is virtual here — resolution happens via the OAuth callback. Registry's `applySubmit` becomes "wait for OAuth, then write to tokens table."
+- **The decoupled flow makes this trivial.** OAuth flows are inherently async (popup → user-action → callback); the widget primitive doesn't care which daemon endpoint resolves the widget, only that *something* does. The pause/resume model would have had to invent a special async lane for this; we don't.
 
-**One real seam discovered:** not every widget resolves via `POST /widgets/:id/submit`. OAuth resolves via callback. We accommodate this by making `widget:resolved` the canonical resolution event, and treating `POST .../submit` as one of *several* possible resolution mechanisms. Worth calling out in the registry shape — `applySubmit` becomes optional, and the registry can declare alternative resolution paths.
+**Registry generalization:** `applySubmit` is one of several resolution paths. The OAuth widget type's registry entry exposes a `resolveFromOAuthCallback` function instead, called from `/oauth/:provider/callback`. The post-resolution machinery (patch message, queue auto-resume, emit event) is identical and lives in a shared helper.
 
 ### 6.3 `agor_widgets_request_mcp_server` — select / attach an MCP server
 
@@ -376,7 +422,7 @@ inputSchema: z.object({
 // submit body: { mcp_server_id: string } | { kind: 'add_new', config: {...} }
 // applySubmit: noop if existing, else creates an mcp_servers row scoped to the session
 // result_meta: { mcp_server_id, name, kind }
-// MCP return: { widget_id, status, mcp_server_id, name, kind }
+// auto-resume prompt: "[Agor] User selected MCP server '${name}'. You can now use it."
 ```
 
 **Fit check:**
@@ -393,31 +439,36 @@ inputSchema: z.object({
 ### PR 1: `feat(widgets): in-conversation widget primitive`
 
 Scope:
-- Add `'widget_request'` to `MessageType` (sqlite + postgres schemas + types).
+- Add `'widget_request'` to `MessageType` (sqlite + postgres schemas + types, migrations).
 - Extend `appendSystemMessage` helper's `type` union to include `widget_request`.
-- Add `metadata.widget` shape to `Message['metadata']` type (typed via a discriminated union over `widget_type`).
-- New FeathersJS service `widget-submissions` registering `POST /widgets/:widget_id/submit` — handler dispatches by `widget_type` to a daemon-side registry (initially empty).
-- Daemon event bus: `widget:resolved` per-widget-id channel, plus per-session-room broadcast.
-- New MCP tool domain marker (`domain: 'widgets'` for `agor_search_tools`).
-- UI: `WidgetBlock` dispatcher component in MessageBlock that switches on `metadata.widget.widget_type`, plus a placeholder "Unknown widget type" fallback.
-- Daemon-restart handling: on startup, mark all `pending` widgets as `timed_out` and append a follow-up system message (mirror PR #1166).
-- Config: `widgets.default_timeout_ms` (default 600_000) in `~/.agor/config.yaml`.
+- Add `metadata.widget` shape to `Message['metadata']` type (typed via a discriminated union over `widget_type`, with `schema_version: number` baked in).
+- Daemon-side registry shape at `apps/agor-daemon/src/widgets/registry.ts` (empty in PR 1; widget types register themselves in their own PRs). The registry entry type includes `paramsSchema`, `submitSchema`, `applySubmit`, `buildResultMeta`, `buildAutoResumePrompt`, `buildDismissedPrompt`.
+- New FeathersJS service `widget-submissions` registering `POST /widgets/:widget_id/submit` and `POST /widgets/:widget_id/dismiss`. Auth: caller must match session creator OR have `prompt`-tier worktree RBAC. Idempotency: status must be `pending`.
+- Submit handler dispatches by `widget_type` to the registry (no-op for empty registry), then: patches the message row, creates an auto-resume task via the existing task-creation path (`tasks.create` with `role: 'user'`, `metadata.system_authored: true`, `metadata.widget_id`), emits `widget:resolved`.
+- `widget:resolved` Feathers event on the per-session room.
+- New MCP tool domain marker (`domain: 'widgets'` for `agor_search_tools` filtering).
+- UI: `WidgetBlock` dispatcher component in `apps/agor-ui/src/components/MessageBlock/` that switches on `metadata.widget.widget_type`, plus a placeholder "Unknown widget type" fallback for forward-compat with newer widgets in older clients.
 
-No widget types ship in PR 1. The framework is callable but produces no actual widgets yet. Tests cover the registry, the submit endpoint's auth/idempotency, and the WebSocket broadcast.
+**Explicitly NOT in PR 1** (deliberately punted vs. the original design):
+- ~~Daemon-restart marking pending widgets as `timed_out`~~ — widgets are durable in the messages table; daemon restart is transparent. Nothing to do.
+- ~~`widgets.default_timeout_ms` config option~~ — the decoupled model has no timeout. A widget sits `pending` until submitted or dismissed (or the session is archived, at which point the widget tombstones along with the rest).
+- ~~Long-poll / event-bus await on the MCP tool side~~ — the tool returns immediately; nothing to await.
 
-**Estimated effort:** ~3-4 eng-days.
+No widget types ship in PR 1. The framework is callable but produces no actual widgets yet. Tests cover the registry shape, the submit endpoint's auth + idempotency, the auto-resume task creation, and the WebSocket broadcast.
+
+**Estimated effort:** ~2-3 eng-days (shrunk from ~3-4 — the dropped pieces were the hardest parts).
 
 ### PR 2: `feat(widgets): env_vars widget`
 
 Scope:
-- Register `env_vars` widget type in the daemon registry: Zod schemas, `applySubmit` = thin shim around `users.patch`.
-- Register `agor_widgets_request_env_vars` MCP tool in `apps/agor-daemon/src/mcp/tools/widgets.ts`.
+- Register `env_vars` widget type in the daemon registry: Zod schemas, `applySubmit` = thin shim around `users.patch`, `buildAutoResumePrompt` and `buildDismissedPrompt` per §3.4.
+- Register `agor_widgets_request_env_vars` MCP tool in `apps/agor-daemon/src/mcp/tools/widgets.ts`. Tool params include `auto_resume: boolean` (default `true`).
 - React component `EnvVarRequestWidget.tsx` (reuses form shape from `EnvVarEditor.tsx`).
 - Wire `widgetComponents['env_vars']` mapping on the UI.
 - Submit handler reuses existing env-var validation (`validateEnvVar`, `isEnvVarAllowed`, regex) and encryption (`encryptApiKey`) — zero net-new logic.
-- Confirmation event shape per §5.1.
+- **`already_present` short-circuit** (per D4 below, recommended yes): submit handler checks at request time whether the user already has all `names` in scope. If yes, immediately patches `metadata.widget.status = 'already_present'`, skips the form render, and queues the auto-resume task with a "values were already configured" prompt.
 - Docs: `apps/agor-docs/pages/guide/in-conversation-widgets.mdx` (user-facing) with the env-var section as the canonical example.
-- Storybook story for the widget in all three states (pending, submitted, dismissed).
+- Storybook story for the widget in pending, submitted, dismissed, and already-present states.
 
 **Estimated effort:** ~2-3 eng-days.
 
@@ -441,17 +492,17 @@ PR 1 → PR 2 → (optional) PR 3. PR 2 cannot land before PR 1 (depends on the 
 
 | # | Risk / question | Mitigation |
 |---|---|---|
-| R1 | **HTTP timeout for the blocked MCP request.** A 10-min await over fetch will trip on infra timeouts. | Keep-alive whitespace heartbeats every 25s; configurable timeout; idempotent re-call by `widget_id` if the agent retries. |
-| R2 | **Daemon restart while a widget is pending** breaks the in-process await. | On startup, mark pending widgets as `timed_out`, append a follow-up system message (mirrors PR #1166). |
-| R3 | **Widget message persists forever in the transcript.** The *names* of submitted env vars are visible to anyone who can read the transcript. | Same surface as User Settings → Env Vars. One-line disclaimer on the widget. If sensitive, the user can dismiss and add via Settings. |
-| R4 | **Widget-version drift** when v2 changes a widget's submit schema. | `metadata.widget.schema_version: number` baked in from v1. UI's `WidgetBlock` renders old versions in a degraded read-only mode. |
-| R5 | **Dismissal UX.** Does the agent treat dismissal as "user said no, stop" or "user said not-now, try again later"? | Confirmation event includes `status: 'dismissed'`. Agent prompt guidance: "On dismissal, ask the user once whether they want to proceed without; do not re-request immediately." |
-| R6 | **Multi-user authz for submission.** Who can submit on behalf of whom? | §5.2 — submitter must match session creator or have `prompt`-tier worktree RBAC. Cross-user submit attributed in `result_meta.submitted_by`. |
-| R7 | **Logging leakage.** Submit handler must not log values. | Lint rule + explicit test in PR 2 (`expect(logs).not.toContain(value)`). |
-| R8 | **Agent uses chat (not the widget) to extract values** by phishing the user. | Widget copy: "Never paste values into chat — only into the form above." Out of scope for code mitigations. |
+| R1 | **Widget message persists forever in the transcript.** The *names* of submitted env vars are visible to anyone who can read the transcript. | Same surface as User Settings → Env Vars. One-line disclaimer on the widget. If sensitive, the user can dismiss and add via Settings. |
+| R2 | **Widget-version drift** when v2 changes a widget's submit schema. | `metadata.widget.schema_version: number` baked in from v1. UI's `WidgetBlock` renders old versions in a degraded read-only mode for forward-compat. |
+| R3 | **Dismissal UX.** Does the agent treat dismissal as "user said no, stop" or "user said not-now, try again later"? | Auto-queued dismissal prompt is explicit: *"Do not re-request immediately — ask whether to proceed without, or move on to other work."* See `buildDismissedPrompt` example in §3.4. |
+| R4 | **Multi-user authz for submission.** Who can submit on behalf of whom? | §5.2 — submitter must match session creator or have `prompt`-tier worktree RBAC. Cross-user submit attributed in `result_meta.submitted_by`. |
+| R5 | **Logging leakage.** Submit handler must not log values. | Explicit test in PR 2 (`expect(logs).not.toContain(value)`). Submit handler accepts the body and immediately hands it to the registry's `applySubmit`; no intermediate variable that gets stringified. |
+| R6 | **Agent uses chat (not the widget) to extract values** by phishing the user. | Widget copy: "Never paste values into chat — only into the form above." Out of scope for code mitigations. |
+| R7 | **Stale widget message** — user submits 4 hours later in a session that's already moved on. Auto-queued task arrives mid-context-switch. | Acceptable. Same surface as "queued prompt arrives in a session you forgot about" — already a thing the user lives with. Mitigated by the prompt being self-explanatory (`[Agor] User submitted X. Retry the operation that needed it.`). Worth a small "Discard pending widgets on session archive" hook — when a session is archived, all its `pending` widgets transition to `dismissed` (no auto-resume task, since the session is gone). |
+| R8 | **Agent ignores the "end your turn" contract** and keeps reasoning after firing the tool. | Harmless — the auto-queued task arrives whenever the user submits. The agent's intermediate reasoning just turns out to have been speculative. Tool description nudges, doesn't enforce. |
+| R9 | **Auto-resume task fires on a session whose user is offline.** No one notices the queued prompt. | Standard task-queue semantics (#1068) — the prompt is durable, will fire when the executor next picks up. If the session is permanently abandoned, the task tombstones with the rest of the session. |
 | Q1 | **One generic `agor_widgets_request` tool vs. one tool per type?** | Recommended: one per type (§3.2). Typed contracts, better progressive discovery, better agent UX. |
-| Q2 | **Should widgets support a "value already exists" short-circuit?** E.g. agent asks for `HUBSPOT_API_KEY`, user already has it set globally → widget auto-resolves with status `already_present`. | **Recommended yes** for env-vars specifically (saves a user click). Daemon checks env-vars presence at request time and immediately resolves the widget if all requested names already exist in the user's scope. The agent gets `status: 'already_present', names_present: [...]` and can proceed without UI flicker. |
-| Q3 | **OAuth widget timeout** — OAuth flows can take minutes. Does the 10-min default suffice? | Per-widget-type override on `widget.timeout_ms` baked into the registry entry. OAuth defaults to 15 min. |
+| Q2 | **`already_present` short-circuit?** E.g. agent asks for `HUBSPOT_API_KEY`, user already has it set globally → widget auto-resolves with status `already_present`. | **Recommended yes** for env-vars specifically (saves a user click). Daemon checks presence at request time and short-circuits to `status: 'already_present'` + an auto-resume task ("`HUBSPOT_API_KEY` was already configured. You can proceed.") without rendering a form. See PR 2 scope. |
 
 ---
 
@@ -470,13 +521,18 @@ PR 1 → PR 2 → (optional) PR 3. PR 2 cannot land before PR 1 (depends on the 
 
 ## 10. Open call (for Max)
 
-Decisions I'd like an explicit thumbs-up/down on before PR 1 lands:
+Decisions Max has signed off on (commit history of this doc):
 
-- **D1:** Message-row-as-state vs. separate `pending_widgets` table. Recommendation: message-row (§3.1). Add a table only when we need cross-session queries.
-- **D2:** One MCP tool per widget type vs. one generic tool. Recommendation: per type (§3.2).
-- **D3:** Default timeout: 10 min (matches `permission_request`)? Or longer for env-vars (user may walk away to fetch a key)?
-- **D4:** Q2 — auto-resolve `already_present` for env-vars at request time?
-- **D5:** Should PR 3 (confirmation widget) ship in the same release as PR 2, or be deferred? It validates the abstraction earliest if it ships together.
+- **D1:** Message-row-as-state vs. separate `pending_widgets` table. **Resolved: row.** Add a table only when we need cross-session queries.
+- **D2:** One MCP tool per widget type vs. one generic tool. **Resolved: per type.**
+- **D3:** ~~Default timeout~~. **Resolved: no timeout.** Decoupled flow makes timeouts unnecessary. A widget sits `pending` until submitted, dismissed, or its session is archived.
+- **D4:** `already_present` short-circuit for env-vars. **Resolved: yes** — saves a user click; ships in PR 2.
+- **D5:** **Resolved: decoupled fire-and-forget flow** (no executor pause, no daemon-side await). MCP tool returns immediately; user submission auto-queues a system-authored task via "Never lose a prompt" (#1068).
+- **D6:** Default `auto_resume: true` on submit. Per-call opt-out via tool param. Dismissal also auto-queues with explicit "don't immediately re-ask" framing. **Resolved: yes.**
+
+Still open for Max:
+
+- **D7:** Should PR 3 (confirmation widget) ship in the same release as PR 2, or be deferred? Shipping together validates the abstraction earliest and closes the AskUserQuestion gap sooner.
 
 ---
 
@@ -490,6 +546,6 @@ _References (file:line)_
 - `packages/core/src/types/message.ts:33-41` — `MessageType` union to extend
 - `packages/core/src/db/encryption.ts` — `encryptApiKey` (do not reimplement)
 - `packages/core/src/config/env-validation.ts:30-90` — env-var validation (regex + blocklist)
-- `packages/executor/src/permissions/permission-service.ts:94-149` — pause/resume reference for the daemon-side await
+- `packages/executor/src/permissions/permission-service.ts:94-149` — pause/resume reference *(NOT followed)* — kept as a cite for the alternative we rejected
 - `packages/executor/src/sdk-handlers/claude/constants.ts:33` — AskUserQuestion disallowed
 - `apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx` — scope-selector UX to mine

--- a/docs/internal/in-conversation-widgets-design-2026-05-19.md
+++ b/docs/internal/in-conversation-widgets-design-2026-05-19.md
@@ -24,15 +24,15 @@ Agor needs a way for agents to render small interactive UI inline in the convers
 
 ## 2. Prior art audit (what we reuse, what we don't)
 
-| Pattern | PR | Verdict |
-|---|---|---|
-| **"Never lose a prompt" — daemon-owned user-messages + task-centric queue** | #1068 | **Direct dependency.** Widget submissions inject a system-authored task into the existing prompt queue. The agent picks it up exactly as it would a user-typed message in an idle/busy session. This is what lets us be fully decoupled. |
-| `permission_request` messages + executor pause/resume (`canUseTool`) | merged | **Architecturally adjacent**, but we diverge on resolution. `permission_request` blocks the executor at `canUseTool`; widgets do **not** block — they fire, the tool returns, and the agent ends its turn. We share only the "message row as widget state" shape and the Feathers broadcast channel. |
-| `appendSystemMessage` helper + `MessageType` discriminant union | #1166 | **Reuse directly.** Add `'widget_request'` to `MessageType` and to the helper's `type` union (`apps/agor-daemon/src/utils/append-system-message.ts:36`). |
-| `ArtifactConsentModal` + `artifact_trust_grants` table + TOFU strict-subset matching | #1147 | **Mine for UX patterns, not architecture.** Artifact consent is a *modal* triggered from an artifact card; widgets render *inline in the transcript*. Reuse the scope-selector copy, the "submit just nominates scope" pattern, and the strict-subset principle. Do **not** reuse the table — widgets are per-session ephemera, not durable grants. |
-| `AskUserQuestion` SDK tool (`input_request` message type, `InputRequestService`, `InputRequestBlock`) | #658 → ripped in #1181 | **Dead.** The SDK tool is in `CLAUDE_CODE_DISALLOWED_TOOLS` (`packages/executor/src/sdk-handlers/claude/constants.ts:33`). It was killed because pause/resume hangs in async contexts (Slack). The widget primitive's **decoupled** design is what makes it survivable; the confirmation widget (§7 PR 3) closes the gap that disallowing left. |
-| Env-var storage (`users.data.env_vars` JSON map, AES-256-GCM via `encryptApiKey`, scope enum, blocklist, `^[A-Z_][A-Z0-9_]*$` regex) | existing | **Reuse the existing users service.** The env-var widget submit handler is a thin shim that PATCHes `/users/:id` with a single-key `env_vars` patch. Validation, encryption, scope handling, blocklist enforcement all already live there. |
-| MCP tool registry (`apps/agor-daemon/src/mcp/tools/*.ts`, `registerTool(name, {description, inputSchema, annotations}, handler)`, `ctx.sessionId`, `textResult(...)`) | existing | **Slot a new `widgets.ts` file alongside other domains.** Standard pattern. |
+| Pattern                                                                                                                                                               | PR                     | Verdict                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **"Never lose a prompt" — daemon-owned user-messages + task-centric queue**                                                                                           | #1068                  | **Direct dependency.** Widget submissions inject a system-authored task into the existing prompt queue. The agent picks it up exactly as it would a user-typed message in an idle/busy session. This is what lets us be fully decoupled.                                                                                                                |
+| `permission_request` messages + executor pause/resume (`canUseTool`)                                                                                                  | merged                 | **Architecturally adjacent**, but we diverge on resolution. `permission_request` blocks the executor at `canUseTool`; widgets do **not** block — they fire, the tool returns, and the agent ends its turn. We share only the "message row as widget state" shape and the Feathers broadcast channel.                                                    |
+| `appendSystemMessage` helper + `MessageType` discriminant union                                                                                                       | #1166                  | **Reuse directly.** Add `'widget_request'` to `MessageType` and to the helper's `type` union (`apps/agor-daemon/src/utils/append-system-message.ts:36`).                                                                                                                                                                                                |
+| `ArtifactConsentModal` + `artifact_trust_grants` table + TOFU strict-subset matching                                                                                  | #1147                  | **Mine for UX patterns, not architecture.** Artifact consent is a _modal_ triggered from an artifact card; widgets render _inline in the transcript_. Reuse the scope-selector copy, the "submit just nominates scope" pattern, and the strict-subset principle. Do **not** reuse the table — widgets are per-session ephemera, not durable grants.     |
+| `AskUserQuestion` SDK tool (`input_request` message type, `InputRequestService`, `InputRequestBlock`)                                                                 | #658 → ripped in #1181 | **Dead.** The SDK tool is in `CLAUDE_CODE_DISALLOWED_TOOLS` (`packages/executor/src/sdk-handlers/claude/constants.ts:33`). It was killed because pause/resume hangs in async contexts (Slack). The widget primitive's **decoupled** design is what makes it survivable; the confirmation widget (§7 follow-up PR) closes the gap that disallowing left. |
+| Env-var storage (`users.data.env_vars` JSON map, AES-256-GCM via `encryptApiKey`, scope enum, blocklist, `^[A-Z_][A-Z0-9_]*$` regex)                                  | existing               | **Reuse the existing users service.** The env-var widget submit handler is a thin shim that PATCHes `/users/:id` with a single-key `env_vars` patch. Validation, encryption, scope handling, blocklist enforcement all already live there.                                                                                                              |
+| MCP tool registry (`apps/agor-daemon/src/mcp/tools/*.ts`, `registerTool(name, {description, inputSchema, annotations}, handler)`, `ctx.sessionId`, `textResult(...)`) | existing               | **Slot a new `widgets.ts` file alongside other domains.** Standard pattern.                                                                                                                                                                                                                                                                             |
 
 ---
 
@@ -85,14 +85,24 @@ server.registerTool(
       'You receive a confirmation event with the variable names that were submitted (no values).',
     annotations: { destructiveHint: false },
     inputSchema: z.object({
-      names: z.array(z.string().regex(/^[A-Z_][A-Z0-9_]*$/))
-        .min(1).max(10)
+      names: z
+        .array(z.string().regex(/^[A-Z_][A-Z0-9_]*$/))
+        .min(1)
+        .max(10)
         .describe('UPPER_SNAKE env var names. Same validation as User Settings.'),
-      reason: z.string().min(1).max(500)
+      reason: z
+        .string()
+        .min(1)
+        .max(500)
         .describe('Short explanation shown to the user — why do you need these?'),
-      instructions: z.string().max(2000).optional()
+      instructions: z
+        .string()
+        .max(2000)
+        .optional()
         .describe('Optional markdown — e.g. "Get a key at https://app.hubspot.com/..."'),
-      default_scope: z.enum(['global', 'session']).default('global')
+      default_scope: z
+        .enum(['global', 'session'])
+        .default('global')
         .describe('Suggested scope. User can override in the form.'),
     }),
   },
@@ -250,7 +260,7 @@ Dismissal (`POST /widgets/:widget_id/dismiss`) follows the same path but skips s
 
 ### 3.6 What happens if the agent doesn't end its turn?
 
-The MCP tool's `description` explicitly instructs: *"This is a fire-and-forget request. The widget is now visible to the user. End your turn after this tool call — you will receive a new user-role message when the user responds, and can resume work then."* If the agent ignores this and keeps reasoning, it just continues without the value (and will likely fail and retry on a later turn). The next-turn message arrives normally when the user submits — the queueing infrastructure doesn't care whether the session was idle or in the middle of something.
+The MCP tool's `description` explicitly instructs: _"This is a fire-and-forget request. The widget is now visible to the user. End your turn after this tool call — you will receive a new user-role message when the user responds, and can resume work then."_ If the agent ignores this and keeps reasoning, it just continues without the value (and will likely fail and retry on a later turn). The next-turn message arrives normally when the user submits — the queueing infrastructure doesn't care whether the session was idle or in the middle of something.
 
 We do **not** rely on tool description alone for correctness; ignoring the contract is annoying but not harmful, and the agent's standard "tool said it succeeded → I'll see results later" reasoning typically works without the explicit instruction.
 
@@ -258,17 +268,17 @@ We do **not** rely on tool description alone for correctness; ignoring the contr
 
 ## 4. The env-var widget (concrete v1)
 
-| Piece | Path | Reuses |
-|---|---|---|
-| MCP tool | `apps/agor-daemon/src/mcp/tools/widgets.ts` (new) | `registerTool` pattern from `worktrees.ts` |
-| MCP tool return | `{ widget_id, status: 'requested' }` — fires immediately, agent ends turn | `textResult()` |
-| Daemon submit endpoint | `POST /widgets/:widget_id/submit`, `POST /widgets/:widget_id/dismiss` (new routes) | FeathersJS service `widget-submissions` |
-| Persistence | Thin shim → `app.service('users').patch(userId, { env_vars: { [name]: { value, scope } } })` | existing users service, `encryptApiKey`, blocklist, regex |
-| Message update | `app.service('messages').patch(widget_id, { metadata.widget: { status, result_meta, resolved_at } })` | existing messages service |
-| **Auto-resume task** | `app.service('tasks').create({ session_id, role: 'user', content: buildAutoResumePrompt(rm), metadata: { system_authored: true, widget_id } })` — picks up via the existing prompt queue | "Never lose a prompt" #1068 |
-| Event broadcast | `widget:resolved` Feathers event on the session room | existing per-session room |
-| UI dispatch | `MessageBlock.tsx`: `if (message.type === 'widget_request') return <WidgetBlock message={message} />` | `PermissionRequestBlock` precedent at MessageBlock.tsx:256-294 |
-| Widget component | `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx` | form shape from `EnvVarEditor.tsx` |
+| Piece                  | Path                                                                                                                                                                                     | Reuses                                                         |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| MCP tool               | `apps/agor-daemon/src/mcp/tools/widgets.ts` (new)                                                                                                                                        | `registerTool` pattern from `worktrees.ts`                     |
+| MCP tool return        | `{ widget_id, status: 'requested' }` — fires immediately, agent ends turn                                                                                                                | `textResult()`                                                 |
+| Daemon submit endpoint | `POST /widgets/:widget_id/submit`, `POST /widgets/:widget_id/dismiss` (new routes)                                                                                                       | FeathersJS service `widget-submissions`                        |
+| Persistence            | Thin shim → `app.service('users').patch(userId, { env_vars: { [name]: { value, scope } } })`                                                                                             | existing users service, `encryptApiKey`, blocklist, regex      |
+| Message update         | `app.service('messages').patch(widget_id, { metadata.widget: { status, result_meta, resolved_at } })`                                                                                    | existing messages service                                      |
+| **Auto-resume task**   | `app.service('tasks').create({ session_id, role: 'user', content: buildAutoResumePrompt(rm), metadata: { system_authored: true, widget_id } })` — picks up via the existing prompt queue | "Never lose a prompt" #1068                                    |
+| Event broadcast        | `widget:resolved` Feathers event on the session room                                                                                                                                     | existing per-session room                                      |
+| UI dispatch            | `MessageBlock.tsx`: `if (message.type === 'widget_request') return <WidgetBlock message={message} />`                                                                                    | `PermissionRequestBlock` precedent at MessageBlock.tsx:256-294 |
+| Widget component       | `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx`                                                                                                                            | form shape from `EnvVarEditor.tsx`                             |
 
 ### UI sketch
 
@@ -314,19 +324,19 @@ After dismissal:
 
 **Proof by code path enumeration:**
 
-| Path | Carries values? | Justification |
-|---|---|---|
-| Agent → MCP tool call (`agor_widgets_request_env_vars`) | **No** | Input schema accepts `names` (strings) + `reason`. No `values` field exists. Zod rejects extras. |
-| Daemon → `appendSystemMessage` → message row | **No** | `metadata.widget.params` is the agent-provided payload (names, reason, instructions); `content` is human-readable preview. Both are filled from the agent's tool args — agent had no values. |
-| Feathers `messages created` WebSocket event | **No** | Payload is the message row above. |
-| MCP tool return value → agent (synchronous) | **No** | Returns `{ widget_id, status: 'requested' }`. Fires immediately, before the user has even seen the widget. Cannot contain values by definition. |
-| UI → `POST /widgets/:id/submit` | **Yes** | Direct browser-to-daemon HTTP request. Auth via the user's session cookie / JWT. **This is the only place values exist on the wire**, and it never traverses the agent. |
-| Daemon submit handler → `users.patch` | **Yes (encrypted in transit at app layer)** | Standard env-var write path. `encryptApiKey()` is called inside the users service before DB write. |
-| Daemon → message status update (`messages.patch`) | **No** | Updates `metadata.widget.status` and `result_meta` (e.g. `{ names_submitted, scope }`). Explicit allow-list — we patch by field, never spread the submit body. |
-| **Daemon → auto-resume task creation** (the prompt the agent next sees) | **No** | `tasks.create` content is `buildAutoResumePrompt(result_meta)`. The registry's prompt-builders take `result_meta` only — they have no access to the submit body. Add unit test: prompt-builder must accept `result_meta` only, not the raw submit payload (type system + runtime assertion). |
-| `widget:resolved` Feathers event | **No** | Payload is `{ widget_id, status, result_meta }`. |
-| Transcript reload | **No** | Re-reads the message row; values were never stored on it. The auto-resume task is a normal task row containing only `result_meta`-derived text. |
-| Logs | **No (must enforce)** | Submit handler MUST NOT log the request body. Add an explicit test: `expect(logs).not.toContain(submittedValue)`. |
+| Path                                                                    | Carries values?                             | Justification                                                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent → MCP tool call (`agor_widgets_request_env_vars`)                 | **No**                                      | Input schema accepts `names` (strings) + `reason`. No `values` field exists. Zod rejects extras.                                                                                                                                                                                             |
+| Daemon → `appendSystemMessage` → message row                            | **No**                                      | `metadata.widget.params` is the agent-provided payload (names, reason, instructions); `content` is human-readable preview. Both are filled from the agent's tool args — agent had no values.                                                                                                 |
+| Feathers `messages created` WebSocket event                             | **No**                                      | Payload is the message row above.                                                                                                                                                                                                                                                            |
+| MCP tool return value → agent (synchronous)                             | **No**                                      | Returns `{ widget_id, status: 'requested' }`. Fires immediately, before the user has even seen the widget. Cannot contain values by definition.                                                                                                                                              |
+| UI → `POST /widgets/:id/submit`                                         | **Yes**                                     | Direct browser-to-daemon HTTP request. Auth via the user's session cookie / JWT. **This is the only place values exist on the wire**, and it never traverses the agent.                                                                                                                      |
+| Daemon submit handler → `users.patch`                                   | **Yes (encrypted in transit at app layer)** | Standard env-var write path. `encryptApiKey()` is called inside the users service before DB write.                                                                                                                                                                                           |
+| Daemon → message status update (`messages.patch`)                       | **No**                                      | Updates `metadata.widget.status` and `result_meta` (e.g. `{ names_submitted, scope }`). Explicit allow-list — we patch by field, never spread the submit body.                                                                                                                               |
+| **Daemon → auto-resume task creation** (the prompt the agent next sees) | **No**                                      | `tasks.create` content is `buildAutoResumePrompt(result_meta)`. The registry's prompt-builders take `result_meta` only — they have no access to the submit body. Add unit test: prompt-builder must accept `result_meta` only, not the raw submit payload (type system + runtime assertion). |
+| `widget:resolved` Feathers event                                        | **No**                                      | Payload is `{ widget_id, status, result_meta }`.                                                                                                                                                                                                                                             |
+| Transcript reload                                                       | **No**                                      | Re-reads the message row; values were never stored on it. The auto-resume task is a normal task row containing only `result_meta`-derived text.                                                                                                                                              |
+| Logs                                                                    | **No (must enforce)**                       | Submit handler MUST NOT log the request body. Add an explicit test: `expect(logs).not.toContain(submittedValue)`.                                                                                                                                                                            |
 
 The only access path to values after submission is the standard env-var read path (decrypt at runtime when launching an executor). That path is unchanged from today.
 
@@ -342,7 +352,7 @@ CSRF: same protections as every other authenticated daemon endpoint (existing CO
 
 ### 5.3 RBAC and multi-user
 
-If a *different* user submits the widget (in a `prompt`-tier multi-user setup): the env var is written to **the executor's identity's** env_vars (= session creator's), because that's whose env the agent will read at retry. **The submitting user is recorded in `result_meta.submitted_by`** for audit. Surfaced to the agent ("submitted by <user>") so the agent can adjust messaging.
+If a _different_ user submits the widget (in a `prompt`-tier multi-user setup): the env var is written to **the executor's identity's** env_vars (= session creator's), because that's whose env the agent will read at retry. **The submitting user is recorded in `result_meta.submitted_by`** for audit. Surfaced to the agent ("submitted by <user>") so the agent can adjust messaging.
 
 This is consistent with `dangerously_allow_session_sharing: false` semantics (default-safe). When session sharing is enabled and a collaborator submits a value, the value lands in the original owner's env — that's an explicit security trade-off documented under that flag.
 
@@ -352,13 +362,13 @@ The widget message persists forever in the transcript with `{ names, status, res
 
 ### 5.5 Threat model
 
-| Threat | Mitigation |
-|---|---|
-| Malicious agent crafts the `reason`/`instructions` to phish the user | Inputs rendered as **markdown with a strict allow-list** (no `<script>`, no inline event handlers, no auto-load images). Reuse the same sanitizer the artifact consent modal uses. |
-| Agent uses a widget to extract a value indirectly (e.g. asks for "type your value, then say it back to me") | The widget message *names* what's requested; an agent prompting the user to type a value in-chat *instead of* using the widget is a UX failure but not new attack surface — same as today. Mitigation is the disclaimer copy on the widget itself: "Type values here, never paste them into chat." |
-| Submission endpoint accepts unsolicited writes (no preceding widget request) | Endpoint requires a valid `widget_id` matching a `pending` widget message bound to the caller's session. No widget-less submissions. |
-| Replay attack with a captured submit payload | Once submitted, status → `submitted`; resubmission rejected on status check. |
-| Stored XSS via env-var name | Existing `^[A-Z_][A-Z0-9_]*$` regex precludes anything renderable as HTML. |
+| Threat                                                                                                      | Mitigation                                                                                                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Malicious agent crafts the `reason`/`instructions` to phish the user                                        | Inputs rendered as **markdown with a strict allow-list** (no `<script>`, no inline event handlers, no auto-load images). Reuse the same sanitizer the artifact consent modal uses.                                                                                                                 |
+| Agent uses a widget to extract a value indirectly (e.g. asks for "type your value, then say it back to me") | The widget message _names_ what's requested; an agent prompting the user to type a value in-chat _instead of_ using the widget is a UX failure but not new attack surface — same as today. Mitigation is the disclaimer copy on the widget itself: "Type values here, never paste them into chat." |
+| Submission endpoint accepts unsolicited writes (no preceding widget request)                                | Endpoint requires a valid `widget_id` matching a `pending` widget message bound to the caller's session. No widget-less submissions.                                                                                                                                                               |
+| Replay attack with a captured submit payload                                                                | Once submitted, status → `submitted`; resubmission rejected on status check.                                                                                                                                                                                                                       |
+| Stored XSS via env-var name                                                                                 | Existing `^[A-Z_][A-Z0-9_]*$` regex precludes anything renderable as HTML.                                                                                                                                                                                                                         |
 
 ---
 
@@ -372,23 +382,29 @@ If the abstraction is wrong, adding the second widget reveals it. Sketches:
 inputSchema: z.object({
   title: z.string().max(120),
   body: z.string().max(2000),
-  options: z.array(z.object({
-    id: z.string(),
-    label: z.string(),
-    style: z.enum(['default', 'primary', 'danger']).default('default'),
-  })).min(2).max(5),
+  options: z
+    .array(
+      z.object({
+        id: z.string(),
+        label: z.string(),
+        style: z.enum(['default', 'primary', 'danger']).default('default'),
+      })
+    )
+    .min(2)
+    .max(5),
   default_option_id: z.string().optional(),
-})
+});
 // submit body: { option_id: string }
 // result_meta: { option_id, option_label }  // label is fine — it's agent-provided
 // auto-resume prompt: "[Agor] User chose: ${option_label}."
 ```
 
 **Fit check:**
+
 - Renders inline in transcript. ✓
 - Submit has no secret material. ✓
 - Generalizes: A/B/C prompts, "delete this?", "which environment?".
-- Replaces the gap left by disallowing AskUserQuestion. **This becomes PR 3** (§7).
+- Replaces the gap left by disallowing AskUserQuestion. **This becomes the follow-up PR** (§7).
 
 ### 6.2 `agor_widgets_request_oauth` — connect a third-party account
 
@@ -405,9 +421,10 @@ inputSchema: z.object({
 ```
 
 **Fit check:**
-- Widget renders a "Connect GitHub" button. Click → popup → OAuth callback hits a *separate* daemon endpoint (`/oauth/:provider/callback`) which then resolves the widget the same way `POST /widgets/:id/submit` would (write result_meta, queue auto-resume task, emit `widget:resolved`).
+
+- Widget renders a "Connect GitHub" button. Click → popup → OAuth callback hits a _separate_ daemon endpoint (`/oauth/:provider/callback`) which then resolves the widget the same way `POST /widgets/:id/submit` would (write result_meta, queue auto-resume task, emit `widget:resolved`).
 - Token never goes anywhere near the agent. ✓
-- **The decoupled flow makes this trivial.** OAuth flows are inherently async (popup → user-action → callback); the widget primitive doesn't care which daemon endpoint resolves the widget, only that *something* does. The pause/resume model would have had to invent a special async lane for this; we don't.
+- **The decoupled flow makes this trivial.** OAuth flows are inherently async (popup → user-action → callback); the widget primitive doesn't care which daemon endpoint resolves the widget, only that _something_ does. The pause/resume model would have had to invent a special async lane for this; we don't.
 
 **Registry generalization:** `applySubmit` is one of several resolution paths. The OAuth widget type's registry entry exposes a `resolveFromOAuthCallback` function instead, called from `/oauth/:provider/callback`. The post-resolution machinery (patch message, queue auto-resume, emit event) is identical and lives in a shared helper.
 
@@ -415,10 +432,12 @@ inputSchema: z.object({
 
 ```ts
 inputSchema: z.object({
-  purpose: z.string().max(300)
+  purpose: z
+    .string()
+    .max(300)
     .describe('Why you need an MCP server — e.g. "browse Linear tickets"'),
   suggested_server_kinds: z.array(z.string()).optional(),
-})
+});
 // submit body: { mcp_server_id: string } | { kind: 'add_new', config: {...} }
 // applySubmit: noop if existing, else creates an mcp_servers row scoped to the session
 // result_meta: { mcp_server_id, name, kind }
@@ -426,6 +445,7 @@ inputSchema: z.object({
 ```
 
 **Fit check:**
+
 - Renders a picker with installed servers + an "Add new" affordance.
 - Adding a new server may itself trigger an OAuth widget — **widgets can chain** by having one widget's resolution kick off the next. Worth noting; not blocking v1.
 - No secret material in the submit body (server config holds credentials, but those are written via the existing mcp-servers service which handles encryption).
@@ -434,47 +454,51 @@ inputSchema: z.object({
 
 ---
 
-## 7. Phased delivery — concrete next-step PRs
+## 7. Delivery
 
-### PR 1: `feat(widgets): in-conversation widget primitive`
+The feature ships as **a single PR** (the one this doc is in: #1224). The framework alone has no user-facing capability — it needs at least one concrete widget type to be exercised end-to-end and to be worth merging. Internally the PR has two parts; the confirmation widget is a separate follow-up PR.
+
+### Part 1 — The primitive (`feat(widgets): in-conversation widget primitive`)
 
 Scope:
+
 - Add `'widget_request'` to `MessageType` (sqlite + postgres schemas + types, migrations).
 - Extend `appendSystemMessage` helper's `type` union to include `widget_request`.
 - Add `metadata.widget` shape to `Message['metadata']` type (typed via a discriminated union over `widget_type`, with `schema_version: number` baked in).
-- Daemon-side registry shape at `apps/agor-daemon/src/widgets/registry.ts` (empty in PR 1; widget types register themselves in their own PRs). The registry entry type includes `paramsSchema`, `submitSchema`, `applySubmit`, `buildResultMeta`, `buildAutoResumePrompt`, `buildDismissedPrompt`.
+- Daemon-side registry shape at `apps/agor-daemon/src/widgets/registry.ts` (empty in Part 1; widget types register themselves in their own PRs). The registry entry type includes `paramsSchema`, `submitSchema`, `applySubmit`, `buildResultMeta`, `buildAutoResumePrompt`, `buildDismissedPrompt`.
 - New FeathersJS service `widget-submissions` registering `POST /widgets/:widget_id/submit` and `POST /widgets/:widget_id/dismiss`. Auth: caller must match session creator OR have `prompt`-tier worktree RBAC. Idempotency: status must be `pending`.
 - Submit handler dispatches by `widget_type` to the registry (no-op for empty registry), then: patches the message row, creates an auto-resume task via the existing task-creation path (`tasks.create` with `role: 'user'`, `metadata.system_authored: true`, `metadata.widget_id`), emits `widget:resolved`.
 - `widget:resolved` Feathers event on the per-session room.
 - New MCP tool domain marker (`domain: 'widgets'` for `agor_search_tools` filtering).
 - UI: `WidgetBlock` dispatcher component in `apps/agor-ui/src/components/MessageBlock/` that switches on `metadata.widget.widget_type`, plus a placeholder "Unknown widget type" fallback for forward-compat with newer widgets in older clients.
 
-**Explicitly NOT in PR 1** (deliberately punted vs. the original design):
+**Explicitly NOT in Part 1** (no longer needed under the decoupled model):
+
 - ~~Daemon-restart marking pending widgets as `timed_out`~~ — widgets are durable in the messages table; daemon restart is transparent. Nothing to do.
 - ~~`widgets.default_timeout_ms` config option~~ — the decoupled model has no timeout. A widget sits `pending` until submitted or dismissed (or the session is archived, at which point the widget tombstones along with the rest).
 - ~~Long-poll / event-bus await on the MCP tool side~~ — the tool returns immediately; nothing to await.
 
-No widget types ship in PR 1. The framework is callable but produces no actual widgets yet. Tests cover the registry shape, the submit endpoint's auth + idempotency, the auto-resume task creation, and the WebSocket broadcast.
+Part 1 alone is callable but produces no actual widgets — it's not shippable on its own; Part 2 (below) lands in the same PR.
 
-**Estimated effort:** ~2-3 eng-days (shrunk from ~3-4 — the dropped pieces were the hardest parts).
+**Status:** ✅ landed on PR #1224 in commits `0b9ef5b2`, `71b70367`, `a3f3b7b2`. 17 unit tests pass.
 
-### PR 2: `feat(widgets): env_vars widget`
+### Part 2 — The env_vars widget (`feat(widgets): env_vars widget`)
 
 Scope:
+
 - Register `env_vars` widget type in the daemon registry: Zod schemas, `applySubmit` = thin shim around `users.patch`, `buildAutoResumePrompt` and `buildDismissedPrompt` per §3.4.
 - Register `agor_widgets_request_env_vars` MCP tool in `apps/agor-daemon/src/mcp/tools/widgets.ts`. Tool params include `auto_resume: boolean` (default `true`).
 - React component `EnvVarRequestWidget.tsx` (reuses form shape from `EnvVarEditor.tsx`).
 - Wire `widgetComponents['env_vars']` mapping on the UI.
 - Submit handler reuses existing env-var validation (`validateEnvVar`, `isEnvVarAllowed`, regex) and encryption (`encryptApiKey`) — zero net-new logic.
-- **`already_present` short-circuit** (per D4 below, recommended yes): submit handler checks at request time whether the user already has all `names` in scope. If yes, immediately patches `metadata.widget.status = 'already_present'`, skips the form render, and queues the auto-resume task with a "values were already configured" prompt.
+- **`already_present` short-circuit** (per D4, resolved yes): submit handler checks at request time whether the user already has all `names` in scope. If yes, immediately patches `metadata.widget.status = 'already_present'`, skips the form render, and queues the auto-resume task with a "values were already configured" prompt.
 - Docs: `apps/agor-docs/pages/guide/in-conversation-widgets.mdx` (user-facing) with the env-var section as the canonical example.
 - Storybook story for the widget in pending, submitted, dismissed, and already-present states.
 
-**Estimated effort:** ~2-3 eng-days.
-
-### PR 3 (optional, validates extensibility): `feat(widgets): confirmation widget`
+### Follow-up PR (separate, validates extensibility): `feat(widgets): confirmation widget`
 
 Scope:
+
 - Register `confirmation` widget type (Zod schemas per §6.1).
 - React component with N option buttons; danger style for `style: 'danger'`.
 - MCP tool `agor_widgets_request_confirmation`.
@@ -484,38 +508,38 @@ Scope:
 
 ### Sequencing
 
-PR 1 → PR 2 → (optional) PR 3. PR 2 cannot land before PR 1 (depends on the registry). PR 3 is independent of PR 2 — could swap order if confirmation is more urgent than env-var capture.
+Parts 1 and 2 ship together on PR #1224 (this PR — they're sequenced commits, not separate PRs). The confirmation widget is a separate follow-up PR that consumes the framework; it doesn't depend on `env_vars` and could be reordered if needed.
 
 ---
 
 ## 8. Risks and open questions
 
-| # | Risk / question | Mitigation |
-|---|---|---|
-| R1 | **Widget message persists forever in the transcript.** The *names* of submitted env vars are visible to anyone who can read the transcript. | Same surface as User Settings → Env Vars. One-line disclaimer on the widget. If sensitive, the user can dismiss and add via Settings. |
-| R2 | **Widget-version drift** when v2 changes a widget's submit schema. | `metadata.widget.schema_version: number` baked in from v1. UI's `WidgetBlock` renders old versions in a degraded read-only mode for forward-compat. |
-| R3 | **Dismissal UX.** Does the agent treat dismissal as "user said no, stop" or "user said not-now, try again later"? | Auto-queued dismissal prompt is explicit: *"Do not re-request immediately — ask whether to proceed without, or move on to other work."* See `buildDismissedPrompt` example in §3.4. |
-| R4 | **Multi-user authz for submission.** Who can submit on behalf of whom? | §5.2 — submitter must match session creator or have `prompt`-tier worktree RBAC. Cross-user submit attributed in `result_meta.submitted_by`. |
-| R5 | **Logging leakage.** Submit handler must not log values. | Explicit test in PR 2 (`expect(logs).not.toContain(value)`). Submit handler accepts the body and immediately hands it to the registry's `applySubmit`; no intermediate variable that gets stringified. |
-| R6 | **Agent uses chat (not the widget) to extract values** by phishing the user. | Widget copy: "Never paste values into chat — only into the form above." Out of scope for code mitigations. |
-| R7 | **Stale widget message** — user submits 4 hours later in a session that's already moved on. Auto-queued task arrives mid-context-switch. | Acceptable. Same surface as "queued prompt arrives in a session you forgot about" — already a thing the user lives with. Mitigated by the prompt being self-explanatory (`[Agor] User submitted X. Retry the operation that needed it.`). Worth a small "Discard pending widgets on session archive" hook — when a session is archived, all its `pending` widgets transition to `dismissed` (no auto-resume task, since the session is gone). |
-| R8 | **Agent ignores the "end your turn" contract** and keeps reasoning after firing the tool. | Harmless — the auto-queued task arrives whenever the user submits. The agent's intermediate reasoning just turns out to have been speculative. Tool description nudges, doesn't enforce. |
-| R9 | **Auto-resume task fires on a session whose user is offline.** No one notices the queued prompt. | Standard task-queue semantics (#1068) — the prompt is durable, will fire when the executor next picks up. If the session is permanently abandoned, the task tombstones with the rest of the session. |
-| Q1 | **One generic `agor_widgets_request` tool vs. one tool per type?** | Recommended: one per type (§3.2). Typed contracts, better progressive discovery, better agent UX. |
-| Q2 | **`already_present` short-circuit?** E.g. agent asks for `HUBSPOT_API_KEY`, user already has it set globally → widget auto-resolves with status `already_present`. | **Recommended yes** for env-vars specifically (saves a user click). Daemon checks presence at request time and short-circuits to `status: 'already_present'` + an auto-resume task ("`HUBSPOT_API_KEY` was already configured. You can proceed.") without rendering a form. See PR 2 scope. |
+| #   | Risk / question                                                                                                                                                    | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | **Widget message persists forever in the transcript.** The _names_ of submitted env vars are visible to anyone who can read the transcript.                        | Same surface as User Settings → Env Vars. One-line disclaimer on the widget. If sensitive, the user can dismiss and add via Settings.                                                                                                                                                                                                                                                                                                         |
+| R2  | **Widget-version drift** when v2 changes a widget's submit schema.                                                                                                 | `metadata.widget.schema_version: number` baked in from v1. UI's `WidgetBlock` renders old versions in a degraded read-only mode for forward-compat.                                                                                                                                                                                                                                                                                           |
+| R3  | **Dismissal UX.** Does the agent treat dismissal as "user said no, stop" or "user said not-now, try again later"?                                                  | Auto-queued dismissal prompt is explicit: _"Do not re-request immediately — ask whether to proceed without, or move on to other work."_ See `buildDismissedPrompt` example in §3.4.                                                                                                                                                                                                                                                           |
+| R4  | **Multi-user authz for submission.** Who can submit on behalf of whom?                                                                                             | §5.2 — submitter must match session creator or have `prompt`-tier worktree RBAC. Cross-user submit attributed in `result_meta.submitted_by`.                                                                                                                                                                                                                                                                                                  |
+| R5  | **Logging leakage.** Submit handler must not log values.                                                                                                           | Explicit test in the env_vars Part (`expect(logs).not.toContain(value)`). Submit handler accepts the body and immediately hands it to the registry's `applySubmit`; no intermediate variable that gets stringified.                                                                                                                                                                                                                           |
+| R6  | **Agent uses chat (not the widget) to extract values** by phishing the user.                                                                                       | Widget copy: "Never paste values into chat — only into the form above." Out of scope for code mitigations.                                                                                                                                                                                                                                                                                                                                    |
+| R7  | **Stale widget message** — user submits 4 hours later in a session that's already moved on. Auto-queued task arrives mid-context-switch.                           | Acceptable. Same surface as "queued prompt arrives in a session you forgot about" — already a thing the user lives with. Mitigated by the prompt being self-explanatory (`[Agor] User submitted X. Retry the operation that needed it.`). Worth a small "Discard pending widgets on session archive" hook — when a session is archived, all its `pending` widgets transition to `dismissed` (no auto-resume task, since the session is gone). |
+| R8  | **Agent ignores the "end your turn" contract** and keeps reasoning after firing the tool.                                                                          | Harmless — the auto-queued task arrives whenever the user submits. The agent's intermediate reasoning just turns out to have been speculative. Tool description nudges, doesn't enforce.                                                                                                                                                                                                                                                      |
+| R9  | **Auto-resume task fires on a session whose user is offline.** No one notices the queued prompt.                                                                   | Standard task-queue semantics (#1068) — the prompt is durable, will fire when the executor next picks up. If the session is permanently abandoned, the task tombstones with the rest of the session.                                                                                                                                                                                                                                          |
+| Q1  | **One generic `agor_widgets_request` tool vs. one tool per type?**                                                                                                 | Recommended: one per type (§3.2). Typed contracts, better progressive discovery, better agent UX.                                                                                                                                                                                                                                                                                                                                             |
+| Q2  | **`already_present` short-circuit?** E.g. agent asks for `HUBSPOT_API_KEY`, user already has it set globally → widget auto-resolves with status `already_present`. | **Resolved yes** for env-vars specifically (saves a user click). Daemon checks presence at request time and short-circuits to `status: 'already_present'` + an auto-resume task ("`HUBSPOT_API_KEY` was already configured. You can proceed.") without rendering a form. Lives in Part 2 scope.                                                                                                                                               |
 
 ---
 
 ## 9. Coordination with adjacent work
 
-| Worktree / PR | Relationship |
-|---|---|
-| `fix-issue-1177-ask-user-question-hang` (merged as #1181) | **Disallowed AskUserQuestion.** PR 3 of this design (the confirmation widget) is the long-term replacement — it gives agents a structured way to ask the user inline that doesn't depend on the dead SDK feature. No code conflict; conceptual handoff. |
-| `design-notification-system` (PR #1135, open) | **Widgets are in-transcript, notifications are out-of-transcript.** No overlap. Worth a one-line cross-reference in both docs. |
-| `feat(artifacts)!: declarative format + TOFU consent flow` (PR #1147, merged) | **Shares UX language**, not architecture. Reuse the scope-selector copy and the markdown sanitizer; do not reuse `artifact_trust_grants` table. |
-| `system-message-on-daemon-restart` (PR #1166, merged) | **Direct reuse** of `appendSystemMessage` + the daemon-restart-marks-orphans pattern. |
-| `design-internal-llm-service` (in flight) | Adjacent (both are "app-invoked" patterns) but no direct integration. |
-| `improve-onboarding-openclaw-integration` / onboarding flows | **Primary consumer of v1.** Onboarding zone-triggers can now ask for env vars inline instead of redirecting to Settings. |
+| Worktree / PR                                                                 | Relationship                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fix-issue-1177-ask-user-question-hang` (merged as #1181)                     | **Disallowed AskUserQuestion.** The follow-up confirmation-widget PR is the long-term replacement — it gives agents a structured way to ask the user inline that doesn't depend on the dead SDK feature. No code conflict; conceptual handoff. |
+| `design-notification-system` (PR #1135, open)                                 | **Widgets are in-transcript, notifications are out-of-transcript.** No overlap. Worth a one-line cross-reference in both docs.                                                                                                                 |
+| `feat(artifacts)!: declarative format + TOFU consent flow` (PR #1147, merged) | **Shares UX language**, not architecture. Reuse the scope-selector copy and the markdown sanitizer; do not reuse `artifact_trust_grants` table.                                                                                                |
+| `system-message-on-daemon-restart` (PR #1166, merged)                         | **Direct reuse** of `appendSystemMessage` + the daemon-restart-marks-orphans pattern.                                                                                                                                                          |
+| `design-internal-llm-service` (in flight)                                     | Adjacent (both are "app-invoked" patterns) but no direct integration.                                                                                                                                                                          |
+| `improve-onboarding-openclaw-integration` / onboarding flows                  | **Primary consumer of v1.** Onboarding zone-triggers can now ask for env vars inline instead of redirecting to Settings.                                                                                                                       |
 
 ---
 
@@ -526,13 +550,11 @@ Decisions Max has signed off on (commit history of this doc):
 - **D1:** Message-row-as-state vs. separate `pending_widgets` table. **Resolved: row.** Add a table only when we need cross-session queries.
 - **D2:** One MCP tool per widget type vs. one generic tool. **Resolved: per type.**
 - **D3:** ~~Default timeout~~. **Resolved: no timeout.** Decoupled flow makes timeouts unnecessary. A widget sits `pending` until submitted, dismissed, or its session is archived.
-- **D4:** `already_present` short-circuit for env-vars. **Resolved: yes** — saves a user click; ships in PR 2.
+- **D4:** `already_present` short-circuit for env-vars. **Resolved: yes** — saves a user click; ships as part of the env_vars widget Part.
 - **D5:** **Resolved: decoupled fire-and-forget flow** (no executor pause, no daemon-side await). MCP tool returns immediately; user submission auto-queues a system-authored task via "Never lose a prompt" (#1068).
 - **D6:** Default `auto_resume: true` on submit. Per-call opt-out via tool param. Dismissal also auto-queues with explicit "don't immediately re-ask" framing. **Resolved: yes.**
 
-Still open for Max:
-
-- **D7:** Should PR 3 (confirmation widget) ship in the same release as PR 2, or be deferred? Shipping together validates the abstraction earliest and closes the AskUserQuestion gap sooner.
+- **D7:** ~~Should the confirmation widget ship in the same PR?~~ **Resolved: no.** This PR (#1224) is framework + env_vars only. Confirmation widget is a separate follow-up PR — keeps this one focused on the motivating use case and lets the AskUserQuestion-replacement work proceed on its own timeline.
 
 ---
 
@@ -546,6 +568,6 @@ _References (file:line)_
 - `packages/core/src/types/message.ts:33-41` — `MessageType` union to extend
 - `packages/core/src/db/encryption.ts` — `encryptApiKey` (do not reimplement)
 - `packages/core/src/config/env-validation.ts:30-90` — env-var validation (regex + blocklist)
-- `packages/executor/src/permissions/permission-service.ts:94-149` — pause/resume reference *(NOT followed)* — kept as a cite for the alternative we rejected
+- `packages/executor/src/permissions/permission-service.ts:94-149` — pause/resume reference _(NOT followed)_ — kept as a cite for the alternative we rejected
 - `packages/executor/src/sdk-handlers/claude/constants.ts:33` — AskUserQuestion disallowed
 - `apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx` — scope-selector UX to mine

--- a/docs/internal/in-conversation-widgets-design-2026-05-19.md
+++ b/docs/internal/in-conversation-widgets-design-2026-05-19.md
@@ -1,0 +1,495 @@
+# In-Conversation Interactive Widgets — Design Doc
+
+Author: Max (drafted by Claude assistant)
+Status: **Draft — not for merge.** Implementation worktrees branch off the PR definitions in §7.
+Companion brief: `design-in-conversation-widget-primitive` worktree.
+
+---
+
+## 1. TL;DR
+
+Agor needs a way for agents to render small interactive UI inline in the conversation transcript — a form, a button, a picker — that captures user input **without that input ever entering the LLM's context**.
+
+**Motivating use case:** during onboarding (and beyond) the agent often needs an env var (`HUBSPOT_API_KEY`, `GITHUB_TOKEN`) before it can do its job. Today: "please go to User Settings → Env Vars and add X." User context-switches; flow breaks. **Wanted:** the agent calls `agor_widgets_request_env_vars({ names, reason })`, a form pops into the transcript, the user types and submits inline, the secret goes **directly from the React widget to the daemon** (not through the model), and the agent receives a sanitized confirmation event (`{ names, status }`, no values) and continues.
+
+**This is the first instance of a broader primitive** — Agor Custom Widgets. v1 ships the framework + the env-var widget. The same primitive will host OAuth-connect, file picker, MCP-server selector, confirmation prompt, and similar agent-driven micro-interactions.
+
+**Three hard requirements drive the design:**
+
+1. **Secret never enters the LLM context.** Triple-checked across every code path. Value flows browser → daemon, never browser → agent → daemon.
+2. **Agent stays informed.** A sanitized confirmation event (`{ widget_id, widget_type, status, names, scope }`) reaches the agent so it can resume work.
+3. **Extensible.** v1 architecture supports 3+ future widget types without re-architecture (validated in §6).
+
+---
+
+## 2. Prior art audit (what we reuse, what we don't)
+
+| Pattern | PR | Verdict |
+|---|---|---|
+| `permission_request` messages + executor pause/resume (`canUseTool`) | merged | **Closest production reference.** Reuse the message-as-state, pause-the-tool-call, broadcast-via-Feathers shape. Differs only in *who initiates* (we initiate from an MCP tool, not a SDK hook). |
+| `appendSystemMessage` helper + `MessageType` discriminant union | #1166 | **Reuse directly.** Add `'widget_request'` to `MessageType` and to the helper's `type` union (`apps/agor-daemon/src/utils/append-system-message.ts:36`). |
+| `ArtifactConsentModal` + `artifact_trust_grants` table + TOFU strict-subset matching | #1147 | **Mine for UX patterns, not architecture.** Artifact consent is a *modal* triggered from an artifact card; widgets render *inline in the transcript*. Reuse the scope-selector copy, the "submit just nominates scope" pattern, and the strict-subset principle. Do **not** reuse the table — widgets are per-session ephemera, not durable grants. |
+| `AskUserQuestion` SDK tool (`input_request` message type, `InputRequestService`, `InputRequestBlock`) | #658 → ripped in #1181 | **Dead.** The SDK tool is in `CLAUDE_CODE_DISALLOWED_TOOLS` (`packages/executor/src/sdk-handlers/claude/constants.ts:33`). The widget primitive is the long-term replacement; a `confirmation`/`question` widget closes the gap that disallowing left (see §6 and §7 PR 3). |
+| Env-var storage (`users.data.env_vars` JSON map, AES-256-GCM via `encryptApiKey`, scope enum, blocklist, `^[A-Z_][A-Z0-9_]*$` regex) | existing | **Reuse the existing users service.** The env-var widget submit handler is a thin shim that PATCHes `/users/:id` with a single-key `env_vars` patch. Validation, encryption, scope handling, blocklist enforcement all already live there. |
+| MCP tool registry (`apps/agor-daemon/src/mcp/tools/*.ts`, `registerTool(name, {description, inputSchema, annotations}, handler)`, `ctx.sessionId`, `textResult(...)`) | existing | **Slot a new `widgets.ts` file alongside other domains.** Standard pattern. |
+
+---
+
+## 3. Architecture
+
+### 3.1 Message type: `widget_request`
+
+Add a new `MessageType` value: `'widget_request'`. A widget message is just a row in `messages` with:
+
+```ts
+{
+  type: 'widget_request',
+  role: MessageRole.SYSTEM,
+  content: '...short human-readable text, e.g. "Please provide HUBSPOT_API_KEY"...',
+  metadata: {
+    widget: {
+      widget_id: MessageID,        // same as message_id — single source of truth
+      widget_type: 'env_vars',     // discriminant for the widget registry
+      params: { ... },             // widget-type-specific payload (validated by registry schema)
+      status: 'pending' | 'submitted' | 'dismissed' | 'timed_out',
+      requested_at: ISO8601,
+      resolved_at?: ISO8601,
+      // RESULT_META is widget-type-specific, scrubbed of secret material.
+      // For env_vars: { names_submitted: string[], scope: 'global' | 'session' }
+      result_meta?: Record<string, unknown>,
+    }
+  }
+}
+```
+
+Why message-as-state (vs. a separate `pending_widgets` table):
+
+- **Transcript persistence comes for free.** Reload shows the widget in its final state.
+- **Single source of truth.** The same row drives the agent's tool-call result, the WebSocket event, and the transcript renderer.
+- **Schema cost is one new enum value**, not a new table + migration + RLS.
+
+We add a real table only if/when we need indexed cross-session queries ("show me all pending widgets across the workspace"). Not v1.
+
+### 3.2 MCP tool surface
+
+Register one tool **per widget type** under a new file `apps/agor-daemon/src/mcp/tools/widgets.ts`:
+
+```ts
+server.registerTool(
+  'agor_widgets_request_env_vars',
+  {
+    description:
+      'Ask the user to provide one or more environment variables via an in-conversation form. ' +
+      'The user types the values directly into the UI; the values never enter your context. ' +
+      'You receive a confirmation event with the variable names that were submitted (no values).',
+    annotations: { destructiveHint: false },
+    inputSchema: z.object({
+      names: z.array(z.string().regex(/^[A-Z_][A-Z0-9_]*$/))
+        .min(1).max(10)
+        .describe('UPPER_SNAKE env var names. Same validation as User Settings.'),
+      reason: z.string().min(1).max(500)
+        .describe('Short explanation shown to the user — why do you need these?'),
+      instructions: z.string().max(2000).optional()
+        .describe('Optional markdown — e.g. "Get a key at https://app.hubspot.com/..."'),
+      default_scope: z.enum(['global', 'session']).default('global')
+        .describe('Suggested scope. User can override in the form.'),
+    }),
+  },
+  widgetsRequestEnvVarsHandler
+);
+```
+
+Why per-widget tools (vs. one generic `agor_widgets_request(type, params)`):
+
+- **Schema validation is per-widget**, and Zod schemas at registration time give the agent a typed contract via MCP `tools/list`.
+- **The agent sees a discoverable name** (`agor_search_tools` already filters by domain — `widgets` becomes a domain).
+- **Progressive disclosure**: each tool's description teaches the agent the exact contract, including the "no values in your context" guarantee.
+
+The handler logic is shared via a small helper (see §3.4) so adding a widget type ≈ defining its Zod schema, its React component, and its submit handler.
+
+### 3.3 Daemon flow (the pause/resume model)
+
+```
+┌──────────┐                ┌─────────────┐               ┌────────┐               ┌────────┐
+│  Agent   │                │ Daemon (MCP │               │   UI   │               │  User  │
+│ (Claude) │                │   server)   │               │ client │               │        │
+└────┬─────┘                └──────┬──────┘               └────┬───┘               └────┬───┘
+     │                             │                           │                        │
+     │ MCP: agor_widgets_request_  │                           │                        │
+     │  env_vars({names, reason})  │                           │                        │
+     │ ──────────────────────────► │                           │                        │
+     │                             │                           │                        │
+     │                             │ appendSystemMessage(      │                        │
+     │                             │   type='widget_request',  │                        │
+     │                             │   metadata.widget={...,   │                        │
+     │                             │     status:'pending'})    │                        │
+     │                             │                           │                        │
+     │                             │ Feathers 'messages         │                        │
+     │                             │  created' WS event ──────►│                        │
+     │                             │                           │ render WidgetBlock     │
+     │                             │                           │ ──────────────────────►│
+     │                             │                           │                        │
+     │                             │ await resolution          │ types HUBSPOT_API_KEY  │
+     │                             │ (long-poll, see §3.5)     │ ◄──────────────────────│
+     │                             │                           │                        │
+     │                             │ POST /widgets/:id/submit  │                        │
+     │                             │ {values, scope}           │                        │
+     │                             │ ◄─────────────────────────│                        │
+     │                             │                           │                        │
+     │                             │ users.patch              │                        │
+     │                             │  (encrypt, store)         │                        │
+     │                             │                           │                        │
+     │                             │ messages.patch           │                        │
+     │                             │  (widget.status =         │                        │
+     │                             │   'submitted',            │                        │
+     │                             │   result_meta = {names,   │                        │
+     │                             │   scope})                 │                        │
+     │                             │                           │                        │
+     │                             │ widget:resolved event ────┼───────────────────────►│
+     │                             │                           │ re-render badge       │
+     │                             │                           │                        │
+     │ MCP tool returns:           │                           │                        │
+     │  { widget_id,               │                           │                        │
+     │    status: 'submitted',     │                           │                        │
+     │    names: [...],            │                           │                        │
+     │    scope: 'global' }        │                           │                        │
+     │ ◄────────────────────────── │                           │                        │
+     │                             │                           │                        │
+     │ resumes — retries           │                           │                        │
+     │ original API call           │                           │                        │
+```
+
+Key properties:
+
+- **Executor doesn't exit.** It's blocked at the MCP tool call (HTTP request to the daemon, same shape as any other long-running tool). This is the same pause model that `permission_request` uses; the difference is the pause lives in the *daemon* (waiting on the human) rather than the *executor* (waiting on `canUseTool`).
+- **The MCP tool result carries names + status + scope, never values.**
+- **Transcript persistence is automatic** because the widget IS a message row.
+
+### 3.4 Widget registry
+
+```ts
+// packages/core/src/types/widget.ts
+export type WidgetType = 'env_vars'; // extended over time
+
+export interface WidgetRegistryEntry<TParams, TSubmit, TResultMeta> {
+  type: WidgetType;
+  /** Zod schema validating MCP tool input */
+  paramsSchema: z.ZodType<TParams>;
+  /** Zod schema validating POST /widgets/:id/submit body */
+  submitSchema: z.ZodType<TSubmit>;
+  /** What goes back to the agent (and into result_meta on the message). NEVER includes secret values. */
+  buildResultMeta: (submit: TSubmit) => TResultMeta;
+  /** Side-effect: persist the submitted values to wherever they belong */
+  applySubmit: (ctx: SubmitCtx, submit: TSubmit) => Promise<void>;
+}
+
+// frontend mirror
+export const widgetComponents: Record<WidgetType, React.FC<WidgetProps>> = {
+  env_vars: EnvVarRequestWidget,
+};
+```
+
+A new widget type is three files: a Zod-typed registry entry on the daemon, a React component on the UI, a registration line on each side. No core changes needed.
+
+### 3.5 Long-poll vs. event subscription
+
+The MCP tool handler needs to block until the widget resolves (or times out). Two implementation options:
+
+| Option | How | Trade-off |
+|---|---|---|
+| **Long-await on internal event bus** (recommended) | Handler subscribes to `widget:resolved:<widget_id>` on the FeathersJS app's event emitter; awaits with a 30-min timeout (configurable via `widgets.default_timeout_ms`). | Same in-process pattern `PermissionService.waitForDecision()` uses. Lives in daemon memory — survives WS disconnects from the UI but not daemon restart. |
+| **Poll the message row** | Handler polls every 2s for `widget.status !== 'pending'`. | Simpler but wastes cycles. Skip. |
+
+**Daemon restart handling**: on startup, scan `messages WHERE metadata->widget.status='pending'` bound to running sessions; if executor is still alive (PID check / `awaiting_widget` task status), it's already disconnected from the in-process await — the executor sees an MCP error and retries, the user sees the widget either still pending or already submitted. **Simplest fix**: mark all pending widgets as `timed_out` on daemon restart, surface a follow-up system message ("The widget request for HUBSPOT_API_KEY was cancelled by a daemon restart — re-prompt the agent to ask again."). Same pattern PR #1166 uses for orphaned sessions.
+
+### 3.6 HTTP timeout for the MCP request
+
+This is the **single biggest implementation risk** (see §8). MCP tool calls flow over HTTP; a 30-minute open request will hit infrastructure timeouts (reverse proxies, load balancers, browser-side fetch idle). Mitigations:
+
+1. **Keep-alive heartbeats**: SSE-style chunked response that emits empty whitespace every 25s (the MCP transport already streams). Implementation lives in the MCP server framework, not per-tool.
+2. **Shorter default timeout** (configurable): start with 10 min — same as `permission_request` (`DEFAULT_PERMISSION_TIMEOUT_MS = 600_000`). Bump if friction proves real.
+3. **Polling fallback**: if a tool times out at the HTTP layer but the widget is still `pending`, the agent's natural retry semantics call it again with the same `widget_id` (idempotency key) — daemon resumes the await on the *same* widget row instead of creating a new one. Stretch goal; not blocking v1.
+
+---
+
+## 4. The env-var widget (concrete v1)
+
+| Piece | Path | Reuses |
+|---|---|---|
+| MCP tool | `apps/agor-daemon/src/mcp/tools/widgets.ts` (new) | `registerTool` pattern from `worktrees.ts` |
+| Daemon submit endpoint | `POST /widgets/:widget_id/submit` (new route) | FeathersJS service for `widget-submissions` |
+| Persistence | Thin shim → `app.service('users').patch(userId, { env_vars: { [name]: { value, scope } } })` | existing users service, `encryptApiKey`, blocklist, regex |
+| Message update | `app.service('messages').patch(widget_id, { metadata.widget: {...} })` | existing messages service |
+| Event | `app.io.to(sessionRoomName(sessionId)).emit('widget:resolved', {...})` | existing per-session room |
+| UI dispatch | `MessageBlock.tsx`: `if (message.type === 'widget_request') return <WidgetBlock message={message} />` | `PermissionRequestBlock` precedent at MessageBlock.tsx:256-294 |
+| Widget component | `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx` | form shape from `EnvVarEditor.tsx` |
+| Confirmation event for agent | MCP tool return: `{ widget_id, status, names, scope }` | `textResult()` |
+
+### UI sketch
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ 🔐  Agent needs env vars                                     │
+│                                                              │
+│ HUBSPOT_API_KEY needed to call the Hubspot API.              │
+│                                                              │
+│ Get a key at https://app.hubspot.com/private-apps            │
+│                                                              │
+│  HUBSPOT_API_KEY  [••••••••••••••••••••••••••]              │
+│  Scope: ( ) Session  (•) Global                              │
+│                                                              │
+│            [ Dismiss ]      [ Save & continue ]              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+After submission:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ✅  HUBSPOT_API_KEY saved (Global)                           │
+│     Submitted by max@preset.io at 14:23                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+After dismissal:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ⊘   HUBSPOT_API_KEY request dismissed                        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Security analysis
+
+### 5.1 The "secret never enters the LLM context" property
+
+**Claim:** in no code path does a submitted secret value reach the agent's MCP transport, message content, message preview, or any tool-call result.
+
+**Proof by code path enumeration:**
+
+| Path | Carries values? | Justification |
+|---|---|---|
+| Agent → MCP tool call (`agor_widgets_request_env_vars`) | **No** | Input schema accepts `names` (strings) + `reason`. No `values` field exists. Zod rejects extras. |
+| Daemon → `appendSystemMessage` → message row | **No** | `metadata.widget.params` is the agent-provided payload (names, reason, instructions); `content` is human-readable preview. Both are filled from the agent's tool args — agent had no values. |
+| Feathers `messages created` WebSocket event | **No** | Payload is the message row above. |
+| UI → `POST /widgets/:id/submit` | **Yes** | Direct browser-to-daemon HTTP request. Auth via the user's session cookie / JWT. **This is the only place values exist on the wire**, and it never traverses the agent. |
+| Daemon submit handler → `users.patch` | **Yes (encrypted in transit at app layer)** | Standard env-var write path. `encryptApiKey()` is called inside the users service before DB write. |
+| Daemon → message status update (`messages.patch`) | **No** | Updates `metadata.widget.status` and `result_meta = { names, scope }`. Explicit allow-list — we patch by field, never spread the submit body. |
+| `widget:resolved` Feathers event | **No** | Payload is `{ widget_id, status, result_meta }`. |
+| MCP tool return value → agent | **No** | Returns `{ widget_id, status, names, scope }`. No `values` field. |
+| Transcript reload | **No** | Re-reads the message row; values were never stored on it. |
+| Logs | **No (must enforce)** | Submit handler MUST NOT log the request body. Add an explicit lint or test: `expect(logs).not.toContain(submittedValue)`. |
+
+The only access path to values after submission is the standard env-var read path (decrypt at runtime when launching an executor). That path is unchanged from today.
+
+### 5.2 Authz / CSRF
+
+`POST /widgets/:widget_id/submit` is authenticated via existing FeathersJS session auth. The handler MUST verify:
+
+1. The caller's `user_id` matches `widget_message.session.created_by` **OR** the caller has `prompt`-tier RBAC on the worktree (`others_can >= prompt`). This mirrors who can already prompt the session.
+2. The widget is still `pending` (idempotency — double-submit is a no-op, not a re-write).
+3. The widget's `requested_at` is within the configured TTL.
+
+CSRF: same protections as every other authenticated daemon endpoint (existing CORS + same-origin policy + JWT).
+
+### 5.3 RBAC and multi-user
+
+If a *different* user submits the widget (in a `prompt`-tier multi-user setup): the env var is written to **the executor's identity's** env_vars (= session creator's), because that's whose env the agent will read at retry. **The submitting user is recorded in `result_meta.submitted_by`** for audit. Surfaced to the agent ("submitted by <user>") so the agent can adjust messaging.
+
+This is consistent with `dangerously_allow_session_sharing: false` semantics (default-safe). When session sharing is enabled and a collaborator submits a value, the value lands in the original owner's env — that's an explicit security trade-off documented under that flag.
+
+### 5.4 Transcript persistence implications
+
+The widget message persists forever in the transcript with `{ names, status, result_meta }` — **names of submitted env vars are visible** to anyone who can read the transcript. This is the same surface as User Settings → Env Vars (names visible, values hidden), so no new exposure. Worth a one-line callout in the UI ("Variable names are logged in the transcript; values are not.").
+
+### 5.5 Threat model
+
+| Threat | Mitigation |
+|---|---|
+| Malicious agent crafts the `reason`/`instructions` to phish the user | Inputs rendered as **markdown with a strict allow-list** (no `<script>`, no inline event handlers, no auto-load images). Reuse the same sanitizer the artifact consent modal uses. |
+| Agent uses a widget to extract a value indirectly (e.g. asks for "type your value, then say it back to me") | The widget message *names* what's requested; an agent prompting the user to type a value in-chat *instead of* using the widget is a UX failure but not new attack surface — same as today. Mitigation is the disclaimer copy on the widget itself: "Type values here, never paste them into chat." |
+| Submission endpoint accepts unsolicited writes (no preceding widget request) | Endpoint requires a valid `widget_id` matching a `pending` widget message bound to the caller's session. No widget-less submissions. |
+| Replay attack with a captured submit payload | Once submitted, status → `submitted`; resubmission rejected on status check. |
+| Stored XSS via env-var name | Existing `^[A-Z_][A-Z0-9_]*$` regex precludes anything renderable as HTML. |
+
+---
+
+## 6. Extensibility — validating against 3 future widgets
+
+If the abstraction is wrong, adding the second widget reveals it. Sketches:
+
+### 6.1 `agor_widgets_request_confirmation` — replaces the disallowed AskUserQuestion
+
+```ts
+inputSchema: z.object({
+  title: z.string().max(120),
+  body: z.string().max(2000),
+  options: z.array(z.object({
+    id: z.string(),
+    label: z.string(),
+    style: z.enum(['default', 'primary', 'danger']).default('default'),
+  })).min(2).max(5),
+  default_option_id: z.string().optional(),
+})
+// submit body: { option_id: string }
+// result_meta: { option_id, option_label }  // label is fine — it's agent-provided
+// MCP return: { widget_id, status, option_id, option_label }
+```
+
+**Fit check:**
+- Renders inline in transcript. ✓
+- Submit has no secret material. ✓
+- Generalizes: A/B/C prompts, "delete this?", "which environment?".
+- Replaces the gap left by disallowing AskUserQuestion. **This becomes PR 3** (§7).
+
+### 6.2 `agor_widgets_request_oauth` — connect a third-party account
+
+```ts
+inputSchema: z.object({
+  provider: z.enum(['github', 'slack', 'linear', 'hubspot', ...]),
+  scopes: z.array(z.string()).min(1),
+  reason: z.string().max(500),
+})
+// submit body: empty — submission happens via OAuth callback, not user form
+// applySubmit: writes to existing OAuth tokens table
+// result_meta: { provider, granted_scopes: string[], account_label: string }
+// MCP return: { widget_id, status, provider, granted_scopes, account_label }
+```
+
+**Fit check:**
+- Widget renders a "Connect GitHub" button. Click → popup → OAuth callback hits a *separate* daemon endpoint (`/oauth/:provider/callback`) which then flips the widget status.
+- Token never goes anywhere near the agent. ✓
+- The submit endpoint is virtual here — resolution happens via the OAuth callback. Registry's `applySubmit` becomes "wait for OAuth, then write to tokens table."
+
+**One real seam discovered:** not every widget resolves via `POST /widgets/:id/submit`. OAuth resolves via callback. We accommodate this by making `widget:resolved` the canonical resolution event, and treating `POST .../submit` as one of *several* possible resolution mechanisms. Worth calling out in the registry shape — `applySubmit` becomes optional, and the registry can declare alternative resolution paths.
+
+### 6.3 `agor_widgets_request_mcp_server` — select / attach an MCP server
+
+```ts
+inputSchema: z.object({
+  purpose: z.string().max(300)
+    .describe('Why you need an MCP server — e.g. "browse Linear tickets"'),
+  suggested_server_kinds: z.array(z.string()).optional(),
+})
+// submit body: { mcp_server_id: string } | { kind: 'add_new', config: {...} }
+// applySubmit: noop if existing, else creates an mcp_servers row scoped to the session
+// result_meta: { mcp_server_id, name, kind }
+// MCP return: { widget_id, status, mcp_server_id, name, kind }
+```
+
+**Fit check:**
+- Renders a picker with installed servers + an "Add new" affordance.
+- Adding a new server may itself trigger an OAuth widget — **widgets can chain** by having one widget's resolution kick off the next. Worth noting; not blocking v1.
+- No secret material in the submit body (server config holds credentials, but those are written via the existing mcp-servers service which handles encryption).
+
+**Verdict:** the registry shape holds. The one refinement is generalizing "submit" → "resolve," accommodating OAuth-style callbacks. We bake that in from v1 by phrasing the abstraction as "the widget resolves" rather than "the widget is submitted via a single endpoint."
+
+---
+
+## 7. Phased delivery — concrete next-step PRs
+
+### PR 1: `feat(widgets): in-conversation widget primitive`
+
+Scope:
+- Add `'widget_request'` to `MessageType` (sqlite + postgres schemas + types).
+- Extend `appendSystemMessage` helper's `type` union to include `widget_request`.
+- Add `metadata.widget` shape to `Message['metadata']` type (typed via a discriminated union over `widget_type`).
+- New FeathersJS service `widget-submissions` registering `POST /widgets/:widget_id/submit` — handler dispatches by `widget_type` to a daemon-side registry (initially empty).
+- Daemon event bus: `widget:resolved` per-widget-id channel, plus per-session-room broadcast.
+- New MCP tool domain marker (`domain: 'widgets'` for `agor_search_tools`).
+- UI: `WidgetBlock` dispatcher component in MessageBlock that switches on `metadata.widget.widget_type`, plus a placeholder "Unknown widget type" fallback.
+- Daemon-restart handling: on startup, mark all `pending` widgets as `timed_out` and append a follow-up system message (mirror PR #1166).
+- Config: `widgets.default_timeout_ms` (default 600_000) in `~/.agor/config.yaml`.
+
+No widget types ship in PR 1. The framework is callable but produces no actual widgets yet. Tests cover the registry, the submit endpoint's auth/idempotency, and the WebSocket broadcast.
+
+**Estimated effort:** ~3-4 eng-days.
+
+### PR 2: `feat(widgets): env_vars widget`
+
+Scope:
+- Register `env_vars` widget type in the daemon registry: Zod schemas, `applySubmit` = thin shim around `users.patch`.
+- Register `agor_widgets_request_env_vars` MCP tool in `apps/agor-daemon/src/mcp/tools/widgets.ts`.
+- React component `EnvVarRequestWidget.tsx` (reuses form shape from `EnvVarEditor.tsx`).
+- Wire `widgetComponents['env_vars']` mapping on the UI.
+- Submit handler reuses existing env-var validation (`validateEnvVar`, `isEnvVarAllowed`, regex) and encryption (`encryptApiKey`) — zero net-new logic.
+- Confirmation event shape per §5.1.
+- Docs: `apps/agor-docs/pages/guide/in-conversation-widgets.mdx` (user-facing) with the env-var section as the canonical example.
+- Storybook story for the widget in all three states (pending, submitted, dismissed).
+
+**Estimated effort:** ~2-3 eng-days.
+
+### PR 3 (optional, validates extensibility): `feat(widgets): confirmation widget`
+
+Scope:
+- Register `confirmation` widget type (Zod schemas per §6.1).
+- React component with N option buttons; danger style for `style: 'danger'`.
+- MCP tool `agor_widgets_request_confirmation`.
+- **Critically:** updates `CLAUDE.md` / Claude's system prompt with guidance: "Use `agor_widgets_request_confirmation` for binary/multi-choice decisions instead of asking inline." This closes the gap left by disallowing `AskUserQuestion`.
+
+**Estimated effort:** ~1.5 eng-days. Mostly UX polish.
+
+### Sequencing
+
+PR 1 → PR 2 → (optional) PR 3. PR 2 cannot land before PR 1 (depends on the registry). PR 3 is independent of PR 2 — could swap order if confirmation is more urgent than env-var capture.
+
+---
+
+## 8. Risks and open questions
+
+| # | Risk / question | Mitigation |
+|---|---|---|
+| R1 | **HTTP timeout for the blocked MCP request.** A 10-min await over fetch will trip on infra timeouts. | Keep-alive whitespace heartbeats every 25s; configurable timeout; idempotent re-call by `widget_id` if the agent retries. |
+| R2 | **Daemon restart while a widget is pending** breaks the in-process await. | On startup, mark pending widgets as `timed_out`, append a follow-up system message (mirrors PR #1166). |
+| R3 | **Widget message persists forever in the transcript.** The *names* of submitted env vars are visible to anyone who can read the transcript. | Same surface as User Settings → Env Vars. One-line disclaimer on the widget. If sensitive, the user can dismiss and add via Settings. |
+| R4 | **Widget-version drift** when v2 changes a widget's submit schema. | `metadata.widget.schema_version: number` baked in from v1. UI's `WidgetBlock` renders old versions in a degraded read-only mode. |
+| R5 | **Dismissal UX.** Does the agent treat dismissal as "user said no, stop" or "user said not-now, try again later"? | Confirmation event includes `status: 'dismissed'`. Agent prompt guidance: "On dismissal, ask the user once whether they want to proceed without; do not re-request immediately." |
+| R6 | **Multi-user authz for submission.** Who can submit on behalf of whom? | §5.2 — submitter must match session creator or have `prompt`-tier worktree RBAC. Cross-user submit attributed in `result_meta.submitted_by`. |
+| R7 | **Logging leakage.** Submit handler must not log values. | Lint rule + explicit test in PR 2 (`expect(logs).not.toContain(value)`). |
+| R8 | **Agent uses chat (not the widget) to extract values** by phishing the user. | Widget copy: "Never paste values into chat — only into the form above." Out of scope for code mitigations. |
+| Q1 | **One generic `agor_widgets_request` tool vs. one tool per type?** | Recommended: one per type (§3.2). Typed contracts, better progressive discovery, better agent UX. |
+| Q2 | **Should widgets support a "value already exists" short-circuit?** E.g. agent asks for `HUBSPOT_API_KEY`, user already has it set globally → widget auto-resolves with status `already_present`. | **Recommended yes** for env-vars specifically (saves a user click). Daemon checks env-vars presence at request time and immediately resolves the widget if all requested names already exist in the user's scope. The agent gets `status: 'already_present', names_present: [...]` and can proceed without UI flicker. |
+| Q3 | **OAuth widget timeout** — OAuth flows can take minutes. Does the 10-min default suffice? | Per-widget-type override on `widget.timeout_ms` baked into the registry entry. OAuth defaults to 15 min. |
+
+---
+
+## 9. Coordination with adjacent work
+
+| Worktree / PR | Relationship |
+|---|---|
+| `fix-issue-1177-ask-user-question-hang` (merged as #1181) | **Disallowed AskUserQuestion.** PR 3 of this design (the confirmation widget) is the long-term replacement — it gives agents a structured way to ask the user inline that doesn't depend on the dead SDK feature. No code conflict; conceptual handoff. |
+| `design-notification-system` (PR #1135, open) | **Widgets are in-transcript, notifications are out-of-transcript.** No overlap. Worth a one-line cross-reference in both docs. |
+| `feat(artifacts)!: declarative format + TOFU consent flow` (PR #1147, merged) | **Shares UX language**, not architecture. Reuse the scope-selector copy and the markdown sanitizer; do not reuse `artifact_trust_grants` table. |
+| `system-message-on-daemon-restart` (PR #1166, merged) | **Direct reuse** of `appendSystemMessage` + the daemon-restart-marks-orphans pattern. |
+| `design-internal-llm-service` (in flight) | Adjacent (both are "app-invoked" patterns) but no direct integration. |
+| `improve-onboarding-openclaw-integration` / onboarding flows | **Primary consumer of v1.** Onboarding zone-triggers can now ask for env vars inline instead of redirecting to Settings. |
+
+---
+
+## 10. Open call (for Max)
+
+Decisions I'd like an explicit thumbs-up/down on before PR 1 lands:
+
+- **D1:** Message-row-as-state vs. separate `pending_widgets` table. Recommendation: message-row (§3.1). Add a table only when we need cross-session queries.
+- **D2:** One MCP tool per widget type vs. one generic tool. Recommendation: per type (§3.2).
+- **D3:** Default timeout: 10 min (matches `permission_request`)? Or longer for env-vars (user may walk away to fetch a key)?
+- **D4:** Q2 — auto-resolve `already_present` for env-vars at request time?
+- **D5:** Should PR 3 (confirmation widget) ship in the same release as PR 2, or be deferred? It validates the abstraction earliest if it ships together.
+
+---
+
+_References (file:line)_
+
+- `apps/agor-daemon/src/utils/append-system-message.ts:27-77` — helper to extend
+- `apps/agor-daemon/src/mcp/tools/worktrees.ts:59-95` — MCP tool registration template
+- `apps/agor-daemon/src/mcp/tools/search.ts:75-140` — progressive-discovery wiring
+- `apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx:256-294` — dispatch precedent (PermissionRequestBlock)
+- `apps/agor-ui/src/components/EnvVarEditor.tsx` — form shape to mirror
+- `packages/core/src/types/message.ts:33-41` — `MessageType` union to extend
+- `packages/core/src/db/encryption.ts` — `encryptApiKey` (do not reimplement)
+- `packages/core/src/config/env-validation.ts:30-90` — env-var validation (regex + blocklist)
+- `packages/executor/src/permissions/permission-service.ts:94-149` — pause/resume reference for the daemon-side await
+- `packages/executor/src/sdk-handlers/claude/constants.ts:33` — AskUserQuestion disallowed
+- `apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx` — scope-selector UX to mine

--- a/packages/core/src/config/env-locking.test.ts
+++ b/packages/core/src/config/env-locking.test.ts
@@ -125,23 +125,27 @@ describe('env-locking', () => {
     it('should prevent race conditions with multiple concurrent calls', async () => {
       const executionOrder: string[] = [];
 
+      // Per-user locks serialize same-user calls; different users run concurrently
+      // because process.env is a shared global. The invariant is that each user
+      // uses DISTINCT env var keys — two users sharing the same key name would
+      // require a global mutex (not implemented). Use unique keys here so
+      // concurrent execution can't stomp on each other.
       vi.mocked(resolverModule.resolveUserEnvironment)
-        .mockResolvedValueOnce({ USER_ID: 'user-1-value' })
-        .mockResolvedValueOnce({ USER_ID: 'user-2-value' });
+        .mockResolvedValueOnce({ USER_1_SPECIFIC_KEY: 'user-1-value' })
+        .mockResolvedValueOnce({ USER_2_SPECIFIC_KEY: 'user-2-value' });
 
       const fn1 = async () => {
         executionOrder.push('start-user1');
-        // Simulate some async work
         await new Promise((resolve) => setTimeout(resolve, 10));
         executionOrder.push('end-user1');
-        expect(process.env.USER_ID).toBe('user-1-value');
+        expect(process.env.USER_1_SPECIFIC_KEY).toBe('user-1-value');
       };
 
       const fn2 = async () => {
         executionOrder.push('start-user2');
         await new Promise((resolve) => setTimeout(resolve, 5));
         executionOrder.push('end-user2');
-        expect(process.env.USER_ID).toBe('user-2-value');
+        expect(process.env.USER_2_SPECIFIC_KEY).toBe('user-2-value');
       };
 
       // Execute both concurrently
@@ -155,6 +159,10 @@ describe('env-locking', () => {
       expect(executionOrder).toContain('end-user1');
       expect(executionOrder).toContain('start-user2');
       expect(executionOrder).toContain('end-user2');
+
+      // Both keys cleaned up after completion
+      expect(process.env.USER_1_SPECIFIC_KEY).toBeUndefined();
+      expect(process.env.USER_2_SPECIFIC_KEY).toBeUndefined();
     });
 
     it('should handle sequential calls to same user', async () => {

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -373,6 +373,7 @@ export const messages = pgTable(
         'input_request',
         'daemon_restart',
         'daemon_crash',
+        'widget_request',
       ],
     }).notNull(),
     role: text('role', {

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -379,6 +379,7 @@ export const messages = sqliteTable(
         'input_request',
         'daemon_restart',
         'daemon_crash',
+        'widget_request',
       ],
     }).notNull(),
     role: text('role', {

--- a/packages/core/src/types/config-services.ts
+++ b/packages/core/src/types/config-services.ts
@@ -120,7 +120,7 @@ export const DEFAULT_SERVICE_TIER: ServiceTier = 'on';
  * Used for conditional MCP tool registration.
  */
 export const SERVICE_GROUP_TO_MCP_DOMAINS: Partial<Record<ServiceGroupName, string[]>> = {
-  core: ['sessions'],
+  core: ['sessions', 'widgets'],
   worktrees: ['worktrees', 'environment'],
   repos: ['repos'],
   users: ['users'],

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -26,4 +26,5 @@ export * from './template';
 export * from './ui';
 export * from './user';
 export * from './utils';
+export * from './widget';
 export * from './worktree';

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MessageID, SessionID, TaskID } from './id';
+import type { WidgetMessageMetadata } from './widget';
 
 /**
  * Message role - who is speaking
@@ -38,7 +39,8 @@ export type MessageType =
   | 'permission_request'
   | 'input_request'
   | 'daemon_restart'
-  | 'daemon_crash';
+  | 'daemon_crash'
+  | 'widget_request';
 
 /**
  * Content block (for multi-modal messages)
@@ -254,6 +256,27 @@ export interface Message {
      * - undefined: Legacy message or source not tracked
      */
     source?: MessageSource;
+
+    /**
+     * Widget request state. Only populated on `type === 'widget_request'`
+     * messages. Discriminated by `widget_type`; see `types/widget.ts`.
+     */
+    widget?: WidgetMessageMetadata;
+
+    /**
+     * Marks the user-role message / task as having been authored by the
+     * daemon on behalf of the user, rather than typed by a human.
+     * Used by widget auto-resume prompts (see `widget_id`) and other
+     * system-injected prompts so the UI can label them appropriately.
+     */
+    system_authored?: boolean;
+
+    /**
+     * For system-authored tasks queued in response to widget resolution,
+     * the widget message that triggered them. Lets the UI link the queued
+     * prompt back to the originating widget for audit / debugging.
+     */
+    widget_id?: MessageID;
 
     /** Additional agent-specific fields */
     [key: string]: unknown;

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -1,5 +1,5 @@
 // src/types/task.ts
-import type { SessionID, TaskID } from './id';
+import type { MessageID, SessionID, TaskID } from './id';
 import type { MessageSource } from './message';
 import type { ReportPath, ReportTemplate } from './report';
 
@@ -42,6 +42,17 @@ export interface TaskMetadata {
   queued_by_user_id?: string;
   child_session_id?: SessionID;
   child_task_id?: TaskID;
+  /**
+   * Marks a task whose prompt was authored by the daemon (not typed by a
+   * human). Used by widget auto-resume so the UI can label the queued
+   * prompt appropriately.
+   */
+  system_authored?: boolean;
+  /**
+   * For tasks queued by widget resolution, the widget message that fired
+   * this prompt. Links the task back to the originating widget for audit.
+   */
+  widget_id?: MessageID;
 }
 
 /**

--- a/packages/core/src/types/widget.ts
+++ b/packages/core/src/types/widget.ts
@@ -1,0 +1,73 @@
+/**
+ * Widget Types
+ *
+ * In-conversation interactive widgets — small UI primitives that agents
+ * render inline in a session's transcript to capture user input without that
+ * input ever entering the LLM's context.
+ *
+ * Architecture lives in `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
+ * The MCP tool fires and returns; the widget message persists in the
+ * transcript and is resolved when the user submits/dismisses via the
+ * `widget-submissions` daemon service.
+ */
+
+import type { MessageID, UserID } from './id';
+
+/** Lifecycle status of a widget request. */
+export type WidgetStatus = 'pending' | 'submitted' | 'dismissed' | 'already_present';
+
+/**
+ * Widget type discriminant. PR 1 ships the framework with no concrete
+ * widget types registered; later PRs add `'env_vars'`, `'confirmation'`, etc.
+ * String widening keeps the framework forward-compatible with newer clients
+ * registering widgets the daemon doesn't yet know about — the UI dispatcher
+ * falls back to an "Unknown widget type" placeholder.
+ */
+export type WidgetType = string;
+
+/**
+ * Shape stored at `messages.metadata.widget` for `type === 'widget_request'`
+ * rows. The row IS the widget — single source of truth for transcript
+ * rendering, WebSocket events, and the submit-handler's state machine.
+ *
+ * Discriminated over `widget_type` so each registered widget can refine
+ * `params` and `result_meta` to its own shape. `schema_version` is baked in
+ * from v1 so future widget evolutions can be detected client-side.
+ *
+ * `result_meta` is the only payload that flows back into the agent's context
+ * (via the auto-resume task prompt). It MUST NOT contain any submitted secret
+ * values — see §5.1 of the design doc.
+ */
+export interface WidgetMessageMetadata<
+  TType extends WidgetType = WidgetType,
+  TParams = unknown,
+  TResultMeta = unknown,
+> {
+  /** Discriminant identifying which widget type this is. */
+  widget_type: TType;
+  /** Stable widget id; equals the host message's `message_id`. */
+  widget_id: MessageID;
+  /** Per-widget-type version of `params`/`submit`/`result_meta`. */
+  schema_version: number;
+  /** Agent-provided parameters that drive widget rendering. NEVER contains user-supplied values. */
+  params: TParams;
+  /** Current lifecycle state. */
+  status: WidgetStatus;
+  /** ISO 8601 timestamp the agent requested the widget. */
+  requested_at: string;
+  /** ISO 8601 timestamp of submit/dismiss/short-circuit. Unset while pending. */
+  resolved_at?: string;
+  /**
+   * Sanitized post-resolution data — names, scope choices, option labels, etc.
+   * NEVER includes secret values. Used to build the auto-resume prompt.
+   */
+  result_meta?: TResultMeta;
+  /** User who resolved the widget (may differ from session creator under prompt-tier RBAC). */
+  submitted_by?: UserID;
+  /**
+   * Whether to auto-queue a system-authored prompt back into the agent on
+   * resolution. Per design D6 defaults to `true`; agents opt-out by passing
+   * `auto_resume: false` to the MCP tool.
+   */
+  auto_resume?: boolean;
+}


### PR DESCRIPTION
## Summary

Adds a general-purpose **in-conversation interactive widget primitive** so agents can render small interactive UI inline in the transcript, with the v1 motivating widget — `env_vars` — that captures secrets directly from the user without the value ever entering the LLM's context.

Design doc: [`docs/internal/in-conversation-widgets-design-2026-05-19.md`](../blob/design-in-conversation-widget-primitive/docs/internal/in-conversation-widgets-design-2026-05-19.md).

User-facing guide: [`apps/agor-docs/pages/guide/in-conversation-widgets.mdx`](../blob/design-in-conversation-widget-primitive/apps/agor-docs/pages/guide/in-conversation-widgets.mdx).

## Motivating use case

During onboarding (and beyond) the agent often needs an env var — `HUBSPOT_API_KEY`, `GITHUB_TOKEN`, etc. — before it can do its work. Today: "please go to User Settings → Env Vars and add X." User context-switches, momentum dies.

**Now:** the agent calls `agor_widgets_request_env_vars({ names, reason })`. A compact form pops into the transcript. The user types and submits inline. The secret flows **browser → daemon** (NOT through the model). A sanitized system-authored prompt (`[Agor] User submitted HUBSPOT_API_KEY (scope: global). Retry the operation that needed it.`) auto-queues into the agent's next turn so it can continue.

## Hard property: secret never enters LLM context

§5.1 of the design doc enumerates every code path. The MCP tool returns `{widget_id, status: 'requested'}` immediately; the message row, the WebSocket event, the auto-resume task prompt, and the agent's next turn carry only **names** and **status** — never values. The values exist only on (1) the browser→daemon submit POST and (2) the standard encrypted env-var write path.

## Architecture (decoupled / fire-and-forget)

```
Agent ──MCP─▶ Daemon: insert widget_request message
       ◀──── { widget_id, status: requested }
       (ends turn; session goes idle)

User types value → POST /widgets/:id/submit → daemon:
  1. users.patch (encrypts + stores)
  2. messages.patch (status → submitted)
  3. tasks.create (system-authored auto-resume prompt — names only)
  4. widget:resolved broadcast

Agent picks up the auto-resume prompt as a normal user-role turn.
```

- **No executor pause / HTTP long-poll** — the design rejected pause/resume after we saw `AskUserQuestion` get killed for hanging in async contexts (#1177). Decoupled flow works in Slack/gateway sessions for free.
- **Widget message-row IS the durable state.** `widget_id == message_id`. Survives daemon restarts, executor exits, hours-long user gaps.
- **Auto-resume task uses the existing "Never lose a prompt" queue (#1068).** The agent sees an ordinary user-role message; idle sessions kick off immediately, busy sessions queue it.

## What ships

### Framework (primitive)
- New `MessageType: 'widget_request'`, `WidgetMessageMetadata` (typed discriminated union with `schema_version` for forward-compat), Message/Task metadata extensions
- Daemon widget registry: `WidgetRegistryEntry<TParams, TSubmit, TResultMeta>` with `paramsSchema`, `submitSchema`, `applySubmit`, `buildResultMeta`, `buildAutoResumePrompt`, `buildDismissedPrompt`
- `POST /widgets/:widget_id/submit` and `POST /widgets/:widget_id/dismiss` — auth: session creator OR `prompt`-tier worktree RBAC; idempotent (status must be `pending`)
- `widget:resolved` event broadcast on per-session Feathers room
- New `widgets` MCP domain for `agor_search_tools`
- UI `WidgetBlock` dispatcher with forward-compat "unknown widget type" fallback (lets newer daemons ship widgets older clients can still render gracefully)

### `env_vars` widget (first concrete type)
- `agor_widgets_request_env_vars` MCP tool — fire-and-forget
- Submit handler reuses the existing `users.patch` path (existing AES-256-GCM encryption, blocklist, `^[A-Z_][A-Z0-9_]*$` regex — zero net-new credential-handling code)
- `already_present` short-circuit: if the user already has all requested names in global scope, skip the form entirely and auto-resume immediately
- Compact UI: title row · optional reason · 🔒 NAME · password input · `Scope: [Global ▾]` · Dismiss · Save. Always defaults to Global. Scope is a user-only choice (the agent has no `default_scope` knob).
- Three one-line terminal states (submitted / dismissed / already_present)
- 6 Storybook stories covering all states

### Docs
- Internal design doc with TL;DR, prior art audit, architecture, security path enumeration, extensibility validation for 3 future widget types (confirmation / OAuth / MCP-server picker), risks, and resolved decisions
- User-facing guide linked from sessions docs

### Follow-up (separate PR)
- Confirmation widget (`agor_widgets_request_confirmation`) — fills the gap left by disallowing `AskUserQuestion` (#1181). Doesn't depend on env_vars; deliberately split out to keep this PR focused on the motivating use case.

## Tests

- **Daemon:** 705 pass / 30 skipped (48 new in widget-area: registry, submission state machine, auth gating, idempotency, registry dispatch, auto-resume queueing, `auto_resume: false`, dismiss path, fallback for unknown types, secret-doesn't-leak-into-logs guard, Zod schema enforcement, `widget:resolved` broadcast, host-task lookup edge cases)
- **UI:** 151 pass (8 new for `EnvVarRequestWidget`: per-name inputs, save-disabled-until-all-filled, POST body shape, dismiss, retry after failure, three terminal-state summaries)
- **Core:** 2298 pass

`pnpm check` green; `pnpm typecheck` clean; biome formatter clean.

## Bugs found and fixed during live testing

1. **`fix(widgets): bind widget_request message to host task_id`** — the transcript renderer queries messages by `task_id`; widget messages were being written with no `task_id` and rendered nowhere despite existing in the DB. Fix: look up the host task and pass it to `appendSystemMessage`.
2. **`fix(widgets): filter active tasks in-process to find the host task`** — `TasksService.find()` short-circuits on `session_id` before applying status/sort filters; my first fix's `{ session_id, status: RUNNING, $sort }` query was silently returning the oldest task. Fix: fetch session tasks once, filter + sort in-process.
3. **`fix(widgets): pass auth params to users.patch from env_vars applySubmit`** — the `applySubmit` handler called `users.patch` with no `params`, so the auth hook saw `params.user = undefined` and threw 403. Fix: thread the submitter's `{user_id, role}` through `WidgetSubmitCtx` and pass them to the patch call.

## Decisions resolved with Max (from design doc §10)

- **D1:** Message-row-as-state vs. separate `pending_widgets` table → **row**
- **D2:** One MCP tool per widget type vs. one generic → **per type**
- **D3:** Default timeout → **no timeout** (decoupled flow doesn't need one)
- **D4:** `already_present` short-circuit for env-vars → **yes**
- **D5:** Resolution model → **decoupled fire-and-forget** (not pause/resume)
- **D6:** `auto_resume` default → **true**, dismissal also auto-queues with explicit don't-immediately-re-ask framing
- **D7:** Confirmation widget in this PR? → **no, separate follow-up PR**

## Test plan

- [ ] Max reviews the design doc + user-facing guide
- [ ] Live test: agent calls `agor_widgets_request_env_vars`, widget renders inline, value saves, agent resumes via the auto-resume prompt
- [ ] Multi-var case (agent requests 2-3 vars at once)
- [ ] Dismiss path (agent receives the don't-re-request framing)
- [ ] `already_present` short-circuit fires when the var is already set globally
- [ ] Confirm `Save` and `Dismiss` actions land cleanly via the toast on failure (no inline error chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
