### PR TITLE
Fix model selector default mismatch

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -3,9 +3,11 @@ import {
   AVAILABLE_CLAUDE_MODEL_ALIASES,
   CODEX_MODEL_METADATA,
   COPILOT_MODEL_METADATA,
+  CURSOR_MODEL_METADATA,
   DEFAULT_CLAUDE_MODEL,
   DEFAULT_CODEX_MODEL,
   DEFAULT_COPILOT_MODEL,
+  DEFAULT_CURSOR_MODEL,
   DEFAULT_GEMINI_MODEL,
   GEMINI_MODELS,
 } from '@agor/core/models';
@@ -1423,12 +1425,12 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           note: 'Gemini models are normally fetched live from the Google API per-user. This is the static fallback list — newer models may exist.',
         },
         cursor: {
-          default: 'composer-latest',
+          default: DEFAULT_CURSOR_MODEL,
           models: [
             {
-              id: 'composer-latest',
-              displayName: 'Composer Latest',
-              description: 'Cursor SDK default model alias (beta).',
+              id: DEFAULT_CURSOR_MODEL,
+              displayName: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].displayName,
+              description: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].description,
             },
           ],
           note: "Cursor models are also fetched live via /cursor-models (uses @cursor/sdk's Cursor.models.list()). This is the static fallback — account-specific models may not appear here.",

--- a/apps/agor-daemon/src/services/cursor-models.ts
+++ b/apps/agor-daemon/src/services/cursor-models.ts
@@ -9,6 +9,7 @@
 
 import { resolveApiKey } from '@agor/core/config';
 import { type Database, shortId } from '@agor/core/db';
