### PR TITLE
fix(ui): global-search row layout + widen popover

### DIFF
--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -232,18 +232,20 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
         <div
           role="listbox"
           id={GLOBAL_SEARCH_LISTBOX_ID}
+          // Anchored to the right edge of the input (input lives in the
+          // right cluster of the navbar) so the popover grows leftward
+          // and doesn't overflow the viewport.
           style={{
             position: 'absolute',
             top: '100%',
-            left: 0,
             right: 0,
+            width: 600,
             marginTop: 4,
             background: token.colorBgElevated,
             border: `1px solid ${token.colorBorderSecondary}`,
             borderRadius: token.borderRadiusLG,
             boxShadow: token.boxShadowSecondary,
             zIndex: 1000,
-            minWidth: 480,
           }}
         >
           <SearchChipRow

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -235,11 +235,19 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
           // Anchored to the right edge of the input (input lives in the
           // right cluster of the navbar) so the popover grows leftward
           // and doesn't overflow the viewport.
+          //
+          // Flex column so the chip row stays sticky at the top and the
+          // result body takes whatever vertical space is left up to 85vh.
+          // Without `min-height: 0` on the scrollable child, flex children
+          // refuse to shrink below their content height and scroll breaks.
           style={{
             position: 'absolute',
             top: '100%',
             right: 0,
             width: 600,
+            maxHeight: '85vh',
+            display: 'flex',
+            flexDirection: 'column',
             marginTop: 4,
             background: token.colorBgElevated,
             border: `1px solid ${token.colorBorderSecondary}`,

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
@@ -31,8 +31,12 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
 
   return (
     <div
+      // Fills the remaining space inside the popover's flex column. The
+      // popover caps total height at 85vh; the chip row above is fixed
+      // height, so this scroll area grows to use whatever's left.
       style={{
-        maxHeight: 480,
+        flex: 1,
+        minHeight: 0,
         overflowY: 'auto',
         padding: '2px 0',
       }}

--- a/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
@@ -1,5 +1,5 @@
 import { getAssistantConfig } from '@agor-live/client';
-import { Space, Typography, theme } from 'antd';
+import { Typography, theme } from 'antd';
 import type React from 'react';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
@@ -57,31 +57,42 @@ export const SearchResult: React.FC<SearchResultProps> = ({
     >
       <span style={{ fontSize: 18, lineHeight: '20px', flexShrink: 0 }}>{icon}</span>
       <div style={{ flex: 1, minWidth: 0 }}>
-        <Space size={8} align="center" style={{ width: '100%', justifyContent: 'space-between' }}>
+        {/* Title row: title takes remaining width and ellipsizes; tag + time
+            stay on one line via whiteSpace:nowrap + flex-shrink:0. Plain flex
+            instead of antd Space because Space wraps each child in a div that
+            ignores parent's nowrap, which produced character-by-character
+            wrapping in the right column on long titles. */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 8,
+            width: '100%',
+          }}
+        >
           <Text
             strong
             style={{
+              flex: 1,
+              minWidth: 0,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              maxWidth: 340,
             }}
           >
             {title}
           </Text>
-          <Space size={8} style={{ flexShrink: 0 }}>
-            {tag && (
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                {tag}
-              </Text>
-            )}
-            {time && (
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                {time}
-              </Text>
-            )}
-          </Space>
-        </Space>
+          {tag && (
+            <Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {tag}
+            </Text>
+          )}
+          {time && (
+            <Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', flexShrink: 0 }}>
+              {time}
+            </Text>
+          )}
+        </div>
         {secondary && (
           <Text
             type="secondary"


### PR DESCRIPTION
Fast-follow on #1246.

## Summary

Two layout bugs on long titles in the just-merged global search:

1. **Right-column text wrapping character-by-character.** AntD `<Space>` wraps each child in a div that doesn't inherit the parent's `whiteSpace: nowrap`, so once the title pushed against its 340px cap, the right side got squeezed and \`claude-code\` became \`c\\na\\nu\\nd\\ne\\n…\`.
2. **Popover was too narrow** (`minWidth: 480`) for a typical session title.

## Fix

Row rewrite in \`SearchResult.tsx\`:
- Title: \`flex: 1\` + \`min-width: 0\` + ellipsis — takes remaining width, truncates cleanly.
- Tag + time: \`white-space: nowrap\` + \`flex-shrink: 0\` — always one line.
- Drop AntD \`Space\` in the title row in favor of plain flex.

Popover (\`GlobalSearch.tsx\`): fixed 600px, anchored to the input's right edge so it grows leftward without overflowing the viewport.

## Test plan

- [ ] Long session titles (>50 chars) ellipsize instead of squeezing the right column
- [ ] Tag (\`claude-code\`) and time (\`7m ago\`) stay on one line
- [ ] Popover sits flush with the input's right edge and extends ~600px to the left
- [ ] Nothing else in the dropdown regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)