### PR TITLE
fix(branches): apply zone filter before pagination

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -113,7 +113,26 @@ describe('agor_branches_list', () => {
   function makeApp(findResult: unknown) {
     return {
       service(name: string) {
-        if (name === 'branches') return { find: vi.fn(async () => findResult) };
+        if (name === 'branches') {
+          return {
+            find: vi.fn(async (params?: { query?: Record<string, unknown> }) => {
+              const zoneId = params?.query?.zone_id;
+              if (!zoneId || Array.isArray(findResult)) return findResult;
+
+              // Simulate BranchesService-level filtering. The MCP tool should
+              // forward zone_id to the service instead of filtering the current
+              // page itself.
+              const result = findResult as {
+                data: Record<string, unknown>[];
+                total: number;
+                limit: number;
+                skip: number;
+              };
+              const filtered = result.data.filter((branch) => branch.zone_id === zoneId);
+              return { ...result, data: filtered, total: filtered.length };
+            }),
+          };
+        }
         throw new Error(`Unexpected service call: ${name}`);
       },
     };
@@ -159,6 +178,32 @@ describe('agor_branches_list', () => {
 
     const branch2 = parsed.data[1];
     expect(branch2.zone_id).toBeUndefined();
+  });
+
+  it('passes zone_id to the service query so filtering is pagination-correct', async () => {
+    const findFn = vi.fn(async () => ({
+      data: [{ branch_id: 'branch-1', zone_id: 'zone-review' }],
+      total: 1,
+      limit: 50,
+      skip: 0,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { find: findFn };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const list = registerAndCaptureHandler('agor_branches_list', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await list({ zoneId: 'zone-review' });
+
+    expect(findFn).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ zone_id: 'zone-review' }) })
+    );
   });
 
   it('filters by zoneId when provided', async () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -193,28 +193,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       } else if (!args.includeArchived) {
         query.archived = false;
       }
+      // Delegate zone filtering to BranchesService so it runs before pagination.
+      if (args.zoneId) query.zone_id = coerceString(args.zoneId);
+
       const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
-
-      // Post-enrichment zone filter: zone_id is added by the service's find() via
-      // enrichManyWithZoneInfo (LEFT JOIN on board_objects). Filter here after enrichment
-      // so the caller doesn't have to fan out with individual get() calls.
-      if (args.zoneId) {
-        const zoneId = coerceString(args.zoneId);
-        if (Array.isArray(result)) {
-          return textResult(result.filter((b: Record<string, unknown>) => b.zone_id === zoneId));
-        } else {
-          const filtered = (
-            result as {
-              data: Record<string, unknown>[];
-              total: number;
-              limit: number;
-              skip: number;
-            }
-          ).data.filter((b) => b.zone_id === zoneId);
-          return textResult({ ...result, data: filtered, total: filtered.length });
-        }
-      }
-
       return textResult(result);
     }
   );

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -77,7 +77,6 @@ import {
   loadSessionBranch,
   PERMISSION_RANK,
   resolveSessionContext,
-  scopeBranchQuery,
   scopeFindToAccessibleBoards,
   scopeFindToAccessibleBranches,
   scopeFindToAccessibleSessions,
@@ -714,8 +713,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireMinimumRole(ROLES.MEMBER, 'access branches'),
       ],
       find: [
-        // RBAC: Optimized SQL-based filtering (single query with JOIN, no N+1)
-        ...(branchRbacEnabled ? [scopeBranchQuery(branchRepository, superadminOpts)] : []),
+        // RBAC: compose an accessible branch_id filter and let BranchesService.find()
+        // handle service-level filters/enrichment (including virtual zone_id).
+        ...(branchRbacEnabled
+          ? [scopeFindToAccessibleBranches(branchRepository, superadminOpts)]
+          : []),
       ],
       get: [
         ...(branchRbacEnabled

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -140,6 +140,40 @@ function createServiceHarness() {
   return { service, boardObjectsService, sessionsService };
 }
 
+function createFindHarness(opts: {
+  branches: Array<Record<string, unknown>>;
+  branchIdsInZone: BranchID[];
+}) {
+  const app = {
+    service(path: string) {
+      throw new Error(`Unknown service: ${path}`);
+    },
+  } as unknown as Application;
+  const repository = {
+    findAll: vi.fn(async () => opts.branches),
+    findById: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+  };
+  const branchRepo = {
+    findBranchIdsByZone: vi.fn(async () => opts.branchIdsInZone),
+    enrichManyWithZoneInfo: vi.fn(async (branches: Array<Record<string, unknown>>) =>
+      branches.map((branch: Record<string, unknown>) => ({
+        ...branch,
+        zone_id: opts.branchIdsInZone.includes(branch.branch_id as BranchID)
+          ? 'zone-review'
+          : undefined,
+      }))
+    ),
+  };
+  const service = new BranchesService({} as never, app);
+  (service as unknown as { repository: typeof repository }).repository = repository;
+  (service as unknown as { branchRepo: typeof branchRepo }).branchRepo = branchRepo;
+
+  return { service, repository, branchRepo };
+}
+
 describe('BranchesService.patch primary assistant invariants', () => {
   it('clears the old primary and sets the new board primary when an assistant moves boards', async () => {
     const boardA = 'board-a' as BoardID;
@@ -363,6 +397,50 @@ describe('BranchesService.unarchive', () => {
       branch_id: branchId,
       position: { x: 7, y: 8 },
     });
+  });
+});
+
+describe('BranchesService.find zone filtering', () => {
+  it('applies zone_id before pagination', async () => {
+    const branch1 = { branch_id: 'branch-1', name: 'outside', board_id: 'board-1' };
+    const branch2 = { branch_id: 'branch-2', name: 'inside-a', board_id: 'board-1' };
+    const branch3 = { branch_id: 'branch-3', name: 'inside-b', board_id: 'board-1' };
+    const { service, branchRepo } = createFindHarness({
+      branches: [branch1, branch2, branch3],
+      branchIdsInZone: ['branch-2' as BranchID, 'branch-3' as BranchID],
+    });
+
+    const result = (await service.find({
+      query: { zone_id: 'zone-review', $limit: 1 },
+    })) as { data: Array<Record<string, unknown>>; total: number; limit: number; skip: number };
+
+    expect(branchRepo.findBranchIdsByZone).toHaveBeenCalledWith('zone-review');
+    expect(result.total).toBe(2);
+    expect(result.limit).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].branch_id).toBe('branch-2');
+    expect(result.data[0].zone_id).toBe('zone-review');
+  });
+
+  it('intersects zone_id filtering with existing branch_id scoping', async () => {
+    const branch1 = { branch_id: 'branch-1', name: 'outside', board_id: 'board-1' };
+    const branch2 = { branch_id: 'branch-2', name: 'inside-a', board_id: 'board-1' };
+    const branch3 = { branch_id: 'branch-3', name: 'inside-b', board_id: 'board-1' };
+    const { service } = createFindHarness({
+      branches: [branch1, branch2, branch3],
+      branchIdsInZone: ['branch-2' as BranchID, 'branch-3' as BranchID],
+    });
+
+    const result = (await service.find({
+      query: {
+        zone_id: 'zone-review',
+        branch_id: { $in: ['branch-3' as BranchID] },
+      },
+    })) as { data: Array<Record<string, unknown>>; total: number };
+
+    expect(result.total).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].branch_id).toBe('branch-3');
   });
 });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -47,9 +47,11 @@ import type { InternalEnrichmentParams } from './sessions';
  * Branch service params
  */
 export type BranchParams = QueryParams<{
+  branch_id?: BranchID | { $in?: BranchID[] };
   repo_id?: UUID;
   name?: string;
   ref?: string;
+  zone_id?: string; // Virtual filter: board_objects.data.zone_id, handled before pagination
   deleteFromFilesystem?: boolean;
   include_sessions?: boolean | 'true' | 'false'; // Opt-in session activity enrichment
   last_message_truncation_length?: number; // Default: 500 chars, min: 50, max: 10000
@@ -541,10 +543,46 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * Override find to enrich with zone information only
    *
    * Note: Session activity is NOT included in list operations - only on single GET
+   *
+   * `zone_id` is a virtual query parameter backed by board_objects.data.zone_id.
+   * Resolve it to a branch_id filter before delegating to DrizzleService so
+   * pagination is applied to the zone-filtered result set, while preserving any
+   * existing branch_id scoping injected by RBAC hooks.
    */
   async find(params?: BranchParams) {
+    const zoneId = params?.query?.zone_id;
+    let findParams = params;
+
+    if (zoneId) {
+      const branchIdsInZone = await this.branchRepo.findBranchIdsByZone(zoneId);
+      const existingBranchFilter = params?.query?.branch_id;
+      let filteredBranchIds = branchIdsInZone;
+
+      if (typeof existingBranchFilter === 'string') {
+        filteredBranchIds = branchIdsInZone.includes(existingBranchFilter as BranchID)
+          ? [existingBranchFilter as BranchID]
+          : [];
+      } else if (
+        existingBranchFilter &&
+        typeof existingBranchFilter === 'object' &&
+        Array.isArray(existingBranchFilter.$in)
+      ) {
+        const allowed = new Set(existingBranchFilter.$in);
+        filteredBranchIds = branchIdsInZone.filter((branchId) => allowed.has(branchId));
+      }
+
+      const { zone_id: _zoneId, ...queryWithoutZone } = params?.query ?? {};
+      findParams = {
+        ...params,
+        query: {
+          ...queryWithoutZone,
+          branch_id: { $in: filteredBranchIds },
+        },
+      } as BranchParams;
+    }
+
     // Use default find to ensure all hooks and scoping are applied (including repo_id filter)
-    const result = await super.find(params);
+    const result = await super.find(findParams);
 
     // Handle both paginated and non-paginated results
     if (Array.isArray(result)) {

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -1094,10 +1094,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     const repo = await this.get(id, params);
     const cleanup = params?.query?.cleanup === true;
 
-    // Get ALL branches for this repo (needed for both filesystem and database cleanup)
-    // CRITICAL: Use internal call (no provider) to avoid RBAC hooks that bypass repo_id filter.
-    // Spreading external params with provider causes scopeBranchQuery to return ALL accessible
-    // branches instead of filtering by repo_id, leading to cross-repo deletion.
+    // Get ALL branches for this repo (needed for both filesystem and database cleanup).
+    // CRITICAL: Use an internal call (no provider) so repo deletion owns the
+    // full branch inventory for this repo, independent of caller RBAC scope.
     const branchesService = this.app.service('branches');
     const branchesResult = await branchesService.find({
       query: { repo_id: repo.repo_id },

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -10,6 +10,7 @@ import { generateId, shortId } from '../../lib/ids';
 import { boards } from '../schema';
 import { dbTest } from '../test-helpers';
 import { AmbiguousIdError, EntityNotFoundError } from './base';
+import { BoardObjectRepository } from './board-objects';
 import { BranchRepository } from './branches';
 import { RepoRepository } from './repos';
 
@@ -89,6 +90,65 @@ function createBranchData(overrides?: {
     clone_depth: overrides?.clone_depth,
   } as const;
 }
+
+describe('BranchRepository.findBranchIdsByZone', () => {
+  dbTest('finds branch ids by board_objects data.zone_id', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const boardObjectRepo = new BoardObjectRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    const boardId = generateId() as UUID;
+    await (db as any).insert(boards).values({
+      board_id: boardId,
+      created_at: new Date(),
+      created_by: 'test-user' as UUID,
+      name: 'Test Board',
+      data: {
+        objects: {
+          'zone-review': { type: 'zone', label: 'Review' },
+          'zone-done': { type: 'zone', label: 'Done' },
+        },
+      },
+    });
+
+    const branchInZone = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        branch_id: generateId() as BranchID,
+        name: 'feature-in-zone',
+        branch_unique_id: 1,
+        board_id: boardId,
+      })
+    );
+    const branchOtherZone = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        branch_id: generateId() as BranchID,
+        name: 'feature-other-zone',
+        branch_unique_id: 2,
+        board_id: boardId,
+      })
+    );
+
+    await boardObjectRepo.create({
+      board_id: boardId,
+      branch_id: branchInZone.branch_id,
+      position: { x: 0, y: 0 },
+      zone_id: 'zone-review',
+    });
+    await boardObjectRepo.create({
+      board_id: boardId,
+      branch_id: branchOtherZone.branch_id,
+      position: { x: 100, y: 0 },
+      zone_id: 'zone-done',
+    });
+
+    await expect(branchRepo.findBranchIdsByZone('zone-review')).resolves.toEqual([
+      branchInZone.branch_id,
+    ]);
+  });
+});
 
 // ============================================================================
 // Create

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -566,6 +566,34 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find branch IDs pinned to a specific board zone.
+   *
+   * Zone membership lives on board_objects.data.zone_id, not on the branches
+   * table. BranchesService.find() uses this helper to turn a zone_id query into
+   * a branch_id filter before the generic adapter applies pagination.
+   */
+  async findBranchIdsByZone(zoneId: string): Promise<BranchID[]> {
+    const { boardObjects: boardObjectsTable } = await import('../schema');
+    const { jsonExtract } = await import('../database-wrapper');
+
+    const rows = await select(this.db, {
+      branch_id: boardObjectsTable.branch_id,
+    })
+      .from(boardObjectsTable)
+      .where(sql`${jsonExtract(this.db, boardObjectsTable.data, 'zone_id')} = ${zoneId}`)
+      .all();
+
+    const uniqueIds = new Set<BranchID>();
+    for (const row of rows as { branch_id: string | null }[]) {
+      if (row.branch_id) {
+        uniqueIds.add(row.branch_id as BranchID);
+      }
+    }
+
+    return Array.from(uniqueIds);
+  }
+
+  /**
    * Enrich a single branch with zone information
    *
    * Uses the batch enrichment method for consistency and efficiency.

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -525,9 +525,10 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
    * Uses LEFT JOIN to check ownership in one query instead of N+1.
    * Returns branches where user is an owner OR others_can allows at least 'view' access.
    *
-   * NOTE: This method should only be called when RBAC is enabled. When RBAC is disabled,
-   * the scopeBranchQuery hook is not registered, so default Feathers query is used
-   * (which returns all branches without filtering).
+   * NOTE: This method should only be called when RBAC is enabled. The branch
+   * find RBAC hook uses it to resolve accessible branch IDs and compose them
+   * into the service query; when RBAC is disabled, default Feathers query
+   * handling returns all branches without access filtering.
    *
    * @param userId - User ID to check access for
    * @param filter - Optional filters

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { boardObjectQueryValidator, typedValidateQuery } from './feathers-validation';
+import {
+  boardObjectQueryValidator,
+  branchQueryValidator,
+  typedValidateQuery,
+} from './feathers-validation';
 
 describe('boardObjectQueryValidator', () => {
   it('preserves supported board-object filters through Feathers query validation', async () => {
@@ -28,6 +32,29 @@ describe('boardObjectQueryValidator', () => {
       entity_type: 'branch',
       $limit: 25,
       $skip: 5,
+    });
+  });
+});
+
+describe('branchQueryValidator', () => {
+  it('preserves zone_id for service-level virtual zone filtering', async () => {
+    const context = {
+      params: {
+        query: {
+          repo_id: '019e8e1c',
+          zone_id: 'zone-review',
+          archived: 'false',
+          unknown: 'removed',
+        },
+      },
+    };
+
+    await typedValidateQuery(branchQueryValidator)(context);
+
+    expect(context.params.query).toEqual({
+      repo_id: '019e8e1c',
+      zone_id: 'zone-review',
+      archived: false,
     });
   });
 });

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -150,6 +150,7 @@ export const branchQuerySchema = createQuerySchema(
     branch_id: Type.Optional(CommonSchemas.uuid),
     repo_id: Type.Optional(CommonSchemas.uuid),
     board_id: Type.Optional(CommonSchemas.uuid),
+    zone_id: Type.Optional(Type.String({ maxLength: 255 })),
     name: Type.Optional(Type.String({ maxLength: 255 })),
     archived: Type.Optional(CommonSchemas.boolean),
     created_at: Type.Optional(CommonSchemas.timestamp),


### PR DESCRIPTION
## Summary
- forward agor_branches_list zoneId to the branches service instead of filtering the current page in the MCP tool
- resolve board zone membership from board_objects.data.zone_id before generic pagination
- preserve/intersect existing branch_id scoping (including RBAC-injected filters)
- keep includeSessions out of this focused bug fix

## Tests
- pnpm check
- pnpm --filter @agor/daemon test src/mcp/tools/branches.test.ts src/services/branches.test.ts
- pnpm --filter @agor/core test src/db/repositories/branches.test.ts

Reference: #1330