### PR TITLE
fix: clear zone_id when dragging off zone and when archiving branch

### DIFF
--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -82,9 +82,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   // Cache board-objects service reference (lazy-loaded to avoid circular deps)
   private boardObjectsService?: {
     find: (params?: unknown) => Promise<unknown>;
-    findByBranchId: (
-      branchId: BranchID
-    ) => Promise<{ object_id: string; zone_id?: string } | null>;
+    findByBranchId: (branchId: BranchID) => Promise<{ object_id: string; zone_id?: string } | null>;
     create: (data: unknown) => Promise<unknown>;
     remove: (id: string) => Promise<unknown>;
     patch: (id: string, data: { zone_id?: string | null }) => Promise<unknown>;

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -82,7 +82,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   // Cache board-objects service reference (lazy-loaded to avoid circular deps)
   private boardObjectsService?: {
     find: (params?: unknown) => Promise<unknown>;
-    findByBranchId: (branchId: BranchID) => Promise<{ object_id: string; zone_id?: string } | null>;
+    findByBranchId: (
+      branchId: BranchID
+    ) => Promise<{ object_id: string; zone_id?: string } | null>;
     create: (data: unknown) => Promise<unknown>;
     remove: (id: string) => Promise<unknown>;
     patch: (id: string, data: { zone_id?: string | null }) => Promise<unknown>;
@@ -139,7 +141,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     if (!this.boardObjectsService) {
       this.boardObjectsService = this.app.service('board-objects') as unknown as {
         find: (params?: unknown) => Promise<unknown>;
-        findByBranchId: (branchId: BranchID) => Promise<{ object_id: string; zone_id?: string } | null>;
+        findByBranchId: (
+          branchId: BranchID
+        ) => Promise<{ object_id: string; zone_id?: string } | null>;
         create: (data: unknown) => Promise<unknown>;
         remove: (id: string) => Promise<unknown>;
         patch: (id: string, data: { zone_id?: string | null }) => Promise<unknown>;

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -82,9 +82,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   // Cache board-objects service reference (lazy-loaded to avoid circular deps)
   private boardObjectsService?: {
     find: (params?: unknown) => Promise<unknown>;
-    findByBranchId: (branchId: BranchID) => Promise<unknown>;
+    findByBranchId: (branchId: BranchID) => Promise<{ object_id: string; zone_id?: string } | null>;
     create: (data: unknown) => Promise<unknown>;
     remove: (id: string) => Promise<unknown>;
+    patch: (id: string, data: { zone_id?: string | null }) => Promise<unknown>;
   };
 
   constructor(db: Database, app: Application) {
@@ -138,9 +139,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     if (!this.boardObjectsService) {
       this.boardObjectsService = this.app.service('board-objects') as unknown as {
         find: (params?: unknown) => Promise<unknown>;
-        findByBranchId: (branchId: BranchID) => Promise<unknown>;
+        findByBranchId: (branchId: BranchID) => Promise<{ object_id: string; zone_id?: string } | null>;
         create: (data: unknown) => Promise<unknown>;
         remove: (id: string) => Promise<unknown>;
+        patch: (id: string, data: { zone_id?: string | null }) => Promise<unknown>;
       };
     }
     return this.boardObjectsService;
@@ -780,6 +782,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       }
 
       console.log(`✅ Archived branch ${branch.name} and ${sessions.length} session(s)`);
+
+      // Clear zone_id on the board entity so archived branches don't move with zones
+      const boardObjectsService = this.getBoardObjectsService();
+      const boardEntity = await boardObjectsService.findByBranchId(id);
+      if (boardEntity?.zone_id) {
+        await boardObjectsService.patch(boardEntity.object_id, { zone_id: null });
+      }
+
       return archivedBranch;
     } else {
       // Delete: Hard delete (CASCADE will remove sessions, messages, tasks)

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1559,7 +1559,10 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 const existingBoardObject = boardObjectByCard.get(cardId);
                 if (existingBoardObject) {
                   // zone_id: null clears zone membership; string sets it
-                  const updateData: { position: { x: number; y: number }; zone_id?: string | null } = {
+                  const updateData: {
+                    position: { x: number; y: number };
+                    zone_id?: string | null;
+                  } = {
                     position: positionToStore,
                     zone_id: droppedZoneId ?? null,
                   };
@@ -1672,7 +1675,10 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 if (existingBoardObject) {
                   // Update existing board_object (position and zone_id)
                   // zone_id: null clears zone membership; string sets it
-                  const updateData: { position: { x: number; y: number }; zone_id?: string | null } = {
+                  const updateData: {
+                    position: { x: number; y: number };
+                    zone_id?: string | null;
+                  } = {
                     position,
                     zone_id,
                   };

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1456,7 +1456,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             const branchUpdates: Array<{
               branch_id: string;
               position: { x: number; y: number };
-              zone_id?: string;
+              zone_id?: string | null;
             }> = [];
             const zoneUpdates: Record<string, { x: number; y: number }> = {};
             const markdownUpdates: Record<string, { x: number; y: number }> = {};
@@ -1558,12 +1558,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 // Find existing board_object for this card
                 const existingBoardObject = boardObjectByCard.get(cardId);
                 if (existingBoardObject) {
-                  const updateData: { position: { x: number; y: number }; zone_id?: string } = {
+                  // zone_id: null clears zone membership; string sets it
+                  const updateData: { position: { x: number; y: number }; zone_id?: string | null } = {
                     position: positionToStore,
+                    zone_id: droppedZoneId ?? null,
                   };
-                  if (droppedZoneId !== undefined) {
-                    updateData.zone_id = droppedZoneId;
-                  }
                   await client
                     .service('board-objects')
                     .patch(existingBoardObject.object_id, updateData);
@@ -1618,11 +1617,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
                 const positionToStore = calculateStoragePosition(absolutePosition, newParent);
 
-                // Branch moved - update board_object position (and zone_id if dropped on zone)
+                // Branch moved - update board_object position (null clears zone, string sets it)
                 branchUpdates.push({
                   branch_id: nodeId,
                   position: positionToStore,
-                  zone_id: droppedZoneId,
+                  zone_id: droppedZoneId ?? null,
                 });
 
                 if (zoneCollision) {
@@ -1672,13 +1671,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
                 if (existingBoardObject) {
                   // Update existing board_object (position and zone_id)
-                  const updateData: { position: { x: number; y: number }; zone_id?: string } = {
+                  // zone_id: null clears zone membership; string sets it
+                  const updateData: { position: { x: number; y: number }; zone_id?: string | null } = {
                     position,
+                    zone_id,
                   };
-                  // Only update zone_id if it's defined (dropped on zone) or explicitly undefined (moved off zone)
-                  if (zone_id !== undefined) {
-                    updateData.zone_id = zone_id;
-                  }
                   await client
                     .service('board-objects')
                     .patch(existingBoardObject.object_id, updateData);


### PR DESCRIPTION
## Summary

- **Bug 1 (drag):** When a branch/card is dragged from inside a zone to empty canvas space, the board entity's `zone_id` was not cleared — it retained the old value. The drag handler was using `undefined` to mean "no zone found" and only patching `zone_id` when it was a string. The patch method on `board-objects` uses `'zone_id' in data` to detect zone updates, so `undefined` was silently skipped. Fix: use `null` instead of `undefined` when no zone is detected, which always writes through to `updateZone(null)` → clears the field.

- **Bug 2 (archive):** Archiving a branch left its board entity `zone_id` intact, so the entity stayed in the zone group and moved with it on drag. Fix: after archiving the branch and its sessions, look up its board entity and patch `zone_id: null` if set.

## Files changed

- `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx` — both branch node and card node drag-stop handlers now use `droppedZoneId ?? null` and always include `zone_id` in the patch payload
- `apps/agor-daemon/src/services/branches.ts` — archive path clears `zone_id` on the branch's board entity; `boardObjectsService` interface extended with `patch` and typed `findByBranchId` return

## Test plan

- [ ] Drag a branch into a zone — confirm zone_id is set, card moves with zone
- [ ] Drag the same branch out to empty canvas — confirm zone_id is cleared, card no longer moves with zone
- [ ] Archive a branch that is inside a zone — confirm dragging the zone does not carry the archived branch entity along
- [ ] Unarchive the branch — confirm it reappears at its stored absolute position

🤖 Generated with [Claude Code](https://claude.com/claude-code)