### PR TITLE
fix(branches): zoneId filter on agor_branches_list always returns 0

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -110,10 +110,27 @@ describe('agor_branches_list', () => {
     user: { user_id: 'user-1', role: 'member' },
   };
 
+  // Simulate service-level zone filtering: the real BranchesService.find() handles
+  // zone_id in the query before pagination, so the mock must do the same.
   function makeApp(findResult: unknown) {
     return {
       service(name: string) {
-        if (name === 'branches') return { find: vi.fn(async () => findResult) };
+        if (name === 'branches') {
+          return {
+            find: vi.fn(async (params?: { query?: Record<string, unknown> }) => {
+              const zoneId = params?.query?.zone_id as string | undefined;
+              if (!zoneId || Array.isArray(findResult)) return findResult;
+              const res = findResult as {
+                data: Record<string, unknown>[];
+                total: number;
+                limit: number;
+                skip: number;
+              };
+              const filtered = res.data.filter((b) => b.zone_id === zoneId);
+              return { ...res, data: filtered, total: filtered.length };
+            }),
+          };
+        }
         throw new Error(`Unexpected service call: ${name}`);
       },
     };
@@ -159,6 +176,35 @@ describe('agor_branches_list', () => {
 
     const branch2 = parsed.data[1];
     expect(branch2.zone_id).toBeUndefined();
+  });
+
+  it('passes zone_id to the service query so filtering is pagination-correct', async () => {
+    // The fix for the always-0 bug: zone filtering must happen inside the service
+    // (before pagination) rather than as a post-enrichment filter in the tool.
+    // Verify that zone_id is forwarded to service.find() via the query object.
+    const findFn = vi.fn(async () => ({
+      data: [{ branch_id: 'branch-1', zone_id: 'zone-review' }],
+      total: 1,
+      limit: 50,
+      skip: 0,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { find: findFn };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await list({ zoneId: 'zone-review' });
+
+    expect(findFn).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ zone_id: 'zone-review' }) })
+    );
   });
 
   it('filters by zoneId when provided', async () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -268,6 +268,41 @@ describe('agor_branches_list', () => {
     expect(parsed.data).toHaveLength(0);
     expect(parsed.total).toBe(0);
   });
+
+  it('passes include_sessions to service query when includeSessions=true', async () => {
+    const findFn = vi.fn(async () => ({
+      data: [
+        {
+          branch_id: 'branch-1',
+          name: 'feature-a',
+          sessions: [{ session_id: 's-1', status: 'idle' }],
+        },
+      ],
+      total: 1,
+      limit: 50,
+      skip: 0,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { find: findFn };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await list({ includeSessions: true });
+
+    expect(findFn).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ include_sessions: true }) })
+    );
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.data[0].sessions).toHaveLength(1);
+  });
 });
 
 describe('agor_branches_cleanup_candidates', () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -155,10 +155,11 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     'agor_branches_list',
     {
       description:
-        'List all branches in a repository. Each branch includes zone_id and zone_label when ' +
-        'the branch is assigned to a board zone — use these fields directly to identify which ' +
-        'zone a branch is in without extra agor_branches_get calls. Also includes ' +
-        'pull_request_url, issue_url, board_object_id, and position when set.',
+        'List branches with rich metadata in one call. Each branch includes zone_id, zone_label, ' +
+        'pull_request_url, issue_url, board_object_id, and position when set. ' +
+        'Use zoneId to get only branches in a specific board zone — no fan-out needed. ' +
+        'Use includeSessions=true to also get recent session activity for each branch — ' +
+        'eliminates the need to call agor_branches_get individually for name/PR/session data.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         repoId: z.string().optional().describe('Repository ID to filter by'),
@@ -180,7 +181,15 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .optional()
           .describe(
             'Filter results to branches in a specific board zone (e.g. "zone-1776863814461"). ' +
-              'Avoids the need to call agor_branches_get on each branch to check zone membership.'
+              'Filtering is pagination-correct: all branches in the zone are considered, not just the first page.'
+          ),
+        includeSessions: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include recent session activity (status, last message, agentic_tool) for each branch. ' +
+              'Default: false. Enable to get the full picture in one call instead of fanning out ' +
+              'with individual agor_branches_get calls.'
           ),
       }),
     },
@@ -198,6 +207,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       // first, then fetches only those branches, ensuring the zone filter is
       // pagination-correct regardless of how many total branches exist.
       if (args.zoneId) query.zone_id = coerceString(args.zoneId);
+      if (args.includeSessions) query.include_sessions = true;
 
       const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
       return textResult(result);

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -193,28 +193,13 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       } else if (!args.includeArchived) {
         query.archived = false;
       }
