### PR TITLE
fix(ui): include superadmin in user role dropdown

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -7,7 +7,7 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
-import { hasMinimumRole, ROLES } from '@agor-live/client';
+import { hasMinimumRole, ROLE_OPTIONS, ROLES } from '@agor-live/client';
 import {
   ApiOutlined,
   CloseOutlined,
@@ -596,12 +596,14 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   : undefined
               }
             >
-              <Select disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}>
-                {/* <Select.Option value="owner">Owner</Select.Option> */}
-                <Select.Option value="admin">Admin</Select.Option>
-                <Select.Option value="member">Member</Select.Option>
-                <Select.Option value="viewer">Viewer</Select.Option>
-              </Select>
+              <Select
+                disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
+                options={ROLE_OPTIONS.map((opt) => ({
+                  value: opt.value,
+                  label: opt.label,
+                  title: opt.description,
+                }))}
+              />
             </Form.Item>
 
             {/* Only show for admins editing other users */}

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -5,6 +5,7 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
+import { ROLE_OPTIONS, ROLES } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import {
   Button,
@@ -61,7 +62,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
           password: values.password,
           name: values.name,
           emoji: values.emoji || '👤',
-          role: values.role || 'member',
+          role: values.role || ROLES.MEMBER,
           unix_username: values.unix_username,
           must_change_password: values.must_change_password || false,
         });
@@ -237,15 +238,16 @@ export const UsersTable: React.FC<UsersTableProps> = ({
           <Form.Item
             label="Role"
             name="role"
-            initialValue="member"
+            initialValue={ROLES.MEMBER}
             rules={[{ required: true, message: 'Please select a role' }]}
           >
-            <Select>
-              {/* <Select.Option value="owner">Owner</Select.Option> */}
-              <Select.Option value="admin">Admin</Select.Option>
-              <Select.Option value="member">Member</Select.Option>
-              <Select.Option value="viewer">Viewer</Select.Option>
-            </Select>
+            <Select
+              options={ROLE_OPTIONS.map((opt) => ({
+                value: opt.value,
+                label: opt.label,
+                title: opt.description,
+              }))}
+            />
           </Form.Item>
 
           <Form.Item name="must_change_password" valuePropName="checked" initialValue={false}>

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -24,6 +24,35 @@ export const ROLES = {
 } as const satisfies Record<string, UserRole>;
 
 /**
+ * Display metadata for each role. Ordered from most → least privileged so UI
+ * dropdowns can render directly from this list without re-sorting.
+ *
+ * This is the single source of truth for role labels and descriptions —
+ * dropdowns, CLI prompts, and any other surface listing roles should map
+ * over this array instead of hard-coding role strings.
+ */
+export interface RoleOption {
+  value: UserRole;
+  label: string;
+  description: string;
+}
+
+export const ROLE_OPTIONS: readonly RoleOption[] = [
+  {
+    value: ROLES.SUPERADMIN,
+    label: 'Superadmin',
+    description: 'Full system access + worktree RBAC bypass',
+  },
+  {
+    value: ROLES.ADMIN,
+    label: 'Admin',
+    description: 'Manage resources (users, MCP servers, config)',
+  },
+  { value: ROLES.MEMBER, label: 'Member', description: 'Standard user' },
+  { value: ROLES.VIEWER, label: 'Viewer', description: 'Read-only access' },
+] as const;
+
+/**
  * Role rank used for minimum-role comparisons.
  * Higher rank = more privileges. 'owner' is a deprecated alias for superadmin.
  */


### PR DESCRIPTION
## Summary

The user-management role dropdown in the settings modal was missing `superadmin` — admins could see existing superadmin users in the table but had no way to assign the role from the UI. CLI (`pnpm agor user create/update`), the MCP `agor_users_update` tool, and the DB schema all support it; the gap was UI-only and dated back to the `owner` → `superadmin` rename.

- **`feat(types)`** — added `ROLE_OPTIONS` to `packages/core/src/types/user.ts` alongside the existing `ROLES` constant: an ordered (most → least privileged) list of `{ value, label, description }` for each role. This becomes the canonical source for any surface that renders a role list. Re-exports through `@agor/core/types` → `@agor/core/client` → `@agor-live/client` like the existing `ROLES`/`hasMinimumRole` exports.
- **`fix(ui)`** — both dropdowns (`UsersTable.tsx` Create User modal, `UserSettingsModal.tsx` Edit User Role field) now render from `ROLE_OPTIONS` via Ant Design's `<Select options>` API. Descriptions render as the option `title` (native tooltip).

### Files changed
- `packages/core/src/types/user.ts` — new `ROLE_OPTIONS` + `RoleOption` interface
- `apps/agor-ui/src/components/SettingsModal/UsersTable.tsx` — Create User dropdown switched to `ROLE_OPTIONS`, replaced two `'member'` literals with `ROLES.MEMBER`
- `apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx` — Edit User dropdown switched to `ROLE_OPTIONS`; existing admin-only gating (`hasMinimumRole(currentUser, ADMIN)`) preserved

### Other role lists audited (not changed)
The CLI (`apps/agor-cli/src/commands/user/{create,update,list}.ts`), MCP tools (`apps/agor-daemon/src/mcp/tools/users.ts`), DB schemas (`packages/core/src/db/schema.{sqlite,postgres}.ts`), and Zod schema (`packages/core/src/config/resource-schemas.ts`) already list all four roles correctly. Switching them to `ROLE_OPTIONS` is a follow-up cleanup, not required to fix the bug — left out to keep scope tight.

### A note on filtering
I didn't find any intentional code path that filters `superadmin` out of the dropdown — the comment `{/* <Select.Option value="owner">Owner</Select.Option> */}` in both files is just leftover from the rename. There is a daemon-level `execution.allow_superadmin` config flag, but it only gates whether the role grants worktree-RBAC bypass; it doesn't restrict admins from *assigning* the role. **Open product question for follow-up:** should the dropdown only offer `superadmin` to users who are themselves superadmin (prevent admin self-promotion)? Today an admin can pick it. Not addressed here; flagging in case it should be.

## Test plan
- [x] `pnpm -w typecheck` — all 9 packages pass
- [x] `pnpm -w lint` — 14 pre-existing warnings, none from this change
- [x] `pnpm test` in `packages/core` (types) — 137 passing
- [x] `pnpm test` in `apps/agor-ui` — 156 passing
- [ ] **Not visually verified in the browser** — no dev server running here. Eyeball-test the Create User modal in Settings → Users (the new role select should list Superadmin first, then Admin / Member / Viewer; hovering shows the description as a tooltip) and the Edit User Role field in `UserSettingsModal` (same list, disabled for non-admins as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)