### PR TITLE
fix(ui): route to the new session via URL after create

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -510,9 +510,19 @@ export const App: React.FC<AppProps> = ({
     const sessionId = await onCreateSession?.(config, currentBoardId);
     setNewSessionBranchId(null);
 
-    // If session was created successfully, open the drawer to show it
+    // Route through the URL so useUrlState owns the resulting selection.
+    // Setting selectedSessionId directly raced with two effects that
+    // could revert it before the drawer ever opened:
+    //   1. `effectiveSelectedSessionId` filters via sessionById.has(...),
+    //      which is false until the socket `created` event arrives.
+    //   2. The cleanup effect below clears selectedSessionId for the
+    //      same reason, then the state→URL self-heal rewrites the URL
+    //      back to /b/<board>/.
+    // goToSession pushes the URL immediately; once the session lands in
+    // sessionById, useUrlState's URL→state effect resolves it and sets
+    // selection, which is the durable path.
     if (sessionId) {
-      setSelectedSessionId(sessionId);
+      navigation.goToSession(sessionId);
     }
   };
 

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -510,17 +510,9 @@ export const App: React.FC<AppProps> = ({
     const sessionId = await onCreateSession?.(config, currentBoardId);
     setNewSessionBranchId(null);
 
-    // Route through the URL so useUrlState owns the resulting selection.
-    // Setting selectedSessionId directly raced with two effects that
-    // could revert it before the drawer ever opened:
-    //   1. `effectiveSelectedSessionId` filters via sessionById.has(...),
-    //      which is false until the socket `created` event arrives.
-    //   2. The cleanup effect below clears selectedSessionId for the
-    //      same reason, then the state→URL self-heal rewrites the URL
-    //      back to /b/<board>/.
-    // goToSession pushes the URL immediately; once the session lands in
-    // sessionById, useUrlState's URL→state effect resolves it and sets
-    // selection, which is the durable path.
+    // Route through the URL so useUrlState owns selection — setting
+    // selectedSessionId directly raced with the cleanup effect (and the
+    // state→URL self-heal) before the socket `created` event arrived.
     if (sessionId) {
       navigation.goToSession(sessionId);
     }
@@ -808,7 +800,7 @@ export const App: React.FC<AppProps> = ({
               onEventStreamClick={() => {
                 // If session is open, close it and show event stream
                 if (effectiveSelectedSessionId) {
-                  setSelectedSessionId(null);
+                  if (currentBoardId) navigation.goToBoard(currentBoardId);
                   setEventStreamPanelCollapsed(false);
                 } else {
                   // Toggle event stream panel

--- a/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
+++ b/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Regression test for `goToSession` — fixates that the helper pushes the
+ * `/s/<short>/` URL even when the target session is not (yet) in the
+ * local `sessionById` map.
+ *
+ * Background: NewSessionModal's success handler routes through
+ * `navigation.goToSession(newId)` immediately after `client.service('sessions').create()`
+ * resolves. The socket-driven `sessionById` update may arrive a tick later,
+ * so a strict `if (!session) return` guard inside `goToSession` would
+ * silently strand the user on the prior URL — the very regression this
+ * fix addresses. The lookup is now scoped to the same-URL recenter
+ * fallback (where it actually matters) instead of gating the navigation.
+ */
+
+import type { Branch, Session } from '@agor-live/client';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { CanvasNavigationProvider } from '../contexts/CanvasNavigationContext';
+import { useAppNavigation } from './useAppNavigation';
+
+// A real UUIDv7. `shortId` strips hyphens and keeps the first
+// SHORT_ID_LENGTH (24) hex chars, so the URL short form is the first
+// 6 groups of hex digits concatenated.
+const NEW_SESSION_ID = '019e9999-0000-7000-8000-000000000001';
+const NEW_SESSION_SHORT = '019e99990000700080000000';
+const EXISTING_BRANCH_ID = '019e8888-0000-7000-8000-000000000001';
+const EXISTING_BOARD_ID = '019e7777-0000-7000-8000-000000000001';
+
+function wrap(initialEntry = '/') {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <CanvasNavigationProvider>{children}</CanvasNavigationProvider>
+    </MemoryRouter>
+  );
+}
+
+/** Pull the current pathname out of MemoryRouter so we can assert on the
+ *  side-effect of `goToSession` without coupling to the navigate mock. */
+function useTestNav(opts: Parameters<typeof useAppNavigation>[0]) {
+  const nav = useAppNavigation(opts);
+  const location = useLocation();
+  return { nav, pathname: location.pathname };
+}
+
+describe('useAppNavigation.goToSession', () => {
+  it('pushes /s/<short>/ even when the session is NOT yet in sessionById (just-created race)', () => {
+    // Empty maps simulate the moment between the create() promise
+    // resolving and the socket `sessions.created` event populating
+    // sessionById.
+    const sessionById = new Map<string, Session>();
+    const branchById = new Map<string, Branch>();
+
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById: new Map(),
+          sessionById,
+          branchById,
+          artifactById: new Map(),
+        }),
+      { wrapper: wrap('/b/somewhere/') }
+    );
+
+    expect(result.current.pathname).toBe('/b/somewhere/');
+
+    act(() => {
+      result.current.nav.goToSession(NEW_SESSION_ID);
+    });
+
+    // Must have navigated despite the session being absent from the map.
+    expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
+  });
+
+  it('still navigates when the session IS in sessionById (known-session click)', () => {
+    const session = {
+      session_id: NEW_SESSION_ID,
+      branch_id: EXISTING_BRANCH_ID,
+    } as Session;
+    const branch = {
+      branch_id: EXISTING_BRANCH_ID,
+      board_id: EXISTING_BOARD_ID,
+    } as Branch;
+
+    const sessionById = new Map([[session.session_id, session]]);
+    const branchById = new Map([[branch.branch_id, branch]]);
+
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById: new Map(),
+          sessionById,
+          branchById,
+          artifactById: new Map(),
+        }),
+      { wrapper: wrap('/b/somewhere/') }
+    );
+
+    act(() => {
+      result.current.nav.goToSession(NEW_SESSION_ID);
+    });
+
+    expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
+  });
+
+  it('does not blow up on same-URL re-click when session is unknown', () => {
+    // Already on the target session URL but sessionById is empty (deep-link
+    // load where data hasn't streamed in yet). The same-URL fallback used
+    // to dereference `session.branch_id` — assert it's safe with a missing
+    // session.
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById: new Map(),
+          sessionById: new Map(),
+          branchById: new Map(),
+          artifactById: new Map(),
+        }),
+      { wrapper: wrap(`/s/${NEW_SESSION_SHORT}/`) }
+    );
+
+    expect(() => {
+      act(() => {
+        result.current.nav.goToSession(NEW_SESSION_ID);
+      });
+    }).not.toThrow();
+
+    // No navigation should have happened — already on this URL.
+    expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
+  });
+});
+
+// Quiet the unused-import lint when vi.mock isn't needed; vitest globals.
+void vi;

