### PR TITLE
Refresh Claude Code and Codex dependencies

### DIFF
--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -42,7 +42,8 @@
     "swagger-ui-dist": "^5.32.6"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.154",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",

--- a/apps/agor-docs/pages/guide/message-gateway.mdx
+++ b/apps/agor-docs/pages/guide/message-gateway.mdx
@@ -45,7 +45,7 @@ A **Channel** is a portal into a branch. It defines:
 
 You can create multiple channels for the same or different branches. For example:
 
-- **"Optimus Prime"** — Claude Code (Opus 4.6) on your main assistant branch, with Slack + GitHub MCP servers
+- **"Optimus Prime"** — Claude Code (Opus 4.8) on your main assistant branch, with Slack + GitHub MCP servers
 - **"Scout"** — Claude Code (Sonnet 4.5) on a lighter review branch, trust mode, no MCP servers
 - **"Codex Runner"** — Codex on a `superset-frontend` branch for quick JS tasks
 
@@ -124,6 +124,7 @@ Open Slack, find your bot under Apps, and send it a message. You should see syst
 When someone mentions `@agor` (or your app's name) in a PR or issue comment, Agor picks it up via API polling and creates a session. The session runs on the target branch, and the agent's final response is posted back as a PR/issue comment under the app's bot identity (e.g., `agor[bot]`).
 
 Key differences from Slack:
+
 - **Polling, not WebSocket** — Agor polls the GitHub API every 15 seconds (configurable). No public endpoint needed.
 - **Per-PR/issue sessions** — Each PR or issue gets its own session. All `@agor` mentions within the same PR route to the same session.
 - **Last-message-only responses** — Unlike Slack (which streams every message), only the agent's final response is posted to GitHub. Intermediate progress is visible in the Agor UI.
@@ -134,6 +135,7 @@ Key differences from Slack:
 You can create the app through Agor's setup wizard or manually:
 
 **Via Agor UI (recommended):**
+
 1. Open **Settings** → **Gateway** tab → **Add Channel**.
 2. Select `github` as the channel type.
 3. Click **"Create GitHub App"** — this opens GitHub's App Manifest flow.
@@ -141,6 +143,7 @@ You can create the app through Agor's setup wizard or manually:
 5. Agor captures the credentials automatically.
 
 **Manually:**
+
 1. Go to your GitHub org's **Settings** → **Developer settings** → **GitHub Apps** → **New GitHub App**.
 2. Set permissions: `Contents: Read`, `Issues: Read & Write`, `Pull requests: Read & Write`, `Metadata: Read`.
 3. Subscribe to events: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`.
@@ -172,6 +175,7 @@ You can create the app through Agor's setup wizard or manually:
 ### 4. Mention @agor on a PR
 
 Comment `@agor review this PR` on any PR in a watched repo. Within 15 seconds:
+
 1. The comment gets a 👀 reaction (instant feedback).
 2. A "Processing..." comment appears with a link to the Agor session.
 3. The agent reviews the PR.
@@ -181,7 +185,7 @@ Follow-up `@agor` mentions on the same PR continue the same session — the agen
 
 ### Setting Up the Assistant
 
-The gateway routes messages to a session on the target branch. What the agent *does* with those messages is up to you — configured via the assistant's instructions on the target branch.
+The gateway routes messages to a session on the target branch. What the agent _does_ with those messages is up to you — configured via the assistant's instructions on the target branch.
 
 A minimal assistant prompt might be:
 
@@ -236,11 +240,7 @@ interface OutboundPayload {
 
 interface GatewayConnector {
   readonly channelType: ChannelType;
-  sendMessage(req: {
-    threadId: string;
-    text: string;
-    blocks?: unknown[];
-  }): Promise<string>;
+  sendMessage(req: { threadId: string; text: string; blocks?: unknown[] }): Promise<string>;
   startListening?(callback: (msg: InboundMessage) => void): Promise<void>;
   stopListening?(): Promise<void>;
   formatMessage?(markdown: string): string | OutboundPayload;

--- a/apps/agor-docs/pages/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/pages/guide/rich-chat-ux.mdx
@@ -43,14 +43,14 @@ Combined with **per-user analytics** (Settings → Analytics), this gives you a 
 
 **Switch models and reasoning depth mid-session.** A model selector and effort dropdown sit in the session panel footer.
 
-| Effort | When |
-|---|---|
-| `low` | Quick lookups, simple edits |
-| `medium` | Balanced speed/quality |
-| `high` | Default — complex coding, reviews |
-| `max` | Critical decisions, architecture (Opus only) |
+| Effort   | When                                         |
+| -------- | -------------------------------------------- |
+| `low`    | Quick lookups, simple edits                  |
+| `medium` | Balanced speed/quality                       |
+| `high`   | Default — complex coding, reviews            |
+| `max`    | Critical decisions, architecture (Opus only) |
 
-Models with the `[1m]` suffix (e.g., `claude-opus-4-6[1m]`) enable Anthropic's 1M-token extended context window. They appear as separate dropdown entries.
+Models with the `[1m]` suffix (e.g., `claude-sonnet-4-6[1m]`) enable Anthropic's 1M-token extended context window. They appear as separate dropdown entries.
 
 You don't have to start a new session to dial things up or down — flip the selector, the next prompt uses the new config.
 
@@ -176,7 +176,7 @@ You don't have to wait for a long-running prompt to finish before you start writ
   </div>
 </div>
 
-White dot (lower-left) means *something is running*. Green dot (lower-right) means *something is ready for input*. Both can show at once. Updates in real time over WebSocket.
+White dot (lower-left) means _something is running_. Green dot (lower-right) means _something is ready for input_. Both can show at once. Updates in real time over WebSocket.
 
 ---
 
@@ -240,12 +240,12 @@ The agent can return a Mermaid diagram of your service architecture, and you'll 
   style={{ maxWidth: '400px' }}
 />
 
-| Setting | Where |
-|---|---|
-| Audio | Settings → Audio |
-| API keys | Settings → Agentic Tools |
-| Env variables | Settings → Environment Variables |
-| Agent defaults | Create Session → Advanced |
+| Setting        | Where                            |
+| -------------- | -------------------------------- |
+| Audio          | Settings → Audio                 |
+| API keys       | Settings → Agentic Tools         |
+| Env variables  | Settings → Environment Variables |
+| Agent defaults | Create Session → Advanced        |
 
 See **[Security](/security)** for the trust boundary on per-user secrets.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,9 +61,9 @@ RUN curl -fsSL "$(curl -s https://api.github.com/repos/cli/cli/releases/latest |
 # NOTE: Update these versions when upgrading Agor SDKs (see packages/core/package.json)
 RUN npm install -g \
   pnpm@9.15.1 \
-  @anthropic-ai/claude-code@2.1.132 \
+  @anthropic-ai/claude-code@2.1.154 \
   @google/gemini-cli@0.31.0 \
-  @openai/codex@0.128.0 \
+  @openai/codex@0.135.0 \
   opencode-ai@1.2.15
 
 # Arguments for matching host user UID/GID (default to 1000)

--- a/packages/agor-live/package-lock.json
+++ b/packages/agor-live/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.87",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.154",
+        "@anthropic-ai/sdk": "^0.100.0",
         "@feathersjs/authentication": "^5.0.41",
         "@feathersjs/authentication-client": "^5.0.41",
         "@feathersjs/authentication-local": "^5.0.41",
@@ -33,7 +34,7 @@
         "@oclif/plugin-help": "^6.2.37",
         "@octokit/auth-app": "^7.1.5",
         "@octokit/rest": "^22.0.0",
-        "@openai/codex-sdk": "^0.116.0",
+        "@openai/codex-sdk": "^0.135.0",
         "@opencode-ai/sdk": "^1.2.15",
         "@slack/socket-mode": "^2.0.5",
         "@slack/web-api": "^7.14.1",
@@ -116,38 +117,36 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.87",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.87.tgz",
-      "integrity": "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA==",
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.154.tgz",
+      "integrity": "sha512-iEn25urI2QrMPFIhId3h7v/7EG5gsmF7ooe+6EvsAosePeLmpVVerp5nXtHnlmBkMinLecurcPA+OddKw76jYw==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.74.0",
-        "@modelcontextprotocol/sdk": "^1.27.1"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.154",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.154"
       },
       "peerDependencies": {
-        "zod": "^4.0.0"
+        "zod": "^4.0.0",
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
-      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.0.tgz",
+      "integrity": "sha512-cAm3aXm6qAiHIvHxyIIGd6tVmsD2gDqlc2h0R20ijNUzGgVnIN822bit4mKbF6CkuV7qIrLQIPoAepHEpanrQQ==",
       "license": "MIT",
       "dependencies": {
+        "standardwebhooks": "^1.0.0",
         "json-schema-to-ts": "^3.1.1"
       },
       "bin": {
@@ -155,11 +154,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3106,9 +3100,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.116.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0.tgz",
-      "integrity": "sha512-K6q9P2ZmpnzGmpS6Ybjvsdtvu8AbJx3f/Z4KmjH1u85StSS9TWMSQB8z0PPObKMejbtiIkHwhGyEIHi4iBYjig==",
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0.tgz",
+      "integrity": "sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -3117,127 +3111,127 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.116.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.116.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.116.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.116.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.116.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.116.0-win32-x64"
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.135.0-linux-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.135.0-linux-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.135.0-darwin-x64",
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.135.0-darwin-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.135.0-win32-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.135.0-win32-arm64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
-      "name": "@openai/codex",
-      "version": "0.116.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0-darwin-arm64.tgz",
-      "integrity": "sha512-WkdL083p8uMeASpg8bwV0DPGgzkm48LjN3MyU2m/YukujbiLnknAmG29O2q2rFCLm0oLSDIGUK8EnXA4ZcAF9Q==",
+      "version": "0.135.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-arm64.tgz",
+      "integrity": "sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      },
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": ">=16"
-      }
+      "name": "@openai/codex",
+      "optional": true
     },
     "node_modules/@openai/codex-darwin-x64": {
-      "name": "@openai/codex",
-      "version": "0.116.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0-darwin-x64.tgz",
-      "integrity": "sha512-Ax8uTwYSNIwGrzcNRcn0jJQhZzNcKGDbbn00Emde7gGOemjSLhRALjUaKjckAaW5xWnNqHTGdtzzPB4phNlDYg==",
+      "version": "0.135.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-darwin-x64.tgz",
+      "integrity": "sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      },
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": ">=16"
-      }
+      "name": "@openai/codex",
+      "optional": true
     },
     "node_modules/@openai/codex-linux-arm64": {
-      "name": "@openai/codex",
-      "version": "0.116.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0-linux-arm64.tgz",
-      "integrity": "sha512-X7cL8rBSGDB+RSZc2FoKiqcMVeLPMmo06bkss/en4lLQsV1XG2DZI56WuXg92IOX3SjYl6Av/eOWgsb1t3UeLQ==",
+      "version": "0.135.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-arm64.tgz",
+      "integrity": "sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      },
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">=16"
-      }
+      "name": "@openai/codex",
+      "optional": true
     },
     "node_modules/@openai/codex-linux-x64": {
-      "name": "@openai/codex",
-      "version": "0.116.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0-linux-x64.tgz",
-      "integrity": "sha512-S9InOgJT3tj6uQp55NqrCA1k5tklwFaH00JdC2ElbRmxchm7ard4WxHSJZX9TiY8enj4cQoLIC04NFTUCO+/PQ==",
+      "version": "0.135.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-linux-x64.tgz",
+      "integrity": "sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      },
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">=16"
-      }
+      "name": "@openai/codex",
+      "optional": true
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.116.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.116.0.tgz",
-      "integrity": "sha512-qrn1Pu5G1GJ9w4m/Lk3L3466ulMGG9SfyR0LPAaXdisuQI1rqgoUOuoZ4byX7cCzn0x1g2+WPc0apZgjMEK04Q==",
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.135.0.tgz",
+      "integrity": "sha512-4FziwR9RmYexAkAUqnWBQRUcFGWpBeBwDJpJKlabnuUXxaKQtBtKMTEYBA27ymn8W6mxxDMmwZC+inw7foFFaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.116.0"
+        "@openai/codex": "0.135.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@openai/codex-win32-arm64": {
-      "name": "@openai/codex",
-      "version": "0.116.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0-win32-arm64.tgz",
-      "integrity": "sha512-kX2oAUzkgZX9OsYpd4omv9IGf+9VWj4Vy3UtIAnQKBu1DTSzmTJmXDuDn87mkyUciSZadm2QbeqQQzm2NC0NYw==",
+      "version": "0.135.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-arm64.tgz",
+      "integrity": "sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      },
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": ">=16"
-      }
+      "name": "@openai/codex",
+      "optional": true
     },
     "node_modules/@openai/codex-win32-x64": {
-      "name": "@openai/codex",
-      "version": "0.116.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.116.0-win32-x64.tgz",
-      "integrity": "sha512-6sBIMOoA9FNuxQvCCnK0P548Wqrlk3I9SMdtOCUg2zYzYU7jOF2mWS1VpRQ6R+Jvo2x50dxeJZ+W37dBmXfprw==",
+      "version": "0.135.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.135.0-win32-x64.tgz",
+      "integrity": "sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      },
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
-      "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": ">=16"
-      }
+      "name": "@openai/codex",
+      "optional": true
     },
     "node_modules/@opencode-ai/sdk": {
       "version": "1.3.3",
@@ -11913,6 +11907,132 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.154.tgz",
+      "integrity": "sha512-oFW3LD5lYrKAU+AKu27Z8hrzqkrh362qQrwi/i3DxGcud9BXUycsXYjShpDj3D3JZu169UzZuSPhx1Wajmbiwg==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "arm64"
+      ],
+      "os": [
+        "darwin"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.154.tgz",
+      "integrity": "sha512-5BgWEueP+cqoctWjZYhCbyltuaV/N2DmKDXD3/69cKaVmJp8XL9OCzlq/HEirA/+Ssjskx6hDUBaOcpuZ3iwQA==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "darwin"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.154.tgz",
+      "integrity": "sha512-rRkW4SBL3W7zQvKscCIfIGlmoeuTbMV6dXFbPdmpRGvmYZIs79RpzO6xrGBnnhmm+B7znQ9oHAnffi/2FBgJbA==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "arm64"
+      ],
+      "os": [
+        "linux"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.154.tgz",
+      "integrity": "sha512-o2bCQN4Xn3UqCLErC5m4T7u0yYArJYmgFCUFnA6K96DdW2RERvx+gTKXxWuHEBkDO+eMoHLHLxk0u2jGES00Ng==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "arm64"
+      ],
+      "os": [
+        "linux"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.154.tgz",
+      "integrity": "sha512-GpiFF8Ez6PbM3m0gqtCo/FKM346qyRdP7VhbmJzdnbNKTiiUZ66vDQyEUPZPCG24ZkrG4m96KpRIUwY08rHiNg==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "linux"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.154.tgz",
+      "integrity": "sha512-zA7S8Lm6O4QBsUpbhiOht8BgiXHOBBFUIo8ZLK6r5wAatK3Q44syWVxICeyCnR6wqfnkf3cugCw27ycS6vVgaA==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "linux"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.154.tgz",
+      "integrity": "sha512-cDW1YFbU/PJFlrGXhlAGcbkXt80sEO6WtnH8nN8YHXLn5NWduy2q7o/qC6i8XozgvRGf6t/eMoH7IasGIEDhDw==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "arm64"
+      ],
+      "os": [
+        "win32"
+      ],
+      "optional": true
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.154",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.154.tgz",
+      "integrity": "sha512-tSKaIIpL72OPg3WfzZTCIl8OJgcbq4qieu8/fDWjsdeQuari9gQMIuEflFphk9HqNsxpSmDqKi8Sm5mW2V566Q==",
+      "license": "SEE LICENSE IN README.md",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "win32"
+      ],
+      "optional": true
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     }
   }
 }

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -46,7 +46,8 @@
   },
   "dependencies": {
     "@agor-live/client": "workspace:*",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.154",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@cursor/sdk": "^1.0.13",
     "@feathersjs/authentication": "^5.0.44",
     "@feathersjs/authentication-client": "^5.0.44",
@@ -68,7 +69,7 @@
     "@oclif/plugin-help": "^6.2.49",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.133.0",
+    "@openai/codex-sdk": "^0.135.0",
     "@opencode-ai/sdk": "^1.2.20",
     "@slack/socket-mode": "^2.0.7",
     "@slack/types": "^2.21.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -317,7 +317,8 @@
     "db:migrate:mcp": "tsx src/db/scripts/migrate-add-mcp-tables.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.154",
+    "@anthropic-ai/sdk": "^0.100.0",
     "@feathersjs/authentication": "^5.0.44",
     "@feathersjs/authentication-client": "^5.0.44",
     "@feathersjs/authentication-local": "^5.0.44",
@@ -334,7 +335,7 @@
     "@libsql/client": "^0.17.3",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.133.0",
+    "@openai/codex-sdk": "^0.135.0",
     "@opencode-ai/sdk": "^1.2.20",
     "@slack/socket-mode": "^2.0.7",
     "@slack/types": "^2.21.1",

--- a/packages/core/src/claude-cli/event-types.ts
+++ b/packages/core/src/claude-cli/event-types.ts
@@ -30,7 +30,7 @@ export interface JsonlLineCommon {
   timestamp?: string;
   /** The CLI session UUID — same value across every line in the file. */
   sessionId?: string;
-  /** `claude` binary version (e.g. "2.1.132"). */
+  /** `claude` binary version (e.g. "2.1.154"). */
   version?: string;
   /** Working dir the session was launched from. */
   cwd?: string;

--- a/packages/core/src/claude-cli/path-utils.ts
+++ b/packages/core/src/claude-cli/path-utils.ts
@@ -7,7 +7,7 @@
  *
  * `<slug>` is the working directory the session was launched from, with every
  * `/` and `.` replaced by `-`. This rule was verified live on
- * `claude` v2.1.132 against multiple paths.
+ * `claude` v2.1.154 against multiple paths.
  *
  * See docs/internal/claude-code-cli-integration-analysis-2026-05-14.md
  * (Appendix A) for the live session sample these helpers were validated

--- a/packages/core/src/claude-cli/spawn-config.ts
+++ b/packages/core/src/claude-cli/spawn-config.ts
@@ -1,7 +1,7 @@
 /**
  * Build the argv for spawning the `claude` shell binary in a Zellij pane.
  *
- * Verified against `claude` v2.1.132. We use the **interactive** subset of
+ * Verified against `claude` v2.1.154. We use the **interactive** subset of
  * flags (NO `-p`/`--print`) — see the analysis doc's "Policy & ToS landscape"
  * section for why the print-mode path is deliberately avoided.
  *
@@ -10,7 +10,7 @@
  *   --session-id <uuid>            REQUIRED. Maps agor.session_id ↔ claude session.
  *   --resume <id>                  Resume an existing session by id.
  *   --fork-session                 With --resume, mint a new session-id.
- *   --model <alias>                e.g. claude-opus-4-7. Stripped of [1m] suffix.
+ *   --model <alias>                e.g. claude-opus-4-8. Stripped of [1m] suffix.
  *   --betas <flag>                 e.g. context-1m-2025-08-07 (only with [1m] models).
  *   --effort <level>               low | medium | high | xhigh | max
  *   --permission-mode <mode>       default|acceptEdits|bypassPermissions|plan|dontAsk|auto.
@@ -84,7 +84,7 @@ export interface ClaudeCliSpawnConfig {
   displayName?: string;
 
   /**
-   * Model alias — `claude-opus-4-7`, `claude-sonnet-4-6`, etc. A trailing
+   * Model alias — `claude-opus-4-8`, `claude-sonnet-4-6`, etc. A trailing
    * `[1m]` suffix enables the 1M context window via the `context-1m-2025-08-07`
    * beta flag.
    */

--- a/packages/core/src/models/claude.ts
+++ b/packages/core/src/models/claude.ts
@@ -24,10 +24,17 @@ export interface ClaudeModel {
  */
 export const AVAILABLE_CLAUDE_MODEL_ALIASES: ClaudeModel[] = [
   {
+    id: 'claude-opus-4-8',
+    displayName: 'Claude Opus 4.8',
+    family: 'claude-4',
+    description:
+      'Most capable model for complex reasoning, long-horizon agentic coding, and high-autonomy work',
+  },
+  {
     id: 'claude-opus-4-7',
     displayName: 'Claude Opus 4.7',
     family: 'claude-4',
-    description: 'Most intelligent model for agents and coding',
+    description: 'Previous generation Opus model for agents and coding',
   },
   {
     id: 'claude-opus-4-7[1m]',
@@ -93,7 +100,7 @@ export const AVAILABLE_CLAUDE_MODEL_ALIASES: ClaudeModel[] = [
     id: 'claude-sonnet-4-0',
     displayName: 'Claude Sonnet 4.0',
     family: 'claude-4',
-    description: 'Legacy balanced model',
+    description: 'Deprecated legacy balanced model; prefer Sonnet 4.6',
   },
 ];
 

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -5,7 +5,7 @@
  */
 
 /** Default Codex model */
-export const DEFAULT_CODEX_MODEL = 'gpt-5.4';
+export const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 
 /** Codex Mini model (GPT-5-Codex-Mini for cost-effective usage) */
 export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
@@ -13,26 +13,37 @@ export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
 /**
  * Model metadata for UI display (single source of truth).
  *
- * Order matters — the UI dropdown renders models in this order,
- * and the first entry is used as the default for alias mode.
+ * Order matters — the UI dropdown renders models in this order.
  *
  * Uses `as const satisfies` to preserve literal key types for CodexModel.
  */
 const _CODEX_MODEL_METADATA = {
-  // GPT-5.5 models (newest — released 2026-04-23, codename "Spud")
+  // GPT-5.5 models (newest frontier model)
   'gpt-5.5': {
-    name: 'GPT-5.5',
+    name: 'GPT-5.5 (Recommended)',
     description:
-      "OpenAI's newest frontier model - complex coding, computer use, research. ChatGPT-auth only at launch; API access rolling out.",
+      "OpenAI's newest frontier model for complex coding, computer use, knowledge work, and research workflows in Codex.",
+  },
+  'gpt-5.5-pro': {
+    name: 'GPT-5.5 Pro',
+    description: 'Higher-compute GPT-5.5 variant for the toughest professional work',
   },
   // GPT-5.4 models
   'gpt-5.4': {
-    name: 'GPT-5.4 (Recommended)',
-    description: 'Most capable model - unified coding, reasoning, and computer use',
+    name: 'GPT-5.4',
+    description: 'Frontier model for professional work with strong coding and agentic workflows',
+  },
+  'gpt-5.4-pro': {
+    name: 'GPT-5.4 Pro',
+    description: 'Higher-compute GPT-5.4 variant for difficult reasoning tasks',
   },
   'gpt-5.4-mini': {
     name: 'GPT-5.4 Mini',
-    description: 'Smaller, faster GPT-5.4 variant',
+    description: 'Fast, efficient model for responsive coding tasks and subagents',
+  },
+  'gpt-5.4-nano': {
+    name: 'GPT-5.4 Nano',
+    description: 'Lowest-cost GPT-5.4-class model for simple high-volume tasks and subagents',
   },
   // GPT-5.3 models
   'gpt-5.3-codex': {
@@ -46,11 +57,11 @@ const _CODEX_MODEL_METADATA = {
   // GPT-5.2 models
   'gpt-5.2-codex': {
     name: 'GPT-5.2 Codex',
-    description: 'Advanced coding model optimized for agentic tasks - 400k context',
+    description: 'Deprecated coding model optimized for agentic tasks - 400k context',
   },
   'gpt-5.2': {
     name: 'GPT-5.2',
-    description: 'Best for complex tasks - 400k context, thinking mode',
+    description: 'Previous frontier model for complex tasks - 400k context, thinking mode',
   },
   'gpt-5.2-pro': {
     name: 'GPT-5.2 Pro',
@@ -63,15 +74,15 @@ const _CODEX_MODEL_METADATA = {
   // GPT-5.1 models
   'gpt-5.1-codex-max': {
     name: 'GPT-5.1 Codex Max',
-    description: 'Optimized for long-horizon agentic coding',
+    description: 'Deprecated model optimized for long-horizon agentic coding',
   },
   'gpt-5.1-codex': {
     name: 'GPT-5.1 Codex',
-    description: 'Optimized for agentic coding tasks',
+    description: 'Deprecated model optimized for agentic coding tasks',
   },
   'gpt-5.1-codex-mini': {
     name: 'GPT-5.1 Codex Mini',
-    description: 'Cost-effective variant with 4x more usage',
+    description: 'Deprecated cost-effective Codex variant',
   },
   'gpt-5.1': {
     name: 'GPT-5.1',
@@ -115,14 +126,17 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
 
 /**
  * Approximate context window limits for Codex-compatible OpenAI models.
- * Values mirror OpenAI's public docs (Dec 2025) and fall back to 200k if unknown.
+ * Values mirror OpenAI's public docs (May 2026) and fall back to 200k if unknown.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
-  // GPT-5.5 models (400k context in Codex; 1M in API when GA)
-  'gpt-5.5': 400_000,
+  // GPT-5.5 models
+  'gpt-5.5': 1_050_000,
+  'gpt-5.5-pro': 1_050_000,
   // GPT-5.4 models
   'gpt-5.4': 1_050_000,
+  'gpt-5.4-pro': 1_050_000,
   'gpt-5.4-mini': 400_000,
+  'gpt-5.4-nano': 400_000,
   // GPT-5.3 models
   'gpt-5.3-codex': 400_000,
   'gpt-5.3-codex-spark': 128_000,
@@ -137,7 +151,7 @@ export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
   'gpt-5.1-codex-mini': 200_000,
   'gpt-5.1': 200_000,
   // GPT-5 models (legacy)
-  'gpt-5-codex': 200_000,
+  'gpt-5-codex': 400_000,
   'gpt-5-codex-mini': 200_000,
   'gpt-5': 200_000,
   // GPT-4o models

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -96,7 +96,7 @@ describe('getDefaultModelForTool', () => {
   it('returns the static default for tools that have one', () => {
     expect(getDefaultModelForTool('claude-code')).toBe('claude-sonnet-4-6');
     expect(getDefaultModelForTool('claude-code-cli')).toBe('claude-sonnet-4-6');
-    expect(getDefaultModelForTool('codex')).toBe('gpt-5.4');
+    expect(getDefaultModelForTool('codex')).toBe('gpt-5.5');
     expect(getDefaultModelForTool('gemini')).toBe('gemini-2.0-flash');
     expect(getDefaultModelForTool('copilot')).toBe('claude-sonnet-4.6');
   });
@@ -123,7 +123,7 @@ describe('resolveModelConfigWithFallback', () => {
     const result = resolveModelConfigWithFallback('codex', [undefined, null], { now });
     expect(result).toEqual({
       mode: 'alias',
-      model: 'gpt-5.4',
+      model: 'gpt-5.5',
       updated_at: '2026-04-23T00:00:00.000Z',
     });
   });

--- a/packages/core/src/sessions/resolve-child-session-config.test.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.test.ts
@@ -54,7 +54,7 @@ describe('resolveChildSessionConfig', () => {
       });
       expect(r.model_config).toEqual({
         mode: 'alias',
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         updated_at: now.toISOString(),
       });
       expect(r.model_config?.model).not.toBe('claude-opus-4-7');

--- a/packages/executor/src/sdk-handlers/codex/models.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/models.test.ts
@@ -6,15 +6,18 @@ describe('getCodexContextWindowLimit', () => {
 
   it('returns expected limits for known Codex-compatible models', () => {
     const cases: Array<{ model: string; expected: number }> = [
-      { model: 'gpt-5.5', expected: 400_000 },
+      { model: 'gpt-5.5', expected: 1_050_000 },
+      { model: 'gpt-5.5-pro', expected: 1_050_000 },
       { model: 'gpt-5.4', expected: 1_050_000 },
+      { model: 'gpt-5.4-pro', expected: 1_050_000 },
       { model: 'gpt-5.4-mini', expected: 400_000 },
+      { model: 'gpt-5.4-nano', expected: 400_000 },
       { model: 'gpt-5.3-codex', expected: 400_000 },
       { model: 'gpt-5.3-codex-spark', expected: 128_000 },
       { model: 'gpt-5.1-codex', expected: defaultLimit },
       { model: 'gpt-5.1-codex-mini', expected: defaultLimit },
       { model: 'gpt-5.1', expected: defaultLimit },
-      { model: 'gpt-5-codex', expected: defaultLimit },
+      { model: 'gpt-5-codex', expected: 400_000 },
       { model: 'gpt-5-codex-mini', expected: defaultLimit },
       { model: 'gpt-5', expected: defaultLimit },
       { model: 'gpt-4o', expected: 128_000 },
@@ -40,7 +43,7 @@ describe('getCodexContextWindowLimit', () => {
 
   it('handles model identifiers case-insensitively', () => {
     expect(getCodexContextWindowLimit('GPT-4O')).toBe(128_000);
-    expect(getCodexContextWindowLimit('GpT-5-CoDeX')).toBe(defaultLimit);
+    expect(getCodexContextWindowLimit('GpT-5-CoDeX')).toBe(400_000);
   });
 
   it('returns default limit when model is undefined or null', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,11 @@ importers:
         version: 5.32.6
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.132
-        version: 0.2.132(zod@4.4.3)
+        specifier: ^0.3.154
+        version: 0.3.154(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(zod@4.4.3)
+      '@anthropic-ai/sdk':
+        specifier: ^0.100.0
+        version: 0.100.0(zod@4.4.3)
       '@types/compression':
         specifier: ^1.8.1
         version: 1.8.1
@@ -446,8 +449,11 @@ importers:
         specifier: workspace:*
         version: link:../client
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.132
-        version: 0.2.132(zod@4.4.3)
+        specifier: ^0.3.154
+        version: 0.3.154(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(zod@4.4.3)
+      '@anthropic-ai/sdk':
+        specifier: ^0.100.0
+        version: 0.100.0(zod@4.4.3)
       '@cursor/sdk':
         specifier: ^1.0.13
         version: 1.0.13
@@ -512,8 +518,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.133.0
-        version: 0.133.0
+        specifier: ^0.135.0
+        version: 0.135.0
       '@opencode-ai/sdk':
         specifier: ^1.2.20
         version: 1.14.33
@@ -660,8 +666,11 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.132
-        version: 0.2.132(zod@4.4.3)
+        specifier: ^0.3.154
+        version: 0.3.154(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(zod@4.4.3)
+      '@anthropic-ai/sdk':
+        specifier: ^0.100.0
+        version: 0.100.0(zod@4.4.3)
       '@feathersjs/authentication':
         specifier: ^5.0.44
         version: 5.0.44(typescript@5.9.3)
@@ -711,8 +720,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.133.0
-        version: 0.133.0
+        specifier: ^0.135.0
+        version: 0.135.0
       '@opencode-ai/sdk':
         specifier: ^1.2.20
         version: 1.14.33
@@ -901,54 +910,56 @@ packages:
   '@antfu/utils@9.3.0':
     resolution: {integrity: sha512-9hFT4RauhcUzqOE4f1+frMKLZrgNog5b06I7VmZQV1BkvwvqrbC8EBZf3L1eEL2AKb6rNKjER0sEvJiSP1FXEA==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.132':
-    resolution: {integrity: sha512-wrGxeqsnhw3JSU25v78FSw85guN0FGqLA7LuAzLe+KVZqJElJvhtae1ceCvgF8e8Bc/RUrniNxRrTur+8vIZYQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.154':
+    resolution: {integrity: sha512-oFW3LD5lYrKAU+AKu27Z8hrzqkrh362qQrwi/i3DxGcud9BXUycsXYjShpDj3D3JZu169UzZuSPhx1Wajmbiwg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.132':
-    resolution: {integrity: sha512-qiutRtM+cz6FPA2AX2fKaINkLpMO9W48d3s4CTcWPT014uJTRxZZRb5TBxnjdxRLIt6njsqvvvh0XzQLGpblBA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.154':
+    resolution: {integrity: sha512-5BgWEueP+cqoctWjZYhCbyltuaV/N2DmKDXD3/69cKaVmJp8XL9OCzlq/HEirA/+Ssjskx6hDUBaOcpuZ3iwQA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.132':
-    resolution: {integrity: sha512-Gu4JCAkXA/XChcrTixtnurSn445O/1EHt2TAlX/rq2gP/wCijKU3eQyZ+YWx2UMud0f9e+E4W/CHhwtCVzgqgw==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.154':
+    resolution: {integrity: sha512-o2bCQN4Xn3UqCLErC5m4T7u0yYArJYmgFCUFnA6K96DdW2RERvx+gTKXxWuHEBkDO+eMoHLHLxk0u2jGES00Ng==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.132':
-    resolution: {integrity: sha512-fWyjKRg+qfThhY9iI5GJRNtBW7qBoV20yn8kJ9RoKG4c6yn3Q+QJX+ybkfgXM45RyrO4SPmdhDeTCTG9LJSN3w==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.154':
+    resolution: {integrity: sha512-rRkW4SBL3W7zQvKscCIfIGlmoeuTbMV6dXFbPdmpRGvmYZIs79RpzO6xrGBnnhmm+B7znQ9oHAnffi/2FBgJbA==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.132':
-    resolution: {integrity: sha512-Ri7RQkbjOVox0TXTN4g04oiO5bU8WLCH9SdChxaZtS/K76Yu1vV6fYyB/wRoYWuvRLHjOANWUFIGs6O/wK5s0w==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.154':
+    resolution: {integrity: sha512-zA7S8Lm6O4QBsUpbhiOht8BgiXHOBBFUIo8ZLK6r5wAatK3Q44syWVxICeyCnR6wqfnkf3cugCw27ycS6vVgaA==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.132':
-    resolution: {integrity: sha512-AAThetjWjCRWQ7IcDTjXLltUB9DJS4S4HpPmTpCOM8muOFWOwpgTmOHe1DJc9uVXbAgFO/WEASDbD4qrsdn0rw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.154':
+    resolution: {integrity: sha512-GpiFF8Ez6PbM3m0gqtCo/FKM346qyRdP7VhbmJzdnbNKTiiUZ66vDQyEUPZPCG24ZkrG4m96KpRIUwY08rHiNg==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.132':
-    resolution: {integrity: sha512-8m5L6MlMqIzvx2V/J1gJwhXt9iMfXFvLOmtm1nhzyslc7czJWZQtHUQ8Tr/1rW32t2oEpXqrDhbjrlHgGp9xBQ==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.154':
+    resolution: {integrity: sha512-cDW1YFbU/PJFlrGXhlAGcbkXt80sEO6WtnH8nN8YHXLn5NWduy2q7o/qC6i8XozgvRGf6t/eMoH7IasGIEDhDw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.132':
-    resolution: {integrity: sha512-NNbAHtl/Bew6HUvOW8R27r/pwwctZbScGAKAxt/p4GiYa0oLKvxq/CGLv+wscRVlebeI0hA6DwC0DtnB0KnA1Q==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.154':
+    resolution: {integrity: sha512-tSKaIIpL72OPg3WfzZTCIl8OJgcbq4qieu8/fDWjsdeQuari9gQMIuEflFphk9HqNsxpSmDqKi8Sm5mW2V566Q==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.132':
-    resolution: {integrity: sha512-3hCkfbHi6d73QcNqgrjU9zXGdNs3BrwWnxV90p+DDFARtnwbszkkEm4nz9c80af3nzGBRVvKNZPVCqVaBrkO0g==}
+  '@anthropic-ai/claude-agent-sdk@0.3.154':
+    resolution: {integrity: sha512-iEn25urI2QrMPFIhId3h7v/7EG5gsmF7ooe+6EvsAosePeLmpVVerp5nXtHnlmBkMinLecurcPA+OddKw76jYw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': '>=1.27.1 <2'
       zod: ^4.3.6
 
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+  '@anthropic-ai/sdk@0.100.0':
+    resolution: {integrity: sha512-cAm3aXm6qAiHIvHxyIIGd6tVmsD2gDqlc2h0R20ijNUzGgVnIN822bit4mKbF6CkuV7qIrLQIPoAepHEpanrQQ==}
     hasBin: true
     peerDependencies:
       zod: ^4.3.6
@@ -2762,47 +2773,47 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
-  '@openai/codex-sdk@0.133.0':
-    resolution: {integrity: sha512-PB82D/1Q0C7nzaV5O+1O4y5LcVwiUvxyHvCUTfz8Cwztv6bOWQ40gFHE5ZFX1EFPJx1cMV0GPVODWuXIKAuayQ==}
+  '@openai/codex-sdk@0.135.0':
+    resolution: {integrity: sha512-4FziwR9RmYexAkAUqnWBQRUcFGWpBeBwDJpJKlabnuUXxaKQtBtKMTEYBA27ymn8W6mxxDMmwZC+inw7foFFaA==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.133.0':
-    resolution: {integrity: sha512-Gh42kLLBo/6gpnHmDzUWDVvyS57ekCB1+1Dz0RG2oIl3Lhk1uwrjSj/PwaJWWh4Rw/rUp1RqkwrMugFfFEOlqQ==}
+  '@openai/codex@0.135.0':
+    resolution: {integrity: sha512-ID75QEYmAT1WsUQmpxPlNsL5W1a+2eeD7fP6ywdwGseiXUG8D5i16L+dzbr8MT+2oTkaVqzOdvAqVOCeV/H/Bw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.133.0-darwin-arm64':
-    resolution: {integrity: sha512-W7f8+DckLujnqGlptKCzgJU+ooeHKMuk6KYgMFP6A9asn7YUsGUgJqjiBaX8oNcXO6w/pTbKGRARx1kCNS8lIg==}
+  '@openai/codex@0.135.0-darwin-arm64':
+    resolution: {integrity: sha512-wpNzssusKfrldVlq39+HyQh1wCyc9SQNpHdAFGKtPenrgRte4Ct8/oVsDtKWuFZsqLBFwbL4MrzrevnB63+9HA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.133.0-darwin-x64':
-    resolution: {integrity: sha512-Ek8ikvLOiXZ8emcIJVBXxK6fm8ratBy0kaEt3JNisTNszxGshUHf/R4xxDxIyKNcUkYYXjW7A/rMwW3iu3OFlg==}
+  '@openai/codex@0.135.0-darwin-x64':
+    resolution: {integrity: sha512-ZrjAqce23lbv9KfkYOhElf1lTI+SysXmyGM0FV5u4+PBCKPkkEs4eaS3H8Uig0i4bUSu1QylrOOCskzYhZ6VyQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.133.0-linux-arm64':
-    resolution: {integrity: sha512-uKXYYSJ3mY16sp4hcG/4BMNRjva/ZS4oARiI1+7k8+NiuoAhdCGWNe5u4KJ3sMuL3tp/IXcmc6B56EFX1+WDBQ==}
+  '@openai/codex@0.135.0-linux-arm64':
+    resolution: {integrity: sha512-dM+cv5ZL+BgIQzEIvMg9AxZ98n5lkKLgtp5zJLXWSrbCllbnUSqxYMUiWI5c1a1uBDUtkbY9fcGKXFLf+d+gyg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.133.0-linux-x64':
-    resolution: {integrity: sha512-9YfyqrfUj/UZ2+aXE4zBz47t6RXbVni95ZorGsNh857vxYK/asVpUtR2cymo9lB3JaI4mQaKFfV/t7IRItqkuA==}
+  '@openai/codex@0.135.0-linux-x64':
+    resolution: {integrity: sha512-5EosY67yU28UJSnl/obdN2F1CDaimYbzm9SLR8dwwzkeBBnY6dHgAKJ2GTu9Nc8CmgmtVFBGzgPqehsIcueVvA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.133.0-win32-arm64':
-    resolution: {integrity: sha512-mRzND0PSGHRoLk0X41GTSoc3tFjZSF4HgDlfjU5fiQcWVi0/kLb7Ku6/tPFT/X2hOLa3YdJkbIcHC0Hc9ni80g==}
+  '@openai/codex@0.135.0-win32-arm64':
+    resolution: {integrity: sha512-SAeR+CUv7KWwE6eTc2UFaFjo6FpHywYfDFKrK6FqLms1rq1NPju2SoX7rhM6UEew/lUx2mdZv/LDs11s/N/Qgg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.133.0-win32-x64':
-    resolution: {integrity: sha512-u3ji78DIPZCGJeELuovsAnaZH+vK9gsA4F6M1y+Uy2s80Sz7/i1S0KL81qGReYji3urSjgBpkQuNP47GXOqxrQ==}
+  '@openai/codex@0.135.0-win32-x64':
+    resolution: {integrity: sha512-uYwUBMbOfmVlCESJZmZsOG+cYwNFYvkMbQ+FB6C1u9RYz0m3mZeYNN0j+l1hRSyUgPMFJHzNpgNx1Usal5QZFQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -3887,6 +3898,9 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6063,6 +6077,9 @@ packages:
 
   fast-levenshtein@3.0.0:
     resolution: {integrity: sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -8666,6 +8683,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   static-browser-server@1.0.3:
     resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
 
@@ -9657,51 +9677,49 @@ snapshots:
 
   '@antfu/utils@9.3.0': {}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.132':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.154':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.132(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.154(@anthropic-ai/sdk@0.100.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.100.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.132
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.132
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.154
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.154
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
 
@@ -11999,35 +12017,35 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
-  '@openai/codex-sdk@0.133.0':
+  '@openai/codex-sdk@0.135.0':
     dependencies:
-      '@openai/codex': 0.133.0
+      '@openai/codex': 0.135.0
 
-  '@openai/codex@0.133.0':
+  '@openai/codex@0.135.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.133.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.133.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.133.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.133.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.133.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.133.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.135.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.135.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.135.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.135.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.135.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.135.0-win32-x64'
 
-  '@openai/codex@0.133.0-darwin-arm64':
+  '@openai/codex@0.135.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.133.0-darwin-x64':
+  '@openai/codex@0.135.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.133.0-linux-arm64':
+  '@openai/codex@0.135.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.133.0-linux-x64':
+  '@openai/codex@0.135.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.133.0-win32-arm64':
+  '@openai/codex@0.135.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.133.0-win32-x64':
+  '@openai/codex@0.135.0-win32-x64':
     optional: true
 
   '@opencode-ai/sdk@1.14.33':
@@ -13215,6 +13233,8 @@ snapshots:
       tslib: 2.8.1
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -15661,6 +15681,8 @@ snapshots:
   fast-levenshtein@3.0.0:
     dependencies:
       fastest-levenshtein: 1.0.16
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -19271,6 +19293,11 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   static-browser-server@1.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Refreshes Claude/Codex-only package pins:
  - `@anthropic-ai/claude-code` Docker CLI: `2.1.132` → `2.1.154`
  - `@anthropic-ai/claude-agent-sdk`: `0.2.132` → `0.3.154`
  - `@anthropic-ai/sdk`: explicit `0.100.0`
  - `@openai/codex` Docker CLI: `0.128.0` → `0.135.0`
  - `@openai/codex-sdk`: `0.133.0` → `0.135.0`
- Adds Claude Opus 4.8 (`claude-opus-4-8`) to the Claude model registry while keeping Sonnet 4.6 as the safe/default Claude model.
- Updates Codex model metadata/defaults for GPT-5.5/GPT-5.4 variants, including `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.4-pro`, and `gpt-5.4-nano`; Codex default moves from `gpt-5.4` to `gpt-5.5`.
- Leaves Gemini, Cursor, Copilot, and OpenCode dependency/model pins untouched per Max's scope clarification.

## Notes

- I did not make Opus 4.8 the Claude default; that stays `claude-sonnet-4-6` for safety/cost/backward compatibility.
- I did not add an Agor `[1m]` alias for Opus 4.8 because Anthropic's current docs describe Opus 4.8 as supporting 1M context by default. Existing `[1m]` aliases for prior models remain.

## Validation

- `pnpm check:agor-live-deps`
- `pnpm --filter @agor/core test -- src/models/resolve-config.test.ts src/sessions/resolve-child-session-config.test.ts src/models/lint-model-tool-match.test.ts`
- `pnpm --filter @agor/core test -- src/client/claude-system-suppression.test.ts src/claude-cli/spawn-config.test.ts`
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/codex/usage.test.ts`
- `pnpm exec tsx -e "...codex model smoke..."`
- `pnpm exec biome check --diagnostic-level=warn ...changed TS files...`
- `git diff --check`

Known validation limitation:

- `pnpm --filter @agor/executor test -- src/sdk-handlers/codex/models.test.ts` currently fails before running tests because `packages/core/dist` is absent and the executor re-export imports `@agor/core/models`. I did not run a build because repo guidance says agents should not run `pnpm build`; I validated the underlying core Codex model utility via the `tsx` smoke check instead.
