### PR TITLE
Add executor heartbeat support

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -111,6 +111,11 @@ export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersP
   fail(id: string, data: { error?: string }, params?: FeathersParams): Promise<Task>;
   getOrphaned(params?: FeathersParams): Promise<Task[]>;
   getActiveWithExecutorHeartbeat(params?: FeathersParams): Promise<Task[]>;
+  failForLostHeartbeat(
+    id: string,
+    data: { completed_at?: string; error_message: string },
+    params?: FeathersParams
+  ): Promise<Task>;
 }
 
 /**

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -110,6 +110,7 @@ export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersP
   ): Promise<Task>;
   fail(id: string, data: { error?: string }, params?: FeathersParams): Promise<Task>;
   getOrphaned(params?: FeathersParams): Promise<Task[]>;
+  getActiveWithExecutorHeartbeat(params?: FeathersParams): Promise<Task[]>;
 }
 
 /**

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -574,6 +574,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // contexts) can resolve it via `getDb(app)`. Existing services that
   // already receive `db` via constructor injection are unaffected.
   app.set('database', db);
+  app.set('config', config);
 
   // --------------------------------------------------------------------------
   // Phase 1: Register services

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -843,6 +843,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
    */
   const sessionTurnLocks: SessionTurnLocks = new Map();
 
+  function sessionCanStartTask(status: SessionStatus, readyForPrompt?: boolean): boolean {
+    return (
+      status === SessionStatus.IDLE || (status === SessionStatus.FAILED && readyForPrompt === true)
+    );
+  }
+
   /**
    * Helper: Safely patch an entity, returning false if it was deleted mid-execution
    */
@@ -1297,7 +1303,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             throw new Error('Cannot send prompt: session is currently stopping');
           }
           const queuedTasks = await taskRepo.findQueued(id as SessionID);
