### PR TITLE
Simplify same-repo issue and PR pills

### DIFF
--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -269,10 +269,16 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
                 />
               )}
               {primaryAssistantBranch.issue_url && (
-                <IssuePill issueUrl={primaryAssistantBranch.issue_url} />
+                <IssuePill
+                  issueUrl={primaryAssistantBranch.issue_url}
+                  currentRepoSlug={primaryAssistantRepo.slug}
+                />
               )}
               {primaryAssistantBranch.pull_request_url && (
-                <PullRequestPill prUrl={primaryAssistantBranch.pull_request_url} />
+                <PullRequestPill
+                  prUrl={primaryAssistantBranch.pull_request_url}
+                  currentRepoSlug={primaryAssistantRepo.slug}
+                />
               )}
             </Space>
             {assistantDescription && (

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -271,13 +271,13 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
               {primaryAssistantBranch.issue_url && (
                 <IssuePill
                   issueUrl={primaryAssistantBranch.issue_url}
-                  currentRepoSlug={primaryAssistantRepo.slug}
+                  currentRepo={primaryAssistantRepo}
                 />
               )}
               {primaryAssistantBranch.pull_request_url && (
                 <PullRequestPill
                   prUrl={primaryAssistantBranch.pull_request_url}
-                  currentRepoSlug={primaryAssistantRepo.slug}
+                  currentRepo={primaryAssistantRepo}
                 />
               )}
             </Space>

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -495,11 +495,9 @@ const BranchCardComponent = ({
               prefix="Created by"
             />
           )}
-          {branch.issue_url && (
-            <IssuePill issueUrl={branch.issue_url} currentRepoSlug={repo.slug} />
-          )}
+          {branch.issue_url && <IssuePill issueUrl={branch.issue_url} currentRepo={repo} />}
           {branch.pull_request_url && (
-            <PullRequestPill prUrl={branch.pull_request_url} currentRepoSlug={repo.slug} />
+            <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo} />
           )}
           <EnvironmentPill
             repo={repo}

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -495,8 +495,12 @@ const BranchCardComponent = ({
               prefix="Created by"
             />
           )}
-          {branch.issue_url && <IssuePill issueUrl={branch.issue_url} />}
-          {branch.pull_request_url && <PullRequestPill prUrl={branch.pull_request_url} />}
+          {branch.issue_url && (
+            <IssuePill issueUrl={branch.issue_url} currentRepoSlug={repo.slug} />
+          )}
+          {branch.pull_request_url && (
+            <PullRequestPill prUrl={branch.pull_request_url} currentRepoSlug={repo.slug} />
+          )}
           <EnvironmentPill
             repo={repo}
             branch={branch}

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -30,6 +30,7 @@ import { resolveContextWindowPercentage } from '../../utils/contextWindow';
 import { parseGitStateSha } from '../../utils/gitState';
 import { type SessionForIds, SessionIdsList } from '../SessionIds';
 import { Tag } from '../Tag';
+import { getUrlDisplayLabel, isGitHubUrl, type UrlDisplayRepo } from './url-helpers';
 
 /**
  * Standardized color palette for pills/badges
@@ -914,76 +915,7 @@ export const RepoPill: React.FC<RepoPillProps> = ({
   );
 };
 
-interface UrlDisplayLabelOptions {
-  /** Repo identity for the current branch/worktree, e.g. "preset-io/agor". */
-  currentRepoSlug?: string;
-}
-
-function normalizeRepoSlug(slug?: string): string | undefined {
-  const normalized = slug
-    ?.trim()
-    .replace(/\.git$/, '')
-    .replace(/^\/+|\/+$/g, '')
-    .toLowerCase();
-  return normalized || undefined;
-}
-
-/**
- * Extract a concise display label from a URL.
- * GitHub: org/repo#123 (or #123 when same as currentRepoSlug), Shortcut: story/12345,
- * Jira/Linear: ticket ID, etc.
- */
-export function getUrlDisplayLabel(url: string, options: UrlDisplayLabelOptions = {}): string {
-  try {
-    const parsed = new URL(url);
-    const pathParts = parsed.pathname.split('/').filter(Boolean);
-
-    if (parsed.hostname === 'github.com' && pathParts.length >= 4) {
-      const [org, repo, kind, number] = pathParts;
-      const urlRepoSlug = `${org}/${repo}`;
-      const isIssueOrPr = kind === 'issues' || kind === 'pull';
-
-      if (
-        isIssueOrPr &&
-        normalizeRepoSlug(urlRepoSlug) === normalizeRepoSlug(options.currentRepoSlug)
-      ) {
-        return `#${number}`;
-      }
-
-      return `${urlRepoSlug}#${number}`;
-    }
-
-    if (parsed.hostname === 'app.shortcut.com' && pathParts.length >= 3) {
-      return `${pathParts[1]}/${pathParts[2]}`;
-    }
-
-    if (parsed.hostname.includes('atlassian.net') || parsed.hostname.includes('jira')) {
-      return pathParts[pathParts.length - 1] || parsed.hostname;
-    }
-
-    if (parsed.hostname === 'linear.app') {
-      // Linear URLs: /issue/TEAM-123/slug — extract the issue ID, not the slug
-      const issueIdx = pathParts.indexOf('issue');
-      if (issueIdx !== -1 && pathParts[issueIdx + 1]) {
-        return pathParts[issueIdx + 1];
-      }
-      return pathParts[pathParts.length - 1] || parsed.hostname;
-    }
-
-    return pathParts[pathParts.length - 1] || parsed.hostname;
-  } catch {
-    return url.split('/').pop() || '?';
-  }
-}
-
-export function isGitHubUrl(url: string): boolean {
-  try {
-    const { hostname } = new URL(url);
-    return hostname === 'github.com' || hostname.endsWith('.github.com');
-  } catch {
-    return false;
-  }
-}
+export { getUrlDisplayLabel, isGitHubUrl } from './url-helpers';
 
 function getIssueIcon(url: string): React.ReactNode {
   if (isGitHubUrl(url)) return <GithubOutlined />;
@@ -1007,16 +939,16 @@ const pillTextStyle: React.CSSProperties = {
 interface IssuePillProps extends BasePillProps {
   issueUrl: string;
   issueNumber?: string;
-  currentRepoSlug?: string;
+  currentRepo?: UrlDisplayRepo;
 }
 
 export const IssuePill: React.FC<IssuePillProps> = ({
   issueUrl,
   issueNumber,
-  currentRepoSlug,
+  currentRepo,
   style,
 }) => {
-  const displayText = issueNumber || getUrlDisplayLabel(issueUrl, { currentRepoSlug });
+  const displayText = issueNumber || getUrlDisplayLabel(issueUrl, { currentRepo });
 
   return (
     <Tooltip title={issueUrl}>
@@ -1035,16 +967,16 @@ export const IssuePill: React.FC<IssuePillProps> = ({
 interface PullRequestPillProps extends BasePillProps {
   prUrl: string;
   prNumber?: string;
-  currentRepoSlug?: string;
+  currentRepo?: UrlDisplayRepo;
 }
 
 export const PullRequestPill: React.FC<PullRequestPillProps> = ({
   prUrl,
   prNumber,
-  currentRepoSlug,
+  currentRepo,
   style,
 }) => {
-  const displayText = prNumber || getUrlDisplayLabel(prUrl, { currentRepoSlug });
+  const displayText = prNumber || getUrlDisplayLabel(prUrl, { currentRepo });
 
   return (
     <Tooltip title={prUrl}>

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -914,18 +914,43 @@ export const RepoPill: React.FC<RepoPillProps> = ({
   );
 };
 
+interface UrlDisplayLabelOptions {
+  /** Repo identity for the current branch/worktree, e.g. "preset-io/agor". */
+  currentRepoSlug?: string;
+}
+
+function normalizeRepoSlug(slug?: string): string | undefined {
+  const normalized = slug
+    ?.trim()
+    .replace(/\.git$/, '')
+    .replace(/^\/+|\/+$/g, '')
+    .toLowerCase();
+  return normalized || undefined;
+}
+
 /**
  * Extract a concise display label from a URL.
- * GitHub: org/repo#123, Shortcut: story/12345, Jira/Linear: ticket ID, etc.
+ * GitHub: org/repo#123 (or #123 when same as currentRepoSlug), Shortcut: story/12345,
+ * Jira/Linear: ticket ID, etc.
  */
-export function getUrlDisplayLabel(url: string): string {
+export function getUrlDisplayLabel(url: string, options: UrlDisplayLabelOptions = {}): string {
   try {
     const parsed = new URL(url);
     const pathParts = parsed.pathname.split('/').filter(Boolean);
 
     if (parsed.hostname === 'github.com' && pathParts.length >= 4) {
-      const [org, repo, , number] = pathParts;
-      return `${org}/${repo}#${number}`;
+      const [org, repo, kind, number] = pathParts;
+      const urlRepoSlug = `${org}/${repo}`;
+      const isIssueOrPr = kind === 'issues' || kind === 'pull';
+
+      if (
+        isIssueOrPr &&
+        normalizeRepoSlug(urlRepoSlug) === normalizeRepoSlug(options.currentRepoSlug)
+      ) {
+        return `#${number}`;
+      }
+
+      return `${urlRepoSlug}#${number}`;
     }
 
     if (parsed.hostname === 'app.shortcut.com' && pathParts.length >= 3) {
@@ -982,10 +1007,16 @@ const pillTextStyle: React.CSSProperties = {
 interface IssuePillProps extends BasePillProps {
   issueUrl: string;
   issueNumber?: string;
+  currentRepoSlug?: string;
 }
 
-export const IssuePill: React.FC<IssuePillProps> = ({ issueUrl, issueNumber, style }) => {
-  const displayText = issueNumber || getUrlDisplayLabel(issueUrl);
+export const IssuePill: React.FC<IssuePillProps> = ({
+  issueUrl,
+  issueNumber,
+  currentRepoSlug,
+  style,
+}) => {
+  const displayText = issueNumber || getUrlDisplayLabel(issueUrl, { currentRepoSlug });
 
   return (
     <Tooltip title={issueUrl}>
@@ -1004,10 +1035,16 @@ export const IssuePill: React.FC<IssuePillProps> = ({ issueUrl, issueNumber, sty
 interface PullRequestPillProps extends BasePillProps {
   prUrl: string;
   prNumber?: string;
+  currentRepoSlug?: string;
 }
 
-export const PullRequestPill: React.FC<PullRequestPillProps> = ({ prUrl, prNumber, style }) => {
-  const displayText = prNumber || getUrlDisplayLabel(prUrl);
+export const PullRequestPill: React.FC<PullRequestPillProps> = ({
+  prUrl,
+  prNumber,
+  currentRepoSlug,
+  style,
+}) => {
+  const displayText = prNumber || getUrlDisplayLabel(prUrl, { currentRepoSlug });
 
   return (
     <Tooltip title={prUrl}>

--- a/apps/agor-ui/src/components/Pill/url-helpers.test.ts
+++ b/apps/agor-ui/src/components/Pill/url-helpers.test.ts
@@ -15,6 +15,46 @@ describe('getUrlDisplayLabel', () => {
       );
     });
 
+    it('omits org/repo for issue URLs from the current repo', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/preset-io/agor/issues/714', {
+          currentRepoSlug: 'preset-io/agor',
+        })
+      ).toBe('#714');
+    });
+
+    it('omits org/repo for pull request URLs from the current repo', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/preset-io/agor/pull/42', {
+          currentRepoSlug: 'preset-io/agor',
+        })
+      ).toBe('#42');
+    });
+
+    it('preserves org/repo for issue URLs from a different repo', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/other-org/other-repo/issues/123', {
+          currentRepoSlug: 'preset-io/agor',
+        })
+      ).toBe('other-org/other-repo#123');
+    });
+
+    it('preserves org/repo for pull request URLs from a different repo', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/other-org/other-repo/pull/123', {
+          currentRepoSlug: 'preset-io/agor',
+        })
+      ).toBe('other-org/other-repo#123');
+    });
+
+    it('compares GitHub repo slugs case-insensitively', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/Preset-IO/Agor/issues/714', {
+          currentRepoSlug: 'preset-io/agor',
+        })
+      ).toBe('#714');
+    });
+
     it('falls back to last segment for short GitHub URLs', () => {
       expect(getUrlDisplayLabel('https://github.com/preset-io/agor')).toBe('agor');
     });
