### PR TITLE
Fix conversation initial auto-scroll after load

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -29,9 +29,12 @@ vi.mock('../../hooks/useSharedReactiveSession', () => ({
 }));
 
 vi.mock('../TaskBlock', () => ({
-  TaskBlock: ({ task, isExpanded, taskMessagesLoaded }: any) => (
+  TaskBlock: ({ task, isExpanded, onExpandChange, taskMessagesLoaded }: any) => (
     <section data-testid={`task-${task.task_id}`} data-expanded={String(isExpanded)}>
       <h2>{task.full_prompt}</h2>
+      <button type="button" onClick={() => onExpandChange(task.task_id, !isExpanded)}>
+        toggle {task.task_id}
+      </button>
       {taskMessagesLoaded ? <div>messages loaded for {task.task_id}</div> : null}
     </section>
   ),
@@ -39,7 +42,12 @@ vi.mock('../TaskBlock', () => ({
 
 const mockUseSharedReactiveSession = vi.mocked(useSharedReactiveSession);
 
-let rafCallbacks: FrameRequestCallback[] = [];
+interface RafEntry {
+  id: number;
+  callback: FrameRequestCallback;
+}
+
+let rafCallbacks: RafEntry[] = [];
 let rafId = 0;
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
 const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
@@ -48,7 +56,7 @@ function flushRaf() {
   const callbacks = rafCallbacks;
   rafCallbacks = [];
   act(() => {
-    for (const callback of callbacks) {
+    for (const { callback } of callbacks) {
       callback(performance.now());
     }
   });
@@ -117,11 +125,13 @@ describe('ConversationView initial auto-scroll', () => {
     rafCallbacks = [];
     rafId = 0;
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
-      rafCallbacks.push(callback);
       rafId += 1;
+      rafCallbacks.push({ id: rafId, callback });
       return rafId;
     });
-    globalThis.cancelAnimationFrame = vi.fn();
+    globalThis.cancelAnimationFrame = vi.fn((id: number) => {
+      rafCallbacks = rafCallbacks.filter((entry) => entry.id !== id);
+    });
   });
 
   afterEach(() => {
@@ -184,6 +194,93 @@ describe('ConversationView initial auto-scroll', () => {
     flushRaf();
 
     expect(scroller.scrollTop).toBe(1600);
+  });
+
+  it('lets a manual scroll before the new-task RAF win', () => {
+    let tasks = [makeTask('task-1', 'first task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="one-task" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushRaf();
+    expect(scroller.scrollTop).toBe(900);
+
+    tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'new task')];
+    state = makeState({ loading: false, tasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
+    );
+    setScrollMetrics(scroller, 1400, 300);
+
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(100);
+  });
+
+  it('does not scroll when latest task messages load after the latest task was collapsed', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushRaf();
+    expect(scroller.scrollTop).toBe(900);
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle task-2' }));
+    expect(screen.getByTestId('task-task-2')).toHaveAttribute('data-expanded', 'false');
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-2']),
+      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+    });
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="messages-loaded"
+      />
+    );
+    setScrollMetrics(scroller, 1600, 300);
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(900);
+  });
+
+  it('cancels pending initial auto-scroll when the view becomes inactive', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    const state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="active" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="inactive"
+        isActive={false}
+      />
+    );
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(0);
+    expect(globalThis.cancelAnimationFrame).toHaveBeenCalled();
   });
 
   it('does not fight the user after they manually scroll away during initial loading', () => {

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@agor-live/client', () => ({
   MessageRole: {
     ASSISTANT: 'assistant',
   },
-  shortId: (id: string) => id.slice(0, 8),
+  shortId: () => 'short-id',
 }));
 
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -1,0 +1,222 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TaskStatus = {
+  COMPLETED: 'completed',
+  QUEUED: 'queued',
+} as const;
+
+const MessageRole = {
+  ASSISTANT: 'assistant',
+} as const;
+
+vi.mock('@agor-live/client', () => ({
+  TaskStatus: {
+    COMPLETED: 'completed',
+    QUEUED: 'queued',
+  },
+  MessageRole: {
+    ASSISTANT: 'assistant',
+  },
+  shortId: (id: string) => id.slice(0, 8),
+}));
+
+import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
+import { ConversationView } from './ConversationView';
+
+vi.mock('../../hooks/useSharedReactiveSession', () => ({
+  useSharedReactiveSession: vi.fn(),
+}));
+
+vi.mock('../TaskBlock', () => ({
+  TaskBlock: ({ task, isExpanded, taskMessagesLoaded }: any) => (
+    <section data-testid={`task-${task.task_id}`} data-expanded={String(isExpanded)}>
+      <h2>{task.full_prompt}</h2>
+      {taskMessagesLoaded ? <div>messages loaded for {task.task_id}</div> : null}
+    </section>
+  ),
+}));
+
+const mockUseSharedReactiveSession = vi.mocked(useSharedReactiveSession);
+
+let rafCallbacks: FrameRequestCallback[] = [];
+let rafId = 0;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+function flushRaf() {
+  const callbacks = rafCallbacks;
+  rafCallbacks = [];
+  act(() => {
+    for (const callback of callbacks) {
+      callback(performance.now());
+    }
+  });
+}
+
+function setScrollMetrics(element: HTMLElement, scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    value: clientHeight,
+  });
+}
+
+function makeTask(id: string, prompt: string): any {
+  return {
+    task_id: id,
+    session_id: 'session-1',
+    full_prompt: prompt,
+    status: TaskStatus.COMPLETED,
+    created_at: `2026-05-31T00:00:0${id.slice(-1)}.000Z`,
+    updated_at: `2026-05-31T00:00:0${id.slice(-1)}.000Z`,
+    created_by: 'user-1',
+    message_range: null,
+    normalized_sdk_response: null,
+    computed_context_window: 0,
+    git_state: {},
+  } as any;
+}
+
+function makeMessage(taskId: string): any {
+  return {
+    message_id: `message-${taskId}`,
+    session_id: 'session-1',
+    task_id: taskId,
+    role: MessageRole.ASSISTANT,
+    content: 'done',
+    index: 1,
+    timestamp: '2026-05-31T00:00:00.000Z',
+  } as any;
+}
+
+function makeState(overrides: Record<string, unknown>): any {
+  return {
+    sessionId: 'session-1',
+    session: null,
+    tasks: [],
+    messagesByTask: new Map(),
+    queuedTasks: [],
+    streamingMessages: new Map(),
+    toolsByTask: new Map(),
+    loadedTaskIds: new Set(),
+    connected: true,
+    loading: false,
+    error: null,
+    terminal: false,
+    lastSyncedAt: null,
+    ...overrides,
+  };
+}
+
+describe('ConversationView initial auto-scroll', () => {
+  beforeEach(() => {
+    rafCallbacks = [];
+    rafId = 0;
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback);
+      rafId += 1;
+      return rafId;
+    });
+    globalThis.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    mockUseSharedReactiveSession.mockReset();
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  it('scrolls to the bottom after the initial task list finishes loading', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: true, tasks: [] });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="initial" />
+    );
+
+    state = makeState({ loading: false, tasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 1200, 300);
+    expect(scroller.scrollTop).toBe(0);
+
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(1200);
+  });
+
+  it('scrolls again when the latest task messages finish loading', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushRaf();
+    expect(scroller.scrollTop).toBe(900);
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-2']),
+      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+    });
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="messages-loaded"
+      />
+    );
+    setScrollMetrics(scroller, 1600, 300);
+
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(1600);
+  });
+
+  it('does not fight the user after they manually scroll away during initial loading', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushRaf();
+
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-2']),
+      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+    });
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="messages-loaded"
+      />
+    );
+    setScrollMetrics(scroller, 1600, 300);
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(100);
+  });
+});

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -165,6 +165,9 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // true when the user has intentionally scrolled away from the bottom;
     // auto-scroll is suppressed while this is set.
     const userScrolledUpRef = useRef(false);