+      // Delegate zone filtering to the service so it runs before pagination.
+      // BranchesService.find() resolves branch IDs in the zone from board_objects
+      // first, then fetches only those branches, ensuring the zone filter is
+      // pagination-correct regardless of how many total branches exist.
+      if (args.zoneId) query.zone_id = coerceString(args.zoneId);
+
       const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
-
-      // Post-enrichment zone filter: zone_id is added by the service's find() via
-      // enrichManyWithZoneInfo (LEFT JOIN on board_objects). Filter here after enrichment
-      // so the caller doesn't have to fan out with individual get() calls.
-      if (args.zoneId) {
-        const zoneId = coerceString(args.zoneId);
-        if (Array.isArray(result)) {
-          return textResult(result.filter((b: Record<string, unknown>) => b.zone_id === zoneId));
-        } else {
-          const filtered = (
-            result as {
-              data: Record<string, unknown>[];
-              total: number;
-              limit: number;
-              skip: number;
-            }
-          ).data.filter((b) => b.zone_id === zoneId);
-          return textResult({ ...result, data: filtered, total: filtered.length });
-        }
-      }
-
       return textResult(result);
     }
   );

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -50,6 +50,7 @@ export type BranchParams = QueryParams<{
   repo_id?: UUID;
   name?: string;
   ref?: string;
+  zone_id?: string; // Filter by board zone (handled pre-pagination in find())
   deleteFromFilesystem?: boolean;
   include_sessions?: boolean | 'true' | 'false'; // Opt-in session activity enrichment
   last_message_truncation_length?: number; // Default: 500 chars, min: 50, max: 10000
@@ -537,9 +538,44 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * Override find to enrich with zone information only
    *
    * Note: Session activity is NOT included in list operations - only on single GET
+   *
+   * zone_id filtering is handled here before calling super.find() so that pagination
+   * is applied to the zone-filtered set. Without this, super.find() would paginate
+   * first (default 50) and the post-enrichment zone filter would miss branches
+   * beyond the first page, always returning 0 for large branch sets.
    */
   async find(params?: BranchParams) {
-    // Use default find to ensure all hooks and scoping are applied (including repo_id filter)
+    const zoneId = params?.query?.zone_id;
+
+    if (zoneId) {
+      // Resolve branch IDs in the zone before pagination
+      const branchIdsInZone = await this.branchRepo.findBranchIdsByZone(zoneId);
+
+      if (branchIdsInZone.length === 0) {
+        const limit = params?.query?.$limit ?? this.paginate?.default ?? 50;
+        const skip = params?.query?.$skip ?? 0;
+        return { data: [], total: 0, limit, skip };
+      }
+
+      // Remove zone_id from query (not a real branch column; DrizzleService would skip it
+      // but keeping it avoids confusion), then filter by the resolved branch IDs.
+      // Cast needed: branch_id with $in operator is not in the typed query shape but
+      // DrizzleService.filterData() handles it correctly at runtime.
+      const { zone_id: _stripped, ...queryWithoutZone } = params?.query ?? {};
+      const filteredParams = {
+        ...params,
+        query: { ...queryWithoutZone, branch_id: { $in: branchIdsInZone } },
+      } as BranchParams;
+
+      const result = await super.find(filteredParams);
+      if (Array.isArray(result)) {
+        return this.branchRepo.enrichManyWithZoneInfo(result as Branch[]);
+      }
+      const enriched = await this.branchRepo.enrichManyWithZoneInfo(result.data as Branch[]);
+      return { ...result, data: enriched };
+    }
+
+    // Normal code path — no zone filter
     const result = await super.find(params);
 
     // Handle both paginated and non-paginated results

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -535,17 +535,30 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   }
 
   /**
-   * Override find to enrich with zone information only
+   * Override find to enrich with zone information and optionally session activity.
    *
-   * Note: Session activity is NOT included in list operations - only on single GET
-   *
-   * zone_id filtering is handled here before calling super.find() so that pagination
+   * zone_id filtering is handled before calling super.find() so that pagination
    * is applied to the zone-filtered set. Without this, super.find() would paginate
-   * first (default 50) and the post-enrichment zone filter would miss branches
-   * beyond the first page, always returning 0 for large branch sets.
+   * first (default 50) and any zone filter would miss branches beyond the first page.
+   *
+   * include_sessions is opt-in: when true, each branch in the result is enriched
+   * with its recent session activity (same data as single GET with include_sessions).
+   * Uses batch enrichment to avoid N+1 queries.
    */
   async find(params?: BranchParams) {
     const zoneId = params?.query?.zone_id;
+    const includeSessions =
+      params?.query?.include_sessions === true || params?.query?.include_sessions === 'true';
+    const truncationLength = parseLastMessageTruncationLength(
+      params?.query?.last_message_truncation_length
+    );
+
+    // Helper: enrich a page of branches with zone info (and optionally sessions)
+    const enrichPage = async (branches: Branch[]) => {
+      const withZone = await this.branchRepo.enrichManyWithZoneInfo(branches);
+      if (!includeSessions) return withZone;
+      return this.branchRepo.enrichManyWithSessionActivity(withZone, truncationLength);
+    };
 
     if (zoneId) {
       // Resolve branch IDs in the zone before pagination
@@ -569,25 +582,20 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
       const result = await super.find(filteredParams);
       if (Array.isArray(result)) {
-        return this.branchRepo.enrichManyWithZoneInfo(result as Branch[]);
+        return enrichPage(result as Branch[]);
       }
-      const enriched = await this.branchRepo.enrichManyWithZoneInfo(result.data as Branch[]);
+      const enriched = await enrichPage(result.data as Branch[]);
       return { ...result, data: enriched };
     }
 
     // Normal code path — no zone filter
     const result = await super.find(params);
 
-    // Handle both paginated and non-paginated results
     if (Array.isArray(result)) {
-      return this.branchRepo.enrichManyWithZoneInfo(result as Branch[]);
-    } else {
-      const enriched = await this.branchRepo.enrichManyWithZoneInfo(result.data as Branch[]);
-      return {
-        ...result,
-        data: enriched,
-      };
+      return enrichPage(result as Branch[]);
     }
+    const enriched = await enrichPage(result.data as Branch[]);
+    return { ...result, data: enriched };
   }
 
   /**

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -566,6 +566,32 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find branch IDs that are pinned to a specific board zone.
+   *
+   * Queries board_objects directly by json_extract(data, '$.zone_id').
+   * Used by BranchesService.find() to resolve zone membership before
+   * applying pagination, so the zoneId filter is pagination-correct.
+   *
+   * @param zoneId - Zone ID to look up (e.g. "zone-1776863814461")
+   * @returns Array of branch_id strings in the zone
+   */
+  async findBranchIdsByZone(zoneId: string): Promise<string[]> {
+    const { boardObjects: boardObjectsTable } = await import('../schema');
+    const { jsonExtract } = await import('../database-wrapper');
+
+    const rows = await select(this.db, {
+      branch_id: boardObjectsTable.branch_id,
+    })
+      .from(boardObjectsTable)
+      .where(sql`${jsonExtract(this.db, boardObjectsTable.data, 'zone_id')} = ${zoneId}`)
+      .all();
+
+    return (rows as { branch_id: string | null }[])
+      .map((r) => r.branch_id)
+      .filter((id): id is string => id !== null && id !== undefined);
+  }
+
+  /**
    * Enrich a single branch with zone information
    *
    * Uses the batch enrichment method for consistency and efficiency.


### PR DESCRIPTION
## Summary

### Bug fix: zoneId filter always returned 0
- **Root cause:** Zone filtering happened post-pagination — the service fetched the first 50 branches, enriched them with zone info, then the MCP tool filtered client-side. Branches in the zone beyond position 50 were invisible.
- **Fix:** `BranchesService.find()` now intercepts `zone_id` before pagination: calls `BranchRepository.findBranchIdsByZone()` to resolve branch IDs in the zone (queries `board_objects` via `json_extract(data, '$.zone_id')`), then fetches only those branches.

### Ergonomics: eliminate fan-out for zone+sessions queries
Before this PR, getting branches in a zone with sessions required:
```
agor_boards_get({ boardId, includeEntities: true })
  → grep for zone entities
  → agor_branches_get(branchId) × N
```
After this PR, one call covers it:
```
agor_branches_list({ zoneId: "zone-xxx", includeSessions: true })
```
- `includeSessions` parameter added to `agor_branches_list`
- `BranchesService.find()` supports `include_sessions` using the existing `enrichManyWithSessionActivity` batch method (no N+1 queries)

## Test plan
- [ ] `agor_branches_list({ zoneId: "zone-xxx" })` returns correct branches regardless of total branch count
- [ ] `agor_branches_list({ zoneId: "zone-xxx", includeSessions: true })` returns branches with session activity in one call
- [ ] `agor_branches_list({})` without filters still works as before
- [ ] Unit tests: mock correctly simulates service-level zone filtering; tests verify query params are forwarded

Fixes: https://app.shortcut.com/preset/story/107954