### PR TITLE
Support unix_username in external launch assertions

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -62,6 +62,12 @@ async function makeDb(): Promise<{ db: Database; cleanup: () => void }> {
   return { db, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 }
 
+async function getUserRow(db: Database, userId: UserID) {
+  const row = await select(db).from(users).where(eq(users.user_id, userId)).one();
+  if (!row) throw new Error('missing user row');
+  return row;
+}
+
 function makeUsersService(db: Database) {
   return {
     async get(id: UserID): Promise<User> {
@@ -79,6 +85,7 @@ function makeUsersService(db: Database) {
         updated_at: row.updated_at ?? undefined,
         avatar: (row.data as { avatar?: string }).avatar,
         preferences: (row.data as { preferences?: Record<string, unknown> }).preferences,
+        unix_username: row.unix_username ?? undefined,
       };
     },
   };
@@ -208,6 +215,67 @@ describe('one-time launch auth service', () => {
     }) as { sub: string; type: string };
     expect(decoded.sub).toBe(result.user.user_id);
     expect(decoded.type).toBe('access');
+  });
+
+  it('sets unix_username from a valid launch assertion for a new user', async () => {
+    mockExchange(signClaims({ unix_username: 'launch_user' }));
+    const result = await service().create({ launchCode: 'new-user-unix-username' });
+
+    expect(result.user.unix_username).toBe('launch_user');
+    const row = await getUserRow(db, result.user.user_id);
+    expect(row.unix_username).toBe('launch_user');
+  });
+
+  it('fills unix_username for an existing external-identity user only when currently unset', async () => {
+    mockExchange(signClaims({ sub: 'fill-unix-user', email: 'fill-unix@example.test' }));
+    const first = await service().create({ launchCode: 'first-without-unix-username' });
+    expect(first.user.unix_username).toBeUndefined();
+
+    mockExchange(
+      signClaims({
+        sub: 'fill-unix-user',
+        email: 'fill-unix@example.test',
+        unix_username: 'filled_user',
+      })
+    );
+    const second = await service().create({ launchCode: 'second-with-unix-username' });
+
+    expect(second.user.user_id).toBe(first.user.user_id);
+    expect(second.user.unix_username).toBe('filled_user');
+    const row = await getUserRow(db, second.user.user_id);
+    expect(row.unix_username).toBe('filled_user');
+  });
+
+  it('preserves an existing unix_username for an external-identity user', async () => {
+    mockExchange(
+      signClaims({
+        sub: 'preserve-unix-user',
+        email: 'preserve-unix@example.test',
+        unix_username: 'original_user',
+      })
+    );
+    const first = await service().create({ launchCode: 'first-unix-username' });
+
+    mockExchange(
+      signClaims({
+        sub: 'preserve-unix-user',
+        email: 'preserve-unix@example.test',
+        unix_username: 'new_user',
+      })
+    );
+    const second = await service().create({ launchCode: 'second-unix-username' });
+
+    expect(second.user.user_id).toBe(first.user.user_id);
+    expect(second.user.unix_username).toBe('original_user');
+    const row = await getUserRow(db, second.user.user_id);
+    expect(row.unix_username).toBe('original_user');
+  });
+
+  it('rejects invalid unix_username claims', async () => {
+    mockExchange(signClaims({ unix_username: 'Bad User' }));
+    await expect(service().create({ launchCode: 'invalid-unix-username' })).rejects.toBeInstanceOf(
+      NotAuthenticated
+    );
   });
 
   it('maps admin roles only when explicitly allowed', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -1,11 +1,12 @@
-import type { JsonWebKey, KeyObject } from 'node:crypto';
+import type { JsonWebKey } from 'node:crypto';
 import { createHash, createPublicKey, randomBytes } from 'node:crypto';
 import type { AgorConfig } from '@agor/core/config';
 import { type Database, eq, generateId, hash, insert, select, update, users } from '@agor/core/db';
 import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
 import type { Params, User, UserExternalIdentity, UserID, UserRole } from '@agor/core/types';
 import { normalizeRole, ROLES } from '@agor/core/types';
-import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
+import { isValidUnixUsername } from '@agor/core/unix/user-manager';
+import jwt, { type JwtHeader, type JwtPayload, type Secret, type SignOptions } from 'jsonwebtoken';
 import { issueRuntimeTokenPair } from './runtime-tokens.js';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -49,6 +50,7 @@ interface LaunchClaims extends JwtPayload {
   provider?: string;
   instance_id?: string;
   runtime_instance_id?: string;
+  unix_username?: string;
   jti?: string;
   nonce?: string;
 }
@@ -192,6 +194,27 @@ function normalizeLaunchEmail(value: string | undefined): string | undefined {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : undefined;
 }
 
+function normalizeLaunchUnixUsername(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const unixUsername = value.trim();
+  if (!isValidUnixUsername(unixUsername)) {
+    throw new NotAuthenticated('Invalid one-time launch assertion Unix username');
+  }
+  return unixUsername;
+}
+
+async function assertUnixUsernameAvailable(
+  db: Database,
+  unixUsername: string | undefined,
+  currentUserId?: UserID
+): Promise<void> {
+  if (!unixUsername) return;
+  const existing = await select(db).from(users).where(eq(users.unix_username, unixUsername)).one();
+  if (existing && existing.user_id !== currentUserId) {
+    throw new NotAuthenticated('Invalid one-time launch assertion Unix username');
+  }
+}
+
 function mapRole(
   claimedRole: string | undefined,
   settings: ResolvedLaunchSettings,
@@ -235,6 +258,7 @@ async function upsertLaunchUser(
   const now = new Date();
   const nowIso = now.toISOString();
   const email = normalizeLaunchEmail(claims.email);
+  const claimedUnixUsername = normalizeLaunchUnixUsername(claims.unix_username);
   const name = claims.name?.trim() || undefined;
   const avatar = claims.avatar || claims.picture;
   const identity: StoredExternalIdentity = {
@@ -264,11 +288,15 @@ async function upsertLaunchUser(
       nextIdentities.push(identity);
     }
 
+    const unixUsernameUpdate = !existing.unix_username ? claimedUnixUsername : undefined;
+    await assertUnixUsernameAvailable(db, unixUsernameUpdate, existing.user_id as UserID);
+
     await update(db, users)
       .set({
         name: name ?? existing.name,
         role,
         updated_at: now,
+        ...(unixUsernameUpdate ? { unix_username: unixUsernameUpdate } : {}),
         data: {
           ...data,
           avatar: avatar ?? data.avatar,
@@ -283,6 +311,7 @@ async function upsertLaunchUser(
 
   const role = mapRole(claims.role, settings, config.execution?.allow_superadmin);
   const localEmail = await chooseLocalEmail(db, email, key, provider, issuer, subject);
+  await assertUnixUsernameAvailable(db, claimedUnixUsername);
   const userId = generateId() as UserID;
   const password = await hash(randomBytes(32).toString('hex'), 10);
 
@@ -294,6 +323,7 @@ async function upsertLaunchUser(
       name,
       emoji: '👤',
       role,
+      unix_username: claimedUnixUsername,
       created_at: now,
       updated_at: now,
       onboarding_completed: false,
@@ -354,7 +384,7 @@ async function exchangeLaunchCode(
 async function resolveVerificationKey(
   header: JwtHeader,
   settings: ResolvedLaunchSettings
-): Promise<string | KeyObject> {
+): Promise<Secret> {
   if (settings.devSharedSecret) return settings.devSharedSecret;
   if (settings.publicKey) return settings.publicKey;
   if (!settings.jwksUrl) throw new NotAuthenticated('Launch assertion verification failed');
@@ -372,7 +402,7 @@ async function resolveVerificationKey(
   if (header.alg && jwk.alg && jwk.alg !== header.alg) {
     throw new NotAuthenticated('Launch assertion verification failed');
   }
-  return createPublicKey({ key: jwk, format: 'jwk' });
+  return createPublicKey({ key: jwk, format: 'jwk' }) as Secret;
 }
 
 async function verifyLaunchAssertion(
@@ -417,6 +447,9 @@ function validateLaunchClaims(claims: LaunchClaims, settings: ResolvedLaunchSett
   }
   if (claims.nonce !== undefined && typeof claims.nonce !== 'string') {
     throw new NotAuthenticated('Invalid one-time launch assertion nonce');
+  }
+  if (claims.unix_username !== undefined && typeof claims.unix_username !== 'string') {
+    throw new NotAuthenticated('Invalid one-time launch assertion Unix username');
   }
 }
 

--- a/apps/agor-daemon/vitest.config.ts
+++ b/apps/agor-daemon/vitest.config.ts
@@ -1,6 +1,24 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { configDefaults, defineConfig } from 'vitest/config';
 
+const coreSrcDir = fileURLToPath(new URL('../../packages/core/src', import.meta.url));
+
+const coreWorkspaceImportResolver = {
+  name: 'daemon-core-workspace-import-resolver',
+  resolveId(id: string) {
+    const match = id.match(/^@agor\/core(?:\/(.+))?$/);
+    if (!match) return null;
+    const subpath = match[1] ?? 'index';
+    const indexTs = path.join(coreSrcDir, subpath, 'index.ts');
+    if (existsSync(indexTs)) return indexTs;
+    return path.join(coreSrcDir, `${subpath}.ts`);
+  },
+};
+
 export default defineConfig({
+  plugins: [coreWorkspaceImportResolver],
   test: {
     globals: true,
     environment: 'node',

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -90,6 +90,7 @@ Optional claims:
 
 - `email`, `name`, `avatar` or `picture`
 - `role`: `viewer` or `member` by default; `admin`/`superadmin` only when `allow_admin_roles` is explicitly enabled, and `superadmin` is still capped unless runtime superadmin support is enabled
+- `unix_username`: optional stable Unix account name for strict Unix user mode. It must match the runtime's Unix username validation rules. New launch-created users receive it immediately; existing external-identity users receive it only if their local `unix_username` is currently unset. Existing values are never overwritten by launch assertions.
 - `provider`: stable provider label used in local identity mapping
 - `jti` or `nonce`: accepted for audit/correlation; one-time replay prevention remains the exchange endpoint's responsibility
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -292,6 +292,12 @@
       "import": "./dist/unix/index.js",
       "require": "./dist/unix/index.cjs"
     },
+    "./unix/user-manager": {
+      "source": "./src/unix/user-manager.ts",
+      "types": "./dist/unix/user-manager.d.ts",
+      "import": "./dist/unix/user-manager.js",
+      "require": "./dist/unix/user-manager.cjs"
+    },
     "./mcp": {
       "source": "./src/mcp/index.ts",
       "types": "./dist/mcp/index.d.ts",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     'tools/mcp/oauth-refresh': 'src/tools/mcp/oauth-refresh.ts', // MCP OAuth refresh_token persistence + mutex
     'tools/mcp/oauth-token-expiry': 'src/tools/mcp/oauth-token-expiry.ts', // MCP OAuth token expiry resolution cascade
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for branch isolation
+    'unix/user-manager': 'src/unix/user-manager.ts', // Unix username validation helpers
     'mcp/index': 'src/mcp/index.ts', // MCP template resolution utilities
     'gateway/index': 'src/gateway/index.ts', // Gateway platform connectors (Slack, etc.)
     'yaml/index': 'src/yaml/index.ts', // Browser-safe js-yaml re-export


### PR DESCRIPTION
## Summary
- accept an optional `unix_username` claim in generic external launch assertions
- validate and trim supplied Unix usernames using the shared Unix username validator
- set `users.unix_username` for newly-created launch users, and backfill existing external-identity users only when unset
- preserve any existing local `unix_username` and document the claim behavior

## Tests
- `pnpm --filter @agor/daemon test -- src/auth/launch-auth.test.ts`
- `pnpm exec tsc --noEmit -p /tmp/agor-launch-tsconfig.json`
- `pnpm exec biome check apps/agor-daemon/src/auth/launch-auth.ts apps/agor-daemon/src/auth/launch-auth.test.ts apps/agor-daemon/vitest.config.ts packages/core/package.json packages/core/tsup.config.ts context/guides/one-time-launch-auth.md`