+    const initialTasksScrollDoneRef = useRef(false);
+    const initialMessagesScrollDoneForTaskRef = useRef<string | null>(null);
+    const previousSessionIdRef = useRef<SessionID | null | undefined>(undefined);
 
     // Within 20px of the end counts as "at the bottom". Tight enough that a
     // mid-swipe scroll won't accidentally keep auto-scroll on, but loose enough
@@ -181,6 +184,14 @@ export const ConversationView = React.memo<ConversationViewProps>(
         containerRef.current.scrollTop = containerRef.current.scrollHeight;
       }
     }, []);
+
+    const scheduleInitialAutoScroll = useCallback(() => {
+      requestAnimationFrame(() => {
+        if (!userScrolledUpRef.current) {
+          doAutoScroll();
+        }
+      });
+    }, [doAutoScroll]);
 
     // Public scroll-to-bottom exposed via onScrollRef (button clicks). Resets
     // user intent so auto-scroll resumes after an explicit "go to bottom".
@@ -214,6 +225,14 @@ export const ConversationView = React.memo<ConversationViewProps>(
         reactiveOptions: { taskHydration: 'lazy' },
       }
     );
+
+    useEffect(() => {
+      if (previousSessionIdRef.current === sessionId) return;
+      previousSessionIdRef.current = sessionId;
+      initialTasksScrollDoneRef.current = false;
+      initialMessagesScrollDoneForTaskRef.current = null;
+      userScrolledUpRef.current = false;
+    }, [sessionId]);
 
     // Queued tasks belong to the queue drawer, not the conversation. They
     // haven't run yet — there's no message_range, no user-message row, no
