### PR TITLE
Fix Claude SDK idle timeout watchdog semantics

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -254,6 +254,28 @@ describe('agor_sessions_create', () => {
     expect(created.model_config.effort).toBe('medium');
   });
 
+  it('rejects sdkIdleTimeoutMs for non-Claude-SDK tools', async () => {
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: { create: vi.fn() },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await expect(
+      agor_sessions_create({
+        branchId: 'wt-1',
+        agenticTool: 'claude-code-cli',
+        sdkIdleTimeoutMs: 900000,
+      })
+    ).rejects.toThrow(/only applies to claude-code/);
+  });
+
   it('attaches explicit mcpServerIds via the /sessions/:id/mcp-servers route (Bug 1)', async () => {
     // Regression: previously called the flat `session-mcp-servers` service which
     // is read-only (find-only), so every attach silently failed with

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -9,7 +9,12 @@ import {
   DEFAULT_GEMINI_MODEL,
   GEMINI_MODELS,
 } from '@agor/core/models';
-import { resolveSessionDefaults } from '@agor/core/sessions';
+import {
+  CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS,
+  CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS,
+  CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS,
+  resolveSessionDefaults,
+} from '@agor/core/sessions';
 import {
   AGENTIC_TOOL_CAPABILITIES,
   type AgenticToolName,
@@ -772,16 +777,19 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         sdkIdleTimeoutMs: z
           .number()
           .int()
-          .min(30000)
-          .max(3600000)
+          .min(CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS)
+          .max(CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS)
           .optional()
           .describe(
-            'Claude SDK idle timeout in milliseconds for this session. If no events are received from the Claude SDK for this duration, the session is considered hung and terminated. Set at create time only — cannot be changed afterward. Default: 300000 (5 minutes). Min: 30000 (30s), Max: 3600000 (1h). Useful for Opus 4.7 with extended thinking, which may batch server-side without streaming deltas for longer periods.'
+            `Claude SDK idle timeout in milliseconds for claude-code sessions. If no events are received from the Claude SDK for this duration, the session is considered hung and terminated. Set at create time only — cannot be changed afterward. Default: ${CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS} (5 minutes). Min: ${CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS} (30s), Max: ${CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS} (1h). Useful for Opus 4.7 with extended thinking, which may batch server-side without streaming deltas for longer periods.`
           ),
       }),
     },
     async (args) => {
       const agenticTool = args.agenticTool as AgenticToolName;
+      if (args.sdkIdleTimeoutMs !== undefined && agenticTool !== 'claude-code') {
+        throw new Error('sdkIdleTimeoutMs only applies to claude-code sessions');
+      }
 
       // Fetch user data to get unix_username
       const user = await ctx.app.service('users').get(ctx.userId, ctx.baseServiceParams);

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -15,6 +15,11 @@
  * - Codex-specific fields are omitted (rendered separately via CodexSettingsForm)
  */
 
+import {
+  CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_SECONDS,
+  CLAUDE_SDK_IDLE_TIMEOUT_MAX_SECONDS,
+  CLAUDE_SDK_IDLE_TIMEOUT_MIN_SECONDS,
+} from '@agor/core/sessions';
 import type { AgenticToolName, AgorClient, MCPServer } from '@agor-live/client';
 import { Form, InputNumber, Select } from 'antd';
 import { CodexNetworkAccessToggle } from '../CodexNetworkAccessToggle';
@@ -82,8 +87,7 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
 }) => {
   const modelLabel = MODEL_LABELS[agenticTool] ?? 'Claude Model';
   const showCodexFields = agenticTool === 'codex' && !compact;
-  const showClaudeSdkIdleTimeout =
-    showSdkIdleTimeout && (agenticTool === 'claude-code' || agenticTool === 'claude-code-cli');
+  const showClaudeSdkIdleTimeout = showSdkIdleTimeout && agenticTool === 'claude-code';
 
   return (
     <>
@@ -131,7 +135,12 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
               : undefined
           }
         >
-          <InputNumber min={30} max={3600} placeholder="300" style={{ width: '100%' }} />
+          <InputNumber
+            min={CLAUDE_SDK_IDLE_TIMEOUT_MIN_SECONDS}
+            max={CLAUDE_SDK_IDLE_TIMEOUT_MAX_SECONDS}
+            placeholder={String(CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_SECONDS)}
+            style={{ width: '100%' }}
+          />
         </Form.Item>
       )}
 

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -49,6 +49,12 @@ export interface AgenticToolConfigFormProps {
    */
   hideMcpServers?: boolean;
   /**
+   * Show the Claude SDK idle-timeout field. This is currently only wired for
+   * new-session creation; other consumers of this shared form either do not
+   * persist the value or edit already-created sessions.
+   */
+  showSdkIdleTimeout?: boolean;
+  /**
    * Optional Feathers client. When set, the embedded ModelSelector can fetch
    * dynamic Copilot models via `/copilot-models`. Without it, the picker
    * silently uses the static fallback — fine for forms that don't need
@@ -71,10 +77,13 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
   showHelpText = true,
   compact = false,
   hideMcpServers = false,
+  showSdkIdleTimeout = false,
   client,
 }) => {
   const modelLabel = MODEL_LABELS[agenticTool] ?? 'Claude Model';
   const showCodexFields = agenticTool === 'codex' && !compact;
+  const showClaudeSdkIdleTimeout =
+    showSdkIdleTimeout && (agenticTool === 'claude-code' || agenticTool === 'claude-code-cli');
 
   return (
     <>
@@ -112,7 +121,7 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
         </Form.Item>
       )}
 
-      {(agenticTool === 'claude-code' || agenticTool === 'claude-code-cli') && (
+      {showClaudeSdkIdleTimeout && (
         <Form.Item
           name="sdkIdleTimeoutSeconds"
           label="Idle timeout (seconds)"

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -280,6 +280,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
                   mcpServerById={mcpServerById}
                   showHelpText={true}
                   hideMcpServers
+                  showSdkIdleTimeout
                   client={client}
                 />
               ),

--- a/packages/core/src/sessions/claude-sdk-timeout.ts
+++ b/packages/core/src/sessions/claude-sdk-timeout.ts
@@ -1,0 +1,18 @@
+export const CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS = 300_000;
+export const CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS = 30_000;
+export const CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS = 3_600_000;
+
+export const CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_SECONDS = CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS / 1000;
+export const CLAUDE_SDK_IDLE_TIMEOUT_MIN_SECONDS = CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS / 1000;
+export const CLAUDE_SDK_IDLE_TIMEOUT_MAX_SECONDS = CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS / 1000;
+
+export function normalizeClaudeSdkIdleTimeoutMs(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS;
+  }
+
+  return Math.min(
+    CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS,
+    Math.max(CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS, Math.trunc(value))
+  );
+}

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -1,3 +1,4 @@
+export * from './claude-sdk-timeout.js';
 export * from './resolve-child-session-config.js';
 export * from './resolve-permission-config.js';
 export * from './resolve-session-defaults.js';

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -64,6 +64,8 @@ export function createCanUseToolCallback(
     }>;
     message?: string;
   }> => {
+    deps.idleWatchdog?.refresh(`permission_callback:${toolName}`);
+
     // Auto-approve MCP tools only if they belong to an attached MCP server
     // MCP tool names follow pattern: mcp__<server_name>__<tool_name>
     if (toolName.startsWith('mcp__')) {
@@ -147,6 +149,9 @@ export function createCanUseToolCallback(
     let idleWatchdogPaused = false;
 
     try {
+      deps.idleWatchdog?.pause(`permission_flow:${toolName}`);
+      idleWatchdogPaused = true;
+
       // STEP 1: Wait for any pending permission check to finish (queue serialization)
       const existingLock = deps.permissionLocks.get(sessionId);
       if (existingLock) {
@@ -228,16 +233,12 @@ export function createCanUseToolCallback(
       });
 
       // Wait for UI decision (Promise pauses SDK execution)
-      deps.idleWatchdog?.pause(`permission_wait:${toolName}`);
-      idleWatchdogPaused = true;
       const decision = await deps.permissionService.waitForDecision(
         requestId,
         taskId,
         sessionId,
         options.signal
       );
-      idleWatchdogPaused = false;
-      deps.idleWatchdog?.resume(`permission_decision:${toolName}`);
 
       // Determine the resulting permission status
       const permissionStatus = decision.timedOut

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -42,6 +42,11 @@ export function createCanUseToolCallback(
     permissionLocks: Map<SessionID, Promise<void>>;
     mcpServerRepo: MCPServerRepository;
     sessionMCPRepo: SessionMCPServerRepository;
+    idleWatchdog?: {
+      refresh(reason: string): void;
+      pause(reason: string): void;
+      resume(reason: string): void;
+    };
   }
 ) {
   return async (
@@ -139,6 +144,7 @@ export function createCanUseToolCallback(
 
     // Track lock release function for finally block
     let releaseLock: (() => void) | undefined;
+    let idleWatchdogPaused = false;
 
     try {
       // STEP 1: Wait for any pending permission check to finish (queue serialization)
@@ -222,12 +228,16 @@ export function createCanUseToolCallback(
       });
 
       // Wait for UI decision (Promise pauses SDK execution)
+      deps.idleWatchdog?.pause(`permission_wait:${toolName}`);
+      idleWatchdogPaused = true;
       const decision = await deps.permissionService.waitForDecision(
         requestId,
         taskId,
         sessionId,
         options.signal
       );
+      idleWatchdogPaused = false;
+      deps.idleWatchdog?.resume(`permission_decision:${toolName}`);
 
       // Determine the resulting permission status
       const permissionStatus = decision.timedOut
@@ -384,6 +394,10 @@ export function createCanUseToolCallback(
         message: error instanceof Error ? error.message : 'Unknown error in permission flow',
       };
     } finally {
+      if (idleWatchdogPaused) {
+        deps.idleWatchdog?.resume(`permission_wait_finished:${toolName}`);
+      }
+
       // STEP 3: Always release the lock when done (success or error)
       if (releaseLock) {
         releaseLock();

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.test.ts
@@ -187,4 +187,40 @@ describe('ClaudePromptService sdk_idle_timeout_ms', () => {
       expect(result.outputTokens).toBe(2);
     });
   });
+
+  describe('ClaudeSdkIdleWatchdog', () => {
+    it('keeps the watchdog paused until all overlapping pauses resume', async () => {
+      vi.useFakeTimers();
+      let watchdog: import('./prompt-service.js').ClaudeSdkIdleWatchdog | undefined;
+
+      try {
+        const { ClaudeSdkIdleWatchdog } = await import('./prompt-service.js');
+        const abortController = new AbortController();
+        watchdog = new ClaudeSdkIdleWatchdog(1000, abortController);
+
+        watchdog.pause('permission_flow:a');
+        watchdog.pause('permission_flow:b');
+        watchdog.resume('permission_wait_finished:a');
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(abortController.signal.aborted).toBe(false);
+        expect(watchdog.hasTimedOut()).toBe(false);
+
+        watchdog.resume('permission_wait_finished:b');
+        await vi.advanceTimersByTimeAsync(999);
+
+        expect(abortController.signal.aborted).toBe(false);
+        expect(watchdog.hasTimedOut()).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(abortController.signal.aborted).toBe(true);
+        expect(watchdog.hasTimedOut()).toBe(true);
+      } finally {
+        watchdog?.stop();
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.test.ts
@@ -16,6 +16,11 @@ type StubSession = {
 
 // Capture constructor args passed to SDKMessageProcessor
 const processorCalls: Array<{ idleTimeoutMs: number }> = [];
+const processorInstances: Array<{
+  process: ReturnType<typeof vi.fn>;
+  hasTimedOut: ReturnType<typeof vi.fn>;
+}> = [];
+let queryMessages: Array<Record<string, unknown>> = [];
 
 vi.mock('./message-processor.js', () => {
   return {
@@ -24,9 +29,12 @@ vi.mock('./message-processor.js', () => {
       this: Record<string, unknown>,
       opts: { idleTimeoutMs: number }
     ) {
+      const process = vi.fn().mockResolvedValue([]);
+      const hasTimedOut = vi.fn().mockReturnValue(false);
       processorCalls.push({ idleTimeoutMs: opts.idleTimeoutMs });
-      this.process = vi.fn().mockResolvedValue([]);
-      this.hasTimedOut = vi.fn().mockReturnValue(false);
+      processorInstances.push({ process, hasTimedOut });
+      this.process = process;
+      this.hasTimedOut = hasTimedOut;
       this.getState = vi.fn().mockReturnValue({
         messageCount: 0,
         lastActivityTime: Date.now(),
@@ -41,14 +49,25 @@ vi.mock('@agor/core/db', () => ({ shortId: (id: string) => id.slice(0, 8) }));
 
 // Return a fresh empty generator on every call so tests don't share state.
 vi.mock('./query-builder.js', () => ({
-  setupQuery: vi.fn().mockImplementation(async () => ({
-    query: (async function* () {})(),
-    getStderr: vi.fn().mockReturnValue(''),
-    releaseInput: vi.fn(),
-    getContextUsage: vi
+  setupQuery: vi.fn().mockImplementation(async () => {
+    const query = (async function* () {
+      for (const msg of queryMessages) {
+        yield msg;
+      }
+    })() as AsyncGenerator<Record<string, unknown>> & {
+      releaseInput: ReturnType<typeof vi.fn>;
+      getContextUsage: ReturnType<typeof vi.fn>;
+    };
+    query.releaseInput = vi.fn();
+    query.getContextUsage = vi
       .fn()
-      .mockResolvedValue({ totalTokens: 0, maxTokens: 200000, percentage: 0 }),
-  })),
+      .mockResolvedValue({ totalTokens: 0, maxTokens: 200000, percentage: 0 });
+
+    return {
+      query,
+      getStderr: vi.fn().mockReturnValue(''),
+    };
+  }),
 }));
 
 describe('ClaudePromptService sdk_idle_timeout_ms', () => {
@@ -56,6 +75,8 @@ describe('ClaudePromptService sdk_idle_timeout_ms', () => {
 
   beforeEach(() => {
     processorCalls.length = 0;
+    processorInstances.length = 0;
+    queryMessages = [];
     sessionsRepo = { findById: vi.fn() };
   });
 
@@ -89,6 +110,27 @@ describe('ClaudePromptService sdk_idle_timeout_ms', () => {
     it('uses minimum valid value (30000) without falling back to default', async () => {
       await runStreaming({ session_id: 'sess-c', model_config: { sdk_idle_timeout_ms: 30000 } });
       expect(processorCalls[0]?.idleTimeoutMs).toBe(30000);
+    });
+
+    it('clamps invalid low and high values before constructing the processor', async () => {
+      await runStreaming({ session_id: 'sess-low', model_config: { sdk_idle_timeout_ms: 1 } });
+      expect(processorCalls[0]?.idleTimeoutMs).toBe(30000);
+
+      processorCalls.length = 0;
+      await runStreaming({
+        session_id: 'sess-high',
+        model_config: { sdk_idle_timeout_ms: 9_999_999 },
+      });
+      expect(processorCalls[0]?.idleTimeoutMs).toBe(3600000);
+    });
+
+    it('processes a newly arrived SDK message instead of rejecting it with a stale timeout check', async () => {
+      queryMessages = [{ type: 'stream_event', event: { type: 'message_start' } }];
+
+      await runStreaming({ session_id: 'sess-msg', model_config: { sdk_idle_timeout_ms: 30000 } });
+
+      expect(processorInstances[0]?.process).toHaveBeenCalledTimes(1);
+      expect(processorInstances[0]?.hasTimedOut).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.test.ts
@@ -21,6 +21,8 @@ const processorInstances: Array<{
   hasTimedOut: ReturnType<typeof vi.fn>;
 }> = [];
 let queryMessages: Array<Record<string, unknown>> = [];
+let queryWaitsForRelease = false;
+let lastReleaseInput: ReturnType<typeof vi.fn> | undefined;
 
 vi.mock('./message-processor.js', () => {
   return {
@@ -29,7 +31,15 @@ vi.mock('./message-processor.js', () => {
       this: Record<string, unknown>,
       opts: { idleTimeoutMs: number }
     ) {
-      const process = vi.fn().mockResolvedValue([]);
+      const process = vi.fn().mockImplementation(async (msg: { type?: string }) => {
+        if (msg.type === 'result') {
+          return [
+            { type: 'result', raw_sdk_message: msg },
+            { type: 'end', reason: 'result' },
+          ];
+        }
+        return [];
+      });
       const hasTimedOut = vi.fn().mockReturnValue(false);
       processorCalls.push({ idleTimeoutMs: opts.idleTimeoutMs });
       processorInstances.push({ process, hasTimedOut });
@@ -50,15 +60,23 @@ vi.mock('@agor/core/db', () => ({ shortId: (id: string) => id.slice(0, 8) }));
 // Return a fresh empty generator on every call so tests don't share state.
 vi.mock('./query-builder.js', () => ({
   setupQuery: vi.fn().mockImplementation(async () => {
+    let releaseInputResolve: (() => void) | undefined;
+    const releaseInputPromise = new Promise<void>((resolve) => {
+      releaseInputResolve = resolve;
+    });
     const query = (async function* () {
       for (const msg of queryMessages) {
         yield msg;
+      }
+      if (queryWaitsForRelease) {
+        await releaseInputPromise;
       }
     })() as AsyncGenerator<Record<string, unknown>> & {
       releaseInput: ReturnType<typeof vi.fn>;
       getContextUsage: ReturnType<typeof vi.fn>;
     };
-    query.releaseInput = vi.fn();
+    query.releaseInput = vi.fn(() => releaseInputResolve?.());
+    lastReleaseInput = query.releaseInput;
     query.getContextUsage = vi
       .fn()
       .mockResolvedValue({ totalTokens: 0, maxTokens: 200000, percentage: 0 });
@@ -77,6 +95,8 @@ describe('ClaudePromptService sdk_idle_timeout_ms', () => {
     processorCalls.length = 0;
     processorInstances.length = 0;
     queryMessages = [];
+    queryWaitsForRelease = false;
+    lastReleaseInput = undefined;
     sessionsRepo = { findById: vi.fn() };
   });
 
@@ -93,7 +113,7 @@ describe('ClaudePromptService sdk_idle_timeout_ms', () => {
     const { ClaudePromptService } = await import('./prompt-service.js');
     const svc = new ClaudePromptService(undefined as never, sessionsRepo as never);
     sessionsRepo.findById.mockResolvedValue(session);
-    await svc.promptSession(session.session_id as SessionID, 'test');
+    return svc.promptSession(session.session_id as SessionID, 'test');
   }
 
   describe('streaming path (promptSessionStreaming)', () => {
@@ -146,6 +166,25 @@ describe('ClaudePromptService sdk_idle_timeout_ms', () => {
         model_config: { sdk_idle_timeout_ms: 900000 },
       });
       expect(processorCalls[0]?.idleTimeoutMs).toBe(900000);
+    });
+
+    it('releases the held SDK input after a successful result', async () => {
+      queryWaitsForRelease = true;
+      queryMessages = [
+        {
+          type: 'result',
+          usage: { input_tokens: 1, output_tokens: 2 },
+        },
+      ];
+
+      const result = await runNonStreaming({
+        session_id: 'sess-f',
+        model_config: { sdk_idle_timeout_ms: 30000 },
+      });
+
+      expect(lastReleaseInput).toHaveBeenCalledTimes(1);
+      expect(result.inputTokens).toBe(1);
+      expect(result.outputTokens).toBe(2);
     });
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -7,6 +7,7 @@
 
 import { shortId } from '@agor/core/db';
 import type { PermissionMode, SDKResultMessage } from '@agor/core/sdk';
+import { normalizeClaudeSdkIdleTimeoutMs } from '@agor/core/sessions';
 import type {
   BranchRepository,
   MCPServerRepository,
@@ -21,21 +22,6 @@ import { MessageRole } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 import { setupQuery } from './query-builder.js';
-
-export const CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS = 300_000;
-export const CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS = 30_000;
-export const CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS = 3_600_000;
-
-export function normalizeClaudeSdkIdleTimeoutMs(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS;
-  }
-
-  return Math.min(
-    CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS,
-    Math.max(CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS, Math.trunc(value))
-  );
-}
 
 class ClaudeSdkIdleWatchdog {
   private timer: ReturnType<typeof setTimeout> | undefined;
@@ -93,6 +79,21 @@ class ClaudeSdkIdleWatchdog {
       idleTimeoutMs: this.idleTimeoutMs,
     };
   }
+}
+
+function buildClaudeSdkIdleTimeoutError(
+  watchdog: ClaudeSdkIdleWatchdog,
+  processor: SDKMessageProcessor
+): Error {
+  const watchdogState = watchdog.getState();
+  const processorState = processor.getState();
+  const idleSeconds = Math.round((Date.now() - watchdogState.lastActivityTime) / 1000);
+  const timeoutSeconds = Math.round(watchdogState.idleTimeoutMs / 1000);
+
+  return new Error(
+    `Claude SDK idle timeout: No SDK activity for ${idleSeconds}s (timeout: ${timeoutSeconds}s). ` +
+      `SDK may have hung or crashed. Last processed message was #${processorState.messageCount}.`
+  );
 }
 
 export interface PromptResult {
@@ -295,6 +296,12 @@ If you continue to see authentication errors, please contact your Agor administr
       idleTimeoutMs,
     });
     watchdog.refresh('query_started');
+    let inputReleased = false;
+    const releaseQueryInput = () => {
+      if (inputReleased) return;
+      result.releaseInput();
+      inputReleased = true;
+    };
 
     // With AbortController passed to SDK, cancellation is handled natively.
     // When abortController.abort() is called, SDK throws AbortError which we catch below.
@@ -343,7 +350,7 @@ If you continue to see authentication errors, please contact your Agor administr
               );
             } finally {
               // Release the held input iterable so the SDK can close stdin
-              result.releaseInput();
+              releaseQueryInput();
             }
           }
 
@@ -364,10 +371,9 @@ If you continue to see authentication errors, please contact your Agor administr
       }
     } catch (error) {
       // Ensure stdin is released on any error so the subprocess can exit cleanly
-      result.releaseInput();
+      releaseQueryInput();
 
       const state = processor.getState();
-      const watchdogState = watchdog.getState();
 
       // Check if this is an AbortError from AbortController.abort()
       // This is EXPECTED during stop - the SDK throws AbortError when cancelled
@@ -376,15 +382,7 @@ If you continue to see authentication errors, please contact your Agor administr
         (error.name === 'AbortError' || error.message.includes('abort'))
       ) {
         if (watchdog.hasTimedOut()) {
-          const idleSeconds = Math.round(
-            (Date.now() - watchdogState.lastActivityTime) / 1000
-          );
-          const timeoutSeconds = Math.round(watchdogState.idleTimeoutMs / 1000);
-
-          throw new Error(
-            `Claude SDK idle timeout: No SDK activity for ${idleSeconds}s (timeout: ${timeoutSeconds}s). ` +
-              `SDK may have hung or crashed. Last processed message was #${state.messageCount}.`
-          );
+          throw buildClaudeSdkIdleTimeoutError(watchdog, processor);
         }
 
         console.log(`🛑 [Stop] Query aborted for session ${shortId(sessionId)} - this is expected`);
@@ -415,6 +413,10 @@ If you continue to see authentication errors, please contact your Agor administr
       throw enhancedError;
     } finally {
       watchdog.stop();
+    }
+
+    if (watchdog.hasTimedOut()) {
+      throw buildClaudeSdkIdleTimeoutError(watchdog, processor);
     }
   }
 
@@ -482,6 +484,12 @@ If you continue to see authentication errors, please contact your Agor administr
       idleTimeoutMs,
     });
     watchdog.refresh('query_started');
+    let inputReleased = false;
+    const releaseQueryInput = () => {
+      if (inputReleased) return;
+      result.releaseInput();
+      inputReleased = true;
+    };
 
     // Collect response messages from async generator
     // IMPORTANT: Keep assistant messages SEPARATE (don't merge into one)
@@ -520,14 +528,18 @@ If you continue to see authentication errors, please contact your Agor administr
             });
           }
 
-          // Capture token usage from result events
-          if (event.type === 'result' && event.raw_sdk_message?.usage) {
-            tokenUsage = event.raw_sdk_message.usage as {
-              input_tokens?: number;
-              output_tokens?: number;
-              cache_creation_tokens?: number;
-              cache_read_tokens?: number;
-            };
+          // Capture token usage from result events and release the held input
+          // iterable so the SDK can close cleanly.
+          if (event.type === 'result') {
+            if (event.raw_sdk_message?.usage) {
+              tokenUsage = event.raw_sdk_message.usage as {
+                input_tokens?: number;
+                output_tokens?: number;
+                cache_creation_tokens?: number;
+                cache_read_tokens?: number;
+              };
+            }
+            releaseQueryInput();
           }
 
           // Break on end event
@@ -537,25 +549,16 @@ If you continue to see authentication errors, please contact your Agor administr
         }
       }
     } catch (error) {
+      // Ensure stdin is released on any error so the subprocess can exit cleanly
+      releaseQueryInput();
+
       // Check if this is an AbortError from interrupt() - this is EXPECTED during stop
       if (
         error instanceof Error &&
         (error.name === 'AbortError' || error.message.includes('abort'))
       ) {
-        result.releaseInput();
-
         if (watchdog.hasTimedOut()) {
-          const watchdogState = watchdog.getState();
-          const state = processor.getState();
-          const idleSeconds = Math.round(
-            (Date.now() - watchdogState.lastActivityTime) / 1000
-          );
-          const timeoutSeconds = Math.round(watchdogState.idleTimeoutMs / 1000);
-
-          throw new Error(
-            `Claude SDK idle timeout: No SDK activity for ${idleSeconds}s (timeout: ${timeoutSeconds}s). ` +
-              `SDK may have hung or crashed. Last processed message was #${state.messageCount}.`
-          );
+          throw buildClaudeSdkIdleTimeoutError(watchdog, processor);
         }
 
         console.log(
@@ -573,6 +576,10 @@ If you continue to see authentication errors, please contact your Agor administr
       throw error;
     } finally {
       watchdog.stop();
+    }
+
+    if (watchdog.hasTimedOut()) {
+      throw buildClaudeSdkIdleTimeoutError(watchdog, processor);
     }
 
     // Extract token counts from SDK result metadata

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -23,10 +23,10 @@ import type { MessagesService, SessionsPatchClient, TasksService } from '../base
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 import { setupQuery } from './query-builder.js';
 
-class ClaudeSdkIdleWatchdog {
+export class ClaudeSdkIdleWatchdog {
   private timer: ReturnType<typeof setTimeout> | undefined;
   private timedOut = false;
-  private paused = false;
+  private pauseDepth = 0;
   private lastActivityTime = Date.now();
 
   constructor(
@@ -38,7 +38,7 @@ class ClaudeSdkIdleWatchdog {
     if (this.timedOut || this.abortController.signal.aborted) return;
 
     this.lastActivityTime = Date.now();
-    if (this.paused) return;
+    if (this.pauseDepth > 0) return;
 
     if (this.timer) clearTimeout(this.timer);
 
@@ -48,11 +48,11 @@ class ClaudeSdkIdleWatchdog {
     }, this.idleTimeoutMs);
   }
 
-  pause(reason: string): void {
+  pause(_reason: string): void {
     if (this.timedOut || this.abortController.signal.aborted) return;
 
-    this.paused = true;
-    this.refresh(reason);
+    this.pauseDepth += 1;
+    this.lastActivityTime = Date.now();
     if (this.timer) clearTimeout(this.timer);
     this.timer = undefined;
   }
@@ -60,13 +60,19 @@ class ClaudeSdkIdleWatchdog {
   resume(reason: string): void {
     if (this.timedOut || this.abortController.signal.aborted) return;
 
-    this.paused = false;
-    this.refresh(reason);
+    this.pauseDepth = Math.max(0, this.pauseDepth - 1);
+    if (this.pauseDepth === 0) {
+      this.refresh(reason);
+      return;
+    }
+
+    this.lastActivityTime = Date.now();
   }
 
   stop(): void {
     if (this.timer) clearTimeout(this.timer);
     this.timer = undefined;
+    this.pauseDepth = 0;
   }
 
   hasTimedOut(): boolean {

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -22,6 +22,79 @@ import type { MessagesService, SessionsPatchClient, TasksService } from '../base
 import { type ProcessedEvent, SDKMessageProcessor } from './message-processor.js';
 import { setupQuery } from './query-builder.js';
 
+export const CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS = 300_000;
+export const CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS = 30_000;
+export const CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS = 3_600_000;
+
+export function normalizeClaudeSdkIdleTimeoutMs(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return CLAUDE_SDK_IDLE_TIMEOUT_DEFAULT_MS;
+  }
+
+  return Math.min(
+    CLAUDE_SDK_IDLE_TIMEOUT_MAX_MS,
+    Math.max(CLAUDE_SDK_IDLE_TIMEOUT_MIN_MS, Math.trunc(value))
+  );
+}
+
+class ClaudeSdkIdleWatchdog {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private timedOut = false;
+  private paused = false;
+  private lastActivityTime = Date.now();
+
+  constructor(
+    private readonly idleTimeoutMs: number,
+    private readonly abortController: AbortController
+  ) {}
+
+  refresh(_reason: string): void {
+    if (this.timedOut || this.abortController.signal.aborted) return;
+
+    this.lastActivityTime = Date.now();
+    if (this.paused) return;
+
+    if (this.timer) clearTimeout(this.timer);
+
+    this.timer = setTimeout(() => {
+      this.timedOut = true;
+      this.abortController.abort();
+    }, this.idleTimeoutMs);
+  }
+
+  pause(reason: string): void {
+    if (this.timedOut || this.abortController.signal.aborted) return;
+
+    this.paused = true;
+    this.refresh(reason);
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+
+  resume(reason: string): void {
+    if (this.timedOut || this.abortController.signal.aborted) return;
+
+    this.paused = false;
+    this.refresh(reason);
+  }
+
+  stop(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+
+  hasTimedOut(): boolean {
+    return this.timedOut;
+  }
+
+  getState(): { lastActivityTime: number; idleTimeoutMs: number } {
+    return {
+      lastActivityTime: this.lastActivityTime,
+      idleTimeoutMs: this.idleTimeoutMs,
+    };
+  }
+}
+
 export interface PromptResult {
   /** Assistant messages (can be multiple: tool invocation, then response) */
   messages: Array<{
@@ -47,9 +120,6 @@ export interface PromptResult {
 export class ClaudePromptService {
   /** Enable token-level streaming from Claude Agent SDK */
   private static readonly ENABLE_TOKEN_STREAMING = true;
-
-  /** Idle timeout for SDK event loop - throws error if no messages received for this duration */
-  private static readonly IDLE_TIMEOUT_MS = 300000; // 5 minutes
 
   /** Serialize permission checks per session to prevent duplicate prompts for concurrent tool calls */
   private permissionLocks = new Map<SessionID, Promise<void>>();
@@ -174,6 +244,13 @@ If you continue to see authentication errors, please contact your Agor administr
       }
     }
 
+    const sessionForTimeout = await this.sessionsRepo?.findById(sessionId);
+    const idleTimeoutMs = normalizeClaudeSdkIdleTimeoutMs(
+      sessionForTimeout?.model_config?.sdk_idle_timeout_ms
+    );
+    const queryAbortController = abortController ?? new AbortController();
+    const watchdog = new ClaudeSdkIdleWatchdog(idleTimeoutMs, queryAbortController);
+
     const { query: result, getStderr } = await setupQuery(
       sessionId,
       prompt,
@@ -197,7 +274,12 @@ If you continue to see authentication errors, please contact your Agor administr
         taskId,
         permissionMode,
         resume: true,
-        abortController,
+        abortController: queryAbortController,
+        idleWatchdog: {
+          refresh: (reason) => watchdog.refresh(reason),
+          pause: (reason) => watchdog.pause(reason),
+          resume: (reason) => watchdog.resume(reason),
+        },
       }
     );
 
@@ -210,28 +292,19 @@ If you continue to see authentication errors, please contact your Agor administr
       sessionId,
       existingSdkSessionId,
       enableTokenStreaming: ClaudePromptService.ENABLE_TOKEN_STREAMING,
-      idleTimeoutMs: Math.max(
-        30000,
-        session?.model_config?.sdk_idle_timeout_ms ?? ClaudePromptService.IDLE_TIMEOUT_MS
-      ),
+      idleTimeoutMs,
     });
