### PR TITLE
Fix explicit session link routing precedence

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -50,6 +50,7 @@ import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPro
 import { createAssistantBranch } from '../../utils/assistantCreation';
 import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
+import { hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { AppHeader } from '../AppHeader';
 import type { BoardAssistantPanelTab } from '../BoardAssistantPanel';
@@ -284,9 +285,7 @@ export const App: React.FC<AppProps> = ({
     branchShortId?: string;
     artifactShortId?: string;
   }>();
-  const hasExplicitEntityTarget = Boolean(
-    routeParams.sessionShortId || routeParams.branchShortId || routeParams.artifactShortId
-  );
+  const hasExplicitEntityTarget = hasExplicitEntityRouteTarget(routeParams);
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionBranchId, setNewSessionBranchId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -357,6 +356,7 @@ export const App: React.FC<AppProps> = ({
   // Props take precedence for backward compatibility with onboarding flow
   const settingsOpen = settingsRouteOpen || !!openSettingsTab;
   const effectiveSettingsTab = openSettingsTab || settingsRouteSection;
+  const shouldAutoRestorePrimaryAssistant = !settingsRouteOpen && !hasExplicitEntityTarget;
 
   // Handle external user settings modal control (e.g., from onboarding "Configure API Keys")
   const effectiveUserSettingsOpen = userSettingsOpen || !!openUserSettings;
@@ -820,7 +820,7 @@ export const App: React.FC<AppProps> = ({
       primaryAssistantBranchId: primaryAssistantBranch?.branch_id,
       effectiveSelectedSessionId,
       autoOpenedAssistantBoardId: autoOpenedAssistantBoardRef.current,
-      hasExplicitEntityTarget,
+      restoreAllowed: shouldAutoRestorePrimaryAssistant,
       sessions: primaryAssistantBranch
         ? sessionsByBranch.get(primaryAssistantBranch.branch_id) || []
         : [],
@@ -834,7 +834,7 @@ export const App: React.FC<AppProps> = ({
     primaryAssistantBranch,
     sessionsByBranch,
     effectiveSelectedSessionId,
-    hasExplicitEntityTarget,
+    shouldAutoRestorePrimaryAssistant,
     navigation,
   ]);
 

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -30,6 +30,7 @@ import {
   PanelGroup,
   PanelResizeHandle,
 } from 'react-resizable-panels';
+import { useParams } from 'react-router-dom';
 import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { AppEntityDataProvider, AppLiveDataProvider } from '../../contexts/AppDataContext';
@@ -68,6 +69,7 @@ import { SessionSettingsModal } from '../SessionSettingsModal';
 import { SettingsModal, UserSettingsModal } from '../SettingsModal';
 import { TerminalModal, WEB_TERMINAL_MIN_ROLE } from '../TerminalModal';
 import { ThemeEditorModal } from '../ThemeEditorModal';
+import { getPrimaryAssistantSessionToRestore } from './primaryAssistantRestore';
 
 const { Content } = Layout;
 
@@ -277,6 +279,14 @@ export const App: React.FC<AppProps> = ({
   webTerminalEnabled = false,
 }) => {
   const { showWarning } = useThemedMessage();
+  const routeParams = useParams<{
+    sessionShortId?: string;
+    branchShortId?: string;
+    artifactShortId?: string;
+  }>();
+  const hasExplicitEntityTarget = Boolean(
+    routeParams.sessionShortId || routeParams.branchShortId || routeParams.artifactShortId
+  );
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionBranchId, setNewSessionBranchId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -805,20 +815,26 @@ export const App: React.FC<AppProps> = ({
   const primaryAssistantInaccessible = Boolean(primaryAssistantId && !primaryAssistantBranch);
 
   useEffect(() => {
-    if (!currentBoard || !primaryAssistantBranch || effectiveSelectedSessionId) return;
-    if (autoOpenedAssistantBoardRef.current === currentBoard.board_id) return;
-    const latestSession = (sessionsByBranch.get(primaryAssistantBranch.branch_id) || [])
-      .filter((session) => !session.archived)
-      .sort((a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime())[0];
-    if (latestSession) {
+    const latestSessionId = getPrimaryAssistantSessionToRestore({
+      currentBoardId: currentBoard?.board_id,
+      primaryAssistantBranchId: primaryAssistantBranch?.branch_id,
+      effectiveSelectedSessionId,
+      autoOpenedAssistantBoardId: autoOpenedAssistantBoardRef.current,
+      hasExplicitEntityTarget,
+      sessions: primaryAssistantBranch
+        ? sessionsByBranch.get(primaryAssistantBranch.branch_id) || []
+        : [],
+    });
+    if (latestSessionId && currentBoard) {
       autoOpenedAssistantBoardRef.current = currentBoard.board_id;
-      navigation.goToSession(latestSession.session_id);
+      navigation.goToSession(latestSessionId);
     }
   }, [
     currentBoard,
     primaryAssistantBranch,
     sessionsByBranch,
     effectiveSelectedSessionId,
+    hasExplicitEntityTarget,
     navigation,
   ]);
 

--- a/apps/agor-ui/src/components/App/primaryAssistantRestore.test.ts
+++ b/apps/agor-ui/src/components/App/primaryAssistantRestore.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { getPrimaryAssistantSessionToRestore } from './primaryAssistantRestore';
+
+const base = {
+  currentBoardId: 'board-1',
+  primaryAssistantBranchId: 'branch-1',
+  effectiveSelectedSessionId: null,
+  autoOpenedAssistantBoardId: null,
+  hasExplicitEntityTarget: false,
+  sessions: [
+    { session_id: 'older', archived: false, last_updated: '2026-01-01T00:00:00.000Z' },
+    { session_id: 'newer', archived: false, last_updated: '2026-01-02T00:00:00.000Z' },
+  ],
+};
+
+describe('getPrimaryAssistantSessionToRestore', () => {
+  it('restores the latest active primary-assistant session for generic board/app URLs', () => {
+    expect(getPrimaryAssistantSessionToRestore(base)).toBe('newer');
+  });
+
+  it('does not restore over an explicit entity URL target', () => {
+    expect(
+      getPrimaryAssistantSessionToRestore({
+        ...base,
+        hasExplicitEntityTarget: true,
+      })
+    ).toBeNull();
+  });
+
+  it('does not restore when a session is already selected', () => {
+    expect(
+      getPrimaryAssistantSessionToRestore({
+        ...base,
+        effectiveSelectedSessionId: 'requested-session',
+      })
+    ).toBeNull();
+  });
+
+  it('does not restore the same board more than once', () => {
+    expect(
+      getPrimaryAssistantSessionToRestore({
+        ...base,
+        autoOpenedAssistantBoardId: 'board-1',
+      })
+    ).toBeNull();
+  });
+
+  it('ignores archived sessions', () => {
+    expect(
+      getPrimaryAssistantSessionToRestore({
+        ...base,
+        sessions: [
+          {
+            session_id: 'archived-newer',
+            archived: true,
+            last_updated: '2026-01-03T00:00:00.000Z',
+          },
+          {
+            session_id: 'active-older',
+            archived: false,
+            last_updated: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      })
+    ).toBe('active-older');
+  });
+});

--- a/apps/agor-ui/src/components/App/primaryAssistantRestore.test.ts
+++ b/apps/agor-ui/src/components/App/primaryAssistantRestore.test.ts
@@ -6,7 +6,7 @@ const base = {
   primaryAssistantBranchId: 'branch-1',
   effectiveSelectedSessionId: null,
   autoOpenedAssistantBoardId: null,
-  hasExplicitEntityTarget: false,
+  restoreAllowed: true,
   sessions: [
     { session_id: 'older', archived: false, last_updated: '2026-01-01T00:00:00.000Z' },
     { session_id: 'newer', archived: false, last_updated: '2026-01-02T00:00:00.000Z' },
@@ -18,11 +18,11 @@ describe('getPrimaryAssistantSessionToRestore', () => {
     expect(getPrimaryAssistantSessionToRestore(base)).toBe('newer');
   });
 
-  it('does not restore over an explicit entity URL target', () => {
+  it('does not restore when route policy disallows generic restore', () => {
     expect(
       getPrimaryAssistantSessionToRestore({
         ...base,
-        hasExplicitEntityTarget: true,
+        restoreAllowed: false,
       })
     ).toBeNull();
   });

--- a/apps/agor-ui/src/components/App/primaryAssistantRestore.ts
+++ b/apps/agor-ui/src/components/App/primaryAssistantRestore.ts
@@ -1,0 +1,37 @@
+export interface PrimaryAssistantRestoreInput {
+  currentBoardId: string | null | undefined;
+  primaryAssistantBranchId: string | null | undefined;
+  effectiveSelectedSessionId: string | null | undefined;
+  autoOpenedAssistantBoardId: string | null | undefined;
+  hasExplicitEntityTarget: boolean;
+  sessions: Array<{ session_id: string; archived: boolean; last_updated: string }>;
+}
+
+/**
+ * Pick the primary assistant session that should be auto-opened for generic
+ * board/app entry points.
+ *
+ * Explicit entity URLs (`/s/...`, `/w/...`, `/a/...`) are deliberately
+ * excluded: those routes already carry the user's target and can spend an
+ * initialization render with no selected session while URL→state resolution
+ * catches up.
+ */
+export function getPrimaryAssistantSessionToRestore({
+  currentBoardId,
+  primaryAssistantBranchId,
+  effectiveSelectedSessionId,
+  autoOpenedAssistantBoardId,
+  hasExplicitEntityTarget,
+  sessions,
+}: PrimaryAssistantRestoreInput): string | null {
+  if (hasExplicitEntityTarget) return null;
+  if (!currentBoardId || !primaryAssistantBranchId || effectiveSelectedSessionId) return null;
+  if (autoOpenedAssistantBoardId === currentBoardId) return null;
+
+  return (
+    sessions
+      .filter((session) => !session.archived)
+      .sort((a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime())[0]
+      ?.session_id ?? null
+  );
+}

--- a/apps/agor-ui/src/components/App/primaryAssistantRestore.ts
+++ b/apps/agor-ui/src/components/App/primaryAssistantRestore.ts
@@ -3,7 +3,7 @@ export interface PrimaryAssistantRestoreInput {
   primaryAssistantBranchId: string | null | undefined;
   effectiveSelectedSessionId: string | null | undefined;
   autoOpenedAssistantBoardId: string | null | undefined;
-  hasExplicitEntityTarget: boolean;
+  restoreAllowed: boolean;
   sessions: Array<{ session_id: string; archived: boolean; last_updated: string }>;
 }
 
@@ -11,20 +11,20 @@ export interface PrimaryAssistantRestoreInput {
  * Pick the primary assistant session that should be auto-opened for generic
  * board/app entry points.
  *
- * Explicit entity URLs (`/s/...`, `/w/...`, `/a/...`) are deliberately
- * excluded: those routes already carry the user's target and can spend an
- * initialization render with no selected session while URL→state resolution
- * catches up.
+ * Callers decide when generic restore is allowed. Explicit entity URLs
+ * (`/s/...`, `/w/...`, `/a/...`) and settings URLs are deliberately excluded:
+ * those routes already carry the user's target and can spend an initialization
+ * render before URL→state resolution catches up.
  */
 export function getPrimaryAssistantSessionToRestore({
   currentBoardId,
   primaryAssistantBranchId,
   effectiveSelectedSessionId,
   autoOpenedAssistantBoardId,
-  hasExplicitEntityTarget,
+  restoreAllowed,
   sessions,
 }: PrimaryAssistantRestoreInput): string | null {
-  if (hasExplicitEntityTarget) return null;
+  if (!restoreAllowed) return null;
   if (!currentBoardId || !primaryAssistantBranchId || effectiveSelectedSessionId) return null;
   if (autoOpenedAssistantBoardId === currentBoardId) return null;
 

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -27,6 +27,7 @@ import { type UseUrlStateOptions, useUrlState } from './useUrlState';
 
 const SESSION_ID = '019e9999-0000-7000-8000-000000000001';
 const SESSION_SHORT = '019e99990000700080000000';
+const OTHER_SESSION_ID = '019eaaaa-0000-7000-8000-000000000001';
 const BRANCH_ID = '019e8888-0000-7000-8000-000000000001';
 const BOARD_ID = '019e7777-0000-7000-8000-000000000001';
 
@@ -135,5 +136,31 @@ describe('useUrlState — deferred session resolution', () => {
 
     expect(onSessionChange).toHaveBeenCalledWith(SESSION_ID);
     expect(pathRef.current).toBe(`/s/${SESSION_SHORT}/`);
+  });
+
+  it('explicit session URLs win over an already-selected/restored session', () => {
+    const onSessionChange = vi.fn();
+    const onBoardChange = vi.fn();
+
+    const requestedSession = { session_id: SESSION_ID, branch_id: BRANCH_ID } as Session;
+    const restoredSession = { session_id: OTHER_SESSION_ID, branch_id: BRANCH_ID } as Session;
+    const branch = { branch_id: BRANCH_ID, board_id: BOARD_ID } as Branch;
+
+    renderAt(
+      `/s/${SESSION_SHORT}/`,
+      baseOptions({
+        currentSessionId: OTHER_SESSION_ID,
+        sessionById: new Map([
+          [requestedSession.session_id, requestedSession],
+          [restoredSession.session_id, restoredSession],
+        ]),
+        branchById: new Map([[branch.branch_id, branch]]),
+        onSessionChange,
+        onBoardChange,
+      })
+    );
+
+    expect(onSessionChange).toHaveBeenCalledWith(SESSION_ID);
+    expect(onBoardChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/utils/routeTargets.test.ts
+++ b/apps/agor-ui/src/utils/routeTargets.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { hasExplicitEntityRouteTarget } from './routeTargets';
+
+describe('hasExplicitEntityRouteTarget', () => {
+  it.each([
+    [{ sessionShortId: 'session' }, true],
+    [{ branchShortId: 'branch' }, true],
+    [{ artifactShortId: 'artifact' }, true],
+    [{}, false],
+  ])('returns the expected value for params %j', (params, expected) => {
+    expect(hasExplicitEntityRouteTarget(params)).toBe(expected);
+  });
+});

--- a/apps/agor-ui/src/utils/routeTargets.ts
+++ b/apps/agor-ui/src/utils/routeTargets.ts
@@ -1,0 +1,13 @@
+export interface EntityRouteParams {
+  sessionShortId?: string;
+  branchShortId?: string;
+  artifactShortId?: string;
+}
+
+/**
+ * Entity routes carry an explicit user target. Generic board/root restore
+ * behavior must not override them while URL→state resolution catches up.
+ */
+export function hasExplicitEntityRouteTarget(params: EntityRouteParams): boolean {
+  return Boolean(params.sessionShortId || params.branchShortId || params.artifactShortId);
+}


### PR DESCRIPTION
## Summary
- Prevent primary-assistant session restore from overriding explicit entity deep links
- Preserve generic board/root auto-restore behavior
- Add route precedence coverage for session URL selection and restore helper logic

## Checks
- pnpm check
- pnpm --filter agor-ui test -- src/components/App/primaryAssistantRestore.test.ts src/hooks/useUrlState.integration.test.tsx