### PR TITLE
feat(mcp): personal API keys and sessionless access

### DIFF
--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { coerceJsonRecord, setupMCPRoutes } from './server.js';
 
@@ -66,9 +67,22 @@ describe('coerceJsonRecord', () => {
  */
 function captureMcpHandler() {
   let handler: ((req: Request, res: Response) => Promise<unknown> | unknown) | null = null;
+  const register = (_path: string, fn: typeof handler) => {
+    handler = fn;
+  };
   const app = {
-    post: (_path: string, fn: typeof handler) => {
-      handler = fn;
+    post: register,
+    get: register,
+    delete: register,
+    service: (name: string) => {
+      if (name !== 'users' && name !== 'sessions') {
+        throw new Error(`Unexpected service lookup: ${name}`);
+      }
+      return {
+        get: vi.fn(async () => {
+          throw new Error(`Unexpected ${name}.get call`);
+        }),
+      };
     },
   } as unknown as Parameters<typeof setupMCPRoutes>[0];
   setupMCPRoutes(app, {} as never, /* toolSearchEnabled */ false);
@@ -143,6 +157,27 @@ describe('POST /mcp token source', () => {
     expect(body?.error?.message).toMatch(/authorization: bearer/i);
   });
 
+  it('rejects an invalid personal API key from X-API-Key (401)', async () => {
+    const { UserApiKeysRepository } = await import('@agor/core/db');
+    vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey').mockResolvedValue(null);
+    const handler = captureMcpHandler();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const req = {
+      method: 'POST',
+      query: {},
+      headers: { 'x-api-key': 'agor_sk_invalid' },
+      body: { id: 10 },
+      ip: '127.0.0.1',
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as Request;
+    const res = buildRes();
+    await handler(req, res as unknown as Response);
+    expect(res.statusCode).toBe(401);
+    const body = res.body as { error?: { message?: string }; id?: number };
+    expect(body.id).toBe(10);
+    expect(body.error?.message).toMatch(/invalid personal api key/i);
+  });
+
   it('rejects even when query has both ?sessionToken= and an Authorization header (query wins → 400)', async () => {
     const handler = captureMcpHandler();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -194,5 +229,80 @@ describe('POST /mcp token source', () => {
     await handler(otherReq, buildRes() as unknown as Response);
     expect(warn.mock.calls.length).toBe(firstCount + 1);
     warn.mockRestore();
+  });
+});
+
+describe('POST /mcp with personal API keys', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('can call a non-session-scoped tool without X-Agor-Session-Id / ?sessionId', async () => {
+    const { UserApiKeysRepository } = await import('@agor/core/db');
+    vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey').mockResolvedValue({
+      id: 'key-1',
+      user_id: 'user-1',
+      name: 'orchestrator',
+      prefix: 'agor_sk_123',
+      key_hash: 'hash',
+      created_at: new Date(),
+      last_used_at: null,
+    });
+    vi.spyOn(UserApiKeysRepository.prototype, 'updateLastUsed').mockResolvedValue();
+
+    const webApp = express();
+    webApp.use(express.json());
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    (webApp as unknown as { service: (name: string) => unknown }).service = (name: string) => {
+      if (name !== 'users') throw new Error(`Unexpected service lookup: ${name}`);
+      return { get: getUser };
+    };
+
+    setupMCPRoutes(webApp as never, {} as never, /* toolSearchEnabled */ false);
+
+    const httpServer = webApp.listen(0);
+    try {
+      const address = httpServer.address();
+      if (!address || typeof address === 'string') throw new Error('no listen address');
+      const resp = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'X-API-Key': 'agor_sk_valid',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'agor_users_get_current', arguments: {} },
+        }),
+      });
+
+      expect(resp.status).toBe(200);
+      const responseText = await resp.text();
+      const dataLine = responseText
+        .split('\n')
+        .find((line) => line.startsWith('data: '))
+        ?.slice('data: '.length);
+      if (!dataLine) throw new Error(`No SSE data line in response: ${responseText}`);
+      const body = JSON.parse(dataLine) as {
+        result?: { content: Array<{ text: string }> };
+        error?: { message: string };
+      };
+      expect(body.error).toBeUndefined();
+      const result = JSON.parse(body.result!.content[0].text);
+      expect(result.user_id).toBe('user-1');
+      expect(getUser).toHaveBeenCalledWith('user-1');
+      expect(UserApiKeysRepository.prototype.updateLastUsed).toHaveBeenCalledWith('key-1');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
   });
 });

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -237,6 +237,98 @@ describe('POST /mcp with personal API keys', () => {
     vi.restoreAllMocks();
   });
 