+    watchdog.refresh('query_started');
 
     // With AbortController passed to SDK, cancellation is handled natively.
     // When abortController.abort() is called, SDK throws AbortError which we catch below.
 
     try {
       for await (const msg of result) {
-        // Check for timeout - throw error to trigger proper cleanup
-        if (processor.hasTimedOut()) {
-          const state = processor.getState();
-          const idleSeconds = Math.round((Date.now() - state.lastActivityTime) / 1000);
-          const timeoutSeconds = Math.round(state.idleTimeoutMs / 1000);
-
-          throw new Error(
-            `Claude SDK idle timeout: No activity for ${idleSeconds}s (timeout: ${timeoutSeconds}s). ` +
-              `SDK may have hung or crashed. Last message type was #${state.messageCount}.`
-          );
-        }
+        // Any SDK message proves the process is alive. Refresh the watchdog
+        // before deeper processing so a delayed-but-valid message is not
+        // rejected solely because the previous quiet period was long.
+        watchdog.refresh(`sdk_message:${(msg as { type?: string }).type ?? 'unknown'}`);
 
         // Process message through processor
         const events = await processor.process(msg);
@@ -294,6 +367,7 @@ If you continue to see authentication errors, please contact your Agor administr
       result.releaseInput();
 
       const state = processor.getState();
+      const watchdogState = watchdog.getState();
 
       // Check if this is an AbortError from AbortController.abort()
       // This is EXPECTED during stop - the SDK throws AbortError when cancelled
@@ -301,6 +375,18 @@ If you continue to see authentication errors, please contact your Agor administr
         error instanceof Error &&
         (error.name === 'AbortError' || error.message.includes('abort'))
       ) {
+        if (watchdog.hasTimedOut()) {
+          const idleSeconds = Math.round(
+            (Date.now() - watchdogState.lastActivityTime) / 1000
+          );
+          const timeoutSeconds = Math.round(watchdogState.idleTimeoutMs / 1000);
+
+          throw new Error(
+            `Claude SDK idle timeout: No SDK activity for ${idleSeconds}s (timeout: ${timeoutSeconds}s). ` +
+              `SDK may have hung or crashed. Last processed message was #${state.messageCount}.`
+          );
+        }
+
         console.log(`🛑 [Stop] Query aborted for session ${shortId(sessionId)} - this is expected`);
         // Yield stopped event to signal execution was halted
         yield { type: 'stopped' } as ProcessedEvent;
@@ -327,6 +413,8 @@ If you continue to see authentication errors, please contact your Agor administr
         stderr: stderrOutput || '(no stderr output)',
       });
       throw enhancedError;