-          const shouldQueue = lockedSession.status !== SessionStatus.IDLE || queuedTasks.length > 0;
+          const shouldQueue =
+            !sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt) ||
+            queuedTasks.length > 0;
 
           if (shouldQueue) {
             const queuedTask = await taskRepo.createPending({
@@ -1319,7 +1327,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
             app.service('tasks').emit('queued', queuedTask);
 
-            if (lockedSession.status === SessionStatus.IDLE) {
+            if (sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt)) {
               setImmediate(async () => {
                 try {
                   await sessionsService.triggerQueueProcessing(id as SessionID, params);
@@ -1497,7 +1505,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           if (session.status === SessionStatus.STOPPING) {
             throw new BadRequest('Cannot run task: session is currently stopping');
           }
-          if (session.status !== SessionStatus.IDLE) {
+          if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
             throw new Conflict(
               `Cannot run task ${shortId(taskId)}: session is '${session.status}'. ` +
                 `To enqueue a prompt on a busy session, POST to /sessions/:id/prompt instead — ` +
@@ -2144,7 +2152,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
     const session = await sessionsService.get(sessionId, taskParams);
 
-    if (session.status !== SessionStatus.IDLE) {
+    if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
       console.log(
         `⏸️  [Queue] Session ${shortId(sessionId)} is ${session.status}, task ${shortId(nextTask.task_id)} waiting in queue ` +
           `(will be processed when session becomes IDLE via patch hook)`

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -800,7 +800,14 @@ function createExecuteHandler(
                 currentTask.status === 'timed_out';
 
               if (isTaskStillActive) {
-                await app.service('tasks').patch(taskId, { status: TaskStatus.FAILED }, params);
+                await app.service('tasks').patch(
+                  taskId,
+                  {
+                    status: TaskStatus.FAILED,
+                    error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
+                  },
+                  params
+                );
                 console.log(
                   `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
                 );

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EXECUTOR_HEARTBEAT_LOST_MESSAGE,
+  ExecutorHeartbeatSupervisor,
+} from './executor-heartbeat-supervisor';
+
+describe('ExecutorHeartbeatSupervisor', () => {
+  it('marks active tasks failed when latest heartbeat is stale', async () => {
+    const staleTask = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      status: 'running',
+      last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+    };
+    const tasksPatch = vi.fn().mockResolvedValue({});
+    const sessionsPatch = vi.fn().mockResolvedValue({});
+    const app = {
+      service: (name: string) => {
+        if (name === 'tasks') {
+          return {
+            getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([staleTask]),
+            get: vi.fn().mockResolvedValue(staleTask),
+            patch: tasksPatch,
+          };
+        }
+        if (name === 'sessions') {
+          return { patch: sessionsPatch };
+        }
+        throw new Error(`unknown service ${name}`);
+      },
+    } as any;
+
+    const supervisor = new ExecutorHeartbeatSupervisor({
+      app,
+      config: {
+        enabled: true,
+        interval_ms: 1000,
+        stale_after_ms: 3000,
+        callback: { command_template: null, timeout_ms: 3000 },
+      },
+      now: () => new Date('2026-01-01T00:00:05.000Z'),
+    });
+
+    await supervisor.checkOnce();
+
+    expect(tasksPatch).toHaveBeenCalledWith(staleTask.task_id, {
+      status: 'failed',
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
+    });
+    expect(sessionsPatch).toHaveBeenCalledWith(staleTask.session_id, {
+      status: 'failed',
+      ready_for_prompt: true,
+    });
+  });
+
+  it('skips tasks that refreshed before failure', async () => {
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      status: 'running',
+      last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+    };
+    const tasksPatch = vi.fn();
+    const app = {
+      service: (name: string) => ({
+        getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([task]),
+        get: vi.fn().mockResolvedValue({
+          ...task,
+          last_executor_heartbeat_at: '2026-01-01T00:00:04.500Z',
+        }),
+        patch: name === 'tasks' ? tasksPatch : vi.fn(),
+      }),
+    } as any;
+
+    const supervisor = new ExecutorHeartbeatSupervisor({
+      app,
+      config: {
+        enabled: true,
+        interval_ms: 1000,
+        stale_after_ms: 3000,
+        callback: { command_template: null, timeout_ms: 3000 },
+      },
+      now: () => new Date('2026-01-01T00:00:05.000Z'),
+    });
+
+    await supervisor.checkOnce();
+    expect(tasksPatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
@@ -12,7 +12,7 @@ describe('ExecutorHeartbeatSupervisor', () => {
       status: 'running',
       last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
     };
-    const tasksPatch = vi.fn().mockResolvedValue({});
+    const failForLostHeartbeat = vi.fn().mockResolvedValue({});
     const sessionsPatch = vi.fn().mockResolvedValue({});
     const app = {
       service: (name: string) => {
@@ -20,7 +20,7 @@ describe('ExecutorHeartbeatSupervisor', () => {
           return {
             getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([staleTask]),
             get: vi.fn().mockResolvedValue(staleTask),
-            patch: tasksPatch,
+            failForLostHeartbeat,
           };
         }
         if (name === 'sessions') {
@@ -43,8 +43,7 @@ describe('ExecutorHeartbeatSupervisor', () => {
 
     await supervisor.checkOnce();
 
-    expect(tasksPatch).toHaveBeenCalledWith(staleTask.task_id, {
-      status: 'failed',
+    expect(failForLostHeartbeat).toHaveBeenCalledWith(staleTask.task_id, {
       completed_at: '2026-01-01T00:00:05.000Z',
       error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
     });

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
@@ -1,0 +1,92 @@
+import type { ResolvedExecutorHeartbeatConfig } from '@agor/core/config';
+import { shortId } from '@agor/core/db';
+import type { Application, TasksServiceImpl } from '../declarations.js';
+
+export const EXECUTOR_HEARTBEAT_LOST_MESSAGE =
+  'Executor heartbeat lost; the executor may have crashed or disconnected.';
+
+export interface ExecutorHeartbeatSupervisorOptions {
+  app: Application;
+  config: ResolvedExecutorHeartbeatConfig;
+  tickIntervalMs?: number;
+  now?: () => Date;
+}
+
+export class ExecutorHeartbeatSupervisor {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly tickIntervalMs: number;
+  private readonly now: () => Date;
+
+  constructor(private options: ExecutorHeartbeatSupervisorOptions) {
+    this.tickIntervalMs = options.tickIntervalMs ?? Math.min(options.config.interval_ms, 30_000);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  start(): void {
+    if (!this.options.config.enabled || this.timer) return;
+    this.timer = setInterval(() => {
+      void this.checkOnce();
+    }, this.tickIntervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async checkOnce(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    try {
+      const tasksService = this.options.app.service('tasks') as unknown as TasksServiceImpl;
+      const tasks = await tasksService.getActiveWithExecutorHeartbeat();
+      const nowMs = this.now().getTime();
+      for (const task of tasks) {
+        if (!task.last_executor_heartbeat_at) continue;
+        const heartbeatMs = new Date(task.last_executor_heartbeat_at).getTime();
+        if (!Number.isFinite(heartbeatMs)) continue;
+        if (nowMs - heartbeatMs <= this.options.config.stale_after_ms) continue;
+
+        try {
+          const current = await this.options.app.service('tasks').get(task.task_id);
+          if (current.status !== task.status || !current.last_executor_heartbeat_at) continue;
+          const currentHeartbeatMs = new Date(current.last_executor_heartbeat_at).getTime();
+          if (!Number.isFinite(currentHeartbeatMs)) continue;
+          if (nowMs - currentHeartbeatMs <= this.options.config.stale_after_ms) continue;
+
+          await this.options.app.service('tasks').patch(task.task_id, {
+            status: 'failed',
+            completed_at: this.now().toISOString(),
+            error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
+          });
+          await this.options.app
+            .service('sessions')
+            .patch(task.session_id, { status: 'failed', ready_for_prompt: true })
+            .catch((error: unknown) => {
+              console.warn(
+                `[executor-heartbeat] Failed to mark session ${shortId(task.session_id)} failed after stale heartbeat:`,
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+          console.warn(
+            `[executor-heartbeat] Marked task ${shortId(task.task_id)} failed after stale heartbeat (${nowMs - currentHeartbeatMs}ms old)`
+          );
+        } catch (error) {
+          console.warn(
+            `[executor-heartbeat] Failed to process stale task ${shortId(task.task_id)}:`,
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+      }
+    } catch (error) {
+      console.warn(
+        '[executor-heartbeat] Supervisor check failed:',
+        error instanceof Error ? error.message : String(error)
+      );
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
@@ -56,8 +56,7 @@ export class ExecutorHeartbeatSupervisor {
           if (!Number.isFinite(currentHeartbeatMs)) continue;
           if (nowMs - currentHeartbeatMs <= this.options.config.stale_after_ms) continue;
 
-          await this.options.app.service('tasks').patch(task.task_id, {
-            status: 'failed',
+          await tasksService.failForLostHeartbeat(task.task_id, {
             completed_at: this.now().toISOString(),
             error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
           });

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -1,0 +1,38 @@
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { TasksService } from './tasks';
+
+describe('TasksService executor heartbeat helpers', () => {
+  it('fails lost heartbeat tasks without idling the session or draining its queue', async () => {
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      patch: ReturnType<typeof vi.fn>;
+    };
+    service.patch = vi.fn().mockResolvedValue({
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      status: TaskStatus.FAILED,
+    });
+
+    await service.failForLostHeartbeat(
+      '018f0000-0000-7000-8000-000000000001',
+      {
+        completed_at: '2026-01-01T00:00:05.000Z',
+        error_message: 'Executor heartbeat lost',
+      },
+      { query: { session_id: '018f0000-0000-7000-8000-000000000002' } }
+    );
+
+    expect(service.patch).toHaveBeenCalledWith(
+      '018f0000-0000-7000-8000-000000000001',
+      {
+        status: TaskStatus.FAILED,
+        completed_at: '2026-01-01T00:00:05.000Z',
+        error_message: 'Executor heartbeat lost',
+      },
+      {
+        query: { session_id: '018f0000-0000-7000-8000-000000000002' },
+        suppressTerminalSessionIdle: true,
+        suppressTerminalQueueProcessing: true,
+      }
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -4,35 +4,66 @@ import { TasksService } from './tasks';
 
 describe('TasksService executor heartbeat helpers', () => {
   it('fails lost heartbeat tasks without idling the session or draining its queue', async () => {
-    const service = Object.create(TasksService.prototype) as TasksService & {
-      patch: ReturnType<typeof vi.fn>;
+    const taskId = '018f0000-0000-7000-8000-000000000001';
+    const sessionId = '018f0000-0000-7000-8000-000000000002';
+    const currentTask = {
+      task_id: taskId,
+      session_id: sessionId,
+      status: TaskStatus.RUNNING,
+      created_at: '2026-01-01T00:00:00.000Z',
     };
-    service.patch = vi.fn().mockResolvedValue({
+    const failedTask = {
+      ...currentTask,
+      status: TaskStatus.FAILED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'Executor heartbeat lost',
+    };
+    const sessionsPatch = vi.fn();
+    const triggerQueueProcessing = vi.fn();
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      app: unknown;
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(currentTask);
+    service.repository = { update: vi.fn().mockResolvedValue(failedTask) };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+    service.app = {
+      service: (name: string) => {
+        if (name === 'sessions') {
+          return {
+            get: vi.fn().mockResolvedValue({
+              session_id: sessionId,
+              status: 'running',
+              tasks: [taskId],
+            }),
+            patch: sessionsPatch,
+            triggerQueueProcessing,
+          };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    };
+
+    const result = await service.failForLostHeartbeat(taskId, {
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'Executor heartbeat lost',
+    });
+
+    expect(result).toMatchObject({
       task_id: '018f0000-0000-7000-8000-000000000001',
       status: TaskStatus.FAILED,
     });
-
-    await service.failForLostHeartbeat(
-      '018f0000-0000-7000-8000-000000000001',
-      {
-        completed_at: '2026-01-01T00:00:05.000Z',
-        error_message: 'Executor heartbeat lost',
-      },
-      { query: { session_id: '018f0000-0000-7000-8000-000000000002' } }
-    );
-
-    expect(service.patch).toHaveBeenCalledWith(
-      '018f0000-0000-7000-8000-000000000001',
-      {
-        status: TaskStatus.FAILED,
-        completed_at: '2026-01-01T00:00:05.000Z',
-        error_message: 'Executor heartbeat lost',
-      },
-      {
-        query: { session_id: '018f0000-0000-7000-8000-000000000002' },
-        suppressTerminalSessionIdle: true,
-        suppressTerminalQueueProcessing: true,
-      }
-    );
+    expect(service.repository.update).toHaveBeenCalledWith(taskId, {
+      status: TaskStatus.FAILED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'Executor heartbeat lost',
+      duration_ms: 5000,
+    });
+    expect(sessionsPatch).not.toHaveBeenCalled();
+    expect(triggerQueueProcessing).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -9,7 +9,7 @@ import {
   type ChildCompletionContext,
   renderChildCompletionCallback,
 } from '@agor/core/callbacks/child-completion-template';
-import { PAGINATION } from '@agor/core/config';
+import { PAGINATION, resolveExecutorHeartbeatConfig } from '@agor/core/config';
 import { type Database, shortId, TaskRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -23,6 +23,10 @@ import type {
 import { TaskStatus } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 import { appendSystemMessage } from '../utils/append-system-message.js';
+import {
+  type ExecutorHeartbeatCallbackPayload,
+  ExecutorHeartbeatCallbackRunner,
+} from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
 import type { SessionsService } from './sessions';
 
@@ -41,6 +45,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   private taskRepo: TaskRepository;
   private app: Application;
   private db: Database;
+  private heartbeatCallbackRunner: ExecutorHeartbeatCallbackRunner;
 
   constructor(db: Database, app: Application) {
     const taskRepo = new TaskRepository(db);
@@ -57,6 +62,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     this.taskRepo = taskRepo;
     this.app = app;
     this.db = db;
+    const heartbeatConfig = resolveExecutorHeartbeatConfig(app.get?.('config')?.execution);
+    this.heartbeatCallbackRunner = new ExecutorHeartbeatCallbackRunner(heartbeatConfig.callback);
   }
 
   /**
@@ -148,6 +155,33 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     return result;
   }
 
+  async getActiveWithExecutorHeartbeat(): Promise<Task[]> {
+    return this.taskRepo.findActiveWithExecutorHeartbeat();
+  }
+
+  private async handleExecutorHeartbeat(task: Task, heartbeatAt: string): Promise<void> {
+    const payload: ExecutorHeartbeatCallbackPayload = {
+      event: 'executor_heartbeat',
+      task_id: task.task_id,
+      session_id: task.session_id,
+      last_executor_heartbeat_at: heartbeatAt,
+    };
+
+    try {
+      const session = await this.app.service('sessions').get(task.session_id);
+      if (session?.branch_id) {
+        payload.branch_id = session.branch_id;
+      }
+    } catch (error) {
+      console.warn(
+        `⚠️  [TasksService] Could not resolve branch_id for heartbeat task ${shortId(task.task_id)}:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+
+    this.heartbeatCallbackRunner.run(payload);
+  }
+
   /**
    * Override patch to detect task completion and:
    * 1. Atomically update session status to IDLE when task reaches terminal state
@@ -213,6 +247,17 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     }
 
     const result = await super.patch(id, data, params);
+
+    if (data.last_executor_heartbeat_at && !Array.isArray(result)) {
+      this.handleExecutorHeartbeat(result as Task, data.last_executor_heartbeat_at).catch(
+        (error) => {
+          console.warn(
+            `⚠️  [TasksService] Executor heartbeat callback failed for task ${shortId((result as Task).task_id)}:`,
+            error
+          );
+        }
+      );
+    }
 
     // If task is being marked as completed, failed, or stopped (terminal status)
     if (

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -36,7 +36,18 @@ import type { SessionsService } from './sessions';
 export type TaskParams = QueryParams<{
   session_id?: string;
   status?: Task['status'];
-}>;
+}> & {
+  /**
+   * Internal-only: terminal task patches normally transition the owning session
+   * back to idle. Heartbeat-loss handling marks the session failed instead.
+   */
+  suppressTerminalSessionIdle?: boolean;
+  /**
+   * Internal-only: terminal task patches normally drain queued work for the
+   * owning session. Heartbeat-loss handling must not auto-start queued prompts.
+   */
+  suppressTerminalQueueProcessing?: boolean;
+};
 
 /**
  * Extended tasks service with custom methods
@@ -63,7 +74,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     this.app = app;
     this.db = db;
     const heartbeatConfig = resolveExecutorHeartbeatConfig(app.get?.('config')?.execution);
-    this.heartbeatCallbackRunner = new ExecutorHeartbeatCallbackRunner(heartbeatConfig.callback);
+    this.heartbeatCallbackRunner = new ExecutorHeartbeatCallbackRunner(heartbeatConfig);
   }
 
   /**
@@ -157,6 +168,27 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
   async getActiveWithExecutorHeartbeat(): Promise<Task[]> {
     return this.taskRepo.findActiveWithExecutorHeartbeat();
+  }
+
+  async failForLostHeartbeat(
+    id: string,
+    data: { completed_at?: string; error_message: string },
+    params?: TaskParams
+  ): Promise<Task> {
+    const result = await this.patch(
+      id,
+      {
+        status: TaskStatus.FAILED,
+        completed_at: data.completed_at,
+        error_message: data.error_message,
+      },
+      {
+        ...params,
+        suppressTerminalSessionIdle: true,
+        suppressTerminalQueueProcessing: true,
+      }
+    );
+    return result as Task;
   }
 
   private async handleExecutorHeartbeat(task: Task, heartbeatAt: string): Promise<void> {
@@ -319,6 +351,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             console.log(
               `⏭️ [TasksService] Skipping session IDLE update for STOPPED task ${shortId(task.task_id)} — stop endpoint handles session state`
             );
+          } else if (params?.suppressTerminalSessionIdle) {
+            console.log(
+              `⏭️ [TasksService] Skipping session IDLE update for task ${shortId(task.task_id)} (${data.status}) due to internal patch params`
+            );
           } else {
             await this.app.service('sessions').patch(
               task.session_id,
@@ -420,7 +456,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           // IMPORTANT: Now that session is idle, process any queued tasks (including callbacks)
           // This handles the case where callbacks were queued while this session was running
           const sessionsService = this.app.service('sessions') as unknown as SessionsService;
-          if (sessionsService.triggerQueueProcessing) {
+          if (!params?.suppressTerminalQueueProcessing && sessionsService.triggerQueueProcessing) {
             await sessionsService.triggerQueueProcessing(task.session_id);
           }
         } catch (error) {

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -8,12 +8,13 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
-import { getAgorHome } from '@agor/core/config';
+import { getAgorHome, resolveExecutorHeartbeatConfig } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import { MessagesRepository, SessionRepository, shortId } from '@agor/core/db';
 import type { Id, Paginated, Session, SessionID, Task } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
+import { ExecutorHeartbeatSupervisor } from './services/executor-heartbeat-supervisor.js';
 import type { GatewayService } from './services/gateway.js';
 import { createHealthMonitor } from './services/health-monitor.js';
 import { SchedulerService } from './services/scheduler.js';
@@ -424,7 +425,19 @@ export async function startup(ctx: StartupContext): Promise<void> {
     }
   }
 
-  // 5. Start scheduler service (background worker)
+  // 5. Start executor heartbeat stale supervisor
+  const heartbeatConfig = resolveExecutorHeartbeatConfig(config.execution);
+  const heartbeatSupervisor = new ExecutorHeartbeatSupervisor({ app, config: heartbeatConfig });
+  heartbeatSupervisor.start();
+  if (heartbeatConfig.enabled) {
+    console.log(
+      `💓 Executor heartbeat supervisor started (interval: ${heartbeatConfig.interval_ms}ms, stale after: ${heartbeatConfig.stale_after_ms}ms)`
+    );
+  } else {
+    console.log('💓 Executor heartbeat disabled');
+  }
+
+  // 6. Start scheduler service (background worker)
   let schedulerService: SchedulerService | null = null;
   if (svcEnabled('scheduler')) {
     schedulerService = new SchedulerService(db, app, {
@@ -440,7 +453,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     console.log(`🔄 Scheduler started (tick interval: 30s)`);
   }
 
-  // 6. Initialize gateway: refresh channel state cache, then start Socket Mode listeners
+  // 7. Initialize gateway: refresh channel state cache, then start Socket Mode listeners
   const gatewayService = safeService('gateway') as unknown as GatewayService | undefined;
   if (gatewayService) {
     gatewayService
@@ -453,7 +466,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
       });
   }
 
-  // 7. Graceful shutdown handler
+  // 8. Graceful shutdown handler
   const shutdown = async (signal: string) => {
     console.log(`\n⏳ Received ${signal}, shutting down gracefully...`);
 
@@ -465,6 +478,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
     try {
       // Clean up health monitor
       healthMonitor.cleanup();
+
+      // Stop heartbeat supervisor
+      heartbeatSupervisor.stop();
 
       // Clean up terminal sessions
       if (terminalsService) {

--- a/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
+++ b/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
@@ -10,7 +10,11 @@
  * can stay focused on subprocess / template / sudo / env-routing concerns.
  */
 
-import { loadConfigSync, type ResolvedConfigSlice } from '@agor/core/config';
+import {
+  loadConfigSync,
+  resolveExecutorHeartbeatConfig,
+  type ResolvedConfigSlice,
+} from '@agor/core/config';
 
 /**
  * Inject a daemon-resolved config slice into an executor payload if the
@@ -46,9 +50,18 @@ export function buildResolvedConfigSlice(): ResolvedConfigSlice {
     // @agor/core/config). Adding a new field to ResolvedConfigSlice
     // without sourcing it here is a compile error.
     const slice: ResolvedConfigSlice = {};
+    const executionSlice: NonNullable<ResolvedConfigSlice['execution']> = {};
     const permissionTimeoutMs = config.execution?.permission_timeout_ms;
     if (permissionTimeoutMs !== undefined) {
-      slice.execution = { permission_timeout_ms: permissionTimeoutMs };
+      executionSlice.permission_timeout_ms = permissionTimeoutMs;
+    }
+    const heartbeat = resolveExecutorHeartbeatConfig(config.execution);
+    executionSlice.executor_heartbeat = {
+      enabled: heartbeat.enabled,
+      interval_ms: heartbeat.interval_ms,
+    };
+    if (Object.keys(executionSlice).length > 0) {
+      slice.execution = executionSlice;
     }
     const opencodeServerUrl = config.opencode?.serverUrl;
     if (opencodeServerUrl !== undefined) {

--- a/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
+++ b/apps/agor-daemon/src/utils/build-resolved-config-slice.ts
@@ -12,8 +12,8 @@
 
 import {
   loadConfigSync,
-  resolveExecutorHeartbeatConfig,
   type ResolvedConfigSlice,
+  resolveExecutorHeartbeatConfig,
 } from '@agor/core/config';
 
 /**

--- a/apps/agor-daemon/src/utils/executor-heartbeat-callback.test.ts
+++ b/apps/agor-daemon/src/utils/executor-heartbeat-callback.test.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type ExecutorHeartbeatCallbackPayload,
+  ExecutorHeartbeatCallbackRunner,
+} from './executor-heartbeat-callback';
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+class FakeChildProcess extends EventEmitter {
+  stdin = Object.assign(new EventEmitter(), {
+    end: vi.fn(),
+  });
+  kill = vi.fn();
+}
+
+const payload: ExecutorHeartbeatCallbackPayload = {
+  event: 'executor_heartbeat',
+  task_id: '018f0000-0000-7000-8000-000000000001',
+  session_id: '018f0000-0000-7000-8000-000000000002',
+  last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+};
+
+function createRunner(
+  overrides: Partial<ConstructorParameters<typeof ExecutorHeartbeatCallbackRunner>[0]> = {}
+) {
+  return new ExecutorHeartbeatCallbackRunner({
+    enabled: true,
+    callback: {
+      command_template: 'cat >/dev/null',
+      timeout_ms: 100,
+    },
+    ...overrides,
+  });
+}
+
+describe('ExecutorHeartbeatCallbackRunner', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  it('does not spawn callbacks when heartbeat callbacks are disabled', () => {
+    const runner = createRunner({ enabled: false });
+
+    runner.run(payload);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps callback coalesced after timeout until the process exits', () => {
+    vi.useFakeTimers();
+    const firstChild = new FakeChildProcess();
+    const secondChild = new FakeChildProcess();
+    spawnMock.mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild);
+    const runner = createRunner();
+
+    runner.run(payload);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+    expect(firstChild.kill).toHaveBeenCalledWith('SIGTERM');
+
+    runner.run(payload);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    firstChild.emit('exit', null, 'SIGTERM');
+    runner.run(payload);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles stdin stream errors as non-fatal callback warnings', () => {
+    const child = new FakeChildProcess();
+    spawnMock.mockReturnValue(child);
+    const runner = createRunner();
+
+    runner.run(payload);
+    child.stdin.emit('error', new Error('EPIPE'));
+    child.emit('exit', 0, null);
+
+    expect(warnSpy).toHaveBeenCalledWith('[executor-heartbeat] Callback stdin failed: EPIPE');
+  });
+});

--- a/apps/agor-daemon/src/utils/executor-heartbeat-callback.ts
+++ b/apps/agor-daemon/src/utils/executor-heartbeat-callback.ts
@@ -1,0 +1,65 @@
+import { spawn } from 'node:child_process';
+import type { ResolvedExecutorHeartbeatConfig } from '@agor/core/config';
+import { shortId } from '@agor/core/db';
+
+export interface ExecutorHeartbeatCallbackPayload {
+  event: 'executor_heartbeat';
+  task_id: string;
+  session_id: string;
+  branch_id?: string;
+  last_executor_heartbeat_at: string;
+}
+
+export class ExecutorHeartbeatCallbackRunner {
+  private runningByTask = new Set<string>();
+
+  constructor(private config: ResolvedExecutorHeartbeatConfig['callback']) {}
+
+  run(payload: ExecutorHeartbeatCallbackPayload): void {
+    const command = this.config.command_template;
+    if (!command) return;
+
+    if (this.runningByTask.has(payload.task_id)) {
+      console.warn(
+        `[executor-heartbeat] Previous callback still running for task ${shortId(payload.task_id)}; skipping heartbeat callback`
+      );
+      return;
+    }
+
+    this.runningByTask.add(payload.task_id);
+    const timeoutMs = this.config.timeout_ms;
+    const child = spawn('sh', ['-c', command], {
+      stdio: ['pipe', 'ignore', 'ignore'],
+    });
+
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (reason?: string) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      this.runningByTask.delete(payload.task_id);
+      if (reason) {
+        console.warn(`[executor-heartbeat] Callback ${reason}`);
+      }
+    };
+
+    timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      finish(`timed out after ${timeoutMs}ms`);
+    }, timeoutMs);
+    timer.unref?.();
+
+    child.on('error', (error) => finish(`spawn failed: ${error.message}`));
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        finish();
+      } else {
+        finish(`exited with ${signal ? `signal ${signal}` : `code ${code}`}`);
+      }
+    });
+
+    child.stdin?.end(`${JSON.stringify(payload)}\n`);
+  }
+}

--- a/apps/agor-daemon/src/utils/executor-heartbeat-callback.ts
+++ b/apps/agor-daemon/src/utils/executor-heartbeat-callback.ts
@@ -13,10 +13,12 @@ export interface ExecutorHeartbeatCallbackPayload {
 export class ExecutorHeartbeatCallbackRunner {
   private runningByTask = new Set<string>();
 
-  constructor(private config: ResolvedExecutorHeartbeatConfig['callback']) {}
+  constructor(private config: Pick<ResolvedExecutorHeartbeatConfig, 'enabled' | 'callback'>) {}
 
   run(payload: ExecutorHeartbeatCallbackPayload): void {
-    const command = this.config.command_template;
+    if (!this.config.enabled) return;
+
+    const command = this.config.callback.command_template;
     if (!command) return;
 
     if (this.runningByTask.has(payload.task_id)) {
@@ -27,18 +29,21 @@ export class ExecutorHeartbeatCallbackRunner {
     }
 
     this.runningByTask.add(payload.task_id);
-    const timeoutMs = this.config.timeout_ms;
+    const timeoutMs = this.config.callback.timeout_ms;
     const child = spawn('sh', ['-c', command], {
       stdio: ['pipe', 'ignore', 'ignore'],
     });
 
     let settled = false;
+    let timedOut = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
 
     const finish = (reason?: string) => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
       this.runningByTask.delete(payload.task_id);
       if (reason) {
         console.warn(`[executor-heartbeat] Callback ${reason}`);
@@ -46,20 +51,42 @@ export class ExecutorHeartbeatCallbackRunner {
     };
 
     timer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      console.warn(`[executor-heartbeat] Callback timed out after ${timeoutMs}ms`);
       child.kill('SIGTERM');
-      finish(`timed out after ${timeoutMs}ms`);
+      killTimer = setTimeout(
+        () => {
+          if (!settled) {
+            child.kill('SIGKILL');
+          }
+        },
+        Math.min(timeoutMs, 1_000)
+      );
+      killTimer.unref?.();
     }, timeoutMs);
     timer.unref?.();
 
     child.on('error', (error) => finish(`spawn failed: ${error.message}`));
     child.on('exit', (code, signal) => {
-      if (code === 0) {
+      if (code === 0 || timedOut) {
         finish();
       } else {
         finish(`exited with ${signal ? `signal ${signal}` : `code ${code}`}`);
       }
     });
 
-    child.stdin?.end(`${JSON.stringify(payload)}\n`);
+    child.stdin?.on('error', (error: Error) => {
+      console.warn(`[executor-heartbeat] Callback stdin failed: ${error.message}`);
+    });
+
+    try {
+      child.stdin?.end(`${JSON.stringify(payload)}\n`);
+    } catch (error) {
+      console.warn(
+        `[executor-heartbeat] Callback stdin failed:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
   }
 }

--- a/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
@@ -48,6 +48,25 @@ describe('buildResolvedConfigSlice', () => {
     });
   });
 
+  it('surfaces executor heartbeat enabled and interval fields', async () => {
+    await writeConfigYaml(
+      [
+        'execution:',
+        '  executor_heartbeat:',
+        '    enabled: false',
+        '    interval_ms: 2500',
+        '    stale_after_ms: 9000',
+        '    callback:',
+        '      command_template: echo should-not-ship',
+        '',
+      ].join('\n')
+    );
+    const slice = buildResolvedConfigSlice();
+    expect(slice.execution?.executor_heartbeat).toEqual({ enabled: false, interval_ms: 2500 });
+    expect(slice.execution?.executor_heartbeat).not.toHaveProperty('stale_after_ms');
+    expect(slice.execution?.executor_heartbeat).not.toHaveProperty('callback');
+  });
+
   it('surfaces opencode.serverUrl', async () => {
     await writeConfigYaml('opencode:\n  serverUrl: http://opencode.internal:4096\n');
     const slice = buildResolvedConfigSlice();
@@ -64,12 +83,11 @@ describe('buildResolvedConfigSlice', () => {
     });
   });
 
-  it('returns an empty slice when no relevant fields are configured', () => {
-    // No config file → no fields surface. Sections are omitted entirely
-    // rather than set to objects with undefined values, so the in-memory
-    // shape matches what survives JSON serialization to the executor.
+  it('returns only heartbeat defaults when no optional fields are configured', () => {
     const slice = buildResolvedConfigSlice();
-    expect(slice).toEqual({});
+    expect(slice).toEqual({
+      execution: { executor_heartbeat: { enabled: true, interval_ms: 10_000 } },
+    });
   });
 
   it('returns the same shape before and after JSON round-trip (wire fidelity)', async () => {
@@ -113,6 +131,7 @@ describe('buildResolvedConfigSlice', () => {
     const slice = buildResolvedConfigSlice() as Record<string, Record<string, unknown>>;
     // Allowed fields surface.
     expect(slice.execution?.permission_timeout_ms).toBe(60_000);
+    expect(slice.execution?.executor_heartbeat).toEqual({ enabled: true, interval_ms: 10_000 });
     expect(slice.daemon?.host_ip_address).toBe('10.0.0.5');
     // Non-allowed top-level sections are absent — slice is a strict subset.
     expect(slice).not.toHaveProperty('credentials');

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircleOutlined,
   ClockCircleOutlined,
   CloseCircleOutlined,
+  HeartOutlined,
   HourglassOutlined,
   PauseCircleOutlined,
   QuestionCircleOutlined,
@@ -26,6 +27,7 @@ interface TimerPillProps {
   startedAt?: string | number | Date;
   endedAt?: string | number | Date;
   durationMs?: number | null;
+  lastExecutorHeartbeatAt?: string | number | Date | null;
   style?: React.CSSProperties;
 }
 
@@ -135,11 +137,16 @@ export const TimerPill: React.FC<TimerPillProps> = ({
   startedAt,
   endedAt,
   durationMs,
+  lastExecutorHeartbeatAt,
   style,
 }) => {
   const { token } = theme.useToken();
   const startMs = useMemo(() => parseTimestamp(startedAt), [startedAt]);
   const endMs = useMemo(() => parseTimestamp(endedAt), [endedAt]);
+  const heartbeatMs = useMemo(
+    () => parseTimestamp(lastExecutorHeartbeatAt ?? undefined),
+    [lastExecutorHeartbeatAt]
+  );
 
   const fixedDuration = useMemo(() => {
     if (typeof durationMs === 'number' && durationMs >= 0) {
@@ -212,6 +219,8 @@ export const TimerPill: React.FC<TimerPillProps> = ({
       alignItems: 'baseline',
     };
 
+    const heartbeatAgeMs = heartbeatMs ? Math.max(0, Date.now() - heartbeatMs) : null;
+
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12 }}>
         {startMs && (
@@ -230,9 +239,21 @@ export const TimerPill: React.FC<TimerPillProps> = ({
           <span style={labelStyle}>Duration</span>
           <span style={valueStyle}>{formatDuration(elapsedMs)}</span>
         </div>
+        {heartbeatMs && (
+          <div style={rowStyle}>
+            <span style={labelStyle}>Heartbeat</span>
+            <span style={valueStyle}>
+              <HeartOutlined style={{ marginRight: 4 }} />
+              {heartbeatAgeMs !== null ? `${formatDuration(heartbeatAgeMs)} ago` : '—'}
+              <span style={{ color: token.colorTextSecondary, marginLeft: 6 }}>
+                {formatAbsoluteTime(new Date(heartbeatMs))}
+              </span>
+            </span>
+          </div>
+        )}
       </div>
     );
-  }, [startMs, endMs, isActive, elapsedMs, token]);
+  }, [startMs, endMs, isActive, elapsedMs, heartbeatMs, token]);
 
   if (!startMs && fixedDuration === null) {
     return null;

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -811,6 +811,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                   footerTimerTask.message_range?.end_timestamp || footerTimerTask.completed_at
                 }
                 durationMs={footerTimerTask.duration_ms}
+                lastExecutorHeartbeatAt={footerTimerTask.last_executor_heartbeat_at}
               />
             )}
             <SessionIdsButton session={session} />

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -489,6 +489,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                   : undefined)
               }
               durationMs={task.duration_ms}
+              lastExecutorHeartbeatAt={task.last_executor_heartbeat_at}
             />
             {scheduledFromBranch && scheduledRunAt && (
               <ScheduledRunPill scheduledRunAt={scheduledRunAt} />

--- a/packages/core/drizzle/postgres/0039_executor_heartbeat.sql
+++ b/packages/core/drizzle/postgres/0039_executor_heartbeat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tasks" ADD COLUMN "last_executor_heartbeat_at" timestamp;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1780400000000,
       "tag": "0038_primary_assistant_id",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1780500000000,
+      "tag": "0039_executor_heartbeat",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0048_executor_heartbeat.sql
+++ b/packages/core/drizzle/sqlite/0048_executor_heartbeat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `last_executor_heartbeat_at` integer;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1780400000000,
       "tag": "0047_primary_assistant_id",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "6",
+      "when": 1780500000000,
+      "tag": "0048_executor_heartbeat",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -10,6 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import yaml from 'js-yaml';
 import { DAEMON, MCP_TOKEN } from './constants';
+import { resolveExecutorHeartbeatConfig } from './executor-heartbeat';
 import type { AgorConfig, UnknownJson } from './types';
 
 // ---------------------------------------------------------------------------
@@ -293,6 +294,7 @@ export function getDefaultConfig(): AgorConfig {
       session_token_max_uses: 1, // Single-use tokens
       mcp_token_expiration_ms: MCP_TOKEN.DEFAULT_EXPIRATION_MS,
       sync_unix_passwords: true, // Default: sync passwords to Unix
+      executor_heartbeat: resolveExecutorHeartbeatConfig(),
     },
   };
 }

--- a/packages/core/src/config/executor-heartbeat.test.ts
+++ b/packages/core/src/config/executor-heartbeat.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultConfig } from './config-manager';
+import { resolveExecutorHeartbeatConfig } from './executor-heartbeat';
+
+describe('resolveExecutorHeartbeatConfig', () => {
+  it('defaults to enabled with a 10s interval and conservative stale threshold', () => {
+    expect(resolveExecutorHeartbeatConfig()).toEqual({
+      enabled: true,
+      interval_ms: 10_000,
+      stale_after_ms: 30_000,
+      callback: { command_template: null, timeout_ms: 3_000 },
+    });
+  });
+
+  it('defaults stale_after_ms to max(3 * interval_ms, 30000)', () => {
+    expect(
+      resolveExecutorHeartbeatConfig({ executor_heartbeat: { interval_ms: 20_000 } }).stale_after_ms
+    ).toBe(60_000);
+    expect(
+      resolveExecutorHeartbeatConfig({ executor_heartbeat: { interval_ms: 1_000 } }).stale_after_ms
+    ).toBe(30_000);
+  });
+
+  it('includes executor heartbeat defaults in getDefaultConfig', () => {
+    expect(getDefaultConfig().execution?.executor_heartbeat).toEqual(
+      resolveExecutorHeartbeatConfig()
+    );
+  });
+});

--- a/packages/core/src/config/executor-heartbeat.ts
+++ b/packages/core/src/config/executor-heartbeat.ts
@@ -1,0 +1,51 @@
+import type { AgorExecutionSettings } from './types';
+
+export const EXECUTOR_HEARTBEAT_DEFAULT_INTERVAL_MS = 10_000;
+export const EXECUTOR_HEARTBEAT_MIN_STALE_AFTER_MS = 30_000;
+export const EXECUTOR_HEARTBEAT_DEFAULT_CALLBACK_TIMEOUT_MS = 3_000;
+
+export interface ResolvedExecutorHeartbeatConfig {
+  enabled: boolean;
+  interval_ms: number;
+  stale_after_ms: number;
+  callback: {
+    command_template: string | null;
+    timeout_ms: number;
+  };
+}
+
+function positiveIntegerOrDefault(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+export function resolveExecutorHeartbeatConfig(
+  execution?: AgorExecutionSettings
+): ResolvedExecutorHeartbeatConfig {
+  const raw = execution?.executor_heartbeat;
+  const intervalMs = positiveIntegerOrDefault(
+    raw?.interval_ms,
+    EXECUTOR_HEARTBEAT_DEFAULT_INTERVAL_MS
+  );
+  const staleAfterMs = positiveIntegerOrDefault(
+    raw?.stale_after_ms,
+    Math.max(3 * intervalMs, EXECUTOR_HEARTBEAT_MIN_STALE_AFTER_MS)
+  );
+  const timeoutMs = positiveIntegerOrDefault(
+    raw?.callback?.timeout_ms,
+    EXECUTOR_HEARTBEAT_DEFAULT_CALLBACK_TIMEOUT_MS
+  );
+
+  return {
+    // Default enabled: the heartbeat is a lightweight task-row timestamp patch,
+    // and callback execution remains opt-in via command_template.
+    enabled: raw?.enabled ?? true,
+    interval_ms: intervalMs,
+    stale_after_ms: staleAfterMs,
+    callback: {
+      command_template: raw?.callback?.command_template ?? null,
+      timeout_ms: timeoutMs,
+    },
+  };
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -12,6 +12,7 @@ export * from './env-locking';
 export * from './env-resolver';
 export * from './env-validation';
 export * from './env-vars';
+export * from './executor-heartbeat';
 export * from './key-resolver';
 export type { ProxyMethod, ResolvedProxy } from './proxies-resolver';
 export { resolveProxies } from './proxies-resolver';

--- a/packages/core/src/config/resolved-config-slice.ts
+++ b/packages/core/src/config/resolved-config-slice.ts
@@ -38,6 +38,12 @@ export const ResolvedConfigSliceSchema = z.object({
   execution: z
     .object({
       permission_timeout_ms: z.number().int().nonnegative().optional(),
+      executor_heartbeat: z
+        .object({
+          enabled: z.boolean(),
+          interval_ms: z.number().int().positive(),
+        })
+        .optional(),
     })
     .optional(),
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -298,7 +298,6 @@ export interface AgorDatabaseSettings {
  */
 export type UnixUserMode = 'simple' | 'insulated' | 'strict';
 
-
 export interface AgorExecutorHeartbeatSettings {
   /** Enable executor task heartbeats (default: true). */
   enabled?: boolean;
@@ -322,7 +321,6 @@ export interface AgorExecutorHeartbeatSettings {
  * Execution settings
  */
 export interface AgorExecutionSettings {
-
   /**
    * Lightweight heartbeat settings for long-running executor tasks.
    *

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -298,10 +298,42 @@ export interface AgorDatabaseSettings {
  */
 export type UnixUserMode = 'simple' | 'insulated' | 'strict';
 
+
+export interface AgorExecutorHeartbeatSettings {
+  /** Enable executor task heartbeats (default: true). */
+  enabled?: boolean;
+
+  /** Heartbeat interval in milliseconds (default: 10000). */
+  interval_ms?: number;
+
+  /** Stale threshold in milliseconds. Default: max(3 * interval_ms, 30000). */
+  stale_after_ms?: number | null;
+
+  /** Optional external command callback invoked on each heartbeat. */
+  callback?: {
+    /** Shell command to run. Receives heartbeat JSON on stdin. Disabled when null/undefined. */
+    command_template?: string | null;
+    /** Callback timeout in milliseconds (default: 3000). */
+    timeout_ms?: number;
+  };
+}
+
 /**
  * Execution settings
  */
 export interface AgorExecutionSettings {
+
+  /**
+   * Lightweight heartbeat settings for long-running executor tasks.
+   *
+   * The executor patches `tasks.last_executor_heartbeat_at` immediately and
+   * then every `interval_ms` while a task is active. The daemon may mark stale
+   * active tasks failed after `stale_after_ms` without retrying automatically.
+   * Optional callbacks are shell commands that receive a small JSON payload on
+   * stdin; keep secrets out of the command argv.
+   */
+  executor_heartbeat?: AgorExecutorHeartbeatSettings;
+
   /** Unix user to run executors as (default: undefined = run as daemon user). When set, uses sudo impersonation. */
   executor_unix_user?: string;
 

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -105,6 +105,7 @@ describe('TaskRepository.create', () => {
     expect(created.status).toBe(data.status);
     expect(created.created_at).toBeDefined();
     expect(created.completed_at).toBeUndefined();
+    expect(created.last_executor_heartbeat_at).toBeUndefined();
   });
 
   dbTest('should generate task_id if not provided', async ({ db }) => {
@@ -693,6 +694,23 @@ describe('TaskRepository.update', () => {
     // Unchanged fields
     expect(updated.full_prompt).toBe(created.full_prompt);
     expect(updated.session_id).toBe(created.session_id);
+  });
+
+  dbTest('should round-trip last_executor_heartbeat_at on update', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const created = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.RUNNING })
+    );
+    const heartbeatAt = '2026-01-01T00:00:00.000Z';
+
+    const updated = await taskRepo.update(created.task_id, {
+      last_executor_heartbeat_at: heartbeatAt,
+    });
+    const found = await taskRepo.findById(created.task_id);
+
+    expect(updated.last_executor_heartbeat_at).toBe(heartbeatAt);
+    expect(found?.last_executor_heartbeat_at).toBe(heartbeatAt);
   });
 
   dbTest('should throw EntityNotFoundError for non-existent ID', async ({ db }) => {

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -38,6 +38,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       queue_position: row.queue_position ?? undefined,
       created_at: new Date(row.created_at).toISOString(),
       completed_at: row.completed_at ? new Date(row.completed_at).toISOString() : undefined,
+      last_executor_heartbeat_at: row.last_executor_heartbeat_at
+        ? new Date(row.last_executor_heartbeat_at).toISOString()
+        : undefined,
       created_by: row.created_by,
       session_md5: row.session_md5 ?? undefined,
       ...row.data,
@@ -69,6 +72,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       session_id: task.session_id,
       created_at: new Date(now), // Always use server timestamp, ignore client-provided value
       completed_at: task.completed_at ? new Date(task.completed_at) : undefined,
+      last_executor_heartbeat_at: task.last_executor_heartbeat_at
+        ? new Date(task.last_executor_heartbeat_at)
+        : undefined,
       status: task.status ?? TaskStatus.CREATED,
       queue_position: task.queue_position ?? null,
       created_by: task.created_by,
@@ -274,6 +280,31 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   }
 
   /**
+   * Find active tasks that have emitted at least one executor heartbeat.
+   *
+   * Tasks with a null heartbeat are intentionally skipped so enabling the
+   * supervisor does not fail legacy/pre-migration rows or tasks still inside
+   * startup grace before the executor sends its first heartbeat.
+   */
+  async findActiveWithExecutorHeartbeat(): Promise<Task[]> {
+    try {
+      const rows = await select(this.db)
+        .from(tasks)
+        .where(
+          sql`${tasks.status} IN ('running', 'stopping', 'awaiting_permission', 'awaiting_input') AND ${tasks.last_executor_heartbeat_at} IS NOT NULL`
+        )
+        .all();
+
+      return rows.map((row: TaskRow) => this.rowToTask(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find active tasks with executor heartbeat: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Find tasks by status
    */
   async findByStatus(status: Task['status']): Promise<Task[]> {
@@ -332,6 +363,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
             status: insertData.status,
             queue_position: insertData.queue_position,
             completed_at: insertData.completed_at,
+            last_executor_heartbeat_at: insertData.last_executor_heartbeat_at,
             session_md5: insertData.session_md5,
             data: insertData.data,
           })

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -250,6 +250,7 @@ export const tasks = pgTable(
     created_at: t.timestamp('created_at').notNull(),
     started_at: t.timestamp('started_at'),
     completed_at: t.timestamp('completed_at'),
+    last_executor_heartbeat_at: t.timestamp('last_executor_heartbeat_at'),
     status: text('status', {
       enum: [
         'queued',

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -257,6 +257,7 @@ export const tasks = sqliteTable(
     created_at: t.timestamp('created_at').notNull(),
     started_at: t.timestamp('started_at'),
     completed_at: t.timestamp('completed_at'),
+    last_executor_heartbeat_at: t.timestamp('last_executor_heartbeat_at'),
     status: text('status', {
       enum: [
         'queued',

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -215,5 +215,7 @@ export interface Task {
 
   created_at: string;
   started_at?: string; // When task status changed to RUNNING (UTC ISO string)
+  /** Latest heartbeat emitted by the executor while this task is active. */
+  last_executor_heartbeat_at?: string; // UTC ISO string
   completed_at?: string; // When task reached terminal status (UTC ISO string)
 }

--- a/packages/executor/src/executor-heartbeat.test.ts
+++ b/packages/executor/src/executor-heartbeat.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { startExecutorHeartbeat } from './executor-heartbeat';
+
+describe('startExecutorHeartbeat', () => {
+  it('writes immediately and then at the configured interval', async () => {
+    vi.useFakeTimers();
+    try {
+      const patch = vi.fn().mockResolvedValue({});
+      const client = { service: () => ({ patch }) } as any;
+      const handle = startExecutorHeartbeat({
+        client,
+        taskId: 'task-1',
+        intervalMs: 1000,
+        now: () => new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      await Promise.resolve();
+      expect(patch).toHaveBeenCalledWith('task-1', {
+        last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(patch).toHaveBeenCalledTimes(2);
+
+      handle.stop();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(patch).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does nothing when disabled', async () => {
+    vi.useFakeTimers();
+    try {
+      const patch = vi.fn().mockResolvedValue({});
+      const client = { service: () => ({ patch }) } as any;
+      startExecutorHeartbeat({ client, taskId: 'task-1', enabled: false, intervalMs: 1000 });
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(patch).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/executor/src/executor-heartbeat.ts
+++ b/packages/executor/src/executor-heartbeat.ts
@@ -1,0 +1,66 @@
+import type { TaskID } from '@agor/core/types';
+import type { AgorClient } from './services/feathers-client.js';
+
+export interface ExecutorHeartbeatOptions {
+  client: AgorClient;
+  taskId: TaskID | string;
+  enabled?: boolean;
+  intervalMs?: number;
+  now?: () => Date;
+  warn?: (...args: unknown[]) => void;
+}
+
+export interface ExecutorHeartbeatHandle {
+  stop(): void;
+}
+
+const DEFAULT_INTERVAL_MS = 10_000;
+
+export function startExecutorHeartbeat(options: ExecutorHeartbeatOptions): ExecutorHeartbeatHandle {
+  const enabled = options.enabled ?? true;
+  if (!enabled) {
+    return { stop() {} };
+  }
+
+  const intervalMs =
+    typeof options.intervalMs === 'number' &&
+    Number.isFinite(options.intervalMs) &&
+    options.intervalMs > 0
+      ? Math.floor(options.intervalMs)
+      : DEFAULT_INTERVAL_MS;
+  const now = options.now ?? (() => new Date());
+  const warn = options.warn ?? console.warn;
+  let stopped = false;
+  let inFlight = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const emit = async () => {
+    if (stopped || inFlight) return;
+    inFlight = true;
+    try {
+      await options.client.service('tasks').patch(options.taskId, {
+        last_executor_heartbeat_at: now().toISOString(),
+      });
+    } catch (error) {
+      warn(
+        '[executor-heartbeat] Failed to write heartbeat:',
+        error instanceof Error ? error.message : String(error)
+      );
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  void emit();
+  timer = setInterval(() => {
+    void emit();
+  }, intervalMs);
+  timer.unref?.();
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer) clearInterval(timer);
+    },
+  };
+}

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -17,6 +17,7 @@ import type {
   TaskID,
 } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
+import { type ExecutorHeartbeatHandle, startExecutorHeartbeat } from './executor-heartbeat.js';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
@@ -39,6 +40,7 @@ export class AgorExecutor {
   private client: AgorClient | null = null;
   private abortController: AbortController;
   private isRunning = false;
+  private heartbeat: ExecutorHeartbeatHandle | null = null;
 
   constructor(private config: ExecutorConfig) {
     this.abortController = new AbortController();
@@ -147,27 +149,39 @@ export class AgorExecutor {
 
     this.isRunning = true;
 
-    console.log(`[executor] Executing task with ${this.config.tool}...`);
-
-    // Import and initialize tool registry
-    const { ToolRegistry, initializeToolRegistry } = await import(
-      './handlers/sdk/tool-registry.js'
-    );
-    await initializeToolRegistry();
-
-    // Execute using registry
-    await ToolRegistry.execute(this.config.tool, {
+    const heartbeatConfig = this.config.resolvedConfig?.execution?.executor_heartbeat;
+    this.heartbeat = startExecutorHeartbeat({
       client: this.client,
-      sessionId: this.config.sessionId as SessionID,
-      taskId: this.config.taskId as TaskID,
-      prompt: this.config.prompt,
-      permissionMode: this.config.permissionMode,
-      abortController: this.abortController,
-      messageSource: this.config.messageSource,
-      resolvedConfig: this.config.resolvedConfig,
+      taskId: this.config.taskId,
+      enabled: heartbeatConfig?.enabled ?? true,
+      intervalMs: heartbeatConfig?.interval_ms,
     });
 
-    this.isRunning = false;
+    console.log(`[executor] Executing task with ${this.config.tool}...`);
+
+    try {
+      // Import and initialize tool registry
+      const { ToolRegistry, initializeToolRegistry } = await import(
+        './handlers/sdk/tool-registry.js'
+      );
+      await initializeToolRegistry();
+
+      // Execute using registry
+      await ToolRegistry.execute(this.config.tool, {
+        client: this.client,
+        sessionId: this.config.sessionId as SessionID,
+        taskId: this.config.taskId as TaskID,
+        prompt: this.config.prompt,
+        permissionMode: this.config.permissionMode,
+        abortController: this.abortController,
+        messageSource: this.config.messageSource,
+        resolvedConfig: this.config.resolvedConfig,
+      });
+    } finally {
+      this.heartbeat?.stop();
+      this.heartbeat = null;
+      this.isRunning = false;
+    }
   }
 
   /**
@@ -181,6 +195,8 @@ export class AgorExecutor {
       if (this.isRunning) {
         this.abortController.abort();
       }
+      this.heartbeat?.stop();
+      this.heartbeat = null;
 
       // The daemon's stop route already patches the task to STOPPED before
       // sending the signal — this fallback only fires if we received an


### PR DESCRIPTION
## Summary
- add `tasks.last_executor_heartbeat_at` persistence, config defaults, and daemon→executor config projection
- emit executor-side task heartbeats immediately and on the configured interval
- add optional bounded shell callback support plus a stale heartbeat supervisor that fails lost tasks/sessions
- surface last executor heartbeat in the timer pill popover

## Validation
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter @agor/core exec vitest run src/config/executor-heartbeat.test.ts src/db/repositories/tasks.test.ts`
- `pnpm --filter @agor/executor exec vitest run src/executor-heartbeat.test.ts`
- `pnpm check:shortid`
- `pnpm exec biome check ...` on touched files (passes with one pre-existing warning in `register-routes.ts`)

## Notes
- `pnpm --filter @agor/core db:generate` could not run in this worktree because the drizzle config imports `./dist/utils/path.js` and `dist/` is absent; per agent instructions I did not run a package build just to generate snapshots. The SQL migrations and journals were added manually.
- Daemon/executor package typechecks currently require built `@agor/core` artifacts in this worktree; without `dist/`, they fail on existing `@agor/core/*` module resolution before reaching this change.