### PR TITLE
fix: inject Agor MCP into Claude CLI sessions

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -19,11 +19,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import {
-  canReceiveMcpTokenForSession,
-  isPromptFlowPatchOnly,
-  PROMPT_FLOW_PATCH_FIELDS,
-} from './register-hooks';
+import { isPromptFlowPatchOnly, PROMPT_FLOW_PATCH_FIELDS } from './register-hooks';
+import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
 
 describe('isPromptFlowPatchOnly', () => {
   describe('accepts whitelisted-only patches', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -89,9 +89,11 @@ import {
 import { inspectBranchViaExecutor } from './utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from './utils/executor-read-impersonation.js';
 import { injectCreatedBy } from './utils/inject-created-by.js';
+import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
 import {
   ensureCurrentScheduleLoaded,
+  ensureScheduleRunsAsCaller,
   recomputeNextRunAt,
   validateScheduleConfig,
 } from './utils/schedule-hooks.js';
@@ -145,41 +147,6 @@ export function isPromptFlowPatchOnly(data: unknown): boolean {
   const keys = Object.keys(data);
   if (keys.length === 0) return false;
   return keys.every((key) => PROMPT_FLOW_PATCH_FIELDS.includes(key));
-}
-
-/**
- * Authorization predicate for emitting an MCP token on `GET /sessions/:id`.
- *
- * The token binds `uid = session.created_by` and lets the bearer act AS the
- * creator on the MCP channel. It must therefore only be handed to callers
- * who are ALREADY allowed to act as that creator:
- *
- *   - the creator themselves, provided they are still `member+` (viewers
- *     never receive a token — see docs: "Viewers never receive an
- *     mcp_token")
- *   - a superadmin (ops access)
- *   - the executor's service identity (spawns the child that uses the
- *     token; see `createServiceToken` in utils/spawn-executor.ts)
- *
- * A plain `member+` with `view` permission on the branch is NOT enough —
- * giving them the token would let them impersonate the creator, sidestepping
- * the `session`-tier "own sessions only" rule enforced elsewhere.
- *
- * Note: `service` is not part of the user-facing role hierarchy (see
- * `ROLE_RANK` in `@agor/core/types/user.ts`), so `hasMinimumRole('service',
- * ...)` returns false — we check for it by exact-string match instead.
- */
-export function canReceiveMcpTokenForSession(params: {
-  callerUserId: string | undefined;
-  callerRole: string | undefined;
-  sessionCreatedBy: string | null | undefined;
-}): boolean {
-  const { callerUserId, callerRole, sessionCreatedBy } = params;
-  const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
-  const isServiceExecutor = callerRole === 'service';
-  const isCreatorMember =
-    !!callerUserId && callerUserId === sessionCreatedBy && hasMinimumRole(callerRole, ROLES.MEMBER);
-  return isCreatorMember || isSuperadmin || isServiceExecutor;
 }
 
 /**
@@ -2131,6 +2098,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // need the merged current+patch shape to do their work
         // correctly, and they have to run on every install.
         ensureCurrentScheduleLoaded(scheduleRepository),
+        ensureScheduleRunsAsCaller(superadminOpts),
         validateScheduleConfig(),
         recomputeNextRunAt(),
       ],

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -106,6 +106,7 @@ import {
 } from './utils/branch-authorization.js';
 import { buildInitialUserMessage } from './utils/build-initial-user-message.js';
 import { buildPrompterPrefixedPrompt } from './utils/build-prompter-prefix.js';
+import { canControlCliSession } from './utils/mcp-token-authorization.js';
 import { ensureScheduleRunsAsCaller } from './utils/schedule-hooks.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
@@ -745,6 +746,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
         const targetUserId = session.created_by;
         if (!targetUserId) throw new Error('Session has no created_by — cannot route restart');
+        if (
+          params.provider &&
+          !canControlCliSession({
+            callerUserId: params.user?.user_id,
+            callerRole: params.user?.role,
+            sessionCreatedBy: session.created_by,
+          })
+        ) {
+          throw new Forbidden('You can only restart Claude CLI sessions you created.');
+        }
 
         const tabName = `cli-${shortId(session.session_id)}`;
         const channel = `user/${targetUserId}/terminal`;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -106,6 +106,7 @@ import {
 } from './utils/branch-authorization.js';
 import { buildInitialUserMessage } from './utils/build-initial-user-message.js';
 import { buildPrompterPrefixedPrompt } from './utils/build-prompter-prefix.js';
+import { ensureScheduleRunsAsCaller } from './utils/schedule-hooks.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
@@ -804,9 +805,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         };
         const cwd = branch?.path;
         if (!cwd) throw new Error('Branch has no path; cannot restart');
-        const { buildSpawnConfigForSession } = await import('./services/claude-cli-integration.js');
+        const { buildSpawnConfigForSession, writeClaudeCliMcpConfigForSession } = await import(
+          './services/claude-cli-integration.js'
+        );
         const { buildClaudeCliSpawn } = await import('@agor/core/claude-cli');
-        const spawnCfg = buildSpawnConfigForSession(session, cwd);
+        const mcpConfigPath = await writeClaudeCliMcpConfigForSession(app, session, {
+          actor: params.user ?? null,
+        });
+        const spawnCfg = buildSpawnConfigForSession(session, cwd, { mcpConfigPath });
         const built = buildClaudeCliSpawn(spawnCfg);
         if (app.io) {
           app.io.to(channel).emit('terminal:tab', {
@@ -2911,6 +2917,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         // / params.branch / params.isBranchOwner) match every other
         // schedule-touching path.
         loadScheduleAndBranch(scheduleRepository, branchRepository),
+        ensureScheduleRunsAsCaller(superadminOpts),
         branchRbacEnabled
           ? ensureBranchPermission('all', 'run schedule', superadminOpts)
           : (context: HookContext) => {

--- a/apps/agor-daemon/src/services/claude-cli-integration.test.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildClaudeCliSpawn } from '@agor/core/claude-cli';
+import type { Application } from '@agor/core/feathers';
+import type { Session } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { generateSessionToken } from '../mcp/tokens.js';
+import {
+  buildClaudeCliAgorMcpConfig,
+  buildSpawnConfigForSession,
+  writeClaudeCliMcpConfigForSession,
+} from './claude-cli-integration';
+
+vi.mock('../mcp/tokens.js', () => ({
+  generateSessionToken: vi.fn(async () => 'tok_test'),
+}));
+
+const generatedPaths: string[] = [];
+
+function makeApp(config: { daemon?: { mcpEnabled?: boolean } } = {}): Application {
+  return {
+    get: (key: string) => (key === 'config' ? config : undefined),
+  } as unknown as Application;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: '019e8abc-0000-7000-8000-000000000001',
+    branch_id: 'branch-1',
+    agentic_tool: 'claude-code-cli',
+    status: 'idle',
+    created_by: 'user-1',
+    scheduled_from_branch: false,
+    tasks: [],
+    contextFiles: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as Session;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const filePath of generatedPaths.splice(0)) {
+    fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
+  }
+});
+
+describe('Claude CLI Agor MCP config', () => {
+  it('renders the Claude CLI mcpServers file shape with a session bearer token', () => {
+    expect(
+      buildClaudeCliAgorMcpConfig({ daemonUrl: 'https://agor.example.test/', mcpToken: 'tok_123' })
+    ).toEqual({
+      mcpServers: {
+        agor: {
+          type: 'http',
+          url: 'https://agor.example.test/mcp',
+          headers: { Authorization: 'Bearer tok_123' },
+        },
+      },
+    });
+  });
+
+  it('passes the generated MCP config path into Claude CLI spawn argv', () => {
+    const spawnCfg = buildSpawnConfigForSession(makeSession(), '/repo/branch', {
+      mcpConfigPath: '/tmp/agor-mcp-test/mcp.json',
+    });
+    const built = buildClaudeCliSpawn(spawnCfg);
+
+    expect(spawnCfg.mcpConfigPath).toBe('/tmp/agor-mcp-test/mcp.json');
+    expect(built.args).toContain('--mcp-config');
+    expect(built.args).toContain('/tmp/agor-mcp-test/mcp.json');
+    expect(built.args).toContain('--strict-mcp-config');
+  });
+
+  it('does not write a config when daemon MCP is disabled', async () => {
+    const filePath = await writeClaudeCliMcpConfigForSession(
+      makeApp({ daemon: { mcpEnabled: false } }),
+      makeSession()
+    );
+
+    expect(filePath).toBeUndefined();
+    expect(generateSessionToken).not.toHaveBeenCalled();
+  });
+
+  it('does not mint an owner-scoped token for an unauthorized external actor', async () => {
+    const filePath = await writeClaudeCliMcpConfigForSession(makeApp(), makeSession(), {
+      actor: { user_id: 'other-user', role: 'member' },
+    });
+
+    expect(filePath).toBeUndefined();
+    expect(generateSessionToken).not.toHaveBeenCalled();
+  });
+
+  it('writes a private temp config for the session creator', async () => {
+    const filePath = await writeClaudeCliMcpConfigForSession(makeApp(), makeSession(), {
+      actor: { user_id: 'user-1', role: 'member' },
+    });
+    expect(filePath).toBeTruthy();
+    generatedPaths.push(filePath as string);
+
+    const dirMode = fs.statSync(path.dirname(filePath as string)).mode & 0o777;
+    const fileMode = fs.statSync(filePath as string).mode & 0o777;
+    expect(dirMode).toBe(0o700);
+    expect(fileMode).toBe(0o600);
+
+    const parsed = JSON.parse(fs.readFileSync(filePath as string, 'utf8'));
+    expect(parsed.mcpServers.agor.url).toBe('http://localhost:3030/mcp');
+    expect(parsed.mcpServers.agor.headers.Authorization).toBe('Bearer tok_test');
+    expect(generateSessionToken).toHaveBeenCalledWith(
+      expect.anything(),
+      makeSession().session_id,
+      'user-1'
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -1052,9 +1052,10 @@ export interface ClaudeCliAgorMcpConfig {
  * This mirrors the Agent SDK path in
  * `packages/executor/src/sdk-handlers/claude/query-builder.ts`, but writes the
  * shape the Claude Code CLI expects in an mcp config file. The Authorization
- * header carries a session-scoped MCP token, so Claude CLI `/schedule`
- * RemoteTrigger runs inherit the same Agor board/session tools as normal Agor
- * sessions instead of falling back to unauthenticated REST.
+ * header carries a session-scoped MCP token, so Claude CLI sessions (including
+ * `/schedule` setup flows that read this config at CLI start time) see the same
+ * Agor board/session tools as normal Agor sessions instead of falling back to
+ * unauthenticated REST.
  */
 export function buildClaudeCliAgorMcpConfig(params: {
   daemonUrl: string;
@@ -1081,6 +1082,12 @@ export function buildClaudeCliAgorMcpConfig(params: {
  * CLI session, but it must be loud in logs because missing this file removes
  * all `agor_*` MCP tools (boards/cards/sessions/etc.) from Claude CLI and
  * RemoteTrigger scheduled runs.
+ *
+ * Token lifetime follows `execution.mcp_token_expiration_ms` via the shared MCP
+ * session-token issuer. This writer does not mint a separate durable
+ * RemoteTrigger credential; if a third-party scheduler snapshots headers for
+ * longer than that TTL, it must refresh this config or use an explicit
+ * future schedule-token design.
  */
 export async function writeClaudeCliMcpConfigForSession(
   app: Application,

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -37,6 +37,7 @@
 import { spawn as spawnProcess } from 'node:child_process';
 import * as fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 import {
   type AssistantUsage,
   buildClaudeCliSpawn,
@@ -68,6 +69,8 @@ import {
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 import { buildInitialUserMessage } from '../utils/build-initial-user-message.js';
+import { canReceiveMcpTokenForSession } from '../utils/mcp-token-authorization.js';
+import { getDaemonUrl } from '../utils/spawn-executor.js';
 import {
   ClaudeCliWatcherRegistry,
   type CliWatcherEventSink,
@@ -1008,7 +1011,8 @@ export function getCliWatcherRegistry(app: Application): ClaudeCliWatcherRegistr
  */
 export function buildSpawnConfigForSession(
   session: Session,
-  branchCwd: string
+  branchCwd: string,
+  opts: { mcpConfigPath?: string } = {}
 ): ClaudeCliSpawnConfig {
   // If the JSONL transcript for this session id already exists on disk,
   // `claude --session-id <X>` errors out with "Session ID is already in
@@ -1027,9 +1031,128 @@ export function buildSpawnConfigForSession(
     effort: session.model_config?.effort as ClaudeCliSpawnConfig['effort'] | undefined,
     permissionMode: permissionModeForCli(session.permission_config?.mode),
     addDirs: [branchCwd],
-    // mcpConfigPath: lands once MCP scoping is plumbed for the CLI adapter.
+    mcpConfigPath: opts.mcpConfigPath,
     // appendSystemPromptFile: lands once session-context rendering is wired.
   };
+}
+
+export interface ClaudeCliAgorMcpConfig {
+  mcpServers: {
+    agor: {
+      type: 'http';
+      url: string;
+      headers: { Authorization: string };
+    };
+  };
+}
+
+/**
+ * Build the Claude CLI `--mcp-config` payload for Agor's built-in MCP server.
+ *
+ * This mirrors the Agent SDK path in
+ * `packages/executor/src/sdk-handlers/claude/query-builder.ts`, but writes the
+ * shape the Claude Code CLI expects in an mcp config file. The Authorization
+ * header carries a session-scoped MCP token, so Claude CLI `/schedule`
+ * RemoteTrigger runs inherit the same Agor board/session tools as normal Agor
+ * sessions instead of falling back to unauthenticated REST.
+ */
+export function buildClaudeCliAgorMcpConfig(params: {
+  daemonUrl: string;
+  mcpToken: string;
+}): ClaudeCliAgorMcpConfig {
+  const daemonUrl = params.daemonUrl.replace(/\/+$/, '');
+  return {
+    mcpServers: {
+      agor: {
+        type: 'http',
+        url: `${daemonUrl}/mcp`,
+        headers: {
+          Authorization: `Bearer ${params.mcpToken}`,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Write a per-session Claude CLI MCP config file and return its path.
+ *
+ * Best-effort by design: failing to write this file should not block opening a
+ * CLI session, but it must be loud in logs because missing this file removes
+ * all `agor_*` MCP tools (boards/cards/sessions/etc.) from Claude CLI and
+ * RemoteTrigger scheduled runs.
+ */
+export async function writeClaudeCliMcpConfigForSession(
+  app: Application,
+  session: Session,
+  opts: {
+    /**
+     * External actor requesting this config. When omitted, the call is an
+     * internal trusted spawn path (session create hook / service account).
+     */
+    actor?: { user_id?: string; role?: string } | null;
+  } = {}
+): Promise<string | undefined> {
+  const config = app.get('config') as { daemon?: { mcpEnabled?: boolean } } | undefined;
+  if (config?.daemon?.mcpEnabled === false) return undefined;
+
+  if (
+    opts.actor &&
+    !canReceiveMcpTokenForSession({
+      callerUserId: opts.actor.user_id,
+      callerRole: opts.actor.role,
+      sessionCreatedBy: session.created_by,
+    })
+  ) {
+    console.warn(
+      `[claude-cli-integration] not writing owner-scoped MCP config for session ${shortId(session.session_id)}: caller ${opts.actor.user_id ?? 'anonymous'} cannot receive session creator token`
+    );
+    return undefined;
+  }
+
+  try {
+    const { generateSessionToken } = await import('../mcp/tokens.js');
+    const mcpToken = await generateSessionToken(
+      app,
+      session.session_id,
+      session.created_by as import('@agor/core/types').UserID
+    );
+    const mcpConfig = buildClaudeCliAgorMcpConfig({
+      daemonUrl: getDaemonUrl(),
+      mcpToken,
+    });
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `agor-mcp-${shortId(session.session_id)}-`));
+    const filePath = path.join(dir, 'mcp.json');
+    fs.writeFileSync(filePath, `${JSON.stringify(mcpConfig, null, 2)}\n`, { mode: 0o600 });
+
+    // In strict Unix-user mode the CLI process may run as the session's Unix
+    // user. If the daemon is privileged, hand ownership of the temp config to
+    // that user so we can keep 0600 instead of making bearer tokens world-
+    // readable in /tmp. Non-root deployments where chown is unavailable still
+    // work in simple mode (same Unix user); otherwise the warning below tells
+    // operators why MCP is missing.
+    if (session.unix_username && typeof process.getuid === 'function' && process.getuid() === 0) {
+      try {
+        const homeStat = fs.statSync(`/home/${session.unix_username}`);
+        fs.chownSync(dir, homeStat.uid, homeStat.gid);
+        fs.chownSync(filePath, homeStat.uid, homeStat.gid);
+      } catch (err) {
+        console.warn(
+          `[claude-cli-integration] failed to chown MCP config for ${session.unix_username}:`,
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+    }
+
+    return filePath;
+  } catch (err) {
+    console.warn(
+      `[claude-cli-integration] failed to write MCP config for session ${shortId(session.session_id)}; Agor MCP tools will be unavailable in Claude CLI/RemoteTrigger:`,
+      err instanceof Error ? err.message : String(err)
+    );
+    return undefined;
+  }
 }
 
 /**
@@ -1090,7 +1213,8 @@ export async function onCliSessionCreated(
   const homeDir = resolveHomeDirForCliSession(session);
   const slug = slugForCwd(branchCwd);
   const jsonlPath = claudeSessionJsonlPath(homeDir, branchCwd, session.session_id);
-  const spawnCfg = buildSpawnConfigForSession(session, branchCwd);
+  const mcpConfigPath = await writeClaudeCliMcpConfigForSession(app, session);
+  const spawnCfg = buildSpawnConfigForSession(session, branchCwd, { mcpConfigPath });
   const built = buildClaudeCliSpawn(spawnCfg);
   const tabName = spawnCfg.displayName ?? `cli-${shortId(session.session_id)}`;
 

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -59,6 +59,7 @@ import {
   txAsDb,
   UsersRepository,
 } from '@agor/core/db';
+import { Forbidden } from '@agor/core/feathers';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   Branch,
@@ -421,6 +422,11 @@ export class SchedulerService {
       throw new ScheduleNotReadyError(
         'schedule_disabled',
         'Schedule is disabled. Enable it before running manually.'
+      );
+    }
+    if (schedule.created_by !== triggeredBy) {
+      throw new Forbidden(
+        'Schedules run as the user who created them. You can only manually run schedules you created.'
       );
     }
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -46,7 +46,11 @@ import {
 } from '@agor/core/unix';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
 import { generateSessionToken, spawnExecutorFireAndForget } from '../utils/spawn-executor.js';
-import { buildSpawnConfigForSession, isClaudeRunningFor } from './claude-cli-integration.js';
+import {
+  buildSpawnConfigForSession,
+  isClaudeRunningFor,
+  writeClaudeCliMcpConfigForSession,
+} from './claude-cli-integration.js';
 
 interface CreateTerminalData {
   rows?: number;
@@ -410,7 +414,10 @@ export class TerminalsService {
       const branchRepo = new BranchRepository(this.db);
       const branch = await branchRepo.findById(session.branch_id);
       if (!branch?.path) return null;
-      const spawnCfg = buildSpawnConfigForSession(session, branch.path);
+      const mcpConfigPath = await writeClaudeCliMcpConfigForSession(this.app, session, {
+        actor: params?.user ?? null,
+      });
+      const spawnCfg = buildSpawnConfigForSession(session, branch.path, { mcpConfigPath });
       const built = buildClaudeCliSpawn(spawnCfg);
       const tabName =
         session.cli_state?.zellij_tab_name ??

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -45,6 +45,7 @@ import {
   validateResolvedUnixUser,
 } from '@agor/core/unix';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
+import { canControlCliSession } from '../utils/mcp-token-authorization.js';
 import { generateSessionToken, spawnExecutorFireAndForget } from '../utils/spawn-executor.js';
 import {
   buildSpawnConfigForSession,
@@ -410,6 +411,16 @@ export class TerminalsService {
             );
           }
         }
+      }
+      if (
+        params?.provider &&
+        !canControlCliSession({
+          callerUserId: params.user?.user_id,
+          callerRole: params.user?.role,
+          sessionCreatedBy: session.created_by,
+        })
+      ) {
+        throw new Forbidden('You can only ensure CLI tabs for Claude CLI sessions you created.');
       }
       const branchRepo = new BranchRepository(this.db);
       const branch = await branchRepo.findById(session.branch_id);

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { canControlCliSession, canReceiveMcpTokenForSession } from './mcp-token-authorization';
+
+const creatorId = 'user-creator';
+
+describe('session actor authorization', () => {
+  it('allows the creator when they are a member or higher', () => {
+    const params = {
+      callerUserId: creatorId,
+      callerRole: 'member',
+      sessionCreatedBy: creatorId,
+    };
+    expect(canReceiveMcpTokenForSession(params)).toBe(true);
+    expect(canControlCliSession(params)).toBe(true);
+  });
+
+  it('denies the creator if they are not a member', () => {
+    const params = {
+      callerUserId: creatorId,
+      callerRole: 'viewer',
+      sessionCreatedBy: creatorId,
+    };
+    expect(canReceiveMcpTokenForSession(params)).toBe(false);
+    expect(canControlCliSession(params)).toBe(false);
+  });
+
+  it('denies other members even when they can access the branch', () => {
+    const params = {
+      callerUserId: 'user-collaborator',
+      callerRole: 'member',
+      sessionCreatedBy: creatorId,
+    };
+    expect(canReceiveMcpTokenForSession(params)).toBe(false);
+    expect(canControlCliSession(params)).toBe(false);
+  });
+
+  it('allows superadmins to receive tokens and control CLI sessions', () => {
+    const params = {
+      callerUserId: 'user-admin',
+      callerRole: 'superadmin',
+      sessionCreatedBy: creatorId,
+    };
+    expect(canReceiveMcpTokenForSession(params)).toBe(true);
+    expect(canControlCliSession(params)).toBe(true);
+  });
+
+  it('allows the internal service identity', () => {
+    const params = {
+      callerUserId: undefined,
+      callerRole: 'service',
+      sessionCreatedBy: creatorId,
+    };
+    expect(canReceiveMcpTokenForSession(params)).toBe(true);
+    expect(canControlCliSession(params)).toBe(true);
+  });
+
+  it('denies unauthenticated or role-less callers', () => {
+    const params = {
+      callerUserId: undefined,
+      callerRole: undefined,
+      sessionCreatedBy: creatorId,
+    };
+    expect(canReceiveMcpTokenForSession(params)).toBe(false);
+    expect(canControlCliSession(params)).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.ts
@@ -1,0 +1,22 @@
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+
+/**
+ * Authorization predicate for handing a session-scoped MCP token to a caller.
+ *
+ * The token binds `uid = session.created_by` and lets the bearer act as the
+ * session creator on the MCP channel. It must therefore only be returned to
+ * callers who are already allowed to act as that creator: the creator (member+),
+ * a superadmin, or the executor/service identity.
+ */
+export function canReceiveMcpTokenForSession(params: {
+  callerUserId: string | undefined;
+  callerRole: string | undefined;
+  sessionCreatedBy: string | null | undefined;
+}): boolean {
+  const { callerUserId, callerRole, sessionCreatedBy } = params;
+  const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
+  const isServiceExecutor = callerRole === 'service';
+  const isCreatorMember =
+    !!callerUserId && callerUserId === sessionCreatedBy && hasMinimumRole(callerRole, ROLES.MEMBER);
+  return isCreatorMember || isSuperadmin || isServiceExecutor;
+}

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.ts
@@ -1,5 +1,11 @@
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 
+export interface SessionActorAuthorizationParams {
+  callerUserId: string | undefined;
+  callerRole: string | undefined;
+  sessionCreatedBy: string | null | undefined;
+}
+
 /**
  * Authorization predicate for handing a session-scoped MCP token to a caller.
  *
@@ -8,15 +14,25 @@ import { hasMinimumRole, ROLES } from '@agor/core/types';
  * callers who are already allowed to act as that creator: the creator (member+),
  * a superadmin, or the executor/service identity.
  */
-export function canReceiveMcpTokenForSession(params: {
-  callerUserId: string | undefined;
-  callerRole: string | undefined;
-  sessionCreatedBy: string | null | undefined;
-}): boolean {
+export function canReceiveMcpTokenForSession(params: SessionActorAuthorizationParams): boolean {
   const { callerUserId, callerRole, sessionCreatedBy } = params;
   const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
   const isServiceExecutor = callerRole === 'service';
   const isCreatorMember =
     !!callerUserId && callerUserId === sessionCreatedBy && hasMinimumRole(callerRole, ROLES.MEMBER);
   return isCreatorMember || isSuperadmin || isServiceExecutor;
+}
+
+/**
+ * Authorization predicate for controlling a Claude CLI process bound to a
+ * session (ensure/focus cold-start tab, restart/kill/re-spawn).
+ *
+ * CLI control is as sensitive as receiving the MCP token: in simple Unix mode
+ * the process may run from the creator's shared home/session state, and even in
+ * stricter modes resuming someone else's CLI session can execute with that
+ * session's credentials/context. Keep this boundary aligned with MCP token
+ * delivery unless the CLI ownership model is redesigned explicitly.
+ */
+export function canControlCliSession(params: SessionActorAuthorizationParams): boolean {
+  return canReceiveMcpTokenForSession(params);
 }

--- a/apps/agor-daemon/src/utils/schedule-hooks.test.ts
+++ b/apps/agor-daemon/src/utils/schedule-hooks.test.ts
@@ -21,6 +21,7 @@ import type { HookContext, Schedule, ScheduleID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
   ensureCurrentScheduleLoaded,
+  ensureScheduleRunsAsCaller,
   recomputeNextRunAt,
   validateScheduleConfig,
 } from './schedule-hooks';
@@ -55,12 +56,18 @@ function makeContext(opts: {
   id?: string;
   data: Partial<Schedule>;
   cachedSchedule?: Schedule;
+  provider?: string;
+  user?: { user_id?: string; role?: string; _isServiceAccount?: boolean };
 }): HookContext {
   return {
     method: opts.method,
     id: opts.id,
     data: opts.data,
-    params: opts.cachedSchedule ? { schedule: opts.cachedSchedule } : {},
+    params: {
+      provider: opts.provider,
+      user: opts.user,
+      ...(opts.cachedSchedule ? { schedule: opts.cachedSchedule } : {}),
+    },
   } as unknown as HookContext;
 }
 
@@ -188,6 +195,90 @@ describe('validateScheduleConfig', () => {
       cachedSchedule: makeSchedule(),
     });
     await expect(validateScheduleConfig()(ctx)).rejects.toThrow(/Schedule prompt cannot be empty/);
+  });
+});
+
+describe('ensureScheduleRunsAsCaller', () => {
+  it('allows the schedule creator to patch their own schedule', () => {
+    const current = makeSchedule({ created_by: 'user-alice' as Schedule['created_by'] });
+    const ctx = makeContext({
+      method: 'patch',
+      id: 'sched-test-0001',
+      data: { name: 'renamed' },
+      cachedSchedule: current,
+      provider: 'rest',
+      user: { user_id: 'user-alice', role: 'member' },
+    });
+
+    expect(() => ensureScheduleRunsAsCaller()(ctx)).not.toThrow();
+  });
+
+  it('rejects external patch attempts against schedules created by another user', () => {
+    const current = makeSchedule({ created_by: 'user-alice' as Schedule['created_by'] });
+    const ctx = makeContext({
+      method: 'patch',
+      id: 'sched-test-0001',
+      data: { prompt: 'do something else' },
+      cachedSchedule: current,
+      provider: 'rest',
+      user: { user_id: 'user-bob', role: 'member' },
+    });
+
+    expect(() => ensureScheduleRunsAsCaller()(ctx)).toThrow(/only modify or run schedules/);
+  });
+
+  it('allows superadmins to patch schedules created by another user', () => {
+    const current = makeSchedule({ created_by: 'user-alice' as Schedule['created_by'] });
+    const ctx = makeContext({
+      method: 'patch',
+      id: 'sched-test-0001',
+      data: { prompt: 'ops fix' },
+      cachedSchedule: current,
+      provider: 'rest',
+      user: { user_id: 'user-admin', role: 'superadmin' },
+    });
+
+    expect(() => ensureScheduleRunsAsCaller()(ctx)).not.toThrow();
+  });
+
+  it('rejects attempts to change created_by/run-as even by the creator', () => {
+    const current = makeSchedule({ created_by: 'user-alice' as Schedule['created_by'] });
+    const ctx = makeContext({
+      method: 'patch',
+      id: 'sched-test-0001',
+      data: { created_by: 'user-bob' as Schedule['created_by'] },
+      cachedSchedule: current,
+      provider: 'rest',
+      user: { user_id: 'user-alice', role: 'member' },
+    });
+
+    expect(() => ensureScheduleRunsAsCaller()(ctx)).toThrow(/Cannot change/);
+  });
+
+  it('rejects attempts to change created_by/run-as even by a superadmin', () => {
+    const current = makeSchedule({ created_by: 'user-alice' as Schedule['created_by'] });
+    const ctx = makeContext({
+      method: 'patch',
+      id: 'sched-test-0001',
+      data: { created_by: 'user-bob' as Schedule['created_by'] },
+      cachedSchedule: current,
+      provider: 'rest',
+      user: { user_id: 'user-admin', role: 'superadmin' },
+    });
+
+    expect(() => ensureScheduleRunsAsCaller()(ctx)).toThrow(/Cannot change/);
+  });
+
+  it('allows internal scheduler/service calls', () => {
+    const current = makeSchedule({ created_by: 'user-alice' as Schedule['created_by'] });
+    const ctx = makeContext({
+      method: 'patch',
+      id: 'sched-test-0001',
+      data: { created_by: 'user-bob' as Schedule['created_by'] },
+      cachedSchedule: current,
+    });
+
+    expect(() => ensureScheduleRunsAsCaller()(ctx)).not.toThrow();
   });
 });
 

--- a/apps/agor-daemon/src/utils/schedule-hooks.ts
+++ b/apps/agor-daemon/src/utils/schedule-hooks.ts
@@ -29,8 +29,9 @@
  */
 
 import type { ScheduleRepository } from '@agor/core/db';
-import { BadRequest } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { HookContext, Schedule } from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
 
 /**
  * Lazy-load the current schedule into `context.params.schedule` on
@@ -92,6 +93,54 @@ export function validateScheduleConfig() {
 
     if (data.prompt !== undefined && data.prompt.trim() === '') {
       throw new BadRequest('Schedule prompt cannot be empty.');
+    }
+
+    return context;
+  };
+}
+
+/**
+ * Enforce the schedule run-as contract for external callers.
+ *
+ * Today `schedules.created_by` is both audit attribution ("scheduled by")
+ * and execution identity ("run as"). That makes it security-sensitive:
+ * patching or manually triggering another user's schedule means controlling
+ * an agent that will execute with that user's Agor MCP token / Unix identity.
+ *
+ * External callers may therefore only modify/run schedules they created.
+ * Superadmins remain an ops escape hatch for modifying schedule definitions,
+ * but the run-as field itself is immutable for everyone. Internal scheduler
+ * ticks bypass this hook.
+ */
+export function ensureScheduleRunsAsCaller(options?: { allowSuperadmin?: boolean }) {
+  return (context: HookContext): HookContext => {
+    if (!context.params.provider) return context;
+    if (context.params.user?._isServiceAccount) return context;
+
+    const user = context.params.user;
+    if (!user?.user_id) {
+      throw new NotAuthenticated('Authentication required');
+    }
+
+    const schedule = context.params.schedule as Schedule | undefined;
+    if (!schedule) {
+      throw new Error('ensureScheduleRunsAsCaller requires params.schedule');
+    }
+
+    const data = context.data as Partial<Schedule> | undefined;
+    if (data?.created_by !== undefined && data.created_by !== schedule.created_by) {
+      throw new Forbidden('Cannot change the user a schedule runs as.');
+    }
+
+    const allowSuperadmin = options?.allowSuperadmin ?? true;
+    if (allowSuperadmin && hasMinimumRole(user.role, ROLES.SUPERADMIN)) {
+      return context;
+    }
+
+    if (schedule.created_by !== user.user_id) {
+      throw new Forbidden(
+        'Schedules run as the user who created them. You can only modify or run schedules you created.'
+      );
     }
 
     return context;

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -89,6 +89,10 @@ export const BranchModal: React.FC<BranchModalProps> = ({
     currentUser,
     open,
   });
+  const userById = useMemo(
+    () => new Map(form.allUsers.map((user) => [user.user_id, user])),
+    [form.allUsers]
+  );
 
   // Sync active tab when modal opens — use defaultTab if specified, otherwise reset to general
   useEffect(() => {
@@ -233,6 +237,8 @@ export const BranchModal: React.FC<BranchModalProps> = ({
           branch={branch}
           client={client}
           mcpServerById={mcpServerById}
+          currentUser={currentUser}
+          userById={userById}
           onOpenSession={(sessionId) => {
             onSessionClick?.(sessionId);
             onClose();

--- a/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
@@ -5,8 +5,8 @@
  * schedules with create / edit / delete / run-now / runs-drawer.
  */
 
-import type { AgorClient, Branch, MCPServer, Schedule } from '@agor-live/client';
-import { humanizeCron } from '@agor-live/client';
+import type { AgorClient, Branch, MCPServer, Schedule, User } from '@agor-live/client';
+import { humanizeCron, shortId } from '@agor-live/client';
 import {
   DeleteOutlined,
   EditOutlined,
@@ -17,6 +17,7 @@ import {
 import { Button, Empty, Popconfirm, Space, Spin, Switch, Table, Typography } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
+import { UserAvatar } from '../../metadata/UserAvatar';
 import { ScheduleModal } from '../../ScheduleModal';
 import { ScheduleRunsPanel } from '../../ScheduleRunsPanel';
 
@@ -26,6 +27,8 @@ interface ScheduleTabProps {
   branch: Branch;
   client: AgorClient | null;
   mcpServerById?: Map<string, MCPServer>;
+  currentUser?: User | null;
+  userById?: Map<string, User>;
   onOpenSession?: (sessionId: string) => void;
 }
 
@@ -44,6 +47,8 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   branch,
   client,
   mcpServerById = new Map(),
+  currentUser,
+  userById = new Map(),
   onOpenSession,
 }) => {
   const { showError, showSuccess } = useThemedMessage();
@@ -168,6 +173,22 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
       title: 'When',
       key: 'cron',
       render: (s: Schedule) => <Text>{formatHumanizedCron(s.cron_expression)}</Text>,
+    },
+    {
+      title: 'Scheduled by / run as',
+      key: 'created_by',
+      render: (s: Schedule) => {
+        const user = userById.get(s.created_by);
+        if (user) {
+          return (
+            <Space size={4}>
+              <UserAvatar user={user} showName size="small" />
+              {currentUser?.user_id === s.created_by && <Text type="secondary">(you)</Text>}
+            </Space>
+          );
+        }
+        return <Text type="secondary">{s.created_by ? shortId(s.created_by) : '—'}</Text>;
+      },
     },
     {
       title: 'Last run',


### PR DESCRIPTION
## Summary
- write a per-session Claude CLI MCP config containing the built-in Agor MCP server and session bearer token
- pass that config on CLI session creation, restart, and cold-start ensure-tab paths
- add regression coverage for the CLI MCP config shape and argv injection

## Tests
- pnpm check
- pnpm --filter @agor/daemon test -- --run src/services/claude-cli-integration.test.ts src/services/scheduler.test.ts

Fixes sc-107619