### PR TITLE
Fix new session action for scheduled-only branch cards

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -1,0 +1,62 @@
+import type { Branch, Session, User } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { BranchSessionSections } from './BranchSessionSections';
+
+const branch = {
+  branch_id: 'branch-1',
+  name: 'feature/cleanup',
+  filesystem_status: 'ready',
+} as Branch;
+
+const scheduledSession = {
+  session_id: 'session-scheduled-1',
+  branch_id: 'branch-1',
+  title: 'Clean up board',
+  agentic_tool: 'codex',
+  status: 'idle',
+  archived: false,
+  scheduled_from_branch: true,
+  scheduled_run_at: 1_780_527_200_000,
+  created_at: '2026-06-03T00:00:00.000Z',
+  last_updated: '2026-06-03T00:00:00.000Z',
+} as unknown as Session;
+
+function renderSections(props: Partial<React.ComponentProps<typeof BranchSessionSections>> = {}) {
+  return render(
+    <ConnectionProvider
+      value={{
+        connected: true,
+        connecting: false,
+        outOfSync: false,
+        capturedSha: null,
+        currentSha: null,
+      }}
+    >
+      <AntApp>
+        <BranchSessionSections
+          branch={branch}
+          sessions={[scheduledSession]}
+          userById={new Map<string, User>()}
+          onSessionClick={vi.fn()}
+          onCreateSession={vi.fn()}
+          client={null}
+          {...props}
+        />
+      </AntApp>
+    </ConnectionProvider>
+  );
+}
+
+describe('BranchSessionSections', () => {
+  it('keeps the new-session affordance visible when only scheduled runs remain', () => {
+    renderSections();
+
+    expect(screen.getByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled Runs')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /new session/i })).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -633,7 +633,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         </div>
       ) : (
         <>
-          {manualSessions.length > 0 && (
+          {manualSessions.length > 0 ? (
             <Collapse
               defaultActiveKey={defaultExpanded ? ['sessions'] : []}
               items={[
@@ -649,7 +649,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
               ghost
               style={{ marginTop: 8 }}
             />
-          )}
+          ) : onCreateSession ? (
+            <div style={{ marginTop: 8 }}>{sessionListHeader}</div>
+          ) : null}
 
           {schedulerEnabled && scheduledSessions.length > 0 && (
             <Collapse


### PR DESCRIPTION
## Summary\n- keep the branch-card Sessions header visible when a branch only has scheduled/gateway sessions\n- preserve the branch-card New Session action in that scheduled-only state\n- add a targeted test covering scheduled-only branch cards\n\n## Checks\n- pnpm i\n- pnpm check (typecheck passed; repo-wide lint failed on pre-existing unrelated Biome diagnostics outside this change)\n- pnpm --filter agor-ui test -- BranchSessionSections.test.tsx\n- pnpm exec biome check apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx