### PR TITLE
fix: facepile overflow bubble — smaller counter text, rich user list tooltip

### DIFF
--- a/apps/agor-ui/src/components/AgorAvatar/AgorAvatar.tsx
+++ b/apps/agor-ui/src/components/AgorAvatar/AgorAvatar.tsx
@@ -15,12 +15,14 @@ const STANDARD_AVATAR_SIZE = 40;
 export interface AgorAvatarProps extends Omit<AvatarProps, 'style' | 'size'> {
   /** Optional style overrides */
   style?: CSSProperties;
+  /** Override font size (defaults to 24px for emoji) */
+  fontSize?: string;
 }
 
 /**
  * Standardized avatar component with consistent Agor styling
  */
-export const AgorAvatar: React.FC<AgorAvatarProps> = ({ style, children, ...props }) => {
+export const AgorAvatar: React.FC<AgorAvatarProps> = ({ style, fontSize, children, ...props }) => {
   const { token } = theme.useToken();
 
   return (
@@ -30,7 +32,7 @@ export const AgorAvatar: React.FC<AgorAvatarProps> = ({ style, children, ...prop
       style={{
         backgroundColor: token.colorPrimaryBg,
         color: token.colorText,
-        fontSize: '24px', // Standard emoji size for 40px avatar
+        fontSize: fontSize ?? '24px',
         ...style,
       }}
     >

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -38,7 +38,8 @@ export const Facepile: React.FC<FacepileProps> = ({
 }) => {
   // Show first N users, with overflow count
   const visibleUsers = activeUsers.slice(0, maxVisible);
-  const overflowCount = Math.max(0, activeUsers.length - maxVisible);
+  const overflowUsers = activeUsers.slice(maxVisible);
+  const overflowCount = overflowUsers.length;
 
   if (activeUsers.length === 0) {
     return null;
@@ -90,9 +91,22 @@ export const Facepile: React.FC<FacepileProps> = ({
       })}
 
       {overflowCount > 0 && (
-        <Tooltip title={`+${overflowCount} more active users`}>
+        <Tooltip
+          title={
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {overflowUsers.map(({ user }) => (
+                <div key={user.user_id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{ fontSize: 16 }}>{user.emoji || '👤'}</span>
+                  <span>{user.name || user.email}</span>
+                </div>
+              ))}
+            </div>
+          }
+        >
           <span>
-            <AgorAvatar>+{overflowCount}</AgorAvatar>
+            <AgorAvatar fontSize="11px" style={{ fontWeight: 'bold' }}>
+              +{overflowCount}
+            </AgorAvatar>
           </span>
         </Tooltip>
       )}

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -104,7 +104,7 @@ export const Facepile: React.FC<FacepileProps> = ({
           }
         >
           <span>
-            <AgorAvatar fontSize="11px" style={{ fontWeight: 'bold' }}>
+            <AgorAvatar fontSize="12px" style={{ fontWeight: 'bold' }}>
               +{overflowCount}
             </AgorAvatar>
           </span>


### PR DESCRIPTION
## What

Two UX fixes for the `+N` overflow bubble in the Facepile (shown when there are more active users than `maxVisible`).

**1. Counter text was too big**

`AgorAvatar` hardcodes `fontSize: 24px` for emoji. The `+N` overflow counter used the same component, making the number look oversized and out of proportion. Added an optional `fontSize` prop to `AgorAvatar` and pass `fontSize="12px"` (a standard multiple of 4, in line with `fontSizeSM`) on the overflow bubble.

**2. Tooltip didn't show who was actually active**

The old tooltip just said `"+3 more active users"` — you had no idea who. Now it renders the actual list of overflow users, each with their emoji and name (or email fallback), matching how Figma, Linear, and similar tools handle this pattern.

## Files changed

- `apps/agor-ui/src/components/AgorAvatar/AgorAvatar.tsx` — adds optional `fontSize?: string` prop; defaults to `'24px'` so no existing callers are affected
- `apps/agor-ui/src/components/Facepile/Facepile.tsx` — derives `overflowUsers = activeUsers.slice(maxVisible)`, replaces the generic tooltip string with a per-user list, passes `fontSize="12px" style={{ fontWeight: 'bold' }}` to the overflow avatar

## Notes

- Fully backwards-compatible — no existing `AgorAvatar` callers are affected
- `12px` chosen: multiple of 4, aligns with `fontSizeSM`, consistent with how badge/count indicators are sized in the codebase (11–12px range for 40px avatar containers)