### PR TITLE
Add backend analytics client

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -149,8 +149,6 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       ? await loadConfigFromFile(options.configPath)
       : await loadConfig();
 
-  await configureAnalyticsLogger(config);
-
   // Set GIT_CONFIG_PARAMETERS before any child-process spawn so every git
   // invocation under Agor's control inherits it. See @agor/core/config
   // (security-resolver) for the defaults + resolver semantics.
@@ -167,6 +165,10 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       '🔒 Agor git hardening disabled (override: []); inherited GIT_CONFIG_PARAMETERS preserved'
     );
   }
+
+  // Configure analytics after process-wide git hardening is installed. Module
+  // plugins are optional dynamic imports and must never prevent daemon startup.
+  await configureAnalyticsLogger(config);
 
   // Surface a clear migration note if the config still carries leftover
   // anonymous-mode keys. Operators upgrading from a release that had

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -16,6 +16,7 @@
 import 'dotenv/config';
 
 // Patch console methods to respect LOG_LEVEL env var
+import { configureAnalyticsLogger } from '@agor/core/analytics';
 import { patchConsole } from '@agor/core/utils/logger';
 import { UI_MOUNT_PATH } from '@agor/core/utils/url';
 
@@ -147,6 +148,8 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     : options?.configPath
       ? await loadConfigFromFile(options.configPath)
       : await loadConfig();
