### PR TITLE
feat: add Codex sandbox/approval/network config to scheduled sessions

### DIFF
--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -60,7 +60,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import { Forbidden } from '@agor/core/feathers';
-import { resolveSessionDefaults } from '@agor/core/sessions';
+import { resolvePermissionConfig, resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   Branch,
   MCPServerID,
@@ -637,9 +637,16 @@ export class SchedulerService {
           ? `${schedule.name} — manual @ ${new Date(scheduledRunAt).toISOString()}`
           : `${schedule.name} — ${new Date(scheduledRunAt).toISOString()}`,
         contextFiles: cfg.context_files ?? [],
-        permission_config: cfg.permission_mode
-          ? { mode: cfg.permission_mode as PermissionMode }
-          : undefined,
+        permission_config: resolvePermissionConfig({
+          effectiveTool: cfg.agentic_tool,
+          overrides: {
+            permissionMode: cfg.permission_mode as PermissionMode | undefined,
+            codexSandboxMode: cfg.codex_sandbox_mode,
+            codexApprovalPolicy: cfg.codex_approval_policy,
+            codexNetworkAccess: cfg.codex_network_access,
+          },
+          userToolDefaults: creator?.default_agentic_config?.[cfg.agentic_tool],
+        }),
         // DefaultModelConfig → Session.model_config. If the schedule
         // only sets ancillary fields (e.g. Claude effort), resolve them
         // against the same model defaults used by fresh sessions.

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts
@@ -106,8 +106,11 @@ export function scheduleConfigToDefaultConfig(
     modelConfig: cfg.model_config,
     permissionMode: cfg.permission_mode,
     mcpServerIds: cfg.mcp_server_ids,
-    // Codex fields aren't surfaced in ScheduleAgenticToolConfig today;
-    // promote them here if/when schedules grow codex sandbox controls.
+    ...(cfg.agentic_tool === 'codex' && {
+      codexSandboxMode: cfg.codex_sandbox_mode,
+      codexApprovalPolicy: cfg.codex_approval_policy,
+      codexNetworkAccess: cfg.codex_network_access,
+    }),
   };
 }
 
@@ -129,6 +132,11 @@ export function buildScheduleConfigFromFormValues(
     model_config: builtDefault.modelConfig,
     mcp_server_ids: builtDefault.mcpServerIds,
     context_files: previous?.context_files,
+    // Codex fields: set when tool is codex, clear when switching away
+    // (prevents stale values lingering from a previous codex config).
+    codex_sandbox_mode: tool === 'codex' ? builtDefault.codexSandboxMode : undefined,
+    codex_approval_policy: tool === 'codex' ? builtDefault.codexApprovalPolicy : undefined,
+    codex_network_access: tool === 'codex' ? builtDefault.codexNetworkAccess : undefined,
   };
 }
 

--- a/apps/agor-ui/src/components/ScheduleModal/ScheduleModal.tsx
+++ b/apps/agor-ui/src/components/ScheduleModal/ScheduleModal.tsx
@@ -8,16 +8,16 @@
  *   MCP servers.
  * - Ghost `<Collapse>` with two panels for the secondary zone:
  *     1. "Agentic Tool Configuration" — same `AgenticToolConfigForm`
- *        component the session modal uses, in `compact` mode + with
- *        `hideMcpServers` (the MCP field is promoted to the primary
- *        zone above).
+ *        component the session modal uses, with `hideMcpServers` (the
+ *        MCP field is promoted to the primary zone above). Full mode
+ *        (not compact) so Codex-specific fields render.
  *     2. "Schedule Settings" — retention + concurrency (schedule-specific).
  *
  * Reuses the same building blocks as `NewSessionModal`:
  * - `AgentSelectionGrid` (with `variant="select"` here vs `cards` there —
  *   schedules don't need to merchandise the agent choice).
  * - `SessionMcpServersField` as a top-level form field.
- * - `AgenticToolConfigForm` with `hideMcpServers + compact`.
+ * - `AgenticToolConfigForm` with `hideMcpServers`.
  * - `getFormValuesFromConfig` / `buildConfigFromFormValues` to translate
  *   between form values and the schedule's `agentic_tool_config` jsonb.
  *
@@ -401,7 +401,6 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
                   agenticTool={agentTool}
                   mcpServerById={mcpServerById}
                   hideMcpServers
-                  compact
                   client={client}
                 />
               ),

--- a/packages/core/src/types/schedule.ts
+++ b/packages/core/src/types/schedule.ts
@@ -1,5 +1,5 @@
 // src/types/schedule.ts
-import type { AgenticToolName } from './agentic-tool';
+import type { AgenticToolName, CodexApprovalPolicy, CodexSandboxMode } from './agentic-tool';
 import type { BranchID, SessionID, UUID } from './id';
 import type { PermissionMode } from './session';
 import type { DefaultModelConfig } from './user';
@@ -61,6 +61,15 @@ export interface ScheduleAgenticToolConfig {
 
   /** Additional context files to load into the spawned session. */
   context_files?: string[];
+
+  /** Codex-specific: sandbox mode (where Codex can write). */
+  codex_sandbox_mode?: CodexSandboxMode;
+
+  /** Codex-specific: approval policy (whether Codex asks before executing). */
+  codex_approval_policy?: CodexApprovalPolicy;
+
+  /** Codex-specific: network access (outbound HTTP/HTTPS). */
+  codex_network_access?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Scheduled Codex sessions previously only inherited `permission_mode`, missing Codex-specific `sandbox`, `approval_policy`, and `network_access` settings — so configuring full-access sandbox or auto-approve for scheduled runs had no effect
- Add `codex_sandbox_mode`, `codex_approval_policy`, `codex_network_access` fields to `ScheduleAgenticToolConfig` type
- Round-trip those fields through the schedule config helpers and `ScheduleModal`
- Use `resolvePermissionConfig` in `scheduler.spawnScheduledSession` to properly populate `session.permission_config.codex` from user/schedule/system defaults

## Test plan

- [ ] Open Schedule modal for a Codex session, set sandbox to `danger-full-access`, approval to `never`, network to enabled
- [ ] Trigger the schedule manually (run now)
- [ ] Confirm daemon log shows `sandboxMode=danger-full-access, approvalPolicy=never, networkAccess=true`
- [ ] Confirm session runs without approval prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)