### PR TITLE
feat(ui): clearer navbar connection state + user actions

### DIFF
--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.test.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Tests for the ConnectionStatus navbar tag state machine.
+ *
+ * The state machine is non-trivial: it has to discriminate transient
+ * reconnects (silent), stuck-too-long reconnects (escalate to red
+ * "Can't reconnect"), short-gap reconnects (green flash), and long-gap
+ * reconnects (yellow "Reconnected — refresh?" cue). Pinning the behavior
+ * here prevents two specific regressions we already burned on:
+ *
+ *   1. Timer started on `connecting && !connected` — missed the 1.5s
+ *      grace window in useAgorClient that keeps `connected=true` while
+ *      flipping `connecting=true`, so sub-grace reconnects silently
+ *      dropped the green flash.
+ *   2. Successful in-place re-auth on TOKENS_REFRESHED_EVENT didn't
+ *      publish to React state, leaving the navbar stuck on "Reconnecting"
+ *      forever. That fix lives in useAgorClient; we cover the navbar's
+ *      reaction to the state it produces.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionStatus } from './ConnectionStatus';
+
+// useConnectionState reads from React context populated by App.tsx. Mock
+// the hook directly so tests don't need to wrap in a provider just to flip
+// `outOfSync`. Default returns "synced" — individual tests override.
+const mockConnectionState = vi.fn(() => ({
+  outOfSync: false,
+  capturedSha: null as string | null,
+  currentSha: null as string | null,
+  connected: true,
+  connecting: false,
+}));
+vi.mock('../../contexts/ConnectionContext', () => ({
+  useConnectionState: () => mockConnectionState(),
+}));
+
+describe('ConnectionStatus', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockConnectionState.mockReturnValue({
+      outOfSync: false,
+      capturedSha: null,
+      currentSha: null,
+      connected: true,
+      connecting: false,
+    });
+    // jsdom's `window.location.reload` is non-configurable, so we replace
+    // the whole `location` global via vi.stubGlobal and restore in
+    // afterEach. Only `reload` is exercised; other properties are passed
+    // through from the real location so anything that reads `pathname`,
+    // `href`, etc. still works.
+    reloadSpy = vi.fn();
+    vi.stubGlobal('location', {
+      ...window.location,
+      reload: reloadSpy,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('renders nothing in steady state (connected, never disconnected)', () => {
+    const { container } = render(<ConnectionStatus connected={true} connecting={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the Reconnecting tag when connecting and forwards clicks to onRetry', () => {
+    const onRetry = vi.fn();
+    render(<ConnectionStatus connected={false} connecting={true} onRetry={onRetry} />);
+    const tag = screen.getByText('Reconnecting');
+    expect(tag).toBeInTheDocument();
+    fireEvent.click(tag);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('escalates to "Can\'t reconnect — reload" after STUCK_RECONNECT_MS (20s)', () => {
+    render(<ConnectionStatus connected={false} connecting={true} />);
+    expect(screen.getByText('Reconnecting')).toBeInTheDocument();
+
+    // Sub-threshold: still Reconnecting.
+    act(() => {
+      vi.advanceTimersByTime(19_000);
+    });
+    expect(screen.getByText('Reconnecting')).toBeInTheDocument();
+
+    // Crosses 20s threshold on the next per-second tick.
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    const tag = screen.getByText("Can't reconnect — reload");
+    expect(tag).toBeInTheDocument();
+    fireEvent.click(tag);
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+
+  it('shows brief green "Connected" flash after a short reconnect (< stale threshold)', () => {
+    const { rerender } = render(<ConnectionStatus connected={false} connecting={true} />);
+    expect(screen.getByText('Reconnecting')).toBeInTheDocument();
+
+    // 3s of downtime — well below STALE_THRESHOLD_MS.
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+
+    // Reconnect: connecting=false, connected=true.
+    rerender(<ConnectionStatus connected={true} connecting={false} />);
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+
+    // Fades after CONNECTED_FLASH_MS (3s).
+    act(() => {
+      vi.advanceTimersByTime(3_500);
+    });
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+  });
+
+  it('shows "Reconnected — refresh?" cue after a long reconnect (≥ stale threshold)', () => {
+    const { rerender } = render(<ConnectionStatus connected={false} connecting={true} />);
+
+    // 15s of downtime — crosses STALE_THRESHOLD_MS (10s).
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+
+    rerender(<ConnectionStatus connected={true} connecting={false} />);
+    expect(screen.getByText('Reconnected — refresh?')).toBeInTheDocument();
+    // Green flash should NOT show — the two cues never compete.
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+
+    // Clicking the tag (anywhere except the × dismiss) reloads.
+    fireEvent.click(screen.getByText('Reconnected — refresh?'));
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+
+  it('dismissing the stale cue with × clears it without reloading', () => {
+    const { rerender } = render(<ConnectionStatus connected={false} connecting={true} />);
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    rerender(<ConnectionStatus connected={true} connecting={false} />);
+    expect(screen.getByText('Reconnected — refresh?')).toBeInTheDocument();
+
+    const dismiss = screen.getByLabelText('Dismiss');
+    fireEvent.click(dismiss);
+
+    expect(screen.queryByText('Reconnected — refresh?')).not.toBeInTheDocument();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto-dismisses the stale cue after STALE_AUTO_DISMISS_MS (60s)', () => {
+    const { rerender } = render(<ConnectionStatus connected={false} connecting={true} />);
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    rerender(<ConnectionStatus connected={true} connecting={false} />);
+    expect(screen.getByText('Reconnected — refresh?')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(61_000);
+    });
+    expect(screen.queryByText('Reconnected — refresh?')).not.toBeInTheDocument();
+  });
+
+  /**
+   * Regression: track on `connecting`, not `connecting && !connected`.
+   *
+   * useAgorClient keeps `connected=true` for a 1.5s grace window after a
+   * transport disconnect to suppress UI flicker. If the timer only started
+   * once `connected` flipped, a reconnect that finished within that window
+   * would see disconnectStartedAtRef === null on the connected→true
+   * transition, and the green "Connected" flash would never appear.
+   */
+  it('records disconnect timestamp on raw `connecting`, even while `connected` is still true (grace window)', () => {
+    // Initial: stable connected.
+    const { rerender } = render(<ConnectionStatus connected={true} connecting={false} />);
+
+    // Grace window state: connecting flips true while connected stays true.
+    rerender(<ConnectionStatus connected={true} connecting={true} />);
+
+    // 800ms passes — well inside the 1.5s grace window.
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    // Reconnect succeeds before the grace timer fires: connecting=false,
+    // connected stayed true throughout.
+    rerender(<ConnectionStatus connected={true} connecting={false} />);
+
+    // The green flash must still appear — the bug Codex caught was that
+    // it didn't, because the timer never started.
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('renders Out of sync (highest priority) when outOfSync is true, click reloads', () => {
+    mockConnectionState.mockReturnValue({
+      outOfSync: true,
+      capturedSha: 'abc1234',
+      currentSha: 'def5678',
+      connected: true,
+      connecting: false,
+    });
+    render(<ConnectionStatus connected={true} connecting={false} />);
+    const tag = screen.getByText('Out of sync — refresh');
+    expect(tag).toBeInTheDocument();
+    fireEvent.click(tag);
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+
+  it('renders Disconnected when neither connected nor connecting, click calls onRetry', () => {
+    const onRetry = vi.fn();
+    render(<ConnectionStatus connected={false} connecting={false} onRetry={onRetry} />);
+    const tag = screen.getByText('Disconnected');
+    expect(tag).toBeInTheDocument();
+    fireEvent.click(tag);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -6,9 +6,10 @@ import {
   WarningOutlined,
 } from '@ant-design/icons';
 import { Space, Tooltip } from 'antd';
+import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useConnectionState } from '../../contexts/ConnectionContext';
-import { Tag } from '../Tag';
+import { Tag, type TagProps } from '../Tag';
 
 export interface ConnectionStatusProps {
   connected: boolean;
@@ -31,11 +32,10 @@ const STUCK_RECONNECT_MS = 20_000;
 /**
  * Disconnect duration above which we surface the "Reconnected — refresh?"
  * cue on the next successful reconnect. Below this, the user almost
- * certainly didn't miss anything material (the disconnect grace window in
- * useAgorClient is 1.5s; real-time events that fire in a 1–10s gap are rare
- * enough not to warrant nagging). At 10s we start to plausibly miss
- * messages, comments, or session updates that the byId caches won't notice
- * are gone.
+ * certainly didn't miss anything material (real-time events that fire in a
+ * 1–10s gap are rare enough not to warrant nagging). At 10s we start to
+ * plausibly miss messages, comments, or session updates that the byId
+ * caches won't notice are gone.
  */
 const STALE_THRESHOLD_MS = 10_000;
 
@@ -50,6 +50,40 @@ const STALE_THRESHOLD_MS = 10_000;
  */
 const STALE_AUTO_DISMISS_MS = 60_000;
 
+/** How long the green "Connected" flash lingers after a short reconnect. */
+const CONNECTED_FLASH_MS = 3_000;
+
+interface StatusTagProps {
+  tooltip: ReactNode;
+  icon: ReactNode;
+  color: TagProps['color'];
+  onClick?: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Local helper that collapses the repeated Tooltip + Tag + Space scaffolding
+ * across the seven branches below. Cursor flips to `pointer` whenever the
+ * tag is actionable so a future variant can't silently lose the affordance.
+ */
+const StatusTag: React.FC<StatusTagProps> = ({ tooltip, icon, color, onClick, children }) => (
+  <Tooltip title={tooltip} placement="bottom">
+    <Tag
+      icon={icon}
+      color={color}
+      onClick={onClick}
+      style={{
+        margin: 0,
+        display: 'flex',
+        alignItems: 'center',
+        cursor: onClick ? 'pointer' : 'default',
+      }}
+    >
+      <Space size={4}>{children}</Space>
+    </Tag>
+  </Tooltip>
+);
+
 /**
  * ConnectionStatus — navbar tag that communicates connection state and the
  * action the user can take. The component is intentionally honest about
@@ -59,23 +93,23 @@ const STALE_AUTO_DISMISS_MS = 60_000;
  *
  * State machine, in priority order:
  *
- * 1. **Out of sync** (red, click → reload) — daemon SHA changed under us.
+ * 1. **Out of sync** (warning, click → reload) — daemon SHA changed under us.
  *    Reload is mandatory; UI bundle assumes a contract that's no longer there.
- * 2. **Can't reconnect** (red, click → reload) — we've been `connecting`
+ * 2. **Can't reconnect** (error, click → reload) — we've been `connecting`
  *    for > STUCK_RECONNECT_MS without succeeding. Honest "this isn't
  *    fixing itself" cue.
- * 3. **Disconnected** (red, click → retry) — `!connected && !connecting`,
+ * 3. **Disconnected** (error, click → retry) — `!connected && !connecting`,
  *    typically socket-server-disconnect after the manual-reconnect cap is
  *    hit.
- * 4. **Reconnecting** (yellow, click → retry) — the normal transient
+ * 4. **Reconnecting** (warning, click → retry) — the normal transient
  *    reconnect window. Click is a manual escape hatch in case socket.io's
  *    own retry is on a slow cycle.
- * 5. **Reconnected — refresh?** (yellow info, click → reload, × dismiss) —
+ * 5. **Reconnected — refresh?** (warning info, click → reload, × dismiss) —
  *    just reconnected after a gap ≥ STALE_THRESHOLD_MS. The byId caches
  *    and reactive sessions auto-resync for the common cases, but a long
  *    gap can drop subtle updates (sessions removed/added, comments,
  *    permission changes). Suggested-not-required.
- * 6. **Connected** (green, ephemeral) — brief success flash after a normal
+ * 6. **Connected** (success, ephemeral) — brief flash after a short
  *    reconnect that didn't qualify as stale.
  * 7. **Nothing** — steady-state connected, no clutter.
  */
@@ -86,9 +120,17 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
 }) => {
   const { outOfSync, capturedSha, currentSha } = useConnectionState();
 
-  // Timestamp the user lost connection (entered `connecting && !connected`).
-  // Null when we're not currently disconnected. Survives across renders so
-  // the second-tick effect below can derive stuck-ness without re-recording.
+  // Timestamp the user lost connection (entered `connecting` for any reason).
+  // We track on raw `connecting` rather than `connecting && !connected`
+  // because useAgorClient keeps `connected=true` for a 1.5s grace window
+  // (DISCONNECT_GRACE_MS in apps/agor-ui/src/hooks/useAgorClient.ts) to
+  // avoid flickering disabled-button states on quick reconnects. If we only
+  // started the timer once `connected` flipped, sub-grace reconnects would
+  // never get the green flash, and longer reconnects would understate
+  // downtime by the grace duration (worse for a backgrounded tab where the
+  // grace setTimeout is throttled). Ref + state in lockstep — ref so the
+  // timing survives a tear-down between effect runs, state so renders see
+  // the up-to-date value for the stuck-too-long derivation below.
   const disconnectStartedAtRef = useRef<number | null>(null);
   const [disconnectStartedAt, setDisconnectStartedAt] = useState<number | null>(null);
 
@@ -114,13 +156,15 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
     return () => clearInterval(id);
   }, [connecting]);
 
-  // Track the disconnect → reconnect transition. We record the start of
-  // every reconnect attempt and, when `connected` flips back to true,
-  // compute the duration to decide whether the user might have missed
-  // events. Ref + state in lockstep — ref so the timing survives a tear-
-  // down between effect runs, state so renders see the up-to-date value.
+  // Track the disconnect → reconnect transition. Record on raw `connecting`
+  // (see disconnectStartedAtRef comment for why), and resolve only when the
+  // socket is *actually* back (`connected && !connecting`) — we don't want a
+  // transient `connecting=false, connected=false` (e.g. the manual-reconnect
+  // cap-hit branch in useAgorClient) to be mistaken for recovery and clear
+  // the timer. That branch leaves the user in "Disconnected"; if they later
+  // recover by clicking retry, we should still count the full elapsed time.
   useEffect(() => {
-    if (connecting && !connected) {
+    if (connecting) {
       if (disconnectStartedAtRef.current === null) {
         const now = Date.now();
         disconnectStartedAtRef.current = now;
@@ -144,7 +188,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // short enough not to clutter.
   useEffect(() => {
     if (!showConnected) return;
-    const id = setTimeout(() => setShowConnected(false), 3000);
+    const id = setTimeout(() => setShowConnected(false), CONNECTED_FLASH_MS);
     return () => clearTimeout(id);
   }, [showConnected]);
 
@@ -167,18 +211,14 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
         ? `Daemon was upgraded from ${capturedSha} to ${currentSha} since this tab loaded. Click to reload and pick up the latest UI. Anything unsaved (form text, etc.) will be lost.`
         : 'Backend was updated — click to reload for the latest UI. Anything unsaved will be lost.';
     return (
-      <Tooltip title={tooltipTitle} placement="bottom">
-        <Tag
-          icon={<ReloadOutlined />}
-          color="warning"
-          onClick={() => window.location.reload()}
-          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-        >
-          <Space size={4}>
-            <span>Out of sync — refresh</span>
-          </Space>
-        </Tag>
-      </Tooltip>
+      <StatusTag
+        tooltip={tooltipTitle}
+        icon={<ReloadOutlined />}
+        color="warning"
+        onClick={() => window.location.reload()}
+      >
+        <span>Out of sync — refresh</span>
+      </StatusTag>
     );
   }
 
@@ -193,21 +233,14 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // thing the user would do manually; making it one click is the point.
   if (stuckTooLong) {
     return (
-      <Tooltip
-        title="Can't reconnect to the daemon. Click to reload the page — anything unsaved will be lost."
-        placement="bottom"
+      <StatusTag
+        tooltip="Can't reconnect to the daemon. Click to reload the page — anything unsaved will be lost."
+        icon={<ReloadOutlined />}
+        color="error"
+        onClick={() => window.location.reload()}
       >
-        <Tag
-          icon={<ReloadOutlined />}
-          color="error"
-          onClick={() => window.location.reload()}
-          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-        >
-          <Space size={4}>
-            <span>Can't reconnect — reload</span>
-          </Space>
-        </Tag>
-      </Tooltip>
+        <span>Can't reconnect — reload</span>
+      </StatusTag>
     );
   }
 
@@ -216,18 +249,14 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // via useAgorClient's `retryConnection`.
   if (!connected && !connecting) {
     return (
-      <Tooltip title="Connection lost. Click to retry connection." placement="bottom">
-        <Tag
-          icon={<WarningOutlined />}
-          color="error"
-          onClick={onRetry}
-          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-        >
-          <Space size={4}>
-            <span>Disconnected</span>
-          </Space>
-        </Tag>
-      </Tooltip>
+      <StatusTag
+        tooltip="Connection lost. Click to retry connection."
+        icon={<WarningOutlined />}
+        color="error"
+        onClick={onRetry}
+      >
+        <span>Disconnected</span>
+      </StatusTag>
     );
   }
 
@@ -237,18 +266,14 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // sitting and waiting, they can force a retry attempt right now.
   if (connecting) {
     return (
-      <Tooltip title="Reconnecting to daemon… Click to retry immediately." placement="bottom">
-        <Tag
-          icon={<LoadingOutlined spin />}
-          color="warning"
-          onClick={onRetry}
-          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-        >
-          <Space size={4}>
-            <span>Reconnecting</span>
-          </Space>
-        </Tag>
-      </Tooltip>
+      <StatusTag
+        tooltip="Reconnecting to daemon… Click to retry immediately."
+        icon={<LoadingOutlined spin />}
+        color="warning"
+        onClick={onRetry}
+      >
+        <span>Reconnecting</span>
+      </StatusTag>
     );
   }
 
@@ -261,29 +286,22 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // would take manually.
   if (staleSince !== null) {
     return (
-      <Tooltip
-        title="You were disconnected long enough that some data may be stale. Click to reload, or × to dismiss."
-        placement="bottom"
+      <StatusTag
+        tooltip="You were disconnected long enough that some data may be stale. Click to reload, or × to dismiss."
+        icon={<ReloadOutlined />}
+        color="warning"
+        onClick={() => window.location.reload()}
       >
-        <Tag
-          icon={<ReloadOutlined />}
-          color="warning"
-          onClick={() => window.location.reload()}
-          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-        >
-          <Space size={4}>
-            <span>Reconnected — refresh?</span>
-            <CloseOutlined
-              aria-label="Dismiss"
-              onClick={(e) => {
-                e.stopPropagation();
-                setStaleSince(null);
-              }}
-              style={{ fontSize: 10, opacity: 0.7 }}
-            />
-          </Space>
-        </Tag>
-      </Tooltip>
+        <span>Reconnected — refresh?</span>
+        <CloseOutlined
+          aria-label="Dismiss"
+          onClick={(e) => {
+            e.stopPropagation();
+            setStaleSince(null);
+          }}
+          style={{ fontSize: 10, opacity: 0.7 }}
+        />
+      </StatusTag>
     );
   }
 
@@ -293,17 +311,9 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // two cues never compete.
   if (showConnected) {
     return (
-      <Tooltip title="Connected to daemon" placement="bottom">
-        <Tag
-          icon={<CheckCircleOutlined />}
-          color="success"
-          style={{ margin: 0, display: 'flex', alignItems: 'center' }}
-        >
-          <Space size={4}>
-            <span>Connected</span>
-          </Space>
-        </Tag>
-      </Tooltip>
+      <StatusTag tooltip="Connected to daemon" icon={<CheckCircleOutlined />} color="success">
+        <span>Connected</span>
+      </StatusTag>
     );
   }
 

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -1,11 +1,12 @@
 import {
   CheckCircleOutlined,
+  CloseOutlined,
   LoadingOutlined,
   ReloadOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
 import { Space, Tooltip } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useConnectionState } from '../../contexts/ConnectionContext';
 import { Tag } from '../Tag';
 
@@ -16,21 +17,67 @@ export interface ConnectionStatusProps {
 }
 
 /**
- * ConnectionStatus - Shows real-time WebSocket connection status
+ * Threshold for escalating a stuck "Reconnecting" tag to the terminal
+ * "Can't reconnect" red tag. Socket.io's `reconnectionDelayMax` is 5s
+ * (packages/core/src/api/index.ts) and a healthy reconnect (daemon restart,
+ * wifi flap, etc.) finishes well under 10s. Once we've spent 20s spinning,
+ * the user is almost certainly looking at the stuck-reconnect bug pattern
+ * (token expired, refresh failed transiently, no auto-recovery path), and
+ * telling them "click to reload" is more honest than continuing to imply
+ * recovery is imminent.
+ */
+const STUCK_RECONNECT_MS = 20_000;
+
+/**
+ * Disconnect duration above which we surface the "Reconnected — refresh?"
+ * cue on the next successful reconnect. Below this, the user almost
+ * certainly didn't miss anything material (the disconnect grace window in
+ * useAgorClient is 1.5s; real-time events that fire in a 1–10s gap are rare
+ * enough not to warrant nagging). At 10s we start to plausibly miss
+ * messages, comments, or session updates that the byId caches won't notice
+ * are gone.
+ */
+const STALE_THRESHOLD_MS = 10_000;
+
+/**
+ * How long the "Reconnected — refresh?" cue stays in the navbar before
+ * auto-dismissing. The cue is a *suggestion*, not a requirement — the
+ * around-hook + per-conversation resync listeners catch the common cases;
+ * this nudges the user only when the gap was long enough that something
+ * subtle might have slipped through. 60s is long enough to notice and
+ * decide; short enough that a tab left open all day doesn't accumulate a
+ * permanent yellow tag.
+ */
+const STALE_AUTO_DISMISS_MS = 60_000;
+
+/**
+ * ConnectionStatus — navbar tag that communicates connection state and the
+ * action the user can take. The component is intentionally honest about
+ * what's recoverable on its own (transient reconnects) vs. what needs
+ * user-driven intervention (terminal stuck-state, post-long-gap data
+ * staleness).
  *
- * States:
- * - Out of sync: Amber refresh icon (FE/BE drift after a deploy — supersedes
- *   Connected and Disconnected; click to hard-reload the tab)
- * - Connected: Green checkmark (only shown briefly after reconnect)
- * - Reconnecting: Yellow spinner (shown during reconnection)
- * - Disconnected: Red warning (shown when connection lost, click to retry)
+ * State machine, in priority order:
  *
- * Auto-hides after 3 seconds when connected to reduce visual clutter.
- *
- * `outOfSync` is read from ConnectionContext (populated by useServerVersion in
- * App.tsx). It's deliberately checked first — when the daemon's build SHA has
- * changed under us, refreshing the tab matters more than any other connection
- * detail. We don't auto-reload (per design); the user clicks.
+ * 1. **Out of sync** (red, click → reload) — daemon SHA changed under us.
+ *    Reload is mandatory; UI bundle assumes a contract that's no longer there.
+ * 2. **Can't reconnect** (red, click → reload) — we've been `connecting`
+ *    for > STUCK_RECONNECT_MS without succeeding. Honest "this isn't
+ *    fixing itself" cue.
+ * 3. **Disconnected** (red, click → retry) — `!connected && !connecting`,
+ *    typically socket-server-disconnect after the manual-reconnect cap is
+ *    hit.
+ * 4. **Reconnecting** (yellow, click → retry) — the normal transient
+ *    reconnect window. Click is a manual escape hatch in case socket.io's
+ *    own retry is on a slow cycle.
+ * 5. **Reconnected — refresh?** (yellow info, click → reload, × dismiss) —
+ *    just reconnected after a gap ≥ STALE_THRESHOLD_MS. The byId caches
+ *    and reactive sessions auto-resync for the common cases, but a long
+ *    gap can drop subtle updates (sessions removed/added, comments,
+ *    permission changes). Suggested-not-required.
+ * 6. **Connected** (green, ephemeral) — brief success flash after a normal
+ *    reconnect that didn't qualify as stale.
+ * 7. **Nothing** — steady-state connected, no clutter.
  */
 export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   connected,
@@ -38,32 +85,82 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   onRetry,
 }) => {
   const { outOfSync, capturedSha, currentSha } = useConnectionState();
+
+  // Timestamp the user lost connection (entered `connecting && !connected`).
+  // Null when we're not currently disconnected. Survives across renders so
+  // the second-tick effect below can derive stuck-ness without re-recording.
+  const disconnectStartedAtRef = useRef<number | null>(null);
+  const [disconnectStartedAt, setDisconnectStartedAt] = useState<number | null>(null);
+
+  // Reflects the most recent reconnect we judged "stale enough to surface a
+  // refresh cue for." Set when connection comes back after ≥ STALE_THRESHOLD_MS;
+  // cleared on user action (click reload or click ×) or after auto-dismiss.
+  const [staleSince, setStaleSince] = useState<number | null>(null);
+
+  // Brief green "Connected" flash after a short reconnect (< stale threshold)
+  // so the user gets a quick "we noticed and fixed it" confirmation when
+  // there's no other cue to render. Long reconnects show the actionable
+  // "Reconnected — refresh?" cue instead, so the two never compete.
   const [showConnected, setShowConnected] = useState(false);
-  const [justReconnected, setJustReconnected] = useState(false);
 
-  // Track when we transition from connecting -> connected to show "Connected!" briefly
+  // Forces re-render every second while `connecting`, so the stuck-reconnect
+  // escalation fires without us having to push timing state up into
+  // useAgorClient. Cheap (the navbar is the only consumer); only ticks when
+  // we're actually waiting.
+  const [, setTick] = useState(0);
   useEffect(() => {
-    if (connected && !connecting && justReconnected) {
-      setShowConnected(true);
-      const timer = setTimeout(() => {
-        setShowConnected(false);
-        setJustReconnected(false);
-      }, 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [connected, connecting, justReconnected]);
+    if (!connecting) return;
+    const id = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [connecting]);
 
-  // Track reconnection events
+  // Track the disconnect → reconnect transition. We record the start of
+  // every reconnect attempt and, when `connected` flips back to true,
+  // compute the duration to decide whether the user might have missed
+  // events. Ref + state in lockstep — ref so the timing survives a tear-
+  // down between effect runs, state so renders see the up-to-date value.
   useEffect(() => {
     if (connecting && !connected) {
-      setJustReconnected(true);
+      if (disconnectStartedAtRef.current === null) {
+        const now = Date.now();
+        disconnectStartedAtRef.current = now;
+        setDisconnectStartedAt(now);
+      }
+      return;
+    }
+    if (connected && disconnectStartedAtRef.current !== null) {
+      const downFor = Date.now() - disconnectStartedAtRef.current;
+      disconnectStartedAtRef.current = null;
+      setDisconnectStartedAt(null);
+      if (downFor >= STALE_THRESHOLD_MS) {
+        setStaleSince(Date.now());
+      } else {
+        setShowConnected(true);
+      }
     }
   }, [connecting, connected]);
 
-  // Out of sync: backend was redeployed under us. Supersedes both connected
-  // and disconnected — the user needs to refresh, period. No auto-reload, since
-  // that would nuke a half-typed message or open modal. Tooltip surfaces the
-  // actual SHA diff so the user can see *what* changed before reloading.
+  // Hide the green flash after a short delay. Long enough to register,
+  // short enough not to clutter.
+  useEffect(() => {
+    if (!showConnected) return;
+    const id = setTimeout(() => setShowConnected(false), 3000);
+    return () => clearTimeout(id);
+  }, [showConnected]);
+
+  // Auto-dismiss the stale cue after STALE_AUTO_DISMISS_MS — a long-open
+  // tab shouldn't accumulate a yellow nag forever. User action (reload or
+  // dismiss) also clears it.
+  useEffect(() => {
+    if (staleSince === null) return;
+    const id = setTimeout(() => setStaleSince(null), STALE_AUTO_DISMISS_MS);
+    return () => clearTimeout(id);
+  }, [staleSince]);
+
+  // --- 1. Out of sync (highest priority) ---
+  // Backend redeployed under us. Reload is mandatory because the bundled UI
+  // may reference removed services. No auto-reload, since it would nuke a
+  // half-typed message or open modal.
   if (outOfSync) {
     const tooltipTitle =
       capturedSha && currentSha
@@ -75,12 +172,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
           icon={<ReloadOutlined />}
           color="warning"
           onClick={() => window.location.reload()}
-          style={{
-            margin: 0,
-            display: 'flex',
-            alignItems: 'center',
-            cursor: 'pointer',
-          }}
+          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
         >
           <Space size={4}>
             <span>Out of sync — refresh</span>
@@ -90,25 +182,46 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
     );
   }
 
-  // Don't show anything when normally connected (reduces clutter)
-  if (connected && !connecting && !showConnected) {
-    return null;
+  const stuckTooLong =
+    connecting &&
+    disconnectStartedAt !== null &&
+    Date.now() - disconnectStartedAt >= STUCK_RECONNECT_MS;
+
+  // --- 2. Can't reconnect (escalated stuck state) ---
+  // Honest message: we tried for STUCK_RECONNECT_MS, it isn't working,
+  // here's the button that actually fixes it. Page reload is the same
+  // thing the user would do manually; making it one click is the point.
+  if (stuckTooLong) {
+    return (
+      <Tooltip
+        title="Can't reconnect to the daemon. Click to reload the page — anything unsaved will be lost."
+        placement="bottom"
+      >
+        <Tag
+          icon={<ReloadOutlined />}
+          color="error"
+          onClick={() => window.location.reload()}
+          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+        >
+          <Space size={4}>
+            <span>Can't reconnect — reload</span>
+          </Space>
+        </Tag>
+      </Tooltip>
+    );
   }
 
-  // Disconnected state
+  // --- 3. Disconnected (transient, before escalation) ---
+  // Matches the previous behavior. The retry button kicks `client.io.connect()`
+  // via useAgorClient's `retryConnection`.
   if (!connected && !connecting) {
     return (
-      <Tooltip title="Connection lost. Click to retry connection..." placement="bottom">
+      <Tooltip title="Connection lost. Click to retry connection." placement="bottom">
         <Tag
           icon={<WarningOutlined />}
           color="error"
           onClick={onRetry}
-          style={{
-            margin: 0,
-            display: 'flex',
-            alignItems: 'center',
-            cursor: 'pointer',
-          }}
+          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
         >
           <Space size={4}>
             <span>Disconnected</span>
@@ -118,18 +231,21 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
     );
   }
 
-  // Reconnecting state
-  if (connecting || !connected) {
+  // --- 4. Reconnecting (now clickable for manual retry) ---
+  // Used to be passive. The click handler gives the user an escape hatch
+  // when socket.io's exponential backoff is on a 5s sleep — instead of
+  // sitting and waiting, they can force a retry attempt right now.
+  if (connecting) {
     return (
-      <Tooltip title="Reconnecting to daemon..." placement="bottom">
+      <Tooltip
+        title="Reconnecting to daemon… Click to retry immediately."
+        placement="bottom"
+      >
         <Tag
           icon={<LoadingOutlined spin />}
           color="warning"
-          style={{
-            margin: 0,
-            display: 'flex',
-            alignItems: 'center',
-          }}
+          onClick={onRetry}
+          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
         >
           <Space size={4}>
             <span>Reconnecting</span>
@@ -139,18 +255,52 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
     );
   }
 
-  // Just reconnected - show success briefly
+  // --- 5. Reconnected — refresh? (post-long-gap cue) ---
+  // Suggested, not required. The around-hook + per-conversation resync
+  // listeners already pick up the common cases; this nudges the user only
+  // when the gap was long enough that something subtle (a removed session,
+  // a comment, a permission change) might have slipped through. Reload is
+  // the simplest universal "rehydrate everything" — same action the user
+  // would take manually.
+  if (staleSince !== null) {
+    return (
+      <Tooltip
+        title="You were disconnected long enough that some data may be stale. Click to reload, or × to dismiss."
+        placement="bottom"
+      >
+        <Tag
+          icon={<ReloadOutlined />}
+          color="warning"
+          onClick={() => window.location.reload()}
+          style={{ margin: 0, display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+        >
+          <Space size={4}>
+            <span>Reconnected — refresh?</span>
+            <CloseOutlined
+              aria-label="Dismiss"
+              onClick={(e) => {
+                e.stopPropagation();
+                setStaleSince(null);
+              }}
+              style={{ fontSize: 10, opacity: 0.7 }}
+            />
+          </Space>
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  // --- 6. Connected (ephemeral success flash for short reconnects) ---
+  // Only set when the gap was below STALE_THRESHOLD_MS — long-gap
+  // reconnects route to "Reconnected — refresh?" above instead, so the
+  // two cues never compete.
   if (showConnected) {
     return (
       <Tooltip title="Connected to daemon" placement="bottom">
         <Tag
           icon={<CheckCircleOutlined />}
           color="success"
-          style={{
-            margin: 0,
-            display: 'flex',
-            alignItems: 'center',
-          }}
+          style={{ margin: 0, display: 'flex', alignItems: 'center' }}
         >
           <Space size={4}>
             <span>Connected</span>
@@ -160,5 +310,6 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
     );
   }
 
+  // --- 7. Nothing (steady state) ---
   return null;
 };

--- a/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/apps/agor-ui/src/components/ConnectionStatus/ConnectionStatus.tsx
@@ -237,10 +237,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
   // sitting and waiting, they can force a retry attempt right now.
   if (connecting) {
     return (
-      <Tooltip
-        title="Reconnecting to daemon… Click to retry immediately."
-        placement="bottom"
-      >
+      <Tooltip title="Reconnecting to daemon… Click to retry immediately." placement="bottom">
         <Tag
           icon={<LoadingOutlined spin />}
           color="warning"

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -445,12 +445,31 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       const detail = (event as CustomEvent<RefreshResult>).detail;
       if (!detail || !client) return;
       if (!client.io.connected) return;
-      client.authenticate({ strategy: 'jwt', accessToken: detail.accessToken }).catch((err) => {
-        // Best-effort — if this fails, the next service call will 401
-        // and the around-hook will take the standard refresh-and-retry
-        // path. Log so the cause isn't invisible.
-        console.error('In-place re-authentication failed after token refresh:', err);
-      });
+      client
+        .authenticate({ strategy: 'jwt', accessToken: detail.accessToken })
+        .then(() => {
+          // Publish recovery to React state. The connect handler above can
+          // strand the UI at `connecting=true, connected=false` when its own
+          // refresh attempt fails transiently (network half-restored, daemon
+          // briefly 5xxs, etc.) — see the `setConnecting(true); return;`
+          // branch above. Without this `setConnected(true)`, a later
+          // successful refresh from any source (proactive timer, around-hook
+          // on a user click, visibility-change handler) re-authenticates the
+          // socket but the navbar stays stuck on "Reconnecting" until page
+          // refresh. We're safe to publish here because (a) `client.io.connected`
+          // was true at entry, (b) `authenticate()` just resolved, so the
+          // socket is connected AND authenticated.
+          if (!mounted) return;
+          setConnected(true);
+          setConnecting(false);
+          setError(null);
+        })
+        .catch((err) => {
+          // Best-effort — if this fails, the next service call will 401
+          // and the around-hook will take the standard refresh-and-retry
+          // path. Log so the cause isn't invisible.
+          console.error('In-place re-authentication failed after token refresh:', err);
+        });
     };
     window.addEventListener(TOKENS_REFRESHED_EVENT, handleTokensRefreshed);
 


### PR DESCRIPTION
## Summary

Reworks the connection-status tag in the navbar to honestly tell the user what's happening and give them the right action — instead of spinning indefinitely on "Reconnecting" with no recovery path.

Two commits:
1. **fix(ui): publish reconnected state after in-place re-auth on token refresh** — when a later refresh succeeds via `TOKENS_REFRESHED_EVENT`, also flip `connected: true` so the navbar unsticks. Was always-correct but never published.
2. **feat(ui): clearer navbar connection state + user actions** — the state-machine rewrite below.

## New navbar state machine

In priority order:

| State | Trigger | Color | Click |
|---|---|---|---|
| Out of sync | daemon SHA changed | warning | reload page |
| **Can't reconnect** (new) | `connecting` for ≥ 20s | error | reload page |
| Disconnected | `!connected && !connecting` | error | retry |
| Reconnecting (now clickable) | `connecting` | warning | retry immediately |
| **Reconnected — refresh?** (new) | downtime ≥ 10s | warning | reload (× to dismiss) |
| Connected | short reconnect just completed | success | — |
| (nothing) | steady state | — | — |

The two new states do the heavy lifting:
- **"Can't reconnect — reload"** addresses the original VPN-stuck bug: after 20s of unproductive spinning, escalate to an honest red tag with a one-click reload. Same action the user does manually today.
- **"Reconnected — refresh?"** addresses the "I was disconnected for a while, might have missed events" worry: after a ≥10s gap, suggest (don't force) a reload, with a × to dismiss and a 60s auto-dismiss timer so it doesn't accumulate.

## Scope (and what's intentionally not here)

- **No auto-recovery added.** The previous PR's small fix to publish reconnected state on `TOKENS_REFRESHED_EVENT` is enough for the common case; the navbar now makes the long-tail cases user-actionable.
- **No proactive rehydrate.** Decided against being hyperactive on microcuts (rehydrate costs 5–10s).
- **No `useAgorClient` plumbing changes.** All timing logic lives locally in `ConnectionStatus` (refs + setTimeout + per-second tick while connecting).
- **No design doc** — pivoted to direct implementation after design discussion.

## Test plan

- [ ] Stop the daemon, leave the UI running >20s → navbar escalates from yellow "Reconnecting" to red "Can't reconnect — reload". Click reloads.
- [ ] Restart daemon within 20s → yellow "Reconnecting" → if downtime ≥ 10s, yellow "Reconnected — refresh?" appears with × dismiss; otherwise brief green "Connected".
- [ ] Drop network for >15m (VPN scenario), restore → navbar escalates correctly. With the bug-fix in commit 1, when the around-hook later refreshes the token on the next user click, the navbar unsticks instead of staying on "Reconnecting" forever.
- [ ] Click the yellow "Reconnecting" tag during a normal reconnect — forces immediate retry instead of waiting on socket.io's backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
