### PR TITLE
fix(url): strip /ui suffix from baseUrl in fullUrl to prevent double-prefix

### DIFF
--- a/packages/core/src/utils/url.test.ts
+++ b/packages/core/src/utils/url.test.ts
@@ -1,5 +1,61 @@
 import { describe, expect, it } from 'vitest';
-import { isAllowedHealthCheckUrl, normalizeOptionalHttpUrl } from './url';
+import type { ArtifactID, BoardID, BranchID, SessionID } from '../types/id';
+import {
+  getArtifactUrl,
+  getBoardUrl,
+  getBranchUrl,
+  getSessionUrl,
+  isAllowedHealthCheckUrl,
+  normalizeOptionalHttpUrl,
+} from './url';
+
+// Minimal UUIDv7-shaped IDs for URL builder tests.
+const SESSION_ID = '01927f9d-0000-7000-8000-000000000001' as SessionID;
+const BRANCH_ID = '01927f9d-0000-7000-8000-000000000002' as BranchID;
+const BOARD_ID = '01927f9d-0000-7000-8000-000000000003' as BoardID;
+const ARTIFACT_ID = '01927f9d-0000-7000-8000-000000000004' as ArtifactID;
+
+describe('entity URL builders — fullUrl double-prefix regression', () => {
+  it('produces correct session URL when baseUrl has no /ui suffix', () => {
+    const url = getSessionUrl(SESSION_ID, 'https://agor.example.com');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/s\//);
+    expect(url).not.toContain('/ui/ui/');
+  });
+
+  it('strips /ui suffix from baseUrl to prevent double /ui/ui/ prefix in session URLs', () => {
+    const url = getSessionUrl(SESSION_ID, 'https://agor.example.com/ui');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/s\//);
+    expect(url).not.toContain('/ui/ui/');
+  });
+
+  it('strips trailing slash then /ui suffix (e.g. https://host/ui/)', () => {
+    const url = getSessionUrl(SESSION_ID, 'https://agor.example.com/ui/');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/s\//);
+    expect(url).not.toContain('/ui/ui/');
+  });
+
+  it('produces correct branch URL when baseUrl has /ui suffix', () => {
+    const url = getBranchUrl(BRANCH_ID, 'https://agor.example.com/ui');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/w\//);
+    expect(url).not.toContain('/ui/ui/');
+  });
+
+  it('produces correct board URL when baseUrl has /ui suffix', () => {
+    const url = getBoardUrl(BOARD_ID, 'my-board', 'https://agor.example.com/ui');
+    expect(url).toBe('https://agor.example.com/ui/b/my-board/');
+  });
+
+  it('produces correct artifact URL when baseUrl has /ui suffix', () => {
+    const url = getArtifactUrl(ARTIFACT_ID, 'https://agor.example.com/ui');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/a\//);
+    expect(url).not.toContain('/ui/ui/');
+  });
+
+  it('does not strip /ui from a path-prefixed base (e.g. https://host/myapp)', () => {
+    const url = getSessionUrl(SESSION_ID, 'https://agor.example.com/myapp');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/myapp\/ui\/s\//);
+  });
+});
 
 describe('normalizeOptionalHttpUrl', () => {
   it('returns undefined for undefined input', () => {

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -103,10 +103,18 @@ export function artifactPath(artifactId: ArtifactID): string {
  *  Strips a trailing slash off `baseUrl` defensively so misconfigured
  *  `daemon.base_url` values (e.g. `https://agor.example.com/`) don't
  *  produce double-slashed URLs like `https://agor.example.com//ui/...`.
+ *  Also strips a trailing `/ui` suffix so operators who set
+ *  `daemon.base_url` to the full UI address (e.g. `https://agor.example.com/ui`)
+ *  don't end up with double-prefixed `/ui/ui/...` entity URLs.
  *  `baseUrl` here comes from `getBaseUrl()` in config-manager, which
  *  reads `daemon.base_url` (with an `AGOR_BASE_URL` env override). */
 function fullUrl(path: string, baseUrl: string): string {
-  return `${baseUrl.replace(/\/$/, '')}${UI_MOUNT_PATH}${path}`;
+  // Strip trailing slash first, then any trailing /ui suffix.
+  let base = baseUrl.replace(/\/$/, '');
+  if (base.endsWith(UI_MOUNT_PATH)) {
+    base = base.slice(0, -UI_MOUNT_PATH.length);
+  }
+  return `${base}${UI_MOUNT_PATH}${path}`;
 }
 
 /** Generate a board URL. */


### PR DESCRIPTION
## Summary

- Fixes `url` fields in MCP API responses containing a double `/ui/ui/` prefix (e.g. `https://agor.sandbox.preset.zone/ui/ui/s/<id>/` instead of `https://agor.sandbox.preset.zone/ui/s/<id>/`)
- `fullUrl()` in `packages/core/src/utils/url.ts` unconditionally appended `/ui` to `baseUrl` — when `daemon.base_url` / `AGOR_BASE_URL` was already set to a URL ending with `/ui`, every entity URL got the double prefix
- Fix strips any trailing `/ui` suffix from `baseUrl` before appending, making the function idempotent

## Root cause

```ts
// before: blindly appends /ui
return `${base}${UI_MOUNT_PATH}${path}`;

// after: strips existing /ui suffix first
if (base.endsWith(UI_MOUNT_PATH)) {
  base = base.slice(0, -UI_MOUNT_PATH.length);
}
return `${base}${UI_MOUNT_PATH}${path}`;
```

## Tests

7 new cases in `url.test.ts` covering the double-prefix regression for all four entity URL builders (`getSessionUrl`, `getBranchUrl`, `getBoardUrl`, `getArtifactUrl`), plus a pass-through for base URLs with non-`/ui` path prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)