### PR TITLE
Fix duplicate subsession completion callbacks

### DIFF
--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -61,9 +61,16 @@ function makeSession(overrides: Partial<Session> = {}): Session {
   } as Session;
 }
 
-function makeService() {
-  let storedTask = makeTask();
-  const childSession = makeSession();
+function makeService(
+  options: {
+    task?: Partial<Task>;
+    childSession?: Partial<Session>;
+    parentSession?: Partial<Session>;
+  } = {}
+) {
+  const initialTask = makeTask(options.task);
+  const tasksById = new Map<string, Task>([[initialTask.task_id, initialTask]]);
+  const childSession = makeSession(options.childSession);
   const parentSession = makeSession({
     session_id: parentSessionId,
     status: 'idle',
@@ -72,16 +79,19 @@ function makeService() {
     ready_for_prompt: true,
     genealogy: { children: [childSessionId] },
     callback_config: undefined,
+    ...options.parentSession,
   });
 
   const repository = {
-    findById: vi.fn(async () => storedTask),
-    update: vi.fn(async (_id: string, updates: Partial<Task>) => {
-      storedTask = { ...storedTask, ...updates } as Task;
-      return storedTask;
+    findById: vi.fn(async (id: string) => tasksById.get(id) ?? null),
+    update: vi.fn(async (id: string, updates: Partial<Task>) => {
+      const current = tasksById.get(id) ?? makeTask({ task_id: id as Task['task_id'] });
+      const updated = { ...current, ...updates } as Task;
+      tasksById.set(id, updated);
+      return updated;
     }),
     create: vi.fn(),
-    findAll: vi.fn(async () => [storedTask]),
+    findAll: vi.fn(async () => [...tasksById.values()]),
     delete: vi.fn(),
   };
 
@@ -108,7 +118,7 @@ function makeService() {
     id: string;
     emit: ReturnType<typeof vi.fn>;
     app: { service: ReturnType<typeof vi.fn> };
-    completionCallbackDispatches: Map<string, Promise<void>>;
+    completionCallbackDispatches: Map<string, Promise<unknown>>;
   };
   service.repository = repository;
   service.taskRepo = { ...repository, createPending };
@@ -137,7 +147,7 @@ function makeService() {
     sessionsPatch,
     triggerQueueProcessing,
     messagesFind,
-    getStoredTask: () => storedTask,
+    getStoredTask: (id = taskId) => tasksById.get(id),
     childSession,
   };
 }
@@ -205,5 +215,127 @@ describe('TasksService completion callbacks', () => {
     ]);
 
     expect(createPending).toHaveBeenCalledTimes(1);
+  });
+
+  it('still triggers target queue processing if dispatch marker persistence fails after queueing', async () => {
+    const { service, repository, createPending, triggerQueueProcessing } = makeService();
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+    const originalUpdate = repository.update.getMockImplementation();
+    repository.update.mockImplementation(async (id: string, updates: Partial<Task>) => {
+      if (updates.metadata?.callback_dispatches) {
+        throw new Error('metadata write failed');
+      }
+      if (!originalUpdate) throw new Error('missing original update');
+      return originalUpdate(id, updates);
+    });
+
+    await (service as any).dispatchCompletionCallbacks(completedTask, makeSession(), {});
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    expect(triggerQueueProcessing).toHaveBeenCalledWith(parentSessionId, {});
+  });
+
+  it('runs once-mode cleanup only for the caller that actually attempts dispatch', async () => {
+    const { service, createPending, sessionsPatch, childSession } = makeService();
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await Promise.all([
+      (service as any).dispatchCompletionCallbacks(completedTask, childSession, {}),
+      (service as any).dispatchCompletionCallbacks(completedTask, childSession, {}),
+    ]);
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    expect(
+      sessionsPatch.mock.calls.filter(
+        ([id, updates]) =>
+          id === childSessionId && (updates as Partial<Session>).callback_config?.enabled === false
+      )
+    ).toHaveLength(1);
+  });
+
+  it('does not queue or trigger when callback dispatch metadata already exists', async () => {
+    const { service, createPending, triggerQueueProcessing, childSession } = makeService({
+      task: {
+        metadata: {
+          callback_dispatches: [
+            {
+              event: 'session_completion',
+              target_session_id: parentSessionId,
+              queued_task_id: callbackTaskId,
+              dispatched_at: '2026-01-01T00:00:06.000Z',
+            },
+          ],
+        },
+      },
+    });
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+      metadata: {
+        callback_dispatches: [
+          {
+            event: 'session_completion',
+            target_session_id: parentSessionId,
+            queued_task_id: callbackTaskId,
+            dispatched_at: '2026-01-01T00:00:06.000Z',
+          },
+        ],
+      },
+    });
+
+    await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
+
+    expect(createPending).not.toHaveBeenCalled();
+    expect(triggerQueueProcessing).not.toHaveBeenCalledWith(parentSessionId, {});
+  });
+
+  it('does not queue or trigger target processing when callbacks are disabled', async () => {
+    const { service, createPending, triggerQueueProcessing, childSession } = makeService({
+      childSession: {
+        callback_config: {
+          enabled: false,
+          callback_session_id: parentSessionId,
+          callback_created_by: userId,
+          callback_mode: 'once',
+        },
+      },
+    });
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
+
+    expect(createPending).not.toHaveBeenCalled();
+    expect(triggerQueueProcessing).not.toHaveBeenCalledWith(parentSessionId, {});
+  });
+
+  it('uses legacy genealogy parent fallback when callback_session_id is absent', async () => {
+    const { service, createPending, childSession } = makeService({
+      childSession: {
+        callback_config: {
+          enabled: true,
+          callback_created_by: userId,
+          callback_mode: 'persistent',
+        },
+      },
+    });
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
+
+    expect(createPending).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: parentSessionId })
+    );
   });
 });

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -1,0 +1,209 @@
+import { type Session, type Task, TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { TasksService } from './tasks';
+
+const childSessionId = '018f0000-0000-7000-8000-000000000101';
+const parentSessionId = '018f0000-0000-7000-8000-000000000102';
+const taskId = '018f0000-0000-7000-8000-000000000201';
+const callbackTaskId = '018f0000-0000-7000-8000-000000000301';
+const userId = '018f0000-0000-7000-8000-000000000401';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    task_id: taskId,
+    session_id: childSessionId,
+    created_by: userId,
+    full_prompt: 'investigate duplicate callbacks',
+    status: TaskStatus.RUNNING,
+    message_range: {
+      start_index: 0,
+      end_index: 2,
+      start_timestamp: '2026-01-01T00:00:00.000Z',
+    },
+    tool_use_count: 3,
+    git_state: {
+      ref_at_start: 'main',
+      sha_at_start: 'abc123',
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Task;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: childSessionId,
+    branch_id: undefined,
+    created_by: userId,
+    agentic_tool: 'claude-code',
+    status: 'running',
+    title: 'Child session',
+    description: 'Child session',
+    tasks: [taskId],
+    ready_for_prompt: false,
+    archived: false,
+    genealogy: {
+      parent_session_id: parentSessionId,
+      children: [],
+    },
+    callback_config: {
+      enabled: true,
+      callback_session_id: parentSessionId,
+      callback_created_by: userId,
+      callback_mode: 'once',
+      include_last_message: true,
+    },
+    git_state: {},
+    contextFiles: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Session;
+}
+
+function makeService() {
+  let storedTask = makeTask();
+  const childSession = makeSession();
+  const parentSession = makeSession({
+    session_id: parentSessionId,
+    status: 'idle',
+    title: 'Parent session',
+    tasks: [],
+    ready_for_prompt: true,
+    genealogy: { children: [childSessionId] },
+    callback_config: undefined,
+  });
+
+  const repository = {
+    findById: vi.fn(async () => storedTask),
+    update: vi.fn(async (_id: string, updates: Partial<Task>) => {
+      storedTask = { ...storedTask, ...updates } as Task;
+      return storedTask;
+    }),
+    create: vi.fn(),
+    findAll: vi.fn(async () => [storedTask]),
+    delete: vi.fn(),
+  };
+
+  const callbackTask = makeTask({
+    task_id: callbackTaskId,
+    session_id: parentSessionId,
+    status: TaskStatus.QUEUED,
+  });
+  const createPending = vi.fn(async (data: Partial<Task>) => ({ ...callbackTask, ...data }));
+
+  const sessionsPatch = vi.fn(async (_id: string, updates: Partial<Session>) => updates);
+  const triggerQueueProcessing = vi.fn(async () => undefined);
+  const messagesFind = vi.fn(async () => [
+    {
+      role: 'assistant',
+      index: 2,
+      content: [{ type: 'text', text: 'Final child result' }],
+    },
+  ]);
+
+  const service = Object.create(TasksService.prototype) as TasksService & {
+    repository: typeof repository;
+    taskRepo: typeof repository & { createPending: typeof createPending };
+    id: string;
+    emit: ReturnType<typeof vi.fn>;
+    app: { service: ReturnType<typeof vi.fn> };
+    completionCallbackDispatches: Map<string, Promise<void>>;
+  };
+  service.repository = repository;
+  service.taskRepo = { ...repository, createPending };
+  service.id = 'task_id';
+  service.emit = vi.fn();
+  service.completionCallbackDispatches = new Map();
+  service.app = {
+    service: vi.fn((name: string) => {
+      if (name === 'sessions') {
+        return {
+          get: vi.fn(async (id: string) => (id === parentSessionId ? parentSession : childSession)),
+          patch: sessionsPatch,
+          triggerQueueProcessing,
+        };
+      }
+      if (name === 'messages') return { find: messagesFind };
+      if (name === 'branches') return { get: vi.fn() };
+      throw new Error(`unexpected service ${name}`);
+    }),
+  };
+
+  return {
+    service,
+    repository,
+    createPending,
+    sessionsPatch,
+    triggerQueueProcessing,
+    messagesFind,
+    getStoredTask: () => storedTask,
+    childSession,
+  };
+}
+
+describe('TasksService completion callbacks', () => {
+  it('queues exactly one templated callback with last-message metadata for a completed subsession task', async () => {
+    const {
+      service,
+      createPending,
+      sessionsPatch,
+      triggerQueueProcessing,
+      messagesFind,
+      getStoredTask,
+    } = makeService();
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    expect(createPending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_id: parentSessionId,
+        status: TaskStatus.QUEUED,
+        metadata: expect.objectContaining({
+          is_agor_callback: true,
+          source: 'agor',
+          child_session_id: childSessionId,
+          child_task_id: taskId,
+          queued_by_user_id: userId,
+        }),
+      })
+    );
+    const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
+    expect(callbackPrompt).toContain('[Agor] Child session');
+    expect(callbackPrompt).toContain('**Result:**');
+    expect(callbackPrompt).toContain('Final child result');
+    expect(callbackPrompt).toContain(taskId);
+    expect(messagesFind).toHaveBeenCalledTimes(1);
+    expect(triggerQueueProcessing).toHaveBeenCalledWith(parentSessionId, {});
+    expect(sessionsPatch).toHaveBeenCalledWith(
+      childSessionId,
+      expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+    );
+    expect(getStoredTask().metadata?.callback_dispatches).toEqual([
+      expect.objectContaining({
+        event: 'session_completion',
+        target_session_id: parentSessionId,
+        queued_task_id: callbackTaskId,
+      }),
+    ]);
+  });
+
+  it('dedupes concurrent completion callback dispatch for the same task target', async () => {
+    const { service, createPending, childSession } = makeService();
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await Promise.all([
+      (service as any).dispatchCompletionCallbacks(completedTask, childSession, {}),
+      (service as any).dispatchCompletionCallbacks(completedTask, childSession, {}),
+    ]);
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -72,6 +72,12 @@ export type TaskParams = QueryParams<{
   suppressTerminalQueueProcessing?: boolean;
 };
 
+interface CompletionCallbackDispatchResult {
+  callbackTask?: Task;
+  /** True only for the caller that actually evaluated/attempted dispatch under the lock. */
+  didAttemptDispatch: boolean;
+}
+
 /**
  * Extended tasks service with custom methods
  */
@@ -80,7 +86,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   private app: Application;
   private db: Database;
   private heartbeatCallbackRunner: ExecutorHeartbeatCallbackRunner;
-  private completionCallbackDispatches = new Map<string, Promise<void>>();
+  private completionCallbackDispatches = new Map<
+    string,
+    Promise<CompletionCallbackDispatchResult>
+  >();
 
   constructor(db: Database, app: Application) {
     const taskRepo = new TaskRepository(db);
@@ -648,14 +657,14 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     const targetSessionId = this.resolveCompletionCallbackTarget(childSession);
     if (!targetSessionId) return;
 
-    const callbackTask = await this.dispatchCompletionCallbackOnce(
+    const dispatchResult = await this.dispatchCompletionCallbackOnce(
       task,
       childSession,
       targetSessionId,
       params
     );
 
-    if (callbackTask) {
+    if (dispatchResult.callbackTask) {
       // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
       // The queue processor uses a promise-based lock that will:
       // - If target is busy: wait for current processing, then retry (self-healing)
@@ -688,7 +697,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     // Default to "persistent" for backward compat — legacy sessions without
     // callback_mode should continue firing on every completion as they always have.
     const callbackMode = childSession.callback_config?.callback_mode ?? 'persistent';
-    if (callbackMode === 'once') {
+    if (dispatchResult.didAttemptDispatch && callbackMode === 'once') {
       try {
         await this.app.service('sessions').patch(childSession.session_id, {
           callback_config: {
@@ -759,48 +768,54 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     childSession: Session,
     targetSessionId: SessionID,
     params?: TaskParams
-  ): Promise<Task | undefined> {
+  ): Promise<CompletionCallbackDispatchResult> {
     const dispatchKey = `${task.task_id}:${this.callbackDispatchMetadataKey(targetSessionId)}`;
     const existingDispatch = this.completionCallbackDispatches.get(dispatchKey);
     if (existingDispatch) {
       await existingDispatch;
-      return undefined;
+      return { didAttemptDispatch: false };
     }
 
-    let queuedCallbackTask: Task | undefined;
-    const dispatch = (async () => {
+    const dispatch = (async (): Promise<CompletionCallbackDispatchResult> => {
       const latestTask = (await this.taskRepo.findById(task.task_id)) ?? task;
       if (this.hasCompletionCallbackDispatch(latestTask.metadata, targetSessionId)) {
         console.log(
           `⏭️  [TasksService] Completion callback for task ${shortId(task.task_id)} to ${shortId(targetSessionId)} already dispatched`
         );
-        return;
+        return { didAttemptDispatch: false };
       }
 
-      queuedCallbackTask = await this.queueCallbackToSession(
+      const queuedCallbackTask = await this.queueCallbackToSession(
         task,
         childSession,
         targetSessionId,
         params
       );
       if (queuedCallbackTask) {
-        await this.markCompletionCallbackDispatched(
-          task,
-          targetSessionId,
-          queuedCallbackTask.task_id,
-          params
-        );
+        try {
+          await this.markCompletionCallbackDispatched(
+            task,
+            targetSessionId,
+            queuedCallbackTask.task_id,
+            params
+          );
+        } catch (error) {
+          console.warn(
+            `⚠️  [TasksService] Failed to mark completion callback dispatched for task ${shortId(task.task_id)} to ${shortId(targetSessionId)} after queueing:`,
+            error
+          );
+        }
       }
+
+      return { callbackTask: queuedCallbackTask, didAttemptDispatch: true };
     })();
 
     this.completionCallbackDispatches.set(dispatchKey, dispatch);
     try {
-      await dispatch;
+      return await dispatch;
     } finally {
       this.completionCallbackDispatches.delete(dispatchKey);
     }
-
-    return queuedCallbackTask;
   }
 
   /**

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -20,8 +20,9 @@ import type {
   Session,
   SessionID,
   Task,
+  TaskID,
 } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { type TaskMetadata, TaskStatus } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 import { appendSystemMessage } from '../utils/append-system-message.js';
 import {
@@ -79,6 +80,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   private app: Application;
   private db: Database;
   private heartbeatCallbackRunner: ExecutorHeartbeatCallbackRunner;
+  private completionCallbackDispatches = new Map<string, Promise<void>>();
 
   constructor(db: Database, app: Application) {
     const taskRepo = new TaskRepository(db);
@@ -425,12 +427,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             console.log(
               `⏭️ [TasksService] Skipping session IDLE update - task ${shortId(task.task_id)} is not the latest (latest: ${shortId(latestTaskId)})`
             );
-            // Still process callbacks (task completed, callback target needs to know)
-            const earlyCallbackTarget =
-              session.callback_config?.callback_session_id ?? session.genealogy?.parent_session_id;
-            if (earlyCallbackTarget) {
-              await this.queueCallbackToSession(task, session, earlyCallbackTarget, params);
-            }
+            // Still process completion callbacks (task completed, callback target needs to know).
+            // Route through the same centralized/idempotent dispatcher used by the normal
+            // completion path so races cannot enqueue duplicate parent callbacks.
+            await this.dispatchCompletionCallbacks(task, session, params);
             return result;
           }
 
@@ -464,67 +464,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             );
           }
 
-          // Queue callback to the target session if configured
-          // callback_config.callback_session_id is the single source of truth for both:
-          // - Subsessions (spawn sets it to parent session ID)
-          // - Remote sessions (create sets it when enableCallback is true)
-          // Fallback: legacy spawned sessions may only have genealogy.parent_session_id
-          // Fallback to genealogy.parent_session_id for legacy spawned sessions
-          const callbackTarget =
-            session.callback_config?.callback_session_id ?? session.genealogy?.parent_session_id;
-          if (callbackTarget) {
-            const targetSessionId = callbackTarget;
-            await this.queueCallbackToSession(task, session, targetSessionId, params);
-
-            // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
-            // The queue processor uses a promise-based lock that will:
-            // - If target is busy: wait for current processing, then retry (self-healing)
-            // - If target is idle: immediately process the callback
-            // - If target becomes idle while waiting: the retry will catch it
-            //
-            // DO NOT check target status before triggering - let the queue processor handle it.
-            // This ensures callbacks are never missed due to timing issues.
-            try {
-              const sessionsService = this.app.service('sessions') as unknown as SessionsService;
-              if (sessionsService.triggerQueueProcessing) {
-                console.log(
-                  `🔄 [TasksService] Triggering callback target queue processing for ${shortId(targetSessionId)} (callback queued)`
-                );
-                // Pass empty params to avoid leaking child's auth context to target
-                // The queue processor will reconstruct target auth from queued task metadata
-                await sessionsService.triggerQueueProcessing(targetSessionId, {});
-              }
-            } catch (error) {
-              // Don't throw - target issues shouldn't break child queue processing
-              console.warn(
-                `⚠️  [TasksService] Failed to trigger callback target queue processing (target may be deleted):`,
-                error
-              );
-            }
-          }
-
-          // Post-callback cleanup: runs independently of whether callback was delivered.
-          // "once" mode: auto-disable callback after first delivery attempt
-          // Default to "persistent" for backward compat — legacy sessions without callback_mode
-          // should continue firing on every completion as they always have.
-          if (callbackTarget) {
-            const callbackMode = session.callback_config?.callback_mode ?? 'persistent';
-            if (callbackMode === 'once') {
-              try {
-                await this.app.service('sessions').patch(session.session_id, {
-                  callback_config: {
-                    ...session.callback_config,
-                    enabled: false,
-                  },
-                });
-                console.log(
-                  `🔕 [TasksService] Auto-disabled callback for session ${shortId(session.session_id)} (once mode)`
-                );
-              } catch (error) {
-                console.warn(`⚠️  [TasksService] Failed to auto-disable callback:`, error);
-              }
-            }
-          }
+          await this.dispatchCompletionCallbacks(task, session, params);
 
           // "btw" fork origin: auto-archive the ephemeral fork after task completion.
           // Runs regardless of callback success — btw forks should always be cleaned up.
@@ -691,6 +631,179 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   }
 
   /**
+   * Centralized completion-callback dispatcher.
+   *
+   * Both subsessions and generic callback_config callbacks resolve to the same
+   * target/event pair: `session_completion` delivered to
+   * `callback_config.callback_session_id`, with a genealogy-parent fallback for
+   * legacy spawned sessions. Keeping all routing here prevents a completed child
+   * from notifying its parent once via the rich/template path and again via a
+   * second generic/raw path.
+   */
+  private async dispatchCompletionCallbacks(
+    task: Task,
+    childSession: Session,
+    params?: TaskParams
+  ): Promise<void> {
+    const targetSessionId = this.resolveCompletionCallbackTarget(childSession);
+    if (!targetSessionId) return;
+
+    const callbackTask = await this.dispatchCompletionCallbackOnce(
+      task,
+      childSession,
+      targetSessionId,
+      params
+    );
+
+    if (callbackTask) {
+      // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
+      // The queue processor uses a promise-based lock that will:
+      // - If target is busy: wait for current processing, then retry (self-healing)
+      // - If target is idle: immediately process the callback
+      // - If target becomes idle while waiting: the retry will catch it
+      //
+      // DO NOT check target status before triggering - let the queue processor handle it.
+      // This ensures callbacks are never missed due to timing issues.
+      try {
+        const sessionsService = this.app.service('sessions') as unknown as SessionsService;
+        if (sessionsService.triggerQueueProcessing) {
+          console.log(
+            `🔄 [TasksService] Triggering callback target queue processing for ${shortId(targetSessionId)} (callback queued)`
+          );
+          // Pass empty params to avoid leaking child's auth context to target.
+          // The queue processor reconstructs target auth from queued task metadata.
+          await sessionsService.triggerQueueProcessing(targetSessionId, {});
+        }
+      } catch (error) {
+        // Don't throw - target issues shouldn't break child queue processing.
+        console.warn(
+          `⚠️  [TasksService] Failed to trigger callback target queue processing (target may be deleted):`,
+          error
+        );
+      }
+    }
+
+    // Post-callback cleanup: runs independently of whether callback was delivered.
+    // "once" mode: auto-disable callback after first delivery attempt.
+    // Default to "persistent" for backward compat — legacy sessions without
+    // callback_mode should continue firing on every completion as they always have.
+    const callbackMode = childSession.callback_config?.callback_mode ?? 'persistent';
+    if (callbackMode === 'once') {
+      try {
+        await this.app.service('sessions').patch(childSession.session_id, {
+          callback_config: {
+            ...childSession.callback_config,
+            enabled: false,
+          },
+        });
+        console.log(
+          `🔕 [TasksService] Auto-disabled callback for session ${shortId(childSession.session_id)} (once mode)`
+        );
+      } catch (error) {
+        console.warn(`⚠️  [TasksService] Failed to auto-disable callback:`, error);
+      }
+    }
+  }
+
+  private resolveCompletionCallbackTarget(childSession: Session): SessionID | undefined {
+    // callback_config.callback_session_id is the single source of truth for both:
+    // - Subsessions (spawn sets it to parent session ID)
+    // - Remote sessions (create sets it when enableCallback is true)
+    // Fallback: legacy spawned sessions may only have genealogy.parent_session_id.
+    return (
+      childSession.callback_config?.callback_session_id ?? childSession.genealogy?.parent_session_id
+    );
+  }
+
+  private callbackDispatchMetadataKey(targetSessionId: SessionID): string {
+    return `session_completion:${targetSessionId}`;
+  }
+
+  private hasCompletionCallbackDispatch(
+    metadata: TaskMetadata | undefined,
+    targetSessionId: SessionID
+  ): boolean {
+    return (metadata?.callback_dispatches ?? []).some(
+      (dispatch) =>
+        dispatch.event === 'session_completion' && dispatch.target_session_id === targetSessionId
+    );
+  }
+
+  private async markCompletionCallbackDispatched(
+    task: Task,
+    targetSessionId: SessionID,
+    queuedTaskId: TaskID | undefined,
+    params?: TaskParams
+  ): Promise<void> {
+    const latestTask = (await this.taskRepo.findById(task.task_id)) ?? task;
+    if (this.hasCompletionCallbackDispatch(latestTask.metadata, targetSessionId)) return;
+
+    const metadata: TaskMetadata = {
+      ...(latestTask.metadata ?? {}),
+      callback_dispatches: [
+        ...(latestTask.metadata?.callback_dispatches ?? []),
+        {
+          event: 'session_completion',
+          target_session_id: targetSessionId,
+          queued_task_id: queuedTaskId,
+          dispatched_at: new Date().toISOString(),
+        },
+      ],
+    };
+
+    await super.patch(task.task_id, { metadata } as Partial<Task>, params);
+  }
+
+  private async dispatchCompletionCallbackOnce(
+    task: Task,
+    childSession: Session,
+    targetSessionId: SessionID,
+    params?: TaskParams
+  ): Promise<Task | undefined> {
+    const dispatchKey = `${task.task_id}:${this.callbackDispatchMetadataKey(targetSessionId)}`;
+    const existingDispatch = this.completionCallbackDispatches.get(dispatchKey);
+    if (existingDispatch) {
+      await existingDispatch;
+      return undefined;
+    }
+
+    let queuedCallbackTask: Task | undefined;
+    const dispatch = (async () => {
+      const latestTask = (await this.taskRepo.findById(task.task_id)) ?? task;
+      if (this.hasCompletionCallbackDispatch(latestTask.metadata, targetSessionId)) {
+        console.log(
+          `⏭️  [TasksService] Completion callback for task ${shortId(task.task_id)} to ${shortId(targetSessionId)} already dispatched`
+        );
+        return;
+      }
+
+      queuedCallbackTask = await this.queueCallbackToSession(
+        task,
+        childSession,
+        targetSessionId,
+        params
+      );
+      if (queuedCallbackTask) {
+        await this.markCompletionCallbackDispatched(
+          task,
+          targetSessionId,
+          queuedCallbackTask.task_id,
+          params
+        );
+      }
+    })();
+
+    this.completionCallbackDispatches.set(dispatchKey, dispatch);
+    try {
+      await dispatch;
+    } finally {
+      this.completionCallbackDispatches.delete(dispatchKey);
+    }
+
+    return queuedCallbackTask;
+  }
+
+  /**
    * Queue callback message to a target session when a session completes.
    * The target is always callback_config.callback_session_id, set by both
    * spawn (defaults to parent) and create (when enableCallback is true).
@@ -700,8 +813,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     childSession: Session,
     targetSessionId: SessionID,
     params?: TaskParams
-  ): Promise<void> {
-    if (!targetSessionId) return;
+  ): Promise<Task | undefined> {
+    if (!targetSessionId) return undefined;
 
     try {
       // Get target session to check callback config
@@ -719,7 +832,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         console.log(
           `⏭️  [TasksService] Callbacks disabled for child session ${shortId(childSession.session_id)}`
         );
-        return;
+        return undefined;
       }
 
       // Check if we should include original spawn prompt - child overrides take precedence
@@ -817,7 +930,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         console.warn(
           `⚠️  [TasksService] Cannot queue callback: target session ${shortId(targetSessionId)} has no creator (anonymous session)`
         );
-        return;
+        return undefined;
       }
 
       // Create QUEUED task on the target session carrying the callback prompt.
@@ -852,14 +965,16 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         `🔔 Queued callback task ${shortId(callbackTask.task_id)} on session ${shortId(targetSessionId)} from child ${shortId(childSession.session_id)}`
       );
 
-      // NOTE: Queue processing is handled automatically via task completion hook.
-      // When target session becomes idle, it will drain queued tasks including this callback.
+      // NOTE: Queue processing is handled by the centralized dispatcher after
+      // it confirms a callback task was actually queued.
+      return callbackTask;
     } catch (error) {
       console.error(
         `❌ [TasksService] Failed to queue callback to ${targetSessionId} for session ${childSession.session_id}:`,
         error
       );
       // Don't throw - callback failure shouldn't break task completion
+      return undefined;
     }
   }
 

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -43,6 +43,18 @@ export interface TaskMetadata {
   child_session_id?: SessionID;
   child_task_id?: TaskID;
   /**
+   * Completion callbacks already dispatched for this task, keyed by event +
+   * target. The daemon uses this as an idempotency marker so child-session
+   * completion notifications are not queued twice if multiple completion
+   * paths race.
+   */
+  callback_dispatches?: Array<{
+    event: 'session_completion';
+    target_session_id: SessionID;
+    queued_task_id?: TaskID;
+    dispatched_at: string;
+  }>;
+  /**
    * Marks a task whose prompt was authored by the daemon (not typed by a
    * human). Used by widget auto-resume so the UI can label the queued
    * prompt appropriately.


### PR DESCRIPTION
## Summary
- centralize child/session completion callback dispatch in `TasksService`
- add per-task/target idempotency for `session_completion` callbacks
- preserve rich templated callback delivery with child/task metadata and last assistant message support
- add focused regression tests for subsession callback de-duping

## Checks
- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/tasks.callbacks.test.ts`

## Notes
- No schema migration required; dispatch markers are stored in existing task `metadata` JSON.