@@ -306,6 +325,17 @@ export const ConversationView = React.memo<ConversationViewProps>(
       });
     }, [lastTaskId, doAutoScroll]);
 
+    // Initial-open scroll phase 1: once the task list bootstrap has completed
+    // and the task DOM is present, land near the latest task. This is separate
+    // from streaming auto-scroll and only runs once per opened session.
+    useEffect(() => {
+      if (initialTasksScrollDoneRef.current) return;
+      if (loading || tasks.length === 0) return;
+
+      initialTasksScrollDoneRef.current = true;
+      scheduleInitialAutoScroll();
+    }, [loading, tasks.length, scheduleInitialAutoScroll]);
+
     // Handle task expand/collapse. Single stable callback shared by every
     // TaskBlock — the callback takes `taskId` so we don't need to mint a
     // per-task closure (which previously rebuilt on every render and broke
@@ -375,6 +405,22 @@ export const ConversationView = React.memo<ConversationViewProps>(
         doAutoScroll();
       }
     }, [allStreamingMessages]);
+
+    const latestTaskMessagesLoaded = lastTaskId
+      ? !!reactiveState?.loadedTaskIds.has(lastTaskId)
+      : false;
+
+    // Initial-open scroll phase 2: when the latest expanded task's lazy message
+    // load finishes, scroll again so the newest message is visible. The
+    // userScrolledUpRef guard is checked in the RAF callback so a manual scroll
+    // between load completion and paint still wins.
+    useEffect(() => {
+      if (!lastTaskId || !latestTaskMessagesLoaded) return;
+      if (initialMessagesScrollDoneForTaskRef.current === lastTaskId) return;
+
+      initialMessagesScrollDoneForTaskRef.current = lastTaskId;
+      scheduleInitialAutoScroll();
+    }, [lastTaskId, latestTaskMessagesLoaded, scheduleInitialAutoScroll]);
 
     if (error) {
       // Deterministic escape hatch when auto-recovery (socket-reconnect resync,
@@ -516,6 +562,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     return (
       <div
         ref={containerRef}
+        data-testid="conversation-scroll-container"
         style={{
           flex: 1,
           overflowY: 'auto',

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -22,7 +22,7 @@ import type {
 import { shortId, TaskStatus } from '@agor-live/client';
 import { BranchesOutlined, CopyOutlined, ForkOutlined } from '@ant-design/icons';
 import { Alert, Button, Spin, Typography, theme } from 'antd';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useCopyToClipboard } from '../../utils/clipboard';
 import { TaskBlock } from '../TaskBlock';
@@ -167,7 +167,8 @@ export const ConversationView = React.memo<ConversationViewProps>(
     const userScrolledUpRef = useRef(false);
     const initialTasksScrollDoneRef = useRef(false);
     const initialMessagesScrollDoneForTaskRef = useRef<string | null>(null);
-    const previousSessionIdRef = useRef<SessionID | null | undefined>(undefined);
+    const scrollLifecycleKeyRef = useRef<string | null>(null);
+    const pendingAutoScrollRafRef = useRef<number | null>(null);
 
     // Within 20px of the end counts as "at the bottom". Tight enough that a
     // mid-swipe scroll won't accidentally keep auto-scroll on, but loose enough
@@ -185,13 +186,23 @@ export const ConversationView = React.memo<ConversationViewProps>(
       }
     }, []);
 
-    const scheduleInitialAutoScroll = useCallback(() => {
-      requestAnimationFrame(() => {
-        if (!userScrolledUpRef.current) {
+    const cancelPendingAutoScroll = useCallback(() => {
+      if (pendingAutoScrollRafRef.current !== null) {
+        cancelAnimationFrame(pendingAutoScrollRafRef.current);
+        pendingAutoScrollRafRef.current = null;
+      }
+    }, []);
+
+    const scheduleGuardedAutoScroll = useCallback(() => {
+      cancelPendingAutoScroll();
+      const lifecycleKey = scrollLifecycleKeyRef.current;
+      pendingAutoScrollRafRef.current = requestAnimationFrame(() => {
+        pendingAutoScrollRafRef.current = null;
+        if (scrollLifecycleKeyRef.current === lifecycleKey && !userScrolledUpRef.current) {
           doAutoScroll();
         }
       });
-    }, [doAutoScroll]);
+    }, [cancelPendingAutoScroll, doAutoScroll]);
 
     // Public scroll-to-bottom exposed via onScrollRef (button clicks). Resets
     // user intent so auto-scroll resumes after an explicit "go to bottom".
@@ -226,13 +237,18 @@ export const ConversationView = React.memo<ConversationViewProps>(
       }
     );
 
-    useEffect(() => {
-      if (previousSessionIdRef.current === sessionId) return;
-      previousSessionIdRef.current = sessionId;
+    useLayoutEffect(() => {
+      const lifecycleKey = isActive && sessionId ? `${sessionId}:active` : null;
+      if (scrollLifecycleKeyRef.current === lifecycleKey) return;
+
+      scrollLifecycleKeyRef.current = lifecycleKey;
+      cancelPendingAutoScroll();
       initialTasksScrollDoneRef.current = false;
       initialMessagesScrollDoneForTaskRef.current = null;
       userScrolledUpRef.current = false;
-    }, [sessionId]);
+    }, [cancelPendingAutoScroll, isActive, sessionId]);
+
+    useEffect(() => cancelPendingAutoScroll, [cancelPendingAutoScroll]);
 
     // Queued tasks belong to the queue drawer, not the conversation. They
     // haven't run yet — there's no message_range, no user-message row, no
@@ -301,8 +317,9 @@ export const ConversationView = React.memo<ConversationViewProps>(
       return new Set();
     });
 
-    // When a new task arrives (i.e. the *last* task id changes), collapse
-    // whatever was open and expand the new one. We deliberately depend on
+    // When a new task arrives (i.e. the *last* task id changes), expand it.
+    // If the user is still at the bottom, collapse older tasks and follow the new one;
+    // if the user has scrolled away, preserve what they were reading. We deliberately depend on
     // `lastTaskId` rather than `tasks` so that:
     //   1. unrelated re-renders don't fire this effect (`tasks` still gets
     //      a new reference whenever any task patch lands — the useMemo bails
@@ -313,28 +330,29 @@ export const ConversationView = React.memo<ConversationViewProps>(
     //      user and showed up as a flicker.
     const lastTaskId = tasks.length > 0 ? tasks[tasks.length - 1].task_id : null;
     useEffect(() => {
-      if (!lastTaskId) return;
+      if (!isActive || !lastTaskId) return;
       setExpandedTaskIds((prev) => {
         if (prev.has(lastTaskId)) return prev;
-        if (!userScrolledUpRef.current) {
-          requestAnimationFrame(() => {
-            doAutoScroll();
-          });
+        if (userScrolledUpRef.current) {
+          const next = new Set(prev);
+          next.add(lastTaskId);
+          return next;
         }
+        scheduleGuardedAutoScroll();
         return new Set([lastTaskId]);
       });
-    }, [lastTaskId, doAutoScroll]);
+    }, [isActive, lastTaskId, scheduleGuardedAutoScroll]);
 
     // Initial-open scroll phase 1: once the task list bootstrap has completed
     // and the task DOM is present, land near the latest task. This is separate
     // from streaming auto-scroll and only runs once per opened session.
     useEffect(() => {
       if (initialTasksScrollDoneRef.current) return;
-      if (loading || tasks.length === 0) return;
+      if (!isActive || loading || tasks.length === 0) return;
 
       initialTasksScrollDoneRef.current = true;
-      scheduleInitialAutoScroll();
-    }, [loading, tasks.length, scheduleInitialAutoScroll]);
+      scheduleGuardedAutoScroll();
+    }, [isActive, loading, tasks.length, scheduleGuardedAutoScroll]);
 
     // Handle task expand/collapse. Single stable callback shared by every
     // TaskBlock — the callback takes `taskId` so we don't need to mint a
@@ -401,26 +419,26 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // Auto-scroll during streaming — only if the user has not scrolled away.
     // biome-ignore lint/correctness/useExhaustiveDependencies: We want to scroll on streaming change
     useEffect(() => {
-      if (!userScrolledUpRef.current) {
+      if (isActive && !userScrolledUpRef.current) {
         doAutoScroll();
       }
-    }, [allStreamingMessages]);
+    }, [allStreamingMessages, isActive]);
 
-    const latestTaskMessagesLoaded = lastTaskId
-      ? !!reactiveState?.loadedTaskIds.has(lastTaskId)
-      : false;
+    const latestTaskExpanded = !!lastTaskId && expandedTaskIds.has(lastTaskId);
+    const latestTaskMessagesLoaded =
+      !!lastTaskId && latestTaskExpanded && !!reactiveState?.loadedTaskIds.has(lastTaskId);
 
     // Initial-open scroll phase 2: when the latest expanded task's lazy message
     // load finishes, scroll again so the newest message is visible. The
     // userScrolledUpRef guard is checked in the RAF callback so a manual scroll
     // between load completion and paint still wins.
     useEffect(() => {
-      if (!lastTaskId || !latestTaskMessagesLoaded) return;
+      if (!isActive || !lastTaskId || !latestTaskMessagesLoaded) return;
       if (initialMessagesScrollDoneForTaskRef.current === lastTaskId) return;
 
       initialMessagesScrollDoneForTaskRef.current = lastTaskId;
-      scheduleInitialAutoScroll();
-    }, [lastTaskId, latestTaskMessagesLoaded, scheduleInitialAutoScroll]);
+      scheduleGuardedAutoScroll();
+    }, [isActive, lastTaskId, latestTaskMessagesLoaded, scheduleGuardedAutoScroll]);
 
     if (error) {
       // Deterministic escape hatch when auto-recovery (socket-reconnect resync,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -506,20 +506,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     setEffortLevel(session?.model_config?.effort || 'high');
   }, [session?.model_config?.effort]);
 
