### PR TITLE
Improve board zone MCP ergonomics

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -1,0 +1,208 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+import { registerBoardTools } from './boards.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+function registerAndCaptureHandler(
+  toolName: string,
+  ctx: {
+    app: unknown;
+    userId: string;
+    baseServiceParams?: Record<string, unknown>;
+  }
+): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const fakeServer = {
+    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+      if (name === toolName) handler = cb;
+    },
+  } as unknown as McpServer;
+
+  registerBoardTools(fakeServer, {
+    app: ctx.app as Parameters<typeof registerBoardTools>[1]['app'],
+    db: {} as Parameters<typeof registerBoardTools>[1]['db'],
+    userId: ctx.userId as Parameters<typeof registerBoardTools>[1]['userId'],
+    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
+      typeof registerBoardTools
+    >[1]['authenticatedUser'],
+    baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
+      typeof registerBoardTools
+    >[1]['baseServiceParams'],
+  });
+
+  if (!handler) throw new Error(`${toolName} was not registered`);
+  return handler;
+}
+
+describe('agor_boards_get', () => {
+  const baseServiceParams = {
+    authenticated: true,
+    provider: 'mcp',
+    user: { user_id: 'user-1', role: 'member' },
+  };
+
+  const board = {
+    board_id: 'board-1',
+    name: 'Test Board',
+    url: 'http://localhost:5173/ui/b/board-1/',
+    created_at: '2026-06-01T00:00:00.000Z',
+    last_updated: '2026-06-01T00:00:00.000Z',
+    created_by: 'user-1',
+    archived: false,
+    objects: {
+      'zone-review': {
+        type: 'zone',
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 300,
+        label: 'Review',
+      },
+      'note-1': {
+        type: 'markdown',
+        x: 500,
+        y: 0,
+        width: 300,
+        content: '# Large note',
+      },
+      'app-1': {
+        type: 'app',
+        x: 0,
+        y: 400,
+        width: 600,
+        height: 400,
+        title: 'Heavy app',
+        template: 'react',
+        files: { '/src/App.tsx': 'export default function App() { return null; }' },
+      },
+    },
+  };
+
+  function makeApp(options?: { boardObjectsFind?: ReturnType<typeof vi.fn> }) {
+    const boardsGet = vi.fn(async () => board);
+    const boardObjectsFind =
+      options?.boardObjectsFind ??
+      vi.fn(async () => ({
+        data: [],
+        total: 0,
+        limit: 100,
+        skip: 0,
+      }));
+
+    return {
+      boardsGet,
+      boardObjectsFind,
+      app: {
+        service(name: string) {
+          if (name === 'boards') return { get: boardsGet };
+          if (name === 'board-objects') return { find: boardObjectsFind };
+          throw new Error(`Unexpected service call: ${name}`);
+        },
+      },
+    };
+  }
+
+  it('can return a lean board definition with only zone objects and no entities', async () => {
+    const { app, boardObjectsFind } = makeApp();
+    const getBoard = registerAndCaptureHandler('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await getBoard({ boardId: 'board-1', objectTypes: ['zone'] });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeFalsy();
+    expect(Object.keys(parsed.objects)).toEqual(['zone-review']);
+    expect(parsed.objects['zone-review'].label).toBe('Review');
+    expect(parsed.entities).toBeUndefined();
+    expect(boardObjectsFind).not.toHaveBeenCalled();
+  });
+
+  it('filters and paginates included positioned entities', async () => {
+    const boardObjectsFind = vi.fn(async () => ({
+      data: [
+        {
+          object_id: 'obj-branch-1',
+          board_id: 'board-1',
+          branch_id: 'branch-1',
+          entity_type: 'branch',
+          position: { x: 10, y: 20 },
+          zone_id: 'zone-review',
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+      total: 3,
+      limit: 1,
+      skip: 1,
+    }));
+    const { app } = makeApp({ boardObjectsFind });
+    const getBoard = registerAndCaptureHandler('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await getBoard({
+      boardId: 'board-1',
+      includeEntities: true,
+      entityZoneId: 'zone-review',
+      entityType: 'branch',
+      entitiesLimit: 1,
+      entitiesSkip: 1,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(boardObjectsFind).toHaveBeenCalledWith({
+      query: {
+        board_id: 'board-1',
+        zone_id: 'zone-review',
+        entity_type: 'branch',
+        $limit: 1,
+        $skip: 1,
+      },
+      ...baseServiceParams,
+    });
+    expect(parsed.entities).toHaveLength(1);
+    expect(parsed.entities[0].branch_id).toBe('branch-1');
+    expect(parsed.entities_pagination).toEqual({ total: 3, limit: 1, skip: 1 });
+  });
+
+  it('preserves includeEntities=true behavior when no entity filters are provided', async () => {
+    const boardObjectsFind = vi.fn(async () => ({
+      data: [
+        {
+          object_id: 'obj-branch-1',
+          board_id: 'board-1',
+          branch_id: 'branch-1',
+          entity_type: 'branch',
+          position: { x: 10, y: 20 },
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      limit: 100,
+      skip: 0,
+    }));
+    const { app } = makeApp({ boardObjectsFind });
+    const getBoard = registerAndCaptureHandler('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await getBoard({ boardId: 'board-1', includeEntities: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(boardObjectsFind).toHaveBeenCalledWith({
+      query: { board_id: 'board-1' },
+      ...baseServiceParams,
+    });
+    expect(parsed.entities).toHaveLength(1);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -128,6 +128,15 @@ describe('agor_boards_get', () => {
     const boardObjectsFind = vi.fn(async () => ({
       data: [
         {
+          object_id: 'obj-branch-0',
+          board_id: 'board-1',
+          branch_id: 'branch-0',
+          entity_type: 'branch',
+          position: { x: 0, y: 0 },
+          zone_id: 'zone-review',
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+        {
           object_id: 'obj-branch-1',
           board_id: 'board-1',
           branch_id: 'branch-1',
@@ -136,10 +145,19 @@ describe('agor_boards_get', () => {
           zone_id: 'zone-review',
           created_at: '2026-06-01T00:00:00.000Z',
         },
+        {
+          object_id: 'obj-branch-2',
+          board_id: 'board-1',
+          branch_id: 'branch-2',
+          entity_type: 'branch',
+          position: { x: 30, y: 40 },
+          zone_id: 'zone-review',
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
       ],
       total: 3,
-      limit: 1,
-      skip: 1,
+      limit: 100,
+      skip: 0,
     }));
     const { app } = makeApp({ boardObjectsFind });
     const getBoard = registerAndCaptureHandler('agor_boards_get', {
@@ -163,8 +181,6 @@ describe('agor_boards_get', () => {
         board_id: 'board-1',
         zone_id: 'zone-review',
         entity_type: 'branch',
-        $limit: 1,
-        $skip: 1,
       },
       ...baseServiceParams,
     });

--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -7,6 +7,30 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 
+type ToolConfig = {
+  inputSchema?: {
+    safeParse: (value: unknown) => { success: boolean };
+  };
+};
+
+function makeMcpContext(ctx: {
+  app: unknown;
+  userId: string;
+  baseServiceParams?: Record<string, unknown>;
+}): Parameters<typeof registerBoardTools>[1] {
+  return {
+    app: ctx.app as Parameters<typeof registerBoardTools>[1]['app'],
+    db: {} as Parameters<typeof registerBoardTools>[1]['db'],
+    userId: ctx.userId as Parameters<typeof registerBoardTools>[1]['userId'],
+    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
+      typeof registerBoardTools
+    >[1]['authenticatedUser'],
+    baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
+      typeof registerBoardTools
+    >[1]['baseServiceParams'],
+  };
+}
+
 function registerAndCaptureHandler(
   toolName: string,
   ctx: {
@@ -22,20 +46,31 @@ function registerAndCaptureHandler(
     },
   } as unknown as McpServer;
 
-  registerBoardTools(fakeServer, {
-    app: ctx.app as Parameters<typeof registerBoardTools>[1]['app'],
-    db: {} as Parameters<typeof registerBoardTools>[1]['db'],
-    userId: ctx.userId as Parameters<typeof registerBoardTools>[1]['userId'],
-    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
-      typeof registerBoardTools
-    >[1]['authenticatedUser'],
-    baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
-      typeof registerBoardTools
-    >[1]['baseServiceParams'],
-  });
+  registerBoardTools(fakeServer, makeMcpContext(ctx));
 
   if (!handler) throw new Error(`${toolName} was not registered`);
   return handler;
+}
+
+function registerAndCaptureConfig(
+  toolName: string,
+  ctx: {
+    app: unknown;
+    userId: string;
+    baseServiceParams?: Record<string, unknown>;
+  }
+): ToolConfig {
+  let config: ToolConfig | undefined;
+  const fakeServer = {
+    registerTool: (name: string, cfg: ToolConfig, _cb: ToolHandler) => {
+      if (name === toolName) config = cfg;
+    },
+  } as unknown as McpServer;
+
+  registerBoardTools(fakeServer, makeMcpContext(ctx));
+
+  if (!config) throw new Error(`${toolName} was not registered`);
+  return config;
 }
 
 describe('agor_boards_get', () => {
@@ -220,5 +255,88 @@ describe('agor_boards_get', () => {
       ...baseServiceParams,
     });
     expect(parsed.entities).toHaveLength(1);
+    expect(parsed.entities_pagination).toEqual({ total: 1, limit: null, skip: 0 });
+  });
+
+  it('reports null pagination limit when only entitiesSkip is provided', async () => {
+    const boardObjectsFind = vi.fn(async () => ({
+      data: [
+        {
+          object_id: 'obj-branch-0',
+          board_id: 'board-1',
+          branch_id: 'branch-0',
+          entity_type: 'branch',
+          position: { x: 0, y: 0 },
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+        {
+          object_id: 'obj-branch-1',
+          board_id: 'board-1',
+          branch_id: 'branch-1',
+          entity_type: 'branch',
+          position: { x: 10, y: 20 },
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+      total: 2,
+      limit: 100,
+      skip: 0,
+    }));
+    const { app } = makeApp({ boardObjectsFind });
+    const getBoard = registerAndCaptureHandler('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await getBoard({
+      boardId: 'board-1',
+      includeEntities: true,
+      entitiesSkip: 1,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.entities).toHaveLength(1);
+    expect(parsed.entities[0].branch_id).toBe('branch-1');
+    expect(parsed.entities_pagination).toEqual({ total: 2, limit: null, skip: 1 });
+  });
+
+  it('validates entity pagination input constraints in the MCP schema', () => {
+    const { app } = makeApp();
+    const config = registerAndCaptureConfig('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    expect(
+      config.inputSchema?.safeParse({
+        boardId: 'board-1',
+        includeEntities: true,
+        entitiesLimit: 25,
+        entitiesSkip: 5,
+      }).success
+    ).toBe(true);
+    expect(
+      config.inputSchema?.safeParse({
+        boardId: 'board-1',
+        includeEntities: true,
+        entitiesLimit: -1,
+      }).success
+    ).toBe(false);
+    expect(
+      config.inputSchema?.safeParse({
+        boardId: 'board-1',
+        includeEntities: true,
+        entitiesLimit: 1.5,
+      }).success
+    ).toBe(false);
+    expect(
+      config.inputSchema?.safeParse({
+        boardId: 'board-1',
+        includeEntities: true,
+        entitiesSkip: 10001,
+      }).success
+    ).toBe(false);
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -1,9 +1,25 @@
-import type { Board } from '@agor/core/types';
+import type { Board, BoardEntityType, BoardObject, BoardObjectType } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BoardsServiceImpl } from '../../declarations.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
+
+const BOARD_OBJECT_TYPES = ['zone', 'text', 'markdown', 'app', 'artifact'] as const;
+const BOARD_ENTITY_TYPES = ['branch', 'card'] as const;
+
+function filterBoardCanvasObjects(board: Board, objectTypes?: BoardObjectType[]): Board {
+  if (!objectTypes) return board;
+
+  const allowedTypes = new Set<BoardObjectType>(objectTypes);
+  const objects = Object.fromEntries(
+    Object.entries(board.objects ?? {}).filter(([, object]) =>
+      allowedTypes.has((object as BoardObject).type)
+    )
+  );
+
+  return { ...board, objects };
+}
 
 export function registerBoardTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_boards_get
@@ -11,34 +27,85 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
     'agor_boards_get',
     {
       description:
-        'Get information about a board, including zones, layout, and positioned entities (branches, cards). ' +
+        'Get information about a board, including zones, canvas objects, and optionally positioned entities (branches, cards). ' +
         'The response includes a `url` field with a clickable link to view the board in the UI. ' +
-        'Set includeEntities=true to include positioned branch/card entities with their coordinates.',
+        'By default, returns board metadata and canvas objects only (no positioned branch/card entities). ' +
+        'Use objectTypes=["zone"] for a lean board definition with just zones. ' +
+        'Set includeEntities=true to include positioned branch/card entities, optionally filtered by entityZoneId/entityType and paginated with entitiesLimit/entitiesSkip.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         boardId: z.string().describe('Board ID (UUIDv7 or short ID)'),
+        objectTypes: z
+          .array(z.enum(BOARD_OBJECT_TYPES))
+          .optional()
+          .describe(
+            'Filter board.objects canvas annotations by type. Use ["zone"] to retrieve zone definitions without heavier text/markdown/app/artifact objects. Omit for backward-compatible behavior returning all board.objects.'
+          ),
         includeEntities: z
           .boolean()
           .optional()
           .describe(
             'Include positioned entities (branches, cards) with their x/y coordinates and zone assignments (default: false). Enable when you need to know where branches are placed on the canvas.'
           ),
+        entityZoneId: z
+          .string()
+          .optional()
+          .describe(
+            'When includeEntities=true, only return positioned entities pinned to this board zone ID.'
+          ),
+        entityType: z
+          .enum(BOARD_ENTITY_TYPES)
+          .optional()
+          .describe(
+            'When includeEntities=true, only return positioned entities of this type ("branch" or "card").'
+          ),
+        entitiesLimit: z
+          .number()
+          .optional()
+          .describe(
+            'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.'
+          ),
+        entitiesSkip: z
+          .number()
+          .optional()
+          .describe(
+            'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).'
+          ),
       }),
     },
     async (args) => {
       const boardId = coerceString(args.boardId);
       if (!boardId) throw new Error('boardId is required');
-      const board = await ctx.app.service('boards').get(boardId, ctx.baseServiceParams);
+      const board = filterBoardCanvasObjects(
+        await ctx.app.service('boards').get(boardId, ctx.baseServiceParams),
+        args.objectTypes as BoardObjectType[] | undefined
+      );
 
       const includeEntities = args.includeEntities === true; // default false, opt-in
       if (includeEntities) {
+        const entityQuery: Record<string, unknown> = { board_id: board.board_id };
+        const entityZoneId = coerceString(args.entityZoneId);
+        if (entityZoneId) entityQuery.zone_id = entityZoneId;
+        if (args.entityType) entityQuery.entity_type = args.entityType as BoardEntityType;
+        if (args.entitiesLimit !== undefined) entityQuery.$limit = args.entitiesLimit;
+        if (args.entitiesSkip !== undefined) entityQuery.$skip = args.entitiesSkip;
+
         const boardObjectsResult = await ctx.app
           .service('board-objects')
-          .find({ query: { board_id: board.board_id }, ...ctx.baseServiceParams });
+          .find({ query: entityQuery, ...ctx.baseServiceParams });
         const entities = (
           boardObjectsResult as { data: import('@agor/core/types').BoardEntityObject[] }
         ).data;
-        return textResult({ ...board, entities });
+        const { total, limit, skip } = boardObjectsResult as {
+          total?: number;
+          limit?: number;
+          skip?: number;
+        };
+        return textResult({
+          ...board,
+          entities,
+          entities_pagination: { total, limit, skip },
+        });
       }
 
       return textResult(board);

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -5,8 +5,14 @@ import type { BoardsServiceImpl } from '../../declarations.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
-const BOARD_OBJECT_TYPES = ['zone', 'text', 'markdown', 'app', 'artifact'] as const;
-const BOARD_ENTITY_TYPES = ['branch', 'card'] as const;
+const BOARD_OBJECT_TYPES = [
+  'zone',
+  'text',
+  'markdown',
+  'app',
+  'artifact',
+] as const satisfies readonly BoardObjectType[];
+const BOARD_ENTITY_TYPES = ['branch', 'card'] as const satisfies readonly BoardEntityType[];
 
 function filterBoardCanvasObjects(board: Board, objectTypes?: BoardObjectType[]): Board {
   if (!objectTypes) return board;
@@ -61,12 +67,18 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           ),
         entitiesLimit: z
           .number()
+          .int()
+          .min(0)
+          .max(10000)
           .optional()
           .describe(
             'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.'
           ),
         entitiesSkip: z
           .number()
+          .int()
+          .min(0)
+          .max(10000)
           .optional()
           .describe(
             'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).'
@@ -87,20 +99,21 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         const entityZoneId = coerceString(args.entityZoneId);
         if (entityZoneId) entityQuery.zone_id = entityZoneId;
         if (args.entityType) entityQuery.entity_type = args.entityType as BoardEntityType;
-        if (args.entitiesLimit !== undefined) entityQuery.$limit = args.entitiesLimit;
-        if (args.entitiesSkip !== undefined) entityQuery.$skip = args.entitiesSkip;
 
         const boardObjectsResult = await ctx.app
           .service('board-objects')
           .find({ query: entityQuery, ...ctx.baseServiceParams });
-        const entities = (
+        const matchedEntities = (
           boardObjectsResult as { data: import('@agor/core/types').BoardEntityObject[] }
         ).data;
-        const { total, limit, skip } = boardObjectsResult as {
-          total?: number;
-          limit?: number;
-          skip?: number;
-        };
+        const total = matchedEntities.length;
+        const skip = args.entitiesSkip ?? 0;
+        const limit = args.entitiesLimit ?? total;
+        const entities =
+          args.entitiesLimit !== undefined || args.entitiesSkip !== undefined
+            ? matchedEntities.slice(skip, skip + limit)
+            : matchedEntities;
+
         return textResult({
           ...board,
           entities,

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -108,10 +108,13 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         ).data;
         const total = matchedEntities.length;
         const skip = args.entitiesSkip ?? 0;
-        const limit = args.entitiesLimit ?? total;
+        const limit = args.entitiesLimit ?? null;
         const entities =
           args.entitiesLimit !== undefined || args.entitiesSkip !== undefined
-            ? matchedEntities.slice(skip, skip + limit)
+            ? matchedEntities.slice(
+                skip,
+                args.entitiesLimit === undefined ? undefined : skip + args.entitiesLimit
+              )
             : matchedEntities;
 
         return textResult({

--- a/apps/agor-daemon/src/services/board-objects.test.ts
+++ b/apps/agor-daemon/src/services/board-objects.test.ts
@@ -1,0 +1,110 @@
+import type { Database } from '@agor/core/db';
+import type { BoardID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { BoardObjectsService } from './board-objects.js';
+
+describe('BoardObjectsService.find', () => {
+  it('filters board entities by zone/type and applies explicit pagination', async () => {
+    const service = new BoardObjectsService({} as Database);
+    const findByBoardId = vi.fn(async () => [
+      {
+        object_id: 'obj-1',
+        board_id: 'board-1',
+        branch_id: 'branch-1',
+        entity_type: 'branch',
+        position: { x: 0, y: 0 },
+        zone_id: 'zone-review',
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        object_id: 'obj-2',
+        board_id: 'board-1',
+        card_id: 'card-1',
+        entity_type: 'card',
+        position: { x: 10, y: 10 },
+        zone_id: 'zone-review',
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        object_id: 'obj-3',
+        board_id: 'board-1',
+        branch_id: 'branch-2',
+        entity_type: 'branch',
+        position: { x: 20, y: 20 },
+        zone_id: 'zone-done',
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        object_id: 'obj-4',
+        board_id: 'board-1',
+        branch_id: 'branch-3',
+        entity_type: 'branch',
+        position: { x: 30, y: 30 },
+        zone_id: 'zone-review',
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+    ]);
+
+    (
+      service as unknown as {
+        boardObjectRepo: {
+          findByBoardId: typeof findByBoardId;
+        };
+      }
+    ).boardObjectRepo = { findByBoardId };
+
+    const result = await service.find({
+      query: {
+        board_id: 'board-1' as BoardID,
+        zone_id: 'zone-review',
+        entity_type: 'branch',
+        $skip: 1,
+        $limit: 1,
+      },
+    });
+
+    expect(findByBoardId).toHaveBeenCalledWith('board-1');
+    expect(result.total).toBe(2);
+    expect(result.skip).toBe(1);
+    expect(result.limit).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].object_id).toBe('obj-4');
+  });
+
+  it('preserves legacy unpaginated data when no $limit/$skip is requested', async () => {
+    const service = new BoardObjectsService({} as Database);
+    const findAll = vi.fn(async () => [
+      {
+        object_id: 'obj-1',
+        board_id: 'board-1',
+        branch_id: 'branch-1',
+        entity_type: 'branch',
+        position: { x: 0, y: 0 },
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        object_id: 'obj-2',
+        board_id: 'board-2',
+        branch_id: 'branch-2',
+        entity_type: 'branch',
+        position: { x: 10, y: 10 },
+        created_at: '2026-06-01T00:00:00.000Z',
+      },
+    ]);
+
+    (
+      service as unknown as {
+        boardObjectRepo: {
+          findAll: typeof findAll;
+        };
+      }
+    ).boardObjectRepo = { findAll };
+
+    const result = await service.find();
+
+    expect(result.total).toBe(2);
+    expect(result.limit).toBe(100);
+    expect(result.skip).toBe(0);
+    expect(result.data).toHaveLength(2);
+  });
+});

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -6,7 +6,14 @@
  */
 
 import { BoardObjectRepository, type Database } from '@agor/core/db';
-import type { BoardEntityObject, BoardID, BranchID, QueryParams } from '@agor/core/types';
+import type {
+  BoardEntityObject,
+  BoardEntityType,
+  BoardID,
+  BranchID,
+  CardID,
+  QueryParams,
+} from '@agor/core/types';
 
 /**
  * Board object service params
@@ -14,6 +21,9 @@ import type { BoardEntityObject, BoardID, BranchID, QueryParams } from '@agor/co
 export type BoardObjectParams = QueryParams<{
   board_id?: BoardID;
   branch_id?: BranchID;
+  card_id?: CardID;
+  zone_id?: string;
+  entity_type?: BoardEntityType;
 }>;
 
 /**
@@ -67,28 +77,47 @@ export class BoardObjectsService {
    * Find board objects
    */
   async find(params?: BoardObjectParams) {
-    const { board_id } = params?.query || {};
+    const { board_id, branch_id, card_id, zone_id, entity_type } = params?.query || {};
+
+    let objects: BoardEntityObject[];
 
     // If board_id filter is provided, use repository method
     if (board_id) {
-      const objects = await this.boardObjectRepo.findByBoardId(board_id);
-
-      return {
-        total: objects.length,
-        limit: params?.query?.$limit || 100,
-        skip: params?.query?.$skip || 0,
-        data: objects,
-      };
+      objects = await this.boardObjectRepo.findByBoardId(board_id);
+    } else {
+      // No board_id - return ALL board objects
+      objects = await this.boardObjectRepo.findAll();
     }
 
-    // No board_id - return ALL board objects
-    const allObjects = await this.boardObjectRepo.findAll();
+    if (branch_id) {
+      objects = objects.filter((object) => object.branch_id === branch_id);
+    }
+    if (card_id) {
+      objects = objects.filter((object) => object.card_id === card_id);
+    }
+    if (zone_id) {
+      objects = objects.filter((object) => object.zone_id === zone_id);
+    }
+    if (entity_type) {
+      objects = objects.filter((object) => object.entity_type === entity_type);
+    }
+
+    const total = objects.length;
+    const requestedSkip = params?.query?.$skip ?? 0;
+    const requestedLimit = params?.query?.$limit;
+    const data =
+      requestedLimit !== undefined || requestedSkip > 0
+        ? objects.slice(
+            requestedSkip,
+            requestedLimit === undefined ? undefined : requestedSkip + requestedLimit
+          )
+        : objects;
 
     return {
-      total: allObjects.length,
-      limit: params?.query?.$limit || 100,
-      skip: params?.query?.$skip || 0,
-      data: allObjects,
+      total,
+      limit: requestedLimit ?? 100,
+      skip: requestedSkip,
+      data,
     };
   }
 

--- a/apps/agor-docs/pages/guide/architecture.mdx
+++ b/apps/agor-docs/pages/guide/architecture.mdx
@@ -380,14 +380,14 @@ $ agor session list | grep running | wc -l
 | Tool | Description | Example |
 |------|-------------|---------|
 | `agor_branches_get` | Get branch details | `{ branchId: '...' }` |
-| `agor_branches_list` | List all branches | `{ limit: 10 }` |
+| `agor_branches_list` | List branches, including zone metadata and optional zone filtering | `{ limit: 10, zoneId: 'zone-review' }` |
 | `agor_branches_create` | Create a branch with optional issue/PR links | `{ repoId: '019a...', branchName: 'feat-x', issueUrl: 'https://...' }` |
 | `agor_branches_update` | Update branch metadata (issue/PR URLs, notes) | `{ branchId: '019a...', pullRequestUrl: 'https://...', notes: 'Ready for review' }` |
 
 **Board Tools:**
 | Tool | Description | Example |
 |------|-------------|---------|
-| `agor_boards_get` | Get board by ID | `{ boardId: '...' }` |
+| `agor_boards_get` | Get board metadata/canvas objects; filter to zones or paginated entities for large boards | `{ boardId: '...', objectTypes: ['zone'], includeEntities: true, entityZoneId: 'zone-review', entitiesLimit: 25 }` |
 | `agor_boards_list` | List all boards | `{}` |
 
 **Task Tools:**

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { boardObjectQueryValidator, typedValidateQuery } from './feathers-validation';
+
+describe('boardObjectQueryValidator', () => {
+  it('preserves supported board-object filters through Feathers query validation', async () => {
+    const context = {
+      params: {
+        query: {
+          board_id: '019e8e1c',
+          branch_id: '019e8e1d',
+          card_id: '019e8e1e',
+          zone_id: 'zone-review',
+          entity_type: 'branch',
+          $limit: 25,
+          $skip: 5,
+          unknown: 'removed',
+        },
+      },
+    };
+
+    await typedValidateQuery(boardObjectQueryValidator)(context);
+
+    expect(context.params.query).toEqual({
+      board_id: '019e8e1c',
+      branch_id: '019e8e1d',
+      card_id: '019e8e1e',
+      zone_id: 'zone-review',
+      entity_type: 'branch',
+      $limit: 25,
+      $skip: 5,
+    });
+  });
+});

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -199,6 +199,9 @@ export const boardObjectQuerySchema = createQuerySchema(
   Type.Object({
     board_id: Type.Optional(CommonSchemas.uuid),
     branch_id: Type.Optional(CommonSchemas.uuid),
+    card_id: Type.Optional(CommonSchemas.uuid),
+    zone_id: Type.Optional(Type.String()),
+    entity_type: Type.Optional(Type.Union([Type.Literal('branch'), Type.Literal('card')])),
     created_at: Type.Optional(CommonSchemas.timestamp),
   })
 );


### PR DESCRIPTION
## Summary
- add lean `agor_boards_get` options for filtering canvas objects to zones
- add filtered/paginated positioned entity retrieval for large boards
- extend board-objects service filters and add MCP/service tests

Fixes #1319

## Checks
- pnpm i
- pnpm check
- pnpm --filter @agor/daemon test -- src/mcp/tools/boards.test.ts src/mcp/tools/branches.test.ts src/services/board-objects.test.ts