### PR TITLE
Add assistant bootstrap session flow

### DIFF
--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -562,6 +562,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       issue_url?: string;
       pull_request_url?: string;
       boardId?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string | null;
       /** Explicit board position. Honored as-is when supplied; otherwise
        *  the service computes a smart placement (zone-relative if a
        *  zoneId was passed, else next-free slot among existing entities).
@@ -725,6 +727,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         last_used: new Date().toISOString(),
         issue_url: data.issue_url,
         pull_request_url: data.pull_request_url,
+        notes: data.notes,
+        custom_context: data.custom_context,
         board_id: data.boardId,
         created_by: userId,
       },

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -989,6 +989,8 @@ function AppContent() {
       issue_url?: string;
       pull_request_url?: string;
       boardId?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string | null;
       position?: { x: number; y: number };
       storage_mode?: 'worktree' | 'clone';
       clone_depth?: number;
@@ -1008,6 +1010,8 @@ function AppContent() {
         issue_url: data.issue_url,
         pull_request_url: data.pull_request_url,
         boardId: data.boardId, // Optional: add to board
+        custom_context: data.custom_context,
+        notes: data.notes,
         position: data.position, // Optional: position on board (defaults to center of viewport)
         storage_mode: data.storage_mode,
         clone_depth: data.clone_depth,

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -45,14 +45,17 @@ import { useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { useTaskCompletionChime } from '../../hooks/useTaskCompletionChime';
 import { type ActiveUrlTarget, useUrlState } from '../../hooks/useUrlState';
 import type { AgenticToolOption } from '../../types';
+import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { createAssistantBranch } from '../../utils/assistantCreation';
 import { initializeAudioOnInteraction } from '../../utils/audio';
+import { useThemedMessage } from '../../utils/message';
+import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { AppHeader } from '../AppHeader';
 import { BranchListDrawer } from '../BranchListDrawer';
 import { BranchModal, type BranchModalTab } from '../BranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
 import { CommentsPanel } from '../CommentsPanel';
-import { CreateDialog } from '../CreateDialog';
+import { CreateDialog, type CreateDialogProgress } from '../CreateDialog';
 import type { AssistantTabResult } from '../CreateDialog/tabs/AssistantTab';
 import type { BranchTabConfig } from '../CreateDialog/tabs/BranchTab';
 import { EnvironmentLogsModal } from '../EnvironmentLogsModal';
@@ -127,7 +130,7 @@ export interface AppProps {
     }
   ) => void;
   onUnarchiveBranch?: (branchId: string, options?: { boardId?: string }) => void;
-  onUpdateBranch?: (branchId: string, updates: BranchUpdate) => void;
+  onUpdateBranch?: (branchId: string, updates: BranchUpdate) => void | Promise<void>;
   onCreateBranch?: (
     repoId: string,
     data: {
@@ -140,6 +143,8 @@ export interface AppProps {
       issue_url?: string;
       pull_request_url?: string;
       boardId?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string | null;
       position?: { x: number; y: number };
       storage_mode?: 'worktree' | 'clone';
       clone_depth?: number;
@@ -258,6 +263,7 @@ export const App: React.FC<AppProps> = ({
   instanceDescription,
   webTerminalEnabled = false,
 }) => {
+  const { showWarning } = useThemedMessage();
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionBranchId, setNewSessionBranchId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -567,9 +573,16 @@ export const App: React.FC<AppProps> = ({
     }
   };
 
-  const handleCreateAssistant = async (result: AssistantTabResult) => {
+  const handleCreateAssistant = async (
+    result: AssistantTabResult,
+    progress?: CreateDialogProgress
+  ) => {
     const repoId = result.repoId;
-    if (!repoId || !onCreateBranch || !onUpdateBranch) return;
+    if (!repoId || !onCreateBranch || !onUpdateBranch) {
+      throw new Error('Missing repository or branch creation handler for assistant creation.');
+    }
+
+    progress?.onStatusChange?.('Creating assistant branch…');
 
     const branch = await createAssistantBranch(
       {
@@ -584,13 +597,61 @@ export const App: React.FC<AppProps> = ({
       { client, repoById, onCreateBranch, onUpdateBranch }
     );
 
-    // Assistants are branches under the hood, so the `/w/<short>/` URL
-    // is the canonical deep link. Routing through goToBranch picks up
-    // the cross-board recenter for free when the assistant was created
-    // on a new board.
-    if (branch) {
-      navigation.goToBranch(branch.branch_id);
+    if (!branch) {
+      throw new Error(
+        'Assistant branch could not be created. Please check the branch details and try again.'
+      );
     }
+
+    const sessionConfig: NewSessionConfig = {
+      branch_id: branch.branch_id,
+      agent: result.agent,
+      title: `${result.emoji ? `${result.emoji} ` : ''}${result.displayName} bootstrap`,
+      initialPrompt: buildAssistantBootstrapPrompt({
+        displayName: result.displayName,
+        emoji: result.emoji,
+        description: result.description,
+        userName: user?.name,
+        userEmail: user?.email,
+      }),
+      modelConfig: result.modelConfig,
+      effort: result.effort,
+      mcpServerIds: result.mcpServerIds,
+      permissionMode: result.permissionMode,
+      codexSandboxMode: result.codexSandboxMode,
+      codexApprovalPolicy: result.codexApprovalPolicy,
+      codexNetworkAccess: result.codexNetworkAccess,
+    };
+
+    try {
+      if (!onCreateSession) {
+        throw new Error('Missing session creation handler.');
+      }
+      const sessionId = await startAssistantBootstrapSession({
+        client,
+        branchId: branch.branch_id,
+        boardId: branch.board_id || currentBoardId,
+        sessionConfig,
+        onCreateSession,
+        onStatusChange: progress?.onStatusChange,
+      });
+      navigation.goToSession(sessionId);
+      return;
+    } catch (error) {
+      console.error('Assistant session bootstrap failed:', error);
+      showWarning(
+        `Assistant branch was created, but the first session could not start: ${
+          error instanceof Error ? error.message : String(error)
+        }. Opening the branch instead.`,
+        { key: 'assistant-bootstrap-session', duration: 8 }
+      );
+    }
+
+    // If the branch was created but the session failed, still take the user
+    // to the assistant branch so the created assistant is not lost. The
+    // top-level create-session handler surfaces the failure toast.
+    progress?.onStatusChange?.('Opening assistant branch…');
+    navigation.goToBranch(branch.branch_id);
   };
 
   // Refs for the data `handleSessionClick` reads. Using refs (vs
@@ -1230,6 +1291,10 @@ export const App: React.FC<AppProps> = ({
               onCreateRepo={(data) => onCreateRepo?.(data)}
               onCreateLocalRepo={(data) => onCreateLocalRepo?.(data)}
               onCreateAssistant={handleCreateAssistant}
+              availableAgents={availableAgents}
+              mcpServerById={mcpServerById}
+              currentUser={user}
+              client={client}
             />
             {logsModalBranchId && (
               <EnvironmentLogsModal

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
@@ -62,6 +62,9 @@ function renderDialog(props: Partial<React.ComponentProps<typeof CreateDialog>> 
       onClose={vi.fn()}
       repoById={repoById}
       boardById={boardById}
+      availableAgents={[
+        { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Claude' },
+      ]}
       onCreateBranch={vi.fn()}
       onCreateBoard={vi.fn()}
       onCreateRepo={vi.fn()}
@@ -82,11 +85,11 @@ function renderDialog(props: Partial<React.ComponentProps<typeof CreateDialog>> 
 const ASYNC = { timeout: 10_000 };
 
 describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () => {
-  it('enables Create Assistant once Display Name is typed', async () => {
+  it('enables Create Assistant once Name is typed', async () => {
     renderDialog({ defaultTab: 'assistant' });
 
-    const displayName = (await screen.findByLabelText(
-      /Display Name/i,
+    const displayName = (await screen.findByPlaceholderText(
+      /PR Reviewer/i,
       undefined,
       ASYNC
     )) as HTMLInputElement;
@@ -101,8 +104,8 @@ describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () =>
   it('preserves Assistant validity when user switches tabs and switches back', async () => {
     renderDialog({ defaultTab: 'assistant' });
 
-    const displayName = (await screen.findByLabelText(
-      /Display Name/i,
+    const displayName = (await screen.findByPlaceholderText(
+      /PR Reviewer/i,
       undefined,
       ASYNC
     )) as HTMLInputElement;
@@ -114,7 +117,7 @@ describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () =>
     fireEvent.click(screen.getByRole('tab', { name: /Board/i }));
     fireEvent.click(screen.getByRole('tab', { name: /Assistant/i }));
 
-    // Display Name is still filled — submit must be enabled without the user
+    // Name is still filled — submit must be enabled without the user
     // having to re-touch the field. Pre-fix: handleTabChange reset the shared
     // isValid to false and AssistantTab's useEffect didn't re-fire (its
     // isFormValid hadn't changed), so the button stayed stuck disabled.
@@ -123,11 +126,42 @@ describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () =>
     }, ASYNC);
   });
 
+  it('submits assistant agentic defaults with the assistant fields', async () => {
+    const onCreateAssistant = vi.fn();
+    renderDialog({ defaultTab: 'assistant', onCreateAssistant });
+
+    const displayName = (await screen.findByPlaceholderText(
+      /PR Reviewer/i,
+      undefined,
+      ASYNC
+    )) as HTMLInputElement;
+    fireEvent.change(displayName, { target: { value: 'Bootstrap Bot' } });
+
+    const button = screen.getByRole('button', { name: /Create Assistant/i });
+    await waitFor(() => {
+      expect(button).not.toBeDisabled();
+    }, ASYNC);
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(onCreateAssistant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          displayName: 'Bootstrap Bot',
+          emoji: '🤖',
+          agent: 'claude-code',
+          permissionMode: 'acceptEdits',
+        }),
+        expect.objectContaining({ onStatusChange: expect.any(Function) })
+      );
+    }, ASYNC);
+  });
+
   it('reports each tab its own validity (no spillover when switching to an empty tab)', async () => {
     renderDialog({ defaultTab: 'assistant' });
 
-    const displayName = (await screen.findByLabelText(
-      /Display Name/i,
+    const displayName = (await screen.findByPlaceholderText(
+      /PR Reviewer/i,
       undefined,
       ASYNC
     )) as HTMLInputElement;

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -1,4 +1,12 @@
-import type { Board, CreateLocalRepoRequest, CreateRepoRequest, Repo } from '@agor-live/client';
+import type {
+  AgorClient,
+  Board,
+  CreateLocalRepoRequest,
+  CreateRepoRequest,
+  MCPServer,
+  Repo,
+  User,
+} from '@agor-live/client';
 import {
   AppstoreOutlined,
   BranchesOutlined,
@@ -7,6 +15,7 @@ import {
 } from '@ant-design/icons';
 import { Alert, Button, Modal, Tabs } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { AgenticToolOption } from '../../types';
 import type { AssistantTabResult } from './tabs/AssistantTab';
 import { AssistantTab } from './tabs/AssistantTab';
 import { BoardTab } from './tabs/BoardTab';
@@ -16,6 +25,10 @@ import type { RepoTabResult } from './tabs/RepoTab';
 import { RepoTab } from './tabs/RepoTab';
 
 type ActiveTab = 'branch' | 'assistant' | 'board' | 'repository';
+
+export interface CreateDialogProgress {
+  onStatusChange?: (status: string) => void;
+}
 
 const INITIAL_VALIDITY: Record<ActiveTab, boolean> = {
   branch: false,
@@ -58,12 +71,19 @@ export interface CreateDialogProps {
   boardById: Map<string, Board>;
   currentBoardId?: string;
   defaultPosition?: { x: number; y: number };
+  availableAgents: AgenticToolOption[];
+  mcpServerById?: Map<string, MCPServer>;
+  currentUser?: User | null;
+  client?: AgorClient | null;
   defaultTab?: ActiveTab;
   onCreateBranch: (config: BranchTabConfig) => void | Promise<void>;
   onCreateBoard: (board: Partial<Board>) => void | Promise<void>;
   onCreateRepo: (data: CreateRepoRequest) => void | Promise<void>;
   onCreateLocalRepo: (data: CreateLocalRepoRequest) => void | Promise<void>;
-  onCreateAssistant: (result: AssistantTabResult) => void | Promise<void>;
+  onCreateAssistant: (
+    result: AssistantTabResult,
+    progress?: CreateDialogProgress
+  ) => void | Promise<void>;
 }
 
 /** Fire the parent handler and close the dialog. We don't `await` here
@@ -82,6 +102,10 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
   boardById,
   currentBoardId,
   defaultPosition,
+  availableAgents,
+  mcpServerById,
+  currentUser,
+  client,
   defaultTab = 'branch',
   onCreateBranch,
   onCreateBoard,
@@ -96,6 +120,8 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
   const [validByTab, setValidByTab] = useState<Record<ActiveTab, boolean>>(INITIAL_VALIDITY);
   const isValid = validByTab[activeTab];
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // Form submit refs — each tab exposes a submit function
   const branchFormRef = useRef<(() => Promise<BranchTabConfig | null>) | null>(null);
@@ -108,6 +134,9 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
     if (!open) {
       setValidByTab(INITIAL_VALIDITY);
       setActiveTab(defaultTab);
+      setIsSubmitting(false);
+      setSubmitStatus(null);
+      setSubmitError(null);
     }
   }, [open, defaultTab]);
 
@@ -128,10 +157,15 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
 
   const handleTabChange = (key: string) => {
     setActiveTab(key as ActiveTab);
+    setSubmitError(null);
+    setSubmitStatus(null);
   };
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitStatus(null);
+
     try {
       switch (activeTab) {
         case 'branch': {
@@ -165,18 +199,22 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
         case 'assistant': {
           const result = await assistantFormRef.current?.();
           if (result) {
-            fireAndForget(onCreateAssistant(result));
+            setSubmitStatus('Creating assistant…');
+            await onCreateAssistant(result, { onStatusChange: setSubmitStatus });
             onClose();
           }
           break;
         }
       }
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : String(error));
     } finally {
       setIsSubmitting(false);
     }
   };
 
   const handleCancel = () => {
+    if (isSubmitting) return;
     onClose();
   };
 
@@ -229,6 +267,10 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
             onValidityChange={handleAssistantValid}
             formRef={assistantFormRef}
             onCreateRepo={onCreateRepo}
+            availableAgents={availableAgents}
+            mcpServerById={mcpServerById}
+            currentUser={currentUser}
+            client={client}
           />
         </div>
       ),
@@ -282,8 +324,11 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
       onCancel={handleCancel}
       destroyOnHidden
       width={720}
+      closable={!isSubmitting}
+      maskClosable={!isSubmitting}
+      keyboard={!isSubmitting}
       footer={[
-        <Button key="cancel" onClick={handleCancel}>
+        <Button key="cancel" onClick={handleCancel} disabled={isSubmitting}>
           Cancel
         </Button>,
         <Button
@@ -293,7 +338,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
           disabled={!isValid}
           loading={isSubmitting}
         >
-          {ACTION_LABELS[activeTab]}
+          {isSubmitting && submitStatus ? submitStatus : ACTION_LABELS[activeTab]}
         </Button>,
       ]}
       styles={{
@@ -306,6 +351,15 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
         items={tabItems}
         style={{ minHeight: 360 }}
       />
+      {submitError && (
+        <Alert
+          type="error"
+          showIcon
+          message="Couldn't finish creating this item"
+          description={submitError}
+          style={{ marginTop: 16 }}
+        />
+      )}
     </Modal>
   );
 };

--- a/apps/agor-ui/src/components/CreateDialog/index.ts
+++ b/apps/agor-ui/src/components/CreateDialog/index.ts
@@ -1,2 +1,2 @@
-export type { CreateDialogProps } from './CreateDialog';
+export type { CreateDialogProgress, CreateDialogProps } from './CreateDialog';
 export { CreateDialog } from './CreateDialog';

--- a/apps/agor-ui/src/components/CreateDialog/tabs/AssistantTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/AssistantTab.tsx
@@ -1,11 +1,29 @@
-import type { Board, CreateRepoRequest, Repo } from '@agor-live/client';
-import { Form } from 'antd';
-import { useEffect } from 'react';
+import type {
+  AgenticToolName,
+  AgorClient,
+  Board,
+  CodexApprovalPolicy,
+  CodexSandboxMode,
+  CreateRepoRequest,
+  EffortLevel,
+  MCPServer,
+  PermissionMode,
+  Repo,
+  User,
+} from '@agor-live/client';
+import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live/client';
+import { DownOutlined } from '@ant-design/icons';
+import { Collapse, Form, Typography } from 'antd';
+import { useEffect, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
 import { slugify } from '@/utils/repoSlug';
 import { useAssistantForm } from '../../../hooks/useAssistantForm';
 import { useEnsureFrameworkRepo } from '../../../hooks/useEnsureFrameworkRepo';
+import type { AgenticToolOption } from '../../../types';
+import { AgenticToolConfigForm, getFormValuesFromConfig } from '../../AgenticToolConfigForm';
+import { AgentSelectionGrid } from '../../AgentSelectionGrid';
 import { AssistantFormFields, CREATE_NEW_BOARD } from '../../forms/AssistantFormFields';
+import type { ModelConfig } from '../../ModelSelector';
 
 export interface AssistantTabResult {
   displayName: string;
@@ -15,6 +33,14 @@ export interface AssistantTabResult {
   repoId?: string;
   branchName?: string;
   sourceBranch?: string;
+  agent: AgenticToolName;
+  modelConfig?: ModelConfig;
+  effort?: EffortLevel;
+  mcpServerIds?: string[];
+  permissionMode?: PermissionMode;
+  codexSandboxMode?: CodexSandboxMode;
+  codexApprovalPolicy?: CodexApprovalPolicy;
+  codexNetworkAccess?: boolean;
 }
 
 export interface AssistantTabProps {
@@ -23,6 +49,10 @@ export interface AssistantTabProps {
   onValidityChange: (valid: boolean) => void;
   formRef: React.MutableRefObject<(() => Promise<AssistantTabResult | null>) | null>;
   onCreateRepo?: (data: CreateRepoRequest) => void | Promise<void>;
+  availableAgents: AgenticToolOption[];
+  mcpServerById?: Map<string, MCPServer>;
+  currentUser?: User | null;
+  client?: AgorClient | null;
 }
 
 export const AssistantTab: React.FC<AssistantTabProps> = ({
@@ -31,10 +61,15 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
   onValidityChange,
   formRef,
   onCreateRepo,
+  availableAgents,
+  mcpServerById = new Map(),
+  currentUser,
+  client,
 }) => {
   const repos = mapToArray(repoById);
   const boards = mapToArray(boardById);
   const { frameworkRepo, isCloning } = useEnsureFrameworkRepo(repos, onCreateRepo);
+  const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
 
   const {
     form,
@@ -45,6 +80,24 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
     handleDisplayNameChange,
   } = useAssistantForm(frameworkRepo);
 
+  useEffect(() => {
+    if (!availableAgents.some((agent) => agent.id === selectedAgent) && availableAgents[0]?.id) {
+      setSelectedAgent(availableAgents[0].id as AgenticToolName);
+    }
+  }, [availableAgents, selectedAgent]);
+
+  useEffect(() => {
+    const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent];
+    form.setFieldsValue({
+      ...getFormValuesFromConfig(selectedAgent, agentDefaults),
+      ...(selectedAgent !== 'codex' && {
+        codexSandboxMode: undefined,
+        codexApprovalPolicy: undefined,
+        codexNetworkAccess: undefined,
+      }),
+    });
+  }, [selectedAgent, currentUser, form]);
+
   // Sync form validity to parent
   useEffect(() => {
     onValidityChange(isFormValid);
@@ -53,7 +106,13 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
   formRef.current = async () => {
     try {
       const values = await form.validateFields();
-      return {
+      const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent];
+      const permissionMode: PermissionMode =
+        (values.permissionMode as PermissionMode | undefined) ??
+        agentDefaults?.permissionMode ??
+        getDefaultPermissionMode(selectedAgent);
+
+      const result: AssistantTabResult = {
         displayName: values.displayName.trim(),
         description: values.description || undefined,
         emoji: values.emoji || undefined,
@@ -61,7 +120,30 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
         repoId: values.repoId || frameworkRepo?.repo_id,
         branchName: values.name || `private-${slugify(values.displayName)}`,
         sourceBranch: values.sourceBranch || 'main',
+        agent: selectedAgent,
+        modelConfig: values.modelConfig ?? agentDefaults?.modelConfig,
+        effort: (values.effort as EffortLevel | undefined) ?? agentDefaults?.modelConfig?.effort,
+        mcpServerIds: values.mcpServerIds ?? agentDefaults?.mcpServerIds,
+        permissionMode,
       };
+
+      if (selectedAgent === 'codex') {
+        const codexDefaults = mapToCodexPermissionConfig(permissionMode);
+        result.codexSandboxMode =
+          (values.codexSandboxMode as CodexSandboxMode | undefined) ??
+          agentDefaults?.codexSandboxMode ??
+          codexDefaults.sandboxMode;
+        result.codexApprovalPolicy =
+          (values.codexApprovalPolicy as CodexApprovalPolicy | undefined) ??
+          agentDefaults?.codexApprovalPolicy ??
+          codexDefaults.approvalPolicy;
+        result.codexNetworkAccess =
+          values.codexNetworkAccess ??
+          agentDefaults?.codexNetworkAccess ??
+          codexDefaults.networkAccess;
+      }
+
+      return result;
     } catch {
       return null;
     }
@@ -83,6 +165,60 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
         onDisplayNameChange={handleDisplayNameChange}
         customRepoSelected={customRepoSelected}
         onCustomRepoChange={setCustomRepoSelected}
+        extraBeforeAdvanced={
+          <Collapse
+            ghost
+            size="small"
+            defaultActiveKey={['first-session']}
+            destroyOnHidden={false}
+            expandIcon={({ isActive }) => <DownOutlined rotate={isActive ? 180 : 0} />}
+            items={[
+              {
+                key: 'first-session',
+                label: <Typography.Text strong>First Session Configuration</Typography.Text>,
+                children: (
+                  <>
+                    <Form.Item label="Agentic Tool" required>
+                      <AgentSelectionGrid
+                        agents={availableAgents}
+                        selectedAgentId={selectedAgent}
+                        onSelect={(agentId) => setSelectedAgent(agentId as AgenticToolName)}
+                        variant="select"
+                        showComparisonLink
+                      />
+                    </Form.Item>
+
+                    <Collapse
+                      ghost
+                      size="small"
+                      destroyOnHidden={false}
+                      expandIcon={({ isActive }) => <DownOutlined rotate={isActive ? 180 : 0} />}
+                      items={[
+                        {
+                          key: 'session-config',
+                          label: (
+                            <Typography.Text type="secondary">
+                              Session Configuration
+                            </Typography.Text>
+                          ),
+                          children: (
+                            <AgenticToolConfigForm
+                              agenticTool={selectedAgent}
+                              mcpServerById={mcpServerById}
+                              showHelpText={false}
+                              client={client}
+                            />
+                          ),
+                        },
+                      ]}
+                    />
+                  </>
+                ),
+              },
+            ]}
+            style={{ marginBottom: 8 }}
+          />
+        }
       />
     </Form>
   );

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
@@ -80,22 +80,17 @@ export const EmojiPickerInput: React.FC<EmojiPickerInputProps> = ({
 
 /**
  * Form.Item wrapper that integrates with Ant Design forms.
- * Thin wrapper around EmojiPickerInput that reads/writes via form.setFieldValue.
+ * Registers the emoji field with the form so validateFields/getFieldsValue
+ * include it in submitted values.
  */
 export const FormEmojiPickerInput: React.FC<{
   form: ReturnType<typeof Form.useForm>[0];
   fieldName: string;
   defaultEmoji?: string;
-}> = ({ form, fieldName, defaultEmoji }) => {
+}> = ({ fieldName, defaultEmoji }) => {
   return (
-    <Form.Item noStyle shouldUpdate>
-      {() => (
-        <EmojiPickerInput
-          value={form.getFieldValue(fieldName)}
-          onChange={(emoji) => form.setFieldValue(fieldName, emoji)}
-          defaultEmoji={defaultEmoji}
-        />
-      )}
+    <Form.Item name={fieldName} noStyle initialValue={defaultEmoji}>
+      <EmojiPickerInput defaultEmoji={defaultEmoji} />
     </Form.Item>
   );
 };

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -2,8 +2,8 @@
  * OnboardingWizard - Multi-step wizard for new user onboarding
  *
  * Two paths:
