### PR TITLE
fix: render assistant welcome note on backend

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2332,6 +2332,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       clone: [requireMinimumRole(ROLES.MEMBER, 'clone boards')],
       setPrimaryAssistant: [requireMinimumRole(ROLES.MEMBER, 'set primary assistant')],
       clearPrimaryAssistant: [requireMinimumRole(ROLES.MEMBER, 'clear primary assistant')],
+      ensureAssistantWelcomeNote: [
+        requireMinimumRole(ROLES.MEMBER, 'create assistant welcome note'),
+      ],
     },
     after: {
       // Strip private artifact objects from board.objects for non-owners
@@ -2437,6 +2440,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
       ],
       clearPrimaryAssistant: [
+        async (context: HookContext<Board>) => {
+          if (context.result) {
+            app.service('boards').emit('patched', context.result);
+          }
+          return context;
+        },
+      ],
+      ensureAssistantWelcomeNote: [
         async (context: HookContext<Board>) => {
           if (context.result) {
             app.service('boards').emit('patched', context.result);

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2449,7 +2449,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       ensureAssistantWelcomeNote: [
         async (context: HookContext<Board>) => {
-          if (context.result) {
+          const assistantWelcomeNoteMutated = (
+            context.params as typeof context.params & {
+              assistantWelcomeNoteMutated?: boolean;
+            }
+          ).assistantWelcomeNoteMutated;
+          if (context.result && assistantWelcomeNoteMutated) {
             app.service('boards').emit('patched', context.result);
           }
           return context;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -275,6 +275,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
           'clone',
           'setPrimaryAssistant',
           'clearPrimaryAssistant',
+          'ensureAssistantWelcomeNote',
         ],
       }
     );

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -231,6 +231,93 @@ describe('BoardsService - Custom Methods', () => {
     }
   );
 
+  dbTest(
+    'ensureAssistantWelcomeNote creates rendered static markdown server-side',
+    async ({ db }) => {
+      const service = new BoardsService(db);
+      const board = (await service.create({
+        name: 'Assistant Board',
+        slug: `assistant-board-${generateId()}`,
+        created_by: TEST_USER,
+      })) as Board;
+
+      const updated = await service.ensureAssistantWelcomeNote({
+        boardId: board.board_id,
+        assistantName: '<img src=x onerror=alert(1)>',
+        assistantEmoji: '[bot](javascript:alert(1))',
+      });
+
+      const note = updated.objects?.['welcome-note'];
+      expect(note?.type).toBe('markdown');
+      expect(note?.content).not.toContain('{{assistant.name}}');
+      expect(note?.content).not.toContain('<img src=x onerror=alert(1)>');
+      expect(note?.content).toContain('&lt;img src&#x3D;x onerror&#x3D;alert\\(1\\)&gt;');
+      expect(note?.content).not.toContain('[bot](javascript:alert(1))');
+      expect(note?.content).toContain('\\[bot\\]\\(javascript:alert\\(1\\)\\)');
+    }
+  );
+
+  dbTest('ensureAssistantWelcomeNote backfills unresolved placeholder notes', async ({ db }) => {
+    const service = new BoardsService(db);
+    const board = (await service.create({
+      name: 'Assistant Board Backfill',
+      slug: `assistant-board-backfill-${generateId()}`,
+      created_by: TEST_USER,
+      objects: {
+        'welcome-note': {
+          type: 'markdown',
+          x: 12,
+          y: 34,
+          width: 456,
+          content: '# Welcome to {{assistant.name}}',
+        },
+      },
+    })) as Board;
+
+    const updated = await service.ensureAssistantWelcomeNote({
+      boardId: board.board_id,
+      assistantName: 'Backfill Bot',
+      assistantEmoji: '🛠️',
+    });
+
+    const note = updated.objects?.['welcome-note'];
+    expect(note).toEqual(
+      expect.objectContaining({
+        type: 'markdown',
+        x: 12,
+        y: 34,
+        width: 456,
+      })
+    );
+    expect(note?.content).toContain("Backfill Bot's Board 🛠️");
+    expect(note?.content).not.toContain('{{assistant.name}}');
+  });
+
+  dbTest('ensureAssistantWelcomeNote preserves custom existing welcome notes', async ({ db }) => {
+    const service = new BoardsService(db);
+    const board = (await service.create({
+      name: 'Assistant Board Custom',
+      slug: `assistant-board-custom-${generateId()}`,
+      created_by: TEST_USER,
+      objects: {
+        'welcome-note': {
+          type: 'markdown',
+          x: 1,
+          y: 2,
+          width: 300,
+          content: 'My custom welcome note',
+        },
+      },
+    })) as Board;
+
+    const updated = await service.ensureAssistantWelcomeNote({
+      boardId: board.board_id,
+      assistantName: 'Ignored Bot',
+    });
+
+    expect(updated.objects?.['welcome-note']).toEqual(board.objects?.['welcome-note']);
+  });
+
   dbTest('should have all custom methods defined', async ({ db }) => {
     const service = new BoardsService(db);
 
@@ -240,5 +327,6 @@ describe('BoardsService - Custom Methods', () => {
     expect(typeof service.toYaml).toBe('function');
     expect(typeof service.fromYaml).toBe('function');
     expect(typeof service.clone).toBe('function');
+    expect(typeof service.ensureAssistantWelcomeNote).toBe('function');
   });
 });

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -331,7 +331,7 @@ describe('BoardsService - Custom Methods', () => {
       const service = new BoardsService(db);
       const interimRenderedContent = ASSISTANT_WELCOME_NOTE_TEMPLATE.replaceAll(
         '{{assistant.name}}',
-        '[docs](javascript:alert(1))'
+        "x's Board [docs](javascript:alert(1))"
       ).replaceAll('{{assistant.emoji}}', '[bot](javascript:alert(1))');
 
       const board = (await service.create({
@@ -370,6 +370,7 @@ describe('BoardsService - Custom Methods', () => {
         })
       );
       expect(note?.content).not.toContain('[docs](javascript:alert(1))');
+      expect(note?.content).not.toContain("x's Board [docs](javascript:alert(1))");
       expect(note?.content).not.toContain('[safe docs](javascript:alert(1))');
       expect(note?.content).toContain('\\[safe docs\\]\\(javascript:alert\\(1\\)\\)');
       expect(note?.content).toContain('\\[safe bot\\]\\(javascript:alert\\(1\\)\\)');

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { BoardObjectRepository, BranchRepository, generateId, RepoRepository } from '@agor/core/db';
+import { ASSISTANT_WELCOME_NOTE_TEMPLATE } from '@agor/core/templates/assistant-welcome-note';
 import type { Board, BranchID, UUID } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
@@ -293,6 +294,57 @@ describe('BoardsService - Custom Methods', () => {
     expect(note?.content).not.toContain('{{assistant.name}}');
   });
 
+  dbTest(
+    'ensureAssistantWelcomeNote backfills generated notes from interim regex renderer',
+    async ({ db }) => {
+      const service = new BoardsService(db);
+      const interimRenderedContent = ASSISTANT_WELCOME_NOTE_TEMPLATE.replaceAll(
+        '{{assistant.name}}',
+        '[docs](javascript:alert(1))'
+      ).replaceAll('{{assistant.emoji}}', '[bot](javascript:alert(1))');
+
+      const board = (await service.create({
+        name: 'Assistant Board Interim Backfill',
+        slug: `assistant-board-interim-backfill-${generateId()}`,
+        created_by: TEST_USER,
+        objects: {
+          'welcome-note': {
+            type: 'markdown',
+            x: 12,
+            y: 34,
+            width: 456,
+            content: interimRenderedContent,
+          },
+        },
+      })) as Board;
+
+      const params = {};
+      const updated = await service.ensureAssistantWelcomeNote(
+        {
+          boardId: board.board_id,
+          assistantName: '[safe docs](javascript:alert(1))',
+          assistantEmoji: '[safe bot](javascript:alert(1))',
+        },
+        params
+      );
+
+      const note = updated.objects?.['welcome-note'];
+      expect(params).toEqual({ assistantWelcomeNoteMutated: true });
+      expect(note).toEqual(
+        expect.objectContaining({
+          type: 'markdown',
+          x: 12,
+          y: 34,
+          width: 456,
+        })
+      );
+      expect(note?.content).not.toContain('[docs](javascript:alert(1))');
+      expect(note?.content).not.toContain('[safe docs](javascript:alert(1))');
+      expect(note?.content).toContain('\\[safe docs\\]\\(javascript:alert\\(1\\)\\)');
+      expect(note?.content).toContain('\\[safe bot\\]\\(javascript:alert\\(1\\)\\)');
+    }
+  );
+
   dbTest('ensureAssistantWelcomeNote preserves custom existing welcome notes', async ({ db }) => {
     const service = new BoardsService(db);
     const board = (await service.create({
@@ -310,11 +362,16 @@ describe('BoardsService - Custom Methods', () => {
       },
     })) as Board;
 
-    const updated = await service.ensureAssistantWelcomeNote({
-      boardId: board.board_id,
-      assistantName: 'Ignored Bot',
-    });
+    const params = {};
+    const updated = await service.ensureAssistantWelcomeNote(
+      {
+        boardId: board.board_id,
+        assistantName: 'Ignored Bot',
+      },
+      params
+    );
 
+    expect(params).toEqual({});
     expect(updated.objects?.['welcome-note']).toEqual(board.objects?.['welcome-note']);
   });
 

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -258,6 +258,37 @@ describe('BoardsService - Custom Methods', () => {
     }
   );
 
+  dbTest(
+    'ensureAssistantWelcomeNote is idempotent for already-correct generated notes',
+    async ({ db }) => {
+      const service = new BoardsService(db);
+      const board = (await service.create({
+        name: 'Assistant Board Idempotent',
+        slug: `assistant-board-idempotent-${generateId()}`,
+        created_by: TEST_USER,
+      })) as Board;
+
+      const first = await service.ensureAssistantWelcomeNote({
+        boardId: board.board_id,
+        assistantName: 'Stable Bot',
+        assistantEmoji: '🤖',
+      });
+
+      const params = {};
+      const second = await service.ensureAssistantWelcomeNote(
+        {
+          boardId: board.board_id,
+          assistantName: 'Stable Bot',
+          assistantEmoji: '🤖',
+        },
+        params
+      );
+
+      expect(params).toEqual({});
+      expect(second.objects?.['welcome-note']).toEqual(first.objects?.['welcome-note']);
+    }
+  );
+
   dbTest('ensureAssistantWelcomeNote backfills unresolved placeholder notes', async ({ db }) => {
     const service = new BoardsService(db);
     const board = (await service.create({

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -5,7 +5,6 @@
  */
 
 import { BoardObjectRepository, BranchRepository, generateId, RepoRepository } from '@agor/core/db';
-import { ASSISTANT_WELCOME_NOTE_TEMPLATE } from '@agor/core/templates/assistant-welcome-note';
 import type { Board, BranchID, UUID } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
@@ -242,101 +241,33 @@ describe('BoardsService - Custom Methods', () => {
         created_by: TEST_USER,
       })) as Board;
 
-      const updated = await service.ensureAssistantWelcomeNote({
-        boardId: board.board_id,
-        assistantName: '<img src=x onerror=alert(1)>',
-        assistantEmoji: '[bot](javascript:alert(1))',
-      });
-
-      const note = updated.objects?.['welcome-note'];
-      expect(note?.type).toBe('markdown');
-      expect(note?.content).not.toContain('{{assistant.name}}');
-      expect(note?.content).not.toContain('<img src=x onerror=alert(1)>');
-      expect(note?.content).toContain('&lt;img src&#x3D;x onerror&#x3D;alert\\(1\\)&gt;');
-      expect(note?.content).not.toContain('[bot](javascript:alert(1))');
-      expect(note?.content).toContain('\\[bot\\]\\(javascript:alert\\(1\\)\\)');
-    }
-  );
-
-  dbTest(
-    'ensureAssistantWelcomeNote is idempotent for already-correct generated notes',
-    async ({ db }) => {
-      const service = new BoardsService(db);
-      const board = (await service.create({
-        name: 'Assistant Board Idempotent',
-        slug: `assistant-board-idempotent-${generateId()}`,
-        created_by: TEST_USER,
-      })) as Board;
-
-      const first = await service.ensureAssistantWelcomeNote({
-        boardId: board.board_id,
-        assistantName: 'Stable Bot',
-        assistantEmoji: '🤖',
-      });
-
       const params = {};
-      const second = await service.ensureAssistantWelcomeNote(
+      const updated = await service.ensureAssistantWelcomeNote(
         {
           boardId: board.board_id,
-          assistantName: 'Stable Bot',
+          assistantName: '<img src=x onerror=alert(1)>',
           assistantEmoji: '🤖',
         },
         params
       );
 
-      expect(params).toEqual({});
-      expect(second.objects?.['welcome-note']).toEqual(first.objects?.['welcome-note']);
+      const note = updated.objects?.['welcome-note'];
+      expect(params).toEqual({ assistantWelcomeNoteMutated: true });
+      expect(note?.type).toBe('markdown');
+      expect(note?.content).not.toContain('{{assistant.name}}');
+      expect(note?.content).not.toContain('<img src=x onerror=alert(1)>');
+      expect(note?.content).toContain('&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;');
+      expect(note?.content).toContain('🤖');
     }
   );
 
-  dbTest('ensureAssistantWelcomeNote backfills unresolved placeholder notes', async ({ db }) => {
-    const service = new BoardsService(db);
-    const board = (await service.create({
-      name: 'Assistant Board Backfill',
-      slug: `assistant-board-backfill-${generateId()}`,
-      created_by: TEST_USER,
-      objects: {
-        'welcome-note': {
-          type: 'markdown',
-          x: 12,
-          y: 34,
-          width: 456,
-          content: '# Welcome to {{assistant.name}}',
-        },
-      },
-    })) as Board;
-
-    const updated = await service.ensureAssistantWelcomeNote({
-      boardId: board.board_id,
-      assistantName: 'Backfill Bot',
-      assistantEmoji: '🛠️',
-    });
-
-    const note = updated.objects?.['welcome-note'];
-    expect(note).toEqual(
-      expect.objectContaining({
-        type: 'markdown',
-        x: 12,
-        y: 34,
-        width: 456,
-      })
-    );
-    expect(note?.content).toContain("Backfill Bot's Board 🛠️");
-    expect(note?.content).not.toContain('{{assistant.name}}');
-  });
-
   dbTest(
-    'ensureAssistantWelcomeNote backfills generated notes from interim regex renderer',
+    'ensureAssistantWelcomeNote is a no-op when welcome note already exists',
     async ({ db }) => {
       const service = new BoardsService(db);
-      const interimRenderedContent = ASSISTANT_WELCOME_NOTE_TEMPLATE.replaceAll(
-        '{{assistant.name}}',
-        "x's Board [docs](javascript:alert(1))"
-      ).replaceAll('{{assistant.emoji}}', '[bot](javascript:alert(1))');
-
       const board = (await service.create({
-        name: 'Assistant Board Interim Backfill',
-        slug: `assistant-board-interim-backfill-${generateId()}`,
+        name: 'Assistant Board Existing Note',
+        slug: `assistant-board-existing-${generateId()}`,
         created_by: TEST_USER,
         objects: {
           'welcome-note': {
@@ -344,7 +275,7 @@ describe('BoardsService - Custom Methods', () => {
             x: 12,
             y: 34,
             width: 456,
-            content: interimRenderedContent,
+            content: '# Welcome to {{assistant.name}}',
           },
         },
       })) as Board;
@@ -353,27 +284,14 @@ describe('BoardsService - Custom Methods', () => {
       const updated = await service.ensureAssistantWelcomeNote(
         {
           boardId: board.board_id,
-          assistantName: '[safe docs](javascript:alert(1))',
-          assistantEmoji: '[safe bot](javascript:alert(1))',
+          assistantName: 'Ignored Bot',
+          assistantEmoji: '🛠️',
         },
         params
       );
 
-      const note = updated.objects?.['welcome-note'];
-      expect(params).toEqual({ assistantWelcomeNoteMutated: true });
-      expect(note).toEqual(
-        expect.objectContaining({
-          type: 'markdown',
-          x: 12,
-          y: 34,
-          width: 456,
-        })
-      );
-      expect(note?.content).not.toContain('[docs](javascript:alert(1))');
-      expect(note?.content).not.toContain("x's Board [docs](javascript:alert(1))");
-      expect(note?.content).not.toContain('[safe docs](javascript:alert(1))');
-      expect(note?.content).toContain('\\[safe docs\\]\\(javascript:alert\\(1\\)\\)');
-      expect(note?.content).toContain('\\[safe bot\\]\\(javascript:alert\\(1\\)\\)');
+      expect(params).toEqual({});
+      expect(updated.objects?.['welcome-note']).toEqual(board.objects?.['welcome-note']);
     }
   );
 

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -10,7 +10,6 @@ import { BoardObjectRepository, BoardRepository, type Database } from '@agor/cor
 import {
   ASSISTANT_WELCOME_NOTE_OBJECT_ID,
   buildAssistantWelcomeNoteObject,
-  shouldReplaceAssistantWelcomeNoteContent,
 } from '@agor/core/templates/assistant-welcome-note';
 import type {
   AssistantWelcomeNoteRequest,
@@ -140,7 +139,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
   }
 
   /**
-   * Custom method: Create or backfill the bundled assistant welcome note.
+   * Custom method: Create the bundled assistant welcome note when missing.
    *
    * Rendering is intentionally server-side from a static Handlebars template so
    * the browser bundle does not import Handlebars (blocked by CSP unsafe-eval),
@@ -164,20 +163,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     });
 
     const existing = board.objects?.[ASSISTANT_WELCOME_NOTE_OBJECT_ID];
-    if (existing) {
-      if (
-        existing.type === 'markdown' &&
-        shouldReplaceAssistantWelcomeNoteContent(existing.content)
-      ) {
-        if (existing.content === objectData.content) return board;
-        if (params) params.assistantWelcomeNoteMutated = true;
-        return this.boardRepo.upsertBoardObject(board.board_id, ASSISTANT_WELCOME_NOTE_OBJECT_ID, {
-          ...existing,
-          content: objectData.content,
-        });
-      }
-      return board;
-    }
+    if (existing) return board;
 
     if (params) params.assistantWelcomeNoteMutated = true;
     return this.boardRepo.upsertBoardObject(

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -36,6 +36,7 @@ export interface BoardParams
     name?: string;
   }> {
   user?: AuthenticatedParams['user'];
+  assistantWelcomeNoteMutated?: boolean;
 }
 
 /**
@@ -146,7 +147,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
    */
   async ensureAssistantWelcomeNote(
     data: AssistantWelcomeNoteRequest,
-    _params?: BoardParams
+    params?: BoardParams
   ): Promise<Board> {
     const boardIdentifier = data.boardId ?? data.id;
     if (!boardIdentifier) throw new Error('Board ID required');
@@ -167,6 +168,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
         existing.type === 'markdown' &&
         shouldReplaceAssistantWelcomeNoteContent(existing.content)
       ) {
+        if (params) params.assistantWelcomeNoteMutated = true;
         return this.boardRepo.upsertBoardObject(board.board_id, ASSISTANT_WELCOME_NOTE_OBJECT_ID, {
           ...existing,
           content: objectData.content,
@@ -175,6 +177,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
       return board;
     }
 
+    if (params) params.assistantWelcomeNoteMutated = true;
     return this.boardRepo.upsertBoardObject(
       board.board_id,
       ASSISTANT_WELCOME_NOTE_OBJECT_ID,

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -36,6 +36,7 @@ export interface BoardParams
     name?: string;
   }> {
   user?: AuthenticatedParams['user'];
+  /** Internal hook signal; set only when ensureAssistantWelcomeNote writes. */
   assistantWelcomeNoteMutated?: boolean;
 }
 
@@ -168,6 +169,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
         existing.type === 'markdown' &&
         shouldReplaceAssistantWelcomeNoteContent(existing.content)
       ) {
+        if (existing.content === objectData.content) return board;
         if (params) params.assistantWelcomeNoteMutated = true;
         return this.boardRepo.upsertBoardObject(board.board_id, ASSISTANT_WELCOME_NOTE_OBJECT_ID, {
           ...existing,

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -7,7 +7,13 @@
 
 import { PAGINATION } from '@agor/core/config';
 import { BoardObjectRepository, BoardRepository, type Database } from '@agor/core/db';
+import {
+  ASSISTANT_WELCOME_NOTE_OBJECT_ID,
+  buildAssistantWelcomeNoteObject,
+  shouldReplaceAssistantWelcomeNoteContent,
+} from '@agor/core/templates/assistant-welcome-note';
 import type {
+  AssistantWelcomeNoteRequest,
   AuthenticatedParams,
   Board,
   BoardExportBlob,
@@ -129,6 +135,51 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     }
 
     return this.boardRepo.removeBoardObject(boardId, objectId);
+  }
+
+  /**
+   * Custom method: Create or backfill the bundled assistant welcome note.
+   *
+   * Rendering is intentionally server-side from a static Handlebars template so
+   * the browser bundle does not import Handlebars (blocked by CSP unsafe-eval),
+   * and callers never provide template source for this path.
+   */
+  async ensureAssistantWelcomeNote(
+    data: AssistantWelcomeNoteRequest,
+    _params?: BoardParams
+  ): Promise<Board> {
+    const boardIdentifier = data.boardId ?? data.id;
+    if (!boardIdentifier) throw new Error('Board ID required');
+
+    const board = await this.boardRepo.findBySlugOrId(String(boardIdentifier));
+    if (!board) {
+      throw new NotFoundError('Board', String(boardIdentifier));
+    }
+
+    const objectData = buildAssistantWelcomeNoteObject({
+      assistantName: typeof data.assistantName === 'string' ? data.assistantName : '',
+      assistantEmoji: typeof data.assistantEmoji === 'string' ? data.assistantEmoji : null,
+    });
+
+    const existing = board.objects?.[ASSISTANT_WELCOME_NOTE_OBJECT_ID];
+    if (existing) {
+      if (
+        existing.type === 'markdown' &&
+        shouldReplaceAssistantWelcomeNoteContent(existing.content)
+      ) {
+        return this.boardRepo.upsertBoardObject(board.board_id, ASSISTANT_WELCOME_NOTE_OBJECT_ID, {
+          ...existing,
+          content: objectData.content,
+        });
+      }
+      return board;
+    }
+
+    return this.boardRepo.upsertBoardObject(
+      board.board_id,
+      ASSISTANT_WELCOME_NOTE_OBJECT_ID,
+      objectData
+    );
   }
 
   /**

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -891,6 +891,14 @@ export function OnboardingWizard({
     const existingBoardId = user?.preferences?.mainBoardId;
     if (existingBoardId && user && boardById.get(existingBoardId)?.created_by === user.user_id) {
       setCreatedBoardId(existingBoardId);
+      if (path === 'assistant') {
+        await ensureAssistantWelcomeNote({
+          client,
+          boardId: existingBoardId,
+          assistantName: assistantDisplayName.trim() || 'My Assistant',
+          assistantEmoji,
+        });
+      }
       setLoading(false);
       setCurrentStep('branch');
       return;

--- a/apps/agor-ui/src/utils/assistantCreation.test.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.test.ts
@@ -41,8 +41,7 @@ describe('createAssistantBranch', () => {
         icon: '🍍',
         objects: {},
       }),
-      get: vi.fn().mockResolvedValue({ board_id: 'board-1', objects: {} }),
-      patch: vi.fn().mockResolvedValue({}),
+      ensureAssistantWelcomeNote: vi.fn().mockResolvedValue({}),
       setPrimaryAssistant: vi.fn().mockResolvedValue({}),
     };
     const client = {
@@ -86,13 +85,11 @@ describe('createAssistantBranch', () => {
       name: "Pineapple Helper's Board",
       icon: '🍍',
     });
-    expect(boardsService.patch).toHaveBeenCalledWith(
-      'board-1',
-      expect.objectContaining({
-        _action: 'upsertObject',
-        objectId: 'welcome-note',
-      })
-    );
+    expect(boardsService.ensureAssistantWelcomeNote).toHaveBeenCalledWith({
+      boardId: 'board-1',
+      assistantName: 'Pineapple Helper',
+      assistantEmoji: '🍍',
+    });
     expect(boardsService.setPrimaryAssistant).toHaveBeenCalledWith({
       boardId: 'board-1',
       branchId: branch.branch_id,

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.test.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ensureAssistantWelcomeNote } from './assistantWelcomeNote';
 
 describe('ensureAssistantWelcomeNote', () => {
-  it('delegates welcome-note rendering and backfill to the boards service', async () => {
+  it('delegates welcome-note rendering to the boards service', async () => {
     const boardsService = {
       ensureAssistantWelcomeNote: vi.fn().mockResolvedValue({}),
     };

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.test.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.test.ts
@@ -1,44 +1,53 @@
-import { describe, expect, it } from 'vitest';
-import {
-  ASSISTANT_WELCOME_NOTE_TEMPLATE,
-  buildAssistantWelcomeNoteContent,
-} from './assistantWelcomeNote';
+import { describe, expect, it, vi } from 'vitest';
+import { ensureAssistantWelcomeNote } from './assistantWelcomeNote';
 
-describe('buildAssistantWelcomeNoteContent', () => {
-  it('substitutes assistant name and emoji into the template', () => {
-    const content = buildAssistantWelcomeNoteContent({
+describe('ensureAssistantWelcomeNote', () => {
+  it('delegates welcome-note rendering and backfill to the boards service', async () => {
+    const boardsService = {
+      ensureAssistantWelcomeNote: vi.fn().mockResolvedValue({}),
+    };
+    const client = {
+      service: vi.fn((name: string) => {
+        if (name === 'boards') return boardsService;
+        throw new Error(`Unexpected service: ${name}`);
+      }),
+    };
+
+    await ensureAssistantWelcomeNote({
+      client: client as never,
+      boardId: 'board-1',
       assistantName: 'Product/Design Agor Board',
       assistantEmoji: '🧋',
     });
 
-    expect(ASSISTANT_WELCOME_NOTE_TEMPLATE).toContain('{{assistant.name}}');
-    expect(content).not.toContain('{{assistant.name}}');
-    expect(content).not.toContain('{{assistant.emoji}}');
-    expect(content).toContain("Product/Design Agor Board's Board 🧋");
-    expect(content).toContain('**Product/Design Agor Board**');
+    expect(boardsService.ensureAssistantWelcomeNote).toHaveBeenCalledWith({
+      boardId: 'board-1',
+      assistantName: 'Product/Design Agor Board',
+      assistantEmoji: '🧋',
+    });
   });
 
-  it('falls back to defaults when name is empty and emoji is missing', () => {
-    const content = buildAssistantWelcomeNoteContent({
-      assistantName: '   ',
-      assistantEmoji: null,
-    });
+  it('is best-effort when the daemon-side call fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const boardsService = {
+      ensureAssistantWelcomeNote: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    const client = {
+      service: vi.fn(() => boardsService),
+    };
 
-    expect(content).toContain("your assistant's Board 🤖");
-    expect(content).not.toContain('{{assistant.name}}');
-    expect(content).not.toContain('{{assistant.emoji}}');
-  });
+    await expect(
+      ensureAssistantWelcomeNote({
+        client: client as never,
+        boardId: 'board-1',
+        assistantName: 'Helper',
+      })
+    ).resolves.toBeUndefined();
 
-  it('replaces all occurrences of the name placeholder', () => {
-    const content = buildAssistantWelcomeNoteContent({
-      assistantName: 'Bug Fixer',
-      assistantEmoji: '🐛',
-    });
-
-    const occurrences = (content.match(/Bug Fixer/g) ?? []).length;
-    const templateOccurrences = (
-      ASSISTANT_WELCOME_NOTE_TEMPLATE.match(/\{\{assistant\.name\}\}/g) ?? []
-    ).length;
-    expect(occurrences).toBe(templateOccurrences);
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to create assistant welcome note:',
+      expect.any(Error)
+    );
+    warn.mockRestore();
   });
 });

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.test.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ASSISTANT_WELCOME_NOTE_TEMPLATE,
+  buildAssistantWelcomeNoteContent,
+} from './assistantWelcomeNote';
+
+describe('buildAssistantWelcomeNoteContent', () => {
+  it('substitutes assistant name and emoji into the template', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: 'Product/Design Agor Board',
+      assistantEmoji: '🧋',
+    });
+
+    expect(ASSISTANT_WELCOME_NOTE_TEMPLATE).toContain('{{assistant.name}}');
+    expect(content).not.toContain('{{assistant.name}}');
+    expect(content).not.toContain('{{assistant.emoji}}');
+    expect(content).toContain("Product/Design Agor Board's Board 🧋");
+    expect(content).toContain('**Product/Design Agor Board**');
+  });
+
+  it('falls back to defaults when name is empty and emoji is missing', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: '   ',
+      assistantEmoji: null,
+    });
+
+    expect(content).toContain("your assistant's Board 🤖");
+    expect(content).not.toContain('{{assistant.name}}');
+    expect(content).not.toContain('{{assistant.emoji}}');
+  });
+
+  it('replaces all occurrences of the name placeholder', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: 'Bug Fixer',
+      assistantEmoji: '🐛',
+    });
+
+    const occurrences = (content.match(/Bug Fixer/g) ?? []).length;
+    const templateOccurrences = (
+      ASSISTANT_WELCOME_NOTE_TEMPLATE.match(/\{\{assistant\.name\}\}/g) ?? []
+    ).length;
+    expect(occurrences).toBe(templateOccurrences);
+  });
+});

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.ts
@@ -8,7 +8,7 @@ export interface AssistantWelcomeNoteInput {
 }
 
 /**
- * Adds or backfills the initial markdown note on an assistant board.
+ * Adds the initial markdown note on an assistant board when missing.
  *
  * The daemon renders the bundled static Handlebars template server-side via a
  * boards custom method. Keeping the browser out of this render path avoids

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.ts
@@ -1,6 +1,4 @@
-import type { AgorClient, Board, BoardID, BoardObject } from '@agor-live/client';
-
-export const ASSISTANT_WELCOME_NOTE_OBJECT_ID = 'welcome-note';
+import type { AgorClient, BoardID } from '@agor-live/client';
 
 export interface AssistantWelcomeNoteInput {
   client: AgorClient | null;
@@ -9,39 +7,14 @@ export interface AssistantWelcomeNoteInput {
   assistantEmoji?: string | null;
 }
 
-export const ASSISTANT_WELCOME_NOTE_TEMPLATE = `# Welcome to {{assistant.name}}'s Board {{assistant.emoji}}
-
-This board is a shared workspace for you and **{{assistant.name}}** to shape and run workflows.
-
-Use it to organize:
-
-- 🌿 **Branches** — coding efforts and their agent sessions
-- 🧩 **Cards** — entities your workflow cares about, like tickets, customers, patients, leads, or incidents
-- 📝 **Notes** — shared context, instructions, diagrams, and checklists
-- 🗺️ **Zones** — named areas that group work and can trigger prompts as branches move through them
-
-| 👈 Assistant | Board | Chat 👉 |
-| --- | --- | --- |
-| Plan and set up workflows | Arrange branches, cards, notes, and zones | Work through conversations |
-
-> Start by asking **{{assistant.name}}** to help set up this board for a workflow that's relevant to you.`;
-
-export function buildAssistantWelcomeNoteContent({
-  assistantName,
-  assistantEmoji,
-}: Pick<AssistantWelcomeNoteInput, 'assistantName' | 'assistantEmoji'>): string {
-  const name = assistantName.trim() || 'your assistant';
-  const emoji = assistantEmoji?.trim() || '🤖';
-  // Handlebars uses new Function() which is blocked by the app's CSP
-  // (script-src has no 'unsafe-eval'). Use simple string replacement instead.
-  return ASSISTANT_WELCOME_NOTE_TEMPLATE.replace(/\{\{assistant\.name\}\}/g, name).replace(
-    /\{\{assistant\.emoji\}\}/g,
-    emoji
-  );
-}
-
 /**
- * Adds the initial markdown note to a newly-created assistant board.
+ * Adds or backfills the initial markdown note on an assistant board.
+ *
+ * The daemon renders the bundled static Handlebars template server-side via a
+ * boards custom method. Keeping the browser out of this render path avoids
+ * importing Handlebars into the UI bundle, where CSP blocks its `new Function`
+ * compilation strategy.
+ *
  * Best-effort: failure should not block assistant/board creation.
  */
 export async function ensureAssistantWelcomeNote({
@@ -52,44 +25,12 @@ export async function ensureAssistantWelcomeNote({
 }: AssistantWelcomeNoteInput): Promise<void> {
   if (!client || !boardId) return;
 
-  const content = buildAssistantWelcomeNoteContent({ assistantName, assistantEmoji });
-  const objectData: BoardObject = {
-    type: 'markdown',
-    x: 80,
-    y: 80,
-    width: 700,
-    content,
-  };
-
   try {
-    const board = (await client.service('boards').get(boardId)) as Board;
-    const existing = board.objects?.[ASSISTANT_WELCOME_NOTE_OBJECT_ID];
-    if (existing) {
-      if (
-        existing.type === 'markdown' &&
-        (existing.content.includes('{{assistant.name}}') ||
-          existing.content.includes('```mermaid') ||
-          existing.content.includes('flowchart LR') ||
-          existing.content.includes('Workflow building blocks') ||
-          existing.content.includes('<--- on your left'))
-      ) {
-        await client.service('boards').patch(boardId, {
-          _action: 'upsertObject',
-          objectId: ASSISTANT_WELCOME_NOTE_OBJECT_ID,
-          objectData: {
-            ...existing,
-            content,
-          },
-        } as unknown as Partial<Board>);
-      }
-      return;
-    }
-
-    await client.service('boards').patch(boardId, {
-      _action: 'upsertObject',
-      objectId: ASSISTANT_WELCOME_NOTE_OBJECT_ID,
-      objectData,
-    } as unknown as Partial<Board>);
+    await client.service('boards').ensureAssistantWelcomeNote({
+      boardId,
+      assistantName,
+      assistantEmoji,
+    });
   } catch (error) {
     console.warn('Failed to create assistant welcome note:', error);
   }

--- a/apps/agor-ui/src/utils/assistantWelcomeNote.ts
+++ b/apps/agor-ui/src/utils/assistantWelcomeNote.ts
@@ -1,4 +1,3 @@
-import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
 import type { AgorClient, Board, BoardID, BoardObject } from '@agor-live/client';
 
 export const ASSISTANT_WELCOME_NOTE_OBJECT_ID = 'welcome-note';
@@ -32,15 +31,12 @@ export function buildAssistantWelcomeNoteContent({
   assistantEmoji,
 }: Pick<AssistantWelcomeNoteInput, 'assistantName' | 'assistantEmoji'>): string {
   const name = assistantName.trim() || 'your assistant';
-  return renderTemplate(
-    ASSISTANT_WELCOME_NOTE_TEMPLATE,
-    {
-      assistant: {
-        name,
-        emoji: assistantEmoji?.trim() || '🤖',
-      },
-    },
-    { onError: 'raw' }
+  const emoji = assistantEmoji?.trim() || '🤖';
+  // Handlebars uses new Function() which is blocked by the app's CSP
+  // (script-src has no 'unsafe-eval'). Use simple string replacement instead.
+  return ASSISTANT_WELCOME_NOTE_TEMPLATE.replace(/\{\{assistant\.name\}\}/g, name).replace(
+    /\{\{assistant\.emoji\}\}/g,
+    emoji
   );
 }
 
@@ -71,7 +67,8 @@ export async function ensureAssistantWelcomeNote({
     if (existing) {
       if (
         existing.type === 'markdown' &&
-        (existing.content.includes('```mermaid') ||
+        (existing.content.includes('{{assistant.name}}') ||
+          existing.content.includes('```mermaid') ||
           existing.content.includes('flowchart LR') ||
           existing.content.includes('Workflow building blocks') ||
           existing.content.includes('<--- on your left'))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -112,6 +112,12 @@
       "import": "./dist/templates/spawn-subsession-template.js",
       "require": "./dist/templates/spawn-subsession-template.cjs"
     },
+    "./templates/assistant-welcome-note": {
+      "source": "./src/templates/assistant-welcome-note.ts",
+      "types": "./dist/templates/assistant-welcome-note.d.ts",
+      "import": "./dist/templates/assistant-welcome-note.js",
+      "require": "./dist/templates/assistant-welcome-note.cjs"
+    },
     "./templates/zone-trigger-context": {
       "source": "./src/templates/zone-trigger-context.ts",
       "types": "./dist/templates/zone-trigger-context.d.ts",

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -398,7 +398,7 @@ export interface BoardsService extends AgorService<Board> {
   clearPrimaryAssistant(boardId: string, params?: Params): Promise<Board>;
 
   /**
-   * Create or backfill the bundled assistant welcome markdown note. Rendering
+   * Create the bundled assistant welcome markdown note when missing. Rendering
    * happens server-side from a static template; callers only provide values.
    */
   ensureAssistantWelcomeNote(data: AssistantWelcomeNoteRequest, params?: Params): Promise<Board>;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -6,6 +6,7 @@
 
 import type {
   Artifact,
+  AssistantWelcomeNoteRequest,
   AuthenticationResult,
   Board,
   BoardExportBlob,
@@ -395,6 +396,12 @@ export interface BoardsService extends AgorService<Board> {
     params?: Params
   ): Promise<Board>;
   clearPrimaryAssistant(boardId: string, params?: Params): Promise<Board>;
+
+  /**
+   * Create or backfill the bundled assistant welcome markdown note. Rendering
+   * happens server-side from a static template; callers only provide values.
+   */
+  ensureAssistantWelcomeNote(data: AssistantWelcomeNoteRequest, params?: Params): Promise<Board>;
 }
 
 /**
@@ -569,7 +576,8 @@ function extendBoardsService(client: AgorClient): void {
         'fromYaml',
         'clone',
         'setPrimaryAssistant',
-        'clearPrimaryAssistant'
+        'clearPrimaryAssistant',
+        'ensureAssistantWelcomeNote'
       );
     }
   };

--- a/packages/core/src/templates/assistant-welcome-note.test.ts
+++ b/packages/core/src/templates/assistant-welcome-note.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   ASSISTANT_WELCOME_NOTE_TEMPLATE,
   buildAssistantWelcomeNoteContent,
-  shouldReplaceAssistantWelcomeNoteContent,
 } from './assistant-welcome-note';
 
 describe('assistant-welcome-note', () => {
@@ -38,56 +37,7 @@ describe('assistant-welcome-note', () => {
 
     expect(content).not.toContain('<img src=x onerror=alert(1)>');
     expect(content).not.toContain('<svg onload=alert(1)>');
-    expect(content).toContain('&lt;img src&#x3D;x onerror&#x3D;alert\\(1\\)&gt;');
-    expect(content).toContain('&lt;svg onload&#x3D;alert\\(1\\)&gt;');
-  });
-
-  it('escapes Markdown metacharacters in assistant values so links remain text', () => {
-    const content = buildAssistantWelcomeNoteContent({
-      assistantName: '[docs](javascript:alert(1))',
-      assistantEmoji: '[bot](javascript:alert(1))',
-    });
-
-    expect(content).not.toContain('[docs](javascript:alert(1))');
-    expect(content).toContain('\\[docs\\]\\(javascript:alert\\(1\\)\\)');
-    expect(content).toContain('\\[bot\\]\\(javascript:alert\\(1\\)\\)');
-  });
-
-  it('detects unresolved placeholder, legacy, and generated welcome-note content for backfill', () => {
-    expect(shouldReplaceAssistantWelcomeNoteContent('# Welcome {{assistant.name}}')).toBe(true);
-    expect(shouldReplaceAssistantWelcomeNoteContent('```mermaid\nflowchart LR')).toBe(true);
-    expect(
-      shouldReplaceAssistantWelcomeNoteContent(
-        buildAssistantWelcomeNoteContent({
-          assistantName: '[docs](javascript:alert(1))',
-          assistantEmoji: '🤖',
-        })
-      )
-    ).toBe(true);
-    expect(
-      shouldReplaceAssistantWelcomeNoteContent(
-        ASSISTANT_WELCOME_NOTE_TEMPLATE.replaceAll(
-          '{{assistant.name}}',
-          "x's Board [docs](javascript:alert(1))"
-        ).replaceAll('{{assistant.emoji}}', '🤖')
-      )
-    ).toBe(true);
-    expect(shouldReplaceAssistantWelcomeNoteContent('My custom note')).toBe(false);
-    expect(
-      shouldReplaceAssistantWelcomeNoteContent(
-        `${buildAssistantWelcomeNoteContent({
-          assistantName: 'Edited Bot',
-          assistantEmoji: '🤖',
-        })}\n\nCustom user addition`
-      )
-    ).toBe(false);
-    expect(
-      shouldReplaceAssistantWelcomeNoteContent(
-        buildAssistantWelcomeNoteContent({
-          assistantName: 'Edited Bot',
-          assistantEmoji: '🤖',
-        }).replace("Edited Bot's Board", "Renamed Bot's Board")
-      )
-    ).toBe(false);
+    expect(content).toContain('&lt;img src&#x3D;x onerror&#x3D;alert(1)&gt;');
+    expect(content).toContain('&lt;svg onload&#x3D;alert(1)&gt;');
   });
 });

--- a/packages/core/src/templates/assistant-welcome-note.test.ts
+++ b/packages/core/src/templates/assistant-welcome-note.test.ts
@@ -64,6 +64,14 @@ describe('assistant-welcome-note', () => {
         })
       )
     ).toBe(true);
+    expect(
+      shouldReplaceAssistantWelcomeNoteContent(
+        ASSISTANT_WELCOME_NOTE_TEMPLATE.replaceAll(
+          '{{assistant.name}}',
+          "x's Board [docs](javascript:alert(1))"
+        ).replaceAll('{{assistant.emoji}}', '🤖')
+      )
+    ).toBe(true);
     expect(shouldReplaceAssistantWelcomeNoteContent('My custom note')).toBe(false);
     expect(
       shouldReplaceAssistantWelcomeNoteContent(

--- a/packages/core/src/templates/assistant-welcome-note.test.ts
+++ b/packages/core/src/templates/assistant-welcome-note.test.ts
@@ -73,5 +73,13 @@ describe('assistant-welcome-note', () => {
         })}\n\nCustom user addition`
       )
     ).toBe(false);
+    expect(
+      shouldReplaceAssistantWelcomeNoteContent(
+        buildAssistantWelcomeNoteContent({
+          assistantName: 'Edited Bot',
+          assistantEmoji: '🤖',
+        }).replace("Edited Bot's Board", "Renamed Bot's Board")
+      )
+    ).toBe(false);
   });
 });

--- a/packages/core/src/templates/assistant-welcome-note.test.ts
+++ b/packages/core/src/templates/assistant-welcome-note.test.ts
@@ -53,9 +53,25 @@ describe('assistant-welcome-note', () => {
     expect(content).toContain('\\[bot\\]\\(javascript:alert\\(1\\)\\)');
   });
 
-  it('detects unresolved placeholder and legacy welcome-note content for backfill', () => {
+  it('detects unresolved placeholder, legacy, and generated welcome-note content for backfill', () => {
     expect(shouldReplaceAssistantWelcomeNoteContent('# Welcome {{assistant.name}}')).toBe(true);
     expect(shouldReplaceAssistantWelcomeNoteContent('```mermaid\nflowchart LR')).toBe(true);
+    expect(
+      shouldReplaceAssistantWelcomeNoteContent(
+        buildAssistantWelcomeNoteContent({
+          assistantName: '[docs](javascript:alert(1))',
+          assistantEmoji: '🤖',
+        })
+      )
+    ).toBe(true);
     expect(shouldReplaceAssistantWelcomeNoteContent('My custom note')).toBe(false);
+    expect(
+      shouldReplaceAssistantWelcomeNoteContent(
+        `${buildAssistantWelcomeNoteContent({
+          assistantName: 'Edited Bot',
+          assistantEmoji: '🤖',
+        })}\n\nCustom user addition`
+      )
+    ).toBe(false);
   });
 });

--- a/packages/core/src/templates/assistant-welcome-note.test.ts
+++ b/packages/core/src/templates/assistant-welcome-note.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ASSISTANT_WELCOME_NOTE_TEMPLATE,
+  buildAssistantWelcomeNoteContent,
+  shouldReplaceAssistantWelcomeNoteContent,
+} from './assistant-welcome-note';
+
+describe('assistant-welcome-note', () => {
+  it('renders the static Handlebars template with assistant identity params', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: 'Product/Design Agor Board',
+      assistantEmoji: '🧋',
+    });
+
+    expect(ASSISTANT_WELCOME_NOTE_TEMPLATE).toContain('{{assistant.name}}');
+    expect(content).not.toContain('{{assistant.name}}');
+    expect(content).not.toContain('{{assistant.emoji}}');
+    expect(content).toContain("Product/Design Agor Board's Board 🧋");
+    expect(content).toContain('**Product/Design Agor Board**');
+  });
+
+  it('falls back to defaults when name is empty and emoji is missing', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: '   ',
+      assistantEmoji: null,
+    });
+
+    expect(content).toContain("your assistant's Board 🤖");
+    expect(content).not.toContain('{{assistant.name}}');
+    expect(content).not.toContain('{{assistant.emoji}}');
+  });
+
+  it('uses Handlebars double-stash escaping for HTML-looking assistant values', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: '<img src=x onerror=alert(1)>',
+      assistantEmoji: '<svg onload=alert(1)>',
+    });
+
+    expect(content).not.toContain('<img src=x onerror=alert(1)>');
+    expect(content).not.toContain('<svg onload=alert(1)>');
+    expect(content).toContain('&lt;img src&#x3D;x onerror&#x3D;alert\\(1\\)&gt;');
+    expect(content).toContain('&lt;svg onload&#x3D;alert\\(1\\)&gt;');
+  });
+
+  it('escapes Markdown metacharacters in assistant values so links remain text', () => {
+    const content = buildAssistantWelcomeNoteContent({
+      assistantName: '[docs](javascript:alert(1))',
+      assistantEmoji: '[bot](javascript:alert(1))',
+    });
+
+    expect(content).not.toContain('[docs](javascript:alert(1))');
+    expect(content).toContain('\\[docs\\]\\(javascript:alert\\(1\\)\\)');
+    expect(content).toContain('\\[bot\\]\\(javascript:alert\\(1\\)\\)');
+  });
+
+  it('detects unresolved placeholder and legacy welcome-note content for backfill', () => {
+    expect(shouldReplaceAssistantWelcomeNoteContent('# Welcome {{assistant.name}}')).toBe(true);
+    expect(shouldReplaceAssistantWelcomeNoteContent('```mermaid\nflowchart LR')).toBe(true);
+    expect(shouldReplaceAssistantWelcomeNoteContent('My custom note')).toBe(false);
+  });
+});

--- a/packages/core/src/templates/assistant-welcome-note.ts
+++ b/packages/core/src/templates/assistant-welcome-note.ts
@@ -25,60 +25,6 @@ Use it to organize:
 
 > Start by asking **{{assistant.name}}** to help set up this board for a workflow that's relevant to you.`;
 
-const LEGACY_WELCOME_NOTE_MARKERS = [
-  '{{assistant.name}}',
-  '{{assistant.emoji}}',
-  '```mermaid',
-  'flowchart LR',
-  'Workflow building blocks',
-  '<--- on your left',
-];
-
-const ASSISTANT_VALUE_PATTERN = /{{assistant\.(name|emoji)}}/g;
-const ASSISTANT_VALUE_SPLIT_PATTERN = /{{assistant\.(?:name|emoji)}}/g;
-const CURRENT_WELCOME_NOTE_STATIC_SEGMENTS = ASSISTANT_WELCOME_NOTE_TEMPLATE.split(
-  ASSISTANT_VALUE_SPLIT_PATTERN
-);
-const CURRENT_WELCOME_NOTE_PLACEHOLDERS = Array.from(
-  ASSISTANT_WELCOME_NOTE_TEMPLATE.matchAll(ASSISTANT_VALUE_PATTERN),
-  (match) => match[1] as 'name' | 'emoji'
-);
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function buildCurrentWelcomeNoteTemplatePattern(): RegExp {
-  const seenPlaceholders = new Set<'name' | 'emoji'>();
-  let pattern = `^${escapeRegExp(CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[0])}`;
-
-  for (let index = 1; index < CURRENT_WELCOME_NOTE_STATIC_SEGMENTS.length; index += 1) {
-    const placeholder = CURRENT_WELCOME_NOTE_PLACEHOLDERS[index - 1];
-
-    if (seenPlaceholders.has(placeholder)) {
-      pattern += `\\k<${placeholder}>`;
-    } else {
-      seenPlaceholders.add(placeholder);
-      pattern += `(?<${placeholder}>[\\s\\S]*?)`;
-    }
-
-    pattern += escapeRegExp(CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[index]);
-  }
-
-  return new RegExp(`${pattern}$`);
-}
-
-const CURRENT_WELCOME_NOTE_TEMPLATE_PATTERN = buildCurrentWelcomeNoteTemplatePattern();
-
-/**
- * Escape text for Markdown inline/text contexts before Handlebars performs its
- * normal HTML escaping. The template source is trusted/static, but assistant
- * identity fields are user-provided and are rendered as Markdown text.
- */
-function escapeMarkdownText(value: string): string {
-  return value.replace(/([\\`*_{}[\]()#+\-.!])/g, '\\$1');
-}
-
 export function buildAssistantWelcomeNoteContext({
   assistantName,
   assistantEmoji,
@@ -88,8 +34,8 @@ export function buildAssistantWelcomeNoteContext({
 
   return {
     assistant: {
-      name: escapeMarkdownText(name),
-      emoji: escapeMarkdownText(emoji),
+      name,
+      emoji,
     },
   };
 }
@@ -102,8 +48,8 @@ export function buildAssistantWelcomeNoteContext({
  *   provide data values, never template source.
  * - Values are interpolated with normal double-stash expressions, so
  *   HTML-significant characters are escaped by Handlebars.
- * - Markdown metacharacters in values are escaped before rendering so names
- *   like `[docs](javascript:...)` remain text rather than links.
+ * - The rendered Markdown is later rendered through the React/Streamdown path,
+ *   not injected with dangerouslySetInnerHTML.
  */
 export function buildAssistantWelcomeNoteContent(input: AssistantWelcomeNoteInput): string {
   return renderTemplate(ASSISTANT_WELCOME_NOTE_TEMPLATE, buildAssistantWelcomeNoteContext(input), {
@@ -121,15 +67,4 @@ export function buildAssistantWelcomeNoteObject(
     width: 700,
     content: buildAssistantWelcomeNoteContent(input),
   };
-}
-
-function matchesCurrentWelcomeNoteTemplateShape(content: string): boolean {
-  return CURRENT_WELCOME_NOTE_TEMPLATE_PATTERN.test(content);
-}
-
-export function shouldReplaceAssistantWelcomeNoteContent(content: string): boolean {
-  return (
-    LEGACY_WELCOME_NOTE_MARKERS.some((marker) => content.includes(marker)) ||
-    matchesCurrentWelcomeNoteTemplateShape(content)
-  );
 }

--- a/packages/core/src/templates/assistant-welcome-note.ts
+++ b/packages/core/src/templates/assistant-welcome-note.ts
@@ -34,9 +34,15 @@ const LEGACY_WELCOME_NOTE_MARKERS = [
   '<--- on your left',
 ];
 
-const ASSISTANT_VALUE_PATTERN = /{{assistant\.(?:name|emoji)}}/g;
-const CURRENT_WELCOME_NOTE_STATIC_SEGMENTS =
-  ASSISTANT_WELCOME_NOTE_TEMPLATE.split(ASSISTANT_VALUE_PATTERN);
+const ASSISTANT_VALUE_PATTERN = /{{assistant\.(name|emoji)}}/g;
+const ASSISTANT_VALUE_SPLIT_PATTERN = /{{assistant\.(?:name|emoji)}}/g;
+const CURRENT_WELCOME_NOTE_STATIC_SEGMENTS = ASSISTANT_WELCOME_NOTE_TEMPLATE.split(
+  ASSISTANT_VALUE_SPLIT_PATTERN
+);
+const CURRENT_WELCOME_NOTE_PLACEHOLDERS = Array.from(
+  ASSISTANT_WELCOME_NOTE_TEMPLATE.matchAll(ASSISTANT_VALUE_PATTERN),
+  (match) => match[1] as 'name' | 'emoji'
+);
 
 /**
  * Escape text for Markdown inline/text contexts before Handlebars performs its
@@ -93,6 +99,7 @@ export function buildAssistantWelcomeNoteObject(
 
 function matchesCurrentWelcomeNoteTemplateShape(content: string): boolean {
   let offset = 0;
+  const capturedValues: Partial<Record<'name' | 'emoji', string>> = {};
 
   for (let index = 0; index < CURRENT_WELCOME_NOTE_STATIC_SEGMENTS.length; index += 1) {
     const segment = CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[index];
@@ -105,6 +112,14 @@ function matchesCurrentWelcomeNoteTemplateShape(content: string): boolean {
 
     const segmentIndex = content.indexOf(segment, offset);
     if (segmentIndex === -1) return false;
+
+    const placeholder = CURRENT_WELCOME_NOTE_PLACEHOLDERS[index - 1];
+    const value = content.slice(offset, segmentIndex);
+    if (capturedValues[placeholder] === undefined) {
+      capturedValues[placeholder] = value;
+    } else if (capturedValues[placeholder] !== value) {
+      return false;
+    }
 
     offset = segmentIndex + segment.length;
   }

--- a/packages/core/src/templates/assistant-welcome-note.ts
+++ b/packages/core/src/templates/assistant-welcome-note.ts
@@ -44,6 +44,32 @@ const CURRENT_WELCOME_NOTE_PLACEHOLDERS = Array.from(
   (match) => match[1] as 'name' | 'emoji'
 );
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildCurrentWelcomeNoteTemplatePattern(): RegExp {
+  const seenPlaceholders = new Set<'name' | 'emoji'>();
+  let pattern = `^${escapeRegExp(CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[0])}`;
+
+  for (let index = 1; index < CURRENT_WELCOME_NOTE_STATIC_SEGMENTS.length; index += 1) {
+    const placeholder = CURRENT_WELCOME_NOTE_PLACEHOLDERS[index - 1];
+
+    if (seenPlaceholders.has(placeholder)) {
+      pattern += `\\k<${placeholder}>`;
+    } else {
+      seenPlaceholders.add(placeholder);
+      pattern += `(?<${placeholder}>[\\s\\S]*?)`;
+    }
+
+    pattern += escapeRegExp(CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[index]);
+  }
+
+  return new RegExp(`${pattern}$`);
+}
+
+const CURRENT_WELCOME_NOTE_TEMPLATE_PATTERN = buildCurrentWelcomeNoteTemplatePattern();
+
 /**
  * Escape text for Markdown inline/text contexts before Handlebars performs its
  * normal HTML escaping. The template source is trusted/static, but assistant
@@ -98,33 +124,7 @@ export function buildAssistantWelcomeNoteObject(
 }
 
 function matchesCurrentWelcomeNoteTemplateShape(content: string): boolean {
-  let offset = 0;
-  const capturedValues: Partial<Record<'name' | 'emoji', string>> = {};
-
-  for (let index = 0; index < CURRENT_WELCOME_NOTE_STATIC_SEGMENTS.length; index += 1) {
-    const segment = CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[index];
-
-    if (index === 0) {
-      if (!content.startsWith(segment)) return false;
-      offset = segment.length;
-      continue;
-    }
-
-    const segmentIndex = content.indexOf(segment, offset);
-    if (segmentIndex === -1) return false;
-
-    const placeholder = CURRENT_WELCOME_NOTE_PLACEHOLDERS[index - 1];
-    const value = content.slice(offset, segmentIndex);
-    if (capturedValues[placeholder] === undefined) {
-      capturedValues[placeholder] = value;
-    } else if (capturedValues[placeholder] !== value) {
-      return false;
-    }
-
-    offset = segmentIndex + segment.length;
-  }
-
-  return offset === content.length;
+  return CURRENT_WELCOME_NOTE_TEMPLATE_PATTERN.test(content);
 }
 
 export function shouldReplaceAssistantWelcomeNoteContent(content: string): boolean {

--- a/packages/core/src/templates/assistant-welcome-note.ts
+++ b/packages/core/src/templates/assistant-welcome-note.ts
@@ -1,0 +1,92 @@
+import type { MarkdownBoardObject } from '../types/board';
+import { renderTemplate } from './handlebars-helpers';
+
+export const ASSISTANT_WELCOME_NOTE_OBJECT_ID = 'welcome-note';
+
+export interface AssistantWelcomeNoteInput {
+  assistantName: string;
+  assistantEmoji?: string | null;
+}
+
+export const ASSISTANT_WELCOME_NOTE_TEMPLATE = `# Welcome to {{assistant.name}}'s Board {{assistant.emoji}}
+
+This board is a shared workspace for you and **{{assistant.name}}** to shape and run workflows.
+
+Use it to organize:
+
+- 🌿 **Branches** — coding efforts and their agent sessions
+- 🧩 **Cards** — entities your workflow cares about, like tickets, customers, patients, leads, or incidents
+- 📝 **Notes** — shared context, instructions, diagrams, and checklists
+- 🗺️ **Zones** — named areas that group work and can trigger prompts as branches move through them
+
+| 👈 Assistant | Board | Chat 👉 |
+| --- | --- | --- |
+| Plan and set up workflows | Arrange branches, cards, notes, and zones | Work through conversations |
+
+> Start by asking **{{assistant.name}}** to help set up this board for a workflow that's relevant to you.`;
+
+const LEGACY_WELCOME_NOTE_MARKERS = [
+  '{{assistant.name}}',
+  '{{assistant.emoji}}',
+  '```mermaid',
+  'flowchart LR',
+  'Workflow building blocks',
+  '<--- on your left',
+];
+
+/**
+ * Escape text for Markdown inline/text contexts before Handlebars performs its
+ * normal HTML escaping. The template source is trusted/static, but assistant
+ * identity fields are user-provided and are rendered as Markdown text.
+ */
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_{}[\]()#+\-.!])/g, '\\$1');
+}
+
+export function buildAssistantWelcomeNoteContext({
+  assistantName,
+  assistantEmoji,
+}: AssistantWelcomeNoteInput): Record<string, unknown> {
+  const name = assistantName.trim().replace(/\s+/g, ' ') || 'your assistant';
+  const emoji = assistantEmoji?.trim().replace(/\s+/g, ' ') || '🤖';
+
+  return {
+    assistant: {
+      name: escapeMarkdownText(name),
+      emoji: escapeMarkdownText(emoji),
+    },
+  };
+}
+
+/**
+ * Render the static assistant board welcome note on the server.
+ *
+ * Security invariants:
+ * - The Handlebars template is bundled/static for this path; callers only
+ *   provide data values, never template source.
+ * - Values are interpolated with normal double-stash expressions, so
+ *   HTML-significant characters are escaped by Handlebars.
+ * - Markdown metacharacters in values are escaped before rendering so names
+ *   like `[docs](javascript:...)` remain text rather than links.
+ */
+export function buildAssistantWelcomeNoteContent(input: AssistantWelcomeNoteInput): string {
+  return renderTemplate(ASSISTANT_WELCOME_NOTE_TEMPLATE, buildAssistantWelcomeNoteContext(input), {
+    onError: 'empty',
+  });
+}
+
+export function buildAssistantWelcomeNoteObject(
+  input: AssistantWelcomeNoteInput
+): MarkdownBoardObject {
+  return {
+    type: 'markdown',
+    x: 80,
+    y: 80,
+    width: 700,
+    content: buildAssistantWelcomeNoteContent(input),
+  };
+}
+
+export function shouldReplaceAssistantWelcomeNoteContent(content: string): boolean {
+  return LEGACY_WELCOME_NOTE_MARKERS.some((marker) => content.includes(marker));
+}

--- a/packages/core/src/templates/assistant-welcome-note.ts
+++ b/packages/core/src/templates/assistant-welcome-note.ts
@@ -34,6 +34,10 @@ const LEGACY_WELCOME_NOTE_MARKERS = [
   '<--- on your left',
 ];
 
+const ASSISTANT_VALUE_PATTERN = /{{assistant\.(?:name|emoji)}}/g;
+const CURRENT_WELCOME_NOTE_STATIC_SEGMENTS =
+  ASSISTANT_WELCOME_NOTE_TEMPLATE.split(ASSISTANT_VALUE_PATTERN);
+
 /**
  * Escape text for Markdown inline/text contexts before Handlebars performs its
  * normal HTML escaping. The template source is trusted/static, but assistant
@@ -87,6 +91,30 @@ export function buildAssistantWelcomeNoteObject(
   };
 }
 
+function matchesCurrentWelcomeNoteTemplateShape(content: string): boolean {
+  let offset = 0;
+
+  for (let index = 0; index < CURRENT_WELCOME_NOTE_STATIC_SEGMENTS.length; index += 1) {
+    const segment = CURRENT_WELCOME_NOTE_STATIC_SEGMENTS[index];
+
+    if (index === 0) {
+      if (!content.startsWith(segment)) return false;
+      offset = segment.length;
+      continue;
+    }
+
+    const segmentIndex = content.indexOf(segment, offset);
+    if (segmentIndex === -1) return false;
+
+    offset = segmentIndex + segment.length;
+  }
+
+  return offset === content.length;
+}
+
 export function shouldReplaceAssistantWelcomeNoteContent(content: string): boolean {
-  return LEGACY_WELCOME_NOTE_MARKERS.some((marker) => content.includes(marker));
+  return (
+    LEGACY_WELCOME_NOTE_MARKERS.some((marker) => content.includes(marker)) ||
+    matchesCurrentWelcomeNoteTemplateShape(content)
+  );
 }

--- a/packages/core/src/types/board.ts
+++ b/packages/core/src/types/board.ts
@@ -194,6 +194,17 @@ export type BoardObject =
   | AppBoardObject
   | ArtifactBoardObject;
 
+export interface AssistantWelcomeNoteRequest {
+  /** Board to create/update the bundled assistant welcome note on. */
+  boardId?: BoardID | string;
+  /** Alias accepted by Feathers custom method callers. */
+  id?: BoardID | string;
+  /** User-provided assistant display name. */
+  assistantName: string;
+  /** Optional user-provided assistant emoji/icon. */
+  assistantEmoji?: string | null;
+}
+
 export interface Board {
   /** Unique board identifier (UUIDv7) */
   board_id: BoardID;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     'templates/handlebars-helpers': 'src/templates/handlebars-helpers.ts', // Handlebars helpers
     'templates/session-context': 'src/templates/session-context.ts', // Agor system prompt rendering
     'templates/spawn-subsession-template': 'src/templates/spawn-subsession-template.ts', // Spawn-subsession meta-prompt
+    'templates/assistant-welcome-note': 'src/templates/assistant-welcome-note.ts', // Assistant board welcome note renderer
     'templates/zone-trigger-context': 'src/templates/zone-trigger-context.ts', // Canonical zone-trigger context builder
     'environment/variable-resolver': 'src/environment/variable-resolver.ts', // Environment variable resolution
     'environment/render-snapshot': 'src/environment/render-snapshot.ts', // v2 branch env snapshot rendering


### PR DESCRIPTION
## Summary

- Move assistant board welcome-note rendering out of the browser and into the daemon.
- Add a server-only `@agor/core/templates/assistant-welcome-note` helper that renders the static Handlebars template with the existing core Handlebars renderer.
- Add `boards.ensureAssistantWelcomeNote(...)` so the UI only sends assistant values; it never sends or compiles template source for this path.
- Keep the behavior simple: create the bundled welcome note when it is missing, and preserve any existing `welcome-note` object unchanged.

## Security notes

- The welcome-note template is trusted/static and bundled in core; callers cannot provide arbitrary template source for this backend path.
- Values use normal double-stash Handlebars interpolation, so HTML-significant characters are escaped.
- No Handlebars prototype-access options are relaxed.
- The rendered note remains markdown text rendered by the existing React/Streamdown UI path; it is not injected via `dangerouslySetInnerHTML` by this change.
- The browser bundle no longer imports/renders Handlebars for the assistant welcome-note path.

## Test plan

- [x] `pnpm i`
- [x] `pnpm check`
- [x] `pnpm --filter @agor/core exec vitest run src/templates/assistant-welcome-note.test.ts`
- [x] `pnpm --filter agor-ui exec vitest run src/utils/assistantWelcomeNote.test.ts src/utils/assistantCreation.test.ts`
- [x] `pnpm --filter @agor/daemon exec vitest run src/services/boards.test.ts`
