### PR TITLE
fix(auth): gate trusted launch email linking

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -3,7 +3,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
-import { createDatabase, eq, initializeDatabase, select, users } from '@agor/core/db';
+import {
+  createDatabase,
+  eq,
+  generateId,
+  hash,
+  initializeDatabase,
+  insert,
+  select,
+  users,
+} from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import type { User, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
@@ -82,6 +91,38 @@ function makeUsersService(db: Database) {
       };
     },
   };
+}
+
+async function seedLocalUser(
+  db: Database,
+  overrides: Partial<{
+    email: string;
+    name: string;
+    role: User['role'];
+  }> = {}
+): Promise<UserID> {
+  const userId = generateId() as UserID;
+  const now = new Date();
+
+  await insert(db, users)
+    .values({
+      user_id: userId,
+      email: overrides.email ?? 'person@example.test',
+      password: await hash('password', 10),
+      name: overrides.name ?? 'Existing Local User',
+      emoji: '👤',
+      role: overrides.role ?? 'member',
+      created_at: now,
+      updated_at: now,
+      onboarding_completed: false,
+      must_change_password: false,
+      data: {
+        preferences: {},
+      },
+    })
+    .run();
+
+  return userId;
 }
 
 describe('one-time launch auth service', () => {
@@ -247,5 +288,53 @@ describe('one-time launch auth service', () => {
     expect(second.user.user_id).not.toBe(first.user.user_id);
     expect(second.user.email).not.toBe('same@example.test');
     expect(second.user.email).toContain('+launch-');
+  });
+
+  it('does not link by email when trusted linking is disabled by default', async () => {
+    const existingUserId = await seedLocalUser(db, { email: 'person@example.test' });
+
+    mockExchange(signClaims({ email_verified: true }));
+    const result = await service().create({ launchCode: 'first' });
+
+    expect(result.user.user_id).not.toBe(existingUserId);
+    expect(result.user.email).toContain('+launch-');
+  });
+
+  it('links an existing local user by email when enabled and email is verified', async () => {
+    const existingUserId = await seedLocalUser(db, { email: 'person@example.test' });
+
+    mockExchange(signClaims({ email_verified: true, name: 'Verified Launch User' }));
+    const result = await service({
+      external_launch: {
+        ...baseConfig().external_launch,
+        trust_verified_email_for_linking: true,
+      },
+    }).create({ launchCode: 'first' });
+
+    expect(result.user.user_id).toBe(existingUserId);
+    expect(result.user.email).toBe('person@example.test');
+
+    const row = await select(db).from(users).where(eq(users.user_id, existingUserId)).one();
+    expect(row).toBeTruthy();
+    const externalIdentities = (row?.data as { external_identities?: Array<{ email?: string }> })
+      .external_identities;
+    expect(externalIdentities).toEqual(
+      expect.arrayContaining([expect.objectContaining({ email: 'person@example.test' })])
+    );
+  });
+
+  it('does not link an existing local user by email when email is unverified', async () => {
+    const existingUserId = await seedLocalUser(db, { email: 'person@example.test' });
+
+    mockExchange(signClaims({ email_verified: false }));
+    const result = await service({
+      external_launch: {
+        ...baseConfig().external_launch,
+        trust_verified_email_for_linking: true,
+      },
+    }).create({ launchCode: 'first' });
+
+    expect(result.user.user_id).not.toBe(existingUserId);
+    expect(result.user.email).toContain('+launch-');
   });
 });

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -28,6 +28,7 @@ interface ResolvedLaunchSettings {
   devSharedSecret?: string;
   serviceCredential?: string;
   allowAdminRoles: boolean;
+  trustVerifiedEmailForLinking: boolean;
   requestTimeoutMs: number;
   algorithms?: string[];
 }
@@ -46,6 +47,7 @@ interface LaunchClaims extends JwtPayload {
   picture?: string;
   avatar?: string;
   role?: string;
+  email_verified?: boolean;
   provider?: string;
   instance_id?: string;
   runtime_instance_id?: string;
@@ -99,6 +101,7 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
     devSharedSecret: process.env[sharedSecretEnv] || raw?.dev_shared_secret,
     serviceCredential: process.env[serviceTokenEnv] || raw?.service_credential,
     allowAdminRoles: raw?.allow_admin_roles === true,
+    trustVerifiedEmailForLinking: raw?.trust_verified_email_for_linking === true,
     requestTimeoutMs: raw?.request_timeout_ms ?? DEFAULT_TIMEOUT_MS,
     algorithms: raw?.algorithms,
   };
@@ -222,6 +225,76 @@ async function findUserByExternalIdentity(
   return null;
 }
 
