### PR TITLE
Fix board crash from missing React Flow zone parents

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2308,24 +2308,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
           if (_action === 'deleteZone' && objectId) {
             if (!context.id) throw new Error('Board ID required');
-            // Look up zone position for coordinate translation
-            const board = await boardsService!.get(context.id as string);
-            const zoneObj = board?.objects?.[objectId as string];
-            const zonePosition =
-              zoneObj && 'x' in zoneObj && 'y' in zoneObj
-                ? { x: zoneObj.x, y: zoneObj.y }
-                : undefined;
-
-            // Clear zone_id on board objects before deleting the zone
-            // Converts relative positions to absolute so entities don't jump
-            const boardObjectsService = app.service(
-              'board-objects'
-            ) as unknown as import('./services/board-objects').BoardObjectsService;
-            await boardObjectsService.clearZoneReferences(
-              context.id as import('@agor/core/types').BoardID,
-              objectId as string,
-              zonePosition
-            );
             const result = await boardsService!.deleteZone(
               context.id as string,
               objectId as string,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -255,23 +255,29 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // ============================================================================
 
   if (svcEnabled('boards')) {
-    app.use('/boards', createBoardsService(db), {
-      methods: [
-        'find',
-        'get',
-        'create',
-        'update',
-        'patch',
-        'remove',
-        'toBlob',
-        'fromBlob',
-        'toYaml',
-        'fromYaml',
-        'clone',
-        'setPrimaryAssistant',
-        'clearPrimaryAssistant',
-      ],
-    });
+    app.use(
+      '/boards',
+      createBoardsService(db, (boardObject) => {
+        app.service('board-objects').emit('patched', boardObject);
+      }),
+      {
+        methods: [
+          'find',
+          'get',
+          'create',
+          'update',
+          'patch',
+          'remove',
+          'toBlob',
+          'fromBlob',
+          'toYaml',
+          'fromYaml',
+          'clone',
+          'setPrimaryAssistant',
+          'clearPrimaryAssistant',
+        ],
+      }
+    );
     app.use('/board-objects', createBoardObjectsService(db));
   }
 

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -224,9 +224,20 @@ export class BoardObjectsService {
   async clearZoneReferences(
     boardId: BoardID,
     zoneId: string,
-    zonePosition?: { x: number; y: number }
-  ): Promise<number> {
-    return this.boardObjectRepo.clearZoneReferences(boardId, zoneId, zonePosition);
+    zonePosition?: { x: number; y: number },
+    params?: BoardObjectParams
+  ): Promise<BoardEntityObject[]> {
+    const cleared = await this.boardObjectRepo.clearZoneReferences(boardId, zoneId, zonePosition);
+
+    for (const boardObject of cleared) {
+      const eventPayload = {
+        ...boardObject,
+        ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
+      };
+      this.emit?.('patched', eventPayload as BoardEntityObject, params);
+    }
+
+    return cleared;
   }
 
   /**

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -15,6 +15,19 @@ import type {
   QueryParams,
 } from '@agor/core/types';
 
+export type BoardObjectPatchedEventPayload = Omit<BoardEntityObject, 'zone_id'> & {
+  zone_id?: string | null;
+};
+
+export function toBoardObjectPatchedEventPayload(
+  boardObject: BoardEntityObject
+): BoardObjectPatchedEventPayload {
+  return {
+    ...boardObject,
+    ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
+  };
+}
+
 /**
  * Board object service params
  */
@@ -148,11 +161,11 @@ export class BoardObjectsService {
 
       // Emit single WebSocket event with both updates
       // Explicitly include zone_id field (even if undefined) to signal zone changes to clients
-      const eventPayload = {
-        ...boardObject,
-        ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
-      };
-      this.emit?.('patched', eventPayload as BoardEntityObject, params);
+      this.emit?.(
+        'patched',
+        toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject,
+        params
+      );
 
       return boardObject;
     }
@@ -207,13 +220,12 @@ export class BoardObjectsService {
   ): Promise<BoardEntityObject> {
     const boardObject = await this.boardObjectRepo.updateZone(objectId, zoneId);
 
-    // Emit WebSocket event with explicit null for undefined zone_id
-    // JSON.stringify strips undefined fields, so convert to null to signal zone was cleared
-    const eventPayload = {
-      ...boardObject,
-      ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
-    };
-    this.emit?.('patched', eventPayload as BoardEntityObject, params);
+    // Emit WebSocket event with explicit null for undefined zone_id.
+    this.emit?.(
+      'patched',
+      toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject,
+      params
+    );
 
     return boardObject;
   }
@@ -230,11 +242,11 @@ export class BoardObjectsService {
     const cleared = await this.boardObjectRepo.clearZoneReferences(boardId, zoneId, zonePosition);
 
     for (const boardObject of cleared) {
-      const eventPayload = {
-        ...boardObject,
-        ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
-      };
-      this.emit?.('patched', eventPayload as BoardEntityObject, params);
+      this.emit?.(
+        'patched',
+        toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject,
+        params
+      );
     }
 
     return cleared;

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -4,13 +4,42 @@
  * Basic tests to verify custom export/import/clone methods are properly wired up.
  */
 
-import type { Board, UUID } from '@agor/core/types';
-import { describe, expect } from 'vitest';
+import { BoardObjectRepository, BranchRepository, generateId, RepoRepository } from '@agor/core/db';
+import type { Board, BranchID, UUID } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { BoardsService } from './boards';
 
 const TEST_USER = 'test-user' as UUID;
 const TEST_PARAMS = { user: { user_id: TEST_USER } } as never;
+
+function createRepoData(overrides?: { repo_id?: UUID; slug?: string }) {
+  const slug = overrides?.slug ?? `test-repo-${generateId()}`;
+  return {
+    repo_id: overrides?.repo_id ?? generateId(),
+    slug,
+    name: slug,
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/home/user/.agor/repos/${slug}`,
+    default_branch: 'main',
+  };
+}
+
+function createBranchData(overrides?: { branch_id?: BranchID; repo_id?: UUID; name?: string }) {
+  const name = overrides?.name ?? `feature-${generateId()}`;
+  return {
+    branch_id: overrides?.branch_id ?? (generateId() as BranchID),
+    repo_id: overrides?.repo_id ?? (generateId() as UUID),
+    name,
+    ref: `refs/heads/${name}`,
+    branch_unique_id: 1,
+    path: `/home/user/.agor/repos/test-repo/${name}`,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    created_by: TEST_USER,
+  };
+}
 
 describe('BoardsService - Custom Methods', () => {
   dbTest('toBlob should export board to JSON blob', async ({ db }) => {
@@ -152,6 +181,55 @@ describe('BoardsService - Custom Methods', () => {
     expect(cloned.name).toBe('Slug Clone Target');
     expect(cloned.slug).toBe('slug-clone-target');
   });
+
+  dbTest(
+    'removeBoardObject clears zone-pinned entities with absolute positions',
+    async ({ db }) => {
+      const emitBoardObjectPatched = vi.fn();
+      const service = new BoardsService(db, emitBoardObjectPatched);
+      const repoRepo = new RepoRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const boardObjectRepo = new BoardObjectRepository(db);
+
+      const repo = await repoRepo.create(createRepoData());
+      const branch = await branchRepo.create(createBranchData({ repo_id: repo.repo_id }));
+      const board = (await service.create({
+        name: 'Zone Cleanup Board',
+        slug: `zone-cleanup-${generateId()}`,
+        created_by: TEST_USER,
+        objects: {
+          'zone-review': {
+            type: 'zone',
+            x: 100,
+            y: 200,
+            width: 400,
+            height: 300,
+            label: 'Review',
+          },
+        },
+      })) as Board;
+
+      const boardObject = await boardObjectRepo.create({
+        board_id: board.board_id,
+        branch_id: branch.branch_id,
+        position: { x: 10, y: 20 },
+        zone_id: 'zone-review',
+      });
+
+      await service.removeBoardObject(board.board_id, 'zone-review');
+
+      const updatedBoardObject = await boardObjectRepo.findByObjectId(boardObject.object_id);
+      expect(updatedBoardObject?.zone_id).toBeUndefined();
+      expect(updatedBoardObject?.position).toEqual({ x: 110, y: 220 });
+      expect(emitBoardObjectPatched).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object_id: boardObject.object_id,
+          position: { x: 110, y: 220 },
+          zone_id: null,
+        })
+      );
+    }
+  );
 
   dbTest('should have all custom methods defined', async ({ db }) => {
     const service = new BoardsService(db);

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -6,7 +6,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { BoardRepository, type Database } from '@agor/core/db';
+import { BoardObjectRepository, BoardRepository, type Database } from '@agor/core/db';
 import type {
   AuthenticatedParams,
   Board,
@@ -33,6 +33,7 @@ export interface BoardParams
  */
 export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardParams> {
   private boardRepo: BoardRepository;
+  private boardObjectRepo: BoardObjectRepository;
 
   constructor(db: Database) {
     const boardRepo = new BoardRepository(db);
@@ -46,6 +47,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     });
 
     this.boardRepo = boardRepo;
+    this.boardObjectRepo = new BoardObjectRepository(db);
   }
 
   /**
@@ -98,6 +100,21 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     objectId: string,
     _params?: BoardParams
   ): Promise<Board> {
+    const board = await this.boardRepo.findBySlugOrId(boardId);
+    const object = board?.objects?.[objectId];
+
+    // A generic removeObject path can remove zones too (e.g. MCP
+    // agor_boards_update.removeObjects). Clear entity zone references first so
+    // future board renders do not construct React Flow children with a missing
+    // parent. Convert zone-relative positions to absolute while the zone origin
+    // is still available.
+    if (board && object?.type === 'zone') {
+      await this.boardObjectRepo.clearZoneReferences(board.board_id, objectId, {
+        x: object.x,
+        y: object.y,
+      });
+    }
+
     return this.boardRepo.removeBoardObject(boardId, objectId);
   }
 
@@ -140,10 +157,14 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
   async deleteZone(
     boardId: string,
     objectId: string,
-    deleteAssociatedSessions: boolean,
+    _deleteAssociatedSessions: boolean,
     _params?: BoardParams
   ): Promise<{ board: Board; affectedSessions: string[] }> {
-    return this.boardRepo.deleteZone(boardId, objectId, deleteAssociatedSessions);
+    const board = await this.removeBoardObject(boardId, objectId);
+    return {
+      board,
+      affectedSessions: [],
+    };
   }
 
   /**

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -10,6 +10,7 @@ import { BoardObjectRepository, BoardRepository, type Database } from '@agor/cor
 import type {
   AuthenticatedParams,
   Board,
+  BoardEntityObject,
   BoardExportBlob,
   BoardObject,
   QueryParams,
@@ -34,8 +35,9 @@ export interface BoardParams
 export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardParams> {
   private boardRepo: BoardRepository;
   private boardObjectRepo: BoardObjectRepository;
+  private emitBoardObjectPatched?: (boardObject: BoardEntityObject) => void;
 
-  constructor(db: Database) {
+  constructor(db: Database, emitBoardObjectPatched?: (boardObject: BoardEntityObject) => void) {
     const boardRepo = new BoardRepository(db);
     super(boardRepo, {
       id: 'board_id',
@@ -48,6 +50,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
 
     this.boardRepo = boardRepo;
     this.boardObjectRepo = new BoardObjectRepository(db);
+    this.emitBoardObjectPatched = emitBoardObjectPatched;
   }
 
   /**
@@ -109,10 +112,17 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     // parent. Convert zone-relative positions to absolute while the zone origin
     // is still available.
     if (board && object?.type === 'zone') {
-      await this.boardObjectRepo.clearZoneReferences(board.board_id, objectId, {
+      const cleared = await this.boardObjectRepo.clearZoneReferences(board.board_id, objectId, {
         x: object.x,
         y: object.y,
       });
+
+      for (const boardObject of cleared) {
+        this.emitBoardObjectPatched?.({
+          ...boardObject,
+          ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
+        } as BoardEntityObject);
+      }
     }
 
     return this.boardRepo.removeBoardObject(boardId, objectId);
@@ -360,6 +370,9 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
 /**
  * Service factory function
  */
-export function createBoardsService(db: Database): BoardsService {
-  return new BoardsService(db);
+export function createBoardsService(
+  db: Database,
+  emitBoardObjectPatched?: (boardObject: BoardEntityObject) => void
+): BoardsService {
+  return new BoardsService(db, emitBoardObjectPatched);
 }

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -10,13 +10,16 @@ import { BoardObjectRepository, BoardRepository, type Database } from '@agor/cor
 import type {
   AuthenticatedParams,
   Board,
-  BoardEntityObject,
   BoardExportBlob,
   BoardObject,
   QueryParams,
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { DrizzleService } from '../adapters/drizzle';
+import {
+  type BoardObjectPatchedEventPayload,
+  toBoardObjectPatchedEventPayload,
+} from './board-objects.js';
 
 /**
  * Board service params
@@ -35,9 +38,12 @@ export interface BoardParams
 export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardParams> {
   private boardRepo: BoardRepository;
   private boardObjectRepo: BoardObjectRepository;
-  private emitBoardObjectPatched?: (boardObject: BoardEntityObject) => void;
+  private emitBoardObjectPatched?: (boardObject: BoardObjectPatchedEventPayload) => void;
 
-  constructor(db: Database, emitBoardObjectPatched?: (boardObject: BoardEntityObject) => void) {
+  constructor(
+    db: Database,
+    emitBoardObjectPatched?: (boardObject: BoardObjectPatchedEventPayload) => void
+  ) {
     const boardRepo = new BoardRepository(db);
     super(boardRepo, {
       id: 'board_id',
@@ -118,10 +124,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
       });
 
       for (const boardObject of cleared) {
-        this.emitBoardObjectPatched?.({
-          ...boardObject,
-          ...(boardObject.zone_id === undefined ? { zone_id: null } : {}),
-        } as BoardEntityObject);
+        this.emitBoardObjectPatched?.(toBoardObjectPatchedEventPayload(boardObject));
       }
     }
 
@@ -372,7 +375,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
  */
 export function createBoardsService(
   db: Database,
-  emitBoardObjectPatched?: (boardObject: BoardEntityObject) => void
+  emitBoardObjectPatched?: (boardObject: BoardObjectPatchedEventPayload) => void
 ): BoardsService {
   return new BoardsService(db, emitBoardObjectPatched);
 }

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -537,25 +537,25 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // stale zone references (or optimistic zone deletes) render unparented
     // instead of crashing the board.
     const warnedMissingParentsRef = useRef<Set<string>>(new Set());
+    const onOrphanedParent = useCallback((node: Node, missingParentId: string) => {
+      const warningKey = `${node.id}:${missingParentId}`;
+      if (warnedMissingParentsRef.current.has(warningKey)) return;
+      warnedMissingParentsRef.current.add(warningKey);
+      console.warn('Ignoring stale React Flow parentId on board node', {
+        nodeId: node.id,
+        nodeType: node.type,
+        missingParentId,
+      });
+    }, []);
+
     const setNodes = useCallback<React.Dispatch<React.SetStateAction<Node[]>>>(
       (value) => {
         setNodesUnsafe((previousNodes) => {
           const nextNodes = typeof value === 'function' ? value(previousNodes) : value;
-          return sanitizeOrphanedNodeParents(nextNodes, {
-            onOrphan: (node, missingParentId) => {
-              const warningKey = `${node.id}:${missingParentId}`;
-              if (warnedMissingParentsRef.current.has(warningKey)) return;
-              warnedMissingParentsRef.current.add(warningKey);
-              console.warn('Ignoring stale React Flow parentId on board node', {
-                nodeId: node.id,
-                nodeType: node.type,
-                missingParentId,
-              });
-            },
-          });
+          return sanitizeOrphanedNodeParents(nextNodes, { onOrphan: onOrphanedParent });
         });
       },
-      [setNodesUnsafe]
+      [setNodesUnsafe, onOrphanedParent]
     );
 
     // Track resize state
@@ -1113,22 +1113,6 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onCommentSelect,
     ]);
 
-    // Helper: Sanitize orphaned parentId references to prevent React Flow "Parent node not found" errors.
-    // This can happen when a branch or zone is removed but child nodes (e.g., comments) still reference it.
-    const sanitizeOrphanedParents = useCallback((nodes: Node[]): Node[] => {
-      const nodeIds = new Set(nodes.map((n) => n.id));
-      return nodes.map((node) => {
-        if (node.parentId && !nodeIds.has(node.parentId)) {
-          // Parent node no longer exists — clear parentId to prevent crash.
-          // Position is already relative to the missing parent, but React Flow
-          // will treat it as absolute once parentId is cleared. This may cause
-          // a slight position jump, but that's preferable to crashing.
-          return { ...node, parentId: undefined };
-        }
-        return node;
-      });
-    }, []);
-
     // Helper: Apply local position overrides to a set of incoming nodes (branches or cards)
     const applyLocalPositions = useCallback(
       (incomingNodes: Node[], currentNodes: Node[], zoneNodes: Node[]) => {
@@ -1233,16 +1217,12 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         comments: Node[],
         apps: Node[] = []
       ) => {
-        return sanitizeOrphanedParents([
-          ...zones,
-          ...branches,
-          ...cards,
-          ...apps,
-          ...markdown,
-          ...comments,
-        ]);
+        return sanitizeOrphanedNodeParents(
+          [...zones, ...branches, ...cards, ...apps, ...markdown, ...comments],
+          { onOrphan: onOrphanedParent }
+        );
       },
-      [sanitizeOrphanedParents]
+      [onOrphanedParent]
     );
 
     // Sync board-derived nodes in a single state update. Zones, markdown,

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -87,6 +87,7 @@ import {
   type ParentInfo,
   relativeToAbsolute,
 } from './canvas/utils/coordinateTransforms';
+import { getValidZoneParentId, sanitizeOrphanedNodeParents } from './canvas/utils/nodeParentUtils';
 import { ZoneTriggerModal } from './canvas/ZoneTriggerModal';
 
 interface SessionCanvasProps {
@@ -528,8 +529,34 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const deletedObjectsRef = useRef<Set<string>>(new Set());
 
     // Initialize nodes and edges state BEFORE using them
-    const [nodes, setNodes, onNodesChangeInternal] = useNodesState([]);
+    const [nodes, setNodesUnsafe, onNodesChangeInternal] = useNodesState([]);
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+    // React Flow throws if any child node has a parentId that is absent from
+    // the same node array. Route all local setNodes calls through this guard so
+    // stale zone references (or optimistic zone deletes) render unparented
+    // instead of crashing the board.
+    const warnedMissingParentsRef = useRef<Set<string>>(new Set());
+    const setNodes = useCallback<React.Dispatch<React.SetStateAction<Node[]>>>(
+      (value) => {
+        setNodesUnsafe((previousNodes) => {
+          const nextNodes = typeof value === 'function' ? value(previousNodes) : value;
+          return sanitizeOrphanedNodeParents(nextNodes, {
+            onOrphan: (node, missingParentId) => {
+              const warningKey = `${node.id}:${missingParentId}`;
+              if (warnedMissingParentsRef.current.has(warningKey)) return;
+              warnedMissingParentsRef.current.add(warningKey);
+              console.warn('Ignoring stale React Flow parentId on board node', {
+                nodeId: node.id,
+                nodeType: node.type,
+                missingParentId,
+              });
+            },
+          });
+        });
+      },
+      [setNodesUnsafe]
+    );
 
     // Track resize state
     const resizeTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -578,6 +605,26 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       });
       return labels;
     }, [board]);
+
+    const warnedInvalidZoneRefsRef = useRef<Set<string>>(new Set());
+    const warnInvalidZoneRef = useCallback(
+      (
+        entityKind: 'branch' | 'card',
+        entityId: string | undefined,
+        zoneId: string,
+        reason: string
+      ) => {
+        const warningKey = `${entityKind}:${entityId ?? 'unknown'}:${zoneId}`;
+        if (warnedInvalidZoneRefsRef.current.has(warningKey)) return;
+        warnedInvalidZoneRefsRef.current.add(warningKey);
+        console.warn(`Ignoring stale board zone reference for ${entityKind} node`, {
+          entityId,
+          zoneId,
+          reason,
+        });
+      },
+      []
+    );
 
     // Handler to unpin a branch from its zone
     const handleUnpinBranch = useCallback(
@@ -664,7 +711,12 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
         // Look up zone name using full zone ID (zoneLabels uses full IDs as keys)
         const zoneName = zoneId ? zoneLabels[zoneId] || 'Unknown Zone' : undefined;
-        const zoneObj = zoneId && board?.objects?.[zoneId] ? board.objects[zoneId] : undefined;
+        const validZoneParentId = getValidZoneParentId(zoneId, board?.objects, {
+          entityId: branch.branch_id,
+          onInvalid: (entityId, invalidZoneId, reason) =>
+            warnInvalidZoneRef('branch', entityId, invalidZoneId, reason),
+        });
+        const zoneObj = validZoneParentId ? board?.objects?.[validZoneParentId] : undefined;
         const zoneColor =
           zoneObj && zoneObj.type === 'zone'
             ? zoneObj.borderColor || zoneObj.color // Backwards compat: borderColor first, then fall back to deprecated color
@@ -693,7 +745,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           height: 200, // Approximate height, will be measured by React Flow
           // Set parentId for visual nesting but allow dragging outside zone
           // Only set if zone actually exists — stale zone_id references cause React Flow errors
-          parentId: zoneObj ? zoneId : undefined,
+          parentId: validZoneParentId,
           extent: undefined, // No movement restriction - can drag anywhere
           data: {
             branch,
@@ -719,7 +771,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onExecuteScheduleNow,
             onUnpin: handleUnpinBranch,
             compact: false,
-            isPinned: !!zoneId,
+            isPinned: !!validZoneParentId,
             zoneName,
             zoneColor,
             client,
@@ -754,6 +806,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onExecuteScheduleNow,
       handleUnpinBranch,
       zoneLabels,
+      warnInvalidZoneRef,
       userById,
       client,
     ]);
@@ -813,7 +866,12 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         const position = { x: boardObject.position.x, y: boardObject.position.y };
         const zoneId = boardObject.zone_id;
         const zoneName = zoneId ? zoneLabels[zoneId] || 'Unknown Zone' : undefined;
-        const zoneObj = zoneId && board?.objects?.[zoneId] ? board.objects[zoneId] : undefined;
+        const validZoneParentId = getValidZoneParentId(zoneId, board?.objects, {
+          entityId: cardId,
+          onInvalid: (entityId, invalidZoneId, reason) =>
+            warnInvalidZoneRef('card', entityId, invalidZoneId, reason),
+        });
+        const zoneObj = validZoneParentId ? board?.objects?.[validZoneParentId] : undefined;
         const zoneColor =
           zoneObj && zoneObj.type === 'zone' ? zoneObj.borderColor || zoneObj.color : undefined;
 
@@ -825,11 +883,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           zIndex: 500, // Same level as branches
           width: 380,
           height: 120,
-          parentId: zoneObj ? zoneId : undefined,
+          parentId: validZoneParentId,
           extent: undefined,
           data: {
             card,
-            isPinned: !!zoneId,
+            isPinned: !!validZoneParentId,
             zoneName,
             zoneColor,
             onClick: handleCardClick,
@@ -839,7 +897,15 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       }
 
       return nodes;
-    }, [board, boardObjectByCard, cardById, zoneLabels, handleCardClick, handleUnpinCard]);
+    }, [
+      board,
+      boardObjectByCard,
+      cardById,
+      zoneLabels,
+      handleCardClick,
+      handleUnpinCard,
+      warnInvalidZoneRef,
+    ]);
 
     // No edges needed for branch-centric boards
     // (Session genealogy is visualized within BranchCard, not as canvas edges)

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -98,27 +98,12 @@ export const useBoardObjects = ({
       // Mark as deleted to prevent re-appearance during WebSocket updates
       deletedObjectsRef.current.add(objectId);
 
-      // Find branches and cards pinned to this zone (via board_objects.zone_id)
-      const affectedObjectIds: string[] = [];
-      for (const boardObj of mapToArray(boardObjectById)) {
-        if (boardObj.zone_id === objectId && (boardObj.branch_id || boardObj.card_id)) {
-          affectedObjectIds.push(boardObj.object_id);
-        }
-      }
-
-      // Optimistic removal of zone (just the zone node, entities remain but unpinned)
+      // Optimistic removal of zone. The SessionCanvas setNodes wrapper clears
+      // any orphaned parentId values locally; the daemon owns persistent
+      // unpinning and converts zone-relative child positions to absolute.
       setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
 
       try {
-        // IMPORTANT: Unpin entities FIRST before deleting the zone
-        // This prevents a race condition where entities have parentId pointing to a deleted zone
-        for (const objId of affectedObjectIds) {
-          await client.service('board-objects').patch(objId, {
-            zone_id: null,
-          });
-        }
-
-        // Now delete the zone after all branches are unpinned
         await client.service('boards').patch(board.board_id, {
           _action: 'deleteZone',
           objectId,
@@ -135,7 +120,7 @@ export const useBoardObjects = ({
         // Note: WebSocket update should restore the actual state
       }
     },
-    [board, client, setNodes, deletedObjectsRef, boardObjectById]
+    [board, client, setNodes, deletedObjectsRef]
   );
 
   /**

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/nodeParentUtils.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/nodeParentUtils.test.ts
@@ -1,0 +1,71 @@
+import type { BoardObject } from '@agor-live/client';
+import type { Node } from 'reactflow';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getValidZoneParentId,
+  isRenderableZoneObject,
+  sanitizeOrphanedNodeParents,
+} from './nodeParentUtils';
+
+describe('nodeParentUtils', () => {
+  it('clears orphaned React Flow parentIds', () => {
+    const onOrphan = vi.fn();
+    const nodes = [
+      {
+        id: 'branch-1',
+        type: 'branchNode',
+        position: { x: 10, y: 20 },
+        parentId: 'zone-missing',
+        data: {},
+      },
+      { id: 'zone-existing', type: 'zone', position: { x: 0, y: 0 }, data: {} },
+    ] satisfies Node[];
+
+    const result = sanitizeOrphanedNodeParents(nodes, { onOrphan });
+
+    expect(result[0].parentId).toBeUndefined();
+    expect(result[1].parentId).toBeUndefined();
+    expect(onOrphan).toHaveBeenCalledWith(nodes[0], 'zone-missing');
+  });
+
+  it('preserves valid React Flow parentIds', () => {
+    const nodes = [
+      { id: 'zone-existing', type: 'zone', position: { x: 0, y: 0 }, data: {} },
+      {
+        id: 'branch-1',
+        type: 'branchNode',
+        position: { x: 10, y: 20 },
+        parentId: 'zone-existing',
+        data: {},
+      },
+    ] satisfies Node[];
+
+    const result = sanitizeOrphanedNodeParents(nodes);
+
+    expect(result).toBe(nodes);
+    expect(result[1].parentId).toBe('zone-existing');
+  });
+
+  it('validates zone parent ids against renderable board zone objects', () => {
+    const objects: Record<string, BoardObject> = {
+      'zone-good': { type: 'zone', x: 0, y: 0, width: 400, height: 300, label: 'Good' },
+      'zone-bad': { type: 'zone', x: 0, y: Number.NaN, width: 400, height: 300, label: 'Bad' },
+      'markdown-1': { type: 'markdown', x: 0, y: 0, width: 400, content: 'not a zone' },
+    };
+    const onInvalid = vi.fn();
+
+    expect(getValidZoneParentId('zone-good', objects, { onInvalid })).toBe('zone-good');
+    expect(
+      getValidZoneParentId('zone-missing', objects, { entityId: 'branch-1', onInvalid })
+    ).toBeUndefined();
+    expect(
+      getValidZoneParentId('zone-bad', objects, { entityId: 'branch-2', onInvalid })
+    ).toBeUndefined();
+    expect(
+      getValidZoneParentId('markdown-1', objects, { entityId: 'branch-3', onInvalid })
+    ).toBeUndefined();
+    expect(isRenderableZoneObject(objects['zone-good'])).toBe(true);
+    expect(isRenderableZoneObject(objects['zone-bad'])).toBe(false);
+    expect(onInvalid).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/nodeParentUtils.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/nodeParentUtils.ts
@@ -1,0 +1,68 @@
+import type { BoardObject } from '@agor-live/client';
+import type { Node } from 'reactflow';
+
+/**
+ * React Flow throws during setNodes/render if a node references a parentId
+ * that is not present in the same node list. Keep this validation close to
+ * node construction so stale zone references degrade to unparented nodes
+ * instead of crashing the entire board.
+ */
+export function sanitizeOrphanedNodeParents(
+  nodes: Node[],
+  options?: {
+    onOrphan?: (node: Node, missingParentId: string) => void;
+  }
+): Node[] {
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  let changed = false;
+
+  const sanitized = nodes.map((node) => {
+    if (node.parentId && !nodeIds.has(node.parentId)) {
+      changed = true;
+      options?.onOrphan?.(node, node.parentId);
+      return { ...node, parentId: undefined };
+    }
+    return node;
+  });
+
+  return changed ? sanitized : nodes;
+}
+
+export function isRenderableZoneObject(object: BoardObject | undefined): boolean {
+  return (
+    object?.type === 'zone' &&
+    Number.isFinite(object.x) &&
+    Number.isFinite(object.y) &&
+    Number.isFinite(object.width) &&
+    Number.isFinite(object.height)
+  );
+}
+
+/**
+ * Zone IDs stored on board entity rows are trusted only if the corresponding
+ * board.objects entry still exists and is a renderable zone. A stale zone_id
+ * can otherwise become a React Flow parentId with no parent node.
+ */
+export function getValidZoneParentId(
+  zoneId: string | null | undefined,
+  boardObjects: Record<string, BoardObject> | undefined,
+  options?: {
+    entityId?: string;
+    onInvalid?: (entityId: string | undefined, zoneId: string, reason: string) => void;
+  }
+): string | undefined {
+  if (!zoneId) return undefined;
+
+  const zone = boardObjects?.[zoneId];
+  if (!zone) {
+    options?.onInvalid?.(options.entityId, zoneId, 'missing zone object');
+    return undefined;
+  }
+
+  if (!isRenderableZoneObject(zone)) {
+    options?.onInvalid?.(options.entityId, zoneId, 'zone object is not renderable');
+    return undefined;
+  }
+
+  return zoneId;
+}

--- a/packages/core/src/db/repositories/board-objects.ts
+++ b/packages/core/src/db/repositories/board-objects.ts
@@ -326,14 +326,14 @@ export class BoardObjectRepository {
     boardId: BoardID,
     zoneId: string,
     zonePosition?: { x: number; y: number }
-  ): Promise<number> {
+  ): Promise<BoardEntityObject[]> {
     try {
       const rows = await select(this.db)
         .from(boardObjects)
         .where(eq(boardObjects.board_id, boardId))
         .all();
 
-      let cleared = 0;
+      const cleared: BoardEntityObject[] = [];
       for (const row of rows) {
         const data = typeof row.data === 'string' ? JSON.parse(row.data) : row.data;
         if (data.zone_id === zoneId) {
@@ -349,7 +349,14 @@ export class BoardObjectRepository {
             })
             .where(eq(boardObjects.object_id, row.object_id))
             .run();
-          cleared++;
+
+          const updated = await select(this.db)
+            .from(boardObjects)
+            .where(eq(boardObjects.object_id, row.object_id))
+            .one();
+          if (updated) {
+            cleared.push(this.rowToEntity(updated));
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- guard React Flow node updates against orphaned parentId values
- validate branch/card zone parent IDs before assigning React Flow parentId
- clear board entity zone references when zones are removed through generic board object paths

## Tests
- pnpm check
- pnpm --filter agor-ui test -- src/components/SessionCanvas/SessionCanvas.zoom.test.tsx src/components/SessionCanvas/canvas/utils/nodeParentUtils.test.ts
- pnpm --filter @agor/daemon test -- src/services/board-objects.test.ts src/mcp/tools/boards.test.ts

Fixes #1332