### PR TITLE
Tune bundled UI cache headers and compression filters

### DIFF
--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -43,7 +43,6 @@ import { buildGitConfigParameters } from '@agor/core/git';
 import { registerHandlebarsHelpers } from '@agor/core/templates/handlebars-helpers';
 import type { HookContext, ServiceGroupName, ServiceTier, User } from '@agor/core/types';
 import { getServiceTier, isServiceEnabled } from '@agor/core/types';
-import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
 import expressStaticGzip from 'express-static-gzip';
@@ -51,6 +50,7 @@ import { registerHooks } from './register-hooks.js';
 import { registerRoutes } from './register-routes.js';
 import { registerServices } from './register-services.js';
 import { loadBuildInfo } from './setup/build-info.js';
+import { createDynamicCompressionMiddleware } from './setup/compression.js';
 import { buildCorsConfig, isSandpackOrigin } from './setup/cors.js';
 import {
   initializeAnthropicApiKey,
@@ -62,6 +62,7 @@ import { warnDeprecatedAnonymousConfig } from './setup/first-run-admin.js';
 import { securityHeaders } from './setup/security-headers.js';
 import { logServicesConfig, resolveServicesConfig } from './setup/service-tiers.js';
 import { configureChannels, createSocketIOConfig } from './setup/socketio.js';
+import { setBundledUiFallbackHeaders, setBundledUiStaticHeaders } from './setup/static-assets.js';
 import { configureSwagger } from './setup/swagger.js';
 import { loadDaemonVersion } from './setup/version.js';
 import { startup } from './startup.js';
@@ -455,12 +456,16 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       app.use(
         UI_MOUNT_PATH,
         expressStaticGzip(uiPath, {
-          enableBrotli: false,
-          orderPreference: ['gz'],
-          serveStatic: { maxAge: '1y' },
+          enableBrotli: true,
+          orderPreference: ['br', 'gz'],
+          serveStatic: {
+            etag: true,
+            setHeaders: setBundledUiStaticHeaders,
+          },
         }) as never
       );
       app.use(`${UI_MOUNT_PATH}/*`, ((_req: unknown, res: express.Response) => {
+        setBundledUiFallbackHeaders(res);
         res.sendFile(path.join(uiPath, 'index.html'));
       }) as never);
       app.use('/', ((req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -507,8 +512,9 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     }
   }) as never);
 
