### PR TITLE
fix(gateway): canonicalize Slack session links

### DIFF
--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -19,6 +19,7 @@ import type { Application } from '@agor/core/feathers';
 import type { GatewayConnector, GatewayContext, InboundMessage } from '@agor/core/gateway';
 import {
   formatGatewayContext,
+  formatGatewaySystemMessage,
   getConnector,
   hasConnector,
   normalizeOutbound,
@@ -278,7 +279,10 @@ export class GatewayService {
     try {
       const connector = getConnector(channel.channel_type as ChannelType, channel.config);
       connector
-        .sendMessage({ threadId, text: `_[system] ${text}_` })
+        .sendMessage({
+          threadId,
+          text: formatGatewaySystemMessage(channel.channel_type as ChannelType, text),
+        })
         .catch((err) => console.warn('[gateway] Debug message failed:', err));
     } catch {
       // Ignore — debug messages are best-effort

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -12,3 +12,4 @@ export { GitHubConnector, parseThreadId as parseGitHubThreadId } from './connect
 export { SlackConnector } from './connectors/slack';
 export type { GatewayContext } from './context';
 export { formatGatewayContext } from './context';
+export { formatGatewaySystemMessage } from './system-message';

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatGatewaySystemMessage } from './system-message';
+
+describe('formatGatewaySystemMessage', () => {
+  it('formats Slack session-created messages without markdown emphasis wrappers', () => {
+    expect(
+      formatGatewaySystemMessage(
+        'slack',
+        'Session created: https://agor.sandbox.preset.zone/ui/s/019e6fca/'
+      )
+    ).toBe(
+      '[system] Session created: <https://agor.sandbox.preset.zone/ui/s/019e6fca/|View session>'
+    );
+  });
+
+  it('keeps generic Slack system messages plain', () => {
+    expect(formatGatewaySystemMessage('slack', 'Creating new codex session...')).toBe(
+      '[system] Creating new codex session...'
+    );
+  });
+
+  it('escapes generic Slack system messages with the shared Slack markdown formatter', () => {
+    expect(formatGatewaySystemMessage('slack', 'A & B < C')).toBe('[system] A &amp; B &lt; C');
+  });
+
+  it('does not apply Slack link syntax to non-Slack channels', () => {
+    expect(
+      formatGatewaySystemMessage(
+        'github',
+        'Session created: https://agor.sandbox.preset.zone/ui/s/019e6fca/'
+      )
+    ).toBe('[system] Session created: https://agor.sandbox.preset.zone/ui/s/019e6fca/');
+  });
+});

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -1,0 +1,24 @@
+import type { ChannelType } from '../types/gateway';
+import { markdownToMrkdwn } from './connectors/slack';
+
+/**
+ * Format low-volume gateway lifecycle messages for external channels.
+ *
+ * Slack uses mrkdwn, where wrapping a whole message in `_..._` makes URLs at
+ * the boundary easy to render with stray emphasis underscores. Keep system
+ * messages plain, and route Slack text through the existing markdown→mrkdwn
+ * converter so link formatting and escaping stay centralized.
+ */
+export function formatGatewaySystemMessage(channelType: ChannelType, text: string): string {
+  const sessionCreatedMatch = text.match(/^Session created: (https?:\/\/\S+)$/);
+
+  if (channelType === 'slack') {
+    const markdown = sessionCreatedMatch
+      ? `[system] Session created: [View session](${sessionCreatedMatch[1]})`
+      : `[system] ${text}`;
+
+    return markdownToMrkdwn(markdown);
+  }
+
+  return `[system] ${text}`;
+}


### PR DESCRIPTION
## Summary
- layer on top of #1282, which already fixed canonical /ui URL joining
- remove gateway debug/system message Slack emphasis wrappers that produced leading/trailing underscores
- route Slack gateway system messages through the existing Slack markdown→mrkdwn converter
- format session-created announcements as a Slack-native `<url|View session>` link via shared markdown conversion

## Relationship to #1282
#1282 is the right URL-level fix and covers all entity URL builders. This PR intentionally leaves that implementation alone and adds the remaining Slack/gateway-channel formatting fix.

## Review follow-up
Addressed Codex subsession feedback by reusing `markdownToMrkdwn` instead of hand-rolling Slack link syntax, which keeps escaping/link conversion centralized and adds generic system-message escaping coverage.

## Tests
- pnpm --filter @agor/core test -- src/gateway/system-message.test.ts src/gateway/connectors/slack.test.ts
- pnpm --filter @agor/core typecheck
- pnpm --filter @agor/daemon typecheck
- pnpm exec biome check packages/core/src/gateway/system-message.ts packages/core/src/gateway/system-message.test.ts packages/core/src/gateway/index.ts apps/agor-daemon/src/services/gateway.ts