- * - Assistant: Clone assistant framework repo -> create board -> create branch -> API keys -> launch
- * - Own Repo: Add user repo -> create board -> create branch -> API keys -> launch
+ * - Assistant: identity -> API keys -> clone assistant framework repo -> create board -> create branch/session
+ * - Own Repo: API keys -> add repo -> create board -> create branch/session
  *
  * Replaces GettingStartedPopover entirely.
  */
@@ -33,7 +33,7 @@ import {
   ExperimentOutlined,
   FolderOpenOutlined,
   KeyOutlined,
-  RocketOutlined,
+  RobotOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
 import {
@@ -59,7 +59,10 @@ import {
   FRAMEWORK_REPO_URL,
   findFrameworkRepo,
 } from '../../hooks/useFrameworkRepo';
-import { extractSlugFromPath } from '../../utils/repoSlug';
+import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
+import { extractSlugFromPath, slugify } from '../../utils/repoSlug';
+import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
+import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 import type { NewSessionConfig } from '../NewSessionModal/NewSessionModal';
 
 const { Text, Title, Paragraph } = Typography;
@@ -69,22 +72,11 @@ const { useToken } = theme;
 
 const CLONE_TIMEOUT_MS = 120_000;
 
-// Minimal kickoff: context only, no role-instructions. The framework owns
-// "who you are / what to do" — putting that in the prompt makes the agent
-// perform an intro for the prompt rather than internalize the framework.
-//
-// BOOTSTRAP.md is the dedicated first-run ritual in the agor-assistant
-// framework: explicit about "ship something useful fast, don't ceremonialize"
-// and self-deletes after. BOOT.md (every-session ritual) just redirects to
-// BOOTSTRAP.md on first run anyway — pointing there saves one indirection
-// and surfaces the first-run-specific tone-setting.
-const ASSISTANT_BOOT_PROMPT = `Fresh Agor branch, first session. Start with BOOTSTRAP.md.`;
-
 // ─── Types ──────────────────────────────────────────────
 
 type WizardPath = 'assistant' | 'own-repo';
 
-type WizardStep = 'welcome' | 'add-repo' | 'clone' | 'board' | 'branch' | 'api-keys' | 'launch';
+type WizardStep = 'welcome' | 'identity' | 'add-repo' | 'clone' | 'board' | 'branch' | 'api-keys';
 
 export interface OnboardingWizardProps {
   open: boolean;
@@ -116,6 +108,8 @@ export interface OnboardingWizardProps {
       sourceBranch: string;
       pullLatest: boolean;
       boardId?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string | null;
       position?: { x: number; y: number };
     }
   ) => Promise<Branch | null>;
@@ -147,10 +141,10 @@ function getUsernameSlug(user?: User | null): string {
 
 function getStepsForPath(path: WizardPath | null): WizardStep[] {
   if (path === 'assistant') {
-    return ['welcome', 'api-keys', 'clone', 'board', 'branch', 'launch'];
+    return ['welcome', 'identity', 'api-keys', 'clone', 'board', 'branch'];
   }
   if (path === 'own-repo') {
-    return ['welcome', 'api-keys', 'add-repo', 'clone', 'board', 'branch', 'launch'];
+    return ['welcome', 'api-keys', 'add-repo', 'clone', 'board', 'branch'];
   }
   return ['welcome'];
 }
@@ -270,7 +264,6 @@ export function OnboardingWizard({
   onCreateBranch,
   onCreateSession,
   onUpdateUser,
-  onUpdateBranch,
   onCheckAuth,
   assistantPending,
   frameworkRepoUrl,
@@ -306,6 +299,8 @@ export function OnboardingWizard({
   const [localRepoPath, setLocalRepoPath] = useState('');
   const [repoMode, setRepoMode] = useState<'remote' | 'local'>('remote');
   const [branchName, setBranchName] = useState('');
+  const [assistantDisplayName, setAssistantDisplayName] = useState('My Assistant');
+  const [assistantEmoji, setAssistantEmoji] = useState('🤖');
   const [apiKey, setApiKey] = useState('');
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
   const [testAuthLoading, setTestAuthLoading] = useState(false);
@@ -458,6 +453,16 @@ export function OnboardingWizard({
       onboarding.path === 'persisted-agent' ? 'assistant' : (onboarding.path as WizardPath);
     setPath(resumedPath);
 
+    if (resumedPath === 'assistant') {
+      if (typeof onboarding.assistantDisplayName === 'string') {
+        setAssistantDisplayName(onboarding.assistantDisplayName);
+        setBranchName(`private-${slugify(onboarding.assistantDisplayName || 'My Assistant')}`);
+      }
+      if (typeof onboarding.assistantEmoji === 'string') {
+        setAssistantEmoji(onboarding.assistantEmoji);
+      }
+    }
+
     // Restore created resource IDs (only the validated ones)
     if (validBoardId) {
       setCreatedBoardId(validBoardId);
@@ -475,8 +480,9 @@ export function OnboardingWizard({
 
     // Figure out which step to resume from
     if (validBranchId) {
-      // Branch exists AND is owned by current user — go to launch
-      setCurrentStep('launch');
+      // Branch exists AND is owned by current user — stay on the branch
+      // step, which can retry launching the first session inline.
+      setCurrentStep('branch');
     } else if (validBoardId) {
       // Board exists AND is owned by current user — go to branch creation
       setCurrentStep('branch');
@@ -484,8 +490,9 @@ export function OnboardingWizard({
       // Repo is registered (already restored above) — go straight to board
       setCurrentStep('board');
     } else {
-      // Nothing the user actually created yet — restart from api-keys
-      setCurrentStep('api-keys');
+      // Nothing the user actually created yet — restart from identity for
+      // assistants so naming/emoji stays in the shared form flow.
+      setCurrentStep(resumedPath === 'assistant' ? 'identity' : 'api-keys');
     }
   }, [
     open,
@@ -706,7 +713,14 @@ export function OnboardingWizard({
   // createdRepoId-persist effect below) reference it — moving this further
   // down re-introduces a TDZ ReferenceError on mount.
   const saveOnboardingProgress = useCallback(
-    (updates: { path?: WizardPath; repoId?: string; boardId?: string; branchId?: string }) => {
+    (updates: {
+      path?: WizardPath;
+      repoId?: string;
+      boardId?: string;
+      branchId?: string;
+      assistantDisplayName?: string;
+      assistantEmoji?: string;
+    }) => {
       if (!user) return;
       const current = user.preferences?.onboarding || {};
       const prefs: Record<string, unknown> = {
@@ -720,6 +734,18 @@ export function OnboardingWizard({
     },
     [user, onUpdateUser]
   );
+
+  const handleAssistantIdentityContinue = useCallback(() => {
+    const trimmedName = assistantDisplayName.trim() || 'My Assistant';
+    setAssistantDisplayName(trimmedName);
+    setBranchName(`private-${slugify(trimmedName)}`);
+    saveOnboardingProgress({
+      assistantDisplayName: trimmedName,
+      assistantEmoji: assistantEmoji || '🤖',
+    });
+    setError(null);
+    setCurrentStep('api-keys');
+  }, [assistantDisplayName, assistantEmoji, saveOnboardingProgress, setCurrentStep]);
 
   // Persist createdRepoId so a refresh / reset-then-resume of the wizard
   // lands back on the branch step with the repo still wired up. Without
@@ -739,7 +765,8 @@ export function OnboardingWizard({
       // Persist chosen path immediately
       saveOnboardingProgress({ path: selectedPath });
 
-      // Always advance to api-keys after path selection.
+      // Assistant path first captures assistant identity (name + emoji) in
+      // form territory. Other paths advance to api-keys after selection.
       //
       // Previously the assistant branch did `findReadyFrameworkRepo(repoById)`
       // and skipped to "board" if any framework repo was found anywhere in
@@ -753,7 +780,7 @@ export function OnboardingWizard({
       // The assistant clone step is now reached via the api-keys path like
       // every other tool; handleStartClone deduplicates against the shared
       // framework repo at the daemon level (so re-cloning is a no-op).
-      setCurrentStep('api-keys');
+      setCurrentStep(selectedPath === 'assistant' ? 'identity' : 'api-keys');
     },
     [saveOnboardingProgress, setCurrentStep]
   );
@@ -871,12 +898,17 @@ export function OnboardingWizard({
     setError(null);
     setLoading(true);
 
-    const displayName = user?.name || user?.email?.split('@')[0] || 'My';
+    const userDisplayName = user?.name || user?.email?.split('@')[0] || 'My';
+    const boardName =
+      path === 'assistant'
+        ? `${assistantDisplayName.trim() || 'My Assistant'}'s Board`
+        : `${userDisplayName}'s Board`;
+    const boardIcon = path === 'assistant' ? assistantEmoji || '🤖' : '\u{1F3E0}';
     try {
       if (!client) throw new Error('Not connected');
       const board = await client.service('boards').create({
-        name: `${displayName}'s Board`,
-        icon: '\u{1F3E0}',
+        name: boardName,
+        icon: boardIcon,
       });
       if (board?.board_id) {
         setCreatedBoardId(board.board_id);
@@ -889,7 +921,78 @@ export function OnboardingWizard({
       setLoading(false);
       setError(`Failed to create board: ${err instanceof Error ? err.message : String(err)}`);
     }
-  }, [client, user, boardById, saveOnboardingProgress, setCurrentStep]);
+  }, [
+    client,
+    user,
+    boardById,
+    saveOnboardingProgress,
+    setCurrentStep,
+    path,
+    assistantDisplayName,
+    assistantEmoji,
+  ]);
+
+  const launchSessionForBranch = useCallback(
+    async (branchId: string, boardId: string) => {
+      if (!path) {
+        setError('Missing onboarding path.');
+        setLoading(false);
+        return;
+      }
+
+      setError(null);
+      setLoading(true);
+
+      try {
+        const sessionConfig: NewSessionConfig = {
+          branch_id: branchId,
+          agent: selectedAgent,
+          ...(path === 'assistant' && {
+            initialPrompt: buildAssistantBootstrapPrompt({
+              displayName: assistantDisplayName,
+              emoji: assistantEmoji,
+              userName: user?.name,
+              userEmail: user?.email,
+            }),
+          }),
+        };
+        const sessionId =
+          path === 'assistant'
+            ? await startAssistantBootstrapSession({
+                client,
+                branchId,
+                boardId,
+                sessionConfig,
+                onCreateSession,
+              })
+            : await onCreateSession(sessionConfig, boardId);
+
+        if (sessionId) {
+          setLoading(false);
+          onComplete({ branchId, sessionId, boardId, path });
+        } else {
+          setLoading(false);
+          setError('Branch created, but failed to create the first session. Please try again.');
+        }
+      } catch (err) {
+        setLoading(false);
+        setError(
+          `Branch created, but failed to create the first session: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    },
+    [
+      path,
+      selectedAgent,
+      assistantDisplayName,
+      assistantEmoji,
+      user?.name,
+      user?.email,
+      onCreateSession,
+      onComplete,
+      client,
+    ]
+  );
 
   const handleCreateBranch = useCallback(async () => {
     if (!createdRepoId || !createdBoardId) {
@@ -909,6 +1012,17 @@ export function OnboardingWizard({
     const sourceBranch = repoById.get(createdRepoId)?.default_branch || 'main';
 
     try {
+      const assistantConfig: AssistantConfig | null =
+        path === 'assistant'
+          ? {
+              kind: 'assistant',
+              displayName: assistantDisplayName.trim() || 'My Assistant',
+              emoji: assistantEmoji || undefined,
+              frameworkRepo: FRAMEWORK_REPO_SLUG,
+              createdViaOnboarding: true,
+            }
+          : null;
+
       const branch = await onCreateBranch(createdRepoId, {
         name: sanitized,
         ref: sanitized,
@@ -916,6 +1030,7 @@ export function OnboardingWizard({
         sourceBranch,
         pullLatest: true,
         boardId: createdBoardId,
+        ...(assistantConfig ? { custom_context: { assistant: assistantConfig } } : {}),
       });
 
       if (branch) {
@@ -923,21 +1038,7 @@ export function OnboardingWizard({
         // Persist branch ID so restarts don't re-create it
         saveOnboardingProgress({ branchId: branch.branch_id });
 
-        // Tag assistant branches
-        if (path === 'assistant' && onUpdateBranch) {
-          const assistantConfig: AssistantConfig = {
-            kind: 'assistant',
-            displayName: 'My Assistant',
-            frameworkRepo: FRAMEWORK_REPO_SLUG,
-            createdViaOnboarding: true,
-          };
-          await onUpdateBranch(branch.branch_id, {
-            custom_context: { ...branch.custom_context, assistant: assistantConfig },
-          });
-        }
-
-        setLoading(false);
-        setCurrentStep('launch');
+        await launchSessionForBranch(branch.branch_id, createdBoardId);
       } else {
         setLoading(false);
         setError('Failed to create branch. Please try again.');
@@ -951,11 +1052,12 @@ export function OnboardingWizard({
     createdBoardId,
     path,
     branchName,
+    assistantDisplayName,
+    assistantEmoji,
     repoById,
     onCreateBranch,
-    onUpdateBranch,
     saveOnboardingProgress,
-    setCurrentStep,
+    launchSessionForBranch,
   ]);
 
   const handleSaveApiKey = useCallback(async () => {
@@ -1001,38 +1103,6 @@ export function OnboardingWizard({
     setManualTestResult(result);
   }, [onCheckAuth, selectedAgent, apiKey]);
 
-  const handleLaunch = useCallback(async () => {
-    if (!createdBranchId || !createdBoardId || !path) {
-      setError('Missing branch or board.');
-      return;
-    }
-
-    setError(null);
-    setLoading(true);
-
-    try {
-      const sessionId = await onCreateSession(
-        {
-          branch_id: createdBranchId,
-          agent: selectedAgent,
-          ...(path === 'assistant' && { initialPrompt: ASSISTANT_BOOT_PROMPT }),
-        },
-        createdBoardId
-      );
-
-      if (sessionId) {
-        setLoading(false);
-        onComplete({ branchId: createdBranchId, sessionId, boardId: createdBoardId, path });
-      } else {
-        setLoading(false);
-        setError('Failed to create session. Please try again.');
-      }
-    } catch (err) {
-      setLoading(false);
-      setError(`Failed to launch session: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }, [createdBranchId, createdBoardId, selectedAgent, path, onCreateSession, onComplete]);
-
   const handleSkip = useCallback(() => {
     if (!user) return;
     // onComplete sets onboarding_completed; updating it here too would double-PATCH.
@@ -1074,6 +1144,8 @@ export function OnboardingWizard({
     setLocalRepoPath('');
     setRepoMode('remote');
     setBranchName('');
+    setAssistantDisplayName('My Assistant');
+    setAssistantEmoji('🤖');
     setApiKey('');
     setSelectedAgent('claude-code');
     setTestAuthLoading(false);
@@ -1083,7 +1155,11 @@ export function OnboardingWizard({
     setCreatedBoardId(null);
     setCreatedBranchId(null);
     setCloneElapsedSeconds(0);
-    resumedRef.current = false;
+    // Do not allow the resume effect to re-run against the still-stale
+    // user.preferences snapshot before the PATCH clearing onboarding state
+    // comes back over the socket. Otherwise Reset(dev) can appear to need
+    // two clicks: first local reset, then stale prefs immediately resume it.
+    resumedRef.current = true;
     branchNameInitRef.current = false;
     knownFailedRepoIdsRef.current = new Set();
 
@@ -1128,7 +1204,7 @@ export function OnboardingWizard({
                 workflows.
               </Paragraph>
               <Text type="secondary" style={{ fontSize: 12 }}>
-                API key → Clone assistant framework → Board → Branch → Launch
+                Identity → API key → Clone assistant framework → Board → Branch/session
               </Text>
             </div>
           </Space>
@@ -1152,12 +1228,48 @@ export function OnboardingWizard({
                 Connect an existing Git repository and start coding with AI agents.
               </Paragraph>
               <Text type="secondary" style={{ fontSize: 12 }}>
-                API key → Add repository → Board → Branch → Launch
+                API key → Add repository → Board → Branch/session
               </Text>
             </div>
           </Space>
         </Card>
       </Space>
+    </div>
+  );
+
+  const renderAssistantIdentity = () => (
+    <div style={{ padding: '16px 0' }}>
+      <Title level={4}>Name Your Assistant</Title>
+      <Paragraph type="secondary">
+        Pick the name and emoji this assistant will use in its first bootstrap session.
+      </Paragraph>
+
+      <Form layout="vertical">
+        <Form.Item label="Name" required>
+          <Space.Compact style={{ display: 'flex' }}>
+            <EmojiPickerInput
+              value={assistantEmoji}
+              onChange={setAssistantEmoji}
+              defaultEmoji="🤖"
+            />
+            <Input
+              placeholder="e.g. PR Reviewer, Command Center"
+              value={assistantDisplayName}
+              onChange={(e) => setAssistantDisplayName(e.target.value)}
+              autoFocus
+              style={{ flex: 1 }}
+            />
+          </Space.Compact>
+        </Form.Item>
+      </Form>
+
+      <Button
+        type="primary"
+        onClick={handleAssistantIdentityContinue}
+        disabled={!assistantDisplayName.trim()}
+      >
+        Continue
+      </Button>
     </div>
   );
 
@@ -1371,14 +1483,43 @@ export function OnboardingWizard({
   const renderBranch = () => {
     const sourceBranch =
       (createdRepoId ? repoById.get(createdRepoId)?.default_branch : null) || 'main';
+
+    if (createdBranchId && createdBoardId) {
+      return (
+        <div style={{ textAlign: 'center', padding: '24px 0' }}>
+          <Result
+            icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
+            title="Branch Created"
+            subTitle="The branch is ready. Create the first session to finish onboarding."
+          />
+          {error && (
+            <Alert
+              type="error"
+              message={error}
+              showIcon
+              style={{ marginBottom: 16, textAlign: 'left' }}
+            />
+          )}
+          <Button
+            type="primary"
+            size="large"
+            onClick={() => launchSessionForBranch(createdBranchId, createdBoardId)}
+            loading={loading}
+          >
+            Create First Session
+          </Button>
+        </div>
+      );
+    }
+
     return (
       <div style={{ padding: '16px 0' }}>
         <Title level={4}>Create Your Branch</Title>
         <Paragraph type="secondary">
           A branch is an isolated workspace backed by its own git branch.
           {path === 'assistant'
-            ? " We'll set up a branch for your assistant."
-            : ' Name it whatever you like.'}
+            ? " We'll set up a branch for your assistant and create its first session."
+            : ' Name it whatever you like. We’ll create the first session after the branch is ready.'}
         </Paragraph>
 
         <Form layout="vertical">
@@ -1407,7 +1548,7 @@ export function OnboardingWizard({
           loading={loading}
           disabled={!branchName.trim()}
         >
-          Create Branch
+          Create Branch & First Session
         </Button>
       </div>
     );
@@ -1609,40 +1750,12 @@ export function OnboardingWizard({
     );
   };
 
-  const renderLaunch = () => (
-    <div style={{ textAlign: 'center', padding: '24px 0' }}>
-      <Title level={4}>Ready to Launch</Title>
-      <Paragraph type="secondary">
-        {path === 'assistant'
-          ? "Your assistant is set up. Let's create your first session!"
-          : "Your branch is ready. Let's launch a session!"}
-      </Paragraph>
-
-      {error && (
-        <Alert
-          type="error"
-          message={error}
-          showIcon
-          style={{ marginBottom: 16, textAlign: 'left' }}
-        />
-      )}
-
-      <Button
-        type="primary"
-        size="large"
-        icon={<RocketOutlined />}
-        onClick={handleLaunch}
-        loading={loading}
-      >
-        Launch Session
-      </Button>
-    </div>
-  );
-
   const renderStepContent = () => {
     switch (currentStep) {
       case 'welcome':
         return renderWelcome();
+      case 'identity':
+        return renderAssistantIdentity();
       case 'add-repo':
         return renderAddRepo();
       case 'clone':
@@ -1653,8 +1766,6 @@ export function OnboardingWizard({
         return renderBranch();
       case 'api-keys':
         return renderApiKeys();
-      case 'launch':
-        return renderLaunch();
       default:
         return null;
     }
@@ -1677,22 +1788,22 @@ export function OnboardingWizard({
 
     const labelMap: Record<WizardStep, string> = {
       welcome: 'Welcome',
+      identity: 'Identity',
       'add-repo': 'Repo',
       clone: path === 'own-repo' ? 'Repo' : 'Clone',
       board: 'Board',
       branch: 'Branch',
       'api-keys': 'Keys',
-      launch: 'Launch',
     };
 
     const iconMap: Record<WizardStep, React.ReactNode> = {
       welcome: null,
+      identity: <RobotOutlined />,
       'add-repo': <FolderOpenOutlined />,
       clone: <CloudDownloadOutlined />,
       board: <ExperimentOutlined />,
       branch: <FolderOpenOutlined />,
       'api-keys': <KeyOutlined />,
-      launch: <RocketOutlined />,
     };
 
     return displaySteps.map((step) => ({

--- a/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
@@ -1,7 +1,7 @@
 import type { Board, Repo } from '@agor-live/client';
-import { InfoCircleOutlined, LoadingOutlined, SettingOutlined } from '@ant-design/icons';
+import { DownOutlined, InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import type { FormInstance } from 'antd';
-import { Alert, Collapse, Form, Input, Select, Space, Typography } from 'antd';
+import { Alert, Collapse, Form, Input, Select, Space, Tooltip, Typography } from 'antd';
 import { CREATE_NEW_BOARD } from '@/utils/assistantConstants';
 import { FormEmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 
@@ -16,13 +16,15 @@ export interface AssistantFormFieldsProps {
   onDisplayNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   customRepoSelected: boolean;
   onCustomRepoChange: (selected: boolean) => void;
+  /** Optional section inserted before the repo/branch advanced settings collapse. */
+  extraBeforeAdvanced?: React.ReactNode;
 }
 
 /**
  * Shared assistant form fields used in both the CreateDialog AssistantTab
  * and the SettingsModal AssistantsTable create modal.
  *
- * Renders: Display Name, Icon, Board, board advice Alert, Advanced collapse
+ * Renders: Name + icon, Board, board advice Alert, Advanced collapse
  * (Framework Repository, Branch Name, Source Branch).
  * Does NOT render a <Form> wrapper — the parent owns the form instance.
  */
@@ -35,6 +37,7 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
   onDisplayNameChange,
   customRepoSelected,
   onCustomRepoChange,
+  extraBeforeAdvanced,
 }) => {
   const boardOptions = [
     {
@@ -57,21 +60,22 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
 
   return (
     <>
-      <Form.Item
-        name="displayName"
-        label="Display Name"
-        rules={[{ required: true, message: 'Please enter a display name' }]}
-        tooltip="Human-friendly name for this assistant"
-      >
-        <Input
-          placeholder="e.g. PR Reviewer, Command Center"
-          autoFocus
-          onChange={onDisplayNameChange}
-        />
-      </Form.Item>
-
-      <Form.Item name="emoji" label="Icon">
-        <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="🤖" />
+      <Form.Item label="Name" required tooltip="Human-friendly name and icon for this assistant">
+        <Space.Compact style={{ display: 'flex' }}>
+          <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="🤖" />
+          <Form.Item
+            name="displayName"
+            noStyle
+            rules={[{ required: true, message: 'Please enter a name' }]}
+          >
+            <Input
+              placeholder="e.g. PR Reviewer, Command Center"
+              autoFocus
+              onChange={onDisplayNameChange}
+              style={{ flex: 1 }}
+            />
+          </Form.Item>
+        </Space.Compact>
       </Form.Item>
 
       <Form.Item
@@ -109,6 +113,8 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
         }
       />
 
+      {extraBeforeAdvanced}
+
       {isCloning && !frameworkRepo && (
         <Alert
           type="info"
@@ -128,13 +134,16 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
         ghost
         size="small"
         destroyOnHidden={false}
+        expandIcon={({ isActive }) => <DownOutlined rotate={isActive ? 180 : 0} />}
         items={[
           {
             key: 'advanced',
             label: (
-              <Space>
-                <SettingOutlined />
-                <Typography.Text type="secondary">Advanced</Typography.Text>
+              <Space size={6}>
+                <Typography.Text type="secondary">Advanced Assistant Settings</Typography.Text>
+                <Tooltip title="Assistants live in an Agor branch. These settings control the framework repository, branch name, and source branch used to create that assistant branch.">
+                  <InfoCircleOutlined style={{ color: 'var(--ant-color-text-tertiary)' }} />
+                </Tooltip>
               </Space>
             ),
             children: (

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -1,16 +1,6 @@
 import type { Board } from '@agor-live/client';
 import type { FormInstance } from 'antd';
-import {
-  Checkbox,
-  Collapse,
-  ColorPicker,
-  Flex,
-  Form,
-  Input,
-  Select,
-  Space,
-  Typography,
-} from 'antd';
+import { Checkbox, Collapse, ColorPicker, Form, Input, Select, Space, Typography } from 'antd';
 import { useState } from 'react';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 
@@ -217,20 +207,17 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
 
   return (
     <>
-      <Form.Item label="Name" style={{ marginBottom: 24 }}>
-        <Flex gap={8}>
-          <Form.Item name="icon" noStyle>
-            <FormEmojiPickerInput form={form} fieldName="icon" defaultEmoji="📋" />
-          </Form.Item>
+      <Form.Item label="Name" required style={{ marginBottom: 24 }}>
+        <Space.Compact style={{ display: 'flex' }}>
+          <FormEmojiPickerInput form={form} fieldName="icon" defaultEmoji="📋" />
           <Form.Item
             name="name"
             noStyle
-            style={{ flex: 1 }}
             rules={[{ required: true, message: 'Please enter a board name' }]}
           >
             <Input placeholder="My Board" style={{ flex: 1 }} autoFocus={autoFocus} />
           </Form.Item>
-        </Flex>
+        </Space.Compact>
       </Form.Item>
 
       <Form.Item label="Description" name="description">

--- a/apps/agor-ui/src/utils/assistantBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/assistantBootstrapPrompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE,
+  buildAssistantBootstrapPrompt,
+  buildAssistantBootstrapPromptContext,
+} from './assistantBootstrapPrompt';
+
+describe('buildAssistantBootstrapPrompt', () => {
+  it('renders the shared Handlebars template with assistant identity params', () => {
+    const prompt = buildAssistantBootstrapPrompt({
+      displayName: 'PR Reviewer',
+      emoji: '🧐',
+      description: 'Reviews pull requests',
+      userName: 'Max',
+      userEmail: 'max@example.com',
+    });
+
+    expect(ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE).toContain('{{assistant.displayName}}');
+    expect(prompt).toContain('### First boot instructions for Agor Assistant');
+    expect(prompt).toContain('- Assistant: PR Reviewer 🧐');
+    expect(prompt).toContain('- Assistant description: Reviews pull requests');
+    expect(prompt).toContain('- User: Max <max@example.com>');
+    expect(prompt).toContain('- User: Max <max@example.com>\n\nRead BOOTSTRAP.md');
+    expect(prompt).toContain('ask only the next useful questions');
+    expect(prompt).not.toContain("don't re-ask");
+  });
+
+  it('normalizes fallback identity values in the template context', () => {
+    const context = buildAssistantBootstrapPromptContext({ displayName: '  ', emoji: null });
+
+    expect(context).toEqual({
+      assistant: {
+        displayName: 'My Assistant',
+        emoji: '🤖',
+      },
+      firstSession: true,
+    });
+  });
+});

--- a/apps/agor-ui/src/utils/assistantBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/assistantBootstrapPrompt.ts
@@ -1,0 +1,75 @@
+import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
+
+export interface AssistantBootstrapPromptInput {
+  displayName: string;
+  emoji?: string | null;
+  description?: string | null;
+  userName?: string | null;
+  userEmail?: string | null;
+}
+
+export interface AssistantBootstrapPromptContext {
+  assistant: {
+    displayName: string;
+    emoji: string;
+    description?: string;
+  };
+  user?: {
+    name?: string;
+    email?: string;
+  };
+  firstSession: true;
+}
+
+export const ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE = `### First boot instructions for Agor Assistant
+
+Context:
+- Assistant: {{assistant.displayName}} {{assistant.emoji}}
+{{#if assistant.description}}- Assistant description: {{assistant.description}}
+{{/if}}{{#if user.name}}- User: {{user.name}}{{#if user.email}} <{{user.email}}>{{/if}}
+{{else}}{{#if user.email}}- User email: {{user.email}}
+{{/if}}{{/if}}
+Read BOOTSTRAP.md, then say hello and ask only the next useful questions to shape this assistant.`;
+
+export function buildAssistantBootstrapPromptContext({
+  displayName,
+  emoji,
+  description,
+  userName,
+  userEmail,
+}: AssistantBootstrapPromptInput): AssistantBootstrapPromptContext {
+  const normalizedUserName = userName?.trim();
+  const normalizedUserEmail = userEmail?.trim();
+
+  return {
+    assistant: {
+      displayName: displayName.trim() || 'My Assistant',
+      emoji: emoji?.trim() || '🤖',
+      ...(description?.trim() ? { description: description.trim() } : {}),
+    },
+    ...(normalizedUserName || normalizedUserEmail
+      ? {
+          user: {
+            ...(normalizedUserName ? { name: normalizedUserName } : {}),
+            ...(normalizedUserEmail ? { email: normalizedUserEmail } : {}),
+          },
+        }
+      : {}),
+    firstSession: true,
+  };
+}
+
+/**
+ * First prompt for a newly-created Assistant branch.
+ *
+ * Shared by onboarding and the board plus-button creation flow. The prompt is
+ * intentionally a Handlebars template so both flows pass the same assistant
+ * identity params through one rendering path.
+ */
+export function buildAssistantBootstrapPrompt(input: AssistantBootstrapPromptInput): string {
+  return renderTemplate(
+    ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE,
+    buildAssistantBootstrapPromptContext(input) as unknown as Record<string, unknown>,
+    { onError: 'raw' }
+  );
+}

--- a/apps/agor-ui/src/utils/assistantCreation.test.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.test.ts
@@ -1,0 +1,69 @@
+import type { Branch, Repo } from '@agor-live/client';
+import { describe, expect, it, vi } from 'vitest';
+import { createAssistantBranch } from './assistantCreation';
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repo_id: 'repo-1',
+    slug: 'preset-io/agor-assistant-framework',
+    name: 'agor-assistant-framework',
+    default_branch: 'main',
+    created_at: '2026-05-26T00:00:00.000Z',
+    updated_at: '2026-05-26T00:00:00.000Z',
+    ...overrides,
+  } as Repo;
+}
+
+function makeBranch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    branch_id: 'branch-1',
+    repo_id: 'repo-1',
+    name: 'private-pineapple',
+    ref: 'private-pineapple',
+    path: '/tmp/private-pineapple',
+    created_at: '2026-05-26T00:00:00.000Z',
+    updated_at: '2026-05-26T00:00:00.000Z',
+    sessions: [],
+    ...overrides,
+  } as Branch;
+}
+
+describe('createAssistantBranch', () => {
+  it('stores assistant identity, including emoji, in the initial branch create payload', async () => {
+    const repo = makeRepo();
+    const branch = makeBranch();
+    const onCreateBranch = vi.fn().mockResolvedValue(branch);
+    const onUpdateBranch = vi.fn();
+
+    await createAssistantBranch(
+      {
+        displayName: 'Pineapple Helper',
+        emoji: '🍍',
+        description: 'Helps with pineapple tasks.',
+        repoId: repo.repo_id,
+      },
+      {
+        client: null,
+        repoById: new Map([[repo.repo_id, repo]]),
+        onCreateBranch,
+        onUpdateBranch,
+      }
+    );
+
+    expect(onCreateBranch).toHaveBeenCalledWith(
+      repo.repo_id,
+      expect.objectContaining({
+        name: 'private-pineapple-helper',
+        custom_context: {
+          assistant: expect.objectContaining({
+            kind: 'assistant',
+            displayName: 'Pineapple Helper',
+            emoji: '🍍',
+          }),
+        },
+        notes: 'Helps with pineapple tasks.',
+      })
+    );
+    expect(onUpdateBranch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/utils/assistantCreation.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.ts
@@ -24,12 +24,14 @@ export interface AssistantCreationDeps {
       sourceBranch: string;
       pullLatest: boolean;
       boardId?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string | null;
     }
   ) => Promise<Branch | null>;
   onUpdateBranch: (
     branchId: string,
     updates: { board_id?: BoardID; custom_context?: Record<string, unknown>; notes?: string | null }
-  ) => void;
+  ) => void | Promise<void>;
 }
 
 /**
@@ -65,7 +67,17 @@ export async function createAssistantBranch(
     boardId = input.boardChoice;
   }
 
-  // Create the branch
+  const assistantConfig: AssistantConfig = {
+    kind: 'assistant',
+    displayName: input.displayName.trim(),
+    emoji: input.emoji || undefined,
+    frameworkRepo: repo?.slug,
+    createdViaOnboarding: false,
+  };
+
+  // Create the branch with assistant metadata on the initial row. That keeps
+  // the board card consistent immediately and avoids a race where a later
+  // executor readiness patch can arrive before the UI sees the metadata patch.
   const branch = await deps.onCreateBranch(input.repoId, {
     name: branchName,
     ref: branchName,
@@ -73,28 +85,17 @@ export async function createAssistantBranch(
     sourceBranch,
     pullLatest: true,
     boardId,
+    custom_context: { assistant: assistantConfig },
+    ...(input.description?.trim() ? { notes: input.description.trim() } : {}),
   });
 
   if (branch) {
     // Assign to board (if not already passed via boardId above)
     if (boardId && !branch.board_id) {
-      deps.onUpdateBranch(branch.branch_id, {
+      await deps.onUpdateBranch(branch.branch_id, {
         board_id: boardId as BoardID,
       });
     }
-
-    // Tag as assistant and set description as notes
-    const assistantConfig: AssistantConfig = {
-      kind: 'assistant',
-      displayName: input.displayName.trim(),
-      emoji: input.emoji || undefined,
-      frameworkRepo: repo?.slug,
-      createdViaOnboarding: false,
-    };
-    deps.onUpdateBranch(branch.branch_id, {
-      custom_context: { assistant: assistantConfig },
-      ...(input.description?.trim() ? { notes: input.description.trim() } : {}),
-    });
   }
 
   return branch;

--- a/apps/agor-ui/src/utils/startAssistantBootstrapSession.ts
+++ b/apps/agor-ui/src/utils/startAssistantBootstrapSession.ts
@@ -1,0 +1,38 @@
+import type { AgorClient } from '@agor-live/client';
+import { waitForBranchFilesystemReady } from './waitForBranchFilesystemReady';
+
+export interface StartAssistantBootstrapSessionInput<TSessionConfig> {
+  client: AgorClient | null;
+  branchId: string;
+  boardId: string;
+  sessionConfig: TSessionConfig;
+  onCreateSession: (config: TSessionConfig, boardId: string) => Promise<string | null>;
+  onStatusChange?: (status: string) => void;
+}
+
+/**
+ * Shared bootstrap-session runner for newly created assistants.
+ *
+ * Keeps the branch-filesystem readiness wait and first-session create behavior
+ * consistent between onboarding and the Assistant create dialog while letting
+ * each caller own its own navigation/fallback UI.
+ */
+export async function startAssistantBootstrapSession<TSessionConfig>({
+  client,
+  branchId,
+  boardId,
+  sessionConfig,
+  onCreateSession,
+  onStatusChange,
+}: StartAssistantBootstrapSessionInput<TSessionConfig>): Promise<string> {
+  onStatusChange?.('Preparing assistant worktree…');
+  await waitForBranchFilesystemReady(client, branchId);
+
+  onStatusChange?.('Starting first session…');
+  const sessionId = await onCreateSession(sessionConfig, boardId);
+  if (!sessionId) {
+    throw new Error('First assistant session could not be created.');
+  }
+
+  return sessionId;
+}

--- a/apps/agor-ui/src/utils/waitForBranchFilesystemReady.ts
+++ b/apps/agor-ui/src/utils/waitForBranchFilesystemReady.ts
@@ -1,0 +1,45 @@
+import type { AgorClient, Branch } from '@agor-live/client';
+
+export interface WaitForBranchFilesystemReadyOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Branch creation can return before the executor has finished materializing the
+ * worktree on disk. Creating/prompting a session during that window fails with
+ * "cwd does not exist". Poll the branch row until the daemon marks the
+ * filesystem ready before starting the first session.
+ */
+export async function waitForBranchFilesystemReady(
+  client: AgorClient | null | undefined,
+  branchId: string,
+  { timeoutMs = 30_000, intervalMs = 500 }: WaitForBranchFilesystemReadyOptions = {}
+): Promise<void> {
+  if (!client) return;
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: Branch['filesystem_status'];
+
+  while (Date.now() < deadline) {
+    const branch = (await client.service('branches').get(branchId)) as Branch;
+    lastStatus = branch.filesystem_status;
+
+    // Legacy rows may not have a filesystem_status; treat missing as ready.
+    if (!lastStatus || lastStatus === 'ready') return;
+
+    if (lastStatus === 'failed') {
+      throw new Error(branch.error_message || 'Branch filesystem creation failed');
+    }
+
+    if (lastStatus === 'deleted' || lastStatus === 'cleaned' || lastStatus === 'preserved') {
+      throw new Error(`Branch filesystem is ${lastStatus}`);
+    }
+
+    await sleep(intervalMs);
+  }
+
+  throw new Error(`Timed out waiting for branch filesystem to become ready (${lastStatus})`);
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -10,6 +10,7 @@ import type {
   Board,
   BoardExportBlob,
   Branch,
+  BranchPermissionLevel,
   CardType,
   CardWithType,
   CloneRepositoryResult,
@@ -303,10 +304,18 @@ export interface ReposService extends AgorService<Repo> {
       issue_url?: string;
       pull_request_url?: string;
       boardId?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string | null;
+      /** Explicit board position. Honored as-is when supplied. */
+      position?: { x: number; y: number };
+      zoneId?: string;
+      others_can?: BranchPermissionLevel;
+      others_fs_access?: 'none' | 'read' | 'write';
+      environment_variant?: string;
       /**
        * Branch storage model — see
        * context/explorations/clone-redesign.md.
-       * 'branch' (default) = native `git worktree add`.
+       * 'worktree' (default) = native `git worktree add`.
        * 'clone' = self-standing `git clone` with its own `.git/`.
        */
       storage_mode?: 'worktree' | 'clone';
@@ -314,7 +323,7 @@ export interface ReposService extends AgorService<Repo> {
       clone_depth?: number;
     },
     params?: Params
-  ): Promise<Repo>;
+  ): Promise<Branch>;
 
   /**
    * Remove a git branch

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -366,6 +366,10 @@ export interface OnboardingState {
   branchId?: string;
   /** The board ID created for this user */
   boardId?: string;
+  /** Assistant display name captured during onboarding identity step */
+  assistantDisplayName?: string;
+  /** Assistant emoji captured during onboarding identity step */
+  assistantEmoji?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add an expanded **First Session Configuration** section to the Assistant create tab, with Agentic Tool visible above Session Configuration and **Advanced Assistant Settings** below.
- After creating the assistant branch, create an initial bootstrap session with the selected agentic tool/config and navigate directly to that session.
- Add an assistant identity step to onboarding so onboarding also captures assistant name + emoji before creating board/branch/session. The identity control is a single **Name** row with emoji picker + name input, matching Assistant creation.
- Persist assistant identity metadata, including emoji, on the initial branch create payload so the worktree card can render it immediately instead of relying on a follow-up patch.
- Fix the shared emoji picker form wrapper so emoji/icon fields are registered with Ant Design forms and included in submitted assistant/board values.
- Hold the Assistant create dialog during bootstrap, using the submit button spinner/status text through branch creation, worktree readiness polling, and first-session start.
- Keep the dialog open with an inline error if assistant branch creation fails before a branch exists; if the branch exists but first-session bootstrap fails, show a warning and fall back to the branch.
- Remove the separate onboarding Launch step; branch creation now creates the first session immediately, with an inline retry if session creation fails after the branch exists.
- Wait for branch `filesystem_status` to become ready before creating/prompting the first session, avoiding cwd-missing races while the branch executor is still materializing the worktree.
- Fix dev reset so it does not immediately re-resume from stale onboarding preferences, avoiding the occasional need to click Reset twice.
- Add a shared Handlebars bootstrap prompt template and renderer used by both onboarding and the board plus-button flow, passing assistant/user identity params consistently.
- Persist onboarding assistant name/emoji in onboarding progress so refresh/resume does not reset identity.
- Extract the shared assistant bootstrap-session runner so onboarding and plus-button creation use the same readiness-wait/session-create behavior.
- Align the core API create-branch type surface with the daemon route for `custom_context`, `notes`, placement/RBAC/environment fields, and branch return type.

## Graceful fallback
If assistant branch creation succeeds but bootstrap session creation fails, the UI warns the user and still navigates to the new assistant branch so the created assistant is not lost.

## Tests / checks
- `pnpm -w exec biome check apps/agor-ui/src/utils/assistantCreation.ts apps/agor-ui/src/utils/assistantCreation.test.ts apps/agor-ui/src/components/App/App.tsx apps/agor-ui/src/App.tsx apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx apps/agor-ui/src/components/CreateDialog/tabs/AssistantTab.tsx apps/agor-ui/src/components/forms/BoardFormFields.tsx apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx apps/agor-daemon/src/services/repos.ts apps/agor-ui/src/utils/startAssistantBootstrapSession.ts packages/core/src/api/index.ts`
- `pnpm --filter agor-ui exec tsc -b --pretty false`
- `pnpm --filter @agor/daemon exec tsc --noEmit --pretty false`
- `pnpm --filter @agor/core exec tsc --noEmit --pretty false`
- `pnpm --filter agor-ui exec vitest run src/components/CreateDialog/CreateDialog.test.tsx src/utils/assistantBootstrapPrompt.test.ts src/utils/assistantCreation.test.ts`

## Review follow-up
Addressed Codex review/CI feedback in this PR: branch-create failures no longer close silently, readiness/session-start failures get user-facing warnings, Codex first-session settings are configurable from Assistant creation, core API create-branch typing is aligned, onboarding assistant identity is persisted, and the bootstrap session wait/create flow is shared.

## Follow-up / future work
- Capture or infer a per-user preferred agentic tool during onboarding instead of defaulting the Assistant create flow to Claude Code.
- Filter/reorder the Assistant create tool list based on tools verified to work for the current user/top-level config.
- Consider applying the same bootstrap-session flow to the Settings → Assistants create modal if we want all assistant creation entry points to behave identically.