+    } finally {
+      watchdog.stop();
     }
   }
 
@@ -343,6 +431,13 @@ If you continue to see authentication errors, please contact your Agor administr
    * @returns Complete assistant response with metadata
    */
   async promptSession(sessionId: SessionID, prompt: string): Promise<PromptResult> {
+    const sessionForTimeout = await this.sessionsRepo?.findById(sessionId);
+    const idleTimeoutMs = normalizeClaudeSdkIdleTimeoutMs(
+      sessionForTimeout?.model_config?.sdk_idle_timeout_ms
+    );
+    const queryAbortController = new AbortController();
+    const watchdog = new ClaudeSdkIdleWatchdog(idleTimeoutMs, queryAbortController);
+
     const { query: result } = await setupQuery(
       sessionId,
       prompt,
@@ -366,6 +461,12 @@ If you continue to see authentication errors, please contact your Agor administr
         taskId: undefined,
         permissionMode: undefined,
         resume: false,
+        abortController: queryAbortController,
+        idleWatchdog: {
+          refresh: (reason) => watchdog.refresh(reason),
+          pause: (reason) => watchdog.pause(reason),
+          resume: (reason) => watchdog.resume(reason),
+        },
       }
     );
 
@@ -378,11 +479,9 @@ If you continue to see authentication errors, please contact your Agor administr
       sessionId,
       existingSdkSessionId,
       enableTokenStreaming: false, // Non-streaming mode
