### PR TITLE
fix(ui): move dirty dot inside git-sha pill (right of SHA)

### DIFF
--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -492,12 +492,12 @@ export const ModelPill: React.FC<ModelPillProps> = ({ model, style }) => {
 
 /**
  * Small amber dot indicating uncommitted ("dirty") working tree changes.
- * Mirrors the VSCode unsaved-file affordance. Purely decorative — the parent
- * pill carries the tooltip that explains both the SHA and the dot, so the
- * dot is `aria-hidden` to avoid duplicating that label for screen readers.
+ * Mirrors the VSCode unsaved-file affordance. Rendered inline at the end of
+ * a git-SHA pill (purely decorative — the parent pill carries the tooltip
+ * that explains both the SHA and the dot, so the dot is `aria-hidden`).
  */
 const DirtyDot: React.FC = () => (
-  <span aria-hidden="true" style={{ display: 'inline-flex', flexShrink: 0 }}>
+  <span aria-hidden="true" style={{ display: 'inline-flex', flexShrink: 0, marginLeft: 6 }}>
     <Badge status="warning" />
   </span>
 );
@@ -529,15 +529,15 @@ export const GitShaPill: React.FC<GitShaPillProps> = ({
 
   return (
     <Tooltip title={tooltip}>
-      <span
-        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}
+      <Tag
+        icon={<GithubOutlined />}
+        color={PILL_COLORS.git}
+        style={{ ...style, cursor: 'pointer' }}
         onClick={handleClick}
       >
+        <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
         {showDirty && <DirtyDot />}
-        <Tag icon={<GithubOutlined />} color={PILL_COLORS.git} style={style}>
-          <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
-        </Tag>
-      </span>
+      </Tag>
     </Tooltip>
   );
 };
@@ -575,16 +575,16 @@ export const GitStatePill: React.FC<GitStatePillProps> = ({
 
   return (
     <Tooltip title={tooltip}>
-      <span
-        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}
+      <Tag
+        icon={<ForkOutlined />}
+        color={PILL_COLORS.git}
+        style={{ ...style, cursor: 'pointer' }}
         onClick={handleClick}
       >
+        {shouldShowBranch && <span>{branch} : </span>}
+        <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
         {showDirty && <DirtyDot />}
-        <Tag icon={<ForkOutlined />} color={PILL_COLORS.git} style={style}>
-          {shouldShowBranch && <span>{branch} : </span>}
-          <span style={{ fontFamily: token.fontFamilyCode }}>{displaySha}</span>
-        </Tag>
-      </span>
+      </Tag>
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Summary

Follow-up to #1232. The dirty dot was rendered outside the pill via an inline-flex wrapper, so it read as a separate visual element next to the pill instead of part of it. Move it **inside the Tag**, immediately after the SHA text, so it reads as one unit (closer to the VSCode unsaved-file convention).

- Drop the outer `<span>` wrapper; \`onClick\` + \`cursor: 'pointer'\` move to the \`<Tag>\` itself.
- \`DirtyDot\` gains \`marginLeft: 6\` to space it from the SHA text inside the tag.
- Applies to both \`GitShaPill\` and \`GitStatePill\`.

No behavior change beyond layout — tooltip text, copy-to-clipboard, and accessibility (\`aria-hidden\` on dot, parent tooltip carries semantics) all stay as in #1232.

## Test plan

- [ ] Visit a session in the conversation view: amber dot appears at the right edge **inside** the SHA pill when dirty
- [ ] When clean: no dot
- [ ] Click the pill (on dot or on SHA) → full SHA is copied
- [ ] Hover tooltip still reads \`Git commit SHA · click to copy\` / \`Git commit SHA (working tree has uncommitted changes) · click to copy\`
- [ ] Light + dark theme: dot still visible, not too loud
- [ ] Storybook → Components/Pill → GitSha: visual sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)