### PR TITLE
fix(ui): stop session panel from jumping scroll position during streaming

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -162,22 +162,38 @@ export const ConversationView = React.memo<ConversationViewProps>(
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
 
-    // Check if user is scrolled near the bottom (within 100px)
+    // true when the user has intentionally scrolled away from the bottom;
+    // auto-scroll is suppressed while this is set.
+    const userScrolledUpRef = useRef(false);
+
+    // Within 20px of the end counts as "at the bottom". Tight enough that a
+    // mid-swipe scroll won't accidentally keep auto-scroll on, but loose enough
+    // to handle sub-pixel rounding.
     const isNearBottom = useCallback(() => {
       if (!containerRef.current) return true;
       const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-      return scrollHeight - scrollTop - clientHeight < 100;
+      return scrollHeight - scrollTop - clientHeight < 20;
     }, []);
 
-    // Scroll to bottom function (wrapped in useCallback to avoid re-renders)
-    const scrollToBottom = useCallback(() => {
+    // Internal scroll used by auto-scroll effects. Does NOT reset user intent.
+    const doAutoScroll = useCallback(() => {
       if (containerRef.current) {
         containerRef.current.scrollTop = containerRef.current.scrollHeight;
       }
     }, []);
 
-    // Scroll to top function
+    // Public scroll-to-bottom exposed via onScrollRef (button clicks). Resets
+    // user intent so auto-scroll resumes after an explicit "go to bottom".
+    const scrollToBottom = useCallback(() => {
+      userScrolledUpRef.current = false;
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      }
+    }, []);
+
+    // Scroll to top: mark user as reading so auto-scroll doesn't yank them back.
     const scrollToTop = useCallback(() => {
+      userScrolledUpRef.current = true;
       if (containerRef.current) {
         containerRef.current.scrollTop = 0;
       }
@@ -281,12 +297,14 @@ export const ConversationView = React.memo<ConversationViewProps>(
       if (!lastTaskId) return;
       setExpandedTaskIds((prev) => {
         if (prev.has(lastTaskId)) return prev;
-        requestAnimationFrame(() => {
-          scrollToBottom();
-        });
+        if (!userScrolledUpRef.current) {
+          requestAnimationFrame(() => {
+            doAutoScroll();
+          });
+        }
         return new Set([lastTaskId]);
       });
-    }, [lastTaskId, scrollToBottom]);
+    }, [lastTaskId, doAutoScroll]);
 
     // Handle task expand/collapse. Single stable callback shared by every
     // TaskBlock — the callback takes `taskId` so we don't need to mint a
@@ -324,13 +342,39 @@ export const ConversationView = React.memo<ConversationViewProps>(
       [reactiveSession]
     );
 
-    // Auto-scroll to bottom when streaming messages arrive (only if user is already at bottom)
+    // Track user scroll intent via scroll events.
+    //
+    // Key design notes:
+    //   1. The scroll event fires for both user scrolls AND programmatic scrollTop
+    //      changes (doAutoScroll). That's fine: when auto-scroll fires it brings
+    //      us to the bottom, so isNearBottom() returns true and the flag stays
+    //      false. When the user scrolls up, isNearBottom() returns false and the
+    //      flag becomes true, pausing auto-scroll.
+    //
+    //   2. This effect MUST be defined after `tasks` so we can include
+    //      `tasks.length > 0` in the dependency array. The container div is only
+    //      rendered when tasks are present, so containerRef.current is null on the
+    //      very first render (loading state). Without this dep, the effect would
+    //      attach no listener on initial mount and never re-run.
+    const hasConversation = tasks.length > 0;
+    // biome-ignore lint/correctness/useExhaustiveDependencies: hasConversation re-triggers when the container mounts
+    useEffect(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      const handleScroll = () => {
+        userScrolledUpRef.current = !isNearBottom();
+      };
+      container.addEventListener('scroll', handleScroll, { passive: true });
+      return () => container.removeEventListener('scroll', handleScroll);
+    }, [isNearBottom, hasConversation]);
+
+    // Auto-scroll during streaming — only if the user has not scrolled away.
     // biome-ignore lint/correctness/useExhaustiveDependencies: We want to scroll on streaming change
     useEffect(() => {
-      if (isNearBottom()) {
-        scrollToBottom();
+      if (!userScrolledUpRef.current) {
+        doAutoScroll();
       }
-    }, [allStreamingMessages, tasks]);
+    }, [allStreamingMessages]);
 
     if (error) {
       // Deterministic escape hatch when auto-recovery (socket-reconnect resync,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -505,7 +505,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     setEffortLevel(session?.model_config?.effort || 'high');
   }, [session?.model_config?.effort]);
 
-  // Scroll to bottom when panel opens or session changes
+  // Scroll to bottom when panel opens or the user switches to a different session.
+  // Deliberately depend on session_id (not the full session object) so streaming
+  // updates — which mint a new session reference on every chunk — don't keep
+  // calling scrollToBottom() and fighting the user's scroll position.
   React.useEffect(() => {
     if (open && scrollToBottom && session) {
       const timeoutId = setTimeout(() => {
@@ -513,7 +516,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       }, 300);
       return () => clearTimeout(timeoutId);
     }
-  }, [open, scrollToBottom, session]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: session_id is the stable identity; full session object changes on every streaming chunk
+  }, [open, scrollToBottom, session?.session_id]);
 
   // When there's no session, render nothing (panel is collapsed to zero).
   // When open=false, we still render the component tree (hidden) so that

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -509,6 +509,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // Deliberately depend on session_id (not the full session object) so streaming
   // updates — which mint a new session reference on every chunk — don't keep
   // calling scrollToBottom() and fighting the user's scroll position.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: session_id is the stable identity; full session object changes on every streaming chunk
   React.useEffect(() => {
     if (open && scrollToBottom && session) {
       const timeoutId = setTimeout(() => {
@@ -516,7 +517,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       }, 300);
       return () => clearTimeout(timeoutId);
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: session_id is the stable identity; full session object changes on every streaming chunk
   }, [open, scrollToBottom, session?.session_id]);
 
   // When there's no session, render nothing (panel is collapsed to zero).


### PR DESCRIPTION
## Summary

- **`SessionPanel.tsx`**: The "scroll to bottom on session change" effect depended on the full `session` object. Since every streaming chunk produces a new session reference, it fired on every chunk — calling `scrollToBottom()` 300ms later, continuously resetting the user's reading position. Fixed by depending on `session?.session_id` instead.

- **`ConversationView.tsx`**: The wheel-event listener was never actually attached. The effect ran once at mount when `containerRef.current` was null (the container div only exists after tasks arrive). Switched to a `scroll` event listener placed after `tasks` is defined, with `hasConversation` (`tasks.length > 0`) in its deps so it re-runs and attaches when the container first mounts.

## Test plan

- [ ] Open a session that is actively streaming
- [ ] Scroll up while streaming — auto-scroll should stop immediately
- [ ] Let streaming continue — view should stay where you left it
- [ ] Scroll back to within ~20px of the bottom — auto-scroll should resume
- [ ] Click the scroll-to-bottom button — auto-scroll should resume
- [ ] Switch to a different session — panel should scroll to bottom on open
- [ ] Verify in both Firefox and Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)