### PR TITLE
Analyze and scaffold Cursor SDK support

### DIFF
--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@agor/core": "workspace:*",
+    "@cursor/sdk": "^1.0.13",
     "@github/copilot-sdk": "^0.2.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@octokit/auth-app": "^8.2.0",

--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -19,7 +19,7 @@ import { textResult } from '../server.js';
 const agenticToolConfigSchema = z
   .object({
     agentic_tool: z
-      .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot'])
+      .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'])
       .describe('Agent to spawn for runs of this schedule.'),
     permission_mode: z.string().optional().describe("Permission mode (e.g., 'auto', 'ask')."),
     model_config: z

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -478,7 +478,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .optional()
           .describe('Optional title for the session (defaults to first 100 chars of prompt)'),
         agenticTool: z
-          .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode'])
+          .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'cursor'])
           .optional()
           .describe('Which agent to use for the subsession (defaults to same as parent)'),
         enableCallback: z
@@ -563,7 +563,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             'How to route the work: continue (add to existing session), fork (create sibling session), subsession (create child session), btw (ephemeral fork — works even on running sessions, auto-callbacks result to caller, auto-archives when done)'
           ),
         agenticTool: z
-          .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini'])
+          .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'cursor'])
           .optional()
           .describe(
             'Agent for subsession (subsession mode only, defaults to parent agent). Fork mode always uses parent agent.'
@@ -722,7 +722,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       inputSchema: z.object({
         branchId: z.string().describe('Branch ID where the session will run (required)'),
         agenticTool: z
-          .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini'])
+          .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'cursor'])
           .describe('Which agent to use for this session (required)'),
         title: z.string().optional().describe('Session title (optional)'),
         description: z.string().optional().describe('Session description (optional)'),
@@ -1314,7 +1314,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         agenticTool: z
-          .enum(['claude-code', 'claude-code-cli', 'codex', 'copilot', 'gemini'])
+          .enum(['claude-code', 'claude-code-cli', 'codex', 'copilot', 'gemini', 'cursor'])
           .optional()
           .describe('Filter to a single agentic tool. Omit to return all tools.'),
       }),
@@ -1375,6 +1375,17 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           default: DEFAULT_GEMINI_MODEL,
           models: geminiModels,
           note: 'Gemini models are normally fetched live from the Google API per-user. This is the static fallback list — newer models may exist.',
+        },
+        cursor: {
+          default: 'composer-latest',
+          models: [
+            {
+              id: 'composer-latest',
+              displayName: 'Composer Latest',
+              description: 'Cursor SDK default model alias (beta; runtime adapter pending).',
+            },
+          ],
+          note: 'Cursor is exposed as a beta provider. Runtime execution currently fails fast until the SDK adapter lands.',
         },
       };
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1302,8 +1302,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
   //   - Gemini's authoritative list is fetched live from the Google API per
   //     user (fetchGeminiModels). The hardcoded fallback IS exposed here as a
   //     best-effort starter list.
-  //   - Copilot has dynamic discovery via `client.listModels()` exposed at
-  //     /copilot-models in the daemon. The static fallback is exposed here.
+  //   - Copilot and Cursor have dynamic discovery exposed via /copilot-models
+  //     and /cursor-models in the daemon. Static fallbacks are exposed here.
   //   - OpenCode is a provider+model matrix and doesn't have a single static
   //     list — it's exposed via the branch config UI today.
   server.registerTool(
@@ -1382,10 +1382,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             {
               id: 'composer-latest',
               displayName: 'Composer Latest',
-              description: 'Cursor SDK default model alias (beta; runtime adapter pending).',
+              description: 'Cursor SDK default model alias (beta).',
             },
           ],
-          note: 'Cursor is exposed as a beta provider. Runtime execution currently fails fast until the SDK adapter lands.',
+          note: "Cursor models are also fetched live via /cursor-models (uses @cursor/sdk's Cursor.models.list()). This is the static fallback — account-specific models may not appear here.",
         },
       };
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -462,7 +462,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     async create(data: { user_id?: string; expiry_ms?: number }, params?: Params) {
       // 1. Caller must be authenticated
       const authParams = params as AuthenticatedParams;
-      if (!authParams?.user || !authParams.user.user_id) {
+      if (!authParams?.user?.user_id) {
         throw new NotAuthenticated('Authentication required');
       }
 
@@ -3366,8 +3366,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // surfaces when true. Server-side gates (e.g. ArtifactsService.
           // grantTrust) are the source of truth and reject regardless.
           multiUser: (config.execution?.unix_user_mode ?? 'simple') !== 'simple',
-          // Experimental Cursor SDK provider surfaces are hidden unless explicitly enabled.
-          cursorSdk: config.execution?.cursor_sdk_enabled === true,
+          // Cursor SDK provider is available as a beta surface. The legacy
+          // cursor_sdk_enabled flag is retained in config for compatibility but
+          // no longer gates provider visibility.
+          cursorSdk: true,
         },
       };
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3344,6 +3344,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             ),
             OPENAI_API_KEY: !!(config.credentials?.OPENAI_API_KEY || process.env.OPENAI_API_KEY),
             GEMINI_API_KEY: !!(config.credentials?.GEMINI_API_KEY || process.env.GEMINI_API_KEY),
+            CURSOR_API_KEY: !!(config.credentials?.CURSOR_API_KEY || process.env.CURSOR_API_KEY),
           },
         },
         services: servicesConfig,
@@ -3365,6 +3366,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // surfaces when true. Server-side gates (e.g. ArtifactsService.
           // grantTrust) are the source of truth and reject regardless.
           multiUser: (config.execution?.unix_user_mode ?? 'simple') !== 'simple',
+          // Experimental Cursor SDK provider surfaces are hidden unless explicitly enabled.
+          cursorSdk: config.execution?.cursor_sdk_enabled === true,
         },
       };
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -536,6 +536,18 @@ function createExecuteHandler(
       throw new Error(`Session ${sessionId} not found`);
     }
 
