### PR TITLE
docs(agor-cloud): swap Join the Beta + Book a Demo CTA URLs

### DIFF
--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -11,10 +11,12 @@ export const GITHUB_REPO_URL = 'https://github.com/preset-io/agor';
 export const GITHUB_DISCUSSIONS_URL = 'https://github.com/preset-io/agor/discussions';
 export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';
 
-// Agor Cloud private beta interest form. Same URL used inline in the
-// agor-cloud / agor-openclaw blog posts — update those in tandem.
+// Agor Cloud private beta sign-up link (HubSpot meetings).
+// Consumed by CloudInviteCTA, which is used in the agor-cloud blog post.
+// Note: agor-openclaw.mdx still has an inline link to the legacy Google
+// Forms URL and is intentionally not kept in tandem here.
 export const AGOR_CLOUD_INVITE_URL =
-  'https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog';
+  'https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-?uuid=a1e65b59-dd57-4f53-ab21-9e07be1daf92';
 
 // Agor Cloud demo / contact form (hosted on the Preset marketing site).
 export const AGOR_CLOUD_DEMO_URL = 'https://preset.io/contact-us-about-agor/';

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -11,12 +11,11 @@ export const GITHUB_REPO_URL = 'https://github.com/preset-io/agor';
 export const GITHUB_DISCUSSIONS_URL = 'https://github.com/preset-io/agor/discussions';
 export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';
 
-// Agor Cloud private beta sign-up link (HubSpot meetings).
-// Consumed by CloudInviteCTA, which is used in the agor-cloud blog post.
-// Note: agor-openclaw.mdx still has an inline link to the legacy Google
-// Forms URL and is intentionally not kept in tandem here.
+// Agor Cloud private beta interest form. Same URL used inline in the
+// agor-cloud / agor-openclaw blog posts — update those in tandem.
 export const AGOR_CLOUD_INVITE_URL =
-  'https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-?uuid=a1e65b59-dd57-4f53-ab21-9e07be1daf92';
+  'https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog';
 
-// Agor Cloud demo / contact form (hosted on the Preset marketing site).
-export const AGOR_CLOUD_DEMO_URL = 'https://preset.io/contact-us-about-agor/';
+// Agor Cloud demo / contact link (HubSpot meetings scheduler).
+export const AGOR_CLOUD_DEMO_URL =
+  'https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-?uuid=a1e65b59-dd57-4f53-ab21-9e07be1daf92';

--- a/apps/agor-docs/lib/links.ts
+++ b/apps/agor-docs/lib/links.ts
@@ -11,11 +11,12 @@ export const GITHUB_REPO_URL = 'https://github.com/preset-io/agor';
 export const GITHUB_DISCUSSIONS_URL = 'https://github.com/preset-io/agor/discussions';
 export const GITHUB_ISSUES_URL = 'https://github.com/preset-io/agor/issues';
 
-// Agor Cloud private beta interest form. Same URL used inline in the
-// agor-cloud / agor-openclaw blog posts — update those in tandem.
-export const AGOR_CLOUD_INVITE_URL =
-  'https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog';
+// Agor Cloud private beta interest form (Preset landing page, replaces
+// the legacy Google Forms link). Consumed by CloudInviteCTA in the
+// agor-cloud blog post. Note: agor-openclaw.mdx still has an inline
+// link to the legacy Google Forms URL and is not updated here.
+export const AGOR_CLOUD_INVITE_URL = 'https://preset.io/contact-us-about-agor/';
 
 // Agor Cloud demo / contact link (HubSpot meetings scheduler).
 export const AGOR_CLOUD_DEMO_URL =
-  'https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-?uuid=a1e65b59-dd57-4f53-ab21-9e07be1daf92';
+  'https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-';


### PR DESCRIPTION
## Summary

Updates both Agor Cloud blog post CTAs in `apps/agor-docs/lib/links.ts` per marketer direction. `CloudInviteCTA` (the only consumer of these constants) renders both CTAs in `agor-cloud.mdx`.

### Link changes

| CTA | Constant | Old | New |
| --- | --- | --- | --- |
| Join the Private Beta | `AGOR_CLOUD_INVITE_URL` | `https://docs.google.com/forms/d/e/1FAIpQLSdXtZwQBHaLFa1LYHvOHXq9IUF_Qm3T12Hr6UZcMdEvjpm2PQ/viewform?usp=dialog` | `https://preset.io/contact-us-about-agor/` |
| Book a Demo | `AGOR_CLOUD_DEMO_URL` | `https://preset.io/contact-us-about-agor/` | `https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-` |

### Follow-up

`apps/agor-docs/pages/blog/agor-openclaw.mdx` still has an inline link to the legacy Google Forms URL. Intentionally left untouched here (scoped to agor-cloud), but worth a follow-up if we want to retire the form globally.

### Commit history

This PR has three iterative commits as the intended mapping was clarified. Net diff vs `main` is just the two URL swaps shown above. Squash on merge.

## Test plan

- [ ] In the rendered Agor Cloud blog post, click "Join the Private Beta →" — opens `https://preset.io/contact-us-about-agor/`.
- [ ] Click "Book a Demo →" — opens `https://meetings.hubspot.com/zane-aitken/agor-cloud-sign-up-link-`.
- [ ] `pnpm prettier --check apps/agor-docs/lib/links.ts` passes.

Generated with [Claude Code](https://claude.com/claude-code)