### PR TITLE
Support Unix usernames in launch auth

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -73,6 +73,7 @@ function makeUsersService(db: Database) {
         name: row.name ?? undefined,
         emoji: row.emoji ?? undefined,
         role: row.role as User['role'],
+        unix_username: row.unix_username ?? undefined,
         onboarding_completed: row.onboarding_completed,
         must_change_password: row.must_change_password,
         created_at: row.created_at,
@@ -208,6 +209,40 @@ describe('one-time launch auth service', () => {
     }) as { sub: string; type: string };
     expect(decoded.sub).toBe(result.user.user_id);
     expect(decoded.type).toBe('access');
+  });
+
+  it('sets unix_username from trusted launch claims on new users', async () => {
+    mockExchange(signClaims({ unix_username: 'launchuser' }));
+
+    const result = await service().create({ launchCode: 'with-unix-user' });
+
+    expect(result.user.unix_username).toBe('launchuser');
+
+    const row = await select(db).from(users).where(eq(users.user_id, result.user.user_id)).one();
+    expect(row?.unix_username).toBe('launchuser');
+  });
+
+  it('fills a missing unix_username for an existing external-launch user', async () => {
+    mockExchange(signClaims());
+    const first = await service().create({ launchCode: 'first' });
+    expect(first.user.unix_username).toBeUndefined();
+
+    mockExchange(signClaims({ unix_username: 'lateruser' }));
+    const second = await service().create({ launchCode: 'second' });
+
+    expect(second.user.user_id).toBe(first.user.user_id);
+    expect(second.user.unix_username).toBe('lateruser');
+  });
+
+  it('rejects launch claims that try to change an existing unix_username', async () => {
+    mockExchange(signClaims({ unix_username: 'originaluser' }));
+    const first = await service().create({ launchCode: 'first' });
+    expect(first.user.unix_username).toBe('originaluser');
+
+    mockExchange(signClaims({ unix_username: 'otheruser' }));
+    await expect(service().create({ launchCode: 'second' })).rejects.toBeInstanceOf(
+      NotAuthenticated
+    );
   });
 
   it('maps admin roles only when explicitly allowed', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -5,6 +5,7 @@ import { type Database, eq, generateId, hash, insert, select, update, users } fr
 import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
 import type { Params, User, UserExternalIdentity, UserID, UserRole } from '@agor/core/types';
 import { normalizeRole, ROLES } from '@agor/core/types';
+import { isValidUnixUsername } from '@agor/core/unix';
 import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
 import { issueRuntimeTokenPair } from './runtime-tokens.js';
 
@@ -51,6 +52,7 @@ interface LaunchClaims extends JwtPayload {
   runtime_instance_id?: string;
   jti?: string;
   nonce?: string;
+  unix_username?: string | null;
 }
 
 type StoredExternalIdentity = UserExternalIdentity;
@@ -186,6 +188,16 @@ function getExternalIdentities(
   return Array.isArray(data?.external_identities) ? data.external_identities : [];
 }
 
+function normalizeLaunchUnixUsername(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const username = value.trim();
+  if (!username) return undefined;
+  if (!isValidUnixUsername(username)) {
+    throw new NotAuthenticated('Launch Unix username is invalid');
+  }
+  return username;
+}
+
 function normalizeLaunchEmail(value: string | undefined): string | undefined {
   const email = value?.trim().toLowerCase();
   if (!email) return undefined;
@@ -237,6 +249,7 @@ async function upsertLaunchUser(
   const email = normalizeLaunchEmail(claims.email);
   const name = claims.name?.trim() || undefined;
   const avatar = claims.avatar || claims.picture;
+  const unixUsername = normalizeLaunchUnixUsername(claims.unix_username);
   const identity: StoredExternalIdentity = {
     key,
     provider,
@@ -264,10 +277,15 @@ async function upsertLaunchUser(
       nextIdentities.push(identity);
     }
 
+    if (unixUsername && existing.unix_username && existing.unix_username !== unixUsername) {
+      throw new NotAuthenticated('Launch Unix username does not match existing user');
+    }
+
     await update(db, users)
       .set({
         name: name ?? existing.name,
         role,
+        unix_username: unixUsername ?? existing.unix_username,
         updated_at: now,
         data: {
           ...data,
@@ -294,6 +312,7 @@ async function upsertLaunchUser(
       name,
       emoji: '👤',
       role,
+      unix_username: unixUsername,
       created_at: now,
       updated_at: now,
       onboarding_completed: false,


### PR DESCRIPTION
## Summary\n- Accept a trusted  claim in one-time launch auth assertions\n- Set the Unix username when creating launch-auth users, or fill it once for existing launch users that do not have one\n- Reject attempts to change an existing launch user's Unix username\n\n## Validation\n- 
> @agor/daemon@0.1.0 test /var/lib/agor/home/agorpg/.agor/worktrees/preset-io/agor/executor-heartbeat/apps/agor-daemon
> vitest run "src/auth/launch-auth.test.ts"


 RUN  v4.1.7 /var/lib/agor/home/agorpg/.agor/worktrees/preset-io/agor/executor-heartbeat/apps/agor-daemon


 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  00:05:49
   Duration  3.92s (transform 460ms, setup 0ms, import 1.48s, tests 2.30s, environment 0ms)\n