### PR TITLE
daemon: actually use execution.executor_command_template

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -63,7 +63,7 @@ import { configureChannels, createSocketIOConfig } from './setup/socketio.js';
 import { configureSwagger } from './setup/swagger.js';
 import { loadDaemonVersion } from './setup/version.js';
 import { startup } from './startup.js';
-import { configureDaemonUrl } from './utils/spawn-executor.js';
+import { configureDaemonUrl, configureExecutor } from './utils/spawn-executor.js';
 import { registerAllWidgets } from './widgets/index.js';
 
 // Load daemon version at startup
@@ -235,6 +235,13 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
 
   const daemonUrl = config.daemon?.public_url || `http://localhost:${DAEMON_PORT}`;
   configureDaemonUrl(daemonUrl);
+
+  // Wire the configured executor command template + impersonation user so the
+  // ~10 spawnExecutorFireAndForget() call sites pick them up without needing
+  // their own config-threading code. Local-subprocess remains the default
+  // when execution.executor_command_template is unset (no behavior change
+  // for existing deployments).
+  configureExecutor(config.execution);
   console.log(`[Executor] Daemon URL configured: ${daemonUrl}`);
 
   initializeAnthropicApiKey(config, process.env.ANTHROPIC_API_KEY);

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -242,7 +242,6 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // when execution.executor_command_template is unset (no behavior change
   // for existing deployments).
   configureExecutor(config.execution);
-  console.log(`[Executor] Daemon URL configured: ${daemonUrl}`);
 
   initializeAnthropicApiKey(config, process.env.ANTHROPIC_API_KEY);
   initializeAnthropicAuthToken(config, process.env.ANTHROPIC_AUTH_TOKEN);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -90,6 +90,7 @@ import {
   getSessionFilePath,
 } from './utils/session-state.js';
 import { pullIfNeeded, pushAsync } from './utils/session-state-hooks.js';
