### PR TITLE
Fix MCP user search and pagination ergonomics

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.test.ts
+++ b/apps/agor-daemon/src/mcp/routes.test.ts
@@ -99,6 +99,7 @@ describeIntegration('MCP Tools - Session Tools', () => {
     expect(toolNames).toContain('agor_tasks_list');
     expect(toolNames).toContain('agor_tasks_get');
     expect(toolNames).toContain('agor_users_list');
+    expect(toolNames).toContain('agor_users_find');
     expect(toolNames).toContain('agor_users_get');
     expect(toolNames).toContain('agor_users_get_current');
     expect(toolNames).toContain('agor_users_update_current');
@@ -537,7 +538,27 @@ describeIntegration('MCP Tools - User Tools', () => {
 
     expect(result).toHaveProperty('total');
     expect(result).toHaveProperty('data');
+    expect(result.limit).toBe(5);
+    expect(result.skip).toBe(0);
     expect(Array.isArray(result.data)).toBe(true);
+    expect(result.data.length).toBeLessThanOrEqual(5);
+    if (result.data.length > 0) {
+      expect(result.data[0]).toHaveProperty('user_id');
+      expect(result.data[0]).toHaveProperty('email');
+      expect(result.data[0]).not.toHaveProperty('env_vars');
+      expect(result.data[0]).not.toHaveProperty('default_agentic_config');
+    }
+  });
+
+  it('agor_users_find returns compact matches', async () => {
+    const currentUser = await callMCPTool('agor_users_get_current');
+    const result = await callMCPTool('agor_users_find', { email: currentUser.email, limit: 5 });
+
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(
+      result.data.some((user: { user_id: string }) => user.user_id === currentUser.user_id)
+    ).toBe(true);
+    expect(result.data[0]).not.toHaveProperty('env_vars');
   });
 
   it('agor_users_get_current returns current user', async () => {

--- a/apps/agor-daemon/src/mcp/tools/users.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.test.ts
@@ -43,4 +43,226 @@ describe('user MCP tools in sessionless context', () => {
     expect(parsed.user_id).toBe('user-1');
     expect(getUser).toHaveBeenCalledWith('user-1', {});
   });
+
+  it('agor_users_list paginates, searches, and returns compact rows by default', async () => {
+    const findUsers = vi.fn(async () => ({
+      total: 2,
+      limit: 1,
+      skip: 1,
+      data: [
+        {
+          user_id: 'user-2',
+          email: 'reed@preset.io',
+          name: 'Reed',
+          emoji: '🎸',
+          role: 'member',
+          unix_username: 'reed',
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: new Date('2026-01-02T00:00:00.000Z'),
+          env_vars: { SECRET: { set: true, scope: 'global' } },
+          default_agentic_config: { 'claude-code': { model_config: { mode: 'alias' } } },
+        },
+      ],
+    }));
+    let handler: ToolHandler | undefined;
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+        if (name === 'agor_users_list') handler = cb;
+      },
+    } as unknown as McpServer;
+
+    registerUserTools(fakeServer, {
+      app: {
+        service: (name: string) => {
+          if (name !== 'users') throw new Error(`Unexpected service: ${name}`);
+          return { find: findUsers };
+        },
+      } as any,
+      db: {} as any,
+      userId: 'admin-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'admin-1', email: 'admin@example.com', role: 'admin' } as any,
+      baseServiceParams: { authenticated: true },
+    });
+
+    if (!handler) throw new Error('agor_users_list was not registered');
+    const result = await handler({ limit: 1, skip: 1, search: 'reed' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(findUsers).toHaveBeenCalledWith({
+      query: { $limit: 1, $skip: 1, search: 'reed' },
+      authenticated: true,
+    });
+    expect(parsed).toMatchObject({ total: 2, limit: 1, skip: 1 });
+    expect(parsed.data[0]).toEqual({
+      user_id: 'user-2',
+      email: 'reed@preset.io',
+      name: 'Reed',
+      emoji: '🎸',
+      role: 'member',
+      unix_username: 'reed',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('agor_users_list supports detailed and field-selected output modes', async () => {
+    const detailedUser = {
+      user_id: 'user-2',
+      email: 'reed@preset.io',
+      name: 'Reed',
+      emoji: '🎸',
+      role: 'member',
+      unix_username: 'reed',
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      env_vars: { SECRET: { set: true, scope: 'global' } },
+    };
+    const findUsers = vi.fn(async () => ({
+      total: 1,
+      limit: 50,
+      skip: 0,
+      data: [detailedUser],
+    }));
+    let handler: ToolHandler | undefined;
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+        if (name === 'agor_users_list') handler = cb;
+      },
+    } as unknown as McpServer;
+
+    registerUserTools(fakeServer, {
+      app: {
+        service: (name: string) => {
+          if (name !== 'users') throw new Error(`Unexpected service: ${name}`);
+          return { find: findUsers };
+        },
+      } as any,
+      db: {} as any,
+      userId: 'admin-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'admin-1', email: 'admin@example.com', role: 'admin' } as any,
+      baseServiceParams: {},
+    });
+
+    if (!handler) throw new Error('agor_users_list was not registered');
+
+    const detailed = JSON.parse((await handler({ lean: false })).content[0].text);
+    expect(detailed.data[0]).toHaveProperty('env_vars');
+
+    const selected = JSON.parse((await handler({ fields: ['user_id', 'emoji'] })).content[0].text);
+    expect(selected.data[0]).toEqual({ user_id: 'user-2', emoji: '🎸' });
+  });
+
+  it('agor_users_find returns compact matches using the search query', async () => {
+    const findUsers = vi.fn(async () => ({
+      total: 1,
+      limit: 10,
+      skip: 0,
+      data: [
+        {
+          user_id: 'user-2',
+          email: 'reed@preset.io',
+          name: 'Reed',
+          emoji: '🎸',
+          role: 'member',
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          onboarding_completed: true,
+          must_change_password: false,
+        },
+      ],
+    }));
+    let handler: ToolHandler | undefined;
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+        if (name === 'agor_users_find') handler = cb;
+      },
+    } as unknown as McpServer;
+
+    registerUserTools(fakeServer, {
+      app: {
+        service: (name: string) => {
+          if (name !== 'users') throw new Error(`Unexpected service: ${name}`);
+          return { find: findUsers };
+        },
+      } as any,
+      db: {} as any,
+      userId: 'admin-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'admin-1', email: 'admin@example.com', role: 'admin' } as any,
+      baseServiceParams: {},
+    });
+
+    if (!handler) throw new Error('agor_users_find was not registered');
+    const result = await handler({ query: 'Reed' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(findUsers).toHaveBeenCalledWith({
+      query: { search: 'Reed', $limit: 10, $skip: 0 },
+    });
+    expect(parsed.data[0]).toEqual({
+      user_id: 'user-2',
+      email: 'reed@preset.io',
+      name: 'Reed',
+      emoji: '🎸',
+      role: 'member',
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('agor_users_find applies field-specific filters after broad service search', async () => {
+    const findUsers = vi.fn(async () => ({
+      total: 2,
+      limit: 10000,
+      skip: 0,
+      data: [
+        {
+          user_id: 'user-2',
+          email: 'reed@preset.io',
+          name: 'Reed',
+          emoji: '🎸',
+          role: 'member',
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        {
+          user_id: 'user-3',
+          email: 'other@example.com',
+          name: 'Reed Elsewhere',
+          emoji: '🧪',
+          role: 'member',
+          created_at: new Date('2026-01-03T00:00:00.000Z'),
+        },
+      ],
+    }));
+    let handler: ToolHandler | undefined;
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+        if (name === 'agor_users_find') handler = cb;
+      },
+    } as unknown as McpServer;
+
+    registerUserTools(fakeServer, {
+      app: {
+        service: (name: string) => {
+          if (name !== 'users') throw new Error(`Unexpected service: ${name}`);
+          return { find: findUsers };
+        },
+      } as any,
+      db: {} as any,
+      userId: 'admin-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'admin-1', email: 'admin@example.com', role: 'admin' } as any,
+      baseServiceParams: {},
+    });
+
+    if (!handler) throw new Error('agor_users_find was not registered');
+    const result = await handler({ email: 'preset.io', limit: 5 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(findUsers).toHaveBeenCalledWith({
+      query: { search: 'preset.io', $limit: 10000, $skip: 0 },
+    });
+    expect(parsed.total).toBe(1);
+    expect(parsed.limit).toBe(5);
+    expect(parsed.data.map((user: { user_id: string }) => user.user_id)).toEqual(['user-2']);
+  });
 });

--- a/apps/agor-daemon/src/mcp/tools/users.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.ts
@@ -1,29 +1,191 @@
-import { ROLES } from '@agor/core/types';
+import { ROLES, type User } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
+
+const USER_LIST_FIELDS = [
+  'user_id',
+  'email',
+  'name',
+  'emoji',
+  'role',
+  'unix_username',
+  'created_at',
+  'updated_at',
+] as const;
+
+const USER_QUERY_LIMIT_MAX = 10000;
+
+type UserListField = (typeof USER_LIST_FIELDS)[number];
+type UserListRow = Pick<User, UserListField>;
+type UserFindField = 'email' | 'name' | 'unix_username';
+
+function compactUser(user: User, fields?: UserListField[]): Partial<UserListRow> {
+  const selectedFields = fields && fields.length > 0 ? fields : USER_LIST_FIELDS;
+  return Object.fromEntries(
+    selectedFields.map((field) => [field, user[field]])
+  ) as Partial<UserListRow>;
+}
+
+function compactUsersResult(
+  result: { total: number; limit: number; skip: number; data: User[] },
+  fields?: UserListField[]
+) {
+  return {
+    ...result,
+    data: result.data.map((user) => compactUser(user, fields)),
+  };
+}
+
+function includesCaseInsensitive(value: string | undefined, term: string): boolean {
+  return value?.toLowerCase().includes(term.toLowerCase()) ?? false;
+}
 
 export function registerUserTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_users_list
   server.registerTool(
     'agor_users_list',
     {
-      description: 'List all users in the system',
+      description:
+        'List users in the system with pagination and optional case-insensitive search across name, email, and unix_username. Returns compact rows by default; pass lean:false for detailed user payloads.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        limit: z
+          .number()
+          .int()
+          .nonnegative()
+          .max(USER_QUERY_LIMIT_MAX)
+          .optional()
+          .describe('Maximum number of results (default: 50)'),
+        skip: z
+          .number()
+          .int()
+          .nonnegative()
+          .max(USER_QUERY_LIMIT_MAX)
+          .optional()
+          .describe('Number of results to skip'),
+        offset: z
+          .number()
+          .int()
+          .nonnegative()
+          .max(USER_QUERY_LIMIT_MAX)
+          .optional()
+          .describe('Alias for skip'),
+        search: z
+          .string()
+          .optional()
+          .describe('Case-insensitive search across name, email, and unix_username'),
+        query: z
+          .string()
+          .optional()
+          .describe('Alias for search; case-insensitive name/email/unix_username lookup'),
+        lean: z
+          .boolean()
+          .optional()
+          .describe('Return compact rows only (default: true). Set false for detailed users.'),
+        fields: z
+          .array(z.enum(USER_LIST_FIELDS))
+          .optional()
+          .describe('Optional compact fields to return when lean is true'),
       }),
     },
     async (args) => {
-      const query: Record<string, unknown> = {};
-      if (args.limit) query.$limit = args.limit;
-      const users = await ctx.app.service('users').find({ query, ...ctx.baseServiceParams });
-      return textResult(users);
+      const query: Record<string, unknown> = {
+        $limit: args.limit ?? 50,
+        $skip: args.skip ?? args.offset ?? 0,
+      };
+      if (args.search) query.search = args.search;
+      if (args.query) query.search = args.query;
+
+      const users = (await ctx.app.service('users').find({
+        query,
+        ...ctx.baseServiceParams,
+      })) as { total: number; limit: number; skip: number; data: User[] };
+
+      return textResult(args.lean === false ? users : compactUsersResult(users, args.fields));
     }
   );
 
-  // Tool 2: agor_users_get
+  // Tool 2: agor_users_find
+  server.registerTool(
+    'agor_users_find',
+    {
+      description:
+        'Find users by name, email, or unix_username. Useful before admin updates: returns compact matching rows with user_id. Pass email when available; matching is case-insensitive substring.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        search: z
+          .string()
+          .optional()
+          .describe('Case-insensitive search across name, email, and unix_username'),
+        query: z.string().optional().describe('Alias for search'),
+        email: z.string().optional().describe('Email to search for (case-insensitive substring)'),
+        name: z.string().optional().describe('Name to search for (case-insensitive substring)'),
+        unix_username: z
+          .string()
+          .optional()
+          .describe('Unix username to search for (case-insensitive substring)'),
+        limit: z
+          .number()
+          .int()
+          .nonnegative()
+          .max(USER_QUERY_LIMIT_MAX)
+          .optional()
+          .describe('Maximum number of matches (default: 10)'),
+      }),
+    },
+    async (args) => {
+      const genericTerms = [args.search, args.query].filter(
+        (term): term is string => typeof term === 'string' && term.trim().length > 0
+      );
+      const fieldFilters = (
+        [
+          ['email', args.email],
+          ['name', args.name],
+          ['unix_username', args.unix_username],
+        ] satisfies Array<[UserFindField, string | undefined]>
+      ).filter((filter): filter is [UserFindField, string] => {
+        const [, term] = filter;
+        return typeof term === 'string' && term.trim().length > 0;
+      });
+      const firstFieldTerm = fieldFilters[0]?.[1];
+      const searchTerm = genericTerms[0] ?? firstFieldTerm;
+
+      if (!searchTerm) {
+        throw new Error('Provide search, query, email, name, or unix_username');
+      }
+
+      const requestedLimit = args.limit ?? 10;
+      const users = (await ctx.app.service('users').find({
+        query: {
+          search: searchTerm,
+          $limit: fieldFilters.length > 0 ? USER_QUERY_LIMIT_MAX : requestedLimit,
+          $skip: 0,
+        },
+        ...ctx.baseServiceParams,
+      })) as { total: number; limit: number; skip: number; data: User[] };
+
+      if (fieldFilters.length === 0) {
+        return textResult(compactUsersResult(users));
+      }
+
+      const filteredData = users.data.filter((user) =>
+        fieldFilters.every(([field, term]) => includesCaseInsensitive(user[field], term))
+      );
+
+      return textResult(
+        compactUsersResult({
+          total: filteredData.length,
+          limit: requestedLimit,
+          skip: 0,
+          data: filteredData.slice(0, requestedLimit),
+        })
+      );
+    }
+  );
+
+  // Tool 3: agor_users_get
   server.registerTool(
     'agor_users_get',
     {
@@ -39,7 +201,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     }
   );
 
-  // Tool 3: agor_users_get_current
+  // Tool 4: agor_users_get_current
   server.registerTool(
     'agor_users_get_current',
     {
@@ -54,7 +216,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     }
   );
 
-  // Tool 4: agor_users_update_current
+  // Tool 5: agor_users_update_current
   server.registerTool(
     'agor_users_update_current',
     {
@@ -85,7 +247,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     }
   );
 
-  // Tool 5: agor_users_update
+  // Tool 6: agor_users_update
   server.registerTool(
     'agor_users_update',
     {
@@ -144,7 +306,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     }
   );
 
-  // Tool 6: agor_user_create
+  // Tool 7: agor_user_create
   server.registerTool(
     'agor_user_create',
     {

--- a/apps/agor-daemon/src/services/users.find.test.ts
+++ b/apps/agor-daemon/src/services/users.find.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { UsersService } from './users';
+
+describe('UsersService.find', () => {
+  dbTest('respects limit/skip pagination and reports total matches', async ({ db }) => {
+    const service = new UsersService(db);
+
+    await service.create({ email: 'alpha@example.com', password: 'password-123', name: 'Alpha' });
+    await service.create({ email: 'bravo@example.com', password: 'password-123', name: 'Bravo' });
+    await service.create({
+      email: 'charlie@example.com',
+      password: 'password-123',
+      name: 'Charlie',
+    });
+
+    const page = await service.find({ query: { $limit: 1, $skip: 1 } });
+
+    expect(page.total).toBe(3);
+    expect(page.limit).toBe(1);
+    expect(page.skip).toBe(1);
+    expect(page.data).toHaveLength(1);
+    expect(page.data[0].email).toBe('bravo@example.com');
+  });
+
+  dbTest('supports offset alias for pagination', async ({ db }) => {
+    const service = new UsersService(db);
+
+    await service.create({ email: 'alpha@example.com', password: 'password-123', name: 'Alpha' });
+    await service.create({ email: 'bravo@example.com', password: 'password-123', name: 'Bravo' });
+
+    const page = await service.find({ query: { limit: 1, offset: 1 } });
+
+    expect(page.total).toBe(2);
+    expect(page.limit).toBe(1);
+    expect(page.skip).toBe(1);
+    expect(page.data.map((user) => user.email)).toEqual(['bravo@example.com']);
+  });
+
+  dbTest(
+    'searches name/email/unix_username case-insensitively before pagination',
+    async ({ db }) => {
+      const service = new UsersService(db);
+
+      await service.create({
+        email: 'reed@preset.io',
+        password: 'password-123',
+        name: 'Reed Thompson',
+        unix_username: 'rthompson',
+      });
+      await service.create({
+        email: 'someone@example.com',
+        password: 'password-123',
+        name: 'Someone Else',
+        unix_username: 'someone',
+      });
+
+      const byName = await service.find({ query: { search: 'REED', $limit: 10 } });
+      expect(byName.total).toBe(1);
+      expect(byName.data[0].email).toBe('reed@preset.io');
+
+      const byEmail = await service.find({ query: { q: 'PRESET.IO', $limit: 10 } });
+      expect(byEmail.total).toBe(1);
+      expect(byEmail.data[0].name).toBe('Reed Thompson');
+
+      const byUnix = await service.find({ query: { query: 'THOMP', $limit: 10 } });
+      expect(byUnix.total).toBe(1);
+      expect(byUnix.data[0].unix_username).toBe('rthompson');
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -51,6 +51,19 @@ import {
   toAgenticToolsStatus,
 } from '@agor/core/types';
 
+function optionalNonNegativeInteger(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return undefined;
+  return Math.floor(numeric);
+}
+
+function queryString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 /**
  * Apply a per-tool credential patch to the encrypted-at-rest blob.
  *
@@ -143,11 +156,20 @@ export class UsersService {
   constructor(protected db: Database) {}
 
   /**
-   * Find all users (supports filtering by email for authentication)
+   * Find all users.
+   *
+   * Supports:
+   * - `email` exact lookup for authentication (includes password, legacy behavior)
+   * - `search` / `query` / `q` case-insensitive substring lookup across
+   *   name, email, and unix_username
+   * - Feathers-style `$limit` / `$skip`, plus plain `limit` / `skip` /
+   *   `offset` for MCP/client ergonomics
    */
   async find(params?: Params): Promise<Paginated<User>> {
+    const rawQuery = (params?.query ?? {}) as Record<string, unknown>;
+
     // Check if filtering by email (for authentication)
-    const email = params?.query?.email as string | undefined;
+    const email = rawQuery.email as string | undefined;
     const includePassword = !!email; // Include password when looking up by email (for authentication)
     const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
       | UserID
@@ -163,12 +185,39 @@ export class UsersService {
       rows = await select(this.db).from(users).all();
     }
 
-    const results = rows.map((row) => this.rowToUser(row, includePassword, requesterId));
+    rows = rows.sort(
+      (a, b) => a.email.localeCompare(b.email) || a.user_id.localeCompare(b.user_id)
+    );
+
+    const search =
+      queryString(rawQuery.search) ?? queryString(rawQuery.query) ?? queryString(rawQuery.q);
+
+    if (search) {
+      const needle = search.toLowerCase();
+      rows = rows.filter((row) =>
+        [row.name, row.email, row.unix_username].some((value) =>
+          (value ?? '').toLowerCase().includes(needle)
+        )
+      );
+    }
+
+    const total = rows.length;
+    const skip =
+      optionalNonNegativeInteger(rawQuery.$skip) ??
+      optionalNonNegativeInteger(rawQuery.skip) ??
+      optionalNonNegativeInteger(rawQuery.offset) ??
+      0;
+    const limit =
+      optionalNonNegativeInteger(rawQuery.$limit) ?? optionalNonNegativeInteger(rawQuery.limit);
+    const pageRows =
+      limit === undefined ? rows.slice(skip) : rows.slice(skip, skip + Math.max(limit, 0));
+
+    const results = pageRows.map((row) => this.rowToUser(row, includePassword, requesterId));
 
     return {
-      total: results.length,
-      limit: results.length,
-      skip: 0,
+      total,
+      limit: limit ?? results.length,
+      skip,
       data: results,
     };
   }

--- a/apps/agor-docs/pages/guide/architecture.mdx
+++ b/apps/agor-docs/pages/guide/architecture.mdx
@@ -399,7 +399,8 @@ $ agor session list | grep running | wc -l
 **User Tools:**
 | Tool | Description | Example |
 |------|-------------|---------|
-| `agor_users_list` | List all users | `{ limit: 10 }` |
+| `agor_users_list` | List users with pagination, compact rows, and optional search | `{ search: 'reed', limit: 10 }` |
+| `agor_users_find` | Find users by name, email, or Unix username before admin updates | `{ email: 'reed@preset.io' }` |
 | `agor_users_get` | Get user by ID | `{ userId: '...' }` |
 | `agor_users_get_current` | Get current authenticated user | `{}` |
 | `agor_users_update_current` | Update own profile | `{ name: 'Alice', emoji: '🚀' }` |

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -3,6 +3,7 @@ import {
   boardObjectQueryValidator,
   branchQueryValidator,
   typedValidateQuery,
+  userQueryValidator,
 } from './feathers-validation';
 
 describe('boardObjectQueryValidator', () => {
@@ -55,6 +56,39 @@ describe('branchQueryValidator', () => {
       repo_id: '019e8e1c',
       zone_id: 'zone-review',
       archived: false,
+    });
+  });
+});
+
+describe('userQueryValidator', () => {
+  it('preserves user search and pagination aliases used by MCP tools', async () => {
+    const context = {
+      params: {
+        query: {
+          search: 'reed',
+          query: 'preset',
+          q: 'unix',
+          limit: '10',
+          skip: '2',
+          offset: '3',
+          $limit: '50',
+          $skip: '5',
+          unknown: 'removed',
+        },
+      },
+    };
+
+    await typedValidateQuery(userQueryValidator)(context);
+
+    expect(context.params.query).toEqual({
+      search: 'reed',
+      query: 'preset',
+      q: 'unix',
+      limit: 10,
+      skip: 2,
+      offset: 3,
+      $limit: 50,
+      $skip: 5,
     });
   });
 });

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -179,6 +179,12 @@ export const userQuerySchema = createQuerySchema(
   Type.Object({
     user_id: Type.Optional(CommonSchemas.uuid),
     email: Type.Optional(Type.String({ maxLength: 255 })),
+    search: Type.Optional(Type.String({ maxLength: 255 })),
+    query: Type.Optional(Type.String({ maxLength: 255 })),
+    q: Type.Optional(Type.String({ maxLength: 255 })),
+    limit: Type.Optional(Type.Integer({ minimum: 0, maximum: 10000 })),
+    skip: Type.Optional(Type.Integer({ minimum: 0, maximum: 10000 })),
+    offset: Type.Optional(Type.Integer({ minimum: 0, maximum: 10000 })),
     role: Type.Optional(
       Type.Union([
         Type.Literal('superadmin'),


### PR DESCRIPTION
## Summary

- make `agor_users_list` respect pagination and support `skip` / `offset`
- add case-insensitive user search across name, email, and Unix username
- return compact user rows from MCP list/find tools by default, with verbose output still available via `lean: false`
- add `agor_users_find` for reliable user lookup before admin updates
- cover service and MCP tool behavior with targeted tests

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test src/mcp/tools/users.test.ts src/services/users.find.test.ts`

## Notes

`agor_users_get` remains the detailed user fetch path. `agor_users_update` remains ID-based; agents can now reliably obtain the ID first via `agor_users_find({ query: "reed" })` or `agor_users_list({ search: "reed" })`.