@@ -65,6 +105,14 @@ describe('getUrlDisplayLabel', () => {
   describe('unknown / generic URLs', () => {
     it('returns last path segment for unknown services', () => {
       expect(getUrlDisplayLabel('https://example.com/project/tasks/42')).toBe('42');
+    });
+
+    it('does not change non-GitHub URL labels when current repo slug is provided', () => {
+      expect(
+        getUrlDisplayLabel('https://example.com/project/tasks/42', {
+          currentRepoSlug: 'preset-io/agor',
+        })
+      ).toBe('42');
     });
 
     it('returns hostname when path is empty', () => {

--- a/apps/agor-ui/src/components/Pill/url-helpers.test.ts
+++ b/apps/agor-ui/src/components/Pill/url-helpers.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from 'vitest';
-import { getUrlDisplayLabel, isGitHubUrl } from './Pill';
+import { getGitHubRepoSlugFromRemoteUrl, getUrlDisplayLabel, isGitHubUrl } from './url-helpers';
+
+const githubRepo = {
+  slug: 'preset-io/agor',
+  remote_url: 'https://github.com/preset-io/agor.git',
+};
+
+const localGithubRepo = {
+  slug: 'local/agor',
+  remote_url: 'git@github.com:preset-io/agor.git',
+};
+
+const gitlabSameSlugRepo = {
+  slug: 'preset-io/agor',
+  remote_url: 'https://gitlab.com/preset-io/agor.git',
+};
+
+describe('getGitHubRepoSlugFromRemoteUrl', () => {
+  it('extracts GitHub repo identity from HTTPS remotes', () => {
+    expect(getGitHubRepoSlugFromRemoteUrl('https://github.com/preset-io/agor.git')).toBe(
+      'preset-io/agor'
+    );
+  });
+
+  it('extracts GitHub repo identity from SSH remotes', () => {
+    expect(getGitHubRepoSlugFromRemoteUrl('git@github.com:Preset-IO/Agor.git')).toBe(
+      'preset-io/agor'
+    );
+  });
+
+  it('does not extract identity from non-GitHub remotes with the same slug', () => {
+    expect(getGitHubRepoSlugFromRemoteUrl('https://gitlab.com/preset-io/agor.git')).toBeUndefined();
+  });
+});
 
 describe('getUrlDisplayLabel', () => {
   describe('GitHub URLs', () => {
@@ -18,7 +51,7 @@ describe('getUrlDisplayLabel', () => {
     it('omits org/repo for issue URLs from the current repo', () => {
       expect(
         getUrlDisplayLabel('https://github.com/preset-io/agor/issues/714', {
-          currentRepoSlug: 'preset-io/agor',
+          currentRepo: githubRepo,
         })
       ).toBe('#714');
     });
@@ -26,7 +59,7 @@ describe('getUrlDisplayLabel', () => {
     it('omits org/repo for pull request URLs from the current repo', () => {
       expect(
         getUrlDisplayLabel('https://github.com/preset-io/agor/pull/42', {
-          currentRepoSlug: 'preset-io/agor',
+          currentRepo: githubRepo,
         })
       ).toBe('#42');
     });
@@ -34,7 +67,7 @@ describe('getUrlDisplayLabel', () => {
     it('preserves org/repo for issue URLs from a different repo', () => {
       expect(
         getUrlDisplayLabel('https://github.com/other-org/other-repo/issues/123', {
-          currentRepoSlug: 'preset-io/agor',
+          currentRepo: githubRepo,
         })
       ).toBe('other-org/other-repo#123');
     });
@@ -42,7 +75,7 @@ describe('getUrlDisplayLabel', () => {
     it('preserves org/repo for pull request URLs from a different repo', () => {
       expect(
         getUrlDisplayLabel('https://github.com/other-org/other-repo/pull/123', {
-          currentRepoSlug: 'preset-io/agor',
+          currentRepo: githubRepo,
         })
       ).toBe('other-org/other-repo#123');
     });
@@ -50,9 +83,25 @@ describe('getUrlDisplayLabel', () => {
     it('compares GitHub repo slugs case-insensitively', () => {
       expect(
         getUrlDisplayLabel('https://github.com/Preset-IO/Agor/issues/714', {
-          currentRepoSlug: 'preset-io/agor',
+          currentRepo: githubRepo,
         })
       ).toBe('#714');
+    });
+
+    it('uses GitHub remote_url identity for local repos with synthetic slugs', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/preset-io/agor/issues/714', {
+          currentRepo: localGithubRepo,
+        })
+      ).toBe('#714');
+    });
+
+    it('does not use slug-only identity for non-GitHub repos with matching slug', () => {
+      expect(
+        getUrlDisplayLabel('https://github.com/preset-io/agor/issues/714', {
+          currentRepo: gitlabSameSlugRepo,
+        })
+      ).toBe('preset-io/agor#714');
     });
 
     it('falls back to last segment for short GitHub URLs', () => {
@@ -110,7 +159,7 @@ describe('getUrlDisplayLabel', () => {
     it('does not change non-GitHub URL labels when current repo slug is provided', () => {
       expect(
         getUrlDisplayLabel('https://example.com/project/tasks/42', {
-          currentRepoSlug: 'preset-io/agor',
+          currentRepo: githubRepo,
         })
       ).toBe('42');
     });

--- a/apps/agor-ui/src/components/Pill/url-helpers.test.ts
+++ b/apps/agor-ui/src/components/Pill/url-helpers.test.ts
@@ -156,7 +156,7 @@ describe('getUrlDisplayLabel', () => {
       expect(getUrlDisplayLabel('https://example.com/project/tasks/42')).toBe('42');
     });
 
-    it('does not change non-GitHub URL labels when current repo slug is provided', () => {
+    it('does not change non-GitHub URL labels when current repo is provided', () => {
       expect(
         getUrlDisplayLabel('https://example.com/project/tasks/42', {
           currentRepo: githubRepo,

--- a/apps/agor-ui/src/components/Pill/url-helpers.ts
+++ b/apps/agor-ui/src/components/Pill/url-helpers.ts
@@ -1,0 +1,108 @@
+import type { Repo } from '@agor-live/client';
+import { extractSlugFromUrl } from '@agor-live/client';
+
+export type UrlDisplayRepo = Pick<Repo, 'slug' | 'remote_url'>;
+
+interface UrlDisplayLabelOptions {
+  /** Repo for the current branch/worktree. Used to identify same-repo GitHub links. */
+  currentRepo?: UrlDisplayRepo;
+}
+
+function normalizeRepoSlug(slug?: string): string | undefined {
+  const normalized = slug
+    ?.trim()
+    .replace(/\.git$/, '')
+    .replace(/^\/+|\/+$/g, '')
+    .toLowerCase();
+  return normalized || undefined;
+}
+
+function gitRemoteHost(remoteUrl: string): string | undefined {
+  try {
+    return new URL(remoteUrl).hostname.toLowerCase();
+  } catch {
+    // scp-like SSH remotes, e.g. git@github.com:owner/repo.git
+    const match = remoteUrl.match(/^[^@]+@([^:]+):/);
+    return match?.[1]?.toLowerCase();
+  }
+}
+
+export function getGitHubRepoSlugFromRemoteUrl(remoteUrl?: string): string | undefined {
+  if (!remoteUrl || gitRemoteHost(remoteUrl) !== 'github.com') return undefined;
+
+  try {
+    return normalizeRepoSlug(extractSlugFromUrl(remoteUrl));
+  } catch {
+    return undefined;
+  }
+}
+
+function getGitHubRepoSlugFromWebUrl(url: URL): string | undefined {
+  const pathParts = url.pathname.split('/').filter(Boolean);
+  if (url.hostname !== 'github.com' || pathParts.length < 2) return undefined;
+  return normalizeRepoSlug(`${pathParts[0]}/${pathParts[1]}`);
+}
+
+function getCurrentGitHubRepoSlug(repo?: UrlDisplayRepo): string | undefined {
+  // Use the repo's actual GitHub remote identity. Do not fall back to the Agor
+  // slug: non-GitHub repos can legitimately share the same owner/repo slug as
+  // a GitHub repo, and local repos may use a synthetic `local/<name>` slug.
+  return getGitHubRepoSlugFromRemoteUrl(repo?.remote_url);
+}
+
+/**
+ * Extract a concise display label from a URL.
+ * GitHub: org/repo#123 (or #123 when same as currentRepo's GitHub remote),
+ * Shortcut: story/12345, Jira/Linear: ticket ID, etc.
+ */
+export function getUrlDisplayLabel(url: string, options: UrlDisplayLabelOptions = {}): string {
+  try {
+    const parsed = new URL(url);
+    const pathParts = parsed.pathname.split('/').filter(Boolean);
+
+    if (parsed.hostname === 'github.com' && pathParts.length >= 4) {
+      const [org, repo, kind, number] = pathParts;
+      const urlRepoSlug = `${org}/${repo}`;
+      const isIssueOrPr = kind === 'issues' || kind === 'pull';
+
+      if (
+        isIssueOrPr &&
+        getGitHubRepoSlugFromWebUrl(parsed) === getCurrentGitHubRepoSlug(options.currentRepo)
+      ) {
+        return `#${number}`;
+      }
+
+      return `${urlRepoSlug}#${number}`;
+    }
+
+    if (parsed.hostname === 'app.shortcut.com' && pathParts.length >= 3) {
+      return `${pathParts[1]}/${pathParts[2]}`;
+    }
+
+    if (parsed.hostname.includes('atlassian.net') || parsed.hostname.includes('jira')) {
+      return pathParts[pathParts.length - 1] || parsed.hostname;
+    }
+
+    if (parsed.hostname === 'linear.app') {
+      // Linear URLs: /issue/TEAM-123/slug — extract the issue ID, not the slug
+      const issueIdx = pathParts.indexOf('issue');
+      if (issueIdx !== -1 && pathParts[issueIdx + 1]) {
+        return pathParts[issueIdx + 1];
+      }
+      return pathParts[pathParts.length - 1] || parsed.hostname;
+    }
+
+    return pathParts[pathParts.length - 1] || parsed.hostname;
+  } catch {
+    return url.split('/').pop() || '?';
+  }
+}
+
+export function isGitHubUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === 'github.com' || hostname.endsWith('.github.com');
+  } catch {
+    return false;
+  }
+}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -130,10 +130,10 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
               )}
               {/* Issue and PR Pills */}
               {branch?.issue_url && (
-                <IssuePill issueUrl={branch.issue_url} currentRepoSlug={repo?.slug} />
+                <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
               )}
               {branch?.pull_request_url && (
-                <PullRequestPill prUrl={branch.pull_request_url} currentRepoSlug={repo?.slug} />
+                <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo ?? undefined} />
               )}
               {/* MCP Servers */}
               {sessionMcpServerIds

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -129,8 +129,12 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                 />
               )}
               {/* Issue and PR Pills */}
-              {branch?.issue_url && <IssuePill issueUrl={branch.issue_url} />}
-              {branch?.pull_request_url && <PullRequestPill prUrl={branch.pull_request_url} />}
+              {branch?.issue_url && (
+                <IssuePill issueUrl={branch.issue_url} currentRepoSlug={repo?.slug} />
+              )}
+              {branch?.pull_request_url && (
+                <PullRequestPill prUrl={branch.pull_request_url} currentRepoSlug={repo?.slug} />
+              )}
               {/* MCP Servers */}
               {sessionMcpServerIds
                 .map((serverId) => mcpServerById.get(serverId))


### PR DESCRIPTION
## Summary
- omit redundant repo identity for same-repo GitHub issue/PR pills
- pass branch repo slug into issue/PR pill formatting
- add focused URL label tests for same-repo, cross-repo, and non-GitHub cases

## Checks
- pnpm check
- pnpm --filter agor-ui test -- src/components/Pill/url-helpers.test.ts