-  // Compress dynamic API responses (after static file serving)
-  app.use(compression() as never);
+  // Compress dynamic REST/API responses after static file serving. The filter
+  // deliberately skips pass-through proxy and streaming/event-stream routes.
+  app.use(createDynamicCompressionMiddleware() as never);
 
   // --------------------------------------------------------------------------
   // REST, Socket.io, Swagger, Database

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -456,8 +456,8 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
       app.use(
         UI_MOUNT_PATH,
         expressStaticGzip(uiPath, {
-          enableBrotli: true,
-          orderPreference: ['br', 'gz'],
+          enableBrotli: false,
+          orderPreference: ['gz'],
           serveStatic: {
             etag: true,
             setHeaders: setBundledUiStaticHeaders,

--- a/apps/agor-daemon/src/setup/compression.test.ts
+++ b/apps/agor-daemon/src/setup/compression.test.ts
@@ -1,0 +1,42 @@
+import type { Request, Response } from 'express';
+import { describe, expect, it } from 'vitest';
+import { shouldCompressResponse } from './compression';
+
+function req(path: string): Request {
+  return {
+    path,
+    url: path,
+    headers: { 'accept-encoding': 'gzip, br' },
+  } as Request;
+}
+
+function res(contentType?: string): Response {
+  const headers = new Map<string, string>();
+  if (contentType) headers.set('content-type', contentType);
+  return {
+    getHeader(name: string) {
+      return headers.get(name.toLowerCase());
+    },
+  } as unknown as Response;
+}
+
+describe('shouldCompressResponse', () => {
+  it('does not compress pass-through proxy responses', () => {
+    expect(shouldCompressResponse(req('/proxies'), res('application/json'))).toBe(false);
+    expect(shouldCompressResponse(req('/proxies/shortcut/stories'), res('application/json'))).toBe(
+      false
+    );
+  });
+
+  it('does not compress event streams', () => {
+    expect(shouldCompressResponse(req('/events'), res('text/event-stream; charset=utf-8'))).toBe(
+      false
+    );
+  });
+
+  it('still compresses ordinary JSON responses when the client accepts compression', () => {
+    expect(shouldCompressResponse(req('/health'), res('application/json; charset=utf-8'))).toBe(
+      true
+    );
+  });
+});

--- a/apps/agor-daemon/src/setup/compression.ts
+++ b/apps/agor-daemon/src/setup/compression.ts
@@ -1,0 +1,37 @@
+import compression from 'compression';
+import type { Request, Response } from 'express';
+
+/**
+ * Dynamic response compression policy.
+ *
+ * Static UI assets are served before this middleware, using express-static-gzip
+ * so pre-compressed files can be returned directly. Keep this middleware focused
+ * on normal REST/JSON responses and avoid byte-for-byte relay or streaming
+ * paths where compression can add buffering or alter upstream semantics.
+ */
+export function shouldCompressResponse(req: Request, res: Response): boolean {
+  const requestPath = req.path || req.url || '';
+
+  // `/proxies` is a pass-through byte relay for artifact HTTP proxying. Some
+  // upstreams may stream responses (including SSE-like APIs), and the proxy
+  // intentionally strips upstream content-encoding before relaying bytes. Do not
+  // wrap that response in dynamic compression; let callers/upstreams control
+  // streaming cadence and avoid extra buffering in this layer.
+  if (requestPath === '/proxies' || requestPath.startsWith('/proxies/')) {
+    return false;
+  }
+
+  // Defense-in-depth for any future Express-mounted SSE route. The app's
+  // current real-time path is Socket.IO, but this keeps compression from
+  // buffering event streams if a route later sets this content type.
+  const contentType = String(res.getHeader('Content-Type') ?? '').toLowerCase();
+  if (contentType.startsWith('text/event-stream')) {
+    return false;
+  }
+
+  return compression.filter(req, res);
+}
+
+export function createDynamicCompressionMiddleware(): ReturnType<typeof compression> {
+  return compression({ filter: shouldCompressResponse });
+}

--- a/apps/agor-daemon/src/setup/static-assets.test.ts
+++ b/apps/agor-daemon/src/setup/static-assets.test.ts
@@ -1,0 +1,40 @@
+import type { Response } from 'express';
+import { describe, expect, it } from 'vitest';
+import { setBundledUiFallbackHeaders, setBundledUiStaticHeaders } from './static-assets';
+
+function res(): Response & { headers: Map<string, string> } {
+  const headers = new Map<string, string>();
+  return {
+    headers,
+    setHeader(name: string, value: string) {
+      headers.set(name.toLowerCase(), value);
+      return this;
+    },
+  } as unknown as Response & { headers: Map<string, string> };
+}
+
+describe('bundled UI cache headers', () => {
+  it('marks hashed Vite assets immutable', () => {
+    const r = res();
+    setBundledUiStaticHeaders(r, '/pkg/dist/ui/assets/index-Ck4a1b2c.js');
+    expect(r.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+  });
+
+  it('keeps index.html revalidatable', () => {
+    const r = res();
+    setBundledUiStaticHeaders(r, '/pkg/dist/ui/index.html');
+    expect(r.headers.get('cache-control')).toBe('no-cache');
+  });
+
+  it('does not make unhashed files immutable', () => {
+    const r = res();
+    setBundledUiStaticHeaders(r, '/pkg/dist/ui/favicon.svg');
+    expect(r.headers.has('cache-control')).toBe(false);
+  });
+
+  it('marks SPA fallback responses revalidatable', () => {
+    const r = res();
+    setBundledUiFallbackHeaders(r);
+    expect(r.headers.get('cache-control')).toBe('no-cache');
+  });
+});

--- a/apps/agor-daemon/src/setup/static-assets.test.ts
+++ b/apps/agor-daemon/src/setup/static-assets.test.ts
@@ -26,6 +26,22 @@ describe('bundled UI cache headers', () => {
     expect(r.headers.get('cache-control')).toBe('no-cache');
   });
 
+  it('keeps precompressed index.html revalidatable', () => {
+    const gzip = res();
+    setBundledUiStaticHeaders(gzip, '/pkg/dist/ui/index.html.gz');
+    expect(gzip.headers.get('cache-control')).toBe('no-cache');
+
+    const brotli = res();
+    setBundledUiStaticHeaders(brotli, '/pkg/dist/ui/index.html.br');
+    expect(brotli.headers.get('cache-control')).toBe('no-cache');
+  });
+
+  it('marks precompressed hashed Vite assets immutable', () => {
+    const r = res();
+    setBundledUiStaticHeaders(r, '/pkg/dist/ui/assets/index-Ck4a1b2c.js.gz');
+    expect(r.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+  });
+
   it('does not make unhashed files immutable', () => {
     const r = res();
     setBundledUiStaticHeaders(r, '/pkg/dist/ui/favicon.svg');

--- a/apps/agor-daemon/src/setup/static-assets.ts
+++ b/apps/agor-daemon/src/setup/static-assets.ts
@@ -4,10 +4,16 @@ import type { Response } from 'express';
 
 const ONE_YEAR_SECONDS = 31_536_000;
 const HASHED_ASSET_RE = /[-.][a-zA-Z0-9_-]{8,}\./;
+const PRECOMPRESSED_SUFFIX_RE = /\.(?:gz|br)$/i;
+
+function stripPrecompressedSuffix(filePath: string): string {
+  return filePath.replace(PRECOMPRESSED_SUFFIX_RE, '');
+}
 
 function isHashedAsset(filePath: string): boolean {
-  const normalized = filePath.split(path.sep).join('/');
-  const basename = path.basename(filePath);
+  const logicalPath = stripPrecompressedSuffix(filePath);
+  const normalized = logicalPath.split(path.sep).join('/');
+  const basename = path.basename(logicalPath);
   return normalized.includes('/assets/') && HASHED_ASSET_RE.test(basename);
 }
 
@@ -17,7 +23,7 @@ export function setBundledUiStaticHeaders(res: ServerResponse, filePath: string)
     return;
   }
 
-  if (path.basename(filePath) === 'index.html') {
+  if (path.basename(stripPrecompressedSuffix(filePath)) === 'index.html') {
     res.setHeader('Cache-Control', 'no-cache');
   }
 }

--- a/apps/agor-daemon/src/setup/static-assets.ts
+++ b/apps/agor-daemon/src/setup/static-assets.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import type { Response } from 'express';
+
+const ONE_YEAR_SECONDS = 31_536_000;
+const HASHED_ASSET_RE = /[-.][a-zA-Z0-9_-]{8,}\./;
+
+function isHashedAsset(filePath: string): boolean {
+  const normalized = filePath.split(path.sep).join('/');
+  const basename = path.basename(filePath);
+  return normalized.includes('/assets/') && HASHED_ASSET_RE.test(basename);
+}
+
+export function setBundledUiStaticHeaders(res: Response, filePath: string): void {
+  if (isHashedAsset(filePath)) {
+    res.setHeader('Cache-Control', `public, max-age=${ONE_YEAR_SECONDS}, immutable`);
+    return;
+  }
+
+  if (path.basename(filePath) === 'index.html') {
+    res.setHeader('Cache-Control', 'no-cache');
+  }
+}
+
+export function setBundledUiFallbackHeaders(res: Response): void {
+  res.setHeader('Cache-Control', 'no-cache');
+}

--- a/apps/agor-daemon/src/setup/static-assets.ts
+++ b/apps/agor-daemon/src/setup/static-assets.ts
@@ -1,3 +1,4 @@
+import type { ServerResponse } from 'node:http';
 import path from 'node:path';
 import type { Response } from 'express';
 
@@ -10,7 +11,7 @@ function isHashedAsset(filePath: string): boolean {
   return normalized.includes('/assets/') && HASHED_ASSET_RE.test(basename);
 }
 
-export function setBundledUiStaticHeaders(res: Response, filePath: string): void {
+export function setBundledUiStaticHeaders(res: ServerResponse, filePath: string): void {
   if (isHashedAsset(filePath)) {
     res.setHeader('Cache-Control', `public, max-age=${ONE_YEAR_SECONDS}, immutable`);
     return;


### PR DESCRIPTION
## Summary
- Keep bundled UI pre-compressed delivery gzip-only, matching the current Vite build/package output.
- Replace blanket 1-year cache headers on all bundled UI files with immutable caching only for hashed Vite assets and `no-cache` for `index.html` / SPA fallbacks.
- Keep dynamic REST/API compression, but skip pass-through `/proxies` and `text/event-stream` responses to avoid buffering or changing streaming/relay semantics.

## Findings addressed
- Static UI delivery already used `express-static-gzip`, and the UI build currently produces `.gz` assets only.
- `packages/agor-live/build.sh` copies the UI build output into the package, so adding Brotli would mean intentionally generating/bundling another compressed asset set. This PR does **not** do that.
- The previous static config put `maxAge: '1y'` on everything under `/ui`, including `index.html`.
- Dynamic `compression()` was mounted before REST routes, so JSON/API responses were compressed, but proxy responses were also eligible for dynamic compression.

## Checks
- `pnpm --filter @agor/daemon exec vitest run src/setup/compression.test.ts src/setup/static-assets.test.ts`
- `pnpm exec biome check apps/agor-daemon/src/index.ts apps/agor-daemon/src/setup/compression.ts apps/agor-daemon/src/setup/compression.test.ts apps/agor-daemon/src/setup/static-assets.ts apps/agor-daemon/src/setup/static-assets.test.ts`
- `pnpm turbo run build typecheck --filter='!@agor/docs'`
- CI: `Lint, typecheck, build, test` and `Pack + boot + curl` passed