+
+  await configureAnalyticsLogger(config);
 
   // Set GIT_CONFIG_PARAMETERS before any child-process spawn so every git
   // invocation under Agor's control inherits it. See @agor/core/config

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -54,6 +54,7 @@ import type {
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
+import { buildSessionCreatedAnalyticsProperties } from './utils/analytics-payloads.js';
 import { applySessionConfigDefaults } from './utils/apply-session-config-defaults.js';
 import {
   ensureMinimumRole,
@@ -1890,19 +1891,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           const session = context.result as Session;
           analyticsLogger.track(
             'session.created',
-            {
-              session_id: session.session_id,
-              branch_id: session.branch_id,
-              agentic_tool: session.agentic_tool,
-              agentic_tool_version: session.agentic_tool_version ?? null,
-              model: session.model_config?.model ?? null,
-              model_mode: session.model_config?.mode ?? null,
-              provider: session.model_config?.provider ?? null,
-              permission_mode: session.permission_config?.mode ?? null,
-              has_parent_session: Boolean(session.genealogy?.parent_session_id),
-              has_fork_source: Boolean(session.genealogy?.forked_from_session_id),
-              fork_origin: session.fork_origin ?? null,
-            },
+            buildSessionCreatedAnalyticsProperties(session),
             { userId: session.created_by }
           );
           return context;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -6,6 +6,7 @@
  * Extracted from index.ts for maintainability.
  */
 
+import { analyticsLogger } from '@agor/core/analytics';
 import { type AgorConfig, isUnixImpersonationEnabled, type UnknownJson } from '@agor/core/config';
 import {
   ArtifactRepository,
@@ -1885,6 +1886,27 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
       ],
       create: [
+        async (context) => {
+          const session = context.result as Session;
+          analyticsLogger.track(
+            'session.created',
+            {
+              session_id: session.session_id,
+              branch_id: session.branch_id,
+              agentic_tool: session.agentic_tool,
+              agentic_tool_version: session.agentic_tool_version ?? null,
+              model: session.model_config?.model ?? null,
+              model_mode: session.model_config?.mode ?? null,
+              provider: session.model_config?.provider ?? null,
+              permission_mode: session.permission_config?.mode ?? null,
+              has_parent_session: Boolean(session.genealogy?.parent_session_id),
+              has_fork_source: Boolean(session.genealogy?.forked_from_session_id),
+              fork_origin: session.fork_origin ?? null,
+            },
+            { userId: session.created_by }
+          );
+          return context;
+        },
         // Claude Code CLI: register watcher + persist cli_state + dispatch
         // the Zellij tab spawn. No-op for other agentic tools.
         async (context) => {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -295,8 +295,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         branch_id: branch.branch_id,
         repo_id: branch.repo_id,
         board_id: branch.board_id ?? null,
-        name: branch.name,
-        ref: branch.ref,
         ref_type: branch.ref_type ?? 'branch',
         new_branch: branch.new_branch,
         is_assistant: isAssistant(branch),

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -10,6 +10,7 @@ import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { analyticsLogger } from '@agor/core/analytics';
 import { ENVIRONMENT, isBranchRbacEnabled, loadConfig, PAGINATION } from '@agor/core/config';
 import {
   BoardRepository,
@@ -275,12 +276,33 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       );
       const created = (await super.create(withDefaults, params)) as Branch[];
       await Promise.all(created.map((branch) => this.maybeSetBoardPrimaryAssistant(branch)));
+      for (const branch of created) {
+        this.trackBranchCreated(branch);
+      }
       return created;
     }
     const withDefaults = await this.applyBranchCreateDefaults(data);
     const created = (await super.create(withDefaults, params)) as Branch;
     await this.maybeSetBoardPrimaryAssistant(created);
+    this.trackBranchCreated(created);
     return created;
+  }
+
+  private trackBranchCreated(branch: Branch): void {
+    analyticsLogger.track(
+      'branch.created',
+      {
+        branch_id: branch.branch_id,
+        repo_id: branch.repo_id,
+        board_id: branch.board_id ?? null,
+        name: branch.name,
+        ref: branch.ref,
+        ref_type: branch.ref_type ?? 'branch',
+        new_branch: branch.new_branch,
+        is_assistant: isAssistant(branch),
+      },
+      { userId: branch.created_by }
+    );
   }
 
   private async maybeSetBoardPrimaryAssistant(branch: Branch): Promise<void> {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -35,6 +35,7 @@ import { getGidFromGroupName, spawnEnvironmentCommand } from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService } from '../adapters/drizzle';
+import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { ensureCanTriggerManagedEnv, ensureMinimumRole } from '../utils/authorization.js';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { resolveGitImpersonationForBranch } from '../utils/git-impersonation.js';
@@ -289,18 +290,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   }
 
   private trackBranchCreated(branch: Branch): void {
-    analyticsLogger.track(
-      'branch.created',
-      {
-        branch_id: branch.branch_id,
-        repo_id: branch.repo_id,
-        board_id: branch.board_id ?? null,
-        ref_type: branch.ref_type ?? 'branch',
-        new_branch: branch.new_branch,
-        is_assistant: isAssistant(branch),
-      },
-      { userId: branch.created_by }
-    );
+    analyticsLogger.track('branch.created', buildBranchCreatedAnalyticsProperties(branch), {
+      userId: branch.created_by,
+    });
   }
 
   private async maybeSetBoardPrimaryAssistant(branch: Branch): Promise<void> {

--- a/apps/agor-daemon/src/services/tasks.analytics.test.ts
+++ b/apps/agor-daemon/src/services/tasks.analytics.test.ts
@@ -127,7 +127,7 @@ describe('TasksService analytics lifecycle events', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
       duration_ms: 5000,
     });
-    const { service } = makeService({
+    const { service, sessionsService } = makeService({
       findById: vi.fn().mockResolvedValueOnce(runningTask).mockResolvedValueOnce(runningTask),
       update: vi.fn().mockResolvedValue(timedOutTask),
     });
@@ -143,6 +143,7 @@ describe('TasksService analytics lifecycle events', () => {
       }),
       { userId: runningTask.created_by }
     );
+    expect(sessionsService.patch).not.toHaveBeenCalled();
 
     track.mockClear();
     service.repository.findById = vi

--- a/apps/agor-daemon/src/services/tasks.analytics.test.ts
+++ b/apps/agor-daemon/src/services/tasks.analytics.test.ts
@@ -1,0 +1,63 @@
+import { resetAnalyticsLoggerForTests, setAnalyticsLoggerForTests } from '@agor/core/analytics';
+import { type Task, TaskStatus } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TasksService } from './tasks';
+
+describe('TasksService analytics lifecycle events', () => {
+  afterEach(() => {
+    resetAnalyticsLoggerForTests();
+  });
+
+  it('emits a curated task.created event when a task is created', async () => {
+    const track = vi.fn();
+    setAnalyticsLoggerForTests({
+      isEnabled: () => true,
+      track,
+    });
+
+    const task: Task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      created_by: '018f0000-0000-7000-8000-000000000003',
+      full_prompt: 'do not emit this prompt',
+      status: TaskStatus.CREATED,
+      message_range: {
+        start_index: 0,
+        end_index: 0,
+        start_timestamp: '2026-01-01T00:00:00.000Z',
+      },
+      tool_use_count: 0,
+      git_state: {
+        ref_at_start: 'main',
+        sha_at_start: 'abc123',
+      },
+      model: 'test-model',
+      created_at: '2026-01-01T00:00:00.000Z',
+    } as Task;
+
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      repository: { create: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+      app: unknown;
+    };
+    service.repository = { create: vi.fn().mockResolvedValue(task) };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+    service.app = { service: vi.fn() };
+
+    await service.create({ session_id: task.session_id, full_prompt: task.full_prompt });
+
+    expect(track).toHaveBeenCalledWith(
+      'task.created',
+      expect.objectContaining({
+        task_id: task.task_id,
+        session_id: task.session_id,
+        status: TaskStatus.CREATED,
+        model: 'test-model',
+      }),
+      { userId: task.created_by }
+    );
+    expect(track.mock.calls[0][1]).not.toHaveProperty('full_prompt');
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.analytics.test.ts
+++ b/apps/agor-daemon/src/services/tasks.analytics.test.ts
@@ -3,6 +3,54 @@ import { type Task, TaskStatus } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TasksService } from './tasks';
 
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    task_id: '018f0000-0000-7000-8000-000000000001',
+    session_id: '018f0000-0000-7000-8000-000000000002',
+    created_by: '018f0000-0000-7000-8000-000000000003',
+    full_prompt: 'do not emit this prompt',
+    status: TaskStatus.CREATED,
+    message_range: {
+      start_index: 0,
+      end_index: 0,
+      start_timestamp: '2026-01-01T00:00:00.000Z',
+    },
+    tool_use_count: 0,
+    git_state: {
+      ref_at_start: 'main',
+      sha_at_start: 'abc123',
+    },
+    model: 'test-model',
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Task;
+}
+
+function makeService(repository: {
+  create?: ReturnType<typeof vi.fn>;
+  findById?: ReturnType<typeof vi.fn>;
+  update?: ReturnType<typeof vi.fn>;
+}) {
+  const sessionsService = {
+    get: vi.fn().mockResolvedValue({
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      tasks: ['018f0000-0000-7000-8000-000000000001'],
+    }),
+    patch: vi.fn().mockResolvedValue({}),
+  };
+  const service = Object.create(TasksService.prototype) as TasksService & {
+    repository: typeof repository;
+    id: string;
+    emit: ReturnType<typeof vi.fn>;
+    app: { service: ReturnType<typeof vi.fn> };
+  };
+  service.repository = repository;
+  service.id = 'task_id';
+  service.emit = vi.fn();
+  service.app = { service: vi.fn(() => sessionsService) };
+  return { service, sessionsService };
+}
+
 describe('TasksService analytics lifecycle events', () => {
   afterEach(() => {
     resetAnalyticsLoggerForTests();
@@ -15,36 +63,8 @@ describe('TasksService analytics lifecycle events', () => {
       track,
     });
 
-    const task: Task = {
-      task_id: '018f0000-0000-7000-8000-000000000001',
-      session_id: '018f0000-0000-7000-8000-000000000002',
-      created_by: '018f0000-0000-7000-8000-000000000003',
-      full_prompt: 'do not emit this prompt',
-      status: TaskStatus.CREATED,
-      message_range: {
-        start_index: 0,
-        end_index: 0,
-        start_timestamp: '2026-01-01T00:00:00.000Z',
-      },
-      tool_use_count: 0,
-      git_state: {
-        ref_at_start: 'main',
-        sha_at_start: 'abc123',
-      },
-      model: 'test-model',
-      created_at: '2026-01-01T00:00:00.000Z',
-    } as Task;
-
-    const service = Object.create(TasksService.prototype) as TasksService & {
-      repository: { create: ReturnType<typeof vi.fn> };
-      id: string;
-      emit: ReturnType<typeof vi.fn>;
-      app: unknown;
-    };
-    service.repository = { create: vi.fn().mockResolvedValue(task) };
-    service.id = 'task_id';
-    service.emit = vi.fn();
-    service.app = { service: vi.fn() };
+    const task = makeTask();
+    const { service } = makeService({ create: vi.fn().mockResolvedValue(task) });
 
     await service.create({ session_id: task.session_id, full_prompt: task.full_prompt });
 
@@ -59,5 +79,78 @@ describe('TasksService analytics lifecycle events', () => {
       { userId: task.created_by }
     );
     expect(track.mock.calls[0][1]).not.toHaveProperty('full_prompt');
+  });
+
+  it('emits task.started once when transitioning into running', async () => {
+    const track = vi.fn();
+    setAnalyticsLoggerForTests({ isEnabled: () => true, track });
+
+    const currentTask = makeTask({ status: TaskStatus.CREATED });
+    const runningTask = makeTask({
+      status: TaskStatus.RUNNING,
+      started_at: '2026-01-01T00:00:01.000Z',
+    });
+    const { service } = makeService({
+      findById: vi.fn().mockResolvedValueOnce(currentTask).mockResolvedValueOnce(currentTask),
+      update: vi.fn().mockResolvedValue(runningTask),
+    });
+
+    await service.patch(currentTask.task_id, { status: TaskStatus.RUNNING });
+
+    expect(track).toHaveBeenCalledWith(
+      'task.started',
+      expect.objectContaining({ task_id: currentTask.task_id, status: TaskStatus.RUNNING }),
+      { userId: currentTask.created_by }
+    );
+
+    track.mockClear();
+    service.repository.findById = vi
+      .fn()
+      .mockResolvedValueOnce(runningTask)
+      .mockResolvedValueOnce(runningTask);
+    await service.patch(currentTask.task_id, { status: TaskStatus.RUNNING });
+
+    expect(track).not.toHaveBeenCalledWith('task.started', expect.anything(), expect.anything());
+  });
+
+  it('emits task.completed once when transitioning to a terminal status, including timed_out', async () => {
+    const track = vi.fn();
+    setAnalyticsLoggerForTests({ isEnabled: () => true, track });
+
+    const runningTask = makeTask({
+      status: TaskStatus.RUNNING,
+      started_at: '2026-01-01T00:00:00.000Z',
+    });
+    const timedOutTask = makeTask({
+      status: TaskStatus.TIMED_OUT,
+      started_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-01T00:00:05.000Z',
+      duration_ms: 5000,
+    });
+    const { service } = makeService({
+      findById: vi.fn().mockResolvedValueOnce(runningTask).mockResolvedValueOnce(runningTask),
+      update: vi.fn().mockResolvedValue(timedOutTask),
+    });
+
+    await service.patch(runningTask.task_id, { status: TaskStatus.TIMED_OUT });
+
+    expect(track).toHaveBeenCalledWith(
+      'task.completed',
+      expect.objectContaining({
+        task_id: runningTask.task_id,
+        status: TaskStatus.TIMED_OUT,
+        duration_ms: 5000,
+      }),
+      { userId: runningTask.created_by }
+    );
+
+    track.mockClear();
+    service.repository.findById = vi
+      .fn()
+      .mockResolvedValueOnce(timedOutTask)
+      .mockResolvedValueOnce(timedOutTask);
+    await service.patch(runningTask.task_id, { status: TaskStatus.TIMED_OUT });
+
+    expect(track).not.toHaveBeenCalledWith('task.completed', expect.anything(), expect.anything());
   });
 });

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -5,6 +5,7 @@
  * Uses DrizzleService adapter with TaskRepository.
  */
 
+import { analyticsLogger } from '@agor/core/analytics';
 import {
   type ChildCompletionContext,
   renderChildCompletionCallback,
@@ -163,7 +164,64 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       }
     }
 
+    if (!Array.isArray(result)) {
+      this.trackTaskCreated(result);
+      if (result.status === TaskStatus.RUNNING) {
+        this.trackTaskStarted(result);
+      }
+    }
+
     return result;
+  }
+
+  private baseTaskAnalyticsProperties(task: Task): Record<string, unknown> {
+    return {
+      task_id: task.task_id,
+      session_id: task.session_id,
+      status: task.status,
+      model: task.model ?? task.normalized_sdk_response?.primaryModel ?? null,
+      queue_position: task.queue_position ?? null,
+      tool_use_count: task.tool_use_count ?? 0,
+      is_callback: task.metadata?.is_agor_callback === true,
+      source: task.metadata?.source ?? null,
+    };
+  }
+
+  private trackTaskCreated(task: Task): void {
+    analyticsLogger.track('task.created', this.baseTaskAnalyticsProperties(task), {
+      userId: task.created_by,
+    });
+  }
+
+  private trackTaskStarted(task: Task): void {
+    analyticsLogger.track(
+      'task.started',
+      {
+        ...this.baseTaskAnalyticsProperties(task),
+        started_at: task.started_at ?? null,
+      },
+      { userId: task.created_by }
+    );
+  }
+
+  private trackTaskCompleted(task: Task): void {
+    const normalized = task.normalized_sdk_response;
+    analyticsLogger.track(
+      'task.completed',
+      {
+        ...this.baseTaskAnalyticsProperties(task),
+        completed_at: task.completed_at ?? null,
+        duration_ms: task.duration_ms ?? normalized?.durationMs ?? null,
+        input_tokens: normalized?.tokenUsage?.inputTokens ?? null,
+        output_tokens: normalized?.tokenUsage?.outputTokens ?? null,
+        total_tokens: normalized?.tokenUsage?.totalTokens ?? null,
+        cost_usd: normalized?.costUsd ?? null,
+        context_window_limit: normalized?.contextWindowLimit ?? null,
+        context_window_percentage: normalized?.contextUsageSnapshot?.percentage ?? null,
+        has_error: Boolean(task.error_message),
+      },
+      { userId: task.created_by }
+    );
   }
 
   async getActiveWithExecutorHeartbeat(): Promise<Task[]> {
@@ -280,7 +338,21 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
     const result = await super.patch(id, data, params);
 
+    if (data.status === TaskStatus.RUNNING && !Array.isArray(result)) {
+      this.trackTaskStarted(result as Task);
+    }
+
     if (data.last_executor_heartbeat_at && !Array.isArray(result)) {
+      analyticsLogger.track(
+        'executor.heartbeat',
+        {
+          task_id: (result as Task).task_id,
+          session_id: (result as Task).session_id,
+          status: (result as Task).status,
+          last_executor_heartbeat_at: data.last_executor_heartbeat_at,
+        },
+        { userId: (result as Task).created_by }
+      );
       this.handleExecutorHeartbeat(result as Task, data.last_executor_heartbeat_at).catch(
         (error) => {
           console.warn(
@@ -299,6 +371,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     ) {
       // Since tasks are patched one at a time, result is always a single Task (not an array)
       const task = result as Task;
+      this.trackTaskCompleted(task);
 
       if (task.session_id && this.app) {
         try {

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -34,6 +34,17 @@ import type { SessionsService } from './sessions';
 /**
  * Task service params
  */
+const TERMINAL_TASK_STATUSES = new Set<Task['status']>([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.STOPPED,
+  TaskStatus.TIMED_OUT,
+]);
+
+function isTerminalTaskStatus(status: Task['status'] | undefined): boolean {
+  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
+}
+
 export type TaskParams = QueryParams<{
   session_id?: string;
   status?: Task['status'];
@@ -281,64 +292,56 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
    * NOTE: Tasks are only ever patched one at a time (never in bulk), so we don't need to loop.
    */
   async patch(id: string, data: Partial<Task>, params?: TaskParams): Promise<Task | Task[]> {
+    const nextStatus = data.status;
+    const mayTransitionStatus =
+      nextStatus === TaskStatus.RUNNING || isTerminalTaskStatus(nextStatus);
+    const currentTask = mayTransitionStatus ? await this.get(id, params) : undefined;
+    const isTerminalTransition =
+      isTerminalTaskStatus(nextStatus) && !isTerminalTaskStatus(currentTask?.status);
+    const isRunningTransition =
+      nextStatus === TaskStatus.RUNNING && currentTask?.status !== TaskStatus.RUNNING;
+
     // When transitioning to a terminal status, auto-compute duration, completed_at,
     // and end_timestamp. This ensures ALL code paths (complete, fail, stop handler)
     // get correct timing data without duplicating logic.
-    const isTerminalTransition =
-      data.status === TaskStatus.COMPLETED ||
-      data.status === TaskStatus.FAILED ||
-      data.status === TaskStatus.STOPPED;
+    if (isTerminalTransition && currentTask) {
+      const completedAt = data.completed_at || new Date().toISOString();
 
-    if (isTerminalTransition) {
-      // Only fetch the current task if we actually need to compute something
-      const currentTask = await this.get(id, params);
+      // Ensure completed_at is always set
+      if (!data.completed_at) {
+        data.completed_at = completedAt;
+      }
 
-      // Guard: skip if task is already in a terminal state (e.g. adding a report
-      // after completion). We only compute timing on the actual transition.
-      const wasAlreadyTerminal =
-        currentTask?.status === TaskStatus.COMPLETED ||
-        currentTask?.status === TaskStatus.FAILED ||
-        currentTask?.status === TaskStatus.STOPPED;
-
-      if (!wasAlreadyTerminal) {
-        const completedAt = data.completed_at || new Date().toISOString();
-
-        // Ensure completed_at is always set
-        if (!data.completed_at) {
-          data.completed_at = completedAt;
+      // Compute duration_ms if not explicitly provided (null check, not falsy,
+      // so an explicit 0 is preserved)
+      if (data.duration_ms == null) {
+        const startTime =
+          currentTask.started_at ||
+          currentTask.message_range?.start_timestamp ||
+          currentTask.created_at;
+        if (startTime) {
+          data.duration_ms = Math.max(
+            0,
+            new Date(completedAt).getTime() - new Date(startTime).getTime()
+          );
         }
+      }
 
-        // Compute duration_ms if not explicitly provided (null check, not falsy,
-        // so an explicit 0 is preserved)
-        if (data.duration_ms == null) {
-          const startTime =
-            currentTask?.started_at ||
-            currentTask?.message_range?.start_timestamp ||
-            currentTask?.created_at;
-          if (startTime) {
-            data.duration_ms = Math.max(
-              0,
-              new Date(completedAt).getTime() - new Date(startTime).getTime()
-            );
-          }
-        }
-
-        // Set end_timestamp if not already meaningfully set
-        const endTs = currentTask?.message_range?.end_timestamp;
-        const startTs = currentTask?.message_range?.start_timestamp;
-        if (currentTask?.message_range && (!endTs || endTs === startTs)) {
-          data.message_range = {
-            ...currentTask.message_range,
-            ...data.message_range,
-            end_timestamp: completedAt,
-          };
-        }
+      // Set end_timestamp if not already meaningfully set
+      const endTs = currentTask.message_range?.end_timestamp;
+      const startTs = currentTask.message_range?.start_timestamp;
+      if (currentTask.message_range && (!endTs || endTs === startTs)) {
+        data.message_range = {
+          ...currentTask.message_range,
+          ...data.message_range,
+          end_timestamp: completedAt,
+        };
       }
     }
 
     const result = await super.patch(id, data, params);
 
-    if (data.status === TaskStatus.RUNNING && !Array.isArray(result)) {
+    if (isRunningTransition && !Array.isArray(result)) {
       this.trackTaskStarted(result as Task);
     }
 
@@ -363,12 +366,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       );
     }
 
-    // If task is being marked as completed, failed, or stopped (terminal status)
-    if (
-      data.status === TaskStatus.COMPLETED ||
-      data.status === TaskStatus.FAILED ||
-      data.status === TaskStatus.STOPPED
-    ) {
+    // If task is transitioning to a terminal status
+    if (isTerminalTransition) {
       // Since tasks are patched one at a time, result is always a single Task (not an array)
       const task = result as Task;
       this.trackTaskCompleted(task);
@@ -416,7 +415,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           // For STOPPED tasks: The stop endpoint directly patches session → IDLE with
           // ready_for_prompt=false. Skip the session update here to avoid racing with it.
           //
-          // For COMPLETED/FAILED tasks: Normal completion - set ready_for_prompt=true
+          // For other terminal tasks: Normal completion - set ready_for_prompt=true
           // to allow auto-queue-processing of any pending messages.
           const isUserInitiatedStop = data.status === TaskStatus.STOPPED;
 

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -34,15 +34,25 @@ import type { SessionsService } from './sessions';
 /**
  * Task service params
  */
-const TERMINAL_TASK_STATUSES = new Set<Task['status']>([
+const ANALYTICS_TERMINAL_TASK_STATUSES = new Set<Task['status']>([
   TaskStatus.COMPLETED,
   TaskStatus.FAILED,
   TaskStatus.STOPPED,
   TaskStatus.TIMED_OUT,
 ]);
 
-function isTerminalTaskStatus(status: Task['status'] | undefined): boolean {
-  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
+const COMPLETION_SIDE_EFFECT_TASK_STATUSES = new Set<Task['status']>([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.STOPPED,
+]);
+
+function isAnalyticsTerminalTaskStatus(status: Task['status'] | undefined): boolean {
+  return status !== undefined && ANALYTICS_TERMINAL_TASK_STATUSES.has(status);
+}
+
+function isCompletionSideEffectTaskStatus(status: Task['status'] | undefined): boolean {
+  return status !== undefined && COMPLETION_SIDE_EFFECT_TASK_STATUSES.has(status);
 }
 
 export type TaskParams = QueryParams<{
@@ -294,17 +304,21 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   async patch(id: string, data: Partial<Task>, params?: TaskParams): Promise<Task | Task[]> {
     const nextStatus = data.status;
     const mayTransitionStatus =
-      nextStatus === TaskStatus.RUNNING || isTerminalTaskStatus(nextStatus);
+      nextStatus === TaskStatus.RUNNING || isAnalyticsTerminalTaskStatus(nextStatus);
     const currentTask = mayTransitionStatus ? await this.get(id, params) : undefined;
-    const isTerminalTransition =
-      isTerminalTaskStatus(nextStatus) && !isTerminalTaskStatus(currentTask?.status);
+    const isAnalyticsTerminalTransition =
+      isAnalyticsTerminalTaskStatus(nextStatus) &&
+      !isAnalyticsTerminalTaskStatus(currentTask?.status);
+    const isCompletionSideEffectTransition =
+      isCompletionSideEffectTaskStatus(nextStatus) &&
+      !isCompletionSideEffectTaskStatus(currentTask?.status);
     const isRunningTransition =
       nextStatus === TaskStatus.RUNNING && currentTask?.status !== TaskStatus.RUNNING;
 
     // When transitioning to a terminal status, auto-compute duration, completed_at,
     // and end_timestamp. This ensures ALL code paths (complete, fail, stop handler)
     // get correct timing data without duplicating logic.
-    if (isTerminalTransition && currentTask) {
+    if (isAnalyticsTerminalTransition && currentTask) {
       const completedAt = data.completed_at || new Date().toISOString();
 
       // Ensure completed_at is always set
@@ -366,11 +380,19 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       );
     }
 
-    // If task is transitioning to a terminal status
-    if (isTerminalTransition) {
-      // Since tasks are patched one at a time, result is always a single Task (not an array)
+    // Emit analytics for terminal task transitions, including timeouts that do not
+    // run the broader task-completion side effects below.
+    if (isAnalyticsTerminalTransition) {
       const task = result as Task;
       this.trackTaskCompleted(task);
+    }
+
+    // Run completion side effects only for statuses that historically completed
+    // executor turns. Timeout paths patch session state separately and should not
+    // enqueue callbacks, mark sessions idle, archive forks, or drain queues here.
+    if (isCompletionSideEffectTransition) {
+      // Since tasks are patched one at a time, result is always a single Task (not an array)
+      const task = result as Task;
 
       if (task.session_id && this.app) {
         try {

--- a/apps/agor-daemon/src/utils/analytics-payloads.test.ts
+++ b/apps/agor-daemon/src/utils/analytics-payloads.test.ts
@@ -1,0 +1,76 @@
+import type { Branch, Session } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  buildBranchCreatedAnalyticsProperties,
+  buildSessionCreatedAnalyticsProperties,
+} from './analytics-payloads.js';
+
+describe('analytics payload builders', () => {
+  it('keeps branch.created payloads curated and avoids branch names/refs', () => {
+    const branch = {
+      branch_id: 'branch-1',
+      repo_id: 'repo-1',
+      board_id: 'board-1',
+      name: 'customer-secret-incident-title',
+      ref: 'feature/customer-secret-incident-title',
+      ref_type: 'branch',
+      new_branch: true,
+      custom_context: { assistant: { kind: 'assistant' } },
+    } as unknown as Branch;
+
+    const payload = buildBranchCreatedAnalyticsProperties(branch);
+
+    expect(payload).toEqual({
+      branch_id: 'branch-1',
+      repo_id: 'repo-1',
+      board_id: 'board-1',
+      ref_type: 'branch',
+      new_branch: true,
+      is_assistant: true,
+    });
+    expect(payload).not.toHaveProperty('name');
+    expect(payload).not.toHaveProperty('ref');
+  });
+
+  it('keeps session.created payloads curated and avoids metadata/full records', () => {
+    const session = {
+      session_id: 'session-1',
+      branch_id: 'branch-1',
+      created_by: 'user-1',
+      name: 'sensitive session title',
+      agentic_tool: 'codex',
+      agentic_tool_version: '1.2.3',
+      model_config: {
+        mode: 'alias',
+        model: 'gpt-test',
+        provider: 'test-provider',
+      },
+      permission_config: { mode: 'allow-all' },
+      genealogy: {
+        parent_session_id: 'parent-1',
+        forked_from_session_id: null,
+      },
+      metadata: { prompt: 'do not emit raw prompt metadata' },
+      callback_config: { callback_session_id: 'callback-1' },
+    } as unknown as Session;
+
+    const payload = buildSessionCreatedAnalyticsProperties(session);
+
+    expect(payload).toEqual({
+      session_id: 'session-1',
+      branch_id: 'branch-1',
+      agentic_tool: 'codex',
+      agentic_tool_version: '1.2.3',
+      model: 'gpt-test',
+      model_mode: 'alias',
+      provider: 'test-provider',
+      permission_mode: 'allow-all',
+      has_parent_session: true,
+      has_fork_source: false,
+      fork_origin: null,
+    });
+    expect(payload).not.toHaveProperty('name');
+    expect(payload).not.toHaveProperty('metadata');
+    expect(payload).not.toHaveProperty('callback_config');
+  });
+});

--- a/apps/agor-daemon/src/utils/analytics-payloads.ts
+++ b/apps/agor-daemon/src/utils/analytics-payloads.ts
@@ -1,0 +1,29 @@
+import type { Branch, Session } from '@agor/core/types';
+import { isAssistant } from '@agor/core/types';
+
+export function buildBranchCreatedAnalyticsProperties(branch: Branch): Record<string, unknown> {
+  return {
+    branch_id: branch.branch_id,
+    repo_id: branch.repo_id,
+    board_id: branch.board_id ?? null,
+    ref_type: branch.ref_type ?? 'branch',
+    new_branch: branch.new_branch,
+    is_assistant: isAssistant(branch),
+  };
+}
+
+export function buildSessionCreatedAnalyticsProperties(session: Session): Record<string, unknown> {
+  return {
+    session_id: session.session_id,
+    branch_id: session.branch_id,
+    agentic_tool: session.agentic_tool,
+    agentic_tool_version: session.agentic_tool_version ?? null,
+    model: session.model_config?.model ?? null,
+    model_mode: session.model_config?.mode ?? null,
+    provider: session.model_config?.provider ?? null,
+    permission_mode: session.permission_config?.mode ?? null,
+    has_parent_session: Boolean(session.genealogy?.parent_session_id),
+    has_fork_source: Boolean(session.genealogy?.forked_from_session_id),
+    fork_origin: session.fork_origin ?? null,
+  };
+}

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -74,6 +74,7 @@
     "@slack/socket-mode": "^2.0.7",
     "@slack/types": "^2.21.1",
     "@slack/web-api": "^7.16.0",
+    "analytics": "^0.8.19",
     "bcryptjs": "^2.4.3",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,12 @@
       "import": "./dist/claude-cli/index.js",
       "require": "./dist/claude-cli/index.cjs"
     },
+    "./analytics": {
+      "source": "./src/analytics/index.ts",
+      "types": "./dist/analytics/index.d.ts",
+      "import": "./dist/analytics/index.js",
+      "require": "./dist/analytics/index.cjs"
+    },
     "./config": {
       "source": "./src/config/index.ts",
       "types": "./dist/config/index.d.ts",
@@ -352,6 +358,7 @@
     "@slack/socket-mode": "^2.0.7",
     "@slack/types": "^2.21.1",
     "@slack/web-api": "^7.16.0",
+    "analytics": "^0.8.19",
     "bcryptjs": "^2.4.3",
     "cron-parser": "^5.5.0",
     "cronstrue": "^3.14.0",

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDefaultAnalyticsConfig } from '../config/analytics-defaults.js';
 import { getDefaultConfig } from '../config/config-manager.js';
 import type { AgorAnalyticsSettings } from '../config/types.js';
 import { isAnalyticsEventExcluded } from './filters.js';
-import { createAnalyticsLogger, getDefaultAnalyticsConfig } from './logger.js';
+import { configureAnalyticsLogger, createAnalyticsLogger } from './logger.js';
 import {
   createHttpBatchAnalyticsPlugin,
   createStdoutAnalyticsPlugin,
@@ -64,6 +65,24 @@ describe('analytics logger', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(log).not.toHaveBeenCalled();
+  });
+
+  it('falls back to no-op when analytics configuration throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const logger = await configureAnalyticsLogger({
+      ...enabledBase,
+      client: {
+        get app(): string {
+          throw new Error('bad client config');
+        },
+      },
+    });
+
+    expect(logger.isEnabled()).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      '[analytics] failed to configure analytics; continuing with analytics disabled:',
+      'bad client config'
+    );
   });
 });
 
@@ -143,5 +162,40 @@ describe('analytics plugins', () => {
         },
       ],
     });
+  });
+
+  it('http_batch flushes events queued during an in-flight delivery', async () => {
+    let resolveFirst: (response: Response) => void = () => undefined;
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const plugin = createHttpBatchAnalyticsPlugin({
+      type: 'http_batch',
+      enabled: true,
+      options: {
+        url: 'https://example.test/collect',
+        max_batch_size: 1,
+        flush_interval_ms: 1000,
+        timeout_ms: 1000,
+      },
+    });
+
+    plugin?.track?.({ payload: { event: 'first' } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    plugin?.track?.({ payload: { event: 'second' } });
+    resolveFirst(new Response(null, { status: 200 }));
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [, secondInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
+    expect(JSON.parse(secondInit.body as string).batch).toEqual([
+      expect.objectContaining({ event: 'second' }),
+    ]);
   });
 });

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDefaultConfig } from '../config/config-manager.js';
+import type { AgorAnalyticsSettings } from '../config/types.js';
+import { isAnalyticsEventExcluded } from './filters.js';
+import { createAnalyticsLogger, getDefaultAnalyticsConfig } from './logger.js';
+import {
+  createHttpBatchAnalyticsPlugin,
+  createStdoutAnalyticsPlugin,
+  resolveAnalyticsPlugins,
+} from './plugins.js';
+
+const enabledBase: AgorAnalyticsSettings = {
+  enabled: true,
+  client: { app: 'test', version: 'dev', debug: false },
+  filters: { exclude_events: [] },
+  plugins: [],
+};
+
+describe('analytics config defaults', () => {
+  it('is disabled by default', () => {
+    expect(getDefaultAnalyticsConfig().enabled).toBe(false);
+    expect(getDefaultConfig().analytics?.enabled).toBe(false);
+  });
+});
+
+describe('analytics event exclusion', () => {
+  it('matches exact event names and simple globs', () => {
+    expect(isAnalyticsEventExcluded('task.created', ['task.created'])).toBe(true);
+    expect(isAnalyticsEventExcluded('task.completed', ['task.*'])).toBe(true);
+    expect(isAnalyticsEventExcluded('session.created', ['task.*'])).toBe(false);
+  });
+});
+
+describe('analytics logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when disabled', async () => {
+    const logger = await createAnalyticsLogger({ enabled: false });
+    expect(logger.isEnabled()).toBe(false);
+    expect(() => logger.track('task.created', { task_id: 'task-1' })).not.toThrow();
+  });
+
+  it('resolves enabled stdout plugins', async () => {
+    const plugins = await resolveAnalyticsPlugins({
+      ...enabledBase,
+      plugins: [{ type: 'stdout', enabled: true, options: { pretty: false } }],
+    });
+
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].name).toBe('agor-stdout-analytics');
+  });
+
+  it('does not deliver excluded events to plugins', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const logger = await createAnalyticsLogger({
+      ...enabledBase,
+      filters: { exclude_events: ['task.*'] },
+      plugins: [{ type: 'stdout', enabled: true, options: { pretty: false } }],
+    });
+
+    logger.track('task.created', { task_id: 'task-1' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(log).not.toHaveBeenCalled();
+  });
+});
+
+describe('analytics plugins', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stdout emits Segment-like track JSON', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const plugin = createStdoutAnalyticsPlugin({
+      type: 'stdout',
+      enabled: true,
+      options: { pretty: false },
+    });
+
+    plugin.track?.({
+      payload: {
+        event: 'session.created',
+        properties: { session_id: 'session-1' },
+        options: { userId: 'user-1', context: { source: 'test' } },
+        meta: { ts: Date.parse('2026-01-01T00:00:00.000Z') },
+      },
+    });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0][0] as string)).toEqual({
+      type: 'track',
+      event: 'session.created',
+      userId: 'user-1',
+      properties: { session_id: 'session-1' },
+      context: { source: 'test' },
+      timestamp: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('http_batch posts a Segment-like batch payload', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const plugin = createHttpBatchAnalyticsPlugin({
+      type: 'http_batch',
+      enabled: true,
+      options: {
+        url: 'https://example.test/collect',
+        max_batch_size: 1,
+        flush_interval_ms: 1000,
+        timeout_ms: 1000,
+        headers: { 'x-test': 'yes' },
+      },
+    });
+
+    plugin?.track?.({
+      payload: {
+        event: 'task.completed',
+        properties: { task_id: 'task-1', duration_ms: 123 },
+        options: { userId: 'user-1' },
+        meta: { ts: Date.parse('2026-01-01T00:00:00.000Z') },
+      },
+    });
+    await plugin?.flush?.();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://example.test/collect');
+    expect(init.headers).toMatchObject({ 'content-type': 'application/json', 'x-test': 'yes' });
+    expect(JSON.parse(init.body as string)).toEqual({
+      sentAt: expect.any(String),
+      batch: [
+        {
+          type: 'track',
+          event: 'task.completed',
+          userId: 'user-1',
+          properties: { task_id: 'task-1', duration_ms: 123 },
+          context: {},
+          timestamp: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -3,7 +3,11 @@ import { getDefaultAnalyticsConfig } from '../config/analytics-defaults.js';
 import { getDefaultConfig } from '../config/config-manager.js';
 import type { AgorAnalyticsSettings } from '../config/types.js';
 import { isAnalyticsEventExcluded } from './filters.js';
-import { configureAnalyticsLogger, createAnalyticsLogger } from './logger.js';
+import {
+  AnalyticsPackageLogger,
+  configureAnalyticsLogger,
+  createAnalyticsLogger,
+} from './logger.js';
 import {
   createHttpBatchAnalyticsPlugin,
   createStdoutAnalyticsPlugin,
@@ -83,6 +87,18 @@ describe('analytics logger', () => {
       '[analytics] failed to configure analytics; continuing with analytics disabled:',
       'bad client config'
     );
+  });
+
+  it('isolates synchronous analytics client track failures', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const logger = new AnalyticsPackageLogger({
+      track: () => {
+        throw new Error('sync boom');
+      },
+    } as never);
+
+    expect(() => logger.track('task.created', { task_id: 'task-1' })).not.toThrow();
+    expect(warn).toHaveBeenCalledWith('[analytics] track failed for "task.created":', 'sync boom');
   });
 });
 

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -214,4 +214,24 @@ describe('analytics plugins', () => {
       expect.objectContaining({ event: 'second' }),
     ]);
   });
+
+  it('skips relative module plugin paths to avoid cwd-dependent imports', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const plugins = await resolveAnalyticsPlugins({
+      ...enabledBase,
+      plugins: [
+        {
+          type: 'module',
+          enabled: true,
+          options: { module_path: './analytics-plugin.js' },
+        },
+      ],
+    });
+
+    expect(plugins).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      '[analytics] module plugin options.module_path must be a package specifier or absolute path; skipping relative path'
+    );
+  });
 });

--- a/packages/core/src/analytics/filters.ts
+++ b/packages/core/src/analytics/filters.ts
@@ -1,0 +1,17 @@
+function escapeRegex(input: string): string {
+  return input.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function eventNameMatchesPattern(eventName: string, pattern: string): boolean {
+  if (!pattern) return false;
+  if (!pattern.includes('*')) return eventName === pattern;
+  const regex = new RegExp(`^${pattern.split('*').map(escapeRegex).join('.*')}$`);
+  return regex.test(eventName);
+}
+
+export function isAnalyticsEventExcluded(
+  eventName: string,
+  patterns: readonly string[] = []
+): boolean {
+  return patterns.some((pattern) => eventNameMatchesPattern(eventName, pattern));
+}

--- a/packages/core/src/analytics/index.ts
+++ b/packages/core/src/analytics/index.ts
@@ -1,0 +1,4 @@
+export * from './filters.js';
+export * from './logger.js';
+export * from './plugins.js';
+export * from './types.js';

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -69,12 +69,19 @@ export class AnalyticsPackageLogger implements AnalyticsLogger {
     if (options.userId) trackOptions.userId = options.userId;
     if (options.anonymousId) trackOptions.anonymousId = options.anonymousId;
 
-    void this.client.track(event, properties, trackOptions).catch((error: unknown) => {
+    try {
+      void this.client.track(event, properties, trackOptions).catch((error: unknown) => {
+        console.warn(
+          `[analytics] track failed for "${event}":`,
+          error instanceof Error ? error.message : String(error)
+        );
+      });
+    } catch (error) {
       console.warn(
         `[analytics] track failed for "${event}":`,
         error instanceof Error ? error.message : String(error)
       );
-    });
+    }
   }
 }
 

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -1,0 +1,158 @@
+import type { AnalyticsInstance } from 'analytics';
+import { Analytics } from 'analytics';
+import type { AgorAnalyticsSettings, AgorConfig } from '../config/types.js';
+import { isAnalyticsEventExcluded } from './filters.js';
+import { resolveAnalyticsPlugins } from './plugins.js';
+import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from './types.js';
+
+export function getDefaultAnalyticsConfig(): AgorAnalyticsSettings {
+  return {
+    enabled: false,
+    client: {
+      app: 'agor-daemon',
+      version: 'dev',
+      debug: false,
+    },
+    filters: {
+      exclude_events: [],
+    },
+    plugins: [
+      {
+        type: 'stdout',
+        enabled: false,
+        options: {
+          pretty: false,
+        },
+      },
+      {
+        type: 'http_batch',
+        enabled: false,
+        options: {
+          url: null,
+          flush_interval_ms: 1000,
+          max_batch_size: 50,
+          timeout_ms: 3000,
+          headers: {},
+        },
+      },
+      {
+        type: 'module',
+        enabled: false,
+        options: {
+          module_path: null,
+          export_name: 'createAnalyticsPlugin',
+          plugin_options: {},
+        },
+      },
+    ],
+  };
+}
+
+function mergeAnalyticsConfig(config?: AgorAnalyticsSettings): AgorAnalyticsSettings {
+  const defaults = getDefaultAnalyticsConfig();
+  if (!config) return defaults;
+
+  return {
+    ...defaults,
+    ...config,
+    client: {
+      ...defaults.client,
+      ...config.client,
+    },
+    filters: {
+      ...defaults.filters,
+      ...config.filters,
+    },
+    plugins: config.plugins ?? defaults.plugins,
+  };
+}
+
+export function resolveAnalyticsConfig(
+  config: AgorConfig | AgorAnalyticsSettings
+): AgorAnalyticsSettings {
+  if ('analytics' in config) {
+    return mergeAnalyticsConfig(config.analytics);
+  }
+  return mergeAnalyticsConfig(config as AgorAnalyticsSettings);
+}
+
+export class NoopAnalyticsLogger implements AnalyticsLogger {
+  isEnabled(): boolean {
+    return false;
+  }
+
+  track(_event: string, _properties?: AnalyticsProperties, _options?: AnalyticsTrackOptions): void {
+    // Intentionally empty: analytics is off by default and must be safe to call unconditionally.
+  }
+}
+
+export class AnalyticsPackageLogger implements AnalyticsLogger {
+  private readonly client: AnalyticsInstance;
+  private readonly excludeEvents: readonly string[];
+
+  constructor(client: AnalyticsInstance, excludeEvents: readonly string[] = []) {
+    this.client = client;
+    this.excludeEvents = excludeEvents;
+  }
+
+  isEnabled(): boolean {
+    return true;
+  }
+
+  track(
+    event: string,
+    properties: AnalyticsProperties = {},
+    options: AnalyticsTrackOptions = {}
+  ): void {
+    if (isAnalyticsEventExcluded(event, this.excludeEvents)) return;
+
+    const trackOptions: Record<string, unknown> = {};
+    if (options.context) trackOptions.context = options.context;
+    if (options.userId) trackOptions.userId = options.userId;
+    if (options.anonymousId) trackOptions.anonymousId = options.anonymousId;
+
+    void this.client.track(event, properties, trackOptions).catch((error: unknown) => {
+      console.warn(
+        `[analytics] track failed for "${event}":`,
+        error instanceof Error ? error.message : String(error)
+      );
+    });
+  }
+}
+
+export async function createAnalyticsLogger(
+  config: AgorConfig | AgorAnalyticsSettings
+): Promise<AnalyticsLogger> {
+  const resolved = resolveAnalyticsConfig(config);
+  if (resolved.enabled !== true) return new NoopAnalyticsLogger();
+
+  const plugins = await resolveAnalyticsPlugins(resolved);
+  const client = Analytics({
+    ...(resolved.client ?? {}),
+    plugins,
+  });
+
+  return new AnalyticsPackageLogger(client, resolved.filters?.exclude_events ?? []);
+}
+
+let globalAnalyticsLogger: AnalyticsLogger = new NoopAnalyticsLogger();
+
+export async function configureAnalyticsLogger(
+  config: AgorConfig | AgorAnalyticsSettings
+): Promise<AnalyticsLogger> {
+  globalAnalyticsLogger = await createAnalyticsLogger(config);
+  return globalAnalyticsLogger;
+}
+
+export function setAnalyticsLoggerForTests(logger: AnalyticsLogger): void {
+  globalAnalyticsLogger = logger;
+}
+
+export function resetAnalyticsLoggerForTests(): void {
+  globalAnalyticsLogger = new NoopAnalyticsLogger();
+}
+
+export const analyticsLogger: AnalyticsLogger = {
+  isEnabled: () => globalAnalyticsLogger.isEnabled(),
+  track: (event, properties, options) => globalAnalyticsLogger.track(event, properties, options),
+};

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -1,52 +1,10 @@
 import type { AnalyticsInstance } from 'analytics';
 import { Analytics } from 'analytics';
+import { getDefaultAnalyticsConfig } from '../config/analytics-defaults.js';
 import type { AgorAnalyticsSettings, AgorConfig } from '../config/types.js';
 import { isAnalyticsEventExcluded } from './filters.js';
 import { resolveAnalyticsPlugins } from './plugins.js';
 import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from './types.js';
-
-export function getDefaultAnalyticsConfig(): AgorAnalyticsSettings {
-  return {
-    enabled: false,
-    client: {
-      app: 'agor-daemon',
-      version: 'dev',
-      debug: false,
-    },
-    filters: {
-      exclude_events: [],
-    },
-    plugins: [
-      {
-        type: 'stdout',
-        enabled: false,
-        options: {
-          pretty: false,
-        },
-      },
-      {
-        type: 'http_batch',
-        enabled: false,
-        options: {
-          url: null,
-          flush_interval_ms: 1000,
-          max_batch_size: 50,
-          timeout_ms: 3000,
-          headers: {},
-        },
-      },
-      {
-        type: 'module',
-        enabled: false,
-        options: {
-          module_path: null,
-          export_name: 'createAnalyticsPlugin',
-          plugin_options: {},
-        },
-      },
-    ],
-  };
-}
 
 function mergeAnalyticsConfig(config?: AgorAnalyticsSettings): AgorAnalyticsSettings {
   const defaults = getDefaultAnalyticsConfig();
@@ -140,7 +98,15 @@ let globalAnalyticsLogger: AnalyticsLogger = new NoopAnalyticsLogger();
 export async function configureAnalyticsLogger(
   config: AgorConfig | AgorAnalyticsSettings
 ): Promise<AnalyticsLogger> {
-  globalAnalyticsLogger = await createAnalyticsLogger(config);
+  try {
+    globalAnalyticsLogger = await createAnalyticsLogger(config);
+  } catch (error) {
+    console.warn(
+      '[analytics] failed to configure analytics; continuing with analytics disabled:',
+      error instanceof Error ? error.message : String(error)
+    );
+    globalAnalyticsLogger = new NoopAnalyticsLogger();
+  }
   return globalAnalyticsLogger;
 }
 

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -136,6 +136,9 @@ export function createHttpBatchAnalyticsPlugin(
       } finally {
         clearTimeout(timeout);
         flushing = undefined;
+        if (batch.length > 0) {
+          void flush();
+        }
       }
     })();
 

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -172,10 +172,15 @@ export function createHttpBatchAnalyticsPlugin(
   };
 }
 
