### PR TITLE
Add external launch login redirect

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -8,7 +8,7 @@ import { NotAuthenticated } from '@agor/core/feathers';
 import type { User, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createLaunchAuthService } from './launch-auth.js';
+import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './launch-auth.js';
 
 const ASSERTION_SECRET = 'test-launch-assertion-secret';
 const RUNTIME_JWT_SECRET = 'test-runtime-jwt-secret';
@@ -247,5 +247,41 @@ describe('one-time launch auth service', () => {
     expect(second.user.user_id).not.toBe(first.user.user_id);
     expect(second.user.email).not.toBe('same@example.test');
     expect(second.user.email).toContain('+launch-');
+  });
+});
+
+describe('public one-time launch auth settings', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns only the public external launch shape', () => {
+    const result = resolvePublicLaunchAuthSettings({
+      external_launch: {
+        ...baseConfig().external_launch,
+        login_redirect_url: 'https://workspace.example.test/open',
+      },
+    });
+
+    expect(result).toEqual({
+      enabled: true,
+      loginRedirectUrl: 'https://workspace.example.test/open',
+    });
+    expect(result).not.toHaveProperty('exchangeUrl');
+    expect(result).not.toHaveProperty('serviceCredential');
+    expect(result).not.toHaveProperty('audience');
+    expect(result).not.toHaveProperty('issuer');
+  });
+
+  it('does not expose an inactive login redirect URL', () => {
+    expect(
+      resolvePublicLaunchAuthSettings({
+        external_launch: {
+          ...baseConfig().external_launch,
+          enabled: false,
+          login_redirect_url: 'https://workspace.example.test/open',
+        },
+      })
+    ).toEqual({ enabled: false });
   });
 });

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -19,6 +19,7 @@ const DEFAULT_INSTANCE_ID_ENV = 'AGOR_EXTERNAL_LAUNCH_INSTANCE_ID';
 interface ResolvedLaunchSettings {
   enabled: boolean;
   exchangeUrl?: string;
+  loginRedirectUrl?: string;
   audience?: string;
   issuer?: string;
   instanceId?: string;
@@ -90,6 +91,7 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
   return {
     enabled: envFlag(process.env.AGOR_EXTERNAL_LAUNCH_ENABLED) ?? raw?.enabled === true,
     exchangeUrl: process.env[DEFAULT_EXCHANGE_URL_ENV] || raw?.exchange_url,
+    loginRedirectUrl: raw?.login_redirect_url,
     audience: process.env[DEFAULT_AUDIENCE_ENV] || raw?.audience,
     issuer: process.env[DEFAULT_ISSUER_ENV] || raw?.issuer,
     instanceId: process.env[DEFAULT_INSTANCE_ID_ENV] || raw?.instance_id,

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -19,7 +19,6 @@ const DEFAULT_INSTANCE_ID_ENV = 'AGOR_EXTERNAL_LAUNCH_INSTANCE_ID';
 interface ResolvedLaunchSettings {
   enabled: boolean;
   exchangeUrl?: string;
-  loginRedirectUrl?: string;
   audience?: string;
   issuer?: string;
   instanceId?: string;
@@ -31,6 +30,11 @@ interface ResolvedLaunchSettings {
   allowAdminRoles: boolean;
   requestTimeoutMs: number;
   algorithms?: string[];
+}
+
+export interface PublicLaunchAuthSettings {
+  enabled: boolean;
+  loginRedirectUrl?: string;
 }
 
 interface LaunchExchangeResponse {
@@ -91,7 +95,6 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
   return {
     enabled: envFlag(process.env.AGOR_EXTERNAL_LAUNCH_ENABLED) ?? raw?.enabled === true,
     exchangeUrl: process.env[DEFAULT_EXCHANGE_URL_ENV] || raw?.exchange_url,
-    loginRedirectUrl: raw?.login_redirect_url,
     audience: process.env[DEFAULT_AUDIENCE_ENV] || raw?.audience,
     issuer: process.env[DEFAULT_ISSUER_ENV] || raw?.issuer,
     instanceId: process.env[DEFAULT_INSTANCE_ID_ENV] || raw?.instance_id,
@@ -103,6 +106,16 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
     allowAdminRoles: raw?.allow_admin_roles === true,
     requestTimeoutMs: raw?.request_timeout_ms ?? DEFAULT_TIMEOUT_MS,
     algorithms: raw?.algorithms,
+  };
+}
+
+export function resolvePublicLaunchAuthSettings(config: AgorConfig): PublicLaunchAuthSettings {
+  const raw = config.external_launch;
+  const enabled = envFlag(process.env.AGOR_EXTERNAL_LAUNCH_ENABLED) ?? raw?.enabled === true;
+
+  return {
+    enabled,
+    ...(enabled && raw?.login_redirect_url ? { loginRedirectUrl: raw.login_redirect_url } : {}),
   };
 }
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -65,7 +65,7 @@ import { NotFoundError } from '@agor/core/utils/errors';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
-import { createLaunchAuthService } from './auth/launch-auth.js';
+import { createLaunchAuthService, resolveLaunchSettings } from './auth/launch-auth.js';
 import {
   issueRuntimeToken,
   issueRuntimeTokenPair,
@@ -3304,6 +3304,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   app.use('/health', {
     async find(params?: AuthenticatedParams) {
+      const launchSettings = resolveLaunchSettings(config);
       const publicResponse = {
         status: 'ok',
         timestamp: Date.now(),
@@ -3316,6 +3317,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         builtAt: DAEMON_BUILD_INFO.builtAt,
         auth: {
           requireAuth: true,
+          externalLaunch: {
+            enabled: launchSettings.enabled,
+            loginRedirectUrl: launchSettings.loginRedirectUrl,
+          },
         },
         instance: {
           label: config.daemon?.instanceLabel,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -65,7 +65,7 @@ import { NotFoundError } from '@agor/core/utils/errors';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
-import { createLaunchAuthService, resolveLaunchSettings } from './auth/launch-auth.js';
+import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './auth/launch-auth.js';
 import {
   issueRuntimeToken,
   issueRuntimeTokenPair,
@@ -3304,7 +3304,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   app.use('/health', {
     async find(params?: AuthenticatedParams) {
-      const launchSettings = resolveLaunchSettings(config);
+      const publicLaunchAuth = resolvePublicLaunchAuthSettings(config);
       const publicResponse = {
         status: 'ok',
         timestamp: Date.now(),
@@ -3317,10 +3317,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         builtAt: DAEMON_BUILD_INFO.builtAt,
         auth: {
           requireAuth: true,
-          externalLaunch: {
-            enabled: launchSettings.enabled,
-            loginRedirectUrl: launchSettings.loginRedirectUrl,
-          },
+          externalLaunch: publicLaunchAuth,
         },
         instance: {
           label: config.daemon?.instanceLabel,

--- a/apps/agor-docs/pages/guide/_meta.ts
+++ b/apps/agor-docs/pages/guide/_meta.ts
@@ -21,6 +21,7 @@ export default {
   artifacts: 'Artifacts',
   'api-proxies': 'API Proxies (CORS bypass)',
   'message-gateway': 'Message Gateway',
+  'one-time-launch-auth': 'One-Time Launch Auth',
   '--- Reference': {
     type: 'separator',
     title: 'Reference',

--- a/apps/agor-docs/pages/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/pages/guide/one-time-launch-auth.mdx
@@ -1,0 +1,128 @@
+# One-time launch-code authentication
+
+Agor can accept a generic external launch handoff when another trusted app has
+already authenticated the user. The browser carries only an opaque, short-lived
+`launch_code`; the daemon exchanges that code over a server-to-server
+backchannel, verifies the returned assertion, maps a local user, and issues the
+same runtime access and refresh tokens used by normal login.
+
+## Flow
+
+1. The external launch provider opens the runtime UI with
+   `/ui/?launch_code=<opaque-code>`.
+2. The UI calls `POST /auth/launch` once with `{ "launchCode": "..." }`.
+3. The daemon posts the code to the configured exchange endpoint with its
+   runtime audience, instance ID, and optional service credential.
+4. The exchange endpoint returns a signed assertion for the authenticated
+   subject.
+5. The daemon verifies issuer, audience, expiration, subject, and the configured
+   instance ID; then it maps or creates a local user by `(provider, issuer,
+   subject)`.
+6. The daemon returns normal runtime auth tokens. The UI stores those tokens and
+   removes `launch_code` from the URL with `replaceState`.
+
+## Configuration
+
+```yaml
+external_launch:
+  enabled: true
+  exchange_url: https://launch.example.com/runtime/exchange
+  issuer: https://launch.example.com
+  audience: agor-runtime:my-instance
+  instance_id: my-instance
+
+  # Production: configure exactly one assertion verification method.
+  jwks_url: https://launch.example.com/.well-known/jwks.json
+
+  # Optional daemon-to-provider bearer credential. Prefer env vars for secrets.
+  service_credential_env: AGOR_EXTERNAL_LAUNCH_SERVICE_TOKEN
+
+  # Optional: allow role claims above member. Defaults to false.
+  allow_admin_roles: false
+
+  # Optional: primary action shown when launch sign-in cannot continue.
+  # Must be http:// or https://.
+  login_redirect_url: https://workspace.example.com/open
+```
+
+For local development only, a symmetric assertion secret can be used:
+
+```yaml
+external_launch:
+  enabled: true
+  exchange_url: http://localhost:4000/exchange
+  issuer: http://localhost:4000
+  audience: agor-runtime:dev
+  dev_shared_secret_env: AGOR_EXTERNAL_LAUNCH_SHARED_SECRET
+```
+
+## Failure behavior and login redirects
+
+When a launch code is missing, expired, already used, invalid, or cannot be
+exchanged because of a non-transient authentication failure, the UI removes the
+one-time code from the URL and shows a clear failure message.
+
+If `external_launch.login_redirect_url` is configured, the unauthenticated
+screen makes **Return to workspace** the primary action so the user can open a
+fresh launch link from the external workspace. Local username/password login is
+still available as a secondary fallback.
+
+If `login_redirect_url` is omitted, the normal local login screen is unchanged.
+
+## Exchange contract
+
+The daemon sends a JSON `POST` to `exchange_url`:
+
+```json
+{
+  "launch_code": "opaque-one-time-code",
+  "audience": "agor-runtime:my-instance",
+  "instance_id": "my-instance"
+}
+```
+
+If `service_credential` or `service_credential_env` is configured, the daemon
+also sends `Authorization: Bearer <credential>`.
+
+The exchange endpoint should consume the launch code exactly once and return:
+
+```json
+{
+  "assertion": "<signed JWT>"
+}
+```
+
+Required assertion claims:
+
+- `iss`: expected issuer
+- `sub`: stable subject at that issuer
+- `aud`: expected runtime audience
+- `exp`: short expiration time
+
+Optional claims:
+
+- `email`, `name`, `avatar` or `picture`
+- `role`: `viewer` or `member` by default; `admin`/`superadmin` only when
+  `allow_admin_roles` is explicitly enabled
+- `provider`: stable provider label used in local identity mapping
+- `jti` or `nonce`: accepted for audit/correlation; one-time replay prevention
+  remains the exchange endpoint's responsibility
+
+Required when `external_launch.instance_id` is configured:
+
+- `instance_id` or `runtime_instance_id`: must match configured `instance_id`
+
+## Security notes
+
+- Put only an opaque, short-lived, one-time code in the browser URL.
+- Do not put runtime bearer tokens or external provider tokens in URLs.
+- The daemon-to-provider exchange should require HTTPS and an authenticated
+  backchannel in production.
+- `login_redirect_url` must be an HTTP(S) URL; malformed URLs and schemes such
+  as `javascript:` are rejected during config loading.
+- Assertions should be audience-bound to the runtime, instance-bound when
+  `instance_id` is configured, and expire quickly.
+- Configure exactly one assertion verification method (`jwks_url`, `public_key`,
+  or dev-only `dev_shared_secret`).
+- Local users are mapped by stable external identity `(provider, issuer,
+  subject)`. A matching email alone never merges identities.

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -369,7 +369,17 @@ function AppContent() {
     !!(localStorage.getItem('agor-access-token') || localStorage.getItem('agor-refresh-token'));
 
   if (!authLoading && !authenticated && !hasTokens) {
-    return <LoginPage onLogin={login} error={authError} />;
+    return (
+      <LoginPage
+        onLogin={login}
+        error={authError}
+        externalLaunchLoginRedirectUrl={
+          authConfig?.externalLaunch?.enabled
+            ? authConfig.externalLaunch.loginRedirectUrl
+            : undefined
+        }
+      />
+    );
   }
 
   // Show reconnecting state if we have tokens but lost connection.

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LoginPage } from './LoginPage';
+
+vi.mock('./ParticleBackground', () => ({
+  ParticleBackground: () => null,
+}));
+
+describe('LoginPage external launch redirect', () => {
+  it('keeps the local login form as the default when no redirect is configured', () => {
+    render(<LoginPage onLogin={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText('Email address')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Return to workspace' })).not.toBeInTheDocument();
+  });
+
+  it('shows the external launch return action as the primary path when configured', () => {
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open"
+      />
+    );
+
+    const returnLink = screen.getByRole('link', { name: 'Return to workspace' });
+    expect(returnLink).toHaveAttribute('href', 'https://workspace.example.com/open');
+    expect(screen.queryByPlaceholderText('Email address')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign In' })).not.toBeInTheDocument();
+  });
+
+  it('offers local login as a secondary fallback for configured deployments', () => {
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use local login instead' }));
+
+    expect(screen.getByPlaceholderText('Email address')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument();
+  });
+
+  it('pairs launch errors with the external return action', () => {
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        error="Launch sign-in failed. The one-time launch code may have expired or already been used."
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open"
+      />
+    );
+
+    expect(screen.getByText('Launch sign-in failed')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Return to workspace' })).toHaveAttribute(
+      'href',
+      'https://workspace.example.com/open'
+    );
+  });
+});

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -58,4 +58,18 @@ describe('LoginPage external launch redirect', () => {
       'https://workspace.example.com/open'
     );
   });
+
+  it('does not label local-login errors as launch failures when external launch is configured', () => {
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        error="Invalid email or password"
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open"
+      />
+    );
+
+    expect(screen.getByText('Login Failed')).toBeInTheDocument();
+    expect(screen.queryByText('Launch sign-in failed')).not.toBeInTheDocument();
+    expect(screen.getByText(/First time setting up/)).toBeInTheDocument();
+  });
 });

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -16,11 +16,20 @@ interface LoginPageProps {
   onLogin: (email: string, password: string) => Promise<boolean>;
   loading?: boolean;
   error?: string | null;
+  externalLaunchLoginRedirectUrl?: string;
 }
 
-export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
+export function LoginPage({
+  onLogin,
+  loading = false,
+  error,
+  externalLaunchLoginRedirectUrl,
+}: LoginPageProps) {
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
+  const [showLocalLogin, setShowLocalLogin] = useState(false);
+  const useExternalLaunch = !!externalLaunchLoginRedirectUrl;
+  const showLoginForm = !useExternalLaunch || showLocalLogin;
 
   const handleSubmit = async (values: { email: string; password: string }) => {
     setSubmitting(true);
@@ -115,23 +124,25 @@ export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
         {error && (
           <Alert
             type="error"
-            title="Login Failed"
+            title={useExternalLaunch ? 'Launch sign-in failed' : 'Login Failed'}
             description={
               <Space orientation="vertical" size="small" style={{ width: '100%' }}>
                 <div>{error}</div>
-                <div
-                  style={{
-                    marginTop: 8,
-                    paddingTop: 8,
-                    borderTop: '1px solid rgba(255,255,255,0.1)',
-                  }}
-                >
-                  <Text type="secondary" style={{ fontSize: 12 }}>
-                    💡 First time setting up? Create an admin user:
-                  </Text>
-                  <br />
-                  <code style={{ fontSize: 11 }}>agor user create-admin</code>
-                </div>
+                {!useExternalLaunch && (
+                  <div
+                    style={{
+                      marginTop: 8,
+                      paddingTop: 8,
+                      borderTop: '1px solid rgba(255,255,255,0.1)',
+                    }}
+                  >
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      💡 First time setting up? Create an admin user:
+                    </Text>
+                    <br />
+                    <code style={{ fontSize: 11 }}>agor user create-admin</code>
+                  </div>
+                )}
               </Space>
             }
             showIcon
@@ -140,48 +151,87 @@ export function LoginPage({ onLogin, loading = false, error }: LoginPageProps) {
           />
         )}
 
-        {/* Login Form */}
-        <Form form={form} name="login" layout="vertical" onFinish={handleSubmit} autoComplete="off">
-          <Form.Item
-            name="email"
-            rules={[
-              { required: true, message: 'Please enter your email' },
-              { type: 'email', message: 'Please enter a valid email' },
-            ]}
-          >
-            <Input
-              prefix={<MailOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
-              placeholder="Email address"
-              autoComplete="email"
-            />
-          </Form.Item>
-
-          <Form.Item
-            name="password"
-            rules={[{ required: true, message: 'Please enter your password' }]}
-          >
-            <Input.Password
-              prefix={<LockOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
-              placeholder="Password"
-              autoComplete="current-password"
-            />
-          </Form.Item>
-
-          <Form.Item style={{ marginBottom: 8 }}>
-            <Button type="primary" htmlType="submit" loading={submitting || loading} block>
-              Sign In
+        {useExternalLaunch && (
+          <Space orientation="vertical" size="middle" style={{ width: '100%', marginBottom: 24 }}>
+            {!error && (
+              <Alert
+                type="info"
+                title="Open from your workspace"
+                description="This runtime is configured for external launch sign-in. Return to your workspace to open a fresh launch link."
+                showIcon
+              />
+            )}
+            <Button
+              type="primary"
+              href={externalLaunchLoginRedirectUrl}
+              block
+              data-testid="external-launch-return"
+            >
+              Return to workspace
             </Button>
-          </Form.Item>
-        </Form>
+            {!showLocalLogin && (
+              <Button type="link" block onClick={() => setShowLocalLogin(true)}>
+                Use local login instead
+              </Button>
+            )}
+          </Space>
+        )}
+
+        {/* Login Form */}
+        {showLoginForm && (
+          <>
+            {useExternalLaunch && <Divider style={{ margin: '0 0 24px 0' }}>Local login</Divider>}
+            <Form
+              form={form}
+              name="login"
+              layout="vertical"
+              onFinish={handleSubmit}
+              autoComplete="off"
+            >
+              <Form.Item
+                name="email"
+                rules={[
+                  { required: true, message: 'Please enter your email' },
+                  { type: 'email', message: 'Please enter a valid email' },
+                ]}
+              >
+                <Input
+                  prefix={<MailOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
+                  placeholder="Email address"
+                  autoComplete="email"
+                />
+              </Form.Item>
+
+              <Form.Item
+                name="password"
+                rules={[{ required: true, message: 'Please enter your password' }]}
+              >
+                <Input.Password
+                  prefix={<LockOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
+                  placeholder="Password"
+                  autoComplete="current-password"
+                />
+              </Form.Item>
+
+              <Form.Item style={{ marginBottom: 8 }}>
+                <Button type="primary" htmlType="submit" loading={submitting || loading} block>
+                  Sign In
+                </Button>
+              </Form.Item>
+            </Form>
+          </>
+        )}
 
         {/* Footer */}
-        <div style={{ textAlign: 'center', marginTop: 24 }}>
-          <Space orientation="vertical" size={4}>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              New user? <code>agor user create-admin</code>
-            </Text>
-          </Space>
-        </div>
+        {showLoginForm && (
+          <div style={{ textAlign: 'center', marginTop: 24 }}>
+            <Space orientation="vertical" size={4}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                New user? <code>agor user create-admin</code>
+              </Text>
+            </Space>
+          </div>
+        )}
       </Card>
     </div>
   );

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -30,6 +30,7 @@ export function LoginPage({
   const [showLocalLogin, setShowLocalLogin] = useState(false);
   const useExternalLaunch = !!externalLaunchLoginRedirectUrl;
   const showLoginForm = !useExternalLaunch || showLocalLogin;
+  const isLaunchError = error?.startsWith('Launch sign-in failed') ?? false;
 
   const handleSubmit = async (values: { email: string; password: string }) => {
     setSubmitting(true);
@@ -124,11 +125,11 @@ export function LoginPage({
         {error && (
           <Alert
             type="error"
-            title={useExternalLaunch ? 'Launch sign-in failed' : 'Login Failed'}
+            title={isLaunchError ? 'Launch sign-in failed' : 'Login Failed'}
             description={
               <Space orientation="vertical" size="small" style={{ width: '100%' }}>
                 <div>{error}</div>
-                {!useExternalLaunch && (
+                {!isLaunchError && (
                   <div
                     style={{
                       marginTop: 8,

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -55,4 +55,16 @@ describe('useAuth launch-code fallback', () => {
     expect(window.location.search).toBe('');
     expect(result.current.error).toBeNull();
   });
+
+  it('surfaces a helpful launch failure when no stored session is available', async () => {
+    launchCreate.mockRejectedValue(new Error('launch code consumed'));
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.authenticated).toBe(false);
+    expect(result.current.error).toContain('Launch sign-in failed');
+    expect(window.location.search).toBe('');
+  });
 });

--- a/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuthConfig.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAuthConfig } from './useAuthConfig';
+
+describe('useAuthConfig', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads external launch redirect config from health', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          status: 'ok',
+          timestamp: Date.now(),
+          version: 'test',
+          database: 'sqlite',
+          auth: {
+            requireAuth: true,
+            externalLaunch: {
+              enabled: true,
+              loginRedirectUrl: 'https://workspace.example.com/open',
+            },
+          },
+        }),
+      }))
+    );
+
+    const { result } = renderHook(() => useAuthConfig());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.config?.externalLaunch).toEqual({
+      enabled: true,
+      loginRedirectUrl: 'https://workspace.example.com/open',
+    });
+  });
+});

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -11,6 +11,10 @@ import { getDaemonUrl } from '../config/daemon';
 
 interface AuthConfig {
   requireAuth: boolean;
+  externalLaunch?: {
+    enabled?: boolean;
+    loginRedirectUrl?: string;
+  };
 }
 
 interface InstanceConfig {

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -11,6 +11,13 @@ Agor can accept a generic external launch handoff when another trusted app has a
 5. The daemon verifies issuer, audience, expiration, subject, and the configured instance ID; then it maps or creates a local user by `(provider, issuer, subject)`.
 6. The daemon returns normal runtime auth tokens. The UI stores those tokens and removes `launch_code` from the URL with `replaceState`.
 
+If the launch code is missing, expired, already used, invalid, or the daemon
+cannot complete a non-transient exchange, the UI shows a clear failure message.
+When `external_launch.login_redirect_url` is configured, the unauthenticated
+screen makes that URL the primary action so users can return to the external
+workspace and open a fresh launch link. If the field is omitted, the normal
+local username/password login screen remains unchanged.
+
 ## Configuration
 
 ```yaml
@@ -34,6 +41,11 @@ external_launch:
 
   # Optional: allow role claims above member. Defaults to false.
   allow_admin_roles: false
+
+  # Optional: where unauthenticated users should return when a launch code is
+  # missing, expired, already used, invalid, or otherwise cannot be exchanged.
+  # Must be http:// or https://.
+  login_redirect_url: https://workspace.example.com/open
 ```
 
 For local development only, a symmetric assertion secret can be used:

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -489,6 +489,17 @@ describe('saveConfig', () => {
     expect(loaded).toEqual({});
   });
 
+  it('validates external launch login redirect before saving', async () => {
+    await expect(
+      saveConfig({
+        external_launch: {
+          enabled: true,
+          login_redirect_url: 'javascript:alert(1)',
+        },
+      })
+    ).rejects.toThrow(/external_launch\.login_redirect_url.*http/i);
+  });
+
   it('should format YAML with proper indentation', async () => {
     const config = createConfigData();
     await saveConfig(config);

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -186,6 +186,50 @@ describe('loadConfig', () => {
     expect(loaded.defaults).toBeUndefined();
     expect(loaded.display).toBeUndefined();
   });
+
+  it('does not configure an external launch login redirect by default', async () => {
+    const loaded = await loadConfig();
+    expect(loaded.external_launch?.login_redirect_url).toBeUndefined();
+  });
+
+  it('accepts an HTTP(S) external launch login redirect URL', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        external_launch: {
+          enabled: true,
+          login_redirect_url: ' https://workspace.example.com/open ',
+        },
+      }),
+      'utf-8'
+    );
+
+    const loaded = await loadConfig();
+    expect(loaded.external_launch?.login_redirect_url).toBe('https://workspace.example.com/open');
+  });
+
+  it('rejects a non-HTTP(S) external launch login redirect URL', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        external_launch: {
+          enabled: true,
+          login_redirect_url: 'javascript:alert(1)',
+        },
+      }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/external_launch\.login_redirect_url.*http/i);
+  });
 });
 
 describe('loadConfig cache', () => {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -199,19 +199,32 @@ function validateOptionalHttpUrl(
     throw new Error(`Config error: ${configPath} must be an HTTP(S) URL string`);
   }
 
-  const trimmed = raw.trim();
+  container[key] = validateHttpUrlString(raw, configPath);
+}
+
+function validateHttpUrlString(
+  url: string,
+  label: string,
+  options: { stripTrailingSlash?: boolean } = {}
+): string {
+  const trimmed = options.stripTrailingSlash ? url.trim().replace(/\/$/, '') : url.trim();
+
+  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+    throw new Error(`Invalid ${label}: "${url}". Must start with http:// or https://`);
+  }
+
   let parsed: URL;
   try {
     parsed = new URL(trimmed);
   } catch {
-    throw new Error(`Config error: ${configPath} must be a valid HTTP(S) URL`);
+    throw new Error(`Invalid ${label} format: "${url}". Must be a valid HTTP(S) URL.`);
   }
 
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(`Config error: ${configPath} must use http:// or https://`);
+    throw new Error(`Invalid ${label}: "${url}". Must use http:// or https://`);
   }
 
-  container[key] = trimmed;
+  return trimmed;
 }
 
 /**
@@ -288,6 +301,7 @@ export async function loadConfigFromFile(filePath: string): Promise<AgorConfig> 
  * Invalidates the in-memory cache so the next load reflects the fresh value.
  */
 export async function saveConfig(config: AgorConfig): Promise<void> {
+  validateConfig(config);
   await ensureAgorHome();
 
   const configPath = getConfigPath();
@@ -501,21 +515,7 @@ export async function getDaemonUrl(): Promise<string> {
  * @throws Error if URL is invalid or uses unsupported scheme
  */
 function validateBaseUrl(url: string): string {
-  const trimmed = url.trim().replace(/\/$/, ''); // Remove trailing slash and whitespace
-
-  // Basic validation: must start with http:// or https://
-  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
-    throw new Error(`Invalid base URL: "${url}". Must start with http:// or https://`);
-  }
-
-  // Additional validation: ensure it's a valid URL structure
-  try {
-    new URL(trimmed);
-  } catch {
-    throw new Error(`Invalid base URL format: "${url}". Must be a valid HTTP(S) URL.`);
-  }
-
-  return trimmed;
+  return validateHttpUrlString(url, 'base URL', { stripTrailingSlash: true });
 }
 
 /**

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -179,6 +179,39 @@ function validateConfig(config: AgorConfig): void {
         `To update: agor config set execution.unix_user_mode insulated`
     );
   }
+
+  validateOptionalHttpUrl(
+    config.external_launch as Record<string, unknown> | undefined,
+    'login_redirect_url',
+    'external_launch.login_redirect_url'
+  );
+}
+
+function validateOptionalHttpUrl(
+  container: Record<string, unknown> | undefined,
+  key: string,
+  configPath: string
+): void {
+  if (!container || container[key] === undefined) return;
+
+  const raw = container[key];
+  if (typeof raw !== 'string') {
+    throw new Error(`Config error: ${configPath} must be an HTTP(S) URL string`);
+  }
+
+  const trimmed = raw.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Config error: ${configPath} must be a valid HTTP(S) URL`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Config error: ${configPath} must use http:// or https://`);
+  }
+
+  container[key] = trimmed;
 }
 
 /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -222,6 +222,12 @@ export interface AgorExternalLaunchSettings {
 
   /** Allow launch assertions to assign admin/superadmin roles (default: false). */
   allow_admin_roles?: boolean;
+
+  /**
+   * Optional HTTP(S) URL shown in the unauthenticated UI when external launch
+   * sign-in is unavailable, missing, expired, or invalid.
+   */
+  login_redirect_url?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add optional `external_launch.login_redirect_url` config with HTTP(S) validation
- expose a safe public external launch redirect shape through `/health`
- show a primary “Return to workspace” action on launch failures when configured without relabeling local-login errors
- document generic one-time launch auth redirect behavior
- refactor URL validation reuse and validate config before saving

## Tests
- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/config/config-manager.test.ts`
- `pnpm --filter @agor/daemon test -- src/auth/launch-auth.test.ts`
- `pnpm --filter agor-ui test -- src/components/LoginPage/LoginPage.test.tsx src/hooks/useAuth.launch.test.tsx src/hooks/useAuthConfig.test.tsx`