+function shouldTrustVerifiedEmailForLinking(
+  settings: ResolvedLaunchSettings,
+  claims: LaunchClaims,
+  email: string | undefined
+): email is string {
+  return (
+    settings.trustVerifiedEmailForLinking &&
+    claims.email_verified === true &&
+    typeof email === 'string'
+  );
+}
+
+async function findTrustedEmailLinkCandidate(
+  db: Database,
+  settings: ResolvedLaunchSettings,
+  claims: LaunchClaims,
+  email: string | undefined
+): Promise<typeof users.$inferSelect | null> {
+  if (!shouldTrustVerifiedEmailForLinking(settings, claims, email)) return null;
+
+  const existing = await select(db).from(users).where(eq(users.email, email)).one();
+  if (!existing) return null;
+
+  const identities = getExternalIdentities(existing.data as UserDataWithExternalIdentities);
+  return identities.length === 0 ? existing : null;
+}
+
+async function updateLaunchUser(
+  options: LaunchAuthServiceOptions,
+  existing: typeof users.$inferSelect,
+  identity: StoredExternalIdentity,
+  settings: ResolvedLaunchSettings,
+  claims: LaunchClaims,
+  now: Date,
+  avatar: string | undefined,
+  name: string | undefined
+): Promise<User> {
+  const { db, config, usersService } = options;
+  const role = mapRole(
+    claims.role,
+    settings,
+    config.execution?.allow_superadmin,
+    normalizeRole(existing.role ?? undefined)
+  );
+  const data = (existing.data ?? {}) as UserDataWithExternalIdentities;
+  const identities = getExternalIdentities(data);
+  const nextIdentities = identities.map((existingIdentity) =>
+    existingIdentity.key === identity.key ? { ...existingIdentity, ...identity } : existingIdentity
+  );
+  if (!nextIdentities.some((existingIdentity) => existingIdentity.key === identity.key)) {
+    nextIdentities.push(identity);
+  }
+
+  await update(db, users)
+    .set({
+      name: name ?? existing.name,
+      role,
+      updated_at: now,
+      data: {
+        ...data,
+        avatar: avatar ?? data.avatar,
+        external_identities: nextIdentities,
+      },
+    })
+    .where(eq(users.user_id, existing.user_id))
+    .run();
+
+  return usersService.get(existing.user_id as UserID, { provider: undefined });
+}
+
 async function upsertLaunchUser(
   options: LaunchAuthServiceOptions,
   claims: LaunchClaims
@@ -249,36 +322,26 @@ async function upsertLaunchUser(
 
   const existing = await findUserByExternalIdentity(db, key);
   if (existing) {
-    const role = mapRole(
-      claims.role,
+    return updateLaunchUser(options, existing, identity, settings, claims, now, avatar, name);
+  }
+
+  const trustedEmailLinkCandidate = await findTrustedEmailLinkCandidate(
+    db,
+    settings,
+    claims,
+    email
+  );
+  if (trustedEmailLinkCandidate) {
+    return updateLaunchUser(
+      options,
+      trustedEmailLinkCandidate,
+      identity,
       settings,
-      config.execution?.allow_superadmin,
-      normalizeRole(existing.role ?? undefined)
+      claims,
+      now,
+      avatar,
+      name
     );
-    const data = (existing.data ?? {}) as UserDataWithExternalIdentities;
-    const identities = getExternalIdentities(data);
-    const nextIdentities = identities.map((existingIdentity) =>
-      existingIdentity.key === key ? { ...existingIdentity, ...identity } : existingIdentity
-    );
-    if (!nextIdentities.some((existingIdentity) => existingIdentity.key === key)) {
-      nextIdentities.push(identity);
-    }
-
-    await update(db, users)
-      .set({
-        name: name ?? existing.name,
-        role,
-        updated_at: now,
-        data: {
-          ...data,
-          avatar: avatar ?? data.avatar,
-          external_identities: nextIdentities,
-        },
-      })
-      .where(eq(users.user_id, existing.user_id))
-      .run();
-
-    return usersService.get(existing.user_id as UserID, { provider: undefined });
   }
 
   const role = mapRole(claims.role, settings, config.execution?.allow_superadmin);

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -222,6 +222,12 @@ export interface AgorExternalLaunchSettings {
 
   /** Allow launch assertions to assign admin/superadmin roles (default: false). */
   allow_admin_roles?: boolean;
+
+  /**
+   * Allow verified assertion emails to link to an existing same-email local user
+   * that has no external identity yet (default: false).
+   */
+  trust_verified_email_for_linking?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a config-gated trusted verified-email linking path for one-time launch auth
- only reuse an existing same-email local user when the assertion explicitly marks the email as verified and the local user has no external identities yet
- add regression tests covering default aliasing, enabled verified linking, and unverified fallback behavior

## Testing
- pnpm --filter @agor/daemon test -- src/auth/launch-auth.test.ts
- pnpm --filter @agor/core typecheck\n- pnpm --filter @agor/daemon typecheck\n- pnpm --filter @agor/core build\n- pnpm --filter @agor/daemon build