-function importTargetForModulePath(modulePath: string): string {
-  if (modulePath.startsWith('.') || modulePath.startsWith('/')) {
-    return pathToFileURL(modulePath.startsWith('.') ? `${process.cwd()}/${modulePath}` : modulePath)
-      .href;
+function importTargetForModulePath(modulePath: string): string | null {
+  if (modulePath.startsWith('.')) {
+    warnAnalytics(
+      'module plugin options.module_path must be a package specifier or absolute path; skipping relative path'
+    );
+    return null;
+  }
+  if (modulePath.startsWith('/')) {
+    return pathToFileURL(modulePath).href;
   }
   return modulePath;
 }
@@ -191,7 +196,10 @@ export async function createModuleAnalyticsPlugins(
   }
 
   try {
-    const imported = await import(importTargetForModulePath(options.module_path));
+    const importTarget = importTargetForModulePath(options.module_path);
+    if (!importTarget) return [];
+
+    const imported = await import(importTarget);
     const exportName = options.export_name ?? 'createAnalyticsPlugin';
     const factory = imported[exportName];
     if (typeof factory !== 'function') {

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -1,0 +1,264 @@
+import { pathToFileURL } from 'node:url';
+import type { AnalyticsPlugin } from 'analytics';
+import type {
+  AgorAnalyticsHttpBatchPluginSettings,
+  AgorAnalyticsModulePluginSettings,
+  AgorAnalyticsPluginSettings,
+  AgorAnalyticsSettings,
+  AgorAnalyticsStdoutPluginSettings,
+} from '../config/types.js';
+import type { AnalyticsPluginContext, ResolvedAnalyticsPlugin } from './types.js';
+
+interface AnalyticsTrackPayload {
+  type?: string;
+  event?: string;
+  properties?: Record<string, unknown>;
+  options?: {
+    userId?: string | null;
+    anonymousId?: string | null;
+    context?: Record<string, unknown>;
+  };
+  userId?: string | null;
+  anonymousId?: string | null;
+  meta?: {
+    ts?: number;
+  };
+}
+
+function warnAnalytics(message: string, error?: unknown): void {
+  if (error === undefined) {
+    console.warn(`[analytics] ${message}`);
+    return;
+  }
+  console.warn(`[analytics] ${message}:`, error instanceof Error ? error.message : String(error));
+}
+
+function toTrackPayload(input: unknown): AnalyticsTrackPayload {
+  if (!input || typeof input !== 'object') return {};
+  const wrapper = input as { payload?: unknown };
+  const payload = wrapper.payload && typeof wrapper.payload === 'object' ? wrapper.payload : input;
+  return payload as AnalyticsTrackPayload;
+}
+
+export function toSegmentLikeTrack(payloadInput: unknown): Record<string, unknown> {
+  const payload = toTrackPayload(payloadInput);
+  const timestamp = payload.meta?.ts
+    ? new Date(payload.meta.ts).toISOString()
+    : new Date().toISOString();
+  const userId = payload.options?.userId ?? payload.userId ?? undefined;
+  const anonymousId = payload.options?.anonymousId ?? payload.anonymousId ?? undefined;
+
+  const event: Record<string, unknown> = {
+    type: 'track',
+    event: payload.event,
+    properties: payload.properties ?? {},
+    context: payload.options?.context ?? {},
+    timestamp,
+  };
+
+  if (userId) event.userId = userId;
+  if (anonymousId) event.anonymousId = anonymousId;
+  return event;
+}
+
+export function createStdoutAnalyticsPlugin(
+  settings: AgorAnalyticsStdoutPluginSettings
+): ResolvedAnalyticsPlugin {
+  const pretty = settings.options?.pretty === true;
+  return {
+    name: 'agor-stdout-analytics',
+    loaded: () => true,
+    track: (input: unknown) => {
+      try {
+        const event = toSegmentLikeTrack(input);
+        console.log(pretty ? JSON.stringify(event, null, 2) : JSON.stringify(event));
+      } catch (error) {
+        warnAnalytics('stdout plugin failed', error);
+      }
+    },
+  };
+}
+
+export function createHttpBatchAnalyticsPlugin(
+  settings: AgorAnalyticsHttpBatchPluginSettings
+): ResolvedAnalyticsPlugin | null {
+  const options = settings.options ?? {};
+  const url = options.url;
+  if (!url) {
+    warnAnalytics('http_batch plugin enabled without options.url; skipping plugin');
+    return null;
+  }
+
+  const flushIntervalMs = Math.max(1, options.flush_interval_ms ?? 1000);
+  const maxBatchSize = Math.max(1, options.max_batch_size ?? 50);
+  const timeoutMs = Math.max(1, options.timeout_ms ?? 3000);
+  const headers = options.headers ?? {};
+  let batch: Record<string, unknown>[] = [];
+  let timer: NodeJS.Timeout | undefined;
+  let flushing: Promise<void> | undefined;
+
+  const clearTimer = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const flush = async () => {
+    if (flushing) return flushing;
+    clearTimer();
+    const events = batch;
+    batch = [];
+    if (events.length === 0) return;
+
+    flushing = (async () => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+      timeout.unref?.();
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            ...headers,
+          },
+          body: JSON.stringify({
+            sentAt: new Date().toISOString(),
+            batch: events,
+          }),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          warnAnalytics(`http_batch delivery returned HTTP ${response.status}`);
+        }
+      } catch (error) {
+        warnAnalytics('http_batch delivery failed', error);
+      } finally {
+        clearTimeout(timeout);
+        flushing = undefined;
+      }
+    })();
+
+    return flushing;
+  };
+
+  const scheduleFlush = () => {
+    if (timer) return;
+    timer = setTimeout(() => {
+      void flush();
+    }, flushIntervalMs);
+    timer.unref?.();
+  };
+
+  return {
+    name: 'agor-http-batch-analytics',
+    loaded: () => true,
+    track: (input: unknown) => {
+      try {
+        batch.push(toSegmentLikeTrack(input));
+        if (batch.length >= maxBatchSize) {
+          void flush();
+        } else {
+          scheduleFlush();
+        }
+      } catch (error) {
+        warnAnalytics('http_batch plugin failed', error);
+      }
+    },
+    flush,
+  };
+}
+
+function importTargetForModulePath(modulePath: string): string {
+  if (modulePath.startsWith('.') || modulePath.startsWith('/')) {
+    return pathToFileURL(modulePath.startsWith('.') ? `${process.cwd()}/${modulePath}` : modulePath)
+      .href;
+  }
+  return modulePath;
+}
+
+export async function createModuleAnalyticsPlugins(
+  settings: AgorAnalyticsModulePluginSettings,
+  context: AnalyticsPluginContext
+): Promise<ResolvedAnalyticsPlugin[]> {
+  const options = settings.options ?? {};
+  if (!options.module_path) {
+    warnAnalytics('module plugin enabled without options.module_path; skipping plugin');
+    return [];
+  }
+
+  try {
+    const imported = await import(importTargetForModulePath(options.module_path));
+    const exportName = options.export_name ?? 'createAnalyticsPlugin';
+    const factory = imported[exportName];
+    if (typeof factory !== 'function') {
+      warnAnalytics(`module plugin export "${exportName}" is not a function; skipping plugin`);
+      return [];
+    }
+    const result = await factory(options.plugin_options ?? {}, context);
+    const plugins = Array.isArray(result) ? result : [result];
+    return plugins.filter((plugin): plugin is ResolvedAnalyticsPlugin => {
+      return (
+        !!plugin &&
+        typeof plugin === 'object' &&
+        typeof (plugin as AnalyticsPlugin).name === 'string'
+      );
+    });
+  } catch (error) {
+    warnAnalytics('module plugin failed to load', error);
+    return [];
+  }
+}
+
+function wrapPluginMethod(pluginName: string, methodName: string, method: unknown): unknown {
+  if (typeof method !== 'function') return method;
+  return (...args: unknown[]) => {
+    try {
+      const result = method(...args);
+      if (result && typeof result === 'object' && 'catch' in result) {
+        return (result as Promise<unknown>).catch((error) => {
+          warnAnalytics(`${pluginName}.${methodName} failed`, error);
+        });
+      }
+      return result;
+    } catch (error) {
+      warnAnalytics(`${pluginName}.${methodName} failed`, error);
+      return undefined;
+    }
+  };
+}
+
+export function wrapAnalyticsPlugin(plugin: ResolvedAnalyticsPlugin): ResolvedAnalyticsPlugin {
+  const wrapped: ResolvedAnalyticsPlugin = { ...plugin };
+  for (const methodName of ['initialize', 'page', 'track', 'identify', 'ready'] as const) {
+    wrapped[methodName] = wrapPluginMethod(plugin.name, methodName, plugin[methodName]) as never;
+  }
+  wrapped.loaded = typeof plugin.loaded === 'function' ? plugin.loaded : () => true;
+  return wrapped;
+}
+
+export async function resolveAnalyticsPlugins(
+  config: AgorAnalyticsSettings
+): Promise<ResolvedAnalyticsPlugin[]> {
+  const resolved: ResolvedAnalyticsPlugin[] = [];
+  for (const pluginConfig of config.plugins ?? []) {
+    if (pluginConfig.enabled !== true) continue;
+
+    const context: AnalyticsPluginContext = { config, pluginConfig };
+    if (pluginConfig.type === 'stdout') {
+      resolved.push(createStdoutAnalyticsPlugin(pluginConfig));
+    } else if (pluginConfig.type === 'http_batch') {
+      const plugin = createHttpBatchAnalyticsPlugin(pluginConfig);
+      if (plugin) resolved.push(plugin);
+    } else if (pluginConfig.type === 'module') {
+      resolved.push(...(await createModuleAnalyticsPlugins(pluginConfig, context)));
+    } else {
+      const unknown = pluginConfig as AgorAnalyticsPluginSettings;
+      warnAnalytics(
+        `unknown plugin type "${(unknown as { type?: string }).type}"; skipping plugin`
+      );
+    }
+  }
+
+  return resolved.map(wrapAnalyticsPlugin);
+}