-      idleTimeoutMs: Math.max(
-        30000,
-        session?.model_config?.sdk_idle_timeout_ms ?? ClaudePromptService.IDLE_TIMEOUT_MS
-      ),
+      idleTimeoutMs,
     });
+    watchdog.refresh('query_started');
 
     // Collect response messages from async generator
     // IMPORTANT: Keep assistant messages SEPARATE (don't merge into one)
@@ -409,6 +508,7 @@ If you continue to see authentication errors, please contact your Agor administr
 
     try {
       for await (const msg of result) {
+        watchdog.refresh(`sdk_message:${(msg as { type?: string }).type ?? 'unknown'}`);
         const events = await processor.process(msg);
 
         for (const event of events) {
@@ -442,6 +542,22 @@ If you continue to see authentication errors, please contact your Agor administr
         error instanceof Error &&
         (error.name === 'AbortError' || error.message.includes('abort'))
       ) {
+        result.releaseInput();
+
+        if (watchdog.hasTimedOut()) {
+          const watchdogState = watchdog.getState();
+          const state = processor.getState();
+          const idleSeconds = Math.round(
+            (Date.now() - watchdogState.lastActivityTime) / 1000
+          );
+          const timeoutSeconds = Math.round(watchdogState.idleTimeoutMs / 1000);
+
+          throw new Error(
+            `Claude SDK idle timeout: No SDK activity for ${idleSeconds}s (timeout: ${timeoutSeconds}s). ` +
+              `SDK may have hung or crashed. Last processed message was #${state.messageCount}.`
+          );
+        }
+
         console.log(
           `🛑 [Stop] Query aborted via interrupt() for session ${shortId(sessionId)} (non-streaming) - this is expected`
         );
@@ -455,6 +571,8 @@ If you continue to see authentication errors, please contact your Agor administr
       }
       // Re-throw other errors
       throw error;
+    } finally {
+      watchdog.stop();
     }
 
     // Extract token counts from SDK result metadata

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -116,6 +116,12 @@ export interface QuerySetupDeps {
   mcpEnabled?: boolean;
 }
 
+export interface IdleWatchdogHooks {
+  refresh(reason: string): void;
+  pause(reason: string): void;
+  resume(reason: string): void;
+}
+
 /**
  * Setup and configure query for Claude Agent SDK
  * Handles session loading, CWD resolution, MCP configuration, and resume/fork/spawn logic
@@ -148,13 +154,14 @@ export async function setupQuery(
     permissionMode?: PermissionMode;
     resume?: boolean;
     abortController?: AbortController;
+    idleWatchdog?: IdleWatchdogHooks;
   } = {}
 ): Promise<{
   query: InterruptibleQuery;
   resolvedModel: string;
   getStderr: () => string;
 }> {
-  const { taskId, permissionMode, resume = true, abortController } = options;
+  const { taskId, permissionMode, resume = true, abortController, idleWatchdog } = options;
 
   const session = await deps.sessionsRepo.findById(sessionId);
   if (!session) {
@@ -346,6 +353,7 @@ export async function setupQuery(
       permissionLocks: deps.permissionLocks,
       mcpServerRepo: deps.mcpServerRepo,
       sessionMCPRepo: deps.sessionMCPRepo,
+      idleWatchdog,
     });
     console.log(`✅ canUseTool callback added (permission mode: ${effectivePermissionMode})`);
   }


### PR DESCRIPTION
## Summary

- scopes the new Claude SDK idle-timeout UI field to the new-session create flow where it is actually persisted
- replaces the stale pre-message timeout check with an in-memory refreshable watchdog
- refreshes the watchdog as soon as any raw SDK message arrives, before processing
- clamps effective SDK idle timeout values to 30s..1h via shared core constants
- pauses the SDK idle watchdog around manual permission flows, with nested pause/resume handling for concurrent permission callbacks
- releases held SDK input on non-streaming successful result
- rejects `sdkIdleTimeoutMs` for non-`claude-code` MCP session creation to avoid inert config

## Validation

- pnpm i
- pnpm check (typecheck completed; command stopped at repo-wide biome lint on existing unrelated diagnostics outside this change, before the final build step)
- pnpm -C packages/core build
- pnpm -C packages/core typecheck
- pnpm -C packages/executor test src/sdk-handlers/claude/prompt-service.test.ts
- pnpm -C apps/agor-daemon test src/mcp/tools/sessions.test.ts src/utils/apply-session-config-defaults.test.ts
- pnpm -C packages/executor typecheck
- pnpm -C apps/agor-ui typecheck
- pnpm -C apps/agor-daemon typecheck
- pnpm exec biome check <changed files>

Stacked on top of #1268.
