### PR TITLE
refactor(ui): drop message-count and tool-count pills from task header

### DIFF
--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -43,12 +43,10 @@ import { CreatedByTag } from '../metadata/CreatedByTag';
 import {
   ContextWindowPill,
   GitStatePill,
-  MessageCountPill,
   ModelPill,
   ScheduledRunPill,
   TimerPill,
   TokenCountPill,
-  ToolCountPill,
 } from '../Pill';
 import { RateLimitBlock } from '../RateLimitBlock';
 import { StickyTodoRenderer } from '../StickyTodoRenderer';
@@ -423,17 +421,6 @@ export const TaskBlock = React.memo<TaskBlockProps>(
       return -1;
     }, [blocks]);
 
-    // Calculate message count from task message_range
-    const messageCount = task.message_range.end_index - task.message_range.start_index + 1;
-
-    // Calculate tool count (hybrid approach)
-    // - For completed tasks: use stored count (no messages needed)
-    // - For running tasks: calculate from loaded messages (live count)
-    const toolCount =
-      task.status === TaskStatus.COMPLETED
-        ? task.tool_use_count
-        : messages.reduce((sum, msg) => sum + (msg.tool_uses?.length || 0), 0);
-
     // Get normalized SDK response (computed by executor, stored in DB)
     const normalized = task.normalized_sdk_response || null;
 
@@ -514,8 +501,6 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 prefix="By"
               />
             )}
-            <MessageCountPill count={messageCount} />
-            <ToolCountPill count={toolCount} />
             {normalized && (
               <TokenCountPill
                 count={normalized.tokenUsage.totalTokens}


### PR DESCRIPTION
## Summary

- Remove `MessageCountPill` and `ToolCountPill` from `TaskBlock` header (and the now-unused count calculations + imports)
- `ToolCountPill` was misleading anyway — rendered as 0 in practice
- `MessageCountPill` carried little signal once we considered what users actually scan for

The remaining pills (timer, scheduled run, created-by, tokens, context window, model-if-changed, git state, report) preserve observability while reducing the metadata band density.

## Test plan

- [ ] Open a task in the conversation view, confirm the two pills are gone
- [ ] Confirm the rest of the header layout still wraps cleanly
- [ ] Storybook `Pill` stories still render (the pill components themselves are untouched in case anything else wants to reuse them)