--- a/packages/core/src/analytics/types.ts
+++ b/packages/core/src/analytics/types.ts
@@ -1,0 +1,25 @@
+import type { AnalyticsPlugin } from 'analytics';
+import type { AgorAnalyticsSettings } from '../config/types.js';
+
+export type AnalyticsProperties = Record<string, unknown>;
+export type AnalyticsContext = Record<string, unknown>;
+
+export interface AnalyticsTrackOptions {
+  userId?: string | null;
+  anonymousId?: string | null;
+  context?: AnalyticsContext;
+}
+
+export interface AnalyticsLogger {
+  isEnabled(): boolean;
+  track(event: string, properties?: AnalyticsProperties, options?: AnalyticsTrackOptions): void;
+}
+
+export interface AnalyticsPluginContext {
+  config: AgorAnalyticsSettings;
+  pluginConfig: NonNullable<AgorAnalyticsSettings['plugins']>[number];
+}
+
+export type ResolvedAnalyticsPlugin = AnalyticsPlugin & {
+  flush?: () => Promise<void> | void;
+};

--- a/packages/core/src/config/analytics-defaults.ts
+++ b/packages/core/src/config/analytics-defaults.ts
@@ -1,0 +1,44 @@
+import type { AgorAnalyticsSettings } from './types.js';
+
+export function getDefaultAnalyticsConfig(): AgorAnalyticsSettings {
+  return {
+    enabled: false,
+    client: {
+      app: 'agor-daemon',
+      version: 'dev',
+      debug: false,
+    },
+    filters: {
+      exclude_events: [],
+    },
+    plugins: [
+      {
+        type: 'stdout',
+        enabled: false,
+        options: {
+          pretty: false,
+        },
+      },
+      {
+        type: 'http_batch',
+        enabled: false,
+        options: {
+          url: null,
+          flush_interval_ms: 1000,
+          max_batch_size: 50,
+          timeout_ms: 3000,
+          headers: {},
+        },
+      },
+      {
+        type: 'module',
+        enabled: false,
+        options: {
+          module_path: null,
+          export_name: 'createAnalyticsPlugin',
+          plugin_options: {},
+        },
+      },
+    ],
+  };
+}

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -96,6 +96,7 @@ describe('getDefaultConfig', () => {
     expect(defaults.daemon?.host).toBe('localhost');
     expect(defaults.ui?.port).toBe(5173);
     expect(defaults.ui?.host).toBe('localhost');
+    expect(defaults.analytics?.enabled).toBe(false);
   });
 });
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import yaml from 'js-yaml';
+import { getDefaultAnalyticsConfig } from '../analytics/logger.js';
 import { DAEMON, MCP_TOKEN } from './constants';
 import { resolveExecutorHeartbeatConfig } from './executor-heartbeat';
 import type { AgorConfig, UnknownJson } from './types';
