### PR TITLE
Improve panel width management

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -43,6 +43,7 @@ import { useRecentBoards } from '../../hooks/useRecentBoards';
 import { useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { useTaskCompletionChime } from '../../hooks/useTaskCompletionChime';
 import { type ActiveUrlTarget, useUrlState } from '../../hooks/useUrlState';
+import { useUserLocalStorage } from '../../hooks/useUserLocalStorage';
 import type { AgenticToolOption } from '../../types';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { createAssistantBranch } from '../../utils/assistantCreation';
@@ -188,6 +189,17 @@ export interface AppProps {
 // Frozen at runtime; the consuming components only read it.
 const EMPTY_STRING_ARRAY: string[] = Object.freeze([] as string[]) as string[];
 
+// 320px keeps the three left-panel tabs (Assistant / All sessions / Comments)
+// on one readable line with Ant's tab padding at the 768px desktop breakpoint.
+const LEFT_PANEL_MIN_WIDTH_PX = 320;
+const LEFT_PANEL_MAX_SIZE_PERCENT = 45;
+
+const getLeftPanelMinSizePercent = (viewportWidth: number) =>
+  Math.min(LEFT_PANEL_MAX_SIZE_PERCENT, (LEFT_PANEL_MIN_WIDTH_PX / viewportWidth) * 100);
+
+const clampPercent = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
 export const App: React.FC<AppProps> = ({
   client,
   user,
@@ -304,6 +316,22 @@ export const App: React.FC<AppProps> = ({
 
   const [leftPanelTab, setLeftPanelTab] = useState<BoardAssistantPanelTab>('assistant');
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window === 'undefined' ? 1440 : window.innerWidth
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const leftPanelMinSize = useMemo(
+    () => getLeftPanelMinSizePercent(viewportWidth),
+    [viewportWidth]
+  );
 
   // Settings modal state via URL routing
   const {
@@ -329,9 +357,10 @@ export const App: React.FC<AppProps> = ({
     false
   );
 
-  // Comments panel size persistence (percentage of available width)
-  const [commentsPanelSize, setCommentsPanelSize] = useLocalStorage<number>(
-    'agor:leftPanelSize',
+  // Left panel size persistence (percentage of available width), scoped per user.
+  const [commentsPanelSize, setCommentsPanelSize] = useUserLocalStorage<number>(
+    user?.user_id,
+    'panel:left:size',
     24
   );
 
@@ -339,11 +368,21 @@ export const App: React.FC<AppProps> = ({
 
   // Ref for programmatically controlling the comments panel
   const commentsPanelRef = useRef<ImperativePanelHandle>(null);
-  // Session panel size persistence (percentage of available width)
-  const [sessionPanelSize, setSessionPanelSize] = useLocalStorage<number>(
-    'agor:sessionPanelSize',
+  const effectiveCommentsPanelSize = clampPercent(
+    commentsPanelSize,
+    leftPanelMinSize,
+    LEFT_PANEL_MAX_SIZE_PERCENT
+  );
+
+  // Session panel size persistence (percentage of available width), scoped per user.
+  const [sessionPanelSize, setSessionPanelSize] = useUserLocalStorage<number>(
+    user?.user_id,
+    'panel:right:size',
     50
   );
+
+  const effectiveSessionPanelSize = clampPercent(sessionPanelSize, 15, 75);
+  const sessionPanelRef = useRef<ImperativePanelHandle>(null);
 
   // Comment highlight state (hover and sticky selection)
   const [hoveredCommentId, setHoveredCommentId] = useState<string | null>(null);
@@ -401,9 +440,16 @@ export const App: React.FC<AppProps> = ({
         commentsPanelRef.current.collapse();
       } else {
         commentsPanelRef.current.expand();
+        commentsPanelRef.current.resize(effectiveCommentsPanelSize);
       }
     }
-  }, [leftPanelCollapsed]);
+  }, [effectiveCommentsPanelSize, leftPanelCollapsed]);
+
+  useEffect(() => {
+    if (sessionPanelRef.current && (effectiveSelectedSessionId || !eventStreamPanelCollapsed)) {
+      sessionPanelRef.current.resize(effectiveSessionPanelSize);
+    }
+  }, [effectiveSelectedSessionId, effectiveSessionPanelSize, eventStreamPanelCollapsed]);
 
   // URL state synchronization - bidirectional sync between URL and state
   useUrlState({
@@ -961,7 +1007,7 @@ export const App: React.FC<AppProps> = ({
                   // Save left panel size when user resizes (only when panel is open)
                   if (!leftPanelCollapsed && sizes.length >= 2) {
                     // Comments panel is the first panel (index 0)
-                    setCommentsPanelSize(sizes[0]);
+                    setCommentsPanelSize(Math.max(sizes[0], leftPanelMinSize));
                   }
                 }}
               >
@@ -970,10 +1016,11 @@ export const App: React.FC<AppProps> = ({
                   order={1}
                   ref={commentsPanelRef}
                   collapsible
-                  defaultSize={leftPanelCollapsed ? 0 : commentsPanelSize}
+                  defaultSize={leftPanelCollapsed ? 0 : effectiveCommentsPanelSize}
                   collapsedSize={0}
-                  minSize={leftPanelCollapsed ? 0 : 15}
-                  maxSize={45}
+                  minSize={leftPanelCollapsed ? 0 : leftPanelMinSize}
+                  maxSize={LEFT_PANEL_MAX_SIZE_PERCENT}
+                  style={{ minWidth: leftPanelCollapsed ? 0 : LEFT_PANEL_MIN_WIDTH_PX }}
                 >
                   {!leftPanelCollapsed && (
                     <BoardAssistantPanel
@@ -1044,7 +1091,7 @@ export const App: React.FC<AppProps> = ({
                 <Panel
                   id="content-panel"
                   order={2}
-                  defaultSize={leftPanelCollapsed ? 100 : 100 - commentsPanelSize}
+                  defaultSize={leftPanelCollapsed ? 100 : 100 - effectiveCommentsPanelSize}
                   minSize={40}
                 >
                   <PanelGroup
@@ -1054,14 +1101,16 @@ export const App: React.FC<AppProps> = ({
                     onLayout={(sizes) => {
                       // Save right panel size when user resizes (only when panel is open)
                       if (effectiveSelectedSessionId && sizes.length === 2) {
-                        setSessionPanelSize(sizes[1]);
+                        setSessionPanelSize(clampPercent(sizes[1], 15, 75));
                       }
                     }}
                   >
                     <Panel
                       id="canvas-panel"
                       order={1}
-                      defaultSize={effectiveSelectedSessionId ? 100 - sessionPanelSize : 100}
+                      defaultSize={
+                        effectiveSelectedSessionId ? 100 - effectiveSessionPanelSize : 100
+                      }
                       minSize={20}
                     >
                       <div style={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
@@ -1136,7 +1185,8 @@ export const App: React.FC<AppProps> = ({
                         <Panel
                           id="session-panel"
                           order={2}
-                          defaultSize={sessionPanelSize}
+                          ref={sessionPanelRef}
+                          defaultSize={effectiveSessionPanelSize}
                           minSize={15}
                           maxSize={75}
                         >

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -383,6 +383,8 @@ export const App: React.FC<AppProps> = ({
 
   const effectiveSessionPanelSize = clampPercent(sessionPanelSize, 15, 75);
   const sessionPanelRef = useRef<ImperativePanelHandle>(null);
+  const leftPanelResizeDraggingRef = useRef(false);
+  const rightPanelResizeDraggingRef = useRef(false);
 
   // Comment highlight state (hover and sticky selection)
   const [hoveredCommentId, setHoveredCommentId] = useState<string | null>(null);
@@ -1004,10 +1006,17 @@ export const App: React.FC<AppProps> = ({
                 direction="horizontal"
                 style={{ flex: 1 }}
                 onLayout={(sizes) => {
-                  // Save left panel size when user resizes (only when panel is open)
-                  if (!leftPanelCollapsed && sizes.length >= 2) {
+                  // Persist only user drag updates. Programmatic resizing enforces
+                  // the responsive minimum without clobbering the user's desired size.
+                  if (
+                    !leftPanelCollapsed &&
+                    leftPanelResizeDraggingRef.current &&
+                    sizes.length >= 2
+                  ) {
                     // Comments panel is the first panel (index 0)
-                    setCommentsPanelSize(Math.max(sizes[0], leftPanelMinSize));
+                    setCommentsPanelSize(
+                      clampPercent(sizes[0], leftPanelMinSize, LEFT_PANEL_MAX_SIZE_PERCENT)
+                    );
                   }
                 }}
               >
@@ -1075,6 +1084,9 @@ export const App: React.FC<AppProps> = ({
                     transition: 'background 0.2s',
                     pointerEvents: leftPanelCollapsed ? 'none' : 'auto',
                   }}
+                  onDragging={(isDragging) => {
+                    leftPanelResizeDraggingRef.current = isDragging;
+                  }}
                   onMouseEnter={(e) => {
                     if (!leftPanelCollapsed) {
                       (e.currentTarget as unknown as HTMLDivElement).style.background =
@@ -1099,8 +1111,13 @@ export const App: React.FC<AppProps> = ({
                     direction="horizontal"
                     style={{ flex: 1 }}
                     onLayout={(sizes) => {
-                      // Save right panel size when user resizes (only when panel is open)
-                      if (effectiveSelectedSessionId && sizes.length === 2) {
+                      // Persist only user drag updates so panel open/close and
+                      // programmatic restores do not overwrite the user's preference.
+                      if (
+                        effectiveSelectedSessionId &&
+                        rightPanelResizeDraggingRef.current &&
+                        sizes.length === 2
+                      ) {
                         setSessionPanelSize(clampPercent(sizes[1], 15, 75));
                       }
                     }}
@@ -1172,6 +1189,9 @@ export const App: React.FC<AppProps> = ({
                             background: 'var(--ant-color-border-secondary)',
                             cursor: 'col-resize',
                             transition: 'background 0.2s',
+                          }}
+                          onDragging={(isDragging) => {
+                            rightPanelResizeDraggingRef.current = isDragging;
                           }}
                           onMouseEnter={(e) => {
                             (e.currentTarget as unknown as HTMLDivElement).style.background =

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.test.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.test.tsx
@@ -1,0 +1,59 @@
+import type { Board, Branch, Repo, Session } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/sessionTitle', () => ({
+  getSessionDisplayTitle: (session: { title?: string }) => session.title ?? 'Untitled session',
+}));
+
+import { BoardSessionList } from './BranchListDrawer';
+
+const board = {
+  board_id: 'board-1',
+  name: 'Board 1',
+} as Board;
+
+const repo = {
+  repo_id: 'repo-1',
+  slug: 'preset-io/agor',
+} as Repo;
+
+const branch = {
+  branch_id: 'branch-1',
+  board_id: 'board-1',
+  repo_id: 'repo-1',
+  name: 'feature/panel-management',
+} as Branch;
+
+const session = {
+  session_id: 'session-1',
+  branch_id: 'branch-1',
+  title: 'Improve panels',
+  description: '',
+  agentic_tool: 'codex',
+  status: 'idle',
+  last_updated: '2026-05-31T00:00:00.000Z',
+} as unknown as Session;
+
+describe('BoardSessionList', () => {
+  it('renders a compact, non-interactive BranchPill for session branches', () => {
+    render(
+      <BoardSessionList
+        board={board}
+        currentBoardId={board.board_id}
+        branchById={new Map([[branch.branch_id, branch]])}
+        repoById={new Map([[repo.repo_id, repo]])}
+        sessionsByBranch={new Map([[branch.branch_id, [session]]])}
+        onSessionClick={vi.fn()}
+      />
+    );
+
+    const pillText = screen.getByText('feature/panel-management');
+    expect(pillText).toBeInTheDocument();
+    expect(pillText.closest('.ant-tag')).toHaveAttribute(
+      'title',
+      'preset-io/agor / feature/panel-management'
+    );
+    expect(pillText.closest('button,a')).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -6,7 +6,7 @@ import { useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
-import { BranchPill } from '../Pill/Pill';
+import { BranchPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
 

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -6,7 +6,7 @@ import { useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
-import { RepoPill } from '../Pill';
+import { BranchPill } from '../Pill/Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
 
@@ -205,7 +205,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
                   <SessionRelationshipIcon session={session} />
                 </div>
 
-                {/* Line 2: repo+branch pill · relative timestamp */}
+                {/* Line 2: compact, non-interactive branch pill · relative timestamp */}
                 <div
                   style={{
                     display: 'flex',
@@ -218,12 +218,12 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
                   }}
                 >
                   <div style={{ minWidth: 0, overflow: 'hidden' }}>
-                    {repo && branch ? (
-                      <RepoPill repoName={repo.slug} branchName={branch.name} color="default" />
-                    ) : branch ? (
-                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                        🌳 {branch.name}
-                      </Typography.Text>
+                    {branch ? (
+                      <BranchPill
+                        branch={branch.name}
+                        compact
+                        title={repo ? `${repo.slug} / ${branch.name}` : branch.name}
+                      />
                     ) : (
                       <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                         No branch

--- a/apps/agor-ui/src/components/Facepile/Facepile.css
+++ b/apps/agor-ui/src/components/Facepile/Facepile.css
@@ -3,7 +3,13 @@
  */
 
 .facepile {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
+  line-height: 1;
+}
+
+.facepile > span {
+  display: inline-flex;
+  line-height: 1;
 }

--- a/apps/agor-ui/src/components/Facepile/Facepile.css
+++ b/apps/agor-ui/src/components/Facepile/Facepile.css
@@ -7,6 +7,7 @@
   align-items: center;
   gap: 8px;
   line-height: 1;
+  vertical-align: middle;
 }
 
 .facepile > span {

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -835,14 +835,43 @@ export const DirtyStatePill: React.FC<DirtyStatePillProps> = ({ style }) => {
 
 interface BranchPillProps extends BasePillProps {
   branch: string;
+  compact?: boolean;
+  title?: string;
 }
 
-export const BranchPill: React.FC<BranchPillProps> = ({ branch, style }) => {
+export const BranchPill: React.FC<BranchPillProps> = ({
+  branch,
+  compact = false,
+  title,
+  style,
+}) => {
   const { token } = theme.useToken();
 
   return (
-    <Tag icon={<BranchesOutlined />} color={PILL_COLORS.git} style={style}>
-      <span style={{ fontFamily: token.fontFamilyCode }}>{branch}</span>
+    <Tag
+      icon={<BranchesOutlined />}
+      color={PILL_COLORS.git}
+      title={title}
+      style={{
+        maxWidth: compact ? '100%' : undefined,
+        marginInlineEnd: compact ? 0 : undefined,
+        cursor: 'default',
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          display: compact ? 'inline-block' : undefined,
+          maxWidth: compact ? 220 : undefined,
+          overflow: compact ? 'hidden' : undefined,
+          textOverflow: compact ? 'ellipsis' : undefined,
+          whiteSpace: compact ? 'nowrap' : undefined,
+          verticalAlign: compact ? 'bottom' : undefined,
+          fontFamily: token.fontFamilyCode,
+        }}
+      >
+        {branch}
+      </span>
     </Tag>
   );
 };

--- a/apps/agor-ui/src/hooks/localStorageJson.ts
+++ b/apps/agor-ui/src/hooks/localStorageJson.ts
@@ -1,0 +1,25 @@
+export function readLocalStorageJson<T>(key: string, initialValue: T): T {
+  if (typeof window === 'undefined') {
+    return initialValue;
+  }
+
+  try {
+    const item = window.localStorage.getItem(key);
+    return item ? JSON.parse(item) : initialValue;
+  } catch (error) {
+    console.error(`Error reading localStorage key "${key}":`, error);
+    return initialValue;
+  }
+}
+
+export function writeLocalStorageJson<T>(key: string, value: T): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(`Error setting localStorage key "${key}":`, error);
+  }
+}

--- a/apps/agor-ui/src/hooks/useLocalStorage.ts
+++ b/apps/agor-ui/src/hooks/useLocalStorage.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { readLocalStorageJson, writeLocalStorageJson } from './localStorageJson';
 
 /**
  * Hook for persisting state to localStorage with type safety.
@@ -10,21 +11,7 @@ export function useLocalStorage<T>(
 ): [T, (value: T | ((val: T) => T)) => void] {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window === 'undefined') {
-      return initialValue;
-    }
-    try {
-      // Get from local storage by key
-      const item = window.localStorage.getItem(key);
-      // Parse stored json or if none return initialValue
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      // If error also return initialValue
-      console.error(`Error reading localStorage key "${key}":`, error);
-      return initialValue;
-    }
-  });
+  const [storedValue, setStoredValue] = useState<T>(() => readLocalStorageJson(key, initialValue));
 
   // Keep key in a ref so the callback doesn't depend on it
   const keyRef = useRef(key);
@@ -35,9 +22,7 @@ export function useLocalStorage<T>(
     try {
       setStoredValue((prev) => {
         const valueToStore = value instanceof Function ? value(prev) : value;
-        if (typeof window !== 'undefined') {
-          window.localStorage.setItem(keyRef.current, JSON.stringify(valueToStore));
-        }
+        writeLocalStorageJson(keyRef.current, valueToStore);
         return valueToStore;
       });
     } catch (error) {

--- a/apps/agor-ui/src/hooks/useUserLocalStorage.test.tsx
+++ b/apps/agor-ui/src/hooks/useUserLocalStorage.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUserLocalStorage } from './useUserLocalStorage';
+
+describe('useUserLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('persists values under a per-user key', () => {
+    const { result } = renderHook(() => useUserLocalStorage('user-a', 'panel:left:size', 24));
+
+    act(() => result.current[1](33));
+
+    expect(localStorage.getItem('agor:user:user-a:panel:left:size')).toBe('33');
+  });
+
+  it('loads a different value when the user changes', () => {
+    localStorage.setItem('agor:user:user-a:panel:right:size', '42');
+    localStorage.setItem('agor:user:user-b:panel:right:size', '55');
+
+    const { result, rerender } = renderHook(
+      ({ userId }) => useUserLocalStorage(userId, 'panel:right:size', 50),
+      { initialProps: { userId: 'user-a' as string | undefined } }
+    );
+
+    expect(result.current[0]).toBe(42);
+
+    rerender({ userId: 'user-b' });
+
+    expect(result.current[0]).toBe(55);
+  });
+
+  it('does not write a shared value before a user id is available', () => {
+    const { result } = renderHook(() => useUserLocalStorage(undefined, 'panel:left:size', 24));
+
+    act(() => result.current[1](30));
+
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/apps/agor-ui/src/hooks/useUserLocalStorage.ts
+++ b/apps/agor-ui/src/hooks/useUserLocalStorage.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { readLocalStorageJson, writeLocalStorageJson } from './localStorageJson';
 
 /**
  * LocalStorage hook for preferences that should be isolated per authenticated
@@ -13,19 +14,10 @@ export function useUserLocalStorage<T>(
 ): [T, (value: T | ((val: T) => T)) => void] {
   const storageKey = useMemo(() => (userId ? `agor:user:${userId}:${key}` : null), [key, userId]);
 
-  const readStoredValue = useCallback((): T => {
-    if (typeof window === 'undefined' || !storageKey) {
-      return initialValue;
-    }
-
-    try {
-      const item = window.localStorage.getItem(storageKey);
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      console.error(`Error reading localStorage key "${storageKey}":`, error);
-      return initialValue;
-    }
-  }, [initialValue, storageKey]);
+  const readStoredValue = useCallback(
+    (): T => (storageKey ? readLocalStorageJson(storageKey, initialValue) : initialValue),
+    [initialValue, storageKey]
+  );
 
   const [storedValue, setStoredValue] = useState<T>(readStoredValue);
   const storageKeyRef = useRef(storageKey);
@@ -40,8 +32,8 @@ export function useUserLocalStorage<T>(
       setStoredValue((prev) => {
         const valueToStore = value instanceof Function ? value(prev) : value;
         const currentKey = storageKeyRef.current;
-        if (typeof window !== 'undefined' && currentKey) {
-          window.localStorage.setItem(currentKey, JSON.stringify(valueToStore));
+        if (currentKey) {
+          writeLocalStorageJson(currentKey, valueToStore);
         }
         return valueToStore;
       });

--- a/apps/agor-ui/src/hooks/useUserLocalStorage.ts
+++ b/apps/agor-ui/src/hooks/useUserLocalStorage.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * LocalStorage hook for preferences that should be isolated per authenticated
+ * user. Values are JSON-encoded just like useLocalStorage, but reads/writes are
+ * skipped until a user id is available so anonymous bootstrap renders do not
+ * leak preferences into a shared key.
+ */
+export function useUserLocalStorage<T>(
+  userId: string | null | undefined,
+  key: string,
+  initialValue: T
+): [T, (value: T | ((val: T) => T)) => void] {
+  const storageKey = useMemo(() => (userId ? `agor:user:${userId}:${key}` : null), [key, userId]);
+
+  const readStoredValue = useCallback((): T => {
+    if (typeof window === 'undefined' || !storageKey) {
+      return initialValue;
+    }
+
+    try {
+      const item = window.localStorage.getItem(storageKey);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.error(`Error reading localStorage key "${storageKey}":`, error);
+      return initialValue;
+    }
+  }, [initialValue, storageKey]);
+
+  const [storedValue, setStoredValue] = useState<T>(readStoredValue);
+  const storageKeyRef = useRef(storageKey);
+  storageKeyRef.current = storageKey;
+
+  useEffect(() => {
+    setStoredValue(readStoredValue());
+  }, [readStoredValue]);
+
+  const setValue = useCallback((value: T | ((val: T) => T)) => {
+    try {
+      setStoredValue((prev) => {
+        const valueToStore = value instanceof Function ? value(prev) : value;
+        const currentKey = storageKeyRef.current;
+        if (typeof window !== 'undefined' && currentKey) {
+          window.localStorage.setItem(currentKey, JSON.stringify(valueToStore));
+        }
+        return valueToStore;
+      });
+    } catch (error) {
+      console.error(`Error setting localStorage key "${storageKeyRef.current}":`, error);
+    }
+  }, []);
+
+  return [storedValue, setValue];
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,21 +7,25 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./config": {
+      "source": "./src/config.ts",
       "types": "./dist/config.d.ts",
       "import": "./dist/config.js",
       "require": "./dist/config.cjs"
     },
     "./yaml": {
+      "source": "./src/yaml.ts",
       "types": "./dist/yaml.d.ts",
       "import": "./dist/yaml.js",
       "require": "./dist/yaml.cjs"
     },
     "./jwt": {
+      "source": "./src/jwt.ts",
       "types": "./dist/jwt.d.ts",
       "import": "./dist/jwt.js",
       "require": "./dist/jwt.cjs"


### PR DESCRIPTION
## Summary
- Enforce a stricter left-panel minimum of 320px (translated to a responsive percentage, capped at the existing 45% max) so the Assistant / All sessions / Comments tab headers remain readable at the 768px desktop breakpoint.
- Persist left and right panel width percentages in per-user localStorage keys via a typed `useUserLocalStorage` helper.
- Render All Sessions branch metadata as a compact, non-interactive `BranchPill` with no action controls.
- Add `source` export conditions for `@agor-live/client` so UI tests can resolve workspace source consistently with the existing Vite/Vitest `conditions: ['source']` config.
- Fix navbar facepile alignment by keeping the facepile inline-flex with a non-inherited line-height, preventing the avatar from being laid out above the header.
- Address review feedback: only persist panel widths during user resize drags so responsive min enforcement does not overwrite the user's saved desired size, and factor shared localStorage JSON helpers used by both localStorage hooks.

## Test plan
- `pnpm exec biome check apps/agor-ui/src/hooks/useUserLocalStorage.ts apps/agor-ui/src/hooks/useUserLocalStorage.test.tsx apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.test.tsx apps/agor-ui/src/components/Pill/Pill.tsx apps/agor-ui/src/components/App/App.tsx packages/client/package.json`
- `pnpm --filter agor-ui test -- src/hooks/useUserLocalStorage.test.tsx src/components/BranchListDrawer/BranchListDrawer.test.tsx`
- `pnpm --filter agor-ui typecheck`
- `pnpm check` (passes; existing repo-wide Biome warnings are emitted at warning level)
- `pnpm exec biome check apps/agor-ui/src/components/Facepile/Facepile.css`
- Playwright manual check at `http://10.33.92.175:6488/b/default/`: facepile avatar rect is within the 64px navbar and visually centered.

## Manual QA
1. Open the board UI, drag the left panel narrower, and confirm it stops at ~320px with all three tab headers visible and not crowded/truncated.
2. Resize the left panel and the right session panel, reload the page, and confirm both widths are restored for the same user.
3. Sign in as or switch to a different user and confirm panel widths use that user's own localStorage-backed values rather than the previous user's widths.
4. In the left panel, open **All sessions** and confirm each session row shows a compact branch pill only; clicking the pill itself should not open branch settings or show any action buttons, while clicking the session row should still open the session.
5. Confirm the navbar facepile avatar is fully visible and vertically centered in the header, not clipped above the viewport.


