### PR TITLE
Fix Codex edit_files diffs and labels

### DIFF
--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.tsx
@@ -262,6 +262,7 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
           display: 'flex',
           alignItems: 'center',
           gap: 6,
+          minWidth: 0,
           padding: `${token.sizeUnit * 0.75}px ${token.sizeUnit}px`,
           cursor: 'pointer',
           borderRadius: expanded
@@ -285,12 +286,12 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
             strong
             style={{
               fontSize: token.fontSizeSM,
-              maxWidth: 72,
+              maxWidth: 96,
               minWidth: 0,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              flexShrink: 1,
+              flexShrink: 0,
             }}
           >
             {operationLabel(operationType)}
@@ -302,8 +303,8 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
             code
             style={{
               fontSize: token.fontSizeSM - 1,
-              maxWidth: 300,
               minWidth: 0,
+              flex: '1 1 auto',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.tsx
@@ -280,9 +280,22 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
           <RightOutlined style={{ fontSize: 10, color: token.colorTextSecondary }} />
         )}
 
-        <Typography.Text strong style={{ fontSize: token.fontSizeSM }}>
-          {operationLabel(operationType)}
-        </Typography.Text>
+        <Tooltip title={operationLabel(operationType)}>
+          <Typography.Text
+            strong
+            style={{
+              fontSize: token.fontSizeSM,
+              maxWidth: 72,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flexShrink: 1,
+            }}
+          >
+            {operationLabel(operationType)}
+          </Typography.Text>
+        </Tooltip>
 
         <Tooltip title={filePath}>
           <Typography.Text
@@ -290,6 +303,7 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
             style={{
               fontSize: token.fontSizeSM - 1,
               maxWidth: 300,
+              minWidth: 0,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx
@@ -53,4 +53,31 @@ describe('EditFilesRenderer', () => {
     expect(screen.getByText('+1')).toBeInTheDocument();
     expect(screen.getByText('-1')).toBeInTheDocument();
   });
+
+  it('keeps edit_files operation labels on one line with ellipsis styles', () => {
+    render(
+      <div style={{ width: 80 }}>
+        <EditFilesRenderer
+          toolUseId="tool-edit-files-fallback"
+          input={{
+            changes: [
+              {
+                path: 'apps/agor-ui/src/components/very/long/path/example.tsx',
+                kind: 'update',
+              },
+            ],
+          }}
+          result={{ content: '[completed]' }}
+        />
+      </div>
+    );
+
+    const labelText = screen.getByText('Update');
+    const label = labelText.closest('.ant-typography') ?? labelText;
+    expect(label).toHaveStyle({
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    });
+  });
 });

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.test.tsx
@@ -52,6 +52,14 @@ describe('EditFilesRenderer', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('+1')).toBeInTheDocument();
     expect(screen.getByText('-1')).toBeInTheDocument();