@@ -296,6 +297,7 @@ export function getDefaultConfig(): AgorConfig {
       sync_unix_passwords: true, // Default: sync passwords to Unix
       executor_heartbeat: resolveExecutorHeartbeatConfig(),
     },
+    analytics: getDefaultAnalyticsConfig(),
   };
 }
 
@@ -349,6 +351,7 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
     ui: { ...defaults.ui, ...config.ui },
     execution: { ...defaults.execution, ...config.execution },
     paths: { ...defaults.paths, ...config.paths },
+    analytics: { ...defaults.analytics, ...config.analytics },
   };
 
   const parts = key.split('.');

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import { getDefaultAnalyticsConfig } from '../analytics/logger.js';
+import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
 import { resolveExecutorHeartbeatConfig } from './executor-heartbeat';
 import type { AgorConfig, UnknownJson } from './types';

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -840,7 +840,7 @@ export interface AgorAnalyticsModulePluginSettings {
   type: 'module';
   enabled?: boolean;
   options?: {
-    /** Package name or local module path to dynamically import. */
+    /** Package name or absolute local module path to dynamically import. */
     module_path?: string | null;
     /** Factory export to call. Defaults to createAnalyticsPlugin. */
     export_name?: string;

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -781,6 +781,75 @@ export interface AgorPathSettings {
 }
 
 /**
+ * Backend analytics settings.
+ *
+ * Disabled by default. When enabled, daemon/server code sends curated
+ * lifecycle events through a central analytics client. Plugin configuration is
+ * resolved by type at daemon startup.
+ */
+export interface AgorAnalyticsSettings {
+  /** Master kill-switch. Defaults to false. */
+  enabled?: boolean;
+
+  /** Static client options passed to the underlying analytics package. */
+  client?: {
+    app?: string;
+    version?: string | number;
+    debug?: boolean;
+  };
+
+  /** Simple event-name filters. */
+  filters?: {
+    /** Exact names or simple `*` globs to exclude before delivery. */
+    exclude_events?: string[];
+  };
+
+  /** Analytics delivery plugins. */
+  plugins?: AgorAnalyticsPluginSettings[];
+}
+
+export type AgorAnalyticsPluginSettings =
+  | AgorAnalyticsStdoutPluginSettings
+  | AgorAnalyticsHttpBatchPluginSettings
+  | AgorAnalyticsModulePluginSettings;
+
+export interface AgorAnalyticsStdoutPluginSettings {
+  type: 'stdout';
+  enabled?: boolean;
+  options?: {
+    /** Pretty-print JSON instead of emitting JSON lines. Defaults to false. */
+    pretty?: boolean;
+  };
+}
+
+export interface AgorAnalyticsHttpBatchPluginSettings {
+  type: 'http_batch';
+  enabled?: boolean;
+  options?: {
+    /** Destination URL. Required when this plugin is enabled. */
+    url?: string | null;
+    flush_interval_ms?: number;
+    max_batch_size?: number;
+    timeout_ms?: number;
+    /** Static headers only. */
+    headers?: Record<string, string>;
+  };
+}
+
+export interface AgorAnalyticsModulePluginSettings {
+  type: 'module';
+  enabled?: boolean;
+  options?: {
+    /** Package name or local module path to dynamically import. */
+    module_path?: string | null;
+    /** Factory export to call. Defaults to createAnalyticsPlugin. */
+    export_name?: string;
+    /** Passed as the first argument to the module factory. */
+    plugin_options?: Record<string, unknown>;
+  };
+}
+
+/**
  * Supported credential keys (enum for type safety)
  */
 export enum CredentialKey {
@@ -940,6 +1009,9 @@ export interface AgorConfig {
   /** Path configuration (data_home for repos/branches separation) */
   paths?: AgorPathSettings;
 
+  /** Backend analytics settings. Disabled by default. */
+  analytics?: AgorAnalyticsSettings;
+
   /** Tool credentials (API keys, tokens) */
   credentials?: AgorCredentials;
 
@@ -994,6 +1066,7 @@ export type ConfigKey =
   | `security.${keyof AgorSecuritySettings}`
   | `branches.${keyof AgorBranchesSettings}`
   | `paths.${keyof AgorPathSettings}`
+  | `analytics.${keyof AgorAnalyticsSettings}`
   | `credentials.${keyof AgorCredentials}`
   | `onboarding.${keyof AgorOnboardingSettings}`
   | `services.${keyof import('../types/config-services').DaemonServicesConfig}`;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@
  * Consolidates types, database, git operations, config, and API client
  */
 
+export * from './analytics/index.js';
 export * from './api/index.js';
 export * from './config/index.js';
 export * from './db/index.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@
  * Consolidates types, database, git operations, config, and API client
  */
 
-export * from './analytics/index.js';
 export * from './api/index.js';
 export * from './config/index.js';
 export * from './db/index.js';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
+    'analytics/index': 'src/analytics/index.ts', // Backend analytics logger and plugin resolution
     'types/index': 'src/types/index.ts',
     'db/index': 'src/db/index.ts',
     'db/session-guard': 'src/db/session-guard.ts', // Defensive programming for deleted sessions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
       '@slack/web-api':
         specifier: ^7.16.0
         version: 7.16.0
+      analytics:
+        specifier: ^0.8.19
+        version: 0.8.19(@types/dlv@1.1.5)
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -861,6 +864,27 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@analytics/cookie-utils@0.2.14':
+    resolution: {integrity: sha512-x51x2cLqvP5Fb1ydgNvTCX+SVv0ALK/yTNwp/53++yk4kLhxb850krWtQ4aASN0612oXrIGotwfmdJIttnLiPQ==}
+
+  '@analytics/core@0.13.2':
+    resolution: {integrity: sha512-ejvfoPP8TEh2hA2szMEq9c4TdeX8FAeY1j/7MxJVZjzDaq8BDHOyaAAQzTFiLMHvV0WcU2YC0smJ5Ids5Ll5ng==}
+
+  '@analytics/global-storage-utils@0.1.9':
+    resolution: {integrity: sha512-+xm6CDnWsVOQIKkqbPRPRdYDXKk3PNgr/bCZWSI+7tEDT5PCDgI0QSBZe+FqCVkCRtTkgOrjFOY7wOM8Gq+ndA==}
+
+  '@analytics/localstorage-utils@0.1.12':
+    resolution: {integrity: sha512-BL3vuZUwWgMqdkQsE0GKsED5SPLC6daI4K4LE0a/BkKv+4Cae5JLLqpO5gju2HUGOjJxIvw8U/G5EcglNY5+1w==}
+
+  '@analytics/session-storage-utils@0.0.9':
+    resolution: {integrity: sha512-fhP9QCpyq45rZKsXaAxyz+VTmOUWljIW08CWSkFzpwOHkDM4Xy5tymc1YcWqSBBaLjHldo3HlY4qfqEIS4Aj1A==}
+
+  '@analytics/storage-utils@0.4.4':
+    resolution: {integrity: sha512-873P4wDIunbOnBqADc2AhTVsLbluUv1dP6k9UrK8FIeV8WXv5+fG12HdwwaniUIxq6QLgZJfKEaCwtWSKrrV0g==}
+
+  '@analytics/type-utils@0.6.4':
+    resolution: {integrity: sha512-Ou1gQxFakOWLcPnbFVsrPb8g1wLLUZYYJXDPjHkG07+5mustGs5yqACx42UAu4A6NszNN6Z5gGxhyH45zPWRxw==}
 
   '@ant-design/colors@8.0.1':
     resolution: {integrity: sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==}
@@ -4426,6 +4450,9 @@ packages:
   '@types/diff@6.0.0':
     resolution: {integrity: sha512-dhVCYGv3ZSbzmQaBSagrv1WJ6rXCdkyTcDyoNu1MD8JohI7pR7k8wdZEm+mvdxRKXyHVwckFzWU1vJc+Z29MlA==}
 
+  '@types/dlv@1.1.5':
+    resolution: {integrity: sha512-JHOWNfiWepAhfwlSw17kiWrWrk6od2dEQgHltJw9AS0JPFoLZJBge5+Dnil2NfdjAvJ/+vGSX60/BRW20PpUXw==}
+
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
@@ -4770,6 +4797,14 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  analytics-utils@1.1.1:
+    resolution: {integrity: sha512-nRybjTpRAcHVhWb1cvYaOLJaI3R79r8XjMbu5c0wd2jKmANNqSrYwybiU0X3mp+CQQdm4YiAggTXb2cIA8XhUg==}
+    peerDependencies:
+      '@types/dlv': ^1.0.0
+
+  analytics@0.8.19:
+    resolution: {integrity: sha512-JFgasxpWFiAoqm5UHaGQv9j9OGz+f1KAeQkABYr3Z7YGhiqhQrBpPhIVAIEyttBRJZmew1QwMhN9/bOGGBnpJA==}
 
   anser@2.3.5:
     resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
@@ -5626,6 +5661,9 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -9622,6 +9660,40 @@ snapshots:
   '@acemir/cssom@0.9.20': {}
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@analytics/cookie-utils@0.2.14':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+
+  '@analytics/core@0.13.2(@types/dlv@1.1.5)':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+      '@analytics/type-utils': 0.6.4
+      analytics-utils: 1.1.1(@types/dlv@1.1.5)
+    transitivePeerDependencies:
+      - '@types/dlv'
+
+  '@analytics/global-storage-utils@0.1.9':
+    dependencies:
+      '@analytics/type-utils': 0.6.4
+
+  '@analytics/localstorage-utils@0.1.12':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+
+  '@analytics/session-storage-utils@0.0.9':
+    dependencies:
+      '@analytics/global-storage-utils': 0.1.9
+
+  '@analytics/storage-utils@0.4.4':
+    dependencies:
+      '@analytics/cookie-utils': 0.2.14
+      '@analytics/global-storage-utils': 0.1.9
+      '@analytics/localstorage-utils': 0.1.12
+      '@analytics/session-storage-utils': 0.0.9
+      '@analytics/type-utils': 0.6.4
+
+  '@analytics/type-utils@0.6.4': {}
 
   '@ant-design/colors@8.0.1':
     dependencies:
@@ -13870,6 +13942,8 @@ snapshots:
 
   '@types/diff@6.0.0': {}
 
+  '@types/dlv@1.1.5': {}
+
   '@types/doctrine@0.0.9': {}
 
   '@types/estree-jsx@1.0.5':
@@ -14250,6 +14324,19 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  analytics-utils@1.1.1(@types/dlv@1.1.5):
+    dependencies:
+      '@analytics/type-utils': 0.6.4
+      '@types/dlv': 1.1.5
+      dlv: 1.1.3
+
+  analytics@0.8.19(@types/dlv@1.1.5):
+    dependencies:
+      '@analytics/core': 0.13.2(@types/dlv@1.1.5)
+      '@analytics/storage-utils': 0.4.4
+    transitivePeerDependencies:
+      - '@types/dlv'
 
   anser@2.3.5: {}
 
@@ -15175,6 +15262,8 @@ snapshots:
       dequal: 2.0.3
 
   diff@8.0.3: {}
+
+  dlv@1.1.3: {}
 
   doctrine@3.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       '@slack/web-api':
         specifier: ^7.16.0
         version: 7.16.0
+      analytics:
+        specifier: ^0.8.19
+        version: 0.8.19(@types/dlv@1.1.5)
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3


### PR DESCRIPTION
## Summary
- Add an off-by-default backend analytics client built on npm's `analytics` package.
- Add generic stdout, HTTP batch, and dynamic module plugin resolution with event-name exclusion filters.
- Instrument curated server-side lifecycle events without raw prompts, messages, tool payloads, env vars, tokens, secrets, or full DB rows.

## Events instrumented
- `session.created`
- `branch.created`
- `task.created`
- `task.started`
- `task.completed`
- `executor.heartbeat`

## Validation
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter @agor/core test -- analytics config-manager`
- `pnpm --filter @agor/core test -- analytics`
- `pnpm exec biome check packages/core/src/analytics packages/core/src/config/config-manager.ts packages/core/src/config/config-manager.test.ts packages/core/src/config/types.ts apps/agor-daemon/src/index.ts apps/agor-daemon/src/register-hooks.ts apps/agor-daemon/src/services/tasks.ts apps/agor-daemon/src/services/branches.ts apps/agor-daemon/src/services/tasks.analytics.test.ts`

Note: direct daemon test execution in this worktree needs built `@agor/core` package outputs; I did not run build commands per agent instructions.
