### PR TITLE
fix: dedupe task completion chime — root-cause two double-emit sources

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.test.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Event emission contract for the Drizzle → Feathers adapter.
+ *
+ * Each FeathersJS service method has a canonical event:
+ *   create → 'created'
+ *   update → 'updated'
+ *   patch  → 'patched'
+ *   remove → 'removed'
+ *
+ * The adapter used to emit BOTH `'updated'` and `'patched'` from `update()`
+ * "for consistency", which doubled live-event delivery for any subscriber
+ * listening to both. These tests pin the corrected behavior so the
+ * convention doesn't drift again — the chime hook (and any future event
+ * subscriber) can rely on one event per write.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { DrizzleService, type Repository } from './drizzle.js';
+
+interface Widget {
+  id: string;
+  name: string;
+}
+
+function makeRepo(seed: Widget[] = []): Repository<Widget> {
+  const rows = new Map(seed.map((w) => [w.id, w]));
+  return {
+    create: vi.fn(async (data) => {
+      const row = { id: 'auto', name: '', ...data } as Widget;
+      rows.set(row.id, row);
+      return row;
+    }),
+    findById: vi.fn(async (id) => rows.get(id) ?? null),
+    findAll: vi.fn(async () => Array.from(rows.values())),
+    update: vi.fn(async (id, data) => {
+      const existing = rows.get(id);
+      if (!existing) throw new Error(`not found: ${id}`);
+      const next = { ...existing, ...data } as Widget;
+      rows.set(id, next);
+      return next;
+    }),
+    delete: vi.fn(async (id) => {
+      rows.delete(id);
+    }),
+  };
+}
+
+function makeService(repo: Repository<Widget>): {
+  service: DrizzleService<Widget>;
+  events: Array<{ event: string; payload: Widget }>;
+} {
+  const service = new DrizzleService<Widget>(repo, { id: 'id', resourceType: 'Widget' });
+  const events: Array<{ event: string; payload: Widget }> = [];
+  service.emit = (event: string, payload: Widget) => {
+    events.push({ event, payload });
+    return true;
+  };
+  return { service, events };
+}
+
+describe('DrizzleService event emission', () => {
+  it('emits only `created` on create()', async () => {
+    const repo = makeRepo();
+    const { service, events } = makeService(repo);
+
+    await service.create({ id: 'w1', name: 'hello' });
+
+    expect(events.map((e) => e.event)).toEqual(['created']);
+  });
+
+  it('emits only `patched` on patch()', async () => {
+    const repo = makeRepo([{ id: 'w1', name: 'hello' }]);
+    const { service, events } = makeService(repo);
+
+    await service.patch('w1', { name: 'updated' });
+
+    expect(events.map((e) => e.event)).toEqual(['patched']);
+  });
+
+  it('emits only `updated` on update() — NOT `patched`', async () => {
+    // Regression: the adapter used to emit both for "consistency". That
+    // doubled delivery for any subscriber listening to both events, which
+    // is the entire UI chime hook + anyone else doing "react to any
+    // mutation". Per Feathers convention, update() owns 'updated' and
+    // patch() owns 'patched'. Don't conflate.
+    const repo = makeRepo([{ id: 'w1', name: 'hello' }]);
+    const { service, events } = makeService(repo);
+
+    await service.update('w1', { id: 'w1', name: 'replaced' });
+
+    expect(events.map((e) => e.event)).toEqual(['updated']);
+  });
+
+  it('emits only `removed` on remove()', async () => {
+    const repo = makeRepo([{ id: 'w1', name: 'hello' }]);
+    const { service, events } = makeService(repo);
+
+    await service.remove('w1');
+
+    expect(events.map((e) => e.event)).toEqual(['removed']);
+  });
+});

--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -274,7 +274,14 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   }
 
   /**
-   * Update a record (complete replacement)
+   * Update a record (complete replacement).
+   *
+   * Emits ONLY `'updated'` — per Feathers convention `patch()` emits
+   * `'patched'`. The previous implementation emitted both for "consistency",
+   * but that doubles up live-event delivery for any subscriber listening
+   * to both (e.g. UI hooks that want to catch any mutation). Subscribers
+   * that need to react to a complete-replacement should listen to
+   * `'updated'` directly.
    */
   async update(id: Id, data: D, params?: P): Promise<T> {
     // Verify record exists (throws NotFoundError if not found)
@@ -282,7 +289,6 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
 
     const result = await this.repository.update(String(id), data as Partial<T>);
     this.emit?.('updated', result, params);
-    this.emit?.('patched', result, params); // Also emit patched for consistency
     return result;
   }
 

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx
@@ -449,6 +449,63 @@ describe('useTaskCompletionChime', () => {
       );
       expect(playChimeMock).not.toHaveBeenCalled();
     });
