### PR TITLE
Hide noisy Claude SDK system telemetry

### DIFF
--- a/packages/core/src/client/claude-system-suppression.test.ts
+++ b/packages/core/src/client/claude-system-suppression.test.ts
@@ -49,6 +49,22 @@ describe('shouldHidePersistedClaudeSdkEvent', () => {
     ).toBe(false);
   });
 
+  it('treats non-zero hook_response exit_code as diagnostic even if outcome says success', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'hook_response',
+        metadata: {
+          subtype: 'hook_response',
+          outcome: 'success',
+          exit_code: 1,
+          stderr: 'hook failed after reporting success',
+        },
+      })
+    ).toBe(false);
+  });
+
   it('hides thinking token telemetry rows', () => {
     expect(
       shouldHidePersistedClaudeSdkEvent({

--- a/packages/core/src/client/claude-system-suppression.test.ts
+++ b/packages/core/src/client/claude-system-suppression.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { shouldHidePersistedClaudeSdkEvent } from './claude-system-suppression';
+import {
+  shouldHidePersistedClaudeSdkEvent,
+  shouldSuppressClaudeSystemEvent,
+} from './claude-system-suppression';
 
 describe('shouldHidePersistedClaudeSdkEvent', () => {
   it('hides task_updated rows (including ones with patch.error)', () => {
@@ -9,6 +12,50 @@ describe('shouldHidePersistedClaudeSdkEvent', () => {
         sdkType: 'system',
         sdkSubtype: 'task_updated',
         metadata: { subtype: 'task_updated', patch: { status: 'failed', error: 'boom' } },
+      })
+    ).toBe(true);
+  });
+
+  it('hides hook lifecycle rows that only describe hook plumbing', () => {
+    for (const sdkSubtype of ['hook_started', 'hook_progress', 'hook_response']) {
+      expect(
+        shouldHidePersistedClaudeSdkEvent({
+          type: 'sdk_event',
+          sdkType: 'system',
+          sdkSubtype,
+          metadata: { subtype: sdkSubtype, hook_event_name: 'PreToolUse' },
+        })
+      ).toBe(true);
+    }
+  });
+
+  it('keeps failed hook_response rows visible for diagnostics', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'hook_response',
+        metadata: { subtype: 'hook_response', outcome: 'error', stderr: 'hook failed' },
+      })
+    ).toBe(false);
+
+    expect(
+      shouldSuppressClaudeSystemEvent({
+        subtype: 'hook_response',
+        exit_code: 2,
+        stdout: '',
+        stderr: 'hook failed',
+      })
+    ).toBe(false);
+  });
+
+  it('hides thinking token telemetry rows', () => {
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'thinking_tokens',
+        metadata: { subtype: 'thinking_tokens', thinking_tokens: 1234 },
       })
     ).toBe(true);
   });

--- a/packages/core/src/client/claude-system-suppression.ts
+++ b/packages/core/src/client/claude-system-suppression.ts
@@ -4,7 +4,7 @@
  * Blacklist philosophy: surface unknown subtypes by default so newly added
  * SDK events (e.g. `mirror_error`, `notification`, `api_retry`, `memory_recall`,
  * `plugin_install`) reach users without code changes. Only entries we have
- * confirmed are pure lifecycle telemetry belong in the suppress set.
+ * confirmed are pure lifecycle/token telemetry belong in the suppress set.
  *
  * Two consumers:
  *   - executor (`message-processor.ts`): drops these before they ever become
@@ -48,14 +48,22 @@ export type ClaudeSystemStatus = Extract<
  * own `tool_result` block (with `is_error: true`) is the authoritative surface
  * for subagent task failures; the parallel `task_*` telemetry stream is
  * redundant. If that invariant ever breaks, revisit this set.