-  // Scroll to bottom when panel opens or the user switches to a different session.
-  // Deliberately depend on session_id (not the full session object) so streaming
-  // updates — which mint a new session reference on every chunk — don't keep
-  // calling scrollToBottom() and fighting the user's scroll position.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: session_id is the stable identity; full session object changes on every streaming chunk
-  React.useEffect(() => {
-    if (open && scrollToBottom && session) {
-      const timeoutId = setTimeout(() => {
-        scrollToBottom();
-      }, 300);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [open, scrollToBottom, session?.session_id]);
-
   // When there's no session, render nothing (panel is collapsed to zero).
   // When open=false, we still render the component tree (hidden) so that
   // antd's CSS-in-JS doesn't garbage-collect component styles.


### PR DESCRIPTION
## Summary
- Add a two-phase initial auto-scroll in `ConversationView`: once after task bootstrap finishes, and again once the latest task's lazy-loaded messages are available.
- Keep the existing user-scroll intent guard so initial auto-scroll does not run if the user has manually scrolled away.
- Add focused ConversationView tests for task-load scroll, latest-message-load scroll, and preserving manual scroll-away behavior.

## Manual QA
1. Open a session with multiple tasks and verify the conversation panel scrolls near the latest task after the task list finishes loading.
2. Verify the latest task expands and, after its comments/messages finish loading, the panel scrolls to show the newest message.
3. During initial load, manually scroll away from the bottom and verify the panel does not yank back down.

## Validation
- `pnpm --filter agor-ui test -- ConversationView.test.tsx`
- `pnpm exec biome check apps/agor-ui/src/components/ConversationView/ConversationView.tsx apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx`
- `pnpm --filter agor-ui typecheck`

Note: this worktree did not have installed/built workspace dependencies initially, so I first ran `pnpm install --frozen-lockfile`, `pnpm --filter @agor-live/client build`, and `pnpm --filter @agor/core build` to enable the focused UI validation commands.