+  function mockPersonalApiKeyUser(userId = 'user-1') {
+    const keyRows = {
+      agor_sk_valid: {
+        id: 'key-1',
+        user_id: userId,
+        name: 'orchestrator',
+        prefix: 'agor_sk_123',
+        key_hash: 'hash',
+        created_at: new Date(),
+        last_used_at: null,
+      },
+      agor_sk_other: {
+        id: 'key-2',
+        user_id: 'user-2',
+        name: 'other',
+        prefix: 'agor_sk_456',
+        key_hash: 'hash',
+        created_at: new Date(),
+        last_used_at: null,
+      },
+    };
+    return import('@agor/core/db').then(({ UserApiKeysRepository }) => {
+      vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey').mockImplementation(async (key) => {
+        return keyRows[key as keyof typeof keyRows] ?? null;
+      });
+      vi.spyOn(UserApiKeysRepository.prototype, 'updateLastUsed').mockResolvedValue();
+    });
+  }
+
+  async function withMcpServer(
+    services: Record<string, unknown>,
+    fn: (baseUrl: string) => Promise<void>
+  ) {
+    const webApp = express();
+    webApp.use(express.json());
+    (webApp as unknown as { service: (name: string) => unknown }).service = (name: string) => {
+      const svc = services[name];
+      if (!svc) throw new Error(`Unexpected service lookup: ${name}`);
+      return svc;
+    };
+
+    setupMCPRoutes(webApp as never, {} as never, /* toolSearchEnabled */ false);
+
+    const httpServer = webApp.listen(0);
+    try {
+      const address = httpServer.address();
+      if (!address || typeof address === 'string') throw new Error('no listen address');
+      await fn(`http://127.0.0.1:${address.port}`);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  }
+
+  function parseMcpResponse(text: string) {
+    const dataLine = text
+      .split('\n')
+      .find((line) => line.startsWith('data: '))
+      ?.slice('data: '.length);
+    return JSON.parse(dataLine ?? text) as {
+      result?: { content?: Array<{ text: string }> };
+      error?: { message: string };
+    };
+  }
+
+  async function initializeStatefulMcp(baseUrl: string, apiKey = 'agor_sk_valid') {
+    const resp = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 100,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'vitest', version: '1.0.0' },
+        },
+      }),
+    });
+    expect(resp.status).toBe(200);
+    const mcpSessionId = resp.headers.get('mcp-session-id');
+    expect(mcpSessionId).toBeTruthy();
+    await resp.text();
+    return mcpSessionId!;
+  }
+
   it('can call a non-session-scoped tool without X-Agor-Session-Id / ?sessionId', async () => {
     const { UserApiKeysRepository } = await import('@agor/core/db');
     vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey').mockResolvedValue({
@@ -304,5 +396,228 @@ describe('POST /mcp with personal API keys', () => {
         httpServer.close((err) => (err ? reject(err) : resolve()));
       });
     }
+  });
+
+  it('accepts a valid personal API key session context from X-Agor-Session-Id', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    const getSession = vi.fn(async () => ({ session_id: 'session-full-id' }));
+
+    await withMcpServer(
+      { users: { get: getUser }, sessions: { get: getSession } },
+      async (baseUrl) => {
+        const resp = await fetch(`${baseUrl}/mcp`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+            'X-Agor-Session-Id': 'session-short',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(200);
+        expect(parseMcpResponse(await resp.text()).error).toBeUndefined();
+        expect(getSession).toHaveBeenCalledWith(
+          'session-short',
+          expect.objectContaining({
+            authenticated: true,
+            provider: 'mcp',
+            user: expect.objectContaining({ user_id: 'user-1', role: 'member' }),
+          })
+        );
+      }
+    );
+  });
+
+  it('accepts a valid personal API key session context from ?sessionId=', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    const getSession = vi.fn(async () => ({ session_id: 'session-full-id' }));
+
+    await withMcpServer(
+      { users: { get: getUser }, sessions: { get: getSession } },
+      async (baseUrl) => {
+        const resp = await fetch(`${baseUrl}/mcp?sessionId=session-query`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(200);
+        expect(parseMcpResponse(await resp.text()).error).toBeUndefined();
+        expect(getSession).toHaveBeenCalledWith('session-query', expect.any(Object));
+      }
+    );
+  });
+
+  it('rejects inaccessible personal API key session context', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    const getSession = vi.fn(async () => {
+      throw new Error('no access');
+    });
+
+    await withMcpServer(
+      { users: { get: getUser }, sessions: { get: getSession } },
+      async (baseUrl) => {
+        const resp = await fetch(`${baseUrl}/mcp`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+            'X-Agor-Session-Id': 'forbidden-session',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 4,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(403);
+        const body = (await resp.json()) as { error?: { message?: string } };
+        expect(body.error?.message).toMatch(/not accessible/i);
+      }
+    );
+  });
+
+  it('rejects adding X-Agor-Session-Id to a sessionless stateful MCP session', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    const getSession = vi.fn(async () => ({ session_id: 'session-full-id' }));
+
+    await withMcpServer(
+      { users: { get: getUser }, sessions: { get: getSession } },
+      async (baseUrl) => {
+        const mcpSessionId = await initializeStatefulMcp(baseUrl);
+        const resp = await fetch(`${baseUrl}/mcp`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+            'Mcp-Session-Id': mcpSessionId,
+            'X-Agor-Session-Id': 'session-full-id',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 5,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(403);
+        const body = (await resp.json()) as { error?: { message?: string } };
+        expect(body.error?.message).toMatch(/initialized without/i);
+      }
+    );
+  });
+
+  it('rejects a stateful MCP request from a different API key user', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async (id: string) => ({
+      user_id: id,
+      email: `${id}@example.com`,
+      role: 'member',
+    }));
+
+    await withMcpServer({ users: { get: getUser } }, async (baseUrl) => {
+      const mcpSessionId = await initializeStatefulMcp(baseUrl, 'agor_sk_valid');
+      const resp = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'X-API-Key': 'agor_sk_other',
+          'Mcp-Session-Id': mcpSessionId,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 6,
+          method: 'tools/call',
+          params: { name: 'agor_users_get_current', arguments: {} },
+        }),
+      });
+
+      expect(resp.status).toBe(403);
+      const body = (await resp.json()) as { error?: { message?: string } };
+      expect(body.error?.message).toMatch(/different user/i);
+    });
+  });
+
+  it('DELETE closes a stateful MCP session and subsequent use returns 404', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+
+    await withMcpServer({ users: { get: getUser } }, async (baseUrl) => {
+      const mcpSessionId = await initializeStatefulMcp(baseUrl);
+      const deleteResp = await fetch(`${baseUrl}/mcp`, {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'X-API-Key': 'agor_sk_valid',
+          'Mcp-Session-Id': mcpSessionId,
+        },
+      });
+      expect(deleteResp.status).toBe(200);
+      await deleteResp.text();
+
+      const resp = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'X-API-Key': 'agor_sk_valid',
+          'Mcp-Session-Id': mcpSessionId,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 7,
+          method: 'tools/call',
+          params: { name: 'agor_users_get_current', arguments: {} },
+        }),
+      });
+
+      expect(resp.status).toBe(404);
+    });
   });
 });

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -329,6 +329,45 @@ describe('POST /mcp with personal API keys', () => {
     return mcpSessionId!;
   }
 
+  async function markStatefulMcpInitialized(baseUrl: string, mcpSessionId: string) {
+    const resp = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'X-API-Key': 'agor_sk_valid',
+        'Mcp-Session-Id': mcpSessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      }),
+    });
+    expect(resp.status).toBeGreaterThanOrEqual(200);
+    expect(resp.status).toBeLessThan(300);
+    await resp.text();
+  }
+
+  async function callCurrentUserStatefully(baseUrl: string, mcpSessionId: string) {
+    const resp = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'X-API-Key': 'agor_sk_valid',
+        'Mcp-Session-Id': mcpSessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 101,
+        method: 'tools/call',
+        params: { name: 'agor_users_get_current', arguments: {} },
+      }),
+    });
+    const parsed = parseMcpResponse(await resp.text());
+    return { resp, parsed };
+  }
+
   it('can call a non-session-scoped tool without X-Agor-Session-Id / ?sessionId', async () => {
     const { UserApiKeysRepository } = await import('@agor/core/db');
     vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey').mockResolvedValue({
@@ -618,6 +657,65 @@ describe('POST /mcp with personal API keys', () => {
       });
 
       expect(resp.status).toBe(404);
+    });
+  });
+
+  it('refreshes user role context on each stateful MCP request', async () => {
+    await mockPersonalApiKeyUser();
+    let role = 'superadmin';
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role,
+    }));
+
+    await withMcpServer({ users: { get: getUser } }, async (baseUrl) => {
+      const mcpSessionId = await initializeStatefulMcp(baseUrl);
+      await markStatefulMcpInitialized(baseUrl, mcpSessionId);
+
+      role = 'member';
+      const { resp, parsed } = await callCurrentUserStatefully(baseUrl, mcpSessionId);
+
+      expect(resp.status).toBe(200);
+      expect(parsed.error).toBeUndefined();
+      const result = JSON.parse(parsed.result!.content![0].text);
+      expect(result.role).toBe('member');
+      // initialize auth, initialized notification auth, tool-call auth, then
+      // the tool itself. The returned role proves the stateful tool context
+      // observed the freshly reloaded user rather than the initialize-time one.
+      expect(getUser).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  it('keeps a stateful MCP session usable after a GET SSE disconnect', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+
+    await withMcpServer({ users: { get: getUser } }, async (baseUrl) => {
+      const mcpSessionId = await initializeStatefulMcp(baseUrl);
+      await markStatefulMcpInitialized(baseUrl, mcpSessionId);
+
+      const sseResp = await fetch(`${baseUrl}/mcp`, {
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          'X-API-Key': 'agor_sk_valid',
+          'Mcp-Session-Id': mcpSessionId,
+        },
+      });
+      expect(sseResp.status).toBe(200);
+      await sseResp.body?.cancel();
+
+      const { resp, parsed } = await callCurrentUserStatefully(baseUrl, mcpSessionId);
+
+      expect(resp.status).toBe(200);
+      expect(parsed.error).toBeUndefined();
+      const result = JSON.parse(parsed.result!.content![0].text);
+      expect(result.user_id).toBe('user-1');
     });
   });
 });

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -13,8 +13,9 @@
  * JSON across requests, which is critical for client-side KV prefix caching.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { Database } from '@agor/core/db';