+
+    const labelText = screen.getByText('Update');
+    const label = labelText.closest('.ant-typography') ?? labelText;
+    expect(label).toHaveStyle({
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    });
   });
 
   it('keeps edit_files operation labels on one line with ellipsis styles', () => {

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.tsx
@@ -6,7 +6,7 @@
  * Falls back to a simple file path display when no diff data exists.
  */
 
-import { Typography, theme } from 'antd';
+import { Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { DiffBlock } from './DiffBlock';
 import { extractErrorMessage, type ToolRendererProps } from './index';
@@ -38,6 +38,14 @@ const kindLabel = (kind: string): string => {
   }
 };
 
+const normalizePathForMatch = (filePath: string): string => filePath.replace(/\\/g, '/');
+
+const pathsMatch = (left: string, right: string): boolean => {
+  const a = normalizePathForMatch(left);
+  const b = normalizePathForMatch(right);
+  return a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+};
+
 export const EditFilesRenderer: React.FC<ToolRendererProps> = ({ input, result }) => {
   const { token } = theme.useToken();
   const changes = input.changes as FileChange[] | undefined;
@@ -49,15 +57,15 @@ export const EditFilesRenderer: React.FC<ToolRendererProps> = ({ input, result }
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       {changes.map((change) => {
-        const fileDiff = fileDiffs?.find((f) => f.path === change.path);
+        const fileDiff = fileDiffs?.find((f) => pathsMatch(f.path, change.path));
 
         // If we have enrichment data, use the full DiffBlock
         if (fileDiff) {
           return (
             <DiffBlock
               key={change.path}
-              filePath={change.path}
-              operationType={kindToOperationType(change.kind)}
+              filePath={fileDiff.path || change.path}
+              operationType={kindToOperationType(fileDiff.kind || change.kind)}
               structuredPatch={fileDiff.structuredPatch}
               isError={result?.is_error}
               errorMessage={extractErrorMessage(result)}
@@ -81,12 +89,36 @@ export const EditFilesRenderer: React.FC<ToolRendererProps> = ({ input, result }
               fontSize: token.fontSizeSM,
             }}
           >
-            <Typography.Text strong style={{ fontSize: token.fontSizeSM }}>
-              {kindLabel(change.kind)}
-            </Typography.Text>
-            <Typography.Text code style={{ fontSize: token.fontSizeSM - 1 }}>
-              {change.path}
-            </Typography.Text>
+            <Tooltip title={kindLabel(change.kind)}>
+              <Typography.Text
+                strong
+                style={{
+                  fontSize: token.fontSizeSM,
+                  maxWidth: 72,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  flexShrink: 1,
+                }}
+              >
+                {kindLabel(change.kind)}
+              </Typography.Text>
+            </Tooltip>
+            <Tooltip title={change.path}>
+              <Typography.Text
+                code
+                style={{
+                  fontSize: token.fontSizeSM - 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {change.path}
+              </Typography.Text>
+            </Tooltip>
           </div>
         );
       })}

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/EditFilesRenderer.tsx
@@ -82,6 +82,7 @@ export const EditFilesRenderer: React.FC<ToolRendererProps> = ({ input, result }
               display: 'flex',
               alignItems: 'center',
               gap: 6,
+              minWidth: 0,
               padding: `${token.sizeUnit * 0.75}px ${token.sizeUnit}px`,
               borderRadius: token.borderRadius,
               background: token.colorBgLayout,
@@ -94,12 +95,12 @@ export const EditFilesRenderer: React.FC<ToolRendererProps> = ({ input, result }
                 strong
                 style={{
                   fontSize: token.fontSizeSM,
-                  maxWidth: 72,
+                  maxWidth: 96,
                   minWidth: 0,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
-                  flexShrink: 1,
+                  flexShrink: 0,
                 }}
               >
                 {kindLabel(change.kind)}
@@ -111,6 +112,7 @@ export const EditFilesRenderer: React.FC<ToolRendererProps> = ({ input, result }
                 style={{
                   fontSize: token.fontSizeSM - 1,
                   minWidth: 0,
+                  flex: '1 1 auto',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -365,6 +365,42 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('"one"'))).toBe(false);
   });
 
+  it('skips tracked symlinks during Codex turn baseline capture', async () => {
+    const repoDir = createTempGitRepo();
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-diff-enrichment-outside-'));
+    tempDirs.push(outsideDir);
+    const outsideFile = path.join(outsideDir, 'secret.txt');
+    const linkPath = path.join(repoDir, 'linked.txt');
+
+    fs.writeFileSync(outsideFile, 'outside-before\n', 'utf-8');
+    fs.symlinkSync(outsideFile, linkPath);
+    execSync('git add linked.txt', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "tracked symlink"', { cwd: repoDir, stdio: 'ignore' });
+
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-symlink' };
+    await registerEditFilesTurnBaseline(context);
+
+    fs.writeFileSync(outsideFile, 'outside-after\n', 'utf-8');
+    const blocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-symlink',
+        name: 'edit_files',
+        input: { changes: [{ path: 'linked.txt', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-symlink',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    expect(blocks[1].diff).toBeUndefined();
+  });
+
   it('skips binary edit_files snapshots instead of rendering bogus text diffs', () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'asset.bin');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -472,6 +472,66 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('+export const added = true;'))).toBe(true);
   });
 
+  it('skips symlinks in edit_files add fallback when no baseline is available', () => {
+    const repoDir = createTempGitRepo();
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-diff-enrichment-add-outside-'));
+    tempDirs.push(outsideDir);
+    const outsideFile = path.join(outsideDir, 'secret.txt');
+    const linkPath = path.join(repoDir, 'linked-add.txt');
+
+    fs.writeFileSync(path.join(repoDir, 'README.md'), '# test\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    fs.writeFileSync(outsideFile, 'outside secret\n', 'utf-8');
+    fs.symlinkSync(outsideFile, linkPath);
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-add-symlink',
+        name: 'edit_files',
+        input: { changes: [{ path: 'linked-add.txt', kind: 'add' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-add-symlink',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    expect(contentBlocks[1].diff).toBeUndefined();
+  });
+
+  it('skips binary files in edit_files add fallback when no baseline is available', () => {
+    const repoDir = createTempGitRepo();
+    fs.writeFileSync(path.join(repoDir, 'README.md'), '# test\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    fs.writeFileSync(path.join(repoDir, 'asset.bin'), Buffer.from([1, 2, 0, 3]));
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-add-binary',
+        name: 'edit_files',
+        input: { changes: [{ path: 'asset.bin', kind: 'add' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-add-binary',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    expect(contentBlocks[1].diff).toBeUndefined();
+  });
+
   it('truncates large edit_files add diffs before storing them', () => {
     const repoDir = createTempGitRepo();
     const srcDir = path.join(repoDir, 'src');

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -4,9 +4,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  clearEditFilesTurnBaseline,
   clearToolInvocationState,
   enrichContentBlocks,
   enrichToolResults,
+  registerEditFilesTurnBaseline,
   registerToolInvocationStart,
   registerToolUses,
 } from './diff-enrichment.js';
@@ -217,6 +219,133 @@ describe('diff enrichment', () => {
       {
         type: 'tool_result',
         tool_use_id: 'tool-codex-edit-files-dirty-untracked-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, { workingDirectory: repoDir });
+
+    expect(contentBlocks[1].diff).toBeUndefined();
+  });
+
+  it('uses the Codex turn baseline when file_change has no start-time paths', () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'src', 'baseline.ts');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'export const value = "before";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    registerEditFilesTurnBaseline({ workingDirectory: repoDir, snapshotScope: 'turn-baseline' });
+    fs.writeFileSync(filePath, 'export const value = "after";\n', 'utf-8');
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-baseline-1',
+        name: 'edit_files',
+        input: { changes: [{ path: 'src/baseline.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-baseline-1',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(contentBlocks, {
+      workingDirectory: repoDir,
+      snapshotScope: 'turn-baseline',
+    });
+    clearEditFilesTurnBaseline({ snapshotScope: 'turn-baseline' });
+
+    const fileDiff = contentBlocks[1].diff?.files?.[0];
+    expect(fileDiff?.path).toBe('src/baseline.ts');
+    expect(fileDiff?.kind).toBe('update');
+    const lines = fileDiff?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-export const value = "before";'))).toBe(true);
+    expect(lines.some((line) => line.includes('+export const value = "after";'))).toBe(true);
+  });
+
+  it('refreshes the Codex turn baseline after each edit_files result', () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'src', 'twice.ts');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'export const value = "one";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-refresh' };
+    registerEditFilesTurnBaseline(context);
+
+    fs.writeFileSync(filePath, 'export const value = "two";\n', 'utf-8');
+    const firstBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-refresh-1',
+        name: 'edit_files',
+        input: { changes: [{ path: 'src/twice.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-refresh-1',
+        content: '[completed]',
+      },
+    ];
+    enrichContentBlocks(firstBlocks, context);
+
+    fs.writeFileSync(filePath, 'export const value = "three";\n', 'utf-8');
+    const secondBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-refresh-2',
+        name: 'edit_files',
+        input: { changes: [{ path: 'src/twice.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-refresh-2',
+        content: '[completed]',
+      },
+    ];
+    enrichContentBlocks(secondBlocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    const firstLines = firstBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(firstLines.some((line) => line.includes('-export const value = "one";'))).toBe(true);
+    expect(firstLines.some((line) => line.includes('+export const value = "two";'))).toBe(true);
+
+    const secondLines = secondBlocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(secondLines.some((line) => line.includes('-export const value = "two";'))).toBe(true);
+    expect(secondLines.some((line) => line.includes('+export const value = "three";'))).toBe(true);
+    expect(secondLines.some((line) => line.includes('"one"'))).toBe(false);
+  });
+
+  it('skips binary edit_files snapshots instead of rendering bogus text diffs', () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'asset.bin');
+    fs.writeFileSync(filePath, Buffer.from([0, 1, 2, 3]));
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    registerToolInvocationStart(
+      'tool-codex-edit-files-binary-1',
+      'edit_files',
+      { changes: [{ path: 'asset.bin', kind: 'update' }] },
+      { workingDirectory: repoDir }
+    );
+    fs.writeFileSync(filePath, Buffer.from([0, 1, 9, 3]));
+
+    const contentBlocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-binary-1',
+        name: 'edit_files',
+        input: { changes: [{ path: 'asset.bin', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-binary-1',
         content: '[completed]',
       },
     ];

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.test.ts
@@ -8,6 +8,7 @@ import {
   clearToolInvocationState,
   enrichContentBlocks,
   enrichToolResults,
+  refreshEditFilesTurnBaseline,
   registerEditFilesTurnBaseline,
   registerToolInvocationStart,
   registerToolUses,
@@ -228,7 +229,7 @@ describe('diff enrichment', () => {
     expect(contentBlocks[1].diff).toBeUndefined();
   });
 
-  it('uses the Codex turn baseline when file_change has no start-time paths', () => {
+  it('uses the Codex turn baseline when file_change has no start-time paths', async () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'src', 'baseline.ts');
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -236,7 +237,10 @@ describe('diff enrichment', () => {
     execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
     execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
 
-    registerEditFilesTurnBaseline({ workingDirectory: repoDir, snapshotScope: 'turn-baseline' });
+    await registerEditFilesTurnBaseline({
+      workingDirectory: repoDir,
+      snapshotScope: 'turn-baseline',
+    });
     fs.writeFileSync(filePath, 'export const value = "after";\n', 'utf-8');
 
     const contentBlocks: TestContentBlock[] = [
@@ -267,7 +271,7 @@ describe('diff enrichment', () => {
     expect(lines.some((line) => line.includes('+export const value = "after";'))).toBe(true);
   });
 
-  it('refreshes the Codex turn baseline after each edit_files result', () => {
+  it('refreshes the Codex turn baseline after each edit_files result', async () => {
     const repoDir = createTempGitRepo();
     const filePath = path.join(repoDir, 'src', 'twice.ts');
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -276,7 +280,7 @@ describe('diff enrichment', () => {
     execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
 
     const context = { workingDirectory: repoDir, snapshotScope: 'turn-refresh' };
-    registerEditFilesTurnBaseline(context);
+    await registerEditFilesTurnBaseline(context);
 
     fs.writeFileSync(filePath, 'export const value = "two";\n', 'utf-8');
     const firstBlocks: TestContentBlock[] = [
@@ -319,6 +323,46 @@ describe('diff enrichment', () => {
     expect(secondLines.some((line) => line.includes('-export const value = "two";'))).toBe(true);
     expect(secondLines.some((line) => line.includes('+export const value = "three";'))).toBe(true);
     expect(secondLines.some((line) => line.includes('"one"'))).toBe(false);
+  });
+
+  it('refreshes the Codex turn baseline after a non-edit_files tool mutates a file', async () => {
+    const repoDir = createTempGitRepo();
+    const filePath = path.join(repoDir, 'src', 'after-bash.ts');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'export const value = "one";\n', 'utf-8');
+    execSync('git add .', { cwd: repoDir, stdio: 'ignore' });
+    execSync('git commit -m "initial"', { cwd: repoDir, stdio: 'ignore' });
+
+    const context = { workingDirectory: repoDir, snapshotScope: 'turn-refresh-after-bash' };
+    await registerEditFilesTurnBaseline(context);
+
+    // Simulate a completed Bash/command_execution tool mutating the worktree
+    // before a later Codex file_change/edit_files item updates the same file.
+    fs.writeFileSync(filePath, 'export const value = "two";\n', 'utf-8');
+    await refreshEditFilesTurnBaseline(context);
+
+    fs.writeFileSync(filePath, 'export const value = "three";\n', 'utf-8');
+    const blocks: TestContentBlock[] = [
+      {
+        type: 'tool_use',
+        id: 'tool-codex-edit-files-after-bash',
+        name: 'edit_files',
+        input: { changes: [{ path: 'src/after-bash.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-codex-edit-files-after-bash',
+        content: '[completed]',
+      },
+    ];
+
+    enrichContentBlocks(blocks, context);
+    clearEditFilesTurnBaseline(context);
+
+    const lines = blocks[1].diff?.files?.[0]?.structuredPatch?.[0]?.lines ?? [];
+    expect(lines.some((line) => line.includes('-export const value = "two";'))).toBe(true);
+    expect(lines.some((line) => line.includes('+export const value = "three";'))).toBe(true);
+    expect(lines.some((line) => line.includes('"one"'))).toBe(false);
   });
 
   it('skips binary edit_files snapshots instead of rendering bogus text diffs', () => {

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -33,6 +33,20 @@ const MAX_FILE_SIZE_BYTES = 1_048_576;
 const CONTEXT_LINES = 3;
 /** Maximum diff lines to persist per file in message JSON. */
 const MAX_STORED_DIFF_LINES_PER_FILE = 200;
+/** Maximum repo files to snapshot at the start of a Codex turn. */
+const MAX_TURN_BASELINE_FILES = 5_000;
+/** Maximum aggregate text bytes to keep in a Codex turn baseline. */
+const MAX_TURN_BASELINE_BYTES = 25 * 1_048_576;
+const TURN_BASELINE_IGNORED_DIRS = new Set([
+  '.git',
+  'node_modules',
+  '.pnpm',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  'coverage',
+]);
 
 interface ToolUseInfo {
   name: string;
@@ -59,6 +73,18 @@ interface EditFilesSnapshot {
 
 interface PendingSnapshotEntry {
   snapshots: EditFilesSnapshot[];
+  createdAt: number;
+}
+
+interface TextFileSnapshot {
+  exists: boolean;
+  content?: string;
+  skipped?: boolean;
+}
+
+interface EditFilesBaselineEntry {
+  gitRoot: string;
+  files: Map<string, TextFileSnapshot>;
   createdAt: number;
 }
 
@@ -92,6 +118,77 @@ function tryRealpath(p: string): string | null {
   } catch {
     return null;
   }
+}
+
+function readTextFileSnapshot(absolutePath: string): TextFileSnapshot {
+  try {
+    const stat = fs.statSync(absolutePath);
+    if (!stat.isFile()) {
+      return { exists: true, skipped: true };
+    }
+    if (stat.size > MAX_FILE_SIZE_BYTES) {
+      return { exists: true, skipped: true };
+    }
+    const buffer = fs.readFileSync(absolutePath);
+    // Avoid rendering binary data as a giant mojibake text diff.
+    if (buffer.includes(0)) {
+      return { exists: true, skipped: true };
+    }
+    return { exists: true, content: buffer.toString('utf-8') };
+  } catch {
+    return { exists: false };
+  }
+}
+
+function getGitRoot(workingDirectory?: string): string | null {
+  try {
+    return execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf-8',
+      timeout: 5000,
+      ...(workingDirectory ? { cwd: workingDirectory } : {}),
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function listTurnBaselineFiles(gitRoot: string): string[] {
+  const files: string[] = [];
+  const stack = [''];
+
+  while (stack.length > 0 && files.length < MAX_TURN_BASELINE_FILES) {
+    const currentRelativeDir = stack.pop() ?? '';
+    const currentAbsoluteDir = path.join(gitRoot, currentRelativeDir);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(currentAbsoluteDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (files.length >= MAX_TURN_BASELINE_FILES) break;
+      if (entry.name.includes('\0')) continue;
+
+      const relativePath = currentRelativeDir
+        ? path.posix.join(currentRelativeDir, entry.name)
+        : entry.name;
+
+      if (entry.isDirectory()) {
+        if (!TURN_BASELINE_IGNORED_DIRS.has(entry.name)) {
+          stack.push(relativePath);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && isSafeRepoRelativePath(relativePath)) {
+        files.push(relativePath);
+      }
+    }
+  }
+
+  return files;
 }
 
 /**
@@ -147,6 +244,7 @@ function resolveRepoRelativePath(gitRoot: string, absolutePath: string): string 
  */
 const pendingToolUses = new Map<string, ToolUseInfo>();
 const pendingEditFilesSnapshots = new Map<string, PendingSnapshotEntry>();
+const pendingEditFilesBaselines = new Map<string, EditFilesBaselineEntry>();
 const MAX_PENDING_EDIT_FILES_SNAPSHOTS = 400;
 
 /**
@@ -179,16 +277,8 @@ export function registerToolInvocationStart(
     if (!changes || changes.length === 0) return;
 
     const workingDirectory = context?.workingDirectory;
-    let gitRoot: string;
-    try {
-      gitRoot = execSync('git rev-parse --show-toplevel', {
-        encoding: 'utf-8',
-        timeout: 5000,
-        ...(workingDirectory ? { cwd: workingDirectory } : {}),
-      }).trim();
-    } catch {
-      return;
-    }
+    const gitRoot = getGitRoot(workingDirectory);
+    if (!gitRoot) return;
 
     const snapshots: EditFilesSnapshot[] = [];
     for (const change of changes) {
@@ -202,24 +292,14 @@ export function registerToolInvocationStart(
       // Only snapshot files inside the repo.
       if (!resolveRepoRelativePath(gitRoot, absolutePath)) continue;
 
-      let beforeExists = false;
-      let beforeContent: string | undefined;
-      try {
-        const stat = fs.statSync(absolutePath);
-        if (stat.size <= MAX_FILE_SIZE_BYTES) {
-          beforeContent = fs.readFileSync(absolutePath, 'utf-8');
-        }
-        beforeExists = true;
-      } catch {
-        beforeExists = false;
-      }
+      const before = readTextFileSnapshot(absolutePath);
 
       snapshots.push({
         path: change.path,
         kind,
         absolutePath,
-        beforeExists,
-        beforeContent,
+        beforeExists: before.exists,
+        beforeContent: before.content,
       });
     }
 
@@ -242,6 +322,54 @@ export function registerToolInvocationStart(
  */
 export function clearToolInvocationState(toolUseId: string, context?: DiffEnrichmentContext): void {
   pendingEditFilesSnapshots.delete(getSnapshotKey(toolUseId, context));
+}
+
+/**
+ * Capture a best-effort in-memory repo baseline at the start of a Codex turn.
+ *
+ * Codex SDK 0.135 emits `file_change` items only after the patch has been
+ * applied, so there is no per-file `tool_start` moment with target paths for
+ * edit_files. This turn baseline gives edit_files a true pre-image for dirty
+ * tracked and untracked files without falling back to git HEAD. The baseline is
+ * updated after each edit_files result so multiple edits to the same file in one
+ * turn render as per-operation diffs.
+ */
+export function registerEditFilesTurnBaseline(context?: DiffEnrichmentContext): void {
+  try {
+    const workingDirectory = context?.workingDirectory;
+    if (!workingDirectory) return;
+
+    const gitRoot = getGitRoot(workingDirectory);
+    if (!gitRoot) return;
+
+    const files = new Map<string, TextFileSnapshot>();
+    let totalBytes = 0;
+    for (const relativePath of listTurnBaselineFiles(gitRoot)) {
+      const absolutePath = path.join(gitRoot, relativePath);
+      const snapshot = readTextFileSnapshot(absolutePath);
+      if (snapshot.content !== undefined) {
+        const byteLength = Buffer.byteLength(snapshot.content, 'utf-8');
+        if (totalBytes + byteLength > MAX_TURN_BASELINE_BYTES) {
+          files.set(relativePath, { exists: true, skipped: true });
+          continue;
+        }
+        totalBytes += byteLength;
+      }
+      files.set(relativePath, snapshot);
+    }
+
+    pendingEditFilesBaselines.set(getBaselineKey(context), {
+      gitRoot,
+      files,
+      createdAt: Date.now(),
+    });
+  } catch {
+    // Best effort — swallow any errors.
+  }
+}
+
+export function clearEditFilesTurnBaseline(context?: DiffEnrichmentContext): void {
+  pendingEditFilesBaselines.delete(getBaselineKey(context));
 }
 
 /**
@@ -517,6 +645,7 @@ function enrichEditFilesResult(
 
   if (snapshots?.length) {
     const snapshotDiffs = enrichFromEditFilesSnapshots(snapshots);
+    refreshEditFilesBaselineFromSnapshots(context, snapshots);
     if (snapshotDiffs.length > 0) {
       block.diff = {
         structuredPatch: snapshotDiffs[0].structuredPatch,
@@ -526,17 +655,22 @@ function enrichEditFilesResult(
     }
   }
 
-  // Find git root once for relative path resolution
-  let gitRoot: string;
-  try {
-    gitRoot = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-      timeout: 5000,
-      ...(workingDirectory ? { cwd: workingDirectory } : {}),
-    }).trim();
-  } catch {
-    return; // Not in a git repo or git unavailable
+  const baselineSnapshots = snapshotsFromEditFilesBaseline(changes, context);
+  if (baselineSnapshots.length > 0) {
+    const baselineDiffs = enrichFromEditFilesSnapshots(baselineSnapshots);
+    refreshEditFilesBaselineFromSnapshots(context, baselineSnapshots);
+    if (baselineDiffs.length > 0) {
+      block.diff = {
+        structuredPatch: baselineDiffs[0].structuredPatch,
+        files: baselineDiffs,
+      };
+      return;
+    }
   }
+
+  // Find git root once for relative path resolution
+  const gitRoot = getGitRoot(workingDirectory);
+  if (!gitRoot) return; // Not in a git repo or git unavailable
 
   const fileDiffs: FileDiff[] = [];
 
@@ -596,6 +730,10 @@ function getSnapshotKey(toolUseId: string, context?: DiffEnrichmentContext): str
   return `${context?.snapshotScope ?? 'global'}:${toolUseId}`;
 }
 
+function getBaselineKey(context?: DiffEnrichmentContext): string {
+  return context?.snapshotScope ?? 'global';
+}
+
 function pruneOldestEditFilesSnapshots(): void {
   if (pendingEditFilesSnapshots.size <= MAX_PENDING_EDIT_FILES_SNAPSHOTS) return;
 
@@ -615,22 +753,20 @@ function enrichFromEditFilesSnapshots(snapshots: EditFilesSnapshot[]): FileDiff[
 
   for (const snapshot of snapshots) {
     try {
-      let afterExists = false;
-      let afterContent = '';
+      const after = readTextFileSnapshot(snapshot.absolutePath);
+      const afterExists = after.exists;
 
-      try {
-        const stat = fs.statSync(snapshot.absolutePath);
-        if (stat.size <= MAX_FILE_SIZE_BYTES) {
-          afterContent = fs.readFileSync(snapshot.absolutePath, 'utf-8');
-        }
-        afterExists = true;
-      } catch {
-        afterExists = false;
+      // Existing but skipped means large/binary/non-regular. Avoid false full-file
+      // add/delete/update diffs from an unknown side of the comparison.
+      if (
+        (snapshot.beforeExists && snapshot.beforeContent === undefined) ||
+        (afterExists && after.content === undefined)
+      ) {
+        continue;
       }
 
-      const beforeContent = snapshot.beforeExists ? (snapshot.beforeContent ?? '') : '';
-      const beforeForDiff = snapshot.beforeExists ? beforeContent : '';
-      const afterForDiff = afterExists ? afterContent : '';
+      const beforeForDiff = snapshot.beforeExists ? (snapshot.beforeContent ?? '') : '';
+      const afterForDiff = afterExists ? (after.content ?? '') : '';
       if (!snapshot.beforeExists && !afterExists) continue;
       if (beforeForDiff === afterForDiff) continue;
 
@@ -670,4 +806,55 @@ function enrichFromEditFilesSnapshots(snapshots: EditFilesSnapshot[]): FileDiff[
 
   // Keep fallback path in calling method if this yields no diffs.
   return fileDiffs;
+}
+
+function snapshotsFromEditFilesBaseline(
+  changes: FileChangeSpec[],
+  context?: DiffEnrichmentContext
+): EditFilesSnapshot[] {
+  const baseline = pendingEditFilesBaselines.get(getBaselineKey(context));
+  if (!baseline) return [];
+
+  const snapshots: EditFilesSnapshot[] = [];
+  for (const change of changes) {
+    if (!change?.path) continue;
+
+    const absolutePath = path.isAbsolute(change.path)
+      ? change.path
+      : path.resolve(context?.workingDirectory || baseline.gitRoot, change.path);
+    const relativePath = resolveRepoRelativePath(baseline.gitRoot, absolutePath);
+    if (!relativePath) continue;
+
+    const before = baseline.files.get(relativePath) ?? { exists: false };
+    snapshots.push({
+      path: relativePath,
+      kind: normalizeChangeKind(change.kind),
+      absolutePath,
+      beforeExists: before.exists,
+      beforeContent: before.content,
+    });
+  }
+
+  return snapshots;
+}
+
+function refreshEditFilesBaselineFromSnapshots(
+  context: DiffEnrichmentContext | undefined,
+  snapshots: EditFilesSnapshot[]
+): void {
+  const baseline = pendingEditFilesBaselines.get(getBaselineKey(context));
+  if (!baseline) return;
+
+  for (const snapshot of snapshots) {
+    const relativePath = resolveRepoRelativePath(baseline.gitRoot, snapshot.absolutePath);
+    if (!relativePath) continue;
+
+    const after = readTextFileSnapshot(snapshot.absolutePath);
+    if (!after.exists) {
+      baseline.files.delete(relativePath);
+      continue;
+    }
+
+    baseline.files.set(relativePath, after);
+  }
 }

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -112,10 +112,11 @@ function tryRealpath(p: string): string | null {
 
 function readTextFileSnapshot(absolutePath: string): TextFileSnapshot {
   try {
-    const stat = fs.statSync(absolutePath);
-    if (!stat.isFile()) {
+    const linkStat = fs.lstatSync(absolutePath);
+    if (!linkStat.isFile()) {
       return { exists: true, skipped: true };
     }
+    const stat = fs.statSync(absolutePath);
     if (stat.size > MAX_FILE_SIZE_BYTES) {
       return { exists: true, skipped: true };
     }

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -702,9 +702,9 @@ function enrichEditFilesResult(
       // Only render files inside the repo.
       if (!resolveRepoRelativePath(gitRoot, resolvedPath)) continue;
 
-      const stat = fs.statSync(resolvedPath);
-      if (stat.size > MAX_FILE_SIZE_BYTES) continue;
-      const content = fs.readFileSync(resolvedPath, 'utf-8');
+      const after = readTextFileSnapshot(resolvedPath);
+      if (!after.exists || after.content === undefined) continue;
+      const content = after.content;
       const patch = structuredPatch(filePath, filePath, '', content, '', '', {
         context: 0,
       });

--- a/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
+++ b/packages/executor/src/sdk-handlers/base/diff-enrichment.ts
@@ -18,9 +18,9 @@
  *    to enrich adjacent tool_result blocks in one pass.
  */
 
-import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { createGit } from '@agor/core/git';
 import type { FileDiff, StructuredPatchHunk } from '@agor/core/types';
 import { structuredPatch } from 'diff';
 
@@ -37,16 +37,6 @@ const MAX_STORED_DIFF_LINES_PER_FILE = 200;
 const MAX_TURN_BASELINE_FILES = 5_000;
 /** Maximum aggregate text bytes to keep in a Codex turn baseline. */
 const MAX_TURN_BASELINE_BYTES = 25 * 1_048_576;
-const TURN_BASELINE_IGNORED_DIRS = new Set([
-  '.git',
-  'node_modules',
-  '.pnpm',
-  'dist',
-  'build',
-  '.next',
-  '.turbo',
-  'coverage',
-]);
 
 interface ToolUseInfo {
   name: string;
@@ -141,54 +131,58 @@ function readTextFileSnapshot(absolutePath: string): TextFileSnapshot {
 }
 
 function getGitRoot(workingDirectory?: string): string | null {
+  let current = path.resolve(workingDirectory ?? process.cwd());
+
   try {
-    return execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-      timeout: 5000,
-      ...(workingDirectory ? { cwd: workingDirectory } : {}),
-    }).trim();
+    const stat = fs.statSync(current);
+    if (!stat.isDirectory()) {
+      current = path.dirname(current);
+    }
+  } catch {
+    current = path.dirname(current);
+  }
+
+  while (true) {
+    if (fs.existsSync(path.join(current, '.git'))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+async function getGitRootFromGit(workingDirectory: string): Promise<string | null> {
+  try {
+    const { git } = createGit(workingDirectory);
+    const gitRoot = (await git.raw(['rev-parse', '--show-toplevel'])).trim();
+    return gitRoot || null;
   } catch {
     return null;
   }
 }
 
-function listTurnBaselineFiles(gitRoot: string): string[] {
-  const files: string[] = [];
-  const stack = [''];
+async function listTurnBaselineFiles(gitRoot: string): Promise<string[]> {
+  try {
+    const { git } = createGit(gitRoot);
+    const output = await git.raw(['ls-files', '--cached', '--others', '--exclude-standard', '-z']);
+    const files: string[] = [];
+    const seen = new Set<string>();
 
-  while (stack.length > 0 && files.length < MAX_TURN_BASELINE_FILES) {
-    const currentRelativeDir = stack.pop() ?? '';
-    const currentAbsoluteDir = path.join(gitRoot, currentRelativeDir);
-
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(currentAbsoluteDir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
+    for (const rawPath of output.split('\0')) {
       if (files.length >= MAX_TURN_BASELINE_FILES) break;
-      if (entry.name.includes('\0')) continue;
-
-      const relativePath = currentRelativeDir
-        ? path.posix.join(currentRelativeDir, entry.name)
-        : entry.name;
-
-      if (entry.isDirectory()) {
-        if (!TURN_BASELINE_IGNORED_DIRS.has(entry.name)) {
-          stack.push(relativePath);
-        }
-        continue;
-      }
-
-      if (entry.isFile() && isSafeRepoRelativePath(relativePath)) {
-        files.push(relativePath);
-      }
+      if (!rawPath || seen.has(rawPath) || !isSafeRepoRelativePath(rawPath)) continue;
+      seen.add(rawPath);
+      files.push(rawPath);
     }
-  }
 
-  return files;
+    return files;
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -334,17 +328,19 @@ export function clearToolInvocationState(toolUseId: string, context?: DiffEnrich
  * updated after each edit_files result so multiple edits to the same file in one
  * turn render as per-operation diffs.
  */
-export function registerEditFilesTurnBaseline(context?: DiffEnrichmentContext): void {
+export async function registerEditFilesTurnBaseline(
+  context?: DiffEnrichmentContext
+): Promise<void> {
   try {
     const workingDirectory = context?.workingDirectory;
     if (!workingDirectory) return;
 
-    const gitRoot = getGitRoot(workingDirectory);
+    const gitRoot = await getGitRootFromGit(workingDirectory);
     if (!gitRoot) return;
 
     const files = new Map<string, TextFileSnapshot>();
     let totalBytes = 0;
-    for (const relativePath of listTurnBaselineFiles(gitRoot)) {
+    for (const relativePath of await listTurnBaselineFiles(gitRoot)) {
       const absolutePath = path.join(gitRoot, relativePath);
       const snapshot = readTextFileSnapshot(absolutePath);
       if (snapshot.content !== undefined) {
@@ -366,6 +362,16 @@ export function registerEditFilesTurnBaseline(context?: DiffEnrichmentContext): 
   } catch {
     // Best effort — swallow any errors.
   }
+}
+
+/**
+ * Refresh an existing turn baseline after a non-edit_files tool that may have
+ * mutated the worktree. This keeps later edit_files diffs scoped to their own
+ * operation instead of diffing against the beginning of the whole Codex turn.
+ */
+export async function refreshEditFilesTurnBaseline(context?: DiffEnrichmentContext): Promise<void> {
+  if (!pendingEditFilesBaselines.has(getBaselineKey(context))) return;
+  await registerEditFilesTurnBaseline(context);
 }
 
 export function clearEditFilesTurnBaseline(context?: DiffEnrichmentContext): void {

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -31,8 +31,10 @@ import {
   type TaskID,
 } from '../../types.js';
 import {
+  clearEditFilesTurnBaseline,
   clearToolInvocationState,
   enrichContentBlocks,
+  registerEditFilesTurnBaseline,
   registerToolInvocationStart,
 } from '../base/diff-enrichment.js';
 import type {
@@ -215,214 +217,68 @@ export class CodexTool implements ITool {
       }
     }
 
-    for await (const event of this.promptService.promptSessionStreaming(
-      sessionId,
-      prompt,
-      taskId,
-      permissionMode,
-      abortController
-    )) {
-      // Detect if execution was stopped early
-      if (event.type === 'stopped') {
-        wasStopped = true;
-        console.log(`🛑 Codex execution was stopped for session ${sessionId}`);
-        for (const toolUseId of pendingSnapshotToolIds) {
-          clearToolInvocationState(toolUseId, snapshotContext);
+    registerEditFilesTurnBaseline({
+      ...(workingDirectory ? { workingDirectory } : {}),
+      ...snapshotContext,
+    });
+
+    try {
+      for await (const event of this.promptService.promptSessionStreaming(
+        sessionId,
+        prompt,
+        taskId,
+        permissionMode,
+        abortController
+      )) {
+        // Detect if execution was stopped early
+        if (event.type === 'stopped') {
+          wasStopped = true;
+          console.log(`🛑 Codex execution was stopped for session ${sessionId}`);
+          for (const toolUseId of pendingSnapshotToolIds) {
+            clearToolInvocationState(toolUseId, snapshotContext);
+          }
+          pendingSnapshotToolIds.clear();
+          continue; // Skip processing this event
         }
-        pendingSnapshotToolIds.clear();
-        continue; // Skip processing this event
-      }
-      // Capture resolved model from partial/complete events
-      if (!resolvedModel) {
-        if (event.type === 'partial') {
-          resolvedModel = event.resolvedModel;
-        } else if (event.type === 'complete') {
-          resolvedModel = event.resolvedModel;
-        }
-      }
-
-      // Handle tool execution start (live UI indicator)
-      if (event.type === 'tool_start') {
-        registerToolInvocationStart(event.toolUse.id, event.toolUse.name, event.toolUse.input, {
-          ...(workingDirectory ? { workingDirectory } : {}),
-          ...snapshotContext,
-        });
-        pendingSnapshotToolIds.add(event.toolUse.id);
-
-        if (taskId) {
-          await this.emitTaskEvent('tool:start', {
-            task_id: taskId,
-            session_id: sessionId,
-            tool_use_id: event.toolUse.id,
-            tool_name: event.toolUse.name,
-          });
-        }
-
-        // Create tool row immediately so UI shows "running" state.
-        const toolMessageId = generateId() as MessageID;
-        await this.createAssistantMessage(
-          sessionId,
-          toolMessageId,
-          [
-            {
-              type: 'tool_use',
-              id: event.toolUse.id,
-              name: event.toolUse.name,
-              input: event.toolUse.input,
-            },
-          ],
-          [
-            {
-              id: event.toolUse.id,
-              name: event.toolUse.name,
-              input: event.toolUse.input,
-            },
-          ],
-          taskId,
-          nextIndex++,
-          resolvedModel
-        );
-        assistantMessageIds.push(toolMessageId);
-        pendingToolMessageIds.set(event.toolUse.id, toolMessageId);
-      }
-
-      if (event.type === 'complete' && event.usage) {
-        tokenUsage = event.usage;
-      }
-
-      if (event.type === 'complete' && event.rawContextUsage) {
-        rawContextUsage = event.rawContextUsage;
-      }
-
-      // Capture raw SDK response for token accounting
-      if (event.type === 'complete' && event.rawSdkEvent) {
-        rawSdkResponse = event.rawSdkEvent;
-      }
-
-      // Capture Codex thread ID
-      if (!capturedThreadId && event.threadId) {
-        capturedThreadId = event.threadId;
-        await this.captureThreadId(sessionId, capturedThreadId);
-      }
-
-      // Handle partial streaming events (token-level chunks)
-      // NOTE: Codex SDK does NOT emit partial/delta events for text — agent_message text
-      // arrives all at once via item.completed → complete events (which are handled below).
-      // This code path is kept for future compatibility if OpenAI adds true token-level streaming.
-      if (event.type === 'partial' && event.textChunk) {
-        // Start new message if needed
-        if (!currentMessageId) {
-          const newMessageId = generateId() as MessageID;
-          _firstTokenTime = Date.now();
-
-          if (streamingCallbacks) {
-            try {
-              await streamingCallbacks.onStreamStart(newMessageId, {
-                session_id: sessionId,
-                task_id: taskId,
-                role: MessageRole.ASSISTANT,
-                timestamp: new Date().toISOString(),
-              });
-              // Only track message ID after successful start
-              currentMessageId = newMessageId;
-              streamStarted = true;
-            } catch (err) {
-              console.error(`[Codex] Streaming start failed for ${newMessageId}:`, err);
-              try {
-                await streamingCallbacks.onStreamError(
-                  newMessageId,
-                  err instanceof Error ? err : new Error(String(err))
-                );
-              } catch {
-                /* best-effort */
-              }
-            }
-          } else {
-            currentMessageId = newMessageId;
+        // Capture resolved model from partial/complete events
+        if (!resolvedModel) {
+          if (event.type === 'partial') {
+            resolvedModel = event.resolvedModel;
+          } else if (event.type === 'complete') {
+            resolvedModel = event.resolvedModel;
           }
         }
 
-        // Emit chunk immediately
-        if (streamingCallbacks && currentMessageId) {
-          try {
-            await streamingCallbacks.onStreamChunk(currentMessageId, event.textChunk);
-          } catch (err) {
-            console.error(`[Codex] Streaming chunk failed for ${currentMessageId}:`, err);
-            try {
-              await streamingCallbacks.onStreamError(
-                currentMessageId,
-                err instanceof Error ? err : new Error(String(err))
-              );
-            } catch {
-              /* best-effort */
-            }
+        // Handle tool execution start (live UI indicator)
+        if (event.type === 'tool_start') {
+          registerToolInvocationStart(event.toolUse.id, event.toolUse.name, event.toolUse.input, {
+            ...(workingDirectory ? { workingDirectory } : {}),
+            ...snapshotContext,
+          });
+          pendingSnapshotToolIds.add(event.toolUse.id);
+
+          if (taskId) {
+            await this.emitTaskEvent('tool:start', {
+              task_id: taskId,
+              session_id: sessionId,
+              tool_use_id: event.toolUse.id,
+              tool_name: event.toolUse.name,
+            });
           }
-        }
-      }
-      // Handle tool completion (create message immediately for live updates)
-      else if (event.type === 'tool_complete') {
-        if (taskId) {
-          await this.emitTaskEvent('tool:complete', {
-            task_id: taskId,
-            session_id: sessionId,
-            tool_use_id: event.toolUse.id,
-          });
-        }
 
-        const toolResultContent =
-          event.toolUse.output !== undefined
-            ? event.toolUse.output
-            : event.toolUse.status
-              ? `[${event.toolUse.status}]`
-              : '';
-        const toolContent = [
-          {
-            type: 'tool_use',
-            id: event.toolUse.id,
-            name: event.toolUse.name,
-            input: event.toolUse.input,
-          },
-          ...(event.toolUse.output !== undefined || event.toolUse.status
-            ? [
-                {
-                  type: 'tool_result',
-                  tool_use_id: event.toolUse.id,
-                  content: toolResultContent,
-                  is_error: event.toolUse.status === 'failed' || event.toolUse.status === 'error',
-                },
-              ]
-            : []),
-        ];
-
-        // Best-effort diff enrichment for Edit/Write tool results
-        enrichContentBlocks(toolContent, {
-          ...(workingDirectory ? { workingDirectory } : {}),
-          ...snapshotContext,
-        });
-        clearToolInvocationState(event.toolUse.id, snapshotContext);
-        pendingSnapshotToolIds.delete(event.toolUse.id);
-
-        const existingToolMessageId = pendingToolMessageIds.get(event.toolUse.id);
-        if (existingToolMessageId) {
-          await this.messagesService?.patch(existingToolMessageId, {
-            content: toolContent as Message['content'],
-            content_preview:
-              typeof toolResultContent === 'string' ? toolResultContent.substring(0, 200) : '',
-          });
-          pendingToolMessageIds.delete(event.toolUse.id);
-        } else {
-          // Fallback path if start event wasn't observed.
+          // Create tool row immediately so UI shows "running" state.
           const toolMessageId = generateId() as MessageID;
           await this.createAssistantMessage(
             sessionId,
             toolMessageId,
-            toolContent as Array<{
-              type: string;
-              text?: string;
-              id?: string;
-              name?: string;
-              input?: Record<string, unknown>;
-            }>,
+            [
+              {
+                type: 'tool_use',
+                id: event.toolUse.id,
+                name: event.toolUse.name,
+                input: event.toolUse.input,
+              },
+            ],
             [
               {
                 id: event.toolUse.id,
@@ -435,58 +291,74 @@ export class CodexTool implements ITool {
             resolvedModel
           );
           assistantMessageIds.push(toolMessageId);
+          pendingToolMessageIds.set(event.toolUse.id, toolMessageId);
         }
-      }
-      // Handle complete message (save to database)
-      else if (event.type === 'complete' && event.content) {
-        const usageForMessage = event.usage ?? tokenUsage;
-        // Filter out tool_use and tool_result blocks (already saved via tool_complete events),
-        // but keep text + thinking blocks so Codex reasoning is visible in the UI.
-        const nonToolContent = event.content.filter(
-          (block) => block.type === 'text' || block.type === 'thinking'
-        );
 
-        // Only create message if there's non-tool content (not just tools)
-        if (nonToolContent.length > 0) {
-          // Extract full text for streaming callback
-          const fullText = nonToolContent
-            .filter((block) => block.type === 'text')
-            .map((block) => (block as { text?: string }).text || '')
-            .join('');
-          const fullThinking = nonToolContent
-            .filter((block) => block.type === 'thinking')
-            .map((block) => (block as { text?: string }).text || '')
-            .join('');
+        if (event.type === 'complete' && event.usage) {
+          tokenUsage = event.usage;
+        }
 
-          // Use existing message ID from streaming (if any) or generate new
-          const assistantMessageId = currentMessageId || (generateId() as MessageID);
+        if (event.type === 'complete' && event.rawContextUsage) {
+          rawContextUsage = event.rawContextUsage;
+        }
 
-          // Codex SDK doesn't support token-level text streaming, but we can still
-          // use streaming callbacks to show text immediately via WebSocket before DB write.
-          // This sends the complete text as a single "chunk" for instant display.
-          if (streamingCallbacks && fullText) {
-            try {
-              if (!currentMessageId) {
-                // No partial path — send full start/chunk/end sequence
-                await streamingCallbacks.onStreamStart(assistantMessageId, {
+        // Capture raw SDK response for token accounting
+        if (event.type === 'complete' && event.rawSdkEvent) {
+          rawSdkResponse = event.rawSdkEvent;
+        }
+
+        // Capture Codex thread ID
+        if (!capturedThreadId && event.threadId) {
+          capturedThreadId = event.threadId;
+          await this.captureThreadId(sessionId, capturedThreadId);
+        }
+
+        // Handle partial streaming events (token-level chunks)
+        // NOTE: Codex SDK does NOT emit partial/delta events for text — agent_message text
+        // arrives all at once via item.completed → complete events (which are handled below).
+        // This code path is kept for future compatibility if OpenAI adds true token-level streaming.
+        if (event.type === 'partial' && event.textChunk) {
+          // Start new message if needed
+          if (!currentMessageId) {
+            const newMessageId = generateId() as MessageID;
+            _firstTokenTime = Date.now();
+
+            if (streamingCallbacks) {
+              try {
+                await streamingCallbacks.onStreamStart(newMessageId, {
                   session_id: sessionId,
                   task_id: taskId,
                   role: MessageRole.ASSISTANT,
                   timestamp: new Date().toISOString(),
                 });
+                // Only track message ID after successful start
+                currentMessageId = newMessageId;
                 streamStarted = true;
-                await streamingCallbacks.onStreamChunk(assistantMessageId, fullText);
+              } catch (err) {
+                console.error(`[Codex] Streaming start failed for ${newMessageId}:`, err);
+                try {
+                  await streamingCallbacks.onStreamError(
+                    newMessageId,
+                    err instanceof Error ? err : new Error(String(err))
+                  );
+                } catch {
+                  /* best-effort */
+                }
               }
-              // Only close stream if one was successfully started
-              if (streamStarted) {
-                await streamingCallbacks.onStreamEnd(assistantMessageId);
-              }
+            } else {
+              currentMessageId = newMessageId;
+            }
+          }
+
+          // Emit chunk immediately
+          if (streamingCallbacks && currentMessageId) {
+            try {
+              await streamingCallbacks.onStreamChunk(currentMessageId, event.textChunk);
             } catch (err) {
-              console.error(`[Codex] Streaming callback failed for ${assistantMessageId}:`, err);
-              // Notify UI so it can clear spinner/pending state
+              console.error(`[Codex] Streaming chunk failed for ${currentMessageId}:`, err);
               try {
                 await streamingCallbacks.onStreamError(
-                  assistantMessageId,
+                  currentMessageId,
                   err instanceof Error ? err : new Error(String(err))
                 );
               } catch {
@@ -494,46 +366,189 @@ export class CodexTool implements ITool {
               }
             }
           }
-
-          // Codex reasoning is not token-streamed by SDK. Emit a synthetic single
-          // thinking chunk so users see reasoning activity in real time.
-          if (streamingCallbacks && fullThinking && !fullText) {
-            try {
-              if (streamingCallbacks.onThinkingStart) {
-                await streamingCallbacks.onThinkingStart(assistantMessageId, {});
-              }
-              if (streamingCallbacks.onThinkingChunk) {
-                await streamingCallbacks.onThinkingChunk(assistantMessageId, fullThinking);
-              }
-              if (streamingCallbacks.onThinkingEnd) {
-                await streamingCallbacks.onThinkingEnd(assistantMessageId);
-              }
-            } catch (err) {
-              console.error(`[Codex] Thinking callback failed for ${assistantMessageId}:`, err);
-            }
+        }
+        // Handle tool completion (create message immediately for live updates)
+        else if (event.type === 'tool_complete') {
+          if (taskId) {
+            await this.emitTaskEvent('tool:complete', {
+              task_id: taskId,
+              session_id: sessionId,
+              tool_use_id: event.toolUse.id,
+            });
           }
 
-          // Create complete message in DB (non-tool content only, tools already saved)
-          await this.createAssistantMessage(
-            sessionId,
-            assistantMessageId,
-            nonToolContent,
-            undefined, // No tool uses in this message (already saved separately)
-            taskId,
-            nextIndex++,
-            resolvedModel,
-            usageForMessage
-          );
-          assistantMessageIds.push(assistantMessageId);
+          const toolResultContent =
+            event.toolUse.output !== undefined
+              ? event.toolUse.output
+              : event.toolUse.status
+                ? `[${event.toolUse.status}]`
+                : '';
+          const toolContent = [
+            {
+              type: 'tool_use',
+              id: event.toolUse.id,
+              name: event.toolUse.name,
+              input: event.toolUse.input,
+            },
+            ...(event.toolUse.output !== undefined || event.toolUse.status
+              ? [
+                  {
+                    type: 'tool_result',
+                    tool_use_id: event.toolUse.id,
+                    content: toolResultContent,
+                    is_error: event.toolUse.status === 'failed' || event.toolUse.status === 'error',
+                  },
+                ]
+              : []),
+          ];
 
-          // Reset for next message
-          currentMessageId = null;
-          streamStarted = false;
+          // Best-effort diff enrichment for Edit/Write tool results
+          enrichContentBlocks(toolContent, {
+            ...(workingDirectory ? { workingDirectory } : {}),
+            ...snapshotContext,
+          });
+          clearToolInvocationState(event.toolUse.id, snapshotContext);
+          pendingSnapshotToolIds.delete(event.toolUse.id);
+
+          const existingToolMessageId = pendingToolMessageIds.get(event.toolUse.id);
+          if (existingToolMessageId) {
+            await this.messagesService?.patch(existingToolMessageId, {
+              content: toolContent as Message['content'],
+              content_preview:
+                typeof toolResultContent === 'string' ? toolResultContent.substring(0, 200) : '',
+            });
+            pendingToolMessageIds.delete(event.toolUse.id);
+          } else {
+            // Fallback path if start event wasn't observed.
+            const toolMessageId = generateId() as MessageID;
+            await this.createAssistantMessage(
+              sessionId,
+              toolMessageId,
+              toolContent as Array<{
+                type: string;
+                text?: string;
+                id?: string;
+                name?: string;
+                input?: Record<string, unknown>;
+              }>,
+              [
+                {
+                  id: event.toolUse.id,
+                  name: event.toolUse.name,
+                  input: event.toolUse.input,
+                },
+              ],
+              taskId,
+              nextIndex++,
+              resolvedModel
+            );
+            assistantMessageIds.push(toolMessageId);
+          }
         }
+        // Handle complete message (save to database)
+        else if (event.type === 'complete' && event.content) {
+          const usageForMessage = event.usage ?? tokenUsage;
+          // Filter out tool_use and tool_result blocks (already saved via tool_complete events),
+          // but keep text + thinking blocks so Codex reasoning is visible in the UI.
+          const nonToolContent = event.content.filter(
+            (block) => block.type === 'text' || block.type === 'thinking'
+          );
 
-        _streamStartTime = Date.now();
-        _firstTokenTime = null;
+          // Only create message if there's non-tool content (not just tools)
+          if (nonToolContent.length > 0) {
+            // Extract full text for streaming callback
+            const fullText = nonToolContent
+              .filter((block) => block.type === 'text')
+              .map((block) => (block as { text?: string }).text || '')
+              .join('');
+            const fullThinking = nonToolContent
+              .filter((block) => block.type === 'thinking')
+              .map((block) => (block as { text?: string }).text || '')
+              .join('');
+
+            // Use existing message ID from streaming (if any) or generate new
+            const assistantMessageId = currentMessageId || (generateId() as MessageID);
+
+            // Codex SDK doesn't support token-level text streaming, but we can still
+            // use streaming callbacks to show text immediately via WebSocket before DB write.
+            // This sends the complete text as a single "chunk" for instant display.
+            if (streamingCallbacks && fullText) {
+              try {
+                if (!currentMessageId) {
+                  // No partial path — send full start/chunk/end sequence
+                  await streamingCallbacks.onStreamStart(assistantMessageId, {
+                    session_id: sessionId,
+                    task_id: taskId,
+                    role: MessageRole.ASSISTANT,
+                    timestamp: new Date().toISOString(),
+                  });
+                  streamStarted = true;
+                  await streamingCallbacks.onStreamChunk(assistantMessageId, fullText);
+                }
+                // Only close stream if one was successfully started
+                if (streamStarted) {
+                  await streamingCallbacks.onStreamEnd(assistantMessageId);
+                }
+              } catch (err) {
+                console.error(`[Codex] Streaming callback failed for ${assistantMessageId}:`, err);
+                // Notify UI so it can clear spinner/pending state
+                try {
+                  await streamingCallbacks.onStreamError(
+                    assistantMessageId,
+                    err instanceof Error ? err : new Error(String(err))
+                  );
+                } catch {
+                  /* best-effort */
+                }
+              }
+            }
+
+            // Codex reasoning is not token-streamed by SDK. Emit a synthetic single
+            // thinking chunk so users see reasoning activity in real time.
+            if (streamingCallbacks && fullThinking && !fullText) {
+              try {
+                if (streamingCallbacks.onThinkingStart) {
+                  await streamingCallbacks.onThinkingStart(assistantMessageId, {});
+                }
+                if (streamingCallbacks.onThinkingChunk) {
+                  await streamingCallbacks.onThinkingChunk(assistantMessageId, fullThinking);
+                }
+                if (streamingCallbacks.onThinkingEnd) {
+                  await streamingCallbacks.onThinkingEnd(assistantMessageId);
+                }
+              } catch (err) {
+                console.error(`[Codex] Thinking callback failed for ${assistantMessageId}:`, err);
+              }
+            }
+
+            // Create complete message in DB (non-tool content only, tools already saved)
+            await this.createAssistantMessage(
+              sessionId,
+              assistantMessageId,
+              nonToolContent,
+              undefined, // No tool uses in this message (already saved separately)
+              taskId,
+              nextIndex++,
+              resolvedModel,
+              usageForMessage
+            );
+            assistantMessageIds.push(assistantMessageId);
+
+            // Reset for next message
+            currentMessageId = null;
+            streamStarted = false;
+          }
+
+          _streamStartTime = Date.now();
+          _firstTokenTime = null;
+        }
       }
+    } finally {
+      for (const toolUseId of pendingSnapshotToolIds) {
+        clearToolInvocationState(toolUseId, snapshotContext);
+      }
+      pendingSnapshotToolIds.clear();
+      clearEditFilesTurnBaseline(snapshotContext);
     }
 
     return {
@@ -679,73 +694,97 @@ export class CodexTool implements ITool {
     let rawSdkResponse: unknown;
     let rawContextUsage: ContextUsageSnapshot | undefined;
     let wasStopped = false;
+    let workingDirectory: string | undefined;
+    const snapshotContext = { snapshotScope: sessionId };
 
-    for await (const event of this.promptService.promptSessionStreaming(
-      sessionId,
-      prompt,
-      taskId,
-      permissionMode
-    )) {
-      // Detect if execution was stopped early
-      if (event.type === 'stopped') {
-        wasStopped = true;
-        console.log(`🛑 Codex execution was stopped for session ${sessionId}`);
-        continue; // Skip processing this event
+    if (this.sessionsRepo && this.branchesRepo) {
+      const session = await this.sessionsRepo.findById(sessionId);
+      if (session) {
+        const branch = await this.branchesRepo.findById(session.branch_id);
+        workingDirectory = branch?.path;
       }
+    }
 
-      // Capture resolved model from partial/complete events
-      if (!resolvedModel) {
-        if (event.type === 'partial') {
-          resolvedModel = event.resolvedModel;
-        } else if (event.type === 'complete') {
-          resolvedModel = event.resolvedModel;
+    registerEditFilesTurnBaseline({
+      ...(workingDirectory ? { workingDirectory } : {}),
+      ...snapshotContext,
+    });
+
+    try {
+      for await (const event of this.promptService.promptSessionStreaming(
+        sessionId,
+        prompt,
+        taskId,
+        permissionMode
+      )) {
+        // Detect if execution was stopped early
+        if (event.type === 'stopped') {
+          wasStopped = true;
+          console.log(`🛑 Codex execution was stopped for session ${sessionId}`);
+          continue; // Skip processing this event
+        }
+
+        // Capture resolved model from partial/complete events
+        if (!resolvedModel) {
+          if (event.type === 'partial') {
+            resolvedModel = event.resolvedModel;
+          } else if (event.type === 'complete') {
+            resolvedModel = event.resolvedModel;
+          }
+        }
+
+        if (event.type === 'complete' && event.usage) {
+          tokenUsage = event.usage;
+        }
+
+        if (event.type === 'complete' && event.rawContextUsage) {
+          rawContextUsage = event.rawContextUsage;
+        }
+
+        // Capture raw SDK response for token accounting
+        if (event.type === 'complete' && event.rawSdkEvent) {
+          rawSdkResponse = event.rawSdkEvent;
+        }
+
+        // Capture Codex thread ID
+        if (!capturedThreadId && event.threadId) {
+          capturedThreadId = event.threadId;
+          await this.captureThreadId(sessionId, capturedThreadId);
+        }
+
+        // Skip partial and tool events in non-streaming mode
+        if (
+          event.type === 'partial' ||
+          event.type === 'tool_start' ||
+          event.type === 'tool_complete'
+        ) {
+          continue;
+        }
+
+        // Handle complete messages only
+        if (event.type === 'complete' && event.content) {
+          enrichContentBlocks(event.content, {
+            ...(workingDirectory ? { workingDirectory } : {}),
+            ...snapshotContext,
+          });
+
+          const messageId = generateId() as MessageID;
+          const usageForMessage = event.usage ?? tokenUsage;
+          await this.createAssistantMessage(
+            sessionId,
+            messageId,
+            event.content,
+            event.toolUses,
+            taskId,
+            nextIndex++,
+            resolvedModel,
+            usageForMessage
+          );
+          assistantMessageIds.push(messageId);
         }
       }
-
-      if (event.type === 'complete' && event.usage) {
-        tokenUsage = event.usage;
-      }
-
-      if (event.type === 'complete' && event.rawContextUsage) {
-        rawContextUsage = event.rawContextUsage;
-      }
-
-      // Capture raw SDK response for token accounting
-      if (event.type === 'complete' && event.rawSdkEvent) {
-        rawSdkResponse = event.rawSdkEvent;
-      }
-
-      // Capture Codex thread ID
-      if (!capturedThreadId && event.threadId) {
-        capturedThreadId = event.threadId;
-        await this.captureThreadId(sessionId, capturedThreadId);
-      }
-
-      // Skip partial and tool events in non-streaming mode
-      if (
-        event.type === 'partial' ||
-        event.type === 'tool_start' ||
-        event.type === 'tool_complete'
-      ) {
-        continue;
-      }
-
-      // Handle complete messages only
-      if (event.type === 'complete' && event.content) {
-        const messageId = generateId() as MessageID;
-        const usageForMessage = event.usage ?? tokenUsage;
-        await this.createAssistantMessage(
-          sessionId,
-          messageId,
-          event.content,
-          event.toolUses,
-          taskId,
-          nextIndex++,
-          resolvedModel,
-          usageForMessage
-        );
-        assistantMessageIds.push(messageId);
-      }
+    } finally {
+      clearEditFilesTurnBaseline(snapshotContext);
     }
 
     return {

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -64,7 +64,13 @@ interface CodexExecutionResult {
 }
 
 function shouldRefreshEditFilesBaselineAfterTool(toolName: string): boolean {
-  return toolName.toLowerCase() !== 'edit_files';
+  const normalized = toolName.toLowerCase();
+  if (normalized === 'edit_files') return false;
+
+  // Codex-native command execution is normalized to Bash. MCP tools are
+  // represented as "server.tool"; keep those conservative because an MCP can
+  // mutate the branch filesystem.
+  return normalized === 'bash' || toolName.includes('.');
 }
 
 export class CodexTool implements ITool {

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -34,6 +34,7 @@ import {
   clearEditFilesTurnBaseline,
   clearToolInvocationState,
   enrichContentBlocks,
+  refreshEditFilesTurnBaseline,
   registerEditFilesTurnBaseline,
   registerToolInvocationStart,
 } from '../base/diff-enrichment.js';
@@ -60,6 +61,10 @@ interface CodexExecutionResult {
   rawSdkResponse?: unknown; // Raw SDK event from Codex
   rawContextUsage?: ContextUsageSnapshot;
   wasStopped?: boolean; // True if execution was stopped early via stopTask()
+}
+
+function shouldRefreshEditFilesBaselineAfterTool(toolName: string): boolean {
+  return toolName.toLowerCase() !== 'edit_files';
 }
 
 export class CodexTool implements ITool {
@@ -217,7 +222,7 @@ export class CodexTool implements ITool {
       }
     }
 
-    registerEditFilesTurnBaseline({
+    await registerEditFilesTurnBaseline({
       ...(workingDirectory ? { workingDirectory } : {}),
       ...snapshotContext,
     });
@@ -407,6 +412,12 @@ export class CodexTool implements ITool {
             ...(workingDirectory ? { workingDirectory } : {}),
             ...snapshotContext,
           });
+          if (shouldRefreshEditFilesBaselineAfterTool(event.toolUse.name)) {
+            await refreshEditFilesTurnBaseline({
+              ...(workingDirectory ? { workingDirectory } : {}),
+              ...snapshotContext,
+            });
+          }
           clearToolInvocationState(event.toolUse.id, snapshotContext);
           pendingSnapshotToolIds.delete(event.toolUse.id);
 
@@ -705,7 +716,7 @@ export class CodexTool implements ITool {
       }
     }
 
-    registerEditFilesTurnBaseline({
+    await registerEditFilesTurnBaseline({
       ...(workingDirectory ? { workingDirectory } : {}),
       ...snapshotContext,
     });
@@ -753,11 +764,17 @@ export class CodexTool implements ITool {
         }
 
         // Skip partial and tool events in non-streaming mode
-        if (
-          event.type === 'partial' ||
-          event.type === 'tool_start' ||
-          event.type === 'tool_complete'
-        ) {
+        if (event.type === 'tool_complete') {
+          if (shouldRefreshEditFilesBaselineAfterTool(event.toolUse.name)) {
+            await refreshEditFilesTurnBaseline({
+              ...(workingDirectory ? { workingDirectory } : {}),
+              ...snapshotContext,
+            });
+          }
+          continue;
+        }
+
+        if (event.type === 'partial' || event.type === 'tool_start') {
           continue;
         }
 


### PR DESCRIPTION
## Summary

- capture Codex `edit_files` pre/post content in memory so update/delete diffs render correctly even when Codex only reports `file_change` after patch application
- refresh the in-memory baseline after each `edit_files` result so repeated edits to the same file show per-operation diffs
- harden diff capture for create/delete, binary/large/non-regular files, stopped tasks, and absolute-vs-relative path matching
- prevent `edit_files` operation labels like `Update` from wrapping by adding nowrap/ellipsis/tooltip styling

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/executor test -- diff-enrichment.test.ts`
- `pnpm --filter agor-ui test -- EditFilesRenderer.test.tsx`