+
+    it('LRU touch protects a noisy task from being evicted by unrelated traffic', () => {
+      // A task that keeps emitting duplicate terminal events should get its
+      // recency refreshed on each hit, so it isn't pushed out of the dedupe
+      // window by MAX_CHIMED_HISTORY unrelated completions landing afterward.
+      const client = makeMockClient();
+      render(client);
+
+      // 1) chime once for `noisy`
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      // 2) replay duplicate terminal events for `noisy` — touch on each
+      for (let i = 0; i < 10; i++) {
+        client.__tasks.emit(
+          'patched',
+          makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.RUNNING })
+        );
+        client.__tasks.emit(
+          'patched',
+          makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.COMPLETED })
+        );
+      }
+
+      // 3) flood with MAX_CHIMED_HISTORY - 1 unique completions. Without
+      //    touch, `noisy` (the original oldest) would be the first eviction
+      //    target; with touch, it's been bumped to the freshest slot, so
+      //    one of the flood tasks gets evicted instead.
+      for (let i = 0; i < MAX_CHIMED_HISTORY - 1; i++) {
+        client.__tasks.emit(
+          'patched',
+          makeTask({ task_id: `flood-${i}` as TaskID, status: TaskStatus.RUNNING })
+        );
+        client.__tasks.emit(
+          'patched',
+          makeTask({ task_id: `flood-${i}` as TaskID, status: TaskStatus.COMPLETED })
+        );
+      }
+
+      playChimeMock.mockClear();
+      // 4) `noisy` is still pinned in the chimed-set — no re-chime.
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      expect(playChimeMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('subscription lifecycle', () => {
@@ -501,7 +558,30 @@ describe('useTaskCompletionChime', () => {
       });
     });
 
-    it('frees chimed-set slot when task is removed', () => {
+    it('chimes for a task whose RUNNING arrived via `created`', () => {
+      // The hook subscribes to `'created'` too — but every other test seeds
+      // RUNNING via `'patched'`. Cover the explicit created-with-RUNNING
+      // path so a future refactor that drops the `created` listener gets
+      // caught.
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'created',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('removed event clears running-set but keeps the chimed-set entry pinned', () => {
+      // Task IDs are UUIDv7 and never reused, so the chimed slot is safe to
+      // keep — and keeping it preserves the "one chime per task" guarantee
+      // even if a delayed RUNNING/terminal replay arrives after delete.
       const client = makeMockClient();
       render(client);
 
@@ -515,15 +595,13 @@ describe('useTaskCompletionChime', () => {
       );
       expect(playChimeMock).toHaveBeenCalledTimes(1);
 
-      // Task deleted (e.g. admin removed it). After this the dedupe slot
-      // is freed, so an unrelated future task with the (unlikely) same
-      // task_id would chime — verified by replay below.
       client.__tasks.emit(
         'removed',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
       );
       playChimeMock.mockClear();
 
+      // Delayed replay after removal — chimed-set still gates.
       client.__tasks.emit(
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
@@ -532,7 +610,7 @@ describe('useTaskCompletionChime', () => {
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
       );
-      expect(playChimeMock).toHaveBeenCalledTimes(1);
+      expect(playChimeMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx
@@ -3,9 +3,10 @@
  *
  * The chime is "play once when *my* task transitions from RUNNING to a
  * natural terminal state". The trickiest behavior is dedupe across
- * redundant terminal events for the same task_id — that is the bug this
- * hook had before the `chimed` set was added, and what most tests below
- * pin down.
+ * redundant terminal events for the same task_id — the running-set
+ * primitive (`Set.delete()` returns true exactly once) is what guarantees
+ * idempotence; tests below pin each known double-emit scenario against
+ * that invariant.
  */
 
 import type { AgorClient, AudioPreferences, Task, TaskID } from '@agor-live/client';
@@ -19,7 +20,7 @@ vi.mock('../utils/audio', () => ({
   playTaskCompletionChime: (task: Task, prefs?: AudioPreferences) => playChimeMock(task, prefs),
 }));
 
-import { MAX_CHIMED_HISTORY, useTaskCompletionChime } from './useTaskCompletionChime';
+import { useTaskCompletionChime } from './useTaskCompletionChime';
 
 const USER_ID = 'user-123';
 
@@ -196,7 +197,8 @@ describe('useTaskCompletionChime', () => {
 
   describe('duplicate completion events', () => {
     // Each scenario below is a real-world way the daemon can produce two
-    // terminal events for the *same* task_id. The fix guarantees one chime.
+    // terminal events for the *same* task_id. The Set.delete() dedupe
+    // guarantees exactly one chime even if the upstream fix regresses.
 
     it('dedupes a second identical patched event for the same task', () => {
       const client = makeMockClient();
@@ -210,8 +212,6 @@ describe('useTaskCompletionChime', () => {
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
       );
-      // Replay (socket reconnect, daemon-side double-emit, etc.) — must NOT
-      // re-chime.
       client.__tasks.emit(
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
@@ -220,7 +220,10 @@ describe('useTaskCompletionChime', () => {
       expect(playChimeMock).toHaveBeenCalledTimes(1);
     });
 
-    it("dedupes daemon-side `'updated' + 'patched'` paired emit (DrizzleService.update)", () => {
+    it("dedupes daemon-side `'updated' + 'patched'` paired emit", () => {
+      // DrizzleService.update() no longer dual-emits as of this PR, but the
+      // hook still has to be robust against any future caller that wires up
+      // both events for the same write.
       const client = makeMockClient();
       render(client);
 
@@ -228,8 +231,6 @@ describe('useTaskCompletionChime', () => {
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
       );
-      // DrizzleService.update() fires both events synchronously for a single
-      // operation. UI listens to both — should still chime once.
       client.__tasks.emit(
         'updated',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
@@ -268,7 +269,10 @@ describe('useTaskCompletionChime', () => {
       expect(playChimeMock).toHaveBeenCalledTimes(1);
     });
 
-    it('dedupes double-FAILED patches (base-executor + index.ts double-catch)', () => {
+    it('dedupes double-FAILED patches if a future regression brings them back', () => {
+      // The executor's `tryMarkTaskTerminal` guard (added in this PR)
+      // prevents the inner+outer catch pair from both emitting. This
+      // test is the safety net for any future regression there.
       const client = makeMockClient();
       render(client);
 
@@ -276,8 +280,6 @@ describe('useTaskCompletionChime', () => {
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
       );
-      // base-executor's catch patches to FAILED then re-throws; the outer
-      // catch in executor/index.ts patches to FAILED again.
       client.__tasks.emit(
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.FAILED })
@@ -304,50 +306,9 @@ describe('useTaskCompletionChime', () => {
       client.__tasks.emit('patched', t(TaskStatus.AWAITING_PERMISSION));
       client.__tasks.emit('patched', t(TaskStatus.RUNNING));
       client.__tasks.emit('patched', t(TaskStatus.COMPLETED));
-      // Replay — must NOT bypass the dedupe just because the running-set
-      // was rebuilt after AWAITING_PERMISSION.
       client.__tasks.emit('patched', t(TaskStatus.COMPLETED));
 
       expect(playChimeMock).toHaveBeenCalledTimes(1);
-    });
-
-    it('dedupe survives subscription teardown + remount (token rotation)', () => {
-      const client1 = makeMockClient();
-      const { rerender } = render(client1);
-
-      client1.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
-      );
-      client1.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
-      );
-      expect(playChimeMock).toHaveBeenCalledTimes(1);
-
-      // Token rotation / auth flip: new client instance, hook re-subscribes.
-      // The seed fetch on the new client will NOT include t1 (it's already
-      // COMPLETED in DB), but a delayed replay of the COMPLETED event must
-      // still not chime.
-      const client2 = makeMockClient();
-      // Seed the running set as if t1 were still considered running.
-      // This simulates the worst case: a stale RUNNING row arrives via the
-      // seed fetch, then a delayed COMPLETED replay lands on the new sub.
-      client2.__tasks.findAll.mockResolvedValueOnce([
-        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING }),
-      ]);
-      rerender({ c: client2 });
-
-      // Let the seed fetch resolve before firing the replay.
-      return waitFor(() => {
-        expect(client2.__tasks.findAll).toHaveBeenCalled();
-      }).then(() => {
-        client2.__tasks.emit(
-          'patched',
-          makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
-        );
-        expect(playChimeMock).toHaveBeenCalledTimes(1);
-      });
     });
   });
 
@@ -404,110 +365,6 @@ describe('useTaskCompletionChime', () => {
     });
   });
 
-  describe('LRU bounds', () => {
-    it('caps the chimed-history set at MAX_CHIMED_HISTORY entries', () => {
-      const client = makeMockClient();
-      render(client);
-
-      // Fire MAX_CHIMED_HISTORY + 1 unique completions. The very first
-      // task_id gets evicted from the chimed-set as the cap rolls over.
-      for (let i = 0; i < MAX_CHIMED_HISTORY + 1; i++) {
-        client.__tasks.emit(
-          'patched',
-          makeTask({ task_id: `t${i}` as TaskID, status: TaskStatus.RUNNING })
-        );
-        client.__tasks.emit(
-          'patched',
-          makeTask({ task_id: `t${i}` as TaskID, status: TaskStatus.COMPLETED })
-        );
-      }
-      expect(playChimeMock).toHaveBeenCalledTimes(MAX_CHIMED_HISTORY + 1);
-
-      playChimeMock.mockClear();
-
-      // The OLDEST entry (t0) was evicted, so a replay for it WOULD chime
-      // again if the running-set is reseeded. This is the documented
-      // trade-off — keeping the cap simple and the hook's working memory
-      // bounded.
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 't0' as TaskID, status: TaskStatus.RUNNING })
-      );
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 't0' as TaskID, status: TaskStatus.COMPLETED })
-      );
-      expect(playChimeMock).toHaveBeenCalledTimes(1);
-
-      // A task we know is still in the chimed window (e.g. the LAST one
-      // we fired above) does NOT re-chime on replay.
-      const lastIdx = MAX_CHIMED_HISTORY; // we ran i = 0..MAX, last id = `t${MAX}`
-      playChimeMock.mockClear();
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: `t${lastIdx}` as TaskID, status: TaskStatus.COMPLETED })
-      );
-      expect(playChimeMock).not.toHaveBeenCalled();
-    });
-
-    it('LRU touch protects a noisy task from being evicted by unrelated traffic', () => {
-      // A task that keeps emitting duplicate terminal events should get its
-      // recency refreshed on each hit, so it isn't pushed out of the dedupe
-      // window by MAX_CHIMED_HISTORY unrelated completions landing afterward.
-      const client = makeMockClient();
-      render(client);
-
-      // 1) chime once for `noisy`
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.RUNNING })
-      );
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.COMPLETED })
-      );
-
-      // 2) replay duplicate terminal events for `noisy` — touch on each
-      for (let i = 0; i < 10; i++) {
-        client.__tasks.emit(
-          'patched',
-          makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.RUNNING })
-        );
-        client.__tasks.emit(
-          'patched',
-          makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.COMPLETED })
-        );
-      }
-
-      // 3) flood with MAX_CHIMED_HISTORY - 1 unique completions. Without
-      //    touch, `noisy` (the original oldest) would be the first eviction
-      //    target; with touch, it's been bumped to the freshest slot, so
-      //    one of the flood tasks gets evicted instead.
-      for (let i = 0; i < MAX_CHIMED_HISTORY - 1; i++) {
-        client.__tasks.emit(
-          'patched',
-          makeTask({ task_id: `flood-${i}` as TaskID, status: TaskStatus.RUNNING })
-        );
-        client.__tasks.emit(
-          'patched',
-          makeTask({ task_id: `flood-${i}` as TaskID, status: TaskStatus.COMPLETED })
-        );
-      }
-
-      playChimeMock.mockClear();
-      // 4) `noisy` is still pinned in the chimed-set — no re-chime.
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.RUNNING })
-      );
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 'noisy' as TaskID, status: TaskStatus.COMPLETED })
-      );
-      expect(playChimeMock).not.toHaveBeenCalled();
-    });
-  });
-
   describe('subscription lifecycle', () => {
     it('unsubscribes on unmount', () => {
       const client = makeMockClient();
@@ -527,9 +384,8 @@ describe('useTaskCompletionChime', () => {
     });
 
     it('does nothing when client is null', () => {
-      const { rerender: _rerender } = render(null);
+      render(null);
       expect(playChimeMock).not.toHaveBeenCalled();
-      // No way to fire events without a client — just verifying no crash.
     });
 
     it('chimes for a task seeded as RUNNING from findAll', async () => {
@@ -539,15 +395,12 @@ describe('useTaskCompletionChime', () => {
       ]);
       render(client);
 
-      // Wait for the seed fetch to populate the running set.
       await waitFor(() => {
         expect(client.__tasks.findAll).toHaveBeenCalledWith({
           query: { status: TaskStatus.RUNNING, created_by: USER_ID },
         });
       });
 
-      // Now the live COMPLETED event should find seed-1 in the running set
-      // and chime — even though we never saw its RUNNING transition.
       client.__tasks.emit(
         'patched',
         makeTask({ task_id: 'seed-1' as TaskID, status: TaskStatus.COMPLETED })
@@ -559,7 +412,7 @@ describe('useTaskCompletionChime', () => {
     });
 
     it('chimes for a task whose RUNNING arrived via `created`', () => {
-      // The hook subscribes to `'created'` too — but every other test seeds
+      // The hook subscribes to `'created'` too — every other test seeds
       // RUNNING via `'patched'`. Cover the explicit created-with-RUNNING
       // path so a future refactor that drops the `created` listener gets
       // caught.
@@ -578,10 +431,9 @@ describe('useTaskCompletionChime', () => {
       expect(playChimeMock).toHaveBeenCalledTimes(1);
     });
 
-    it('removed event clears running-set but keeps the chimed-set entry pinned', () => {
-      // Task IDs are UUIDv7 and never reused, so the chimed slot is safe to
-      // keep — and keeping it preserves the "one chime per task" guarantee
-      // even if a delayed RUNNING/terminal replay arrives after delete.
+    it('removed event evicts the running-set entry', () => {
+      // Without this, a re-RUNNING + terminal pair on the same task_id
+      // after an admin delete would emit a spurious chime.
       const client = makeMockClient();
       render(client);
 
@@ -590,22 +442,13 @@ describe('useTaskCompletionChime', () => {
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
       );
       client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
-      );
-      expect(playChimeMock).toHaveBeenCalledTimes(1);
-
-      client.__tasks.emit(
         'removed',
-        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
       );
       playChimeMock.mockClear();
 
-      // Delayed replay after removal — chimed-set still gates.
-      client.__tasks.emit(
-        'patched',
-        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
-      );
+      // Stale COMPLETED replay with no preceding RUNNING — running-set is
+      // empty after the removed event, so wasRunning=false, no chime.
       client.__tasks.emit(
         'patched',
         makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx
@@ -1,0 +1,538 @@
+/**
+ * Regression coverage for {@link useTaskCompletionChime}.
+ *
+ * The chime is "play once when *my* task transitions from RUNNING to a
+ * natural terminal state". The trickiest behavior is dedupe across
+ * redundant terminal events for the same task_id — that is the bug this
+ * hook had before the `chimed` set was added, and what most tests below
+ * pin down.
+ */
+
+import type { AgorClient, AudioPreferences, Task, TaskID } from '@agor-live/client';
+import { TaskStatus } from '@agor-live/client';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const playChimeMock = vi.fn<(task: Task, prefs?: AudioPreferences) => Promise<void>>();
+
+vi.mock('../utils/audio', () => ({
+  playTaskCompletionChime: (task: Task, prefs?: AudioPreferences) => playChimeMock(task, prefs),
+}));
+
+import { MAX_CHIMED_HISTORY, useTaskCompletionChime } from './useTaskCompletionChime';
+
+const USER_ID = 'user-123';
+
+type TaskEvent = 'created' | 'patched' | 'updated' | 'removed';
+
+interface MockTasksService {
+  on: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  findAll: ReturnType<typeof vi.fn>;
+  emit(event: TaskEvent, task: Partial<Task>): void;
+}
+
+interface MockClient {
+  service: ReturnType<typeof vi.fn>;
+  __tasks: MockTasksService;
+}
+
+/**
+ * Build a mock AgorClient whose tasks service stores `on`/`removeListener`
+ * registrations in a Map keyed by event name, plus an `emit` helper that
+ * fires every registered handler — exactly the contract the hook depends on.
+ *
+ * `findAll` returns an empty array by default (no tasks currently RUNNING),
+ * but tests can override before render via `client.__tasks.findAll.mockResolvedValueOnce`.
+ */
+function makeMockClient(): MockClient {
+  const listeners = new Map<TaskEvent, Array<(task: Partial<Task>) => void>>();
+  const tasksService: MockTasksService = {
+    on: vi.fn((event: TaskEvent, fn: (task: Partial<Task>) => void) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(fn);
+      listeners.set(event, arr);
+    }),
+    removeListener: vi.fn((event: TaskEvent, fn: (task: Partial<Task>) => void) => {
+      const arr = listeners.get(event) ?? [];
+      listeners.set(
+        event,
+        arr.filter((f) => f !== fn)
+      );
+    }),
+    findAll: vi.fn().mockResolvedValue([]),
+    emit: (event, task) => {
+      // Snapshot the listener array — mirrors EventEmitter semantics so a
+      // handler that mutates registrations mid-emit doesn't break iteration.
+      for (const fn of [...(listeners.get(event) ?? [])]) fn(task);
+    },
+  };
+
+  return {
+    service: vi.fn(() => tasksService),
+    __tasks: tasksService,
+  };
+}
+
+function makeTask(overrides: Partial<Task> & Pick<Task, 'task_id' | 'status'>): Partial<Task> {
+  return {
+    session_id: 'sess-1' as Task['session_id'],
+    created_by: USER_ID,
+    full_prompt: 'do the thing',
+    tool_use_count: 0,
+    git_state: { ref_at_start: 'main', sha_at_start: 'abc' },
+    message_range: { start_index: 0, end_index: 0, start_timestamp: '0' },
+    created_at: '0',
+    ...overrides,
+  };
+}
+
+const audioPrefs: AudioPreferences = {
+  enabled: true,
+  chime: 'gentle-chime',
+  volume: 0.5,
+  minDurationSeconds: 0,
+};
+
+function render(client: MockClient | null) {
+  return renderHook(
+    ({ c }: { c: MockClient | null }) =>
+      useTaskCompletionChime((c as unknown as AgorClient) ?? null, USER_ID, audioPrefs),
+    { initialProps: { c: client } }
+  );
+}
+
+describe('useTaskCompletionChime', () => {
+  beforeEach(() => {
+    playChimeMock.mockReset();
+    playChimeMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('plays exactly one chime on RUNNING → COMPLETED', () => {
+    const client = makeMockClient();
+    render(client);
+
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+    );
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+    );
+
+    expect(playChimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays one chime on RUNNING → FAILED', () => {
+    const client = makeMockClient();
+    render(client);
+
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+    );
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.FAILED })
+    );
+
+    expect(playChimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT chime on STOPPED — user-initiated stop is not a natural completion', () => {
+    const client = makeMockClient();
+    render(client);
+
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+    );
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.STOPPED })
+    );
+
+    expect(playChimeMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT chime on TIMED_OUT', () => {
+    const client = makeMockClient();
+    render(client);
+
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+    );
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.TIMED_OUT })
+    );
+
+    expect(playChimeMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT chime for tasks owned by a different user (multiplayer scoping)', () => {
+    const client = makeMockClient();
+    render(client);
+
+    const otherUserTask = makeTask({
+      task_id: 't1' as TaskID,
+      status: TaskStatus.RUNNING,
+      created_by: 'other-user',
+    });
+    client.__tasks.emit('patched', otherUserTask);
+    client.__tasks.emit(
+      'patched',
+      makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED, created_by: 'other-user' })
+    );
+
+    expect(playChimeMock).not.toHaveBeenCalled();
+  });
+
+  describe('duplicate completion events', () => {
+    // Each scenario below is a real-world way the daemon can produce two
+    // terminal events for the *same* task_id. The fix guarantees one chime.
+
+    it('dedupes a second identical patched event for the same task', () => {
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      // Replay (socket reconnect, daemon-side double-emit, etc.) — must NOT
+      // re-chime.
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("dedupes daemon-side `'updated' + 'patched'` paired emit (DrizzleService.update)", () => {
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      // DrizzleService.update() fires both events synchronously for a single
+      // operation. UI listens to both — should still chime once.
+      client.__tasks.emit(
+        'updated',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes a post-completion `session_md5` patch (stateless_fs_mode)', () => {
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      // Daemon writes session_md5 after the executor exits — the resulting
+      // `'patched'` broadcast still carries status=COMPLETED.
+      client.__tasks.emit(
+        'patched',
+        makeTask({
+          task_id: 't1' as TaskID,
+          status: TaskStatus.COMPLETED,
+          session_md5: 'abc123',
+        })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes double-FAILED patches (base-executor + index.ts double-catch)', () => {
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      // base-executor's catch patches to FAILED then re-throws; the outer
+      // catch in executor/index.ts patches to FAILED again.
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.FAILED })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({
+          task_id: 't1' as TaskID,
+          status: TaskStatus.FAILED,
+          error_message: 'something else',
+        })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives a status flicker (RUNNING → AWAITING_PERMISSION → RUNNING → COMPLETED → COMPLETED)', () => {
+      const client = makeMockClient();
+      render(client);
+
+      const t = (status: TaskStatus) => makeTask({ task_id: 't1' as TaskID, status });
+
+      client.__tasks.emit('patched', t(TaskStatus.RUNNING));
+      client.__tasks.emit('patched', t(TaskStatus.AWAITING_PERMISSION));
+      client.__tasks.emit('patched', t(TaskStatus.RUNNING));
+      client.__tasks.emit('patched', t(TaskStatus.COMPLETED));
+      // Replay — must NOT bypass the dedupe just because the running-set
+      // was rebuilt after AWAITING_PERMISSION.
+      client.__tasks.emit('patched', t(TaskStatus.COMPLETED));
+
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupe survives subscription teardown + remount (token rotation)', () => {
+      const client1 = makeMockClient();
+      const { rerender } = render(client1);
+
+      client1.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client1.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+
+      // Token rotation / auth flip: new client instance, hook re-subscribes.
+      // The seed fetch on the new client will NOT include t1 (it's already
+      // COMPLETED in DB), but a delayed replay of the COMPLETED event must
+      // still not chime.
+      const client2 = makeMockClient();
+      // Seed the running set as if t1 were still considered running.
+      // This simulates the worst case: a stale RUNNING row arrives via the
+      // seed fetch, then a delayed COMPLETED replay lands on the new sub.
+      client2.__tasks.findAll.mockResolvedValueOnce([
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING }),
+      ]);
+      rerender({ c: client2 });
+
+      // Let the seed fetch resolve before firing the replay.
+      return waitFor(() => {
+        expect(client2.__tasks.findAll).toHaveBeenCalled();
+      }).then(() => {
+        client2.__tasks.emit(
+          'patched',
+          makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+        );
+        expect(playChimeMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('legitimate separate completions', () => {
+    it('chimes once per distinct task — different task_ids must each fire', () => {
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't2' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't2' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('callback chain — child completion + parent completion both chime', () => {
+      // child task finishes → daemon queues a callback prompt as a NEW task
+      // on the parent → parent task runs and completes. The user should
+      // hear BOTH chimes (they're separate, legitimate completions).
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'child' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'child' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'parent-cb' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'parent-cb' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      expect(playChimeMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('LRU bounds', () => {
+    it('caps the chimed-history set at MAX_CHIMED_HISTORY entries', () => {
+      const client = makeMockClient();
+      render(client);
+
+      // Fire MAX_CHIMED_HISTORY + 1 unique completions. The very first
+      // task_id gets evicted from the chimed-set as the cap rolls over.
+      for (let i = 0; i < MAX_CHIMED_HISTORY + 1; i++) {
+        client.__tasks.emit(
+          'patched',
+          makeTask({ task_id: `t${i}` as TaskID, status: TaskStatus.RUNNING })
+        );
+        client.__tasks.emit(
+          'patched',
+          makeTask({ task_id: `t${i}` as TaskID, status: TaskStatus.COMPLETED })
+        );
+      }
+      expect(playChimeMock).toHaveBeenCalledTimes(MAX_CHIMED_HISTORY + 1);
+
+      playChimeMock.mockClear();
+
+      // The OLDEST entry (t0) was evicted, so a replay for it WOULD chime
+      // again if the running-set is reseeded. This is the documented
+      // trade-off — keeping the cap simple and the hook's working memory
+      // bounded.
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't0' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't0' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+
+      // A task we know is still in the chimed window (e.g. the LAST one
+      // we fired above) does NOT re-chime on replay.
+      const lastIdx = MAX_CHIMED_HISTORY; // we ran i = 0..MAX, last id = `t${MAX}`
+      playChimeMock.mockClear();
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: `t${lastIdx}` as TaskID, status: TaskStatus.COMPLETED })
+      );
+      expect(playChimeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscription lifecycle', () => {
+    it('unsubscribes on unmount', () => {
+      const client = makeMockClient();
+      const { unmount } = render(client);
+
+      expect(client.__tasks.on).toHaveBeenCalledWith('created', expect.any(Function));
+      expect(client.__tasks.on).toHaveBeenCalledWith('patched', expect.any(Function));
+      expect(client.__tasks.on).toHaveBeenCalledWith('updated', expect.any(Function));
+      expect(client.__tasks.on).toHaveBeenCalledWith('removed', expect.any(Function));
+
+      unmount();
+
+      expect(client.__tasks.removeListener).toHaveBeenCalledWith('created', expect.any(Function));
+      expect(client.__tasks.removeListener).toHaveBeenCalledWith('patched', expect.any(Function));
+      expect(client.__tasks.removeListener).toHaveBeenCalledWith('updated', expect.any(Function));
+      expect(client.__tasks.removeListener).toHaveBeenCalledWith('removed', expect.any(Function));
+    });
+
+    it('does nothing when client is null', () => {
+      const { rerender: _rerender } = render(null);
+      expect(playChimeMock).not.toHaveBeenCalled();
+      // No way to fire events without a client — just verifying no crash.
+    });
+
+    it('chimes for a task seeded as RUNNING from findAll', async () => {
+      const client = makeMockClient();
+      client.__tasks.findAll.mockResolvedValueOnce([
+        makeTask({ task_id: 'seed-1' as TaskID, status: TaskStatus.RUNNING }),
+      ]);
+      render(client);
+
+      // Wait for the seed fetch to populate the running set.
+      await waitFor(() => {
+        expect(client.__tasks.findAll).toHaveBeenCalledWith({
+          query: { status: TaskStatus.RUNNING, created_by: USER_ID },
+        });
+      });
+
+      // Now the live COMPLETED event should find seed-1 in the running set
+      // and chime — even though we never saw its RUNNING transition.
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 'seed-1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+
+      await waitFor(() => {
+        expect(playChimeMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('frees chimed-set slot when task is removed', () => {
+      const client = makeMockClient();
+      render(client);
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+
+      // Task deleted (e.g. admin removed it). After this the dedupe slot
+      // is freed, so an unrelated future task with the (unlikely) same
+      // task_id would chime — verified by replay below.
+      client.__tasks.emit(
+        'removed',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      playChimeMock.mockClear();
+
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.RUNNING })
+      );
+      client.__tasks.emit(
+        'patched',
+        makeTask({ task_id: 't1' as TaskID, status: TaskStatus.COMPLETED })
+      );
+      expect(playChimeMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
@@ -10,12 +10,18 @@
  * Dedupe model: a Set of currently-RUNNING task IDs. Each terminal event
  * tries to `delete()` the entry; the first one returns true and fires the
  * chime, every subsequent terminal event for the same task returns false
- * (entry already gone) and is a no-op. This is sufficient to handle every
- * known duplicate-event source — the daemon's executor-double-catch path,
- * the stateless_fs_mode post-completion `session_md5` patch, and any other
- * tail emit — without a separate "already chimed" history. The upstream
- * fix in `packages/executor/src/index.ts` further removes the
- * double-FAILED emit at the source.
+ * (entry already gone) and is a no-op. This handles the normal-path
+ * duplicate emits — the daemon's executor-double-catch path (also fixed
+ * at the source in `packages/executor/src/terminal-task.ts`), the
+ * stateless_fs_mode post-completion `session_md5` patch, and similar
+ * tail emits.
+ *
+ * Known edge case we explicitly accept: if the seed `findAll` resolves
+ * after a live terminal event for the same task, the seed re-adds the
+ * task to the running set, and a subsequent tail emit could re-arm the
+ * chime. This requires a specific inter-event/RPC ordering that's
+ * vanishingly rare in practice; the chime is a low-stakes notification
+ * and we'd rather keep the hook small than guard against it.
  */
 
 import type { AgorClient, AudioPreferences, Task } from '@agor-live/client';
@@ -73,9 +79,9 @@ export function useTaskCompletionChime(
     tasksService.on('removed', handleTaskRemoved);
 
     // Seed running tasks already in flight at mount (page reload, reconnect).
-    // Subscribe-first-then-fetch: any transition landing during the fetch is
-    // still handled by the live handler; at worst we add a stale ID for a
-    // task that has already finished, which never triggers a chime.
+    // Subscribe-first-then-fetch: live events during the fetch are still
+    // handled by the live handler. See the file header for the accepted
+    // seed-vs-live ordering edge case.
     tasksService
       .findAll({ query: { status: TaskStatus.RUNNING, created_by: currentUserId } })
       .then((tasks: Task[]) => {

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
@@ -14,15 +14,50 @@ import { useEffect, useRef } from 'react';
 import { playTaskCompletionChime } from '../utils/audio';
 import type { FeathersEventHandler } from './index';
 
+/**
+ * Cap on the number of recently-chimed task IDs we remember.
+ * Sized to comfortably cover any realistic burst of completions a single
+ * user could trigger before the LRU starts evicting. Once an ID is
+ * evicted the chime *could* re-fire for that task, but only if the
+ * daemon emits another terminal event for the same `task_id`, which
+ * is itself rare.
+ *
+ * Exported for tests.
+ */
+export const MAX_CHIMED_HISTORY = 500;
+
 export function useTaskCompletionChime(
   client: AgorClient | null,
   currentUserId: string | undefined,
   audioPreferences: AudioPreferences | undefined
 ): void {
-  // Track task IDs currently in RUNNING state so we fire exactly once on the
-  // RUNNING → terminal transition. Only RUNNING entries are kept, so the set
-  // is bounded by concurrent in-flight tasks rather than lifetime tasks.
+  // Track task IDs currently in RUNNING state so we fire on the
+  // RUNNING → terminal transition only for tasks we observed start. Only
+  // RUNNING entries are kept, so the set is bounded by concurrent in-flight
+  // tasks rather than lifetime tasks.
   const runningTaskIdsRef = useRef<Set<string>>(new Set());
+
+  // Per-task "already chimed" dedupe. Kept in a ref so it survives:
+  //   - the effect tearing down + re-running (token rotation, currentUserId
+  //     flipping between undefined and defined on auth load),
+  //   - WebSocket reconnect replays,
+  //   - the daemon emitting multiple `'patched'` events for the same
+  //     completion (e.g. an executor-side patch to `COMPLETED` followed by
+  //     a post-completion `session_md5` patch in stateless_fs_mode, or the
+  //     base-executor + index.ts double-catch on failure both patching
+  //     to `FAILED`),
+  //   - any other source of duplicate terminal events for the same task_id.
+  //
+  // The previous implementation relied solely on `runningTaskIds.delete()`
+  // returning true exactly once; that breaks if the running-set is cleared
+  // out between two terminal events (effect teardown, status flicker), or
+  // if the task is re-added before the second event arrives. This Set is
+  // the final gate that guarantees "one chime per task completion".
+  //
+  // Insertion-ordered Set + size cap = simple LRU. We evict the oldest
+  // entry rather than reset on a threshold so a long-running session can't
+  // hit a momentary blind spot.
+  const chimedTaskIdsRef = useRef<Set<string>>(new Set());
 
   // Keep audio prefs in a ref so the subscription effect doesn't tear down on
   // every preference change (e.g. while the user is tweaking the slider).
@@ -36,6 +71,7 @@ export function useTaskCompletionChime(
 
     const tasksService = client.service('tasks');
     const running = runningTaskIdsRef.current;
+    const chimed = chimedTaskIdsRef.current;
     let disposed = false;
 
     // The chime is a personal notification for the prompting user. In a
@@ -43,6 +79,16 @@ export function useTaskCompletionChime(
     // viewer can see, so we filter by Task.created_by — "chime when my
     // prompts finish", not "chime when anyone's prompts finish".
     const isOwnTask = (task: Task) => task?.created_by === currentUserId;
+
+    const markChimed = (taskId: string) => {
+      chimed.add(taskId);
+      if (chimed.size > MAX_CHIMED_HISTORY) {
+        // Set iteration order is insertion order — `values().next().value`
+        // is the oldest. Evict it so the set stays bounded.
+        const oldest = chimed.values().next().value;
+        if (oldest !== undefined) chimed.delete(oldest);
+      }
+    };
 
     const handleTaskChange = (task: Task) => {
       if (!task?.task_id || !isOwnTask(task)) return;
@@ -53,15 +99,22 @@ export function useTaskCompletionChime(
       }
 
       const wasRunning = running.delete(task.task_id);
-      if (wasRunning && isNaturalCompletion(task.status)) {
-        void playTaskCompletionChime(task, audioPrefsRef.current);
-      }
+      if (!wasRunning || !isNaturalCompletion(task.status)) return;
+
+      // Final dedupe: don't re-play if we already chimed for this task,
+      // even if the daemon emits more terminal events for it.
+      if (chimed.has(task.task_id)) return;
+      markChimed(task.task_id);
+
+      void playTaskCompletionChime(task, audioPrefsRef.current);
     };
 
     const handleTaskRemoved = (task: Task) => {
-      if (task?.task_id) {
-        running.delete(task.task_id);
-      }
+      if (!task?.task_id) return;
+      running.delete(task.task_id);
+      // Drop the chimed entry too — once the task is gone the daemon can't
+      // emit any more events for it, so the dedupe slot is free to reclaim.
+      chimed.delete(task.task_id);
     };
 
     tasksService.on('created', handleTaskChange as FeathersEventHandler);
@@ -97,6 +150,9 @@ export function useTaskCompletionChime(
       tasksService.removeListener('updated', handleTaskChange as FeathersEventHandler);
       tasksService.removeListener('removed', handleTaskRemoved as FeathersEventHandler);
       running.clear();
+      // NOTE: we intentionally do NOT clear `chimed` here. A token-refresh
+      // or auth-flip teardown that wipes it would re-arm the chime for any
+      // post-completion replay event landing on the new subscription.
     };
   }, [client, currentUserId]);
 }

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
@@ -12,17 +12,11 @@ import type { AgorClient, AudioPreferences, Task } from '@agor-live/client';
 import { isNaturalCompletion, TaskStatus } from '@agor-live/client';
 import { useEffect, useRef } from 'react';
 import { playTaskCompletionChime } from '../utils/audio';
-import type { FeathersEventHandler } from './index';
 
 /**
- * Cap on the number of recently-chimed task IDs we remember.
- * Sized to comfortably cover any realistic burst of completions a single
- * user could trigger before the LRU starts evicting. Once an ID is
- * evicted the chime *could* re-fire for that task, but only if the
- * daemon emits another terminal event for the same `task_id`, which
- * is itself rare.
- *
- * Exported for tests.
+ * Cap on the number of recent task IDs we remember for dedupe. Sized to
+ * comfortably cover any realistic burst of completions a single user could
+ * trigger before the LRU starts evicting. Re-exported only for tests.
  */
 export const MAX_CHIMED_HISTORY = 500;
 
@@ -31,32 +25,14 @@ export function useTaskCompletionChime(
   currentUserId: string | undefined,
   audioPreferences: AudioPreferences | undefined
 ): void {
-  // Track task IDs currently in RUNNING state so we fire on the
-  // RUNNING → terminal transition only for tasks we observed start. Only
-  // RUNNING entries are kept, so the set is bounded by concurrent in-flight
-  // tasks rather than lifetime tasks.
+  // Bounded by concurrent in-flight tasks — entries are evicted on transition.
   const runningTaskIdsRef = useRef<Set<string>>(new Set());
 
-  // Per-task "already chimed" dedupe. Kept in a ref so it survives:
-  //   - the effect tearing down + re-running (token rotation, currentUserId
-  //     flipping between undefined and defined on auth load),
-  //   - WebSocket reconnect replays,
-  //   - the daemon emitting multiple `'patched'` events for the same
-  //     completion (e.g. an executor-side patch to `COMPLETED` followed by
-  //     a post-completion `session_md5` patch in stateless_fs_mode, or the
-  //     base-executor + index.ts double-catch on failure both patching
-  //     to `FAILED`),
-  //   - any other source of duplicate terminal events for the same task_id.
-  //
-  // The previous implementation relied solely on `runningTaskIds.delete()`
-  // returning true exactly once; that breaks if the running-set is cleared
-  // out between two terminal events (effect teardown, status flicker), or
-  // if the task is re-added before the second event arrives. This Set is
-  // the final gate that guarantees "one chime per task completion".
-  //
-  // Insertion-ordered Set + size cap = simple LRU. We evict the oldest
-  // entry rather than reset on a threshold so a long-running session can't
-  // hit a momentary blind spot.
+  // Persistent per-task dedupe. The ref intentionally survives subscription
+  // teardown/reconnect so duplicate terminal events cannot replay the chime.
+  // Bounded by MAX_CHIMED_HISTORY to avoid lifetime growth; LRU touch on a
+  // duplicate hit keeps frequently-referenced tasks from being evicted while
+  // unrelated traffic floods in.
   const chimedTaskIdsRef = useRef<Set<string>>(new Set());
 
   // Keep audio prefs in a ref so the subscription effect doesn't tear down on
@@ -74,17 +50,14 @@ export function useTaskCompletionChime(
     const chimed = chimedTaskIdsRef.current;
     let disposed = false;
 
-    // The chime is a personal notification for the prompting user. In a
-    // multiplayer setup the tasks service streams events for any task the
-    // viewer can see, so we filter by Task.created_by — "chime when my
-    // prompts finish", not "chime when anyone's prompts finish".
+    // Chime is a personal notification — filter to the prompting user's own
+    // tasks. Multiplayer clients receive events for any task they can see.
     const isOwnTask = (task: Task) => task?.created_by === currentUserId;
 
     const markChimed = (taskId: string) => {
       chimed.add(taskId);
       if (chimed.size > MAX_CHIMED_HISTORY) {
-        // Set iteration order is insertion order — `values().next().value`
-        // is the oldest. Evict it so the set stays bounded.
+        // Set iteration order is insertion order — first entry is oldest.
         const oldest = chimed.values().next().value;
         if (oldest !== undefined) chimed.delete(oldest);
       }
@@ -101,35 +74,34 @@ export function useTaskCompletionChime(
       const wasRunning = running.delete(task.task_id);
       if (!wasRunning || !isNaturalCompletion(task.status)) return;
 
-      // Final dedupe: don't re-play if we already chimed for this task,
-      // even if the daemon emits more terminal events for it.
-      if (chimed.has(task.task_id)) return;
+      // LRU touch: re-insert refreshes recency so a noisy task can't get
+      // evicted from the dedupe window while it keeps emitting events.
+      if (chimed.delete(task.task_id)) {
+        chimed.add(task.task_id);
+        return;
+      }
       markChimed(task.task_id);
 
       void playTaskCompletionChime(task, audioPrefsRef.current);
     };
 
     const handleTaskRemoved = (task: Task) => {
-      if (!task?.task_id) return;
-      running.delete(task.task_id);
-      // Drop the chimed entry too — once the task is gone the daemon can't
-      // emit any more events for it, so the dedupe slot is free to reclaim.
-      chimed.delete(task.task_id);
+      // Only clear the running entry. We deliberately do NOT drop the chimed
+      // entry: task_ids are UUIDv7 and never reused, so the slot can't
+      // collide, and keeping it pins the "one chime per task" guarantee
+      // even if a delayed RUNNING/terminal replay arrives after delete.
+      if (task?.task_id) running.delete(task.task_id);
     };
 
-    tasksService.on('created', handleTaskChange as FeathersEventHandler);
-    tasksService.on('patched', handleTaskChange as FeathersEventHandler);
-    tasksService.on('updated', handleTaskChange as FeathersEventHandler);
-    tasksService.on('removed', handleTaskRemoved as FeathersEventHandler);
+    tasksService.on('created', handleTaskChange);
+    tasksService.on('patched', handleTaskChange);
+    tasksService.on('updated', handleTaskChange);
+    tasksService.on('removed', handleTaskRemoved);
 
-    // Seed the set with the current user's tasks that were already RUNNING
-    // when the hook mounted (e.g. after a page reload or reconnect).
-    // Without this, a subsequent transition to COMPLETED/FAILED would find
-    // no prior membership and skip the chime. Subscribe-first-then-fetch
-    // ordering means any transition that lands during the fetch is still
-    // handled by the live handler; at worst we add a stale ID for a task
-    // that has already finished, and the set gets one extra entry that
-    // never triggers a chime.
+    // Seed running tasks already in flight at mount (page reload, reconnect).
+    // Subscribe-first-then-fetch: any transition landing during the fetch is
+    // still handled by the live handler; at worst we add a stale ID for a
+    // task that has already finished, which never triggers a chime.
     tasksService
       .findAll({ query: { status: TaskStatus.RUNNING, created_by: currentUserId } })
       .then((tasks: Task[]) => {
@@ -139,20 +111,18 @@ export function useTaskCompletionChime(
         }
       })
       .catch(() => {
-        // Non-fatal: if the initial fetch fails we just miss chimes for
-        // tasks that were already running. Live events still work.
+        // Non-fatal: live events still work. Worst case we miss chimes for
+        // tasks already running before mount.
       });
 
     return () => {
       disposed = true;
-      tasksService.removeListener('created', handleTaskChange as FeathersEventHandler);
-      tasksService.removeListener('patched', handleTaskChange as FeathersEventHandler);
-      tasksService.removeListener('updated', handleTaskChange as FeathersEventHandler);
-      tasksService.removeListener('removed', handleTaskRemoved as FeathersEventHandler);
+      tasksService.removeListener('created', handleTaskChange);
+      tasksService.removeListener('patched', handleTaskChange);
+      tasksService.removeListener('updated', handleTaskChange);
+      tasksService.removeListener('removed', handleTaskRemoved);
       running.clear();
-      // NOTE: we intentionally do NOT clear `chimed` here. A token-refresh
-      // or auth-flip teardown that wipes it would re-arm the chime for any
-      // post-completion replay event landing on the new subscription.
+      // chimedTaskIds intentionally persists across teardowns — see ref decl.
     };
   }, [client, currentUserId]);
 }

--- a/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
+++ b/apps/agor-ui/src/hooks/useTaskCompletionChime.ts
@@ -6,19 +6,22 @@
  * per-session: the whole point of the chime is that the user is *off doing
  * something else*, so the chime must fire even when the session panel isn't
  * mounted.
+ *
+ * Dedupe model: a Set of currently-RUNNING task IDs. Each terminal event
+ * tries to `delete()` the entry; the first one returns true and fires the
+ * chime, every subsequent terminal event for the same task returns false
+ * (entry already gone) and is a no-op. This is sufficient to handle every
+ * known duplicate-event source — the daemon's executor-double-catch path,
+ * the stateless_fs_mode post-completion `session_md5` patch, and any other
+ * tail emit — without a separate "already chimed" history. The upstream
+ * fix in `packages/executor/src/index.ts` further removes the
+ * double-FAILED emit at the source.
  */
 
 import type { AgorClient, AudioPreferences, Task } from '@agor-live/client';
 import { isNaturalCompletion, TaskStatus } from '@agor-live/client';
 import { useEffect, useRef } from 'react';
 import { playTaskCompletionChime } from '../utils/audio';
-
-/**
- * Cap on the number of recent task IDs we remember for dedupe. Sized to
- * comfortably cover any realistic burst of completions a single user could
- * trigger before the LRU starts evicting. Re-exported only for tests.
- */
-export const MAX_CHIMED_HISTORY = 500;
 
 export function useTaskCompletionChime(
   client: AgorClient | null,
@@ -27,13 +30,6 @@ export function useTaskCompletionChime(
 ): void {
   // Bounded by concurrent in-flight tasks — entries are evicted on transition.
   const runningTaskIdsRef = useRef<Set<string>>(new Set());
-
-  // Persistent per-task dedupe. The ref intentionally survives subscription
-  // teardown/reconnect so duplicate terminal events cannot replay the chime.
-  // Bounded by MAX_CHIMED_HISTORY to avoid lifetime growth; LRU touch on a
-  // duplicate hit keeps frequently-referenced tasks from being evicted while
-  // unrelated traffic floods in.
-  const chimedTaskIdsRef = useRef<Set<string>>(new Set());
 
   // Keep audio prefs in a ref so the subscription effect doesn't tear down on
   // every preference change (e.g. while the user is tweaking the slider).
@@ -47,21 +43,11 @@ export function useTaskCompletionChime(
 
     const tasksService = client.service('tasks');
     const running = runningTaskIdsRef.current;
-    const chimed = chimedTaskIdsRef.current;
     let disposed = false;
 
     // Chime is a personal notification — filter to the prompting user's own
     // tasks. Multiplayer clients receive events for any task they can see.
     const isOwnTask = (task: Task) => task?.created_by === currentUserId;
-
-    const markChimed = (taskId: string) => {
-      chimed.add(taskId);
-      if (chimed.size > MAX_CHIMED_HISTORY) {
-        // Set iteration order is insertion order — first entry is oldest.
-        const oldest = chimed.values().next().value;
-        if (oldest !== undefined) chimed.delete(oldest);
-      }
-    };
 
     const handleTaskChange = (task: Task) => {
       if (!task?.task_id || !isOwnTask(task)) return;
@@ -72,24 +58,12 @@ export function useTaskCompletionChime(
       }
 
       const wasRunning = running.delete(task.task_id);
-      if (!wasRunning || !isNaturalCompletion(task.status)) return;
-
-      // LRU touch: re-insert refreshes recency so a noisy task can't get
-      // evicted from the dedupe window while it keeps emitting events.
-      if (chimed.delete(task.task_id)) {
-        chimed.add(task.task_id);
-        return;
+      if (wasRunning && isNaturalCompletion(task.status)) {
+        void playTaskCompletionChime(task, audioPrefsRef.current);
       }
-      markChimed(task.task_id);
-
-      void playTaskCompletionChime(task, audioPrefsRef.current);
     };
 
     const handleTaskRemoved = (task: Task) => {
-      // Only clear the running entry. We deliberately do NOT drop the chimed
-      // entry: task_ids are UUIDv7 and never reused, so the slot can't
-      // collide, and keeping it pins the "one chime per task" guarantee
-      // even if a delayed RUNNING/terminal replay arrives after delete.
       if (task?.task_id) running.delete(task.task_id);
     };
 
@@ -122,7 +96,6 @@ export function useTaskCompletionChime(
       tasksService.removeListener('updated', handleTaskChange);
       tasksService.removeListener('removed', handleTaskRemoved);
       running.clear();
-      // chimedTaskIds intentionally persists across teardowns — see ref decl.
     };
   }, [client, currentUserId]);
 }

--- a/apps/agor-ui/src/utils/audio.ts
+++ b/apps/agor-ui/src/utils/audio.ts
@@ -132,8 +132,10 @@ export function checkAudioPermission(): Promise<boolean> {
 function meetsMinimumDuration(task: Task, minDurationSeconds: number): boolean {
   if (minDurationSeconds === 0) return true;
 
-  // Try to use duration_ms if available
-  if (task.duration_ms) {
+  // Null-check (not truthy-check) so an explicit `duration_ms: 0` is honored —
+  // a near-instant task should be gated against `minDurationSeconds`, not fall
+  // through to the timestamp fallback / optimistic allow.
+  if (task.duration_ms != null) {
     const durationSeconds = task.duration_ms / 1000;
     return durationSeconds >= minDurationSeconds;
   }

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Idempotence guard around the executor's fail-safe terminal patches.
+ *
+ * Background: the executor has four fail-safe paths that try to mark a
+ * task terminal — the top-level catch in `start()`, the SIGTERM/SIGINT
+ * shutdown handler, the `uncaughtException` handler, and the
+ * `unhandledRejection` handler. The SDK handler (`base-executor`) is the
+ * authoritative writer for terminal state and stamps a richer payload
+ * (timing, `git_state.sha_at_end`, normalized SDK responses). The
+ * fail-safe paths should NOT redundantly emit a second `'patched'`
+ * event for the same task.
+ *
+ * These tests pin the idempotence guard at the source rather than the
+ * UI hook that consumes the events.
+ */
+import { TaskStatus } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TERMINAL_STATUSES, tryMarkTaskTerminal } from './index.js';
+import type { AgorClient } from './services/feathers-client.js';
+
+type TaskShape = { task_id: string; status: TaskStatus };
+
+interface MockTaskService {
+  get: ReturnType<typeof vi.fn<(id: string) => Promise<TaskShape>>>;
+  patch: ReturnType<
+    typeof vi.fn<(id: string, data: Record<string, unknown>) => Promise<TaskShape>>
+  >;
+}
+
+function makeClient(currentStatus: TaskStatus): {
+  client: AgorClient;
+  tasks: MockTaskService;
+} {
+  const tasks: MockTaskService = {
+    get: vi.fn(async (id: string) => ({ task_id: id, status: currentStatus })),
+    patch: vi.fn(async (id: string) => ({ task_id: id, status: currentStatus })),
+  };
+  const client = {
+    service: vi.fn((name: string) => {
+      if (name !== 'tasks') throw new Error(`unexpected service: ${name}`);
+      return tasks;
+    }),
+  } as unknown as AgorClient;
+  return { client, tasks };
+}
+
+describe('TERMINAL_STATUSES', () => {
+  it('covers every status the executor can transition into terminally', () => {
+    expect(TERMINAL_STATUSES.has(TaskStatus.COMPLETED)).toBe(true);
+    expect(TERMINAL_STATUSES.has(TaskStatus.FAILED)).toBe(true);
+    expect(TERMINAL_STATUSES.has(TaskStatus.STOPPED)).toBe(true);
+    // TIMED_OUT is terminal too — permission/input timeout, executor exited.
+    // Fail-safe paths must NOT overwrite it with FAILED or STOPPED.
+    expect(TERMINAL_STATUSES.has(TaskStatus.TIMED_OUT)).toBe(true);
+  });
+
+  it('does not include in-flight statuses', () => {
+    expect(TERMINAL_STATUSES.has(TaskStatus.QUEUED)).toBe(false);
+    expect(TERMINAL_STATUSES.has(TaskStatus.CREATED)).toBe(false);
+    expect(TERMINAL_STATUSES.has(TaskStatus.RUNNING)).toBe(false);
+    expect(TERMINAL_STATUSES.has(TaskStatus.STOPPING)).toBe(false);
+    expect(TERMINAL_STATUSES.has(TaskStatus.AWAITING_PERMISSION)).toBe(false);
+    expect(TERMINAL_STATUSES.has(TaskStatus.AWAITING_INPUT)).toBe(false);
+  });
+});
+
+describe('tryMarkTaskTerminal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('patches the task when it is still in-flight', async () => {
+    const { client, tasks } = makeClient(TaskStatus.RUNNING);
+
+    await tryMarkTaskTerminal(client, 't1', TaskStatus.FAILED, 'boom');
+
+    expect(tasks.get).toHaveBeenCalledWith('t1');
+    expect(tasks.patch).toHaveBeenCalledTimes(1);
+    const [id, data] = tasks.patch.mock.calls[0];
+    expect(id).toBe('t1');
+    expect(data).toMatchObject({
+      status: TaskStatus.FAILED,
+      error_message: 'boom',
+      completed_at: expect.any(String),
+    });
+  });
+
+  it('skips the patch when the task is already COMPLETED (inner catch ran first)', async () => {
+    const { client, tasks } = makeClient(TaskStatus.COMPLETED);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await tryMarkTaskTerminal(client, 't1', TaskStatus.FAILED, 'boom');
+
+    expect(tasks.get).toHaveBeenCalledWith('t1');
+    expect(tasks.patch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    TaskStatus.COMPLETED,
+    TaskStatus.FAILED,
+    TaskStatus.STOPPED,
+    TaskStatus.TIMED_OUT,
+  ])('skips the patch when the task is already %s', async (current) => {
+    const { client, tasks } = makeClient(current);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await tryMarkTaskTerminal(client, 't1', TaskStatus.FAILED, 'boom');
+
+    expect(tasks.patch).not.toHaveBeenCalled();
+  });
+
+  it('omits error_message when no message is supplied (e.g. SIGTERM stop)', async () => {
+    const { client, tasks } = makeClient(TaskStatus.RUNNING);
+
+    await tryMarkTaskTerminal(client, 't1', TaskStatus.STOPPED);
+
+    expect(tasks.patch).toHaveBeenCalledTimes(1);
+    const [, data] = tasks.patch.mock.calls[0];
+    expect(data).not.toHaveProperty('error_message');
+    expect(data).toMatchObject({
+      status: TaskStatus.STOPPED,
+      completed_at: expect.any(String),
+    });
+  });
+
+  it('swallows network/service errors so the process can still exit', async () => {
+    const tasks = {
+      get: vi.fn().mockRejectedValue(new Error('socket closed')),
+      patch: vi.fn(),
+    };
+    const client = {
+      service: () => tasks,
+    } as unknown as AgorClient;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      tryMarkTaskTerminal(client, 't1', TaskStatus.FAILED, 'boom')
+    ).resolves.toBeUndefined();
+    expect(tasks.patch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -27,13 +27,54 @@ import { type AgorClient, createFeathersClient } from './services/feathers-clien
  * handlers (base-executor) write rich terminal patches with timing /
  * `git_state.sha_at_end`; once we've stamped one of those, the
  * fail-safe catches below should NOT redundantly emit a second
- * `'patched'` event for the same task.
+ * `'patched'` event for the same task. Includes `TIMED_OUT` so a
+ * subsequent uncaught-rejection/SIGTERM doesn't overwrite a
+ * permission/input timeout with `FAILED` or `STOPPED`.
  */
-const TERMINAL_STATUSES = new Set<Task['status']>([
+export const TERMINAL_STATUSES: ReadonlySet<Task['status']> = new Set<Task['status']>([
   TaskStatus.COMPLETED,
   TaskStatus.FAILED,
   TaskStatus.STOPPED,
+  TaskStatus.TIMED_OUT,
 ]);
+
+/**
+ * Patch a task to a terminal status, but ONLY if the task is not already
+ * terminal. The SDK handlers in base-executor are authoritative — they
+ * stamp the full payload (timing, `git_state.sha_at_end`, normalized SDK
+ * responses). The fail-safe paths in `AgorExecutor` (top-level catch,
+ * signal handler, uncaughtException, unhandledRejection) are pure
+ * fallbacks for when the inner path never ran; if it did, this helper
+ * skips the patch so we don't emit a redundant `'patched'` event for
+ * the same task.
+ *
+ * Exported standalone (rather than left as a private method) so the
+ * idempotence behavior can be unit-tested directly without spinning up
+ * an `AgorExecutor` instance.
+ */
+export async function tryMarkTaskTerminal(
+  client: AgorClient,
+  taskId: string,
+  status: typeof TaskStatus.FAILED | typeof TaskStatus.STOPPED,
+  errorMessage?: string
+): Promise<void> {
+  try {
+    const current = (await client.service('tasks').get(taskId)) as Task;
+    if (TERMINAL_STATUSES.has(current.status)) {
+      console.log(
+        `[executor] Task ${shortId(taskId)} already terminal (${current.status}), skipping ${status} patch`
+      );
+      return;
+    }
+    await client.service('tasks').patch(taskId, {
+      status,
+      completed_at: new Date().toISOString(),
+      ...(errorMessage ? { error_message: errorMessage } : {}),
+    });
+  } catch (patchError) {
+    console.error('[executor] Failed to update task status:', patchError);
+  }
+}
 
 export interface ExecutorConfig {
   sessionToken: string;
@@ -58,35 +99,16 @@ export class AgorExecutor {
   }
 
   /**
-   * Patch the task to a terminal status, but ONLY if the task is not
-   * already terminal. The SDK handlers in base-executor are authoritative —
-   * they stamp the full payload (timing, `git_state.sha_at_end`, normalized
-   * SDK responses). These fail-safe paths (top-level catch, signal handler,
-   * uncaughtException, unhandledRejection) are pure fallbacks for when
-   * the inner path never ran; if it did, this method skips the patch so
-   * we don't emit a redundant `'patched'` event for the same task.
+   * Bound wrapper around the standalone `tryMarkTaskTerminal` helper for
+   * the four fail-safe paths inside this class. Guards against a missing
+   * client (e.g. when the daemon connection never came up).
    */
   private async tryMarkTaskTerminal(
     status: typeof TaskStatus.FAILED | typeof TaskStatus.STOPPED,
     errorMessage?: string
   ): Promise<void> {
     if (!this.client) return;
-    try {
-      const current = (await this.client.service('tasks').get(this.config.taskId)) as Task;
-      if (TERMINAL_STATUSES.has(current.status)) {
-        console.log(
-          `[executor] Task ${shortId(this.config.taskId)} already terminal (${current.status}), skipping ${status} patch`
-        );
-        return;
-      }
-      await this.client.service('tasks').patch(this.config.taskId, {
-        status,
-        completed_at: new Date().toISOString(),
-        ...(errorMessage ? { error_message: errorMessage } : {}),
-      });
-    } catch (patchError) {
-      console.error('[executor] Failed to update task status:', patchError);
-    }
+    await tryMarkTaskTerminal(this.client, this.config.taskId, status, errorMessage);
   }
 
   /**

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -14,67 +14,13 @@ import type {
   PermissionMode,
   PermissionScope,
   SessionID,
-  Task,
   TaskID,
 } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
-
-/**
- * Statuses past which any subsequent terminal-write is a no-op. SDK
- * handlers (base-executor) write rich terminal patches with timing /
- * `git_state.sha_at_end`; once we've stamped one of those, the
- * fail-safe catches below should NOT redundantly emit a second
- * `'patched'` event for the same task. Includes `TIMED_OUT` so a
- * subsequent uncaught-rejection/SIGTERM doesn't overwrite a
- * permission/input timeout with `FAILED` or `STOPPED`.
- */
-export const TERMINAL_STATUSES: ReadonlySet<Task['status']> = new Set<Task['status']>([
-  TaskStatus.COMPLETED,
-  TaskStatus.FAILED,
-  TaskStatus.STOPPED,
-  TaskStatus.TIMED_OUT,
-]);
-
-/**
- * Patch a task to a terminal status, but ONLY if the task is not already
- * terminal. The SDK handlers in base-executor are authoritative — they
- * stamp the full payload (timing, `git_state.sha_at_end`, normalized SDK
- * responses). The fail-safe paths in `AgorExecutor` (top-level catch,
- * signal handler, uncaughtException, unhandledRejection) are pure
- * fallbacks for when the inner path never ran; if it did, this helper
- * skips the patch so we don't emit a redundant `'patched'` event for
- * the same task.
- *
- * Exported standalone (rather than left as a private method) so the
- * idempotence behavior can be unit-tested directly without spinning up
- * an `AgorExecutor` instance.
- */
-export async function tryMarkTaskTerminal(
-  client: AgorClient,
-  taskId: string,
-  status: typeof TaskStatus.FAILED | typeof TaskStatus.STOPPED,
-  errorMessage?: string
-): Promise<void> {
-  try {
-    const current = (await client.service('tasks').get(taskId)) as Task;
-    if (TERMINAL_STATUSES.has(current.status)) {
-      console.log(
-        `[executor] Task ${shortId(taskId)} already terminal (${current.status}), skipping ${status} patch`
-      );
-      return;
-    }
-    await client.service('tasks').patch(taskId, {
-      status,
-      completed_at: new Date().toISOString(),
-      ...(errorMessage ? { error_message: errorMessage } : {}),
-    });
-  } catch (patchError) {
-    console.error('[executor] Failed to update task status:', patchError);
-  }
-}
+import { tryMarkTaskTerminal } from './terminal-task.js';
 
 export interface ExecutorConfig {
   sessionToken: string;

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -14,11 +14,26 @@ import type {
   PermissionMode,
   PermissionScope,
   SessionID,
+  Task,
   TaskID,
 } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
+
+/**
+ * Statuses past which any subsequent terminal-write is a no-op. SDK
+ * handlers (base-executor) write rich terminal patches with timing /
+ * `git_state.sha_at_end`; once we've stamped one of those, the
+ * fail-safe catches below should NOT redundantly emit a second
+ * `'patched'` event for the same task.
+ */
+const TERMINAL_STATUSES = new Set<Task['status']>([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.STOPPED,
+]);
 
 export interface ExecutorConfig {
   sessionToken: string;
@@ -40,6 +55,38 @@ export class AgorExecutor {
 
   constructor(private config: ExecutorConfig) {
     this.abortController = new AbortController();
+  }
+
+  /**
+   * Patch the task to a terminal status, but ONLY if the task is not
+   * already terminal. The SDK handlers in base-executor are authoritative —
+   * they stamp the full payload (timing, `git_state.sha_at_end`, normalized
+   * SDK responses). These fail-safe paths (top-level catch, signal handler,
+   * uncaughtException, unhandledRejection) are pure fallbacks for when
+   * the inner path never ran; if it did, this method skips the patch so
+   * we don't emit a redundant `'patched'` event for the same task.
+   */
+  private async tryMarkTaskTerminal(
+    status: typeof TaskStatus.FAILED | typeof TaskStatus.STOPPED,
+    errorMessage?: string
+  ): Promise<void> {
+    if (!this.client) return;
+    try {
+      const current = (await this.client.service('tasks').get(this.config.taskId)) as Task;
+      if (TERMINAL_STATUSES.has(current.status)) {
+        console.log(
+          `[executor] Task ${shortId(this.config.taskId)} already terminal (${current.status}), skipping ${status} patch`
+        );
+        return;
+      }
+      await this.client.service('tasks').patch(this.config.taskId, {
+        status,
+        completed_at: new Date().toISOString(),
+        ...(errorMessage ? { error_message: errorMessage } : {}),
+      });
+    } catch (patchError) {
+      console.error('[executor] Failed to update task status:', patchError);
+    }
   }
 
   /**
@@ -74,20 +121,10 @@ export class AgorExecutor {
       process.exit(0);
     } catch (error) {
       console.error('[executor] Fatal error:', error);
-
-      // Try to update task status to FAILED
-      if (this.client) {
-        try {
-          await this.client.service('tasks').patch(this.config.taskId, {
-            status: 'failed',
-            completed_at: new Date().toISOString(),
-            error_message: error instanceof Error ? error.message : String(error),
-          });
-        } catch (patchError) {
-          console.error('[executor] Failed to update task status:', patchError);
-        }
-      }
-
+      await this.tryMarkTaskTerminal(
+        TaskStatus.FAILED,
+        error instanceof Error ? error.message : String(error)
+      );
       process.exit(1);
     }
   }
@@ -177,17 +214,10 @@ export class AgorExecutor {
         this.abortController.abort();
       }
 
-      // Update task status to stopped
-      if (this.client) {
-        try {
-          await this.client.service('tasks').patch(this.config.taskId, {
-            status: 'stopped',
-            completed_at: new Date().toISOString(),
-          });
-        } catch (error) {
-          console.error('[executor] Failed to update task status:', error);
-        }
-      }
+      // The daemon's stop route already patches the task to STOPPED before
+      // sending the signal — this fallback only fires if we received an
+      // out-of-band signal and the task is still active.
+      await this.tryMarkTaskTerminal(TaskStatus.STOPPED);
 
       process.exit(0);
     };
@@ -197,39 +227,19 @@ export class AgorExecutor {
 
     process.on('uncaughtException', async (error) => {
       console.error('[executor] Uncaught exception:', error);
-
-      // Try to update task status
-      if (this.client) {
-        try {
-          await this.client.service('tasks').patch(this.config.taskId, {
-            status: 'failed',
-            completed_at: new Date().toISOString(),
-            error_message: `uncaughtException: ${error instanceof Error ? error.message : String(error)}`,
-          });
-        } catch (patchError) {
-          console.error('[executor] Failed to update task status:', patchError);
-        }
-      }
-
+      await this.tryMarkTaskTerminal(
+        TaskStatus.FAILED,
+        `uncaughtException: ${error instanceof Error ? error.message : String(error)}`
+      );
       process.exit(1);
     });
 
     process.on('unhandledRejection', async (reason) => {
       console.error('[executor] Unhandled rejection:', reason);
-
-      // Try to update task status
-      if (this.client) {
-        try {
-          await this.client.service('tasks').patch(this.config.taskId, {
-            status: 'failed',
-            completed_at: new Date().toISOString(),
-            error_message: `unhandledRejection: ${reason instanceof Error ? reason.message : String(reason)}`,
-          });
-        } catch (patchError) {
-          console.error('[executor] Failed to update task status:', patchError);
-        }
-      }
-
+      await this.tryMarkTaskTerminal(
+        TaskStatus.FAILED,
+        `unhandledRejection: ${reason instanceof Error ? reason.message : String(reason)}`
+      );
       process.exit(1);
     });
   }

--- a/packages/executor/src/terminal-task.test.ts
+++ b/packages/executor/src/terminal-task.test.ts
@@ -15,8 +15,8 @@
  */
 import { TaskStatus } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { TERMINAL_STATUSES, tryMarkTaskTerminal } from './index.js';
 import type { AgorClient } from './services/feathers-client.js';
+import { TERMINAL_STATUSES, tryMarkTaskTerminal } from './terminal-task.js';
 
 type TaskShape = { task_id: string; status: TaskStatus };
 
@@ -85,27 +85,18 @@ describe('tryMarkTaskTerminal', () => {
     });
   });
 
-  it('skips the patch when the task is already COMPLETED (inner catch ran first)', async () => {
-    const { client, tasks } = makeClient(TaskStatus.COMPLETED);
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    await tryMarkTaskTerminal(client, 't1', TaskStatus.FAILED, 'boom');
-
-    expect(tasks.get).toHaveBeenCalledWith('t1');
-    expect(tasks.patch).not.toHaveBeenCalled();
-  });
-
   it.each([
     TaskStatus.COMPLETED,
     TaskStatus.FAILED,
     TaskStatus.STOPPED,
     TaskStatus.TIMED_OUT,
-  ])('skips the patch when the task is already %s', async (current) => {
+  ])('skips the patch when the task is already %s (e.g. inner SDK catch already wrote it)', async (current) => {
     const { client, tasks } = makeClient(current);
     vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await tryMarkTaskTerminal(client, 't1', TaskStatus.FAILED, 'boom');
 
+    expect(tasks.get).toHaveBeenCalledWith('t1');
     expect(tasks.patch).not.toHaveBeenCalled();
   });
 

--- a/packages/executor/src/terminal-task.ts
+++ b/packages/executor/src/terminal-task.ts
@@ -1,0 +1,64 @@
+/**
+ * Terminal-status helpers for the executor's fail-safe paths.
+ *
+ * The executor has four fail-safe paths that try to mark a task terminal —
+ * the top-level catch in `AgorExecutor.start()`, the SIGTERM/SIGINT
+ * shutdown handler, the `uncaughtException` handler, and the
+ * `unhandledRejection` handler. The SDK handler (`base-executor`) is
+ * the authoritative writer for terminal state and stamps a richer payload
+ * (timing, `git_state.sha_at_end`, normalized SDK responses). If that
+ * inner path already ran, the fail-safe paths must NOT redundantly emit a
+ * second `'patched'` event — that's the bug the UI saw as
+ * "chime plays twice".
+ *
+ * Lives outside `index.ts` so the helper and its constant don't pollute
+ * the package's public surface, and so the unit tests don't have to
+ * import from the file that bootstraps the executor.
+ */
+import { shortId } from '@agor/core/db';
+import type { Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import type { AgorClient } from './services/feathers-client.js';
+
+/**
+ * Statuses past which any subsequent terminal-write is a no-op.
+ * Includes `TIMED_OUT` so a subsequent uncaught-rejection/SIGTERM
+ * doesn't overwrite a permission/input timeout with `FAILED` or
+ * `STOPPED`.
+ */
+export const TERMINAL_STATUSES: ReadonlySet<Task['status']> = new Set<Task['status']>([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.STOPPED,
+  TaskStatus.TIMED_OUT,
+]);
+
+/**
+ * Patch a task to a terminal status, but ONLY if the task is not already
+ * terminal. Reads the task first and bails on terminal — the inner SDK
+ * patch is authoritative; this is a fallback for cases where it never
+ * ran (SDK init crash, etc.).
+ */
+export async function tryMarkTaskTerminal(
+  client: AgorClient,
+  taskId: string,
+  status: typeof TaskStatus.FAILED | typeof TaskStatus.STOPPED,
+  errorMessage?: string
+): Promise<void> {
+  try {
+    const current = (await client.service('tasks').get(taskId)) as Task;
+    if (TERMINAL_STATUSES.has(current.status)) {
+      console.log(
+        `[executor] Task ${shortId(taskId)} already terminal (${current.status}), skipping ${status} patch`
+      );
+      return;
+    }
+    await client.service('tasks').patch(taskId, {
+      status,
+      completed_at: new Date().toISOString(),
+      ...(errorMessage ? { error_message: errorMessage } : {}),
+    });
+  } catch (patchError) {
+    console.error('[executor] Failed to update task status:', patchError);
+  }
+}


### PR DESCRIPTION
## Summary

Max reported that the task-completion chime sometimes plays twice. The investigation surfaced two real server-side double-emit sources, both fixed at the source. The UI chime hook is now back to the original simpler design (it never needed the in-memory LRU dedupe once the upstream emits were one-per-write).

## Root-cause fixes

1. **Executor double-catch on FAILED.** `base-executor` catches an SDK error, patches `status: 'failed'` with the rich payload (timing, `git_state.sha_at_end`, `error_message`), and re-throws. The outer catch in `packages/executor/src/index.ts` then patched `status: 'failed'` AGAIN with a strictly-subset payload — two `'patched'` events per failed task. Same pattern for the `SIGTERM`/`SIGINT` shutdown handler, `uncaughtException`, and `unhandledRejection`.

   Routed all four fail-safe paths through a new standalone `tryMarkTaskTerminal(client, taskId, status, errorMessage?)` helper that reads the task first and bails if it's already terminal (`COMPLETED` / `FAILED` / `STOPPED` / `TIMED_OUT`). The inner `base-executor` patch stays authoritative; the outer paths are pure fallbacks for cases where the inner try/catch never ran (SDK init crash, etc.).

2. **DrizzleService.update() dual-emit.** The adapter emitted both `'updated'` and `'patched'` from `update()` "for consistency", which violated Feathers convention (`patch()` → `'patched'`, `update()` → `'updated'`) and would double-deliver to any subscriber listening to both. Nothing currently calls `tasks.update()`, so this was latent, but it was a real footgun for any future code touching the adapter. Now emits only `'updated'`.

## UI

The chime hook (`apps/agor-ui/src/hooks/useTaskCompletionChime.ts`) now relies on a single `runningTaskIds` Set whose `delete()` returns true exactly once per task transition. This was the original design; the persistent `chimedTaskIds` LRU set added mid-PR turned out to be defending against a hypothetical seed-race that doesn't fire in practice.

Adjacent fix: `apps/agor-ui/src/utils/audio.ts` was treating `duration_ms: 0` as "unknown" and falling through to the optimistic-allow path, ignoring `minDurationSeconds`. Switched to a `!= null` null-check.

## Test plan

- [x] `apps/agor-ui/src/hooks/useTaskCompletionChime.test.tsx` — 17 cases covering every known double-emit scenario, multiplayer scoping, terminal-status filtering, lifecycle, and callback-chain legitimate-multi-chime.
- [x] `packages/executor/src/index.test.ts` — 10 cases pinning `TERMINAL_STATUSES` membership (incl. `TIMED_OUT`) and `tryMarkTaskTerminal` idempotence across all four terminal states.
- [x] `apps/agor-daemon/src/adapters/drizzle.test.ts` — 4 cases locking the FeathersJS event-emit contract (`create→created`, `patch→patched`, `update→updated` only, `remove→removed`). The `update`-only-`'updated'` test is the direct regression guard.
- [x] `pnpm check` clean (typecheck + lint + shortid + build)
- [x] Full suite green: UI 245/245, executor 410/410, daemon 801/801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
