### PR TITLE
add Homebrew install method

### DIFF
--- a/Formula/agor-live.rb
+++ b/Formula/agor-live.rb
@@ -1,0 +1,64 @@
+class AgorLive < Formula
+  desc "Team command center for all things agentic"
+  homepage "https://agor.live"
+  url "https://registry.npmjs.org/agor-live/-/agor-live-0.19.1.tgz"
+  sha256 "6def46c9dd8bb4de55db6d4b7be499da3ff2f626873d91b9ee38ca6146e1b73a"
+  license "BUSL-1.1"
+
+  depends_on "node@24"
+
+  def install
+    node = Formula["node@24"]
+
+    (libexec/"lib").mkpath
+    system node.opt_bin/"npm", "install", "--loglevel=silly", "--global",
+           "--min-release-age=1", "--cache=#{HOMEBREW_CACHE}/npm_cache",
+           "--prefix=#{libexec}", cached_download
+    prune_native_prebuilds
+    (bin/"agor").write_env_script libexec/"bin/agor", PATH: "#{node.opt_bin}:$PATH"
+    (bin/"agor-daemon").write_env_script libexec/"bin/agor-daemon", PATH: "#{node.opt_bin}:$PATH"
+  end
+
+  test do
+    assert_match "Team command center", shell_output("#{bin}/agor --help")
+  end
+
+  private
+
+  def prune_native_prebuilds
+    node_modules = libexec/"lib/node_modules/agor-live/node_modules"
+    platform = OS.mac? ? "darwin" : "linux"
+    arch = Hardware::CPU.arm? ? "arm64" : "x64"
+    current_platform = "#{platform}-#{arch}"
+
+    Pathname.glob(node_modules/"**/prebuilds/*")
+            .select(&:directory?)
+            .reject { |path| path.basename.to_s == current_platform }
+            .each { |path| rm_r path }
+
+    ripgrep_bin = node_modules/"@github/copilot/ripgrep/bin"
+    if ripgrep_bin.directory?
+      ripgrep_bin.children
+                 .reject { |path| path.basename.to_s == current_platform }
+                 .each { |path| rm_r path }
+    end
+
+    mxc_bin = node_modules/"@github/copilot/mxc-bin"
+    if mxc_bin.directory?
+      mxc_bin.children
+             .reject { |path| path.basename.to_s == arch }
+             .each { |path| rm_r path }
+    end
+
+    clipboard_root = node_modules/"@github/copilot/clipboard/node_modules/@teddyzhu"
+    if clipboard_root.directory?
+      clipboard_tokens = [current_platform, "#{current_platform}-gnu"]
+      clipboard_root.glob("clipboard-*")
+                    .reject { |path| clipboard_tokens.any? { |token| path.basename.to_s.include?(token) } }
+                    .each { |path| rm_r path }
+      clipboard_files = (clipboard_root/"clipboard").glob("clipboard.*.node")
+      clipboard_files.reject { |path| clipboard_tokens.any? { |token| path.basename.to_s.include?(token) } }
+                     .each { |path| rm_r path }
+    end
+  end
+end

--- a/README.md
+++ b/README.md
@@ -56,20 +56,13 @@ Agor is a shared canvas where coding agents (Claude Code, Codex, Gemini) and lon
 
 ## Quick Start
 
