### PR TITLE
Add BranchModal schedules tab count

### DIFF
--- a/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
@@ -1,0 +1,163 @@
+import type { AgorClient, Branch, Repo, Schedule } from '@agor-live/client';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { App } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { BranchModal } from './BranchModal';
+
+type Handler = (schedule: Schedule) => void;
+
+function makeSchedule(overrides: Partial<Schedule>): Schedule {
+  return {
+    schedule_id: 'schedule-1',
+    branch_id: 'branch-1',
+    name: 'Schedule',
+    cron_expression: '0 9 * * *',
+    enabled: true,
+    created_by: 'user-1',
+    created_at: 1,
+    updated_at: 1,
+    prompt: 'Run this',
+    model_config: {},
+    last_run_at: null,
+    last_run_session_id: null,
+    next_run_at: null,
+    ...overrides,
+  } as unknown as Schedule;
+}
+
+function makeBranch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    branch_id: 'branch-1',
+    repo_id: 'repo-1',
+    name: 'feature/counts',
+    ref: 'feature/counts',
+    path: '/tmp/repo/feature-counts',
+    created_at: 1,
+    updated_at: 1,
+    archived: false,
+    mcp_server_ids: [],
+    ...overrides,
+  } as unknown as Branch;
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repo_id: 'repo-1',
+    slug: 'org/repo',
+    name: 'repo',
+    default_branch: 'main',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/org/repo.git',
+    local_path: '/tmp/repo',
+    ...overrides,
+  } as unknown as Repo;
+}
+
+function makeClient(initialSchedules: Schedule[]) {
+  const handlers = new Map<string, Set<Handler>>();
+  const scheduleService = {
+    find: vi.fn(async () => ({ data: initialSchedules })),
+    on: vi.fn((event: string, handler: Handler) => {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)?.add(handler);
+    }),
+    off: vi.fn((event: string, handler: Handler) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    patch: vi.fn(),
+    remove: vi.fn(),
+  };
+  const ownersService = {
+    find: vi.fn(async () => {
+      const error = new Error('not found') as Error & { code: number };
+      error.code = 404;
+      throw error;
+    }),
+  };
+  const client = {
+    service: vi.fn((name: string) => {
+      if (name === 'schedules') return scheduleService;
+      if (name === 'branches/:id/owners') return ownersService;
+      return {};
+    }),
+  } as unknown as AgorClient;
+
+  const emitSchedule = (event: string, schedule: Schedule) => {
+    for (const handler of handlers.get(event) ?? []) {
+      handler(schedule);
+    }
+  };
+
+  return { client, scheduleService, emitSchedule };
+}
+
+describe('BranchModal schedule tab count', () => {
+  it('uses the same branch schedule list for the Schedules tab badge and table', async () => {
+    const schedules = [
+      makeSchedule({ schedule_id: 'schedule-1', name: 'Morning summary', created_at: 2 }),
+      makeSchedule({ schedule_id: 'schedule-2', name: 'Weekly retro', created_at: 1 }),
+    ];
+    const { client, scheduleService, emitSchedule } = makeClient(schedules);
+
+    render(
+      <App>
+        <BranchModal
+          open
+          defaultTab="schedule"
+          onClose={vi.fn()}
+          branch={makeBranch()}
+          repo={makeRepo()}
+          sessions={[]}
+          client={client}
+        />
+      </App>
+    );
+
+    await waitFor(() => {
+      expect(scheduleService.find).toHaveBeenCalledWith({
+        query: { branch_id: 'branch-1', $sort: { created_at: -1 } },
+      });
+    });
+
+    await waitFor(() => {
+      const schedulesTab = screen.getByRole('tab', { name: /Schedules/i });
+      expect(within(schedulesTab).getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('Morning summary')).toBeInTheDocument();
+      expect(screen.getByText('Weekly retro')).toBeInTheDocument();
+    });
+
+    act(() => {
+      emitSchedule(
+        'created',
+        makeSchedule({
+          schedule_id: 'other-branch-schedule',
+          branch_id: 'branch-2',
+          name: 'Other branch schedule',
+        })
+      );
+    });
+
+    expect(screen.queryByText('Other branch schedule')).not.toBeInTheDocument();
+    expect(
+      within(screen.getByRole('tab', { name: /Schedules/i })).getByText('2')
+    ).toBeInTheDocument();
+
+    act(() => {
+      emitSchedule(
+        'created',
+        makeSchedule({
+          schedule_id: 'schedule-3',
+          branch_id: 'branch-1',
+          name: 'Hourly heartbeat',
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Hourly heartbeat')).toBeInTheDocument();
+      expect(
+        within(screen.getByRole('tab', { name: /Schedules/i })).getByText('3')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -20,6 +20,7 @@ import { GeneralTab } from './tabs/GeneralTab';
 import { PermissionsTab } from './tabs/PermissionsTab';
 import { ScheduleTab } from './tabs/ScheduleTab';
 import { SessionsTab } from './tabs/SessionsTab';
+import { useBranchSchedules } from './tabs/useBranchSchedules';
 import { type BranchUpdate, useBranchModalForm } from './useBranchModalForm';
 
 export type BranchModalTab =
@@ -82,6 +83,7 @@ export const BranchModal: React.FC<BranchModalProps> = ({
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
   const [activeTab, setActiveTab] = useState<BranchModalTab>('general');
+  const branchId = open ? (branch?.branch_id ?? null) : null;
 
   const form = useBranchModalForm({
     branch,
@@ -93,6 +95,11 @@ export const BranchModal: React.FC<BranchModalProps> = ({
     () => new Map(form.allUsers.map((user) => [user.user_id, user])),
     [form.allUsers]
   );
+  const schedulesState = useBranchSchedules({
+    client,
+    branchId,
+    onError: showError,
+  });
 
   // Sync active tab when modal opens — use defaultTab if specified, otherwise reset to general
   useEffect(() => {
@@ -231,7 +238,17 @@ export const BranchModal: React.FC<BranchModalProps> = ({
       : []),
     {
       key: 'schedule',
-      label: 'Schedules',
+      label: (
+        <span>
+          Schedules{' '}
+          <Badge
+            count={schedulesState.schedules.length}
+            showZero
+            size="small"
+            style={{ backgroundColor: token.colorPrimaryBgHover }}
+          />
+        </span>
+      ),
       children: (
         <ScheduleTab
           branch={branch}
@@ -239,6 +256,7 @@ export const BranchModal: React.FC<BranchModalProps> = ({
           mcpServerById={mcpServerById}
           currentUser={currentUser}
           userById={userById}
+          schedulesState={schedulesState}
           onOpenSession={(sessionId) => {
             onSessionClick?.(sessionId);
             onClose();

--- a/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
@@ -15,11 +15,12 @@ import {
   UnorderedListOutlined,
 } from '@ant-design/icons';
 import { Button, Empty, Popconfirm, Space, Spin, Switch, Table, Typography } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
 import { UserAvatar } from '../../metadata/UserAvatar';
 import { ScheduleModal } from '../../ScheduleModal';
 import { ScheduleRunsPanel } from '../../ScheduleRunsPanel';
+import type { UseBranchSchedulesResult } from './useBranchSchedules';
 
 const { Text } = Typography;
 
@@ -30,6 +31,7 @@ interface ScheduleTabProps {
   currentUser?: User | null;
   userById?: Map<string, User>;
   onOpenSession?: (sessionId: string) => void;
+  schedulesState: UseBranchSchedulesResult;
 }
 
 const formatTimestamp = (ms: number | null | undefined) =>
@@ -50,64 +52,14 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   currentUser,
   userById = new Map(),
   onOpenSession,
+  schedulesState,
 }) => {
   const { showError, showSuccess } = useThemedMessage();
-  const [schedules, setSchedules] = useState<Schedule[]>([]);
-  const [loading, setLoading] = useState(false);
+  const { schedules, loading, fetchSchedules } = schedulesState;
   const [modalOpen, setModalOpen] = useState(false);
   const [editingSchedule, setEditingSchedule] = useState<Schedule | null>(null);
   const [runsPanelSchedule, setRunsPanelSchedule] = useState<Schedule | null>(null);
   const [runningId, setRunningId] = useState<string | null>(null);
-
-  const fetchSchedules = useCallback(async () => {
-    if (!client) return;
-    setLoading(true);
-    try {
-      const result = await client.service('schedules').find({
-        query: {
-          branch_id: branch.branch_id,
-          $sort: { created_at: -1 },
-        },
-      });
-      setSchedules(Array.isArray(result) ? result : result.data);
-    } catch (err) {
-      console.error('Failed to load schedules:', err);
-      showError('Failed to load schedules');
-    } finally {
-      setLoading(false);
-    }
-  }, [client, branch.branch_id, showError]);
-
-  useEffect(() => {
-    fetchSchedules();
-  }, [fetchSchedules]);
-
-  // Live updates via Feathers events. The service emits these for every
-  // CRUD op, including ones on other branches — filter to ours.
-  useEffect(() => {
-    if (!client) return;
-    const service = client.service('schedules');
-    const matchesBranch = (s: Schedule) => s.branch_id === branch.branch_id;
-    const onCreated = (s: Schedule) => {
-      if (matchesBranch(s)) setSchedules((prev) => [s, ...prev]);
-    };
-    const onPatched = (s: Schedule) => {
-      if (matchesBranch(s)) {
-        setSchedules((prev) => prev.map((p) => (p.schedule_id === s.schedule_id ? s : p)));
-      }
-    };
-    const onRemoved = (s: Schedule) => {
-      setSchedules((prev) => prev.filter((p) => p.schedule_id !== s.schedule_id));
-    };
-    service.on('created', onCreated);
-    service.on('patched', onPatched);
-    service.on('removed', onRemoved);
-    return () => {
-      service.off('created', onCreated);
-      service.off('patched', onPatched);
-      service.off('removed', onRemoved);
-    };
-  }, [client, branch.branch_id]);
 
   const handleNew = () => {
     setEditingSchedule(null);

--- a/apps/agor-ui/src/components/BranchModal/tabs/useBranchSchedules.ts
+++ b/apps/agor-ui/src/components/BranchModal/tabs/useBranchSchedules.ts
@@ -1,0 +1,82 @@
+import type { AgorClient, Schedule } from '@agor-live/client';
+import { useCallback, useEffect, useState } from 'react';
+
+interface UseBranchSchedulesOptions {
+  client: AgorClient | null;
+  branchId: string | null;
+  onError?: (message: string) => void;
+}
+
+export interface UseBranchSchedulesResult {
+  schedules: Schedule[];
+  loading: boolean;
+  fetchSchedules: () => Promise<void>;
+}
+
+export function useBranchSchedules({
+  client,
+  branchId,
+  onError,
+}: UseBranchSchedulesOptions): UseBranchSchedulesResult {
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchSchedules = useCallback(async () => {
+    if (!client || !branchId) {
+      setSchedules([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await client.service('schedules').find({
+        query: {
+          branch_id: branchId,
+          $sort: { created_at: -1 },
+        },
+      });
+      setSchedules(Array.isArray(result) ? result : result.data);
+    } catch (err) {
+      console.error('Failed to load schedules:', err);
+      onError?.('Failed to load schedules');
+    } finally {
+      setLoading(false);
+    }
+  }, [client, branchId, onError]);
+
+  useEffect(() => {
+    fetchSchedules();
+  }, [fetchSchedules]);
+
+  // Live updates via Feathers events. The service emits these for every
+  // CRUD op, including ones on other branches — filter to ours.
+  useEffect(() => {
+    if (!client || !branchId) return;
+    const service = client.service('schedules');
+    const matchesBranch = (s: Schedule) => s.branch_id === branchId;
+    const onCreated = (s: Schedule) => {
+      if (matchesBranch(s)) setSchedules((prev) => [s, ...prev]);
+    };
+    const onPatched = (s: Schedule) => {
+      if (matchesBranch(s)) {
+        setSchedules((prev) => prev.map((p) => (p.schedule_id === s.schedule_id ? s : p)));
+      }
+    };
+    const onRemoved = (s: Schedule) => {
+      if (matchesBranch(s)) {
+        setSchedules((prev) => prev.filter((p) => p.schedule_id !== s.schedule_id));
+      }
+    };
+    service.on('created', onCreated);
+    service.on('patched', onPatched);
+    service.on('removed', onRemoved);
+    return () => {
+      service.off('created', onCreated);
+      service.off('patched', onPatched);
+      service.off('removed', onRemoved);
+    };
+  }, [client, branchId]);
+
+  return { schedules, loading, fetchSchedules };
+}


### PR DESCRIPTION
## Summary

- Add a Sessions-style badge/count to the BranchModal Schedules tab.
- Lift branch schedule loading/live updates into a shared `useBranchSchedules` hook so the tab count and rendered schedule table use the same branch-filtered list.
- Add a focused BranchModal test covering schedule count/list sync and branch-filtered schedule events.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui exec vitest run src/components/BranchModal/BranchModal.test.tsx`

## Notes

- `pnpm check` completed successfully; existing Biome warning diagnostics were printed during the lint step.
- The focused Vitest run passed; jsdom/AntD emitted existing CSS parsing and `getComputedStyle` pseudo-element warnings.
