### PR TITLE
perf(board): bail out useAgorData no-op socket events

### DIFF
--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -218,4 +218,64 @@ describe('useAgorData — socket-event bailouts', () => {
     expect(result.current.boardById).toBe(beforeBoards);
     expect(result.current.userById).toBe(beforeUsers);
   });
+
+  it('migrates a session between branches when branch_id changes', async () => {
+    const session = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const { client, emit } = makeMockClient({ sessions: [session] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    expect(result.current.sessionsByBranch.get('b-1')?.map((s) => s.session_id)).toEqual(['s-1']);
+
+    act(() => emit('sessions', 'patched', { ...session, branch_id: 'b-2' }));
+
+    // Old branch bucket is cleaned up; new branch bucket holds the session.
+    expect(result.current.sessionsByBranch.has('b-1')).toBe(false);
+    expect(result.current.sessionsByBranch.get('b-2')?.map((s) => s.session_id)).toEqual(['s-1']);
+    expect(result.current.sessionById.get('s-1')?.branch_id).toBe('b-2');
+  });
+
+  it('evicts a branch and its sessions on `branches.removed`', async () => {
+    const session = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const branch = makeBranch({ branch_id: 'b-1' });
+    const { client, emit } = makeMockClient({ sessions: [session], branches: [branch] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    expect(result.current.branchById.has('b-1')).toBe(true);
+    expect(result.current.sessionById.has('s-1')).toBe(true);
+    expect(result.current.sessionsByBranch.has('b-1')).toBe(true);
+
+    act(() => emit('branches', 'removed', branch));
+
+    expect(result.current.branchById.has('b-1')).toBe(false);
+    expect(result.current.sessionById.has('s-1')).toBe(false);
+    expect(result.current.sessionsByBranch.has('b-1')).toBe(false);
+  });
+
+  it('dispatches `agor:artifact-patched` when the artifact actually changes', async () => {
+    const artifact = {
+      artifact_id: 'a-1',
+      name: 'demo',
+      content_hash: 'h1',
+      board_id: 'board-1',
+      created_by: 'u-1',
+    };
+    const { client, emit } = makeMockClient({ artifacts: [artifact] });
+    const events: Array<{ artifactId: string; contentHash: string }> = [];
+    const listener = (e: Event) => events.push((e as CustomEvent).detail);
+    window.addEventListener('agor:artifact-patched', listener);
+
+    try {
+      const { result } = renderHook(() => useAgorData(client));
+      await waitForInitialLoad(result);
+
+      act(() => emit('artifacts', 'patched', { ...artifact, content_hash: 'h2' }));
+
+      expect(events).toEqual([{ artifactId: 'a-1', contentHash: 'h2' }]);
+      expect(result.current.artifactById.get('a-1')?.content_hash).toBe('h2');
+    } finally {
+      window.removeEventListener('agor:artifact-patched', listener);
+    }
+  });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Tests for `useAgorData` socket-event handling. The focus is on the
+ * subscription side of the hook (event handlers + state bailouts) — the
+ * initial /findAll fetch lives in `fetchData()` and is tested implicitly
+ * by populating the byId Maps with the initial response.
+ *
+ * Why this exists: socket events arrive at high frequency (especially when
+ * agents are streaming). Even when an event is a no-op for the central
+ * store (idempotent patch, archive event for an unknown id, etc.), an
+ * earlier bug always produced a fresh `maps` reference, cascading
+ * re-renders into the board canvas. These tests pin down the bailout
+ * contract: if an event doesn't change byId content, the hook return
+ * shape is reference-stable.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAgorData } from './useAgorData';
+
+/**
+ * Minimal AgorClient stand-in. Implements just enough of the service /
+ * socket surface the hook touches:
+ *   - `service(name).findAll({...})` — initial fetch, returns the
+ *     pre-seeded list for that service (default empty).
+ *   - `service(name).on/removeListener` — wires up event handlers we
+ *     dispatch from tests via `emit(name, event, payload)`.
+ *   - `service(name).get(id)` — only used by the OAuth refetch path,
+ *     resolves with whatever the test stubbed.
+ *   - `io.on/off` — captures connect / oauth listeners; tests don't
+ *     trigger reconnect refetches.
+ *
+ * Anything we don't model is left as a noop or absent — the hook handles
+ * its own optional-feature paths.
+ */
+type Listener = (payload: unknown) => void;
+
+function makeMockClient(seed: Record<string, unknown[]> = {}) {
+  const serviceListeners = new Map<string, Map<string, Listener[]>>();
+  const ioListeners = new Map<string, Listener[]>();
+
+  const service = (name: string) => ({
+    findAll: vi.fn().mockResolvedValue(seed[name] ?? []),
+    find: vi.fn().mockResolvedValue(seed[name] ?? []),
+    get: vi.fn().mockResolvedValue(seed[`${name}:get`] ?? null),
+    on: (event: string, fn: Listener) => {
+      let svc = serviceListeners.get(name);
+      if (!svc) {
+        svc = new Map();
+        serviceListeners.set(name, svc);
+      }
+      const arr = svc.get(event) ?? [];
+      arr.push(fn);
+      svc.set(event, arr);
+    },
+    removeListener: (event: string, fn: Listener) => {
+      const svc = serviceListeners.get(name);
+      if (!svc) return;
+      const arr = svc.get(event) ?? [];
+      svc.set(
+        event,
+        arr.filter((f) => f !== fn)
+      );
+    },
+  });
+
+  return {
+    client: {
+      service,
+      io: {
+        on: (event: string, fn: Listener) => {
+          const arr = ioListeners.get(event) ?? [];
+          arr.push(fn);
+          ioListeners.set(event, arr);
+        },
+        off: (event: string, fn: Listener) => {
+          const arr = ioListeners.get(event) ?? [];
+          ioListeners.set(
+            event,
+            arr.filter((f) => f !== fn)
+          );
+        },
+      },
+    } as never,
+    emit: (svc: string, event: string, payload: unknown) => {
+      for (const fn of serviceListeners.get(svc)?.get(event) ?? []) fn(payload);
+    },
+  };
+}
+
+const makeBranch = (overrides: Record<string, unknown> = {}) => ({
+  branch_id: 'b-1',
+  repo_id: 'r-1',
+  name: 'main',
+  status: 'idle',
+  archived: false,
+  ...overrides,
+});
+
+const makeSession = (overrides: Record<string, unknown> = {}) => ({
+  session_id: 's-1',
+  branch_id: 'b-1',
+  status: 'idle',
+  archived: false,
+  created_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+/**
+ * Wait until the initial fetch has populated the byId maps. The hook
+ * fetches a fixed set of services on mount; we wait for one (sessions)
+ * to land which implies the others completed in the same Promise.all.
+ */
+async function waitForInitialLoad(result: { current: ReturnType<typeof useAgorData> }) {
+  await waitFor(() => expect(result.current.initialLoadComplete).toBe(true));
+}
+
+describe('useAgorData — socket-event bailouts', () => {
+  it('drops a duplicate `sessions.patched` (content-equal) without changing byId references', async () => {
+    const session = makeSession();
+    const { client, emit } = makeMockClient({ sessions: [session] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const beforeSessions = result.current.sessionById;
+    const beforeByBranch = result.current.sessionsByBranch;
+
+    // Feathers re-emits a fresh object on every patch — same content,
+    // different reference. The hook MUST bail out (no-op patch).
+    act(() => emit('sessions', 'patched', { ...session }));
+
+    expect(result.current.sessionById).toBe(beforeSessions);
+    expect(result.current.sessionsByBranch).toBe(beforeByBranch);
+  });
+
+  it('updates byId references when a session field actually changes', async () => {
+    const session = makeSession({ status: 'idle' });
+    const { client, emit } = makeMockClient({ sessions: [session] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const beforeSessions = result.current.sessionById;
+
+    act(() => emit('sessions', 'patched', { ...session, status: 'running' }));
+
+    expect(result.current.sessionById).not.toBe(beforeSessions);
+    expect(result.current.sessionById.get('s-1')).toMatchObject({ status: 'running' });
+  });
+
+  it('ignores `sessions.removed` for a session not in the map', async () => {
+    const { client, emit } = makeMockClient();
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const beforeSessions = result.current.sessionById;
+    const beforeByBranch = result.current.sessionsByBranch;
+
+    act(() => emit('sessions', 'removed', makeSession({ session_id: 'unknown' })));
+
+    expect(result.current.sessionById).toBe(beforeSessions);
+    expect(result.current.sessionsByBranch).toBe(beforeByBranch);
+  });
+
+  it('drops a no-op `branches.patched` (idempotent content)', async () => {
+    const branch = makeBranch();
+    const { client, emit } = makeMockClient({ branches: [branch] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const before = result.current.branchById;
+    act(() => emit('branches', 'patched', { ...branch }));
+    expect(result.current.branchById).toBe(before);
+  });
+
+  it('updates branchById when a branch field flips', async () => {
+    const branch = makeBranch({ name: 'main' });
+    const { client, emit } = makeMockClient({ branches: [branch] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const before = result.current.branchById;
+    act(() => emit('branches', 'patched', { ...branch, name: 'feature/x' }));
+
+    expect(result.current.branchById).not.toBe(before);
+    expect(result.current.branchById.get('b-1')?.name).toBe('feature/x');
+  });
+
+  it('drops a duplicate `sessions.created` for an existing id', async () => {
+    const session = makeSession();
+    const { client, emit } = makeMockClient({ sessions: [session] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const beforeSessions = result.current.sessionById;
+    const beforeByBranch = result.current.sessionsByBranch;
+
+    act(() => emit('sessions', 'created', { ...session }));
+
+    expect(result.current.sessionById).toBe(beforeSessions);
+    expect(result.current.sessionsByBranch).toBe(beforeByBranch);
+  });
+
+  it('keeps unrelated byId maps reference-stable across a session patch', async () => {
+    const session = makeSession({ status: 'idle' });
+    const branch = makeBranch();
+    const { client, emit } = makeMockClient({ sessions: [session], branches: [branch] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const beforeBranches = result.current.branchById;
+    const beforeBoards = result.current.boardById;
+    const beforeUsers = result.current.userById;
+
+    act(() => emit('sessions', 'patched', { ...session, status: 'running' }));
+
+    // Only sessionById / sessionsByBranch flip — the rest must stay put so
+    // their consumers (SessionCanvas, boards UI, user settings) don't
+    // needlessly re-render.
+    expect(result.current.branchById).toBe(beforeBranches);
+    expect(result.current.boardById).toBe(beforeBoards);
+    expect(result.current.userById).toBe(beforeUsers);
+  });
+});

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -105,12 +105,18 @@ const makeSession = (overrides: Record<string, unknown> = {}) => ({
 });
 
 /**
- * Wait until the initial fetch has populated the byId maps. The hook
- * fetches a fixed set of services on mount; we wait for one (sessions)
- * to land which implies the others completed in the same Promise.all.
+ * Wait until the hook has finished its initial fetch AND populated the
+ * byId maps. The two flip in separate setState calls — `itemCounts` is
+ * updated as each tracked promise resolves (driving `initialLoadComplete`)
+ * while the byId Maps are populated after the `Promise.all` body runs —
+ * so we gate on `loading === false` which only flips inside the same
+ * `finally` block as the map writes.
  */
 async function waitForInitialLoad(result: { current: ReturnType<typeof useAgorData> }) {
-  await waitFor(() => expect(result.current.initialLoadComplete).toBe(true));
+  await waitFor(() => {
+    expect(result.current.loading).toBe(false);
+    expect(result.current.initialLoadComplete).toBe(true);
+  });
 }
 
 describe('useAgorData — socket-event bailouts', () => {
@@ -277,5 +283,28 @@ describe('useAgorData — socket-event bailouts', () => {
     } finally {
       window.removeEventListener('agor:artifact-patched', listener);
     }
+  });
+
+  it('keeps `artifactById` reference-stable on a content-equal artifact patch', async () => {
+    // Pin the contract: idempotent artifact patches must NOT invalidate
+    // `artifactById`. The window event fires either way (consumer filters
+    // by contentHash), but the central store stays put — that's what
+    // protects the canvas from re-rendering on no-op artifact patches.
+    const artifact = {
+      artifact_id: 'a-1',
+      name: 'demo',
+      content_hash: 'h1',
+      board_id: 'board-1',
+      created_by: 'u-1',
+    };
+    const { client, emit } = makeMockClient({ artifacts: [artifact] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const before = result.current.artifactById;
+
+    act(() => emit('artifacts', 'patched', { ...artifact }));
+
+    expect(result.current.artifactById).toBe(before);
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -101,6 +101,25 @@ interface UseAgorDataResult extends DataMaps {
   refetch: () => Promise<void>;
 }
 
+// Generic byId-map replacer used by the per-entity `*Patched` handlers below.
+// Returns `prev` unchanged when the incoming entity is shallow-equal to what
+// we already hold — combined with the wrapper-level no-op short-circuit in
+// `setMapSlice`, idempotent server-side patches become true no-ops. The
+// per-entity handlers stay responsible for archive / branch-migration /
+// cross-map cleanup; this helper only covers the plain "replace one entry"
+// case.
+function replaceIfChanged<T extends object>(
+  prev: Map<string, T>,
+  id: string,
+  entity: T
+): Map<string, T> {
+  const existing = prev.get(id);
+  if (existing && shallowEqualEntity(existing, entity)) return prev;
+  const next = new Map(prev);
+  next.set(id, entity);
+  return next;
+}
+
 /**
  * Fetch and subscribe to Agor data from daemon
  *
@@ -118,99 +137,37 @@ export function useAgorData(
   // Single state for all server-backed maps — reset is setMaps(EMPTY_MAPS), one call, can't miss a field.
   const [maps, setMaps] = useState<DataMaps>(EMPTY_MAPS);
 
-  // Per-field setter helpers with the same functional-update API as individual useState setters.
-  // Plain functions are fine — they only close over setMaps which is a stable useState setter.
-  // Biome can't statically prove stability so fetchData and the subscribe effect below carry
-  // a biome-ignore instead of listing every setter in the dep arrays.
-  //
-  // No-op short-circuit: when the inner functional update returns the same
-  // reference for the slice it owns (handler bailouts on `return prev`), the
-  // wrapper returns the outer `maps` object unchanged. Without this, the
-  // spread `{ ...m, sessionById: same }` would still produce a fresh `maps`
-  // reference and force `AppContent` → `App` → SessionCanvas to re-render on
-  // every socket event the handler chose to discard (e.g. `messages` /
-  // `tasks` events arriving for sessions we've already pruned from the map,
-  // archived branch patches for branches we don't track, idempotent entity
-  // patches caught by the shallow-equal checks below). The downstream cost
-  // is real — board re-layout work, MiniMap repaint, React Flow internal
-  // diff — so bailing at the source is the cheapest fix.
-  const setSessionById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.sessionById) : v;
-      return next === m.sessionById ? m : { ...m, sessionById: next };
-    });
-  const setSessionsByBranch = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.sessionsByBranch) : v;
-      return next === m.sessionsByBranch ? m : { ...m, sessionsByBranch: next };
-    });
-  const setBoardById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.boardById) : v;
-      return next === m.boardById ? m : { ...m, boardById: next };
-    });
-  const setBoardObjectById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.boardObjectById) : v;
-      return next === m.boardObjectById ? m : { ...m, boardObjectById: next };
-    });
-  const setCommentById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.commentById) : v;
-      return next === m.commentById ? m : { ...m, commentById: next };
-    });
-  const setCardById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.cardById) : v;
-      return next === m.cardById ? m : { ...m, cardById: next };
-    });
-  const setCardTypeById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.cardTypeById) : v;
-      return next === m.cardTypeById ? m : { ...m, cardTypeById: next };
-    });
-  const setRepoById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.repoById) : v;
-      return next === m.repoById ? m : { ...m, repoById: next };
-    });
-  const setBranchById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.branchById) : v;
-      return next === m.branchById ? m : { ...m, branchById: next };
-    });
-  const setUserById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.userById) : v;
-      return next === m.userById ? m : { ...m, userById: next };
-    });
-  const setMcpServerById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.mcpServerById) : v;
-      return next === m.mcpServerById ? m : { ...m, mcpServerById: next };
-    });
-  const setGatewayChannelById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.gatewayChannelById) : v;
-      return next === m.gatewayChannelById ? m : { ...m, gatewayChannelById: next };
-    });
-  const setArtifactById = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.artifactById) : v;
-      return next === m.artifactById ? m : { ...m, artifactById: next };
-    });
-  const setSessionMcpServerIds = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.sessionMcpServerIds) : v;
-      return next === m.sessionMcpServerIds ? m : { ...m, sessionMcpServerIds: next };
-    });
-  const setUserAuthenticatedMcpServerIds = (v) =>
-    setMaps((m) => {
-      const next = typeof v === 'function' ? v(m.userAuthenticatedMcpServerIds) : v;
-      return next === m.userAuthenticatedMcpServerIds
-        ? m
-        : { ...m, userAuthenticatedMcpServerIds: next };
-    });
+  // Per-field setter factory. Returns a setter with the same functional-update
+  // API as `useState`, with a no-op short-circuit: when the inner update
+  // returns the same reference for its slice, we preserve the outer `maps`
+  // reference too. Without this, `{ ...m, key: same }` would always allocate
+  // a fresh `maps` and force every `useAppLiveData()` / `useAppRepoData()`
+  // consumer to re-render on socket events the handler decided to discard.
+  const setMapSlice =
+    <K extends keyof DataMaps>(key: K) =>
+    (value: DataMaps[K] | ((prev: DataMaps[K]) => DataMaps[K])) =>
+      setMaps((prev) => {
+        const next =
+          typeof value === 'function'
+            ? (value as (p: DataMaps[K]) => DataMaps[K])(prev[key])
+            : value;
+        return Object.is(next, prev[key]) ? prev : { ...prev, [key]: next };
+      });
+  const setSessionById = setMapSlice('sessionById');
+  const setSessionsByBranch = setMapSlice('sessionsByBranch');
+  const setBoardById = setMapSlice('boardById');
+  const setBoardObjectById = setMapSlice('boardObjectById');
+  const setCommentById = setMapSlice('commentById');
+  const setCardById = setMapSlice('cardById');
+  const setCardTypeById = setMapSlice('cardTypeById');
+  const setRepoById = setMapSlice('repoById');
+  const setBranchById = setMapSlice('branchById');
+  const setUserById = setMapSlice('userById');
+  const setMcpServerById = setMapSlice('mcpServerById');
+  const setGatewayChannelById = setMapSlice('gatewayChannelById');
+  const setArtifactById = setMapSlice('artifactById');
+  const setSessionMcpServerIds = setMapSlice('sessionMcpServerIds');
+  const setUserAuthenticatedMcpServerIds = setMapSlice('userAuthenticatedMcpServerIds');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Per-item counts captured at fetch-resolution time. Presence in this
@@ -678,16 +635,7 @@ export function useAgorData(
       });
     };
     const handleBoardPatched = (board: Board) => {
-      setBoardById((prev) => {
-        const existing = prev.get(board.board_id);
-        // Bail out on content-equal patches. Wrapper-level `same-ref` check
-        // turns this `prev` return into a true no-op (no `maps` churn, no
-        // downstream re-renders).
-        if (existing && shallowEqualEntity(existing, board)) return prev;
-        const next = new Map(prev);
-        next.set(board.board_id, board);
-        return next;
-      });
+      setBoardById((prev) => replaceIfChanged(prev, board.board_id, board));
     };
     const handleBoardRemoved = (board: Board) => {
       setBoardById((prev) => {
@@ -714,13 +662,7 @@ export function useAgorData(
       });
     };
     const handleBoardObjectPatched = (boardObject: BoardEntityObject) => {
-      setBoardObjectById((prev) => {
-        const existing = prev.get(boardObject.object_id);
-        if (existing && shallowEqualEntity(existing, boardObject)) return prev;
-        const next = new Map(prev);
-        next.set(boardObject.object_id, boardObject);
-        return next;
-      });
+      setBoardObjectById((prev) => replaceIfChanged(prev, boardObject.object_id, boardObject));
     };
     const handleBoardObjectRemoved = (boardObject: BoardEntityObject) => {
       setBoardObjectById((prev) => {
@@ -747,13 +689,7 @@ export function useAgorData(
       });
     };
     const handleRepoPatched = (repo: Repo) => {
-      setRepoById((prev) => {
-        const existing = prev.get(repo.repo_id);
-        if (existing && shallowEqualEntity(existing, repo)) return prev;
-        const next = new Map(prev);
-        next.set(repo.repo_id, repo);
-        return next;
-      });
+      setRepoById((prev) => replaceIfChanged(prev, repo.repo_id, repo));
     };
     const handleRepoRemoved = (repo: Repo) => {
       setRepoById((prev) => {
@@ -781,56 +717,48 @@ export function useAgorData(
         return next;
       });
     };
+    // Drop a branch from `branchById` and prune every session that lived on
+    // it from `sessionById` / `sessionsByBranch`. Shared between the
+    // `archived: true` patch path and the hard-delete `removed` path —
+    // either way we never want an orphan session card to linger.
+    const evictBranchAndSessions = (branchId: string) => {
+      setBranchById((prev) => {
+        if (!prev.has(branchId)) return prev;
+        const next = new Map(prev);
+        next.delete(branchId);
+        return next;
+      });
+      setSessionsByBranch((prev) => {
+        if (!prev.has(branchId)) return prev;
+        const next = new Map(prev);
+        next.delete(branchId);
+        return next;
+      });
+      setSessionById((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        for (const [sessionId, session] of prev.entries()) {
+          if (session.branch_id === branchId) {
+            next.delete(sessionId);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    };
+
     const handleBranchPatched = (branch: Branch) => {
       if (branch.archived) {
-        // Remove archived branch from core map
-        setBranchById((prev) => {
-          if (!prev.has(branch.branch_id)) return prev;
-          const next = new Map(prev);
-          next.delete(branch.branch_id);
-          return next;
-        });
-
-        // Remove sessions under archived branch from core maps
-        setSessionsByBranch((prev) => {
-          if (!prev.has(branch.branch_id)) return prev;
-          const next = new Map(prev);
-          next.delete(branch.branch_id);
-          return next;
-        });
-        setSessionById((prev) => {
-          let changed = false;
-          const next = new Map(prev);
-          for (const [sessionId, session] of prev.entries()) {
-            if (session.branch_id === branch.branch_id) {
-              next.delete(sessionId);
-              changed = true;
-            }
-          }
-          return changed ? next : prev;
-        });
+        evictBranchAndSessions(branch.branch_id);
         return;
       }
 
-      setBranchById((prev) => {
-        const existing = prev.get(branch.branch_id);
-        // Drop ghost patches that don't actually move any branch field — the
-        // board canvas only depends on branchById for its initialNodes useMemo,
-        // so bailing here is what keeps zoom/pan smooth when daemon-side
-        // bookkeeping fires `branches.patched` with unchanged content.
-        if (existing && shallowEqualEntity(existing, branch)) return prev;
-        const next = new Map(prev);
-        next.set(branch.branch_id, branch);
-        return next;
-      });
+      setBranchById((prev) => replaceIfChanged(prev, branch.branch_id, branch));
     };
     const handleBranchRemoved = (branch: Branch) => {
-      setBranchById((prev) => {
-        if (!prev.has(branch.branch_id)) return prev; // Doesn't exist, nothing to remove
-        const next = new Map(prev);
-        next.delete(branch.branch_id);
-        return next;
-      });
+      // Mirror the archive path: a hard delete should also evict any
+      // sessions we still track on that branch.
+      evictBranchAndSessions(branch.branch_id);
     };
 
     branchesService.on('created', handleBranchCreated);
@@ -849,13 +777,7 @@ export function useAgorData(
       });
     };
     const handleUserPatched = (user: User) => {
-      setUserById((prev) => {
-        const existing = prev.get(user.user_id);
-        if (existing && shallowEqualEntity(existing, user)) return prev;
-        const next = new Map(prev);
-        next.set(user.user_id, user);
-        return next;
-      });
+      setUserById((prev) => replaceIfChanged(prev, user.user_id, user));
     };
     const handleUserRemoved = (user: User) => {
       setUserById((prev) => {
@@ -882,13 +804,7 @@ export function useAgorData(
       });
     };
     const handleMCPServerPatched = (server: MCPServer) => {
-      setMcpServerById((prev) => {
-        const existing = prev.get(server.mcp_server_id);
-        if (existing && shallowEqualEntity(existing, server)) return prev;
-        const next = new Map(prev);
-        next.set(server.mcp_server_id, server);
-        return next;
-      });
+      setMcpServerById((prev) => replaceIfChanged(prev, server.mcp_server_id, server));
     };
     const handleMCPServerRemoved = (server: MCPServer) => {
       setMcpServerById((prev) => {
@@ -915,13 +831,7 @@ export function useAgorData(
       });
     };
     const handleGatewayChannelPatched = (channel: GatewayChannel) => {
-      setGatewayChannelById((prev) => {
-        const existing = prev.get(channel.id);
-        if (existing && shallowEqualEntity(existing, channel)) return prev;
-        const next = new Map(prev);
-        next.set(channel.id, channel);
-        return next;
-      });
+      setGatewayChannelById((prev) => replaceIfChanged(prev, channel.id, channel));
     };
     const handleGatewayChannelRemoved = (channel: GatewayChannel) => {
       setGatewayChannelById((prev) => {
@@ -941,19 +851,14 @@ export function useAgorData(
     const cardsService = client.service('cards');
     const handleCardCreated = (card: CardWithType) => {
       setCardById((prev) => {
+        if (prev.has(card.card_id)) return prev; // Duplicate event — bail.
         const next = new Map(prev);
         next.set(card.card_id, card);
         return next;
       });
     };
     const handleCardPatched = (card: CardWithType) => {
-      setCardById((prev) => {
-        const existing = prev.get(card.card_id);
-        if (existing && shallowEqualEntity(existing, card)) return prev;
-        const next = new Map(prev);
-        next.set(card.card_id, card);
-        return next;
-      });
+      setCardById((prev) => replaceIfChanged(prev, card.card_id, card));
     };
     const handleCardRemoved = (card: CardWithType) => {
       setCardById((prev) => {
@@ -973,19 +878,14 @@ export function useAgorData(
     const cardTypesService = client.service('card-types');
     const handleCardTypeCreated = (cardType: CardType) => {
       setCardTypeById((prev) => {
+        if (prev.has(cardType.card_type_id)) return prev; // Duplicate event — bail.
         const next = new Map(prev);
         next.set(cardType.card_type_id, cardType);
         return next;
       });
     };
     const handleCardTypePatched = (cardType: CardType) => {
-      setCardTypeById((prev) => {
-        const existing = prev.get(cardType.card_type_id);
-        if (existing && shallowEqualEntity(existing, cardType)) return prev;
-        const next = new Map(prev);
-        next.set(cardType.card_type_id, cardType);
-        return next;
-      });
+      setCardTypeById((prev) => replaceIfChanged(prev, cardType.card_type_id, cardType));
     };
     const handleCardTypeRemoved = (cardType: CardType) => {
       setCardTypeById((prev) => {
@@ -1012,27 +912,18 @@ export function useAgorData(
       });
     };
     const handleArtifactPatched = (artifact: Artifact) => {
-      let payloadChanged = true;
-      setArtifactById((prev) => {
-        const existing = prev.get(artifact.artifact_id);
-        if (existing && shallowEqualEntity(existing, artifact)) {
-          payloadChanged = false;
-          return prev;
-        }
-        const next = new Map(prev);
-        next.set(artifact.artifact_id, artifact);
-        return next;
-      });
-      // Notify ArtifactNode components that payload may have changed.
-      // Skip the dispatch on no-op patches so iframes don't churn on
-      // idempotent server-side bookkeeping.
-      if (payloadChanged) {
-        window.dispatchEvent(
-          new CustomEvent('agor:artifact-patched', {
-            detail: { artifactId: artifact.artifact_id, contentHash: artifact.content_hash },
-          })
-        );
-      }
+      setArtifactById((prev) => replaceIfChanged(prev, artifact.artifact_id, artifact));
+      // Notify ArtifactNode components that payload may have changed. The
+      // consumer (apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx)
+      // already filters by `contentHash !== lastHashRef.current`, so an
+      // idempotent dispatch is a cheap no-op there — no need to mirror the
+      // shallow-equal bailout from a state-updater side effect (which would
+      // not be pure under StrictMode anyway).
+      window.dispatchEvent(
+        new CustomEvent('agor:artifact-patched', {
+          detail: { artifactId: artifact.artifact_id, contentHash: artifact.content_hash },
+        })
+      );
     };
     const handleArtifactRemoved = (artifact: Artifact) => {
       setArtifactById((prev) => {
@@ -1115,13 +1006,7 @@ export function useAgorData(
       });
     };
     const handleCommentPatched = (comment: BoardComment) => {
-      setCommentById((prev) => {
-        const existing = prev.get(comment.comment_id);
-        if (existing && shallowEqualEntity(existing, comment)) return prev;
-        const next = new Map(prev);
-        next.set(comment.comment_id, comment);
-        return next;
-      });
+      setCommentById((prev) => replaceIfChanged(prev, comment.comment_id, comment));
     };
     const handleCommentRemoved = (comment: BoardComment) => {
       setCommentById((prev) => {

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -1055,11 +1055,7 @@ export function useAgorData(
       // `apps/agor-daemon/src/register-hooks.ts`), so a single `get` is enough.
       try {
         const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
-        setMcpServerById((prev) => {
-          const next = new Map(prev);
-          next.set(fresh.mcp_server_id, fresh);
-          return next;
-        });
+        setMcpServerById((prev) => replaceIfChanged(prev, fresh.mcp_server_id, fresh));
       } catch (err) {
         console.warn('[OAuth] Failed to refetch MCP server after re-auth:', err);
       }
@@ -1103,11 +1099,7 @@ export function useAgorData(
       // Still refetch to get the canonical server state from the daemon.
       try {
         const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
-        setMcpServerById((prev) => {
-          const next = new Map(prev);
-          next.set(fresh.mcp_server_id, fresh);
-          return next;
-        });
+        setMcpServerById((prev) => replaceIfChanged(prev, fresh.mcp_server_id, fresh));
       } catch (err) {
         console.warn('[OAuth] Failed to refetch MCP server after disconnect:', err);
       }

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -22,6 +22,7 @@ import type {
 } from '@agor-live/client';
 import { PAGINATION } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { shallowEqualEntity } from '../utils/shallowEqual';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 
 // Canonical list of initial-load items tracked by the loading checklist.
@@ -121,49 +122,95 @@ export function useAgorData(
   // Plain functions are fine — they only close over setMaps which is a stable useState setter.
   // Biome can't statically prove stability so fetchData and the subscribe effect below carry
   // a biome-ignore instead of listing every setter in the dep arrays.
+  //
+  // No-op short-circuit: when the inner functional update returns the same
+  // reference for the slice it owns (handler bailouts on `return prev`), the
+  // wrapper returns the outer `maps` object unchanged. Without this, the
+  // spread `{ ...m, sessionById: same }` would still produce a fresh `maps`
+  // reference and force `AppContent` → `App` → SessionCanvas to re-render on
+  // every socket event the handler chose to discard (e.g. `messages` /
+  // `tasks` events arriving for sessions we've already pruned from the map,
+  // archived branch patches for branches we don't track, idempotent entity
+  // patches caught by the shallow-equal checks below). The downstream cost
+  // is real — board re-layout work, MiniMap repaint, React Flow internal
+  // diff — so bailing at the source is the cheapest fix.
   const setSessionById = (v) =>
-    setMaps((m) => ({ ...m, sessionById: typeof v === 'function' ? v(m.sessionById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.sessionById) : v;
+      return next === m.sessionById ? m : { ...m, sessionById: next };
+    });
   const setSessionsByBranch = (v) =>
-    setMaps((m) => ({
-      ...m,
-      sessionsByBranch: typeof v === 'function' ? v(m.sessionsByBranch) : v,
-    }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.sessionsByBranch) : v;
+      return next === m.sessionsByBranch ? m : { ...m, sessionsByBranch: next };
+    });
   const setBoardById = (v) =>
-    setMaps((m) => ({ ...m, boardById: typeof v === 'function' ? v(m.boardById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.boardById) : v;
+      return next === m.boardById ? m : { ...m, boardById: next };
+    });
   const setBoardObjectById = (v) =>
-    setMaps((m) => ({ ...m, boardObjectById: typeof v === 'function' ? v(m.boardObjectById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.boardObjectById) : v;
+      return next === m.boardObjectById ? m : { ...m, boardObjectById: next };
+    });
   const setCommentById = (v) =>
-    setMaps((m) => ({ ...m, commentById: typeof v === 'function' ? v(m.commentById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.commentById) : v;
+      return next === m.commentById ? m : { ...m, commentById: next };
+    });
   const setCardById = (v) =>
-    setMaps((m) => ({ ...m, cardById: typeof v === 'function' ? v(m.cardById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.cardById) : v;
+      return next === m.cardById ? m : { ...m, cardById: next };
+    });
   const setCardTypeById = (v) =>
-    setMaps((m) => ({ ...m, cardTypeById: typeof v === 'function' ? v(m.cardTypeById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.cardTypeById) : v;
+      return next === m.cardTypeById ? m : { ...m, cardTypeById: next };
+    });
   const setRepoById = (v) =>
-    setMaps((m) => ({ ...m, repoById: typeof v === 'function' ? v(m.repoById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.repoById) : v;
+      return next === m.repoById ? m : { ...m, repoById: next };
+    });
   const setBranchById = (v) =>
-    setMaps((m) => ({ ...m, branchById: typeof v === 'function' ? v(m.branchById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.branchById) : v;
+      return next === m.branchById ? m : { ...m, branchById: next };
+    });
   const setUserById = (v) =>
-    setMaps((m) => ({ ...m, userById: typeof v === 'function' ? v(m.userById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.userById) : v;
+      return next === m.userById ? m : { ...m, userById: next };
+    });
   const setMcpServerById = (v) =>
-    setMaps((m) => ({ ...m, mcpServerById: typeof v === 'function' ? v(m.mcpServerById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.mcpServerById) : v;
+      return next === m.mcpServerById ? m : { ...m, mcpServerById: next };
+    });
   const setGatewayChannelById = (v) =>
-    setMaps((m) => ({
-      ...m,
-      gatewayChannelById: typeof v === 'function' ? v(m.gatewayChannelById) : v,
-    }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.gatewayChannelById) : v;
+      return next === m.gatewayChannelById ? m : { ...m, gatewayChannelById: next };
+    });
   const setArtifactById = (v) =>
-    setMaps((m) => ({ ...m, artifactById: typeof v === 'function' ? v(m.artifactById) : v }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.artifactById) : v;
+      return next === m.artifactById ? m : { ...m, artifactById: next };
+    });
   const setSessionMcpServerIds = (v) =>
-    setMaps((m) => ({
-      ...m,
-      sessionMcpServerIds: typeof v === 'function' ? v(m.sessionMcpServerIds) : v,
-    }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.sessionMcpServerIds) : v;
+      return next === m.sessionMcpServerIds ? m : { ...m, sessionMcpServerIds: next };
+    });
   const setUserAuthenticatedMcpServerIds = (v) =>
-    setMaps((m) => ({
-      ...m,
-      userAuthenticatedMcpServerIds:
-        typeof v === 'function' ? v(m.userAuthenticatedMcpServerIds) : v,
-    }));
+    setMaps((m) => {
+      const next = typeof v === 'function' ? v(m.userAuthenticatedMcpServerIds) : v;
+      return next === m.userAuthenticatedMcpServerIds
+        ? m
+        : { ...m, userAuthenticatedMcpServerIds: next };
+    });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Per-item counts captured at fetch-resolution time. Presence in this
@@ -515,7 +562,12 @@ export function useAgorData(
           return next;
         }
 
-        if (existing === session) return prev; // Same reference, no change
+        // Bail out on no-op patches. Feathers always emits a fresh object so
+        // `existing === session` never holds, but the daemon does emit
+        // idempotent patches (e.g. callback bookkeeping that lands at the same
+        // status). Shallow-equal misses nested fields the daemon reserializes
+        // — that's a safe false negative.
+        if (existing && shallowEqualEntity(existing, session)) return prev;
 
         const next = new Map(prev);
         next.set(session.session_id, session);
@@ -563,7 +615,15 @@ export function useAgorData(
           return next;
         }
 
-        if (branchSessions[index] === session) {
+        // Bail out when the session is content-equal to what we already hold.
+        // Mirrors the sessionById bailout above so an idempotent patch doesn't
+        // produce a fresh branch-bucket array (which would invalidate
+        // `data.sessions === n.sessions` in BranchNode's custom areEqual and
+        // re-render every BranchCard on the affected branch).
+        if (
+          branchSessions[index] === session ||
+          shallowEqualEntity(branchSessions[index], session)
+        ) {
           return changed ? next : prev;
         }
 
@@ -574,17 +634,23 @@ export function useAgorData(
       });
     };
     const handleSessionRemoved = (session: Session) => {
-      // Update sessionById
+      // Update sessionById — bail out when the id isn't tracked so the
+      // wrapper short-circuit prevents the spurious `maps` update.
       setSessionById((prev) => {
+        if (!prev.has(session.session_id)) return prev;
         const next = new Map(prev);
         next.delete(session.session_id);
         return next;
       });
 
-      // Update sessionsByBranch
+      // Update sessionsByBranch — same bail when the session isn't in the
+      // branch's bucket.
       setSessionsByBranch((prev) => {
+        const branchSessions = prev.get(session.branch_id);
+        if (!branchSessions?.some((s) => s.session_id === session.session_id)) {
+          return prev;
+        }
         const next = new Map(prev);
-        const branchSessions = next.get(session.branch_id) || [];
         const filtered = branchSessions.filter((s) => s.session_id !== session.session_id);
         if (filtered.length > 0) {
           next.set(session.branch_id, filtered);
@@ -614,9 +680,10 @@ export function useAgorData(
     const handleBoardPatched = (board: Board) => {
       setBoardById((prev) => {
         const existing = prev.get(board.board_id);
-        if (existing === board) {
-          return prev; // Same reference, no change
-        }
+        // Bail out on content-equal patches. Wrapper-level `same-ref` check
+        // turns this `prev` return into a true no-op (no `maps` churn, no
+        // downstream re-renders).
+        if (existing && shallowEqualEntity(existing, board)) return prev;
         const next = new Map(prev);
         next.set(board.board_id, board);
         return next;
@@ -649,7 +716,7 @@ export function useAgorData(
     const handleBoardObjectPatched = (boardObject: BoardEntityObject) => {
       setBoardObjectById((prev) => {
         const existing = prev.get(boardObject.object_id);
-        if (existing === boardObject) return prev; // Same reference, no change
+        if (existing && shallowEqualEntity(existing, boardObject)) return prev;
         const next = new Map(prev);
         next.set(boardObject.object_id, boardObject);
         return next;
@@ -682,7 +749,7 @@ export function useAgorData(
     const handleRepoPatched = (repo: Repo) => {
       setRepoById((prev) => {
         const existing = prev.get(repo.repo_id);
-        if (existing === repo) return prev; // Same reference, no change
+        if (existing && shallowEqualEntity(existing, repo)) return prev;
         const next = new Map(prev);
         next.set(repo.repo_id, repo);
         return next;
@@ -747,7 +814,11 @@ export function useAgorData(
 
       setBranchById((prev) => {
         const existing = prev.get(branch.branch_id);
-        if (existing === branch) return prev; // Same reference, no change
+        // Drop ghost patches that don't actually move any branch field — the
+        // board canvas only depends on branchById for its initialNodes useMemo,
+        // so bailing here is what keeps zoom/pan smooth when daemon-side
+        // bookkeeping fires `branches.patched` with unchanged content.
+        if (existing && shallowEqualEntity(existing, branch)) return prev;
         const next = new Map(prev);
         next.set(branch.branch_id, branch);
         return next;
@@ -780,7 +851,7 @@ export function useAgorData(
     const handleUserPatched = (user: User) => {
       setUserById((prev) => {
         const existing = prev.get(user.user_id);
-        if (existing === user) return prev; // Same reference, no change
+        if (existing && shallowEqualEntity(existing, user)) return prev;
         const next = new Map(prev);
         next.set(user.user_id, user);
         return next;
@@ -813,7 +884,7 @@ export function useAgorData(
     const handleMCPServerPatched = (server: MCPServer) => {
       setMcpServerById((prev) => {
         const existing = prev.get(server.mcp_server_id);
-        if (existing === server) return prev; // Same reference, no change
+        if (existing && shallowEqualEntity(existing, server)) return prev;
         const next = new Map(prev);
         next.set(server.mcp_server_id, server);
         return next;
@@ -846,7 +917,7 @@ export function useAgorData(
     const handleGatewayChannelPatched = (channel: GatewayChannel) => {
       setGatewayChannelById((prev) => {
         const existing = prev.get(channel.id);
-        if (existing === channel) return prev;
+        if (existing && shallowEqualEntity(existing, channel)) return prev;
         const next = new Map(prev);
         next.set(channel.id, channel);
         return next;
@@ -878,7 +949,7 @@ export function useAgorData(
     const handleCardPatched = (card: CardWithType) => {
       setCardById((prev) => {
         const existing = prev.get(card.card_id);
-        if (existing === card) return prev;
+        if (existing && shallowEqualEntity(existing, card)) return prev;
         const next = new Map(prev);
         next.set(card.card_id, card);
         return next;
@@ -910,7 +981,7 @@ export function useAgorData(
     const handleCardTypePatched = (cardType: CardType) => {
       setCardTypeById((prev) => {
         const existing = prev.get(cardType.card_type_id);
-        if (existing === cardType) return prev;
+        if (existing && shallowEqualEntity(existing, cardType)) return prev;
         const next = new Map(prev);
         next.set(cardType.card_type_id, cardType);
         return next;
@@ -941,19 +1012,27 @@ export function useAgorData(
       });
     };
     const handleArtifactPatched = (artifact: Artifact) => {
+      let payloadChanged = true;
       setArtifactById((prev) => {
         const existing = prev.get(artifact.artifact_id);
-        if (existing === artifact) return prev;
+        if (existing && shallowEqualEntity(existing, artifact)) {
+          payloadChanged = false;
+          return prev;
+        }
         const next = new Map(prev);
         next.set(artifact.artifact_id, artifact);
         return next;
       });
-      // Notify ArtifactNode components that payload may have changed
-      window.dispatchEvent(
-        new CustomEvent('agor:artifact-patched', {
-          detail: { artifactId: artifact.artifact_id, contentHash: artifact.content_hash },
-        })
-      );
+      // Notify ArtifactNode components that payload may have changed.
+      // Skip the dispatch on no-op patches so iframes don't churn on
+      // idempotent server-side bookkeeping.
+      if (payloadChanged) {
+        window.dispatchEvent(
+          new CustomEvent('agor:artifact-patched', {
+            detail: { artifactId: artifact.artifact_id, contentHash: artifact.content_hash },
+          })
+        );
+      }
     };
     const handleArtifactRemoved = (artifact: Artifact) => {
       setArtifactById((prev) => {
@@ -1038,7 +1117,7 @@ export function useAgorData(
     const handleCommentPatched = (comment: BoardComment) => {
       setCommentById((prev) => {
         const existing = prev.get(comment.comment_id);
-        if (existing === comment) return prev; // Same reference, no change
+        if (existing && shallowEqualEntity(existing, comment)) return prev;
         const next = new Map(prev);
         next.set(comment.comment_id, comment);
         return next;

--- a/apps/agor-ui/src/utils/shallowEqual.test.ts
+++ b/apps/agor-ui/src/utils/shallowEqual.test.ts
@@ -21,6 +21,17 @@ describe('shallowEqualEntity', () => {
     ).toBe(false);
   });
 
+  it('returns false when key sets differ but lengths match (both undefined values)', () => {
+    // Regression: bag-of-keys check that only compared lengths would say
+    // `{a: undefined}` equals `{b: undefined}` because `obj.a` and `obj.b`
+    // both read back as `undefined`. The hasOwnProperty check catches this.
+    expect(shallowEqualEntity({ a: undefined } as object, { b: undefined } as object)).toBe(false);
+  });
+
+  it('treats NaN as equal to NaN (Object.is semantics)', () => {
+    expect(shallowEqualEntity({ x: Number.NaN }, { x: Number.NaN })).toBe(true);
+  });
+
   it('returns false when a nested object has a fresh reference', () => {
     // Documents the safe failure mode — fresh JSON-parsed payloads always
     // produce new nested object refs, so shallow-equal won't catch content-

--- a/apps/agor-ui/src/utils/shallowEqual.test.ts
+++ b/apps/agor-ui/src/utils/shallowEqual.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { shallowEqualEntity } from './shallowEqual';
+
+describe('shallowEqualEntity', () => {
+  it('returns true for identical references', () => {
+    const a = { id: '1', name: 'x' };
+    expect(shallowEqualEntity(a, a)).toBe(true);
+  });
+
+  it('returns true for structurally equal objects with primitive fields', () => {
+    expect(shallowEqualEntity({ id: '1', n: 2 }, { id: '1', n: 2 })).toBe(true);
+  });
+
+  it('returns false when a top-level primitive differs', () => {
+    expect(shallowEqualEntity({ id: '1', n: 2 }, { id: '1', n: 3 })).toBe(false);
+  });
+
+  it('returns false when key sets differ', () => {
+    expect(
+      shallowEqualEntity({ id: '1', n: 2 } as { id: string; n: number }, { id: '1', n: 2, m: 5 })
+    ).toBe(false);
+  });
+
+  it('returns false when a nested object has a fresh reference', () => {
+    // Documents the safe failure mode — fresh JSON-parsed payloads always
+    // produce new nested object refs, so shallow-equal won't catch content-
+    // identical patches with nested fields. Bailing out is opportunistic.
+    expect(shallowEqualEntity({ id: '1', nested: { v: 1 } }, { id: '1', nested: { v: 1 } })).toBe(
+      false
+    );
+  });
+
+  it('returns true when nested object has the same reference', () => {
+    const nested = { v: 1 };
+    expect(shallowEqualEntity({ id: '1', nested }, { id: '1', nested })).toBe(true);
+  });
+
+  it('handles null and undefined inputs', () => {
+    expect(shallowEqualEntity(null, null)).toBe(true);
+    expect(shallowEqualEntity(undefined, undefined)).toBe(true);
+    expect(shallowEqualEntity({ a: 1 }, null)).toBe(false);
+    expect(shallowEqualEntity(null, { a: 1 })).toBe(false);
+  });
+});

--- a/apps/agor-ui/src/utils/shallowEqual.ts
+++ b/apps/agor-ui/src/utils/shallowEqual.ts
@@ -1,0 +1,47 @@
+/**
+ * Shallow-equal helpers for filtering socket-driven re-renders.
+ *
+ * Feathers re-emits a fresh entity object on every `created` / `patched`
+ * event — JSON.parse on the server side guarantees a new reference even
+ * when the row is content-identical. Without a content check, the central
+ * store handlers in useAgorData would replace the existing entry on every
+ * "ghost" patch and cascade an unnecessary re-render through every consumer
+ * of `useAppLiveData()` / `useAppRepoData()` etc.
+ *
+ * These helpers compare top-level keys only. Nested objects that the daemon
+ * always reserializes (e.g. `session.model_config`, `branch.git_state`) will
+ * read as "different" even when content-equal — that's the safe failure
+ * mode: a false negative just means we keep the existing pass-through
+ * behavior, no correctness risk.
+ */
+
+/**
+ * Strict-equal two values. Used as the leaf comparator for shallow-equal.
+ */
+const sameValue = (a: unknown, b: unknown): boolean => a === b;
+
+/**
+ * Shallow-equal two plain objects. Returns true iff both have the same
+ * key set and every top-level key holds a referentially equal value.
+ *
+ * - `null` / `undefined` are never equal to a populated object.
+ * - Arrays compare by reference (use a dedicated array helper if you need
+ *   element-by-element checks).
+ * - Nested objects compare by reference — see file docstring above.
+ */
+export function shallowEqualEntity<T extends object>(
+  a: T | null | undefined,
+  b: T | null | undefined
+): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+
+  const keysA = Object.keys(a) as Array<keyof T>;
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+
+  for (const key of keysA) {
+    if (!sameValue(a[key], b[key as keyof T])) return false;
+  }
+  return true;
+}

--- a/apps/agor-ui/src/utils/shallowEqual.ts
+++ b/apps/agor-ui/src/utils/shallowEqual.ts
@@ -16,18 +16,16 @@
  */
 
 /**
- * Strict-equal two values. Used as the leaf comparator for shallow-equal.
- */
-const sameValue = (a: unknown, b: unknown): boolean => a === b;
-
-/**
  * Shallow-equal two plain objects. Returns true iff both have the same
- * key set and every top-level key holds a referentially equal value.
+ * key set (own enumerable keys) and every top-level key holds a referentially
+ * equal value.
  *
  * - `null` / `undefined` are never equal to a populated object.
  * - Arrays compare by reference (use a dedicated array helper if you need
  *   element-by-element checks).
  * - Nested objects compare by reference — see file docstring above.
+ * - Same length but different keys (e.g. `{a: undefined}` vs `{b: undefined}`)
+ *   is correctly false because we verify `b` owns each key from `a`.
  */
 export function shallowEqualEntity<T extends object>(
   a: T | null | undefined,
@@ -41,7 +39,8 @@ export function shallowEqualEntity<T extends object>(
   if (keysA.length !== keysB.length) return false;
 
   for (const key of keysA) {
-    if (!sameValue(a[key], b[key as keyof T])) return false;
+    if (!Object.hasOwn(b, key)) return false;
+    if (!Object.is(a[key], b[key as keyof T])) return false;
   }
   return true;
 }


### PR DESCRIPTION
## Summary

- Per-key setters in `useAgorData` short-circuit when the inner update returns the same map reference, so handler-level `return prev` bailouts no longer leak a fresh `maps` object back into the React tree. The 15 copy-pasted setters are now a single typed `setMapSlice<K>(key)` factory.
- `*.patched` handlers gain a shallow-equal entity bailout so idempotent server-side patches (status didn't really flip, daemon-side bookkeeping that re-saves the same row) become true no-ops. The simple cases (boards, board-objects, repos, users, MCP servers, gateway channels, cards, card-types, comments, artifacts) route through a shared `replaceIfChanged(prev, id, entity)` helper; sessions/branches stay explicit because they own archive / branch-migration / cross-map cleanup.
- `handleSessionRemoved` bails when the id isn't tracked. `branches.removed` (hard delete) now evicts sessions too via a shared `evictBranchAndSessions` helper, mirroring the existing archived-patch path so orphan session cards can't linger either way.
- `handleArtifactPatched` is now pure (no outer-scope mutation from a state updater, which wouldn't be safe under StrictMode). It always dispatches `agor:artifact-patched` — the consumer (`ArtifactNode.tsx:544`) already filters by `contentHash !== lastHashRef.current`, so an idempotent dispatch is a cheap no-op at the consumer and we don't need a side effect in the updater to suppress it.

## Why

Streaming sessions emit a steady stream of message/chunk events alongside occasional task/session/branch patches. Even though the central store doesn't subscribe to message events, the per-key setters used to rebuild the top-level `maps` object on every patch — including ones the handler explicitly chose to discard:

```ts
setMaps((m) => ({ ...m, sessionById: v(m.sessionById) }))  // fresh ref even when v returned prev
```

That spurious `maps` re-render propagated through `AppContent → App → SessionCanvas`, forcing React Flow to re-diff the node graph and the MiniMap to repaint. Board zoom/pan felt sluggish whenever agents were streaming.

Two surgical wins:

1. **Wrapper-level no-op short-circuit** in `setMapSlice` — each per-key setter now returns the outer `maps` unchanged when the inner functional update produced the same reference.
2. **Shallow-equal entity bailouts** in the `*.patched` handlers. Feathers always emits a fresh object, so the existing `existing === entity` check was unreachable. A top-level shallow compare catches idempotent patches; nested objects the daemon reserializes (e.g. `model_config`, `git_state`) read as 'different' — that's the safe failure mode, called out in `shallowEqualEntity`'s docstring.

`shallowEqualEntity` itself uses `Object.hasOwn(b, key)` so different key sets with `undefined` values (`{a: undefined}` vs `{b: undefined}`) don't falsely compare equal, and `Object.is` for the leaf comparator so NaN works.

Streaming behavior for the currently open session is **untouched**: `useSharedReactiveSession` / `useMessages` live outside the central store and continue to receive every chunk and task event.

## Test plan

- [x] `pnpm -C apps/agor-ui test` — 198/198 pass (incl. 9 `shallowEqual` cases + 10 `useAgorData` bailout cases covering idempotent patches, removed-unknown, duplicate created, unrelated map isolation, branch migration during patch, `branches.removed` eviction, artifact dispatch path)
- [x] `pnpm -C apps/agor-ui typecheck` — clean
- [x] `pnpm -C apps/agor-ui lint` — no new warnings (3 pre-existing)
- [ ] Manual: open board with multiple branches, kick off a long agent run, confirm zoom/pan stays fluid while chunks stream
- [ ] Manual: with a session panel open, confirm streaming content still renders live (no regression on the foreground session)
- [ ] Manual: archive/delete a session, confirm cards/lists update immediately
- [ ] Manual: edit an artifact via MCP, confirm the sandbox iframe re-fetches the new payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
