### PR TITLE
feat(session-search): relevancy-scored search with match highlighting

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -20,7 +20,6 @@ import {
   Collapse,
   ConfigProvider,
   Dropdown,
-  Empty,
   Input,
   Space,
   Spin,
@@ -634,11 +633,16 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       <>
         {sessionSearchBar}
         {results.length === 0 ? (
-          <Empty
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description={`No sessions match "${searchQuery}"`}
-            style={{ padding: '16px 0' }}
-          />
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '24px 16px', gap: 6 }}>
+            <div style={{ width: 36, height: 36, borderRadius: '50%', background: token.colorFillTertiary, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 2 }}>
+              <SearchOutlined style={{ fontSize: 16, color: token.colorTextTertiary }} />
+            </div>
+            <Typography.Text strong style={{ fontSize: 13 }}>No results</Typography.Text>
+            <Typography.Text type="secondary" style={{ fontSize: 12, textAlign: 'center', lineHeight: 1.5, maxWidth: 180 }}>
+              Nothing matched{' '}
+              <Typography.Text code style={{ fontSize: 11 }}>{searchQuery.trim()}</Typography.Text>
+            </Typography.Text>
+          </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
             {results.map(({ session }) => {

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -19,6 +19,7 @@ import {
   ConfigProvider,
   Empty,
   Input,
+  Select,
   Space,
   Spin,
   Tooltip,
@@ -33,7 +34,7 @@ import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
-import { HighlightMatch, getMatchSnippet, scoreSession } from '../../utils/sessionSearch';
+import { HighlightMatch, SESSION_SORT_OPTIONS, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { ChannelPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
@@ -163,6 +164,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+  const [sort, setSort] = useState<SessionSort>('recent');
 
   useEffect(() => {
     const id = setTimeout(() => setSearchQuery(searchInput), 150);
@@ -238,7 +240,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     () => activeSessions.filter((s) => isGatewaySession(s)),
     [activeSessions, isGatewaySession]
   );
-  const sessionTreeData = useMemo(() => buildSessionTree(manualSessions), [manualSessions]);
+  const sortedManualSessions = useMemo(
+    () => sortSessions(manualSessions, sort),
+    [manualSessions, sort]
+  );
+  const sessionTreeData = useMemo(() => buildSessionTree(sortedManualSessions), [sortedManualSessions]);
 
   const hasRunningScheduledSession = useMemo(
     () => scheduledSessions.some((s) => s.status === 'running' || s.status === 'stopping'),
@@ -365,23 +371,35 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           style={{ backgroundColor: token.colorPrimaryBgHover }}
         />
       </Space>
-      {onCreateSession && (
-        <div className="nodrag">
-          <Button
-            type="default"
+      <Space size={4}>
+        {!isPanel && (
+          <Select
+            value={sort}
+            onChange={setSort}
             size="small"
-            icon={<PlusOutlined />}
-            disabled={connectionDisabled || isCreating}
-            onClick={(e) => {
-              e.stopPropagation();
-              onCreateSession(branch.branch_id);
-            }}
-            title={isCreating ? 'Branch is being created...' : undefined}
-          >
-            New Session
-          </Button>
-        </div>
-      )}
+            style={{ width: 88 }}
+            options={SESSION_SORT_OPTIONS}
+            onClick={(e) => e.stopPropagation()}
+          />
+        )}
+        {onCreateSession && (
+          <div className="nodrag">
+            <Button
+              type="default"
+              size="small"
+              icon={<PlusOutlined />}
+              disabled={connectionDisabled || isCreating}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCreateSession(branch.branch_id);
+              }}
+              title={isCreating ? 'Branch is being created...' : undefined}
+            >
+              New Session
+            </Button>
+          </div>
+        )}
+      </Space>
     </div>
   );
 
@@ -542,14 +560,25 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const sessionSearchBar =
     isPanel && activeSessions.length > 0 ? (
       <div style={{ paddingBottom: 12, paddingTop: 4 }}>
-        <Input
-          placeholder="Search sessions..."
-          prefix={<SearchOutlined />}
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          allowClear
-          size="small"
-        />
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <Input
+            style={{ flex: 1 }}
+            placeholder="Search sessions..."
+            prefix={<SearchOutlined />}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            allowClear
+            size="small"
+          />
+          <Select
+            value={sort}
+            onChange={setSort}
+            size="small"
+            style={{ width: 96, flexShrink: 0 }}
+            disabled={!!searchQuery.trim()}
+            options={SESSION_SORT_OPTIONS}
+          />
+        </div>
       </div>
     ) : null;
 

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -4,12 +4,14 @@ import {
   isGatewaySession as isGatewaySessionCore,
 } from '@agor-live/client';
 import {
+  CheckOutlined,
   ClockCircleOutlined,
   InboxOutlined,
   MessageOutlined,
   PlusOutlined,
   SearchOutlined,
   SettingOutlined,
+  SortDescendingOutlined,
 } from '@ant-design/icons';
 import {
   App,
@@ -17,9 +19,9 @@ import {
   Button,
   Collapse,
   ConfigProvider,
+  Dropdown,
   Empty,
   Input,
-  Select,
   Space,
   Spin,
   Tooltip,
@@ -34,7 +36,7 @@ import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
-import { HighlightMatch, SESSION_SORT_OPTIONS, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
+import { HighlightMatch, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { ChannelPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
@@ -370,18 +372,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           showZero
           style={{ backgroundColor: token.colorPrimaryBgHover }}
         />
+        {!isPanel && sortButton}
       </Space>
       <Space size={4}>
-        {!isPanel && (
-          <Select
-            value={sort}
-            onChange={setSort}
-            size="small"
-            style={{ width: 88 }}
-            options={SESSION_SORT_OPTIONS}
-            onClick={(e) => e.stopPropagation()}
-          />
-        )}
         {onCreateSession && (
           <div className="nodrag">
             <Button
@@ -557,27 +550,75 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     </div>
   );
 
+  const sortDropdownItems = [
+    {
+      key: 'recent',
+      label: 'Most recent',
+      icon: sort === 'recent' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+    },
+    {
+      key: 'oldest',
+      label: 'Oldest first',
+      icon: sort === 'oldest' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+    },
+    {
+      key: 'alpha',
+      label: 'A–Z',
+      icon: sort === 'alpha' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+    },
+  ];
+
+  const sortButton = (
+    <Dropdown
+      menu={{
+        items: sortDropdownItems,
+        onClick: ({ key }) => setSort(key as SessionSort),
+        selectedKeys: [sort],
+      }}
+      trigger={['click']}
+    >
+      <Tooltip
+        title={sort !== 'recent' ? `Sort: ${sort === 'oldest' ? 'Oldest first' : 'A–Z'}` : 'Sort'}
+        placement="topRight"
+      >
+        <Button
+          type="text"
+          size="small"
+          icon={
+            <SortDescendingOutlined
+              style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+            />
+          }
+          style={{ flexShrink: 0, padding: '0 6px' }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </Tooltip>
+    </Dropdown>
+  );
+
   const sessionSearchBar =
     isPanel && activeSessions.length > 0 ? (
       <div style={{ paddingBottom: 12, paddingTop: 4 }}>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <Input
+            size="small"
             style={{ flex: 1 }}
             placeholder="Search sessions..."
             prefix={<SearchOutlined />}
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             allowClear
-            size="small"
           />
-          <Select
-            value={sort}
-            onChange={setSort}
-            size="small"
-            style={{ width: 96, flexShrink: 0 }}
-            disabled={!!searchQuery.trim()}
-            options={SESSION_SORT_OPTIONS}
-          />
+          <div
+            style={{
+              opacity: searchQuery.trim() ? 0 : 1,
+              pointerEvents: searchQuery.trim() ? 'none' : 'auto',
+              transition: 'opacity 0.15s ease',
+              display: 'flex',
+            }}
+          >
+            {sortButton}
+          </div>
         </div>
       </div>
     ) : null;

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -11,6 +11,7 @@ import {
   PlusOutlined,
   SearchOutlined,
   SettingOutlined,
+  SortAscendingOutlined,
   SortDescendingOutlined,
 } from '@ant-design/icons';
 import {
@@ -383,21 +384,20 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       }}
       trigger={['click']}
     >
-      <Tooltip
-        title={sort !== 'recent' ? `Sort: ${sort === 'oldest' ? 'Oldest first' : 'A–Z'}` : 'Sort'}
-        placement="topRight"
-      >
+      <Tooltip title="Sort" placement="topRight" open={sort !== 'recent' ? false : undefined}>
         <Button
           type="text"
           size="small"
           icon={
-            <SortDescendingOutlined
-              style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
-            />
+            sort === 'oldest'
+              ? <SortAscendingOutlined style={{ color: token.colorPrimary }} />
+              : <SortDescendingOutlined style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }} />
           }
-          style={{ flexShrink: 0, padding: '0 6px' }}
+          style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
           onClick={(e) => e.stopPropagation()}
-        />
+        >
+          {sort === 'oldest' ? 'Oldest' : sort === 'alpha' ? 'A–Z' : null}
+        </Button>
       </Tooltip>
     </Dropdown>
   );
@@ -601,7 +601,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       <div style={{ paddingBottom: 12, paddingTop: 4 }}>
         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <Input
-            size="small"
             style={{ flex: 1 }}
             placeholder="Search sessions..."
             prefix={<SearchOutlined />}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -609,21 +609,23 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             onChange={(e) => setSearchInput(e.target.value)}
             allowClear
           />
-          {searchQuery.trim() ? (
-            <Tooltip
-              title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher."
-              placement="topRight"
-            >
-              <Button
-                type="text"
-                size="small"
-                icon={<InfoCircleOutlined style={{ color: token.colorTextTertiary }} />}
-                style={{ flexShrink: 0, padding: '0 6px', color: token.colorTextTertiary }}
+          <div style={{ flexShrink: 0, minWidth: 96, display: 'flex', justifyContent: 'flex-end' }}>
+            {searchQuery.trim() ? (
+              <Tooltip
+                title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher."
+                placement="topRight"
               >
-                Relevance
-              </Button>
-            </Tooltip>
-          ) : sortButton}
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<InfoCircleOutlined style={{ color: token.colorTextTertiary }} />}
+                  style={{ padding: '0 6px', color: token.colorTextTertiary }}
+                >
+                  Relevance
+                </Button>
+              </Tooltip>
+            ) : sortButton}
+          </div>
         </div>
       </div>
     ) : null;

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -8,6 +8,7 @@ import {
   InboxOutlined,
   MessageOutlined,
   PlusOutlined,
+  SearchOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import {
@@ -16,6 +17,8 @@ import {
   Button,
   Collapse,
   ConfigProvider,
+  Empty,
+  Input,
   Space,
   Spin,
   Tooltip,
@@ -30,6 +33,7 @@ import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
+import { HighlightMatch, getMatchSnippet, scoreSession } from '../../utils/sessionSearch';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { ChannelPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
@@ -157,6 +161,13 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   });
   const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    const id = setTimeout(() => setSearchQuery(searchInput), 150);
+    return () => clearTimeout(id);
+  }, [searchInput]);
 
   const isPanel = mode === 'panel';
 
@@ -528,8 +539,111 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     </div>
   );
 
+  const sessionSearchBar =
+    isPanel && activeSessions.length > 0 ? (
+      <div style={{ paddingBottom: 12, paddingTop: 4 }}>
+        <Input
+          placeholder="Search sessions..."
+          prefix={<SearchOutlined />}
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          allowClear
+          size="small"
+        />
+      </div>
+    ) : null;
+
+  // Search results mode — flat list sorted by relevance (panel only)
+  if (isPanel && searchQuery.trim() && activeSessions.length > 0) {
+    const results = activeSessions
+      .map((s) => ({ session: s, score: scoreSession(s, searchQuery) }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score);
+
+    return (
+      <>
+        {sessionSearchBar}
+        {results.length === 0 ? (
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={`No sessions match "${searchQuery}"`}
+            style={{ padding: '16px 0' }}
+          />
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {results.map(({ session }) => {
+              const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
+              const titleLower = titleText.toLowerCase();
+              const qLower = searchQuery.trim().toLowerCase();
+              const titleMatches = titleLower.includes(qLower);
+              const descSnippet =
+                !titleMatches && session.description
+                  ? getMatchSnippet(session.description, searchQuery)
+                  : null;
+              const isActive = session.status === 'running' || session.status === 'stopping';
+
+              return (
+                <SessionItemWithActions
+                  key={session.session_id}
+                  sessionId={session.session_id}
+                  isArchiving={archivingSessionIds.has(session.session_id)}
+                  onArchive={handleArchiveSession}
+                  onSettings={
+                    onOpenSessionSettings
+                      ? (id, e) => {
+                          e.stopPropagation();
+                          onOpenSessionSettings(id);
+                        }
+                      : undefined
+                  }
+                >
+                  <div
+                    style={sessionRowStyle(session)}
+                    onClick={() => onSessionClick?.(session.session_id)}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
+                      {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+                      <SessionRelationshipIcon session={session} size={10} />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <Typography.Text
+                          strong
+                          style={{ fontSize: 13, display: 'block', ...getSessionTitleStyles(2) }}
+                        >
+                          <HighlightMatch text={titleText} query={searchQuery} />
+                        </Typography.Text>
+                        {descSnippet && (
+                          <Typography.Text
+                            type="secondary"
+                            style={{ fontSize: 11, fontStyle: 'italic', lineHeight: 1.4, display: 'block', marginTop: 2 }}
+                          >
+                            <HighlightMatch text={descSnippet} query={searchQuery} />
+                          </Typography.Text>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </SessionItemWithActions>
+              );
+            })}
+          </div>
+        )}
+        <ForkSpawnModal
+          open={forkSpawnModal.open}
+          action={forkSpawnModal.action}
+          session={forkSpawnModal.session}
+          currentUser={currentUserId ? userById.get(currentUserId) : undefined}
+          onConfirm={handleForkSpawnConfirm}
+          onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
+          client={client}
+          userById={userById}
+        />
+      </>
+    );
+  }
+
   return (
     <>
+      {sessionSearchBar}
       {activeSessions.length === 0 ? (
         <div
           style={{

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -633,6 +633,14 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     return (
       <>
         {sessionSearchBar}
+        {results.length > 0 && (
+          <Typography.Text
+            type="secondary"
+            style={{ fontSize: 11, padding: '2px 8px 4px', display: 'block' }}
+          >
+            {results.length} of {activeSessions.length} · by relevance
+          </Typography.Text>
+        )}
         {results.length === 0 ? (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '24px 16px', gap: 6 }}>
             <div style={{ width: 36, height: 36, borderRadius: '50%', background: token.colorFillTertiary, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 2 }}>
@@ -648,13 +656,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
             {results.map(({ session }) => {
               const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
-              const titleLower = titleText.toLowerCase();
-              const qLower = searchQuery.trim().toLowerCase();
-              const titleMatches = titleLower.includes(qLower);
-              const descSnippet =
-                !titleMatches && session.description
-                  ? getMatchSnippet(session.description, searchQuery)
-                  : null;
+              const descSnippet = session.description
+                ? (getMatchSnippet(session.description, searchQuery) ??
+                    (session.description.length > 80
+                      ? `${session.description.slice(0, 80).trimEnd()}…`
+                      : session.description))
+                : null;
               const isActive = session.status === 'running' || session.status === 'stopping';
 
               return (

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -6,6 +6,7 @@ import {
 import {
   CheckOutlined,
   ClockCircleOutlined,
+  InfoCircleOutlined,
   InboxOutlined,
   MessageOutlined,
   PlusOutlined,
@@ -384,21 +385,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       }}
       trigger={['click']}
     >
-      <Tooltip title="Sort" placement="topRight" open={sort !== 'recent' ? false : undefined}>
-        <Button
-          type="text"
-          size="small"
-          icon={
-            sort === 'oldest'
-              ? <SortAscendingOutlined style={{ color: token.colorPrimary }} />
-              : <SortDescendingOutlined style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }} />
-          }
-          style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {sort === 'oldest' ? 'Oldest' : sort === 'alpha' ? 'A–Z' : null}
-        </Button>
-      </Tooltip>
+      <Button
+        type="text"
+        size="small"
+        icon={sort === 'oldest' ? <SortAscendingOutlined /> : <SortDescendingOutlined />}
+        style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {sort === 'recent' ? 'Recent' : sort === 'oldest' ? 'Oldest' : 'A–Z'}
+      </Button>
     </Dropdown>
   );
 
@@ -608,16 +603,21 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             onChange={(e) => setSearchInput(e.target.value)}
             allowClear
           />
-          <div
-            style={{
-              opacity: searchQuery.trim() ? 0 : 1,
-              pointerEvents: searchQuery.trim() ? 'none' : 'auto',
-              transition: 'opacity 0.15s ease',
-              display: 'flex',
-            }}
-          >
-            {sortButton}
-          </div>
+          {searchQuery.trim() ? (
+            <Tooltip
+              title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher."
+              placement="topRight"
+            >
+              <Button
+                type="text"
+                size="small"
+                icon={<InfoCircleOutlined style={{ color: token.colorTextTertiary }} />}
+                style={{ flexShrink: 0, padding: '0 6px', color: token.colorTextTertiary }}
+              >
+                Relevance
+              </Button>
+            </Tooltip>
+          ) : sortButton}
         </div>
       </div>
     ) : null;
@@ -637,7 +637,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             type="secondary"
             style={{ fontSize: 11, padding: '2px 8px 4px', display: 'block' }}
           >
-            {results.length} of {activeSessions.length} · by relevance
+            {results.length} of {activeSessions.length}{' · '}
+            <Tooltip title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher.">
+              <span style={{ borderBottom: `1px dashed ${token.colorTextTertiary}`, cursor: 'help' }}>
+                by relevance
+              </span>
+            </Tooltip>
           </Typography.Text>
         )}
         {results.length === 0 ? (

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -36,7 +36,7 @@ import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
-import { HighlightMatch, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
+import { HighlightMatch, SESSION_SORT_STORAGE_KEY, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { ChannelPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
@@ -166,7 +166,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sort, setSort] = useLocalStorage<SessionSort>('agor:session-sort', 'recent');
+  const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
 
   useEffect(() => {
     const id = setTimeout(() => setSearchQuery(searchInput), 150);

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -356,6 +356,52 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     </ConfigProvider>
   );
 
+  const sortDropdownItems = [
+    {
+      key: 'recent',
+      label: 'Most recent',
+      icon: sort === 'recent' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+    },
+    {
+      key: 'oldest',
+      label: 'Oldest first',
+      icon: sort === 'oldest' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+    },
+    {
+      key: 'alpha',
+      label: 'A–Z',
+      icon: sort === 'alpha' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+    },
+  ];
+
+  const sortButton = (
+    <Dropdown
+      menu={{
+        items: sortDropdownItems,
+        onClick: ({ key }) => setSort(key as SessionSort),
+        selectedKeys: [sort],
+      }}
+      trigger={['click']}
+    >
+      <Tooltip
+        title={sort !== 'recent' ? `Sort: ${sort === 'oldest' ? 'Oldest first' : 'A–Z'}` : 'Sort'}
+        placement="topRight"
+      >
+        <Button
+          type="text"
+          size="small"
+          icon={
+            <SortDescendingOutlined
+              style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+            />
+          }
+          style={{ flexShrink: 0, padding: '0 6px' }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </Tooltip>
+    </Dropdown>
+  );
+
   const sessionListHeader = (
     <div
       style={{
@@ -548,52 +594,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         );
       })}
     </div>
-  );
-
-  const sortDropdownItems = [
-    {
-      key: 'recent',
-      label: 'Most recent',
-      icon: sort === 'recent' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
-    },
-    {
-      key: 'oldest',
-      label: 'Oldest first',
-      icon: sort === 'oldest' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
-    },
-    {
-      key: 'alpha',
-      label: 'A–Z',
-      icon: sort === 'alpha' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
-    },
-  ];
-
-  const sortButton = (
-    <Dropdown
-      menu={{
-        items: sortDropdownItems,
-        onClick: ({ key }) => setSort(key as SessionSort),
-        selectedKeys: [sort],
-      }}
-      trigger={['click']}
-    >
-      <Tooltip
-        title={sort !== 'recent' ? `Sort: ${sort === 'oldest' ? 'Oldest first' : 'A–Z'}` : 'Sort'}
-        placement="topRight"
-      >
-        <Button
-          type="text"
-          size="small"
-          icon={
-            <SortDescendingOutlined
-              style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
-            />
-          }
-          style={{ flexShrink: 0, padding: '0 6px' }}
-          onClick={(e) => e.stopPropagation()}
-        />
-      </Tooltip>
-    </Dropdown>
   );
 
   const sessionSearchBar =

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -389,7 +389,13 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         type="text"
         size="small"
         icon={sort === 'oldest' ? <SortAscendingOutlined /> : <SortDescendingOutlined />}
-        style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+        style={{
+          flexShrink: 0,
+          padding: '0 6px',
+          color: token.colorTextSecondary,
+          background: sort !== 'recent' ? token.colorFillSecondary : undefined,
+          borderRadius: token.borderRadiusSM,
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         {sort === 'recent' ? 'Recent' : sort === 'oldest' ? 'Oldest' : 'A–Z'}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -31,6 +31,7 @@ import {
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useThemedMessage } from '../../utils/message';
@@ -165,7 +166,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sort, setSort] = useState<SessionSort>('recent');
+  const [sort, setSort] = useLocalStorage<SessionSort>('agor:session-sort', 'recent');
 
   useEffect(() => {
     const id = setTimeout(() => setSearchQuery(searchInput), 150);

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -2,7 +2,7 @@ import type { Board, Branch, Repo, Session } from '@agor-live/client';
 import { SearchOutlined } from '@ant-design/icons';
 import { Badge, Drawer, Empty, Input, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
@@ -43,6 +43,136 @@ const getBadgeTone = (
 ): Exclude<StatusTone, 'success' | 'default'> | null => {
   const tone = getSessionStatusTone(status);
   return tone === 'success' || tone === 'default' ? null : tone;
+};
+
+const SCORE_WEIGHTS = {
+  TITLE_EXACT: 1000,
+  TITLE_STARTS: 800,
+  TITLE_PHRASE: 600,
+  TITLE_ALL_WORDS: 400,
+  TITLE_PARTIAL_WORDS: 200,
+  DESC_PHRASE: 120,
+  DESC_ALL_WORDS: 80,
+  DESC_PARTIAL_WORDS: 40,
+  TOOL_MATCH: 30,
+  STATUS_RUNNING: 20,
+  STATUS_AWAITING: 15,
+  RECENCY_MAX: 50,
+} as const;
+
+function scoreSession(session: Session, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+
+  const words = q.split(/\s+/).filter(Boolean);
+  const displayTitle = getSessionDisplayTitle(session, { includeAgentFallback: false }).toLowerCase();
+  const desc = (session.description ?? '').toLowerCase();
+  const tool = session.agentic_tool.toLowerCase();
+
+  let score = 0;
+
+  // Title scoring
+  if (displayTitle === q) {
+    score += SCORE_WEIGHTS.TITLE_EXACT;
+  } else if (displayTitle.startsWith(q)) {
+    score += SCORE_WEIGHTS.TITLE_STARTS;
+  } else if (displayTitle.includes(q)) {
+    score += SCORE_WEIGHTS.TITLE_PHRASE;
+  } else {
+    const matched = words.filter((w) => displayTitle.includes(w));
+    if (matched.length === words.length) {
+      score += SCORE_WEIGHTS.TITLE_ALL_WORDS;
+    } else if (matched.length > 0) {
+      score += Math.round(SCORE_WEIGHTS.TITLE_PARTIAL_WORDS * (matched.length / words.length));
+    }
+  }
+
+  // Description scoring (skip if description is empty or same as title)
+  if (desc && desc !== displayTitle) {
+    if (desc.includes(q)) {
+      score += SCORE_WEIGHTS.DESC_PHRASE;
+    } else {
+      const matched = words.filter((w) => desc.includes(w));
+      if (matched.length === words.length) {
+        score += SCORE_WEIGHTS.DESC_ALL_WORDS;
+      } else if (matched.length > 0) {
+        score += Math.round(SCORE_WEIGHTS.DESC_PARTIAL_WORDS * (matched.length / words.length));
+      }
+    }
+  }
+
+  // Tool match
+  if (words.some((w) => tool.includes(w))) {
+    score += SCORE_WEIGHTS.TOOL_MATCH;
+  }
+
+  // Recency bonus — only added when there is already a match (score > 0)
+  if (score > 0) {
+    const ageDays = (Date.now() - new Date(session.last_updated).getTime()) / 86_400_000;
+    score += Math.round(SCORE_WEIGHTS.RECENCY_MAX * Math.exp(-ageDays));
+  }
+
+  // Status bonus for actively running sessions
+  if (session.status === 'running') score += SCORE_WEIGHTS.STATUS_RUNNING;
+  else if (session.status === 'awaiting_permission') score += SCORE_WEIGHTS.STATUS_AWAITING;
+
+  return score;
+}
+
+function getMatchSnippet(text: string, query: string, contextLen = 60): string | null {
+  if (!text || !query.trim()) return null;
+
+  const q = query.trim().toLowerCase();
+  const lower = text.toLowerCase();
+
+  let pos = lower.indexOf(q);
+  if (pos === -1) {
+    for (const w of q.split(/\s+/).filter(Boolean)) {
+      const idx = lower.indexOf(w);
+      if (idx !== -1) { pos = idx; break; }
+    }
+  }
+  if (pos === -1) return null;
+
+  const start = Math.max(0, pos - contextLen);
+  const end = Math.min(text.length, pos + Math.max(q.length, 10) + contextLen);
+  let snippet = text.slice(start, end);
+  if (start > 0) snippet = '…' + snippet;
+  if (end < text.length) snippet = snippet + '…';
+  return snippet;
+}
+
+const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text, query }) => {
+  const { token } = theme.useToken();
+  if (!query.trim() || !text) return <>{text}</>;
+
+  const escaped = query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(re);
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? ( // odd indices are matches from split with capture group
+          <mark
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional marks in a static string split
+            key={i}
+            style={{
+              background: token.colorWarningBg,
+              color: 'inherit',
+              padding: '0 1px',
+              borderRadius: 2,
+            }}
+          >
+            {part}
+          </mark>
+        ) : (
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional text in a static string split
+          <span key={i}>{part}</span>
+        )
+      )}
+    </>
+  );
 };
 
 export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
@@ -91,7 +221,14 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
   onAfterSessionClick,
 }) => {
   const { token } = theme.useToken();
+  const [inputValue, setInputValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+
+  // Debounce input → searchQuery by 150 ms
+  useEffect(() => {
+    const id = setTimeout(() => setSearchQuery(inputValue), 150);
+    return () => clearTimeout(id);
+  }, [inputValue]);
 
   // Filter sessions by current board (branch-centric model)
   const boardSessions = useMemo(() => {
@@ -109,13 +246,15 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
       .sort((a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime());
   }, [sessionsByBranch, branchById, currentBoardId]);
 
-  // Filter sessions by search query
-  const filteredSessions = boardSessions.filter(
-    (session) =>
-      session.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      session.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      session.agentic_tool.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const displaySessions = useMemo(() => {
+    if (!searchQuery.trim()) return boardSessions; // recency order, no filter
+
+    return boardSessions
+      .map((s) => ({ session: s, score: scoreSession(s, searchQuery) }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map(({ session }) => session);
+  }, [boardSessions, searchQuery]);
 
   return (
     <div style={{ height: '100%', position: 'relative', overflow: 'hidden' }}>
@@ -129,22 +268,26 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
         <Input
           placeholder="Search sessions..."
           prefix={<SearchOutlined />}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
           allowClear
         />
       </div>
 
       {/* Session List */}
       <div style={{ padding: '8px 0' }}>
-        {filteredSessions.length === 0 ? (
+        {displaySessions.length === 0 ? (
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="No sessions in this board"
+            description={
+              searchQuery.trim()
+                ? `No sessions match "${searchQuery}"`
+                : 'No sessions in this board'
+            }
             style={{ padding: '24px 0' }}
           />
         ) : (
-          filteredSessions.map((session) => {
+          displaySessions.map((session) => {
             const branch = session.branch_id ? branchById.get(session.branch_id) : undefined;
             const repo = branch ? repoById.get(branch.repo_id) : undefined;
 
@@ -167,78 +310,107 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
                   onAfterSessionClick?.();
                 }}
               >
-                {/* Line 1: tool icon (with corner status badge) · title · genealogy */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    gap: 8,
-                    minWidth: 0,
-                  }}
-                >
-                  <span style={{ flexShrink: 0, display: 'inline-flex' }}>
-                    {(() => {
-                      const tone = getBadgeTone(session.status);
-                      const icon = <ToolIcon tool={session.agentic_tool} size={18} />;
-                      return tone ? (
-                        <Badge dot status={tone} offset={[-3, 3]}>
-                          {icon}
-                        </Badge>
-                      ) : (
-                        icon
-                      );
-                    })()}
-                  </span>
-                  {(() => {
-                    const titleText = getSessionDisplayTitle(session, {
-                      includeAgentFallback: true,
-                    });
-                    return (
-                      <Typography.Text
-                        ellipsis={{ tooltip: titleText }}
-                        style={{ flex: 1, minWidth: 0 }}
-                      >
-                        {titleText}
-                      </Typography.Text>
-                    );
-                  })()}
-                  <SessionRelationshipIcon session={session} />
-                </div>
+                {(() => {
+                  const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
+                  const titleLower = titleText.toLowerCase();
+                  const qLower = searchQuery.trim().toLowerCase();
+                  const titleMatches = searchQuery.trim() && titleLower.includes(qLower);
+                  const descSnippet =
+                    searchQuery.trim() && !titleMatches && session.description
+                      ? getMatchSnippet(session.description, searchQuery)
+                      : null;
 
-                {/* Line 2: repo+branch pill · relative timestamp */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    gap: 8,
-                    marginTop: 6,
-                    marginLeft: 26, // align under title (icon 18 + gap 8)
-                    minWidth: 0,
-                  }}
-                >
-                  <div style={{ minWidth: 0, overflow: 'hidden' }}>
-                    {repo && branch ? (
-                      <RepoPill repoName={repo.slug} branchName={branch.name} color="default" />
-                    ) : branch ? (
-                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                        🌳 {branch.name}
-                      </Typography.Text>
-                    ) : (
-                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                        No branch
-                      </Typography.Text>
-                    )}
-                  </div>
-                  <Tooltip title={formatTimestampWithRelative(session.last_updated)}>
-                    <Typography.Text
-                      type="secondary"
-                      style={{ fontSize: 11, whiteSpace: 'nowrap', flexShrink: 0 }}
-                    >
-                      {formatRelativeTime(session.last_updated)}
-                    </Typography.Text>
-                  </Tooltip>
-                </div>
+                  return (
+                    <>
+                      {/* Line 1: tool icon + title + genealogy icon */}
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'flex-start',
+                          gap: 8,
+                          minWidth: 0,
+                        }}
+                      >
+                        <span style={{ flexShrink: 0, display: 'inline-flex' }}>
+                          {(() => {
+                            const tone = getBadgeTone(session.status);
+                            const icon = <ToolIcon tool={session.agentic_tool} size={18} />;
+                            return tone ? (
+                              <Badge dot status={tone} offset={[-3, 3]}>
+                                {icon}
+                              </Badge>
+                            ) : (
+                              icon
+                            );
+                          })()}
+                        </span>
+                        <Typography.Text
+                          ellipsis={{ tooltip: titleText }}
+                          style={{ flex: 1, minWidth: 0 }}
+                        >
+                          {searchQuery.trim() ? (
+                            <HighlightMatch text={titleText} query={searchQuery} />
+                          ) : (
+                            titleText
+                          )}
+                        </Typography.Text>
+                        <SessionRelationshipIcon session={session} />
+                      </div>
+
+                      {/* Description snippet — only shown when match is in description, not in title */}
+                      {descSnippet && (
+                        <Typography.Text
+                          type="secondary"
+                          style={{
+                            fontSize: 11,
+                            display: 'block',
+                            marginTop: 3,
+                            marginLeft: 26, // aligns under title text (icon 18px + gap 8px)
+                            lineHeight: 1.4,
+                            fontStyle: 'italic',
+                          }}
+                        >
+                          <HighlightMatch text={descSnippet} query={searchQuery} />
+                        </Typography.Text>
+                      )}
+
+                      {/* Line 2: repo+branch pill · relative timestamp */}
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: 8,
+                          marginTop: 6,
+                          marginLeft: 26, // align under title (icon 18 + gap 8)
+                          minWidth: 0,
+                        }}
+                      >
+                        <div style={{ minWidth: 0, overflow: 'hidden' }}>
+                          {repo && branch ? (
+                            <RepoPill repoName={repo.slug} branchName={branch.name} color="default" />
+                          ) : branch ? (
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              🌳 {branch.name}
+                            </Typography.Text>
+                          ) : (
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              No branch
+                            </Typography.Text>
+                          )}
+                        </div>
+                        <Tooltip title={formatTimestampWithRelative(session.last_updated)}>
+                          <Typography.Text
+                            type="secondary"
+                            style={{ fontSize: 11, whiteSpace: 'nowrap', flexShrink: 0 }}
+                          >
+                            {formatRelativeTime(session.last_updated)}
+                          </Typography.Text>
+                        </Tooltip>
+                      </div>
+                    </>
+                  );
+                })()}
               </div>
             );
           })
@@ -259,7 +431,10 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
           }}
         >
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            {filteredSessions.length} of {boardSessions.length} sessions
+            {searchQuery.trim()
+              ? `${displaySessions.length} result${displaySessions.length !== 1 ? 's' : ''} · sorted by relevance`
+              : `${boardSessions.length} session${boardSessions.length !== 1 ? 's' : ''}`
+            }
             {board.description && ` • ${board.description}`}
           </Typography.Text>
         </div>

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -1,12 +1,12 @@
 import type { Board, Branch, Repo, Session } from '@agor-live/client';
 import { SearchOutlined } from '@ant-design/icons';
-import { Badge, Drawer, Empty, Input, Tooltip, Typography, theme } from 'antd';
+import { Badge, Drawer, Empty, Input, Select, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
-import { HighlightMatch, getMatchSnippet, scoreSession } from '../../utils/sessionSearch';
+import { HighlightMatch, SESSION_SORT_OPTIONS, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
 import { RepoPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
@@ -94,6 +94,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
   const { token } = theme.useToken();
   const [inputValue, setInputValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+  const [sort, setSort] = useState<SessionSort>('recent');
 
   // Debounce input → searchQuery by 150 ms
   useEffect(() => {
@@ -101,48 +102,54 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
     return () => clearTimeout(id);
   }, [inputValue]);
 
-  // Filter sessions by current board (branch-centric model)
+  // Collect sessions for current board (unsorted — sort applied separately)
   const boardSessions = useMemo(() => {
-    // Get branch IDs for this board by iterating the Map
     const boardBranchIds: string[] = [];
     for (const branch of branchById.values()) {
       if (branch.board_id === currentBoardId) {
         boardBranchIds.push(branch.branch_id);
       }
     }
-
-    // Get sessions for these branches using O(1) Map lookups, sorted by last_updated desc
-    return boardBranchIds
-      .flatMap((branchId) => sessionsByBranch.get(branchId) || [])
-      .sort((a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime());
+    return boardBranchIds.flatMap((branchId) => sessionsByBranch.get(branchId) || []);
   }, [sessionsByBranch, branchById, currentBoardId]);
 
   const displaySessions = useMemo(() => {
-    if (!searchQuery.trim()) return boardSessions; // recency order, no filter
+    if (!searchQuery.trim()) return sortSessions(boardSessions, sort);
 
     return boardSessions
       .map((s) => ({ session: s, score: scoreSession(s, searchQuery) }))
       .filter(({ score }) => score > 0)
       .sort((a, b) => b.score - a.score)
       .map(({ session }) => session);
-  }, [boardSessions, searchQuery]);
+  }, [boardSessions, searchQuery, sort]);
 
   return (
     <div style={{ height: '100%', position: 'relative', overflow: 'hidden' }}>
-      {/* Search Bar */}
+      {/* Search Bar + Sort */}
       <div
         style={{
           padding: '16px 24px',
           borderBottom: `1px solid ${token.colorBorder}`,
         }}
       >
-        <Input
-          placeholder="Search sessions..."
-          prefix={<SearchOutlined />}
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          allowClear
-        />
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <Input
+            style={{ flex: 1 }}
+            placeholder="Search sessions..."
+            prefix={<SearchOutlined />}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            allowClear
+          />
+          <Select
+            value={sort}
+            onChange={setSort}
+            size="small"
+            style={{ width: 96, flexShrink: 0 }}
+            disabled={!!searchQuery.trim()}
+            options={SESSION_SORT_OPTIONS}
+          />
+        </div>
       </div>
 
       {/* Session List */}
@@ -304,7 +311,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
             {searchQuery.trim()
               ? `${displaySessions.length} result${displaySessions.length !== 1 ? 's' : ''} · sorted by relevance`
-              : `${boardSessions.length} session${boardSessions.length !== 1 ? 's' : ''}`
+              : `${displaySessions.length} session${displaySessions.length !== 1 ? 's' : ''}${sort !== 'recent' ? ` · ${sort === 'alpha' ? 'A–Z' : 'oldest first'}` : ''}`
             }
             {board.description && ` • ${board.description}`}
           </Typography.Text>

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -1,12 +1,12 @@
 import type { Board, Branch, Repo, Session } from '@agor-live/client';
-import { SearchOutlined } from '@ant-design/icons';
-import { Badge, Drawer, Empty, Input, Select, Tooltip, Typography, theme } from 'antd';
+import { CheckOutlined, SearchOutlined, SortDescendingOutlined } from '@ant-design/icons';
+import { Badge, Button, Drawer, Dropdown, Empty, Input, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
-import { HighlightMatch, SESSION_SORT_OPTIONS, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
+import { HighlightMatch, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
 import { RepoPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
@@ -132,7 +132,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
           borderBottom: `1px solid ${token.colorBorder}`,
         }}
       >
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
           <Input
             style={{ flex: 1 }}
             placeholder="Search sessions..."
@@ -141,14 +141,55 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
             onChange={(e) => setInputValue(e.target.value)}
             allowClear
           />
-          <Select
-            value={sort}
-            onChange={setSort}
-            size="small"
-            style={{ width: 96, flexShrink: 0 }}
-            disabled={!!searchQuery.trim()}
-            options={SESSION_SORT_OPTIONS}
-          />
+          <div
+            style={{
+              opacity: searchQuery.trim() ? 0 : 1,
+              pointerEvents: searchQuery.trim() ? 'none' : 'auto',
+              transition: 'opacity 0.15s ease',
+              display: 'flex',
+            }}
+          >
+            <Dropdown
+              menu={{
+                items: [
+                  {
+                    key: 'recent',
+                    label: 'Most recent',
+                    icon: sort === 'recent' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+                  },
+                  {
+                    key: 'oldest',
+                    label: 'Oldest first',
+                    icon: sort === 'oldest' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+                  },
+                  {
+                    key: 'alpha',
+                    label: 'A–Z',
+                    icon: sort === 'alpha' ? <CheckOutlined /> : <span style={{ width: 12, display: 'inline-block' }} />,
+                  },
+                ],
+                onClick: ({ key }) => setSort(key as SessionSort),
+                selectedKeys: [sort],
+              }}
+              trigger={['click']}
+            >
+              <Tooltip
+                title={sort !== 'recent' ? `Sort: ${sort === 'oldest' ? 'Oldest first' : 'A–Z'}` : 'Sort'}
+                placement="topRight"
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  icon={
+                    <SortDescendingOutlined
+                      style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+                    />
+                  }
+                  style={{ flexShrink: 0, padding: '0 6px' }}
+                />
+              </Tooltip>
+            </Dropdown>
+          </div>
         </div>
       </div>
 
@@ -310,8 +351,8 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
         >
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
             {searchQuery.trim()
-              ? `${displaySessions.length} result${displaySessions.length !== 1 ? 's' : ''} · sorted by relevance`
-              : `${displaySessions.length} session${displaySessions.length !== 1 ? 's' : ''}${sort !== 'recent' ? ` · ${sort === 'alpha' ? 'A–Z' : 'oldest first'}` : ''}`
+              ? `${displaySessions.length} result${displaySessions.length !== 1 ? 's' : ''} · by relevance`
+              : `${displaySessions.length} session${displaySessions.length !== 1 ? 's' : ''}`
             }
             {board.description && ` • ${board.description}`}
           </Typography.Text>

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -239,13 +239,12 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
               >
                 {(() => {
                   const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
-                  const titleLower = titleText.toLowerCase();
-                  const qLower = searchQuery.trim().toLowerCase();
-                  const titleMatches = searchQuery.trim() && titleLower.includes(qLower);
-                  const descSnippet =
-                    searchQuery.trim() && !titleMatches && session.description
-                      ? getMatchSnippet(session.description, searchQuery)
-                      : null;
+                  const descSnippet = searchQuery.trim() && session.description
+                    ? (getMatchSnippet(session.description, searchQuery) ??
+                        (session.description.length > 80
+                          ? `${session.description.slice(0, 80).trimEnd()}…`
+                          : session.description))
+                    : null;
 
                   return (
                     <>
@@ -359,8 +358,8 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
         >
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
             {searchQuery.trim()
-              ? `${displaySessions.length} result${displaySessions.length !== 1 ? 's' : ''} · by relevance`
-              : `${displaySessions.length} session${displaySessions.length !== 1 ? 's' : ''}`
+              ? `${displaySessions.length} of ${boardSessions.length} · by relevance`
+              : `${boardSessions.length} session${boardSessions.length !== 1 ? 's' : ''}`
             }
             {board.description && ` • ${board.description}`}
           </Typography.Text>

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -3,6 +3,7 @@ import { CheckOutlined, SearchOutlined, SortDescendingOutlined } from '@ant-desi
 import { Badge, Button, Drawer, Dropdown, Input, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
@@ -94,7 +95,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
   const { token } = theme.useToken();
   const [inputValue, setInputValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sort, setSort] = useState<SessionSort>('recent');
+  const [sort, setSort] = useLocalStorage<SessionSort>('agor:session-sort', 'recent');
 
   // Debounce input → searchQuery by 150 ms
   useEffect(() => {

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -1,6 +1,6 @@
 import type { Board, Branch, Repo, Session } from '@agor-live/client';
 import { CheckOutlined, SearchOutlined, SortDescendingOutlined } from '@ant-design/icons';
-import { Badge, Button, Drawer, Dropdown, Empty, Input, Tooltip, Typography, theme } from 'antd';
+import { Badge, Button, Drawer, Dropdown, Input, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
@@ -196,15 +196,22 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
       {/* Session List */}
       <div style={{ padding: '8px 0' }}>
         {displaySessions.length === 0 ? (
-          <Empty
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description={
-              searchQuery.trim()
-                ? `No sessions match "${searchQuery}"`
-                : 'No sessions in this board'
-            }
-            style={{ padding: '24px 0' }}
-          />
+          searchQuery.trim() ? (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '28px 16px', gap: 6 }}>
+              <div style={{ width: 36, height: 36, borderRadius: '50%', background: token.colorFillTertiary, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 2 }}>
+                <SearchOutlined style={{ fontSize: 16, color: token.colorTextTertiary }} />
+              </div>
+              <Typography.Text strong style={{ fontSize: 13 }}>No results</Typography.Text>
+              <Typography.Text type="secondary" style={{ fontSize: 12, textAlign: 'center', lineHeight: 1.5, maxWidth: 200 }}>
+                Nothing matched{' '}
+                <Typography.Text code style={{ fontSize: 11 }}>{searchQuery.trim()}</Typography.Text>
+              </Typography.Text>
+            </div>
+          ) : (
+            <Typography.Text type="secondary" style={{ display: 'block', textAlign: 'center', padding: '24px 0', fontSize: 12 }}>
+              No sessions in this board
+            </Typography.Text>
+          )
         ) : (
           displaySessions.map((session) => {
             const branch = session.branch_id ? branchById.get(session.branch_id) : undefined;

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -189,7 +189,13 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
                     ? <SortAscendingOutlined />
                     : <SortDescendingOutlined />
                 }
-                style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+                style={{
+                  flexShrink: 0,
+                  padding: '0 6px',
+                  color: token.colorTextSecondary,
+                  background: sort !== 'recent' ? token.colorFillSecondary : undefined,
+                  borderRadius: token.borderRadiusSM,
+                }}
               >
                 {sort === 'recent' ? 'Recent' : sort === 'oldest' ? 'Oldest' : 'A–Z'}
               </Button>

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -142,21 +142,22 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
             onChange={(e) => setInputValue(e.target.value)}
             allowClear
           />
-          {searchQuery.trim() ? (
-            <Tooltip
-              title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher."
-              placement="topRight"
-            >
-              <Button
-                type="text"
-                size="small"
-                icon={<InfoCircleOutlined style={{ color: token.colorTextTertiary }} />}
-                style={{ flexShrink: 0, padding: '0 6px', color: token.colorTextTertiary }}
+          <div style={{ flexShrink: 0, minWidth: 96, display: 'flex', justifyContent: 'flex-end' }}>
+            {searchQuery.trim() ? (
+              <Tooltip
+                title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher."
+                placement="topRight"
               >
-                Relevance
-              </Button>
-            </Tooltip>
-          ) : (
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<InfoCircleOutlined style={{ color: token.colorTextTertiary }} />}
+                  style={{ padding: '0 6px', color: token.colorTextTertiary }}
+                >
+                  Relevance
+                </Button>
+              </Tooltip>
+            ) : (
             <Dropdown
               menu={{
                 items: [
@@ -200,7 +201,8 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
                 {sort === 'recent' ? 'Recent' : sort === 'oldest' ? 'Oldest' : 'A–Z'}
               </Button>
             </Dropdown>
-          )}
+            )}
+          </div>
         </div>
       </div>
 

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -7,7 +7,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
-import { HighlightMatch, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
+import { HighlightMatch, SESSION_SORT_STORAGE_KEY, type SessionSort, getMatchSnippet, scoreSession, sortSessions } from '../../utils/sessionSearch';
 import { RepoPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
@@ -95,7 +95,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
   const { token } = theme.useToken();
   const [inputValue, setInputValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [sort, setSort] = useLocalStorage<SessionSort>('agor:session-sort', 'recent');
+  const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
 
   // Debounce input → searchQuery by 150 ms
   useEffect(() => {

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
+import { HighlightMatch, getMatchSnippet, scoreSession } from '../../utils/sessionSearch';
 import { RepoPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
@@ -43,136 +44,6 @@ const getBadgeTone = (
 ): Exclude<StatusTone, 'success' | 'default'> | null => {
   const tone = getSessionStatusTone(status);
   return tone === 'success' || tone === 'default' ? null : tone;
-};
-
-const SCORE_WEIGHTS = {
-  TITLE_EXACT: 1000,
-  TITLE_STARTS: 800,
-  TITLE_PHRASE: 600,
-  TITLE_ALL_WORDS: 400,
-  TITLE_PARTIAL_WORDS: 200,
-  DESC_PHRASE: 120,
-  DESC_ALL_WORDS: 80,
-  DESC_PARTIAL_WORDS: 40,
-  TOOL_MATCH: 30,
-  STATUS_RUNNING: 20,
-  STATUS_AWAITING: 15,
-  RECENCY_MAX: 50,
-} as const;
-
-function scoreSession(session: Session, query: string): number {
-  const q = query.trim().toLowerCase();
-  if (!q) return 0;
-
-  const words = q.split(/\s+/).filter(Boolean);
-  const displayTitle = getSessionDisplayTitle(session, { includeAgentFallback: false }).toLowerCase();
-  const desc = (session.description ?? '').toLowerCase();
-  const tool = session.agentic_tool.toLowerCase();
-
-  let score = 0;
-
-  // Title scoring
-  if (displayTitle === q) {
-    score += SCORE_WEIGHTS.TITLE_EXACT;
-  } else if (displayTitle.startsWith(q)) {
-    score += SCORE_WEIGHTS.TITLE_STARTS;
-  } else if (displayTitle.includes(q)) {
-    score += SCORE_WEIGHTS.TITLE_PHRASE;
-  } else {
-    const matched = words.filter((w) => displayTitle.includes(w));
-    if (matched.length === words.length) {
-      score += SCORE_WEIGHTS.TITLE_ALL_WORDS;
-    } else if (matched.length > 0) {
-      score += Math.round(SCORE_WEIGHTS.TITLE_PARTIAL_WORDS * (matched.length / words.length));
-    }
-  }
-
-  // Description scoring (skip if description is empty or same as title)
-  if (desc && desc !== displayTitle) {
-    if (desc.includes(q)) {
-      score += SCORE_WEIGHTS.DESC_PHRASE;
-    } else {
-      const matched = words.filter((w) => desc.includes(w));
-      if (matched.length === words.length) {
-        score += SCORE_WEIGHTS.DESC_ALL_WORDS;
-      } else if (matched.length > 0) {
-        score += Math.round(SCORE_WEIGHTS.DESC_PARTIAL_WORDS * (matched.length / words.length));
-      }
-    }
-  }
-
-  // Tool match
-  if (words.some((w) => tool.includes(w))) {
-    score += SCORE_WEIGHTS.TOOL_MATCH;
-  }
-
-  // Recency bonus — only added when there is already a match (score > 0)
-  if (score > 0) {
-    const ageDays = (Date.now() - new Date(session.last_updated).getTime()) / 86_400_000;
-    score += Math.round(SCORE_WEIGHTS.RECENCY_MAX * Math.exp(-ageDays));
-  }
-
-  // Status bonus for actively running sessions
-  if (session.status === 'running') score += SCORE_WEIGHTS.STATUS_RUNNING;
-  else if (session.status === 'awaiting_permission') score += SCORE_WEIGHTS.STATUS_AWAITING;
-
-  return score;
-}
-
-function getMatchSnippet(text: string, query: string, contextLen = 60): string | null {
-  if (!text || !query.trim()) return null;
-
-  const q = query.trim().toLowerCase();
-  const lower = text.toLowerCase();
-
-  let pos = lower.indexOf(q);
-  if (pos === -1) {
-    for (const w of q.split(/\s+/).filter(Boolean)) {
-      const idx = lower.indexOf(w);
-      if (idx !== -1) { pos = idx; break; }
-    }
-  }
-  if (pos === -1) return null;
-
-  const start = Math.max(0, pos - contextLen);
-  const end = Math.min(text.length, pos + Math.max(q.length, 10) + contextLen);
-  let snippet = text.slice(start, end);
-  if (start > 0) snippet = '…' + snippet;
-  if (end < text.length) snippet = snippet + '…';
-  return snippet;
-}
-
-const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text, query }) => {
-  const { token } = theme.useToken();
-  if (!query.trim() || !text) return <>{text}</>;
-
-  const escaped = query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const re = new RegExp(`(${escaped})`, 'gi');
-  const parts = text.split(re);
-
-  return (
-    <>
-      {parts.map((part, i) =>
-        i % 2 === 1 ? ( // odd indices are matches from split with capture group
-          <mark
-            // biome-ignore lint/suspicious/noArrayIndexKey: positional marks in a static string split
-            key={i}
-            style={{
-              background: token.colorWarningBg,
-              color: 'inherit',
-              padding: '0 1px',
-              borderRadius: 2,
-            }}
-          >
-            {part}
-          </mark>
-        ) : (
-          // biome-ignore lint/suspicious/noArrayIndexKey: positional text in a static string split
-          <span key={i}>{part}</span>
-        )
-      )}
-    </>
-  );
 };
 
 export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -1,5 +1,5 @@
 import type { Board, Branch, Repo, Session } from '@agor-live/client';
-import { CheckOutlined, SearchOutlined, SortAscendingOutlined, SortDescendingOutlined } from '@ant-design/icons';
+import { CheckOutlined, InfoCircleOutlined, SearchOutlined, SortAscendingOutlined, SortDescendingOutlined } from '@ant-design/icons';
 import { Badge, Button, Drawer, Dropdown, Input, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
@@ -142,14 +142,21 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
             onChange={(e) => setInputValue(e.target.value)}
             allowClear
           />
-          <div
-            style={{
-              opacity: searchQuery.trim() ? 0 : 1,
-              pointerEvents: searchQuery.trim() ? 'none' : 'auto',
-              transition: 'opacity 0.15s ease',
-              display: 'flex',
-            }}
-          >
+          {searchQuery.trim() ? (
+            <Tooltip
+              title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher."
+              placement="topRight"
+            >
+              <Button
+                type="text"
+                size="small"
+                icon={<InfoCircleOutlined style={{ color: token.colorTextTertiary }} />}
+                style={{ flexShrink: 0, padding: '0 6px', color: token.colorTextTertiary }}
+              >
+                Relevance
+              </Button>
+            </Tooltip>
+          ) : (
             <Dropdown
               menu={{
                 items: [
@@ -174,22 +181,20 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
               }}
               trigger={['click']}
             >
-              <Tooltip title="Sort" placement="topRight" open={sort !== 'recent' ? false : undefined}>
-                <Button
-                  type="text"
-                  size="small"
-                  icon={
-                    sort === 'oldest'
-                      ? <SortAscendingOutlined style={{ color: token.colorPrimary }} />
-                      : <SortDescendingOutlined style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }} />
-                  }
-                  style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
-                >
-                  {sort === 'oldest' ? 'Oldest' : sort === 'alpha' ? 'A–Z' : null}
-                </Button>
-              </Tooltip>
+              <Button
+                type="text"
+                size="small"
+                icon={
+                  sort === 'oldest'
+                    ? <SortAscendingOutlined />
+                    : <SortDescendingOutlined />
+                }
+                style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+              >
+                {sort === 'recent' ? 'Recent' : sort === 'oldest' ? 'Oldest' : 'A–Z'}
+              </Button>
             </Dropdown>
-          </div>
+          )}
         </div>
       </div>
 
@@ -356,11 +361,19 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
           }}
         >
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            {searchQuery.trim()
-              ? `${displaySessions.length} of ${boardSessions.length} · by relevance`
-              : `${boardSessions.length} session${boardSessions.length !== 1 ? 's' : ''}`
-            }
-            {board.description && ` • ${board.description}`}
+            {searchQuery.trim() ? (
+              <>
+                {displaySessions.length} of {boardSessions.length}{' · '}
+                <Tooltip title="Matched by: exact title > title prefix > keywords > description. Active and recently used sessions rank higher.">
+                  <span style={{ borderBottom: `1px dashed ${token.colorTextTertiary}`, cursor: 'help' }}>
+                    by relevance
+                  </span>
+                </Tooltip>
+                {board.description && ` • ${board.description}`}
+              </>
+            ) : (
+              `${boardSessions.length} session${boardSessions.length !== 1 ? 's' : ''}${board.description ? ` • ${board.description}` : ''}`
+            )}
           </Typography.Text>
         </div>
       )}

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -1,5 +1,5 @@
 import type { Board, Branch, Repo, Session } from '@agor-live/client';
-import { CheckOutlined, SearchOutlined, SortDescendingOutlined } from '@ant-design/icons';
+import { CheckOutlined, SearchOutlined, SortAscendingOutlined, SortDescendingOutlined } from '@ant-design/icons';
 import { Badge, Button, Drawer, Dropdown, Input, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
@@ -174,20 +174,19 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
               }}
               trigger={['click']}
             >
-              <Tooltip
-                title={sort !== 'recent' ? `Sort: ${sort === 'oldest' ? 'Oldest first' : 'A–Z'}` : 'Sort'}
-                placement="topRight"
-              >
+              <Tooltip title="Sort" placement="topRight" open={sort !== 'recent' ? false : undefined}>
                 <Button
                   type="text"
                   size="small"
                   icon={
-                    <SortDescendingOutlined
-                      style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
-                    />
+                    sort === 'oldest'
+                      ? <SortAscendingOutlined style={{ color: token.colorPrimary }} />
+                      : <SortDescendingOutlined style={{ color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }} />
                   }
-                  style={{ flexShrink: 0, padding: '0 6px' }}
-                />
+                  style={{ flexShrink: 0, padding: '0 6px', color: sort !== 'recent' ? token.colorPrimary : token.colorTextTertiary }}
+                >
+                  {sort === 'oldest' ? 'Oldest' : sort === 'alpha' ? 'A–Z' : null}
+                </Button>
               </Tooltip>
             </Dropdown>
           </div>

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -1,0 +1,134 @@
+import type { Session } from '@agor-live/client';
+import { theme } from 'antd';
+import type React from 'react';
+import { getSessionDisplayTitle } from './sessionTitle';
+
+const SCORE_WEIGHTS = {
+  TITLE_EXACT: 1000,
+  TITLE_STARTS: 800,
+  TITLE_PHRASE: 600,
+  TITLE_ALL_WORDS: 400,
+  TITLE_PARTIAL_WORDS: 200,
+  DESC_PHRASE: 120,
+  DESC_ALL_WORDS: 80,
+  DESC_PARTIAL_WORDS: 40,
+  TOOL_MATCH: 30,
+  STATUS_RUNNING: 20,
+  STATUS_AWAITING: 15,
+  RECENCY_MAX: 50,
+} as const;
+
+export function scoreSession(session: Session, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+
+  const words = q.split(/\s+/).filter(Boolean);
+  const displayTitle = getSessionDisplayTitle(session, { includeAgentFallback: false }).toLowerCase();
+  const desc = (session.description ?? '').toLowerCase();
+  const tool = session.agentic_tool.toLowerCase();
+
+  let score = 0;
+
+  // Title scoring
+  if (displayTitle === q) {
+    score += SCORE_WEIGHTS.TITLE_EXACT;
+  } else if (displayTitle.startsWith(q)) {
+    score += SCORE_WEIGHTS.TITLE_STARTS;
+  } else if (displayTitle.includes(q)) {
+    score += SCORE_WEIGHTS.TITLE_PHRASE;
+  } else {
+    const matched = words.filter((w) => displayTitle.includes(w));
+    if (matched.length === words.length) {
+      score += SCORE_WEIGHTS.TITLE_ALL_WORDS;
+    } else if (matched.length > 0) {
+      score += Math.round(SCORE_WEIGHTS.TITLE_PARTIAL_WORDS * (matched.length / words.length));
+    }
+  }
+
+  // Description scoring (skip if description is empty or same as title)
+  if (desc && desc !== displayTitle) {
+    if (desc.includes(q)) {
+      score += SCORE_WEIGHTS.DESC_PHRASE;
+    } else {
+      const matched = words.filter((w) => desc.includes(w));
+      if (matched.length === words.length) {
+        score += SCORE_WEIGHTS.DESC_ALL_WORDS;
+      } else if (matched.length > 0) {
+        score += Math.round(SCORE_WEIGHTS.DESC_PARTIAL_WORDS * (matched.length / words.length));
+      }
+    }
+  }
+
+  // Tool match
+  if (words.some((w) => tool.includes(w))) {
+    score += SCORE_WEIGHTS.TOOL_MATCH;
+  }
+
+  // Recency bonus — only added when there is already a match (score > 0)
+  if (score > 0) {
+    const ageDays = (Date.now() - new Date(session.last_updated).getTime()) / 86_400_000;
+    score += Math.round(SCORE_WEIGHTS.RECENCY_MAX * Math.exp(-ageDays));
+  }
+
+  // Status bonus for actively running sessions
+  if (session.status === 'running') score += SCORE_WEIGHTS.STATUS_RUNNING;
+  else if (session.status === 'awaiting_permission') score += SCORE_WEIGHTS.STATUS_AWAITING;
+
+  return score;
+}
+
+export function getMatchSnippet(text: string, query: string, contextLen = 60): string | null {
+  if (!text || !query.trim()) return null;
+
+  const q = query.trim().toLowerCase();
+  const lower = text.toLowerCase();
+
+  let pos = lower.indexOf(q);
+  if (pos === -1) {
+    for (const w of q.split(/\s+/).filter(Boolean)) {
+      const idx = lower.indexOf(w);
+      if (idx !== -1) { pos = idx; break; }
+    }
+  }
+  if (pos === -1) return null;
+
+  const start = Math.max(0, pos - contextLen);
+  const end = Math.min(text.length, pos + Math.max(q.length, 10) + contextLen);
+  let snippet = text.slice(start, end);
+  if (start > 0) snippet = '…' + snippet;
+  if (end < text.length) snippet = snippet + '…';
+  return snippet;
+}
+
+export const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text, query }) => {
+  const { token } = theme.useToken();
+  if (!query.trim() || !text) return <>{text}</>;
+
+  const escaped = query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(re);
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? ( // odd indices are matches from split with capture group
+          <mark
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional marks in a static string split
+            key={i}
+            style={{
+              background: token.colorWarningBg,
+              color: 'inherit',
+              padding: '0 1px',
+              borderRadius: 2,
+            }}
+          >
+            {part}
+          </mark>
+        ) : (
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional text in a static string split
+          <span key={i}>{part}</span>
+        )
+      )}
+    </>
+  );
+};

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -132,7 +132,7 @@ export function sortSessions(sessions: Session[], sort: SessionSort): Session[] 
 
 export function HighlightMatch({ text, query }: { text: string; query: string }) {
   const { token } = theme.useToken();
-  if (!query.trim() || !text) return <>{text}</>;
+  if (!query.trim() || query.trim().length < 3 || !text) return <>{text}</>;
 
   const escaped = query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp(`(${escaped})`, 'gi');

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -146,10 +146,11 @@ export function HighlightMatch({ text, query }: { text: string; query: string })
             // biome-ignore lint/suspicious/noArrayIndexKey: positional marks in a static string split
             key={i}
             style={{
-              background: token.colorWarningBg,
-              color: 'inherit',
+              background: token.colorWarning,
+              color: 'rgba(0, 0, 0, 0.88)',
               padding: `0 ${token.paddingXXS}px`,
               borderRadius: token.borderRadiusSM,
+              fontWeight: 600,
             }}
           >
             {part}

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -150,6 +150,8 @@ export function HighlightMatch({ text, query }: { text: string; query: string })
               color: 'inherit',
               padding: `0 ${token.paddingXXS}px`,
               borderRadius: token.borderRadiusSM,
+              borderBottom: `2px solid ${token.colorWarning}`,
+              fontWeight: 500,
             }}
           >
             {part}

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -100,6 +100,35 @@ export function getMatchSnippet(text: string, query: string, contextLen = 60): s
   return snippet;
 }
 
+export type SessionSort = 'recent' | 'oldest' | 'alpha';
+
+export const SESSION_SORT_OPTIONS: { value: SessionSort; label: string }[] = [
+  { value: 'recent', label: 'Recent' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'alpha', label: 'A–Z' },
+];
+
+export function sortSessions(sessions: Session[], sort: SessionSort): Session[] {
+  const copy = [...sessions];
+  switch (sort) {
+    case 'oldest':
+      return copy.sort(
+        (a, b) => new Date(a.last_updated).getTime() - new Date(b.last_updated).getTime()
+      );
+    case 'alpha':
+      return copy.sort((a, b) =>
+        getSessionDisplayTitle(a, { includeAgentFallback: true }).localeCompare(
+          getSessionDisplayTitle(b, { includeAgentFallback: true })
+        )
+      );
+    case 'recent':
+    default:
+      return copy.sort(
+        (a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime()
+      );
+  }
+}
+
 export const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text, query }) => {
   const { token } = theme.useToken();
   if (!query.trim() || !text) return <>{text}</>;

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -1,7 +1,8 @@
 import type { Session } from '@agor-live/client';
 import { theme } from 'antd';
-import type React from 'react';
 import { getSessionDisplayTitle } from './sessionTitle';
+
+export const SESSION_SORT_STORAGE_KEY = 'agor:session-sort';
 
 const SCORE_WEIGHTS = {
   TITLE_EXACT: 1000,
@@ -129,7 +130,7 @@ export function sortSessions(sessions: Session[], sort: SessionSort): Session[] 
   }
 }
 
-export const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text, query }) => {
+export function HighlightMatch({ text, query }: { text: string; query: string }) {
   const { token } = theme.useToken();
   if (!query.trim() || !text) return <>{text}</>;
 
@@ -147,8 +148,8 @@ export const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text
             style={{
               background: token.colorWarningBg,
               color: 'inherit',
-              padding: '0 1px',
-              borderRadius: 2,
+              padding: `0 ${token.paddingXXS}px`,
+              borderRadius: token.borderRadiusSM,
             }}
           >
             {part}
@@ -160,4 +161,4 @@ export const HighlightMatch: React.FC<{ text: string; query: string }> = ({ text
       )}
     </>
   );
-};
+}

--- a/apps/agor-ui/src/utils/sessionSearch.tsx
+++ b/apps/agor-ui/src/utils/sessionSearch.tsx
@@ -150,8 +150,6 @@ export function HighlightMatch({ text, query }: { text: string; query: string })
               color: 'inherit',
               padding: `0 ${token.paddingXXS}px`,
               borderRadius: token.borderRadiusSM,
-              borderBottom: `2px solid ${token.colorWarning}`,
-              fontWeight: 500,
             }}
           >
             {part}


### PR DESCRIPTION
## Summary

- Replaces naive \`includes()\` filter with a weighted scoring function that sorts results by relevance
- Adds match highlighting (\`<mark>\` with warning-bg tint) in titles and description snippets
- Debounces input 150 ms so scoring only runs after the user pauses typing
- **Phase 2**: Same search available in the assistant panel (\`BranchSessionSections\` in \`panel\` mode)
- **Phase 3**: Sort control (Recent / Oldest / A–Z) in all three surfaces — drawer, panel, card
- Shared utilities in \`utils/sessionSearch.tsx\`: \`scoreSession\`, \`getMatchSnippet\`, \`HighlightMatch\`, \`sortSessions\`, \`SESSION_SORT_OPTIONS\`

## Scoring algorithm

Results are ranked by a numeric score built from these signals, highest to lowest priority:

| Signal | Weight |
|---|---|
| Title exact match | 1000 |
| Title starts-with | 800 |
| Title contains phrase | 600 |
| Title contains all query words | 400 |
| Title contains some query words | 0–200 (proportional) |
| Description contains phrase | 120 |
| Description contains all query words | 80 |
| Description contains some query words | 0–40 (proportional) |
| Tool name matches any word | 30 |
| Session is \`running\` | 20 |
| Session is \`awaiting_permission\` | 15 |
| Recency (exponential decay over days) | 0–50 (only added when score > 0) |

Sessions with score = 0 are excluded entirely — no near-miss noise.

## Sort control

Three options, accessible everywhere:

| Option | Behavior |
|---|---|
| Recent | Most recently updated first (default) |
| Oldest | Least recently updated first |
| A–Z | Alphabetical by display title |

Sort is **disabled while a search query is active** — relevance takes over. The drawer footer appends "oldest first" or "A–Z" when a non-default sort is active.

## UX design decisions

- **Sort placement**: In the drawer and panel, the select is inline with the search input. In card mode, it lives in the Sessions Collapse header (with stopPropagation to prevent Collapse toggle)
- **Panel-only search in BranchSessionSections**: The card view on the canvas is too cramped for a search bar; search only activates in \`mode === 'panel'\`
- **Flat list replaces tree when searching**: The normal Collapse/Tree hierarchy is replaced by a flat relevance-sorted list when a query is active
- **Search bar hidden when no sessions**: \`sessionSearchBar\` is \`null\` when \`activeSessions.length === 0\`
- **Debounce**: 150 ms keeps the list stable while typing without perceptible lag
- **Snippet only on description match**: Description snippet row appears only when the query matches the description but not the title
- **Recency as a tiebreaker**: Recency bonus only applies when another match already exists
- **No new packages**: HighlightMatch uses \`String.split(/(capture)/)\`

## Files changed

- \`apps/agor-ui/src/utils/sessionSearch.tsx\` *(new)* — \`scoreSession\`, \`getMatchSnippet\`, \`HighlightMatch\`, \`sortSessions\`, \`SESSION_SORT_OPTIONS\`, \`SessionSort\`
- \`apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx\` — search + sort in drawer
- \`apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx\` — search (panel) + sort (panel + card)

## Test plan

- [ ] **Drawer**: Switch to Oldest — confirm list flips; switch to A–Z — confirm alphabetical order
- [ ] **Drawer**: Type a query — confirm sort select is disabled and list sorts by relevance
- [ ] **Drawer**: Clear query — confirm sort select re-enables and chosen sort is still applied
- [ ] **Drawer**: Footer shows "oldest first" / "A–Z" suffix when non-default sort is active
- [ ] **Assistant panel**: Sort select appears next to search bar; changes order of tree nodes
- [ ] **Card mode**: Sort select appears in the Sessions collapse header; does not toggle collapse when clicked
- [ ] **Relevance search**: Match in title ranks higher than match only in description
- [ ] **Description snippet**: Italic snippet row appears when match is only in description
- [ ] **Card mode**: Confirm no search bar appears on the board canvas card

🤖 Generated with [Claude Code](https://claude.com/claude-code)