+import { CURSOR_MODEL_METADATA, DEFAULT_CURSOR_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import { Cursor, type SDKModel } from '@cursor/sdk';
 
@@ -25,7 +26,6 @@ export interface CursorModelsResult {
   source: 'dynamic' | 'static';
 }
 
-const DEFAULT_CURSOR_MODEL = 'composer-latest';
 const CURSOR_MODELS_TIMEOUT_MS = 8_000;
 
 const STATIC_RESULT: CursorModelsResult = {
@@ -33,8 +33,8 @@ const STATIC_RESULT: CursorModelsResult = {
   models: [
     {
       id: DEFAULT_CURSOR_MODEL,
-      displayName: 'Composer Latest',
-      description: 'Cursor SDK default model alias (beta)',
+      displayName: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].displayName,
+      description: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].description,
       source: 'static',
     },
   ],

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -59,6 +59,7 @@ import {
   txAsDb,
   UsersRepository,
 } from '@agor/core/db';
+import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   Branch,
   MCPServerID,
@@ -604,6 +605,14 @@ export class SchedulerService {
       const { creator, unixUsername } = await this.resolveCreatorUnixUsername(schedule);
 
       const cfg = schedule.agentic_tool_config;
+      const scheduleModelConfig = cfg.model_config
+        ? resolveSessionDefaults({
+            agenticTool: cfg.agentic_tool,
+            user: creator,
+            overrides: { modelConfig: cfg.model_config },
+            now: new Date(now),
+          }).model_config
+        : undefined;
 
       // 6. Create session with schedule metadata + FK back to schedule.
       const session: Partial<Session> = {
@@ -625,17 +634,10 @@ export class SchedulerService {
         permission_config: cfg.permission_mode
           ? { mode: cfg.permission_mode as PermissionMode }
           : undefined,
-        // DefaultModelConfig → Session.model_config. When the schedule
-        // has no `model` set we leave model_config undefined so the
-        // session inherits the agent's defaults.
-        model_config: cfg.model_config?.model
-          ? {
-              mode: cfg.model_config.mode ?? 'alias',
-              model: cfg.model_config.model,
-              effort: cfg.model_config.effort,
-              updated_at: new Date(now).toISOString(),
-            }
-          : undefined,
+        // DefaultModelConfig → Session.model_config. If the schedule
+        // only sets ancillary fields (e.g. Claude effort), resolve them
+        // against the same model defaults used by fresh sessions.
+        model_config: scheduleModelConfig,
         custom_context: {
           scheduled_run: {
             rendered_prompt: renderedPrompt,

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -110,6 +110,28 @@ describe('applySessionConfigDefaults', () => {
     );
   });
 
+  it('fills a partial effort-only model_config with the default model and preserves effort', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'claude-code',
+        created_by: ALICE,
+        model_config: { effort: 'max', updated_at: 'client-time' },
+      },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+    await hook(ctx);
+    expect(
+      (ctx.data as { model_config: { mode: string; model: string; effort: string } }).model_config
+    ).toMatchObject({
+      mode: 'alias',
+      model: 'claude-sonnet-4-6',
+      effort: 'max',
+    });
+  });
+
   it('falls back to system default permission mode when user has no defaults', async () => {
     const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
     const ctx = makeContext({

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
@@ -67,7 +67,7 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
     if (!data) return context;
 
     const hasPermission = data.permission_config != null;
-    const hasModel = data.model_config != null;
+    const hasModel = !!data.model_config?.model;
     if (hasPermission && hasModel) return context; // nothing to fill
 
     const agenticTool = data.agentic_tool as AgenticToolName | undefined;
@@ -96,7 +96,11 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
       user = null;
     }
 
-    const resolved = resolveSessionDefaults({ agenticTool, user });
+    const resolved = resolveSessionDefaults({
+      agenticTool,
+      user,
+      overrides: { modelConfig: data.model_config ?? undefined },
+    });
 
     if (!hasPermission) {
       data.permission_config = resolved.permission_config;

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -16,6 +16,7 @@
  */
 
 import type { AgenticToolName, AgorClient, MCPServer } from '@agor-live/client';
+import { DEFAULT_CLAUDE_MODEL } from '@agor-live/client';
 import { Form, Select } from 'antd';
 import { CodexNetworkAccessToggle } from '../CodexNetworkAccessToggle';
 import { EffortSelector } from '../EffortSelector';
@@ -83,7 +84,7 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
         label={modelLabel}
         help={
           showHelpText && agenticTool === 'claude-code'
-            ? 'Choose which Claude model to use (defaults to claude-sonnet-4-6)'
+            ? `Choose which Claude model to use (defaults to ${DEFAULT_CLAUDE_MODEL})`
             : undefined
         }
       >

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -16,7 +16,7 @@ import type {
 import { getDefaultPermissionMode } from '@agor-live/client';
 import { DownOutlined } from '@ant-design/icons';
 import { Checkbox, Collapse, Form, Modal, Radio, Typography } from 'antd';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
@@ -58,6 +58,31 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
   );
   const [envVarNames, setEnvVarNames] = useState<string[]>([]);
 
+  const getCustomConfigDefaults = useCallback(
+    (agentTool: AgenticToolName) => {
+      const userDefaults = currentUser?.default_agentic_config?.[agentTool];
+      const sameToolAsParent = agentTool === session?.agentic_tool;
+      return {
+        agent: agentTool,
+        permissionMode:
+          userDefaults?.permissionMode ||
+          (sameToolAsParent ? session?.permission_config?.mode : undefined) ||
+          getDefaultPermissionMode(agentTool),
+        // Existing user defaults are sent as explicit form values. If the user
+        // has no saved model default and the child keeps the same tool, leaving
+        // this undefined would inherit the parent model in resolveChildSessionConfig;
+        // initialize that effective value so the picker doesn't imply a different default.
+        modelConfig:
+          userDefaults?.modelConfig ?? (sameToolAsParent ? session?.model_config : undefined),
+        codexSandboxMode: userDefaults?.codexSandboxMode,
+        codexApprovalPolicy: userDefaults?.codexApprovalPolicy,
+        codexNetworkAccess: userDefaults?.codexNetworkAccess,
+        mcpServerIds: userDefaults?.mcpServerIds || [],
+      };
+    },
+    [currentUser, session]
+  );
+
   // Reset form and preset when modal opens
   useEffect(() => {
     if (open && session) {
@@ -74,22 +99,14 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
     }
   }, [open, session, form, initialPrompt]);
 
-  // When switching to "Custom config", load user defaults for non-prompt fields
+  // When switching to "Custom config", load the values that will be
+  // effective if the user submits without touching individual fields.
   useEffect(() => {
     if (!open || !session || configPreset !== 'custom') return;
     const agentTool = session.agentic_tool || 'claude-code';
-    const userDefaults = currentUser?.default_agentic_config?.[agentTool];
-    form.setFieldsValue({
-      agent: agentTool,
-      permissionMode: userDefaults?.permissionMode || getDefaultPermissionMode(agentTool),
-      modelConfig: userDefaults?.modelConfig,
-      codexSandboxMode: userDefaults?.codexSandboxMode,
-      codexApprovalPolicy: userDefaults?.codexApprovalPolicy,
-      codexNetworkAccess: userDefaults?.codexNetworkAccess,
-      mcpServerIds: userDefaults?.mcpServerIds || [],
-    });
+    form.setFieldsValue(getCustomConfigDefaults(agentTool));
     setSelectedAgent(agentTool);
-  }, [open, session, configPreset, form, currentUser]);
+  }, [open, session, configPreset, form, getCustomConfigDefaults]);
 
   const handleOk = async () => {
     // Validate fields first. If validation fails, bail out WITHOUT clearing
@@ -243,8 +260,9 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
                     agents={AVAILABLE_AGENTS}
                     selectedAgentId={selectedAgent}
                     onSelect={(agentId) => {
-                      setSelectedAgent(agentId as AgenticToolName);
-                      form.setFieldValue('agent', agentId);
+                      const agentTool = agentId as AgenticToolName;
+                      setSelectedAgent(agentTool);
+                      form.setFieldsValue(getCustomConfigDefaults(agentTool));
                     }}
                     columns={2}
                   />

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -3,6 +3,7 @@ import {
   AVAILABLE_CLAUDE_MODEL_ALIASES,
   CODEX_MODEL_METADATA,
   COPILOT_MODEL_METADATA,
+  CURSOR_MODEL_METADATA,
   DEFAULT_CODEX_MODEL,
   DEFAULT_COPILOT_MODEL,
   GEMINI_MODELS,
@@ -11,6 +12,11 @@ import {
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Input, Radio, Select, Space, Tooltip } from 'antd';
 import { useEffect, useState } from 'react';
+import {
+  DEFAULT_CURSOR_MODEL,
+  ensureDefaultModelOption,
+  getModelSelectorFallbackModel,
+} from './modelDefaults';
 import { type OpenCodeModelConfig, OpenCodeModelSelector } from './OpenCodeModelSelector';
 
 export interface ModelConfig {
@@ -88,13 +94,11 @@ const COPILOT_STATIC_MODEL_OPTIONS = Object.entries(COPILOT_MODEL_METADATA).map(
 
 const CURSOR_MODEL_OPTIONS = [
   {
-    id: 'composer-latest',
-    label: 'Composer Latest',
-    description: 'Cursor SDK default model alias (experimental)',
+    id: DEFAULT_CURSOR_MODEL,
+    label: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].displayName,
+    description: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].description,
   },
 ];
-const DEFAULT_CURSOR_MODEL = 'composer-latest';
-
 function preferDefaultModel<T extends { id: string }>(models: T[], defaultModel: string): T[] {
   const defaultIndex = models.findIndex((model) => model.id === defaultModel);
   if (defaultIndex <= 0) return models;
@@ -142,6 +146,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     description?: string;
   }> | null>(null);
   const [cursorSource, setCursorSource] = useState<'dynamic' | 'static' | null>(null);
+  const [copilotDefaultModel, setCopilotDefaultModel] = useState(DEFAULT_COPILOT_MODEL);
   const [cursorDefaultModel, setCursorDefaultModel] = useState(DEFAULT_CURSOR_MODEL);
 
   useEffect(() => {
@@ -152,13 +157,23 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         const raw = await client.service('copilot-models').find();
         const response = raw as unknown as DynamicModelsResponse;
         if (cancelled || !response?.models?.length) return;
+        const defaultModel = response.default || DEFAULT_COPILOT_MODEL;
+        const models = response.models.map((m) => ({
+          id: m.id,
+          label: m.displayName,
+          description: m.description,
+        }));
         setCopilotServerOptions(
-          response.models.map((m) => ({
-            id: m.id,
-            label: m.displayName,
-            description: m.description,
-          }))
+          preferDefaultModel(
+            ensureDefaultModelOption(models, defaultModel, (id) => ({
+              id,
+              label: id,
+              description: 'Default model',
+            })),
+            defaultModel
+          )
         );
+        setCopilotDefaultModel(defaultModel);
         setCopilotSource(response.source);
       } catch {
         // Silent fallback to local static — best-effort.
@@ -178,12 +193,17 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         const response = raw as unknown as DynamicModelsResponse;
         if (cancelled || !response?.models?.length) return;
         const defaultModel = response.default || DEFAULT_CURSOR_MODEL;
+        const models = response.models.map((m) => ({
+          id: m.id,
+          label: m.displayName,
+          description: m.description,
+        }));
         setCursorServerOptions(
           preferDefaultModel(
-            response.models.map((m) => ({
-              id: m.id,
-              label: m.displayName,
-              description: m.description,
+            ensureDefaultModelOption(models, defaultModel, (id) => ({
+              id,
+              label: id,
+              description: 'Default model',
             })),
             defaultModel
           )
@@ -245,28 +265,19 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     );
   }
 
+  const fallbackModel = getModelSelectorFallbackModel(effectiveTool, modelList, {
+    copilotDefaultModel,
+    cursorDefaultModel,
+  });
+
   const handleModeChange = (newMode: 'alias' | 'exact') => {
     setMode(newMode);
     if (onChange) {
-      // When switching modes, provide a default model
-      let defaultModel: string;
-      if (newMode === 'alias') {
-        defaultModel = modelList[0].id;
-      } else if (effectiveTool === 'codex') {
-        defaultModel = DEFAULT_CODEX_MODEL;
-      } else if (effectiveTool === 'gemini') {
-        defaultModel = 'gemini-2.5-flash';
-      } else if (effectiveTool === 'copilot') {
-        defaultModel = DEFAULT_COPILOT_MODEL;
-      } else if (effectiveTool === 'cursor') {
-        defaultModel = cursorDefaultModel;
-      } else {
-        // claude-code (opencode is handled earlier in the component)
-        defaultModel = 'claude-sonnet-4-6';
-      }
+      // When switching modes, provide the same effective default the daemon
+      // applies if the form is submitted without a model_config.
       onChange({
         mode: newMode,
-        model: value?.model || defaultModel,
+        model: value?.model || fallbackModel,
       });
     }
   };
@@ -296,10 +307,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           {mode === 'alias' && (
             <div style={{ marginLeft: 24, marginTop: 8 }}>
               <Select
-                value={
-                  value?.model ||
-                  (effectiveTool === 'cursor' ? cursorDefaultModel : modelList[0].id)
-                }
+                value={value?.model || fallbackModel}
                 onChange={handleModelChange}
                 style={{ width: '100%', minWidth: 400 }}
                 options={modelList.map((m) => ({
@@ -361,7 +369,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                       : effectiveTool === 'copilot'
                         ? 'e.g., gpt-4o or claude-3.5-sonnet'
                         : effectiveTool === 'cursor'
-                          ? 'e.g., composer-latest'
+                          ? `e.g., ${DEFAULT_CURSOR_MODEL}`
                           : 'e.g., claude-opus-4-20250514' // claude-code (opencode handled earlier)
                 }
                 style={{ width: '100%', minWidth: 400 }}

--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.test.ts
@@ -1,0 +1,47 @@
+import {
+  AVAILABLE_CLAUDE_MODEL_ALIASES,
+  DEFAULT_CLAUDE_MODEL,
+  DEFAULT_GEMINI_MODEL,
+} from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CURSOR_MODEL,
+  ensureDefaultModelOption,
+  getModelSelectorFallbackModel,
+} from './modelDefaults';
+
+describe('getModelSelectorFallbackModel', () => {
+  it('uses the daemon Claude default instead of the first listed Claude alias', () => {
+    expect(AVAILABLE_CLAUDE_MODEL_ALIASES[0]?.id).not.toBe(DEFAULT_CLAUDE_MODEL);
+
+    expect(getModelSelectorFallbackModel('claude-code', AVAILABLE_CLAUDE_MODEL_ALIASES)).toBe(
+      DEFAULT_CLAUDE_MODEL
+    );
+    expect(getModelSelectorFallbackModel('claude-code-cli', AVAILABLE_CLAUDE_MODEL_ALIASES)).toBe(
+      DEFAULT_CLAUDE_MODEL
+    );
+  });
+
+  it('uses canonical non-Claude defaults even when model lists are newest-first', () => {
+    expect(getModelSelectorFallbackModel('gemini', [{ id: 'gemini-3-flash' }])).toBe(
+      DEFAULT_GEMINI_MODEL
+    );
+  });
+
+  it('adds a synthetic option when a dynamic default is absent from the returned list', () => {
+    const options = ensureDefaultModelOption([{ id: 'account-model' }], 'default-model', (id) => ({
+      id,
+    }));
+    expect(options.map((option) => option.id)).toEqual(['default-model', 'account-model']);
+  });
+
+  it('uses dynamic tool defaults for cursor and copilot', () => {
+    expect(getModelSelectorFallbackModel('cursor', [])).toBe(DEFAULT_CURSOR_MODEL);
+    expect(
+      getModelSelectorFallbackModel('cursor', [], { cursorDefaultModel: 'cursor-account-default' })
+    ).toBe('cursor-account-default');
+    expect(
+      getModelSelectorFallbackModel('copilot', [], { copilotDefaultModel: 'copilot-live-default' })
+    ).toBe('copilot-live-default');
+  });
+});

--- a/apps/agor-ui/src/components/ModelSelector/modelDefaults.ts
+++ b/apps/agor-ui/src/components/ModelSelector/modelDefaults.ts
@@ -1,0 +1,52 @@
+import type { AgenticToolName } from '@agor-live/client';
+import {
+  DEFAULT_COPILOT_MODEL,
+  DEFAULT_CURSOR_MODEL,
+  getDefaultModelForTool,
+} from '@agor-live/client';
+
+export { DEFAULT_CURSOR_MODEL };
+
+export interface ModelOptionLike {
+  id: string;
+}
+
+export function ensureDefaultModelOption<T extends ModelOptionLike>(
+  models: T[],
+  defaultModel: string,
+  makeOption: (id: string) => T
+): T[] {
+  if (!defaultModel || models.some((model) => model.id === defaultModel)) return models;
+  return [makeOption(defaultModel), ...models];
+}
+
+export interface ModelSelectorFallbackOptions {
+  /** Cursor's default can be discovered asynchronously from the daemon. */
+  cursorDefaultModel?: string;
+  /** Copilot's dynamic endpoint returns the daemon's effective default. */
+  copilotDefaultModel?: string;
+}
+
+/**
+ * Return the model the selector should render when the form has no value.
+ *
+ * This intentionally follows the same canonical defaults as the daemon's
+ * resolveSessionDefaults/applySessionConfigDefaults path. The model list is
+ * only an availability/display list; its first item may be newest/flashiest,
+ * but it is not the runtime default.
+ */
+export function getModelSelectorFallbackModel(
+  tool: AgenticToolName,
+  modelList: ModelOptionLike[],
+  options: ModelSelectorFallbackOptions = {}
+): string {
+  if (tool === 'cursor') {
+    return options.cursorDefaultModel || DEFAULT_CURSOR_MODEL;
+  }
+
+  if (tool === 'copilot') {
+    return options.copilotDefaultModel || getDefaultModelForTool(tool) || DEFAULT_COPILOT_MODEL;
+  }
+
+  return getDefaultModelForTool(tool) || modelList[0]?.id || '';
+}

--- a/packages/core/src/models/browser.ts
+++ b/packages/core/src/models/browser.ts
@@ -5,4 +5,8 @@
 export * from './claude.js';
 export * from './codex.js';
 export * from './copilot.js';
+export * from './cursor.js';
 export * from './gemini-shared.js';
+
+// Default-model resolver shared by daemon and browser UI.
+export * from './resolve-config.js';

--- a/packages/core/src/models/cursor.ts
+++ b/packages/core/src/models/cursor.ts
@@ -1,0 +1,14 @@
+/**
+ * Cursor model constants shared by daemon, executor, MCP, and browser UI.
+ *
+ * Cursor can return an account-specific live model list via the SDK, but the
+ * fallback/default alias is static and safe to share across packages.
+ */
+export const DEFAULT_CURSOR_MODEL = 'composer-latest';
+
+export const CURSOR_MODEL_METADATA = {
+  [DEFAULT_CURSOR_MODEL]: {
+    displayName: 'Composer Latest',
+    description: 'Cursor SDK default model alias (experimental)',
+  },
+} as const;

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -13,6 +13,7 @@ export * from './codex.js';
 
 // Copilot models
 export * from './copilot.js';
+export * from './cursor.js';
 
 // Gemini models
 export * from './gemini.js';

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -152,6 +152,21 @@ describe('resolveModelConfigWithFallback', () => {
     });
   });
 
+  it('does not carry model-less mode/provider onto a fallback model', () => {
+    const result = resolveModelConfigWithFallback(
+      'claude-code',
+      [{ mode: 'exact', provider: 'anthropic', effort: 'max' }],
+      { now }
+    );
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-sonnet-4-6',
+      effort: 'max',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+    expect(result).not.toHaveProperty('provider');
+  });
+
   it('returns undefined for cursor / opencode when sources are empty', () => {
     expect(resolveModelConfigWithFallback('cursor', [undefined], { now })).toBeUndefined();
     expect(resolveModelConfigWithFallback('opencode', [undefined], { now })).toBeUndefined();

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -128,6 +128,30 @@ describe('resolveModelConfigWithFallback', () => {
     });
   });
 
+  it('merges effort-only high-priority input onto the next model source', () => {
+    const result = resolveModelConfigWithFallback(
+      'claude-code',
+      [{ effort: 'max' }, { model: 'claude-opus-4-6', effort: 'high' }],
+      { now }
+    );
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-opus-4-6',
+      effort: 'max',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
+  it('merges effort-only input onto the tool fallback when no source has a model', () => {
+    const result = resolveModelConfigWithFallback('claude-code', [{ effort: 'max' }], { now });
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-sonnet-4-6',
+      effort: 'max',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
   it('returns undefined for cursor / opencode when sources are empty', () => {
     expect(resolveModelConfigWithFallback('cursor', [undefined], { now })).toBeUndefined();
     expect(resolveModelConfigWithFallback('opencode', [undefined], { now })).toBeUndefined();

--- a/packages/core/src/models/resolve-config.ts
+++ b/packages/core/src/models/resolve-config.ts
@@ -115,18 +115,49 @@ export function getDefaultModelForTool(tool: AgenticToolName): string | undefine
   }
 }
 
+/** Internal predicate for partial configs such as `{ effort }`. */
+function hasModelConfigAncillaryFields(input: ModelConfigInput | undefined | null): boolean {
+  return (
+    !!input &&
+    (input.mode !== undefined || input.effort !== undefined || input.provider !== undefined)
+  );
+}
+
 /**
- * `resolveModelConfigPrecedence` plus a final fallback to the tool's static
- * default. Use this at the session-create boundary.
+ * Resolve model config at a session-create boundary.
+ *
+ * Full model configs remain first-wins and are not merged with lower-priority
+ * sources. However, a higher-priority source that only carries ancillary
+ * fields (today most commonly `{ effort }` from the UI's separate effort
+ * selector) is merged onto the next source that supplies the actual model, or
+ * onto the tool fallback. This prevents partial persisted model_config objects
+ * while preserving the user's explicit effort choice.
  */
 export function resolveModelConfigWithFallback(
   tool: AgenticToolName,
   sources: Array<ModelConfigInput | undefined | null>,
   opts?: { now?: Date }
 ): ResolvedModelConfig | undefined {
-  const fromSources = resolveModelConfigPrecedence(sources, opts);
-  if (fromSources) return fromSources;
+  let pendingAncillary: ModelConfigInput | undefined;
+
+  for (const source of sources) {
+    if (source?.model) {
+      return resolveModelConfig(
+        pendingAncillary ? { ...source, ...pendingAncillary, model: source.model } : source,
+        opts
+      );
+    }
+    if (!pendingAncillary && hasModelConfigAncillaryFields(source)) {
+      pendingAncillary = source ?? undefined;
+    }
+  }
+
   const toolDefault = getDefaultModelForTool(tool);
   if (!toolDefault) return undefined;
-  return resolveModelConfig({ mode: 'alias', model: toolDefault }, opts);
+  return resolveModelConfig(
+    pendingAncillary
+      ? { mode: 'alias', ...pendingAncillary, model: toolDefault }
+      : { mode: 'alias', model: toolDefault },
+    opts
+  );
 }

--- a/packages/core/src/models/resolve-config.ts
+++ b/packages/core/src/models/resolve-config.ts
@@ -115,22 +115,23 @@ export function getDefaultModelForTool(tool: AgenticToolName): string | undefine
   }
 }
 
-/** Internal predicate for partial configs such as `{ effort }`. */
-function hasModelConfigAncillaryFields(input: ModelConfigInput | undefined | null): boolean {
-  return (
-    !!input &&
-    (input.mode !== undefined || input.effort !== undefined || input.provider !== undefined)
-  );
+/** Extract model-less overrides that are safe to carry onto a fallback model. */
+function getModelLessFallbackOverrides(
+  input: ModelConfigInput | undefined | null
+): ModelConfigInput | undefined {
+  if (input?.effort === undefined) return undefined;
+  return { effort: input.effort };
 }
 
 /**
  * Resolve model config at a session-create boundary.
  *
  * Full model configs remain first-wins and are not merged with lower-priority
- * sources. However, a higher-priority source that only carries ancillary
- * fields (today most commonly `{ effort }` from the UI's separate effort
- * selector) is merged onto the next source that supplies the actual model, or
- * onto the tool fallback. This prevents partial persisted model_config objects
+ * sources. However, a higher-priority source that only carries `effort` (from
+ * the UI's separate effort selector) is merged onto the next source that
+ * supplies the actual model, or onto the tool fallback. We intentionally do not
+ * carry model-less `mode` / `provider` because their meaning depends on the
+ * missing model value. This prevents partial persisted model_config objects
  * while preserving the user's explicit effort choice.
  */
 export function resolveModelConfigWithFallback(
@@ -138,25 +139,27 @@ export function resolveModelConfigWithFallback(
   sources: Array<ModelConfigInput | undefined | null>,
   opts?: { now?: Date }
 ): ResolvedModelConfig | undefined {
-  let pendingAncillary: ModelConfigInput | undefined;
+  let pendingModelLessOverrides: ModelConfigInput | undefined;
 
   for (const source of sources) {
     if (source?.model) {
       return resolveModelConfig(
-        pendingAncillary ? { ...source, ...pendingAncillary, model: source.model } : source,
+        pendingModelLessOverrides
+          ? { ...source, ...pendingModelLessOverrides, model: source.model }
+          : source,
         opts
       );
     }
-    if (!pendingAncillary && hasModelConfigAncillaryFields(source)) {
-      pendingAncillary = source ?? undefined;
+    if (!pendingModelLessOverrides) {
+      pendingModelLessOverrides = getModelLessFallbackOverrides(source);
     }
   }
 
   const toolDefault = getDefaultModelForTool(tool);
   if (!toolDefault) return undefined;
   return resolveModelConfig(
-    pendingAncillary
-      ? { mode: 'alias', ...pendingAncillary, model: toolDefault }
+    pendingModelLessOverrides
+      ? { mode: 'alias', ...pendingModelLessOverrides, model: toolDefault }
       : { mode: 'alias', model: toolDefault },
     opts
   );

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -175,6 +175,35 @@ describe('resolveSessionDefaults', () => {
       expect(r.model_config?.updated_at).toBe(now.toISOString());
     });
 
+    it('merges an effort-only override onto the tool default model', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        overrides: { modelConfig: { effort: 'max' } },
+        now,
+      });
+      expect(r.model_config).toEqual({
+        mode: 'alias',
+        model: 'claude-sonnet-4-6',
+        effort: 'max',
+        updated_at: now.toISOString(),
+      });
+    });
+
+    it('merges an effort-only override onto the user default model', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({ 'claude-code': { modelConfig: { model: 'claude-opus-4-6' } } }),
+        overrides: { modelConfig: { effort: 'max' } },
+        now,
+      });
+      expect(r.model_config).toEqual({
+        mode: 'alias',
+        model: 'claude-opus-4-6',
+        effort: 'max',
+        updated_at: now.toISOString(),
+      });
+    });
+
     it('explicit override wins over user default (no field merging)', () => {
       const r = resolveSessionDefaults({
         agenticTool: 'claude-code',

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -9,6 +9,7 @@
  */
 
 import { generateId, shortId } from '@agor/core/db';
+import { DEFAULT_CURSOR_MODEL } from '@agor/core/models';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type {
   ContentBlock,
@@ -51,7 +52,7 @@ function stringifyForPreview(value: unknown): string {
 }
 
 function toCursorModel(model: string | undefined): { id: string } {
-  return { id: model?.trim() || 'composer-latest' };
+  return { id: model?.trim() || DEFAULT_CURSOR_MODEL };
 }
 
 function asRecord(value: unknown): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Make `ModelSelector` render the same canonical default model that session/default resolution uses, instead of falling back visually to the first model in the list.
- Harden model default resolution for ancillary-only configs (for example Claude effort without a chosen model), preserving effort while filling the canonical/user default model.
- Centralize Cursor default metadata in core and reuse it in UI, daemon model listing, MCP model listing, and executor fallback.

Fixes #1306.

## Affected paths
- New Session / Assistant / Schedule untouched-model flows now display/submit consistently with daemon defaults.
- Fork/spawn custom config now visually seeds from inherited parent config for same-tool spawns, or the selected tool default for cross-tool spawns.
- Effort-only New Session and Schedule configs now resolve to a complete model config instead of persisting/dropping partial model config.

## Testing
- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/models/resolve-config.test.ts src/sessions/resolve-session-defaults.test.ts`
- `pnpm --filter @agor/daemon test -- src/utils/apply-session-config-defaults.test.ts`
- `pnpm --filter agor-ui test -- src/components/ModelSelector/modelDefaults.test.ts`
- Manual env validation at `http://10.33.92.175:6558`: Claude picker visually showed `claude-sonnet-4-6`; creating an untouched session persisted `model_config.model = claude-sonnet-4-6`; effort-only API create resolved to `claude-sonnet-4-6` plus effort.
