### PR TITLE
feat(mcp): expose zone_id/zone_label in agor_branches_list + add zoneId filter

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -7,16 +7,19 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 
-function registerAndCaptureUpdate(ctx: {
-  app: unknown;
-  userId: string;
-  sessionId?: string;
-  baseServiceParams?: Record<string, unknown>;
-}): ToolHandler {
+function registerAndCaptureHandler(
+  toolName: string,
+  ctx: {
+    app: unknown;
+    userId: string;
+    sessionId?: string;
+    baseServiceParams?: Record<string, unknown>;
+  }
+): ToolHandler {
   let handler: ToolHandler | undefined;
   const fakeServer = {
     registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
-      if (name === 'agor_branches_update') handler = cb;
+      if (name === toolName) handler = cb;
     },
   } as unknown as McpServer;
 
@@ -33,8 +36,17 @@ function registerAndCaptureUpdate(ctx: {
     >[1]['baseServiceParams'],
   });
 
-  if (!handler) throw new Error('agor_branches_update was not registered');
+  if (!handler) throw new Error(`${toolName} was not registered`);
   return handler;
+}
+
+function registerAndCaptureUpdate(ctx: {
+  app: unknown;
+  userId: string;
+  sessionId?: string;
+  baseServiceParams?: Record<string, unknown>;
+}): ToolHandler {
+  return registerAndCaptureHandler('agor_branches_update', ctx);
 }
 
 describe('agor_branches_update', () => {
@@ -84,5 +96,126 @@ describe('agor_branches_update', () => {
     expect(parsed.error).toMatch(/requires current Agor session context/i);
     expect(parsed.error).toMatch(/X-Agor-Session-Id/);
     expect(sessionsGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('agor_branches_list', () => {
+  const baseServiceParams = {
+    authenticated: true,
+    provider: 'mcp',
+    user: { user_id: 'user-1', role: 'member' },
+  };
+
+  function makeApp(findResult: unknown) {
+    return {
+      service(name: string) {
+        if (name === 'branches') return { find: vi.fn(async () => findResult) };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+  }
+
+  it('includes zone_id and zone_label from enriched branches', async () => {
+    const enrichedBranches = {
+      data: [
+        {
+          branch_id: 'branch-1',
+          name: 'my-feature',
+          archived: false,
+          board_id: 'board-1',
+          zone_id: 'zone-1776863814461',
+          zone_label: 'in progress',
+          board_object_id: 'obj-1',
+        },
+        {
+          branch_id: 'branch-2',
+          name: 'other-feature',
+          archived: false,
+          board_id: 'board-1',
+          // No zone — branch on board but not in a zone
+        },
+      ],
+      total: 2,
+      limit: 50,
+      skip: 0,
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app: makeApp(enrichedBranches),
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await list({});
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text);
+
+    const branch1 = parsed.data[0];
+    expect(branch1.zone_id).toBe('zone-1776863814461');
+    expect(branch1.zone_label).toBe('in progress');
+
+    const branch2 = parsed.data[1];
+    expect(branch2.zone_id).toBeUndefined();
+  });
+
+  it('filters by zoneId when provided', async () => {
+    const enrichedBranches = {
+      data: [
+        {
+          branch_id: 'branch-1',
+          name: 'feature-a',
+          archived: false,
+          zone_id: 'zone-review',
+          zone_label: 'Review',
+        },
+        {
+          branch_id: 'branch-2',
+          name: 'feature-b',
+          archived: false,
+          zone_id: 'zone-done',
+          zone_label: 'Done',
+        },
+        {
+          branch_id: 'branch-3',
+          name: 'feature-c',
+          archived: false,
+          // no zone
+        },
+      ],
+      total: 3,
+      limit: 50,
+      skip: 0,
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app: makeApp(enrichedBranches),
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await list({ zoneId: 'zone-review' });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0].branch_id).toBe('branch-1');
+    expect(parsed.total).toBe(1);
+  });
+
+  it('returns empty data when zoneId matches no branches', async () => {
+    const enrichedBranches = {
+      data: [{ branch_id: 'branch-1', name: 'feature-a', zone_id: 'zone-other' }],
+      total: 1,
+      limit: 50,
+      skip: 0,
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app: makeApp(enrichedBranches),
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await list({ zoneId: 'zone-review' });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.data).toHaveLength(0);
+    expect(parsed.total).toBe(0);
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -108,9 +108,14 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         if (Array.isArray(result)) {
           return textResult(result.filter((b: Record<string, unknown>) => b.zone_id === zoneId));
         } else {
-          const filtered = (result as { data: Record<string, unknown>[]; total: number; limit: number; skip: number }).data.filter(
-            (b) => b.zone_id === zoneId
-          );
+          const filtered = (
+            result as {
+              data: Record<string, unknown>[];
+              total: number;
+              limit: number;
+              skip: number;
+            }
+          ).data.filter((b) => b.zone_id === zoneId);
           return textResult({ ...result, data: filtered, total: filtered.length });
         }
       }

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -59,7 +59,11 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
     'agor_branches_list',
     {
-      description: 'List all branches in a repository',
+      description:
+        'List all branches in a repository. Each branch includes zone_id and zone_label when ' +
+        'the branch is assigned to a board zone — use these fields directly to identify which ' +
+        'zone a branch is in without extra agor_branches_get calls. Also includes ' +
+        'pull_request_url, issue_url, board_object_id, and position when set.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         repoId: z.string().optional().describe('Repository ID to filter by'),
@@ -76,6 +80,13 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Filter to show ONLY archived branches. When true, returns only archived branches. Overrides includeArchived.'
           ),
+        zoneId: z
+          .string()
+          .optional()
+          .describe(
+            'Filter results to branches in a specific board zone (e.g. "zone-1776863814461"). ' +
+              'Avoids the need to call agor_branches_get on each branch to check zone membership.'
+          ),
       }),
     },
     async (args) => {
@@ -87,8 +98,24 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       } else if (!args.includeArchived) {
         query.archived = false;
       }
-      const branches = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
-      return textResult(branches);
+      const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
+
+      // Post-enrichment zone filter: zone_id is added by the service's find() via
+      // enrichManyWithZoneInfo (LEFT JOIN on board_objects). Filter here after enrichment
+      // so the caller doesn't have to fan out with individual get() calls.
+      if (args.zoneId) {
+        const zoneId = coerceString(args.zoneId);
+        if (Array.isArray(result)) {
+          return textResult(result.filter((b: Record<string, unknown>) => b.zone_id === zoneId));
+        } else {
+          const filtered = (result as { data: Record<string, unknown>[]; total: number; limit: number; skip: number }).data.filter(
+            (b) => b.zone_id === zoneId
+          );
+          return textResult({ ...result, data: filtered, total: filtered.length });
+        }
+      }
+
+      return textResult(result);
     }
   );
 


### PR DESCRIPTION
## Summary

- `agor_branches_list` already enriches each branch with `zone_id` and `zone_label` via `BranchesService.find()` → `enrichManyWithZoneInfo` (LEFT JOIN on `board_objects`), but the MCP tool description didn't document this and provided no way to filter by zone
- Callers were doing an O(n) fan-out of `agor_branches_get` calls just to find zone membership (documented as the intended workaround in the `agor-zone-ops` skill)
- This PR makes the zone data discoverable and filterable without extra round-trips

**Changes:**
1. **MCP tool description** updated to document that `zone_id`, `zone_label`, `pull_request_url`, `issue_url`, `board_object_id`, and `position` are included in list results
2. **`zoneId` filter parameter** added to `agor_branches_list` — filters results to branches in a specific zone post-enrichment; `total` is updated to reflect the filtered count
3. **Three tests** added covering: zone field pass-through, `zoneId` filtering, and empty result when no branches match
4. **`agor-zone-ops` skill** updated (in `~/.claude/skills/`) to remove the incorrect "why list doesn't work" section and replace with guidance to use `zoneId` directly

## Test plan

- [ ] `agor_branches_list` returns `zone_id` and `zone_label` on branches that have zone assignments
- [ ] `agor_branches_list({ zoneId: "zone-xxx" })` returns only branches in that zone, with correct `total`
- [ ] Branches without zone assignment continue to appear in results without `zone_id` field
- [ ] Existing `agor_branches_update` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)