+import { spawnExecutor } from './utils/spawn-executor.js';
 
 /**
  * Interface for dependencies needed by service registration.
@@ -533,10 +534,6 @@ function createExecuteHandler(
     // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type varies by context
     params: any
   ) => {
-    const { spawn } = await import('node:child_process');
-    const path = await import('node:path');
-    const { fileURLToPath } = await import('node:url');
-
     const session = await sessionsService.get(sessionId, params);
     if (!session) {
       throw new Error(`Session ${sessionId} not found`);
@@ -584,32 +581,12 @@ function createExecuteHandler(
       }
     }
 
-    // Find executor binary
-    const dirname =
-      typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
-    const { existsSync } = await import('node:fs');
-    const possiblePaths = [
-      path.join(dirname, '../executor/cli.js'),
-      path.join(dirname, '../../../packages/executor/bin/agor-executor'),
-      path.join(dirname, '../../../packages/executor/dist/cli.js'),
-    ];
-    const executorPath = possiblePaths.find((p) => existsSync(p));
-    if (!executorPath) {
-      throw new Error(
-        `Executor binary not found. Tried:\n${possiblePaths.map((p) => `  - ${p}`).join('\n')}`
-      );
-    }
-    console.log(`[Daemon] Using executor at: ${executorPath}`);
-
     // Determine Unix user for executor
     const {
       resolveUnixUserForImpersonation,
       validateResolvedUnixUser,
       UnixUserNotFoundError,
-      buildSpawnArgs,
       getHomedirFromUsername,
-      prepareImpersonationEnv,
-      attachEnvFileCleanup,
     } = await import('@agor/core/unix');
 
     const unixUserMode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
@@ -740,28 +717,6 @@ function createExecuteHandler(
       },
     };
 
-    // Route secret-looking env vars through an on-disk env file owned by the
-    // target user (mode 0600) so API keys/tokens never appear in argv.
-    const prepared = executorUnixUser
-      ? prepareImpersonationEnv({ asUser: executorUnixUser, env: executorEnv })
-      : { inlineEnv: undefined, envFilePath: undefined };
-
-    const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
-      asUser: executorUnixUser || undefined,
-      env: executorUnixUser ? prepared.inlineEnv : undefined,
-      envFilePath: prepared.envFilePath,
-    });
-
-    if (executorUnixUser) {
-      console.log(
-        `[Daemon] Spawning executor as user=${executorUnixUser}${
-          prepared.envFilePath ? ' (secrets in env-file)' : ''
-        }`
-      );
-    } else {
-      console.log(`[Daemon] Spawning executor as current user (no impersonation)`);
-    }
-
     // Stateless FS mode: resolve executor home dir for session file path
     const executorHomeDir = executorUnixUser ? getHomedirFromUsername(executorUnixUser) : undefined;
 
@@ -785,153 +740,142 @@ function createExecuteHandler(
       }
     }
 
-    const executorProcess = spawn(cmd, args, {
+    const logPrefix = `[Executor ${shortId(sessionId)}]`;
+
+    spawnExecutor(executorPayload, {
       cwd,
-      env: executorUnixUser ? undefined : executorEnv,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    // Safety-net cleanup for the env file. The inner bash script `rm -f`s
-    // the file before exec in the normal path, so this only fires if sudo
-    // or bash failed to launch at all, or `set -eu` aborted the source
-    // step. Uses sudo when asUser is set so it works under sticky /tmp.
-    attachEnvFileCleanup(executorProcess, {
-      envFilePath: prepared.envFilePath,
       asUser: executorUnixUser || undefined,
-    });
+      preparedEnv: executorEnv,
+      logPrefix,
+      templateVariables: {
+        session_id: sessionId,
+        task_id: taskId,
+        unix_user: executorUnixUser || undefined,
+      },
+      onSpawn: (child) => {
+        if (child.pid) {
+          trackExecutorProcess(sessionId, child.pid);
+          console.log(`${logPrefix} PID: ${child.pid}`);
+        }
+      },
+      onExit: async (code) => {
+        console.log(`${logPrefix} Exited with code ${code}`);
+        untrackExecutorProcess(sessionId);
 
-    if (executorProcess.pid) {
-      trackExecutorProcess(sessionId, executorProcess.pid);
-      console.log(`[Executor ${shortId(sessionId)}] PID: ${executorProcess.pid}`);
-    }
+        // Safety net: check if task is still running
+        try {
+          const currentSession = await app.service('sessions').get(sessionId, params);
+          const latestTaskId = currentSession.tasks?.[currentSession.tasks.length - 1];
 
-    executorProcess.stdin?.write(JSON.stringify(executorPayload));
-    executorProcess.stdin?.end();
+          if (latestTaskId && latestTaskId !== taskId) {
+            console.log(
+              `⏭️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}), skipping safety net`
+            );
+          } else if (
+            currentSession.status === SessionStatus.RUNNING ||
+            currentSession.status === SessionStatus.AWAITING_PERMISSION ||
+            currentSession.status === SessionStatus.AWAITING_INPUT ||
+            currentSession.status === SessionStatus.STOPPING ||
+            currentSession.status === SessionStatus.TIMED_OUT
+          ) {
+            try {
+              const currentTask = await app.service('tasks').get(taskId, params);
+              const isTaskStillActive =
+                currentTask.status === TaskStatus.RUNNING ||
+                currentTask.status === 'awaiting_permission' ||
+                currentTask.status === 'awaiting_input' ||
+                currentTask.status === 'stopping' ||
+                currentTask.status === 'timed_out';
 
-    executorProcess.stdout?.on('data', (data) => {
-      console.log(`[Executor ${shortId(sessionId)}] ${data.toString().trim()}`);
-    });
-    executorProcess.stderr?.on('data', (data) => {
-      console.error(`[Executor ${shortId(sessionId)}] ${data.toString().trim()}`);
-    });
-
-    executorProcess.on('exit', async (code) => {
-      console.log(`[Executor ${shortId(sessionId)}] Exited with code ${code}`);
-      untrackExecutorProcess(sessionId);
-
-      // Safety net: check if task is still running
-      try {
-        const currentSession = await app.service('sessions').get(sessionId, params);
-        const latestTaskId = currentSession.tasks?.[currentSession.tasks.length - 1];
-
-        if (latestTaskId && latestTaskId !== taskId) {
-          console.log(
-            `⏭️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}), skipping safety net`
-          );
-        } else if (
-          currentSession.status === SessionStatus.RUNNING ||
-          currentSession.status === SessionStatus.AWAITING_PERMISSION ||
-          currentSession.status === SessionStatus.AWAITING_INPUT ||
-          currentSession.status === SessionStatus.STOPPING ||
-          currentSession.status === SessionStatus.TIMED_OUT
-        ) {
-          try {
-            const currentTask = await app.service('tasks').get(taskId, params);
-            const isTaskStillActive =
-              currentTask.status === TaskStatus.RUNNING ||
-              currentTask.status === 'awaiting_permission' ||
-              currentTask.status === 'awaiting_input' ||
-              currentTask.status === 'stopping' ||
-              currentTask.status === 'timed_out';
-
-            if (isTaskStillActive) {
-              await app.service('tasks').patch(taskId, { status: TaskStatus.FAILED }, params);
-              console.log(
-                `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
-              );
-            } else {
-              console.log(
-                `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask.status}, but session still ${currentSession.status} — repairing session state`
+              if (isTaskStillActive) {
+                await app.service('tasks').patch(taskId, { status: TaskStatus.FAILED }, params);
+                console.log(
+                  `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
+                );
+              } else {
+                console.log(
+                  `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask.status}, but session still ${currentSession.status} — repairing session state`
+                );
+                await app
+                  .service('sessions')
+                  .patch(sessionId, { status: SessionStatus.IDLE, ready_for_prompt: true }, params);
+              }
+            } catch (taskError) {
+              console.error(
+                `⚠️  [Executor] Failed to mark task ${shortId(taskId)} as FAILED, falling back to session IDLE update:`,
+                taskError
               );
               await app
                 .service('sessions')
                 .patch(sessionId, { status: SessionStatus.IDLE, ready_for_prompt: true }, params);
-            }
-          } catch (taskError) {
-            console.error(
-              `⚠️  [Executor] Failed to mark task ${shortId(taskId)} as FAILED, falling back to session IDLE update:`,
-              taskError
-            );
-            await app
-              .service('sessions')
-              .patch(sessionId, { status: SessionStatus.IDLE, ready_for_prompt: true }, params);
-            console.log(
-              `✅ [Executor] Session ${shortId(sessionId)} status updated to IDLE after executor exit (was: ${currentSession.status})`
-            );
-          }
-        } else {
-          console.log(
-            `ℹ️  [Executor] Session ${shortId(sessionId)} already in ${currentSession.status} state, skipping IDLE update`
-          );
-        }
-      } catch (error) {
-        console.error(`❌ [Executor] Failed to handle executor exit:`, error);
-      }
-
-      // Stateless FS mode: serialize session file to DB after executor exits
-      if (config.execution?.stateless_fs_mode) {
-        try {
-          // Re-fetch session to get sdk_session_id (may have been set during execution)
-          const freshSession = await app.service('sessions').get(sessionId, params);
-          if (freshSession.sdk_session_id) {
-            pushAsync({
-              db,
-              sessionId,
-              worktreeId: freshSession.worktree_id,
-              taskId,
-              sdkSessionId: freshSession.sdk_session_id,
-              worktreePath: cwd,
-              tool: freshSession.agentic_tool,
-              executorHomeDir,
-            });
-
-            // Also compute and write session_md5 to the task record
-            try {
-              let filePath: string;
-              if (freshSession.agentic_tool === 'codex') {
-                const codexHome = getCodexHome(executorHomeDir);
-                const found = await findCodexSessionFile(codexHome, freshSession.sdk_session_id);
-                filePath = found || '';
-              } else {
-                filePath = getSessionFilePath(
-                  freshSession.agentic_tool,
-                  cwd,
-                  freshSession.sdk_session_id,
-                  executorHomeDir
-                );
-              }
-              if (filePath) {
-                const md5 = await computeFileHash(filePath);
-                if (md5) {
-                  await app.service('tasks').patch(taskId, { session_md5: md5 }, params);
-                }
-              }
-            } catch (md5Err) {
-              console.error(
-                '[stateless-fs] Failed to write session_md5 to task:',
-                md5Err instanceof Error ? md5Err.message : md5Err
+              console.log(
+                `✅ [Executor] Session ${shortId(sessionId)} status updated to IDLE after executor exit (was: ${currentSession.status})`
               );
             }
+          } else {
+            console.log(
+              `ℹ️  [Executor] Session ${shortId(sessionId)} already in ${currentSession.status} state, skipping IDLE update`
+            );
           }
-        } catch (pushErr) {
-          console.error(
-            '[stateless-fs] pushAsync setup failed:',
-            pushErr instanceof Error ? pushErr.message : pushErr
-          );
+        } catch (error) {
+          console.error(`❌ [Executor] Failed to handle executor exit:`, error);
         }
-      }
 
-      appWithExecutor.sessionTokenService?.revokeToken(sessionToken);
+        // Stateless FS mode: serialize session file to DB after executor exits
+        if (config.execution?.stateless_fs_mode) {
+          try {
+            // Re-fetch session to get sdk_session_id (may have been set during execution)
+            const freshSession = await app.service('sessions').get(sessionId, params);
+            if (freshSession.sdk_session_id) {
+              pushAsync({
+                db,
+                sessionId,
+                worktreeId: freshSession.worktree_id,
+                taskId,
+                sdkSessionId: freshSession.sdk_session_id,
+                worktreePath: cwd,
+                tool: freshSession.agentic_tool,
+                executorHomeDir,
+              });
+
+              // Also compute and write session_md5 to the task record
+              try {
+                let filePath: string;
+                if (freshSession.agentic_tool === 'codex') {
+                  const codexHome = getCodexHome(executorHomeDir);
+                  const found = await findCodexSessionFile(codexHome, freshSession.sdk_session_id);
+                  filePath = found || '';
+                } else {
+                  filePath = getSessionFilePath(
+                    freshSession.agentic_tool,
+                    cwd,
+                    freshSession.sdk_session_id,
+                    executorHomeDir
+                  );
+                }
+                if (filePath) {
+                  const md5 = await computeFileHash(filePath);
+                  if (md5) {
+                    await app.service('tasks').patch(taskId, { session_md5: md5 }, params);
+                  }
+                }
+              } catch (md5Err) {
+                console.error(
+                  '[stateless-fs] Failed to write session_md5 to task:',
+                  md5Err instanceof Error ? md5Err.message : md5Err
+                );
+              }
+            }
+          } catch (pushErr) {
+            console.error(
+              '[stateless-fs] pushAsync setup failed:',
+              pushErr instanceof Error ? pushErr.message : pushErr
+            );
+          }
+        }
+
+        appWithExecutor.sessionTokenService?.revokeToken(sessionToken);
+      },
     });
 
     return {

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from 'node:events';
+import { Writable } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock('@agor/core/unix', () => ({
+  attachEnvFileCleanup: vi.fn(),
+  buildSpawnArgs: vi.fn(),
+  isSecretEnvKey: vi.fn(),
+  prepareImpersonationEnv: vi.fn(),
+}));
+
+vi.mock('./build-resolved-config-slice.js', () => ({
+  withResolvedConfig: (payload: Record<string, unknown>) => ({
+    ...payload,
+    resolvedConfig: {},
+  }),
+}));
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdin: Writable;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    written: string;
+  };
+  proc.written = '';
+  proc.stdin = new Writable({
+    write(chunk, _encoding, callback) {
+      proc.written += chunk.toString();
+      callback();
+    },
+  });
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
+describe('configured executor spawning', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    spawnMock.mockReset();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { configureExecutor } = await import('./spawn-executor');
+    configureExecutor(null);
+  });
+
+  it('uses execution.executor_command_template configured at startup', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { configureExecutor, spawnExecutor } = await import('./spawn-executor');
+
+    configureExecutor({
+      executor_command_template: 'kubectl run executor-{task_id} --user {unix_user} -- {command}',
+      executor_unix_user: 'agor-exec',
+    });
+
+    spawnExecutor({ command: 'prompt' }, { logPrefix: '[test]' });
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      [
+        '-c',
+        expect.stringMatching(/^kubectl run executor-[0-9a-f]{8} --user agor-exec -- prompt$/),
+      ],
+      { stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    expect(JSON.parse(proc.written)).toMatchObject({
+      command: 'prompt',
+      resolvedConfig: expect.any(Object),
+    });
+  });
+
+  it('lets explicit spawn options override configured defaults', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { configureExecutor, spawnExecutor } = await import('./spawn-executor');
+
+    configureExecutor({
+      executor_command_template: 'configured {unix_user} {command}',
+      executor_unix_user: 'configured-user',
+    });
+
+    spawnExecutor(
+      { command: 'git.clone' },
+      {
+        executorCommandTemplate: 'explicit {unix_user} {command}',
+        asUser: 'explicit-user',
+      }
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'explicit explicit-user git.clone'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  });
+
+  it('calls onExit for templated spawns', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const onExit = vi.fn();
+    const { configureExecutor, spawnExecutor } = await import('./spawn-executor');
+
+    configureExecutor({ executor_command_template: 'echo {command}' });
+    spawnExecutor({ command: 'git.clone' }, { onExit });
+
+    proc.emit('exit', 17);
+
+    expect(onExit).toHaveBeenCalledWith(17);
+  });
+
+  it('keeps createConfiguredSpawner isolated from module-level defaults', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { configureExecutor, createConfiguredSpawner } = await import('./spawn-executor');
+
+    configureExecutor({
+      executor_command_template: 'global {command}',
+      executor_unix_user: 'global-user',
+    });
+    const injectedSpawner = createConfiguredSpawner({
+      executor_command_template: 'injected {unix_user} {command}',
+      executor_unix_user: 'injected-user',
+    });
+
+    injectedSpawner({ command: 'prompt' });
+
+    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'injected injected-user prompt'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  });
+});

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -161,6 +161,37 @@ export interface SpawnExecutorOptions {
    * Used to clean up resources when executor terminates.
    */
   onExit?: (code: number | null) => void;
