### PR TITLE
feat(search): iter-1 polish — count tags, sectioned recents, close button, highlighting, registry DRY

### DIFF
--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -318,16 +318,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           connecting={connecting}
           onRetry={onRetryConnection}
         />
-        <GlobalSearch
-          currentUserId={currentUserId}
-          sessionById={sessionById}
-          branchById={branchById}
-          artifactById={artifactById}
-          boardById={boardById}
-          mcpServerById={mcpServerById}
-          onSettingsClick={onSettingsClick}
-        />
-        <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />
         {activeUsers.length > 0 && (
           <>
             <Facepile
@@ -343,6 +333,16 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />
           </>
         )}
+        <GlobalSearch
+          currentUserId={currentUserId}
+          sessionById={sessionById}
+          branchById={branchById}
+          artifactById={artifactById}
+          boardById={boardById}
+          mcpServerById={mcpServerById}
+          onSettingsClick={onSettingsClick}
+        />
+        <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />
         {eventStreamEnabled && (
           <Tooltip title="Live Event Stream" placement="bottom">
             <Button

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -62,7 +62,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
     artifactById,
   });
 
-  const { results, hasAnyResults, debouncedQuery, flush } = useGlobalSearch({
+  const { results, counts, hasAnyResults, debouncedQuery, flush } = useGlobalSearch({
     query,
     ownedByMe,
     activeTypeChip: activeChip,
@@ -267,6 +267,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
               setOwnedByMe((v) => !v);
               setSelectedIndex(0);
             }}
+            counts={showRecents ? undefined : counts}
           />
           <GlobalSearchDropdown
             query={effectiveQuery}

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -79,7 +79,16 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
     sessionById,
     branchById,
     artifactById,
+    boardById,
+    mcpServerById,
   });
+  const hasAnyRecents =
+    recents.session.length > 0 ||
+    recents.branch.length > 0 ||
+    recents.assistant.length > 0 ||
+    recents.artifact.length > 0 ||
+    recents.board.length > 0 ||
+    recents.mcp.length > 0;
 
   // Recents/results predicate is derived from the **raw** query so deleting
   // a long query back to <MIN_QUERY_LENGTH feels immediate — without this,
@@ -88,11 +97,11 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
   const showRecents = query.trim().length < MIN_QUERY_LENGTH;
   const effectiveQuery = showRecents ? '' : debouncedQuery.trim();
 
-  // Flatten current dropdown rows for keyboard nav. Order matches dropdown
-  // section order; recents mode is a single flat list.
+  // Flatten current dropdown rows for keyboard nav. Recents and live results
+  // share the same sectioned shape, so the flattening is identical.
   const visibleRows = useMemo<SearchResultItem[]>(() => {
-    if (showRecents) return recents;
-    return SECTION_ORDER.flatMap((t) => results[t]);
+    const source = showRecents ? recents : results;
+    return SECTION_ORDER.flatMap((t) => source[t]);
   }, [showRecents, recents, results]);
 
   // Keep selection inside the row list when results change.
@@ -274,6 +283,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
             results={results}
             hasAnyResults={hasAnyResults}
             recents={recents}
+            hasAnyRecents={hasAnyRecents}
             selectedIndex={selectedIndex}
             onResultClick={navigateToResult}
             onResultHover={setSelectedIndex}

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -1,4 +1,3 @@
-import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, Input, type InputRef, theme } from 'antd';
 import type React from 'react';
@@ -6,21 +5,20 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { GLOBAL_SEARCH_LISTBOX_ID, GlobalSearchDropdown, rowDomId } from './GlobalSearchDropdown';
 import { SearchChipRow } from './SearchChipRow';
-import { type ChipFilter, MIN_QUERY_LENGTH, SECTION_ORDER, type SearchResultItem } from './types';
+import {
+  type ChipFilter,
+  type GlobalSearchEntityMaps,
+  MIN_QUERY_LENGTH,
+  type SearchResultItem,
+} from './types';
 import { useGlobalSearch } from './useGlobalSearch';
 import { useRecents } from './useRecents';
+import { flattenResults, hasAnyEntries } from './utils';
 
 const INPUT_WIDTH = 260;
 
