### PR TITLE
fix(comments): show date in session panel comment timestamps

### DIFF
--- a/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
+++ b/apps/agor-ui/src/components/CommentsPanel/CommentsPanel.tsx
@@ -196,7 +196,12 @@ const ReplyItem: React.FC<{
                 {replyUser?.name || 'Anonymous'}
               </Text>
               <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-                {new Date(reply.created_at).toLocaleTimeString()}
+                {new Date(reply.created_at).toLocaleString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
               </Text>
             </Space>
           }
@@ -319,7 +324,12 @@ const CommentThread: React.FC<{
                 {user?.name || 'Anonymous'}
               </Text>
               <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-                {new Date(comment.created_at).toLocaleTimeString()}
+                {new Date(comment.created_at).toLocaleString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
               </Text>
               {comment.edited && (
                 <Text type="secondary" style={{ fontSize: token.fontSizeSM, fontStyle: 'italic' }}>


### PR DESCRIPTION
## Summary

- Session panel comment timestamps showed time only (e.g. `10:03:37 PM`)
- Updated both root comments and replies in `CommentsPanel.tsx` to show date + time without seconds (e.g. `Jun 4  10:03 PM`)
- Uses the same `toLocaleString` options as the board view (`BoardObjectNodes.tsx`): `month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit'`

## Test plan

- [ ] Open a session with comments in the left panel
- [ ] Verify comments display `Mon DD  H:MM AM/PM` format (no seconds, with date)
- [ ] Verify replies in threads also show the date+time format
- [ ] Compare with board view comment pins — formats should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)