### PR TITLE
Add MCP cleanup candidate inventory for archived branches

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { registerBranchTools } from './branches.js';
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
@@ -48,6 +48,10 @@ function registerAndCaptureUpdate(ctx: {
 }): ToolHandler {
   return registerAndCaptureHandler('agor_branches_update', ctx);
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('agor_branches_update', () => {
   it('uses authenticated service params when falling back to the current session branch', async () => {
@@ -217,5 +221,176 @@ describe('agor_branches_list', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.data).toHaveLength(0);
     expect(parsed.total).toBe(0);
+  });
+});
+
+describe('agor_branches_cleanup_candidates', () => {
+  const baseServiceParams = {
+    authenticated: true,
+    provider: 'mcp',
+    user: { user_id: 'user-1', role: 'member' },
+  };
+
+  const repo = {
+    repo_id: 'repo-1',
+    slug: 'preset-io/agor',
+    name: 'Agor',
+  };
+
+  function makeBranch(overrides: Record<string, unknown>) {
+    return {
+      branch_id: overrides.branch_id ?? 'branch-1',
+      repo_id: overrides.repo_id ?? 'repo-1',
+      name: overrides.name ?? 'old-feature',
+      ref: overrides.ref ?? 'old-feature',
+      archived: true,
+      archived_at: overrides.archived_at ?? '2026-05-20T00:00:00.000Z',
+      archived_by: 'user-1',
+      last_used: '2026-05-19T00:00:00.000Z',
+      filesystem_status: overrides.filesystem_status,
+      storage_mode: overrides.storage_mode ?? 'worktree',
+      path: overrides.path ?? process.cwd(),
+      pull_request_url: overrides.pull_request_url,
+      issue_url: overrides.issue_url,
+      notes: overrides.notes,
+      others_can: overrides.others_can ?? 'session',
+      custom_context: overrides.custom_context,
+      ...overrides,
+    };
+  }
+
+  function makeCleanupApp(branches: unknown[]) {
+    const branchesFind = vi.fn(async () => ({
+      data: branches,
+      total: branches.length,
+      limit: 10000,
+      skip: 0,
+    }));
+    const reposGet = vi.fn(async () => repo);
+
+    return {
+      branchesFind,
+      reposGet,
+      app: {
+        service(name: string) {
+          if (name === 'branches') return { find: branchesFind };
+          if (name === 'repos') return { get: reposGet };
+          throw new Error(`Unexpected service call: ${name}`);
+        },
+      },
+    };
+  }
+
+  it('applies safe defaults: archived only, older than 7 days, not deleted, not assistant/private', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const { app, branchesFind } = makeCleanupApp([
+      makeBranch({ branch_id: 'candidate-ready', filesystem_status: undefined }),
+      makeBranch({ branch_id: 'candidate-preserved', filesystem_status: 'preserved' }),
+      makeBranch({ branch_id: 'candidate-cleaned', filesystem_status: 'cleaned' }),
+      makeBranch({
+        branch_id: 'too-recent',
+        archived_at: '2026-05-30T00:00:00.000Z',
+        filesystem_status: 'ready',
+      }),
+      makeBranch({ branch_id: 'deleted', filesystem_status: 'deleted' }),
+      makeBranch({
+        branch_id: 'assistant',
+        filesystem_status: 'ready',
+        custom_context: { assistant: { kind: 'assistant', displayName: 'Helper' } },
+      }),
+      makeBranch({ branch_id: 'private', filesystem_status: 'ready', others_can: 'none' }),
+      makeBranch({ branch_id: 'active', archived: false, filesystem_status: 'ready' }),
+    ]);
+
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await cleanupCandidates({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(branchesFind).toHaveBeenCalledWith({
+      query: { archived: true, $limit: 10000, $sort: { archived_at: 1 } },
+      ...baseServiceParams,
+    });
+    expect(
+      parsed.candidates.map((candidate: { branch_id: string }) => candidate.branch_id)
+    ).toEqual(['candidate-ready', 'candidate-preserved', 'candidate-cleaned']);
+    expect(parsed.safety).toMatchObject({
+      read_only: true,
+      archived_only: true,
+      archived_older_than_days: 7,
+      filesystem_statuses: ['ready', 'preserved', 'cleaned'],
+      exclude_assistants: true,
+      exclude_private: true,
+    });
+    expect(parsed.candidates[0]).toMatchObject({
+      repo_slug: 'preset-io/agor',
+      filesystem_status: 'ready',
+      path_exists: true,
+    });
+  });
+
+  it('supports explicit filters and pagination after safety filtering', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const { app } = makeCleanupApp([
+      makeBranch({
+        branch_id: 'missing-clone-a',
+        storage_mode: 'clone',
+        filesystem_status: 'cleaned',
+        path: '/tmp/agor-definitely-missing-a',
+      }),
+      makeBranch({
+        branch_id: 'missing-clone-b',
+        storage_mode: 'clone',
+        filesystem_status: 'cleaned',
+        path: '/tmp/agor-definitely-missing-b',
+      }),
+      makeBranch({
+        branch_id: 'existing-clone',
+        storage_mode: 'clone',
+        filesystem_status: 'cleaned',
+        path: process.cwd(),
+      }),
+      makeBranch({
+        branch_id: 'missing-worktree',
+        storage_mode: 'worktree',
+        filesystem_status: 'cleaned',
+        path: '/tmp/agor-definitely-missing-c',
+      }),
+    ]);
+
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await cleanupCandidates({
+      archivedOlderThanDays: 1,
+      filesystemStatuses: ['cleaned'],
+      storageMode: 'clone',
+      pathExists: false,
+      skip: 1,
+      limit: 1,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.total).toBe(2);
+    expect(parsed.skip).toBe(1);
+    expect(parsed.limit).toBe(1);
+    expect(parsed.candidates).toHaveLength(1);
+    expect(parsed.candidates[0]).toMatchObject({
+      branch_id: 'missing-clone-b',
+      storage_mode: 'clone',
+      filesystem_status: 'cleaned',
+      path_exists: false,
+    });
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -259,14 +259,21 @@ describe('agor_branches_cleanup_candidates', () => {
     };
   }
 
-  function makeCleanupApp(branches: unknown[]) {
-    const branchesFind = vi.fn(async () => ({
-      data: branches,
-      total: branches.length,
-      limit: 10000,
-      skip: 0,
-    }));
-    const reposGet = vi.fn(async () => repo);
+  function makeCleanupApp(branches: unknown[], options?: { repoGetFails?: boolean }) {
+    const branchesFind = vi.fn(async (params?: { query?: Record<string, unknown> }) => {
+      const skip = Number(params?.query?.$skip ?? 0);
+      const limit = Number(params?.query?.$limit ?? branches.length);
+      return {
+        data: branches.slice(skip, skip + limit),
+        total: branches.length,
+        limit,
+        skip,
+      };
+    });
+    const reposGet = vi.fn(async () => {
+      if (options?.repoGetFails) throw new Error('repo unavailable');
+      return repo;
+    });
 
     return {
       branchesFind,
@@ -314,7 +321,7 @@ describe('agor_branches_cleanup_candidates', () => {
     const parsed = JSON.parse(result.content[0].text);
 
     expect(branchesFind).toHaveBeenCalledWith({
-      query: { archived: true, $limit: 10000, $sort: { archived_at: 1 } },
+      query: { archived: true, $limit: 10000, $skip: 0, $sort: { archived_at: 1 } },
       ...baseServiceParams,
     });
     expect(
@@ -332,6 +339,11 @@ describe('agor_branches_cleanup_candidates', () => {
       repo_slug: 'preset-io/agor',
       filesystem_status: 'ready',
       path_exists: true,
+    });
+    expect(parsed.scanned).toMatchObject({
+      archived_branches: 8,
+      source_pages: 1,
+      source_page_limit: 10000,
     });
   });
 
@@ -392,5 +404,161 @@ describe('agor_branches_cleanup_candidates', () => {
       filesystem_status: 'cleaned',
       path_exists: false,
     });
+  });
+
+  it('scans multiple source pages before applying cleanup filters and pagination', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const nonCandidates = Array.from({ length: 10000 }, (_, index) =>
+      makeBranch({
+        branch_id: `deleted-${index}`,
+        filesystem_status: 'deleted',
+      })
+    );
+    const { app, branchesFind } = makeCleanupApp([
+      ...nonCandidates,
+      makeBranch({ branch_id: 'page-two-candidate', filesystem_status: 'ready' }),
+    ]);
+
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await cleanupCandidates({ limit: 1 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(branchesFind).toHaveBeenCalledTimes(2);
+    expect(branchesFind).toHaveBeenNthCalledWith(2, {
+      query: { archived: true, $limit: 10000, $skip: 10000, $sort: { archived_at: 1 } },
+      ...baseServiceParams,
+    });
+    expect(parsed.total).toBe(1);
+    expect(parsed.candidates[0].branch_id).toBe('page-two-candidate');
+    expect(parsed.scanned.source_pages).toBe(2);
+  });
+
+  it('excludes malformed archived_at values instead of treating them as old', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const { app } = makeCleanupApp([
+      makeBranch({ branch_id: 'bad-date', archived_at: 'not-a-date', filesystem_status: 'ready' }),
+      makeBranch({ branch_id: 'good-date', filesystem_status: 'ready' }),
+    ]);
+
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await cleanupCandidates({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(
+      parsed.candidates.map((candidate: { branch_id: string }) => candidate.branch_id)
+    ).toEqual(['good-date']);
+  });
+
+  it('supports explicit archivedBefore and opt-in inclusion of assistant/private branches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const { app } = makeCleanupApp([
+      makeBranch({
+        branch_id: 'assistant',
+        filesystem_status: 'ready',
+        custom_context: { assistant: { kind: 'assistant', displayName: 'Helper' } },
+      }),
+      makeBranch({ branch_id: 'private', filesystem_status: 'ready', others_can: 'none' }),
+      makeBranch({
+        branch_id: 'after-cutoff',
+        archived_at: '2026-05-22T00:00:00.000Z',
+        filesystem_status: 'ready',
+      }),
+    ]);
+
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await cleanupCandidates({
+      archivedBefore: '2026-05-21T00:00:00.000Z',
+      excludeAssistants: false,
+      excludePrivate: false,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(
+      parsed.candidates.map((candidate: { branch_id: string }) => candidate.branch_id)
+    ).toEqual(['assistant', 'private']);
+    expect(parsed.safety).toMatchObject({
+      cutoff_source: 'archivedBefore',
+      archived_older_than_days: null,
+      exclude_assistants: false,
+      exclude_private: false,
+    });
+  });
+
+  it('falls back to null repo metadata when repo enrichment fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const { app } = makeCleanupApp(
+      [makeBranch({ branch_id: 'candidate', filesystem_status: 'ready' })],
+      { repoGetFails: true }
+    );
+
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await cleanupCandidates({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.candidates[0]).toMatchObject({
+      branch_id: 'candidate',
+      repo_slug: null,
+      repo_name: null,
+    });
+  });
+
+  it('rejects ambiguous filesystem status inputs', async () => {
+    const { app } = makeCleanupApp([]);
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await expect(
+      cleanupCandidates({ filesystemStatus: 'ready', filesystemStatuses: ['cleaned'] })
+    ).rejects.toThrow(/either filesystemStatus or filesystemStatuses/i);
+  });
+
+  it('rejects non-old cleanup cutoffs', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T00:00:00.000Z'));
+
+    const { app } = makeCleanupApp([]);
+    const cleanupCandidates = registerAndCaptureHandler('agor_branches_cleanup_candidates', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await expect(cleanupCandidates({ archivedOlderThanDays: 0 })).rejects.toThrow(
+      /at least 1 day/i
+    );
+    await expect(cleanupCandidates({ archivedBefore: '2026-06-04T00:00:00.000Z' })).rejects.toThrow(
+      /must not be in the future/i
+    );
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { isBranchRbacEnabled } from '@agor/core/config';
 import { BranchRepository, shortId } from '@agor/core/db';
 import type {
@@ -29,6 +30,55 @@ import { assertValidVariant } from './_environment-helpers.js';
 
 const BRANCH_NAME_PATTERN = /^[a-z0-9-]+$/;
 const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const CLEANUP_CANDIDATE_DEFAULT_OLDER_THAN_DAYS = 7;
+const CLEANUP_CANDIDATE_DEFAULT_FILESYSTEM_STATUSES = ['ready', 'preserved', 'cleaned'] as const;
+const CLEANUP_CANDIDATE_FILESYSTEM_STATUSES = [
+  'creating',
+  'ready',
+  'failed',
+  'preserved',
+  'cleaned',
+  'deleted',
+] as const;
+const CLEANUP_CANDIDATE_STORAGE_MODES = ['worktree', 'clone'] as const;
+
+function normalizeFilesystemStatus(
+  branch: Branch
+): (typeof CLEANUP_CANDIDATE_FILESYSTEM_STATUSES)[number] {
+  return branch.filesystem_status ?? 'ready';
+}
+
+function parseCleanupCutoff(args: { archivedBefore?: string; archivedOlderThanDays?: number }): {
+  cutoff: Date;
+  source: 'archivedBefore' | 'archivedOlderThanDays';
+  olderThanDays?: number;
+} {
+  const archivedBefore = coerceString(args.archivedBefore);
+  if (archivedBefore) {
+    const cutoff = new Date(archivedBefore);
+    if (Number.isNaN(cutoff.getTime())) {
+      throw new Error('archivedBefore must be a valid ISO-8601 date/time string');
+    }
+    return { cutoff, source: 'archivedBefore' };
+  }
+
+  const olderThanDays = args.archivedOlderThanDays ?? CLEANUP_CANDIDATE_DEFAULT_OLDER_THAN_DAYS;
+  if (!Number.isFinite(olderThanDays) || olderThanDays < 0) {
+    throw new Error('archivedOlderThanDays must be a non-negative number');
+  }
+  return {
+    cutoff: new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000),
+    source: 'archivedOlderThanDays',
+    olderThanDays,
+  };
+}
+
+function notesPreview(notes: string | undefined, maxLength = 200): string | null {
+  if (!notes) return null;
+  const singleLine = notes.replace(/\s+/g, ' ').trim();
+  if (singleLine.length <= maxLength) return singleLine;
+  return `${singleLine.slice(0, maxLength - 1)}…`;
+}
 
 export function registerBranchTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_branches_get
@@ -121,6 +171,189 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       }
 
       return textResult(result);
+    }
+  );
+
+  // Tool 2b: agor_branches_cleanup_candidates
+  server.registerTool(
+    'agor_branches_cleanup_candidates',
+    {
+      description:
+        'Safely inventory archived branch worktrees that may be candidates for disk cleanup. ' +
+        'Read-only: never deletes or mutates anything. This tool ALWAYS restricts results to archived branches, ' +
+        'defaults to branches archived more than 7 days ago, excludes filesystem_status="deleted", ' +
+        'and excludes assistant/private branches by default. It returns repo metadata, archive timestamps, ' +
+        'filesystem/storage status, path, and a path_exists boolean computed from the recorded branch path only.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        repoId: z.string().optional().describe('Repository ID to filter by'),
+        archivedBefore: z
+          .string()
+          .optional()
+          .describe(
+            'Only include branches archived before this ISO-8601 date/time. Overrides the default archivedOlderThanDays=7 cutoff.'
+          ),
+        archivedOlderThanDays: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe(
+            'Only include branches archived more than this many days ago. Default: 7. Ignored when archivedBefore is provided.'
+          ),
+        filesystemStatus: z
+          .enum(CLEANUP_CANDIDATE_FILESYSTEM_STATUSES)
+          .optional()
+          .describe(
+            'Single filesystem_status to include. Undefined branch statuses are treated as "ready".'
+          ),
+        filesystemStatuses: z
+          .array(z.enum(CLEANUP_CANDIDATE_FILESYSTEM_STATUSES))
+          .optional()
+          .describe(
+            'Filesystem statuses to include. Default: ["ready","preserved","cleaned"], intentionally excluding "deleted". Undefined branch statuses are treated as "ready".'
+          ),
+        storageMode: z
+          .enum(CLEANUP_CANDIDATE_STORAGE_MODES)
+          .optional()
+          .describe('Filter by branch storage mode ("worktree" or "clone").'),
+        excludeAssistants: z
+          .boolean()
+          .optional()
+          .describe('Exclude long-lived assistant branches. Default: true.'),
+        excludePrivate: z
+          .boolean()
+          .optional()
+          .describe('Exclude branches with others_can="none" (private to owners). Default: true.'),
+        pathExists: z
+          .boolean()
+          .optional()
+          .describe(
+            'Filter by whether the recorded branch path currently exists. This checks the exact stored path; it does not scan the filesystem.'
+          ),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Maximum number of results (default: 50)'),
+        skip: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe('Number of filtered candidates to skip (default: 0)'),
+      }),
+    },
+    async (args) => {
+      const cutoff = parseCleanupCutoff(args);
+      const statuses = new Set(
+        args.filesystemStatuses ??
+          (args.filesystemStatus
+            ? [args.filesystemStatus]
+            : [...CLEANUP_CANDIDATE_DEFAULT_FILESYSTEM_STATUSES])
+      );
+      const excludeAssistants = args.excludeAssistants ?? true;
+      const excludePrivate = args.excludePrivate ?? true;
+      const limit = args.limit ?? 50;
+      const skip = args.skip ?? 0;
+
+      const query: Record<string, unknown> = {
+        archived: true,
+        $limit: 10000,
+        $sort: { archived_at: 1 },
+      };
+      if (args.repoId) query.repo_id = await resolveRepoId(ctx, args.repoId);
+
+      const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
+      const branches: Branch[] = Array.isArray(result)
+        ? (result as Branch[])
+        : ((result as { data: Branch[] }).data ?? []);
+      const scannedArchivedBranches = Array.isArray(result)
+        ? branches.length
+        : ((result as { total?: number }).total ?? branches.length);
+
+      const repoIds = [...new Set(branches.map((branch) => branch.repo_id))];
+      const reposById = new Map<string, Repo>();
+      await Promise.all(
+        repoIds.map(async (repoId) => {
+          try {
+            const repo = await ctx.app.service('repos').get(repoId, ctx.baseServiceParams);
+            reposById.set(repoId, repo as Repo);
+          } catch {
+            // Keep the inventory useful even if a repo row is missing or inaccessible.
+          }
+        })
+      );
+
+      const filtered = branches
+        .map((branch) => {
+          const pathExists = branch.path ? existsSync(branch.path) : false;
+          return {
+            branch,
+            pathExists,
+            filesystemStatus: normalizeFilesystemStatus(branch),
+            repo: reposById.get(branch.repo_id),
+          };
+        })
+        .filter(({ branch, pathExists, filesystemStatus }) => {
+          if (!branch.archived) return false; // Defense in depth: this tool never returns active branches.
+          if (!branch.archived_at) return false;
+          if (new Date(branch.archived_at).getTime() >= cutoff.cutoff.getTime()) return false;
+          if (!statuses.has(filesystemStatus)) return false;
+          if (args.storageMode && (branch.storage_mode ?? 'worktree') !== args.storageMode) {
+            return false;
+          }
+          if (excludeAssistants && isAssistant(branch)) return false;
+          if (excludePrivate && branch.others_can === 'none') return false;
+          if (args.pathExists !== undefined && pathExists !== args.pathExists) return false;
+          return true;
+        });
+
+      const candidates = filtered.slice(skip, skip + limit).map(({ branch, pathExists, repo }) => ({
+        repo_id: branch.repo_id,
+        repo_slug: repo?.slug ?? null,
+        repo_name: repo?.name ?? null,
+        branch_id: branch.branch_id,
+        name: branch.name,
+        ref: branch.ref,
+        archived: true,
+        archived_at: branch.archived_at,
+        archived_by: branch.archived_by ?? null,
+        last_used: branch.last_used ?? null,
+        filesystem_status: normalizeFilesystemStatus(branch),
+        storage_mode: branch.storage_mode ?? 'worktree',
+        path: branch.path,
+        path_exists: pathExists,
+        pull_request_url: branch.pull_request_url ?? null,
+        issue_url: branch.issue_url ?? null,
+        notes_preview: notesPreview(branch.notes),
+        is_assistant: isAssistant(branch),
+        is_private: branch.others_can === 'none',
+      }));
+
+      return textResult({
+        total: filtered.length,
+        limit,
+        skip,
+        candidates,
+        safety: {
+          read_only: true,
+          archived_only: true,
+          cutoff: cutoff.cutoff.toISOString(),
+          cutoff_source: cutoff.source,
+          archived_older_than_days:
+            cutoff.source === 'archivedOlderThanDays' ? cutoff.olderThanDays : null,
+          filesystem_statuses: [...statuses],
+          exclude_assistants: excludeAssistants,
+          exclude_private: excludePrivate,
+          path_exists_filter: args.pathExists ?? null,
+        },
+        scanned: {
+          archived_branches: scannedArchivedBranches,
+          returned_page_source_count: branches.length,
+        },
+      });
     }
   );
 

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -31,7 +31,13 @@ import { assertValidVariant } from './_environment-helpers.js';
 const BRANCH_NAME_PATTERN = /^[a-z0-9-]+$/;
 const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 const CLEANUP_CANDIDATE_DEFAULT_OLDER_THAN_DAYS = 7;
-const CLEANUP_CANDIDATE_DEFAULT_FILESYSTEM_STATUSES = ['ready', 'preserved', 'cleaned'] as const;
+const CLEANUP_CANDIDATE_SOURCE_PAGE_LIMIT = 10000;
+type CleanupCandidateFilesystemStatus = NonNullable<Branch['filesystem_status']>;
+const CLEANUP_CANDIDATE_DEFAULT_FILESYSTEM_STATUSES = [
+  'ready',
+  'preserved',
+  'cleaned',
+] as const satisfies readonly CleanupCandidateFilesystemStatus[];
 const CLEANUP_CANDIDATE_FILESYSTEM_STATUSES = [
   'creating',
   'ready',
@@ -39,12 +45,10 @@ const CLEANUP_CANDIDATE_FILESYSTEM_STATUSES = [
   'preserved',
   'cleaned',
   'deleted',
-] as const;
+] as const satisfies readonly CleanupCandidateFilesystemStatus[];
 const CLEANUP_CANDIDATE_STORAGE_MODES = ['worktree', 'clone'] as const;
 
-function normalizeFilesystemStatus(
-  branch: Branch
-): (typeof CLEANUP_CANDIDATE_FILESYSTEM_STATUSES)[number] {
+function normalizeFilesystemStatus(branch: Branch): CleanupCandidateFilesystemStatus {
   return branch.filesystem_status ?? 'ready';
 }
 
@@ -59,12 +63,15 @@ function parseCleanupCutoff(args: { archivedBefore?: string; archivedOlderThanDa
     if (Number.isNaN(cutoff.getTime())) {
       throw new Error('archivedBefore must be a valid ISO-8601 date/time string');
     }
+    if (cutoff.getTime() > Date.now()) {
+      throw new Error('archivedBefore must not be in the future');
+    }
     return { cutoff, source: 'archivedBefore' };
   }
 
   const olderThanDays = args.archivedOlderThanDays ?? CLEANUP_CANDIDATE_DEFAULT_OLDER_THAN_DAYS;
-  if (!Number.isFinite(olderThanDays) || olderThanDays < 0) {
-    throw new Error('archivedOlderThanDays must be a non-negative number');
+  if (!Number.isFinite(olderThanDays) || olderThanDays < 1) {
+    throw new Error('archivedOlderThanDays must be at least 1 day');
   }
   return {
     cutoff: new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000),
@@ -78,6 +85,44 @@ function notesPreview(notes: string | undefined, maxLength = 200): string | null
   const singleLine = notes.replace(/\s+/g, ' ').trim();
   if (singleLine.length <= maxLength) return singleLine;
   return `${singleLine.slice(0, maxLength - 1)}…`;
+}
+
+async function findAllArchivedBranchesForCleanup(
+  ctx: McpContext,
+  baseQuery: Record<string, unknown>
+): Promise<{ branches: Branch[]; total: number; pages: number }> {
+  const branches: Branch[] = [];
+  let skip = 0;
+  let total: number | undefined;
+  let pages = 0;
+
+  while (total === undefined || branches.length < total) {
+    const result = await ctx.app.service('branches').find({
+      query: {
+        ...baseQuery,
+        $limit: CLEANUP_CANDIDATE_SOURCE_PAGE_LIMIT,
+        $skip: skip,
+      },
+      ...ctx.baseServiceParams,
+    });
+    pages += 1;
+
+    if (Array.isArray(result)) {
+      branches.push(...(result as Branch[]));
+      total = branches.length;
+      break;
+    }
+
+    const paginated = result as { data: Branch[]; total?: number; limit?: number; skip?: number };
+    const pageData = paginated.data ?? [];
+    branches.push(...pageData);
+    total = paginated.total ?? branches.length;
+
+    if (pageData.length === 0) break;
+    skip += pageData.length;
+  }
+
+  return { branches, total: total ?? branches.length, pages };
 }
 
 export function registerBranchTools(server: McpServer, ctx: McpContext): void {
@@ -196,10 +241,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         archivedOlderThanDays: z
           .number()
           .int()
-          .nonnegative()
+          .positive()
           .optional()
           .describe(
-            'Only include branches archived more than this many days ago. Default: 7. Ignored when archivedBefore is provided.'
+            'Only include branches archived more than this many days ago. Must be at least 1. Default: 7. Ignored when archivedBefore is provided.'
           ),
         filesystemStatus: z
           .enum(CLEANUP_CANDIDATE_FILESYSTEM_STATUSES)
@@ -246,6 +291,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
+      if (args.filesystemStatus && args.filesystemStatuses) {
+        throw new Error('Pass either filesystemStatus or filesystemStatuses, not both');
+      }
+
       const cutoff = parseCleanupCutoff(args);
       const statuses = new Set(
         args.filesystemStatuses ??
@@ -260,18 +309,15 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
 
       const query: Record<string, unknown> = {
         archived: true,
-        $limit: 10000,
         $sort: { archived_at: 1 },
       };
       if (args.repoId) query.repo_id = await resolveRepoId(ctx, args.repoId);
 
-      const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
-      const branches: Branch[] = Array.isArray(result)
-        ? (result as Branch[])
-        : ((result as { data: Branch[] }).data ?? []);
-      const scannedArchivedBranches = Array.isArray(result)
-        ? branches.length
-        : ((result as { total?: number }).total ?? branches.length);
+      const {
+        branches,
+        total: scannedArchivedBranches,
+        pages: scannedPages,
+      } = await findAllArchivedBranchesForCleanup(ctx, query);
 
       const repoIds = [...new Set(branches.map((branch) => branch.repo_id))];
       const reposById = new Map<string, Repo>();
@@ -299,7 +345,9 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         .filter(({ branch, pathExists, filesystemStatus }) => {
           if (!branch.archived) return false; // Defense in depth: this tool never returns active branches.
           if (!branch.archived_at) return false;
-          if (new Date(branch.archived_at).getTime() >= cutoff.cutoff.getTime()) return false;
+          const archivedAtMs = new Date(branch.archived_at).getTime();
+          if (!Number.isFinite(archivedAtMs)) return false;
+          if (archivedAtMs >= cutoff.cutoff.getTime()) return false;
           if (!statuses.has(filesystemStatus)) return false;
           if (args.storageMode && (branch.storage_mode ?? 'worktree') !== args.storageMode) {
             return false;
@@ -351,7 +399,8 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         },
         scanned: {
           archived_branches: scannedArchivedBranches,
-          returned_page_source_count: branches.length,
+          source_pages: scannedPages,
+          source_page_limit: CLEANUP_CANDIDATE_SOURCE_PAGE_LIMIT,
         },
       });
     }


### PR DESCRIPTION
## Summary
- add read-only `agor_branches_cleanup_candidates` MCP tool for safe archived branch cleanup inventory
- default to archived-only, older-than-7-days, not-deleted filesystem statuses, excluding assistants/private branches
- include repo metadata, archive timestamps, storage/filesystem status, path existence, links, and notes preview

## Validation
- pnpm check
- pnpm --filter @agor/daemon test -- src/mcp/tools/branches.test.ts

## Notes
- This is inventory-only and does not implement destructive cleanup.