--- a/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
+++ b/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
@@ -16,7 +16,7 @@ import type { Branch, Session } from '@agor-live/client';
 import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { CanvasNavigationProvider } from '../contexts/CanvasNavigationContext';
 import { useAppNavigation } from './useAppNavigation';
 
@@ -130,6 +130,3 @@ describe('useAppNavigation.goToSession', () => {
     expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
   });
 });
-
-// Quiet the unused-import lint when vi.mock isn't needed; vitest globals.
-void vi;

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -44,7 +44,10 @@ interface UseAppNavigationOptions {
    *  Each map is optional: callers only pass what their methods need
    *  (e.g. a Settings table that only uses `goToBranch` can omit
    *  `sessionById` and `artifactById`). The unused maps fall back to
-   *  empty Maps; the corresponding goToX no-ops on lookup miss. */
+   *  empty Maps. URL pushes work from the ID alone — the lookups are
+   *  only needed for the same-URL recenter fallback (re-click on the
+   *  entity that's already focused), which silently no-ops when the
+   *  map is empty. */
   sessionById?: Map<string, Session>;
   branchById?: Map<string, Branch>;
   artifactById?: Map<string, Artifact>;
@@ -151,14 +154,19 @@ export function useAppNavigation({
 
   const goToBranch = useCallback(
     (branchId: string, opts?: NavigationOpts) => {
-      const branch = branchByIdRef.current.get(branchId);
-      if (!branch?.board_id) return;
-      // Push first; let useUrlState's URL→state effect fire the
-      // recenter. Only fall back to a direct recenter when the URL
-      // didn't actually change (no history transition, so the effect
-      // won't re-run) — avoids the prior double-recenter animation.
+      // Push unconditionally — same rationale as goToSession: the URL
+      // can be built from the ID alone, and bailing on a missing local
+      // entity would silently strand future "create branch then
+      // navigate immediately" flows on the prior URL. useUrlState's
+      // URL→state effect resolves the branch when it lands in the map.
       if (!pushPath(branchPath(branchId as BranchID), opts)) {
-        recenterMap(branchId, { boardId: branch.board_id });
+        // Same-URL fallback: no history transition, so the URL→state
+        // recenter effect won't run — recenter directly when we know
+        // the board.
+        const branch = branchByIdRef.current.get(branchId);
+        if (branch?.board_id) {
+          recenterMap(branchId, { boardId: branch.board_id });
+        }
       }
     },
     [pushPath, recenterMap]
@@ -166,13 +174,14 @@ export function useAppNavigation({
 
   const goToArtifact = useCallback(
     (artifactId: string, opts?: NavigationOpts) => {
-      const artifact = artifactByIdRef.current.get(artifactId);
-      if (!artifact?.board_id) return;
-      // Parallel to goToBranch. The canvas's recenter impl handles
-      // the artifact-id-vs-board-object-id mismatch via a
-      // data.artifactId fallback scan, so callers stay logical-id-only.
+      // Parallel to goToBranch / goToSession. The canvas's recenter
+      // impl handles the artifact-id-vs-board-object-id mismatch via
+      // a data.artifactId fallback scan, so callers stay logical-id-only.
       if (!pushPath(artifactPath(artifactId as ArtifactID), opts)) {
-        recenterMap(artifactId, { boardId: artifact.board_id });
+        const artifact = artifactByIdRef.current.get(artifactId);
+        if (artifact?.board_id) {
+          recenterMap(artifactId, { boardId: artifact.board_id });
+        }
       }
     },
     [pushPath, recenterMap]

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -98,8 +98,9 @@ export function useAppNavigation({
   // created from `useRef(...)` directly) doesn't falsely flag the
   // useCallback deps below.
   //
-  // Missing optional maps fall back to a shared empty map — the goToX
-  // method just no-ops on lookup miss, same as if the id wasn't found.
+  // Missing optional maps fall back to a shared empty map. URL pushes
+  // work from the ID alone; the lookups are only consulted for the
+  // same-URL recenter fallback, which silently no-ops on miss.
   const sessionByIdRef = useRef(sessionById ?? (EMPTY_MAP as Map<string, Session>));
   sessionByIdRef.current = sessionById ?? (EMPTY_MAP as Map<string, Session>);
   const branchByIdRef = useRef(branchById ?? (EMPTY_MAP as Map<string, Branch>));

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -128,13 +128,19 @@ export function useAppNavigation({
 
   const goToSession = useCallback(
     (sessionId: string, opts?: NavigationOpts) => {
-      const session = sessionByIdRef.current.get(sessionId);
-      if (!session) return;
-      // pushPath returns false when the target equals current path — no
-      // history transition fires, so the URL→state recenter effect
-      // won't run. Fall back to a direct recenter via the branch.
+      // Push unconditionally: a just-created session may not be in
+      // `sessionById` yet (socket `created` event still in flight), and
+      // bailing here on lookup miss would silently strand the caller on
+      // the prior URL. useUrlState's URL→state effect re-runs when the
+      // session arrives in the map and drives selection from there.
       if (!pushPath(sessionPath(sessionId as SessionID), opts)) {
-        const branch = branchByIdRef.current.get(session.branch_id);
+        // Same-URL click on the already-open session — no history
+        // transition, so the URL→state recenter effect won't run. Fall
+        // back to a direct recenter via the branch when we have it.
+        const session = sessionByIdRef.current.get(sessionId);
+        const branch = session?.branch_id
+          ? branchByIdRef.current.get(session.branch_id)
+          : undefined;
         if (branch?.board_id) {
           recenterMap(branch.branch_id, { boardId: branch.board_id });
         }

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -20,7 +20,7 @@
 
 import type { Branch, Session } from '@agor-live/client';
 import { act, render } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { CanvasNavigationProvider } from '../contexts/CanvasNavigationContext';
 import { type UseUrlStateOptions, useUrlState } from './useUrlState';
@@ -30,8 +30,17 @@ const SESSION_SHORT = '019e99990000700080000000';
 const BRANCH_ID = '019e8888-0000-7000-8000-000000000001';
 const BOARD_ID = '019e7777-0000-7000-8000-000000000001';
 
-function HookHost({ options }: { options: UseUrlStateOptions }) {
+/** Read the live pathname out of MemoryRouter into a shared ref so
+ *  tests can assert that the state→URL self-heal did NOT fire. */
+function HookHost({
+  options,
+  pathRef,
+}: {
+  options: UseUrlStateOptions;
+  pathRef: { current: string };
+}) {
   useUrlState(options);
+  pathRef.current = useLocation().pathname;
   return null;
 }
 
@@ -39,18 +48,23 @@ function HookHost({ options }: { options: UseUrlStateOptions }) {
  *  inside `useUrlState` sees `sessionShortId`. Mirrors the routing
  *  shape declared in `apps/agor-ui/src/App.tsx`. */
 function renderAt(pathname: string, options: UseUrlStateOptions) {
-  const ui = (
+  const pathRef = { current: pathname };
+  const tree = (opts: UseUrlStateOptions) => (
     <MemoryRouter initialEntries={[pathname]}>
       <CanvasNavigationProvider>
         <Routes>
-          <Route path="/s/:sessionShortId/" element={<HookHost options={options} />} />
-          <Route path="/b/:boardParam/" element={<HookHost options={options} />} />
-          <Route path="/*" element={<HookHost options={options} />} />
+          <Route
+            path="/s/:sessionShortId/"
+            element={<HookHost options={opts} pathRef={pathRef} />}
+          />
+          <Route path="/b/:boardParam/" element={<HookHost options={opts} pathRef={pathRef} />} />
+          <Route path="/*" element={<HookHost options={opts} pathRef={pathRef} />} />
         </Routes>
       </CanvasNavigationProvider>
     </MemoryRouter>
   );
-  return render(ui);
+  const { rerender } = render(tree(options));
+  return { pathRef, rerender: (next: UseUrlStateOptions) => rerender(tree(next)) };
 }
 
 function baseOptions(overrides: Partial<UseUrlStateOptions> = {}): UseUrlStateOptions {
@@ -68,13 +82,13 @@ function baseOptions(overrides: Partial<UseUrlStateOptions> = {}): UseUrlStateOp
 }
 
 describe('useUrlState — deferred session resolution', () => {
-  it('does not fire onSessionChange while the session is missing from sessionById', () => {
+  it('does not fire onSessionChange OR rewrite the URL while the session is missing', () => {
     const onSessionChange = vi.fn();
     const onBoardChange = vi.fn();
 
     // URL points at /s/<short>/, but sessionById is empty (simulates the
     // window between create() resolving and the socket `created` event).
-    renderAt(
+    const { pathRef } = renderAt(
       `/s/${SESSION_SHORT}/`,
       baseOptions({
         sessionById: new Map(),
@@ -86,9 +100,12 @@ describe('useUrlState — deferred session resolution', () => {
 
     expect(onSessionChange).not.toHaveBeenCalled();
     expect(onBoardChange).not.toHaveBeenCalled();
+    // State→URL self-heal must NOT erase the unresolved session segment
+    // back to /b/<board>/ — that was the original regression.
+    expect(pathRef.current).toBe(`/s/${SESSION_SHORT}/`);
   });
 
-  it('fires onSessionChange once the session arrives in sessionById', () => {
+  it('fires onSessionChange and preserves the URL once the session arrives in sessionById', () => {
     const onSessionChange = vi.fn();
     const onBoardChange = vi.fn();
 
@@ -99,7 +116,7 @@ describe('useUrlState — deferred session resolution', () => {
       onBoardChange,
     });
 
-    const { rerender } = renderAt(`/s/${SESSION_SHORT}/`, initial);
+    const { pathRef, rerender } = renderAt(`/s/${SESSION_SHORT}/`, initial);
     expect(onSessionChange).not.toHaveBeenCalled();
 
     // Socket `created` event lands: session + branch flow into the hook.
@@ -113,19 +130,10 @@ describe('useUrlState — deferred session resolution', () => {
     });
 
     act(() => {
-      rerender(
-        <MemoryRouter initialEntries={[`/s/${SESSION_SHORT}/`]}>
-          <CanvasNavigationProvider>
-            <Routes>
-              <Route path="/s/:sessionShortId/" element={<HookHost options={resolved} />} />
-              <Route path="/b/:boardParam/" element={<HookHost options={resolved} />} />
-              <Route path="/*" element={<HookHost options={resolved} />} />
-            </Routes>
-          </CanvasNavigationProvider>
-        </MemoryRouter>
-      );
+      rerender(resolved);
     });
 
     expect(onSessionChange).toHaveBeenCalledWith(SESSION_ID);
+    expect(pathRef.current).toBe(`/s/${SESSION_SHORT}/`);
   });
 });

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Integration tests for `useUrlState` covering the deferred-resolution
+ * contract that the create-session fix depends on.
+ *
+ * When the URL is `/s/<short>/` but the target session hasn't landed in
+ * `sessionById` yet (typical of "navigate to a just-created session
+ * before the socket `created` event arrives"), the hook must:
+ *
+ *   1. NOT call `onSessionChange` (nothing to resolve to).
+ *   2. NOT rewrite the URL via the state→URL self-heal (would otherwise
+ *      drop the unresolved session segment and revert to `/b/<board>/`).
+ *
+ * Once the session arrives in the map on a subsequent render, the hook
+ * must resolve the URL and fire `onSessionChange(<full id>)`.
+ *
+ * This is the load-bearing complement to `useAppNavigation.goToSession`
+ * pushing the URL unconditionally — together they make the "create
+ * session → navigate immediately" path safe.
+ */
+
+import type { Branch, Session } from '@agor-live/client';
+import { act, render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { CanvasNavigationProvider } from '../contexts/CanvasNavigationContext';
+import { type UseUrlStateOptions, useUrlState } from './useUrlState';
+
+const SESSION_ID = '019e9999-0000-7000-8000-000000000001';
+const SESSION_SHORT = '019e99990000700080000000';
+const BRANCH_ID = '019e8888-0000-7000-8000-000000000001';
+const BOARD_ID = '019e7777-0000-7000-8000-000000000001';
+
+function HookHost({ options }: { options: UseUrlStateOptions }) {
+  useUrlState(options);
+  return null;
+}
+
+/** Mount HookHost inside the session-deep-link route so `useParams`
+ *  inside `useUrlState` sees `sessionShortId`. Mirrors the routing
+ *  shape declared in `apps/agor-ui/src/App.tsx`. */
+function renderAt(pathname: string, options: UseUrlStateOptions) {
+  const ui = (
+    <MemoryRouter initialEntries={[pathname]}>
+      <CanvasNavigationProvider>
+        <Routes>
+          <Route path="/s/:sessionShortId/" element={<HookHost options={options} />} />
+          <Route path="/b/:boardParam/" element={<HookHost options={options} />} />
+          <Route path="/*" element={<HookHost options={options} />} />
+        </Routes>
+      </CanvasNavigationProvider>
+    </MemoryRouter>
+  );
+  return render(ui);
+}
+
+function baseOptions(overrides: Partial<UseUrlStateOptions> = {}): UseUrlStateOptions {
+  return {
+    currentBoardId: BOARD_ID,
+    currentSessionId: null,
+    boardById: new Map([[BOARD_ID, { board_id: BOARD_ID, slug: 'board' }]]),
+    sessionById: new Map(),
+    branchById: new Map(),
+    artifactById: new Map(),
+    onBoardChange: vi.fn(),
+    onSessionChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useUrlState — deferred session resolution', () => {
+  it('does not fire onSessionChange while the session is missing from sessionById', () => {
+    const onSessionChange = vi.fn();
+    const onBoardChange = vi.fn();
+
+    // URL points at /s/<short>/, but sessionById is empty (simulates the
+    // window between create() resolving and the socket `created` event).
+    renderAt(
+      `/s/${SESSION_SHORT}/`,
+      baseOptions({
+        sessionById: new Map(),
+        branchById: new Map(),
+        onSessionChange,
+        onBoardChange,
+      })
+    );
+
+    expect(onSessionChange).not.toHaveBeenCalled();
+    expect(onBoardChange).not.toHaveBeenCalled();
+  });
+
+  it('fires onSessionChange once the session arrives in sessionById', () => {
+    const onSessionChange = vi.fn();
+    const onBoardChange = vi.fn();
+
+    const initial = baseOptions({
+      sessionById: new Map(),
+      branchById: new Map(),
+      onSessionChange,
+      onBoardChange,
+    });
+
+    const { rerender } = renderAt(`/s/${SESSION_SHORT}/`, initial);
+    expect(onSessionChange).not.toHaveBeenCalled();
+
+    // Socket `created` event lands: session + branch flow into the hook.
+    const session = { session_id: SESSION_ID, branch_id: BRANCH_ID } as Session;
+    const branch = { branch_id: BRANCH_ID, board_id: BOARD_ID } as Branch;
+    const resolved = baseOptions({
+      sessionById: new Map([[session.session_id, session]]),
+      branchById: new Map([[branch.branch_id, branch]]),
+      onSessionChange,
+      onBoardChange,
+    });
+
+    act(() => {
+      rerender(
+        <MemoryRouter initialEntries={[`/s/${SESSION_SHORT}/`]}>
+          <CanvasNavigationProvider>
+            <Routes>
+              <Route path="/s/:sessionShortId/" element={<HookHost options={resolved} />} />
+              <Route path="/b/:boardParam/" element={<HookHost options={resolved} />} />
+              <Route path="/*" element={<HookHost options={resolved} />} />
+            </Routes>
+          </CanvasNavigationProvider>
+        </MemoryRouter>
+      );
+    });
+
+    expect(onSessionChange).toHaveBeenCalledWith(SESSION_ID);
+  });
+});


### PR DESCRIPTION
## Summary

Creating a new session from the UI briefly routed to the new session and then reverted to the previous one. The flat-URL refactor made the URL the single source of truth for board / session selection, but `handleCreateSession` was still calling `setSelectedSessionId(sessionId)` directly — exactly what `useAppNavigation`'s docstring warns against.

The direct setter raced with two effects in `App.tsx` that revert the selection before the drawer can open:

1. `effectiveSelectedSessionId` (App.tsx:287) filters via `sessionById.has(...)`, which is `false` until the socket `created` event lands a tick after the `create()` response.
2. The cleanup effect at App.tsx:639-643 actively clears `selectedSessionId` for the same reason.

Once selection drops to `null`, the state→URL self-heal in `useUrlState` rewrites the URL to `/b/<board>/` and the new session is lost.

**Fix:** route session creation through `navigation.goToSession(sessionId)` so `useUrlState` owns selection. `goToSession` was bailing on lookup miss (`if (!session) return`), which would silently strand a just-created session whose `created` socket event hadn't landed yet — the same race. Move that lookup inside the same-URL recenter branch (where it's actually needed) so the URL push always fires; `useUrlState`'s URL→state effect re-runs when the session arrives in the map and drives selection from there.

## Test plan

- [x] Added `apps/agor-ui/src/hooks/useAppNavigation.test.tsx` — regression test fixates that `goToSession` pushes `/s/<short>/` even when the session is not yet in `sessionById` (the just-created race). Verified the test fails on the pre-fix code and passes after.
- [x] `pnpm --filter agor-ui test` → 27 files, 175 tests pass
- [x] `pnpm --filter agor-ui typecheck` clean
- [x] `pnpm --filter agor-ui lint` clean (3 pre-existing warnings unrelated to these files)
- [ ] Manual QA: open a board with an existing session selected, create a new session from a branch card → drawer opens on the new session and URL becomes `/s/<newShort>/` and stays there across socket refresh
- [ ] Manual QA: existing `/s/<short>/` deep links still resolve, open the drawer, and recenter the owning branch card
- [ ] Manual QA: `/b/`, `/w/`, `/a/` URL behavior from the recent flat-URL work remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)