### PR TITLE
fix(ui): replace (dirty) jargon with dot icon + clearer git-sha tooltip

### DIFF
--- a/apps/agor-ui/src/components/Pill/Pill.stories.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.stories.tsx
@@ -7,6 +7,7 @@ import {
   DirtyStatePill,
   ForkPill,
   GitShaPill,
+  GitStatePill,
   MessageCountPill,
   ReportPill,
   SessionIdPill,
@@ -50,6 +51,8 @@ export const AllPills: Story = {
           <GitShaPill sha="abc123def456" />
           <GitShaPill sha="abc123def456-dirty" isDirty={true} />
           <GitShaPill sha="abc123def456-dirty" isDirty={true} showDirtyIndicator={false} />
+          <GitStatePill sha="abc123def456" branch="main" />
+          <GitStatePill sha="abc123def456-dirty" branch="feature/foo" />
           <DirtyStatePill />
         </Space>
       </div>
@@ -130,10 +133,17 @@ export const ToolCount: Story = {
 
 export const GitSha: Story = {
   render: () => (
-    <Space>
-      <GitShaPill sha="abc123def456" />
-      <GitShaPill sha="abc123def456-dirty" isDirty={true} />
-      <GitShaPill sha="abc123def456-dirty" isDirty={true} showDirtyIndicator={false} />
+    <Space orientation="vertical">
+      <Space>
+        <GitShaPill sha="abc123def456" />
+        <GitShaPill sha="abc123def456-dirty" isDirty={true} />
+        <GitShaPill sha="abc123def456-dirty" isDirty={true} showDirtyIndicator={false} />
+      </Space>
+      <Space>
+        <GitStatePill sha="abc123def456" branch="main" />
+        <GitStatePill sha="abc123def456-dirty" branch="feature/foo" />
+        <GitStatePill sha="abc123def456" branch="main" worktreeName="main" />
+      </Space>
     </Space>
   ),
 };

--- a/apps/agor-ui/src/components/Pill/Pill.stories.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.stories.tsx
@@ -143,6 +143,7 @@ export const GitSha: Story = {
         <GitStatePill sha="abc123def456" branch="main" />
         <GitStatePill sha="abc123def456-dirty" branch="feature/foo" />
         <GitStatePill sha="abc123def456" branch="main" worktreeName="main" />
+        <GitStatePill sha="abc123def456-dirty" branch="main" worktreeName="main" />
       </Space>
     </Space>
   ),

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -489,6 +489,29 @@ export const ModelPill: React.FC<ModelPillProps> = ({ model, style }) => {
   );
 };
 
+/**
+ * Small amber dot indicating uncommitted ("dirty") working tree changes.
+ * Mirrors the VSCode unsaved-file affordance. Purely visual — the parent
+ * pill carries a single tooltip that explains both the SHA and the dot.
+ */
+const DirtyDot: React.FC = () => {
+  const { token } = theme.useToken();
+  return (
+    <span
+      role="img"
+      aria-label="Uncommitted changes"
+      style={{
+        display: 'inline-block',
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        backgroundColor: token.colorWarning,
+        flexShrink: 0,
+      }}
+    />
+  );
+};
+
 interface GitShaPillProps extends BasePillProps {
   sha: string;
   isDirty?: boolean;
@@ -499,22 +522,25 @@ export const GitShaPill: React.FC<GitShaPillProps> = ({
   sha,
   isDirty = false,
   showDirtyIndicator = true,
-  size,
   style,
 }) => {
   const { token } = theme.useToken();
   const cleanSha = sha.replace('-dirty', '');
   const displaySha = cleanSha.substring(0, 7);
+  const showDirty = isDirty && showDirtyIndicator;
+  const tooltip = showDirty
+    ? 'Git commit SHA (working tree has uncommitted changes)'
+    : 'Git commit SHA';
 
   return (
-    <Tag
-      icon={<GithubOutlined />}
-      color={isDirty && showDirtyIndicator ? PILL_COLORS.warning : PILL_COLORS.git}
-      style={style}
-    >
-      <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
-      {isDirty && showDirtyIndicator && ' (dirty)'}
-    </Tag>
+    <Tooltip title={tooltip}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        {showDirty && <DirtyDot />}
+        <Tag icon={<GithubOutlined />} color={PILL_COLORS.git} style={style}>
+          <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
+        </Tag>
+      </span>
+    </Tooltip>
   );
 };
 
@@ -536,9 +562,14 @@ export const GitStatePill: React.FC<GitStatePillProps> = ({
   const isDirty = sha.endsWith('-dirty');
   const cleanSha = sha.replace('-dirty', '');
   const displaySha = cleanSha.substring(0, 7);
+  const showDirty = isDirty && showDirtyIndicator;
 
   // Only show branch if it differs from worktree name
   const shouldShowBranch = branch && branch !== worktreeName;
+
+  const tooltip = showDirty
+    ? 'Git commit SHA (working tree has uncommitted changes) · click to copy'
+    : 'Git commit SHA · click to copy';
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -546,17 +577,17 @@ export const GitStatePill: React.FC<GitStatePillProps> = ({
   };
 
   return (
-    <Tooltip title="Click to copy full SHA">
-      <Tag
-        icon={<ForkOutlined />}
-        color={isDirty && showDirtyIndicator ? 'cyan' : PILL_COLORS.git}
-        style={{ ...style, cursor: 'pointer' }}
+    <Tooltip title={tooltip}>
+      <span
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}
         onClick={handleClick}
       >
-        {shouldShowBranch && <span>{branch} : </span>}
-        <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
-        {isDirty && showDirtyIndicator && ' (dirty)'}
-      </Tag>
+        {showDirty && <DirtyDot />}
+        <Tag icon={<ForkOutlined />} color={PILL_COLORS.git} style={style}>
+          {shouldShowBranch && <span>{branch} : </span>}
+          <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
+        </Tag>
+      </span>
     </Tooltip>
   );
 };

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -22,10 +22,11 @@ import {
   ThunderboltOutlined,
   ToolOutlined,
 } from '@ant-design/icons';
-import { Collapse, Popover, Tooltip, theme } from 'antd';
+import { Badge, Collapse, Popover, Tooltip, theme } from 'antd';
 import type React from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
 import { getContextWindowPercentage } from '../../utils/contextWindow';
+import { parseGitStateSha } from '../../utils/gitState';
 import { type SessionForIds, SessionIdsList } from '../SessionIds';
 import { Tag } from '../Tag';
 
@@ -491,26 +492,15 @@ export const ModelPill: React.FC<ModelPillProps> = ({ model, style }) => {
 
 /**
  * Small amber dot indicating uncommitted ("dirty") working tree changes.
- * Mirrors the VSCode unsaved-file affordance. Purely visual — the parent
- * pill carries a single tooltip that explains both the SHA and the dot.
+ * Mirrors the VSCode unsaved-file affordance. Purely decorative — the parent
+ * pill carries the tooltip that explains both the SHA and the dot, so the
+ * dot is `aria-hidden` to avoid duplicating that label for screen readers.
  */
-const DirtyDot: React.FC = () => {
-  const { token } = theme.useToken();
-  return (
-    <span
-      role="img"
-      aria-label="Uncommitted changes"
-      style={{
-        display: 'inline-block',
-        width: 8,
-        height: 8,
-        borderRadius: '50%',
-        backgroundColor: token.colorWarning,
-        flexShrink: 0,
-      }}
-    />
-  );
-};
+const DirtyDot: React.FC = () => (
+  <span aria-hidden="true" style={{ display: 'inline-flex', flexShrink: 0 }}>
+    <Badge status="warning" />
+  </span>
+);
 
 interface GitShaPillProps extends BasePillProps {
   sha: string;
@@ -525,16 +515,24 @@ export const GitShaPill: React.FC<GitShaPillProps> = ({
   style,
 }) => {
   const { token } = theme.useToken();
-  const cleanSha = sha.replace('-dirty', '');
+  const { cleanSha } = parseGitStateSha(sha);
   const displaySha = cleanSha.substring(0, 7);
   const showDirty = isDirty && showDirtyIndicator;
   const tooltip = showDirty
-    ? 'Git commit SHA (working tree has uncommitted changes)'
-    : 'Git commit SHA';
+    ? 'Git commit SHA (working tree has uncommitted changes) · click to copy'
+    : 'Git commit SHA · click to copy';
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await copyToClipboard(cleanSha);
+  };
 
   return (
     <Tooltip title={tooltip}>
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <span
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}
+        onClick={handleClick}
+      >
         {showDirty && <DirtyDot />}
         <Tag icon={<GithubOutlined />} color={PILL_COLORS.git} style={style}>
           <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
@@ -559,8 +557,7 @@ export const GitStatePill: React.FC<GitStatePillProps> = ({
   style,
 }) => {
   const { token } = theme.useToken();
-  const isDirty = sha.endsWith('-dirty');
-  const cleanSha = sha.replace('-dirty', '');
+  const { cleanSha, isDirty } = parseGitStateSha(sha);
   const displaySha = cleanSha.substring(0, 7);
   const showDirty = isDirty && showDirtyIndicator;
 

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -12,6 +12,7 @@ import {
 } from '@ant-design/icons';
 import { App, Button, Card, Collapse, Space, Typography } from 'antd';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { parseGitStateSha } from '../../utils/gitState';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { CreatedByTag } from '../metadata';
 import { Tag } from '../Tag';
@@ -75,9 +76,7 @@ const SessionCard = ({
   const isForked = !!session.genealogy.forked_from_session_id;
   const isSpawned = !!session.genealogy.parent_session_id;
 
-  // Check if git state is dirty
-  const isDirty = session.git_state.current_sha.endsWith('-dirty');
-  const cleanSha = session.git_state.current_sha.replace('-dirty', '');
+  const { cleanSha, isDirty } = parseGitStateSha(session.git_state.current_sha);
 
   // Task list collapse header (just the "Tasks" label)
   const taskListHeader = (

--- a/apps/agor-ui/src/components/TaskListItem/TaskListItem.tsx
+++ b/apps/agor-ui/src/components/TaskListItem/TaskListItem.tsx
@@ -7,6 +7,7 @@ import {
   ToolOutlined,
 } from '@ant-design/icons';
 import { Space, Tooltip, Typography, theme } from 'antd';
+import { parseGitStateSha } from '../../utils/gitState';
 import { Tag } from '../Tag';
 import { TaskStatusIcon } from '../TaskStatusIcon';
 
@@ -31,10 +32,9 @@ const TaskListItem = ({ task, onClick, compact = false }: TaskListItemProps) => 
   const shaAtEnd = task.git_state.sha_at_end;
   const hasTransition = shaAtEnd && shaAtEnd !== 'unknown' && shaAtEnd !== shaAtStart;
 
-  // Check if end state is dirty (or start state if no end)
+  // Prefer end-state SHA when available, fall back to start
   const displaySha = shaAtEnd && shaAtEnd !== 'unknown' ? shaAtEnd : shaAtStart;
-  const isDirty = displaySha?.endsWith('-dirty');
-  const cleanSha = displaySha?.replace('-dirty', '');
+  const { cleanSha, isDirty } = parseGitStateSha(displaySha);
 
   // Truncate prompt if too long
   const description = task.full_prompt || 'Untitled task';

--- a/apps/agor-ui/src/utils/gitState.test.ts
+++ b/apps/agor-ui/src/utils/gitState.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseGitStateSha } from './gitState';
+
+describe('parseGitStateSha', () => {
+  it('returns empty + clean for null/undefined/empty', () => {
+    expect(parseGitStateSha(null)).toEqual({ cleanSha: '', isDirty: false });
+    expect(parseGitStateSha(undefined)).toEqual({ cleanSha: '', isDirty: false });
+    expect(parseGitStateSha('')).toEqual({ cleanSha: '', isDirty: false });
+  });
+
+  it('returns clean SHA unchanged', () => {
+    expect(parseGitStateSha('abc123def456')).toEqual({
+      cleanSha: 'abc123def456',
+      isDirty: false,
+    });
+  });
+
+  it('strips the -dirty suffix when present', () => {
+    expect(parseGitStateSha('abc123def456-dirty')).toEqual({
+      cleanSha: 'abc123def456',
+      isDirty: true,
+    });
+  });
+
+  it('only strips suffix, not arbitrary occurrences', () => {
+    // Pathological SHA-like input where "-dirty" appears mid-string.
+    // String.replace would have eaten it; we should leave it alone.
+    expect(parseGitStateSha('abc-dirty-def')).toEqual({
+      cleanSha: 'abc-dirty-def',
+      isDirty: false,
+    });
+  });
+
+  it('passes through the sentinel "unknown" value', () => {
+    expect(parseGitStateSha('unknown')).toEqual({ cleanSha: 'unknown', isDirty: false });
+  });
+});

--- a/apps/agor-ui/src/utils/gitState.ts
+++ b/apps/agor-ui/src/utils/gitState.ts
@@ -1,0 +1,26 @@
+/**
+ * Parse the `<sha>-dirty` format produced by `getGitState` in
+ * `packages/core/src/git/index.ts`. The daemon appends a literal `-dirty`
+ * suffix when the working tree has uncommitted changes; UI code needs to
+ * split that back out for display.
+ *
+ * Returns `{ cleanSha: '', isDirty: false }` for empty / `'unknown'` input
+ * so callers can pass `session.git_state.current_sha` directly without
+ * pre-filtering.
+ */
+const DIRTY_SUFFIX = '-dirty';
+
+export interface ParsedGitStateSha {
+  /** The raw commit SHA with the `-dirty` suffix removed (if present). */
+  cleanSha: string;
+  /** True when the working tree had uncommitted changes when the SHA was captured. */
+  isDirty: boolean;
+}
+
+export function parseGitStateSha(sha: string | null | undefined): ParsedGitStateSha {
+  if (!sha) return { cleanSha: '', isDirty: false };
+  if (sha.endsWith(DIRTY_SUFFIX)) {
+    return { cleanSha: sha.slice(0, -DIRTY_SUFFIX.length), isDirty: true };
+  }
+  return { cleanSha: sha, isDirty: false };
+}


### PR DESCRIPTION
## Summary

Non-technical user feedback: the git SHA pill in the conversation view said \" (dirty)\" and the tooltip only said \"Click to copy full SHA\" — they didn't know it was a *git* SHA, and \"dirty\" is jargon.

This swaps the suffix for a small amber dot (VSCode's unsaved-file convention) and uses a single conditional tooltip on the whole pill that names \"git\" explicitly and explains the dot in plain language.

- ` (dirty)` text suffix → small amber dot (`token.colorWarning`, theme-aware) rendered before the pill
- Single tooltip on the whole pill (no nested-hover weirdness):
  - **Clean:** `Git commit SHA · click to copy`
  - **Dirty:** `Git commit SHA (working tree has uncommitted changes) · click to copy`
- Same treatment applied to `GitShaPill` (was suffix-only, now gets an informational tooltip too)
- Underlying `dirty` data-layer naming untouched — presentation-only
- Storybook: added a `GitStatePill` demo row (was previously only `GitShaPill`)

## Test plan

- [ ] Visit a session in the conversation view; confirm the SHA pill renders with no `(dirty)` text
- [ ] When the worktree is dirty, an amber dot appears before the pill
- [ ] Hover the pill (clean): tooltip says `Git commit SHA · click to copy`
- [ ] Hover the pill (dirty): tooltip says `Git commit SHA (working tree has uncommitted changes) · click to copy`
- [ ] Click the pill (dot or tag): full SHA is copied to clipboard
- [ ] Light + dark theme: dot is visible in both, not too loud
- [ ] Storybook → Components/Pill → GitSha: visual sanity check for both clean and dirty states

🤖 Generated with [Claude Code](https://claude.com/claude-code)