+    // Cursor SDK support is scaffolded but intentionally hidden until the
+    // runtime adapter is implemented and smoke-tested.
+    if (session.agentic_tool === 'cursor') {
+      const flagHint =
+        config.execution?.cursor_sdk_enabled === true
+          ? 'The runtime adapter is not implemented in this build.'
+          : 'The provider is hidden unless execution.cursor_sdk_enabled is true.';
+      throw new Error(
+        `Cursor SDK sessions are scaffolded but execution is not available yet. ${flagHint}`
+      );
+    }
+
     // Validate stateless_fs_mode compatibility with agentic tool
     if (config.execution?.stateless_fs_mode) {
       const toolName = session.agentic_tool as import('@agor/core/types').AgenticToolName;
@@ -707,7 +719,13 @@ function createExecuteHandler(
         sessionId,
         taskId,
         prompt: data.prompt,
-        tool: session.agentic_tool as 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot',
+        tool: session.agentic_tool as
+          | 'claude-code'
+          | 'gemini'
+          | 'codex'
+          | 'opencode'
+          | 'copilot'
+          | 'cursor',
         permissionMode: permissionModeForPayload as 'ask' | 'auto' | 'allow-all' | undefined,
         cwd,
         messageSource: data.messageSource,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -536,18 +536,6 @@ function createExecuteHandler(
       throw new Error(`Session ${sessionId} not found`);
     }
 
-    // Cursor SDK support is scaffolded but intentionally hidden until the
-    // runtime adapter is implemented and smoke-tested.
-    if (session.agentic_tool === 'cursor') {
-      const flagHint =
-        config.execution?.cursor_sdk_enabled === true
-          ? 'The runtime adapter is not implemented in this build.'
-          : 'The provider is hidden unless execution.cursor_sdk_enabled is true.';
-      throw new Error(
-        `Cursor SDK sessions are scaffolded but execution is not available yet. ${flagHint}`
-      );
-    }
-
     // Validate stateless_fs_mode compatibility with agentic tool
     if (config.execution?.stateless_fs_mode) {
       const toolName = session.agentic_tool as import('@agor/core/types').AgenticToolName;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -62,6 +62,7 @@ import { createCheckAuthService } from './services/check-auth.js';
 import { createConfigService } from './services/config.js';
 import { createContextService } from './services/context.js';
 import { createCopilotModelsService } from './services/copilot-models.js';
+import { createCursorModelsService } from './services/cursor-models.js';
 import { createFileService } from './services/file.js';
 import { createFilesService } from './services/files.js';
 import { createGatewayService } from './services/gateway.js';
@@ -375,6 +376,12 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // token is configured or the SDK call fails.
   app.use('/copilot-models', createCopilotModelsService(db));
   app.service('/copilot-models').hooks({ before: { find: [ctx.requireAuth] } });
+
+  // Cursor dynamic model discovery via @cursor/sdk's Cursor.models.list().
+  // Resolves CURSOR_API_KEY per-user (with config.yaml + env fallback) and
+  // falls back to composer-latest if no key is configured or the SDK call fails.
+  app.use('/cursor-models', createCursorModelsService(db));
+  app.service('/cursor-models').hooks({ before: { find: [ctx.requireAuth] } });
 
   const branchRepository = new BranchRepository(db);
   const { UsersRepository, SessionRepository } = await import('@agor/core/db');

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -197,6 +197,11 @@ async function validateApiKey(tool: string, key: string): Promise<boolean> {
         headers.Accept = 'application/vnd.github.v3+json';
         break;
       }
+      case 'cursor': {
+        const { Cursor } = await import('@cursor/sdk');
+        await Cursor.me({ apiKey: key });
+        return true;
+      }
       default:
         return false;
     }
@@ -230,17 +235,7 @@ export function createCheckAuthService(db: Database) {
       }
 
       // If caller provided a raw key (user typed it in the wizard), validate directly.
-      // Cursor does not document a cheap key-validation endpoint; accept presence
-      // here and let @cursor/sdk return the authoritative auth error at session start.
       if (rawKey?.trim()) {
-        if (tool === 'cursor') {
-          return {
-            authenticated: true,
-            method: 'api-key',
-            hint: 'Cursor key saved; the SDK will validate it when a session starts.',
-          };
-        }
-
         const ok = await validateApiKey(tool, rawKey.trim());
         return {
           authenticated: ok,
@@ -269,14 +264,6 @@ export function createCheckAuthService(db: Database) {
       }
 
       if (apiKey) {
-        if (tool === 'cursor') {
-          return {
-            authenticated: true,
-            method: 'api-key',
-            hint: 'Cursor key configured; the SDK will validate it when a session starts.',
-          };
-        }
-
         const ok = await validateApiKey(tool, apiKey);
         return {
           authenticated: ok,

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -13,7 +13,7 @@
  *   codex CLI writes after `codex login`). Executor reads from the same path,
  *   so a green check matches session behavior in simple Unix mode
  * - Server-based tools (opencode): always ready
- * - Cursor SDK: scaffolded but not validated until the runtime adapter lands
+ * - Cursor SDK: API-key presence check; the SDK validates the key at session start
  *
  * Resolution precedence (when no raw key is provided by the caller):
  *   user encrypted key → config.yaml → env var → native auth
@@ -224,21 +224,23 @@ export function createCheckAuthService(db: Database) {
         return { authenticated: true, method: 'native' };
       }
 
-      if (tool === 'cursor') {
-        return {
-          authenticated: false,
-          method: 'api-key',
-          hint: 'Cursor SDK support is scaffolded but auth validation is not implemented until the runtime adapter lands.',
-        };
-      }
-
       const keyName = TOOL_API_KEY_NAMES[tool as keyof typeof TOOL_API_KEY_NAMES];
       if (!keyName) {
         return { authenticated: false, method: 'none', hint: 'Unsupported tool' };
       }
 
       // If caller provided a raw key (user typed it in the wizard), validate directly.
+      // Cursor does not document a cheap key-validation endpoint; accept presence
+      // here and let @cursor/sdk return the authoritative auth error at session start.
       if (rawKey?.trim()) {
+        if (tool === 'cursor') {
+          return {
+            authenticated: true,
+            method: 'api-key',
+            hint: 'Cursor key saved; the SDK will validate it when a session starts.',
+          };
+        }
+
         const ok = await validateApiKey(tool, rawKey.trim());
         return {
           authenticated: ok,
@@ -267,6 +269,14 @@ export function createCheckAuthService(db: Database) {
       }
 
       if (apiKey) {
+        if (tool === 'cursor') {
+          return {
+            authenticated: true,
+            method: 'api-key',
+            hint: 'Cursor key configured; the SDK will validate it when a session starts.',
+          };
+        }
+
         const ok = await validateApiKey(tool, apiKey);
         return {
           authenticated: ok,

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -42,6 +42,20 @@ const SDK_AUTH_PROBE_TIMEOUT_MS = 10_000;
 // Codex treats the OAuth session as stale after ~8 days (per OpenAI docs).
 const CODEX_SESSION_STALE_MS = 8 * 24 * 60 * 60 * 1000;
 
+async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /**
  * Verify Claude Code auth by spawning the SDK in streaming-input mode and
  * reading `accountInfo()` from its init handshake. The SDK launches the
@@ -199,7 +213,11 @@ async function validateApiKey(tool: string, key: string): Promise<boolean> {
       }
       case 'cursor': {
         const { Cursor } = await import('@cursor/sdk');
-        await Cursor.me({ apiKey: key });
+        await withTimeout(
+          Cursor.me({ apiKey: key }),
+          FETCH_TIMEOUT_MS,
+          'Cursor auth check timed out'
+        );
         return true;
       }
       default:

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -13,6 +13,7 @@
  *   codex CLI writes after `codex login`). Executor reads from the same path,
  *   so a green check matches session behavior in simple Unix mode
  * - Server-based tools (opencode): always ready
+ * - Cursor SDK: scaffolded but not validated until the runtime adapter lands
  *
  * Resolution precedence (when no raw key is provided by the caller):
  *   user encrypted key → config.yaml → env var → native auth
@@ -221,6 +222,14 @@ export function createCheckAuthService(db: Database) {
       // opencode is server-based — no credentials concept, always ready
       if (tool === 'opencode') {
         return { authenticated: true, method: 'native' };
+      }
+
+      if (tool === 'cursor') {
+        return {
+          authenticated: false,
+          method: 'api-key',
+          hint: 'Cursor SDK support is scaffolded but auth validation is not implemented until the runtime adapter lands.',
+        };
       }
 
       const keyName = TOOL_API_KEY_NAMES[tool as keyof typeof TOOL_API_KEY_NAMES];

--- a/apps/agor-daemon/src/services/cursor-models.test.ts
+++ b/apps/agor-daemon/src/services/cursor-models.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configMocks = vi.hoisted(() => ({
+  resolveApiKey: vi.fn(),
+}));
+
+const cursorMocks = vi.hoisted(() => ({
+  modelsList: vi.fn(),
+}));
+
+vi.mock('@agor/core/config', () => configMocks);
+vi.mock('@cursor/sdk', () => ({
+  Cursor: {
+    models: {
+      list: cursorMocks.modelsList,
+    },
+  },
+}));
+
+import { CursorModelsService } from './cursor-models.js';
+
+describe('CursorModelsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the live model list with the server-reported default', async () => {
+    configMocks.resolveApiKey.mockResolvedValue({ apiKey: 'cursor-key', source: 'user' });
+    cursorMocks.modelsList.mockResolvedValue([
+      { id: 'other-model', displayName: 'Other Model' },
+      { id: 'composer-latest', displayName: 'Composer Latest' },
+    ]);
+
+    const service = new CursorModelsService({} as never);
+    const result = await service.find({ user: { user_id: 'user-id' } } as never);
+
+    expect(result.default).toBe('composer-latest');
+    expect(result.source).toBe('dynamic');
+    expect(result.models.map((model) => model.id)).toEqual(['other-model', 'composer-latest']);
+  });
+
+  it('falls back to the static model list when the SDK call fails', async () => {
+    configMocks.resolveApiKey.mockResolvedValue({ apiKey: 'cursor-key', source: 'user' });
+    cursorMocks.modelsList.mockRejectedValue(new Error('boom'));
+
+    const service = new CursorModelsService({} as never);
+    const result = await service.find({ user: { user_id: 'user-id' } } as never);
+
+    expect(result).toMatchObject({
+      default: 'composer-latest',
+      source: 'static',
+      models: [{ id: 'composer-latest', source: 'static' }],
+    });
+  });
+});

--- a/apps/agor-daemon/src/services/cursor-models.ts
+++ b/apps/agor-daemon/src/services/cursor-models.ts
@@ -26,6 +26,7 @@ export interface CursorModelsResult {
 }
 
 const DEFAULT_CURSOR_MODEL = 'composer-latest';
+const CURSOR_MODELS_TIMEOUT_MS = 8_000;
 
 const STATIC_RESULT: CursorModelsResult = {
   default: DEFAULT_CURSOR_MODEL,
@@ -53,6 +54,20 @@ function toModelOption(model: SDKModel): CursorModelOption {
   };
 }
 
+async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export class CursorModelsService {
   constructor(private db: Database) {}
 
@@ -72,7 +87,11 @@ export class CursorModelsService {
     }
 
     try {
-      const dynamic = await Cursor.models.list({ apiKey: resolution.apiKey });
+      const dynamic = await withTimeout(
+        Cursor.models.list({ apiKey: resolution.apiKey }),
+        CURSOR_MODELS_TIMEOUT_MS,
+        'Cursor.models.list() timed out'
+      );
       console.log(
         `[Cursor Models] Fetched ${dynamic.length} models for user ${userId ? shortId(userId) : 'unknown'} (source: ${resolution.source})`
       );

--- a/apps/agor-daemon/src/services/cursor-models.ts
+++ b/apps/agor-daemon/src/services/cursor-models.ts
@@ -1,0 +1,96 @@
+/**
+ * Cursor Models Service
+ *
+ * Exposes `Cursor.models.list()` from @cursor/sdk as a Feathers endpoint so the
+ * UI can render the live model list available to the caller's Cursor account.
+ * Falls back to Cursor's documented default alias when no key is configured or
+ * the SDK call fails.
+ */
+
+import { resolveApiKey } from '@agor/core/config';
+import { type Database, shortId } from '@agor/core/db';
+import type { Params, UserID } from '@agor/core/types';
+import { Cursor, type SDKModel } from '@cursor/sdk';
+
+export interface CursorModelOption {
+  id: string;
+  displayName: string;
+  description?: string;
+  source: 'dynamic' | 'static';
+}
+
+export interface CursorModelsResult {
+  default: string;
+  models: CursorModelOption[];
+  source: 'dynamic' | 'static';
+}
+
+const DEFAULT_CURSOR_MODEL = 'composer-latest';
+
+const STATIC_RESULT: CursorModelsResult = {
+  default: DEFAULT_CURSOR_MODEL,
+  models: [
+    {
+      id: DEFAULT_CURSOR_MODEL,
+      displayName: 'Composer Latest',
+      description: 'Cursor SDK default model alias (beta)',
+      source: 'static',
+    },
+  ],
+  source: 'static',
+};
+
+interface AuthenticatedParams extends Params {
+  user?: { user_id: UserID };
+}
+
+function toModelOption(model: SDKModel): CursorModelOption {
+  return {
+    id: model.id,
+    displayName: model.displayName || model.id,
+    description: model.description,
+    source: 'dynamic',
+  };
+}
+
+export class CursorModelsService {
+  constructor(private db: Database) {}
+
+  async find(params?: AuthenticatedParams): Promise<CursorModelsResult> {
+    const userId = params?.user?.user_id;
+    const resolution = await resolveApiKey('CURSOR_API_KEY', {
+      userId,
+      db: this.db,
+      tool: 'cursor',
+    });
+
+    if (!resolution.apiKey) {
+      console.log(
+        `[Cursor Models] No Cursor API key for user ${userId ? shortId(userId) : 'unknown'} — returning static list`
+      );
+      return STATIC_RESULT;
+    }
+
+    try {
+      const dynamic = await Cursor.models.list({ apiKey: resolution.apiKey });
+      console.log(
+        `[Cursor Models] Fetched ${dynamic.length} models for user ${userId ? shortId(userId) : 'unknown'} (source: ${resolution.source})`
+      );
+      return {
+        default: DEFAULT_CURSOR_MODEL,
+        models: dynamic.map(toModelOption),
+        source: 'dynamic',
+      };
+    } catch (err) {
+      console.warn(
+        '[Cursor Models] Cursor.models.list() failed, falling back to static list:',
+        err instanceof Error ? err.message : err
+      );
+      return STATIC_RESULT;
+    }
+  }
+}
+
+export function createCursorModelsService(db: Database): CursorModelsService {
+  return new CursorModelsService(db);
+}

--- a/apps/agor-daemon/src/setup/credentials.ts
+++ b/apps/agor-daemon/src/setup/credentials.ts
@@ -19,6 +19,7 @@ export interface InitializedCredentials {
   anthropicBaseUrl?: string;
   geminiApiKey?: string;
   copilotGithubToken?: string;
+  cursorApiKey?: string;
 }
 
 /**
@@ -171,6 +172,25 @@ export function initializeCopilotGithubToken(
 }
 
 /**
+ * Initialize Cursor API key for the experimental Cursor SDK provider.
+ *
+ * Priority: config.yaml > env var. Runtime support is intentionally gated
+ * elsewhere; this only keeps config/env propagation consistent with other
+ * provider credentials.
+ */
+export function initializeCursorApiKey(
+  config: { credentials?: CredentialsConfig },
+  envApiKey?: string
+): string | undefined {
+  if (config.credentials?.CURSOR_API_KEY && !envApiKey) {
+    process.env.CURSOR_API_KEY = config.credentials.CURSOR_API_KEY;
+    console.log('✅ Set CURSOR_API_KEY from config for Cursor SDK');
+  }
+
+  return config.credentials?.CURSOR_API_KEY || envApiKey;
+}
+
+/**
  * Initialize all AI service credentials
  *
  * Convenience function to initialize all supported API keys at once.
@@ -192,5 +212,6 @@ export function initializeCredentials(config: {
       process.env.GH_TOKEN,
       process.env.GITHUB_TOKEN
     ),
+    cursorApiKey: initializeCursorApiKey(config, process.env.CURSOR_API_KEY),
   };
 }

--- a/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
@@ -34,6 +34,13 @@ export const AVAILABLE_AGENTS: AgenticToolOption[] = [
     beta: true,
   },
   {
+    id: 'cursor',
+    name: 'Cursor SDK',
+    icon: '⌘',
+    description: 'Cursor agentic runtime via the Cursor SDK',
+    beta: true,
+  },
+  {
     id: 'copilot',
     name: 'GitHub Copilot',
     icon: '✈️',

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -62,6 +62,7 @@ const MODEL_LABELS: Record<string, string> = {
   gemini: 'Gemini Model',
   opencode: 'OpenCode LLM Provider',
   copilot: 'Copilot Model',
+  cursor: 'Cursor Model',
 };
 
 export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -104,6 +104,15 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       docUrl: 'https://github.com/settings/tokens',
     },
   ],
+  cursor: [
+    {
+      field: 'CURSOR_API_KEY',
+      label: 'Cursor API Key',
+      description: '(experimental SDK)',
+      placeholder: 'key_...',
+      docUrl: 'https://cursor.com/dashboard/integrations',
+    },
+  ],
   opencode: [],
   // Claude Code CLI uses the same Anthropic credentials as the SDK
   // path — surface the same fields so the Defaults panel renders

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -40,24 +40,24 @@ export interface ModelSelectorProps {
     | 'copilot'
     | 'cursor';
   /**
-   * Optional Feathers client. When provided AND the agentic tool is Copilot,
-   * the picker fetches the live model list from /copilot-models (which calls
-   * the SDK's `listModels()` server-side) and merges it with the static
-   * fallback. Without a client, the picker only shows static models.
+   * Optional Feathers client. When provided AND the agentic tool supports
+   * dynamic model discovery (Copilot/Cursor), the picker fetches the live
+   * model list server-side and merges it with the static fallback. Without a
+   * client, the picker only shows static models.
    */
   client?: AgorClient | null;
 }
 
-interface CopilotModelOption {
+interface DynamicModelOption {
   id: string;
   displayName: string;
   description?: string;
   source: 'dynamic' | 'static';
 }
 
-interface CopilotModelsResponse {
+interface DynamicModelsResponse {
   default: string;
-  models: CopilotModelOption[];
+  models: DynamicModelOption[];
   source: 'dynamic' | 'static';
 }
 
@@ -125,6 +125,12 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     description?: string;
   }> | null>(null);
   const [copilotSource, setCopilotSource] = useState<'dynamic' | 'static' | null>(null);
+  const [cursorServerOptions, setCursorServerOptions] = useState<Array<{
+    id: string;
+    label: string;
+    description?: string;
+  }> | null>(null);
+  const [cursorSource, setCursorSource] = useState<'dynamic' | 'static' | null>(null);
 
   useEffect(() => {
     if (effectiveTool !== 'copilot' || !client) return;
@@ -132,7 +138,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     (async () => {
       try {
         const raw = await client.service('copilot-models').find();
-        const response = raw as unknown as CopilotModelsResponse;
+        const response = raw as unknown as DynamicModelsResponse;
         if (cancelled || !response?.models?.length) return;
         setCopilotServerOptions(
           response.models.map((m) => ({
@@ -142,6 +148,31 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           }))
         );
         setCopilotSource(response.source);
+      } catch {
+        // Silent fallback to local static — best-effort.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [effectiveTool, client]);
+
+  useEffect(() => {
+    if (effectiveTool !== 'cursor' || !client) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await client.service('cursor-models').find();
+        const response = raw as unknown as DynamicModelsResponse;
+        if (cancelled || !response?.models?.length) return;
+        setCursorServerOptions(
+          response.models.map((m) => ({
+            id: m.id,
+            label: m.displayName,
+            description: m.description,
+          }))
+        );
+        setCursorSource(response.source);
       } catch {
         // Silent fallback to local static — best-effort.
       }
@@ -161,7 +192,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           : effectiveTool === 'copilot'
             ? (copilotServerOptions ?? COPILOT_STATIC_MODEL_OPTIONS)
             : effectiveTool === 'cursor'
-              ? CURSOR_MODEL_OPTIONS
+              ? (cursorServerOptions ?? CURSOR_MODEL_OPTIONS)
               : AVAILABLE_CLAUDE_MODEL_ALIASES;
 
   // Determine initial mode based on whether the value is in the aliases list
@@ -266,6 +297,21 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                     <>
                       Showing static fallback. Set <code>COPILOT_GITHUB_TOKEN</code> on the daemon
                       to see your account's live list (including BYOK models).
+                    </>
+                  )}
+                </div>
+              )}
+              {effectiveTool === 'cursor' && cursorSource && (
+                <div style={{ marginTop: 6, fontSize: 12, color: 'rgba(255, 255, 255, 0.45)' }}>
+                  {cursorSource === 'dynamic' ? (
+                    <>
+                      Live list from your Cursor account (via SDK <code>Cursor.models.list()</code>
+                      ).
+                    </>
+                  ) : (
+                    <>
+                      Showing static fallback. Set <code>CURSOR_API_KEY</code> to see your account's
+                      live Cursor model list.
                     </>
                   )}
                 </div>

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -23,8 +23,22 @@ export interface ModelConfig {
 export interface ModelSelectorProps {
   value?: ModelConfig;
   onChange?: (config: ModelConfig) => void;
-  agent?: 'claude-code' | 'claude-code-cli' | 'codex' | 'gemini' | 'opencode' | 'copilot'; // Kept as 'agent' for backwards compat in prop name
-  agentic_tool?: 'claude-code' | 'claude-code-cli' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+  agent?:
+    | 'claude-code'
+    | 'claude-code-cli'
+    | 'codex'
+    | 'gemini'
+    | 'opencode'
+    | 'copilot'
+    | 'cursor'; // Kept as 'agent' for backwards compat in prop name
+  agentic_tool?:
+    | 'claude-code'
+    | 'claude-code-cli'
+    | 'codex'
+    | 'gemini'
+    | 'opencode'
+    | 'copilot'
+    | 'cursor';
   /**
    * Optional Feathers client. When provided AND the agentic tool is Copilot,
    * the picker fetches the live model list from /copilot-models (which calls
@@ -71,6 +85,14 @@ const COPILOT_STATIC_MODEL_OPTIONS = Object.entries(COPILOT_MODEL_METADATA).map(
     description: meta.description,
   })
 );
+
+const CURSOR_MODEL_OPTIONS = [
+  {
+    id: 'composer-latest',
+    label: 'Composer Latest',
+    description: 'Cursor SDK default model alias (experimental)',
+  },
+];
 
 /**
  * Model Selector Component
@@ -138,7 +160,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           ? [] // OpenCode doesn't use this list
           : effectiveTool === 'copilot'
             ? (copilotServerOptions ?? COPILOT_STATIC_MODEL_OPTIONS)
-            : AVAILABLE_CLAUDE_MODEL_ALIASES;
+            : effectiveTool === 'cursor'
+              ? CURSOR_MODEL_OPTIONS
+              : AVAILABLE_CLAUDE_MODEL_ALIASES;
 
   // Determine initial mode based on whether the value is in the aliases list
   // If no value provided, default to 'alias' mode (recommended)
@@ -186,6 +210,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         defaultModel = 'gemini-2.5-flash';
       } else if (effectiveTool === 'copilot') {
         defaultModel = DEFAULT_COPILOT_MODEL;
+      } else if (effectiveTool === 'cursor') {
+        defaultModel = 'composer-latest';
       } else {
         // claude-code (opencode is handled earlier in the component)
         defaultModel = 'claude-sonnet-4-6';
@@ -268,7 +294,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                       ? 'e.g., gemini-2.5-pro'
                       : effectiveTool === 'copilot'
                         ? 'e.g., gpt-4o or claude-3.5-sonnet'
-                        : 'e.g., claude-opus-4-20250514' // claude-code (opencode handled earlier)
+                        : effectiveTool === 'cursor'
+                          ? 'e.g., composer-latest'
+                          : 'e.g., claude-opus-4-20250514' // claude-code (opencode handled earlier)
                 }
                 style={{ width: '100%', minWidth: 400 }}
               />
@@ -282,7 +310,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                         ? 'https://ai.google.dev/gemini-api/docs/models'
                         : effectiveTool === 'copilot'
                           ? 'https://github.com/features/copilot'
-                          : 'https://platform.claude.com/docs/en/about-claude/models' // claude-code (opencode handled earlier)
+                          : effectiveTool === 'cursor'
+                            ? 'https://cursor.com/docs/api/sdk/typescript'
+                            : 'https://platform.claude.com/docs/en/about-claude/models' // claude-code (opencode handled earlier)
                   }
                   target="_blank"
                   rel="noopener noreferrer"

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -93,6 +93,17 @@ const CURSOR_MODEL_OPTIONS = [
     description: 'Cursor SDK default model alias (experimental)',
   },
 ];
+const DEFAULT_CURSOR_MODEL = 'composer-latest';
+
+function preferDefaultModel<T extends { id: string }>(models: T[], defaultModel: string): T[] {
+  const defaultIndex = models.findIndex((model) => model.id === defaultModel);
+  if (defaultIndex <= 0) return models;
+  return [
+    models[defaultIndex],
+    ...models.slice(0, defaultIndex),
+    ...models.slice(defaultIndex + 1),
+  ];
+}
 
 /**
  * Model Selector Component
@@ -131,6 +142,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     description?: string;
   }> | null>(null);
   const [cursorSource, setCursorSource] = useState<'dynamic' | 'static' | null>(null);
+  const [cursorDefaultModel, setCursorDefaultModel] = useState(DEFAULT_CURSOR_MODEL);
 
   useEffect(() => {
     if (effectiveTool !== 'copilot' || !client) return;
@@ -165,13 +177,18 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         const raw = await client.service('cursor-models').find();
         const response = raw as unknown as DynamicModelsResponse;
         if (cancelled || !response?.models?.length) return;
+        const defaultModel = response.default || DEFAULT_CURSOR_MODEL;
         setCursorServerOptions(
-          response.models.map((m) => ({
-            id: m.id,
-            label: m.displayName,
-            description: m.description,
-          }))
+          preferDefaultModel(
+            response.models.map((m) => ({
+              id: m.id,
+              label: m.displayName,
+              description: m.description,
+            })),
+            defaultModel
+          )
         );
+        setCursorDefaultModel(defaultModel);
         setCursorSource(response.source);
       } catch {
         // Silent fallback to local static — best-effort.
@@ -192,7 +209,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           : effectiveTool === 'copilot'
             ? (copilotServerOptions ?? COPILOT_STATIC_MODEL_OPTIONS)
             : effectiveTool === 'cursor'
-              ? (cursorServerOptions ?? CURSOR_MODEL_OPTIONS)
+              ? preferDefaultModel(cursorServerOptions ?? CURSOR_MODEL_OPTIONS, cursorDefaultModel)
               : AVAILABLE_CLAUDE_MODEL_ALIASES;
 
   // Determine initial mode based on whether the value is in the aliases list
@@ -242,7 +259,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       } else if (effectiveTool === 'copilot') {
         defaultModel = DEFAULT_COPILOT_MODEL;
       } else if (effectiveTool === 'cursor') {
-        defaultModel = 'composer-latest';
+        defaultModel = cursorDefaultModel;
       } else {
         // claude-code (opencode is handled earlier in the component)
         defaultModel = 'claude-sonnet-4-6';
@@ -279,7 +296,10 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           {mode === 'alias' && (
             <div style={{ marginLeft: 24, marginTop: 8 }}>
               <Select
-                value={value?.model || modelList[0].id}
+                value={
+                  value?.model ||
+                  (effectiveTool === 'cursor' ? cursorDefaultModel : modelList[0].id)
+                }
                 onChange={handleModelChange}
                 style={{ width: '100%', minWidth: 400 }}
                 options={modelList.map((m) => ({

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -175,6 +175,8 @@ function apiKeyPlaceholder(agent: AgenticToolName): string {
       return 'AIza...';
     case 'copilot':
       return 'ghp_...';
+    case 'cursor':
+      return 'key_...';
     default:
       return 'sk-ant-...';
   }
@@ -187,6 +189,7 @@ const AGENT_LABELS: Record<AgenticToolName, string> = {
   gemini: 'Gemini',
   opencode: 'OpenCode',
   copilot: 'GitHub Copilot',
+  cursor: 'Cursor SDK',
 };
 
 /**
@@ -248,6 +251,7 @@ const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string }
   codex: { label: 'platform.openai.com', url: 'https://platform.openai.com/api-keys' },
   gemini: { label: 'aistudio.google.com', url: 'https://aistudio.google.com/apikey' },
   copilot: { label: 'github.com/features/copilot', url: 'https://github.com/features/copilot' },
+  cursor: { label: 'cursor.com', url: 'https://cursor.com' },
   opencode: null,
 };
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1497,6 +1497,7 @@ export function OnboardingWizard({
                 { value: 'gemini', label: 'Gemini' },
                 { value: 'copilot', label: 'GitHub Copilot' },
                 { value: 'opencode', label: 'OpenCode' },
+                { value: 'cursor', label: 'Cursor SDK (Beta)' },
               ]}
               style={{ width: '100%' }}
             />

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -137,7 +137,7 @@ const GEMINI_MODES: ModeOption[] = [
   },
 ];
 
-// Copilot/Cursor autonomous permission modes.
+// Copilot autonomous permission modes.
 const COPILOT_MODES: ModeOption[] = [
   {
     mode: 'default',
@@ -159,6 +159,19 @@ const COPILOT_MODES: ModeOption[] = [
     description: 'Auto-approve all operations without prompting',
     icon: <UnlockOutlined />,
     color: '#faad14', // Orange/yellow
+  },
+];
+
+// Cursor SDK is currently autonomous in Agor: @cursor/sdk does not expose a
+// blocking permission callback that we can proxy to the Agor UI. Keep the UI
+// honest by showing only the effective mode instead of borrowed Copilot modes.
+const CURSOR_MODES: ModeOption[] = [
+  {
+    mode: 'bypassPermissions',
+    label: 'Autonomous',
+    description: 'Cursor SDK runs autonomously; Agor cannot intercept permission requests yet',
+    icon: <UnlockOutlined />,
+    color: '#faad14',
   },
 ];
 
@@ -240,8 +253,9 @@ const getModesForTool = (tool: PermissionModeSelectorProps['agentic_tool']): Mod
     case 'opencode':
       return OPENCODE_MODES;
     case 'copilot':
-    case 'cursor':
       return COPILOT_MODES;
+    case 'cursor':
+      return CURSOR_MODES;
     default:
       return CLAUDE_CODE_MODES;
   }
@@ -260,7 +274,10 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
 }) => {
   const { token } = theme.useToken();
   const modes = getModesForTool(agentic_tool);
-  const effectiveValue = value || getDefaultPermissionMode(agentic_tool);
+  const effectiveValue =
+    agentic_tool === 'cursor'
+      ? 'bypassPermissions'
+      : value || getDefaultPermissionMode(agentic_tool);
   // Fill Codex prop defaults from the resolved mode so the dropdown shows
   // the same values the executor will actually run with for a session
   // missing explicit sub-config.

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -20,7 +20,14 @@ interface ModeOption {
 export interface PermissionModeSelectorProps {
   value?: PermissionMode;
   onChange?: (value: PermissionMode) => void;
-  agentic_tool?: 'claude-code' | 'claude-code-cli' | 'codex' | 'gemini' | 'opencode' | 'copilot';
+  agentic_tool?:
+    | 'claude-code'
+    | 'claude-code-cli'
+    | 'codex'
+    | 'gemini'
+    | 'opencode'
+    | 'copilot'
+    | 'cursor';
   /** If true, renders as a compact Select dropdown instead of Radio buttons */
   compact?: boolean;
   /**
@@ -130,7 +137,7 @@ const GEMINI_MODES: ModeOption[] = [
   },
 ];
 
-// Copilot permission modes (GitHub Copilot SDK - same semantics as Claude Code)
+// Copilot/Cursor autonomous permission modes.
 const COPILOT_MODES: ModeOption[] = [
   {
     mode: 'default',
@@ -233,6 +240,7 @@ const getModesForTool = (tool: PermissionModeSelectorProps['agentic_tool']): Mod
     case 'opencode':
       return OPENCODE_MODES;
     case 'copilot':
+    case 'cursor':
       return COPILOT_MODES;
     default:
       return CLAUDE_CODE_MODES;

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -355,6 +355,21 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
             ),
           },
           {
+            key: 'cursor',
+            label: 'Cursor SDK',
+            children: (
+              <ApiKeyTabContent
+                tool="cursor"
+                fieldStatus={fieldStatus}
+                keysError={keysError}
+                savingKeys={savingKeys}
+                onSave={handleSaveKey}
+                onClear={handleClearKey}
+                onClearError={() => setKeysError(null)}
+              />
+            ),
+          },
+          {
             key: 'opencode',
             label: 'OpenCode',
             children: (

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -48,6 +48,7 @@ const GLOBAL_TOOL_FIELDS: Record<AgenticToolName, AgenticToolFieldConfig[]> = {
   codex: TOOL_FIELD_CONFIGS.codex.filter((f) => f.field !== 'OPENAI_BASE_URL'),
   gemini: TOOL_FIELD_CONFIGS.gemini,
   copilot: TOOL_FIELD_CONFIGS.copilot,
+  cursor: TOOL_FIELD_CONFIGS.cursor,
   opencode: TOOL_FIELD_CONFIGS.opencode,
 };
 

--- a/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
@@ -128,6 +128,12 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
       form: opencodeForm,
     },
     {
+      key: 'cursor',
+      label: 'Cursor SDK',
+      tool: 'cursor',
+      form: cursorForm,
+    },
+    {
       key: 'copilot',
       label: 'GitHub Copilot',
       tool: 'copilot',

--- a/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/DefaultAgenticSettings.tsx
@@ -39,6 +39,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
   const [geminiForm] = Form.useForm();
   const [opencodeForm] = Form.useForm();
   const [copilotForm] = Form.useForm();
+  const [cursorForm] = Form.useForm();
 
   const [saving, setSaving] = useState<Record<AgenticToolName, boolean>>({
     'claude-code': false,
@@ -47,6 +48,7 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
     gemini: false,
     opencode: false,
     copilot: false,
+    cursor: false,
   });
   const [activeTab, setActiveTab] = useState<AgenticToolName>('claude-code');
 
@@ -67,6 +69,8 @@ export const DefaultAgenticSettings: React.FC<DefaultAgenticSettingsProps> = ({
         return opencodeForm;
       case 'copilot':
         return copilotForm;
+      case 'cursor':
+        return cursorForm;
     }
   };
 

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -80,6 +80,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [geminiForm] = Form.useForm();
   const [opencodeForm] = Form.useForm();
   const [copilotForm] = Form.useForm();
+  const [cursorForm] = Form.useForm();
   const [audioForm] = Form.useForm();
 
   // Per-tool credential presence state, keyed `${tool}.${field}` for spinner
@@ -92,6 +93,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     gemini: {},
     opencode: {},
     copilot: {},
+    cursor: {},
   });
   const [savingToolField, setSavingToolField] = useState<Record<string, boolean>>({});
 
@@ -107,6 +109,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     gemini: false,
     opencode: false,
     copilot: false,
+    cursor: false,
   });
 
   // Initialize forms when user changes or modal opens
@@ -129,6 +132,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       claudeForm.setFieldsValue(getFormValuesFromConfig('claude-code', defaults?.['claude-code']));
       codexForm.setFieldsValue(getFormValuesFromConfig('codex', defaults?.codex));
       geminiForm.setFieldsValue(getFormValuesFromConfig('gemini', defaults?.gemini));
+      opencodeForm.setFieldsValue(getFormValuesFromConfig('opencode', defaults?.opencode));
+      copilotForm.setFieldsValue(getFormValuesFromConfig('copilot', defaults?.copilot));
+      cursorForm.setFieldsValue(getFormValuesFromConfig('cursor', defaults?.cursor));
 
       // Initialize audio form with user's preferences
       const audioPrefs = userData.preferences?.audio;
@@ -140,7 +146,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           audioPrefs?.minDurationSeconds ?? DEFAULT_AUDIO_PREFERENCES.minDurationSeconds,
       });
     },
-    [form, claudeForm, codexForm, geminiForm, audioForm]
+    [form, claudeForm, codexForm, geminiForm, opencodeForm, copilotForm, cursorForm, audioForm]
   );
 
   // Initialize when modal opens with user data
@@ -162,6 +168,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: {},
       opencode: {},
       copilot: {},
+      cursor: {},
     };
     const stored = user?.agentic_tools;
     if (stored) {
@@ -187,6 +194,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     claudeForm.resetFields();
     codexForm.resetFields();
     geminiForm.resetFields();
+    opencodeForm.resetFields();
+    copilotForm.resetFields();
+    cursorForm.resetFields();
     setActiveTab('general');
     onClose();
   };
@@ -359,6 +369,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: geminiForm,
       opencode: opencodeForm,
       copilot: copilotForm,
+      cursor: cursorForm,
     };
 
     try {
@@ -394,6 +405,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       gemini: geminiForm,
       opencode: opencodeForm,
       copilot: copilotForm,
+      cursor: cursorForm,
     };
 
     formMap[tool].setFieldsValue(getClearedFormValues(tool));
@@ -655,7 +667,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'codex':
       case 'gemini':
       case 'opencode':
-      case 'copilot': {
+      case 'copilot':
+      case 'cursor': {
         const toolName = activeTab as AgenticToolName;
         const formMap: Record<AgenticToolName, ReturnType<typeof Form.useForm>[0]> = {
           'claude-code': claudeForm,
@@ -664,6 +677,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           gemini: geminiForm,
           opencode: opencodeForm,
           copilot: copilotForm,
+          cursor: cursorForm,
         };
         const currentForm = formMap[toolName];
         const displayNames: Record<AgenticToolName, string> = {
@@ -673,6 +687,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           gemini: 'Gemini',
           opencode: 'OpenCode',
           copilot: 'Copilot',
+          cursor: 'Cursor SDK',
         };
         // Field set is owned by ApiKeyFields' `TOOL_FIELD_CONFIGS`. Per-field
         // saving spinners are tracked in `savingToolField` keyed by `${tool}.${field}`.

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -519,6 +519,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           icon: <RobotOutlined />,
         },
         {
+          key: 'cursor',
+          label: 'Cursor SDK',
+          icon: <RobotOutlined />,
+        },
+        {
           key: 'copilot',
           label: 'GitHub Copilot',
           icon: <RobotOutlined />,
@@ -765,6 +770,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       codex: 'Codex',
       gemini: 'Gemini',
       opencode: 'OpenCode',
+      cursor: 'Cursor SDK',
       copilot: 'GitHub Copilot',
     };
     return titles[activeTab] || 'User Settings';

--- a/apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx
+++ b/apps/agor-ui/src/components/ToolIcon/ToolIcon.tsx
@@ -49,6 +49,7 @@ export const ToolIcon: React.FC<ToolIconProps> = ({ tool, size = 32, className =
     gemini: '💎',
     opencode: '🌐',
     copilot: '✈️',
+    cursor: '⌘',
   };
 
   if (!logoSrc) {

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -22,6 +22,7 @@ interface SystemCredentials {
   ANTHROPIC_API_KEY?: boolean;
   OPENAI_API_KEY?: boolean;
   GEMINI_API_KEY?: boolean;
+  CURSOR_API_KEY?: boolean;
 }
 
 interface OnboardingConfig {
@@ -53,6 +54,8 @@ interface FeaturesConfig {
    * consent modal). Server-side gates are the source of truth.
    */
   multiUser?: boolean;
+  /** Experimental Cursor SDK provider enabled on the daemon. */
+  cursorSdk?: boolean;
 }
 
 interface HealthResponse {

--- a/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
+++ b/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
@@ -1,19 +1,19 @@
 # Cursor SDK Support Analysis — 2026-05-25
 
 **Author:** Cursor SDK support audit (`analyze-cursor-sdk-support` worktree)  
-**Status:** Draft for Max review. Initial provider skeleton added after the audit; runtime execution intentionally still unimplemented.
-**Recommendation:** **Prototype behind a feature flag, local runtime first. Do not ship as a default provider yet.**
+**Status:** Draft for Max review. Cursor is now surfaced as a beta provider scaffold; runtime execution intentionally still fails fast until the adapter lands.
+**Recommendation:** **Expose as a beta provider only; prototype local runtime next. Do not make it default/recommended until runtime, permission, and usage risks are resolved.**
 
 ---
 
 ## TL;DR
 
-Cursor's new TypeScript SDK is a credible fit for Agor's provider model, but it is still public beta and it adds a native-heavy package/runtime surface that deserves an isolated spike before user-facing support.
+Cursor's new TypeScript SDK is a credible fit for Agor's provider model, but it is still public beta and it adds a native-heavy package/runtime surface that deserves an isolated spike before non-beta support.
 
 1. **What exists today:** `@cursor/sdk` exposes `Agent.create`, `Agent.resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`, artifact APIs, model/repository discovery, local/cloud runtimes, inline MCP config, custom subagents, and a structured error hierarchy. The launch post says the SDK uses the same runtime/harness/models as Cursor desktop, CLI, and web, can run locally or on Cursor cloud, and is billed with standard token-based consumption pricing ([Cursor changelog](https://cursor.com/changelog/sdk-release), [Cursor blog](https://cursor.com/blog/typescript-sdk)). The npm package currently inspected was `@cursor/sdk@1.0.13`.
 2. **Best Agor fit:** local runtime against the Agor branch worktree (`local: { cwd: branch.path }`) because Agor already owns branches, RBAC, Unix identity, git state capture, MCP session tokens, and process lifecycle. Cursor cloud runtime is valuable, but conflicts with Agor's branch-centric “worktree as card” model unless treated as a separate remote-execution mode.
 3. **Largest blocker:** no obvious public permission callback equivalent to Claude/Copilot. Cursor has hooks and sandbox options, and the background/cloud agent docs warn cloud agents auto-run terminal commands, but the SDK public types do not expose an Agor-style interactive permission request channel. Treat v1 as “autonomous/auto-approved inside Agor's OS sandbox,” similar to OpenCode, until proven otherwise.
-4. **Maturity risk:** Cursor marks the SDK public beta; their Terms say beta services are evaluation/non-production, as-is, and may be discontinued ([Terms §1.6](https://cursor.com/en-US/terms-of-service)). That argues for `experimental.cursor_sdk` or equivalent.
+4. **Maturity risk:** Cursor marks the SDK public beta; their Terms say beta services are evaluation/non-production, as-is, and may be discontinued ([Terms §1.6](https://cursor.com/en-US/terms-of-service)). That argues for beta labeling plus an operator-visible experimental flag/runtime guard.
 5. **Implementation shape:** add a `cursor` agentic tool, credentials (`CURSOR_API_KEY`), model discovery/cache, `CursorTool` adapter that maps `SDKMessage` events to Agor messages/tool widgets, session persistence via `sdk_session_id = Cursor agentId`, run tracking via task metadata, MCP injection via inline `mcpServers`, and cancellation via `Run.cancel()`.
 
 ---
@@ -208,7 +208,7 @@ Follow-up options:
 
 ## Recommendation
 
-**Prototype behind a feature flag, local runtime only, with no permission-modal promise.**
+**Expose as beta, then prototype local runtime only, with no permission-modal promise.**
 
 Reasons to prototype now:
 
@@ -231,9 +231,9 @@ Reasons not to ship broadly yet:
 
 - ✅ Add `cursor` to core/executor/UI type unions and static capability maps.
 - ✅ Add `CURSOR_API_KEY` credential plumbing.
-- ✅ Hide normal agent-selection UI unless feature flag/runtime implementation is completed.
+- ✅ Surface Cursor as a beta provider in agent selection/settings, matching the OpenCode beta posture.
 - Add package dependency and import smoke test for Linux CI.
-- ✅ No execution yet: executor handler is a fail-fast skeleton and the daemon exposes `execution.cursor_sdk_enabled` only as an experimental surface flag.
+- ✅ No execution yet: executor handler and daemon route are fail-fast until the local runtime adapter lands.
 
 ### PR 2 — Local runtime happy path
 

--- a/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
+++ b/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
@@ -1,0 +1,293 @@
+# Cursor SDK Support Analysis — 2026-05-25
+
+**Author:** Cursor SDK support audit (`analyze-cursor-sdk-support` worktree)  
+**Status:** Draft for Max review. Doc-only; no production integration code.  
+**Recommendation:** **Prototype behind a feature flag, local runtime first. Do not ship as a default provider yet.**
+
+---
+
+## TL;DR
+
+Cursor's new TypeScript SDK is a credible fit for Agor's provider model, but it is still public beta and it adds a native-heavy package/runtime surface that deserves an isolated spike before user-facing support.
+
+1. **What exists today:** `@cursor/sdk` exposes `Agent.create`, `Agent.resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`, artifact APIs, model/repository discovery, local/cloud runtimes, inline MCP config, custom subagents, and a structured error hierarchy. The launch post says the SDK uses the same runtime/harness/models as Cursor desktop, CLI, and web, can run locally or on Cursor cloud, and is billed with standard token-based consumption pricing ([Cursor changelog](https://cursor.com/changelog/sdk-release), [Cursor blog](https://cursor.com/blog/typescript-sdk)). The npm package currently inspected was `@cursor/sdk@1.0.13`.
+2. **Best Agor fit:** local runtime against the Agor branch worktree (`local: { cwd: branch.path }`) because Agor already owns branches, RBAC, Unix identity, git state capture, MCP session tokens, and process lifecycle. Cursor cloud runtime is valuable, but conflicts with Agor's branch-centric “worktree as card” model unless treated as a separate remote-execution mode.
+3. **Largest blocker:** no obvious public permission callback equivalent to Claude/Copilot. Cursor has hooks and sandbox options, and the background/cloud agent docs warn cloud agents auto-run terminal commands, but the SDK public types do not expose an Agor-style interactive permission request channel. Treat v1 as “autonomous/auto-approved inside Agor's OS sandbox,” similar to OpenCode, until proven otherwise.
+4. **Maturity risk:** Cursor marks the SDK public beta; their Terms say beta services are evaluation/non-production, as-is, and may be discontinued ([Terms §1.6](https://cursor.com/en-US/terms-of-service)). That argues for `experimental.cursor_sdk` or equivalent.
+5. **Implementation shape:** add a `cursor` agentic tool, credentials (`CURSOR_API_KEY`), model discovery/cache, `CursorTool` adapter that maps `SDKMessage` events to Agor messages/tool widgets, session persistence via `sdk_session_id = Cursor agentId`, run tracking via task metadata, MCP injection via inline `mcpServers`, and cancellation via `Run.cancel()`.
+
+---
+
+## Sources reviewed
+
+### External primary sources
+
+- Cursor SDK changelog, 2026-04-29: package install, public beta, local/cloud runtime, streaming example, Cloud Agents API v1 updates ([cursor.com/changelog/sdk-release](https://cursor.com/changelog/sdk-release)).
+- Cursor SDK announcement blog, 2026-04-29: cloud dedicated VMs, reconnectable runs, PR/artifacts, self-hosted/local runtime, MCP/skills/hooks/subagents, token-based pricing ([cursor.com/blog/typescript-sdk](https://cursor.com/blog/typescript-sdk)).
+- Cursor SDK TypeScript docs entry linked from the package README: [cursor.com/docs/api/sdk/typescript](https://cursor.com/docs/api/sdk/typescript) (also linked as `/docs/sdk/typescript` from the changelog).
+- Cursor public package inspected with `npm view @cursor/sdk` and `npm pack @cursor/sdk` on 2026-05-25: `@cursor/sdk@1.0.13`, Node `>=18`, license “SEE LICENSE IN LICENSE.md”, dependencies and `.d.ts` API surface.
+- Cursor cookbook examples repo: says SDK supports local and cloud runtimes, event streaming, prompts, models, cancellation, artifacts, and conversation state; API keys come from the Cursor integrations dashboard and are exposed as `CURSOR_API_KEY` ([github.com/cursor/cookbook](https://github.com/cursor/cookbook)).
+- Cursor MCP docs: supports `stdio`, `SSE`, and Streamable HTTP transports; tools/prompts/resources/roots/elicitation; project/global `.cursor/mcp.json`; MCP tools ask for approval by default in Cursor chat ([docs.cursor.com/context/model-context-protocol](https://docs.cursor.com/context/model-context-protocol)).
+- Cursor background/cloud agent docs: cloud/background agents run in isolated Ubuntu VMs, have internet access, clone GitHub repos, run on separate branches, and auto-run terminal commands with prompt-injection/data-exfiltration caveats ([docs.cursor.com/en/background-agent](https://docs.cursor.com/en/background-agent)).
+- Cursor Terms of Service: service includes APIs/docs/tools, paid add-ons can be usage-based, beta services are non-production/as-is/discontinuable, and auto-code execution risk is user's responsibility ([cursor.com/en-US/terms-of-service](https://cursor.com/en-US/terms-of-service)).
+
+### Agor code/docs reviewed
+
+- SDK comparison guide source: `apps/agor-docs/pages/guide/sdk-comparison.mdx`.
+- Agentic tool names/capabilities/API key map: `packages/core/src/types/agentic-tool.ts:11`, `packages/core/src/types/agentic-tool.ts:38`, `packages/core/src/types/agentic-tool.ts:198`, `packages/core/src/types/agentic-tool.ts:205`.
+- Session model and default permission mode: `packages/core/src/types/session.ts:59`, `packages/core/src/types/session.ts:108`, `packages/core/src/types/session.ts:123`, `packages/core/src/types/session.ts:221`, `packages/core/src/types/session.ts:237`.
+- Per-user credential/default config surfaces: `packages/core/src/types/user.ts:100`, `packages/core/src/types/user.ts:118`, `packages/core/src/types/user.ts:127`, `packages/core/src/types/user.ts:154`, `packages/core/src/types/user.ts:254`.
+- Global config credential whitelist: `packages/core/src/config/config-manager.ts:635`, `packages/core/src/config/types.ts:698`, `packages/core/src/config/types.ts:710`.
+- Executor payload/registry surfaces: `packages/executor/src/payload-types.ts:74`, `packages/executor/src/index.ts:23`, `packages/executor/src/handlers/sdk/tool-registry.ts:16`, `packages/executor/src/handlers/sdk/tool-registry.ts:120`.
+- Shared executor lifecycle/callbacks/token normalization: `packages/executor/src/handlers/sdk/base-executor.ts:31`, `packages/executor/src/handlers/sdk/base-executor.ts:109`, `packages/executor/src/handlers/sdk/base-executor.ts:274`, `packages/executor/src/handlers/sdk/base-executor.ts:302`, `packages/executor/src/handlers/sdk/base-executor.ts:428`, `packages/executor/src/sdk-handlers/normalizer-factory.ts:31`.
+- MCP scoping/template resolution: `packages/executor/src/sdk-handlers/base/mcp-scoping.ts:69`, `packages/executor/src/sdk-handlers/base/mcp-scoping.ts:144`.
+- Provider precedents: Claude wrapper `packages/executor/src/handlers/sdk/claude.ts:20`, Codex wrapper `packages/executor/src/handlers/sdk/codex.ts:17`, OpenCode special-case session handling `packages/executor/src/handlers/sdk/opencode.ts:26`.
+
+---
+
+## What Cursor SDK exposes today
+
+Based on `@cursor/sdk@1.0.13` package types plus Cursor's launch materials:
+
+| Area                   | Current Cursor SDK surface                                                                                                                                                                                                                       | Agor implication                                                                                                                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Package                | `@cursor/sdk`, ESM/CJS exports, `Agent` and `Cursor` namespaces. `package.json` says Node `>=18`; Agor root already requires Node `>=22.12.0`.                                                                                                   | Compatible with Agor's Node floor. Add dependency to `packages/executor` only; avoid browser imports.                                                                                     |
+| Native deps/platform   | Package depends on `sqlite3` and optional platform packages: `@cursor/sdk-darwin-*`, `@cursor/sdk-linux-*`, `@cursor/sdk-win32-x64`.                                                                                                             | CI/install smoke tests must cover Linux x64. Native dependency makes this higher-risk than pure TS SDKs.                                                                                  |
+| License/terms          | Package license points to Cursor Terms. Terms cover APIs/docs/tools and beta/auto-execution risk.                                                                                                                                                | Legal/product review before broad enablement; include feature-flag warning.                                                                                                               |
+| Auth                   | `AgentOptions.apiKey`; `CursorRequestOptions.apiKey`; docs/examples use `process.env.CURSOR_API_KEY`; cookbook says create key in Cursor integrations dashboard.                                                                                 | Add `CURSOR_API_KEY` to `ApiKeyName`, per-user encrypted bucket, maybe global config only if Cursor service-account/team keys are acceptable.                                             |
+| Runtime                | `AgentOptions.local.cwd` accepts a string or string array; local options include `settingSources` and `sandboxOptions`. `cloud` options include env, repos, current-branch work, auto-PRs, and env vars. Blog also mentions self-hosted workers. | v1 should use local runtime with Agor branch path. Cloud runtime is a later, separate mode because it creates remote branches/PRs outside Agor's worktree lifecycle.                      |
+| Models                 | `model?: { id, params? }`; `Cursor.models.list()` returns ids, aliases, params, variants; README suggests `composer-latest`.                                                                                                                     | Static defaults are possible, but model discovery/cache is better. Need UI model provider entry.                                                                                          |
+| Session/resume         | `Agent.create({ agentId? })`; `Agent.resume(agentId)`; `SDKAgent.agentId`; `agent.send()` creates a `Run`; `Agent.list`, `Agent.get`, `Agent.messages.list`.                                                                                     | Store `agentId` in `sessions.sdk_session_id`. Store active `run.id` in task metadata/raw response if needed for cancellation/reconnect.                                                   |
+| Runs/cancellation      | `Run` has `id`, `agentId`, `stream()`, `conversation()`, `wait()`, `cancel()`, status callbacks, `result`, `model`, `durationMs`, `git`. Static `Agent.getRun` and `Agent.cancelRun`.                                                            | Maps cleanly to Agor task lifecycle and `AbortController`; implement `stopTask()` around current `Run.cancel()`.                                                                          |
+| Streaming/events       | `run.stream()` yields `SDKMessage`: `system`, `user`, `assistant`, `tool_call`, `thinking`, `status`, `request`, `task`. `agent.send` also accepts `onStep` and `onDelta` callbacks.                                                             | Good fit for Agor `StreamingCallbacks`; use `assistant` text blocks for chunks, `thinking` for thinking callbacks, `tool_call` for tool widgets. Need tests for duplicate/partial events. |
+| Tool calling/editing   | Exported tool-call types include shell/read/write/edit/delete/grep/glob/semantic search/MCP/todos/subagent/create-plan/read-lints. `SDKToolUseMessage` has `name`, `status`, `args`, `result`, truncation flags.                                 | Normalize to Agor `tool_use`/`tool_result` blocks. Cursor can produce rich widgets, likely closer to OpenCode/Copilot than Codex.                                                         |
+| MCP                    | `mcpServers?: Record<string, McpServerConfig>` on agent and send options; configs support `stdio`, `http`, `sse`, env/headers/OAuth fields. Blog says MCP can come from `.cursor/mcp.json` or inline.                                            | Reuse Agor MCP scoping, inject built-in Agor MCP as Streamable HTTP with Authorization header, and convert user MCP rows to Cursor `McpServerConfig`.                                     |
+| Skills/hooks/subagents | Blog says SDK agents pick up `.cursor/skills`, `.cursor/hooks.json`, and named subagents via `agents?: Record<string, AgentDefinition>`.                                                                                                         | Mostly leave native. Potential collision with Agor skills/AGENTS.md should be documented. Avoid writing `.cursor/*` in v1.                                                                |
+| Permissions/sandbox    | Public types expose `sandboxOptions?: { enabled: boolean }`, but no Agor-style permission callback. Cursor MCP docs mention chat approval by default; background-agent docs say cloud agents auto-run terminal commands.                         | Treat as auto-approved/autonomous inside Agor's Unix/worktree sandbox. Do not promise interactive approvals until a Cursor hook/callback can block decisions safely.                      |
+| Usage/cost             | Public types expose `RunResult.durationMs`, `model`, `git`, but no token/cost fields in inspected `.d.ts`. Changelog/blog say billing is token-based.                                                                                            | v1 may not populate Agor token/context pills unless hidden runtime events contain usage. Store raw responses and leave normalized usage blank initially.                                  |
+| Errors                 | `CursorSdkError` with `code`, `status`, `isRetryable`, `endpoint`, `requestId`, plus `AuthenticationError`, `RateLimitError`, `ConfigurationError`, `AgentBusyError`, `IntegrationNotConnectedError`, `NetworkError`, `UnknownAgentError`.       | Map directly to user-facing task errors; retryable/auth/rate-limit affordances can be surfaced cleanly.                                                                                   |
+
+---
+
+## Comparison row for the SDK guide
+
+If Cursor support is added, this is the likely row/column content for the existing guide's categories:
+
+| Feature                     | Cursor SDK       | Notes                                                                                                      |
+| --------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Streaming responses**     | ✅ Text + tools  | `run.stream()` yields assistant/tool/thinking/status messages; `onDelta` may provide finer-grained deltas. |
+| **Stop mid-execution**      | ✅ Yes           | `Run.cancel()` / `Agent.cancelRun()`, with cloud run-scoped cancellation.                                  |
+| **Session import/export**   | ❌ No            | Agent/message list APIs exist, but no portable transcript/import format found.                             |
+| **Session forkable**        | ❌ Not found     | Resume exists; fork primitive not found in public SDK types.                                               |
+| **MCP integration**         | ✅ Native        | Inline `mcpServers` plus `.cursor/mcp.json`; supports stdio/http/sse.                                      |
+| **Permission requests**     | ⚠️ Not exposed   | Sandbox/hooks exist, but no typed blocking permission callback found. Treat as auto-approved for v1.       |
+| **Project instructions**    | ✅ Cursor-native | `.cursor/rules`, skills, hooks, and Cursor context/indexing; AGENTS.md behavior needs empirical check.     |
+| **Tool execution**          | ✅ Rich events   | `SDKToolUseMessage` and exported typed tool-call unions for shell/read/write/edit/MCP/subagents/todos.     |
+| **Session continuity**      | ✅ SDK-managed   | Store `SDKAgent.agentId` in `sessions.sdk_session_id`; sends create per-prompt `Run`s.                     |
+| **Token usage tracking**    | ❌ Not exposed   | Token-based billing exists, but inspected public types lack usage/cost payloads.                           |
+| **Context window tracking** | ❌ Not exposed   | No context-window counters in inspected public types. Could estimate from Agor DB later.                   |
+
+Positioning against existing integrations:
+
+- **Closest to OpenCode/Copilot** for event-rich tool lifecycle and SDK-managed sessions.
+- **Better than Codex/Gemini** for resume ergonomics if `agentId` is durable across process restarts.
+- **Worse than Claude/Copilot** for permissions unless Cursor exposes a blocking hook.
+- **Worse than Claude/Codex/OpenCode** for Agor token/cost UI today, because no usage payload was visible in public types.
+- **Potentially strongest native harness** for indexing/semantic search/skills/hooks/subagents, but that is also the largest black box and maturity risk.
+
+---
+
+## Proposed Agor architecture
+
+### 1. Product/config surfaces
+
+Smallest viable config additions:
+
+- Add `cursor` to `AgenticToolName`, payload `ToolTypeSchema`, executor registry `Tool`, and static capabilities.
+  - Existing enums/maps live at `packages/core/src/types/agentic-tool.ts:38`, `packages/executor/src/payload-types.ts:74`, and `packages/executor/src/handlers/sdk/tool-registry.ts:16`.
+- Add `CURSOR_API_KEY` to `ApiKeyName`, `TOOL_API_KEY_NAMES`, `AgenticToolsConfig`, `AgenticToolConfigField`, and possibly `ConfigCredentialKey` / `AgorCredentials`.
+  - Per-user encrypted SDK credentials are modeled in `packages/core/src/types/user.ts:127` and scoped by the daemon resolver before executor spawn (`packages/executor/src/handlers/sdk/base-executor.ts:274`).
+  - Max question: should Cursor keys be user-only like Copilot, or allowed globally like OpenAI/Gemini? Service-account API keys make global plausible; personal Cursor API keys argue user-only.
+- Add default model config and model list:
+  - Minimal: static `composer-latest` / `composer-2` defaults.
+  - Better: `Cursor.models.list()` server-side cache behind auth, with fallback static aliases.
+- Add a feature flag such as `experimental.cursor_sdk: false` or `execution.providers.cursor.enabled: false` before showing the provider in the UI.
+
+### 2. Executor handler/tool adapter
+
+Create a normal SDK-path adapter, not a Zellij/PTY adapter:
+
+- `packages/executor/src/handlers/sdk/cursor.ts` analogous to `claude.ts`/`codex.ts` for normal `executeToolTask` flow.
+- `packages/executor/src/sdk-handlers/cursor/cursor-tool.ts` implementing `BaseTool.executePromptWithStreaming()` and `stopTask()`.
+- Optional `cursor/normalizer.ts` returning no usage at first but preserving model/duration/git if present.
+- Add dependency `@cursor/sdk` to `packages/executor/package.json` only. Do **not** expose it through `packages/core` browser-safe exports.
+
+Execution flow:
+
+1. Resolve session and branch path.
+2. Resolve `CURSOR_API_KEY` through existing key resolver.
+3. If `session.sdk_session_id` exists: `Agent.resume(agentId, { apiKey, local: { cwd: branch.path } })`.
+4. Else: `Agent.create({ apiKey, model, local: { cwd: branch.path, sandboxOptions }, mcpServers })`, then patch `sessions.sdk_session_id = agent.agentId`.
+5. Create the Agor user message.
+6. `const run = await agent.send(prompt, { model, mcpServers, onStep, onDelta })`.
+7. Save `run.id` in raw task metadata as soon as available.
+8. Iterate `for await (const event of run.stream())` and map to Agor streaming + final messages.
+9. Await terminal result (`run.wait()` if stream does not return final state), patch task status/model/git/duration.
+10. `agent.close()`/async dispose in finally.
+
+### 3. Normalized message/event mapping
+
+Suggested v1 mapping from Cursor `SDKMessage`:
+
+- `system(subtype:init)`: store in raw SDK response; maybe use `tools[]` for diagnostics.
+- `assistant.message.content[].type === 'text'`: stream chunks with `onStreamStart`/`onStreamChunk`/`onStreamEnd`, then create final assistant message.
+- `thinking`: use `onThinkingStart`/`onThinkingChunk`/`onThinkingEnd`; include duration in metadata when present.
+- `tool_call`: create/update `tool_use` and `tool_result` content blocks keyed by `call_id`; map `running`/`completed`/`error` to Agor tool lifecycle.
+- `status`: optional lightweight system/status events; do not spam message rows unless terminal/error.
+- `task`: map subagent/task progress as tool/status content after inspecting real events.
+- `request`: unknown; preserve raw until understood.
+
+Agor already has a provider-neutral callback contract at `packages/executor/src/sdk-handlers/base/types.ts:36` and daemon broadcast implementation at `packages/executor/src/handlers/sdk/base-executor.ts:109`.
+
+### 4. MCP handling
+
+Reuse `getMcpServersForSession()` and template resolution (`packages/executor/src/sdk-handlers/base/mcp-scoping.ts:69`, `:144`). Convert Agor MCP rows to Cursor SDK configs:
+
+- Built-in Agor MCP: `type: "http"`, `url: daemonUrl + "/mcp"`, and an `Authorization: Bearer <session.mcp_token>` header.
+- `stdio`: `{ type: 'stdio', command, args, env, cwd }`.
+- HTTP/SSE: `{ type: 'http' | 'sse', url, headers }` plus OAuth fields only after verifying Cursor's exact OAuth expectations.
+
+Open question: Cursor supports `.cursor/mcp.json`; Agor should prefer inline `mcpServers` so session-specific selection, OAuth token injection, and `mcp_token` scoping remain daemon-controlled.
+
+### 5. Permissions/sandbox
+
+V1 should be explicit: **Cursor SDK provider is autonomous.**
+
+- Use Agor's existing branch Unix isolation/RBAC as the outer boundary.
+- For local runtime, set `local.cwd = branch.path`; evaluate `sandboxOptions.enabled = true` in the spike and document actual effects.
+- Do not wire Agor permission modals until Cursor exposes either:
+  - a blocking SDK permission callback,
+  - hook events that can deny/allow synchronously per operation, or
+  - a reliable config policy language Agor can generate per task.
+
+This is similar to OpenCode's current “auto-granted by Agor” behavior, but should be even more conservatively labeled because Cursor's harness includes rich native tools and context indexing.
+
+### 6. Usage/cost/context
+
+Initial state:
+
+- Persist raw `RunResult` and any stream terminal event.
+- Populate task `model` from `run.model` / agent model.
+- Populate duration from `run.durationMs` if present.
+- Leave token/cost/context fields empty unless real events reveal usage data.
+
+Follow-up options:
+
+- Ask Cursor whether usage metrics are intentionally absent or available in a hidden/stable event.
+- Estimate context from Agor message history for UI only, clearly labeled “estimated,” if Max wants parity.
+- Never infer billing cost without token counts; Cursor bills standard token-based pricing but the SDK types inspected do not expose the counters.
+
+---
+
+## Risks and blockers
+
+| Risk/blocker                        | Severity   | Notes/mitigation                                                                                                                               |
+| ----------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public beta / non-production terms  | High       | Cursor calls SDK public beta; Terms say beta services are as-is and can be discontinued. Ship behind feature flag only.                        |
+| Native dependency/platform packages | Medium     | `sqlite3` and optional platform packages can break CI, Alpine, strict Linux envs, or isolated executor users. Add install smoke test.          |
+| Permission surface unclear          | High       | No public blocking permission callback found. V1 must be autonomous/sandboxed only.                                                            |
+| Token/cost absent                   | Medium     | Agor UI would lack pills/cost for Cursor unless Cursor adds usage events. Not a blocker for execution.                                         |
+| Cursor local state location         | Medium     | Need empirical test where local agent stores state and whether `agentId` survives under Agor's Unix user/home isolation.                       |
+| Cursor indexing/caches              | Medium     | Local runtime may create `.cursor`/home caches or read broad project state; verify secrets behavior and `.gitignore`/`.cursorignore` handling. |
+| Cloud runtime model mismatch        | Medium     | Cursor cloud clones GitHub and creates branches/PRs externally; Agor branch cards would no longer be source of truth. Defer cloud mode.        |
+| Licensing/redistribution            | Low/Medium | Package license is proprietary/Terms-based. Using as dependency may be fine, but get product/legal comfort before enabling for all users.      |
+| Credentials/secrets                 | Medium     | Cursor API key must stay per-tool scoped like existing credentials; local agent can read env/files exposed to its Unix process.                |
+| Headless suitability                | Low/Medium | SDK is explicitly programmatic/headless, but local runtime behavior in a daemon/executor process must be smoke-tested.                         |
+
+---
+
+## Recommendation
+
+**Prototype behind a feature flag, local runtime only, with no permission-modal promise.**
+
+Reasons to prototype now:
+
+- The SDK surface matches Agor's executor architecture better than the older Cursor CLI would.
+- `agentId` + run-scoped streaming/cancel is a clean fit for `sdk_session_id` and task lifecycle.
+- Cursor's harness (indexing, semantic search, MCP, skills, hooks, subagents) could be a strong differentiator for Agor users who already use Cursor.
+
+Reasons not to ship broadly yet:
+
+- Beta/Terms posture.
+- Native package/runtime unknowns.
+- Missing permission and usage/cost surfaces.
+- Cloud runtime semantics overlap/conflict with Agor's own branch/worktree orchestration.
+
+---
+
+## Proposed implementation plan split into PRs
+
+### PR 1 — Provider skeleton behind feature flag
+
+- Add `cursor` to core/executor/UI type unions and static capability maps.
+- Add `CURSOR_API_KEY` credential plumbing.
+- Hide UI unless feature flag enabled.
+- Add package dependency and import smoke test for Linux CI.
+- No execution yet.
+
+### PR 2 — Local runtime happy path
+
+- Implement `CursorTool` local runtime with `Agent.create/resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`.
+- Persist `agentId` in `sessions.sdk_session_id` and active `run.id` in task raw metadata.
+- Create user/assistant messages and basic text streaming.
+- Tests with mocked `@cursor/sdk`.
+
+### PR 3 — Tool/thinking/status event normalization
+
+- Map `tool_call`, `thinking`, `status`, and terminal errors to Agor messages/tool widgets.
+- Add `cursor/normalizer.ts` for model/duration/git and no-token explicit behavior.
+- Golden tests for representative SDK events.
+
+### PR 4 — MCP injection
+
+- Convert Agor session/global MCP server configs to Cursor `McpServerConfig`.
+- Inject built-in Agor MCP with session bearer token.
+- Tests for stdio/http/sse conversion, env template resolution, and OAuth/header handling.
+
+### PR 5 — UI polish and model discovery
+
+- Add Cursor model defaults and `Cursor.models.list()`-backed cache/API if desired.
+- Settings copy warning: beta, autonomous execution, token-based billing, Cursor Terms.
+- Add docs guide row once behavior is verified.
+
+### PR 6 — Optional cloud runtime spike
+
+- Treat Cursor cloud as separate runtime mode, not default `cursor` provider behavior.
+- Decide how remote branches/PR URLs become Agor branch cards or artifacts.
+- Only after local provider is stable.
+
+---
+
+## Concrete next-step checklist
+
+- [ ] Max decision: feature flag name/config shape.
+- [ ] Max decision: user-only vs global `CURSOR_API_KEY` storage.
+- [ ] Run a live local smoke test with a throwaway Cursor key in an Agor worktree:
+  - [ ] Does `Agent.create({ local: { cwd } })` run headlessly under executor user?
+  - [ ] Where is local state stored?
+  - [ ] Does `Agent.resume(agentId)` work after process exit?
+  - [ ] What exact `SDKMessage` sequence arrives for text, shell, file edit, MCP, and error?
+  - [ ] Does `Run.cancel()` stop shell/file edits cleanly?
+  - [ ] Does `sandboxOptions.enabled` materially constrain writes/commands?
+  - [ ] Are token/cost metrics hidden anywhere in stream/onDelta/onStep/raw result?
+- [ ] Ask Cursor/support/forum about stable permission and usage APIs.
+- [ ] Add import/install smoke test before enabling in CI.
+- [ ] Update `apps/agor-docs/pages/guide/sdk-comparison.mdx` only after behavior is empirically verified.
+
+## Open questions for Max
+
+1. Should Cursor API keys be **per-user only** (like Copilot) or also allowed in global `config.yaml` (like OpenAI/Gemini)?
+2. Is an **autonomous/no-permission-modal** provider acceptable if clearly labeled and constrained by Agor Unix isolation?
+3. Should cloud runtime be explicitly out-of-scope for v1, or should the spike include a “remote Cursor branch artifact” concept?
+4. Is losing token/cost/context pills acceptable for an experimental provider?
+5. Do we want to expose Cursor-native `.cursor/skills`/hooks/subagent affordances in Agor UI, or leave them as repo-native files only?

--- a/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
+++ b/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
@@ -1,14 +1,14 @@
 # Cursor SDK Support Analysis — 2026-05-25
 
 **Author:** Cursor SDK support audit (`analyze-cursor-sdk-support` worktree)  
-**Status:** Draft for Max review. Cursor is now surfaced as a beta provider scaffold; runtime execution intentionally still fails fast until the adapter lands.
-**Recommendation:** **Expose as a beta provider only; prototype local runtime next. Do not make it default/recommended until runtime, permission, and usage risks are resolved.**
+**Status:** Draft for Max review. Cursor is surfaced as a beta provider and this branch now includes an initial local-runtime `@cursor/sdk` adapter. Runtime support is still early and should remain beta until smoke-tested with real Cursor keys/worktrees.
+**Recommendation:** **Keep as beta; continue the local-runtime integration behind explicit beta labeling. Do not make it default/recommended until permission, usage, and live-runtime risks are resolved.**
 
 ---
 
 ## TL;DR
 
-Cursor's new TypeScript SDK is a credible fit for Agor's provider model, but it is still public beta and it adds a native-heavy package/runtime surface that deserves an isolated spike before non-beta support.
+Cursor's new TypeScript SDK is a credible fit for Agor's provider model, but it is still public beta and it adds a native-heavy package/runtime surface that deserves live smoke testing before non-beta support.
 
 1. **What exists today:** `@cursor/sdk` exposes `Agent.create`, `Agent.resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`, artifact APIs, model/repository discovery, local/cloud runtimes, inline MCP config, custom subagents, and a structured error hierarchy. The launch post says the SDK uses the same runtime/harness/models as Cursor desktop, CLI, and web, can run locally or on Cursor cloud, and is billed with standard token-based consumption pricing ([Cursor changelog](https://cursor.com/changelog/sdk-release), [Cursor blog](https://cursor.com/blog/typescript-sdk)). The npm package currently inspected was `@cursor/sdk@1.0.13`.
 2. **Best Agor fit:** local runtime against the Agor branch worktree (`local: { cwd: branch.path }`) because Agor already owns branches, RBAC, Unix identity, git state capture, MCP session tokens, and process lifecycle. Cursor cloud runtime is valuable, but conflicts with Agor's branch-centric “worktree as card” model unless treated as a separate remote-execution mode.
@@ -111,7 +111,7 @@ Smallest viable config additions:
 - Add default model config and model list:
   - Minimal: static `composer-latest` / `composer-2` defaults.
   - Better: `Cursor.models.list()` server-side cache behind auth, with fallback static aliases.
-- Add a feature flag such as `experimental.cursor_sdk: false` or `execution.providers.cursor.enabled: false` before showing the provider in the UI.
+- Keep Cursor visibly marked as beta wherever providers are selected. A hard feature flag can still be added later if live smoke testing exposes runtime instability.
 
 ### 2. Executor handler/tool adapter
 
@@ -227,31 +227,32 @@ Reasons not to ship broadly yet:
 
 ## Proposed implementation plan split into PRs
 
-### PR 1 — Provider skeleton behind feature flag
+### PR 1 — Provider skeleton as beta
 
 - ✅ Add `cursor` to core/executor/UI type unions and static capability maps.
 - ✅ Add `CURSOR_API_KEY` credential plumbing.
 - ✅ Surface Cursor as a beta provider in agent selection/settings, matching the OpenCode beta posture.
-- Add package dependency and import smoke test for Linux CI.
-- ✅ No execution yet: executor handler and daemon route are fail-fast until the local runtime adapter lands.
+- ✅ Add package dependency (`@cursor/sdk`) to executor.
+- Add import/install smoke test for Linux CI.
 
 ### PR 2 — Local runtime happy path
 
-- Implement `CursorTool` local runtime with `Agent.create/resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`.
-- Persist `agentId` in `sessions.sdk_session_id` and active `run.id` in task raw metadata.
-- Create user/assistant messages and basic text streaming.
+- ✅ Implement initial local runtime with `Agent.create/resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`.
+- ✅ Persist `agentId` in `sessions.sdk_session_id`; store terminal run/raw messages in task raw metadata.
+- ✅ Create user/assistant messages and basic text streaming.
 - Tests with mocked `@cursor/sdk`.
 
 ### PR 3 — Tool/thinking/status event normalization
 
-- Map `tool_call`, `thinking`, `status`, and terminal errors to Agor messages/tool widgets.
+- ✅ Initial mapping for `tool_call`, `thinking`, and terminal errors to Agor messages/tool callbacks.
+- Further refine `status`, `task`, and duplicate/partial event behavior after live SDK traces.
 - Add `cursor/normalizer.ts` for model/duration/git and no-token explicit behavior.
 - Golden tests for representative SDK events.
 
 ### PR 4 — MCP injection
 
-- Convert Agor session/global MCP server configs to Cursor `McpServerConfig`.
-- Inject built-in Agor MCP with session bearer token.
+- ✅ Convert Agor session/global MCP server configs to Cursor `McpServerConfig`.
+- ✅ Inject built-in Agor MCP with session bearer token.
 - Tests for stdio/http/sse conversion, env template resolution, and OAuth/header handling.
 
 ### PR 5 — UI polish and model discovery
@@ -270,8 +271,6 @@ Reasons not to ship broadly yet:
 
 ## Concrete next-step checklist
 
-- [ ] Max decision: feature flag name/config shape.
-- [ ] Max decision: user-only vs global `CURSOR_API_KEY` storage.
 - [ ] Run a live local smoke test with a throwaway Cursor key in an Agor worktree:
   - [ ] Does `Agent.create({ local: { cwd } })` run headlessly under executor user?
   - [ ] Where is local state stored?
@@ -286,8 +285,7 @@ Reasons not to ship broadly yet:
 
 ## Open questions for Max
 
-1. Should Cursor API keys be **per-user only** (like Copilot) or also allowed in global `config.yaml` (like OpenAI/Gemini)?
-2. Is an **autonomous/no-permission-modal** provider acceptable if clearly labeled and constrained by Agor Unix isolation?
-3. Should cloud runtime be explicitly out-of-scope for v1, or should the spike include a “remote Cursor branch artifact” concept?
-4. Is losing token/cost/context pills acceptable for an experimental provider?
-5. Do we want to expose Cursor-native `.cursor/skills`/hooks/subagent affordances in Agor UI, or leave them as repo-native files only?
+1. Is an **autonomous/no-permission-modal** provider acceptable if clearly labeled and constrained by Agor Unix isolation?
+2. Should cloud runtime be explicitly out-of-scope for v1, or should the spike include a “remote Cursor branch artifact” concept?
+3. Is losing token/cost/context pills acceptable for an experimental provider?
+4. Do we want to expose Cursor-native `.cursor/skills`/hooks/subagent affordances in Agor UI, or leave them as repo-native files only?

--- a/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
+++ b/docs/internal/cursor-sdk-support-analysis-2026-05-25.md
@@ -1,7 +1,7 @@
 # Cursor SDK Support Analysis — 2026-05-25
 
 **Author:** Cursor SDK support audit (`analyze-cursor-sdk-support` worktree)  
-**Status:** Draft for Max review. Doc-only; no production integration code.  
+**Status:** Draft for Max review. Initial provider skeleton added after the audit; runtime execution intentionally still unimplemented.
 **Recommendation:** **Prototype behind a feature flag, local runtime first. Do not ship as a default provider yet.**
 
 ---
@@ -229,11 +229,11 @@ Reasons not to ship broadly yet:
 
 ### PR 1 — Provider skeleton behind feature flag
 
-- Add `cursor` to core/executor/UI type unions and static capability maps.
-- Add `CURSOR_API_KEY` credential plumbing.
-- Hide UI unless feature flag enabled.
+- ✅ Add `cursor` to core/executor/UI type unions and static capability maps.
+- ✅ Add `CURSOR_API_KEY` credential plumbing.
+- ✅ Hide normal agent-selection UI unless feature flag/runtime implementation is completed.
 - Add package dependency and import smoke test for Linux CI.
-- No execution yet.
+- ✅ No execution yet: executor handler is a fail-fast skeleton and the daemon exposes `execution.cursor_sdk_enabled` only as an experimental surface flag.
 
 ### PR 2 — Local runtime happy path
 

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@agor-live/client": "workspace:*",
     "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+    "@cursor/sdk": "^1.0.13",
     "@feathersjs/authentication": "^5.0.44",
     "@feathersjs/authentication-client": "^5.0.44",
     "@feathersjs/authentication-local": "^5.0.44",

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -637,7 +637,8 @@ export type ConfigCredentialKey =
   | 'ANTHROPIC_AUTH_TOKEN'
   | 'ANTHROPIC_BASE_URL'
   | 'OPENAI_API_KEY'
-  | 'GEMINI_API_KEY';
+  | 'GEMINI_API_KEY'
+  | 'CURSOR_API_KEY';
 
 const CONFIG_CREDENTIAL_KEYS: ReadonlySet<string> = new Set<ConfigCredentialKey>([
   'ANTHROPIC_API_KEY',
@@ -645,6 +646,7 @@ const CONFIG_CREDENTIAL_KEYS: ReadonlySet<string> = new Set<ConfigCredentialKey>
   'ANTHROPIC_BASE_URL',
   'OPENAI_API_KEY',
   'GEMINI_API_KEY',
+  'CURSOR_API_KEY',
 ]);
 
 export function isConfigCredentialKey(key: string): key is ConfigCredentialKey {

--- a/packages/core/src/config/env-resolver.test.ts
+++ b/packages/core/src/config/env-resolver.test.ts
@@ -240,6 +240,7 @@ describe('resolveUserEnvironment — per-tool credential scoping', () => {
     );
     await usersRepo.setToolConfigField(userId, 'gemini', 'GEMINI_API_KEY', 'gemini-key');
     await usersRepo.setToolConfigField(userId, 'copilot', 'COPILOT_GITHUB_TOKEN', 'gh-copilot');
+    await usersRepo.setToolConfigField(userId, 'cursor', 'CURSOR_API_KEY', 'cursor-key');
 
     return userId;
   }
@@ -254,6 +255,7 @@ describe('resolveUserEnvironment — per-tool credential scoping', () => {
     expect(env.OPENAI_API_KEY).toBeUndefined();
     expect(env.GEMINI_API_KEY).toBeUndefined();
     expect(env.COPILOT_GITHUB_TOKEN).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBeUndefined();
   });
 
   dbTest('tool=claude-code merges only claude-code fields', async ({ db }) => {
@@ -265,6 +267,7 @@ describe('resolveUserEnvironment — per-tool credential scoping', () => {
     expect(env.OPENAI_API_KEY).toBeUndefined();
     expect(env.GEMINI_API_KEY).toBeUndefined();
     expect(env.COPILOT_GITHUB_TOKEN).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBeUndefined();
   });
 
   dbTest('tool=codex merges OPENAI_API_KEY + OPENAI_BASE_URL only', async ({ db }) => {
@@ -278,6 +281,7 @@ describe('resolveUserEnvironment — per-tool credential scoping', () => {
     expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
     expect(env.GEMINI_API_KEY).toBeUndefined();
     expect(env.COPILOT_GITHUB_TOKEN).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBeUndefined();
   });
 
   dbTest('tool=gemini merges only GEMINI_API_KEY', async ({ db }) => {
@@ -286,6 +290,7 @@ describe('resolveUserEnvironment — per-tool credential scoping', () => {
     expect(env.GEMINI_API_KEY).toBe('gemini-key');
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBeUndefined();
   });
 
   dbTest('tool=copilot merges only COPILOT_GITHUB_TOKEN', async ({ db }) => {
@@ -295,6 +300,17 @@ describe('resolveUserEnvironment — per-tool credential scoping', () => {
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.OPENAI_API_KEY).toBeUndefined();
     expect(env.GEMINI_API_KEY).toBeUndefined();
+    expect(env.CURSOR_API_KEY).toBeUndefined();
+  });
+
+  dbTest('tool=cursor merges only CURSOR_API_KEY', async ({ db }) => {
+    const userId = await createUserWithToolCreds(db);
+    const env = await resolveUserEnvironment(userId, db, { tool: 'cursor' });
+    expect(env.CURSOR_API_KEY).toBe('cursor-key');
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.GEMINI_API_KEY).toBeUndefined();
+    expect(env.COPILOT_GITHUB_TOKEN).toBeUndefined();
   });
 
   dbTest('tool credentials override same-named global env vars', async ({ db }) => {

--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -93,6 +93,7 @@ export const ALLOWED_ENV_VARS = new Set([
   'OPENAI_BASE_URL',
   'GEMINI_API_KEY',
   'GOOGLE_API_KEY',
+  'CURSOR_API_KEY',
 
   // Vertex AI (Claude Code on GCP)
   'CLAUDE_CODE_USE_VERTEX',

--- a/packages/core/src/config/key-resolver.test.ts
+++ b/packages/core/src/config/key-resolver.test.ts
@@ -96,4 +96,17 @@ describe('resolveApiKey — per-tool credential scoping', () => {
     expect(result.apiKey).toBe('copilot-key');
     expect(result.source).toBe('user');
   });
+
+  dbTest('tool=cursor resolves CURSOR_API_KEY from its own bucket', async ({ db }) => {
+    const userId = await createUserWithToolCreds(db, {
+      cursor: { CURSOR_API_KEY: encryptApiKey('cursor-key') },
+      // A nonsense entry under another bucket should never be returned even
+      // though a cross-bucket sweep would otherwise pick it up first.
+      'claude-code': { CURSOR_API_KEY: encryptApiKey('wrong-bucket') },
+    });
+
+    const result = await resolveApiKey('CURSOR_API_KEY', { userId, db, tool: 'cursor' });
+    expect(result.apiKey).toBe('cursor-key');
+    expect(result.source).toBe('user');
+  });
 });

--- a/packages/core/src/config/resource-schemas.ts
+++ b/packages/core/src/config/resource-schemas.ts
@@ -29,7 +29,7 @@ const repoSlugSchema = z
 
 export const enforcedAgentConfigSchema = z.object({
   agentic_tool: z
-    .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot'])
+    .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'])
     .optional(),
   permission_mode: z.string().optional(),
   model: z.string().optional(),

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -275,6 +275,9 @@ export interface AgorExecutionSettings {
    */
   allow_web_terminal?: boolean;
 
+  /** Enable experimental Cursor SDK provider surfaces (default: false). */
+  cursor_sdk_enabled?: boolean;
+
   /** Allow superadmin role (default: false). When true, superadmin role gets branch RBAC bypass. Opt-in for self-hosted deployments. */
   allow_superadmin?: boolean;
 
@@ -702,6 +705,7 @@ export enum CredentialKey {
   OPENAI_API_KEY = 'OPENAI_API_KEY',
   GEMINI_API_KEY = 'GEMINI_API_KEY',
   COPILOT_GITHUB_TOKEN = 'COPILOT_GITHUB_TOKEN',
+  CURSOR_API_KEY = 'CURSOR_API_KEY',
 }
 
 /**
@@ -727,6 +731,9 @@ export interface AgorCredentials {
 
   /** GitHub token for Copilot */
   COPILOT_GITHUB_TOKEN?: string;
+
+  /** Cursor API key for the experimental Cursor SDK provider */
+  CURSOR_API_KEY?: string;
 }
 
 /**

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -86,7 +86,7 @@ export const sessions = pgTable(
       ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
-      enum: ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot'],
+      enum: ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'],
     }).notNull(),
     board_id: varchar('board_id', { length: 36 }), // NULL = no board
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -74,7 +74,7 @@ export const sessions = sqliteTable(
       ],
     }).notNull(),
     agentic_tool: text('agentic_tool', {
-      enum: ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot'],
+      enum: ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'],
     }).notNull(),
     board_id: text('board_id', { length: 36 }), // NULL = no board
 

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -47,6 +47,8 @@ export const CommonSchemas = {
     Type.Literal('gemini'),
     Type.Literal('opencode'),
     Type.Literal('copilot'),
+    Type.Literal('claude-code-cli'),
+    Type.Literal('cursor'),
   ]),
 
   // Permission mode enum - union of all native SDK modes

--- a/packages/core/src/models/lint-model-tool-match.ts
+++ b/packages/core/src/models/lint-model-tool-match.ts
@@ -29,7 +29,11 @@ const TOOL_MODEL_PREFIXES: Partial<Record<AgenticToolName, readonly string[]>> =
  * A `claude-*` model on a Copilot session is legitimate — there is no useful
  * lint to perform. The validator returns `null` (no opinion) for these.
  */
-const UNOPINIONATED_TOOLS: ReadonlySet<AgenticToolName> = new Set(['copilot', 'opencode']);
+const UNOPINIONATED_TOOLS: ReadonlySet<AgenticToolName> = new Set([
+  'copilot',
+  'opencode',
+  'cursor',
+]);
 
 /** Result of a model/tool match check. `null` means "no opinion". */
 export type ModelToolMatch =

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -14,7 +14,8 @@ export type ApiKeyName =
   | 'CLAUDE_CODE_OAUTH_TOKEN'
   | 'OPENAI_API_KEY'
   | 'GEMINI_API_KEY'
-  | 'COPILOT_GITHUB_TOKEN';
+  | 'COPILOT_GITHUB_TOKEN'
+  | 'CURSOR_API_KEY';
 
 /**
  * Agentic coding tool names
@@ -31,6 +32,7 @@ export type ApiKeyName =
  * - gemini: Google's Gemini Code Assist
  * - opencode: Open-source terminal-based AI assistant with 75+ LLM providers
  * - copilot: GitHub Copilot's agentic runtime via @github/copilot-sdk
+ * - cursor: Cursor's agentic runtime via @cursor/sdk (experimental)
  *
  * Not to be confused with "execution tools" (Bash, Write, Read, etc.)
  * which are the primitives that agentic tools use to perform work.
@@ -41,7 +43,8 @@ export type AgenticToolName =
   | 'codex'
   | 'gemini'
   | 'opencode'
-  | 'copilot';
+  | 'copilot'
+  | 'cursor';
 
 /**
  * Agentic tool metadata for UI display
@@ -154,6 +157,14 @@ export type CodexNetworkAccess = boolean;
  */
 export type CopilotPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
 
+/**
+ * Cursor permission modes (via @cursor/sdk, experimental).
+ *
+ * Cursor SDK does not currently expose a blocking Agor-style permission callback,
+ * so these mirror the autonomous-provider modes until a richer policy surface exists.
+ */
+export type CursorPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
+
 // ============================================================================
 // Tool Capabilities (static, shared between backend and UI)
 // ============================================================================
@@ -200,6 +211,7 @@ export const TOOL_API_KEY_NAMES: Partial<Record<AgenticToolName, ApiKeyName>> = 
   codex: 'OPENAI_API_KEY',
   gemini: 'GEMINI_API_KEY',
   copilot: 'COPILOT_GITHUB_TOKEN',
+  cursor: 'CURSOR_API_KEY',
 };
 
 export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapabilities> = {
@@ -240,6 +252,12 @@ export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapab
     supportsStatelessFsMode: false,
   },
   copilot: {
+    supportsSessionFork: false,
+    supportsChildSpawn: true,
+    supportsSessionImport: false,
+    supportsStatelessFsMode: false,
+  },
+  cursor: {
     supportsSessionFork: false,
     supportsChildSpawn: true,
     supportsSessionImport: false,

--- a/packages/core/src/types/session.test.ts
+++ b/packages/core/src/types/session.test.ts
@@ -9,6 +9,7 @@
  *   default_tools_approval_mode in the executor)
  * - Gemini: autoEdit (unchanged — pending separate audit)
  * - OpenCode: autoEdit (unchanged — pending separate audit)
+ * - Cursor: bypassPermissions (experimental/autonomous until permission callbacks exist)
  */
 
 import { describe, expect, it } from 'vitest';
@@ -30,6 +31,10 @@ describe('getDefaultPermissionMode', () => {
 
   it('returns "autoEdit" for opencode (uses Gemini-like modes)', () => {
     expect(getDefaultPermissionMode('opencode')).toBe('autoEdit');
+  });
+
+  it('returns "bypassPermissions" for cursor (experimental autonomous provider)', () => {
+    expect(getDefaultPermissionMode('cursor')).toBe('bypassPermissions');
   });
 
   it('returns "acceptEdits" for any unknown tool (default case)', () => {
@@ -68,7 +73,15 @@ describe('getDefaultPermissionMode', () => {
 
   describe('all agentic tools coverage', () => {
     it('handles all valid AgenticToolName values', () => {
-      const allTools: AgenticToolName[] = ['claude-code', 'codex', 'gemini', 'opencode'];
+      const allTools: AgenticToolName[] = [
+        'claude-code',
+        'claude-code-cli',
+        'codex',
+        'gemini',
+        'opencode',
+        'copilot',
+        'cursor',
+      ];
       const results: Record<string, string> = {};
 
       for (const tool of allTools) {
@@ -79,10 +92,20 @@ describe('getDefaultPermissionMode', () => {
       expect(results.codex).toBe('allow-all');
       expect(results.gemini).toBe('autoEdit');
       expect(results.opencode).toBe('autoEdit');
+      expect(results.copilot).toBe('acceptEdits');
+      expect(results.cursor).toBe('bypassPermissions');
     });
 
     it('returns valid PermissionMode values', () => {
-      const allTools: AgenticToolName[] = ['claude-code', 'codex', 'gemini', 'opencode'];
+      const allTools: AgenticToolName[] = [
+        'claude-code',
+        'claude-code-cli',
+        'codex',
+        'gemini',
+        'opencode',
+        'copilot',
+        'cursor',
+      ];
       const validModes = [
         // Claude Code native modes
         'default',

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -12,6 +12,7 @@ import type {
   CodexApprovalPolicy,
   CodexPermissionMode,
   CodexSandboxMode,
+  CursorPermissionMode,
   GeminiPermissionMode,
   OpenCodePermissionMode,
 } from './agentic-tool';
@@ -78,6 +79,7 @@ export type {
   CodexApprovalPolicy,
   CodexPermissionMode,
   CodexSandboxMode,
+  CursorPermissionMode,
   GeminiPermissionMode,
   OpenCodePermissionMode,
 };
@@ -101,6 +103,8 @@ export type {
  *   sandbox still constrains shell exec.
  * - Gemini: 'autoEdit' (unchanged — pending separate audit)
  * - OpenCode: 'autoEdit' (unchanged — pending separate audit)
+ * - Cursor: 'bypassPermissions' — scaffolded as autonomous until the SDK
+ *   exposes/Agor wires a permission callback.
  *
  * Users / parent sessions / per-session overrides still trump these
  * defaults via resolvePermissionConfig.
@@ -115,6 +119,8 @@ export function getDefaultPermissionMode(agenticTool: AgenticToolName): Permissi
       return 'autoEdit'; // OpenCode auto-approves, similar to Gemini
     case 'copilot':
       return 'acceptEdits'; // Copilot uses same semantics as Claude Code
+    case 'cursor':
+      return 'bypassPermissions'; // Cursor SDK is experimental/autonomous until permission callbacks exist
     default:
       return 'acceptEdits'; // Claude Code
   }

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -122,6 +122,7 @@ export interface DefaultAgenticConfig {
   gemini?: DefaultAgenticToolConfig;
   opencode?: DefaultAgenticToolConfig;
   copilot?: DefaultAgenticToolConfig;
+  cursor?: DefaultAgenticToolConfig;
 }
 
 /**
@@ -151,6 +152,10 @@ export interface CopilotConfig {
   COPILOT_GITHUB_TOKEN?: string;
 }
 
+export interface CursorConfig {
+  CURSOR_API_KEY?: string;
+}
+
 /**
  * Per-tool credential map. Each tool's config is independent and
  * scoped to its own SDK at session-spawn time.
@@ -165,6 +170,7 @@ export interface AgenticToolsConfig {
   codex?: CodexConfig;
   gemini?: GeminiConfig;
   copilot?: CopilotConfig;
+  cursor?: CursorConfig;
   opencode?: Record<string, never>;
 }
 
@@ -173,7 +179,8 @@ export type AgenticToolConfigField =
   | keyof ClaudeCodeConfig
   | keyof CodexConfig
   | keyof GeminiConfig
-  | keyof CopilotConfig;
+  | keyof CopilotConfig
+  | keyof CursorConfig;
 
 /**
  * Public DTO shape: per-tool credential presence flags.

--- a/packages/core/src/utils/permission-mode-mapper.ts
+++ b/packages/core/src/utils/permission-mode-mapper.ts
@@ -9,6 +9,7 @@
  * - Claude Code: default, acceptEdits, bypassPermissions, plan, dontAsk
  * - Gemini: default, autoEdit, yolo
  * - Codex: ask, auto, on-failure, allow-all
+ * - Cursor: default, acceptEdits, bypassPermissions (experimental surface)
  */
 
 import type {
@@ -36,6 +37,7 @@ export function mapPermissionMode(
   switch (agenticTool) {
     case 'claude-code':
     case 'copilot':
+    case 'cursor':
       // Claude Code native modes: default, acceptEdits, bypassPermissions, plan, dontAsk
       switch (mode) {
         // Native Claude modes - pass through

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@agor/core": "workspace:*",
+    "@cursor/sdk": "^1.0.13",
     "@github/copilot-sdk": "^0.2.2",
     "@opencode-ai/sdk": "^1.2.20",
     "diff": "^7.0.0",

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -233,7 +233,7 @@ async function handleLegacyMode(values: {
     sessionId: values['session-id'] as string,
     taskId: values['task-id'] as string,
     prompt: values.prompt as string,
-    tool: values.tool as 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot',
+    tool: values.tool as 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor',
     permissionMode: (values['permission-mode'] as 'ask' | 'auto' | 'allow-all') || undefined,
     daemonUrl: resolvedDaemonUrl,
   });

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -219,7 +219,7 @@ export function createExecutionContext(
  * Returns the SHA (with "-dirty" suffix if working directory has uncommitted changes)
  * or undefined if it cannot be determined.
  */
-async function captureGitStateAtTaskEnd(
+export async function captureGitStateAtTaskEnd(
   client: AgorClient,
   sessionId: SessionID
 ): Promise<string | undefined> {

--- a/packages/executor/src/handlers/sdk/cursor.test.ts
+++ b/packages/executor/src/handlers/sdk/cursor.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCursorAssistantContent,
+  normalizeCursorToolInput,
+  normalizeCursorToolName,
+} from './cursor.js';
+
+describe('Cursor SDK handler helpers', () => {
+  it('persists thinking before assistant text', () => {
+    expect(
+      buildCursorAssistantContent({
+        thinkingText: 'Reasoning trace',
+        text: 'Final answer',
+      })
+    ).toEqual([
+      { type: 'thinking', text: 'Reasoning trace' },
+      { type: 'text', text: 'Final answer' },
+    ]);
+  });
+
+  it('normalizes shell commands for existing Bash tool widgets', () => {
+    const input = normalizeCursorToolInput({
+      type: 'tool_call',
+      call_id: 'call-1',
+      name: 'run_terminal_cmd',
+      status: 'running',
+      args: { cmd: 'pnpm check' },
+    } as never);
+
+    expect(normalizeCursorToolName('run_terminal_cmd')).toBe('Bash');
+    expect(input).toMatchObject({
+      command: 'pnpm check',
+      cursor_tool_name: 'run_terminal_cmd',
+      status: 'running',
+    });
+  });
+
+  it('normalizes file paths for existing file tool widgets', () => {
+    const input = normalizeCursorToolInput({
+      type: 'tool_call',
+      call_id: 'call-2',
+      name: 'edit',
+      status: 'completed',
+      args: { path: 'packages/executor/src/handlers/sdk/cursor.ts' },
+    } as never);
+
+    expect(normalizeCursorToolName('edit')).toBe('Edit');
+    expect(input).toMatchObject({
+      file_path: 'packages/executor/src/handlers/sdk/cursor.ts',
+      cursor_tool_name: 'edit',
+      status: 'completed',
+    });
+  });
+});

--- a/packages/executor/src/handlers/sdk/cursor.test.ts
+++ b/packages/executor/src/handlers/sdk/cursor.test.ts
@@ -18,6 +18,15 @@ describe('Cursor SDK handler helpers', () => {
     ]);
   });
 
+  it('does not persist a thinking block that duplicates the final answer', () => {
+    expect(
+      buildCursorAssistantContent({
+        thinkingText: 'Hello!  How can I help you today?',
+        text: 'Hello! How can I help you today?',
+      })
+    ).toEqual([{ type: 'text', text: 'Hello! How can I help you today?' }]);
+  });
+
   it('normalizes shell commands for existing Bash tool widgets', () => {
     const input = normalizeCursorToolInput({
       type: 'tool_call',

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -12,6 +12,7 @@ import { generateId, shortId } from '@agor/core/db';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type {
   ContentBlock,
+  Message,
   MessageID,
   MessageSource,
   PermissionMode,
@@ -140,15 +141,22 @@ async function buildCursorMcpServers(args: {
   return count > 0 ? mcpServers : undefined;
 }
 
-async function getNextMessageIndex(client: AgorClient, sessionId: SessionID): Promise<number> {
+async function getSessionMessages(client: AgorClient, sessionId: SessionID): Promise<Message[]> {
   const existingMessages = await client.service('messages').find({
     query: {
       session_id: sessionId,
       $sort: { index: 1 },
     },
   });
-  const messages = Array.isArray(existingMessages) ? existingMessages : existingMessages.data;
-  return messages?.length || 0;
+  return Array.isArray(existingMessages) ? existingMessages : existingMessages.data;
+}
+
+function getNextMessageIndexFrom(messages: ReadonlyArray<Message>): number {
+  return messages.length;
+}
+
+async function getNextMessageIndex(client: AgorClient, sessionId: SessionID): Promise<number> {
+  return getNextMessageIndexFrom(await getSessionMessages(client, sessionId));
 }
 
 async function createUserMessage(args: {
@@ -157,7 +165,15 @@ async function createUserMessage(args: {
   taskId: TaskID;
   prompt: string;
   index: number;
-}): Promise<MessageID> {
+  existingMessages?: ReadonlyArray<Message>;
+}): Promise<Message> {
+  const existing = args.existingMessages?.find(
+    (message) => message.task_id === args.taskId && message.role === MessageRole.USER
+  );
+  if (existing) {
+    return existing;
+  }
+
   const messageId = generateId() as MessageID;
   await args.client.service('messages').create({
     message_id: messageId,
@@ -170,7 +186,17 @@ async function createUserMessage(args: {
     content_preview: args.prompt.substring(0, 200),
     content: args.prompt,
   });
-  return messageId;
+  return {
+    message_id: messageId,
+    session_id: args.sessionId,
+    task_id: args.taskId,
+    type: 'user',
+    role: MessageRole.USER,
+    index: args.index,
+    timestamp: new Date().toISOString(),
+    content_preview: args.prompt.substring(0, 200),
+    content: args.prompt,
+  };
 }
 
 async function createAssistantMessage(args: {
@@ -327,11 +353,18 @@ export async function executeCursorTask(params: {
         await client.service('sessions').patch(sessionId, { sdk_session_id: agent.agentId });
       }
 
-      const userIndex = await getNextMessageIndex(client, sessionId);
-      await createUserMessage({ client, sessionId, taskId, prompt, index: userIndex });
+      const existingMessages = await getSessionMessages(client, sessionId);
+      const userMessage = await createUserMessage({
+        client,
+        sessionId,
+        taskId,
+        prompt,
+        index: getNextMessageIndexFrom(existingMessages),
+        existingMessages,
+      });
 
       const assistantMessageId = generateId() as MessageID;
-      let nextIndex = userIndex + 1;
+      let nextIndex = Math.max(getNextMessageIndexFrom(existingMessages), userMessage.index + 1);
       let assistantStreamStarted = false;
       let assistantText = '';
       let thinkingStarted = false;
@@ -392,7 +425,8 @@ export async function executeCursorTask(params: {
       }
 
       const runResult = await currentRun.wait();
-      const finalText = assistantText || runResult.result || '';
+      const resultText = typeof runResult.result === 'string' ? runResult.result : '';
+      const finalText = resultText.length > assistantText.length ? resultText : assistantText;
       if (finalText) {
         await createAssistantMessage({
           client,
@@ -463,10 +497,10 @@ async function handleCursorEvent(args: {
         .map((block) => block.text)
         .join('');
       const previousText = args.getAssistantText();
-      const delta = nextText.startsWith(previousText)
-        ? nextText.slice(previousText.length)
-        : nextText;
+      const isCumulative = nextText.startsWith(previousText);
+      const delta = isCumulative ? nextText.slice(previousText.length) : nextText;
       if (!delta) return;
+      const updatedText = isCumulative ? nextText : previousText + nextText;
 
       if (!args.isAssistantStreamStarted()) {
         await args.callbacks.onStreamStart(args.assistantMessageId, {
@@ -478,7 +512,7 @@ async function handleCursorEvent(args: {
         args.setAssistantStreamStarted(true);
       }
       await args.callbacks.onStreamChunk(args.assistantMessageId, delta);
-      args.setAssistantText(nextText);
+      args.setAssistantText(updatedText);
       return;
     }
 

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -223,6 +223,39 @@ async function createAssistantMessage(args: {
   });
 }
 
+function getToolMessageContent(event: Extract<SDKMessage, { type: 'tool_call' }>): {
+  content: ContentBlock[];
+  preview: string;
+} {
+  const resultText =
+    event.result !== undefined ? stringifyForPreview(event.result) : `[${event.status}]`;
+  const content: ContentBlock[] = [
+    {
+      type: 'tool_use',
+      id: event.call_id,
+      name: event.name,
+      input: event.args ?? {},
+      status: event.status,
+      ...(event.truncated ? { truncated: event.truncated } : {}),
+    },
+  ];
+
+  if (event.status !== 'running') {
+    content.push({
+      type: 'tool_result',
+      tool_use_id: event.call_id,
+      content: resultText,
+      is_error: event.status === 'error',
+      ...(event.truncated ? { truncated: event.truncated } : {}),
+    });
+  }
+
+  return {
+    content,
+    preview: `${event.name}: ${resultText}`,
+  };
+}
+
 async function createToolMessage(args: {
   client: AgorClient;
   sessionId: SessionID;
@@ -232,24 +265,7 @@ async function createToolMessage(args: {
   model?: string;
 }): Promise<MessageID> {
   const messageId = generateId() as MessageID;
-  const resultText =
-    args.event.result !== undefined
-      ? stringifyForPreview(args.event.result)
-      : `[${args.event.status}]`;
-  const content: ContentBlock[] = [
-    {
-      type: 'tool_use',
-      id: args.event.call_id,
-      name: args.event.name,
-      input: args.event.args ?? {},
-    },
-    {
-      type: 'tool_result',
-      tool_use_id: args.event.call_id,
-      content: resultText,
-      is_error: args.event.status === 'error',
-    },
-  ];
+  const { content, preview } = getToolMessageContent(args.event);
 
   await createAssistantMessage({
     client: args.client,
@@ -258,10 +274,22 @@ async function createToolMessage(args: {
     messageId,
     index: args.index,
     content,
-    preview: `${args.event.name}: ${resultText}`,
+    preview,
     model: args.model,
   });
   return messageId;
+}
+
+async function updateToolMessage(args: {
+  client: AgorClient;
+  messageId: MessageID;
+  event: Extract<SDKMessage, { type: 'tool_call' }>;
+}): Promise<void> {
+  const { content, preview } = getToolMessageContent(args.event);
+  await args.client.service('messages').patch(args.messageId, {
+    content,
+    content_preview: preview.substring(0, 200),
+  });
 }
 
 async function createSystemErrorMessage(args: {
@@ -370,6 +398,7 @@ export async function executeCursorTask(params: {
       let thinkingStarted = false;
       let thinkingText = '';
       const toolCallMessageIds: MessageID[] = [];
+      const toolCallMessageIdsByCallId = new Map<string, MessageID>();
       const rawMessages: SDKMessage[] = [];
 
       currentRun = await agent.send(prompt, {
@@ -398,6 +427,7 @@ export async function executeCursorTask(params: {
           model: model.id,
           getNextIndex: () => nextIndex++,
           toolCallMessageIds,
+          toolCallMessageIdsByCallId,
           getAssistantText: () => assistantText,
           setAssistantText: (value) => {
             assistantText = value;
@@ -481,6 +511,7 @@ async function handleCursorEvent(args: {
   model: string;
   getNextIndex: () => number;
   toolCallMessageIds: MessageID[];
+  toolCallMessageIdsByCallId: Map<string, MessageID>;
   getAssistantText: () => string;
   setAssistantText: (value: string) => void;
   getThinkingText: () => string;
@@ -534,7 +565,16 @@ async function handleCursorEvent(args: {
     }
 
     case 'tool_call': {
-      if (args.event.status === 'running') return;
+      const existingMessageId = args.toolCallMessageIdsByCallId.get(args.event.call_id);
+      if (existingMessageId) {
+        await updateToolMessage({
+          client: args.client,
+          messageId: existingMessageId,
+          event: args.event,
+        });
+        return;
+      }
+
       const messageId = await createToolMessage({
         client: args.client,
         sessionId: args.sessionId,
@@ -543,6 +583,7 @@ async function handleCursorEvent(args: {
         event: args.event,
         model: args.model,
       });
+      args.toolCallMessageIdsByCallId.set(args.event.call_id, messageId);
       args.toolCallMessageIds.push(messageId);
       return;
     }

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -17,6 +17,7 @@ import type {
   MessageSource,
   PermissionMode,
   SessionID,
+  Task,
   TaskID,
 } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
@@ -27,7 +28,7 @@ import type { ResolvedConfigSlice } from '../../payload-types.js';
 import { getMcpServersForSession } from '../../sdk-handlers/base/mcp-scoping.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import type { AgorClient } from '../../services/feathers-client.js';
-import { createStreamingCallbacks } from './base-executor.js';
+import { captureGitStateAtTaskEnd, createStreamingCallbacks } from './base-executor.js';
 
 type CursorKeyResolution = {
   apiKey?: string;
@@ -54,7 +55,7 @@ function asRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-function normalizeCursorToolName(name: string): string {
+export function normalizeCursorToolName(name: string): string {
   switch (name.toLowerCase()) {
     case 'shell':
     case 'bash':
@@ -83,7 +84,7 @@ function normalizeCursorToolName(name: string): string {
   }
 }
 
-function normalizeCursorToolInput(
+export function normalizeCursorToolInput(
   event: Extract<SDKMessage, { type: 'tool_call' }>
 ): Record<string, unknown> {
   const input = { ...asRecord(event.args) };
@@ -120,6 +121,20 @@ function normalizeCursorToolInput(
   }
 
   return input;
+}
+
+export function buildCursorAssistantContent(args: {
+  text: string;
+  thinkingText?: string;
+}): ContentBlock[] {
+  const content: ContentBlock[] = [];
+  if (args.thinkingText?.trim()) {
+    content.push({ type: 'thinking', text: args.thinkingText });
+  }
+  if (args.text) {
+    content.push({ type: 'text', text: args.text });
+  }
+  return content;
 }
 
 function claimMcpName(rawName: string, claimed: Set<string>): string {
@@ -239,6 +254,7 @@ async function createUserMessage(args: {
   taskId: TaskID;
   prompt: string;
   index: number;
+  messageSource?: MessageSource;
   existingMessages?: ReadonlyArray<Message>;
 }): Promise<Message> {
   const existing = args.existingMessages?.find(
@@ -259,6 +275,7 @@ async function createUserMessage(args: {
     timestamp: new Date().toISOString(),
     content_preview: args.prompt.substring(0, 200),
     content: args.prompt,
+    metadata: args.messageSource ? { source: args.messageSource } : undefined,
   });
   return {
     message_id: messageId,
@@ -270,6 +287,7 @@ async function createUserMessage(args: {
     timestamp: new Date().toISOString(),
     content_preview: args.prompt.substring(0, 200),
     content: args.prompt,
+    metadata: args.messageSource ? { source: args.messageSource } : undefined,
   };
 }
 
@@ -404,6 +422,11 @@ export async function executeCursorTask(params: {
   const { client, sessionId, taskId, prompt } = params;
 
   console.log(`[cursor] Executing task ${shortId(taskId)}...`);
+  if (params.permissionMode && params.permissionMode !== 'bypassPermissions') {
+    console.warn(
+      `[cursor] Ignoring permission mode "${params.permissionMode}"; @cursor/sdk currently runs autonomously in Agor.`
+    );
+  }
 
   let currentRun: Run | undefined;
   const abortHandler = () => {
@@ -464,11 +487,17 @@ export async function executeCursorTask(params: {
         taskId,
         prompt,
         index: getNextMessageIndexFrom(existingMessages),
+        messageSource: params.messageSource,
         existingMessages,
       });
 
       const assistantMessageId = generateId() as MessageID;
       let nextIndex = Math.max(getNextMessageIndexFrom(existingMessages), userMessage.index + 1);
+      let assistantMessageIndex: number | undefined;
+      const ensureAssistantMessageIndex = () => {
+        assistantMessageIndex ??= nextIndex++;
+        return assistantMessageIndex;
+      };
       let assistantStreamStarted = false;
       let assistantText = '';
       let thinkingStarted = false;
@@ -516,6 +545,7 @@ export async function executeCursorTask(params: {
           setAssistantStreamStarted: (value) => {
             assistantStreamStarted = value;
           },
+          ensureAssistantMessageIndex,
           isThinkingStarted: () => thinkingStarted,
           setThinkingStarted: (value) => {
             thinkingStarted = value;
@@ -533,14 +563,15 @@ export async function executeCursorTask(params: {
       const runResult = await currentRun.wait();
       const resultText = typeof runResult.result === 'string' ? runResult.result : '';
       const finalText = resultText.length > assistantText.length ? resultText : assistantText;
-      if (finalText) {
+      const finalContent = buildCursorAssistantContent({ text: finalText, thinkingText });
+      if (finalContent.length > 0) {
         await createAssistantMessage({
           client,
           sessionId,
           taskId,
           messageId: assistantMessageId,
-          index: nextIndex++,
-          content: [{ type: 'text', text: finalText }],
+          index: assistantMessageIndex ?? nextIndex++,
+          content: finalContent,
           preview: finalText,
           model: runResult.model?.id ?? model.id,
         });
@@ -548,7 +579,8 @@ export async function executeCursorTask(params: {
 
       const failed = runResult.status === 'error';
       const stopped = runResult.status === 'cancelled' || params.abortController.signal.aborted;
-      await client.service('tasks').patch(taskId, {
+      const shaAtEnd = await captureGitStateAtTaskEnd(client, sessionId);
+      const taskPatch: Partial<Task> = {
         status: stopped ? 'stopped' : failed ? 'failed' : 'completed',
         completed_at: new Date().toISOString(),
         model: runResult.model?.id ?? model.id,
@@ -558,18 +590,29 @@ export async function executeCursorTask(params: {
           agentId: agent.agentId,
           toolCallMessageIds,
         },
-      });
+      };
+      if (shaAtEnd) {
+        // @ts-expect-error - Partial update of nested git_state object is handled by repository deep merge
+        taskPatch.git_state = { sha_at_end: shaAtEnd };
+      }
+      await client.service('tasks').patch(taskId, taskPatch);
     } finally {
       agent.close();
     }
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     console.error('[cursor] Execution failed:', err);
-    await client.service('tasks').patch(taskId, {
+    const shaAtEnd = await captureGitStateAtTaskEnd(client, sessionId);
+    const taskPatch: Partial<Task> = {
       status: 'failed',
       completed_at: new Date().toISOString(),
       error_message: err.message,
-    });
+    };
+    if (shaAtEnd) {
+      // @ts-expect-error - Partial update of nested git_state object is handled by repository deep merge
+      taskPatch.git_state = { sha_at_end: shaAtEnd };
+    }
+    await client.service('tasks').patch(taskId, taskPatch);
     await createSystemErrorMessage({ client, sessionId, taskId, message: err.message });
     throw err;
   } finally {
@@ -594,6 +637,7 @@ async function handleCursorEvent(args: {
   setThinkingText: (value: string) => void;
   isAssistantStreamStarted: () => boolean;
   setAssistantStreamStarted: (value: boolean) => void;
+  ensureAssistantMessageIndex: () => number;
   isThinkingStarted: () => boolean;
   setThinkingStarted: (value: boolean) => void;
 }): Promise<void> {
@@ -610,6 +654,7 @@ async function handleCursorEvent(args: {
       const updatedText = isCumulative ? nextText : previousText + nextText;
 
       if (!args.isAssistantStreamStarted()) {
+        args.ensureAssistantMessageIndex();
         await args.callbacks.onStreamStart(args.assistantMessageId, {
           session_id: args.sessionId,
           task_id: args.taskId,
@@ -626,17 +671,18 @@ async function handleCursorEvent(args: {
     case 'thinking': {
       if (!args.callbacks.onThinkingChunk) return;
       const previousText = args.getThinkingText();
-      const delta = args.event.text.startsWith(previousText)
-        ? args.event.text.slice(previousText.length)
-        : args.event.text;
+      const isCumulative = args.event.text.startsWith(previousText);
+      const delta = isCumulative ? args.event.text.slice(previousText.length) : args.event.text;
       if (!delta) return;
+      const updatedText = isCumulative ? args.event.text : previousText + args.event.text;
 
       if (!args.isThinkingStarted() && args.callbacks.onThinkingStart) {
+        args.ensureAssistantMessageIndex();
         await args.callbacks.onThinkingStart(args.assistantMessageId, {});
         args.setThinkingStarted(true);
       }
       await args.callbacks.onThinkingChunk(args.assistantMessageId, delta);
-      args.setThinkingText(args.event.text);
+      args.setThinkingText(updatedText);
       return;
     }
 

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -48,6 +48,80 @@ function toCursorModel(model: string | undefined): { id: string } {
   return { id: model?.trim() || 'composer-latest' };
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function normalizeCursorToolName(name: string): string {
+  switch (name.toLowerCase()) {
+    case 'shell':
+    case 'bash':
+    case 'terminal':
+    case 'run_terminal_cmd':
+      return 'Bash';
+    case 'read':
+    case 'ls':
+      return 'Read';
+    case 'write':
+      return 'Write';
+    case 'edit':
+      return 'Edit';
+    case 'delete':
+      return 'Delete';
+    case 'grep':
+      return 'Grep';
+    case 'glob':
+      return 'Glob';
+    case 'update_todos':
+      return 'TodoWrite';
+    case 'task':
+      return 'Task';
+    default:
+      return name;
+  }
+}
+
+function normalizeCursorToolInput(
+  event: Extract<SDKMessage, { type: 'tool_call' }>
+): Record<string, unknown> {
+  const input = { ...asRecord(event.args) };
+  const normalizedName = normalizeCursorToolName(event.name);
+
+  // Preserve Cursor's native tool name when we map it to an Agor/Claude-ish
+  // renderer name. This keeps raw provenance inspectable while unlocking
+  // existing UI renderers like BashRenderer/EditRenderer/WriteRenderer.
+  if (normalizedName !== event.name) {
+    input.cursor_tool_name = event.name;
+  }
+  input.status = event.status;
+
+  if (normalizedName === 'Bash' && input.command == null) {
+    const command = input.cmd ?? input.script ?? input.shell ?? input.shellCommand ?? input.args;
+    if (Array.isArray(command)) {
+      input.command = command.map(String).join(' ');
+    } else if (command != null) {
+      input.command = String(command);
+    }
+  }
+
+  if (
+    (normalizedName === 'Read' ||
+      normalizedName === 'Write' ||
+      normalizedName === 'Edit' ||
+      normalizedName === 'Delete') &&
+    input.file_path == null
+  ) {
+    const path = input.path ?? input.file ?? input.target;
+    if (path != null) {
+      input.file_path = String(path);
+    }
+  }
+
+  return input;
+}
+
 function claimMcpName(rawName: string, claimed: Set<string>): string {
   const base = rawName.toLowerCase().replace(/[^a-z0-9_-]/g, '_') || 'server';
   let name = base;
@@ -229,12 +303,14 @@ function getToolMessageContent(event: Extract<SDKMessage, { type: 'tool_call' }>
 } {
   const resultText =
     event.result !== undefined ? stringifyForPreview(event.result) : `[${event.status}]`;
+  const toolName = normalizeCursorToolName(event.name);
+  const input = normalizeCursorToolInput(event);
   const content: ContentBlock[] = [
     {
       type: 'tool_use',
       id: event.call_id,
-      name: event.name,
-      input: event.args ?? {},
+      name: toolName,
+      input,
       status: event.status,
       ...(event.truncated ? { truncated: event.truncated } : {}),
     },
@@ -252,7 +328,7 @@ function getToolMessageContent(event: Extract<SDKMessage, { type: 'tool_call' }>
 
   return {
     content,
-    preview: `${event.name}: ${resultText}`,
+    preview: `${toolName}: ${input.command ? String(input.command) : resultText}`,
   };
 }
 

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -1,16 +1,267 @@
 /**
- * Cursor SDK Handler (experimental skeleton)
+ * Cursor SDK Handler (beta)
  *
- * The provider is type-plumbed behind `execution.cursor_sdk_enabled`, but the
- * runtime adapter is intentionally deferred until a live SDK smoke test verifies
- * headless execution, permission behavior, MCP events, and usage metrics.
+ * Minimal local-runtime adapter for @cursor/sdk. Cursor is exposed as a beta
+ * provider, so this first implementation favors a small, observable happy path:
+ * local cwd = Agor branch worktree, SDK agent id persisted in sdk_session_id,
+ * stream text/thinking/tool events into Agor messages, and cancel the active
+ * Cursor run when Agor stops the executor.
  */
 
-import type { MessageSource, PermissionMode, SessionID, TaskID } from '@agor/core/types';
+import { generateId, shortId } from '@agor/core/db';
+import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
+import type {
+  ContentBlock,
+  MessageID,
+  MessageSource,
+  PermissionMode,
+  SessionID,
+  TaskID,
+} from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { Agent, type McpServerConfig, type Run, type SDKMessage } from '@cursor/sdk';
+import { getDaemonUrl } from '../../config.js';
+import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { ResolvedConfigSlice } from '../../payload-types.js';
+import { getMcpServersForSession } from '../../sdk-handlers/base/mcp-scoping.js';
+import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import type { AgorClient } from '../../services/feathers-client.js';
+import { createStreamingCallbacks } from './base-executor.js';
 
-export async function executeCursorTask(_params: {
+type CursorKeyResolution = {
+  apiKey?: string;
+  source?: string;
+  decryptionFailed?: boolean;
+};
+
+function stringifyForPreview(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function toCursorModel(model: string | undefined): { id: string } {
+  return { id: model?.trim() || 'composer-latest' };
+}
+
+function claimMcpName(rawName: string, claimed: Set<string>): string {
+  const base = rawName.toLowerCase().replace(/[^a-z0-9_-]/g, '_') || 'server';
+  let name = base;
+  let suffix = 2;
+  while (claimed.has(name)) {
+    name = `${base}_${suffix++}`;
+  }
+  claimed.add(name);
+  return name;
+}
+
+async function resolveCursorApiKey(client: AgorClient, taskId: TaskID): Promise<string> {
+  const result = (await client.service('config/resolve-api-key').create({
+    taskId,
+    keyName: 'CURSOR_API_KEY',
+    tool: 'cursor',
+  })) as CursorKeyResolution;
+
+  if (result.decryptionFailed) {
+    throw new Error(
+      'CURSOR_API_KEY could not be decrypted. Re-enter it in Settings → Agent Setup → Cursor SDK.'
+    );
+  }
+
+  const key = result.apiKey || process.env.CURSOR_API_KEY;
+  if (!key) {
+    throw new Error(
+      'No CURSOR_API_KEY configured. Add one in Settings → Agent Setup → Cursor SDK.'
+    );
+  }
+
+  console.log(`[cursor] Using CURSOR_API_KEY from ${result.source ?? 'environment'} level`);
+  return key;
+}
+
+async function buildCursorMcpServers(args: {
+  sessionId: SessionID;
+  mcpToken?: string;
+  repos: ReturnType<typeof createFeathersBackedRepositories>;
+  forUserId?: string;
+}): Promise<Record<string, McpServerConfig> | undefined> {
+  const claimed = new Set<string>();
+  const mcpServers: Record<string, McpServerConfig> = {};
+
+  if (args.mcpToken) {
+    const daemonUrl = await getDaemonUrl();
+    claimed.add('agor');
+    mcpServers.agor = {
+      type: 'http',
+      url: `${daemonUrl}/mcp`,
+      headers: {
+        Authorization: `Bearer ${args.mcpToken}`,
+      },
+    };
+  }
+
+  const serversWithSource = await getMcpServersForSession(args.sessionId, {
+    sessionMCPRepo: args.repos.sessionMCP,
+    mcpServerRepo: args.repos.mcpServers,
+    forUserId: args.forUserId,
+  });
+
+  for (const { server } of serversWithSource) {
+    const name = claimMcpName(server.name, claimed);
+    if (server.transport === 'stdio') {
+      if (!server.command) {
+        console.warn(`[cursor] Skipping MCP stdio server ${server.name}: missing command`);
+        continue;
+      }
+      mcpServers[name] = {
+        type: 'stdio',
+        command: server.command,
+        args: server.args,
+        env: server.env,
+      };
+      continue;
+    }
+
+    if ((server.transport === 'http' || server.transport === 'sse') && server.url) {
+      const headers = await resolveMCPAuthHeaders(server.auth, server.url);
+      mcpServers[name] = {
+        type: server.transport,
+        url: server.url,
+        ...(headers ? { headers } : {}),
+      };
+    }
+  }
+
+  const count = Object.keys(mcpServers).length;
+  console.log(`[cursor] Configured ${count} MCP server(s)`);
+  return count > 0 ? mcpServers : undefined;
+}
+
+async function getNextMessageIndex(client: AgorClient, sessionId: SessionID): Promise<number> {
+  const existingMessages = await client.service('messages').find({
+    query: {
+      session_id: sessionId,
+      $sort: { index: 1 },
+    },
+  });
+  const messages = Array.isArray(existingMessages) ? existingMessages : existingMessages.data;
+  return messages?.length || 0;
+}
+
+async function createUserMessage(args: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  prompt: string;
+  index: number;
+}): Promise<MessageID> {
+  const messageId = generateId() as MessageID;
+  await args.client.service('messages').create({
+    message_id: messageId,
+    session_id: args.sessionId,
+    task_id: args.taskId,
+    type: 'user',
+    role: MessageRole.USER,
+    index: args.index,
+    timestamp: new Date().toISOString(),
+    content_preview: args.prompt.substring(0, 200),
+    content: args.prompt,
+  });
+  return messageId;
+}
+
+async function createAssistantMessage(args: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  messageId: MessageID;
+  index: number;
+  content: string | ContentBlock[];
+  preview: string;
+  model?: string;
+}): Promise<void> {
+  await args.client.service('messages').create({
+    message_id: args.messageId,
+    session_id: args.sessionId,
+    task_id: args.taskId,
+    type: 'assistant',
+    role: MessageRole.ASSISTANT,
+    index: args.index,
+    timestamp: new Date().toISOString(),
+    content_preview: args.preview.substring(0, 200),
+    content: args.content,
+    metadata: args.model ? { model: args.model } : undefined,
+  });
+}
+
+async function createToolMessage(args: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  index: number;
+  event: Extract<SDKMessage, { type: 'tool_call' }>;
+  model?: string;
+}): Promise<MessageID> {
+  const messageId = generateId() as MessageID;
+  const resultText =
+    args.event.result !== undefined
+      ? stringifyForPreview(args.event.result)
+      : `[${args.event.status}]`;
+  const content: ContentBlock[] = [
+    {
+      type: 'tool_use',
+      id: args.event.call_id,
+      name: args.event.name,
+      input: args.event.args ?? {},
+    },
+    {
+      type: 'tool_result',
+      tool_use_id: args.event.call_id,
+      content: resultText,
+      is_error: args.event.status === 'error',
+    },
+  ];
+
+  await createAssistantMessage({
+    client: args.client,
+    sessionId: args.sessionId,
+    taskId: args.taskId,
+    messageId,
+    index: args.index,
+    content,
+    preview: `${args.event.name}: ${resultText}`,
+    model: args.model,
+  });
+  return messageId;
+}
+
+async function createSystemErrorMessage(args: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  message: string;
+}): Promise<void> {
+  const index = await getNextMessageIndex(args.client, args.sessionId);
+  await args.client.service('messages').create({
+    message_id: generateId() as MessageID,
+    session_id: args.sessionId,
+    task_id: args.taskId,
+    type: 'system',
+    role: MessageRole.SYSTEM,
+    index,
+    timestamp: new Date().toISOString(),
+    content: args.message,
+    content_preview: args.message.substring(0, 200),
+  });
+}
+
+/**
+ * Execute Cursor task (Feathers/WebSocket architecture).
+ */
+export async function executeCursorTask(params: {
   client: AgorClient;
   sessionId: SessionID;
   taskId: TaskID;
@@ -20,7 +271,253 @@ export async function executeCursorTask(_params: {
   messageSource?: MessageSource;
   resolvedConfig?: ResolvedConfigSlice;
 }): Promise<void> {
-  throw new Error(
-    'Cursor SDK execution is not implemented yet. Enable only after the experimental runtime adapter lands.'
-  );
+  const { client, sessionId, taskId, prompt } = params;
+
+  console.log(`[cursor] Executing task ${shortId(taskId)}...`);
+
+  let currentRun: Run | undefined;
+  const abortHandler = () => {
+    if (!currentRun) return;
+    console.log(`[cursor] Abort signal received; cancelling Cursor run ${currentRun.id}`);
+    currentRun.cancel().catch((error) => {
+      console.warn('[cursor] Failed to cancel Cursor run:', error);
+    });
+  };
+  params.abortController.signal.addEventListener('abort', abortHandler);
+
+  try {
+    const apiKey = await resolveCursorApiKey(client, taskId);
+    const session = await client.service('sessions').get(sessionId);
+    const repos = createFeathersBackedRepositories(client);
+    const callbacks = createStreamingCallbacks(client, 'cursor', sessionId);
+
+    if (!session.branch_id) {
+      throw new Error('Cursor sessions require a branch_id so the local runtime has a cwd.');
+    }
+    const branch = await client.service('branches').get(session.branch_id);
+    if (!branch.path) {
+      throw new Error('Cursor sessions require a branch worktree path.');
+    }
+
+    const model = toCursorModel(session.model_config?.model);
+    const mcpServers = await buildCursorMcpServers({
+      sessionId,
+      mcpToken: session.mcp_token,
+      repos,
+      forUserId: session.created_by,
+    });
+
+    const agent = session.sdk_session_id
+      ? await Agent.resume(session.sdk_session_id, {
+          apiKey,
+          model,
+          local: { cwd: branch.path },
+          mcpServers,
+        })
+      : await Agent.create({
+          apiKey,
+          model,
+          name: session.title || `Agor ${shortId(sessionId)}`,
+          local: { cwd: branch.path },
+          mcpServers,
+        });
+
+    try {
+      if (!session.sdk_session_id || session.sdk_session_id !== agent.agentId) {
+        await client.service('sessions').patch(sessionId, { sdk_session_id: agent.agentId });
+      }
+
+      const userIndex = await getNextMessageIndex(client, sessionId);
+      await createUserMessage({ client, sessionId, taskId, prompt, index: userIndex });
+
+      const assistantMessageId = generateId() as MessageID;
+      let nextIndex = userIndex + 1;
+      let assistantStreamStarted = false;
+      let assistantText = '';
+      let thinkingStarted = false;
+      let thinkingText = '';
+      const toolCallMessageIds: MessageID[] = [];
+      const rawMessages: SDKMessage[] = [];
+
+      currentRun = await agent.send(prompt, {
+        model,
+        mcpServers,
+        idempotencyKey: taskId,
+      });
+
+      if (params.abortController.signal.aborted) {
+        await currentRun.cancel();
+      }
+
+      for await (const event of currentRun.stream()) {
+        rawMessages.push(event);
+        if (params.abortController.signal.aborted) {
+          await currentRun.cancel();
+          break;
+        }
+        await handleCursorEvent({
+          event,
+          client,
+          callbacks,
+          sessionId,
+          taskId,
+          assistantMessageId,
+          model: model.id,
+          getNextIndex: () => nextIndex++,
+          toolCallMessageIds,
+          getAssistantText: () => assistantText,
+          setAssistantText: (value) => {
+            assistantText = value;
+          },
+          getThinkingText: () => thinkingText,
+          setThinkingText: (value) => {
+            thinkingText = value;
+          },
+          isAssistantStreamStarted: () => assistantStreamStarted,
+          setAssistantStreamStarted: (value) => {
+            assistantStreamStarted = value;
+          },
+          isThinkingStarted: () => thinkingStarted,
+          setThinkingStarted: (value) => {
+            thinkingStarted = value;
+          },
+        });
+      }
+
+      if (assistantStreamStarted) {
+        await callbacks.onStreamEnd(assistantMessageId);
+      }
+      if (thinkingStarted && callbacks.onThinkingEnd) {
+        await callbacks.onThinkingEnd(assistantMessageId);
+      }
+
+      const runResult = await currentRun.wait();
+      const finalText = assistantText || runResult.result || '';
+      if (finalText) {
+        await createAssistantMessage({
+          client,
+          sessionId,
+          taskId,
+          messageId: assistantMessageId,
+          index: nextIndex++,
+          content: [{ type: 'text', text: finalText }],
+          preview: finalText,
+          model: runResult.model?.id ?? model.id,
+        });
+      }
+
+      const failed = runResult.status === 'error';
+      const stopped = runResult.status === 'cancelled' || params.abortController.signal.aborted;
+      await client.service('tasks').patch(taskId, {
+        status: stopped ? 'stopped' : failed ? 'failed' : 'completed',
+        completed_at: new Date().toISOString(),
+        model: runResult.model?.id ?? model.id,
+        raw_sdk_response: {
+          run: runResult,
+          messages: rawMessages,
+          agentId: agent.agentId,
+          toolCallMessageIds,
+        },
+      });
+    } finally {
+      agent.close();
+    }
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    console.error('[cursor] Execution failed:', err);
+    await client.service('tasks').patch(taskId, {
+      status: 'failed',
+      completed_at: new Date().toISOString(),
+      error_message: err.message,
+    });
+    await createSystemErrorMessage({ client, sessionId, taskId, message: err.message });
+    throw err;
+  } finally {
+    params.abortController.signal.removeEventListener('abort', abortHandler);
+  }
+}
+
+async function handleCursorEvent(args: {
+  event: SDKMessage;
+  client: AgorClient;
+  callbacks: StreamingCallbacks;
+  sessionId: SessionID;
+  taskId: TaskID;
+  assistantMessageId: MessageID;
+  model: string;
+  getNextIndex: () => number;
+  toolCallMessageIds: MessageID[];
+  getAssistantText: () => string;
+  setAssistantText: (value: string) => void;
+  getThinkingText: () => string;
+  setThinkingText: (value: string) => void;
+  isAssistantStreamStarted: () => boolean;
+  setAssistantStreamStarted: (value: boolean) => void;
+  isThinkingStarted: () => boolean;
+  setThinkingStarted: (value: boolean) => void;
+}): Promise<void> {
+  switch (args.event.type) {
+    case 'assistant': {
+      const nextText = args.event.message.content
+        .filter((block) => block.type === 'text')
+        .map((block) => block.text)
+        .join('');
+      const previousText = args.getAssistantText();
+      const delta = nextText.startsWith(previousText)
+        ? nextText.slice(previousText.length)
+        : nextText;
+      if (!delta) return;
+
+      if (!args.isAssistantStreamStarted()) {
+        await args.callbacks.onStreamStart(args.assistantMessageId, {
+          session_id: args.sessionId,
+          task_id: args.taskId,
+          role: MessageRole.ASSISTANT,
+          timestamp: new Date().toISOString(),
+        });
+        args.setAssistantStreamStarted(true);
+      }
+      await args.callbacks.onStreamChunk(args.assistantMessageId, delta);
+      args.setAssistantText(nextText);
+      return;
+    }
+
+    case 'thinking': {
+      if (!args.callbacks.onThinkingChunk) return;
+      const previousText = args.getThinkingText();
+      const delta = args.event.text.startsWith(previousText)
+        ? args.event.text.slice(previousText.length)
+        : args.event.text;
+      if (!delta) return;
+
+      if (!args.isThinkingStarted() && args.callbacks.onThinkingStart) {
+        await args.callbacks.onThinkingStart(args.assistantMessageId, {});
+        args.setThinkingStarted(true);
+      }
+      await args.callbacks.onThinkingChunk(args.assistantMessageId, delta);
+      args.setThinkingText(args.event.text);
+      return;
+    }
+
+    case 'tool_call': {
+      if (args.event.status === 'running') return;
+      const messageId = await createToolMessage({
+        client: args.client,
+        sessionId: args.sessionId,
+        taskId: args.taskId,
+        index: args.getNextIndex(),
+        event: args.event,
+        model: args.model,
+      });
+      args.toolCallMessageIds.push(messageId);
+      return;
+    }
+
+    case 'status':
+    case 'system':
+    case 'request':
+    case 'task':
+    case 'user':
+      return;
+  }
 }

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -128,7 +128,14 @@ export function buildCursorAssistantContent(args: {
   thinkingText?: string;
 }): ContentBlock[] {
   const content: ContentBlock[] = [];
-  if (args.thinkingText?.trim()) {
+  const normalizedText = args.text.trim().replace(/\s+/g, ' ');
+  const normalizedThinkingText = args.thinkingText?.trim().replace(/\s+/g, ' ');
+
+  // Cursor can emit answer-like content on `thinking` events for simple
+  // prompts. Persist real reasoning when it differs from the final answer, but
+  // avoid showing the same assistant answer twice (once as a thought, once as
+  // normal text).
+  if (args.thinkingText?.trim() && normalizedThinkingText !== normalizedText) {
     content.push({ type: 'thinking', text: args.thinkingText });
   }
   if (args.text) {

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -1,0 +1,26 @@
+/**
+ * Cursor SDK Handler (experimental skeleton)
+ *
+ * The provider is type-plumbed behind `execution.cursor_sdk_enabled`, but the
+ * runtime adapter is intentionally deferred until a live SDK smoke test verifies
+ * headless execution, permission behavior, MCP events, and usage metrics.
+ */
+
+import type { MessageSource, PermissionMode, SessionID, TaskID } from '@agor/core/types';
+import type { ResolvedConfigSlice } from '../../payload-types.js';
+import type { AgorClient } from '../../services/feathers-client.js';
+
+export async function executeCursorTask(_params: {
+  client: AgorClient;
+  sessionId: SessionID;
+  taskId: TaskID;
+  prompt: string;
+  permissionMode?: PermissionMode;
+  abortController: AbortController;
+  messageSource?: MessageSource;
+  resolvedConfig?: ResolvedConfigSlice;
+}): Promise<void> {
+  throw new Error(
+    'Cursor SDK execution is not implemented yet. Enable only after the experimental runtime adapter lands.'
+  );
+}

--- a/packages/executor/src/handlers/sdk/tool-registry.ts
+++ b/packages/executor/src/handlers/sdk/tool-registry.ts
@@ -13,7 +13,7 @@ import type { AgorClient } from '../../services/feathers-client.js';
 /**
  * Tool identifier
  */
-export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot';
+export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor';
 
 /**
  * Tool runner function - executes via Feathers WebSocket
@@ -119,12 +119,13 @@ export class ToolRegistry {
  */
 export async function initializeToolRegistry(): Promise<void> {
   // Import all tool handlers
-  const [claude, codex, gemini, opencode, copilot] = await Promise.all([
+  const [claude, codex, gemini, opencode, copilot, cursor] = await Promise.all([
     import('./claude.js'),
     import('./codex.js'),
     import('./gemini.js'),
     import('./opencode.js'),
     import('./copilot.js'),
+    import('./cursor.js'),
   ]);
 
   // Register Claude Code
@@ -165,5 +166,13 @@ export async function initializeToolRegistry(): Promise<void> {
     name: 'GitHub Copilot',
     apiKeyEnvVar: TOOL_API_KEY_NAMES['copilot']!, // Note: execution also accepts GH_TOKEN / GITHUB_TOKEN aliases
     runner: copilot.executeCopilotTask,
+  });
+
+  // Register Cursor SDK (experimental skeleton; handler intentionally fails until runtime lands)
+  ToolRegistry.register({
+    tool: 'cursor',
+    name: 'Cursor SDK',
+    apiKeyEnvVar: TOOL_API_KEY_NAMES.cursor!,
+    runner: cursor.executeCursorTask,
   });
 }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -25,7 +25,7 @@ export interface ExecutorConfig {
   sessionId: string;
   taskId: string;
   prompt: string;
-  tool: 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot';
+  tool: 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor';
   permissionMode?: PermissionMode;
   daemonUrl: string;
   messageSource?: MessageSource;

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -78,6 +78,7 @@ export const ToolTypeSchema = z.enum([
   'codex',
   'opencode',
   'copilot',
+  'cursor',
 ]);
 export type ToolType = z.infer<typeof ToolTypeSchema>;
 

--- a/packages/executor/src/sdk-handlers/base/types.ts
+++ b/packages/executor/src/sdk-handlers/base/types.ts
@@ -16,7 +16,8 @@ export type ToolType =
   | 'codex'
   | 'gemini'
   | 'opencode'
-  | 'copilot';
+  | 'copilot'
+  | 'cursor';
 
 /**
  * Streaming callback interface for agents that support real-time streaming

--- a/packages/executor/src/sdk-handlers/normalizer-factory.ts
+++ b/packages/executor/src/sdk-handlers/normalizer-factory.ts
@@ -29,7 +29,7 @@ const geminiNormalizer = new GeminiNormalizer();
  * @returns Normalized data with consistent structure, or undefined if normalization fails
  */
 export function normalizeRawSdkResponse(
-  agenticTool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | string,
+  agenticTool: 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'cursor' | string,
   rawSdkResponse: unknown
 ): NormalizedSdkData | undefined {
   if (!rawSdkResponse) {
@@ -61,6 +61,11 @@ export function normalizeRawSdkResponse(
       case 'opencode':
         // OpenCode doesn't have a normalizer yet - return undefined
         console.debug('[Normalizer] OpenCode normalizer not implemented yet');
+        return undefined;
+
+      case 'cursor':
+        // Cursor runtime adapter and event normalizer are not implemented yet.
+        console.debug('[Normalizer] Cursor normalizer not implemented yet');
         return undefined;
 
       default:

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -71,7 +71,7 @@ export async function createExecutorClient(
       resolve();
     });
 
-    client.io.once('connect_error', (error) => {
+    client.io.once('connect_error', (error: Error) => {
       clearTimeout(timeout);
       reject(error);
     });

--- a/packages/executor/src/types.ts
+++ b/packages/executor/src/types.ts
@@ -80,7 +80,7 @@ export interface ExecutePromptParams {
   session_token: string;
   session_id: string;
   task_id: string;
-  agentic_tool: string; // 'claude-code' | 'codex' | 'gemini' | 'opencode'
+  agentic_tool: string; // 'claude-code' | 'codex' | 'gemini' | 'opencode' | 'copilot' | 'cursor'
   prompt: string;
   cwd: string;
   tools: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,7 +482,7 @@ importers:
         version: 0.2.2
       '@google/gemini-cli-core':
         specifier: ^0.31.0
-        version: 0.31.0(@grpc/grpc-js@1.14.4)(express@5.2.1)
+        version: 0.31.0(@grpc/grpc-js@1.14.4)(encoding@0.1.13)(express@5.2.1)
       '@google/genai':
         specifier: ^1.43.0
         version: 1.43.0(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))
@@ -548,7 +548,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+        version: 0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(postgres@3.4.9)(sqlite3@5.1.7)
       express:
         specifier: ^5.2.0
         version: 5.2.1
@@ -690,7 +690,7 @@ importers:
         version: 5.0.44(typescript@5.9.3)
       '@google/gemini-cli-core':
         specifier: ^0.31.0
-        version: 0.31.0(@grpc/grpc-js@1.14.4)(express@5.2.1)
+        version: 0.31.0(@grpc/grpc-js@1.14.4)(encoding@0.1.13)(express@5.2.1)
       '@google/genai':
         specifier: ^1.43.0
         version: 1.43.0(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))
@@ -729,7 +729,7 @@ importers:
         version: 3.14.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+        version: 0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(postgres@3.4.9)(sqlite3@5.1.7)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -791,6 +791,9 @@ importers:
       '@agor/core':
         specifier: workspace:*
         version: link:../core
+      '@cursor/sdk':
+        specifier: ^1.0.13
+        version: 1.0.13
       '@github/copilot-sdk':
         specifier: ^0.2.2
         version: 0.2.2
@@ -1216,6 +1219,9 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
   '@chevrotain/cst-dts-gen@11.0.3':
     resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
 
@@ -1298,6 +1304,18 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
   '@corex/deepmerge@4.0.43':
     resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
 
@@ -1331,6 +1349,35 @@ packages:
 
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@cursor/sdk-darwin-arm64@1.0.13':
+    resolution: {integrity: sha512-zHRTNtVRHw4KSAEFmtO0Av7jv9D60DrB+pygVNWGyKtRR44fcwtRHuLAJmO4HThxQw7MMvUJuAaNmCQxzHtPDQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cursor/sdk-darwin-x64@1.0.13':
+    resolution: {integrity: sha512-7XsIkMKp6h/4W9zBx02Py1euJLAJVxlkwmm9GSoUjc+3hfFvHY/R/WTbX2TFgF4g1vOAq/HM7GmXBXq+e4M4+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cursor/sdk-linux-arm64@1.0.13':
+    resolution: {integrity: sha512-bDgfPPgc84gUn3k+Iiq5OLZozzM0UYZdKbQ821pbZy1OPWTFaSkjXsoAB6xqf9wALWyW1eQxOC4RprPBLoy+yA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cursor/sdk-linux-x64@1.0.13':
+    resolution: {integrity: sha512-BTccnB5hVqK8Y0778oql6gbk7kIIlzQrBqt5QNLJpwBidjjde/mlvAajVB9hB3a29jelOwm0gJjMsLfqTkEPdw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cursor/sdk-win32-x64@1.0.13':
+    resolution: {integrity: sha512-GxWlwj4G513EfGmvPVBa4y+vNn9B5Cj+npu8fVcJ0P+U9sruhgo4pvqGbWxkn5EIKbpGoraLq9QB4nFeoT1uRQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@cursor/sdk@1.0.13':
+    resolution: {integrity: sha512-w6MWkgOTL6yb6GV/4Odx7QcamQgqhzX/CzcMBkqiiOPTPuEWItWrgA0qdivchm5YJXTt+LZkFSEQ/Ti44hVbfg==}
     engines: {node: '>=18'}
 
   '@drizzle-team/brocli@0.10.2':
@@ -1750,6 +1797,9 @@ packages:
 
   '@formatjs/intl-localematcher@0.5.10':
     resolution: {integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==}
+
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@github/copilot-darwin-arm64@1.0.24':
     resolution: {integrity: sha512-lejn6KV+09rZEICX3nRx9a58DQFQ2kK3NJ3EICfVLngUCWIUmwn1BLezjeTQc9YNasHltA1hulvfsWqX+VjlMw==}
@@ -2604,6 +2654,14 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@oclif/core@4.11.3':
     resolution: {integrity: sha512-gQCSYAtUhJilGKaSaZhqejH9X1dDu+jWQjLmtGOgN/XcKaAEPPSeT2mu1UvlvtPox1/NNRdlBcUa8KRKo2HnJQ==}
@@ -3829,6 +3887,12 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
+
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
@@ -4022,6 +4086,10 @@ packages:
 
   '@theguild/remark-npm2yarn@0.3.3':
     resolution: {integrity: sha512-ma6DvR03gdbvwqfKx1omqhg9May/VYGdMHvTzB4VuxkyS7KzfZ/lzrj43hmcsggpMje0x7SADA/pcMph0ejRnA==}
+
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
 
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
@@ -4610,6 +4678,9 @@ packages:
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -4649,6 +4720,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -4713,6 +4792,14 @@ packages:
 
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -4818,6 +4905,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -4892,6 +4982,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
 
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
@@ -4981,6 +5075,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   chromatic@12.2.0:
     resolution: {integrity: sha512-GswmBW9ZptAoTns1BMyjbm55Z7EsIJnUvYKdQqXIBZIKbGErmpA+p4c0BYA+nzw5B0M+rb3Iqp1IaH8TFwIQew==}
     hasBin: true
@@ -5001,6 +5099,10 @@ packages:
 
   clean-set@1.1.2:
     resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   clean-stack@3.0.1:
     resolution: {integrity: sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==}
@@ -5053,6 +5155,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -5116,6 +5222,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
@@ -5452,6 +5561,9 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -5690,6 +5802,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -5712,9 +5827,16 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -5988,6 +6110,9 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -6095,6 +6220,10 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6105,6 +6234,11 @@ packages:
 
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
@@ -6290,6 +6424,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -6394,6 +6531,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -6421,6 +6562,9 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -6452,6 +6596,10 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -6459,6 +6607,9 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -6557,6 +6708,9 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-mobile@5.0.0:
     resolution: {integrity: sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==}
@@ -6956,6 +7110,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lucide-react@0.542.0:
     resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
     peerDependencies:
@@ -6978,6 +7136,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -7310,15 +7472,52 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
 
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -7471,6 +7670,11 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
   node-pty@1.0.0:
     resolution: {integrity: sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==}
 
@@ -7480,6 +7684,11 @@ packages:
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -7496,6 +7705,11 @@ packages:
   npm-to-yarn@3.0.1:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7581,6 +7795,10 @@ packages:
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -7772,8 +7990,20 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -8146,6 +8376,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
@@ -8259,6 +8494,9 @@ packages:
   server-destroy@1.0.1:
     resolution: {integrity: sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==}
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -8337,6 +8575,10 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -8358,6 +8600,14 @@ packages:
   socket.io@4.8.3:
     resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
@@ -8402,6 +8652,13 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sqlite3@5.1.7:
+    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -8603,6 +8860,11 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teeny-request@10.1.2:
     resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
@@ -8828,6 +9090,12 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -9148,6 +9416,9 @@ packages:
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
   widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
@@ -9231,6 +9502,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -9869,6 +10143,8 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bufbuild/protobuf@1.10.0': {}
+
   '@chevrotain/cst-dts-gen@11.0.3':
     dependencies:
       '@chevrotain/gast': 11.0.3
@@ -10046,6 +10322,16 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 7.25.0
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
   '@corex/deepmerge@4.0.43': {}
 
   '@csstools/color-helpers@5.1.0': {}
@@ -10069,6 +10355,39 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.15': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@cursor/sdk-darwin-arm64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.13':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.13':
+    optional: true
+
+  '@cursor/sdk@1.0.13':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      sqlite3: 5.1.7
+      zod: 4.4.3
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.13
+      '@cursor/sdk-darwin-x64': 1.0.13
+      '@cursor/sdk-linux-arm64': 1.0.13
+      '@cursor/sdk-linux-x64': 1.0.13
+      '@cursor/sdk-win32-x64': 1.0.13
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -10408,6 +10727,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@gar/promisify@1.1.3':
+    optional: true
+
   '@github/copilot-darwin-arm64@1.0.24':
     optional: true
 
@@ -10449,24 +10771,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/common@5.0.2':
+  '@google-cloud/common@5.0.2(encoding@0.1.13)':
     dependencies:
       '@google-cloud/projectify': 4.0.0
       '@google-cloud/promisify': 4.0.0
       arrify: 2.0.1
       duplexify: 4.1.3
       extend: 3.0.2
-      google-auth-library: 9.15.1
+      google-auth-library: 9.15.1(encoding@0.1.13)
       html-entities: 2.6.0
-      retry-request: 7.0.2
-      teeny-request: 9.0.0
+      retry-request: 7.0.2(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@google-cloud/logging@11.2.1':
+  '@google-cloud/logging@11.2.1(encoding@0.1.13)':
     dependencies:
-      '@google-cloud/common': 5.0.2
+      '@google-cloud/common': 5.0.2(encoding@0.1.13)
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
       '@google-cloud/promisify': 4.0.0
@@ -10475,9 +10797,9 @@ snapshots:
       dot-prop: 6.0.1
       eventid: 2.0.1
       extend: 3.0.2
-      gcp-metadata: 6.1.1
-      google-auth-library: 9.15.1
-      google-gax: 4.6.1
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-gax: 4.6.1(encoding@0.1.13)
       on-finished: 2.4.1
       pumpify: 2.0.1
       stream-events: 1.0.5
@@ -10486,40 +10808,40 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.5.1(@opentelemetry/api@1.9.0))':
+  '@google-cloud/opentelemetry-cloud-monitoring-exporter@0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       '@google-cloud/precise-date': 4.0.0
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
-      google-auth-library: 9.15.1
-      googleapis: 137.1.0
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      googleapis: 137.1.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))':
+  '@google-cloud/opentelemetry-cloud-trace-exporter@3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
-      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))
+      '@google-cloud/opentelemetry-resource-util': 3.0.0(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       '@grpc/grpc-js': 1.14.0
       '@grpc/proto-loader': 0.8.0
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      google-auth-library: 9.15.1
+      google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))':
+  '@google-cloud/opentelemetry-resource-util@3.0.0(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
-      gcp-metadata: 6.1.1
+      gcp-metadata: 6.1.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10535,12 +10857,12 @@ snapshots:
 
   '@google-cloud/promisify@4.0.0': {}
 
-  '@google/gemini-cli-core@0.31.0(@grpc/grpc-js@1.14.4)(express@5.2.1)':
+  '@google/gemini-cli-core@0.31.0(@grpc/grpc-js@1.14.4)(encoding@0.1.13)(express@5.2.1)':
     dependencies:
       '@a2a-js/sdk': 0.3.10(@grpc/grpc-js@1.14.4)(express@5.2.1)
-      '@google-cloud/logging': 11.2.1
-      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.5.1(@opentelemetry/api@1.9.0))
-      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))
+      '@google-cloud/logging': 11.2.1(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       '@google/genai': 1.43.0(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))
       '@iarna/toml': 2.2.5
       '@joshua.litt/get-ripgrep': 0.0.3
@@ -11515,6 +11837,18 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.8.1
+    optional: true
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    optional: true
 
   '@oclif/core@4.11.3':
     dependencies:
@@ -12888,6 +13222,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
+
   '@stitches/core@1.2.8': {}
 
   '@storybook/addon-a11y@9.1.16(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.14(@types/node@24.10.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.8.3)))':
@@ -13098,6 +13438,9 @@ snapshots:
     dependencies:
       npm-to-yarn: 3.0.1
       unist-util-visit: 5.0.0
+
+  '@tootallnate/once@1.1.2':
+    optional: true
 
   '@tootallnate/once@2.0.1': {}
 
@@ -13810,6 +14153,9 @@ snapshots:
 
   '@xterm/xterm@5.5.0': {}
 
+  abbrev@1.1.1:
+    optional: true
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -13843,6 +14189,17 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+    optional: true
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    optional: true
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -13947,6 +14304,15 @@ snapshots:
 
   append-field@1.0.0: {}
 
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
+
   arg@5.0.2: {}
 
   argparse@1.0.10:
@@ -14034,12 +14400,15 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   body-parser@1.20.4:
     dependencies:
@@ -14108,7 +14477,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -14133,6 +14501,30 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 11.1.0
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
+    optional: true
 
   cacheable-lookup@7.0.0: {}
 
@@ -14245,8 +14637,9 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
 
   chromatic@12.2.0: {}
 
@@ -14255,6 +14648,9 @@ snapshots:
   classcat@5.0.5: {}
 
   clean-set@1.1.2: {}
+
+  clean-stack@2.2.0:
+    optional: true
 
   clean-stack@3.0.1:
     dependencies:
@@ -14312,6 +14708,9 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-support@1.1.3:
+    optional: true
 
   colorette@2.0.20: {}
 
@@ -14375,6 +14774,9 @@ snapshots:
       proto-list: 1.2.4
 
   consola@3.4.2: {}
+
+  console-control-strings@1.1.0:
+    optional: true
 
   constant-case@3.0.4:
     dependencies:
@@ -14691,8 +15093,7 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -14714,6 +15115,9 @@ snapshots:
       robust-predicates: 3.0.2
 
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -14793,11 +15197,12 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.3
 
-  drizzle-orm@0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(postgres@3.4.9):
+  drizzle-orm@0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(postgres@3.4.9)(sqlite3@5.1.7):
     optionalDependencies:
       '@libsql/client': 0.17.3
       '@opentelemetry/api': 1.9.0
       postgres: 3.4.9
+      sqlite3: 5.1.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14849,6 +15254,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -14887,7 +15297,13 @@ snapshots:
 
   entities@6.0.1: {}
 
+  env-paths@2.2.1:
+    optional: true
+
   environment@1.1.0: {}
+
+  err-code@2.0.3:
+    optional: true
 
   error-ex@1.3.4:
     dependencies:
@@ -15124,8 +15540,7 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -15305,6 +15720,8 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-uri-to-path@1.0.0: {}
+
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
@@ -15400,8 +15817,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -15421,6 +15837,10 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fsevents@2.3.3:
     optional: true
 
@@ -15428,12 +15848,24 @@ snapshots:
 
   fzf@0.5.2: {}
 
-  gaxios@6.7.1:
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
+
+  gaxios@6.7.1(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
@@ -15456,9 +15888,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@6.1.1:
+  gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(encoding@0.1.13)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -15522,8 +15954,7 @@ snapshots:
 
   git-hooks-list@3.2.0: {}
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -15565,31 +15996,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1:
+  google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1
-      gcp-metadata: 6.1.1
-      gtoken: 7.1.0
+      gaxios: 6.7.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gtoken: 7.1.0(encoding@0.1.13)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-gax@4.6.1:
+  google-gax@4.6.1(encoding@0.1.13):
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       '@types/long': 4.0.2
       abort-controller: 3.0.0
       duplexify: 4.1.3
-      google-auth-library: 9.15.1
-      node-fetch: 2.7.0
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      node-fetch: 2.7.0(encoding@0.1.13)
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.1
-      retry-request: 7.0.2
+      retry-request: 7.0.2(encoding@0.1.13)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
@@ -15617,11 +16048,11 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0:
+  googleapis-common@7.2.0(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
-      gaxios: 6.7.1
-      google-auth-library: 9.15.1
+      gaxios: 6.7.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)
       qs: 6.15.1
       url-template: 2.0.8
       uuid: 9.0.1
@@ -15629,10 +16060,10 @@ snapshots:
       - encoding
       - supports-color
 
-  googleapis@137.1.0:
+  googleapis@137.1.0(encoding@0.1.13):
     dependencies:
-      google-auth-library: 9.15.1
-      googleapis-common: 7.2.0
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      googleapis-common: 7.2.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15679,9 +16110,9 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  gtoken@7.1.0:
+  gtoken@7.1.0(encoding@0.1.13):
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 6.7.1(encoding@0.1.13)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -15712,6 +16143,9 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+
+  has-unicode@2.0.1:
+    optional: true
 
   hasown@2.0.3:
     dependencies:
@@ -15933,6 +16367,15 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.1
@@ -15971,6 +16414,11 @@ snapshots:
 
   human-signals@8.0.1: {}
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+    optional: true
+
   husky@9.1.7: {}
 
   iconv-lite@0.4.24:
@@ -15998,9 +16446,15 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
+  imurmurhash@0.1.4:
+    optional: true
+
   indent-string@4.0.0: {}
 
   index-to-position@1.2.0: {}
+
+  infer-owner@1.0.4:
+    optional: true
 
   inherits@2.0.4: {}
 
@@ -16084,6 +16538,9 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-lambda@1.0.1:
+    optional: true
 
   is-mobile@5.0.0: {}
 
@@ -16483,6 +16940,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
   lucide-react@0.542.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -16504,6 +16966,29 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.1
+
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
 
   markdown-extensions@2.0.0: {}
 
@@ -17139,12 +17624,53 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.2: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
 
   mj-context-menu@0.6.1: {}
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   mlly@1.8.0:
     dependencies:
@@ -17185,8 +17711,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  napi-build-utils@2.0.0: {}
 
   negotiator@0.6.3: {}
 
@@ -17310,7 +17835,6 @@ snapshots:
   node-abi@3.85.0:
     dependencies:
       semver: 7.8.1
-    optional: true
 
   node-addon-api@4.3.0:
     optional: true
@@ -17321,9 +17845,11 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-fetch@3.3.2:
     dependencies:
@@ -17332,6 +17858,23 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-gyp-build@4.8.4: {}
+
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 11.1.0
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.8.1
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
 
   node-pty@1.0.0:
     dependencies:
@@ -17343,6 +17886,11 @@ snapshots:
       node-addon-api: 7.1.1
 
   node-releases@2.0.46: {}
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
 
   normalize-package-data@6.0.2:
     dependencies:
@@ -17357,6 +17905,14 @@ snapshots:
       path-key: 4.0.0
 
   npm-to-yarn@3.0.1: {}
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -17486,6 +18042,11 @@ snapshots:
   p-limit@6.2.0:
     dependencies:
       yocto-queue: 1.2.1
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+    optional: true
 
   p-queue@6.6.2:
     dependencies:
@@ -17664,7 +18225,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
-    optional: true
 
   prettier@3.8.3: {}
 
@@ -17680,7 +18240,16 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  promise-inflight@1.0.1:
+    optional: true
+
   promise-limit@2.7.0: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+    optional: true
 
   prompts@2.4.2:
     dependencies:
@@ -17793,7 +18362,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   react-devtools-inline@4.4.0:
     dependencies:
@@ -18197,11 +18765,11 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  retry-request@7.0.2:
+  retry-request@7.0.2(encoding@0.1.13):
     dependencies:
       '@types/request': 2.48.13
       extend: 3.0.2
-      teeny-request: 9.0.0
+      teeny-request: 9.0.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18220,6 +18788,11 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 11.1.0
+    optional: true
 
   rimraf@5.0.10:
     dependencies:
@@ -18428,6 +19001,9 @@ snapshots:
 
   server-destroy@1.0.1: {}
 
+  set-blocking@2.0.0:
+    optional: true
+
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
@@ -18528,15 +19104,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   simple-git@3.36.0:
     dependencies:
@@ -18568,6 +19142,9 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smart-buffer@4.2.0:
+    optional: true
 
   smol-toml@1.6.1: {}
 
@@ -18617,6 +19194,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+    optional: true
+
   sort-object-keys@1.1.3: {}
 
   sort-package-json@2.15.1:
@@ -18664,6 +19256,23 @@ snapshots:
       wicked-good-xpath: 1.3.0
 
   sprintf-js@1.0.3: {}
+
+  sqlite3@5.1.7:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+      tar: 6.2.1
+    optionalDependencies:
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -18802,8 +19411,7 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -18872,7 +19480,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.3
       tar-stream: 2.2.0
-    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -18881,7 +19488,15 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   teeny-request@10.1.2:
     dependencies:
@@ -18892,11 +19507,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  teeny-request@9.0.0:
+  teeny-request@9.0.0(encoding@0.1.13):
     dependencies:
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -19100,6 +19715,16 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+    optional: true
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
 
   unist-util-find-after@5.0.0:
     dependencies:
@@ -19370,6 +19995,11 @@ snapshots:
 
   wicked-good-xpath@1.3.0: {}
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
   widest-line@3.1.0:
     dependencies:
       string-width: 4.2.3
@@ -19428,6 +20058,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.132
         version: 0.2.132(zod@4.4.3)
+      '@cursor/sdk':
+        specifier: ^1.0.13
+        version: 1.0.13
       '@feathersjs/authentication':
         specifier: ^5.0.44
         version: 5.0.44(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@agor/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@cursor/sdk':
+        specifier: ^1.0.13
+        version: 1.0.13
       '@github/copilot-sdk':
         specifier: ^0.2.2
         version: 0.2.2


### PR DESCRIPTION
## Summary
- Documents Cursor SDK support tradeoffs and comparison row in `docs/internal/cursor-sdk-support-analysis-2026-05-25.md`
- Adds Cursor as a beta agentic provider across core types, config/env credential plumbing, settings/auth/model-list UI, MCP schemas, and executor registry
- Adds `@cursor/sdk` to the executor and wires an initial local-runtime adapter: `Agent.create/resume`, `agent.send`, `run.stream`, `run.wait`, `run.cancel`, `sdk_session_id` persistence, basic assistant/thinking/tool event mapping, inline MCP server injection, and Cursor auth checks
- Fixes the first smoke-test issues by reusing the daemon pre-written prompt row and accumulating Cursor assistant stream chunks correctly when events arrive as deltas
- Adds `/cursor-models`, backed by `Cursor.models.list({ apiKey })`, so the model picker can show the authenticated Cursor account's live model list with `composer-latest` fallback
- Improves Cursor auth/tool handling by validating keys with `Cursor.me()` and creating/updating tool blocks for running/completed/error tool_call events
- Normalizes Cursor tool names/inputs into Agor's existing renderers, e.g. shell/terminal tool calls become `Bash` blocks with `input.command`, and file tools expose `file_path` when possible
- Addresses code-review findings: Cursor permission UI now only presents the effective autonomous mode, Cursor SDK auth/model-list calls have bounded timeouts, model picker honors the server-provided Cursor default, thinking blocks are persisted, assistant message index is reserved before tool blocks when streaming starts, and Cursor task completion now reuses shared git SHA capture
- Suppresses Cursor thinking blocks that duplicate the final assistant answer, preventing simple responses from rendering as both a thought and normal text
- Syncs `@cursor/sdk` into `packages/agor-live/package.json` and the lockfile so CI/package build dependency alignment passes

## Scope / caveats
- Cursor remains beta and should be live-smoke-tested more deeply with a real `CURSOR_API_KEY` before treating it as stable.
- Runtime is local-worktree only (`local.cwd = branch.path`); Cursor cloud runtime is intentionally out of scope.
- Permission requests are not normalized yet because the public SDK surface does not expose an Agor-equivalent blocking permission API; Cursor currently behaves as autonomous within Agor's outer branch/Unix sandbox.
- Token/cost/context metrics are not normalized yet because the public SDK surface does not expose usage payloads.

## Checks
- `pnpm i` (completed; `node-pty` native rebuild warned about missing `make`, install exited 0)
- `pnpm check` (passed; existing Biome warnings only)
- `pnpm --filter @agor/executor test` (24 files / 374 tests)
- `pnpm --filter @agor/daemon test -- src/services/cursor-models.test.ts` (1 file / 2 tests)
- `pnpm --filter @agor/core test -- src/config/key-resolver.test.ts src/config/env-resolver.test.ts src/types/session.test.ts` (3 files / 36 tests)
- Focused typechecks: `@agor/executor`, `@agor/daemon`, `agor-ui`
- Focused Cursor handler regression: duplicate answer-like thinking suppression
- `pnpm check:agor-live-deps` and `cd packages/agor-live && ./build.sh --skip-install`