-interface GlobalSearchProps {
+interface GlobalSearchProps extends GlobalSearchEntityMaps {
   currentUserId?: string;
-  /** Live entity maps from useAgorData / contexts — passed in by AppHeader. */
-  sessionById: Map<string, Session>;
-  branchById: Map<string, Branch>;
-  artifactById: Map<string, Artifact>;
-  boardById: Map<string, Board>;
-  mcpServerById: Map<string, MCPServer>;
-
   /**
    * Open the Settings modal — used as a coarse landing for entity types
    * that don't live on the canvas (MCP servers today). Stays as a callback
@@ -82,13 +80,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
     boardById,
     mcpServerById,
   });
-  const hasAnyRecents =
-    recents.session.length > 0 ||
-    recents.branch.length > 0 ||
-    recents.assistant.length > 0 ||
-    recents.artifact.length > 0 ||
-    recents.board.length > 0 ||
-    recents.mcp.length > 0;
+  const hasAnyRecents = hasAnyEntries(recents);
 
   // Recents/results predicate is derived from the **raw** query so deleting
   // a long query back to <MIN_QUERY_LENGTH feels immediate — without this,
@@ -99,10 +91,10 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
 
   // Flatten current dropdown rows for keyboard nav. Recents and live results
   // share the same sectioned shape, so the flattening is identical.
-  const visibleRows = useMemo<SearchResultItem[]>(() => {
-    const source = showRecents ? recents : results;
-    return SECTION_ORDER.flatMap((t) => source[t]);
-  }, [showRecents, recents, results]);
+  const visibleRows = useMemo<SearchResultItem[]>(
+    () => flattenResults(showRecents ? recents : results),
+    [showRecents, recents, results]
+  );
 
   // Keep selection inside the row list when results change.
   useEffect(() => {
@@ -243,8 +235,10 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
       />
       {open && (
         <div
-          role="listbox"
-          id={GLOBAL_SEARCH_LISTBOX_ID}
+          // Plain popover wrapper. `role="listbox"` lives on the inner result-rows
+          // container in `GlobalSearchDropdown` — this outer div also holds the
+          // chip row, close button, and BETA tag, which aren't list options.
+          //
           // Anchored to the right edge of the input (input lives in the
           // right cluster of the navbar) so the popover grows leftward
           // and doesn't overflow the viewport.

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -221,7 +221,18 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
       <Input
         ref={inputRef}
         placeholder="Search…  ⌘K"
-        prefix={<SearchOutlined style={{ color: token.colorTextQuaternary }} />}
+        // Right-aligned search icon (matches `<Input.Search>` visual
+        // convention) without adopting its press-to-search semantics — this
+        // input is type-ahead. When the query is non-empty, hide the icon so
+        // `allowClear`'s X owns the right edge; otherwise the X and icon
+        // would stack.
+        suffix={
+          query ? (
+            <span style={{ width: 0 }} />
+          ) : (
+            <SearchOutlined style={{ color: token.colorTextQuaternary }} />
+          )
+        }
         value={query}
         onChange={(e) => {
           setQuery(e.target.value);

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -1,6 +1,6 @@
 import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
-import { SearchOutlined } from '@ant-design/icons';
-import { Input, type InputRef, theme } from 'antd';
+import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
+import { Button, Input, type InputRef, theme } from 'antd';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
@@ -171,6 +171,12 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
     [navigation, onSettingsClick]
   );
 
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    inputRef.current?.blur();
+  }, []);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Escape') {
       e.preventDefault();
@@ -265,6 +271,30 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
             zIndex: 1000,
           }}
         >
+          {/*
+           * Close affordance. Esc still works (combobox keyboard contract);
+           * this is for users reaching for the mouse. Absolute-positioned so
+           * it doesn't reflow the chip row, sized to match the BETA tag's
+           * visual weight on the second chip row.
+           */}
+          <Button
+            type="text"
+            size="small"
+            icon={<CloseOutlined />}
+            onClick={handleClose}
+            aria-label="Close search"
+            style={{
+              position: 'absolute',
+              top: 4,
+              right: 4,
+              width: 24,
+              height: 24,
+              minWidth: 24,
+              padding: 0,
+              color: token.colorTextTertiary,
+              zIndex: 1,
+            }}
+          />
           <SearchChipRow
             activeChip={activeChip}
             onChipChange={(chip) => {

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearch.tsx
@@ -1,5 +1,5 @@
 import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
-import { CloseOutlined, SearchOutlined } from '@ant-design/icons';
+import { CloseOutlined } from '@ant-design/icons';
 import { Button, Input, type InputRef, theme } from 'antd';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -198,41 +198,27 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
       setSelectedIndex((idx) => Math.max(idx - 1, 0));
       return;
     }
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      // If the user pressed Enter before the 220ms debounce settled, flush
-      // the debounced query so the dropdown shows fresh rows on the next
-      // render. The current Enter doesn't navigate — the next one does.
-      // This is intentionally a 2-press UX in the (rare) stale case; doing
-      // a true single-press would require synchronous filter computation
-      // outside React's render cycle. Acceptable since debounce is 220ms.
-      if (query.trim() !== debouncedQuery.trim()) {
-        flush();
-        return;
-      }
-      const target = visibleRows[selectedIndex];
-      if (target) navigateToResult(target);
+    // Enter is handled by `<Input.Search>`'s onSearch — see handleSubmit.
+  };
+
+  // Fired by `<Input.Search>` on both Enter keypress and click of the
+  // built-in search-icon button. If the user submits before the 220ms
+  // debounce settled, flush instead of navigating — next press will land
+  // on fresh rows. Acceptable 2-press UX in the rare stale case.
+  const handleSubmit = (value: string) => {
+    if (value.trim() !== debouncedQuery.trim()) {
+      flush();
       return;
     }
+    const target = visibleRows[selectedIndex];
+    if (target) navigateToResult(target);
   };
 
   return (
     <div ref={containerRef} style={{ position: 'relative', width: INPUT_WIDTH }}>
-      <Input
+      <Input.Search
         ref={inputRef}
         placeholder="Search…  ⌘K"
-        // Right-aligned search icon (matches `<Input.Search>` visual
-        // convention) without adopting its press-to-search semantics — this
-        // input is type-ahead. When the query is non-empty, hide the icon so
-        // `allowClear`'s X owns the right edge; otherwise the X and icon
-        // would stack.
-        suffix={
-          query ? (
-            <span style={{ width: 0 }} />
-          ) : (
-            <SearchOutlined style={{ color: token.colorTextQuaternary }} />
-          )
-        }
         value={query}
         onChange={(e) => {
           setQuery(e.target.value);
@@ -243,6 +229,7 @@ export const GlobalSearch: React.FC<GlobalSearchProps> = ({
         }}
         onFocus={() => setOpen(true)}
         onKeyDown={handleKeyDown}
+        onSearch={handleSubmit}
         allowClear
         aria-label="Global search"
         aria-autocomplete="list"

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
@@ -1,11 +1,40 @@
 import { tokenizeSearchQuery } from '@agor-live/client';
+import {
+  ApiOutlined,
+  AppstoreOutlined,
+  BranchesOutlined,
+  ExperimentOutlined,
+  MessageOutlined,
+  RobotOutlined,
+} from '@ant-design/icons';
 import { Typography, theme } from 'antd';
 import type React from 'react';
 import { useMemo } from 'react';
 import { SearchResult } from './SearchResult';
-import { type ResultsByType, SECTION_LABELS, SECTION_ORDER, type SearchResultItem } from './types';
+import {
+  type ResultsByType,
+  SECTION_LABELS,
+  SECTION_ORDER,
+  type SearchEntityType,
+  type SearchResultItem,
+} from './types';
 
 const { Text } = Typography;
+
+/**
+ * AntD icon per entity type for the dropdown's section headers. Mirrors the
+ * Settings modal's tab icons (apps/agor-ui/src/components/SettingsModal/
+ * SettingsModal.tsx) so users see the same glyph in both surfaces. Sessions
+ * don't have a Settings tab — `MessageOutlined` is the conversational match.
+ */
+const SECTION_ICONS: Record<SearchEntityType, React.ReactNode> = {
+  session: <MessageOutlined />,
+  branch: <BranchesOutlined />,
+  assistant: <RobotOutlined />,
+  artifact: <ExperimentOutlined />,
+  board: <AppstoreOutlined />,
+  mcp: <ApiOutlined />,
+};
 
 interface GlobalSearchDropdownProps {
   /** Trimmed query (post-debounce). Empty string = render Recents view. */
@@ -75,7 +104,12 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
           // typed-query states. A single header rule above the column makes it
           // clear the whole list is "recent."
           return (
-            <SectionShell key={type} title={SECTION_LABELS[type]} token={token}>
+            <SectionShell
+              key={type}
+              title={SECTION_LABELS[type]}
+              icon={SECTION_ICONS[type]}
+              token={token}
+            >
               {items.map((result, i) => {
                 const flatIndex = offset + i;
                 return (
@@ -100,14 +134,20 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
 
 interface SectionShellProps {
   title: string;
+  /** AntD icon rendered to the left of the section label, matching the
+   * Settings modal's tab glyphs. */
+  icon?: React.ReactNode;
   token: ReturnType<typeof theme.useToken>['token'];
   children: React.ReactNode;
 }
 
-const SectionShell: React.FC<SectionShellProps> = ({ title, token, children }) => (
+const SectionShell: React.FC<SectionShellProps> = ({ title, icon, token, children }) => (
   <div style={{ padding: '2px 0' }}>
     <div
       style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
         padding: '2px 16px 1px',
         fontSize: 11,
         textTransform: 'uppercase',
@@ -115,6 +155,7 @@ const SectionShell: React.FC<SectionShellProps> = ({ title, token, children }) =
         color: token.colorTextTertiary,
       }}
     >
+      {icon}
       {title}
     </div>
     {children}

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
@@ -1,5 +1,7 @@
+import { tokenizeSearchQuery } from '@agor-live/client';
 import { Typography, theme } from 'antd';
 import type React from 'react';
+import { useMemo } from 'react';
 import { SearchResult } from './SearchResult';
 import { type ResultsByType, SECTION_LABELS, SECTION_ORDER, type SearchResultItem } from './types';
 
@@ -32,6 +34,13 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
 
   const showRecents = query.length === 0;
   const sectioned = showRecents ? recents : results;
+  // Tokens drive hit highlighting inside rendered result rows. Reusing the
+  // same tokenizer that the search hook uses keeps highlight ranges aligned
+  // with what the filter actually matched against. Empty in recents mode.
+  const tokens = useMemo(
+    () => (showRecents ? [] : tokenizeSearchQuery(query)),
+    [showRecents, query]
+  );
 
   return (
     <div
@@ -77,6 +86,7 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
                     selected={flatIndex === selectedIndex}
                     onClick={() => onResultClick(result)}
                     onHover={() => onResultHover(flatIndex)}
+                    tokens={tokens}
                   />
                 );
               })}

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
@@ -10,7 +10,9 @@ interface GlobalSearchDropdownProps {
   query: string;
   results: ResultsByType;
   hasAnyResults: boolean;
-  recents: SearchResultItem[];
+  /** Recents reuse `ResultsByType` so the section renderer is shared. */
+  recents: ResultsByType;
+  hasAnyRecents: boolean;
   selectedIndex: number;
   onResultClick: (result: SearchResultItem) => void;
   onResultHover: (index: number) => void;
@@ -21,6 +23,7 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
   results,
   hasAnyResults,
   recents,
+  hasAnyRecents,
   selectedIndex,
   onResultClick,
   onResultHover,
@@ -28,6 +31,7 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
   const { token } = theme.useToken();
 
   const showRecents = query.length === 0;
+  const sectioned = showRecents ? recents : results;
 
   return (
     <div
@@ -41,37 +45,26 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
         padding: '2px 0',
       }}
     >
-      {showRecents ? (
-        <SectionShell title="Recent" token={token}>
-          {recents.length === 0 ? (
-            <EmptyHint text="Recent items you've created will show up here." token={token} />
-          ) : (
-            recents.map((result, index) => (
-              <SearchResult
-                key={resultKey(result)}
-                rowId={rowDomId(result)}
-                result={result}
-                selected={index === selectedIndex}
-                onClick={() => onResultClick(result)}
-                onHover={() => onResultHover(index)}
-              />
-            ))
-          )}
-        </SectionShell>
-      ) : !hasAnyResults ? (
+      {showRecents && !hasAnyRecents ? (
+        <EmptyHint text="Recent items you've created will show up here." token={token} />
+      ) : !showRecents && !hasAnyResults ? (
         <EmptyHint text={`No matches for "${query}"`} token={token} />
       ) : (
         SECTION_ORDER.map((type) => {
-          const items = results[type];
+          const items = sectioned[type];
           if (items.length === 0) return null;
 
           // Compute global index offset so the keyboard cursor lines up.
           let offset = 0;
           for (const t of SECTION_ORDER) {
             if (t === type) break;
-            offset += results[t].length;
+            offset += sectioned[t].length;
           }
 
+          // Recents reuse the live-search section labels (e.g. "Sessions") so
+          // the visual contract stays identical between empty-query and
+          // typed-query states. A single header rule above the column makes it
+          // clear the whole list is "recent."
           return (
             <SectionShell key={type} title={SECTION_LABELS[type]} token={token}>
               {items.map((result, i) => {

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
@@ -73,11 +73,7 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
           }
 
           return (
-            <SectionShell
-              key={type}
-              title={`${SECTION_LABELS[type]} · ${items.length}`}
-              token={token}
-            >
+            <SectionShell key={type} title={SECTION_LABELS[type]} token={token}>
               {items.map((result, i) => {
                 const flatIndex = offset + i;
                 return (

--- a/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/GlobalSearchDropdown.tsx
@@ -18,6 +18,7 @@ import {
   type SearchEntityType,
   type SearchResultItem,
 } from './types';
+import { sectionOffsets } from './utils';
 
 const { Text } = Typography;
 
@@ -71,8 +72,19 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
     [showRecents, query]
   );
 
+  // Precompute per-section flat-index offsets so the keyboard cursor index
+  // resolves to the right row across sections — single pass instead of
+  // re-scanning the section order for each row.
+  const offsets = useMemo(() => sectionOffsets(sectioned), [sectioned]);
+
   return (
+    // The listbox role is anchored here, not on the outer popover: the popover
+    // also contains the chip row, switch, close button, and BETA tag — none
+    // are list options. The Input's `aria-controls` points at this id so the
+    // combobox contract is intact.
     <div
+      role="listbox"
+      id={GLOBAL_SEARCH_LISTBOX_ID}
       // Fills the remaining space inside the popover's flex column. The
       // popover caps total height at 85vh; the chip row above is fixed
       // height, so this scroll area grows to use whatever's left.
@@ -91,13 +103,7 @@ export const GlobalSearchDropdown: React.FC<GlobalSearchDropdownProps> = ({
         SECTION_ORDER.map((type) => {
           const items = sectioned[type];
           if (items.length === 0) return null;
-
-          // Compute global index offset so the keyboard cursor lines up.
-          let offset = 0;
-          for (const t of SECTION_ORDER) {
-            if (t === type) break;
-            offset += sectioned[t].length;
-          }
+          const offset = offsets.get(type) ?? 0;
 
           // Recents reuse the live-search section labels (e.g. "Sessions") so
           // the visual contract stays identical between empty-query and

--- a/apps/agor-ui/src/components/GlobalSearch/SearchChipRow.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/SearchChipRow.tsx
@@ -1,12 +1,15 @@
 import { Segmented, Switch, Tag, Tooltip, theme } from 'antd';
 import type React from 'react';
-import { type ChipFilter, TYPE_CHIP_LABELS, TYPE_CHIP_ORDER } from './types';
+import { type ChipFilter, type SearchCounts, TYPE_CHIP_LABELS, TYPE_CHIP_ORDER } from './types';
 
 interface SearchChipRowProps {
   activeChip: ChipFilter;
   onChipChange: (chip: ChipFilter) => void;
   ownedByMe: boolean;
   onOwnedByMeToggle: () => void;
+  /** Per-type match totals. `undefined` (or all-zero) hides badges — used to
+   * suppress count tags when there's no live query (recents view). */
+  counts?: SearchCounts;
 }
 
 /**
@@ -21,8 +24,19 @@ export const SearchChipRow: React.FC<SearchChipRowProps> = ({
   onChipChange,
   ownedByMe,
   onOwnedByMeToggle,
+  counts,
 }) => {
   const { token } = theme.useToken();
+
+  const totalCount = counts
+    ? counts.session +
+      counts.branch +
+      counts.assistant +
+      counts.artifact +
+      counts.board +
+      counts.mcp
+    : 0;
+  const showCounts = !!counts && totalCount > 0;
 
   return (
     <div style={{ padding: '6px 12px', borderBottom: `1px solid ${token.colorBorderSecondary}` }}>
@@ -31,7 +45,14 @@ export const SearchChipRow: React.FC<SearchChipRowProps> = ({
         value={activeChip}
         onChange={(value) => onChipChange(value as ChipFilter)}
         options={TYPE_CHIP_ORDER.map((chip) => ({
-          label: TYPE_CHIP_LABELS[chip],
+          label: (
+            <ChipLabel
+              label={TYPE_CHIP_LABELS[chip]}
+              count={showCounts ? (chip === 'all' ? totalCount : (counts?.[chip] ?? 0)) : undefined}
+              isActive={activeChip === chip}
+              token={token}
+            />
+          ),
           value: chip,
         }))}
         style={{ marginBottom: 4, fontSize: 12 }}
@@ -85,5 +106,40 @@ export const SearchChipRow: React.FC<SearchChipRowProps> = ({
         </Tooltip>
       </div>
     </div>
+  );
+};
+
+/**
+ * Chip label with optional count badge. The badge sits to the right of the
+ * label and uses a muted, borderless tag so it reads as supplementary rather
+ * than competing with the label. The count for the active chip is rendered
+ * with the active token color so it stays legible against Segmented's
+ * highlight background.
+ */
+const ChipLabel: React.FC<{
+  label: string;
+  count: number | undefined;
+  isActive: boolean;
+  token: ReturnType<typeof theme.useToken>['token'];
+}> = ({ label, count, isActive, token }) => {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      {label}
+      {count !== undefined && (
+        <Tag
+          style={{
+            margin: 0,
+            padding: '0 5px',
+            fontSize: 10,
+            lineHeight: '14px',
+            border: 'none',
+            background: isActive ? token.colorFillSecondary : token.colorFillTertiary,
+            color: token.colorTextSecondary,
+          }}
+        >
+          {count}
+        </Tag>
+      )}
+    </span>
   );
 };

--- a/apps/agor-ui/src/components/GlobalSearch/SearchChipRow.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/SearchChipRow.tsx
@@ -1,6 +1,7 @@
 import { Segmented, Switch, Tag, Tooltip, theme } from 'antd';
 import type React from 'react';
 import { type ChipFilter, type SearchCounts, TYPE_CHIP_LABELS, TYPE_CHIP_ORDER } from './types';
+import { sumCounts } from './utils';
 
 interface SearchChipRowProps {
   activeChip: ChipFilter;
@@ -28,14 +29,7 @@ export const SearchChipRow: React.FC<SearchChipRowProps> = ({
 }) => {
   const { token } = theme.useToken();
 
-  const totalCount = counts
-    ? counts.session +
-      counts.branch +
-      counts.assistant +
-      counts.artifact +
-      counts.board +
-      counts.mcp
-    : 0;
+  const totalCount = counts ? sumCounts(counts) : 0;
   const showCounts = !!counts && totalCount > 0;
 
   return (

--- a/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
@@ -3,6 +3,7 @@ import { Typography, theme } from 'antd';
 import type React from 'react';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
+import { highlightTokens } from './highlight';
 import { type SearchResultItem, TYPE_CHIP_ICONS } from './types';
 
 const { Text } = Typography;
@@ -14,6 +15,9 @@ interface SearchResultProps {
   onHover?: () => void;
   /** Stable DOM id so the input's aria-activedescendant can point at the row. */
   rowId?: string;
+  /** Query tokens to highlight inside the visible title/secondary fields.
+   * Empty array (recents view, or a no-token query) disables highlighting. */
+  tokens?: string[];
 }
 
 /**
@@ -29,9 +33,18 @@ export const SearchResult: React.FC<SearchResultProps> = ({
   onClick,
   onHover,
   rowId,
+  tokens = [],
 }) => {
   const { token } = theme.useToken();
   const { title, tag, secondary, time, icon } = renderResult(result);
+  // Token highlighting style: warning-bg accent so matches stand out without
+  // looking like links or status pills. Inherits text color from parent so
+  // the secondary (muted) line still highlights legibly.
+  const markStyle: React.CSSProperties = {
+    backgroundColor: token.colorWarningBg,
+    color: 'inherit',
+    padding: 0,
+  };
 
   return (
     <button
@@ -80,7 +93,7 @@ export const SearchResult: React.FC<SearchResultProps> = ({
               whiteSpace: 'nowrap',
             }}
           >
-            {title}
+            {highlightTokens(title, tokens, markStyle)}
           </Text>
           {tag && (
             <Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', flexShrink: 0 }}>
@@ -104,7 +117,7 @@ export const SearchResult: React.FC<SearchResultProps> = ({
               whiteSpace: 'nowrap',
             }}
           >
-            {secondary}
+            {highlightTokens(secondary, tokens, markStyle)}
           </Text>
         )}
       </div>

--- a/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
@@ -2,7 +2,7 @@ import { getAssistantConfig } from '@agor-live/client';
 import { Typography, theme } from 'antd';
 import type React from 'react';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
-import { formatRelativeTime } from '../../utils/time';
+import { formatRelativeTimeSafe } from '../../utils/time';
 import { highlightTokens } from './highlight';
 import type { SearchResultItem } from './types';
 
@@ -146,14 +146,14 @@ function renderResult(result: SearchResultItem): {
         title,
         tag: result.item.agentic_tool,
         secondary: result.parentBranch ? `in ${result.parentBranch.name}` : undefined,
-        time: safeRelativeTime(result.item.last_updated),
+        time: formatRelativeTimeSafe(result.item.last_updated),
       };
     }
     case 'branch': {
       return {
         title: result.item.name,
         tag: result.item.ref,
-        time: safeRelativeTime(result.item.updated_at),
+        time: formatRelativeTimeSafe(result.item.updated_at),
       };
     }
     case 'assistant': {
@@ -161,7 +161,7 @@ function renderResult(result: SearchResultItem): {
       return {
         icon: config?.emoji,
         title: config?.displayName ?? result.item.name,
-        time: safeRelativeTime(result.item.updated_at),
+        time: formatRelativeTimeSafe(result.item.updated_at),
       };
     }
     case 'artifact': {
@@ -169,14 +169,14 @@ function renderResult(result: SearchResultItem): {
         title: result.item.name,
         tag: result.item.template,
         secondary: result.parentBranch ? `in ${result.parentBranch.name}` : undefined,
-        time: safeRelativeTime(result.item.updated_at),
+        time: formatRelativeTimeSafe(result.item.updated_at),
       };
     }
     case 'board': {
       return {
         icon: result.item.icon,
         title: result.item.name,
-        time: safeRelativeTime(result.item.last_updated),
+        time: formatRelativeTimeSafe(result.item.last_updated),
       };
     }
     case 'mcp': {
@@ -187,16 +187,4 @@ function renderResult(result: SearchResultItem): {
       };
     }
   }
-}
-
-/**
- * Optional- and invalid-tolerant wrapper around formatRelativeTime — undefined
- * in, undefined out. Without the invalid-date guard, a bad timestamp would
- * render as "NaNy ago" via the shared formatter.
- */
-function safeRelativeTime(ts: string | Date | undefined | null): string | undefined {
-  if (!ts) return undefined;
-  const date = typeof ts === 'string' ? new Date(ts) : ts;
-  if (Number.isNaN(date.getTime())) return undefined;
-  return formatRelativeTime(date);
 }

--- a/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/SearchResult.tsx
@@ -4,7 +4,7 @@ import type React from 'react';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
 import { highlightTokens } from './highlight';
-import { type SearchResultItem, TYPE_CHIP_ICONS } from './types';
+import type { SearchResultItem } from './types';
 
 const { Text } = Typography;
 
@@ -68,7 +68,11 @@ export const SearchResult: React.FC<SearchResultProps> = ({
         borderRadius: token.borderRadiusSM,
       }}
     >
-      <span style={{ fontSize: 18, lineHeight: '20px', flexShrink: 0 }}>{icon}</span>
+      {/* Icon column is opt-in: rendered only when the entity itself has an
+          emoji/icon (assistant `config.emoji`, board `item.icon`). For other
+          types the section header above already conveys the kind, so we drop
+          the per-row glyph to keep visual noise down. */}
+      {icon && <span style={{ fontSize: 18, lineHeight: '20px', flexShrink: 0 }}>{icon}</span>}
       <div style={{ flex: 1, minWidth: 0 }}>
         {/* Title row: title takes remaining width and ellipsizes; tag + time
             stay on one line via whiteSpace:nowrap + flex-shrink:0. Plain flex
@@ -130,13 +134,15 @@ function renderResult(result: SearchResultItem): {
   tag?: string;
   secondary?: string;
   time?: string;
-  icon: string;
+  /** Only set when the entity itself has an emoji/icon (assistant config,
+   * board icon). Generic per-type emojis dropped — section headers carry
+   * the entity-kind affordance instead. */
+  icon?: string;
 } {
   switch (result.type) {
     case 'session': {
       const title = getSessionDisplayTitle(result.item, { includeAgentFallback: true });
       return {
-        icon: TYPE_CHIP_ICONS.session,
         title,
         tag: result.item.agentic_tool,
         secondary: result.parentBranch ? `in ${result.parentBranch.name}` : undefined,
@@ -145,7 +151,6 @@ function renderResult(result: SearchResultItem): {
     }
     case 'branch': {
       return {
-        icon: TYPE_CHIP_ICONS.branch,
         title: result.item.name,
         tag: result.item.ref,
         time: safeRelativeTime(result.item.updated_at),
@@ -154,14 +159,13 @@ function renderResult(result: SearchResultItem): {
     case 'assistant': {
       const config = getAssistantConfig(result.item);
       return {
-        icon: config?.emoji || TYPE_CHIP_ICONS.assistant,
+        icon: config?.emoji,
         title: config?.displayName ?? result.item.name,
         time: safeRelativeTime(result.item.updated_at),
       };
     }
     case 'artifact': {
       return {
-        icon: TYPE_CHIP_ICONS.artifact,
         title: result.item.name,
         tag: result.item.template,
         secondary: result.parentBranch ? `in ${result.parentBranch.name}` : undefined,
@@ -170,14 +174,13 @@ function renderResult(result: SearchResultItem): {
     }
     case 'board': {
       return {
-        icon: result.item.icon || TYPE_CHIP_ICONS.board,
+        icon: result.item.icon,
         title: result.item.name,
         time: safeRelativeTime(result.item.last_updated),
       };
     }
     case 'mcp': {
       return {
-        icon: TYPE_CHIP_ICONS.mcp,
         title: result.item.display_name || result.item.name,
         tag: result.item.transport,
         secondary: result.item.description,

--- a/apps/agor-ui/src/components/GlobalSearch/highlight.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/highlight.tsx
@@ -1,0 +1,43 @@
+import type React from 'react';
+
+/**
+ * Wrap any substring matching a search token in `<mark>` for hit highlighting.
+ * Case-insensitive, multi-token aware (uses a single regex alternation so
+ * overlapping tokens collapse into a single match span).
+ *
+ * Returns plain text when:
+ *   - the text is empty/undefined
+ *   - no tokens (recents view — nothing to highlight against)
+ *
+ * Only used on fields the row actually renders (title, secondary line).
+ * Highlighting on fields that aren't visible — e.g. a hit in `worktree.notes`
+ * showing up inside a session row — would require snippet extraction, which
+ * is V2 territory.
+ */
+export function highlightTokens(
+  text: string | undefined | null,
+  tokens: string[],
+  markStyle?: React.CSSProperties
+): React.ReactNode {
+  if (!text) return text ?? '';
+  if (tokens.length === 0) return text;
+  // Escape regex specials so a query containing `(foo)` doesn't try to
+  // capture-group anything.
+  const escaped = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const re = new RegExp(`(${escaped.join('|')})`, 'gi');
+  const parts = text.split(re);
+  if (parts.length === 1) return text;
+  // String.split with a capture group yields alternating non-match (even
+  // index) and match (odd index) parts. Key combines ordinal + content so
+  // React's reconciler stays stable across token-list changes (the list
+  // shape is stable per (text, tokens) tuple anyway).
+  return parts.map((part, i) =>
+    i % 2 === 1 ? (
+      <mark key={`m${i}:${part}`} style={markStyle}>
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}

--- a/apps/agor-ui/src/components/GlobalSearch/highlight.tsx
+++ b/apps/agor-ui/src/components/GlobalSearch/highlight.tsx
@@ -2,15 +2,14 @@ import type React from 'react';
 
 /**
  * Wrap any substring matching a search token in `<mark>` for hit highlighting.
- * Case-insensitive, multi-token aware (uses a single regex alternation so
- * overlapping tokens collapse into a single match span).
+ * Case-insensitive, multi-token aware (single regex alternation).
  *
  * Returns plain text when:
  *   - the text is empty/undefined
- *   - no tokens (recents view — nothing to highlight against)
+ *   - tokens list is empty after sanitization (recents view, all-whitespace input)
  *
  * Only used on fields the row actually renders (title, secondary line).
- * Highlighting on fields that aren't visible — e.g. a hit in `worktree.notes`
+ * Highlighting on fields that aren't visible — e.g. a hit in `branch.notes`
  * showing up inside a session row — would require snippet extraction, which
  * is V2 territory.
  */
@@ -20,10 +19,17 @@ export function highlightTokens(
   markStyle?: React.CSSProperties
 ): React.ReactNode {
   if (!text) return text ?? '';
-  if (tokens.length === 0) return text;
+  // Sanitize + sort longest-first so overlapping tokens (e.g. ["ag", "agor"])
+  // greedy-match the longer alternative. Regex alternation otherwise tries
+  // branches left-to-right and would stop at "ag" inside "agor".
+  const sanitized = tokens
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+  if (sanitized.length === 0) return text;
   // Escape regex specials so a query containing `(foo)` doesn't try to
   // capture-group anything.
-  const escaped = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const escaped = sanitized.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
   const re = new RegExp(`(${escaped.join('|')})`, 'gi');
   const parts = text.split(re);
   if (parts.length === 1) return text;

--- a/apps/agor-ui/src/components/GlobalSearch/types.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/types.ts
@@ -90,6 +90,23 @@ export const EMPTY_RESULTS: ResultsByType = {
   mcp: [],
 };
 
+/**
+ * Per-entity-type total match counts — used by the chip row to render badges
+ * like "Worktree (12)". Independent of `activeTypeChip` so an inactive chip
+ * still surfaces "how many would I find if I clicked this." Pre-cap; the
+ * `results` arrays are slice-limited per section while counts are not.
+ */
+export type SearchCounts = Record<SearchEntityType, number>;
+
+export const EMPTY_COUNTS: SearchCounts = {
+  session: 0,
+  branch: 0,
+  assistant: 0,
+  artifact: 0,
+  board: 0,
+  mcp: 0,
+};
+
 /** Per-section cap in the dropdown — matches §3.4 of the design doc. */
 export const SECTION_LIMIT = 5;
 

--- a/apps/agor-ui/src/components/GlobalSearch/types.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/types.ts
@@ -63,14 +63,19 @@ export type SearchResultItem =
   | { type: 'board'; item: Board }
   | { type: 'mcp'; item: MCPServer };
 
-export interface ResultsByType {
-  session: SearchResultItem[];
-  branch: SearchResultItem[];
-  assistant: SearchResultItem[];
-  artifact: SearchResultItem[];
-  board: SearchResultItem[];
-  mcp: SearchResultItem[];
-}
+/** Narrowed result variant for a given entity type — keeps the union's
+ * type discrimination intact when buckets are typed per section. */
+export type SearchResultFor<T extends SearchEntityType> = Extract<SearchResultItem, { type: T }>;
+
+/** Record keyed by every entity type. Used to share shape between
+ * `ResultsByType` (rows) and `SearchCounts` (numbers). */
+export type EntityRecord<T> = Record<SearchEntityType, T>;
+
+/** Sectioned result buckets. Each bucket only contains rows of its own
+ * entity type (TS-enforced via the mapped `SearchResultFor` extraction). */
+export type ResultsByType = {
+  [K in SearchEntityType]: SearchResultFor<K>[];
+};
 
 export const EMPTY_RESULTS: ResultsByType = {
   session: [],
@@ -83,11 +88,11 @@ export const EMPTY_RESULTS: ResultsByType = {
 
 /**
  * Per-entity-type total match counts — used by the chip row to render badges
- * like "Worktree (12)". Independent of `activeTypeChip` so an inactive chip
+ * like "Branch (12)". Independent of `activeTypeChip` so an inactive chip
  * still surfaces "how many would I find if I clicked this." Pre-cap; the
  * `results` arrays are slice-limited per section while counts are not.
  */
-export type SearchCounts = Record<SearchEntityType, number>;
+export type SearchCounts = EntityRecord<number>;
 
 export const EMPTY_COUNTS: SearchCounts = {
   session: 0,
@@ -98,11 +103,31 @@ export const EMPTY_COUNTS: SearchCounts = {
   mcp: 0,
 };
 
+/**
+ * Live entity maps streamed by `useAgorData` (WebSocket-synced). Bundled into
+ * one interface so the navbar component, the search hook, and the recents
+ * hook can all consume the same shape via composition.
+ */
+export interface GlobalSearchEntityMaps {
+  sessionById: Map<string, Session>;
+  branchById: Map<string, Branch>;
+  artifactById: Map<string, Artifact>;
+  boardById: Map<string, Board>;
+  mcpServerById: Map<string, MCPServer>;
+}
+
 /** Per-section cap in the dropdown — matches §3.4 of the design doc. */
 export const SECTION_LIMIT = 5;
 
 /** Cap when a single type chip is active and the section expands. */
 export const SECTION_LIMIT_EXPANDED = 15;
+
+/**
+ * Cap per recents section. Smaller than `SECTION_LIMIT` because recents is
+ * the at-rest empty-query view — six sections × 3 rows is already a
+ * comfortable column of suggestions before the user has typed anything.
+ */
+export const RECENTS_SECTION_LIMIT = 3;
 
 /** Minimum query length before live results fire; below this we show recents. */
 export const MIN_QUERY_LENGTH = 2;

--- a/apps/agor-ui/src/components/GlobalSearch/types.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/types.ts
@@ -32,8 +32,7 @@ export const TYPE_CHIP_ORDER: ChipFilter[] = [
 /**
  * Chip labels intentionally use the singular ("Session" / "Branch") so the
  * Segmented control fits the 480px dropdown without wrapping. Section headers
- * in the dropdown body keep the plural ("Sessions · 5") since they sit on
- * their own line with a count beside them.
+ * in the dropdown body use the plural form (see `SECTION_LABELS`).
  */
 export const TYPE_CHIP_LABELS: Record<ChipFilter, string> = {
   all: 'All',
@@ -45,7 +44,8 @@ export const TYPE_CHIP_LABELS: Record<ChipFilter, string> = {
   mcp: 'MCP',
 };
 
-/** Plural section-header labels for the dropdown body (e.g. "Sessions · 5"). */
+/** Plural section-header labels for the dropdown body (e.g. "Sessions"). Per-
+ * section counts are surfaced as badges on the chip row, not inline here. */
 export const SECTION_LABELS: Record<SearchEntityType, string> = {
   session: 'Sessions',
   branch: 'Branches',

--- a/apps/agor-ui/src/components/GlobalSearch/types.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/types.ts
@@ -55,15 +55,6 @@ export const SECTION_LABELS: Record<SearchEntityType, string> = {
   mcp: 'MCP',
 };
 
-export const TYPE_CHIP_ICONS: Record<SearchEntityType, string> = {
-  session: '🤖',
-  branch: '📁',
-  assistant: '✨',
-  artifact: '🧩',
-  board: '🗺️',
-  mcp: '🔌',
-};
-
 export type SearchResultItem =
   | { type: 'session'; item: Session; parentBranch?: Branch }
   | { type: 'branch'; item: Branch }

--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
@@ -2,12 +2,14 @@ import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/cli
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  EMPTY_COUNTS,
   EMPTY_RESULTS,
   MIN_QUERY_LENGTH,
   type ResultsByType,
   SEARCH_DEBOUNCE_MS,
   SECTION_LIMIT,
   SECTION_LIMIT_EXPANDED,
+  type SearchCounts,
   type SearchResultItem,
 } from './types';
 import { byTimestamp } from './utils';
@@ -44,6 +46,9 @@ export function useGlobalSearch({
   mcpServerById,
 }: UseGlobalSearchInput): {
   results: ResultsByType;
+  /** Pre-cap per-type match counts. Independent of `activeTypeChip` so chip
+   * badges reflect "how many you'd find here," not "how many fit on screen." */
+  counts: SearchCounts;
   hasAnyResults: boolean;
   debouncedQuery: string;
   /** Force the debounced query to match the raw query immediately — used by
@@ -59,110 +64,108 @@ export function useGlobalSearch({
 
   const flush = useCallback(() => setDebouncedQuery(query), [query]);
 
-  const results = useMemo<ResultsByType>(() => {
+  const { results, counts } = useMemo<{ results: ResultsByType; counts: SearchCounts }>(() => {
     const trimmed = debouncedQuery.trim();
-    if (trimmed.length < MIN_QUERY_LENGTH) return EMPTY_RESULTS;
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      return { results: EMPTY_RESULTS, counts: EMPTY_COUNTS };
+    }
 
     const tokens = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
-    if (tokens.length === 0) return EMPTY_RESULTS;
+    if (tokens.length === 0) {
+      return { results: EMPTY_RESULTS, counts: EMPTY_COUNTS };
+    }
 
-    const sectionLimit = activeTypeChip === 'all' ? SECTION_LIMIT : SECTION_LIMIT_EXPANDED;
-    const buckets: ResultsByType = {
-      session: [],
-      branch: [],
-      assistant: [],
-      artifact: [],
-      board: [],
-      mcp: [],
-    };
-
+    // Counts must be independent of `activeTypeChip`: an inactive chip still
+    // shows its real match count so the badge tells you what's behind that
+    // tab. So we always run the full match pass for every type, then apply
+    // the chip filter only when slicing into `results` for render.
+    const limitFor = (t: SearchResultItem['type']) =>
+      activeTypeChip === t ? SECTION_LIMIT_EXPANDED : SECTION_LIMIT;
     const includeType = (t: SearchResultItem['type']) =>
       activeTypeChip === 'all' || activeTypeChip === t;
 
     // Sessions (timestamp field is `last_updated`, not `updated_at`)
-    if (includeType('session')) {
-      const sessions = Array.from(sessionById.values())
-        .filter((s) => !ownedByMe || s.created_by === currentUserId)
-        .filter((s) => matchTokens(tokens, [s.title, s.description]))
-        .sort(byTimestamp((s) => s.last_updated));
-      for (const s of sessions.slice(0, sectionLimit)) {
-        buckets.session.push({
-          type: 'session',
-          item: s,
-          parentBranch: branchById.get(s.branch_id),
-        });
-      }
-    }
+    const sessions = Array.from(sessionById.values())
+      .filter((s) => !ownedByMe || s.created_by === currentUserId)
+      .filter((s) => matchTokens(tokens, [s.title, s.description]))
+      .sort(byTimestamp((s) => s.last_updated));
 
     // Branches + Assistants share the same table — split via the canonical
     // isAssistant() helper from @agor-live/client. Assistants' user-visible
     // displayName lives in custom_context.assistant and must be searchable too.
-    if (includeType('branch') || includeType('assistant')) {
-      const allBranches = Array.from(branchById.values())
-        .filter((w) => !ownedByMe || w.created_by === currentUserId)
-        .filter((w) =>
-          matchTokens(tokens, [
-            w.name,
-            w.issue_url,
-            w.pull_request_url,
-            getAssistantConfig(w)?.displayName,
-          ])
-        )
-        .sort(byTimestamp((w) => w.updated_at));
-
-      for (const w of allBranches) {
-        if (isAssistant(w) && includeType('assistant') && buckets.assistant.length < sectionLimit) {
-          buckets.assistant.push({ type: 'assistant', item: w });
-        } else if (
-          !isAssistant(w) &&
-          includeType('branch') &&
-          buckets.branch.length < sectionLimit
-        ) {
-          buckets.branch.push({ type: 'branch', item: w });
-        }
-      }
-    }
+    const allBranches = Array.from(branchById.values())
+      .filter((b) => !ownedByMe || b.created_by === currentUserId)
+      .filter((b) =>
+        matchTokens(tokens, [
+          b.name,
+          b.issue_url,
+          b.pull_request_url,
+          getAssistantConfig(b)?.displayName,
+        ])
+      )
+      .sort(byTimestamp((b) => b.updated_at));
+    const branches = allBranches.filter((b) => !isAssistant(b));
+    const assistants = allBranches.filter((b) => isAssistant(b));
 
     // Artifacts (filter archived — useAgorData keeps them in the map regardless)
-    if (includeType('artifact')) {
-      const arts = Array.from(artifactById.values())
-        .filter((a) => !a.archived)
-        .filter((a) => !ownedByMe || a.created_by === currentUserId)
-        .filter((a) => matchTokens(tokens, [a.name, a.description]))
-        .sort(byTimestamp((a) => a.updated_at));
-      for (const a of arts.slice(0, sectionLimit)) {
-        buckets.artifact.push({
-          type: 'artifact',
-          item: a,
-          parentBranch: a.branch_id ? branchById.get(a.branch_id) : undefined,
-        });
-      }
-    }
+    const arts = Array.from(artifactById.values())
+      .filter((a) => !a.archived)
+      .filter((a) => !ownedByMe || a.created_by === currentUserId)
+      .filter((a) => matchTokens(tokens, [a.name, a.description]))
+      .sort(byTimestamp((a) => a.updated_at));
 
     // Boards (filter archived)
-    if (includeType('board')) {
-      const bs = Array.from(boardById.values())
-        .filter((b) => !b.archived)
-        .filter((b) => !ownedByMe || b.created_by === currentUserId)
-        .filter((b) => matchTokens(tokens, [b.name]))
-        .sort(byTimestamp((b) => b.last_updated));
-      for (const b of bs.slice(0, sectionLimit)) {
-        buckets.board.push({ type: 'board', item: b });
-      }
-    }
+    const bs = Array.from(boardById.values())
+      .filter((b) => !b.archived)
+      .filter((b) => !ownedByMe || b.created_by === currentUserId)
+      .filter((b) => matchTokens(tokens, [b.name]))
+      .sort(byTimestamp((b) => b.last_updated));
 
     // MCP servers (uses owner_user_id instead of created_by; updated_at is a Date object)
-    if (includeType('mcp')) {
-      const servers = Array.from(mcpServerById.values())
-        .filter((m) => !ownedByMe || m.owner_user_id === currentUserId)
-        .filter((m) => matchTokens(tokens, [m.name, m.display_name, m.description]))
-        .sort(byTimestamp((m) => m.updated_at));
-      for (const m of servers.slice(0, sectionLimit)) {
-        buckets.mcp.push({ type: 'mcp', item: m });
-      }
-    }
+    const servers = Array.from(mcpServerById.values())
+      .filter((m) => !ownedByMe || m.owner_user_id === currentUserId)
+      .filter((m) => matchTokens(tokens, [m.name, m.display_name, m.description]))
+      .sort(byTimestamp((m) => m.updated_at));
 
-    return buckets;
+    const counts: SearchCounts = {
+      session: sessions.length,
+      branch: branches.length,
+      assistant: assistants.length,
+      artifact: arts.length,
+      board: bs.length,
+      mcp: servers.length,
+    };
+
+    const buckets: ResultsByType = {
+      session: includeType('session')
+        ? sessions.slice(0, limitFor('session')).map((s) => ({
+            type: 'session',
+            item: s,
+            parentBranch: branchById.get(s.branch_id),
+          }))
+        : [],
+      branch: includeType('branch')
+        ? branches.slice(0, limitFor('branch')).map((b) => ({ type: 'branch', item: b }))
+        : [],
+      assistant: includeType('assistant')
+        ? assistants.slice(0, limitFor('assistant')).map((b) => ({ type: 'assistant', item: b }))
+        : [],
+      artifact: includeType('artifact')
+        ? arts.slice(0, limitFor('artifact')).map((a) => ({
+            type: 'artifact',
+            item: a,
+            parentBranch: a.branch_id ? branchById.get(a.branch_id) : undefined,
+          }))
+        : [],
+      board: includeType('board')
+        ? bs.slice(0, limitFor('board')).map((b) => ({ type: 'board', item: b }))
+        : [],
+      mcp: includeType('mcp')
+        ? servers.slice(0, limitFor('mcp')).map((m) => ({ type: 'mcp', item: m }))
+        : [],
+    };
+
+    return { results: buckets, counts };
   }, [
     debouncedQuery,
     ownedByMe,
@@ -183,7 +186,7 @@ export function useGlobalSearch({
     results.board.length > 0 ||
     results.mcp.length > 0;
 
-  return { results, hasAnyResults, debouncedQuery, flush };
+  return { results, counts, hasAnyResults, debouncedQuery, flush };
 }
 
 /** Every token must appear (case-insensitive substring) in at least one field. */

--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
@@ -1,4 +1,3 @@
-import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
 import {
   isAssistant,
   matchSearchTokens,
@@ -7,8 +6,10 @@ import {
 } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  type ChipFilter,
   EMPTY_COUNTS,
   EMPTY_RESULTS,
+  type GlobalSearchEntityMaps,
   MIN_QUERY_LENGTH,
   type ResultsByType,
   SEARCH_DEBOUNCE_MS,
@@ -17,18 +18,13 @@ import {
   type SearchCounts,
   type SearchResultItem,
 } from './types';
-import { byTimestamp } from './utils';
+import { byTimestamp, hasAnyEntries } from './utils';
 
-interface UseGlobalSearchInput {
+interface UseGlobalSearchInput extends GlobalSearchEntityMaps {
   query: string;
   ownedByMe: boolean;
-  activeTypeChip: 'all' | 'session' | 'branch' | 'assistant' | 'artifact' | 'board' | 'mcp';
+  activeTypeChip: ChipFilter;
   currentUserId?: string;
-  sessionById: Map<string, Session>;
-  branchById: Map<string, Branch>;
-  artifactById: Map<string, Artifact>;
-  boardById: Map<string, Board>;
-  mcpServerById: Map<string, MCPServer>;
 }
 
 /**
@@ -176,13 +172,7 @@ export function useGlobalSearch({
     mcpServerById,
   ]);
 
-  const hasAnyResults =
-    results.session.length > 0 ||
-    results.branch.length > 0 ||
-    results.assistant.length > 0 ||
-    results.artifact.length > 0 ||
-    results.board.length > 0 ||
-    results.mcp.length > 0;
+  const hasAnyResults = hasAnyEntries(results);
 
   return { results, counts, hasAnyResults, debouncedQuery, flush };
 }

--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
@@ -30,10 +30,11 @@ interface UseGlobalSearchInput extends GlobalSearchEntityMaps {
 /**
  * Global-search client-side filter over the in-memory entity maps from useAgorData.
  *
- * V1 scaffolding: title-only AND-of-tokens LIKE across each entity's searchable fields.
- * No backend round-trip; the maps are already streamed by WebSocket. When V2 lands
- * (message search, FTS), this hook gets replaced with a server-driven fan-out
- * keeping the same return shape.
+ * V1 scaffolding: AND-of-tokens substring match over each entity's
+ * `SEARCHABLE_FIELDS` set (the canonical registry in `@agor/core/search`).
+ * No backend round-trip; the maps are already streamed by WebSocket. When V2
+ * lands (message search, FTS), this hook gets replaced with a server-driven
+ * fan-out keeping the same return shape and reading the same registry.
  */
 export function useGlobalSearch({
   query,

--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
@@ -1,5 +1,10 @@
 import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
-import { getAssistantConfig, isAssistant } from '@agor-live/client';
+import {
+  isAssistant,
+  matchSearchTokens,
+  SEARCHABLE_FIELDS,
+  tokenizeSearchQuery,
+} from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   EMPTY_COUNTS,
@@ -70,7 +75,7 @@ export function useGlobalSearch({
       return { results: EMPTY_RESULTS, counts: EMPTY_COUNTS };
     }
 
-    const tokens = trimmed.toLowerCase().split(/\s+/).filter(Boolean);
+    const tokens = tokenizeSearchQuery(trimmed);
     if (tokens.length === 0) {
       return { results: EMPTY_RESULTS, counts: EMPTY_COUNTS };
     }
@@ -87,22 +92,15 @@ export function useGlobalSearch({
     // Sessions (timestamp field is `last_updated`, not `updated_at`)
     const sessions = Array.from(sessionById.values())
       .filter((s) => !ownedByMe || s.created_by === currentUserId)
-      .filter((s) => matchTokens(tokens, [s.title, s.description]))
+      .filter((s) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.session(s)))
       .sort(byTimestamp((s) => s.last_updated));
 
-    // Branches + Assistants share the same table — split via the canonical
-    // isAssistant() helper from @agor-live/client. Assistants' user-visible
-    // displayName lives in custom_context.assistant and must be searchable too.
+    // Branches + Assistants share one registry entry: the field set covers
+    // both row variants (assistant displayName is included), and the type
+    // split below uses `isAssistant()` to bucket matched rows.
     const allBranches = Array.from(branchById.values())
       .filter((b) => !ownedByMe || b.created_by === currentUserId)
-      .filter((b) =>
-        matchTokens(tokens, [
-          b.name,
-          b.issue_url,
-          b.pull_request_url,
-          getAssistantConfig(b)?.displayName,
-        ])
-      )
+      .filter((b) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.branch(b)))
       .sort(byTimestamp((b) => b.updated_at));
     const branches = allBranches.filter((b) => !isAssistant(b));
     const assistants = allBranches.filter((b) => isAssistant(b));
@@ -111,20 +109,20 @@ export function useGlobalSearch({
     const arts = Array.from(artifactById.values())
       .filter((a) => !a.archived)
       .filter((a) => !ownedByMe || a.created_by === currentUserId)
-      .filter((a) => matchTokens(tokens, [a.name, a.description]))
+      .filter((a) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.artifact(a)))
       .sort(byTimestamp((a) => a.updated_at));
 
     // Boards (filter archived)
     const bs = Array.from(boardById.values())
       .filter((b) => !b.archived)
       .filter((b) => !ownedByMe || b.created_by === currentUserId)
-      .filter((b) => matchTokens(tokens, [b.name]))
+      .filter((b) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.board(b)))
       .sort(byTimestamp((b) => b.last_updated));
 
     // MCP servers (uses owner_user_id instead of created_by; updated_at is a Date object)
     const servers = Array.from(mcpServerById.values())
       .filter((m) => !ownedByMe || m.owner_user_id === currentUserId)
-      .filter((m) => matchTokens(tokens, [m.name, m.display_name, m.description]))
+      .filter((m) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.mcp(m)))
       .sort(byTimestamp((m) => m.updated_at));
 
     const counts: SearchCounts = {
@@ -187,13 +185,4 @@ export function useGlobalSearch({
     results.mcp.length > 0;
 
   return { results, counts, hasAnyResults, debouncedQuery, flush };
-}
-
-/** Every token must appear (case-insensitive substring) in at least one field. */
-function matchTokens(tokens: string[], fields: Array<string | undefined | null>): boolean {
-  const haystack = fields
-    .filter((f): f is string => Boolean(f))
-    .join(' \n ')
-    .toLowerCase();
-  return tokens.every((t) => haystack.includes(t));
 }

--- a/apps/agor-ui/src/components/GlobalSearch/useRecents.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useRecents.ts
@@ -1,7 +1,7 @@
-import type { Artifact, Branch, Session } from '@agor-live/client';
+import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
 import { isAssistant } from '@agor-live/client';
 import { useMemo } from 'react';
-import type { SearchResultItem } from './types';
+import { EMPTY_RESULTS, type ResultsByType } from './types';
 import { tsValue } from './utils';
 
 interface UseRecentsInput {
@@ -9,63 +9,87 @@ interface UseRecentsInput {
   sessionById: Map<string, Session>;
   branchById: Map<string, Branch>;
   artifactById: Map<string, Artifact>;
+  boardById: Map<string, Board>;
+  mcpServerById: Map<string, MCPServer>;
 }
 
-const RECENT_SESSION_LIMIT = 5;
-const RECENT_BRANCH_LIMIT = 3;
-const RECENT_ARTIFACT_LIMIT = 2;
+/**
+ * Cap per recents section. Smaller than `SECTION_LIMIT` (5) because recents is
+ * the at-rest empty-query view — six sections × 3 rows is already a 100+px
+ * column of suggestions before the user has typed anything.
+ */
+const RECENTS_SECTION_LIMIT = 3;
 
 /**
- * Backend-free recents — "stuff I created."
+ * Backend-free recents — "stuff I created, most-recently-updated first," now
+ * grouped by entity type so the dropdown can reuse the same section renderer
+ * as live search results.
  *
  * Sources directly from the in-memory entity maps that useAgorData keeps
- * WebSocket-synced. No localStorage, no new schema. Per design doc §3.2.
+ * WebSocket-synced (per design doc §3.2 — no localStorage, no new tracking
+ * tables). Each section caps at RECENTS_SECTION_LIMIT.
  *
- * Note: recents are **section-biased** by entity type (5 sessions / 3 branches /
- * 2 artifacts) and concatenated in that order — NOT globally sorted by recency.
- * Sessions are the highest-churn / highest-signal surface, so we always lead
- * with them even when a recently-updated branch edges out the 5th-place session
- * on raw timestamp. If we ever want true global ordering, merge the three lists
- * and re-sort by their per-entity timestamp before slicing.
+ * Coverage matches the live-search section set: sessions, branches,
+ * assistants, artifacts, boards, MCP servers.
  */
 export function useRecents({
   currentUserId,
   sessionById,
   branchById,
   artifactById,
-}: UseRecentsInput): SearchResultItem[] {
+  boardById,
+  mcpServerById,
+}: UseRecentsInput): ResultsByType {
   return useMemo(() => {
-    if (!currentUserId) return [];
+    if (!currentUserId) return EMPTY_RESULTS;
 
     const sessions = Array.from(sessionById.values())
       .filter((s) => s.created_by === currentUserId)
       .sort((a, b) => tsValue(b.last_updated) - tsValue(a.last_updated))
-      .slice(0, RECENT_SESSION_LIMIT)
-      .map<SearchResultItem>((s) => ({
-        type: 'session',
-        item: s,
-        parentBranch: branchById.get(s.branch_id),
-      }));
+      .slice(0, RECENTS_SECTION_LIMIT);
 
-    const branches = Array.from(branchById.values())
-      .filter((w) => w.created_by === currentUserId)
-      .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at))
-      .slice(0, RECENT_BRANCH_LIMIT)
-      .map<SearchResultItem>((w) =>
-        isAssistant(w) ? { type: 'assistant', item: w } : { type: 'branch', item: w }
-      );
+    // Pre-sort all the user's branches once, then bucket into branch vs.
+    // assistant — preserves recency order within each sub-type without two
+    // separate passes through the map.
+    const myBranches = Array.from(branchById.values())
+      .filter((b) => b.created_by === currentUserId)
+      .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at));
+    const branches = myBranches.filter((b) => !isAssistant(b)).slice(0, RECENTS_SECTION_LIMIT);
+    const assistants = myBranches.filter((b) => isAssistant(b)).slice(0, RECENTS_SECTION_LIMIT);
 
     const artifacts = Array.from(artifactById.values())
       .filter((a) => !a.archived)
       .filter((a) => a.created_by === currentUserId)
       .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at))
-      .slice(0, RECENT_ARTIFACT_LIMIT)
-      .map<SearchResultItem>((a) => ({
-        type: 'artifact',
+      .slice(0, RECENTS_SECTION_LIMIT);
+
+    const boards = Array.from(boardById.values())
+      .filter((b) => !b.archived)
+      .filter((b) => b.created_by === currentUserId)
+      .sort((a, b) => tsValue(b.last_updated) - tsValue(a.last_updated))
+      .slice(0, RECENTS_SECTION_LIMIT);
+
+    // MCP uses owner_user_id (not created_by) and a Date timestamp.
+    const mcpServers = Array.from(mcpServerById.values())
+      .filter((m) => m.owner_user_id === currentUserId)
+      .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at))
+      .slice(0, RECENTS_SECTION_LIMIT);
+
+    return {
+      session: sessions.map((s) => ({
+        type: 'session' as const,
+        item: s,
+        parentBranch: branchById.get(s.branch_id),
+      })),
+      branch: branches.map((b) => ({ type: 'branch' as const, item: b })),
+      assistant: assistants.map((b) => ({ type: 'assistant' as const, item: b })),
+      artifact: artifacts.map((a) => ({
+        type: 'artifact' as const,
         item: a,
         parentBranch: a.branch_id ? branchById.get(a.branch_id) : undefined,
-      }));
-
-    return [...sessions, ...branches, ...artifacts];
-  }, [currentUserId, sessionById, branchById, artifactById]);
+      })),
+      board: boards.map((b) => ({ type: 'board' as const, item: b })),
+      mcp: mcpServers.map((m) => ({ type: 'mcp' as const, item: m })),
+    };
+  }, [currentUserId, sessionById, branchById, artifactById, boardById, mcpServerById]);
 }

--- a/apps/agor-ui/src/components/GlobalSearch/useRecents.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useRecents.ts
@@ -1,24 +1,16 @@
-import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
 import { isAssistant } from '@agor-live/client';
 import { useMemo } from 'react';
-import { EMPTY_RESULTS, type ResultsByType } from './types';
-import { tsValue } from './utils';
+import {
+  EMPTY_RESULTS,
+  type GlobalSearchEntityMaps,
+  RECENTS_SECTION_LIMIT,
+  type ResultsByType,
+} from './types';
+import { byTimestamp } from './utils';
 
-interface UseRecentsInput {
+type UseRecentsInput = GlobalSearchEntityMaps & {
   currentUserId?: string;
-  sessionById: Map<string, Session>;
-  branchById: Map<string, Branch>;
-  artifactById: Map<string, Artifact>;
-  boardById: Map<string, Board>;
-  mcpServerById: Map<string, MCPServer>;
-}
-
-/**
- * Cap per recents section. Smaller than `SECTION_LIMIT` (5) because recents is
- * the at-rest empty-query view — six sections × 3 rows is already a 100+px
- * column of suggestions before the user has typed anything.
- */
-const RECENTS_SECTION_LIMIT = 3;
+};
 
 /**
  * Backend-free recents — "stuff I created, most-recently-updated first," now
@@ -45,7 +37,7 @@ export function useRecents({
 
     const sessions = Array.from(sessionById.values())
       .filter((s) => s.created_by === currentUserId)
-      .sort((a, b) => tsValue(b.last_updated) - tsValue(a.last_updated))
+      .sort(byTimestamp((s) => s.last_updated))
       .slice(0, RECENTS_SECTION_LIMIT);
 
     // Pre-sort all the user's branches once, then bucket into branch vs.
@@ -53,26 +45,26 @@ export function useRecents({
     // separate passes through the map.
     const myBranches = Array.from(branchById.values())
       .filter((b) => b.created_by === currentUserId)
-      .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at));
+      .sort(byTimestamp((b) => b.updated_at));
     const branches = myBranches.filter((b) => !isAssistant(b)).slice(0, RECENTS_SECTION_LIMIT);
     const assistants = myBranches.filter((b) => isAssistant(b)).slice(0, RECENTS_SECTION_LIMIT);
 
     const artifacts = Array.from(artifactById.values())
       .filter((a) => !a.archived)
       .filter((a) => a.created_by === currentUserId)
-      .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at))
+      .sort(byTimestamp((a) => a.updated_at))
       .slice(0, RECENTS_SECTION_LIMIT);
 
     const boards = Array.from(boardById.values())
       .filter((b) => !b.archived)
       .filter((b) => b.created_by === currentUserId)
-      .sort((a, b) => tsValue(b.last_updated) - tsValue(a.last_updated))
+      .sort(byTimestamp((b) => b.last_updated))
       .slice(0, RECENTS_SECTION_LIMIT);
 
     // MCP uses owner_user_id (not created_by) and a Date timestamp.
     const mcpServers = Array.from(mcpServerById.values())
       .filter((m) => m.owner_user_id === currentUserId)
-      .sort((a, b) => tsValue(b.updated_at) - tsValue(a.updated_at))
+      .sort(byTimestamp((m) => m.updated_at))
       .slice(0, RECENTS_SECTION_LIMIT);
 
     return {

--- a/apps/agor-ui/src/components/GlobalSearch/utils.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/utils.ts
@@ -3,11 +3,19 @@
  * navbar hooks don't reach into a generic utilities bucket for one-call helpers.
  */
 
+import {
+  type ResultsByType,
+  SECTION_ORDER,
+  type SearchCounts,
+  type SearchResultItem,
+} from './types';
+
 /**
  * Coerce a timestamp (string ISO or Date) to a millisecond number for sorting.
- * Returns 0 for missing/invalid values so they sort to the end of a DESC list.
+ * File-private — callers should use `byTimestamp()` instead of comparing
+ * directly.
  */
-export function tsValue(ts: string | Date | undefined | null): number {
+function tsValue(ts: string | Date | undefined | null): number {
   if (!ts) return 0;
   if (ts instanceof Date) return ts.getTime();
   const parsed = Date.parse(ts);
@@ -23,4 +31,38 @@ export function byTimestamp<T>(
   getTs: (item: T) => string | Date | undefined | null
 ): (a: T, b: T) => number {
   return (a, b) => tsValue(getTs(b)) - tsValue(getTs(a));
+}
+
+/** True when any section in a `ResultsByType` has at least one row. */
+export function hasAnyEntries(results: ResultsByType): boolean {
+  return SECTION_ORDER.some((t) => results[t].length > 0);
+}
+
+/** Flatten sectioned results into a single array in `SECTION_ORDER` order —
+ * the canonical sequence used by keyboard navigation. The cast widens each
+ * per-section narrow variant back to the union — TS otherwise tries to unify
+ * the heterogeneous `flatMap` callback returns against the first variant. */
+export function flattenResults(results: ResultsByType): SearchResultItem[] {
+  return SECTION_ORDER.flatMap((t) => results[t] as SearchResultItem[]);
+}
+
+/** Total match count across all entity types. */
+export function sumCounts(counts: SearchCounts): number {
+  return SECTION_ORDER.reduce((sum, t) => sum + counts[t], 0);
+}
+
+/**
+ * Cumulative section offsets for keyboard cursor index alignment — each entry
+ * is the count of rows that come before that section in `SECTION_ORDER`. Used
+ * by the dropdown renderer to translate a `(section, indexInSection)` pair to
+ * the flat index that matches `flattenResults`.
+ */
+export function sectionOffsets(results: ResultsByType): Map<SearchResultItem['type'], number> {
+  const offsets = new Map<SearchResultItem['type'], number>();
+  let running = 0;
+  for (const type of SECTION_ORDER) {
+    offsets.set(type, running);
+    running += results[type].length;
+  }
+  return offsets;
 }

--- a/apps/agor-ui/src/utils/time.ts
+++ b/apps/agor-ui/src/utils/time.ts
@@ -40,6 +40,20 @@ export function formatRelativeTime(timestamp: string | Date): string {
 }
 
 /**
+ * Optional- and invalid-tolerant wrapper around `formatRelativeTime`. Returns
+ * `undefined` when the input is missing or an unparseable date — guards
+ * against the bare formatter rendering invalid dates as `NaNy ago`.
+ */
+export function formatRelativeTimeSafe(
+  timestamp: string | Date | undefined | null
+): string | undefined {
+  if (!timestamp) return undefined;
+  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  if (Number.isNaN(date.getTime())) return undefined;
+  return formatRelativeTime(date);
+}
+
+/**
  * Format a timestamp as absolute time in ISO-ish format (local timezone)
  * Format: "2025-01-12 15:45:30"
  */

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -37,6 +37,14 @@ export {
 
 export * from '../config/browser.js';
 export type { AgorConfig } from '../config/types.js';
+// Global-search field registry — same module on client (V1 in-memory filter)
+// and server (future V2 SQL fan-out per design doc §5.7).
+export {
+  matchSearchTokens,
+  SEARCHABLE_FIELDS,
+  type SearchFieldExtractor,
+  tokenizeSearchQuery,
+} from '../search/index.js';
 // Browser-safe zone-trigger context builder (pure JS, no Handlebars). The
 // daemon and MCP path render against this shape too — keep them in sync.
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from './environment/render-snapshot.js';
 export * from './git/index.js';
 export * from './lib/validation.js';
 export * from './mcp/index.js';
+export * from './search/index.js';
 export * from './sessions/index.js';
 // Re-export everything from submodules
 export * from './types/index.js';

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,0 +1,6 @@
+export {
+  matchSearchTokens,
+  SEARCHABLE_FIELDS,
+  type SearchFieldExtractor,
+  tokenizeSearchQuery,
+} from './searchable-fields.js';

--- a/packages/core/src/search/searchable-fields.ts
+++ b/packages/core/src/search/searchable-fields.ts
@@ -48,7 +48,12 @@ export const SEARCHABLE_FIELDS = {
 /**
  * AND-of-ORs substring match per design doc §3.3 — every token must appear in
  * at least one of the supplied field values (case-insensitive). `null` and
- * `undefined` field values are skipped. Use directly with a registry entry:
+ * `undefined` field values are skipped, as are empty/whitespace-only tokens.
+ *
+ * Tokens are lowercased internally, so callers don't have to pre-normalize.
+ * The default UI client already runs them through `tokenizeSearchQuery()`
+ * (which lowercases too), but external callers — e.g. a future server-side
+ * fan-out — can pass arbitrary case without surprises.
  *
  *     matchSearchTokens(tokens, SEARCHABLE_FIELDS.session(session))
  */
@@ -56,12 +61,13 @@ export function matchSearchTokens(
   tokens: string[],
   fields: Array<string | undefined | null>
 ): boolean {
-  if (tokens.length === 0) return false;
+  const normalized = tokens.map((t) => t.toLowerCase()).filter(Boolean);
+  if (normalized.length === 0) return false;
   const haystack = fields
     .filter((f): f is string => Boolean(f))
     .join(' \n ')
     .toLowerCase();
-  return tokens.every((t) => haystack.includes(t));
+  return normalized.every((t) => haystack.includes(t));
 }
 
 /**

--- a/packages/core/src/search/searchable-fields.ts
+++ b/packages/core/src/search/searchable-fields.ts
@@ -1,0 +1,74 @@
+/**
+ * Searchable-fields registry — single source of truth for which fields each
+ * entity type exposes to global search.
+ *
+ * V1 consumes these client-side via `useGlobalSearch` (substring AND-of-ORs
+ * over the entity's full field set, see `matchSearchTokens` below). V2's
+ * server-side fan-out (per design doc §5.7) will read the same registry to
+ * build dialect-specific SQL — for SQLite via `like`, for Postgres via
+ * `ilike` / `tsvector`. Either way, adding/removing a searchable field is a
+ * one-place change here.
+ *
+ * Why functions, not column-name lists: V1 needs to extract live values from
+ * in-memory entity objects (some fields live in JSON columns like
+ * `data.custom_context.assistant.displayName`, which can't be expressed as a
+ * column name alone). V2 can layer a parallel column-name list onto the same
+ * shape when it lands.
+ *
+ * The `branch` entry covers both pure branches and assistants — they share
+ * the underlying table row, so the field set is unified. Render-time type
+ * discrimination (branch vs. assistant) happens at the caller via
+ * `isAssistant()`.
+ */
+
+import type { Artifact } from '../types/artifact.js';
+import type { Board } from '../types/board.js';
+import { type Branch, getAssistantConfig } from '../types/branch.js';
+import type { MCPServer } from '../types/mcp.js';
+import type { Session } from '../types/session.js';
+
+/** Extracts the searchable string values from an entity. */
+export type SearchFieldExtractor<T> = (item: T) => Array<string | undefined | null>;
+
+export const SEARCHABLE_FIELDS = {
+  session: ((s) => [s.title, s.description]) as SearchFieldExtractor<Session>,
+  branch: ((b) => [
+    b.name,
+    b.ref,
+    b.notes,
+    b.issue_url,
+    b.pull_request_url,
+    getAssistantConfig(b)?.displayName,
+  ]) as SearchFieldExtractor<Branch>,
+  artifact: ((a) => [a.name, a.description]) as SearchFieldExtractor<Artifact>,
+  board: ((b) => [b.name, b.description]) as SearchFieldExtractor<Board>,
+  mcp: ((m) => [m.name, m.display_name, m.description]) as SearchFieldExtractor<MCPServer>,
+} as const;
+
+/**
+ * AND-of-ORs substring match per design doc §3.3 — every token must appear in
+ * at least one of the supplied field values (case-insensitive). `null` and
+ * `undefined` field values are skipped. Use directly with a registry entry:
+ *
+ *     matchSearchTokens(tokens, SEARCHABLE_FIELDS.session(session))
+ */
+export function matchSearchTokens(
+  tokens: string[],
+  fields: Array<string | undefined | null>
+): boolean {
+  if (tokens.length === 0) return false;
+  const haystack = fields
+    .filter((f): f is string => Boolean(f))
+    .join(' \n ')
+    .toLowerCase();
+  return tokens.every((t) => haystack.includes(t));
+}
+
+/**
+ * Tokenize a raw query into lowercase whitespace-separated tokens, dropping
+ * empties. Centralized here so client and (future) server fan-out agree on
+ * the same split rules.
+ */
+export function tokenizeSearchQuery(query: string): string[] {
+  return query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+}

--- a/packages/core/src/search/searchable-fields.ts
+++ b/packages/core/src/search/searchable-fields.ts
@@ -61,7 +61,7 @@ export function matchSearchTokens(
   tokens: string[],
   fields: Array<string | undefined | null>
 ): boolean {
-  const normalized = tokens.map((t) => t.toLowerCase()).filter(Boolean);
+  const normalized = tokens.map((t) => t.trim().toLowerCase()).filter(Boolean);
   if (normalized.length === 0) return false;
   const haystack = fields
     .filter((f): f is string => Boolean(f))


### PR DESCRIPTION
## Summary

Iteration on the global-search feature that landed in #1246. Ships five focused improvements; one (#2 below) is intentionally deferred.

**Note on rebase:** rebased onto main after #1250 (the Worktree → Branch rename) merged. All commits use the new `Branch` naming throughout.

## Commits

1. **`feat(search): per-tab result count tags`** — small AntD `<Tag>` next to each Segmented chip label showing match count for that section. Counts are computed for every entity type regardless of active chip, so an inactive chip still tells you "click here to find 12 results." Drops the redundant `Sessions · 5` text from section headers (chip badges now own that surface).

2. **`refactor(search): completeness sweep and DRY for searchable-fields registry`** — extracts the inlined per-entity field arrays from `useGlobalSearch.ts` into `packages/core/src/search/searchable-fields.ts` as the design doc proposed (§5.2). Single source of truth that V2's server-side fan-out will reuse. Completeness sweep adds three missing fields: `branch.notes`, `branch.ref`, `board.description`. Also centralizes `tokenizeSearchQuery()` and `matchSearchTokens()` so client and (future) server agree on the same tokenization + match semantics.

3. **`feat(search): group recents by entity type`** — reshapes `useRecents` to return `ResultsByType` so the dropdown's section renderer is reused verbatim between empty-query (recents) and typed-query (live results) views. Extends recents coverage from sessions/branches/artifacts only to also include assistants, boards, and MCP servers. Cap is 3 per section (vs 5 for live results).

4. **`feat(search): close button on global-search popover`** — small `<CloseOutlined>` button in the top-right corner, absolute-positioned so it doesn't reflow the chip row. Esc still works (combobox keyboard contract); the button is for users reaching for the mouse.

5. **`feat(search): highlight matched substrings in visible fields`** — wraps any token-matched substring in result-row titles and secondary lines in `<mark>` styled with `colorWarningBg`. Multi-token, case-insensitive (single regex alternation), no DOM thrash. Limited to **visible fields only** — matches in non-rendered fields (e.g. a hit in `branch.notes` showing up inside a session row) would need snippet extraction, which is V2 territory.

## Deferred

**Per-tab loading spinners** — surfaced via stop-and-report. The shipped V1 implementation is a synchronous client-side filter over WebSocket-synced entity maps (`useGlobalSearch.ts:84-163` confirms this is intentional V1 scaffolding, with V2 fan-out being the explicit follow-up). There are no per-entity promises to reflect, so per-tab spinners can't meaningfully exist until the V2 server-driven fan-out lands. Documenting the architectural mismatch here as the planned precursor for spinners.

## What to eyeball (dev server already running in this worktree per CLAUDE.md)

- **Empty query** — recents render as sectioned columns (Sessions / Branches / Assistants / Artifacts / Boards / MCP), each capped at 3 rows. Empty-state copy only appears when ALL sections are empty.
- **One-keyword query** — chip badges show per-type counts (e.g. `[Session 4]`, `[Branch 12]`); the `All` chip shows the sum. Highlighted matches appear inside titles and the secondary "in <branch>" line. Section headers no longer show inline counts.
- **Multi-token query** — every token must match somewhere in the entity's searchable-field set; both tokens get highlighted in titles independently.
- **Close button** — top-right corner X; click closes + clears query. Esc still works.
- **Completeness sweep** — searching for a worktree's branch ref, notes content, or a board description should now return matches that previously didn't fire.

## CI status

Typechecks clean across `@agor/core`, `@agor-live/client`, and `agor-ui` after the post-rebase build. All five commits pass pre-commit hooks (biome + format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)