+ *
+ * Hook lifecycle events (`hook_started`, `hook_progress`) are emitted around
+ * Claude Code hook execution and are usually adjacent, repeated chrome-only
+ * rows. `hook_response` is handled conditionally below so failed hooks still
+ * have a diagnostic surface.
  */
 export const SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES: ReadonlySet<ClaudeSystemSubtype> = new Set([
   'files_persisted',
+  'hook_started',
+  'hook_progress',
   'session_state_changed',
   'task_started',
   'task_progress',
   'task_updated',
   'task_notification',
+  'thinking_tokens',
 ] as const);
 
 /**
@@ -82,6 +90,55 @@ interface PersistedSdkEventBlock {
   metadata?: unknown;
 }
 
+function getObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function isFailedHookResponse(metadata: unknown): boolean {
+  const event = getObject(metadata);
+  if (!event) return false;
+
+  if (event.outcome === 'error') return true;
+  return typeof event.exit_code === 'number' && event.exit_code !== 0;
+}
+
+/**
+ * Runtime filter for Claude SDK `type:'system'` events before they are
+ * converted into persisted Agor `sdk_event` blocks.
+ */
+export function shouldSuppressClaudeSystemEvent(event: {
+  subtype?: string;
+  [key: string]: unknown;
+}): boolean {
+  const subtype = event.subtype;
+  if (!subtype) return false;
+
+  if ((SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES as ReadonlySet<string>).has(subtype)) {
+    return true;
+  }
+
+  // Successful/cancelled hook responses are repeated lifecycle chrome. Keep
+  // failed hook responses visible because they may be the only clue that a
+  // configured hook is broken.
+  if (subtype === 'hook_response') {
+    return !isFailedHookResponse(event);
+  }
+
+  if (subtype === 'status') {
+    const status = event.status;
+    if (
+      typeof status === 'string' &&
+      (SUPPRESSED_CLAUDE_STATUSES as ReadonlySet<string>).has(status)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Defensive UI filter: returns true when an already-persisted `sdk_event`
  * block matches one of our suppression rules and should be hidden from the
@@ -92,22 +149,9 @@ export function shouldHidePersistedClaudeSdkEvent(block: PersistedSdkEventBlock)
   if (block.sdkType !== 'system') return false;
   if (!block.sdkSubtype) return false;
 
-  if ((SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES as ReadonlySet<string>).has(block.sdkSubtype)) {
-    return true;
-  }
-
-  if (block.sdkSubtype === 'status') {
-    const status =
-      typeof block.metadata === 'object' && block.metadata !== null
-        ? (block.metadata as { status?: unknown }).status
-        : undefined;
-    if (
-      typeof status === 'string' &&
-      (SUPPRESSED_CLAUDE_STATUSES as ReadonlySet<string>).has(status)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  const metadata = getObject(block.metadata);
+  return shouldSuppressClaudeSystemEvent({
+    ...(metadata ?? {}),
+    subtype: block.sdkSubtype,
+  });
 }

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -39,6 +39,55 @@ describe('SDKMessageProcessor system event suppression', () => {
     expect(events.filter((e) => e.type === 'sdk_event')).toHaveLength(0);
   });
 
+  it('suppresses hook lifecycle telemetry', async () => {
+    const processor = createProcessor();
+
+    for (const subtype of ['hook_started', 'hook_progress', 'hook_response']) {
+      const events = await processor.process(
+        systemMsg({
+          subtype,
+          hook_event_name: 'PreToolUse',
+          session_id: 's',
+          uuid: `u-${subtype}`,
+        })
+      );
+      expect(events.filter((e) => e.type === 'sdk_event')).toHaveLength(0);
+    }
+  });
+
+  it('suppresses thinking token telemetry', async () => {
+    const processor = createProcessor();
+    const events = await processor.process(
+      systemMsg({
+        subtype: 'thinking_tokens',
+        thinking_tokens: 1234,
+        session_id: 's',
+        uuid: 'u',
+      })
+    );
+    expect(events.filter((e) => e.type === 'sdk_event')).toHaveLength(0);
+  });
+
+  it('surfaces failed hook responses for diagnostics', async () => {
+    const processor = createProcessor();
+    const events = await processor.process(
+      systemMsg({
+        subtype: 'hook_response',
+        hook_event: 'PreToolUse',
+        outcome: 'error',
+        stderr: 'hook failed',
+        exit_code: 1,
+        session_id: 's',
+        uuid: 'u',
+      })
+    );
+
+    const sdkEvents = events.filter((e) => e.type === 'sdk_event');
+    expect(sdkEvents).toHaveLength(1);
+    const event = sdkEvents[0] as Extract<ProcessedEvent, { type: 'sdk_event' }>;
+    expect(event.sdkSubtype).toBe('hook_response');
+  });
+
   it('surfaces user-meaningful system subtypes (e.g. mirror_error)', async () => {
     const processor = createProcessor();
     const events = await processor.process(

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -13,7 +13,7 @@
 
 import {
   SUPPRESSED_CLAUDE_STATUSES,
-  SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES,
+  shouldSuppressClaudeSystemEvent,
 } from '@agor/core/client/claude-system-suppression';
 import { shortId } from '@agor/core/db';
 import type {
@@ -744,7 +744,7 @@ export class SDKMessageProcessor {
     const subtype =
       ('subtype' in msg ? (msg as { subtype?: string }).subtype : undefined) || 'unknown';
 
-    if ((SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES as ReadonlySet<string>).has(subtype)) {
+    if (shouldSuppressClaudeSystemEvent(msg as { subtype?: string; [key: string]: unknown })) {
       console.debug(`🔇 Suppressed system subtype: ${subtype}`);
       return [];
     }


### PR DESCRIPTION
## Summary
- suppress low-value Claude SDK system telemetry for hook lifecycle and thinking token events
- keep failed hook responses visible for diagnostics
- share suppression logic between executor processing and persisted UI filtering

## Checks
- pnpm check
- pnpm --filter @agor/core test src/client/claude-system-suppression.test.ts
- pnpm --filter @agor/executor test src/sdk-handlers/claude/message-processor.test.ts