+
+  /**
+   * Callback fired immediately after the child process is spawned, before
+   * stdin is written. Receives the ChildProcess so callers can track its
+   * pid (e.g. for /sessions/:id/stop), wire additional event listeners, or
+   * attach custom cleanup. Called for both local and templated spawn paths.
+   */
+  onSpawn?: (child: import('node:child_process').ChildProcess) => void;
+
+  /**
+   * Pre-curated environment for the executor process. When set, the local-
+   * subprocess path uses this verbatim instead of building its own
+   * essentialEnv (which curates down to a hardcoded set of API-key vars).
+   *
+   * Use this when the caller has already assembled an env that includes
+   * downstream-specific values (gateway env vars, scoped credentials,
+   * DAEMON_URL, …) that the built-in curation would drop. Ignored by the
+   * templated spawn path (the template controls its own env).
+   */
+  preparedEnv?: Record<string, string>;
+
+  /**
+   * Pre-written impersonation env file (mode 0600, owned by `asUser`).
+   * When set, the local-subprocess path uses this path verbatim instead of
+   * calling prepareImpersonationEnv() itself. Useful when the caller has
+   * already prepared an env file with a different env mix than spawn-
+   * executor's defaults would produce.
+   *
+   * Only applies when `asUser` is set. Ignored by the templated path.
+   */
+  preparedEnvFilePath?: string;
 }
 
 /**
@@ -322,6 +353,9 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     env = process.env as Record<string, string>,
     logPrefix = '[Executor]',
     asUser: rawAsUser,
+    onSpawn,
+    preparedEnv,
+    preparedEnvFilePath,
   } = options;
   const asUser = rawAsUser || undefined;
 
@@ -331,37 +365,48 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   // `resolvedConfig` (see buildResolvedConfigSlice).
   const daemonUrl = getDaemonUrl();
 
-  // When impersonating, pass minimal env vars and let sudo set HOME correctly
-  const essentialEnv: Record<string, string> = asUser
-    ? Object.fromEntries(
-        Object.entries({
-          DAEMON_URL: daemonUrl,
-          PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
-          NODE_ENV: env.NODE_ENV,
-          // HOME: not set - sudo will set it to the target user's home directory
-          ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
-          ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
-          ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
-          CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
-          OPENAI_API_KEY: env.OPENAI_API_KEY,
-          OPENAI_BASE_URL: env.OPENAI_BASE_URL,
-          GEMINI_API_KEY: env.GEMINI_API_KEY,
-          GOOGLE_API_KEY: env.GOOGLE_API_KEY,
-          // Forward git hardening pairs across the sudo boundary (sudoers
-          // env_keep is the belt; this is the suspenders for this path).
-          GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
-        }).filter(([_, v]) => v !== undefined)
-      )
-    : { ...env, DAEMON_URL: daemonUrl };
-
-  const envWithDaemonUrl = essentialEnv;
+  // When impersonating, pass minimal env vars and let sudo set HOME correctly.
+  // If the caller supplied a pre-curated env (preparedEnv), use it verbatim
+  // (still ensuring DAEMON_URL is present) instead of the hardcoded curation.
+  const envWithDaemonUrl: Record<string, string> = preparedEnv
+    ? { DAEMON_URL: daemonUrl, ...preparedEnv }
+    : asUser
+      ? Object.fromEntries(
+          Object.entries({
+            DAEMON_URL: daemonUrl,
+            PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
+            NODE_ENV: env.NODE_ENV,
+            // HOME: not set - sudo will set it to the target user's home directory
+            ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+            ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
+            ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
+            CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
+            OPENAI_API_KEY: env.OPENAI_API_KEY,
+            OPENAI_BASE_URL: env.OPENAI_BASE_URL,
+            GEMINI_API_KEY: env.GEMINI_API_KEY,
+            GOOGLE_API_KEY: env.GOOGLE_API_KEY,
+            // Forward git hardening pairs across the sudo boundary (sudoers
+            // env_keep is the belt; this is the suspenders for this path).
+            GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
+          }).filter(([_, v]) => v !== undefined)
+        )
+      : { ...env, DAEMON_URL: daemonUrl };
 
   // Route secret-looking env vars through an on-disk env file owned by the
   // target user (mode 0600). This keeps API keys/tokens out of argv and out
   // of /proc/<pid>/cmdline. Non-secret vars (PATH, DAEMON_URL, NODE_ENV)
   // are still inlined for simplicity.
+  // If the caller already wrote an env file (preparedEnvFilePath), skip the
+  // prepareImpersonationEnv() call and use the pre-written file directly.
   const prepared = asUser
-    ? prepareImpersonationEnv({ asUser, env: envWithDaemonUrl })
+    ? preparedEnvFilePath
+      ? {
+          inlineEnv: Object.fromEntries(
+            Object.entries(envWithDaemonUrl).filter(([k]) => !isSecretEnvKey(k))
+          ),
+          envFilePath: preparedEnvFilePath,
+        }
+      : prepareImpersonationEnv({ asUser, env: envWithDaemonUrl })
     : { inlineEnv: undefined, envFilePath: undefined };
 
   // Build spawn command - handles impersonation via sudo -u when asUser is set
@@ -420,6 +465,10 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   // uses `sudo -u <asUser> rm -f` so it works under sticky /tmp.
   attachEnvFileCleanup(executorProcess, { envFilePath: prepared.envFilePath, asUser });
 
+  // Notify caller that the process is live (before stdin is written so the
+  // caller can attach additional listeners without racing against data).
+  onSpawn?.(executorProcess);
+
   // Log if process fails to spawn
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
@@ -477,6 +526,9 @@ function spawnExecutorWithTemplate(
   const executorProcess = spawn('sh', ['-c', command], {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+
+  // Notify caller that the process is live (before stdin is written).
+  options.onSpawn?.(executorProcess);
 
   // Log stdout in real-time
   executorProcess.stdout?.on('data', (data) => {

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -21,7 +21,7 @@
  * argv / /proc/<pid>/cmdline.
  */
 
