### PR TITLE
Fix BranchCard sessions count drift

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -25,6 +25,21 @@ const scheduledSession = {
   last_updated: '2026-06-03T00:00:00.000Z',
 } as unknown as Session;
 
+function makeManualSession(
+  overrides: { session_id: string; title: string } & Record<string, unknown>
+): Session {
+  return {
+    branch_id: 'branch-1',
+    agentic_tool: 'codex',
+    status: 'idle',
+    archived: false,
+    created_at: '2026-06-03T00:00:00.000Z',
+    last_updated: '2026-06-03T00:00:00.000Z',
+    genealogy: { children: [] },
+    ...overrides,
+  } as unknown as Session;
+}
+
 function renderSections(props: Partial<React.ComponentProps<typeof BranchSessionSections>> = {}) {
   return render(
     <ConnectionProvider
@@ -58,5 +73,25 @@ describe('BranchSessionSections', () => {
     expect(screen.getByText('Sessions')).toBeInTheDocument();
     expect(screen.getByText('Scheduled Runs')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /new session/i })).toBeInTheDocument();
+  });
+
+  it('counts and renders only visible manual sessions when archived ancestors are filtered out', () => {
+    const archivedParent = makeManualSession({
+      session_id: 'session-archived-parent',
+      title: 'Archived parent',
+      archived: true,
+      genealogy: { children: ['session-visible-child'] },
+    });
+    const visibleChild = makeManualSession({
+      session_id: 'session-visible-child',
+      title: 'Visible child',
+      genealogy: { parent_session_id: 'session-archived-parent', children: [] },
+    });
+
+    renderSections({ sessions: [archivedParent, visibleChild] });
+
+    expect(screen.queryByText('Archived parent')).not.toBeInTheDocument();
+    expect(screen.getByText('Visible child')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
+++ b/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
@@ -32,12 +32,16 @@ export function buildSessionTree(sessions: Session[]): SessionTreeNode[] {
     sessionMap.set(session.session_id, session);
   }
 
-  // Organize by parent/fork relationships
+  // Organize by parent/fork relationships. The input list may already be
+  // filtered (for example, archived sessions are removed before rendering in
+  // BranchSessionSections), so only attach to a parent that is also present in
+  // this render set. Otherwise promote the session to a root so the tree does
+  // not silently hide visible sessions behind a filtered-out ancestor.
   for (const session of sessions) {
     const parentId =
       session.genealogy?.parent_session_id || session.genealogy?.forked_from_session_id;
 
-    if (parentId) {
+    if (parentId && sessionMap.has(parentId)) {
       // Has a parent - add to children map
       const siblings = childrenMap.get(parentId) || [];
       siblings.push(session);


### PR DESCRIPTION
## Summary

- Ensure the BranchCard Sessions tree does not hide visible sessions whose parent/fork ancestor was filtered out, such as an archived parent session.
- Keep the Sessions badge aligned with the rendered tree by making filtered-out ancestors promote their visible children to root nodes.
- Add a focused BranchSessionSections regression test for an archived parent with a visible child session.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- BranchSessionSections.test.tsx`