-import { shortId } from '@agor/core/db';
+import { shortId, UserApiKeysRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { DaemonServicesConfig, ServiceGroupName, SessionID, UserID } from '@agor/core/types';
 import { getServiceTier, SERVICE_GROUP_TO_MCP_DOMAINS, SERVICE_TIER_RANK } from '@agor/core/types';
@@ -52,7 +53,8 @@ export interface McpContext {
   app: Application;
   db: Database;
   userId: UserID;
-  sessionId: SessionID;
+  /** Current Agor session context, when the caller supplied or authenticated with one. */
+  sessionId?: SessionID;
   authenticatedUser: AuthenticatedUser;
   baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider'>;
 }
@@ -88,6 +90,20 @@ export function coerceJsonRecord(value: unknown): unknown {
 export function textResult(data: unknown) {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+export const SESSION_CONTEXT_REQUIRED_MESSAGE =
+  'This MCP tool requires current Agor session context. Reconnect or call /mcp with X-Agor-Session-Id: <session-id> (or ?sessionId=<session-id>) when using a personal API key.';
+
+export function sessionContextRequiredResult() {
+  return {
+    ...textResult({
+      error: SESSION_CONTEXT_REQUIRED_MESSAGE,
+      how_to_fix:
+        'Set the X-Agor-Session-Id header or ?sessionId= query parameter to an accessible session ID, or use a session-scoped MCP token.',
+    }),
+    isError: true,
   };
 }
 
@@ -436,6 +452,93 @@ export function setupMCPRoutes(
     console.log(`✅ MCP tool registry built (${cachedRegistry!.size} tools cached)`);
   }
 
+  const personalApiKeys = new UserApiKeysRepository(db);
+
+  type StatefulTransportEntry = {
+    transport: StreamableHTTPServerTransport;
+    server: McpServer;
+    userId: UserID;
+    sessionId?: SessionID;
+    lastUsedAt: number;
+    ttlTimer: NodeJS.Timeout;
+  };
+
+  // Streamable HTTP sessions are intentionally in-memory and modestly bounded:
+  // external orchestrators can hold an SSE session, but abandoned clients must
+  // not grow this map forever if they never send DELETE /mcp.
+  const STATEFUL_TRANSPORT_TTL_MS = 30 * 60 * 1000;
+  const STATEFUL_TRANSPORT_MAX = 100;
+  const statefulTransports = new Map<string, StatefulTransportEntry>();
+
+  const closeStatefulTransport = (mcpSessionId: string): void => {
+    const entry = statefulTransports.get(mcpSessionId);
+    if (!entry) return;
+    statefulTransports.delete(mcpSessionId);
+    clearTimeout(entry.ttlTimer);
+    entry.transport.close().catch(() => {});
+    entry.server.close().catch(() => {});
+  };
+
+  const armStatefulTransportTtl = (mcpSessionId: string, entry: StatefulTransportEntry): void => {
+    clearTimeout(entry.ttlTimer);
+    entry.lastUsedAt = Date.now();
+    entry.ttlTimer = setTimeout(() => {
+      console.warn(`⚠️  MCP streamable HTTP session expired: ${mcpSessionId}`);
+      closeStatefulTransport(mcpSessionId);
+    }, STATEFUL_TRANSPORT_TTL_MS);
+    entry.ttlTimer.unref?.();
+  };
+
+  const evictOldestStatefulTransportIfNeeded = (): void => {
+    if (statefulTransports.size < STATEFUL_TRANSPORT_MAX) return;
+    let oldestId: string | undefined;
+    let oldestLastUsed = Number.POSITIVE_INFINITY;
+    for (const [id, entry] of statefulTransports) {
+      if (entry.lastUsedAt < oldestLastUsed) {
+        oldestLastUsed = entry.lastUsedAt;
+        oldestId = id;
+      }
+    }
+    if (oldestId) {
+      console.warn(`⚠️  MCP streamable HTTP session limit reached; evicting ${oldestId}`);
+      closeStatefulTransport(oldestId);
+    }
+  };
+
+  const isInitializeRequest = (body: unknown): boolean => {
+    if (!body || typeof body !== 'object') return false;
+    const maybeRequest = body as { method?: unknown };
+    return maybeRequest.method === 'initialize';
+  };
+
+  const getBodyId = (req: Request): unknown => (req.body as { id?: unknown } | undefined)?.id;
+
+  const jsonRpcError = (req: Request, code: number, message: string) => ({
+    jsonrpc: '2.0',
+    id: getBodyId(req),
+    error: { code, message },
+  });
+
+  const getCredential = (req: Request): string | undefined => {
+    const authHeader = req.headers.authorization;
+    if (authHeader) {
+      const [scheme, ...rest] = authHeader.split(' ');
+      const token = rest.join(' ').trim();
+      if (scheme?.toLowerCase() === 'bearer' && token) return token;
+    }
+
+    const xApiKey = req.headers['x-api-key'];
+    return coerceString(Array.isArray(xApiKey) ? xApiKey[0] : xApiKey);
+  };
+
+  const getRequestedSessionId = (req: Request): string | undefined => {
+    const fromQuery = coerceString(req.query.sessionId);
+    if (fromQuery) return fromQuery;
+
+    const fromHeader = req.headers['x-agor-session-id'];
+    return coerceString(Array.isArray(fromHeader) ? fromHeader[0] : fromHeader);
+  };
+
   const handler = async (req: Request, res: Response) => {
     try {
       console.log(`🔌 Incoming MCP request: ${req.method} /mcp`);
@@ -450,70 +553,78 @@ export function setupMCPRoutes(
       if ('sessionToken' in req.query) {
         logQueryParamDeprecation(req);
         return res.status(400).json({
-          jsonrpc: '2.0',
-          id: (req.body as { id?: unknown })?.id,
-          error: {
-            code: -32600,
-            message:
-              'Session token in query string is no longer accepted. Send it as an Authorization: Bearer <token> header instead.',
-          },
+          ...jsonRpcError(
+            req,
+            -32600,
+            'Session token in query string is no longer accepted. Send it as an Authorization: Bearer <token> header instead.'
+          ),
         });
       }
 
-      // Extract session token from Authorization header only
-      let sessionToken: string | undefined;
-      const authHeader = req.headers.authorization;
-      if (authHeader?.startsWith('Bearer ')) {
-        sessionToken = authHeader.slice(7);
-      }
-
-      if (!sessionToken) {
-        console.warn('⚠️  MCP request missing Authorization header');
+      const credential = getCredential(req);
+      if (!credential) {
+        console.warn('⚠️  MCP request missing credentials');
         return res.status(401).json({
-          jsonrpc: '2.0',
-          id: (req.body as { id?: unknown })?.id,
-          error: {
-            code: -32001,
-            message:
-              'Authentication required: session token must be provided via Authorization: Bearer header',
-          },
+          ...jsonRpcError(
+            req,
+            -32001,
+            'Authentication required: provide a session MCP token or personal API key via Authorization: Bearer <token> (or X-API-Key for personal API keys).'
+          ),
         });
       }
 
-      // Validate token and extract context
-      const context = await validateSessionToken(app, sessionToken);
-      if (!context) {
-        console.warn('⚠️  Invalid MCP session token');
-        return res.status(401).json({
-          jsonrpc: '2.0',
-          id: (req.body as { id?: unknown })?.id,
-          error: {
-            code: -32001,
-            message: 'Invalid or expired session token',
-          },
-        });
-      }
-
-      console.log(
-        `🔌 MCP request authenticated (user: ${shortId(context.userId)}, session: ${shortId(context.sessionId)})`
-      );
-
-      // Fetch the authenticated user
       let authenticatedUser: AuthenticatedUser;
-      try {
-        authenticatedUser = await app.service('users').get(context.userId);
-      } catch (error) {
-        if (error instanceof NotFoundError) {
+      let userId: UserID;
+      let sessionId: SessionID | undefined;
+      const isPersonalApiKey = credential.startsWith('agor_sk_');
+
+      if (isPersonalApiKey) {
+        const keyRow = await personalApiKeys.verifyKey(credential);
+        if (!keyRow) {
+          console.warn('⚠️  Invalid MCP personal API key');
           return res.status(401).json({
-            jsonrpc: '2.0',
-            id: (req.body as { id?: unknown })?.id,
-            error: {
-              code: -32001,
-              message: 'Invalid or expired session token',
-            },
+            ...jsonRpcError(req, -32001, 'Invalid personal API key'),
           });
         }
-        throw error;
+
+        personalApiKeys.updateLastUsed(keyRow.id).catch((err: unknown) => {
+          console.warn('Failed to update MCP personal API key last_used_at:', err);
+        });
+
+        userId = keyRow.user_id as UserID;
+        try {
+          authenticatedUser = await app.service('users').get(userId);
+        } catch (error) {
+          if (error instanceof NotFoundError) {
+            return res.status(401).json({
+              ...jsonRpcError(req, -32001, 'Invalid personal API key'),
+            });
+          }
+          throw error;
+        }
+        sessionId = getRequestedSessionId(req) as SessionID | undefined;
+      } else {
+        const context = await validateSessionToken(app, credential);
+        if (!context) {
+          console.warn('⚠️  Invalid MCP session token');
+          return res.status(401).json({
+            ...jsonRpcError(req, -32001, 'Invalid or expired session token'),
+          });
+        }
+
+        userId = context.userId;
+        sessionId = context.sessionId;
+
+        try {
+          authenticatedUser = await app.service('users').get(userId);
+        } catch (error) {
+          if (error instanceof NotFoundError) {
+            return res.status(401).json({
+              ...jsonRpcError(req, -32001, 'Invalid or expired session token'),
+            });
+          }
+          throw error;
+        }
       }
 
       const baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider'> = {
@@ -526,19 +637,136 @@ export function setupMCPRoutes(
         provider: 'mcp',
       };
 
-      // Create a per-request McpServer with tools registered per service tier
-      const mcpServer = createMcpServer(
-        {
-          app,
-          db,
-          userId: context.userId,
-          sessionId: context.sessionId,
-          authenticatedUser,
-          baseServiceParams,
-        },
-        toolSearchEnabled,
-        servicesConfig
+      // Personal API key callers may optionally bind a current-session context
+      // using a header/query param. Validate through the normal sessions
+      // service so branch RBAC and short-ID resolution stay identical to REST.
+      if (isPersonalApiKey && sessionId) {
+        try {
+          const session = await app.service('sessions').get(sessionId, baseServiceParams);
+          sessionId = session.session_id;
+        } catch {
+          return res.status(403).json({
+            ...jsonRpcError(
+              req,
+              -32003,
+              'Forbidden: X-Agor-Session-Id / ?sessionId is invalid or not accessible to this API key user.'
+            ),
+          });
+        }
+      }
+
+      console.log(
+        `🔌 MCP request authenticated (user: ${shortId(userId)}, session: ${sessionId ? shortId(sessionId) : 'none'})`
       );
+
+      const mcpContext: McpContext = {
+        app,
+        db,
+        userId,
+        sessionId,
+        authenticatedUser,
+        baseServiceParams,
+      };
+
+      const mcpSessionHeader = req.headers['mcp-session-id'];
+      const mcpSessionId = coerceString(
+        Array.isArray(mcpSessionHeader) ? mcpSessionHeader[0] : mcpSessionHeader
+      );
+
+      if (req.method === 'GET' || req.method === 'DELETE' || mcpSessionId) {
+        if (!mcpSessionId) {
+          return res.status(400).json({
+            ...jsonRpcError(req, -32000, 'Bad Request: Mcp-Session-Id header is required'),
+          });
+        }
+        const entry = statefulTransports.get(mcpSessionId);
+        if (!entry) {
+          return res.status(404).json({
+            ...jsonRpcError(req, -32001, 'Session not found for Mcp-Session-Id'),
+          });
+        }
+        if (entry.userId !== userId) {
+          return res.status(403).json({
+            ...jsonRpcError(req, -32003, 'Forbidden: MCP session belongs to a different user'),
+          });
+        }
+        if (entry.sessionId && sessionId && entry.sessionId !== sessionId) {
+          return res.status(403).json({
+            ...jsonRpcError(
+              req,
+              -32003,
+              'Forbidden: MCP session is already bound to a different X-Agor-Session-Id / ?sessionId context'
+            ),
+          });
+        }
+
+        armStatefulTransportTtl(mcpSessionId, entry);
+
+        // If an SSE client disconnects without DELETE, close the stateful
+        // transport so its server, stream, and map entry are released.
+        if (req.method === 'GET') {
+          let closed = false;
+          req.on('close', () => {
+            if (closed) return;
+            closed = true;
+            closeStatefulTransport(mcpSessionId);
+          });
+        }
+
+        await entry.transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      if (req.method === 'POST' && isInitializeRequest(req.body)) {
+        evictOldestStatefulTransportIfNeeded();
+
+        const mcpServer = createMcpServer(mcpContext, toolSearchEnabled, servicesConfig);
+        let transport: StreamableHTTPServerTransport;
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (newSessionId) => {
+            const ttlTimer = setTimeout(
+              () => closeStatefulTransport(newSessionId),
+              STATEFUL_TRANSPORT_TTL_MS
+            );
+            ttlTimer.unref?.();
+            const entry: StatefulTransportEntry = {
+              transport,
+              server: mcpServer,
+              userId,
+              sessionId,
+              lastUsedAt: Date.now(),
+              ttlTimer,
+            };
+            statefulTransports.set(newSessionId, entry);
+          },
+          onsessionclosed: (closedSessionId) => {
+            if (closedSessionId) closeStatefulTransport(closedSessionId);
+          },
+        });
+
+        transport.onclose = () => {
+          const sid = transport.sessionId;
+          if (sid) {
+            const entry = statefulTransports.get(sid);
+            statefulTransports.delete(sid);
+            if (entry) clearTimeout(entry.ttlTimer);
+          }
+          mcpServer.close().catch(() => {});
+        };
+
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      if (req.method !== 'POST') {
+        return res.status(405).json({
+          ...jsonRpcError(req, -32005, `Method ${req.method} not allowed on /mcp`),
+        });
+      }
+
+      const mcpServer = createMcpServer(mcpContext, toolSearchEnabled, servicesConfig);
 
       // Create stateless transport (one per request, no session tracking)
       const transport = new StreamableHTTPServerTransport({
@@ -568,6 +796,10 @@ export function setupMCPRoutes(
   // Register as Express POST route
   // @ts-expect-error - FeathersJS app extends Express
   app.post('/mcp', handler);
+  // @ts-expect-error - FeathersJS app extends Express
+  app.get('/mcp', handler);
+  // @ts-expect-error - FeathersJS app extends Express
+  app.delete('/mcp', handler);
 
-  console.log('✅ MCP routes registered at POST /mcp');
+  console.log('✅ MCP routes registered at /mcp (POST + GET + DELETE)');
 }

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -457,7 +457,10 @@ export function setupMCPRoutes(
   type StatefulTransportEntry = {
     transport: StreamableHTTPServerTransport;
     server: McpServer;
+    /** Mutable context object captured by registered tool handlers. */
+    context: McpContext;
     userId: UserID;
+    /** Immutable Agor session binding established at MCP initialize time, if any. */
     sessionId?: SessionID;
     lastUsedAt: number;
     ttlTimer: NodeJS.Timeout;
@@ -475,7 +478,8 @@ export function setupMCPRoutes(
     if (!entry) return;
     statefulTransports.delete(mcpSessionId);
     clearTimeout(entry.ttlTimer);
-    entry.transport.close().catch(() => {});
+    // McpServer owns the connected transport; closing the server closes the
+    // transport. Calling both can recurse through transport.onclose.
     entry.server.close().catch(() => {});
   };
 
@@ -690,6 +694,20 @@ export function setupMCPRoutes(
             ...jsonRpcError(req, -32003, 'Forbidden: MCP session belongs to a different user'),
           });
         }
+
+        // A stateful MCP transport's Agor session binding is immutable. Tool
+        // handlers close over `entry.context`, so allowing callers to add or
+        // change X-Agor-Session-Id on later requests would be confusing at
+        // best and a stale-context authorization footgun at worst.
+        if (!entry.sessionId && sessionId) {
+          return res.status(403).json({
+            ...jsonRpcError(
+              req,
+              -32003,
+              'Forbidden: MCP session was initialized without X-Agor-Session-Id / ?sessionId context; start a new MCP session with session context instead.'
+            ),
+          });
+        }
         if (entry.sessionId && sessionId && entry.sessionId !== sessionId) {
           return res.status(403).json({
             ...jsonRpcError(
@@ -702,16 +720,30 @@ export function setupMCPRoutes(
 
         armStatefulTransportTtl(mcpSessionId, entry);
 
-        // If an SSE client disconnects without DELETE, close the stateful
-        // transport so its server, stream, and map entry are released.
-        if (req.method === 'GET') {
-          let closed = false;
-          req.on('close', () => {
-            if (closed) return;
-            closed = true;
+        // Rebuild the mutable context captured by registered handlers on each
+        // stateful request. Credentials have just been re-authenticated and
+        // the user was reloaded, so this keeps role/user data fresh for
+        // long-lived streamable HTTP sessions. If the immutable Agor session
+        // binding is no longer accessible to this user, evict the MCP session.
+        if (entry.sessionId) {
+          try {
+            const session = await app.service('sessions').get(entry.sessionId, baseServiceParams);
+            entry.sessionId = session.session_id;
+          } catch {
             closeStatefulTransport(mcpSessionId);
-          });
+            return res.status(403).json({
+              ...jsonRpcError(
+                req,
+                -32003,
+                'Forbidden: the X-Agor-Session-Id / ?sessionId context bound to this MCP session is no longer accessible.'
+              ),
+            });
+          }
         }
+        entry.context.userId = userId;
+        entry.context.sessionId = entry.sessionId;
+        entry.context.authenticatedUser = authenticatedUser;
+        entry.context.baseServiceParams = baseServiceParams;
 
         await entry.transport.handleRequest(req, res, req.body);
         return;
@@ -733,6 +765,7 @@ export function setupMCPRoutes(
             const entry: StatefulTransportEntry = {
               transport,
               server: mcpServer,
+              context: mcpContext,
               userId,
               sessionId,
               lastUsedAt: Date.now(),
@@ -752,7 +785,6 @@ export function setupMCPRoutes(
             statefulTransports.delete(sid);
             if (entry) clearTimeout(entry.ttlTimer);
           }
-          mcpServer.close().catch(() => {});
         };
 
         await mcpServer.connect(transport);
@@ -779,7 +811,6 @@ export function setupMCPRoutes(
 
       // Clean up after response is done
       res.on('close', () => {
-        transport.close().catch(() => {});
         mcpServer.close().catch(() => {});
       });
     } catch (error) {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -1,0 +1,88 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+import { registerBranchTools } from './branches.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function registerAndCaptureUpdate(ctx: {
+  app: unknown;
+  userId: string;
+  sessionId?: string;
+  baseServiceParams?: Record<string, unknown>;
+}): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const fakeServer = {
+    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+      if (name === 'agor_branches_update') handler = cb;
+    },
+  } as unknown as McpServer;
+
+  registerBranchTools(fakeServer, {
+    app: ctx.app as Parameters<typeof registerBranchTools>[1]['app'],
+    db: {} as Parameters<typeof registerBranchTools>[1]['db'],
+    userId: ctx.userId as Parameters<typeof registerBranchTools>[1]['userId'],
+    sessionId: ctx.sessionId as Parameters<typeof registerBranchTools>[1]['sessionId'],
+    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
+      typeof registerBranchTools
+    >[1]['authenticatedUser'],
+    baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
+      typeof registerBranchTools
+    >[1]['baseServiceParams'],
+  });
+
+  if (!handler) throw new Error('agor_branches_update was not registered');
+  return handler;
+}
+
+describe('agor_branches_update', () => {
+  it('uses authenticated service params when falling back to the current session branch', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const sessionsGet = vi.fn(async () => ({ session_id: 'session-1', branch_id: 'branch-1' }));
+    const branchesPatch = vi.fn(async () => ({ branch_id: 'branch-1', notes: 'updated' }));
+    const app = {
+      service(name: string) {
+        if (name === 'sessions') return { get: sessionsGet };
+        if (name === 'branches') return { patch: branchesPatch };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const update = registerAndCaptureUpdate({
+      app,
+      userId: 'user-1',
+      sessionId: 'session-1',
+      baseServiceParams,
+    });
+
+    await update({ notes: 'updated' });
+
+    expect(sessionsGet).toHaveBeenCalledWith('session-1', baseServiceParams);
+    expect(branchesPatch).toHaveBeenCalledWith('branch-1', { notes: 'updated' }, baseServiceParams);
+  });
+
+  it('returns an actionable error when branchId is omitted without session context', async () => {
+    const sessionsGet = vi.fn();
+    const app = {
+      service(name: string) {
+        if (name === 'sessions') return { get: sessionsGet };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const update = registerAndCaptureUpdate({ app, userId: 'user-1' });
+    const result = await update({ notes: 'updated' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/requires current Agor session context/i);
+    expect(parsed.error).toMatch(/X-Agor-Session-Id/);
+    expect(sessionsGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -470,7 +470,9 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         resolvedBranchId = await resolveBranchId(ctx, coerceString(args.branchId)!);
       } else {
         if (!ctx.sessionId) return sessionContextRequiredResult();
-        const currentSession = await ctx.app.service('sessions').get(ctx.sessionId);
+        const currentSession = await ctx.app
+          .service('sessions')
+          .get(ctx.sessionId, ctx.baseServiceParams);
         const sessionBranchId = currentSession.branch_id;
         if (!sessionBranchId)
           throw new Error('branchId is required when current session is not bound to a branch');

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -24,7 +24,7 @@ import {
   resolveSessionId,
 } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { coerceString, textResult } from '../server.js';
+import { coerceString, sessionContextRequiredResult, textResult } from '../server.js';
 import { assertValidVariant } from './_environment-helpers.js';
 
 const BRANCH_NAME_PATTERN = /^[a-z0-9-]+$/;
@@ -469,6 +469,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       if (coerceString(args.branchId)) {
         resolvedBranchId = await resolveBranchId(ctx, coerceString(args.branchId)!);
       } else {
+        if (!ctx.sessionId) return sessionContextRequiredResult();
         const currentSession = await ctx.app.service('sessions').get(ctx.sessionId);
         const sessionBranchId = currentSession.branch_id;
         if (!sessionBranchId)

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -29,6 +29,8 @@ vi.mock('../../utils/branch-authorization.js', () => ({
 
 vi.mock('@agor/core/db', () => ({
   BranchRepository: class FakeBranchRepository {},
+  UserApiKeysRepository: class FakeUserApiKeysRepository {},
+  shortId: (id: string) => id,
 }));
 
 // Helper to build a minimal fake Feathers app. Each test supplies spies for
@@ -49,6 +51,7 @@ function makeFakeApp(services: Record<string, ServiceStub>) {
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
   content: Array<{ type: string; text: string }>;
+  isError?: boolean;
 }>;
 
 /** Cfg captured alongside the handler — includes inputSchema for tests that
@@ -60,7 +63,7 @@ async function registerAndCaptureTools(
   ctx: {
     app: unknown;
     userId: string;
-    sessionId: string;
+    sessionId?: string;
   },
   toolNames: string[]
 ): Promise<Record<string, CapturedTool>> {
@@ -90,12 +93,58 @@ async function registerAndCaptureTools(
 }
 
 async function registerAndCaptureHandlers(
-  ctx: { app: unknown; userId: string; sessionId: string },
+  ctx: { app: unknown; userId: string; sessionId?: string },
   toolNames: string[]
 ): Promise<Record<string, ToolHandler>> {
   const tools = await registerAndCaptureTools(ctx, toolNames);
   return Object.fromEntries(Object.entries(tools).map(([name, { cb }]) => [name, cb]));
 }
+
+describe('sessionless MCP context', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('agor_sessions_get_current returns an actionable session-context error', async () => {
+    const sessionsGet = vi.fn();
+    const app = makeFakeApp({
+      sessions: { get: sessionsGet },
+    });
+    const { agor_sessions_get_current } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1' },
+      ['agor_sessions_get_current']
+    );
+
+    const result = await agor_sessions_get_current({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/requires current Agor session context/i);
+    expect(parsed.error).toMatch(/X-Agor-Session-Id/);
+    expect(parsed.error).toMatch(/\\?sessionId=/);
+    expect(sessionsGet).not.toHaveBeenCalled();
+  });
+
+  it('agor_sessions_spawn returns an actionable session-context error', async () => {
+    const spawn = vi.fn();
+    const app = makeFakeApp({
+      sessions: { spawn },
+      '/sessions/:id/prompt': { create: vi.fn() },
+    });
+    const { agor_sessions_spawn } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
+      'agor_sessions_spawn',
+    ]);
+
+    const result = await agor_sessions_spawn({ prompt: 'delegate this' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/requires current Agor session context/i);
+    expect(parsed.error).toMatch(/X-Agor-Session-Id/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});
 
 describe('agor_sessions_create', () => {
   const baseBranch = {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -31,7 +31,7 @@ import {
   resolveSessionId,
 } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { sessionContextRequiredResult, textResult } from '../server.js';
 import { listAttachedMcpServers } from './mcp-servers.js';
 
 /**
@@ -212,6 +212,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       inputSchema: z.object({}),
     },
     async () => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       const currentSessionParams: SessionParams = {
         ...ctx.baseServiceParams,
         _include_last_message: true,
@@ -219,7 +221,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       };
       const session = await ctx.app
         .service('sessions')
-        .get(ctx.sessionId, currentSessionParams as Parameters<SessionsServiceImpl['get']>[1]);
+        .get(currentSessionId, currentSessionParams as Parameters<SessionsServiceImpl['get']>[1]);
 
       // Denormalize branch, repo, and board context
       let branch: Record<string, unknown> | null = null;
@@ -270,7 +272,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         }
       }
 
-      const attached_mcp_servers = await listAttachedMcpServers(ctx, ctx.sessionId);
+      const attached_mcp_servers = await listAttachedMcpServers(ctx, currentSessionId);
 
       return textResult({
         session,
@@ -301,11 +303,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       const includeSiblings = args.includeSiblings !== false;
 
       // Fetch session and user in parallel (no dependencies)
       const [session, user] = await Promise.all([
-        ctx.app.service('sessions').get(ctx.sessionId, ctx.baseServiceParams),
+        ctx.app.service('sessions').get(currentSessionId, ctx.baseServiceParams),
         ctx.app.service('users').get(ctx.userId, ctx.baseServiceParams),
       ]);
 
@@ -504,6 +508,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       const spawnData: Partial<import('@agor/core/types').SpawnConfig> = {
         prompt: args.prompt,
         title: args.title,
@@ -519,7 +525,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       const childSession = await (
         ctx.app.service('sessions') as unknown as SessionsServiceImpl
-      ).spawn(ctx.sessionId, spawnData, ctx.baseServiceParams);
+      ).spawn(currentSessionId, spawnData, ctx.baseServiceParams);
 
       const task = await ctx.app.service('/sessions/:id/prompt').create(
         {
@@ -614,6 +620,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             error: `${targetSession.agentic_tool} does not support session forking. Use mode "subsession" instead to delegate work to a fresh session.`,
           });
         }
+        let btwCallbackSessionId: typeof ctx.sessionId;
+        if (mode === 'btw') {
+          if (!ctx.sessionId) return sessionContextRequiredResult();
+          btwCallbackSessionId = ctx.sessionId;
+        }
 
         // Shared fork+prompt flow for both "fork" and "btw" modes
         const forkData: { prompt: string; task_id?: string } = { prompt: args.prompt };
@@ -631,7 +642,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           forkPatch.fork_origin = 'btw';
           forkPatch.callback_config = {
             enabled: true,
-            callback_session_id: ctx.sessionId,
+            callback_session_id: btwCallbackSessionId,
             callback_created_by: ctx.userId,
             callback_mode: 'once',
           };
@@ -812,6 +823,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // Determine the effective callback target session ID
       const effectiveCallbackSessionId = args.callbackSessionId || ctx.sessionId;
       const wantsCallback = args.enableCallback || args.callbackSessionId;
+      if (wantsCallback && !effectiveCallbackSessionId) return sessionContextRequiredResult();
 
       // Validate user has prompt permission on the callback target session's branch
       if (wantsCallback && args.callbackSessionId) {

--- a/apps/agor-daemon/src/mcp/tools/users.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.test.ts
@@ -1,0 +1,46 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+import { registerUserTools } from './users.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+describe('user MCP tools in sessionless context', () => {
+  it('agor_users_get_current works without current session context', async () => {
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    let handler: ToolHandler | undefined;
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+        if (name === 'agor_users_get_current') handler = cb;
+      },
+    } as unknown as McpServer;
+
+    registerUserTools(fakeServer, {
+      app: {
+        service: (name: string) => {
+          if (name !== 'users') throw new Error(`Unexpected service: ${name}`);
+          return { get: getUser };
+        },
+      } as any,
+      db: {} as any,
+      userId: 'user-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'user-1', email: 'alice@example.com', role: 'member' } as any,
+      baseServiceParams: {},
+    });
+
+    if (!handler) throw new Error('agor_users_get_current was not registered');
+    const result = await handler({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.user_id).toBe('user-1');
+    expect(getUser).toHaveBeenCalledWith('user-1', {});
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -20,7 +20,6 @@ import type {
   EnvVarScope,
   MessageID,
   Session,
-  SessionID,
   TaskID,
   User,
   UserID,
@@ -32,7 +31,7 @@ import { appendSystemMessage } from '../../utils/append-system-message.js';
 import { findHostTaskForSession } from '../../utils/session-tasks.js';
 import { type EnvVarsParams, envVarsParamsSchema } from '../../widgets/env-vars/index.js';
 import type { McpContext } from '../server.js';
-import { textResult } from '../server.js';
+import { sessionContextRequiredResult, textResult } from '../server.js';
 
 /**
  * Build a short, user-visible message body for the widget transcript row.
@@ -77,6 +76,8 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       inputSchema: envVarsParamsSchema,
     },
     async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const currentSessionId = ctx.sessionId;
       // Validated by Zod via the SDK; `args` has Zod defaults applied.
       const params: EnvVarsParams = args as EnvVarsParams;
 
@@ -85,7 +86,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       // matches the `dangerously_allow_session_sharing: false` semantics.
       const session = (await ctx.app
         .service('sessions')
-        .get(ctx.sessionId, ctx.baseServiceParams)) as Session;
+        .get(currentSessionId, ctx.baseServiceParams)) as Session;
       const sessionCreatorId = session.created_by as UserID;
       const creator = (await ctx.app
         .service('users')
@@ -120,7 +121,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       // semantics (active-first, recency-DESC fallback).
       const hostTask = await findHostTaskForSession(
         ctx.app,
-        ctx.sessionId as SessionID,
+        currentSessionId,
         ctx.baseServiceParams
       );
       const hostTaskId = hostTask?.task_id as TaskID | undefined;
@@ -128,7 +129,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       const created = await appendSystemMessage({
         app: ctx.app,
         db: ctx.db,
-        sessionId: ctx.sessionId,
+        sessionId: currentSessionId,
         taskId: hostTaskId,
         content: widgetContentPreview(params),
         contentPreview: `Widget: env_vars (${params.names.join(', ')})`,
@@ -198,7 +199,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
                 widget_id: widgetId,
               },
             },
-            { ...ctx.baseServiceParams, route: { id: ctx.sessionId as SessionID } }
+            { ...ctx.baseServiceParams, route: { id: currentSessionId } }
           );
         }
         return textResult({ widget_id: widgetId, status: 'already_present' });

--- a/apps/agor-ui/src/utils/clipboard.test.ts
+++ b/apps/agor-ui/src/utils/clipboard.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyToClipboard } from './clipboard';
+
+function setSecureContext(value: boolean | undefined) {
+  Object.defineProperty(globalThis, 'isSecureContext', {
+    value,
+    configurable: true,
+  });
+}
+
+function setClipboard(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+}
+
+function setExecCommand(value: boolean) {
+  const execCommand = vi.fn().mockReturnValue(value);
+  Object.defineProperty(document, 'execCommand', {
+    value: execCommand,
+    configurable: true,
+  });
+  return execCommand;
+}
+
+describe('copyToClipboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setSecureContext(undefined);
+  });
+
+  it('uses navigator.clipboard in secure contexts', async () => {
+    setSecureContext(true);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard(writeText);
+    const execCommand = setExecCommand(true);
+
+    await expect(copyToClipboard('secret')).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith('secret');
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it('uses execCommand first in insecure HTTP contexts to preserve user activation', async () => {
+    setSecureContext(false);
+    const writeText = vi.fn().mockRejectedValue(new Error('not allowed'));
+    setClipboard(writeText);
+    const execCommand = setExecCommand(true);
+
+    await expect(copyToClipboard('agor_sk_test')).resolves.toBe(true);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to execCommand when navigator.clipboard fails', async () => {
+    setSecureContext(true);
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    setClipboard(writeText);
+    const execCommand = setExecCommand(true);
+
+    await expect(copyToClipboard('fallback')).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith('fallback');
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+});

--- a/apps/agor-ui/src/utils/clipboard.ts
+++ b/apps/agor-ui/src/utils/clipboard.ts
@@ -16,6 +16,15 @@ import React from 'react';
  * @returns true if copy succeeded, false otherwise
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
+  // On HTTP/local-network dev URLs, `navigator.clipboard.writeText` may exist
+  // but reject because the page is not a secure context. If we await that
+  // rejection first, browsers can consume the click's transient user activation
+  // and make the execCommand fallback fail too. Prefer the synchronous fallback
+  // immediately in known-insecure contexts.
+  if (globalThis.isSecureContext === false && copyWithExecCommand(text)) {
+    return true;
+  }
+
   // Try modern Clipboard API first (requires HTTPS / secure context)
   if (navigator.clipboard?.writeText) {
     try {
@@ -27,8 +36,13 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   }
 
   // Fallback to execCommand for HTTP/dev mode
+  return copyWithExecCommand(text);
+}
+
+function copyWithExecCommand(text: string): boolean {
+  let textArea: HTMLTextAreaElement | undefined;
   try {
-    const textArea = document.createElement('textarea');
+    textArea = document.createElement('textarea');
     textArea.value = text;
     textArea.style.position = 'fixed';
     textArea.style.left = '-999999px';
@@ -38,13 +52,14 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     textArea.select();
 
     const successful = document.execCommand('copy');
-    document.body.removeChild(textArea);
 
     if (successful) {
       return true;
     }
   } catch (error) {
     console.error('Failed to copy to clipboard:', error);
+  } finally {
+    textArea?.remove();
   }
 
   return false;


### PR DESCRIPTION
## Summary

Supersedes / takes over #1164 against current `main` after the Worktree→Branch refactor.

- Allows `/mcp` callers to authenticate with personal `agor_sk_*` API keys before they are bound to an Agor session.
- Keeps session-scoped MCP tokens working as before, while making `McpContext.sessionId` truly optional.
- Lets API-key callers optionally bind session context with `X-Agor-Session-Id` or `?sessionId=`; the session is resolved through the normal sessions service so RBAC/short-ID behavior matches REST.
- Adds explicit session-context errors for tools/fallbacks that need the current session (`agor_sessions_get_current`, `agor_sessions_get_current_context`, `agor_sessions_spawn`, `btw` callbacks, branch update fallback, widgets, session-create callbacks).
- Adds streamable HTTP session support on `/mcp` (`POST` initialize, `GET` SSE, `DELETE` close), including same-user enforcement, request-close cleanup, a 30-minute TTL, and a 100-session cap with oldest-entry eviction.

No UI changes: the existing User Settings → Personal API Keys / Agor API Tokens UI remains the single place to manage personal keys.

## Tests

- `pnpm --filter @agor/daemon test -- src/mcp/server.test.ts src/mcp/tools/sessions.test.ts src/mcp/tools/users.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm check` (passes; existing repo-wide Biome warnings remain warnings)
