### PR TITLE
feat(docs): promote Agor Cloud invite CTA in navbar

### DIFF
--- a/apps/agor-docs/components/CloudInviteCTA.module.css
+++ b/apps/agor-docs/components/CloudInviteCTA.module.css
@@ -1,47 +1,99 @@
 .wrapper {
   margin: 2rem 0;
-  text-align: center;
+  display: flex;
+  gap: 0.85rem;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
-.cta {
+/* Shared sizing so primary + secondary line up. */
+.primary,
+.secondary {
   display: inline-flex;
   align-items: center;
   padding: 0.9rem 1.85rem;
   font-size: 1.0625rem;
   font-weight: 700;
-  color: #0a0a0a;
-  background: linear-gradient(135deg, #2e9a92 0%, #4ec4ba 100%);
   border-radius: 8px;
   text-decoration: none;
   white-space: nowrap;
   transition:
     transform 0.15s ease,
     box-shadow 0.15s ease,
-    background 0.15s ease;
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+/* Primary — saturated teal pill, the "Join Private Beta" path. */
+.primary {
+  color: #0a0a0a;
+  background: linear-gradient(135deg, #2e9a92 0%, #4ec4ba 100%);
   box-shadow: 0 4px 14px rgba(46, 154, 146, 0.4);
 }
 
-.cta:hover {
+.primary:hover {
   transform: translateY(-1px);
   background: linear-gradient(135deg, #3db4aa 0%, #6dd5cb 100%);
   box-shadow: 0 6px 20px rgba(46, 154, 146, 0.55);
 }
 
-.cta:focus-visible {
+.primary:focus-visible {
   outline: 2px solid #a8f5ed;
   outline-offset: 3px;
 }
 
-/* Override the global `.dark a` color rule from pages/styles.css so the
- * dark button text stays readable against the bright teal background. */
-:global(.dark) .cta,
-:global(.dark) .cta:hover {
+/* Secondary — outline / ghost, the "Book a Demo" path. Lighter visual
+ * weight so the primary stays the obvious default. */
+.secondary {
+  color: #7fe8df;
+  background: rgba(46, 154, 146, 0.08);
+  border: 1.5px solid rgba(127, 232, 223, 0.45);
+  box-shadow: 0 2px 8px rgba(46, 154, 146, 0.12);
+}
+
+.secondary:hover {
+  transform: translateY(-1px);
+  color: #a8f5ed;
+  background: rgba(46, 154, 146, 0.15);
+  border-color: rgba(127, 232, 223, 0.75);
+  box-shadow: 0 4px 14px rgba(46, 154, 146, 0.25);
+}
+
+.secondary:focus-visible {
+  outline: 2px solid #a8f5ed;
+  outline-offset: 3px;
+}
+
+/* Beat the global `.dark a` color rule from pages/styles.css so the
+ * dark text on the bright primary, and the brand-teal text on the
+ * outline secondary, both stay correct. */
+:global(.dark) .primary,
+:global(.dark) .primary:hover {
   color: #0a0a0a;
 }
 
-@media (max-width: 768px) {
-  .cta {
-    padding: 0.75rem 1.4rem;
+:global(.dark) .secondary {
+  color: #7fe8df;
+}
+
+:global(.dark) .secondary:hover {
+  color: #a8f5ed;
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .primary,
+  .secondary {
+    width: 100%;
+    max-width: 320px;
+    justify-content: center;
+    padding: 0.8rem 1.5rem;
     font-size: 1rem;
   }
 }

--- a/apps/agor-docs/components/CloudInviteCTA.module.css
+++ b/apps/agor-docs/components/CloudInviteCTA.module.css
@@ -1,0 +1,47 @@
+.wrapper {
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.9rem 1.85rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: #0a0a0a;
+  background: linear-gradient(135deg, #2e9a92 0%, #4ec4ba 100%);
+  border-radius: 8px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
+  box-shadow: 0 4px 14px rgba(46, 154, 146, 0.4);
+}
+
+.cta:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, #3db4aa 0%, #6dd5cb 100%);
+  box-shadow: 0 6px 20px rgba(46, 154, 146, 0.55);
+}
+
+.cta:focus-visible {
+  outline: 2px solid #a8f5ed;
+  outline-offset: 3px;
+}
+
+/* Override the global `.dark a` color rule from pages/styles.css so the
+ * dark button text stays readable against the bright teal background. */
+:global(.dark) .cta,
+:global(.dark) .cta:hover {
+  color: #0a0a0a;
+}
+
+@media (max-width: 768px) {
+  .cta {
+    padding: 0.75rem 1.4rem;
+    font-size: 1rem;
+  }
+}

--- a/apps/agor-docs/components/CloudInviteCTA.tsx
+++ b/apps/agor-docs/components/CloudInviteCTA.tsx
@@ -20,7 +20,12 @@ export function CloudInviteCTA({
       >
         {primaryLabel} →
       </a>
-      <a href={AGOR_CLOUD_DEMO_URL} className={styles.secondary}>
+      <a
+        href={AGOR_CLOUD_DEMO_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.secondary}
+      >
         {demoLabel} →
       </a>
     </div>

--- a/apps/agor-docs/components/CloudInviteCTA.tsx
+++ b/apps/agor-docs/components/CloudInviteCTA.tsx
@@ -1,20 +1,27 @@
-import { AGOR_CLOUD_INVITE_URL } from '../lib/links';
+import { AGOR_CLOUD_DEMO_URL, AGOR_CLOUD_INVITE_URL } from '../lib/links';
 import styles from './CloudInviteCTA.module.css';
 
 interface CloudInviteCTAProps {
-  label?: string;
+  primaryLabel?: string;
+  demoLabel?: string;
 }
 
-export function CloudInviteCTA({ label = 'Join the Private Beta' }: CloudInviteCTAProps) {
+export function CloudInviteCTA({
+  primaryLabel = 'Join the Private Beta',
+  demoLabel = 'Book a Demo',
+}: CloudInviteCTAProps) {
   return (
     <div className={styles.wrapper}>
       <a
         href={AGOR_CLOUD_INVITE_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className={styles.cta}
+        className={styles.primary}
       >
-        {label} →
+        {primaryLabel} →
+      </a>
+      <a href={AGOR_CLOUD_DEMO_URL} className={styles.secondary}>
+        {demoLabel} →
       </a>
     </div>
   );

--- a/apps/agor-docs/components/CloudInviteCTA.tsx
+++ b/apps/agor-docs/components/CloudInviteCTA.tsx
@@ -1,0 +1,21 @@
+import { AGOR_CLOUD_INVITE_URL } from '../lib/links';
+import styles from './CloudInviteCTA.module.css';
+
+interface CloudInviteCTAProps {
+  label?: string;
+}
+
+export function CloudInviteCTA({ label = 'Join the Private Beta' }: CloudInviteCTAProps) {
+  return (
+    <div className={styles.wrapper}>
+      <a
+        href={AGOR_CLOUD_INVITE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.cta}
+      >
+        {label} →
+      </a>
+    </div>
+  );
+}

--- a/apps/agor-docs/components/NavbarCloudCTA.module.css
+++ b/apps/agor-docs/components/NavbarCloudCTA.module.css
@@ -1,56 +1,42 @@
-.cta {
+.link {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.85rem;
-  margin-right: 0.25rem;
-  font-size: 0.8125rem;
+  padding: 0.35rem 0.7rem;
+  margin-right: 0.5rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  line-height: 1.2;
-  color: #0a0a0a;
-  background: linear-gradient(135deg, rgba(46, 154, 146, 0.85) 0%, rgba(61, 180, 170, 0.85) 100%);
-  border-radius: 6px;
+  color: #7fe8df;
   text-decoration: none;
+  border-radius: 6px;
   white-space: nowrap;
   transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease,
+    color 0.15s ease,
     background 0.15s ease;
-  box-shadow: 0 2px 8px rgba(46, 154, 146, 0.25);
 }
 
-.cta:hover {
-  transform: translateY(-1px);
-  color: #0a0a0a;
-  background: linear-gradient(135deg, rgba(61, 180, 170, 0.95) 0%, rgba(78, 196, 186, 0.95) 100%);
-  box-shadow: 0 4px 12px rgba(46, 154, 146, 0.35);
+.link:hover {
+  color: #a8f5ed;
+  background: rgba(46, 154, 146, 0.15);
 }
 
-.cta:focus-visible {
+.link:focus-visible {
   outline: 2px solid #7fe8df;
   outline-offset: 2px;
 }
 
-.full {
-  display: inline;
+/* Override the global `.dark a` color rule from pages/styles.css. */
+:global(.dark) .link {
+  color: #7fe8df;
 }
 
-.short {
-  display: none;
+:global(.dark) .link:hover {
+  color: #a8f5ed;
 }
 
-/* Tighten on small navbar widths so we don't crowd the search box. */
 @media (max-width: 768px) {
-  .cta {
-    padding: 0.35rem 0.65rem;
-    font-size: 0.75rem;
-  }
-
-  .full {
-    display: none;
-  }
-
-  .short {
-    display: inline;
+  .link {
+    font-size: 0.8125rem;
+    padding: 0.3rem 0.55rem;
+    margin-right: 0.25rem;
   }
 }

--- a/apps/agor-docs/components/NavbarCloudCTA.module.css
+++ b/apps/agor-docs/components/NavbarCloudCTA.module.css
@@ -1,0 +1,56 @@
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  margin-right: 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #0a0a0a;
+  background: linear-gradient(135deg, rgba(46, 154, 146, 0.85) 0%, rgba(61, 180, 170, 0.85) 100%);
+  border-radius: 6px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
+  box-shadow: 0 2px 8px rgba(46, 154, 146, 0.25);
+}
+
+.cta:hover {
+  transform: translateY(-1px);
+  color: #0a0a0a;
+  background: linear-gradient(135deg, rgba(61, 180, 170, 0.95) 0%, rgba(78, 196, 186, 0.95) 100%);
+  box-shadow: 0 4px 12px rgba(46, 154, 146, 0.35);
+}
+
+.cta:focus-visible {
+  outline: 2px solid #7fe8df;
+  outline-offset: 2px;
+}
+
+.full {
+  display: inline;
+}
+
+.short {
+  display: none;
+}
+
+/* Tighten on small navbar widths so we don't crowd the search box. */
+@media (max-width: 768px) {
+  .cta {
+    padding: 0.35rem 0.65rem;
+    font-size: 0.75rem;
+  }
+
+  .full {
+    display: none;
+  }
+
+  .short {
+    display: inline;
+  }
+}

--- a/apps/agor-docs/components/NavbarCloudCTA.module.css
+++ b/apps/agor-docs/components/NavbarCloudCTA.module.css
@@ -1,42 +1,109 @@
+/* CTA pill: cloud icon + label, animated teal gradient, subtle sonar pulse.
+ *
+ * Position: by default Nextra renders `navbar.extraContent` at the END of
+ * the navbar (after the GitHub/Discord icons). We want this CTA to sit
+ * just to the LEFT of the search box. The :global() rules at the bottom
+ * of this file use CSS flex `order` to reshuffle Nextra's nav children
+ * so the visible order becomes:
+ *
+ *   [Logo]  [Page items]  [Agor Cloud CTA]  [Search]  [GitHub]  [Discord]  [Hamburger]
+ *
+ * Those rules depend on the nav DOM order that nextra-theme-docs@3.3.x
+ * emits — see the comment block above the :global rules. If a Nextra
+ * upgrade shifts that DOM, this file is the only place that needs to
+ * change.
+ */
+
 .link {
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.7rem;
+  gap: 0.45rem;
+  padding: 0.4rem 0.9rem;
   margin-right: 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
-  color: #7fe8df;
+  line-height: 1.2;
+  color: #0a0a0a;
+  background: linear-gradient(120deg, #2e9a92 0%, #4ec4ba 45%, #7fe8df 100%);
+  background-size: 220% 220%;
+  background-position: 0% 50%;
+  border-radius: 999px;
   text-decoration: none;
-  border-radius: 6px;
   white-space: nowrap;
+  box-shadow:
+    0 0 0 0 rgba(127, 232, 223, 0.45),
+    0 2px 8px rgba(46, 154, 146, 0.35);
   transition:
-    color 0.15s ease,
-    background 0.15s ease;
+    background-position 0.4s ease,
+    box-shadow 0.25s ease,
+    transform 0.15s ease;
+  animation: cloudPulse 3.2s ease-in-out infinite;
+  order: 2;
 }
 
 .link:hover {
-  color: #a8f5ed;
-  background: rgba(46, 154, 146, 0.15);
+  transform: translateY(-1px);
+  background-position: 100% 50%;
+  box-shadow:
+    0 0 0 5px rgba(127, 232, 223, 0.18),
+    0 4px 18px rgba(46, 154, 146, 0.55);
+  animation-play-state: paused;
 }
 
 .link:focus-visible {
-  outline: 2px solid #7fe8df;
-  outline-offset: 2px;
+  outline: 2px solid #a8f5ed;
+  outline-offset: 3px;
 }
 
-/* Override the global `.dark a` color rule from pages/styles.css. */
-:global(.dark) .link {
-  color: #7fe8df;
+.icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
 }
 
+@keyframes cloudPulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(127, 232, 223, 0.45),
+      0 2px 8px rgba(46, 154, 146, 0.35);
+  }
+  50% {
+    box-shadow:
+      0 0 0 7px rgba(127, 232, 223, 0),
+      0 2px 14px rgba(46, 154, 146, 0.5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link {
+    animation: none;
+  }
+  .link:hover {
+    transform: none;
+  }
+}
+
+/* Beat the global `.dark a { color: var(--agor-teal-light) }` rule in
+ * pages/styles.css so the dark pill text stays legible. */
+:global(.dark) .link,
 :global(.dark) .link:hover {
-  color: #a8f5ed;
+  color: #0a0a0a;
 }
 
 @media (max-width: 768px) {
   .link {
     font-size: 0.8125rem;
-    padding: 0.3rem 0.55rem;
+    padding: 0.32rem 0.65rem;
+    gap: 0.35rem;
     margin-right: 0.25rem;
   }
+  .icon {
+    width: 15px;
+    height: 15px;
+  }
 }
+
+/* The Nextra nav reorder rules that put this CTA left-of-search live in
+ * pages/styles.css — Next.js CSS modules don't allow standalone :global
+ * selectors. See the "Navbar CTA position" block there. */

--- a/apps/agor-docs/components/NavbarCloudCTA.module.css
+++ b/apps/agor-docs/components/NavbarCloudCTA.module.css
@@ -17,36 +17,44 @@
 .link {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.4rem 0.9rem;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
   margin-right: 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
   line-height: 1.2;
   color: #0a0a0a;
-  background: linear-gradient(120deg, #2e9a92 0%, #4ec4ba 45%, #7fe8df 100%);
-  background-size: 220% 220%;
-  background-position: 0% 50%;
+  /* Narrow gradient kept inside saturated brand teal — no pale-mint wash.
+   * Subtle ~12% lightness swing for depth, not a sweep. */
+  background: linear-gradient(135deg, #2e9a92 0%, #38ada3 100%);
   border-radius: 999px;
   text-decoration: none;
   white-space: nowrap;
+  /* Layered shadow: inset top highlight + inset bottom rim for glassy
+   * depth, soft drop shadow underneath, plus the pulse halo (default
+   * collapsed to 0px — animation expands it). */
   box-shadow:
-    0 0 0 0 rgba(127, 232, 223, 0.45),
-    0 2px 8px rgba(46, 154, 146, 0.35);
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.12),
+    0 0 0 0 rgba(127, 232, 223, 0.35),
+    0 2px 6px rgba(20, 80, 76, 0.45);
   transition:
-    background-position 0.4s ease,
+    background 0.2s ease,
     box-shadow 0.25s ease,
     transform 0.15s ease;
-  animation: cloudPulse 3.2s ease-in-out infinite;
+  animation: cloudPulse 3.4s ease-in-out infinite;
   order: 2;
 }
 
 .link:hover {
   transform: translateY(-1px);
-  background-position: 100% 50%;
+  /* Saturation + brightness step, not a gradient slide — feels committed. */
+  background: linear-gradient(135deg, #3aa9a0 0%, #4ec4ba 100%);
   box-shadow:
-    0 0 0 5px rgba(127, 232, 223, 0.18),
-    0 4px 18px rgba(46, 154, 146, 0.55);
+    inset 0 1px 0 rgba(255, 255, 255, 0.28),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.12),
+    0 0 0 4px rgba(127, 232, 223, 0.18),
+    0 4px 14px rgba(20, 80, 76, 0.55);
   animation-play-state: paused;
 }
 
@@ -61,17 +69,24 @@
   flex-shrink: 0;
 }
 
+/* Sonar-ping pulse: a single teal ring expands and fades outward.
+ * Keeps the inset highlight/rim and drop shadow steady so the pill
+ * itself doesn't flicker — only the halo breathes. */
 @keyframes cloudPulse {
-  0%,
+  0% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.22),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.12),
+      0 0 0 0 rgba(127, 232, 223, 0.45),
+      0 2px 6px rgba(20, 80, 76, 0.45);
+  }
+  70%,
   100% {
     box-shadow:
-      0 0 0 0 rgba(127, 232, 223, 0.45),
-      0 2px 8px rgba(46, 154, 146, 0.35);
-  }
-  50% {
-    box-shadow:
-      0 0 0 7px rgba(127, 232, 223, 0),
-      0 2px 14px rgba(46, 154, 146, 0.5);
+      inset 0 1px 0 rgba(255, 255, 255, 0.22),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.12),
+      0 0 0 6px rgba(127, 232, 223, 0),
+      0 2px 6px rgba(20, 80, 76, 0.45);
   }
 }
 

--- a/apps/agor-docs/components/NavbarCloudCTA.tsx
+++ b/apps/agor-docs/components/NavbarCloudCTA.tsx
@@ -1,17 +1,10 @@
-import { AGOR_CLOUD_INVITE_URL } from '../lib/links';
+import Link from 'next/link';
 import styles from './NavbarCloudCTA.module.css';
 
 export function NavbarCloudCTA() {
   return (
-    <a
-      href={AGOR_CLOUD_INVITE_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={styles.cta}
-      aria-label="Request Agor Cloud access"
-    >
-      <span className={styles.full}>Request Cloud access</span>
-      <span className={styles.short}>Cloud access</span>
-    </a>
+    <Link href="/blog/agor-cloud" className={styles.link}>
+      Agor Cloud
+    </Link>
   );
 }

--- a/apps/agor-docs/components/NavbarCloudCTA.tsx
+++ b/apps/agor-docs/components/NavbarCloudCTA.tsx
@@ -1,0 +1,17 @@
+import { AGOR_CLOUD_INVITE_URL } from '../lib/links';
+import styles from './NavbarCloudCTA.module.css';
+
+export function NavbarCloudCTA() {
+  return (
+    <a
+      href={AGOR_CLOUD_INVITE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.cta}
+      aria-label="Request Agor Cloud access"
+    >
+      <span className={styles.full}>Request Cloud access</span>
+      <span className={styles.short}>Cloud access</span>
+    </a>
+  );
+}

--- a/apps/agor-docs/components/NavbarCloudCTA.tsx
+++ b/apps/agor-docs/components/NavbarCloudCTA.tsx
@@ -3,8 +3,11 @@ import styles from './NavbarCloudCTA.module.css';
 
 export function NavbarCloudCTA() {
   return (
-    <Link href="/blog/agor-cloud" className={styles.link}>
-      Agor Cloud
+    <Link href="/blog/agor-cloud" className={styles.link} aria-label="Agor Cloud">
+      <svg className={styles.icon} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4a7.5 7.5 0 0 0-6.93 4.74A5.99 5.99 0 0 0 6 20h13a5 5 0 0 0 .35-9.96zM19 18H6a4 4 0 0 1-.39-7.98 5.5 5.5 0 0 1 10.83-.97A3.5 3.5 0 1 1 19 18z" />
+      </svg>
+      <span>Agor Cloud</span>
     </Link>
   );
 }

--- a/apps/agor-docs/components/index.ts
+++ b/apps/agor-docs/components/index.ts
@@ -3,4 +3,5 @@ export { BlogIndex } from './BlogIndex';
 export { DocsBackground } from './DocsBackground';
 export { GifGallery } from './GifGallery';
 export { Hero } from './Hero';
+export { NavbarCloudCTA } from './NavbarCloudCTA';
 export { ParticleBackground } from './ParticleBackground';

--- a/apps/agor-docs/components/index.ts
+++ b/apps/agor-docs/components/index.ts
@@ -1,5 +1,6 @@
 export { BlogCard } from './BlogCard';
 export { BlogIndex } from './BlogIndex';
+export { CloudInviteCTA } from './CloudInviteCTA';
 export { DocsBackground } from './DocsBackground';
 export { GifGallery } from './GifGallery';
 export { Hero } from './Hero';

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -16,8 +16,5 @@ export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';
 export const AGOR_CLOUD_INVITE_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog';
 
-// Agor Cloud demo booking. TODO: replace with the actual Calendly /
-// HubSpot Meetings link when set up. Mailto is the safe default so the
-// button is never broken in the meantime.
-export const AGOR_CLOUD_DEMO_URL =
-  'mailto:hello@agor.live?subject=Agor%20Cloud%20demo%20request&body=Hi%20—%20I%27d%20like%20to%20see%20Agor%20Cloud%20in%20action.%20A%20bit%20about%20my%20team%3A';
+// Agor Cloud demo / contact form (hosted on the Preset marketing site).
+export const AGOR_CLOUD_DEMO_URL = 'https://preset.io/contact-us-about-agor/';

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -15,3 +15,9 @@ export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';
 // agor-cloud / agor-openclaw blog posts — update those in tandem.
 export const AGOR_CLOUD_INVITE_URL =
   'https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog';
+
+// Agor Cloud demo booking. TODO: replace with the actual Calendly /
+// HubSpot Meetings link when set up. Mailto is the safe default so the
+// button is never broken in the meantime.
+export const AGOR_CLOUD_DEMO_URL =
+  'mailto:hello@agor.live?subject=Agor%20Cloud%20demo%20request&body=Hi%20—%20I%27d%20like%20to%20see%20Agor%20Cloud%20in%20action.%20A%20bit%20about%20my%20team%3A';

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -10,3 +10,8 @@ export const DISCORD_INVITE_URL = 'https://discord.gg/Qh4TrFQZpd';
 export const GITHUB_REPO_URL = 'https://github.com/preset-io/agor';
 export const GITHUB_DISCUSSIONS_URL = 'https://github.com/preset-io/agor/discussions';
 export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';
+
+// Agor Cloud private beta interest form. Same URL used inline in the
+// agor-cloud / agor-openclaw blog posts — update those in tandem.
+export const AGOR_CLOUD_INVITE_URL =
+  'https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog';

--- a/apps/agor-docs/package.json
+++ b/apps/agor-docs/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.15.1",
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build && next-sitemap --config next-sitemap.config.cjs",

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Agor Cloud - Opening a Private Beta'
-description: 'Fully managed Agor: bring your own API keys, run on a tuned Kubernetes fleet with same-day security patching, Unix-level user isolation, private network access to your VPC, and an audit trail your security team will accept. Built and operated by the team behind Preset Cloud.'
+description: 'Fully managed Agor: bring your own API keys, pen-tested and hardened for public-internet use (mobile included), same-day security patching, Unix-level user isolation, private network access to your VPC, and an audit trail your security team will accept. Built and operated by the team behind Preset Cloud.'
 date: 2025-11-23
 image: '/images/blog/agor-cloud.png'
 ---
@@ -71,6 +71,19 @@ Inside every Agor instance, sessions, worktrees, and dev environments run as dis
 
 This is how multi-user systems were designed to work, and it's the security floor we build everything else on top of.
 
+### Hardened for the Public Internet
+
+Agor is powerful software, and some of its capabilities — broad filesystem access, freeform shell, multi-user shared dev environments — are great inside a trusted network and risky on the open internet. If you self-host, you should think carefully about where you put it (and probably run it behind a VPN).
+
+Agor Cloud is built the other way: hardened from day one to sit safely on the public internet.
+
+- **Pen-tested** by an independent security firm. Daemon, executor, and exposed APIs all under scrutiny.
+- **SOC 2 Type II** audit cycle in flight.
+- **Locked-down feature surface.** The OSS feature flags and configs that expand attack surface — shared dev boxes, certain bypass modes, broad sudo paths — are off in Cloud. We know exactly which knobs should be in which position for a reliable, secure, public-facing instance, because that's what we run for ourselves.
+- **Safer alternatives where it matters.** Where a feature is too risky to expose publicly but still valuable, we ship a safer shape of it. Environment integration on Cloud, for example, goes through a webhook surface rather than in-instance shared dev envs — same outcome, much smaller blast radius.
+
+The payoff is the obvious one: **use Agor from anywhere, mobile included, with no VPN gymnastics.** Same posture you'd want from any modern SaaS your team relies on.
+
 ### Managed Private Cloud
 
 The default public Agor Cloud is a managed single-tenant instance per team, hosted on our infrastructure. For organizations whose code, data, or networking story rules that out, **Managed Private Cloud (MPC)** is a different deployment model:
@@ -123,7 +136,6 @@ API authentication, user isolation, secret management, network access controls �
 
 A few things customers ask about that we're committed to but haven't shipped yet. We surface them here so nothing's a surprise:
 
-- **SOC 2 Type II** — in progress.
 - **Self-serve point-in-time restore** — backups exist today and we recover from them; the tested restore UX and customer-visible drill cadence are not MVP.
 - **Prompt-injection guardrails** — exploring tooling that catches obvious injection patterns at the agent boundary. Nothing committed yet; flag interest if this is a blocker.
 
@@ -157,8 +169,9 @@ We're not trying to sell you something you don't need. We're looking for teams w
 
 - **Dedicated Agor instance** with your team's repos and worktrees
 - **Bring-your-own-key** for Claude, Codex, Gemini—no proxy, no markup, no cut
-- **Unix-level user isolation** for secure multi-tenant development
-- **Private network access** to your VPC, VPN, or own-cloud account
+- **Pen-tested and public-internet hardened**—use from anywhere, mobile included, no VPN required
+- **Unix-level user isolation** as defense-in-depth
+- **Private network access** to your VPC, VPN, or own-cloud account (Managed Private Cloud)
 - **Audit log + multi-cast metrics** integrated with your existing observability stack
 - **CI-ready agent sessions** that persist and stay visible on your board
 - **Managed infrastructure**—same-day patching, monitoring, capacity, support

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -30,9 +30,7 @@ When you're excited about shared dev environments, worktrees, and AI sessions, y
 - An audit trail your security team will actually accept
 - Same-day patching when the next zero-day in your stack lands
 
-**The insight:** The best people to operate any given piece of software are the people building that software.
-
-We're building Agor. We're running it in production for ourselves. And as a SaaS company offering Preset Cloud, we had all the infrastructure expertise in place to do this right—for us and for anyone else who wants it.
+That's a lot to own well. Most teams shouldn't have to.
 
 ## What Agor Cloud Offers
 
@@ -54,7 +52,9 @@ You optimize AI spend with the people who actually have the data: the providers.
 
 ### We Run It Better Than You Would
 
-A self-hosted Agor is a real piece of infrastructure: a stateful database, a multi-tenant filesystem, isolated worktrees, Docker resource budgets, agent processes that can hang or run away. Doing that well full-time is what we do.
+Who's best positioned to keep a given piece of software running reliably? The team that wrote it. They know which assumptions are load-bearing, which edge cases bite first, which knobs actually matter, which logs to grep when things go sideways. **Trust the people who wrote the software to run the software.**
+
+A self-hosted Agor is a real piece of infrastructure: a stateful database, a multi-tenant filesystem, isolated worktrees, Docker resource budgets, agent processes that can hang or run away. Running that well, full-time, is our job — not a side concern.
 
 What that buys you:
 

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -19,7 +19,7 @@ So why Agor Cloud?
 
 Here's what we learned productionizing Agor at Preset for our own use:
 
-When you're excited about shared dev environments, worktrees, and AI sessions, you quickly realize the scale of what it takes to run this safely in production:
+When you start running Agor for your team—multiple users, worktrees, dev environments per branch, AI sessions touching real code—you quickly realize the scale of what it takes to run this safely in production:
 
 - A stateful database that needs backups, migrations, and a recovery story
 - Per-user API key management for multiple agent providers (Claude, Gemini, Codex)
@@ -67,21 +67,18 @@ This is boring infrastructure work that someone has to do. You can pay people to
 
 ### Unix-Level User Isolation
 
-We're bringing back shared, fat servers—the right way.
+Inside every Agor instance, sessions, worktrees, and dev environments run as distinct Unix users. Filesystem permissions enforce boundaries between users, between branches, between agents. No shared process space, no leaky abstractions, no "well, they're all in the same container."
 
-If you're going to share and collaborate on dev environments, there's no way around this: each user needs real isolation. Not just process separation, not just containers, but **Unix-level user isolation**.
-
-Every developer gets their own Unix user on the Agor server. Worktrees, sessions, and dev environments run as that user. Filesystem permissions enforce boundaries. No accidental cross-contamination, no leaky abstractions.
-
-This is how multi-user systems were designed to work. Agor Cloud makes it seamless.
+This is how multi-user systems were designed to work, and it's the security floor we build everything else on top of.
 
 ### Managed Private Cloud
 
-For teams whose interesting code and data live behind a network boundary, the default public managed offering isn't enough. Agor Cloud meets you where your infrastructure lives:
+The default public Agor Cloud is a managed single-tenant instance per team, hosted on our infrastructure. For organizations whose code, data, or networking story rules that out, **Managed Private Cloud (MPC)** is a different deployment model:
 
-- **Private network peering.** Connect your Agor instance to your VPC so agents can reach internal git servers, private APIs, staging databases, and ticketing systems—without exposing any of it to the public internet.
+- **Bring-your-own-cloud deployments.** We deploy and manage Agor inside your own AWS or GCP account—data and compute stay in your tenancy.
+- **Private network peering.** Reach internal git servers, private APIs, staging databases, and ticketing systems over your VPC—nothing exposed to the public internet.
 - **VPN-fronted access.** Sit Agor behind your existing VPN if your security policy requires it.
-- **Bring-your-own-cloud deployments.** For organizations that need data and compute to stay in their own AWS or GCP tenancy, we can deploy and manage Agor inside your account.
+- **Bring back the shared, fat dev server.** MPC unlocks the "team works on one beefy dev box" model—with the Unix-level isolation above keeping users from stepping on each other. It's how multi-user systems were designed to work, before everyone moved to laptops. Not part of the default Cloud offering; ask about it if it fits your team.
 
 Network topology is a conversation, not a checkbox—tell us what your security team needs and we'll work out the shape.
 
@@ -98,7 +95,7 @@ You stay accountable to your own security and compliance people. We don't ask yo
 
 ### Always Up
 
-Managing a large box running all sorts of dev environments is challenging: containers that need health checks, processes that hang, disks that fill, ports that collide, SSH tunnels that drop. Cloud handles it—monitoring, auto-recovery, capacity management.
+Running the infrastructure underneath a fleet of dev environments is challenging: containers that need health checks, processes that hang, disks that fill, ports that collide, network paths that drop. Cloud handles it—monitoring, auto-recovery, capacity management.
 
 You focus on building. We focus on keeping the lights on.
 
@@ -134,7 +131,7 @@ If any of these are dealbreakers for your team, say so in the interest form—we
 
 ## Who Agor Cloud Is For
 
-- **Teams that want shared, multi-user dev environments** without the ops burden
+- **Teams that want a managed multi-user Agor instance** without the ops burden
 - **Engineering orgs exploring AI-assisted development** at scale who want to bring their own keys
 - **Companies whose security or compliance posture** rules out running open source locally without a vendor on the hook
 - **Teams whose interesting code and data live behind a VPC or VPN** and want agents that can reach it safely

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Agor Cloud - Opening a Private Beta'
-description: 'Fully managed Agor with Unix-level user isolation, automated backups, CI-ready agent sessions, and enterprise observability. Built by the team running it for themselves at Preset.'
+description: 'Fully managed Agor: bring your own API keys, run on a tuned Kubernetes fleet with same-day security patching, Unix-level user isolation, private network access to your VPC, and an audit trail your security team will accept. Built and operated by the team behind Preset Cloud.'
 date: 2025-11-23
 image: '/images/blog/agor-cloud.png'
 ---
@@ -21,14 +21,14 @@ Here's what we learned productionizing Agor at Preset for our own use:
 
 When you're excited about shared dev environments, worktrees, and AI sessions, you quickly realize the scale of what it takes to run this safely in production:
 
-- A stateful database that needs backups and migrations
-- API keys for multiple agent providers (Claude, Gemini, Codex)
+- A stateful database that needs backups, migrations, and a recovery story
+- Per-user API key management for multiple agent providers (Claude, Gemini, Codex)
 - Prompt injection risks when agents have filesystem access
 - User isolation so one developer's session doesn't stomp another's
-- Docker resource containment—when people can fire up dev environments at the click of a button, you need resource isolation to ensure core services remain healthy while people go to town on the shared box
+- Docker resource containment—when people can fire up dev environments at the click of a button, you need resource isolation to keep core services healthy while people go to town on the shared box
 - Observability across a fleet of dev environments
-- Analytics to understand usage patterns and costs
-- Policies to prevent runaway token spend
+- An audit trail your security team will actually accept
+- Same-day patching when the next zero-day in your stack lands
 
 **The insight:** The best people to operate any given piece of software are the people building that software.
 
@@ -36,7 +36,34 @@ We're building Agor. We're running it in production for ourselves. And as a SaaS
 
 ## What Agor Cloud Offers
 
-Agor Cloud is a fully managed service, turnkey. Up in minutes, reliable, always running the latest fully secured version of Agor with all the bells and whistles.
+Agor Cloud is a fully managed Agor instance. Up in minutes, reliable, always on the latest secured release. The pitch is simple: someone is going to operate this thing for your team — we'd like to make the case that it should be us.
+
+### Bring Your Own Keys
+
+We don't sell tokens.
+
+You bring your own API keys for Claude, Codex, Gemini—whatever you use. Agor Cloud doesn't proxy them, doesn't mark them up, doesn't take a cut. Your AI spend is between you and the model providers.
+
+Why this matters:
+
+- **No incentive mismatch.** We make money running Agor well, not on how many tokens your team burns.
+- **No opaque markup.** Your provider bills you directly; we never insert ourselves into that flow.
+- **No model lock-in.** Add or swap providers without renegotiating anything with us.
+
+You optimize AI spend with the people who actually have the data: the providers.
+
+### We Run It Better Than You Would
+
+A self-hosted Agor is a real piece of infrastructure: a stateful database, a multi-tenant filesystem, isolated worktrees, Docker resource budgets, agent processes that can hang or run away. Doing that well full-time is what we do.
+
+What that buys you:
+
+- **Economies of scale on Kubernetes.** Tuned node pools, autoscaling, resource budgets that took us months to get right—you get the result without the calendar.
+- **The latest/stable/secure balance.** New Agor releases land on Cloud after they've been validated against our own production traffic, not yours.
+- **Same-day patching for zero-days.** When CVEs hit Node, Postgres, the kernel, or any of Agor's deps, the same SRE rotation that runs Preset Cloud ships the fix that day. You don't have to track Agor changelogs or rebuild images.
+- **No on-call rotation for your team.** We're on-call for Agor; you're on-call for your product.
+
+This is boring infrastructure work that someone has to do. You can pay people to do it in-house, or you can pay us to do it once for everyone.
 
 ### Unix-Level User Isolation
 
@@ -48,91 +75,70 @@ Every developer gets their own Unix user on the Agor server. Worktrees, sessions
 
 This is how multi-user systems were designed to work. Agor Cloud makes it seamless.
 
+### Managed Private Cloud
+
+For teams whose interesting code and data live behind a network boundary, the default public managed offering isn't enough. Agor Cloud meets you where your infrastructure lives:
+
+- **Private network peering.** Connect your Agor instance to your VPC so agents can reach internal git servers, private APIs, staging databases, and ticketing systems—without exposing any of it to the public internet.
+- **VPN-fronted access.** Sit Agor behind your existing VPN if your security policy requires it.
+- **Bring-your-own-cloud deployments.** For organizations that need data and compute to stay in their own AWS or GCP tenancy, we can deploy and manage Agor inside your account.
+
+Network topology is a conversation, not a checkbox—tell us what your security team needs and we'll work out the shape.
+
+### Auditing & Observability
+
+If Agor is becoming critical to your PDLC, you need to see what's happening in it—both for ops and for the security review your team will eventually get pulled into.
+
+- **Audit log** of session creation, prompt submissions, branch changes, owner edits, and admin actions—queryable, retained, exportable.
+- **Multi-cast metrics.** Logs and metrics flow to both your stack and ours (StatsD, Datadog, CloudWatch, Prometheus). We don't get in the way of your existing observability.
+- **Built-in dashboards** for CPU, memory, disk, and network across every dev environment.
+- **Alerting** when environments spike, disk fills, or processes hang.
+
+You stay accountable to your own security and compliance people. We don't ask you to trust a black box.
+
 ### Always Up
 
-Managing a large box running all sorts of dev environments is challenging:
-
-- Docker containers that need health checks
-- Background processes that hang
-- Disk space that fills up
-- Network ports that collide
-- SSH tunnels that disconnect
-
-Agor Cloud ensures the infrastructure stays healthy. Monitoring, auto-recovery, capacity management—handled.
+Managing a large box running all sorts of dev environments is challenging: containers that need health checks, processes that hang, disks that fill, ports that collide, SSH tunnels that drop. Cloud handles it—monitoring, auto-recovery, capacity management.
 
 You focus on building. We focus on keeping the lights on.
 
-### Backups & Snapshots
-
-Agor sits at the center of your team's development workflow—sessions, branches, tasks, message history, configuration. Losing it would be painful.
-
-Agor Cloud handles this for you:
-
-- **Automated daemon DB snapshots** on a regular cadence
-- **Point-in-time restore** so you can roll back to a known-good state
-- **Coordinated worktree filesystem snapshots** alongside the DB, so branches stay coherent across a restore
-- **Off-host backup replication** for disaster recovery
-- **Tested restore drills**—we don't ship a backup story we haven't verified end-to-end
-
-If something goes sideways, restore is a support ticket, not a postmortem.
-
 ### CI-Ready: Agents That Don't Disappear
 
-Being able to `@claude` and `@codex` in GitHub issues and pull requests has made GitHub a better place for all of us and our agents. But there are clear limitations:
+Being able to `@claude` and `@codex` in GitHub issues and pull requests has made GitHub a better place for all of us and our agents. But the ephemeral model has clear limits:
 
-**The problem with ephemeral CI agents:**
+- You hope the agent one-shots it in CI; if not, you can't see what it actually did
+- Sessions vanish when the job ends—the built-up context window is gone
+- No way to follow up with "that was close, but can you also check X?"
+- The agent doesn't know how the branch was built in the first place
 
-- You hope the agent will one-shot the solution in CI
-- Things remain opaque—you can't see what the agent actually did
-- Sessions are ephemeral—once the job finishes, the context vanishes
-- You can't reuse the context window that was built up
-- No way to say "that was close, but can you also check X?"
-- Missing context about how the branch got built in the first place
-
-**How nice would it be if agents in CI could:**
-
-- Work with live dev environments instead of cold checkouts
-- Access the full context of how the branch was built
-- Persist their sessions so you can go in and ask for a few more things
-- Appear on your board alongside your other work, not in a black box
-
-**That's exactly what Agor Cloud enables.**
-
-With Agor Cloud, you can allow your agents in CI to benefit from everything across the Agor platform:
+Agor Cloud lets your CI agents live on the same platform as the rest of your team's work:
 
 - **See CI-triggered sessions spawn** in your Agor environment in real-time
 - **Watch agents work** with full visibility into tool use, file reads, and reasoning
-- **Resume sessions** after CI completes—"Thanks for the review, now can you fix the issues you found?"
+- **Resume sessions** after CI completes—"thanks for the review, now fix the issues you found"
 - **Reuse context** from the session that created the branch
-- **Connect to live dev environments** instead of starting from scratch
-- **Track genealogy** from issue → PR → review → fixes—all as a session tree
+- **Connect to live dev environments** instead of starting from a cold checkout
+- **Track genealogy** from issue → PR → review → fixes, all as a session tree
 
-Getting something like that to work securely can be quite complex—API authentication, user isolation, secret management, network access controls. Agor Cloud handles all of it.
+API authentication, user isolation, secret management, network access controls — Agor Cloud handles the wiring. Your CI agents become first-class citizens, not ephemeral scripts.
 
-Your CI agents become first-class citizens in your Agor environment, not ephemeral scripts that run and disappear.
+### On the Roadmap
 
-### Full Observability
+A few things customers ask about that we're committed to but haven't shipped yet. We surface them here so nothing's a surprise:
 
-If you're using Agor to spin up dev environments—likely through Docker, Kubernetes, or local processes—you need visibility into what's running and how it's performing.
+- **SOC 2 Type II** — in progress.
+- **Self-serve point-in-time restore** — backups exist today and we recover from them; the tested restore UX and customer-visible drill cadence are not MVP.
+- **Prompt-injection guardrails** — exploring tooling that catches obvious injection patterns at the agent boundary. Nothing committed yet; flag interest if this is a blocker.
 
-Agor Cloud provides:
-
-- **Multi-cast observability** - logs and metrics flow to both your tools and ours
-- **Integration with your existing stack** - StatsD, Datadog, CloudWatch, Prometheus
-- **Built-in dashboards** - CPU, memory, disk, network for every environment
-- **Alerting** - get notified when environments spike, disk space runs low, or processes hang
-
-You maintain full observability on a system that's quickly becoming critical to your PDLC. We ensure our internal monitoring doesn't interfere with yours—multi-cast means both systems see the same data stream.
-
-Agor becomes the heart of your development process. You need visibility into it just like you need visibility into production.
+If any of these are dealbreakers for your team, say so in the interest form—we prioritize based on what we hear.
 
 ## Who Agor Cloud Is For
 
-- **Teams that want shared dev environments** without the ops burden
-- **Engineering orgs exploring AI-assisted development** at scale
-- **Companies with security and compliance requirements** that rule out running open source locally
-- **Teams that can't afford to lose their dev environment state** and want managed backup/restore
-- **Anyone who wants Agor's capabilities** without managing infrastructure
+- **Teams that want shared, multi-user dev environments** without the ops burden
+- **Engineering orgs exploring AI-assisted development** at scale who want to bring their own keys
+- **Companies whose security or compliance posture** rules out running open source locally without a vendor on the hook
+- **Teams whose interesting code and data live behind a VPC or VPN** and want agents that can reach it safely
+- **Anyone who wants Agor's capabilities** without owning the infrastructure underneath
 
 ## Signing Up for the Private Beta
 
@@ -153,16 +159,17 @@ We're not trying to sell you something you don't need. We're looking for teams w
 ## What You Get
 
 - **Dedicated Agor instance** with your team's repos and worktrees
+- **Bring-your-own-key** for Claude, Codex, Gemini—no proxy, no markup, no cut
 - **Unix-level user isolation** for secure multi-tenant development
-- **Automated backups** with tested point-in-time restore
+- **Private network access** to your VPC, VPN, or own-cloud account
+- **Audit log + multi-cast metrics** integrated with your existing observability stack
 - **CI-ready agent sessions** that persist and stay visible on your board
-- **Full observability** integrated with your existing monitoring stack
-- **Managed infrastructure**—updates, monitoring, capacity, support
+- **Managed infrastructure**—same-day patching, monitoring, capacity, support
 - **Direct access to the team** building Agor—fast feedback loop, feature requests welcome
 
 ## Pricing
 
-We're figuring this out during the private beta. Usage-based makes sense (token usage, active users, worktree count). We'll work with early customers to find a model that's fair and sustainable.
+We're figuring this out during the private beta. Because Agor Cloud is BYOK, our pricing has nothing to do with your AI spend—it's about the managed infrastructure: per-user, per-instance, or per-worktree models all make sense and we're working with early customers to land on something fair and sustainable.
 
 For now, focus is on fit and value. Pricing comes after we've proven this solves real problems.
 
@@ -189,7 +196,7 @@ The open source project benefits too: production learnings at Preset feed back i
 
 ## Let's Get Cooking
 
-AI-assisted development is changing how we build software. But the tooling around it—observability, cost controls, collaboration, security—hasn't caught up.
+AI-assisted development is changing how we build software. But the operational tooling around it—observability, collaboration, isolation, security patching, audit—hasn't caught up.
 
 Agor Cloud bridges that gap. Fully managed, secure, observable, built by the team using it every day.
 

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -1,15 +1,19 @@
 ---
 title: 'Agor Cloud - Opening a Private Beta'
-description: 'Fully managed Agor with Unix-level isolation, analytics dashboards, policy controls, and enterprise observability. Built by the team running it for themselves at Preset.'
+description: 'Fully managed Agor with Unix-level user isolation, automated backups, CI-ready agent sessions, and enterprise observability. Built by the team running it for themselves at Preset.'
 date: 2025-11-23
 image: '/images/blog/agor-cloud.png'
 ---
+
+import { CloudInviteCTA } from '../../components/CloudInviteCTA';
 
 # Agor Cloud - Opening a Private Beta
 
 Agor is BSL-licensed and vastly open source. You're free to run it however you want—you just can't commercialize it. It has all the building blocks for anyone without commercial intent to build next-gen, multi-agent, multiplayer servers that can really change how you build software.
 
 So why Agor Cloud?
+
+<CloudInviteCTA />
 
 ## The Gap Between "Works for Me" and "Works for Production"
 
@@ -58,35 +62,19 @@ Agor Cloud ensures the infrastructure stays healthy. Monitoring, auto-recovery, 
 
 You focus on building. We focus on keeping the lights on.
 
-### Analytics Dashboards
+### Backups & Snapshots
 
-Want to see who's using AI? How much? Who's ramping slowly? Where the token spend is going?
+Agor sits at the center of your team's development workflow—sessions, branches, tasks, message history, configuration. Losing it would be painful.
 
-**Agor Cloud comes with embedded, rich, interactive reporting through Preset Portals.**
+Agor Cloud handles this for you:
 
-Every Agor Cloud instance includes a fully-loaded Preset (managed Apache Superset) workspace. Pre-built dashboards show:
+- **Automated daemon DB snapshots** on a regular cadence
+- **Point-in-time restore** so you can roll back to a known-good state
+- **Coordinated worktree filesystem snapshots** alongside the DB, so branches stay coherent across a restore
+- **Off-host backup replication** for disaster recovery
+- **Tested restore drills**—we don't ship a backup story we haven't verified end-to-end
 
-- Token usage by user, worktree, and repo
-- Cost breakdown by agent type (Claude, Codex, Gemini)
-- Session duration and completion rates
-- Worktree lifecycle metrics
-- Agent performance and error rates
-
-You get full SQL access to your Agor database through Superset, so you can build custom reports for your team's workflow.
-
-All your PDLC (Product Development Life Cycle) and AI development data in one place. Explore it however you want.
-
-### Usage Policies
-
-AI is powerful. It's also expensive. You want to enable usage, but you probably want guardrails:
-
-- **Token quotas** per user or team
-- **Rate limits** to prevent chain reactions
-- **Max concurrent sessions** to manage compute load
-- **Approval workflows** for high-cost operations
-- **Spending caps** to avoid surprise bills
-
-Agor Cloud lets you configure policies that fit your team's needs. Enable the productivity boost, contain the blast radius.
+If something goes sideways, restore is a support ticket, not a postmortem.
 
 ### CI-Ready: Agents That Don't Disappear
 
@@ -143,7 +131,7 @@ Agor becomes the heart of your development process. You need visibility into it 
 - **Teams that want shared dev environments** without the ops burden
 - **Engineering orgs exploring AI-assisted development** at scale
 - **Companies with security and compliance requirements** that rule out running open source locally
-- **Teams that need analytics and cost controls** around AI usage
+- **Teams that can't afford to lose their dev environment state** and want managed backup/restore
 - **Anyone who wants Agor's capabilities** without managing infrastructure
 
 ## Signing Up for the Private Beta
@@ -160,19 +148,17 @@ Here's how it works:
 4. **Trial period** - Use Agor Cloud, see if it delivers value for your workflow
 5. **Decide** - If it's solving real problems, stay on. If not, no hard feelings.
 
-We're not trying to sell you something you don't need. We're looking for teams where Agor Cloud makes a measurable difference—faster onboarding, better collaboration, cleaner development workflows, controlled AI spend.
-
-**[Join the Private Beta →](https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog)**
+We're not trying to sell you something you don't need. We're looking for teams where Agor Cloud makes a measurable difference—faster onboarding, better collaboration, cleaner development workflows.
 
 ## What You Get
 
 - **Dedicated Agor instance** with your team's repos and worktrees
 - **Unix-level user isolation** for secure multi-tenant development
-- **Preset Cloud workspace** with pre-built analytics dashboards
-- **Policy controls** for token quotas, rate limits, and spending caps
+- **Automated backups** with tested point-in-time restore
+- **CI-ready agent sessions** that persist and stay visible on your board
 - **Full observability** integrated with your existing monitoring stack
-- **Managed infrastructure** - backups, updates, monitoring, support
-- **Direct access to the team** building Agor - fast feedback loop, feature requests welcome
+- **Managed infrastructure**—updates, monitoring, capacity, support
+- **Direct access to the team** building Agor—fast feedback loop, feature requests welcome
 
 ## Pricing
 
@@ -209,7 +195,7 @@ Agor Cloud bridges that gap. Fully managed, secure, observable, built by the tea
 
 If that sounds like what your team needs, we'd love to talk.
 
-**[Join the Private Beta →](https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog)**
+<CloudInviteCTA />
 
 ---
 

--- a/apps/agor-docs/pages/styles.css
+++ b/apps/agor-docs/pages/styles.css
@@ -73,3 +73,45 @@ main {
   position: relative;
   z-index: 1;
 }
+
+/* ─── Navbar CTA position ────────────────────────────────────────────────
+ *
+ * The Agor Cloud CTA (components/NavbarCloudCTA) is mounted into Nextra's
+ * `navbar.extraContent` slot, which renders at the END of the nav by
+ * default (after the GitHub/Discord icons). We want it just to the LEFT
+ * of the search box so it reads as a nav destination, not a utility
+ * icon.
+ *
+ * Default flex `order` on every nav child is 0. The CTA itself gets
+ * `order: 2` in its module CSS; the rules below reorder the remaining
+ * children so the visible left-to-right order becomes:
+ *
+ *   [Logo]  [Page items]  [Agor Cloud CTA]  [Search]  [GitHub]  [Discord]  [Hamburger]
+ *
+ * nextra-theme-docs@3.3.x renders these direct children of
+ * `.nextra-nav-container nav` in this source order (when project.link,
+ * chat.link, and navbar.extraContent are all set):
+ *
+ *   1. <a>     logo                  (mr-auto pushes it to the far left)
+ *   2. <div>   page items wrapper
+ *   3. <div>   search box wrapper
+ *   4. <a>     project (GitHub) icon
+ *   5. <a>     chat (Discord) icon
+ *   6. <a>     extraContent — the CTA
+ *   7. <button> hamburger menu
+ *
+ * If a Nextra upgrade changes that DOM shape, this block + the CTA's
+ * own `order: 2` are the only places that need to be revisited.
+ */
+.nextra-nav-container nav > div:nth-of-type(2) {
+  order: 3;
+}
+.nextra-nav-container nav > a:nth-of-type(2) {
+  order: 4;
+}
+.nextra-nav-container nav > a:nth-of-type(3) {
+  order: 5;
+}
+.nextra-nav-container nav > button {
+  order: 6;
+}

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import type { DocsThemeConfig } from 'nextra-theme-docs';
 import { useConfig } from 'nextra-theme-docs';
+import { NavbarCloudCTA } from './components/NavbarCloudCTA';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from './lib/links';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
@@ -36,6 +37,9 @@ const config: DocsThemeConfig = {
   },
   chat: {
     link: DISCORD_INVITE_URL,
+  },
+  navbar: {
+    extraContent: NavbarCloudCTA,
   },
   docsRepositoryBase: 'https://github.com/preset-io/agor/tree/main/apps/agor-docs',
 


### PR DESCRIPTION
## Summary

- Adds a small **"Request Cloud access"** button to the docs navbar (next to the GitHub/Discord icons) pointing at the existing Agor Cloud private-beta interest form.
- Centralizes the form URL as `AGOR_CLOUD_INVITE_URL` in `apps/agor-docs/lib/links.ts` — same Google Form already linked from `blog/agor-cloud.mdx` and `blog/agor-openclaw.mdx`. The inline blog links were left as-is for now; we can DRY them up in a follow-up if we want.
- Button shortens from **"Request Cloud access"** to **"Cloud access"** below 768px so it doesn't crowd the mobile search box. The home page (`pages/index.mdx`) uses `layout: 'raw'`, so the navbar (and this CTA) only appear on guide/blog/api/security pages — exactly the audience evaluating Cloud.

## Wording options considered

Max asked for a polished, clear, not-salesy label. I weighed:

| Option | Notes |
| --- | --- |
| **Request Cloud access** ← picked | Short, action-verb, no marketing language. "Cloud" is unambiguous in-context (the navbar is already inside Agor docs), so "Agor" is implicit. Pairs naturally with the form's existing "Private Beta" framing without leaning into beta-speak. |
| Request Agor Cloud invite | Slightly more explicit but longer and the word "invite" implies a closed list — fine, but "access" reads more open. |
| Join Agor Cloud waitlist | "Waitlist" carries a wait connotation that may discourage clicks. Also longer. |
| Get Agor Cloud access | Reads more like a marketing CTA than a docs nav item. |

If Max prefers a different label, swapping it is a one-line edit in `components/NavbarCloudCTA.tsx`.

## Form destination

Reused the existing Google Form (`docs.google.com/forms/d/e/1FAIpQLSd…`) — it's already in production via two blog posts, so swapping to something else (Tally, Typeform, in-app form) would be a larger decision and out of scope here. Centralized constant means migration is a one-liner whenever we want.

## Implementation notes

- Uses Nextra v3's `navbar.extraContent` slot (typed `ReactNode | FC`) — no theme overrides or custom layout needed.
- Styling lives in a colocated `*.module.css` matching the existing Hero/GifGallery pattern. Reuses the brand teal gradient from `Hero.module.css` at a navbar-appropriate size (`0.8125rem`, `padding 0.4rem 0.85rem`).
- `target="_blank" rel="noopener noreferrer"` + `aria-label`.

## Test plan

- [ ] `pnpm --filter @agor/docs dev` and visit `http://localhost:3001/guide` — confirm the green "Request Cloud access" button appears in the navbar to the left of the GitHub/Discord icons
- [ ] Resize to mobile width (<768px) and confirm the label collapses to "Cloud access" and doesn't push the search box off-screen
- [ ] Click the button — should open the Agor Cloud Google Form in a new tab
- [ ] Confirm the home page (`/`) is unaffected (uses `layout: 'raw'`, so no navbar)
- [ ] Visual check on a couple of long-title pages (e.g. `/guide/multiplayer-unix-isolation`) to confirm no wrapping issues

## QA caveat

I wasn't able to spin up the Next dev server inside this sandbox (`next` binary not resolvable through the worktree's pnpm symlinks), so the above is unverified visually. The biome check on touched files is clean and the change is small and self-contained, but please eyeball it locally before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)