### PR TITLE
fix(ui): navigate to newly created branch / assistant / board

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2456,6 +2456,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           issue_url?: string;
           pull_request_url?: string;
           boardId?: string;
+          /** Explicit board position. Omit to let the service compute a
+           *  smart default — preferred for MCP/agent callers. The UI
+           *  passes the viewport center so the new card lands where the
+           *  user invoked the dialog. */
+          position?: { x: number; y: number };
           // Branch storage model — see context/explorations/clone-redesign.md.
           storage_mode?: 'worktree' | 'clone';
           clone_depth?: number;

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -562,6 +562,12 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       issue_url?: string;
       pull_request_url?: string;
       boardId?: string;
+      /** Explicit board position. Honored as-is when supplied; otherwise
+       *  the service computes a smart placement (zone-relative if a
+       *  zoneId was passed, else next-free slot among existing entities).
+       *  Agents/MCP callers should omit this so they don't have to think
+       *  about x/y; the UI passes the viewport center. */
+      position?: { x: number; y: number };
       zoneId?: string;
       others_can?: BranchPermissionLevel;
       others_fs_access?: 'none' | 'read' | 'write';
@@ -735,13 +741,16 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     if (data.boardId) {
       const boardObjectsService = this.app.service('board-objects');
 
-      // Compute position automatically — agents should never need to think about x/y
-      let position: { x: number; y: number } | undefined;
+      // Honor an explicit position from the caller (the UI passes the
+      // viewport center so the new card lands where the user invoked
+      // the dialog). Agents/MCP callers omit `position` so they don't
+      // have to think about x/y; fall through to smart placement.
+      let position: { x: number; y: number } | undefined = data.position;
       const resolvedZoneId = data.zoneId;
 
       try {
         // If placing in a zone, compute zone-relative position
-        if (resolvedZoneId && board) {
+        if (!position && resolvedZoneId && board) {
           const zone = board.objects?.[resolvedZoneId];
           if (zone?.type === 'zone') {
             const { computeZoneRelativePosition } = await import(

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -701,16 +701,18 @@ function AppContent() {
   };
 
   // Handle board CRUD
-  const handleCreateBoard = async (board: Partial<Board>) => {
+  const handleCreateBoard = async (board: Partial<Board>): Promise<Board | null> => {
     if (board.board_id) {
-      // Board already exists (clone/import already persisted it)
-      return;
+      // Board already exists (clone/import already persisted it) — return
+      // the prebuilt row so callers can navigate to it without re-creating.
+      return board as Board;
     }
 
     const created = await createBoard(board);
     if (created) {
       showSuccess('Board created successfully!');
     }
+    return created;
   };
 
   const handleUpdateBoard = async (boardId: string, updates: Partial<Board>) => {

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -110,7 +110,7 @@ export interface AppProps {
   onSendPrompt?: (sessionId: string, prompt: string, permissionMode?: PermissionMode) => void;
   onUpdateSession?: (sessionId: string, updates: Partial<Session>) => void;
   onDeleteSession?: (sessionId: string) => void;
-  onCreateBoard?: (board: Partial<Board>) => void;
+  onCreateBoard?: (board: Partial<Board>) => Promise<Board | null> | undefined;
   onUpdateBoard?: (boardId: string, updates: Partial<Board>) => void;
   onDeleteBoard?: (boardId: string) => void;
   onArchiveBoard?: (boardId: string) => void;
@@ -540,13 +540,34 @@ export const App: React.FC<AppProps> = ({
     }
 
     setCreateDialogOpen(false);
+
+    // Mirror handleCreateSession: route through the URL so useUrlState
+    // owns selection. The just-created branch may not be in branchById
+    // yet (socket `created` event still in flight) — goToBranch pushes
+    // `/w/<short>/` unconditionally and useUrlState's URL→state effect
+    // resolves the branch on a subsequent render to switch boards (if
+    // needed) and recenter the canvas.
+    if (branch) {
+      navigation.goToBranch(branch.branch_id);
+    }
+  };
+
+  const handleCreateBoardFromDialog = async (board: Partial<Board>) => {
+    const created = await onCreateBoard?.(board);
+    // Boards have their own URL (/b/<slug-or-short>/) — switch to the
+    // new board after creation so the user lands on the empty canvas
+    // they're about to populate. Same intent as goToBranch/goToSession
+    // after their respective creates.
+    if (created?.board_id) {
+      navigation.goToBoard(created.board_id);
+    }
   };
 
   const handleCreateAssistant = async (result: AssistantTabResult) => {
     const repoId = result.repoId;
     if (!repoId || !onCreateBranch || !onUpdateBranch) return;
 
-    await createAssistantBranch(
+    const branch = await createAssistantBranch(
       {
         displayName: result.displayName,
         description: result.description,
@@ -558,6 +579,14 @@ export const App: React.FC<AppProps> = ({
       },
       { client, repoById, onCreateBranch, onUpdateBranch }
     );
+
+    // Assistants are branches under the hood, so the `/w/<short>/` URL
+    // is the canonical deep link. Routing through goToBranch picks up
+    // the cross-board recenter for free when the assistant was created
+    // on a new board.
+    if (branch) {
+      navigation.goToBranch(branch.branch_id);
+    }
   };
 
   // Refs for the data `handleSessionClick` reads. Using refs (vs
@@ -1193,7 +1222,7 @@ export const App: React.FC<AppProps> = ({
               currentBoardId={currentBoardId}
               defaultPosition={newBranchDefaultPosition || undefined}
               onCreateBranch={handleCreateBranch}
-              onCreateBoard={(board) => onCreateBoard?.(board)}
+              onCreateBoard={handleCreateBoardFromDialog}
               onCreateRepo={(data) => onCreateRepo?.(data)}
               onCreateLocalRepo={(data) => onCreateLocalRepo?.(data)}
               onCreateAssistant={handleCreateAssistant}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -110,7 +110,7 @@ export interface AppProps {
   onSendPrompt?: (sessionId: string, prompt: string, permissionMode?: PermissionMode) => void;
   onUpdateSession?: (sessionId: string, updates: Partial<Session>) => void;
   onDeleteSession?: (sessionId: string) => void;
-  onCreateBoard?: (board: Partial<Board>) => Promise<Board | null> | undefined;
+  onCreateBoard?: (board: Partial<Board>) => Promise<Board | null>;
   onUpdateBoard?: (boardId: string, updates: Partial<Board>) => void;
   onDeleteBoard?: (boardId: string) => void;
   onArchiveBoard?: (boardId: string) => void;
@@ -139,6 +139,8 @@ export interface AppProps {
       pullLatest: boolean;
       issue_url?: string;
       pull_request_url?: string;
+      boardId?: string;
+      position?: { x: number; y: number };
       storage_mode?: 'worktree' | 'clone';
       clone_depth?: number;
     }
@@ -519,6 +521,12 @@ export const App: React.FC<AppProps> = ({
   };
 
   const handleCreateBranch = async (config: BranchTabConfig) => {
+    // Thread board placement (boardId + position) through the create
+    // call so it lands atomically. The previous shape did a follow-up
+    // PATCH for board_id and dropped position entirely — the API already
+    // accepts both at create time, so the patch is redundant and the
+    // dropped position made the BranchTab `defaultPosition` plumbing a
+    // no-op.
     const branch = await onCreateBranch?.(config.repoId, {
       name: config.name,
       ref: config.ref,
@@ -528,16 +536,11 @@ export const App: React.FC<AppProps> = ({
       pullLatest: config.pullLatest,
       issue_url: config.issue_url,
       pull_request_url: config.pull_request_url,
+      ...(config.board_id ? { boardId: config.board_id } : {}),
+      ...(config.position ? { position: config.position } : {}),
       ...(config.storage_mode ? { storage_mode: config.storage_mode } : {}),
       ...(config.clone_depth !== undefined ? { clone_depth: config.clone_depth } : {}),
     });
-
-    // If board_id is provided and branch was created, assign it to the board
-    if (branch && config.board_id) {
-      await onUpdateBranch?.(branch.branch_id, {
-        board_id: config.board_id as BoardID,
-      });
-    }
 
     setCreateDialogOpen(false);
 
@@ -553,7 +556,8 @@ export const App: React.FC<AppProps> = ({
   };
 
   const handleCreateBoardFromDialog = async (board: Partial<Board>) => {
-    const created = await onCreateBoard?.(board);
+    if (!onCreateBoard) return;
+    const created = await onCreateBoard(board);
     // Boards have their own URL (/b/<slug-or-short>/) — switch to the
     // new board after creation so the user lands on the empty canvas
     // they're about to populate. Same intent as goToBranch/goToSession

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -59,11 +59,20 @@ export interface CreateDialogProps {
   currentBoardId?: string;
   defaultPosition?: { x: number; y: number };
   defaultTab?: ActiveTab;
-  onCreateBranch: (config: BranchTabConfig) => void;
+  onCreateBranch: (config: BranchTabConfig) => void | Promise<void>;
   onCreateBoard: (board: Partial<Board>) => void | Promise<void>;
   onCreateRepo: (data: CreateRepoRequest) => void | Promise<void>;
   onCreateLocalRepo: (data: CreateLocalRepoRequest) => void | Promise<void>;
-  onCreateAssistant: (result: AssistantTabResult) => void;
+  onCreateAssistant: (result: AssistantTabResult) => void | Promise<void>;
+}
+
+/** Fire the parent handler and close the dialog. We don't `await` here
+ *  because the parent may navigate (away from the dialog's host
+ *  component) as part of its work — blocking the close on that would
+ *  delay the modal teardown. Rejections are swallowed: each parent
+ *  handler already surfaces its own errors via toasts. */
+function fireAndForget(result: void | Promise<void>) {
+  Promise.resolve(result).catch(() => {});
 }
 
 export const CreateDialog: React.FC<CreateDialogProps> = ({
@@ -128,7 +137,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
         case 'branch': {
           const config = await branchFormRef.current?.();
           if (config) {
-            onCreateBranch(config);
+            fireAndForget(onCreateBranch(config));
             onClose();
           }
           break;
@@ -136,11 +145,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
         case 'board': {
           const board = await boardFormRef.current?.();
           if (board) {
-            // Fire-and-forget: the parent's handler may navigate after
-            // create resolves; closing the modal first matches the
-            // branch/assistant/repo cases. Swallow rejections to avoid
-            // unhandled-rejection noise — the parent surfaces errors.
-            Promise.resolve(onCreateBoard(board)).catch(() => {});
+            fireAndForget(onCreateBoard(board));
             onClose();
           }
           break;
@@ -149,12 +154,9 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
           const result = await repoFormRef.current?.();
           if (result) {
             if (result.mode === 'local' && result.local) {
-              onCreateLocalRepo(result.local);
+              fireAndForget(onCreateLocalRepo(result.local));
             } else if (result.remote) {
-              // Fire-and-forget: handleCreateRepo in App.tsx already surfaces
-              // errors via a toast. Swallow here to avoid unhandled-rejection
-              // noise from its re-throw.
-              Promise.resolve(onCreateRepo(result.remote)).catch(() => {});
+              fireAndForget(onCreateRepo(result.remote));
             }
             onClose();
           }
@@ -163,7 +165,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
         case 'assistant': {
           const result = await assistantFormRef.current?.();
           if (result) {
-            onCreateAssistant(result);
+            fireAndForget(onCreateAssistant(result));
             onClose();
           }
           break;

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -60,7 +60,7 @@ export interface CreateDialogProps {
   defaultPosition?: { x: number; y: number };
   defaultTab?: ActiveTab;
   onCreateBranch: (config: BranchTabConfig) => void;
-  onCreateBoard: (board: Partial<Board>) => void;
+  onCreateBoard: (board: Partial<Board>) => void | Promise<void>;
   onCreateRepo: (data: CreateRepoRequest) => void | Promise<void>;
   onCreateLocalRepo: (data: CreateLocalRepoRequest) => void | Promise<void>;
   onCreateAssistant: (result: AssistantTabResult) => void;
@@ -136,7 +136,11 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
         case 'board': {
           const board = await boardFormRef.current?.();
           if (board) {
-            onCreateBoard(board);
+            // Fire-and-forget: the parent's handler may navigate after
+            // create resolves; closing the modal first matches the
+            // branch/assistant/repo cases. Swallow rejections to avoid
+            // unhandled-rejection noise — the parent surfaces errors.
+            Promise.resolve(onCreateBoard(board)).catch(() => {});
             onClose();
           }
           break;

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2747,13 +2747,18 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                   }
                 }
 
-                // Execute action
+                // Execute action and capture the session the user
+                // should land on so we can route through the normal
+                // session-click pipe afterward (same URL push as
+                // handleCreateSession / a card click).
+                let resultSessionId: string | undefined;
                 switch (action) {
                   case 'prompt': {
                     await client.sessions.prompt(targetSessionId, renderedTemplate, {
                       permissionMode,
                       messageSource: 'agor',
                     });
+                    resultSessionId = targetSessionId;
                     break;
                   }
                   case 'fork': {
@@ -2764,6 +2769,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       permissionMode,
                       messageSource: 'agor',
                     });
+                    resultSessionId = forkedSession.session_id;
                     break;
                   }
                   case 'spawn': {
@@ -2774,9 +2780,16 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       permissionMode,
                       messageSource: 'agor',
                     });
+                    resultSessionId = spawnedSession.session_id;
                     break;
                   }
                 }
+
+                // Open the session the trigger landed on (new for
+                // fork/spawn/new-session, existing for prompt). Routes
+                // through the same handler as a session-card click, so
+                // URL push + recenter + flag cleanup all run in lockstep.
+                if (resultSessionId) onSessionClick?.(resultSessionId);
               } catch (error) {
                 console.error('❌ Failed to execute zone trigger:', error);
               } finally {

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -151,7 +151,7 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
 
       if (!onCreateBranch || !onUpdateBranch) return;
 
-      await createAssistantBranch(
+      const branch = await createAssistantBranch(
         {
           displayName: values.displayName.trim(),
           description: values.description || undefined,
@@ -166,6 +166,15 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
 
       setCreateModalOpen(false);
       resetForm();
+
+      // Match the recenter-from-row behavior: close the Settings modal
+      // so the canvas isn't obscured, then push `/w/<short>/`. Cross-
+      // board switching (when the assistant landed on a freshly created
+      // board) is handled by useUrlState's URL→state effect.
+      if (branch) {
+        onClose?.();
+        navigation.goToBranch(branch.branch_id);
+      }
     } catch (error) {
       console.error('Assistant creation failed:', error);
     } finally {

--- a/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
+++ b/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
@@ -10,6 +10,11 @@
  * silently strand the user on the prior URL — the very regression this
  * fix addresses. The lookup is now scoped to the same-URL recenter
  * fallback (where it actually matters) instead of gating the navigation.
+ *
+ * The same contract applies to `goToBranch` and `goToBoard` — used by the
+ * post-create handlers in `App/App.tsx` (handleCreateBranch,
+ * handleCreateAssistant, handleCreateBoardFromDialog) — so each helper
+ * has its own race-condition test below.
  */
 
 import type { Branch, Session } from '@agor-live/client';
@@ -27,6 +32,10 @@ const NEW_SESSION_ID = '019e9999-0000-7000-8000-000000000001';
 const NEW_SESSION_SHORT = '019e99990000700080000000';
 const EXISTING_BRANCH_ID = '019e8888-0000-7000-8000-000000000001';
 const EXISTING_BOARD_ID = '019e7777-0000-7000-8000-000000000001';
+const NEW_BRANCH_ID = '019e6666-0000-7000-8000-000000000001';
+const NEW_BRANCH_SHORT = '019e66660000700080000000';
+const NEW_BOARD_ID = '019e5555-0000-7000-8000-000000000001';
+const NEW_BOARD_SHORT = '019e55550000700080000000';
 
 function wrap(initialEntry = '/') {
   return ({ children }: { children: ReactNode }) => (
@@ -128,5 +137,103 @@ describe('useAppNavigation.goToSession', () => {
 
     // No navigation should have happened — already on this URL.
     expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
+  });
+});
+
+describe('useAppNavigation.goToBranch', () => {
+  it('pushes /w/<short>/ even when the branch is NOT yet in branchById (just-created race)', () => {
+    // Mirror the create-session race: handleCreateBranch (in App/App.tsx)
+    // calls navigation.goToBranch immediately after the create() promise
+    // resolves, but the `branches.created` socket event may not have
+    // populated branchById yet. The URL push must fire anyway —
+    // useUrlState's URL→state effect re-runs when the branch lands in
+    // the map and drives selection + cross-board recenter from there.
+    const branchById = new Map<string, Branch>();
+
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById: new Map(),
+          branchById,
+        }),
+      { wrapper: wrap('/b/somewhere/') }
+    );
+
+    expect(result.current.pathname).toBe('/b/somewhere/');
+
+    act(() => {
+      result.current.nav.goToBranch(NEW_BRANCH_ID);
+    });
+
+    expect(result.current.pathname).toBe(`/w/${NEW_BRANCH_SHORT}/`);
+  });
+
+  it('still navigates when the branch IS in branchById', () => {
+    const branch = {
+      branch_id: NEW_BRANCH_ID,
+      board_id: EXISTING_BOARD_ID,
+    } as Branch;
+
+    const branchById = new Map([[branch.branch_id, branch]]);
+
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById: new Map(),
+          branchById,
+        }),
+      { wrapper: wrap('/b/somewhere/') }
+    );
+
+    act(() => {
+      result.current.nav.goToBranch(NEW_BRANCH_ID);
+    });
+
+    expect(result.current.pathname).toBe(`/w/${NEW_BRANCH_SHORT}/`);
+  });
+});
+
+describe('useAppNavigation.goToBoard', () => {
+  it('pushes /b/<short>/ even when the board is NOT yet in boardById (just-created race)', () => {
+    // handleCreateBoardFromDialog (in App/App.tsx) calls
+    // navigation.goToBoard immediately after the create() promise
+    // resolves. The `boards.created` socket event may land later — the
+    // URL must still flip so the user lands on the new board.
+    const boardById = new Map<string, { board_id: string; slug?: string }>();
+
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById,
+        }),
+      { wrapper: wrap('/b/somewhere/') }
+    );
+
+    act(() => {
+      result.current.nav.goToBoard(NEW_BOARD_ID);
+    });
+
+    // No slug yet — buildBoardPath falls back to the short id.
+    expect(result.current.pathname).toBe(`/b/${NEW_BOARD_SHORT}/`);
+  });
+
+  it('prefers the slug when the board IS in boardById', () => {
+    const boardById = new Map<string, { board_id: string; slug?: string }>([
+      [NEW_BOARD_ID, { board_id: NEW_BOARD_ID, slug: 'my-board' }],
+    ]);
+
+    const { result } = renderHook(
+      () =>
+        useTestNav({
+          boardById,
+        }),
+      { wrapper: wrap('/b/somewhere/') }
+    );
+
+    act(() => {
+      result.current.nav.goToBoard(NEW_BOARD_ID);
+    });
+
+    expect(result.current.pathname).toBe('/b/my-board/');
   });
 });


### PR DESCRIPTION
## Summary

Extend the post-create URL-routing pattern that landed in #1263 (sessions) to the other CreateDialog tabs and to the AssistantsTable in Settings. Previously the dialog closed but the user stayed wherever they were — the new branch / assistant card landed silently via the socket broadcast and they had to hunt for it off-screen.

- **Branch create** (`handleCreateBranch`): after the branch creates (and optional board-assignment patch), push `/w/<short>/` via `navigation.goToBranch`. `useUrlState`'s URL→state effect switches boards if the branch landed on a different one and recenters the canvas on the new card.
- **Assistant create** (`handleCreateAssistant`): assistants are branches under the hood, so the same `/w/<short>/` deep link works — picks up the cross-board hop for free when the assistant was created on a freshly-created board (the "Create new board" option in the Assistant tab).
- **Board create** (`handleCreateBoardFromDialog`, new wrapper): await the parent's `onCreateBoard`, then push `/b/<slug-or-short>/` so the user lands on the empty canvas they're about to populate. Required widening the parent's `handleCreateBoard` return type to `Board | null`.
- **Settings → AssistantsTable.handleCreate**: close the Settings modal and push `/w/<short>/` after a successful create so the user isn't stranded staring at the settings table.

All four helpers (`goToSession`/`goToBranch`/`goToArtifact`/`goToBoard`) already push the URL unconditionally even when the entity isn't yet in the live data map — the just-created race that #1263 fixed. New regression tests on `goToBranch` and `goToBoard` lock that contract across all four post-create call sites so future "create entity → navigate immediately" flows stay safe.

## Test plan

- [x] `pnpm typecheck` clean (agor-ui)
- [x] `pnpm lint` clean for modified files
- [x] `pnpm test` — all 183 tests pass (12 in the targeted hooks/dialog suites)
- [ ] Manual: Create branch from CreateDialog → lands on new card on correct board
- [ ] Manual: Create assistant from CreateDialog (existing board) → lands on assistant card
- [ ] Manual: Create assistant from CreateDialog (new board) → switches boards then lands on card
- [ ] Manual: Create assistant from Settings → AssistantsTable → Settings closes, lands on card
- [ ] Manual: Create board from CreateDialog → switches to the new empty board

🤖 Generated with [Claude Code](https://claude.com/claude-code)