-import { spawn } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -35,47 +35,17 @@ import {
 import jwt from 'jsonwebtoken';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
 
-/**
- * Module-level daemon URL configuration.
- * Set once at daemon startup via configureDaemonUrl().
- * Used by getDaemonUrl() for all executor payloads.
- */
 let configuredDaemonUrl: string | null = null;
 
-/**
- * Configure the daemon URL for executor payloads.
- * Call this once at daemon startup.
- *
- * @param url - The URL executors should use to reach the daemon
- *              (e.g., "http://agor-daemon.agor.svc.cluster.local:3030" for k8s)
- */
+/** Set the daemon URL for executor payloads. Call once at daemon startup. */
 export function configureDaemonUrl(url: string): void {
   configuredDaemonUrl = url;
   console.log(`[Executor] Daemon URL configured: ${url}`);
 }
 
-/**
- * Module-level executor spawn defaults (template + impersonation user).
- * Set once at daemon startup via configureExecutor().
- *
- * Used as the default by spawnExecutor() so call sites don't need to thread
- * `executor_command_template` / `executor_unix_user` through every layer.
- * Pre-existing call sites that pass `executorCommandTemplate` or `asUser`
- * explicitly still win — this only kicks in when the option is omitted.
- *
- * Without this, the `execution.executor_command_template` config field was
- * silently a no-op: `createConfiguredSpawner()` existed but had zero callers,
- * so every spawn defaulted to the local-subprocess path regardless of config.
- */
 let configuredExecutorDefaults: ExecutorSpawnDefaults = {};
 
-/**
- * Configure the default executor settings (template + impersonation user).
- * Call this once at daemon startup, before any spawnExecutor() calls.
- *
- * @param config - The `execution` block from loadConfig(). Undefined / null
- *                 clears defaults (local-subprocess, no impersonation).
- */
+/** Set default executor template + impersonation user from config. Call once at daemon startup. */
 export function configureExecutor(config?: ExecutorConfig | null): void {
   configuredExecutorDefaults = {
     executorCommandTemplate: config?.executor_command_template || undefined,
@@ -94,103 +64,31 @@ export function configureExecutor(config?: ExecutorConfig | null): void {
   }
 }
 
-/**
- * Template variables for executor command template substitution.
- * These are substituted into the executor_command_template at spawn time.
- */
 export interface ExecutorTemplateVariables {
-  /** Unique task identifier (for pod/container naming) */
   task_id?: string;
-
-  /** Executor command (prompt, git.clone, etc.) */
   command?: string;
-
-  /** Target Unix username */
   unix_user?: string;
-
-  /** Target Unix UID (for runAsUser in k8s) */
   unix_user_uid?: number;
-
-  /** Target Unix GID (for fsGroup in k8s) */
   unix_user_gid?: number;
-
-  /** Session ID (if available) */
   session_id?: string;
-
-  /** Worktree ID (if available) */
   worktree_id?: string;
 }
 
-/**
- * Options for spawning executor
- */
 export interface SpawnExecutorOptions {
-  /** Working directory for executor process */
   cwd?: string;
-
-  /** Environment variables for executor process */
   env?: Record<string, string>;
-
-  /** Log prefix for console output */
   logPrefix?: string;
-
-  /**
-   * Unix user to run executor as (impersonation)
-   * When set, spawns via `sudo -n -u $asUser bash -c '...'` so the executor
-   * gets fresh group memberships for the target user. Secret env vars are
-   * routed through a 0600 env-file owned by `asUser` so their values stay
-   * out of argv / /proc/<pid>/cmdline.
-   */
+  /** When set, spawns via `sudo -n -u $asUser`. Secrets go through a 0600 env-file. */
   asUser?: string | null;
-
-  /**
-   * Executor command template for remote/containerized execution.
-   * When provided, uses template substitution instead of local subprocess.
-   * Takes precedence over local spawning.
-   */
+  /** When set, uses template substitution instead of local subprocess. */
   executorCommandTemplate?: string | null;
-
-  /**
-   * Template variables for substitution in executor_command_template.
-   * Used when executorCommandTemplate is provided.
-   */
   templateVariables?: ExecutorTemplateVariables;
-
-  /**
-   * Callback when executor process exits.
-   * Used to clean up resources when executor terminates.
-   */
   onExit?: (code: number | null) => void;
-
-  /**
-   * Callback fired immediately after the child process is spawned, before
-   * stdin is written. Receives the ChildProcess so callers can track its
-   * pid (e.g. for /sessions/:id/stop), wire additional event listeners, or
-   * attach custom cleanup. Called for both local and templated spawn paths.
-   */
-  onSpawn?: (child: import('node:child_process').ChildProcess) => void;
-
-  /**
-   * Pre-curated environment for the executor process. When set, the local-
-   * subprocess path uses this verbatim instead of building its own
-   * essentialEnv (which curates down to a hardcoded set of API-key vars).
-   *
-   * Use this when the caller has already assembled an env that includes
-   * downstream-specific values (gateway env vars, scoped credentials,
-   * DAEMON_URL, …) that the built-in curation would drop. Ignored by the
-   * templated spawn path (the template controls its own env).
-   */
+  /** Fired after spawn, before stdin is written. Works for both local and templated paths. */
+  onSpawn?: (child: ChildProcess) => void;
+  /** Caller-assembled env; bypasses internal curation. Ignored by templated path. */
   preparedEnv?: Record<string, string>;
-
-  /**
-   * Pre-written impersonation env file (mode 0600, owned by `asUser`).
-   * When set, the local-subprocess path uses this path verbatim instead of
-   * calling prepareImpersonationEnv() itself. Useful when the caller has
-   * already prepared an env file with a different env mix than spawn-
-   * executor's defaults would produce.
-   *
-   * Only applies when `asUser` is set. Ignored by the templated path.
-   */
+  /** Pre-written 0600 env file; bypasses prepareImpersonationEnv(). Only with asUser. */
   preparedEnvFilePath?: string;
 }
 
@@ -210,7 +108,6 @@ export function substituteTemplateVariables(
 ): string {
   let result = template;
 
-  // Substitute each known variable
   const substitutions: Record<string, string | number | undefined> = {
     task_id: variables.task_id,
     command: variables.command,
@@ -223,7 +120,6 @@ export function substituteTemplateVariables(
 
   for (const [key, value] of Object.entries(substitutions)) {
     if (value !== undefined) {
-      // Replace all occurrences of {key} with the value
       const placeholder = new RegExp(`\\{${key}\\}`, 'g');
       result = result.replace(placeholder, String(value));
     }
@@ -232,12 +128,7 @@ export function substituteTemplateVariables(
   return result;
 }
 
-/**
- * Generate a unique task ID for executor pod/container naming.
- * Uses a short random string that's safe for k8s resource names.
- */
 export function generateTaskId(): string {
-  // Generate 8 character hex string (32 bits of entropy)
   const bytes = new Uint8Array(4);
   crypto.getRandomValues(bytes);
   return Array.from(bytes)
@@ -245,14 +136,6 @@ export function generateTaskId(): string {
     .join('');
 }
 
-/**
- * Find the executor binary path
- *
- * Searches multiple possible locations for development and production:
- * - Bundled in agor-live package
- * - Development bin script
- * - Built dist directory
- */
 export function findExecutorPath(): string {
   const dirname =
     typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
@@ -299,12 +182,6 @@ export function spawnExecutor(
 ): void {
   const { templateVariables, logPrefix = '[Executor]' } = options;
 
-  // Resolve the command template + impersonation user from explicit options
-  // first, falling back to the module-level configuration set at startup via
-  // configureExecutor(). This lets the existing ~10 call sites keep their
-  // current shape (no `executorCommandTemplate` arg threaded through) while
-  // still honoring the `execution.executor_command_template` config field
-  // for remote / k8s deployments.
   const executorCommandTemplate =
     options.executorCommandTemplate !== undefined
       ? options.executorCommandTemplate || undefined
@@ -312,12 +189,8 @@ export function spawnExecutor(
   const asUser =
     options.asUser !== undefined ? options.asUser || undefined : configuredExecutorDefaults.asUser;
 
-  // Daemon resolves the small config slice the executor needs (permission
-  // timeout, opencode URL, host IP override) so the executor never has to
-  // read config.yaml itself. See build-resolved-config-slice.ts.
   const payloadWithConfig = withResolvedConfig(payload);
 
-  // Decide execution mode: templated or local
   if (executorCommandTemplate) {
     spawnExecutorWithTemplate(payloadWithConfig, {
       ...options,
@@ -359,15 +232,8 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   } = options;
   const asUser = rawAsUser || undefined;
 
-  // Add DAEMON_URL to env so the executor can connect back via Feathers.
-  // The executor itself never reads config.yaml — all config values it
-  // needs are pre-resolved by the daemon and embedded in the payload as
-  // `resolvedConfig` (see buildResolvedConfigSlice).
   const daemonUrl = getDaemonUrl();
 
-  // When impersonating, pass minimal env vars and let sudo set HOME correctly.
-  // If the caller supplied a pre-curated env (preparedEnv), use it verbatim
-  // (still ensuring DAEMON_URL is present) instead of the hardcoded curation.
   const envWithDaemonUrl: Record<string, string> = preparedEnv
     ? { DAEMON_URL: daemonUrl, ...preparedEnv }
     : asUser
@@ -392,12 +258,6 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
         )
       : { ...env, DAEMON_URL: daemonUrl };
 
-  // Route secret-looking env vars through an on-disk env file owned by the
-  // target user (mode 0600). This keeps API keys/tokens out of argv and out
-  // of /proc/<pid>/cmdline. Non-secret vars (PATH, DAEMON_URL, NODE_ENV)
-  // are still inlined for simplicity.
-  // If the caller already wrote an env file (preparedEnvFilePath), skip the
-  // prepareImpersonationEnv() call and use the pre-written file directly.
   const prepared = asUser
     ? preparedEnvFilePath
       ? {
@@ -409,7 +269,6 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
       : prepareImpersonationEnv({ asUser, env: envWithDaemonUrl })
     : { inlineEnv: undefined, envFilePath: undefined };
 
-  // Build spawn command - handles impersonation via sudo -u when asUser is set
   const { cmd, args } = buildSpawnArgs('node', [executorPath, '--stdin'], {
     asUser,
     env: asUser ? prepared.inlineEnv : undefined, // Non-secret env only; secrets are sourced from envFilePath
@@ -465,45 +324,25 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   // uses `sudo -u <asUser> rm -f` so it works under sticky /tmp.
   attachEnvFileCleanup(executorProcess, { envFilePath: prepared.envFilePath, asUser });
 
-  // Notify caller that the process is live (before stdin is written so the
-  // caller can attach additional listeners without racing against data).
   onSpawn?.(executorProcess);
 
-  // Log if process fails to spawn
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
   });
 
-  // Log when process exits (for debugging) and call onExit callback
   executorProcess.on('exit', (code) => {
     if (code === 0) {
       console.log(`${logPrefix} Executor completed successfully`);
     } else {
       console.error(`${logPrefix} Executor exited with code ${code}`);
     }
-    // Call onExit callback if provided (for cleanup)
     options.onExit?.(code);
   });
 
-  // Write JSON payload to stdin and close it
   executorProcess.stdin?.write(JSON.stringify(payload));
   executorProcess.stdin?.end();
 }
 
-/**
- * Spawn executor using a command template (for k8s, docker, etc.).
- *
- * The template is executed via `sh -c` with the JSON payload piped to stdin.
- * stdout/stderr are captured and logged (since kubectl needs to pipe them back).
- *
- * @example kubectl template
- * ```
- * kubectl run executor-{task_id} \
- *   --image=ghcr.io/preset-io/agor-executor:latest \
- *   --rm -i --restart=Never \
- *   -- agor-executor --stdin
- * ```
- */
 function spawnExecutorWithTemplate(
   payload: Record<string, unknown>,
   options: SpawnExecutorOptions & {
@@ -513,7 +352,6 @@ function spawnExecutorWithTemplate(
 ): void {
   const { executorCommandTemplate, templateVariables, logPrefix = '[Executor]' } = options;
 
-  // Substitute template variables
   const command = substituteTemplateVariables(executorCommandTemplate, templateVariables);
 
   console.log(`${logPrefix} Templated execution mode`);
@@ -521,31 +359,24 @@ function spawnExecutorWithTemplate(
   console.log(`${logPrefix} Command: ${payload.command}`);
   console.log(`${logPrefix} Template command (first 200 chars): ${command.slice(0, 200)}...`);
 
-  // Execute the template command via sh -c
-  // Use pipe for stdout/stderr so we can capture kubectl output and log it
   const executorProcess = spawn('sh', ['-c', command], {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  // Notify caller that the process is live (before stdin is written).
   options.onSpawn?.(executorProcess);
 
-  // Log stdout in real-time
   executorProcess.stdout?.on('data', (data) => {
     console.log(`${logPrefix} ${data.toString().trim()}`);
   });
 
-  // Log stderr in real-time
   executorProcess.stderr?.on('data', (data) => {
     console.error(`${logPrefix} ${data.toString().trim()}`);
   });
 
-  // Log if process fails to spawn
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
   });
 
-  // Log when process exits
   executorProcess.on('exit', (code) => {
     if (code === 0) {
       console.log(
@@ -559,31 +390,13 @@ function spawnExecutorWithTemplate(
     options.onExit?.(code);
   });
 
-  // Write JSON payload to stdin and close it
   executorProcess.stdin?.write(JSON.stringify(payload));
   executorProcess.stdin?.end();
 }
 
-/**
- * Get daemon URL for executor communication.
- *
- * Priority:
- * 1. Module-level configured URL (set via configureDaemonUrl at startup)
- * 2. Environment variable PORT with localhost
- * 3. Default localhost:3030
- *
- * In containerized (k8s) mode, configureDaemonUrl() should be called at startup
- * with the internal service URL (e.g., http://agor-daemon.agor.svc.cluster.local:3030)
- */
 export function getDaemonUrl(): string {
-  // Use configured URL if set (for k8s/containerized mode)
-  if (configuredDaemonUrl) {
-    return configuredDaemonUrl;
-  }
-
-  // Otherwise, use localhost with port from env or default
-  const effectivePort = process.env.PORT || '3030';
-  return `http://localhost:${effectivePort}`;
+  if (configuredDaemonUrl) return configuredDaemonUrl;
+  return `http://localhost:${process.env.PORT || '3030'}`;
 }
 
 /**
@@ -656,22 +469,7 @@ interface ExecutorSpawnDefaults {
   asUser?: string;
 }
 
-/**
- * Create a configured spawn function with execution settings baked in.
- *
- * This factory creates a spawn function that automatically includes
- * the executor_command_template from config. Use this when you have
- * access to config at initialization time.
- *
- * @example
- * ```typescript
- * const config = await loadConfig();
- * const spawn = createConfiguredSpawner(config.execution);
- *
- * // Now spawn automatically uses template if configured
- * spawn({ command: 'prompt', ... }, { logPrefix: '[Task]' });
- * ```
- */
+/** DI-based factory that bakes execution config into a spawner, independent of module-level defaults. */
 export function createConfiguredSpawner(executionConfig?: ExecutorConfig) {
   return function configuredSpawnExecutor(
     payload: Record<string, unknown>,

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -25,6 +25,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { AgorExecutionSettings } from '@agor/core/config';
 import {
   attachEnvFileCleanup,
   buildSpawnArgs,
@@ -54,7 +55,7 @@ export function configureDaemonUrl(url: string): void {
 }
 
 /**
- * Module-level executor configuration (template + impersonation user).
+ * Module-level executor spawn defaults (template + impersonation user).
  * Set once at daemon startup via configureExecutor().
  *
  * Used as the default by spawnExecutor() so call sites don't need to thread
@@ -66,26 +67,30 @@ export function configureDaemonUrl(url: string): void {
  * silently a no-op: `createConfiguredSpawner()` existed but had zero callers,
  * so every spawn defaulted to the local-subprocess path regardless of config.
  */
-let configuredExecutorConfig: ExecutorConfig | null = null;
+let configuredExecutorDefaults: ExecutorSpawnDefaults = {};
 
 /**
  * Configure the default executor settings (template + impersonation user).
  * Call this once at daemon startup, before any spawnExecutor() calls.
  *
  * @param config - The `execution` block from loadConfig(). Undefined / null
- *                 leaves defaults intact (local-subprocess, no impersonation).
+ *                 clears defaults (local-subprocess, no impersonation).
  */
 export function configureExecutor(config?: ExecutorConfig | null): void {
-  configuredExecutorConfig = config ?? null;
-  if (configuredExecutorConfig?.executor_command_template) {
+  configuredExecutorDefaults = {
+    executorCommandTemplate: config?.executor_command_template || undefined,
+    asUser: config?.executor_unix_user || undefined,
+  };
+
+  if (configuredExecutorDefaults.executorCommandTemplate) {
     const preview =
-      configuredExecutorConfig.executor_command_template.split('\n')[0]?.slice(0, 80) ?? '';
+      configuredExecutorDefaults.executorCommandTemplate.split('\n')[0]?.slice(0, 80) ?? '';
     console.log(
       `[Executor] Command template configured (first line): ${preview}${preview.length === 80 ? '…' : ''}`
     );
   }
-  if (configuredExecutorConfig?.executor_unix_user) {
-    console.log(`[Executor] Default impersonation user: ${configuredExecutorConfig.executor_unix_user}`);
+  if (configuredExecutorDefaults.asUser) {
+    console.log(`[Executor] Default impersonation user: ${configuredExecutorDefaults.asUser}`);
   }
 }
 
@@ -136,14 +141,14 @@ export interface SpawnExecutorOptions {
    * routed through a 0600 env-file owned by `asUser` so their values stay
    * out of argv / /proc/<pid>/cmdline.
    */
-  asUser?: string;
+  asUser?: string | null;
 
   /**
    * Executor command template for remote/containerized execution.
    * When provided, uses template substitution instead of local subprocess.
    * Takes precedence over local spawning.
    */
-  executorCommandTemplate?: string;
+  executorCommandTemplate?: string | null;
 
   /**
    * Template variables for substitution in executor_command_template.
@@ -270,8 +275,11 @@ export function spawnExecutor(
   // still honoring the `execution.executor_command_template` config field
   // for remote / k8s deployments.
   const executorCommandTemplate =
-    options.executorCommandTemplate ?? configuredExecutorConfig?.executor_command_template;
-  const asUser = options.asUser ?? configuredExecutorConfig?.executor_unix_user;
+    options.executorCommandTemplate !== undefined
+      ? options.executorCommandTemplate || undefined
+      : configuredExecutorDefaults.executorCommandTemplate;
+  const asUser =
+    options.asUser !== undefined ? options.asUser || undefined : configuredExecutorDefaults.asUser;
 
   // Daemon resolves the small config slice the executor needs (permission
   // timeout, opencode URL, host IP override) so the executor never has to
@@ -287,6 +295,7 @@ export function spawnExecutor(
       templateVariables: {
         command: payloadWithConfig.command as string,
         task_id: generateTaskId(),
+        unix_user: asUser,
         ...templateVariables,
       },
       logPrefix,
@@ -312,8 +321,9 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     cwd = executorDir,
     env = process.env as Record<string, string>,
     logPrefix = '[Executor]',
-    asUser,
+    asUser: rawAsUser,
   } = options;
+  const asUser = rawAsUser || undefined;
 
   // Add DAEMON_URL to env so the executor can connect back via Feathers.
   // The executor itself never reads config.yaml — all config values it
@@ -494,6 +504,7 @@ function spawnExecutorWithTemplate(
         `${logPrefix} Executor exited with code ${code} (task: ${templateVariables.task_id})`
       );
     }
+    options.onExit?.(code);
   });
 
   // Write JSON payload to stdin and close it
@@ -581,11 +592,16 @@ export function generateSessionToken(app: {
  * Configuration for executor spawning.
  * Loaded from ~/.agor/config.yaml execution section.
  */
-export interface ExecutorConfig {
+export type ExecutorConfig = Pick<
+  AgorExecutionSettings,
+  'executor_command_template' | 'executor_unix_user'
+>;
+
+interface ExecutorSpawnDefaults {
   /** Executor command template for containerized execution */
-  executor_command_template?: string;
+  executorCommandTemplate?: string;
   /** Unix user to run executors as */
-  executor_unix_user?: string;
+  asUser?: string;
 }
 
 /**
@@ -611,8 +627,14 @@ export function createConfiguredSpawner(executionConfig?: ExecutorConfig) {
   ): void {
     spawnExecutor(payload, {
       ...options,
-      executorCommandTemplate: executionConfig?.executor_command_template,
-      asUser: options.asUser ?? executionConfig?.executor_unix_user,
+      // `null` intentionally suppresses module-level defaults so this
+      // factory remains an explicit dependency-injection variant rather than
+      // accidentally inheriting whatever configureExecutor() last installed.
+      executorCommandTemplate: executionConfig?.executor_command_template ?? null,
+      asUser:
+        options.asUser !== undefined
+          ? options.asUser
+          : (executionConfig?.executor_unix_user ?? null),
     });
   };
 }

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -54,6 +54,42 @@ export function configureDaemonUrl(url: string): void {
 }
 
 /**
+ * Module-level executor configuration (template + impersonation user).
+ * Set once at daemon startup via configureExecutor().
+ *
+ * Used as the default by spawnExecutor() so call sites don't need to thread
+ * `executor_command_template` / `executor_unix_user` through every layer.
+ * Pre-existing call sites that pass `executorCommandTemplate` or `asUser`
+ * explicitly still win — this only kicks in when the option is omitted.
+ *
+ * Without this, the `execution.executor_command_template` config field was
+ * silently a no-op: `createConfiguredSpawner()` existed but had zero callers,
+ * so every spawn defaulted to the local-subprocess path regardless of config.
+ */
+let configuredExecutorConfig: ExecutorConfig | null = null;
+
+/**
+ * Configure the default executor settings (template + impersonation user).
+ * Call this once at daemon startup, before any spawnExecutor() calls.
+ *
+ * @param config - The `execution` block from loadConfig(). Undefined / null
+ *                 leaves defaults intact (local-subprocess, no impersonation).
+ */
+export function configureExecutor(config?: ExecutorConfig | null): void {
+  configuredExecutorConfig = config ?? null;
+  if (configuredExecutorConfig?.executor_command_template) {
+    const preview =
+      configuredExecutorConfig.executor_command_template.split('\n')[0]?.slice(0, 80) ?? '';
+    console.log(
+      `[Executor] Command template configured (first line): ${preview}${preview.length === 80 ? '…' : ''}`
+    );
+  }
+  if (configuredExecutorConfig?.executor_unix_user) {
+    console.log(`[Executor] Default impersonation user: ${configuredExecutorConfig.executor_unix_user}`);
+  }
+}
+
+/**
  * Template variables for executor command template substitution.
  * These are substituted into the executor_command_template at spawn time.
  */
@@ -225,7 +261,17 @@ export function spawnExecutor(
   payload: Record<string, unknown>,
   options: SpawnExecutorOptions = {}
 ): void {
-  const { executorCommandTemplate, templateVariables, logPrefix = '[Executor]' } = options;
+  const { templateVariables, logPrefix = '[Executor]' } = options;
+
+  // Resolve the command template + impersonation user from explicit options
+  // first, falling back to the module-level configuration set at startup via
+  // configureExecutor(). This lets the existing ~10 call sites keep their
+  // current shape (no `executorCommandTemplate` arg threaded through) while
+  // still honoring the `execution.executor_command_template` config field
+  // for remote / k8s deployments.
+  const executorCommandTemplate =
+    options.executorCommandTemplate ?? configuredExecutorConfig?.executor_command_template;
+  const asUser = options.asUser ?? configuredExecutorConfig?.executor_unix_user;
 
   // Daemon resolves the small config slice the executor needs (permission
   // timeout, opencode URL, host IP override) so the executor never has to
@@ -236,6 +282,7 @@ export function spawnExecutor(
   if (executorCommandTemplate) {
     spawnExecutorWithTemplate(payloadWithConfig, {
       ...options,
+      asUser,
       executorCommandTemplate,
       templateVariables: {
         command: payloadWithConfig.command as string,
@@ -245,7 +292,7 @@ export function spawnExecutor(
       logPrefix,
     });
   } else {
-    spawnExecutorLocal(payloadWithConfig, options);
+    spawnExecutorLocal(payloadWithConfig, { ...options, asUser });
   }
 }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -865,7 +865,15 @@ export class CodexPromptService {
     // of truth for what "system default" means across daemon + executor.
     const codexConfig = session.permission_config?.codex;
     const defaults = getDefaultCodexPermissionConfig();
-    const sandboxMode = codexConfig?.sandboxMode ?? defaults.sandboxMode;
+    // AGOR_CODEX_SANDBOX_MODE lets k8s operators bypass workspace-write, which
+    // requires Linux user namespaces (bwrap) not available in pods. Set to
+    // 'danger-full-access' when the pod's own security context provides isolation.
+    const sandboxModeEnvOverride = process.env.AGOR_CODEX_SANDBOX_MODE as
+      | 'read-only'
+      | 'workspace-write'
+      | 'danger-full-access'
+      | undefined;
+    const sandboxMode = sandboxModeEnvOverride ?? codexConfig?.sandboxMode ?? defaults.sandboxMode;
     const approvalPolicy = codexConfig?.approvalPolicy ?? defaults.approvalPolicy;
     const networkAccess = codexConfig?.networkAccess ?? defaults.networkAccess;
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -31,7 +31,7 @@ import type { CodexOptions, Thread, ThreadItem } from '@agor/core/sdk';
 import { Codex } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
-import type { EffortLevel } from '@agor/core/types';
+import type { CodexSandboxMode, EffortLevel } from '@agor/core/types';
 import { getDefaultCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
 import { getDaemonUrl } from '../../config.js';
 import type {
@@ -865,13 +865,9 @@ export class CodexPromptService {
     // of truth for what "system default" means across daemon + executor.
     const codexConfig = session.permission_config?.codex;
     const defaults = getDefaultCodexPermissionConfig();
-    // AGOR_CODEX_SANDBOX_MODE lets k8s operators bypass workspace-write, which
-    // requires Linux user namespaces (bwrap) not available in pods. Set to
-    // 'danger-full-access' when the pod's own security context provides isolation.
+    // workspace-write uses bwrap not available in pods; override with danger-full-access for k8s.
     const sandboxModeEnvOverride = process.env.AGOR_CODEX_SANDBOX_MODE as
-      | 'read-only'
-      | 'workspace-write'
-      | 'danger-full-access'
+      | CodexSandboxMode
       | undefined;
     const sandboxMode = sandboxModeEnvOverride ?? codexConfig?.sandboxMode ?? defaults.sandboxMode;
     const approvalPolicy = codexConfig?.approvalPolicy ?? defaults.approvalPolicy;


### PR DESCRIPTION
## Summary

\`execution.executor_command_template\` was silently a no-op in two ways:

1. **\`configureExecutor()\` had zero callers** — every \`spawnExecutor()\` site used the raw function without threading the template through. The daemon always fell back to local subprocess regardless of config.

2. **\`createExecuteHandler\` in \`register-services.ts\` re-implemented spawn inline** — it never called \`spawnExecutor()\` at all, so even after fixing (1), prompt tasks still bypassed the template.

Both holes are closed here.

## Changes

### \`spawn-executor.ts\` — three new \`SpawnExecutorOptions\` fields
- \`onSpawn(child)\`: fired after process is live, before stdin is written — lets callers track PIDs without racing against data
- \`preparedEnv\`: caller-assembled env map that bypasses internal env curation
- \`preparedEnvFilePath\`: pre-written 0600 env file that bypasses \`prepareImpersonationEnv()\`

Module-level \`configuredExecutorConfig\` (set once at startup via \`configureExecutor()\`) provides template + unix user as fallback for all call sites.

### \`index.ts\`
Calls \`configureExecutor(config.execution)\` at startup — mirrors the existing \`configureDaemonUrl()\` pattern.

### \`register-services.ts\` — \`createExecuteHandler\` refactor
Removed ~170 lines of inline binary-finding, impersonation env setup, \`buildSpawnArgs\`, and \`spawn()\`. Now delegates entirely to \`spawnExecutor()\`, which holds the template-vs-local-subprocess decision.

### \`prompt-service.ts\` (executor package)
Adds \`AGOR_CODEX_SANDBOX_MODE\` env var override. \`workspace-write\` uses bwrap/Linux user-namespaces not available in k8s pods without \`CAP_SYS_ADMIN\`. Setting \`AGOR_CODEX_SANDBOX_MODE=danger-full-access\` in the pod template lets Codex skip the bwrap sandbox while the pod's own security context provides isolation.

## Backwards compatibility

- No behavior change when \`execution.executor_command_template\` is unset — local subprocess remains the default.
- No behavior change for callers that pass \`executorCommandTemplate\` explicitly — explicit options still win.

## Testing

Verified end-to-end in the [\`preset-io/agor-k8s-poc\`](https://github.com/preset-io/agor-k8s-poc) kind cluster (\`agor-poc-phase1-bootstrap\`, namespace \`agor-poc-tenant-1\`):

- Daemon logs show \`[Executor <id>] Templated execution mode\` + \`Template command: kubectl run executor-<task-id> …\`
- Executor pod connects back to daemon via cluster-internal DNS (\`agor-poc-tenant-1-daemon.agor-poc-tenant-1.svc.cluster.local:3030\`)
- Codex session completes with exit code 0
- \`git.worktree.add\` operations also route through ephemeral pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)