### PR TITLE
Make boards assistant-centric

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -199,6 +199,11 @@ export interface BoardsServiceImpl extends Service<Board, Partial<Board>, Feathe
   toYaml(boardId: string, params?: FeathersParams): Promise<string>;
   fromYaml(yamlContent: string, params?: FeathersParams): Promise<Board>;
   clone(boardId: string, newName: string, params?: FeathersParams): Promise<Board>;
+  setPrimaryAssistant(
+    data: { id?: string; boardId?: string; branchId: string },
+    params?: FeathersParams
+  ): Promise<Board>;
+  clearPrimaryAssistant(boardId: string, params?: FeathersParams): Promise<Board>;
   archive(id: string, params?: FeathersParams): Promise<Board>;
   unarchive(id: string, params?: FeathersParams): Promise<Board>;
 }

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1978,7 +1978,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 // Load branch to check others_fs_access
                 try {
                   const branch = await branchRepository.findById(session.branch_id);
-                  if (!branch || !branch.others_fs_access || branch.others_fs_access === 'none') {
+                  if (!branch?.others_fs_access || branch.others_fs_access === 'none') {
                     return context;
                   }
 
@@ -2323,6 +2323,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       fromBlob: [requireMinimumRole(ROLES.MEMBER, 'import boards')],
       fromYaml: [requireMinimumRole(ROLES.MEMBER, 'import boards')],
       clone: [requireMinimumRole(ROLES.MEMBER, 'clone boards')],
+      setPrimaryAssistant: [requireMinimumRole(ROLES.MEMBER, 'set primary assistant')],
+      clearPrimaryAssistant: [requireMinimumRole(ROLES.MEMBER, 'clear primary assistant')],
     },
     after: {
       // Strip private artifact objects from board.objects for non-owners
@@ -2415,6 +2417,22 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         async (context: HookContext<Board>) => {
           if (context.result) {
             app.service('boards').emit('created', context.result);
+          }
+          return context;
+        },
+      ],
+      setPrimaryAssistant: [
+        async (context: HookContext<Board>) => {
+          if (context.result) {
+            app.service('boards').emit('patched', context.result);
+          }
+          return context;
+        },
+      ],
+      clearPrimaryAssistant: [
+        async (context: HookContext<Board>) => {
+          if (context.result) {
+            app.service('boards').emit('patched', context.result);
           }
           return context;
         },

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -263,6 +263,8 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
         'toYaml',
         'fromYaml',
         'clone',
+        'setPrimaryAssistant',
+        'clearPrimaryAssistant',
       ],
     });
     app.use('/board-objects', createBoardObjectsService(db));

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -102,6 +102,28 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
   }
 
   /**
+   * Custom method: Set the board's primary assistant branch.
+   */
+  async setPrimaryAssistant(
+    data: { boardId?: string; id?: string; branchId?: string } | string,
+    branchIdOrParams?: string | BoardParams,
+    _maybeParams?: BoardParams
+  ): Promise<Board> {
+    const boardId = typeof data === 'string' ? data : (data.boardId ?? data.id);
+    const branchId = typeof data === 'string' ? branchIdOrParams : data.branchId;
+    if (!boardId) throw new Error('Board ID required');
+    if (!branchId || typeof branchId !== 'string') throw new Error('Branch ID required');
+    return this.boardRepo.setPrimaryAssistant(boardId, branchId);
+  }
+
+  /**
+   * Custom method: Clear the board's primary assistant branch.
+   */
+  async clearPrimaryAssistant(boardId: string, _params?: BoardParams): Promise<Board> {
+    return this.boardRepo.clearPrimaryAssistant(boardId);
+  }
+
+  /**
    * Custom method: Batch upsert board objects
    */
   async batchUpsertBoardObjects(

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -43,6 +43,71 @@ function createRenderEnvHarness(opts: {
   return { service, reposGet, patchSpy };
 }
 
+function createPatchHarness(opts: {
+  current: Record<string, unknown>;
+  updated: Record<string, unknown>;
+}) {
+  const boardObjectsService = {
+    find: vi.fn(async () => ({ data: [] })),
+    findByBranchId: vi.fn(async () => null),
+    create: vi.fn(async () => ({ object_id: 'obj-1' })),
+    remove: vi.fn(async () => ({})),
+  };
+  const boardsService = {
+    get: vi.fn(async () => ({ objects: {} })),
+    emit: vi.fn(),
+  };
+  const branchesFindService = {
+    find: vi.fn(async () => []),
+  };
+  const app = {
+    service(path: string) {
+      if (path === 'board-objects') return boardObjectsService;
+      if (path === 'boards') return boardsService;
+      if (path === 'branches') return branchesFindService;
+      throw new Error(`Unknown service: ${path}`);
+    },
+  } as unknown as Application;
+
+  const branchId = opts.current.branch_id as BranchID;
+  const repository = {
+    findById: vi.fn(async () => opts.current),
+    update: vi.fn(async () => opts.updated),
+    create: vi.fn(),
+    findAll: vi.fn(async () => []),
+    delete: vi.fn(),
+  };
+  const boardRepo = {
+    clearPrimaryAssistantIfMatches: vi.fn(async () => ({
+      board_id: opts.current.board_id,
+      primary_assistant_id: undefined,
+    })),
+    setPrimaryAssistantIfUnset: vi.fn(async () => ({
+      board_id: opts.updated.board_id,
+      primary_assistant_id: branchId,
+    })),
+  };
+  const service = new BranchesService({} as never, app);
+  (service as unknown as { repository: typeof repository }).repository = repository;
+  (service as unknown as { boardRepo: typeof boardRepo }).boardRepo = boardRepo;
+  (service as unknown as { branchRepo: { enrichWithZoneInfo: typeof vi.fn } }).branchRepo = {
+    enrichWithZoneInfo: vi.fn(async (branch) => branch),
+  } as never;
+  vi.spyOn(service as never, 'computeDefaultBoardPositionForBranch').mockResolvedValue({
+    x: 10,
+    y: 20,
+  });
+
+  return { service, repository, boardRepo, boardObjectsService, boardsService, branchId };
+}
+
+const assistantContext = {
+  assistant: {
+    kind: 'assistant',
+    displayName: 'Assistant',
+  },
+};
+
 function createServiceHarness() {
   const boardObjectsService = {
     find: vi.fn(async () => ({ data: [] })),
@@ -74,6 +139,112 @@ function createServiceHarness() {
   const service = new BranchesService({} as never, app);
   return { service, boardObjectsService, sessionsService };
 }
+
+describe('BranchesService.patch primary assistant invariants', () => {
+  it('clears the old primary and sets the new board primary when an assistant moves boards', async () => {
+    const boardA = 'board-a' as BoardID;
+    const boardB = 'board-b' as BoardID;
+    const branchId = 'assistant-1' as BranchID;
+    const { service, boardRepo, boardObjectsService, boardsService } = createPatchHarness({
+      current: {
+        branch_id: branchId,
+        board_id: boardA,
+        custom_context: assistantContext,
+      },
+      updated: {
+        branch_id: branchId,
+        board_id: boardB,
+        custom_context: assistantContext,
+      },
+    });
+
+    await service.patch(branchId, { board_id: boardB });
+
+    expect(boardRepo.clearPrimaryAssistantIfMatches).toHaveBeenCalledWith(boardA, branchId);
+    expect(boardRepo.setPrimaryAssistantIfUnset).toHaveBeenCalledWith(boardB, branchId);
+    expect(boardsService.emit).toHaveBeenCalledWith(
+      'patched',
+      expect.objectContaining({ board_id: boardA })
+    );
+    expect(boardsService.emit).toHaveBeenCalledWith(
+      'patched',
+      expect.objectContaining({ board_id: boardB })
+    );
+    expect(boardObjectsService.create).toHaveBeenCalledWith({
+      board_id: boardB,
+      branch_id: branchId,
+      position: { x: 10, y: 20 },
+    });
+  });
+
+  it('clears the primary pointer when an assistant is archived in place', async () => {
+    const boardId = 'board-a' as BoardID;
+    const branchId = 'assistant-archive' as BranchID;
+    const { service, boardRepo } = createPatchHarness({
+      current: {
+        branch_id: branchId,
+        board_id: boardId,
+        archived: false,
+        custom_context: assistantContext,
+      },
+      updated: {
+        branch_id: branchId,
+        board_id: boardId,
+        archived: true,
+        custom_context: assistantContext,
+      },
+    });
+
+    await service.patch(branchId, { archived: true });
+
+    expect(boardRepo.clearPrimaryAssistantIfMatches).toHaveBeenCalledWith(boardId, branchId);
+    expect(boardRepo.setPrimaryAssistantIfUnset).not.toHaveBeenCalled();
+  });
+
+  it('rejects converting a normal branch into an assistant', async () => {
+    const boardId = 'board-a' as BoardID;
+    const branchId = 'branch-1' as BranchID;
+    const { service, repository } = createPatchHarness({
+      current: {
+        branch_id: branchId,
+        board_id: boardId,
+        custom_context: {},
+      },
+      updated: {
+        branch_id: branchId,
+        board_id: boardId,
+        custom_context: assistantContext,
+      },
+    });
+
+    await expect(service.patch(branchId, { custom_context: assistantContext })).rejects.toThrow(
+      /cannot be converted/i
+    );
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects converting an assistant into a normal branch', async () => {
+    const boardId = 'board-a' as BoardID;
+    const branchId = 'assistant-2' as BranchID;
+    const { service, repository } = createPatchHarness({
+      current: {
+        branch_id: branchId,
+        board_id: boardId,
+        custom_context: assistantContext,
+      },
+      updated: {
+        branch_id: branchId,
+        board_id: boardId,
+        custom_context: { assistant: null },
+      },
+    });
+
+    await expect(service.patch(branchId, { custom_context: { assistant: null } })).rejects.toThrow(
+      /cannot be converted/i
+    );
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+});
 
 describe('BranchesService.unarchive', () => {
   it('preserves existing board_id when options.boardId is not provided', async () => {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -18,7 +18,7 @@ import {
   type Database,
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
-import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   BoardID,
@@ -302,6 +302,113 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
   }
 
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      !(value instanceof Date) &&
+      Object.getPrototypeOf(value) === Object.prototype
+    );
+  }
+
+  /**
+   * Mirrors BranchRepository's patch merge semantics so we can reject
+   * assistant/non-assistant conversions before the repository writes them.
+   */
+  private mergePatchPreview(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>
+  ): Record<string, unknown> {
+    const result = { ...target };
+
+    for (const key in source) {
+      if (!Object.hasOwn(source, key)) continue;
+
+      const sourceValue = source[key];
+      const targetValue = target[key];
+
+      if (sourceValue === undefined) continue;
+      if (sourceValue === null || Array.isArray(sourceValue)) {
+        result[key] = sourceValue;
+        continue;
+      }
+
+      if (this.isPlainObject(sourceValue) && this.isPlainObject(targetValue)) {
+        result[key] = this.mergePatchPreview(targetValue, sourceValue);
+        continue;
+      }
+
+      result[key] = sourceValue;
+    }
+
+    return result;
+  }
+
+  private assertAssistantKindIsStable(currentBranch: Branch, patchData: Partial<Branch>): void {
+    const wouldBeBranch = this.mergePatchPreview(
+      currentBranch as unknown as Record<string, unknown>,
+      patchData as Record<string, unknown>
+    ) as unknown as Branch;
+    if (isAssistant(currentBranch) === isAssistant(wouldBeBranch)) return;
+
+    throw new BadRequest(
+      'Branches cannot be converted between assistant and non-assistant types. Create a new branch or assistant instead.'
+    );
+  }
+
+  private async maintainPrimaryAssistantAfterPatch(
+    previousBranch: Branch,
+    updatedBranch: Branch
+  ): Promise<void> {
+    const oldBoardId = previousBranch.board_id;
+    const newBoardId = updatedBranch.board_id;
+    const wasAssistant = isAssistant(previousBranch);
+    const isNowAssistant = isAssistant(updatedBranch);
+
+    const shouldClearOldPrimary = Boolean(
+      oldBoardId &&
+        wasAssistant &&
+        (oldBoardId !== newBoardId || !isNowAssistant || updatedBranch.archived === true)
+    );
+
+    const shouldSetNewPrimary = Boolean(
+      newBoardId &&
+        isNowAssistant &&
+        updatedBranch.archived !== true &&
+        (oldBoardId !== newBoardId || previousBranch.archived === true)
+    );
+
+    if (!shouldClearOldPrimary && !shouldSetNewPrimary) return;
+
+    try {
+      if (shouldClearOldPrimary) {
+        const updatedOldBoard = await this.boardRepo.clearPrimaryAssistantIfMatches(
+          oldBoardId!,
+          previousBranch.branch_id
+        );
+        if (updatedOldBoard) {
+          this.app.service('boards').emit('patched', updatedOldBoard);
+        }
+      }
+
+      if (shouldSetNewPrimary) {
+        const updatedNewBoard = await this.boardRepo.setPrimaryAssistantIfUnset(
+          newBoardId!,
+          updatedBranch.branch_id
+        );
+        if (updatedNewBoard) {
+          this.app.service('boards').emit('patched', updatedNewBoard);
+        }
+      }
+    } catch (error) {
+      console.warn(
+        `⚠️ Failed to maintain primary assistant pointer for branch ${updatedBranch.branch_id}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
   /**
    * Override patch to handle board_objects when board_id changes.
    *
@@ -314,14 +421,17 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     data: Partial<Branch>,
     params?: BranchParams
   ): Promise<BranchWithZoneAndSessions> {
-    // Get current branch to check if board_id is changing
+    // Get current branch to check type/board changes
     const currentBranch = await super.get(id, params);
+    this.assertAssistantKindIsStable(currentBranch, data);
+
     const oldBoardId = currentBranch.board_id;
     const boardIdProvided = Object.hasOwn(data, 'board_id');
     const newBoardId = data.board_id;
 
     // Call parent patch
     const updatedBranch = (await super.patch(id, data, params)) as Branch;
+    await this.maintainPrimaryAssistantAfterPatch(currentBranch, updatedBranch);
 
     // Handle board_objects changes if board_id changed
     if (!boardIdProvided) {
@@ -340,35 +450,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     if (oldBoardId !== newBoardId) {
       const boardObjectsService = this.getBoardObjectsService();
-
-      if (isAssistant(currentBranch)) {
-        try {
-          if (oldBoardId) {
-            const updatedOldBoard = await this.boardRepo.clearPrimaryAssistantIfMatches(
-              oldBoardId,
-              currentBranch.branch_id
-            );
-            if (updatedOldBoard) {
-              this.app.service('boards').emit('patched', updatedOldBoard);
-            }
-          }
-
-          if (newBoardId && isAssistant(updatedBranch)) {
-            const updatedNewBoard = await this.boardRepo.setPrimaryAssistantIfUnset(
-              newBoardId,
-              updatedBranch.branch_id
-            );
-            if (updatedNewBoard) {
-              this.app.service('boards').emit('patched', updatedNewBoard);
-            }
-          }
-        } catch (error) {
-          console.warn(
-            `⚠️ Failed to maintain primary assistant pointer for branch ${id}:`,
-            error instanceof Error ? error.message : String(error)
-          );
-        }
-      }
 
       try {
         // First, check if a board_object already exists

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -11,7 +11,12 @@ import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { ENVIRONMENT, isBranchRbacEnabled, loadConfig, PAGINATION } from '@agor/core/config';
-import { BranchRepository, type BranchWithZoneAndSessions, type Database } from '@agor/core/db';
+import {
+  BoardRepository,
+  BranchRepository,
+  type BranchWithZoneAndSessions,
+  type Database,
+} from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
 import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
@@ -24,7 +29,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { ROLES } from '@agor/core/types';
+import { isAssistant, ROLES } from '@agor/core/types';
 import { getGidFromGroupName, spawnEnvironmentCommand } from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
@@ -68,6 +73,7 @@ interface ManagedProcess {
  */
 export class BranchesService extends DrizzleService<Branch, Partial<Branch>, BranchParams> {
   private branchRepo: BranchRepository;
+  private boardRepo: BoardRepository;
   private db: Database;
   private app: Application;
   private processes = new Map<BranchID, ManagedProcess>();
@@ -91,6 +97,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     });
 
     this.branchRepo = branchRepo;
+    this.boardRepo = new BoardRepository(db);
     this.db = db;
     this.app = app;
   }
@@ -266,10 +273,34 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       const withDefaults = await Promise.all(
         data.map((item) => this.applyBranchCreateDefaults(item))
       );
-      return super.create(withDefaults, params) as Promise<Branch[]>;
+      const created = (await super.create(withDefaults, params)) as Branch[];
+      await Promise.all(created.map((branch) => this.maybeSetBoardPrimaryAssistant(branch)));
+      return created;
     }
     const withDefaults = await this.applyBranchCreateDefaults(data);
-    return super.create(withDefaults, params) as Promise<Branch>;
+    const created = (await super.create(withDefaults, params)) as Branch;
+    await this.maybeSetBoardPrimaryAssistant(created);
+    return created;
+  }
+
+  private async maybeSetBoardPrimaryAssistant(branch: Branch): Promise<void> {
+    if (!branch.board_id || !isAssistant(branch)) return;
+
+    try {
+      const board = await this.boardRepo.findById(branch.board_id);
+      if (!board || board.primary_assistant_id) return;
+
+      const updatedBoard = await this.boardRepo.setPrimaryAssistant(
+        branch.board_id,
+        branch.branch_id
+      );
+      this.app.service('boards').emit('patched', updatedBoard);
+    } catch (error) {
+      console.warn(
+        `⚠️ Failed to set primary assistant for board ${branch.board_id}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
   }
 
   /**

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -287,14 +287,13 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     if (!branch.board_id || !isAssistant(branch)) return;
 
     try {
-      const board = await this.boardRepo.findById(branch.board_id);
-      if (!board || board.primary_assistant_id) return;
-
-      const updatedBoard = await this.boardRepo.setPrimaryAssistant(
+      const updatedBoard = await this.boardRepo.setPrimaryAssistantIfUnset(
         branch.board_id,
         branch.branch_id
       );
-      this.app.service('boards').emit('patched', updatedBoard);
+      if (updatedBoard) {
+        this.app.service('boards').emit('patched', updatedBoard);
+      }
     } catch (error) {
       console.warn(
         `⚠️ Failed to set primary assistant for board ${branch.board_id}:`,
@@ -341,6 +340,35 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     if (oldBoardId !== newBoardId) {
       const boardObjectsService = this.getBoardObjectsService();
+
+      if (isAssistant(currentBranch)) {
+        try {
+          if (oldBoardId) {
+            const updatedOldBoard = await this.boardRepo.clearPrimaryAssistantIfMatches(
+              oldBoardId,
+              currentBranch.branch_id
+            );
+            if (updatedOldBoard) {
+              this.app.service('boards').emit('patched', updatedOldBoard);
+            }
+          }
+
+          if (newBoardId && isAssistant(updatedBranch)) {
+            const updatedNewBoard = await this.boardRepo.setPrimaryAssistantIfUnset(
+              newBoardId,
+              updatedBranch.branch_id
+            );
+            if (updatedNewBoard) {
+              this.app.service('boards').emit('patched', updatedNewBoard);
+            }
+          }
+        } catch (error) {
+          console.warn(
+            `⚠️ Failed to maintain primary assistant pointer for branch ${id}:`,
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+      }
 
       try {
         // First, check if a board_object already exists

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1354,6 +1354,7 @@ function AppContent() {
       onUserSettingsClose={handleUserSettingsClose}
       openNewBranchModal={openNewBranch}
       onNewBranchModalClose={handleNewBranchModalClose}
+      suppressLeftPanel={onboardingWizardOpen}
       onCreateSession={handleCreateSession}
       onForkSession={handleForkSession}
       onBtwForkSession={handleBtwForkSession}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -332,8 +332,8 @@ export const App: React.FC<AppProps> = ({
 
   // Comments panel size persistence (percentage of available width)
   const [commentsPanelSize, setCommentsPanelSize] = useLocalStorage<number>(
-    'agor:commentsPanelSize',
-    25
+    'agor:leftPanelSize',
+    32
   );
 
   const leftPanelCollapsed = commentsPanelCollapsed || suppressLeftPanel;
@@ -996,7 +996,7 @@ export const App: React.FC<AppProps> = ({
                   defaultSize={leftPanelCollapsed ? 0 : commentsPanelSize}
                   collapsedSize={0}
                   minSize={leftPanelCollapsed ? 0 : 15}
-                  maxSize={40}
+                  maxSize={45}
                 >
                   {!leftPanelCollapsed && (
                     <BoardAssistantPanel

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -333,7 +333,7 @@ export const App: React.FC<AppProps> = ({
   // Comments panel size persistence (percentage of available width)
   const [commentsPanelSize, setCommentsPanelSize] = useLocalStorage<number>(
     'agor:leftPanelSize',
-    32
+    24
   );
 
   const leftPanelCollapsed = commentsPanelCollapsed || suppressLeftPanel;

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -106,6 +106,7 @@ export interface AppProps {
   onUserSettingsClose?: () => void; // Called when user settings modal closes
   openNewBranchModal?: boolean; // Open new branch modal
   onNewBranchModalClose?: () => void; // Called when new branch modal closes
+  suppressLeftPanel?: boolean; // Temporarily hide the assistant/comments panel behind modal-first flows
   onCreateSession?: (config: NewSessionConfig, boardId: string) => Promise<string | null>;
   onForkSession?: (sessionId: string, prompt: string) => Promise<void>;
   onBtwForkSession?: (sessionId: string, prompt: string) => Promise<void>;
@@ -214,6 +215,7 @@ export const App: React.FC<AppProps> = ({
   onUserSettingsClose,
   openNewBranchModal,
   onNewBranchModalClose,
+  suppressLeftPanel = false,
   onCreateSession,
   onForkSession,
   onBtwForkSession,
@@ -334,6 +336,8 @@ export const App: React.FC<AppProps> = ({
     25
   );
 
+  const leftPanelCollapsed = commentsPanelCollapsed || suppressLeftPanel;
+
   // Ref for programmatically controlling the comments panel
   const commentsPanelRef = useRef<ImperativePanelHandle>(null);
   // Session panel size persistence (percentage of available width)
@@ -391,16 +395,16 @@ export const App: React.FC<AppProps> = ({
   // Subscribed globally so it fires regardless of which session panel is open.
   useTaskCompletionChime(client, user?.user_id, user?.preferences?.audio);
 
-  // Programmatically collapse/expand the comments panel when toggle state changes
+  // Programmatically collapse/expand the left panel when toggle/suppression state changes
   useEffect(() => {
     if (commentsPanelRef.current) {
-      if (commentsPanelCollapsed) {
+      if (leftPanelCollapsed) {
         commentsPanelRef.current.collapse();
       } else {
         commentsPanelRef.current.expand();
       }
     }
-  }, [commentsPanelCollapsed]);
+  }, [leftPanelCollapsed]);
 
   // URL state synchronization - bidirectional sync between URL and state
   useUrlState({
@@ -978,7 +982,7 @@ export const App: React.FC<AppProps> = ({
                 style={{ flex: 1 }}
                 onLayout={(sizes) => {
                   // Save left panel size when user resizes (only when panel is open)
-                  if (!commentsPanelCollapsed && sizes.length >= 2) {
+                  if (!leftPanelCollapsed && sizes.length >= 2) {
                     // Comments panel is the first panel (index 0)
                     setCommentsPanelSize(sizes[0]);
                   }
@@ -989,12 +993,12 @@ export const App: React.FC<AppProps> = ({
                   order={1}
                   ref={commentsPanelRef}
                   collapsible
-                  defaultSize={commentsPanelCollapsed ? 0 : commentsPanelSize}
+                  defaultSize={leftPanelCollapsed ? 0 : commentsPanelSize}
                   collapsedSize={0}
-                  minSize={commentsPanelCollapsed ? 0 : 15}
+                  minSize={leftPanelCollapsed ? 0 : 15}
                   maxSize={40}
                 >
-                  {!commentsPanelCollapsed && (
+                  {!leftPanelCollapsed && (
                     <BoardAssistantPanel
                       client={client}
                       board={currentBoard || null}
@@ -1041,20 +1045,20 @@ export const App: React.FC<AppProps> = ({
                 </Panel>
                 <PanelResizeHandle
                   style={{
-                    width: commentsPanelCollapsed ? '0px' : '4px',
+                    width: leftPanelCollapsed ? '0px' : '4px',
                     background: 'var(--ant-color-border-secondary)',
-                    cursor: commentsPanelCollapsed ? 'default' : 'col-resize',
+                    cursor: leftPanelCollapsed ? 'default' : 'col-resize',
                     transition: 'background 0.2s',
-                    pointerEvents: commentsPanelCollapsed ? 'none' : 'auto',
+                    pointerEvents: leftPanelCollapsed ? 'none' : 'auto',
                   }}
                   onMouseEnter={(e) => {
-                    if (!commentsPanelCollapsed) {
+                    if (!leftPanelCollapsed) {
                       (e.currentTarget as unknown as HTMLDivElement).style.background =
                         'var(--ant-color-primary)';
                     }
                   }}
                   onMouseLeave={(e) => {
-                    if (!commentsPanelCollapsed) {
+                    if (!leftPanelCollapsed) {
                       (e.currentTarget as unknown as HTMLDivElement).style.background =
                         'var(--ant-color-border-secondary)';
                     }
@@ -1063,7 +1067,7 @@ export const App: React.FC<AppProps> = ({
                 <Panel
                   id="content-panel"
                   order={2}
-                  defaultSize={commentsPanelCollapsed ? 100 : 100 - commentsPanelSize}
+                  defaultSize={leftPanelCollapsed ? 100 : 100 - commentsPanelSize}
                   minSize={40}
                 >
                   <PanelGroup

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -51,10 +51,10 @@ import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { AppHeader } from '../AppHeader';
-import { BranchListDrawer } from '../BranchListDrawer';
+import type { BoardAssistantPanelTab } from '../BoardAssistantPanel';
+import { BoardAssistantPanel } from '../BoardAssistantPanel';
 import { BranchModal, type BranchModalTab } from '../BranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
-import { CommentsPanel } from '../CommentsPanel';
 import { CreateDialog, type CreateDialogProgress } from '../CreateDialog';
 import type { AssistantTabResult } from '../CreateDialog/tabs/AssistantTab';
 import type { BranchTabConfig } from '../CreateDialog/tabs/BranchTab';
@@ -267,11 +267,15 @@ export const App: React.FC<AppProps> = ({
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionBranchId, setNewSessionBranchId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createDialogDefaultTab, setCreateDialogDefaultTab] = useState<
+    'branch' | 'assistant' | 'board' | 'repository'
+  >('branch');
   const [newBranchDefaultPosition, setNewBranchDefaultPosition] = useState<{
     x: number;
     y: number;
   } | null>(null);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const autoOpenedAssistantBoardRef = useRef<string | null>(null);
   // Active URL deep-link target (branch or artifact). Folds into the
   // unified dashed "selected" outline alongside `selectedSessionId` —
   // both answer "what am I looking at right now?" so they share one
@@ -297,7 +301,7 @@ export const App: React.FC<AppProps> = ({
     [selectedSessionId, sessionById]
   );
 
-  const [listDrawerOpen, setListDrawerOpen] = useState(false);
+  const [leftPanelTab, setLeftPanelTab] = useState<BoardAssistantPanelTab>('assistant');
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
 
   // Settings modal state via URL routing
@@ -321,7 +325,7 @@ export const App: React.FC<AppProps> = ({
   // Initialize comments panel state from localStorage (collapsed by default)
   const [commentsPanelCollapsed, setCommentsPanelCollapsed] = useLocalStorage<boolean>(
     'agor:commentsPanelCollapsed',
-    true
+    false
   );
 
   // Comments panel size persistence (percentage of available width)
@@ -491,6 +495,7 @@ export const App: React.FC<AppProps> = ({
   // render — that propagated into the canvas's `initialNodes` useMemo deps
   // and triggered a full node-list recompute on every socket event.
   const handleOpenCommentsPanel = useCallback(() => {
+    setLeftPanelTab('comments');
     setCommentsPanelCollapsed(false);
   }, [setCommentsPanelCollapsed]);
 
@@ -740,6 +745,32 @@ export const App: React.FC<AppProps> = ({
 
   const sessionSettingsSession = sessionSettingsId ? sessionById.get(sessionSettingsId) : null;
   const currentBoard = boardById.get(currentBoardId);
+  const primaryAssistantId = currentBoard?.primary_assistant_id ?? null;
+  const primaryAssistantBranch = primaryAssistantId
+    ? branchById.get(primaryAssistantId)
+    : undefined;
+  const primaryAssistantRepo = primaryAssistantBranch
+    ? repoById.get(primaryAssistantBranch.repo_id)
+    : undefined;
+  const primaryAssistantInaccessible = Boolean(primaryAssistantId && !primaryAssistantBranch);
+
+  useEffect(() => {
+    if (!currentBoard || !primaryAssistantBranch || effectiveSelectedSessionId) return;
+    if (autoOpenedAssistantBoardRef.current === currentBoard.board_id) return;
+    const latestSession = (sessionsByBranch.get(primaryAssistantBranch.branch_id) || [])
+      .filter((session) => !session.archived)
+      .sort((a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime())[0];
+    if (latestSession) {
+      autoOpenedAssistantBoardRef.current = currentBoard.board_id;
+      navigation.goToSession(latestSession.session_id);
+    }
+  }, [
+    currentBoard,
+    primaryAssistantBranch,
+    sessionsByBranch,
+    effectiveSelectedSessionId,
+    navigation,
+  ]);
 
   // Update browser tab title based on current board
   useBoardTitle(currentBoard);
@@ -889,8 +920,11 @@ export const App: React.FC<AppProps> = ({
               currentUserId={user?.user_id}
               connected={connected}
               connecting={connecting}
-              onMenuClick={() => setListDrawerOpen(true)}
-              onCommentsClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
+              onMenuClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
+              onCommentsClick={() => {
+                setLeftPanelTab('comments');
+                setCommentsPanelCollapsed(false);
+              }}
               onEventStreamClick={() => {
                 // If session is open, close it and show event stream
                 if (effectiveSelectedSessionId) {
@@ -952,7 +986,7 @@ export const App: React.FC<AppProps> = ({
                 }}
               >
                 <Panel
-                  id="comments-panel"
+                  id="assistant-panel"
                   order={1}
                   ref={commentsPanelRef}
                   collapsible
@@ -962,18 +996,44 @@ export const App: React.FC<AppProps> = ({
                   maxSize={40}
                 >
                   {!commentsPanelCollapsed && (
-                    <CommentsPanel
+                    <BoardAssistantPanel
                       client={client}
-                      boardId={currentBoardId || ''}
+                      board={currentBoard || null}
+                      activeTab={leftPanelTab}
+                      onTabChange={setLeftPanelTab}
+                      primaryAssistantBranch={primaryAssistantBranch}
+                      primaryAssistantRepo={primaryAssistantRepo}
+                      primaryAssistantInaccessible={primaryAssistantInaccessible}
+                      sessionsByBranch={sessionsByBranch}
+                      branchById={branchById}
+                      repoById={repoById}
+                      userById={userById}
+                      currentUserId={user?.user_id}
+                      selectedSessionId={effectiveSelectedSessionId}
+                      onSessionClick={handleSessionClick}
+                      onCreateSession={setNewSessionBranchId}
+                      onForkSession={onForkSession}
+                      onSpawnSession={onSpawnSession}
+                      onArchiveOrDelete={onArchiveOrDeleteBranch}
+                      onOpenSettings={(branchId, tab) => {
+                        setBranchModalBranchId(branchId);
+                        setBranchModalTab(tab);
+                      }}
+                      onOpenSessionSettings={setSessionSettingsId}
+                      onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
+                      onStartEnvironment={onStartEnvironment}
+                      onStopEnvironment={onStopEnvironment}
+                      onViewLogs={setLogsModalBranchId}
+                      onNukeEnvironment={onNukeEnvironment}
+                      onExecuteScheduleNow={onExecuteScheduleNow}
+                      onCreateAssistant={() => {
+                        setCreateDialogDefaultTab('assistant');
+                        setCreateDialogOpen(true);
+                      }}
                       comments={mapToArray(commentById).filter(
                         (c: BoardComment) => c.board_id === currentBoardId
                       )}
-                      userById={userById}
-                      currentUserId={user?.user_id || 'unknown'}
                       boardObjects={currentBoard?.objects}
-                      branchById={branchById}
-                      collapsed={commentsPanelCollapsed}
-                      onToggleCollapse={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
                       onSendComment={(content) => onSendComment?.(currentBoardId || '', content)}
                       onReplyComment={onReplyComment}
                       onResolveComment={onResolveComment}
@@ -1038,6 +1098,7 @@ export const App: React.FC<AppProps> = ({
                           userById={userById}
                           repoById={repoById}
                           branches={boardBranches}
+                          primaryAssistantId={primaryAssistantId}
                           branchById={branchById}
                           boardObjectById={boardObjectById}
                           commentById={commentById}
@@ -1072,6 +1133,7 @@ export const App: React.FC<AppProps> = ({
                           onClick={() => {
                             const center = sessionCanvasRef.current?.getViewportCenter();
                             setNewBranchDefaultPosition(center || null);
+                            setCreateDialogDefaultTab('branch');
                             setCreateDialogOpen(true);
                           }}
                         />
@@ -1257,17 +1319,6 @@ export const App: React.FC<AppProps> = ({
               onSessionClick={handleSessionClick}
               onExecuteScheduleNow={onExecuteScheduleNow}
             />
-            <BranchListDrawer
-              open={listDrawerOpen}
-              onClose={() => setListDrawerOpen(false)}
-              boards={mapToArray(boardById)}
-              currentBoardId={currentBoardId}
-              onBoardChange={navigation.goToBoard}
-              sessionsByBranch={sessionsByBranch}
-              branchById={branchById}
-              repoById={repoById}
-              onSessionClick={handleSessionClick}
-            />
             <TerminalModal
               open={terminalOpen}
               onClose={handleCloseTerminal}
@@ -1280,8 +1331,10 @@ export const App: React.FC<AppProps> = ({
               open={createDialogOpen}
               onClose={() => {
                 setCreateDialogOpen(false);
+                setCreateDialogDefaultTab('branch');
                 setNewBranchDefaultPosition(null);
               }}
+              defaultTab={createDialogDefaultTab}
               repoById={repoById}
               boardById={boardById}
               currentBoardId={currentBoardId}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -594,7 +594,6 @@ export const App: React.FC<AppProps> = ({
         displayName: result.displayName,
         description: result.description,
         emoji: result.emoji,
-        boardChoice: result.boardChoice,
         repoId,
         branchName: result.branchName,
         sourceBranch: result.sourceBranch,
@@ -1026,10 +1025,6 @@ export const App: React.FC<AppProps> = ({
                       onViewLogs={setLogsModalBranchId}
                       onNukeEnvironment={onNukeEnvironment}
                       onExecuteScheduleNow={onExecuteScheduleNow}
-                      onCreateAssistant={() => {
-                        setCreateDialogDefaultTab('assistant');
-                        setCreateDialogOpen(true);
-                      }}
                       comments={mapToArray(commentById).filter(
                         (c: BoardComment) => c.board_id === currentBoardId
                       )}
@@ -1336,7 +1331,6 @@ export const App: React.FC<AppProps> = ({
               }}
               defaultTab={createDialogDefaultTab}
               repoById={repoById}
-              boardById={boardById}
               currentBoardId={currentBoardId}
               defaultPosition={newBranchDefaultPosition || undefined}
               onCreateBranch={handleCreateBranch}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -269,7 +269,7 @@ export const App: React.FC<AppProps> = ({
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createDialogDefaultTab, setCreateDialogDefaultTab] = useState<
     'branch' | 'assistant' | 'board' | 'repository'
-  >('branch');
+  >('assistant');
   const [newBranchDefaultPosition, setNewBranchDefaultPosition] = useState<{
     x: number;
     y: number;
@@ -1133,7 +1133,7 @@ export const App: React.FC<AppProps> = ({
                           onClick={() => {
                             const center = sessionCanvasRef.current?.getViewportCenter();
                             setNewBranchDefaultPosition(center || null);
-                            setCreateDialogDefaultTab('branch');
+                            setCreateDialogDefaultTab('assistant');
                             setCreateDialogOpen(true);
                           }}
                         />
@@ -1331,7 +1331,7 @@ export const App: React.FC<AppProps> = ({
               open={createDialogOpen}
               onClose={() => {
                 setCreateDialogOpen(false);
-                setCreateDialogDefaultTab('branch');
+                setCreateDialogDefaultTab('assistant');
                 setNewBranchDefaultPosition(null);
               }}
               defaultTab={createDialogDefaultTab}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -164,6 +164,11 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   const userEmoji = user?.emoji || '👤';
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
 
+  const headerIconButtonStyle = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as const;
   // Check if audio notifications are enabled
   const audioEnabled = user?.preferences?.audio?.enabled ?? false;
 
@@ -267,6 +272,17 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             See docs/disconnected-state-design.md. */}
         {currentBoardId && boards.length > 0 && (
           <>
+            {currentBoardName && (
+              <Tooltip title="Toggle board panel" placement="bottom">
+                <Button
+                  type="text"
+                  icon={<UnorderedListOutlined style={{ fontSize: token.fontSizeLG }} />}
+                  style={headerIconButtonStyle}
+                  onClick={onMenuClick}
+                  disabled={mutationDisabled}
+                />
+              </Tooltip>
+            )}
             <div style={{ minWidth: 200 }}>
               <BoardSwitcher
                 boards={boards}
@@ -283,27 +299,19 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           </>
         )}
         {currentBoardName && (
-          <Tooltip title="Toggle session drawer" placement="bottom">
-            <Button
-              type="text"
-              icon={<UnorderedListOutlined style={{ fontSize: token.fontSizeLG }} />}
-              onClick={onMenuClick}
-              disabled={mutationDisabled}
-            />
-          </Tooltip>
-        )}
-        {currentBoardName && (
           <Badge
             count={unreadCommentsCount}
             offset={[-2, 2]}
             style={{
               backgroundColor: hasUserMentions ? token.colorError : token.colorPrimaryBgHover,
             }}
+            className="app-header-icon-badge"
           >
-            <Tooltip title="Toggle comments panel" placement="bottom">
+            <Tooltip title="Show comments tab" placement="bottom">
               <Button
                 type="text"
                 icon={<CommentOutlined style={{ fontSize: token.fontSizeLG }} />}
+                style={headerIconButtonStyle}
                 onClick={onCommentsClick}
                 disabled={mutationDisabled}
               />
@@ -348,6 +356,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             <Button
               type="text"
               icon={<ApiOutlined style={{ fontSize: token.fontSizeLG }} />}
+              style={headerIconButtonStyle}
               onClick={onEventStreamClick}
               disabled={mutationDisabled}
             />
@@ -357,6 +366,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           <Button
             type="text"
             icon={<QuestionCircleOutlined style={{ fontSize: token.fontSizeLG }} />}
+            style={headerIconButtonStyle}
             href="https://agor.live/guide/getting-started"
             target="_blank"
             rel="noopener noreferrer"
@@ -367,6 +377,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           <Button
             type="text"
             icon={<SettingOutlined style={{ fontSize: token.fontSizeLG }} />}
+            style={headerIconButtonStyle}
             onClick={onSettingsClick}
             disabled={mutationDisabled}
           />
@@ -383,6 +394,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             <Button
               type="text"
               icon={<UserOutlined style={{ fontSize: token.fontSizeLG }} />}
+              style={headerIconButtonStyle}
               disabled={mutationDisabled}
             />
           </Tooltip>

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -71,6 +71,8 @@ interface AutocompleteTextareaProps {
   slashCommands?: string[];
   /** Available skills from the SDK (stored on session.custom_context) */
   skills?: string[];
+  /** Draw attention to the textarea while it is empty. */
+  highlightWhenEmpty?: boolean;
 }
 
 // Minimum characters required after : before showing emoji picker (like Slack)
@@ -251,6 +253,7 @@ export const AutocompleteTextarea = React.forwardRef<
       onFilesDrop,
       slashCommands = [],
       skills = [],
+      highlightWhenEmpty = false,
     },
     ref
   ) => {
@@ -929,6 +932,7 @@ export const AutocompleteTextarea = React.forwardRef<
     // Compute highlighted text
     const highlightColor = token.colorBgTextHover;
     const hasHighlights = value?.includes('@') ?? false;
+    const shouldHighlightEmpty = highlightWhenEmpty && !value.trim();
 
     return (
       <Popover
@@ -1040,8 +1044,12 @@ export const AutocompleteTextarea = React.forwardRef<
             autoSize={autoSize || { minRows: 2, maxRows: 10 }}
             className="agor-textarea agor-textarea-with-highlights"
             style={{
-              borderColor: token.colorBorder,
+              borderColor: shouldHighlightEmpty ? token.colorPrimary : token.colorBorder,
+              boxShadow: shouldHighlightEmpty
+                ? `0 0 0 ${token.controlOutlineWidth}px ${token.controlOutline}`
+                : undefined,
               backgroundColor: hasHighlights ? 'transparent' : undefined,
+              transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
               position: 'relative',
               zIndex: 1,
             }}

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -68,7 +68,6 @@ interface BoardAssistantPanelProps {
   onViewLogs?: (branchId: string) => void;
   onNukeEnvironment?: (branchId: string) => void;
   onExecuteScheduleNow?: (branchId: string) => Promise<void>;
-  onCreateAssistant?: () => void;
   comments?: BoardComment[];
   boardObjects?: Record<string, BoardObject>;
   onSendComment?: (content: string) => void;

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -1,0 +1,431 @@
+import type {
+  AgorClient,
+  Board,
+  BoardComment,
+  BoardObject,
+  Branch,
+  Repo,
+  Session,
+  SpawnConfig,
+  User,
+} from '@agor-live/client';
+import { getAssistantConfig, isAssistant } from '@agor-live/client';
+import { RobotOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  App as AntApp,
+  Button,
+  Empty,
+  Select,
+  Space,
+  Spin,
+  Tabs,
+  Typography,
+  theme,
+} from 'antd';
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { BranchSessionSections } from '../BranchCard';
+import { BranchHeaderPill } from '../BranchHeaderPill';
+import { BoardSessionList } from '../BranchListDrawer';
+import type { BranchModalTab } from '../BranchModal';
+import { CommentsPanel } from '../CommentsPanel';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import { CreatedByTag } from '../metadata';
+import { IssuePill, PullRequestPill } from '../Pill';
+
+export type BoardAssistantPanelTab = 'assistant' | 'all-sessions' | 'comments';
+
+interface BoardAssistantPanelProps {
+  board: Board | null;
+  activeTab?: BoardAssistantPanelTab;
+  onTabChange?: (tab: BoardAssistantPanelTab) => void;
+  primaryAssistantBranch?: Branch;
+  primaryAssistantRepo?: Repo;
+  primaryAssistantInaccessible: boolean;
+  sessionsByBranch: Map<string, Session[]>;
+  branchById: Map<string, Branch>;
+  repoById: Map<string, Repo>;
+  userById: Map<string, User>;
+  currentUserId?: string;
+  selectedSessionId?: string | null;
+  onSessionClick: (sessionId: string) => void;
+  onCreateSession?: (branchId: string) => void;
+  onForkSession?: (sessionId: string, prompt: string) => Promise<void>;
+  onSpawnSession?: (sessionId: string, config: string | Partial<SpawnConfig>) => Promise<void>;
+  onArchiveOrDelete?: (
+    branchId: string,
+    options: {
+      metadataAction: 'archive' | 'delete';
+      filesystemAction: 'preserved' | 'cleaned' | 'deleted';
+    }
+  ) => void;
+  onOpenSettings?: (branchId: string, tab?: BranchModalTab) => void;
+  onOpenSessionSettings?: (sessionId: string) => void;
+  onOpenTerminal?: (commands: string[], branchId?: string) => void;
+  onStartEnvironment?: (branchId: string) => void;
+  onStopEnvironment?: (branchId: string) => void;
+  onViewLogs?: (branchId: string) => void;
+  onNukeEnvironment?: (branchId: string) => void;
+  onExecuteScheduleNow?: (branchId: string) => Promise<void>;
+  onCreateAssistant?: () => void;
+  comments?: BoardComment[];
+  boardObjects?: Record<string, BoardObject>;
+  onSendComment?: (content: string) => void;
+  onReplyComment?: (parentId: string, content: string) => void;
+  onResolveComment?: (commentId: string) => void;
+  onToggleReaction?: (commentId: string, emoji: string) => void;
+  onDeleteComment?: (commentId: string) => void;
+  hoveredCommentId?: string | null;
+  selectedCommentId?: string | null;
+  client: AgorClient | null;
+}
+
+export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
+  board,
+  activeTab: controlledActiveTab,
+  onTabChange,
+  primaryAssistantBranch,
+  primaryAssistantRepo,
+  primaryAssistantInaccessible,
+  sessionsByBranch,
+  branchById,
+  repoById,
+  userById,
+  currentUserId,
+  selectedSessionId,
+  onSessionClick,
+  onCreateSession,
+  onForkSession,
+  onSpawnSession,
+  onOpenSettings,
+  onOpenSessionSettings,
+  comments = [],
+  boardObjects,
+  onSendComment,
+  onReplyComment,
+  onResolveComment,
+  onToggleReaction,
+  onDeleteComment,
+  hoveredCommentId,
+  selectedCommentId,
+  client,
+}) => {
+  const { token } = theme.useToken();
+  const { message } = AntApp.useApp();
+  const defaultTab: BoardAssistantPanelTab = primaryAssistantInaccessible
+    ? 'all-sessions'
+    : 'assistant';
+  const [uncontrolledActiveTab, setUncontrolledActiveTab] =
+    useState<BoardAssistantPanelTab>(defaultTab);
+  const activeTab = controlledActiveTab ?? uncontrolledActiveTab;
+  const setActiveTab = (tab: BoardAssistantPanelTab) => {
+    setUncontrolledActiveTab(tab);
+    onTabChange?.(tab);
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset the tab when switching boards, even if the default tab string is unchanged.
+  useEffect(() => {
+    setUncontrolledActiveTab(defaultTab);
+    onTabChange?.(defaultTab);
+  }, [defaultTab, board?.board_id, onTabChange]);
+
+  const assistantOptions = useMemo(
+    () =>
+      Array.from(branchById.values())
+        .filter((branch) => isAssistant(branch) && !branch.archived)
+        .sort((a, b) => {
+          const aConfig = getAssistantConfig(a);
+          const bConfig = getAssistantConfig(b);
+          return (aConfig?.displayName ?? a.name).localeCompare(bConfig?.displayName ?? b.name);
+        })
+        .map((branch) => {
+          const config = getAssistantConfig(branch);
+          const repo = repoById.get(branch.repo_id);
+          const label = config?.displayName ?? branch.name;
+          return {
+            value: branch.branch_id,
+            label,
+            searchText: `${label} ${branch.name} ${repo?.slug ?? ''}`,
+            branch,
+            repo,
+          };
+        }),
+    [branchById, repoById]
+  );
+  const [selectedAssistantId, setSelectedAssistantId] = useState<string | undefined>();
+  const [assigningAssistant, setAssigningAssistant] = useState(false);
+
+  useEffect(() => {
+    if (
+      selectedAssistantId &&
+      assistantOptions.some((option) => option.value === selectedAssistantId)
+    ) {
+      return;
+    }
+    setSelectedAssistantId(assistantOptions[0]?.value);
+  }, [assistantOptions, selectedAssistantId]);
+
+  const handleAssignAssistant = async () => {
+    if (!board || !client || !selectedAssistantId) return;
+
+    const assistant = branchById.get(selectedAssistantId);
+    if (!assistant) return;
+
+    setAssigningAssistant(true);
+    try {
+      if (assistant.board_id !== board.board_id) {
+        await client.service('branches').patch(selectedAssistantId, {
+          board_id: board.board_id,
+        });
+      }
+      await client.service('boards').setPrimaryAssistant({
+        boardId: board.board_id,
+        branchId: selectedAssistantId,
+      });
+      message.success('Assistant assigned');
+    } catch (error) {
+      message.error(
+        `Failed to assign assistant: ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      setAssigningAssistant(false);
+    }
+  };
+
+  const assistantSessions = useMemo(
+    () =>
+      primaryAssistantBranch ? sessionsByBranch.get(primaryAssistantBranch.branch_id) || [] : [],
+    [primaryAssistantBranch, sessionsByBranch]
+  );
+
+  const assistantContent = (() => {
+    if (primaryAssistantBranch && primaryAssistantRepo) {
+      const assistantConfig = getAssistantConfig(primaryAssistantBranch);
+      const assistantDescription = primaryAssistantBranch.notes?.trim();
+      const isCreating = primaryAssistantBranch.filesystem_status === 'creating';
+
+      return (
+        <div style={{ padding: 16 }}>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
+              paddingBottom: 12,
+              marginBottom: 4,
+              borderBottom: `1px solid ${token.colorBorderSecondary}`,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  flexShrink: 0,
+                }}
+              >
+                {isCreating ? (
+                  <Spin />
+                ) : assistantConfig?.emoji ? (
+                  <span style={{ fontSize: 30 }}>{assistantConfig.emoji}</span>
+                ) : (
+                  <RobotOutlined style={{ fontSize: 30, color: token.colorInfo }} />
+                )}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+                <Typography.Title
+                  level={4}
+                  style={{ margin: 0, fontWeight: 600 }}
+                  ellipsis={{
+                    tooltip: assistantConfig?.displayName ?? primaryAssistantBranch.name,
+                  }}
+                >
+                  {assistantConfig?.displayName ?? primaryAssistantBranch.name}
+                </Typography.Title>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Primary assistant
+                </Typography.Text>
+              </div>
+            </div>
+
+            <Space size={4} wrap>
+              <BranchHeaderPill
+                repo={primaryAssistantRepo}
+                branch={primaryAssistantBranch}
+                sessionCount={assistantSessions.length}
+                onOpenBranch={onOpenSettings}
+                showEnvButtons={false}
+              />
+              {primaryAssistantBranch.created_by && (
+                <CreatedByTag
+                  createdBy={primaryAssistantBranch.created_by}
+                  currentUserId={currentUserId}
+                  userById={userById}
+                  prefix="Created by"
+                />
+              )}
+              {primaryAssistantBranch.issue_url && (
+                <IssuePill issueUrl={primaryAssistantBranch.issue_url} />
+              )}
+              {primaryAssistantBranch.pull_request_url && (
+                <PullRequestPill prUrl={primaryAssistantBranch.pull_request_url} />
+              )}
+            </Space>
+            {assistantDescription && (
+              <div className="markdown-compact" style={{ color: token.colorTextSecondary }}>
+                <MarkdownRenderer content={assistantDescription} compact showControls={false} />
+              </div>
+            )}
+          </div>
+
+          <BranchSessionSections
+            branch={primaryAssistantBranch}
+            sessions={assistantSessions}
+            userById={userById}
+            currentUserId={currentUserId}
+            selectedSessionId={selectedSessionId}
+            onSessionClick={onSessionClick}
+            onCreateSession={onCreateSession}
+            onForkSession={onForkSession}
+            onSpawnSession={onSpawnSession}
+            onOpenSessionSettings={onOpenSessionSettings}
+            mode="panel"
+            client={client}
+          />
+        </div>
+      );
+    }
+
+    if (primaryAssistantInaccessible) {
+      return (
+        <div style={{ padding: 16 }}>
+          <Alert
+            type="info"
+            showIcon
+            message="Assistant unavailable"
+            description="This board has a primary assistant, but you do not have access to that assistant branch."
+          />
+        </div>
+      );
+    }
+
+    return (
+      <div style={{ padding: 16 }}>
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <Typography.Text type="secondary">
+              This board does not have a primary assistant yet.
+            </Typography.Text>
+          }
+          style={{ padding: '24px 0 16px' }}
+        />
+        <Space orientation="vertical" size={12} style={{ width: '100%' }}>
+          <Typography.Text strong>Assign an existing assistant</Typography.Text>
+          <Select
+            showSearch
+            placeholder="Select an assistant"
+            value={selectedAssistantId}
+            onChange={setSelectedAssistantId}
+            options={assistantOptions}
+            optionFilterProp="searchText"
+            disabled={assigningAssistant || assistantOptions.length === 0}
+            style={{ width: '100%' }}
+          />
+          {assistantOptions.length === 0 && (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              No existing assistants are available to assign.
+            </Typography.Text>
+          )}
+          <Button
+            type="primary"
+            onClick={handleAssignAssistant}
+            loading={assigningAssistant}
+            disabled={!selectedAssistantId || !board || !client}
+          >
+            Assign
+          </Button>
+        </Space>
+      </div>
+    );
+  })();
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        background: token.colorBgContainer,
+        borderRight: `1px solid ${token.colorBorderSecondary}`,
+        overflow: 'hidden',
+      }}
+    >
+      <Tabs
+        activeKey={activeTab}
+        onChange={(key) => setActiveTab(key as BoardAssistantPanelTab)}
+        items={[
+          {
+            key: 'assistant',
+            label: 'Assistant',
+            children: (
+              <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
+                {assistantContent}
+              </div>
+            ),
+          },
+          {
+            key: 'all-sessions',
+            label: 'All sessions',
+            children: board ? (
+              <div style={{ height: 'calc(100vh - 112px)' }}>
+                <BoardSessionList
+                  board={board}
+                  currentBoardId={board.board_id}
+                  branchById={branchById}
+                  repoById={repoById}
+                  sessionsByBranch={sessionsByBranch}
+                  onSessionClick={onSessionClick}
+                />
+              </div>
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No board selected" />
+            ),
+          },
+          {
+            key: 'comments',
+            label: 'Comments',
+            children: board ? (
+              <div style={{ height: 'calc(100vh - 112px)' }}>
+                <CommentsPanel
+                  client={client}
+                  boardId={board.board_id}
+                  comments={comments}
+                  userById={userById}
+                  currentUserId={currentUserId || 'unknown'}
+                  boardObjects={boardObjects}
+                  branchById={branchById}
+                  onSendComment={(content) => onSendComment?.(content)}
+                  onReplyComment={onReplyComment}
+                  onResolveComment={onResolveComment}
+                  onToggleReaction={onToggleReaction}
+                  onDeleteComment={onDeleteComment}
+                  hoveredCommentId={hoveredCommentId}
+                  selectedCommentId={selectedCommentId}
+                />
+              </div>
+            ) : (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No board selected" />
+            ),
+          },
+        ]}
+        style={{ height: '100%' }}
+        tabBarStyle={{ margin: 0, padding: '0 12px' }}
+      />
+    </div>
+  );
+};
+
+export default BoardAssistantPanel;

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -258,6 +258,7 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
                 sessionCount={assistantSessions.length}
                 onOpenBranch={onOpenSettings}
                 showEnvButtons={false}
+                compact
               />
               {primaryAssistantBranch.created_by && (
                 <CreatedByTag

--- a/apps/agor-ui/src/components/BoardAssistantPanel/index.ts
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/index.ts
@@ -1,0 +1,2 @@
+export type { BoardAssistantPanelTab } from './BoardAssistantPanel';
+export { BoardAssistantPanel, default } from './BoardAssistantPanel';

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -1,138 +1,28 @@
-import type {
-  AgorClient,
-  Branch,
-  Repo,
-  Session,
-  SessionID,
-  SpawnConfig,
-  User,
-} from '@agor-live/client';
-import {
-  getAssistantConfig,
-  getGatewaySource as getGatewaySourceCore,
-  isAssistant,
-  isGatewaySession as isGatewaySessionCore,
-} from '@agor-live/client';
+import type { AgorClient, Branch, Repo, Session, SpawnConfig, User } from '@agor-live/client';
+import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import {
   BranchesOutlined,
-  ClockCircleOutlined,
   CodeOutlined,
   DeleteOutlined,
   DragOutlined,
   EditOutlined,
-  ForkOutlined,
-  InboxOutlined,
-  MessageOutlined,
-  PlusOutlined,
   PushpinFilled,
   RobotOutlined,
-  SettingOutlined,
-  SubnodeOutlined,
 } from '@ant-design/icons';
-import type { MenuProps } from 'antd';
-import {
-  App,
-  Badge,
-  Button,
-  Card,
-  Collapse,
-  ConfigProvider,
-  Space,
-  Spin,
-  Tooltip,
-  Tree,
-  Typography,
-  theme,
-} from 'antd';
+import { Button, Card, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import { AggregationColor } from 'antd/es/color-picker/color';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
-import { useServiceEnabled } from '../../hooks/useServicesConfig';
-import { useSessionActions } from '../../hooks/useSessionActions';
-import { useThemedMessage } from '../../utils/message';
-import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { EnvironmentPill } from '../EnvironmentPill';
-import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { CreatedByTag } from '../metadata';
-import { ChannelPill, IssuePill, PullRequestPill } from '../Pill';
-import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
-import { ToolIcon } from '../ToolIcon';
-import { buildSessionTree, type SessionTreeNode } from './buildSessionTree';
+import { IssuePill, PullRequestPill } from '../Pill';
+import { BranchSessionSections } from './BranchSessionSections';
 
 const _BRANCH_CARD_MAX_WIDTH = 600;
 const NOTES_MAX_LENGTH = 200; // Character limit for truncated notes
-
-/** Wrapper that adds hover action buttons (settings + archive) overlay to session items */
-const SessionItemWithActions: React.FC<{
-  sessionId: string;
-  isArchiving: boolean;
-  onArchive: (sessionId: string, e: React.MouseEvent) => void;
-  onSettings?: (sessionId: string, e: React.MouseEvent) => void;
-  children: React.ReactNode;
-}> = ({ sessionId, isArchiving, onArchive, onSettings, children }) => {
-  const [hovered, setHovered] = useState(false);
-  const { token } = theme.useToken();
-
-  const buttonStyle: React.CSSProperties = {
-    background: `${token.colorBgContainer}cc`,
-    borderRadius: 4,
-    width: 24,
-    height: 24,
-    minWidth: 24,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  };
-
-  return (
-    <div
-      style={{ position: 'relative', minWidth: 120 }}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-    >
-      {children}
-      <div
-        style={{
-          position: 'absolute',
-          right: 4,
-          top: '50%',
-          transform: 'translateY(-50%)',
-          opacity: hovered ? 1 : 0,
-          transition: 'opacity 0.15s ease-in-out',
-          pointerEvents: hovered ? 'auto' : 'none',
-          display: 'flex',
-          gap: 2,
-          width: 'fit-content',
-        }}
-      >
-        {onSettings && (
-          <Tooltip title="Session settings">
-            <Button
-              type="text"
-              size="small"
-              icon={<SettingOutlined />}
-              onClick={(e) => onSettings(sessionId, e)}
-              style={buttonStyle}
-            />
-          </Tooltip>
-        )}
-        <Tooltip title="Archive session">
-          <Button
-            type="text"
-            size="small"
-            icon={<InboxOutlined />}
-            loading={isArchiving}
-            onClick={(e) => onArchive(sessionId, e)}
-            style={buttonStyle}
-          />
-        </Tooltip>
-      </div>
-    </div>
-  );
-};
 
 interface BranchCardProps {
   branch: Branch;
@@ -167,6 +57,7 @@ interface BranchCardProps {
   zoneColor?: string;
   defaultExpanded?: boolean;
   inPopover?: boolean; // NEW: Enable popover-optimized mode (hides board-specific controls)
+  panelMode?: boolean; // Render inside side panel instead of as a draggable canvas card
   /** True when this branch is the deep-link target of the current URL
    *  (`/w/<branchShort>/`). Folded together with `isFocused` (a session
    *  is open in the drawer) into a unified "selected" state — rendered
@@ -183,7 +74,6 @@ const BranchCardComponent = ({
   userById,
   currentUserId,
   selectedSessionId,
-  onTaskClick,
   onSessionClick,
   onCreateSession,
   onForkSession,
@@ -196,141 +86,32 @@ const BranchCardComponent = ({
   onStopEnvironment,
   onViewLogs,
   onNukeEnvironment,
-  onExecuteScheduleNow,
   onUnpin,
   isPinned = false,
   zoneName,
   zoneColor,
   defaultExpanded = true,
   inPopover = false,
+  panelMode = false,
   isActiveUrlTarget = false,
   client,
 }: BranchCardProps) => {
   const { token } = theme.useToken();
-  const { modal } = App.useApp();
-  const { showSuccess, showError } = useThemedMessage();
   const connectionDisabled = useConnectionDisabled();
-  const schedulerEnabled = useServiceEnabled('scheduler');
-  const gatewayEnabled = useServiceEnabled('gateway');
-
-  // Fork/Spawn modal state
-  const [forkSpawnModal, setForkSpawnModal] = useState<{
-    open: boolean;
-    action: ForkSpawnAction;
-    session: Session | null;
-  }>({
-    open: false,
-    action: 'fork',
-    session: null,
-  });
 
   // Archive/Delete modal state
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
 
-  // Tree expansion state - track which nodes are expanded
-  const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
-
   // Notes expansion state
   const [notesExpanded, setNotesExpanded] = useState(false);
 
-  // Handle fork/spawn modal confirm
-  const handleForkSpawnConfirm = async (config: string | Partial<SpawnConfig>) => {
-    if (!forkSpawnModal.session) return;
-
-    if (forkSpawnModal.action === 'fork') {
-      // Fork only takes a string prompt
-      const prompt = typeof config === 'string' ? config : config.prompt || '';
-      await onForkSession?.(forkSpawnModal.session.session_id, prompt);
-    } else {
-      // Spawn accepts full SpawnConfig
-      await onSpawnSession?.(forkSpawnModal.session.session_id, config);
-    }
-  };
-
-  // Session archive via shared hook
-  const { archiveSession } = useSessionActions(client);
-  const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
-
-  const handleArchiveSession = useCallback(
-    (sessionId: string, e: React.MouseEvent) => {
-      e.stopPropagation();
-
-      modal.confirm({
-        title: 'Archive Session',
-        content: 'Are you sure you want to archive this session?',
-        okText: 'Archive',
-        cancelText: 'Cancel',
-        onOk: async () => {
-          setArchivingSessionIds((prev) => new Set(prev).add(sessionId));
-          try {
-            const result = await archiveSession(sessionId as SessionID);
-            if (result) {
-              showSuccess('Session archived');
-            } else {
-              showError('Failed to archive session');
-            }
-          } finally {
-            setArchivingSessionIds((prev) => {
-              const next = new Set(prev);
-              next.delete(sessionId);
-              return next;
-            });
-          }
-        },
-      });
-    },
-    [archiveSession, modal, showSuccess, showError]
-  );
-
-  // Gateway session helpers (delegating to @agor-live/client)
-  const getGatewaySource = useCallback(
-    (session: Session) => getGatewaySourceCore(session) ?? undefined,
-    []
-  );
-
-  const isGatewaySession = useCallback((session: Session): boolean => {
-    return isGatewaySessionCore(session);
-  }, []);
-
   // Filter out archived sessions from board card display
   const activeSessions = useMemo(() => sessions.filter((s) => !s.archived), [sessions]);
-
-  // Separate sessions by type: manual, scheduled, and gateway
-  const manualSessions = useMemo(
-    () => activeSessions.filter((s) => !s.scheduled_from_branch && !isGatewaySession(s)),
-    [activeSessions, isGatewaySession]
-  );
-  const scheduledSessions = useMemo(
-    () =>
-      activeSessions
-        .filter((s) => s.scheduled_from_branch)
-        .sort((a, b) => (b.scheduled_run_at || 0) - (a.scheduled_run_at || 0)), // Most recent first
-    [activeSessions]
-  );
-  const gatewaySessions = useMemo(
-    () => activeSessions.filter((s) => isGatewaySession(s)),
-    [activeSessions, isGatewaySession]
-  );
-
-  // Build genealogy tree structure (only for manual sessions)
-  const sessionTreeData = useMemo(() => buildSessionTree(manualSessions), [manualSessions]);
 
   // Check if any active (non-archived) session is running or stopping
   const hasRunningSession = useMemo(
     () => activeSessions.some((s) => s.status === 'running' || s.status === 'stopping'),
     [activeSessions]
-  );
-
-  // Check if any scheduled session is running (for collapse header spinner)
-  const hasRunningScheduledSession = useMemo(
-    () => scheduledSessions.some((s) => s.status === 'running' || s.status === 'stopping'),
-    [scheduledSessions]
-  );
-
-  // Check if any gateway session is running (for collapse header spinner)
-  const hasRunningGatewaySession = useMemo(
-    () => gatewaySessions.some((s) => s.status === 'running' || s.status === 'stopping'),
-    [gatewaySessions]
   );
 
   // Check if branch is still being created on filesystem
@@ -359,356 +140,6 @@ const BranchCardComponent = ({
 
     return shouldHighlight;
   }, [activeSessions, branch.needs_attention, isFocused]);
-
-  // Auto-expand all nodes on mount and when new nodes with children are added
-  useEffect(() => {
-    // Collect all node keys that have children
-    const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
-      const keys: React.Key[] = [];
-      for (const node of nodes) {
-        if (node.children && node.children.length > 0) {
-          keys.push(node.key);
-          keys.push(...collectKeysWithChildren(node.children));
-        }
-      }
-      return keys;
-    };
-
-    const allKeysWithChildren = collectKeysWithChildren(sessionTreeData);
-    setExpandedKeys(allKeysWithChildren);
-  }, [sessionTreeData]);
-
-  // Render function for tree nodes (our rich session cards)
-  const renderSessionNode = (node: SessionTreeNode) => {
-    const session = node.session;
-
-    // Dropdown menu items for session actions
-    const _sessionMenuItems: MenuProps['items'] = [
-      {
-        key: 'fork',
-        icon: <ForkOutlined />,
-        label: 'Fork Session',
-        disabled: connectionDisabled,
-        onClick: () => {
-          setForkSpawnModal({
-            open: true,
-            action: 'fork',
-            session,
-          });
-        },
-      },
-      {
-        key: 'spawn',
-        icon: <SubnodeOutlined />,
-        label: 'Spawn Subsession',
-        disabled: connectionDisabled,
-        onClick: () => {
-          setForkSpawnModal({
-            open: true,
-            action: 'spawn',
-            session,
-          });
-        },
-      },
-    ];
-
-    const isActive = session.status === 'running' || session.status === 'stopping';
-    // Mirrors the branch-card "selected" channel: when the URL points at
-    // a session, the session opens in the drawer (`selectedSessionId` is
-    // set) — give the matching row the same dashed selection outline so
-    // it's obvious which session inside the card the user landed on.
-    const isSessionSelected = session.session_id === selectedSessionId;
-
-    return (
-      <SessionItemWithActions
-        sessionId={session.session_id}
-        isArchiving={archivingSessionIds.has(session.session_id)}
-        onArchive={handleArchiveSession}
-        onSettings={
-          onOpenSessionSettings
-            ? (id, e) => {
-                e.stopPropagation();
-                onOpenSessionSettings(id);
-              }
-            : undefined
-        }
-      >
-        <div
-          style={{
-            border: session.ready_for_prompt
-              ? `2px solid ${token.colorPrimary}`
-              : `1px solid rgba(255, 255, 255, 0.1)`,
-            borderRadius: 4,
-            padding: 8,
-            background: 'transparent',
-            display: 'flex',
-            alignItems: 'center',
-            cursor: 'pointer',
-            marginBottom: 4,
-            boxShadow: session.ready_for_prompt ? `0 0 12px ${token.colorPrimary}30` : undefined,
-            ...(isSessionSelected
-              ? { outline: `2px dashed ${token.colorTextBase}`, outlineOffset: -2 }
-              : {}),
-          }}
-          onClick={() => onSessionClick?.(session.session_id)}
-          onContextMenu={(e) => {
-            // Show fork/spawn menu on right-click if handlers exist
-            if (onForkSession || onSpawnSession) {
-              e.preventDefault();
-            }
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
-            {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
-            <SessionRelationshipIcon session={session} size={10} />
-            <Typography.Text
-              strong
-              style={{
-                fontSize: 12,
-                flex: 1,
-                minWidth: 0,
-                ...getSessionTitleStyles(2),
-              }}
-            >
-              {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-            </Typography.Text>
-          </div>
-        </div>
-      </SessionItemWithActions>
-    );
-  };
-
-  // Session list content (collapsible) - only used when sessions exist
-  const sessionListContent = (
-    <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
-      <Tree
-        treeData={sessionTreeData}
-        expandedKeys={expandedKeys}
-        onExpand={(keys) => setExpandedKeys(keys as React.Key[])}
-        showLine
-        showIcon={false}
-        selectable={false}
-        titleRender={renderSessionNode}
-      />
-    </ConfigProvider>
-  );
-
-  // Session list collapse header
-  const sessionListHeader = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      }}
-    >
-      <Space size={4} align="center">
-        <Typography.Text strong>Sessions</Typography.Text>
-        <Badge
-          count={manualSessions.length}
-          showZero
-          style={{ backgroundColor: token.colorPrimaryBgHover }}
-        />
-      </Space>
-      {onCreateSession && (
-        <div className="nodrag">
-          <Button
-            type="default"
-            size="small"
-            icon={<PlusOutlined />}
-            disabled={connectionDisabled || isCreating}
-            onClick={(e) => {
-              e.stopPropagation();
-              onCreateSession(branch.branch_id);
-            }}
-            title={isCreating ? 'Branch is being created...' : undefined}
-          >
-            New Session
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-
-  // Scheduled runs header
-  const scheduledRunsHeader = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      }}
-    >
-      <Space size={4} align="center">
-        <ClockCircleOutlined style={{ color: token.colorInfo }} />
-        <Typography.Text strong>Scheduled Runs</Typography.Text>
-        <Badge
-          count={scheduledSessions.length}
-          showZero
-          style={{ backgroundColor: token.colorInfoBgHover }}
-        />
-        {hasRunningScheduledSession && <Spin size="small" />}
-      </Space>
-    </div>
-  );
-
-  // Scheduled runs content (flat list, no genealogy tree needed)
-  const scheduledRunsContent = (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {scheduledSessions.map((session) => {
-        const isActive = session.status === 'running' || session.status === 'stopping';
-        return (
-          <SessionItemWithActions
-            key={session.session_id}
-            sessionId={session.session_id}
-            isArchiving={archivingSessionIds.has(session.session_id)}
-            onArchive={handleArchiveSession}
-            onSettings={
-              onOpenSessionSettings
-                ? (id, e) => {
-                    e.stopPropagation();
-                    onOpenSessionSettings(id);
-                  }
-                : undefined
-            }
-          >
-            <div
-              style={{
-                border: `1px solid rgba(255, 255, 255, 0.1)`,
-                borderRadius: 4,
-                padding: 8,
-                background: 'transparent',
-                display: 'flex',
-                alignItems: 'center',
-                cursor: 'pointer',
-              }}
-              onClick={() => onSessionClick?.(session.session_id)}
-            >
-              <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
-                {isActive ? (
-                  <Spin size="small" />
-                ) : (
-                  <ToolIcon tool={session.agentic_tool} size={20} />
-                )}
-                <Typography.Text
-                  style={{
-                    fontSize: 12,
-                    flex: 1,
-                    color: token.colorTextSecondary,
-                    ...getSessionTitleStyles(2),
-                  }}
-                >
-                  {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-                </Typography.Text>
-              </Space>
-            </div>
-          </SessionItemWithActions>
-        );
-      })}
-    </div>
-  );
-
-  // Gateway sessions header
-  const gatewaySessionsHeader = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      }}
-    >
-      <Space size={4} align="center">
-        <MessageOutlined style={{ color: token.colorSuccess }} />
-        <Typography.Text strong>Gateway Sessions</Typography.Text>
-        <Badge
-          count={gatewaySessions.length}
-          showZero
-          style={{ backgroundColor: token.colorSuccessBgHover }}
-        />
-        {hasRunningGatewaySession && <Spin size="small" />}
-      </Space>
-    </div>
-  );
-
-  // Gateway sessions content (flat list with channel info)
-  const gatewaySessionsContent = (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {gatewaySessions.map((session) => {
-        // Extract denormalized gateway metadata (stamped at session creation)
-        const gatewaySource = getGatewaySource(session);
-
-        const isActive = session.status === 'running' || session.status === 'stopping';
-
-        return (
-          <SessionItemWithActions
-            key={session.session_id}
-            sessionId={session.session_id}
-            isArchiving={archivingSessionIds.has(session.session_id)}
-            onArchive={handleArchiveSession}
-            onSettings={
-              onOpenSessionSettings
-                ? (id, e) => {
-                    e.stopPropagation();
-                    onOpenSessionSettings(id);
-                  }
-                : undefined
-            }
-          >
-            <div
-              style={{
-                border: `1px solid rgba(255, 255, 255, 0.1)`,
-                borderRadius: 4,
-                padding: 8,
-                background: 'transparent',
-                display: 'flex',
-                alignItems: 'center',
-                cursor: 'pointer',
-              }}
-              onClick={() => onSessionClick?.(session.session_id)}
-            >
-              <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
-                {isActive ? (
-                  <Spin size="small" />
-                ) : (
-                  <ToolIcon tool={session.agentic_tool} size={20} />
-                )}
-                <div
-                  style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}
-                >
-                  <Typography.Text
-                    style={{
-                      fontSize: 12,
-                      ...getSessionTitleStyles(2),
-                    }}
-                  >
-                    {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-                  </Typography.Text>
-                  <div style={{ alignSelf: 'flex-start' }}>
-                    {gatewaySource ? (
-                      <ChannelPill
-                        channelType={gatewaySource.channel_type}
-                        channelName={gatewaySource.channel_name}
-                      />
-                    ) : (
-                      <Typography.Text
-                        type="secondary"
-                        style={{ fontSize: 11, fontStyle: 'italic' }}
-                      >
-                        (Gateway - metadata unavailable)
-                      </Typography.Text>
-                    )}
-                  </div>
-                </div>
-              </Space>
-            </div>
-          </SessionItemWithActions>
-        );
-      })}
-    </div>
-  );
 
   const isDarkMode = isDarkTheme(token);
 
@@ -801,7 +232,7 @@ const BranchCardComponent = ({
   return (
     <Card
       style={{
-        width: 500,
+        width: panelMode ? '100%' : 500,
         cursor: 'default', // Override React Flow's drag cursor - only drag handles should show grab cursor
         transition:
           'box-shadow 0.6s ease-in-out, outline 0.2s ease-in-out, border 0.6s ease-in-out, opacity 0.2s ease-in-out',
@@ -845,7 +276,7 @@ const BranchCardComponent = ({
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                cursor: 'grab',
+                cursor: panelMode ? 'default' : 'grab',
                 width: 32,
                 height: 32,
                 justifyContent: 'center',
@@ -905,7 +336,7 @@ const BranchCardComponent = ({
         </div>
 
         <Space size={4} style={{ flexShrink: 0 }}>
-          {!inPopover && isPinned && (
+          {!inPopover && !panelMode && isPinned && (
             <Tooltip
               title={
                 zoneName
@@ -925,7 +356,7 @@ const BranchCardComponent = ({
               />
             </Tooltip>
           )}
-          {!inPopover && (
+          {!inPopover && !panelMode && (
             <Button
               type="text"
               size="small"
@@ -968,7 +399,7 @@ const BranchCardComponent = ({
                 title="Edit branch"
               />
             )}
-            {!inPopover && onArchiveOrDelete && (
+            {!inPopover && !panelMode && onArchiveOrDelete && (
               <Button
                 type="text"
                 size="small"
@@ -1051,138 +482,24 @@ const BranchCardComponent = ({
         </div>
       )}
 
-      {/* Sessions & Scheduled Runs - collapsible sections */}
+      {/* Sessions & Scheduled Runs - composable content shared with the assistant panel */}
       <div className="nodrag">
-        {activeSessions.length === 0 ? (
-          // No active sessions: show create button without collapse wrapper
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 8,
-              alignItems: 'center',
-              padding: '16px 0',
-              marginTop: 8,
-            }}
-          >
-            {isCreating ? (
-              <Typography.Text type="secondary">Creating branch on filesystem...</Typography.Text>
-            ) : isFailed ? (
-              <div
-                style={{ display: 'flex', flexDirection: 'column', gap: 8, textAlign: 'center' }}
-              >
-                <Typography.Text type="danger" strong>
-                  Branch creation failed
-                </Typography.Text>
-                {branch.error_message && (
-                  <Tooltip title={branch.error_message} placement="bottom">
-                    <Typography.Text
-                      type="secondary"
-                      style={{
-                        fontSize: 12,
-                        maxWidth: 220,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        cursor: 'help',
-                      }}
-                    >
-                      {branch.error_message}
-                    </Typography.Text>
-                  </Tooltip>
-                )}
-              </div>
-            ) : onCreateSession ? (
-              <Button
-                type="primary"
-                icon={<PlusOutlined />}
-                disabled={connectionDisabled}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCreateSession(branch.branch_id);
-                }}
-                size="middle"
-              >
-                Create Session
-              </Button>
-            ) : null}
-          </div>
-        ) : (
-          // Has sessions: show collapsible sections
-          <>
-            {/* Manual Sessions */}
-            {manualSessions.length > 0 && (
-              <Collapse
-                defaultActiveKey={defaultExpanded ? ['sessions'] : []}
-                items={[
-                  {
-                    key: 'sessions',
-                    label: sessionListHeader,
-                    children: sessionListContent,
-                    styles: { body: { background: 'transparent' } },
-                  },
-                ]}
-                ghost
-                style={{ marginTop: 8 }}
-              />
-            )}
-
-            {/* Scheduled Runs */}
-            {schedulerEnabled && scheduledSessions.length > 0 && (
-              <Collapse
-                defaultActiveKey={[]}
-                items={[
-                  {
-                    key: 'scheduled-runs',
-                    label: scheduledRunsHeader,
-                    children: scheduledRunsContent,
-                    styles: { body: { background: 'transparent' } },
-                  },
-                ]}
-                ghost
-                style={{ marginTop: manualSessions.length > 0 ? 0 : 8 }}
-              />
-            )}
-
-            {/* Gateway Sessions */}
-            {gatewayEnabled && gatewaySessions.length > 0 && (
-              <Collapse
-                defaultActiveKey={[]}
-                items={[
-                  {
-                    key: 'gateway-sessions',
-                    label: gatewaySessionsHeader,
-                    children: gatewaySessionsContent,
-                    styles: { body: { background: 'transparent' } },
-                  },
-                ]}
-                ghost
-                style={{
-                  marginTop: manualSessions.length > 0 || scheduledSessions.length > 0 ? 0 : 8,
-                }}
-              />
-            )}
-          </>
-        )}
+        <BranchSessionSections
+          branch={branch}
+          sessions={sessions}
+          userById={userById}
+          currentUserId={currentUserId}
+          selectedSessionId={selectedSessionId}
+          onSessionClick={onSessionClick}
+          onCreateSession={onCreateSession}
+          onForkSession={onForkSession}
+          onSpawnSession={onSpawnSession}
+          onOpenSessionSettings={onOpenSessionSettings}
+          defaultExpanded={defaultExpanded}
+          mode="card"
+          client={client}
+        />
       </div>
-
-      {/* Fork/Spawn Modal */}
-      <ForkSpawnModal
-        open={forkSpawnModal.open}
-        action={forkSpawnModal.action}
-        session={forkSpawnModal.session}
-        currentUser={currentUserId ? userById.get(currentUserId) : undefined}
-        onConfirm={handleForkSpawnConfirm}
-        onCancel={() =>
-          setForkSpawnModal({
-            open: false,
-            action: 'fork',
-            session: null,
-          })
-        }
-        client={client}
-        userById={userById}
-      />
 
       {/* Archive/Delete Modal */}
       <ArchiveDeleteBranchModal

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -1,0 +1,656 @@
+import type { AgorClient, Branch, Session, SessionID, SpawnConfig, User } from '@agor-live/client';
+import {
+  getGatewaySource as getGatewaySourceCore,
+  isGatewaySession as isGatewaySessionCore,
+} from '@agor-live/client';
+import {
+  ClockCircleOutlined,
+  InboxOutlined,
+  MessageOutlined,
+  PlusOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
+import {
+  App,
+  Badge,
+  Button,
+  Collapse,
+  ConfigProvider,
+  Space,
+  Spin,
+  Tooltip,
+  Tree,
+  Typography,
+  theme,
+} from 'antd';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useServiceEnabled } from '../../hooks/useServicesConfig';
+import { useSessionActions } from '../../hooks/useSessionActions';
+import { useThemedMessage } from '../../utils/message';
+import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
+import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
+import { ChannelPill } from '../Pill';
+import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
+import { ToolIcon } from '../ToolIcon';
+import { buildSessionTree, type SessionTreeNode } from './buildSessionTree';
+
+export type BranchSessionSectionsMode = 'card' | 'panel';
+
+export interface BranchSessionSectionsProps {
+  branch: Branch;
+  sessions: Session[];
+  userById: Map<string, User>;
+  currentUserId?: string;
+  selectedSessionId?: string | null;
+  onSessionClick?: (sessionId: string) => void;
+  onCreateSession?: (branchId: string) => void;
+  onForkSession?: (sessionId: string, prompt: string) => Promise<void>;
+  onSpawnSession?: (sessionId: string, config: string | Partial<SpawnConfig>) => Promise<void>;
+  onOpenSessionSettings?: (sessionId: string) => void;
+  defaultExpanded?: boolean;
+  mode?: BranchSessionSectionsMode;
+  client: AgorClient | null;
+}
+
+/** Wrapper that adds hover action buttons (settings + archive) overlay to session items */
+const SessionItemWithActions: React.FC<{
+  sessionId: string;
+  isArchiving: boolean;
+  onArchive: (sessionId: string, e: React.MouseEvent) => void;
+  onSettings?: (sessionId: string, e: React.MouseEvent) => void;
+  children: React.ReactNode;
+}> = ({ sessionId, isArchiving, onArchive, onSettings, children }) => {
+  const [hovered, setHovered] = useState(false);
+  const { token } = theme.useToken();
+
+  const buttonStyle: React.CSSProperties = {
+    background: `${token.colorBgContainer}cc`,
+    borderRadius: 4,
+    width: 24,
+    height: 24,
+    minWidth: 24,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  return (
+    <div
+      style={{ position: 'relative', minWidth: 120 }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {children}
+      <div
+        style={{
+          position: 'absolute',
+          right: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          opacity: hovered ? 1 : 0,
+          transition: 'opacity 0.15s ease-in-out',
+          pointerEvents: hovered ? 'auto' : 'none',
+          display: 'flex',
+          gap: 2,
+          width: 'fit-content',
+        }}
+      >
+        {onSettings && (
+          <Tooltip title="Session settings">
+            <Button
+              type="text"
+              size="small"
+              icon={<SettingOutlined />}
+              onClick={(e) => onSettings(sessionId, e)}
+              style={buttonStyle}
+            />
+          </Tooltip>
+        )}
+        <Tooltip title="Archive session">
+          <Button
+            type="text"
+            size="small"
+            icon={<InboxOutlined />}
+            loading={isArchiving}
+            onClick={(e) => onArchive(sessionId, e)}
+            style={buttonStyle}
+          />
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
+  branch,
+  sessions,
+  userById,
+  currentUserId,
+  selectedSessionId,
+  onSessionClick,
+  onCreateSession,
+  onForkSession,
+  onSpawnSession,
+  onOpenSessionSettings,
+  defaultExpanded = true,
+  mode = 'card',
+  client,
+}) => {
+  const { token } = theme.useToken();
+  const { modal } = App.useApp();
+  const { showSuccess, showError } = useThemedMessage();
+  const connectionDisabled = useConnectionDisabled();
+  const schedulerEnabled = useServiceEnabled('scheduler');
+  const gatewayEnabled = useServiceEnabled('gateway');
+  const { archiveSession } = useSessionActions(client);
+
+  const [forkSpawnModal, setForkSpawnModal] = useState<{
+    open: boolean;
+    action: ForkSpawnAction;
+    session: Session | null;
+  }>({
+    open: false,
+    action: 'fork',
+    session: null,
+  });
+  const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
+  const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
+
+  const isPanel = mode === 'panel';
+
+  const handleForkSpawnConfirm = async (config: string | Partial<SpawnConfig>) => {
+    if (!forkSpawnModal.session) return;
+
+    if (forkSpawnModal.action === 'fork') {
+      const prompt = typeof config === 'string' ? config : config.prompt || '';
+      await onForkSession?.(forkSpawnModal.session.session_id, prompt);
+    } else {
+      await onSpawnSession?.(forkSpawnModal.session.session_id, config);
+    }
+  };
+
+  const handleArchiveSession = useCallback(
+    (sessionId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+
+      modal.confirm({
+        title: 'Archive Session',
+        content: 'Are you sure you want to archive this session?',
+        okText: 'Archive',
+        cancelText: 'Cancel',
+        onOk: async () => {
+          setArchivingSessionIds((prev) => new Set(prev).add(sessionId));
+          try {
+            const result = await archiveSession(sessionId as SessionID);
+            if (result) {
+              showSuccess('Session archived');
+            } else {
+              showError('Failed to archive session');
+            }
+          } finally {
+            setArchivingSessionIds((prev) => {
+              const next = new Set(prev);
+              next.delete(sessionId);
+              return next;
+            });
+          }
+        },
+      });
+    },
+    [archiveSession, modal, showSuccess, showError]
+  );
+
+  const getGatewaySource = useCallback(
+    (session: Session) => getGatewaySourceCore(session) ?? undefined,
+    []
+  );
+
+  const isGatewaySession = useCallback((session: Session): boolean => {
+    return isGatewaySessionCore(session);
+  }, []);
+
+  const activeSessions = useMemo(() => sessions.filter((s) => !s.archived), [sessions]);
+  const manualSessions = useMemo(
+    () => activeSessions.filter((s) => !s.scheduled_from_branch && !isGatewaySession(s)),
+    [activeSessions, isGatewaySession]
+  );
+  const scheduledSessions = useMemo(
+    () =>
+      activeSessions
+        .filter((s) => s.scheduled_from_branch)
+        .sort((a, b) => (b.scheduled_run_at || 0) - (a.scheduled_run_at || 0)),
+    [activeSessions]
+  );
+  const gatewaySessions = useMemo(
+    () => activeSessions.filter((s) => isGatewaySession(s)),
+    [activeSessions, isGatewaySession]
+  );
+  const sessionTreeData = useMemo(() => buildSessionTree(manualSessions), [manualSessions]);
+
+  const hasRunningScheduledSession = useMemo(
+    () => scheduledSessions.some((s) => s.status === 'running' || s.status === 'stopping'),
+    [scheduledSessions]
+  );
+  const hasRunningGatewaySession = useMemo(
+    () => gatewaySessions.some((s) => s.status === 'running' || s.status === 'stopping'),
+    [gatewaySessions]
+  );
+
+  const isCreating = branch.filesystem_status === 'creating';
+  const isFailed = branch.filesystem_status === 'failed';
+
+  useEffect(() => {
+    const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
+      const keys: React.Key[] = [];
+      for (const node of nodes) {
+        if (node.children && node.children.length > 0) {
+          keys.push(node.key);
+          keys.push(...collectKeysWithChildren(node.children));
+        }
+      }
+      return keys;
+    };
+
+    setExpandedKeys(collectKeysWithChildren(sessionTreeData));
+  }, [sessionTreeData]);
+
+  const sessionRowStyle = (session: Session): React.CSSProperties => {
+    const isSessionSelected = session.session_id === selectedSessionId;
+    return {
+      border: session.ready_for_prompt
+        ? `1px solid ${token.colorPrimary}`
+        : `1px solid ${isPanel ? token.colorBorderSecondary : 'rgba(255, 255, 255, 0.1)'}`,
+      borderRadius: isPanel ? 6 : 4,
+      padding: isPanel ? 10 : 8,
+      background: isPanel ? token.colorBgContainer : 'transparent',
+      display: 'flex',
+      alignItems: 'center',
+      cursor: 'pointer',
+      marginBottom: 4,
+      boxShadow: session.ready_for_prompt ? `0 0 12px ${token.colorPrimary}30` : undefined,
+      ...(isSessionSelected
+        ? { outline: `1px dashed ${token.colorTextBase}`, outlineOffset: -2 }
+        : {}),
+    };
+  };
+
+  const renderSessionNode = (node: SessionTreeNode) => {
+    const session = node.session;
+    const isActive = session.status === 'running' || session.status === 'stopping';
+
+    return (
+      <SessionItemWithActions
+        sessionId={session.session_id}
+        isArchiving={archivingSessionIds.has(session.session_id)}
+        onArchive={handleArchiveSession}
+        onSettings={
+          onOpenSessionSettings
+            ? (id, e) => {
+                e.stopPropagation();
+                onOpenSessionSettings(id);
+              }
+            : undefined
+        }
+      >
+        <div
+          style={sessionRowStyle(session)}
+          onClick={() => onSessionClick?.(session.session_id)}
+          onContextMenu={(e) => {
+            if (onForkSession || onSpawnSession) {
+              e.preventDefault();
+            }
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
+            {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+            <SessionRelationshipIcon session={session} size={10} />
+            <Typography.Text
+              strong
+              style={{
+                fontSize: isPanel ? 13 : 12,
+                flex: 1,
+                minWidth: 0,
+                ...getSessionTitleStyles(2),
+              }}
+            >
+              {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+            </Typography.Text>
+          </div>
+        </div>
+      </SessionItemWithActions>
+    );
+  };
+
+  const sessionListContent = (
+    <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
+      <Tree
+        treeData={sessionTreeData}
+        expandedKeys={expandedKeys}
+        onExpand={(keys) => setExpandedKeys(keys as React.Key[])}
+        showLine
+        showIcon={false}
+        selectable={false}
+        titleRender={renderSessionNode}
+      />
+    </ConfigProvider>
+  );
+
+  const sessionListHeader = (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: '100%',
+      }}
+    >
+      <Space size={4} align="center">
+        <Typography.Text strong>Sessions</Typography.Text>
+        <Badge
+          count={manualSessions.length}
+          showZero
+          style={{ backgroundColor: token.colorPrimaryBgHover }}
+        />
+      </Space>
+      {onCreateSession && (
+        <div className="nodrag">
+          <Button
+            type="default"
+            size="small"
+            icon={<PlusOutlined />}
+            disabled={connectionDisabled || isCreating}
+            onClick={(e) => {
+              e.stopPropagation();
+              onCreateSession(branch.branch_id);
+            }}
+            title={isCreating ? 'Branch is being created...' : undefined}
+          >
+            New Session
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+
+  const scheduledRunsHeader = (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: '100%',
+      }}
+    >
+      <Space size={4} align="center">
+        <ClockCircleOutlined style={{ color: token.colorInfo }} />
+        <Typography.Text strong>Scheduled Runs</Typography.Text>
+        <Badge
+          count={scheduledSessions.length}
+          showZero
+          style={{ backgroundColor: token.colorInfoBgHover }}
+        />
+        {hasRunningScheduledSession && <Spin size="small" />}
+      </Space>
+    </div>
+  );
+
+  const scheduledRunsContent = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {scheduledSessions.map((session) => {
+        const isActive = session.status === 'running' || session.status === 'stopping';
+        return (
+          <SessionItemWithActions
+            key={session.session_id}
+            sessionId={session.session_id}
+            isArchiving={archivingSessionIds.has(session.session_id)}
+            onArchive={handleArchiveSession}
+            onSettings={
+              onOpenSessionSettings
+                ? (id, e) => {
+                    e.stopPropagation();
+                    onOpenSessionSettings(id);
+                  }
+                : undefined
+            }
+          >
+            <div
+              style={sessionRowStyle(session)}
+              onClick={() => onSessionClick?.(session.session_id)}
+            >
+              <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
+                {isActive ? (
+                  <Spin size="small" />
+                ) : (
+                  <ToolIcon tool={session.agentic_tool} size={20} />
+                )}
+                <Typography.Text
+                  style={{
+                    fontSize: isPanel ? 13 : 12,
+                    flex: 1,
+                    color: token.colorTextSecondary,
+                    ...getSessionTitleStyles(2),
+                  }}
+                >
+                  {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+                </Typography.Text>
+              </Space>
+            </div>
+          </SessionItemWithActions>
+        );
+      })}
+    </div>
+  );
+
+  const gatewaySessionsHeader = (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: '100%',
+      }}
+    >
+      <Space size={4} align="center">
+        <MessageOutlined style={{ color: token.colorSuccess }} />
+        <Typography.Text strong>Gateway Sessions</Typography.Text>
+        <Badge
+          count={gatewaySessions.length}
+          showZero
+          style={{ backgroundColor: token.colorSuccessBgHover }}
+        />
+        {hasRunningGatewaySession && <Spin size="small" />}
+      </Space>
+    </div>
+  );
+
+  const gatewaySessionsContent = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {gatewaySessions.map((session) => {
+        const gatewaySource = getGatewaySource(session);
+        const isActive = session.status === 'running' || session.status === 'stopping';
+
+        return (
+          <SessionItemWithActions
+            key={session.session_id}
+            sessionId={session.session_id}
+            isArchiving={archivingSessionIds.has(session.session_id)}
+            onArchive={handleArchiveSession}
+            onSettings={
+              onOpenSessionSettings
+                ? (id, e) => {
+                    e.stopPropagation();
+                    onOpenSessionSettings(id);
+                  }
+                : undefined
+            }
+          >
+            <div
+              style={sessionRowStyle(session)}
+              onClick={() => onSessionClick?.(session.session_id)}
+            >
+              <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
+                {isActive ? (
+                  <Spin size="small" />
+                ) : (
+                  <ToolIcon tool={session.agentic_tool} size={20} />
+                )}
+                <div
+                  style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}
+                >
+                  <Typography.Text
+                    style={{ fontSize: isPanel ? 13 : 12, ...getSessionTitleStyles(2) }}
+                  >
+                    {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+                  </Typography.Text>
+                  <div style={{ alignSelf: 'flex-start' }}>
+                    {gatewaySource ? (
+                      <ChannelPill
+                        channelType={gatewaySource.channel_type}
+                        channelName={gatewaySource.channel_name}
+                      />
+                    ) : (
+                      <Typography.Text
+                        type="secondary"
+                        style={{ fontSize: 11, fontStyle: 'italic' }}
+                      >
+                        (Gateway - metadata unavailable)
+                      </Typography.Text>
+                    )}
+                  </div>
+                </div>
+              </Space>
+            </div>
+          </SessionItemWithActions>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <>
+      {activeSessions.length === 0 ? (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            alignItems: 'center',
+            padding: isPanel ? '24px 0' : '16px 0',
+            marginTop: 8,
+          }}
+        >
+          {isCreating ? (
+            <Typography.Text type="secondary">Creating branch on filesystem...</Typography.Text>
+          ) : isFailed ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, textAlign: 'center' }}>
+              <Typography.Text type="danger" strong>
+                Branch creation failed
+              </Typography.Text>
+              {branch.error_message && (
+                <Tooltip title={branch.error_message} placement="bottom">
+                  <Typography.Text
+                    type="secondary"
+                    style={{
+                      fontSize: 12,
+                      maxWidth: 220,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      cursor: 'help',
+                    }}
+                  >
+                    {branch.error_message}
+                  </Typography.Text>
+                </Tooltip>
+              )}
+            </div>
+          ) : onCreateSession ? (
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              disabled={connectionDisabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCreateSession(branch.branch_id);
+              }}
+              size="middle"
+            >
+              Create Session
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <>
+          {manualSessions.length > 0 && (
+            <Collapse
+              defaultActiveKey={defaultExpanded ? ['sessions'] : []}
+              items={[
+                {
+                  key: 'sessions',
+                  label: sessionListHeader,
+                  children: sessionListContent,
+                  styles: {
+                    body: { background: 'transparent', paddingInline: isPanel ? 0 : undefined },
+                  },
+                },
+              ]}
+              ghost
+              style={{ marginTop: 8 }}
+            />
+          )}
+
+          {schedulerEnabled && scheduledSessions.length > 0 && (
+            <Collapse
+              defaultActiveKey={[]}
+              items={[
+                {
+                  key: 'scheduled-runs',
+                  label: scheduledRunsHeader,
+                  children: scheduledRunsContent,
+                  styles: {
+                    body: { background: 'transparent', paddingInline: isPanel ? 0 : undefined },
+                  },
+                },
+              ]}
+              ghost
+              style={{ marginTop: manualSessions.length > 0 ? 0 : 8 }}
+            />
+          )}
+
+          {gatewayEnabled && gatewaySessions.length > 0 && (
+            <Collapse
+              defaultActiveKey={[]}
+              items={[
+                {
+                  key: 'gateway-sessions',
+                  label: gatewaySessionsHeader,
+                  children: gatewaySessionsContent,
+                  styles: {
+                    body: { background: 'transparent', paddingInline: isPanel ? 0 : undefined },
+                  },
+                },
+              ]}
+              ghost
+              style={{
+                marginTop: manualSessions.length > 0 || scheduledSessions.length > 0 ? 0 : 8,
+              }}
+            />
+          )}
+        </>
+      )}
+
+      <ForkSpawnModal
+        open={forkSpawnModal.open}
+        action={forkSpawnModal.action}
+        session={forkSpawnModal.session}
+        currentUser={currentUserId ? userById.get(currentUserId) : undefined}
+        onConfirm={handleForkSpawnConfirm}
+        onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
+        client={client}
+        userById={userById}
+      />
+    </>
+  );
+};

--- a/apps/agor-ui/src/components/BranchCard/index.ts
+++ b/apps/agor-ui/src/components/BranchCard/index.ts
@@ -1,1 +1,6 @@
 export { default } from './BranchCard';
+export type {
+  BranchSessionSectionsMode,
+  BranchSessionSectionsProps,
+} from './BranchSessionSections';
+export { BranchSessionSections } from './BranchSessionSections';

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -32,6 +32,8 @@ interface BranchHeaderPillProps {
   onNukeEnvironment?: (branchId: string) => void;
   onViewLogs?: (branchId: string) => void;
   connectionDisabled?: boolean;
+  /** Show environment status/controls and environment shortcut. Defaults to true. */
+  showEnvButtons?: boolean;
 }
 
 const PILL_HEIGHT = 22;
@@ -53,6 +55,7 @@ export function BranchHeaderPill({
   onNukeEnvironment,
   onViewLogs,
   connectionDisabled = false,
+  showEnvButtons = true,
 }: BranchHeaderPillProps) {
   const { token } = theme.useToken();
   const confirmNuke = useConfirmNukeEnvironment();
@@ -189,169 +192,171 @@ export function BranchHeaderPill({
       </Tooltip>
 
       {/* Section 2: Environment status + controls */}
-      <div
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 2,
-          padding: '0 4px',
-          height: PILL_HEIGHT,
-          borderLeft: `1px solid ${token.colorBorderSecondary}`,
-        }}
-      >
-        {hasConfig ? (
-          <>
-            {/* Env label — clickable to env URL when running, otherwise opens env tab */}
-            {isRunning && environmentUrl ? (
-              <Tooltip title={`Open ${environmentUrl}`}>
-                <a
-                  href={environmentUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 3,
-                    color: 'inherit',
-                    textDecoration: 'none',
-                    padding: '0 2px',
-                  }}
-                >
-                  {getStatusIcon()}
-                  <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
-                </a>
-              </Tooltip>
-            ) : (
-              <Tooltip title={getEnvTooltip()}>
-                <button
-                  type="button"
-                  onClick={openTab('environment')}
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 3,
-                    cursor: 'pointer',
-                    padding: '0 2px',
-                    background: 'none',
-                    border: 'none',
-                    color: 'inherit',
-                    font: 'inherit',
-                  }}
-                >
-                  {getStatusIcon()}
-                  <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
-                </button>
-              </Tooltip>
-            )}
+      {showEnvButtons && (
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 2,
+            padding: '0 4px',
+            height: PILL_HEIGHT,
+            borderLeft: `1px solid ${token.colorBorderSecondary}`,
+          }}
+        >
+          {hasConfig ? (
+            <>
+              {/* Env label — clickable to env URL when running, otherwise opens env tab */}
+              {isRunning && environmentUrl ? (
+                <Tooltip title={`Open ${environmentUrl}`}>
+                  <a
+                    href={environmentUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 3,
+                      color: 'inherit',
+                      textDecoration: 'none',
+                      padding: '0 2px',
+                    }}
+                  >
+                    {getStatusIcon()}
+                    <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
+                  </a>
+                </Tooltip>
+              ) : (
+                <Tooltip title={getEnvTooltip()}>
+                  <button
+                    type="button"
+                    onClick={openTab('environment')}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 3,
+                      cursor: 'pointer',
+                      padding: '0 2px',
+                      background: 'none',
+                      border: 'none',
+                      color: 'inherit',
+                      font: 'inherit',
+                    }}
+                  >
+                    {getStatusIcon()}
+                    <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
+                  </button>
+                </Tooltip>
+              )}
 
-            {/* Play button */}
-            {onStartEnvironment && (
-              <Tooltip title={isRunning ? 'Environment running' : 'Start environment'}>
-                <Button
-                  type="text"
-                  size="small"
-                  aria-label="Start environment"
-                  icon={<PlayCircleOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!startDisabled) onStartEnvironment(branch.branch_id);
-                  }}
-                  disabled={startDisabled}
-                  style={iconButtonStyle}
-                />
-              </Tooltip>
-            )}
+              {/* Play button */}
+              {onStartEnvironment && (
+                <Tooltip title={isRunning ? 'Environment running' : 'Start environment'}>
+                  <Button
+                    type="text"
+                    size="small"
+                    aria-label="Start environment"
+                    icon={<PlayCircleOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!startDisabled) onStartEnvironment(branch.branch_id);
+                    }}
+                    disabled={startDisabled}
+                    style={iconButtonStyle}
+                  />
+                </Tooltip>
+              )}
 
-            {/* Stop button */}
-            {onStopEnvironment && (
-              <Tooltip
-                title={
-                  isRunning
-                    ? 'Stop environment'
-                    : isStarting
-                      ? 'Cancel startup'
-                      : isStopping
-                        ? 'Stopping...'
-                        : 'Not running'
-                }
+              {/* Stop button */}
+              {onStopEnvironment && (
+                <Tooltip
+                  title={
+                    isRunning
+                      ? 'Stop environment'
+                      : isStarting
+                        ? 'Cancel startup'
+                        : isStopping
+                          ? 'Stopping...'
+                          : 'Not running'
+                  }
+                >
+                  <Button
+                    type="text"
+                    size="small"
+                    aria-label="Stop environment"
+                    icon={<StopOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!stopDisabled) onStopEnvironment(branch.branch_id);
+                    }}
+                    disabled={stopDisabled}
+                    style={iconButtonStyle}
+                  />
+                </Tooltip>
+              )}
+
+              {/* Logs button */}
+              {onViewLogs && effectiveEnv.logs && (
+                <Tooltip title="View logs">
+                  <Button
+                    type="text"
+                    size="small"
+                    aria-label="View environment logs"
+                    icon={<FileTextOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onViewLogs(branch.branch_id);
+                    }}
+                    style={iconButtonStyle}
+                  />
+                </Tooltip>
+              )}
+
+              {/* Nuke button */}
+              {onNukeEnvironment && branch.nuke_command && (
+                <Tooltip title="Nuke environment (destructive)">
+                  <Button
+                    type="text"
+                    size="small"
+                    danger
+                    aria-label="Nuke environment"
+                    icon={<FireOutlined />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      confirmNuke(() => onNukeEnvironment(branch.branch_id));
+                    }}
+                    disabled={connectionDisabled}
+                    style={iconButtonStyle}
+                  />
+                </Tooltip>
+              )}
+            </>
+          ) : (
+            /* No env config — show dim env label with edit icon */
+            <Tooltip title="Configure environment">
+              <button
+                type="button"
+                onClick={openTab('environment')}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 3,
+                  cursor: 'pointer',
+                  opacity: 0.5,
+                  padding: '0 2px',
+                  background: 'none',
+                  border: 'none',
+                  color: 'inherit',
+                  font: 'inherit',
+                }}
               >
-                <Button
-                  type="text"
-                  size="small"
-                  aria-label="Stop environment"
-                  icon={<StopOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!stopDisabled) onStopEnvironment(branch.branch_id);
-                  }}
-                  disabled={stopDisabled}
-                  style={iconButtonStyle}
-                />
-              </Tooltip>
-            )}
-
-            {/* Logs button */}
-            {onViewLogs && effectiveEnv.logs && (
-              <Tooltip title="View logs">
-                <Button
-                  type="text"
-                  size="small"
-                  aria-label="View environment logs"
-                  icon={<FileTextOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onViewLogs(branch.branch_id);
-                  }}
-                  style={iconButtonStyle}
-                />
-              </Tooltip>
-            )}
-
-            {/* Nuke button */}
-            {onNukeEnvironment && branch.nuke_command && (
-              <Tooltip title="Nuke environment (destructive)">
-                <Button
-                  type="text"
-                  size="small"
-                  danger
-                  aria-label="Nuke environment"
-                  icon={<FireOutlined />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    confirmNuke(() => onNukeEnvironment(branch.branch_id));
-                  }}
-                  disabled={connectionDisabled}
-                  style={iconButtonStyle}
-                />
-              </Tooltip>
-            )}
-          </>
-        ) : (
-          /* No env config — show dim env label with edit icon */
-          <Tooltip title="Configure environment">
-            <button
-              type="button"
-              onClick={openTab('environment')}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 3,
-                cursor: 'pointer',
-                opacity: 0.5,
-                padding: '0 2px',
-                background: 'none',
-                border: 'none',
-                color: 'inherit',
-                font: 'inherit',
-              }}
-            >
-              <GlobalOutlined style={{ fontSize: 11 }} />
-              <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
-            </button>
-          </Tooltip>
-        )}
-      </div>
+                <GlobalOutlined style={{ fontSize: 11 }} />
+                <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      )}
 
       {/* Section 3: Tab shortcut icons */}
       <div
@@ -394,13 +399,16 @@ export function BranchHeaderPill({
             style={iconButtonStyle}
           />
         </Tooltip>
-        <Tooltip title="Edit environment">
+        <Tooltip title="Edit branch">
           <Button
             type="text"
             size="small"
-            aria-label="Edit environment"
+            aria-label="Edit branch"
             icon={<EditOutlined />}
-            onClick={openTab('environment')}
+            onClick={(e) => {
+              e.stopPropagation();
+              openModal();
+            }}
             style={iconButtonStyle}
           />
         </Tooltip>

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -34,6 +34,8 @@ interface BranchHeaderPillProps {
   connectionDisabled?: boolean;
   /** Show environment status/controls and environment shortcut. Defaults to true. */
   showEnvButtons?: boolean;
+  /** Compact identity section for constrained side panels. Hides the repo slug but keeps it in the tooltip. */
+  compact?: boolean;
 }
 
 const PILL_HEIGHT = 22;
@@ -56,6 +58,7 @@ export function BranchHeaderPill({
   onViewLogs,
   connectionDisabled = false,
   showEnvButtons = true,
+  compact = false,
 }: BranchHeaderPillProps) {
   const { token } = theme.useToken();
   const confirmNuke = useConfirmNukeEnvironment();
@@ -138,6 +141,10 @@ export function BranchHeaderPill({
     }
   };
 
+  const identityTooltip = compact
+    ? `${repo.slug} / ${branch.name} · Open branch settings`
+    : 'Open branch settings';
+
   // --- Render ---
 
   return (
@@ -154,7 +161,7 @@ export function BranchHeaderPill({
       }}
     >
       {/* Section 1: Repo + Branch — click opens modal (General tab) */}
-      <Tooltip title="Open branch settings">
+      <Tooltip title={identityTooltip}>
         <button
           type="button"
           onClick={openModal}
@@ -162,7 +169,7 @@ export function BranchHeaderPill({
             display: 'inline-flex',
             alignItems: 'center',
             gap: 4,
-            padding: '0 8px',
+            padding: compact ? '0 6px' : '0 8px',
             cursor: 'pointer',
             height: PILL_HEIGHT,
             background: 'none',
@@ -172,15 +179,19 @@ export function BranchHeaderPill({
           }}
         >
           <BranchesOutlined style={{ fontSize: 12 }} />
-          <span style={{ fontFamily: token.fontFamilyCode, fontSize: token.fontSizeSM }}>
-            {repo.slug}
-          </span>
-          <ApartmentOutlined style={{ fontSize: 10, opacity: 0.6 }} />
+          {!compact && (
+            <>
+              <span style={{ fontFamily: token.fontFamilyCode, fontSize: token.fontSizeSM }}>
+                {repo.slug}
+              </span>
+              <ApartmentOutlined style={{ fontSize: 10, opacity: 0.6 }} />
+            </>
+          )}
           <span
             style={{
               fontFamily: token.fontFamilyCode,
               fontSize: token.fontSizeSM,
-              maxWidth: 180,
+              maxWidth: compact ? 220 : 180,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -22,6 +22,16 @@ interface BranchListDrawerProps {
   onSessionClick: (sessionId: string) => void;
 }
 
+export interface BoardSessionListProps {
+  board?: Board;
+  currentBoardId: string;
+  branchById: Map<string, Branch>;
+  repoById: Map<string, Repo>;
+  sessionsByBranch: Map<string, Session[]>;
+  onSessionClick: (sessionId: string) => void;
+  onAfterSessionClick?: () => void;
+}
+
 /**
  * Drawer suppresses badges for the "boring" tones (`success`/`default`) so
  * idle and completed rows show a clean avatar with no decoration. The absence
@@ -40,17 +50,48 @@ export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
   onClose,
   boards,
   currentBoardId,
-  onBoardChange,
   branchById,
   repoById,
   sessionsByBranch,
   onSessionClick,
 }) => {
+  const currentBoard = boards.find((b) => b.board_id === currentBoardId);
+
+  return (
+    <Drawer
+      title={null}
+      placement="left"
+      size={480}
+      open={open}
+      onClose={onClose}
+      styles={{
+        body: { padding: 0 },
+      }}
+    >
+      <BoardSessionList
+        board={currentBoard}
+        currentBoardId={currentBoardId}
+        branchById={branchById}
+        repoById={repoById}
+        sessionsByBranch={sessionsByBranch}
+        onSessionClick={onSessionClick}
+        onAfterSessionClick={onClose}
+      />
+    </Drawer>
+  );
+};
+
+export const BoardSessionList: React.FC<BoardSessionListProps> = ({
+  board,
+  currentBoardId,
+  branchById,
+  repoById,
+  sessionsByBranch,
+  onSessionClick,
+  onAfterSessionClick,
+}) => {
   const { token } = theme.useToken();
   const [searchQuery, setSearchQuery] = useState('');
-
-  // Get current board
-  const currentBoard = boards.find((b) => b.board_id === currentBoardId);
 
   // Filter sessions by current board (branch-centric model)
   const boardSessions = useMemo(() => {
@@ -77,16 +118,7 @@ export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
   );
 
   return (
-    <Drawer
-      title={null}
-      placement="left"
-      size={480}
-      open={open}
-      onClose={onClose}
-      styles={{
-        body: { padding: 0 },
-      }}
-    >
+    <div style={{ height: '100%', position: 'relative', overflow: 'hidden' }}>
       {/* Search Bar */}
       <div
         style={{
@@ -132,7 +164,7 @@ export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
                 }}
                 onClick={() => {
                   onSessionClick(session.session_id);
-                  onClose();
+                  onAfterSessionClick?.();
                 }}
               >
                 {/* Line 1: tool icon (with corner status badge) · title · genealogy */}
@@ -214,7 +246,7 @@ export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
       </div>
 
       {/* Board Info Footer */}
-      {currentBoard && (
+      {board && (
         <div
           style={{
             position: 'absolute',
@@ -228,11 +260,11 @@ export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
         >
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
             {filteredSessions.length} of {boardSessions.length} sessions
-            {currentBoard.description && ` • ${currentBoard.description}`}
+            {board.description && ` • ${board.description}`}
           </Typography.Text>
         </div>
       )}
-    </Drawer>
+    </div>
   );
 };
 

--- a/apps/agor-ui/src/components/BranchListDrawer/index.ts
+++ b/apps/agor-ui/src/components/BranchListDrawer/index.ts
@@ -1,1 +1,2 @@
-export { BranchListDrawer, default } from './BranchListDrawer';
+export type { BoardSessionListProps } from './BranchListDrawer';
+export { BoardSessionList, BranchListDrawer, default } from './BranchListDrawer';

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
@@ -18,7 +18,7 @@
  * own slot, and the footer reads `validByTab[activeTab]`.
  */
 
-import type { Board, Repo } from '@agor-live/client';
+import type { Repo } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { CreateDialog } from './CreateDialog';
@@ -54,14 +54,12 @@ function renderDialog(props: Partial<React.ComponentProps<typeof CreateDialog>> 
     [frameworkRepo.repo_id, frameworkRepo],
     [userRepo.repo_id, userRepo],
   ]);
-  const boardById = new Map<string, Board>();
 
   return render(
     <CreateDialog
       open
       onClose={vi.fn()}
       repoById={repoById}
-      boardById={boardById}
       availableAgents={[
         { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Claude' },
       ]}

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
@@ -85,6 +85,16 @@ function renderDialog(props: Partial<React.ComponentProps<typeof CreateDialog>> 
 const ASYNC = { timeout: 10_000 };
 
 describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () => {
+  it('defaults to Assistant as the primary create path', async () => {
+    renderDialog();
+
+    expect(await screen.findByRole('tab', { name: /Assistant/i }, ASYNC)).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.getByRole('button', { name: /Create Assistant/i })).toBeDisabled();
+  });
+
   it('enables Create Assistant once Name is typed', async () => {
     renderDialog({ defaultTab: 'assistant' });
 

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -68,7 +68,6 @@ export interface CreateDialogProps {
   open: boolean;
   onClose: () => void;
   repoById: Map<string, Repo>;
-  boardById: Map<string, Board>;
   currentBoardId?: string;
   defaultPosition?: { x: number; y: number };
   availableAgents: AgenticToolOption[];
@@ -99,7 +98,6 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
   open,
   onClose,
   repoById,
-  boardById,
   currentBoardId,
   defaultPosition,
   availableAgents,
@@ -237,7 +235,6 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
           />
           <AssistantTab
             repoById={repoById}
-            boardById={boardById}
             onValidityChange={handleAssistantValid}
             formRef={assistantFormRef}
             onCreateRepo={onCreateRepo}

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -106,7 +106,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
   mcpServerById,
   currentUser,
   client,
-  defaultTab = 'branch',
+  defaultTab = 'assistant',
   onCreateBranch,
   onCreateBoard,
   onCreateRepo,
@@ -220,32 +220,6 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
 
   const tabItems = [
     {
-      key: 'branch',
-      label: (
-        <span>
-          <BranchesOutlined style={{ marginRight: 8 }} />
-          Branch
-        </span>
-      ),
-      children: (
-        <div>
-          <Alert
-            type="info"
-            showIcon
-            description={PURPOSE_TEXT.branch}
-            style={{ marginBottom: 16 }}
-          />
-          <BranchTab
-            repoById={repoById}
-            currentBoardId={currentBoardId}
-            defaultPosition={defaultPosition}
-            onValidityChange={handleBranchValid}
-            formRef={branchFormRef}
-          />
-        </div>
-      ),
-    },
-    {
       key: 'assistant',
       label: (
         <span>
@@ -271,6 +245,32 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
             mcpServerById={mcpServerById}
             currentUser={currentUser}
             client={client}
+          />
+        </div>
+      ),
+    },
+    {
+      key: 'branch',
+      label: (
+        <span>
+          <BranchesOutlined style={{ marginRight: 8 }} />
+          Branch
+        </span>
+      ),
+      children: (
+        <div>
+          <Alert
+            type="info"
+            showIcon
+            description={PURPOSE_TEXT.branch}
+            style={{ marginBottom: 16 }}
+          />
+          <BranchTab
+            repoById={repoById}
+            currentBoardId={currentBoardId}
+            defaultPosition={defaultPosition}
+            onValidityChange={handleBranchValid}
+            formRef={branchFormRef}
           />
         </div>
       ),

--- a/apps/agor-ui/src/components/CreateDialog/tabs/AssistantTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/AssistantTab.tsx
@@ -1,7 +1,6 @@
 import type {
   AgenticToolName,
   AgorClient,
-  Board,
   CodexApprovalPolicy,
   CodexSandboxMode,
   CreateRepoRequest,
@@ -15,21 +14,19 @@ import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live
 import { DownOutlined } from '@ant-design/icons';
 import { Collapse, Form, Typography } from 'antd';
 import { useEffect, useState } from 'react';
-import { mapToArray } from '@/utils/mapHelpers';
 import { slugify } from '@/utils/repoSlug';
 import { useAssistantForm } from '../../../hooks/useAssistantForm';
 import { useEnsureFrameworkRepo } from '../../../hooks/useEnsureFrameworkRepo';
 import type { AgenticToolOption } from '../../../types';
 import { AgenticToolConfigForm, getFormValuesFromConfig } from '../../AgenticToolConfigForm';
 import { AgentSelectionGrid } from '../../AgentSelectionGrid';
-import { AssistantFormFields, CREATE_NEW_BOARD } from '../../forms/AssistantFormFields';
+import { AssistantFormFields } from '../../forms/AssistantFormFields';
 import type { ModelConfig } from '../../ModelSelector';
 
 export interface AssistantTabResult {
   displayName: string;
   description?: string;
   emoji?: string;
-  boardChoice?: string;
   repoId?: string;
   branchName?: string;
   sourceBranch?: string;
@@ -45,7 +42,6 @@ export interface AssistantTabResult {
 
 export interface AssistantTabProps {
   repoById: Map<string, Repo>;
-  boardById: Map<string, Board>;
   onValidityChange: (valid: boolean) => void;
   formRef: React.MutableRefObject<(() => Promise<AssistantTabResult | null>) | null>;
   onCreateRepo?: (data: CreateRepoRequest) => void | Promise<void>;
@@ -57,7 +53,6 @@ export interface AssistantTabProps {
 
 export const AssistantTab: React.FC<AssistantTabProps> = ({
   repoById,
-  boardById,
   onValidityChange,
   formRef,
   onCreateRepo,
@@ -66,8 +61,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
   currentUser,
   client,
 }) => {
-  const repos = mapToArray(repoById);
-  const boards = mapToArray(boardById);
+  const repos = Array.from(repoById.values());
   const { frameworkRepo, isCloning } = useEnsureFrameworkRepo(repos, onCreateRepo);
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
 
@@ -116,7 +110,6 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
         displayName: values.displayName.trim(),
         description: values.description || undefined,
         emoji: values.emoji || undefined,
-        boardChoice: values.boardChoice,
         repoId: values.repoId || frameworkRepo?.repo_id,
         branchName: values.name || `private-${slugify(values.displayName)}`,
         sourceBranch: values.sourceBranch || 'main',
@@ -154,12 +147,11 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
       form={form}
       layout="vertical"
       onFieldsChange={validateForm}
-      initialValues={{ boardChoice: CREATE_NEW_BOARD, sourceBranch: 'main' }}
+      initialValues={{ sourceBranch: 'main' }}
     >
       <AssistantFormFields
         form={form}
         repos={repos}
-        boards={boards}
         frameworkRepo={frameworkRepo}
         isCloning={isCloning}
         onDisplayNameChange={handleDisplayNameChange}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -60,6 +60,7 @@ import {
   findFrameworkRepo,
 } from '../../hooks/useFrameworkRepo';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
+import { ensureAssistantWelcomeNote } from '../../utils/assistantWelcomeNote';
 import { extractSlugFromPath, slugify } from '../../utils/repoSlug';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
@@ -914,6 +915,14 @@ export function OnboardingWizard({
         setCreatedBoardId(board.board_id);
         // Persist board ID immediately so restarts don't re-create it
         saveOnboardingProgress({ boardId: board.board_id });
+        if (path === 'assistant') {
+          await ensureAssistantWelcomeNote({
+            client,
+            boardId: board.board_id,
+            assistantName: assistantDisplayName.trim() || 'My Assistant',
+            assistantEmoji,
+          });
+        }
         setLoading(false);
         setCurrentStep('branch');
       }
@@ -1038,6 +1047,12 @@ export function OnboardingWizard({
         // Persist branch ID so restarts don't re-create it
         saveOnboardingProgress({ branchId: branch.branch_id });
 
+        if (path === 'assistant') {
+          await client
+            ?.service('boards')
+            .setPrimaryAssistant({ boardId: createdBoardId, branchId: branch.branch_id });
+        }
+
         await launchSessionForBranch(branch.branch_id, createdBoardId);
       } else {
         setLoading(false);
@@ -1056,6 +1071,7 @@ export function OnboardingWizard({
     assistantEmoji,
     repoById,
     onCreateBranch,
+    client,
     saveOnboardingProgress,
     launchSessionForBranch,
   ]);

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -98,6 +98,7 @@ interface SessionCanvasProps {
   userById: Map<string, User>; // Map-based user storage
   repoById: Map<string, Repo>; // Map-based repo storage
   branches: Branch[];
+  primaryAssistantId?: string | null;
   branchById: Map<string, Branch>;
   boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
   commentById: Map<string, BoardComment>; // Map-based comment storage
@@ -341,6 +342,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       sessionsByBranch,
       repoById,
       branches,
+      primaryAssistantId,
       branchById,
       boardObjectById,
       commentById,
@@ -584,7 +586,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         // Find the board_object for this branch
         const boardObject = boardObjectByBranch.get(branchId);
 
-        if (!boardObject || !boardObject.zone_id) {
+        if (!boardObject?.zone_id) {
           return;
         }
 
@@ -643,6 +645,10 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       const nodes: Node[] = [];
 
       branches.forEach((branch, index) => {
+        if (primaryAssistantId && branch.branch_id === primaryAssistantId) {
+          return;
+        }
+
         // Find board object for this branch (if positioned on this board)
         const boardObject = boardObjectByBranch.get(branch.branch_id);
 
@@ -724,6 +730,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     }, [
       board,
       branches,
+      primaryAssistantId,
       boardObjectByBranch,
       repoById,
       sessionsByBranch,
@@ -767,7 +774,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       async (cardId: string) => {
         if (!board || !client) return;
         const boardObject = boardObjectByCard.get(cardId);
-        if (!boardObject || !boardObject.zone_id) return;
+        if (!boardObject?.zone_id) return;
 
         const zone = board.objects?.[boardObject.zone_id];
         if (!zone) return;
@@ -2182,6 +2189,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 }
               },
               onEdit: handleEditMarkdownNote,
+              onDelete: deleteObject,
             },
           },
         ];
@@ -2221,6 +2229,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       markdownWidth,
       setNodes,
       handleEditMarkdownNote,
+      deleteObject,
       mutationGate.canMutate,
     ]);
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/MarkdownNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/MarkdownNode.tsx
@@ -1,6 +1,7 @@
 import type { BoardObject } from '@agor-live/client';
-import { EditOutlined } from '@ant-design/icons';
-import { Button, Card, Typography, theme } from 'antd';
+import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { App, Button, Card, Space, Typography, theme } from 'antd';
+import { useMutationGate } from '../../../contexts/ConnectionContext';
 import { MarkdownRenderer } from '../../MarkdownRenderer/MarkdownRenderer';
 
 interface MarkdownNodeData {
@@ -9,16 +10,34 @@ interface MarkdownNodeData {
   width: number;
   onUpdate: (id: string, data: BoardObject) => void;
   onEdit?: (objectId: string, content: string, width: number) => void;
+  onDelete?: (objectId: string) => void;
 }
 
 export const MarkdownNode = ({ data }: { data: MarkdownNodeData }) => {
   const { token } = theme.useToken();
+  const { modal } = App.useApp();
+  const mutationGate = useMutationGate();
+  const mutationDisabled = !mutationGate.canMutate;
 
   const handleEdit = () => {
+    if (mutationDisabled) return;
     // Trigger edit by calling the onEdit callback if provided
     if (data.onEdit) {
       data.onEdit(data.objectId, data.content, data.width);
     }
+  };
+
+  const handleDelete = () => {
+    if (mutationDisabled || !data.onDelete) return;
+
+    modal.confirm({
+      title: 'Delete note?',
+      content: 'This note will be removed from the board.',
+      okText: 'Delete',
+      okButtonProps: { danger: true },
+      cancelText: 'Cancel',
+      onOk: () => data.onDelete?.(data.objectId),
+    });
   };
 
   return (
@@ -44,16 +63,33 @@ export const MarkdownNode = ({ data }: { data: MarkdownNodeData }) => {
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
             Markdown Note
           </Typography.Text>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleEdit();
-            }}
-            title="Edit note"
-          />
+          <Space size={2}>
+            <Button
+              className="nodrag nopan"
+              type="text"
+              size="small"
+              icon={<EditOutlined />}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleEdit();
+              }}
+              disabled={mutationDisabled}
+              title="Edit note"
+            />
+            <Button
+              className="nodrag nopan"
+              type="text"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete();
+              }}
+              disabled={mutationDisabled}
+              title="Delete note"
+            />
+          </Space>
         </div>
       }
       styles={{ body: { padding: token.sizeUnit * 8 } }}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -289,6 +289,7 @@ export const useBoardObjects = ({
               width: objectData.width,
               onUpdate: handleUpdateObject,
               onEdit: onEditMarkdown,
+              onDelete: deleteObject,
             },
           };
         }

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -199,6 +199,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
         onFilesDrop={onFilesDrop}
         slashCommands={slashCommands}
         skills={skills}
+        highlightWhenEmpty
       />
     );
   }

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -36,7 +36,7 @@ import { mapToArray } from '@/utils/mapHelpers';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
-import { AssistantFormFields, CREATE_NEW_BOARD } from '../forms/AssistantFormFields';
+import { AssistantFormFields } from '../forms/AssistantFormFields';
 import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
 import { UserAvatar } from '../metadata/UserAvatar';
 
@@ -88,7 +88,6 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
   onClose,
 }) => {
   const repos = mapToArray(repoById);
-  const boards = mapToArray(boardById);
 
   // Assistants ARE branches (just branches flagged via
   // `custom_context.assistant`), so navigation reuses the `/w/<short>/`
@@ -156,7 +155,6 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
           displayName: values.displayName.trim(),
           description: values.description || undefined,
           emoji: values.emoji || undefined,
-          boardChoice: values.boardChoice,
           repoId,
           branchName: values.name || undefined,
           sourceBranch: values.sourceBranch || undefined,
@@ -428,12 +426,11 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
           form={form}
           layout="vertical"
           onFieldsChange={validateForm}
-          initialValues={{ boardChoice: CREATE_NEW_BOARD, sourceBranch: 'main' }}
+          initialValues={{ sourceBranch: 'main' }}
         >
           <AssistantFormFields
             form={form}
             repos={repos}
-            boards={boards}
             frameworkRepo={frameworkRepo}
             isCloning={isCloning}
             onDisplayNameChange={handleDisplayNameChange}

--- a/apps/agor-ui/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/apps/agor-ui/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -65,6 +65,7 @@ export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({ onOpenThemeEditor 
         type="text"
         icon={<BgColorsOutlined style={{ fontSize: token.fontSizeLG }} />}
         title="Change theme"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
       />
     </Dropdown>
   );

--- a/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
@@ -1,16 +1,12 @@
-import type { Board, Repo } from '@agor-live/client';
+import type { Repo } from '@agor-live/client';
 import { DownOutlined, InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import type { FormInstance } from 'antd';
 import { Alert, Collapse, Form, Input, Select, Space, Tooltip, Typography } from 'antd';
-import { CREATE_NEW_BOARD } from '@/utils/assistantConstants';
 import { FormEmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
-
-export { CREATE_NEW_BOARD };
 
 export interface AssistantFormFieldsProps {
   form: FormInstance;
   repos: Repo[];
-  boards: Board[];
   frameworkRepo: Repo | undefined;
   isCloning?: boolean;
   onDisplayNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -24,7 +20,7 @@ export interface AssistantFormFieldsProps {
  * Shared assistant form fields used in both the CreateDialog AssistantTab
  * and the SettingsModal AssistantsTable create modal.
  *
- * Renders: Name + icon, Board, board advice Alert, Advanced collapse
+ * Renders: Name + icon, assistant board advice Alert, Advanced collapse
  * (Framework Repository, Branch Name, Source Branch).
  * Does NOT render a <Form> wrapper — the parent owns the form instance.
  */

--- a/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
@@ -31,7 +31,6 @@ export interface AssistantFormFieldsProps {
 export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
   form,
   repos,
-  boards,
   frameworkRepo,
   isCloning,
   onDisplayNameChange,
@@ -39,19 +38,6 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
   onCustomRepoChange,
   extraBeforeAdvanced,
 }) => {
-  const boardOptions = [
-    {
-      value: CREATE_NEW_BOARD,
-      label: '+ Create a new board for this assistant (Recommended)',
-    },
-    ...[...boards]
-      .sort((a: Board, b: Board) => a.name.localeCompare(b.name))
-      .map((board: Board) => ({
-        value: board.board_id,
-        label: `${board.icon || '\u{1F4CB}'} ${board.name}`,
-      })),
-  ];
-
   const repoPlaceholder = frameworkRepo
     ? `${frameworkRepo.name || frameworkRepo.slug} (default)`
     : isCloning
@@ -89,26 +75,13 @@ export const AssistantFormFields: React.FC<AssistantFormFieldsProps> = ({
         />
       </Form.Item>
 
-      <Form.Item name="boardChoice" label="Board">
-        <Select
-          showSearch
-          filterOption={(input, option) =>
-            String(option?.label ?? '')
-              .toLowerCase()
-              .includes(input.toLowerCase())
-          }
-          options={boardOptions}
-        />
-      </Form.Item>
-
       <Alert
         type="info"
         showIcon={false}
         style={{ marginBottom: 16 }}
         title={
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            While assistants can act across boards, we recommend giving each assistant its own
-            board.
+            Each assistant gets a fresh board and becomes that board&apos;s primary assistant.
           </Typography.Text>
         }
       />

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -5,6 +5,14 @@
 
 /* Global styles for Agor UI */
 
+/* Header icon buttons are inline-flex by default in AntD, which lets the
+   inherited 64px header line-height place them on the text baseline. Force the
+   badge wrapper into flex layout so comment icon buttons center like the rest. */
+.app-header-icon-badge {
+  display: flex;
+  align-items: center;
+}
+
 /* Prevent long text from causing horizontal scroll in collapse headers,
    but allow vertical overflow so flex-wrapped pill rows aren't clipped (#869). */
 .ant-collapse-header {

--- a/apps/agor-ui/src/utils/assistantConstants.ts
+++ b/apps/agor-ui/src/utils/assistantConstants.ts
@@ -1,2 +1,0 @@
-/** Special sentinel value for the "create new board" option in assistant forms */
-export const CREATE_NEW_BOARD = '__create_new__';

--- a/apps/agor-ui/src/utils/assistantCreation.test.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.test.ts
@@ -31,9 +31,26 @@ function makeBranch(overrides: Partial<Branch> = {}): Branch {
 describe('createAssistantBranch', () => {
   it('stores assistant identity, including emoji, in the initial branch create payload', async () => {
     const repo = makeRepo();
-    const branch = makeBranch();
+    const branch = makeBranch({ board_id: 'board-1' });
     const onCreateBranch = vi.fn().mockResolvedValue(branch);
     const onUpdateBranch = vi.fn();
+    const boardsService = {
+      create: vi.fn().mockResolvedValue({
+        board_id: 'board-1',
+        name: "Pineapple Helper's Board",
+        icon: '🍍',
+        objects: {},
+      }),
+      get: vi.fn().mockResolvedValue({ board_id: 'board-1', objects: {} }),
+      patch: vi.fn().mockResolvedValue({}),
+      setPrimaryAssistant: vi.fn().mockResolvedValue({}),
+    };
+    const client = {
+      service: vi.fn((name: string) => {
+        if (name === 'boards') return boardsService;
+        throw new Error(`Unexpected service: ${name}`);
+      }),
+    };
 
     await createAssistantBranch(
       {
@@ -43,7 +60,7 @@ describe('createAssistantBranch', () => {
         repoId: repo.repo_id,
       },
       {
-        client: null,
+        client: client as never,
         repoById: new Map([[repo.repo_id, repo]]),
         onCreateBranch,
         onUpdateBranch,
@@ -54,6 +71,7 @@ describe('createAssistantBranch', () => {
       repo.repo_id,
       expect.objectContaining({
         name: 'private-pineapple-helper',
+        boardId: 'board-1',
         custom_context: {
           assistant: expect.objectContaining({
             kind: 'assistant',
@@ -64,6 +82,21 @@ describe('createAssistantBranch', () => {
         notes: 'Helps with pineapple tasks.',
       })
     );
+    expect(boardsService.create).toHaveBeenCalledWith({
+      name: "Pineapple Helper's Board",
+      icon: '🍍',
+    });
+    expect(boardsService.patch).toHaveBeenCalledWith(
+      'board-1',
+      expect.objectContaining({
+        _action: 'upsertObject',
+        objectId: 'welcome-note',
+      })
+    );
+    expect(boardsService.setPrimaryAssistant).toHaveBeenCalledWith({
+      boardId: 'board-1',
+      branchId: branch.branch_id,
+    });
     expect(onUpdateBranch).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/utils/assistantCreation.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.ts
@@ -6,7 +6,6 @@ export interface AssistantCreationInput {
   displayName: string;
   description?: string;
   emoji?: string;
-  boardChoice?: string;
   repoId: string;
   branchName?: string;
   sourceBranch?: string;

--- a/apps/agor-ui/src/utils/assistantCreation.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.ts
@@ -1,5 +1,5 @@
 import type { AgorClient, AssistantConfig, Board, BoardID, Branch, Repo } from '@agor-live/client';
-import { CREATE_NEW_BOARD } from '@/utils/assistantConstants';
+import { ensureAssistantWelcomeNote } from '@/utils/assistantWelcomeNote';
 import { slugify } from '@/utils/repoSlug';
 
 export interface AssistantCreationInput {
@@ -38,8 +38,8 @@ export interface AssistantCreationDeps {
  * Shared assistant creation logic used by both the CreateDialog (via App.tsx)
  * and the SettingsModal AssistantsTable.
  *
- * Flow: resolve repo → generate branch name → optionally create board →
- * create branch → tag branch with assistant metadata.
+ * Flow: resolve repo → create board → create branch → tag branch with
+ * assistant metadata → designate the branch as the board primary.
  */
 export async function createAssistantBranch(
   input: AssistantCreationInput,
@@ -49,23 +49,23 @@ export async function createAssistantBranch(
   const branchName = input.branchName || `private-${slugify(input.displayName)}`;
   const sourceBranch = input.sourceBranch || repo?.default_branch || 'main';
 
-  // Create a new board if requested
-  let boardId: string | undefined;
-  if (input.boardChoice === CREATE_NEW_BOARD) {
-    if (deps.client) {
-      try {
-        const newBoard = (await deps.client.service('boards').create({
-          name: input.displayName.trim(),
-          icon: input.emoji || '\u{1F916}',
-        })) as Board;
-        boardId = newBoard.board_id;
-      } catch (err) {
-        console.error('Failed to create board:', err);
-      }
-    }
-  } else if (input.boardChoice) {
-    boardId = input.boardChoice;
+  if (!deps.client) {
+    throw new Error('Not connected');
   }
+
+  const displayName = input.displayName.trim() || 'My Assistant';
+  const newBoard = (await deps.client.service('boards').create({
+    name: `${displayName}'s Board`,
+    icon: input.emoji || '\u{1F916}',
+  })) as Board;
+  const boardId = newBoard.board_id;
+
+  await ensureAssistantWelcomeNote({
+    client: deps.client,
+    boardId,
+    assistantName: displayName,
+    assistantEmoji: input.emoji,
+  });
 
   const assistantConfig: AssistantConfig = {
     kind: 'assistant',
@@ -95,6 +95,11 @@ export async function createAssistantBranch(
       await deps.onUpdateBranch(branch.branch_id, {
         board_id: boardId as BoardID,
       });
+    }
+    if (boardId) {
+      await deps.client
+        ?.service('boards')
+        .setPrimaryAssistant({ boardId, branchId: branch.branch_id });
     }
   }
 

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.ts
@@ -1,0 +1,99 @@
+import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
+import type { AgorClient, Board, BoardID, BoardObject } from '@agor-live/client';
+
+export const ASSISTANT_WELCOME_NOTE_OBJECT_ID = 'welcome-note';
+
+export interface AssistantWelcomeNoteInput {
+  client: AgorClient | null;
+  boardId: BoardID | string;
+  assistantName: string;
+  assistantEmoji?: string | null;
+}
+
+export const ASSISTANT_WELCOME_NOTE_TEMPLATE = `# Welcome to {{assistant.name}}'s Board {{assistant.emoji}}
+
+This board is a shared workspace for you and **{{assistant.name}}** to shape and run workflows.
+
+Use it to organize:
+
+- 🌿 **Branches** — coding efforts and their agent sessions
+- 🧩 **Cards** — entities your workflow cares about, like tickets, customers, patients, leads, or incidents
+- 📝 **Notes** — shared context, instructions, diagrams, and checklists
+- 🗺️ **Zones** — named areas that group work and can trigger prompts as branches move through them
+
+| 👈 Assistant | Board | Chat 👉 |
+| --- | --- | --- |
+| Plan and set up workflows | Arrange branches, cards, notes, and zones | Work through conversations |
+
+> Start by asking **{{assistant.name}}** to help set up this board for a workflow that's relevant to you.`;
+
+export function buildAssistantWelcomeNoteContent({
+  assistantName,
+  assistantEmoji,
+}: Pick<AssistantWelcomeNoteInput, 'assistantName' | 'assistantEmoji'>): string {
+  const name = assistantName.trim() || 'your assistant';
+  return renderTemplate(
+    ASSISTANT_WELCOME_NOTE_TEMPLATE,
+    {
+      assistant: {
+        name,
+        emoji: assistantEmoji?.trim() || '🤖',
+      },
+    },
+    { onError: 'raw' }
+  );
+}
+
+/**
+ * Adds the initial markdown note to a newly-created assistant board.
+ * Best-effort: failure should not block assistant/board creation.
+ */
+export async function ensureAssistantWelcomeNote({
+  client,
+  boardId,
+  assistantName,
+  assistantEmoji,
+}: AssistantWelcomeNoteInput): Promise<void> {
+  if (!client || !boardId) return;
+
+  const content = buildAssistantWelcomeNoteContent({ assistantName, assistantEmoji });
+  const objectData: BoardObject = {
+    type: 'markdown',
+    x: 80,
+    y: 80,
+    width: 700,
+    content,
+  };
+
+  try {
+    const board = (await client.service('boards').get(boardId)) as Board;
+    const existing = board.objects?.[ASSISTANT_WELCOME_NOTE_OBJECT_ID];
+    if (existing) {
+      if (
+        existing.type === 'markdown' &&
+        (existing.content.includes('```mermaid') ||
+          existing.content.includes('flowchart LR') ||
+          existing.content.includes('Workflow building blocks') ||
+          existing.content.includes('<--- on your left'))
+      ) {
+        await client.service('boards').patch(boardId, {
+          _action: 'upsertObject',
+          objectId: ASSISTANT_WELCOME_NOTE_OBJECT_ID,
+          objectData: {
+            ...existing,
+            content,
+          },
+        } as unknown as Partial<Board>);
+      }
+      return;
+    }
+
+    await client.service('boards').patch(boardId, {
+      _action: 'upsertObject',
+      objectId: ASSISTANT_WELCOME_NOTE_OBJECT_ID,
+      objectData,
+    } as unknown as Partial<Board>);
+  } catch (error) {
+    console.warn('Failed to create assistant welcome note:', error);
+  }
+}

--- a/packages/core/drizzle/postgres/0038_primary_assistant_id.sql
+++ b/packages/core/drizzle/postgres/0038_primary_assistant_id.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "boards" ADD COLUMN "primary_assistant_id" varchar(36);--> statement-breakpoint
+ALTER TABLE "boards" ADD CONSTRAINT "boards_primary_assistant_id_branches_branch_id_fk" FOREIGN KEY ("primary_assistant_id") REFERENCES "public"."branches"("branch_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+WITH assistant_counts AS (
+  SELECT
+    board_id,
+    COUNT(*) AS assistant_count,
+    MIN(branch_id) AS branch_id
+  FROM branches
+  WHERE board_id IS NOT NULL
+    AND (
+      data->'custom_context'->'assistant'->>'kind' = 'assistant'
+      OR data->'custom_context'->'agent'->>'kind' = 'assistant'
+    )
+  GROUP BY board_id
+)
+UPDATE boards
+SET primary_assistant_id = assistant_counts.branch_id
+FROM assistant_counts
+WHERE boards.primary_assistant_id IS NULL
+  AND boards.board_id = assistant_counts.board_id
+  AND assistant_counts.assistant_count = 1;

--- a/packages/core/drizzle/postgres/0038_primary_assistant_id.sql
+++ b/packages/core/drizzle/postgres/0038_primary_assistant_id.sql
@@ -8,8 +8,8 @@ WITH assistant_counts AS (
   FROM branches
   WHERE board_id IS NOT NULL
     AND (
-      data->'custom_context'->'assistant'->>'kind' = 'assistant'
-      OR data->'custom_context'->'agent'->>'kind' = 'assistant'
+      data->'custom_context'->'assistant'->>'kind' IN ('assistant', 'persisted-agent')
+      OR data->'custom_context'->'agent'->>'kind' IN ('assistant', 'persisted-agent')
     )
   GROUP BY board_id
 )

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1780300000000,
       "tag": "0037_schedules_table",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1780400000000,
+      "tag": "0038_primary_assistant_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0047_primary_assistant_id.sql
+++ b/packages/core/drizzle/sqlite/0047_primary_assistant_id.sql
@@ -7,8 +7,8 @@ WITH assistant_counts AS (
   FROM branches
   WHERE board_id IS NOT NULL
     AND (
-      json_extract(data, '$.custom_context.assistant.kind') = 'assistant'
-      OR json_extract(data, '$.custom_context.agent.kind') = 'assistant'
+      json_extract(data, '$.custom_context.assistant.kind') IN ('assistant', 'persisted-agent')
+      OR json_extract(data, '$.custom_context.agent.kind') IN ('assistant', 'persisted-agent')
     )
   GROUP BY board_id
 )

--- a/packages/core/drizzle/sqlite/0047_primary_assistant_id.sql
+++ b/packages/core/drizzle/sqlite/0047_primary_assistant_id.sql
@@ -1,0 +1,27 @@
+ALTER TABLE `boards` ADD `primary_assistant_id` text(36) REFERENCES branches(branch_id) ON DELETE set null;--> statement-breakpoint
+WITH assistant_counts AS (
+  SELECT
+    board_id,
+    COUNT(*) AS assistant_count,
+    MIN(branch_id) AS branch_id
+  FROM branches
+  WHERE board_id IS NOT NULL
+    AND (
+      json_extract(data, '$.custom_context.assistant.kind') = 'assistant'
+      OR json_extract(data, '$.custom_context.agent.kind') = 'assistant'
+    )
+  GROUP BY board_id
+)
+UPDATE boards
+SET primary_assistant_id = (
+  SELECT branch_id
+  FROM assistant_counts
+  WHERE assistant_counts.board_id = boards.board_id
+    AND assistant_counts.assistant_count = 1
+)
+WHERE primary_assistant_id IS NULL
+  AND board_id IN (
+    SELECT board_id
+    FROM assistant_counts
+    WHERE assistant_count = 1
+  );

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1780300000000,
       "tag": "0046_schedules_table",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1780400000000,
+      "tag": "0047_primary_assistant_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -386,6 +386,15 @@ export interface BoardsService extends AgorService<Board> {
     newName?: string,
     params?: Params
   ): Promise<Board>;
+
+  /**
+   * Set or clear the board's primary assistant branch.
+   */
+  setPrimaryAssistant(
+    data: { id?: string; boardId?: string; branchId: string },
+    params?: Params
+  ): Promise<Board>;
+  clearPrimaryAssistant(boardId: string, params?: Params): Promise<Board>;
 }
 
 /**
@@ -552,7 +561,16 @@ function extendBoardsService(client: AgorClient): void {
     ).methods;
 
     if (typeof methodsFn === 'function') {
-      methodsFn.call(service, 'toBlob', 'fromBlob', 'toYaml', 'fromYaml', 'clone');
+      methodsFn.call(
+        service,
+        'toBlob',
+        'fromBlob',
+        'toYaml',
+        'fromYaml',
+        'clone',
+        'setPrimaryAssistant',
+        'clearPrimaryAssistant'
+      );
     }
   };
 

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -59,6 +59,7 @@ async function createBranchForBoard(
   overrides: {
     name?: string;
     assistant?: boolean;
+    archived?: boolean;
     custom_context?: Record<string, unknown>;
   } = {}
 ) {
@@ -75,6 +76,7 @@ async function createBranchForBoard(
     branch_unique_id: branchUniqueId++,
     path: `/tmp/${name}`,
     board_id: boardId,
+    archived: overrides.archived,
     created_by: generateId(),
     custom_context:
       overrides.custom_context ??
@@ -640,6 +642,26 @@ describe('BoardRepository primary assistant', () => {
     });
   });
 
+  dbTest(
+    'should accept short branch IDs when setting and clearing primary assistant',
+    async ({ db }) => {
+      const boardRepo = new BoardRepository(db);
+      const board = await boardRepo.create(createBoardData());
+      const assistant = await createBranchForBoard(db, board.board_id, { assistant: true });
+      const assistantShortId = toShortId(assistant.branch_id, 8);
+
+      const updated = await boardRepo.setPrimaryAssistant(board.board_id, assistantShortId);
+
+      expect(updated.primary_assistant_id).toBe(assistant.branch_id);
+
+      const cleared = await boardRepo.clearPrimaryAssistantIfMatches(
+        board.board_id,
+        assistantShortId
+      );
+      expect(cleared?.primary_assistant_id).toBeUndefined();
+    }
+  );
+
   dbTest('should reject non-assistant primary branches', async ({ db }) => {
     const boardRepo = new BoardRepository(db);
     const board = await boardRepo.create(createBoardData());
@@ -648,6 +670,19 @@ describe('BoardRepository primary assistant', () => {
     await expect(boardRepo.setPrimaryAssistant(board.board_id, branch.branch_id)).rejects.toThrow(
       /assistant branch/
     );
+  });
+
+  dbTest('should reject archived assistant primary branches', async ({ db }) => {
+    const boardRepo = new BoardRepository(db);
+    const board = await boardRepo.create(createBoardData());
+    const assistant = await createBranchForBoard(db, board.board_id, {
+      assistant: true,
+      archived: true,
+    });
+
+    await expect(
+      boardRepo.setPrimaryAssistant(board.board_id, assistant.branch_id)
+    ).rejects.toThrow(/active/);
   });
 
   dbTest('should reject assistant branches from another board', async ({ db }) => {

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -8,15 +8,18 @@
 import type { Board, BoardObject, UUID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, shortId, toShortId } from '../../lib/ids';
+import type { Database } from '../client';
 import { dbTest } from '../test-helpers';
 import { AmbiguousIdError, EntityNotFoundError } from './base';
 import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
 
 /**
  * Create test board data with defaults
  */
 function createBoardData(overrides?: Partial<Board>): Partial<Board> {
-  return {
+  const data: Partial<Board> = {
     board_id: overrides?.board_id ?? generateId(),
     name: overrides?.name ?? 'Test Board',
     slug: overrides?.slug,
@@ -29,6 +32,61 @@ function createBoardData(overrides?: Partial<Board>): Partial<Board> {
     created_at: overrides?.created_at,
     last_updated: overrides?.last_updated,
   };
+  if (Object.hasOwn(overrides ?? {}, 'primary_assistant_id')) {
+    data.primary_assistant_id = overrides?.primary_assistant_id;
+  }
+  return data;
+}
+
+function createRepoData(overrides?: { repo_id?: UUID; slug?: string }) {
+  const slug = overrides?.slug ?? 'test-repo';
+  return {
+    repo_id: overrides?.repo_id ?? generateId(),
+    slug,
+    name: slug,
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/${slug}`,
+    default_branch: 'main',
+  };
+}
+
+let branchUniqueId = 1_000;
+
+async function createBranchForBoard(
+  db: Database,
+  boardId: UUID,
+  overrides: {
+    name?: string;
+    assistant?: boolean;
+    custom_context?: Record<string, unknown>;
+  } = {}
+) {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const repo = await repoRepo.create(createRepoData({ slug: `repo-${branchUniqueId}` }));
+  const name = overrides.name ?? `branch-${generateId().slice(0, 8)}`;
+
+  return branchRepo.create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: branchUniqueId++,
+    path: `/tmp/${name}`,
+    board_id: boardId,
+    created_by: generateId(),
+    custom_context:
+      overrides.custom_context ??
+      (overrides.assistant
+        ? {
+            assistant: {
+              kind: 'assistant',
+              displayName: name,
+            },
+          }
+        : undefined),
+  });
 }
 
 // ============================================================================
@@ -81,6 +139,15 @@ describe('BoardRepository.create', () => {
     delete (data as any).created_by;
 
     await expect(repo.create(data)).rejects.toThrow(/created_by/);
+  });
+
+  dbTest('should reject primary_assistant_id in generic create input', async ({ db }) => {
+    const repo = new BoardRepository(db);
+    const data = createBoardData({
+      primary_assistant_id: generateId(),
+    } as Partial<Board>);
+
+    await expect(repo.create(data)).rejects.toThrow(/setPrimaryAssistant/);
   });
 
   dbTest('should store all optional fields correctly', async ({ db }) => {
@@ -506,6 +573,17 @@ describe('BoardRepository.update', () => {
     await expect(repo.update('99999999', { name: 'Updated' })).rejects.toThrow(EntityNotFoundError);
   });
 
+  dbTest('should reject primary_assistant_id in generic update input', async ({ db }) => {
+    const repo = new BoardRepository(db);
+    const board = await repo.create(createBoardData());
+
+    await expect(
+      repo.update(board.board_id, {
+        primary_assistant_id: generateId(),
+      } as Partial<Board>)
+    ).rejects.toThrow(/setPrimaryAssistant/);
+  });
+
   dbTest('should preserve unchanged fields', async ({ db }) => {
     const repo = new BoardRepository(db);
     const data = createBoardData({
@@ -536,6 +614,103 @@ describe('BoardRepository.update', () => {
     const updated = await repo.update(betaCreated.board_id!, { slug: 'alpha' });
 
     expect(updated.slug).toBe('alpha-1');
+  });
+});
+
+// ============================================================================
+// Primary assistant
+// ============================================================================
+
+describe('BoardRepository primary assistant', () => {
+  dbTest('should set and fetch a valid primary assistant', async ({ db }) => {
+    const boardRepo = new BoardRepository(db);
+    const board = await boardRepo.create(createBoardData());
+    const assistant = await createBranchForBoard(db, board.board_id, {
+      assistant: true,
+      name: 'assistant-branch',
+    });
+
+    const updated = await boardRepo.setPrimaryAssistant(board.board_id, assistant.branch_id);
+
+    expect(updated.primary_assistant_id).toBe(assistant.branch_id);
+    await expect(boardRepo.getPrimaryAssistant(board.board_id)).resolves.toMatchObject({
+      branch_id: assistant.branch_id,
+      name: 'assistant-branch',
+      url: expect.any(String),
+    });
+  });
+
+  dbTest('should reject non-assistant primary branches', async ({ db }) => {
+    const boardRepo = new BoardRepository(db);
+    const board = await boardRepo.create(createBoardData());
+    const branch = await createBranchForBoard(db, board.board_id);
+
+    await expect(boardRepo.setPrimaryAssistant(board.board_id, branch.branch_id)).rejects.toThrow(
+      /assistant branch/
+    );
+  });
+
+  dbTest('should reject assistant branches from another board', async ({ db }) => {
+    const boardRepo = new BoardRepository(db);
+    const boardA = await boardRepo.create(createBoardData({ name: 'Board A' }));
+    const boardB = await boardRepo.create(createBoardData({ name: 'Board B' }));
+    const assistant = await createBranchForBoard(db, boardB.board_id, { assistant: true });
+
+    await expect(
+      boardRepo.setPrimaryAssistant(boardA.board_id, assistant.branch_id)
+    ).rejects.toThrow(/belong to the board/);
+  });
+
+  dbTest('should conditionally set primary assistant only when unset', async ({ db }) => {
+    const boardRepo = new BoardRepository(db);
+    const board = await boardRepo.create(createBoardData());
+    const firstAssistant = await createBranchForBoard(db, board.board_id, {
+      assistant: true,
+      name: 'first-assistant',
+    });
+    const secondAssistant = await createBranchForBoard(db, board.board_id, {
+      assistant: true,
+      name: 'second-assistant',
+    });
+
+    const firstUpdate = await boardRepo.setPrimaryAssistantIfUnset(
+      board.board_id,
+      firstAssistant.branch_id
+    );
+    const secondUpdate = await boardRepo.setPrimaryAssistantIfUnset(
+      board.board_id,
+      secondAssistant.branch_id
+    );
+
+    expect(firstUpdate?.primary_assistant_id).toBe(firstAssistant.branch_id);
+    expect(secondUpdate).toBeNull();
+    await expect(boardRepo.findById(board.board_id)).resolves.toMatchObject({
+      primary_assistant_id: firstAssistant.branch_id,
+    });
+  });
+
+  dbTest('should clear primary assistant only when it matches', async ({ db }) => {
+    const boardRepo = new BoardRepository(db);
+    const board = await boardRepo.create(createBoardData());
+    const assistant = await createBranchForBoard(db, board.board_id, { assistant: true });
+    const otherAssistant = await createBranchForBoard(db, board.board_id, { assistant: true });
+
+    await boardRepo.setPrimaryAssistant(board.board_id, assistant.branch_id);
+
+    const skipped = await boardRepo.clearPrimaryAssistantIfMatches(
+      board.board_id,
+      otherAssistant.branch_id
+    );
+    expect(skipped).toBeNull();
+    await expect(boardRepo.findById(board.board_id)).resolves.toMatchObject({
+      primary_assistant_id: assistant.branch_id,
+    });
+
+    const cleared = await boardRepo.clearPrimaryAssistantIfMatches(
+      board.board_id,
+      assistant.branch_id
+    );
+    expect(cleared?.primary_assistant_id).toBeUndefined();
   });
 });
 

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -4,8 +4,8 @@
  * Type-safe CRUD operations for boards with short ID support.
  */
 
-import type { Board, BoardExportBlob, BoardObject, UUID } from '@agor/core/types';
-import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
+import type { Board, BoardExportBlob, BoardObject, Branch, UUID } from '@agor/core/types';
+import { BRANCH_PERMISSION_LEVELS, isAssistant } from '@agor/core/types';
 import { and, eq, exists, inArray, isNotNull, like, ne, or, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
@@ -55,6 +55,8 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       board_id: boardId,
       name: row.name,
       slug,
+      primary_assistant_id:
+        (row.primary_assistant_id as Board['primary_assistant_id']) ?? undefined,
       created_at: new Date(row.created_at).toISOString(),
       last_updated: row.updated_at
         ? new Date(row.updated_at).toISOString()
@@ -82,6 +84,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       board_id: boardId,
       name: board.name ?? 'Untitled Board',
       slug: board.slug !== undefined ? board.slug : null,
+      primary_assistant_id: board.primary_assistant_id ?? null,
       created_at: new Date(board.created_at ?? now),
       updated_at: board.last_updated ? new Date(board.last_updated) : new Date(now),
       created_by: board.created_by,
@@ -355,6 +358,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       const setData: Record<string, unknown> = {
         name: insertData.name,
         slug: insertData.slug,
+        primary_assistant_id: insertData.primary_assistant_id,
         updated_at: new Date(),
         data: insertData.data,
       };
@@ -405,6 +409,150 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
         error
       );
     }
+  }
+
+  /**
+   * Get the branch designated as this board's primary assistant.
+   */
+  async getPrimaryAssistant(boardId: string): Promise<Branch | null> {
+    try {
+      const board = await this.findById(boardId);
+      if (!board?.primary_assistant_id) return null;
+
+      const row = await select(this.db)
+        .from(branches)
+        .where(eq(branches.branch_id, board.primary_assistant_id))
+        .one();
+
+      if (!row) return null;
+      return this.branchRowToMinimalBranch(row);
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) return null;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to get primary assistant: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Set a board's primary assistant after validating that the branch is an
+   * assistant branch already attached to the board.
+   */
+  async setPrimaryAssistant(boardId: string, branchId: string): Promise<Board> {
+    try {
+      const fullBoardId = await this.resolveId(boardId);
+      const board = await this.findById(fullBoardId);
+      if (!board) throw new EntityNotFoundError('Board', boardId);
+
+      const branchRow = await select(this.db)
+        .from(branches)
+        .where(eq(branches.branch_id, branchId))
+        .one();
+
+      if (!branchRow) throw new EntityNotFoundError('Branch', branchId);
+      if (branchRow.board_id !== fullBoardId) {
+        throw new RepositoryError('Primary assistant branch must belong to the board');
+      }
+      if (!this.branchRowIsAssistant(branchRow)) {
+        throw new RepositoryError('Primary assistant branch must be an assistant branch');
+      }
+
+      await update(this.db, boards)
+        .set({
+          primary_assistant_id: branchRow.branch_id,
+          updated_at: new Date(),
+        })
+        .where(eq(boards.board_id, fullBoardId))
+        .run();
+
+      const updated = await this.findById(fullBoardId);
+      if (!updated) throw new RepositoryError('Failed to retrieve updated board');
+      return updated;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to set primary assistant: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Clear a board's primary assistant pointer without deleting either entity.
+   */
+  async clearPrimaryAssistant(boardId: string): Promise<Board> {
+    try {
+      const fullBoardId = await this.resolveId(boardId);
+      await update(this.db, boards)
+        .set({ primary_assistant_id: null, updated_at: new Date() })
+        .where(eq(boards.board_id, fullBoardId))
+        .run();
+
+      const updated = await this.findById(fullBoardId);
+      if (!updated) throw new EntityNotFoundError('Board', boardId);
+      return updated;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to clear primary assistant: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  private branchRowIsAssistant(row: { data: unknown }): boolean {
+    const data = row.data as { custom_context?: Record<string, unknown> } | null;
+    return isAssistant({ custom_context: data?.custom_context });
+  }
+
+  private branchRowToMinimalBranch(row: typeof branches.$inferSelect): Branch {
+    const data = row.data as {
+      path: string;
+      new_branch: boolean;
+      last_used?: string;
+      custom_context?: Record<string, unknown>;
+      notes?: string;
+      issue_url?: string;
+      pull_request_url?: string;
+    };
+
+    return {
+      branch_id: row.branch_id as Branch['branch_id'],
+      repo_id: row.repo_id as Branch['repo_id'],
+      branch_unique_id: row.branch_unique_id,
+      created_at: new Date(row.created_at).toISOString(),
+      updated_at: row.updated_at
+        ? new Date(row.updated_at).toISOString()
+        : new Date(row.created_at).toISOString(),
+      created_by: row.created_by as Branch['created_by'],
+      name: row.name as Branch['name'],
+      ref: row.ref,
+      ref_type: row.ref_type ?? undefined,
+      path: data.path ?? '',
+      board_id: (row.board_id as Branch['board_id']) ?? undefined,
+      notes: data.notes,
+      issue_url: data.issue_url,
+      pull_request_url: data.pull_request_url,
+      new_branch: Boolean(data.new_branch),
+      needs_attention: Boolean(row.needs_attention),
+      archived: Boolean(row.archived),
+      archived_at: row.archived_at ? new Date(row.archived_at).toISOString() : undefined,
+      archived_by: (row.archived_by as Branch['archived_by']) ?? undefined,
+      filesystem_status: row.filesystem_status ?? undefined,
+      custom_context: data.custom_context,
+      last_used: data.last_used ?? new Date(row.updated_at ?? row.created_at).toISOString(),
+      storage_mode: row.storage_mode as Branch['storage_mode'],
+      clone_depth: row.clone_depth ?? undefined,
+      others_can: row.others_can ?? undefined,
+      unix_group: row.unix_group ?? undefined,
+      others_fs_access: row.others_fs_access ?? undefined,
+    };
   }
 
   /**

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -452,22 +452,11 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       const board = await this.findById(fullBoardId);
       if (!board) throw new EntityNotFoundError('Board', boardId);
 
-      const branchRow = await select(this.db)
-        .from(branches)
-        .where(eq(branches.branch_id, branchId))
-        .one();
-
-      if (!branchRow) throw new EntityNotFoundError('Branch', branchId);
-      if (branchRow.board_id !== fullBoardId) {
-        throw new RepositoryError('Primary assistant branch must belong to the board');
-      }
-      if (!this.branchRowIsAssistant(branchRow)) {
-        throw new RepositoryError('Primary assistant branch must be an assistant branch');
-      }
+      const branch = await this.getValidatedPrimaryAssistantBranch(fullBoardId, branchId);
 
       await update(this.db, boards)
         .set({
-          primary_assistant_id: branchRow.branch_id,
+          primary_assistant_id: branch.branch_id,
           updated_at: new Date(),
         })
         .where(eq(boards.board_id, fullBoardId))
@@ -498,22 +487,11 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   async setPrimaryAssistantIfUnset(boardId: string, branchId: string): Promise<Board | null> {
     try {
       const fullBoardId = await this.resolveId(boardId);
-      const branchRow = await select(this.db)
-        .from(branches)
-        .where(eq(branches.branch_id, branchId))
-        .one();
-
-      if (!branchRow) throw new EntityNotFoundError('Branch', branchId);
-      if (branchRow.board_id !== fullBoardId) {
-        throw new RepositoryError('Primary assistant branch must belong to the board');
-      }
-      if (!this.branchRowIsAssistant(branchRow)) {
-        throw new RepositoryError('Primary assistant branch must be an assistant branch');
-      }
+      const branch = await this.getValidatedPrimaryAssistantBranch(fullBoardId, branchId);
 
       const result = await update(this.db, boards)
         .set({
-          primary_assistant_id: branchRow.branch_id,
+          primary_assistant_id: branch.branch_id,
           updated_at: new Date(),
         })
         .where(and(eq(boards.board_id, fullBoardId), isNull(boards.primary_assistant_id)))
@@ -544,9 +522,14 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   async clearPrimaryAssistantIfMatches(boardId: string, branchId: string): Promise<Board | null> {
     try {
       const fullBoardId = await this.resolveId(boardId);
+      const branch = await new BranchRepository(this.db).findById(branchId);
+      if (!branch) throw new EntityNotFoundError('Branch', branchId);
+
       const result = await update(this.db, boards)
         .set({ primary_assistant_id: null, updated_at: new Date() })
-        .where(and(eq(boards.board_id, fullBoardId), eq(boards.primary_assistant_id, branchId)))
+        .where(
+          and(eq(boards.board_id, fullBoardId), eq(boards.primary_assistant_id, branch.branch_id))
+        )
         .run();
 
       if (result.rowsAffected === 0) return null;
@@ -590,9 +573,25 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
     }
   }
 
-  private branchRowIsAssistant(row: { data: unknown }): boolean {
-    const data = row.data as { custom_context?: Record<string, unknown> } | null;
-    return isAssistant({ custom_context: data?.custom_context });
+  private async getValidatedPrimaryAssistantBranch(
+    fullBoardId: string,
+    branchId: string
+  ): Promise<Branch> {
+    const branchRepo = new BranchRepository(this.db);
+    const branch = await branchRepo.findById(branchId);
+    if (!branch) throw new EntityNotFoundError('Branch', branchId);
+
+    if (branch.board_id !== fullBoardId) {
+      throw new RepositoryError('Primary assistant branch must belong to the board');
+    }
+    if (!isAssistant(branch)) {
+      throw new RepositoryError('Primary assistant branch must be an assistant branch');
+    }
+    if (branch.archived) {
+      throw new RepositoryError('Primary assistant branch must be active');
+    }
+
+    return branch;
   }
 
   /**

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -6,7 +6,7 @@
 
 import type { Board, BoardExportBlob, BoardObject, Branch, UUID } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, isAssistant } from '@agor/core/types';
-import { and, eq, exists, inArray, isNotNull, like, ne, or, sql } from 'drizzle-orm';
+import { and, eq, exists, inArray, isNotNull, isNull, like, ne, or, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
@@ -23,6 +23,7 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
+import { BranchRepository } from './branches';
 
 /**
  * Board repository implementation
@@ -100,6 +101,14 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
     };
   }
 
+  private rejectGenericPrimaryAssistantWrite(data: Partial<Board>, operation: string): void {
+    if (Object.hasOwn(data, 'primary_assistant_id')) {
+      throw new RepositoryError(
+        `Cannot ${operation} primary_assistant_id via generic board writes; use setPrimaryAssistant() or clearPrimaryAssistant()`
+      );
+    }
+  }
+
   /**
    * Resolve short ID to full ID via the centralized helper.
    */
@@ -161,6 +170,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
    */
   async create(data: Partial<Board>): Promise<Board> {
     try {
+      this.rejectGenericPrimaryAssistantWrite(data, 'set');
       const boardId = data.board_id ?? generateId();
       const baseUrl = await getBaseUrl();
       let finalSlug: string | undefined;
@@ -327,6 +337,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
    */
   async update(id: string, updates: Partial<Board>): Promise<Board> {
     try {
+      this.rejectGenericPrimaryAssistantWrite(updates, 'set');
       const fullId = await this.resolveId(id);
 
       // Get current board to merge updates
@@ -419,13 +430,8 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       const board = await this.findById(boardId);
       if (!board?.primary_assistant_id) return null;
 
-      const row = await select(this.db)
-        .from(branches)
-        .where(eq(branches.branch_id, board.primary_assistant_id))
-        .one();
-
-      if (!row) return null;
-      return this.branchRowToMinimalBranch(row);
+      const branchRepo = new BranchRepository(this.db);
+      return branchRepo.findById(board.primary_assistant_id);
     } catch (error) {
       if (error instanceof EntityNotFoundError) return null;
       if (error instanceof AmbiguousIdError) throw error;
@@ -482,6 +488,84 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   }
 
   /**
+   * Set a board's primary assistant only when it is currently unset.
+   *
+   * Returns the updated board when this call wins the race, or null when the
+   * board already had a primary assistant by the time the conditional update
+   * ran. The same branch/board/assistant invariants as setPrimaryAssistant()
+   * are validated before attempting the conditional write.
+   */
+  async setPrimaryAssistantIfUnset(boardId: string, branchId: string): Promise<Board | null> {
+    try {
+      const fullBoardId = await this.resolveId(boardId);
+      const branchRow = await select(this.db)
+        .from(branches)
+        .where(eq(branches.branch_id, branchId))
+        .one();
+
+      if (!branchRow) throw new EntityNotFoundError('Branch', branchId);
+      if (branchRow.board_id !== fullBoardId) {
+        throw new RepositoryError('Primary assistant branch must belong to the board');
+      }
+      if (!this.branchRowIsAssistant(branchRow)) {
+        throw new RepositoryError('Primary assistant branch must be an assistant branch');
+      }
+
+      const result = await update(this.db, boards)
+        .set({
+          primary_assistant_id: branchRow.branch_id,
+          updated_at: new Date(),
+        })
+        .where(and(eq(boards.board_id, fullBoardId), isNull(boards.primary_assistant_id)))
+        .run();
+
+      if (result.rowsAffected === 0) return null;
+
+      const updated = await this.findById(fullBoardId);
+      if (!updated) throw new RepositoryError('Failed to retrieve updated board');
+      return updated;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to set primary assistant if unset: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Clear a board's primary assistant only if it still points at branchId.
+   *
+   * This keeps board metadata consistent when an assistant branch is moved off
+   * a board without clearing a newer primary assistant assignment by mistake.
+   */
+  async clearPrimaryAssistantIfMatches(boardId: string, branchId: string): Promise<Board | null> {
+    try {
+      const fullBoardId = await this.resolveId(boardId);
+      const result = await update(this.db, boards)
+        .set({ primary_assistant_id: null, updated_at: new Date() })
+        .where(and(eq(boards.board_id, fullBoardId), eq(boards.primary_assistant_id, branchId)))
+        .run();
+
+      if (result.rowsAffected === 0) return null;
+
+      const updated = await this.findById(fullBoardId);
+      if (!updated) throw new EntityNotFoundError('Board', boardId);
+      return updated;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to clear primary assistant if matched: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Clear a board's primary assistant pointer without deleting either entity.
    */
   async clearPrimaryAssistant(boardId: string): Promise<Board> {
@@ -509,50 +593,6 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   private branchRowIsAssistant(row: { data: unknown }): boolean {
     const data = row.data as { custom_context?: Record<string, unknown> } | null;
     return isAssistant({ custom_context: data?.custom_context });
-  }
-
-  private branchRowToMinimalBranch(row: typeof branches.$inferSelect): Branch {
-    const data = row.data as {
-      path: string;
-      new_branch: boolean;
-      last_used?: string;
-      custom_context?: Record<string, unknown>;
-      notes?: string;
-      issue_url?: string;
-      pull_request_url?: string;
-    };
-
-    return {
-      branch_id: row.branch_id as Branch['branch_id'],
-      repo_id: row.repo_id as Branch['repo_id'],
-      branch_unique_id: row.branch_unique_id,
-      created_at: new Date(row.created_at).toISOString(),
-      updated_at: row.updated_at
-        ? new Date(row.updated_at).toISOString()
-        : new Date(row.created_at).toISOString(),
-      created_by: row.created_by as Branch['created_by'],
-      name: row.name as Branch['name'],
-      ref: row.ref,
-      ref_type: row.ref_type ?? undefined,
-      path: data.path ?? '',
-      board_id: (row.board_id as Branch['board_id']) ?? undefined,
-      notes: data.notes,
-      issue_url: data.issue_url,
-      pull_request_url: data.pull_request_url,
-      new_branch: Boolean(data.new_branch),
-      needs_attention: Boolean(row.needs_attention),
-      archived: Boolean(row.archived),
-      archived_at: row.archived_at ? new Date(row.archived_at).toISOString() : undefined,
-      archived_by: (row.archived_by as Branch['archived_by']) ?? undefined,
-      filesystem_status: row.filesystem_status ?? undefined,
-      custom_context: data.custom_context,
-      last_used: data.last_used ?? new Date(row.updated_at ?? row.created_at).toISOString(),
-      storage_mode: row.storage_mode as Branch['storage_mode'],
-      clone_depth: row.clone_depth ?? undefined,
-      others_can: row.others_can ?? undefined,
-      unix_group: row.unix_group ?? undefined,
-      others_fs_access: row.others_fs_access ?? undefined,
-    };
   }
 
   /**

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -21,6 +21,7 @@ import type {
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
 import { relations, sql } from 'drizzle-orm';
 import {
+  type AnyPgColumn,
   bigint,
   boolean,
   customType,
@@ -438,6 +439,12 @@ export const boards = pgTable(
     // Materialized for lookups
     name: text('name').notNull(),
     slug: text('slug').unique(),
+    primary_assistant_id: varchar('primary_assistant_id', { length: 36 }).references(
+      (): AnyPgColumn => branches.branch_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
 
     // JSON blob for the rest
     data: t
@@ -588,7 +595,7 @@ export const branches = pgTable(
     environment_variant: text('environment_variant'),
 
     // Board relationship (nullable - branches can exist without boards)
-    board_id: varchar('board_id', { length: 36 }).references(() => boards.board_id, {
+    board_id: varchar('board_id', { length: 36 }).references((): AnyPgColumn => boards.board_id, {
       onDelete: 'set null', // If board is deleted, branch remains but loses board association
     }),
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -21,6 +21,7 @@ import type {
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
 import { relations, sql } from 'drizzle-orm';
 import {
+  type AnySQLiteColumn,
   blob,
   index,
   integer,
@@ -449,6 +450,12 @@ export const boards = sqliteTable(
     // Materialized for lookups
     name: text('name').notNull(),
     slug: text('slug').unique(),
+    primary_assistant_id: text('primary_assistant_id', { length: 36 }).references(
+      (): AnySQLiteColumn => branches.branch_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
 
     // JSON blob for the rest
     data: t
@@ -599,7 +606,7 @@ export const branches = sqliteTable(
     environment_variant: text('environment_variant'),
 
     // Board relationship (nullable - branches can exist without boards)
-    board_id: text('board_id', { length: 36 }).references(() => boards.board_id, {
+    board_id: text('board_id', { length: 36 }).references((): AnySQLiteColumn => boards.board_id, {
       onDelete: 'set null', // If board is deleted, branch remains but loses board association
     }),
 

--- a/packages/core/src/types/board.ts
+++ b/packages/core/src/types/board.ts
@@ -153,6 +153,15 @@ export interface AppBoardObject {
   title: string;
   /** Optional description */
   description?: string;
+
+  /**
+   * Board-level assistant-in-charge.
+   *
+   * Nullable by design: human-managed boards and boards with no accessible
+   * primary assistant are valid states. The branch itself still belongs to
+   * the board through Branch.board_id.
+   */
+  primary_assistant_id?: BranchID;
   /** Sandpack template (default: 'react') */
   template: SandpackTemplate;
   /** File map: path -> code content */
@@ -212,6 +221,7 @@ export interface Board {
   slug?: string;
 
   description?: string;
+  primary_assistant_id?: BranchID;
 
   /**
    * DEPRECATED: Sessions and layout are now tracked in board_objects table

--- a/packages/core/src/types/board.ts
+++ b/packages/core/src/types/board.ts
@@ -154,14 +154,6 @@ export interface AppBoardObject {
   /** Optional description */
   description?: string;
 
-  /**
-   * Board-level assistant-in-charge.
-   *
-   * Nullable by design: human-managed boards and boards with no accessible
-   * primary assistant are valid states. The branch itself still belongs to
-   * the board through Branch.board_id.
-   */
-  primary_assistant_id?: BranchID;
   /** Sandpack template (default: 'react') */
   template: SandpackTemplate;
   /** File map: path -> code content */


### PR DESCRIPTION
## Summary
- Add `boards.primary_assistant_id` schema/API/service support with migrations and backfill behavior.
- Replace the old branch/session drawer path with an assistant-centric left panel: **Assistant**, **All sessions**, and **Comments** tabs.
- Compose assistant panel content from shared branch/session building blocks instead of embedding a full branch card.
- Wire assistant board creation/onboarding, including primary-assistant assignment, assistant description rendering, and a default welcome markdown note.
- Make the main `Create New...` flow assistant-first: Assistant is now the default/left-most tab, while Branch, Board, and Repository remain available.
- Add markdown note delete affordance, prompt textarea empty-state highlight, navbar icon alignment tweaks, and a lighter session-tree selected highlight.
- Suppress the assistant/comments left panel while the onboarding modal is open, without changing board metadata or persisted panel preference.
- Set the assistant left panel default width to 24% and add a compact `BranchHeaderPill` mode for the assistant panel that hides the repo slug while keeping full repo/branch context in the tooltip.

## Follow-up review fixes included
- Harden `primary_assistant_id` invariants: generic board create/update cannot set it directly; dedicated repository methods validate assistant kind and board membership.
- Make create-time primary assignment conditional (`if unset`) to avoid last-write-wins races.
- Clear stale primary-assistant pointers when assistant branches move off a board.
- Update migration backfill to include legacy `persisted-agent` assistants.
- Remove stale assistant `boardChoice` UI plumbing and accidental `primary_assistant_id` typing on canvas objects.

- Close second-pass edge cases: primary assistants must be active, branch short IDs are accepted by primary-assistant setters, assistant/branch type conversions are rejected, and archiving an assistant clears stale board primary pointers.

## Validation
- `pnpm i`
- `pnpm typecheck`
- `pnpm exec biome check <changed files>`
- `pnpm --filter agor-ui test` — 37 files / 245 tests passed
- `pnpm --filter @agor/core test` — 77 files / 2399 passed / 2 skipped
- `pnpm --filter @agor/daemon test` — 63 passed / 1 skipped; 806 passed / 30 skipped
- `pnpm --filter agor-ui test -- src/components/CreateDialog/CreateDialog.test.tsx` — 5 tests passed
- `pnpm --filter agor-ui typecheck`
- Review-fix pass: `pnpm --filter @agor/core typecheck`
- Review-fix pass: `pnpm --filter @agor/core test -- src/db/repositories/boards.test.ts` — 73 tests passed
- Review-fix pass: `pnpm --filter agor-ui test -- src/components/CreateDialog/CreateDialog.test.tsx src/utils/assistantCreation.test.ts` — 6 tests passed
- Review-fix pass: `pnpm --filter @agor/daemon test` — 63 files passed / 1 skipped; 806 passed / 30 skipped

- Second review-fix pass: `pnpm --filter @agor/core typecheck && pnpm --filter @agor/daemon typecheck`
- Second review-fix pass: `pnpm --filter @agor/core test -- src/db/repositories/boards.test.ts` — 75 tests passed
- Second review-fix pass: `pnpm --filter @agor/daemon test -- src/services/branches.test.ts` — 10 tests passed

- Onboarding left-panel pass: `pnpm exec biome check apps/agor-ui/src/App.tsx apps/agor-ui/src/components/App/App.tsx`
- Onboarding left-panel pass: `pnpm --filter agor-ui typecheck`

- Panel density pass: `pnpm exec biome check apps/agor-ui/src/components/App/App.tsx apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx`
- Panel density pass: `pnpm --filter agor-ui typecheck`

- Panel width tweak: `pnpm exec biome check apps/agor-ui/src/components/App/App.tsx`
- Panel width tweak: `pnpm --filter agor-ui typecheck`

## Known notes
- `pnpm check` gets through typecheck/build, then fails on repo-wide Biome diagnostics outside this slice (mostly optional-chain/style warnings and unused suppressions in unrelated files/scripts).
- Mermaid welcome-note support was deferred because the current Vite/Streamdown/Mermaid dependency combination threw `require_dist is not a function`; the welcome note now uses plain markdown.