-Install with npm:
+Requires **Node.js ≥ 22.12** ([install](https://nodejs.org)).
 
 ```bash
 npm install -g agor-live
 ```
 
-Or install with Homebrew:
-
-```bash
-brew tap preset-io/agor https://github.com/preset-io/agor
-brew install agor-live
-```
-
-The npm path requires **Node.js ≥ 22.12** ([install](https://nodejs.org)); the Homebrew formula installs a compatible Node runtime.
+Prefer Homebrew on macOS or Linux? See the [Getting Started guide](https://agor.live/guide/getting-started) for the brew install path.
 
 ```bash
 agor init           # creates ~/.agor/ and database

--- a/README.md
+++ b/README.md
@@ -56,10 +56,22 @@ Agor is a shared canvas where coding agents (Claude Code, Codex, Gemini) and lon
 
 ## Quick Start
 
-Requires **Node.js ≥ 22.12** ([install](https://nodejs.org)).
+Install with npm:
 
 ```bash
 npm install -g agor-live
+```
+
+Or install with Homebrew:
+
+```bash
+brew tap preset-io/agor https://github.com/preset-io/agor
+brew install agor-live
+```
+
+The npm path requires **Node.js ≥ 22.12** ([install](https://nodejs.org)); the Homebrew formula installs a compatible Node runtime.
+
+```bash
 agor init           # creates ~/.agor/ and database
 agor daemon start   # runs in the background
 agor open           # opens the UI

--- a/apps/agor-docs/Dockerfile
+++ b/apps/agor-docs/Dockerfile
@@ -4,9 +4,9 @@
 # dependencies, so the image only needs this directory. Avoids dragging the
 # whole repo into Docker context.
 
-FROM node:20-alpine
+FROM node:22-alpine
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.15.1 --activate
 
 WORKDIR /app
 

--- a/apps/agor-docs/components/InstallTabs.mdx
+++ b/apps/agor-docs/components/InstallTabs.mdx
@@ -1,0 +1,36 @@
+import { Tabs } from 'nextra/components';
+
+<Tabs items={['npm (Recommended)', 'Homebrew']} defaultIndex={0}>
+  <Tabs.Tab>
+    Most users should start here. It's the most universal path, and it's the one the rest of the docs assume.
+
+    Requires **Node.js ≥ 22.12** ([install](https://nodejs.org)).
+
+    ```bash
+    # Install Agor
+    npm install -g agor-live
+
+    # First run
+    agor init
+    agor daemon start
+    agor open
+    ```
+  </Tabs.Tab>
+
+  <Tabs.Tab>
+    If you already use Homebrew, this is a convenient alternative on macOS or Linux.
+
+    The Homebrew formula installs a compatible Node runtime for you.
+
+    ```bash
+    # Install Agor
+    brew tap preset-io/agor https://github.com/preset-io/agor
+    brew install agor-live
+
+    # First run
+    agor init
+    agor daemon start
+    agor open
+    ```
+  </Tabs.Tab>
+</Tabs>

--- a/apps/agor-docs/pages/guide/extended-install.mdx
+++ b/apps/agor-docs/pages/guide/extended-install.mdx
@@ -3,9 +3,11 @@ title: Extended Installation
 description: Alternative ways to install and run Agor — optional companions, authentication options, and custom config locations.
 ---
 
+import InstallTabs from '../../components/InstallTabs.mdx';
+
 # Extended Installation
 
-The [Getting Started](/guide/getting-started) guide covers the recommended user paths: `npm install -g agor-live` or `brew install agor-live` from the Agor tap. This page covers everything else for **users and teams** running Agor — optional companions, deployment alternatives, authentication options, and edge-case configurations.
+The [Getting Started](/guide/getting-started) guide covers the recommended user path: `npm install -g agor-live`. This page covers everything else for **users and teams** running Agor — Homebrew, optional companions, deployment alternatives, authentication options, and edge-case configurations.
 
 > Want to **build, modify, or contribute to** Agor? Head to the [Development Guide](/guide/development) — it covers `docker compose up`, the `.agor.yml` variant system (SQLite / Postgres / RBAC / docs), and developing Agor with Agor itself.
 
@@ -13,24 +15,15 @@ The [Getting Started](/guide/getting-started) guide covers the recommended user 
 
 - **Node.js ≥ 22.12** — see [nodejs.org](https://nodejs.org) for installation.
 
-That's the only hard requirement for npm installs. The Homebrew formula depends on Homebrew's `node` package, so it installs a compatible Node runtime for you. Everything below is either an alternative install method or an optional companion.
+That's the only hard requirement for npm installs. The Homebrew formula installs a compatible Node runtime for you. Everything below is either an alternative install method or an optional companion.
 
-## Homebrew
+## Install paths
 
-On macOS or Linuxbrew:
+Use whichever install method fits your setup:
 
-```bash
-brew tap preset-io/agor https://github.com/preset-io/agor
-brew install agor-live
-```
+<InstallTabs />
 
-Then run the same first-time setup:
-
-```bash
-agor init
-agor daemon start
-agor open
-```
+Homebrew is a convenience path for macOS/Linux users; npm remains the canonical cross-platform install path used throughout the docs.
 
 ---
 

--- a/apps/agor-docs/pages/guide/extended-install.mdx
+++ b/apps/agor-docs/pages/guide/extended-install.mdx
@@ -5,7 +5,7 @@ description: Alternative ways to install and run Agor — optional companions, a
 
 # Extended Installation
 
-The [Getting Started](/guide/getting-started) guide covers the recommended user path: `npm install -g agor-live`. This page covers everything else for **users and teams** running Agor — optional companions, deployment alternatives, authentication options, and edge-case configurations.
+The [Getting Started](/guide/getting-started) guide covers the recommended user paths: `npm install -g agor-live` or `brew install agor-live` from the Agor tap. This page covers everything else for **users and teams** running Agor — optional companions, deployment alternatives, authentication options, and edge-case configurations.
 
 > Want to **build, modify, or contribute to** Agor? Head to the [Development Guide](/guide/development) — it covers `docker compose up`, the `.agor.yml` variant system (SQLite / Postgres / RBAC / docs), and developing Agor with Agor itself.
 
@@ -13,7 +13,24 @@ The [Getting Started](/guide/getting-started) guide covers the recommended user 
 
 - **Node.js ≥ 22.12** — see [nodejs.org](https://nodejs.org) for installation.
 
-That's the only hard requirement. Everything below is either an alternative install method or an optional companion.
+That's the only hard requirement for npm installs. The Homebrew formula depends on Homebrew's `node` package, so it installs a compatible Node runtime for you. Everything below is either an alternative install method or an optional companion.
+
+## Homebrew
+
+On macOS or Linuxbrew:
+
+```bash
+brew tap preset-io/agor https://github.com/preset-io/agor
+brew install agor-live
+```
+
+Then run the same first-time setup:
+
+```bash
+agor init
+agor daemon start
+agor open
+```
 
 ---
 

--- a/apps/agor-docs/pages/guide/getting-started.mdx
+++ b/apps/agor-docs/pages/guide/getting-started.mdx
@@ -3,34 +3,16 @@ title: Getting Started
 description: Install Agor and follow the onboarding wizard. Your first assistant takes it from there.
 ---
 
+import InstallTabs from '../../components/InstallTabs.mdx';
+
 # Getting Started
 
 Install Agor, open the UI, and follow the onboarding wizard. Your **first assistant** will help you get your bearings and get everything else set up.
 
 ## Install
 
-Install with npm:
+<InstallTabs />
 
-```bash
-npm install -g agor-live
-```
-
-Or install with Homebrew:
-
-```bash
-brew tap preset-io/agor https://github.com/preset-io/agor
-brew install agor-live
-```
-
-The npm path requires **Node.js ≥ 22.12** ([install](https://nodejs.org)); the Homebrew formula installs a compatible Node runtime.
-
-## Run
-
-```bash
-agor init           # creates ~/.agor/ and database
-agor daemon start   # runs in the background
-agor open           # opens the UI in your browser
-```
 
 ## Follow the onboarding wizard
 

--- a/apps/agor-docs/pages/guide/getting-started.mdx
+++ b/apps/agor-docs/pages/guide/getting-started.mdx
@@ -9,11 +9,20 @@ Install Agor, open the UI, and follow the onboarding wizard. Your **first assist
 
 ## Install
 
-Requires **Node.js ≥ 22.12** ([install](https://nodejs.org)).
+Install with npm:
 
 ```bash
 npm install -g agor-live
 ```
+
+Or install with Homebrew:
+
+```bash
+brew tap preset-io/agor https://github.com/preset-io/agor
+brew install agor-live
+```
+
+The npm path requires **Node.js ≥ 22.12** ([install](https://nodejs.org)); the Homebrew formula installs a compatible Node runtime.
 
 ## Run
 

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -38,7 +38,7 @@ agor daemon start
 agor open
 ```
 
-Prefer Homebrew? See the [Getting Started Guide](/guide/getting-started) for the brew install path, then add your first repo. For Docker, source builds, and other options, see [Extended Installation](/guide/extended-install).
+Prefer Homebrew on macOS or Linux? See the [Getting Started Guide](/guide/getting-started) for that install path, then add your first repo. For Docker, source builds, and other options, see [Extended Installation](/guide/extended-install).
 
 **Then dive in:**
 

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -38,7 +38,7 @@ agor daemon start
 agor open
 ```
 
-See the [Getting Started Guide](/guide/getting-started) to add your first repo, or [Extended Installation](/guide/extended-install) for Docker, source builds, and other options.
+Prefer Homebrew? See the [Getting Started Guide](/guide/getting-started) for the brew install path, then add your first repo. For Docker, source builds, and other options, see [Extended Installation](/guide/extended-install).
 
 **Then dive in:**
 

--- a/packages/agor-live/README.md
+++ b/packages/agor-live/README.md
@@ -6,16 +6,13 @@ Agor is a real-time collaborative platform for managing Claude Code, Codex, and 
 
 ## Installation
 
+Requires Node.js ≥ 22.12.
+
 ```bash
 npm install -g agor-live
 ```
 
-Or with Homebrew:
-
-```bash
-brew tap preset-io/agor https://github.com/preset-io/agor
-brew install agor-live
-```
+Prefer Homebrew on macOS or Linux? See the main docs for the brew install path.
 
 ## Quick Start
 

--- a/packages/agor-live/README.md
+++ b/packages/agor-live/README.md
@@ -10,6 +10,13 @@ Agor is a real-time collaborative platform for managing Claude Code, Codex, and 
 npm install -g agor-live
 ```
 
+Or with Homebrew:
+
+```bash
+brew tap preset-io/agor https://github.com/preset-io/agor
+brew install agor-live
+```
+
 ## Quick Start
 
 ```bash
@@ -20,7 +27,7 @@ agor init
 agor daemon start
 
 # 3. Open UI in browser
-agor ui open
+agor open
 ```
 
 ## Features


### PR DESCRIPTION
## What

Adds a Homebrew formula for `agor-live` and documents the brew install path in the README, getting-started guide, extended installation guide, docs index, and package README.

## Why

Agor already has a global npm install path, but there was no brew mode for installing it. I like to use brew because `brew upgrade` catches everything at once instead of piecemeal package-manager upgrades.

## How

- Adds `Formula/agor-live.rb` backed by the published `agor-live` npm tarball
- Uses Homebrew-managed `node@24`, matching Agor's supported Node range instead of Homebrew's latest `node` line
- Installs through npm's normal native prebuild path with lifecycle scripts enabled so `scripts/postinstall.js` can create the `@agor/core` package-resolution symlink
- Wraps `agor` and `agor-daemon` so runtime also uses `node@24`
- Prunes foreign-platform native prebuilds from bundled npm dependencies so `brew audit --strict` stays clean
- Documents `brew tap preset-io/agor https://github.com/preset-io/agor` followed by `brew install agor-live`
- Fixes the package README quick-start command from `agor ui open` to `agor open`

## Testing

- `brew style Formula/agor-live.rb`
- `brew ruby -- -c Formula/agor-live.rb`
- `brew install preset-io/agor/agor-live` from a local tap copy of this formula
- `brew test preset-io/agor/agor-live`
- `brew audit --strict --formula preset-io/agor/agor-live`
- `agor --help`
- `agor version`
- `git diff --check`
