### PR TITLE
Fix large conversation initial autoscroll

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -51,6 +51,29 @@ let rafCallbacks: RafEntry[] = [];
 let rafId = 0;
 const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
 const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+const originalResizeObserver = globalThis.ResizeObserver;
+
+const resizeObserverInstances: MockResizeObserver[] = [];
+
+class MockResizeObserver implements ResizeObserver {
+  callback: ResizeObserverCallback;
+  disconnected = false;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    resizeObserverInstances.push(this);
+  }
+
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn(() => {
+    this.disconnected = true;
+  });
+
+  trigger() {
+    this.callback([] as unknown as ResizeObserverEntry[], this);
+  }
+}
 
 function flushRaf() {
   const callbacks = rafCallbacks;
@@ -60,6 +83,12 @@ function flushRaf() {
       callback(performance.now());
     }
   });
+}
+
+function flushAllRaf(maxFrames = 20) {
+  for (let i = 0; i < maxFrames && rafCallbacks.length > 0; i += 1) {
+    flushRaf();
+  }
 }
 
 function setScrollMetrics(element: HTMLElement, scrollHeight: number, clientHeight: number) {
@@ -124,6 +153,7 @@ describe('ConversationView initial auto-scroll', () => {
   beforeEach(() => {
     rafCallbacks = [];
     rafId = 0;
+    resizeObserverInstances.length = 0;
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
       rafId += 1;
       rafCallbacks.push({ id: rafId, callback });
@@ -132,12 +162,14 @@ describe('ConversationView initial auto-scroll', () => {
     globalThis.cancelAnimationFrame = vi.fn((id: number) => {
       rafCallbacks = rafCallbacks.filter((entry) => entry.id !== id);
     });
+    globalThis.ResizeObserver = MockResizeObserver;
   });
 
   afterEach(() => {
     mockUseSharedReactiveSession.mockReset();
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    globalThis.ResizeObserver = originalResizeObserver;
   });
 
   it('scrolls to the bottom after the initial task list finishes loading', () => {
@@ -196,6 +228,123 @@ describe('ConversationView initial auto-scroll', () => {
     expect(scroller.scrollTop).toBe(1600);
   });
 
+  it('does not treat task-list layout growth as a manual scroll-away before messages load', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushRaf();
+    expect(scroller.scrollTop).toBe(900);
+
+    // Simulate late task-list layout growth before the latest task messages
+    // finish loading. This may fire a scroll event, but without an explicit user
+    // scroll input it must not suppress the phase-2 latest-message scroll.
+    setScrollMetrics(scroller, 1600, 300);
+    fireEvent.scroll(scroller);
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-2']),
+      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+    });
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="messages-loaded"
+      />
+    );
+    setScrollMetrics(scroller, 2400, 300);
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(2400);
+  });
+
+  it('keeps initial message-load auto-scroll active until large content layout stabilizes', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushAllRaf();
+    expect(scroller.scrollTop).toBe(900);
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-2']),
+      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+    });
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="messages-loaded"
+      />
+    );
+
+    setScrollMetrics(scroller, 1600, 300);
+    flushRaf();
+    expect(scroller.scrollTop).toBe(1600);
+
+    setScrollMetrics(scroller, 3200, 300);
+    resizeObserverInstances.at(-1)?.trigger();
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(3200);
+  });
+
+  it('stops layout-stabilizing initial auto-scroll when the user scrolls away', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushAllRaf();
+    expect(scroller.scrollTop).toBe(900);
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-2']),
+      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+    });
+    rerender(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="messages-loaded"
+      />
+    );
+
+    setScrollMetrics(scroller, 1600, 300);
+    flushRaf();
+    expect(scroller.scrollTop).toBe(1600);
+
+    fireEvent.wheel(scroller);
+    scroller.scrollTop = 1000;
+    fireEvent.scroll(scroller);
+    setScrollMetrics(scroller, 3200, 300);
+    resizeObserverInstances.at(-1)?.trigger();
+    flushRaf();
+
+    expect(scroller.scrollTop).toBe(1000);
+  });
+
   it('lets a manual scroll before the new-task RAF win', () => {
     let tasks = [makeTask('task-1', 'first task')];
     let state = makeState({ loading: false, tasks });
@@ -216,11 +365,39 @@ describe('ConversationView initial auto-scroll', () => {
     );
     setScrollMetrics(scroller, 1400, 300);
 
+    fireEvent.wheel(scroller);
     scroller.scrollTop = 100;
     fireEvent.scroll(scroller);
     flushRaf();
 
     expect(scroller.scrollTop).toBe(100);
+  });
+
+  it('keeps streaming locked to the bottom while the user is still at bottom', () => {
+    const tasks = [makeTask('task-1', 'latest task')];
+    let state = makeState({ loading: false, tasks, loadedTaskIds: new Set(['task-1']) });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="loaded" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 1000, 300);
+    flushAllRaf();
+    expect(scroller.scrollTop).toBe(1000);
+
+    state = makeState({
+      loading: false,
+      tasks,
+      loadedTaskIds: new Set(['task-1']),
+      streamingMessages: new Map([['stream-1', makeMessage('task-1')]]),
+    });
+    setScrollMetrics(scroller, 1400, 300);
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="streaming" />
+    );
+
+    expect(scroller.scrollTop).toBe(1400);
   });
 
   it('does not scroll when latest task messages load after the latest task was collapsed', () => {
@@ -295,6 +472,7 @@ describe('ConversationView initial auto-scroll', () => {
     setScrollMetrics(scroller, 900, 300);
     flushRaf();
 
+    fireEvent.wheel(scroller);
     scroller.scrollTop = 100;
     fireEvent.scroll(scroller);
 

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -228,6 +228,40 @@ describe('ConversationView initial auto-scroll', () => {
     expect(scroller.scrollTop).toBe(1600);
   });
 
+  it('ignores stale reactive session state during a session switch', () => {
+    const sessionOneTasks = [makeTask('task-1', 'session one task')];
+    const sessionTwoTasks = [makeTask('task-2', 'session two latest')];
+    let state = makeState({ sessionId: 'session-1', loading: false, tasks: sessionOneTasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="session-1" />
+    );
+    const firstScroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(firstScroller, 900, 300);
+    flushAllRaf();
+    expect(firstScroller.scrollTop).toBe(900);
+
+    // useSharedReactiveSession can return the previous session's state for one
+    // render after sessionId changes. That stale render must not complete the
+    // new session's initial task-list scroll phase.
+    rerender(
+      <ConversationView client={null} sessionId={'session-2' as any} sessionModel="stale-state" />
+    );
+    expect(screen.queryByTestId('conversation-scroll-container')).not.toBeInTheDocument();
+
+    state = makeState({ sessionId: 'session-2', loading: false, tasks: sessionTwoTasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-2' as any} sessionModel="session-2" />
+    );
+
+    const secondScroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(secondScroller, 1400, 300);
+    flushAllRaf();
+
+    expect(secondScroller.scrollTop).toBe(1400);
+  });
+
   it('does not treat task-list layout growth as a manual scroll-away before messages load', () => {
     const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
     let state = makeState({ loading: false, tasks });
@@ -371,6 +405,38 @@ describe('ConversationView initial auto-scroll', () => {
     flushRaf();
 
     expect(scroller.scrollTop).toBe(100);
+  });
+
+  it('treats explicit task expand/collapse as reading intent before a new task arrives', () => {
+    let tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
+    );
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    setScrollMetrics(scroller, 900, 300);
+    flushAllRaf();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle task-1' }));
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+
+    tasks = [
+      makeTask('task-1', 'first task'),
+      makeTask('task-2', 'previous latest task'),
+      makeTask('task-3', 'new latest task'),
+    ];
+    state = makeState({ loading: false, tasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="three-tasks" />
+    );
+    setScrollMetrics(scroller, 1500, 300);
+    flushAllRaf();
+
+    expect(scroller.scrollTop).toBe(900);
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+    expect(screen.getByTestId('task-task-3')).toHaveAttribute('data-expanded', 'true');
   });
 
   it('keeps streaming locked to the bottom while the user is still at bottom', () => {

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -33,6 +33,8 @@ const EMPTY_STREAMING_MESSAGES = new Map();
 // reference for tasks whose messages haven't been loaded — otherwise `|| []`
 // would mint a fresh array on every render and thrash TaskBlock's React.memo.
 const EMPTY_MESSAGES: Message[] = [];
+const INITIAL_AUTO_SCROLL_STABLE_FRAMES = 3;
+const INITIAL_AUTO_SCROLL_MAX_FRAMES = 90;
 
 /**
  * Check if two Maps are equal (same keys and same content)
@@ -159,16 +161,21 @@ export const ConversationView = React.memo<ConversationViewProps>(
     assistantEmoji,
   }) => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
 
     // true when the user has intentionally scrolled away from the bottom;
-    // auto-scroll is suppressed while this is set.
+    // auto-scroll is suppressed while this is set. We only set it after an
+    // explicit scroll interaction, not merely because layout growth made the
+    // viewport no longer be near the bottom.
     const userScrolledUpRef = useRef(false);
+    const userScrollIntentRef = useRef(false);
     const initialTasksScrollDoneRef = useRef(false);
     const initialMessagesScrollDoneForTaskRef = useRef<string | null>(null);
     const scrollLifecycleKeyRef = useRef<string | null>(null);
     const pendingAutoScrollRafRef = useRef<number | null>(null);
+    const pendingAutoScrollResizeObserverRef = useRef<ResizeObserver | null>(null);
 
     // Within 20px of the end counts as "at the bottom". Tight enough that a
     // mid-swipe scroll won't accidentally keep auto-scroll on, but loose enough
@@ -191,23 +198,92 @@ export const ConversationView = React.memo<ConversationViewProps>(
         cancelAnimationFrame(pendingAutoScrollRafRef.current);
         pendingAutoScrollRafRef.current = null;
       }
+      if (pendingAutoScrollResizeObserverRef.current) {
+        pendingAutoScrollResizeObserverRef.current.disconnect();
+        pendingAutoScrollResizeObserverRef.current = null;
+      }
     }, []);
 
-    const scheduleGuardedAutoScroll = useCallback(() => {
-      cancelPendingAutoScroll();
-      const lifecycleKey = scrollLifecycleKeyRef.current;
-      pendingAutoScrollRafRef.current = requestAnimationFrame(() => {
-        pendingAutoScrollRafRef.current = null;
-        if (scrollLifecycleKeyRef.current === lifecycleKey && !userScrolledUpRef.current) {
-          doAutoScroll();
+    const scheduleGuardedAutoScroll = useCallback(
+      ({ waitForStableLayout = false }: { waitForStableLayout?: boolean } = {}) => {
+        cancelPendingAutoScroll();
+        const lifecycleKey = scrollLifecycleKeyRef.current;
+        const contentElement = contentRef.current;
+        let lastScrollHeight = -1;
+        let stableFrameCount = 0;
+        let totalFrameCount = 0;
+
+        const isAutoScrollStillAllowed = () =>
+          scrollLifecycleKeyRef.current === lifecycleKey &&
+          !userScrolledUpRef.current &&
+          !!containerRef.current;
+
+        const disconnectResizeObserver = () => {
+          if (pendingAutoScrollResizeObserverRef.current) {
+            pendingAutoScrollResizeObserverRef.current.disconnect();
+            pendingAutoScrollResizeObserverRef.current = null;
+          }
+        };
+
+        function scheduleNextFrame() {
+          if (pendingAutoScrollRafRef.current !== null) return;
+          pendingAutoScrollRafRef.current = requestAnimationFrame(runAutoScrollFrame);
         }
-      });
-    }, [cancelPendingAutoScroll, doAutoScroll]);
+
+        function runAutoScrollFrame() {
+          pendingAutoScrollRafRef.current = null;
+
+          if (!isAutoScrollStillAllowed()) {
+            disconnectResizeObserver();
+            return;
+          }
+
+          doAutoScroll();
+
+          if (!waitForStableLayout || !containerRef.current) {
+            disconnectResizeObserver();
+            return;
+          }
+
+          const currentScrollHeight = containerRef.current.scrollHeight;
+          totalFrameCount += 1;
+
+          if (currentScrollHeight === lastScrollHeight) {
+            stableFrameCount += 1;
+          } else {
+            lastScrollHeight = currentScrollHeight;
+            stableFrameCount = 0;
+          }
+
+          if (
+            stableFrameCount >= INITIAL_AUTO_SCROLL_STABLE_FRAMES ||
+            totalFrameCount >= INITIAL_AUTO_SCROLL_MAX_FRAMES
+          ) {
+            disconnectResizeObserver();
+            return;
+          }
+
+          scheduleNextFrame();
+        }
+
+        if (waitForStableLayout && contentElement && typeof ResizeObserver !== 'undefined') {
+          pendingAutoScrollResizeObserverRef.current = new ResizeObserver(() => {
+            stableFrameCount = 0;
+            scheduleNextFrame();
+          });
+          pendingAutoScrollResizeObserverRef.current.observe(contentElement);
+        }
+
+        scheduleNextFrame();
+      },
+      [cancelPendingAutoScroll, doAutoScroll]
+    );
 
     // Public scroll-to-bottom exposed via onScrollRef (button clicks). Resets
     // user intent so auto-scroll resumes after an explicit "go to bottom".
     const scrollToBottom = useCallback(() => {
       userScrolledUpRef.current = false;
+      userScrollIntentRef.current = false;
       if (containerRef.current) {
         containerRef.current.scrollTop = containerRef.current.scrollHeight;
       }
@@ -216,6 +292,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // Scroll to top: mark user as reading so auto-scroll doesn't yank them back.
     const scrollToTop = useCallback(() => {
       userScrolledUpRef.current = true;
+      userScrollIntentRef.current = true;
       if (containerRef.current) {
         containerRef.current.scrollTop = 0;
       }
@@ -246,6 +323,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
       initialTasksScrollDoneRef.current = false;
       initialMessagesScrollDoneForTaskRef.current = null;
       userScrolledUpRef.current = false;
+      userScrollIntentRef.current = false;
     }, [cancelPendingAutoScroll, isActive, sessionId]);
 
     useEffect(() => cancelPendingAutoScroll, [cancelPendingAutoScroll]);
@@ -351,24 +429,34 @@ export const ConversationView = React.memo<ConversationViewProps>(
       if (!isActive || loading || tasks.length === 0) return;
 
       initialTasksScrollDoneRef.current = true;
-      scheduleGuardedAutoScroll();
+      scheduleGuardedAutoScroll({ waitForStableLayout: true });
     }, [isActive, loading, tasks.length, scheduleGuardedAutoScroll]);
 
     // Handle task expand/collapse. Single stable callback shared by every
     // TaskBlock — the callback takes `taskId` so we don't need to mint a
     // per-task closure (which previously rebuilt on every render and broke
     // TaskBlock's React.memo for the entire task list).
-    const handleTaskExpandChange = useCallback((taskId: string, expanded: boolean) => {
-      setExpandedTaskIds((prev) => {
-        const next = new Set(prev);
-        if (expanded) {
-          next.add(taskId);
-        } else {
-          next.delete(taskId);
-        }
-        return next;
-      });
-    }, []);
+    const handleTaskExpandChange = useCallback(
+      (taskId: string, expanded: boolean) => {
+        // Treat explicit task expand/collapse as user intent. In particular,
+        // stop any initial-load layout stabilization loop so a large task
+        // finishing render does not yank the viewport after the user has begun
+        // interacting with the conversation.
+        userScrolledUpRef.current = true;
+        userScrollIntentRef.current = true;
+        cancelPendingAutoScroll();
+        setExpandedTaskIds((prev) => {
+          const next = new Set(prev);
+          if (expanded) {
+            next.add(taskId);
+          } else {
+            next.delete(taskId);
+          }
+          return next;
+        });
+      },
+      [cancelPendingAutoScroll]
+    );
 
     // Stable load/unload callbacks. The previous inline arrows were minted on
     // every ConversationView render → every TaskBlock saw new `onLoadTaskMessages`
@@ -390,30 +478,58 @@ export const ConversationView = React.memo<ConversationViewProps>(
       [reactiveSession]
     );
 
-    // Track user scroll intent via scroll events.
-    //
-    // Key design notes:
-    //   1. The scroll event fires for both user scrolls AND programmatic scrollTop
-    //      changes (doAutoScroll). That's fine: when auto-scroll fires it brings
-    //      us to the bottom, so isNearBottom() returns true and the flag stays
-    //      false. When the user scrolls up, isNearBottom() returns false and the
-    //      flag becomes true, pausing auto-scroll.
-    //
-    //   2. This effect MUST be defined after `tasks` so we can include
-    //      `tasks.length > 0` in the dependency array. The container div is only
-    //      rendered when tasks are present, so containerRef.current is null on the
-    //      very first render (loading state). Without this dep, the effect would
-    //      attach no listener on initial mount and never re-run.
+    // Track user scroll intent separately from scroll position. The scroll event
+    // also fires for programmatic scrolls and browser/layout adjustments while a
+    // large conversation is still rendering; treating every non-bottom scroll as
+    // user intent can suppress the second initial-load scroll before latest
+    // messages finish loading. Only explicit scroll inputs are allowed to break
+    // the bottom lock.
     const hasConversation = tasks.length > 0;
     // biome-ignore lint/correctness/useExhaustiveDependencies: hasConversation re-triggers when the container mounts
     useEffect(() => {
       const container = containerRef.current;
       if (!container) return;
-      const handleScroll = () => {
-        userScrolledUpRef.current = !isNearBottom();
+
+      const markUserScrollIntent = () => {
+        userScrollIntentRef.current = true;
       };
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (
+          event.key === 'ArrowUp' ||
+          event.key === 'ArrowDown' ||
+          event.key === 'PageUp' ||
+          event.key === 'PageDown' ||
+          event.key === 'Home' ||
+          event.key === 'End' ||
+          event.key === ' '
+        ) {
+          markUserScrollIntent();
+        }
+      };
+      const handleScroll = () => {
+        if (isNearBottom()) {
+          userScrolledUpRef.current = false;
+          userScrollIntentRef.current = false;
+          return;
+        }
+
+        if (userScrollIntentRef.current) {
+          userScrolledUpRef.current = true;
+        }
+      };
+
+      container.addEventListener('wheel', markUserScrollIntent, { passive: true });
+      container.addEventListener('touchstart', markUserScrollIntent, { passive: true });
+      container.addEventListener('pointerdown', markUserScrollIntent);
+      container.addEventListener('keydown', handleKeyDown);
       container.addEventListener('scroll', handleScroll, { passive: true });
-      return () => container.removeEventListener('scroll', handleScroll);
+      return () => {
+        container.removeEventListener('wheel', markUserScrollIntent);
+        container.removeEventListener('touchstart', markUserScrollIntent);
+        container.removeEventListener('pointerdown', markUserScrollIntent);
+        container.removeEventListener('keydown', handleKeyDown);
+        container.removeEventListener('scroll', handleScroll);
+      };
     }, [isNearBottom, hasConversation]);
 
     // Auto-scroll during streaming — only if the user has not scrolled away.
@@ -437,7 +553,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
       if (initialMessagesScrollDoneForTaskRef.current === lastTaskId) return;
 
       initialMessagesScrollDoneForTaskRef.current = lastTaskId;
-      scheduleGuardedAutoScroll();
+      scheduleGuardedAutoScroll({ waitForStableLayout: true });
     }, [isActive, lastTaskId, latestTaskMessagesLoaded, scheduleGuardedAutoScroll]);
 
     if (error) {
@@ -588,35 +704,37 @@ export const ConversationView = React.memo<ConversationViewProps>(
           minHeight: 0,
         }}
       >
-        {/* Genealogy Banner */}
-        <GenealogyBanner />
+        <div ref={contentRef}>
+          {/* Genealogy Banner */}
+          <GenealogyBanner />
 
-        {/* Task-organized conversation */}
-        {tasks.map((task, taskIndex) => (
-          <TaskBlock
-            key={task.task_id}
-            task={task}
-            agentic_tool={agentic_tool}
-            sessionModel={sessionModel}
-            userById={userById}
-            currentUserId={currentUserId}
-            isExpanded={expandedTaskIds.has(task.task_id)}
-            onExpandChange={handleTaskExpandChange}
-            sessionId={sessionId}
-            onPermissionDecision={onPermissionDecision}
-            branchName={branchName}
-            scheduledFromBranch={scheduledFromBranch}
-            scheduledRunAt={scheduledRunAt}
-            streamingMessages={streamingMessagesByTask.get(task.task_id)}
-            taskMessages={reactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES}
-            taskMessagesLoaded={!!reactiveState?.loadedTaskIds.has(task.task_id)}
-            onLoadTaskMessages={handleLoadTaskMessages}
-            onUnloadTaskMessages={handleUnloadTaskMessages}
-            assistantEmoji={assistantEmoji}
-            isLatestTask={taskIndex === tasks.length - 1}
-            client={client}
-          />
-        ))}
+          {/* Task-organized conversation */}
+          {tasks.map((task, taskIndex) => (
+            <TaskBlock
+              key={task.task_id}
+              task={task}
+              agentic_tool={agentic_tool}
+              sessionModel={sessionModel}
+              userById={userById}
+              currentUserId={currentUserId}
+              isExpanded={expandedTaskIds.has(task.task_id)}
+              onExpandChange={handleTaskExpandChange}
+              sessionId={sessionId}
+              onPermissionDecision={onPermissionDecision}
+              branchName={branchName}
+              scheduledFromBranch={scheduledFromBranch}
+              scheduledRunAt={scheduledRunAt}
+              streamingMessages={streamingMessagesByTask.get(task.task_id)}
+              taskMessages={reactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES}
+              taskMessagesLoaded={!!reactiveState?.loadedTaskIds.has(task.task_id)}
+              onLoadTaskMessages={handleLoadTaskMessages}
+              onUnloadTaskMessages={handleUnloadTaskMessages}
+              assistantEmoji={assistantEmoji}
+              isLatestTask={taskIndex === tasks.length - 1}
+              client={client}
+            />
+          ))}
+        </div>
       </div>
     );
   }

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -313,6 +313,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
         reactiveOptions: { taskHydration: 'lazy' },
       }
     );
+    const currentReactiveState = reactiveState?.sessionId === sessionId ? reactiveState : null;
 
     useLayoutEffect(() => {
       const lifecycleKey = isActive && sessionId ? `${sessionId}:active` : null;
@@ -338,13 +339,14 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // every streaming chunk produced a fresh array → every downstream useMemo
     // depending on `tasks` would invalidate and rebuild.
     const tasks = useMemo(
-      () => (reactiveState?.tasks || []).filter((t) => t.status !== TaskStatus.QUEUED),
-      [reactiveState?.tasks]
+      () => (currentReactiveState?.tasks || []).filter((t) => t.status !== TaskStatus.QUEUED),
+      [currentReactiveState?.tasks]
     );
-    const allStreamingMessages = reactiveState?.streamingMessages || EMPTY_STREAMING_MESSAGES;
-    const loading = reactiveState ? reactiveState.loading : !!sessionId;
-    const error = reactiveState?.error || null;
-    const isTerminalError = !!reactiveState?.terminal;
+    const allStreamingMessages =
+      currentReactiveState?.streamingMessages || EMPTY_STREAMING_MESSAGES;
+    const loading = currentReactiveState ? currentReactiveState.loading : !!sessionId;
+    const error = currentReactiveState?.error || null;
+    const isTerminalError = !!currentReactiveState?.terminal;
     const [isReloading, setIsReloading] = useState(false);
 
     // Store previous task maps to maintain stable references
@@ -542,7 +544,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
 
     const latestTaskExpanded = !!lastTaskId && expandedTaskIds.has(lastTaskId);
     const latestTaskMessagesLoaded =
-      !!lastTaskId && latestTaskExpanded && !!reactiveState?.loadedTaskIds.has(lastTaskId);
+      !!lastTaskId && latestTaskExpanded && !!currentReactiveState?.loadedTaskIds.has(lastTaskId);
 
     // Initial-open scroll phase 2: when the latest expanded task's lazy message
     // load finishes, scroll again so the newest message is visible. The
@@ -569,7 +571,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
           description={error}
           showIcon
           action={
-            reactiveSession && !isTerminalError ? (
+            reactiveSession && currentReactiveState && !isTerminalError ? (
               <Button
                 size="small"
                 loading={isReloading}
@@ -725,8 +727,10 @@ export const ConversationView = React.memo<ConversationViewProps>(
               scheduledFromBranch={scheduledFromBranch}
               scheduledRunAt={scheduledRunAt}
               streamingMessages={streamingMessagesByTask.get(task.task_id)}
-              taskMessages={reactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES}
-              taskMessagesLoaded={!!reactiveState?.loadedTaskIds.has(task.task_id)}
+              taskMessages={
+                currentReactiveState?.messagesByTask.get(task.task_id) || EMPTY_MESSAGES
+              }
+              taskMessagesLoaded={!!currentReactiveState?.loadedTaskIds.has(task.task_id)}
               onLoadTaskMessages={handleLoadTaskMessages}
               onUnloadTaskMessages={handleUnloadTaskMessages}
               assistantEmoji={assistantEmoji}


### PR DESCRIPTION
## Summary

- Preserve the two-phase initial conversation load behavior: scroll after task-list load, then scroll again after latest expanded task messages load.
- Keep the initial load scroll pinned through large delayed layout growth using guarded RAF + content `ResizeObserver` stabilization.
- Separate explicit user scroll intent from layout/programmatic scroll events so task-list growth cannot accidentally disable the second latest-message scroll.
- Preserve bottom lock for streaming: if the user is still at bottom, streaming content keeps the viewport at bottom; explicit user scroll/expand/collapse breaks the lock.

## Testing

- `pnpm --filter agor-ui test -- ConversationView.test.tsx`
- `pnpm exec biome check apps/agor-ui/src/components/ConversationView/ConversationView.tsx apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx`
- `pnpm --filter agor-ui typecheck`
- `pnpm check` (passes; repo has existing Biome warnings)

## Manual QA

1. Open a session with many tasks and a very large latest task; verify the panel lands near the latest task after the task list loads.
2. Wait for the latest expanded task's comments/messages to finish loading; verify the newest message is visible at the bottom after large content finishes rendering.
3. Reopen the same large session and manually scroll away during initial load/render; verify the viewport is not pulled back down.
4. During initial load/render, collapse or expand a task; verify the initial auto-scroll stabilization stops and does not fight that interaction.
5. Start/observe streaming while already at bottom; verify new streamed content keeps the viewport pinned to bottom.
