### PR TITLE
chore(nix): add Nix dev environment (flake.nix + shell.nix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ apps/agor-desktop/out/
 
 # Playwright MCP tool artifacts
 .playwright-mcp/
+
+# Nix
+result

--- a/apps/agor-ui/src/components/CodeEditor/CodeEditor.inner.tsx
+++ b/apps/agor-ui/src/components/CodeEditor/CodeEditor.inner.tsx
@@ -66,7 +66,7 @@ const CodeEditorInner: React.FC<CodeEditorInnerProps> = ({
       .then(({ markdown }) => {
         const createMarkdownWithCodeLanguages = () =>
           markdown({
-            codeLanguages: (info) => {
+            codeLanguages: (info: string) => {
               const languageName = info.trim().split(/\s+/, 1)[0]?.toLowerCase();
               if (languageName === 'yaml' || languageName === 'yml') return yaml().language;
               if (languageName === 'json') return json().language;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Agor dev environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        runtimeDeps = with pkgs; [ nodejs_22 pnpm git python3 pkg-config bash ];
+        binPath     = pkgs.lib.makeBinPath runtimeDeps;
+
+        # Helper: nix run app that cds into a subdir and runs pnpm dev.
+        # Uses writeShellScriptBin (no shellcheck) with explicit PATH.
+        mkDevApp = name: subdir:
+          let
+            script = pkgs.writeShellScriptBin name ''
+              export PATH="${binPath}:$PATH"
+              root="$(git rev-parse --show-toplevel)"
+              cd "$root/${subdir}"
+              exec pnpm dev
+            '';
+          in
+          { type = "app"; program = "${script}/bin/${name}"; };
+
+        daemonApp = mkDevApp "agor-daemon" "apps/agor-daemon";
+        uiApp     = mkDevApp "agor-ui"    "apps/agor-ui";
+
+        # nix run / nix run .#dev — build UI then start daemon
+        # The daemon serves the built UI at /ui/ — no Vite dev server needed.
+        devApp =
+          let
+            script = pkgs.writeShellScriptBin "agor-dev" ''
+              export PATH="${binPath}:$PATH"
+              root="$(git rev-parse --show-toplevel)"
+              echo "Installing dependencies..."
+              (cd "$root" && pnpm install --frozen-lockfile)
+              echo "Building executor..."
+              (cd "$root" && pnpm --filter @agor/executor build)
+              echo "Building UI..."
+              (cd "$root" && pnpm --filter @agor-live/client... build && pnpm --filter agor-ui build && rm -rf apps/agor-daemon/ui && cp -r apps/agor-ui/dist apps/agor-daemon/ui)
+              exec pnpm --dir "$root/apps/agor-daemon" run dev:daemon-only
+            '';
+          in
+          { type = "app"; program = "${script}/bin/agor-dev"; };
+      in
+      {
+        # nix develop
+        devShells.default = pkgs.mkShell {
+          buildInputs = runtimeDeps;
+          shellHook = ''
+            echo "agor dev shell — node $(node -v), pnpm $(pnpm -v)"
+          '';
+        };
+
+        # nix run           — daemon + UI together (default)
+        # nix run .#dev     — same
+        # nix run .#daemon  — daemon only
+        # nix run .#ui      — UI only
+        apps.daemon  = daemonApp;
+        apps.ui      = uiApp;
+        apps.dev     = devApp;
+        apps.default = devApp;
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    nodejs_22
+    pnpm
+    git
+    python3      # needed by node-pty native build
+    pkg-config
+  ];
+
+  shellHook = ''
+    echo "agor dev shell — node $(node -v), pnpm $(pnpm -v)"
+  '';
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` with `nix run` apps for one-command dev startup
- Add `shell.nix` for legacy `nix-shell` support
- Add `result` to `.gitignore` (Nix build symlink)

## How it works

`nix run` (default) builds the UI bundle (`@agor-live/client` + `agor-ui`) into `apps/agor-daemon/ui/`, then starts the daemon with `dev:daemon-only`. The daemon serves the pre-built UI — no Vite dev server needed.

## Usage

```bash
nix run           # build UI + start daemon (default)
nix run .#daemon  # daemon only (skip UI build)
nix develop       # dev shell with node 22, pnpm, git, python3, pkg-config
nix-shell         # same via legacy shell.nix
```

## Test plan

- [ ] `nix run` builds UI and starts daemon on `:3030`, UI accessible at `/ui/`
- [ ] `nix run .#daemon` starts daemon only
- [ ] `nix develop` drops into shell with correct node/pnpm versions