### PR TITLE
Fix groups/users Select search

### DIFF
--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
@@ -14,7 +14,11 @@ import { UserOutlined, WarningOutlined } from '@ant-design/icons';
 import { Alert, Form, Select, Space, Switch, Typography } from 'antd';
 import { useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
-import { filterSelectOptionBySearchText, groupSelectSearchText } from '../../../utils/selectSearch';
+import {
+  filterSelectOptionBySearchText,
+  groupSelectLabel,
+  groupSelectSearchText,
+} from '../../../utils/selectSearch';
 import { Tag } from '../../Tag';
 import type { FsAccessLevel, GroupGrantsStatus, PermissionsFormState } from '../useBranchModalForm';
 
@@ -182,7 +186,7 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
               options={allGroups
                 .map((group) => ({
                   value: group.group_id,
-                  label: group.name,
+                  label: groupSelectLabel(group),
                   searchText: groupSelectSearchText(group),
                 }))
                 .sort((a, b) => a.label.localeCompare(b.label))}

--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
@@ -9,15 +9,15 @@
  */
 
 import type { BranchPermissionLevel, Group, User } from '@agor-live/client';
-import { shortId } from '@agor-live/client';
 import { UserOutlined, WarningOutlined } from '@ant-design/icons';
 import { Alert, Form, Select, Space, Switch, Typography } from 'antd';
 import { useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
 import {
-  filterSelectOptionBySearchText,
-  groupSelectLabel,
-  groupSelectSearchText,
+  searchableSelectProps,
+  selectSearchTextFromLabel,
+  toGroupSelectOption,
+  toUserSelectOption,
 } from '../../../utils/selectSearch';
 import { Tag } from '../../Tag';
 import type { FsAccessLevel, GroupGrantsStatus, PermissionsFormState } from '../useBranchModalForm';
@@ -121,17 +121,17 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
             onChange={handleOwnersChange}
             loading={loadingOwners}
             disabled={!canEdit}
-            showSearch
-            filterOption={(input, option) =>
-              (option?.label?.toString() || '').toLowerCase().includes(input.toLowerCase())
-            }
-            optionLabelProp="label"
+            {...searchableSelectProps}
             options={allUsers
               .map((user) => {
                 const isCurrentUser = user.user_id === currentUserId;
-                const label = user.email || `User ${shortId(user.user_id)}`;
-                const displayLabel = isCurrentUser ? `${label} (You)` : label;
-                return { value: user.user_id, label: displayLabel };
+                const option = toUserSelectOption(user);
+                const label = isCurrentUser ? `${option.label} (You)` : option.label;
+                return {
+                  ...option,
+                  label,
+                  searchText: selectSearchTextFromLabel(label),
+                };
               })
               .sort((a, b) => a.label.localeCompare(b.label))}
             tagRender={(props) => {
@@ -184,16 +184,9 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
               loading={groupGrantsLoading}
               disabled={!canEditGroups}
               options={allGroups
-                .map((group) => ({
-                  value: group.group_id,
-                  label: groupSelectLabel(group),
-                  searchText: groupSelectSearchText(group),
-                }))
+                .map(toGroupSelectOption)
                 .sort((a, b) => a.label.localeCompare(b.label))}
-              showSearch
-              optionFilterProp="searchText"
-              optionLabelProp="label"
-              filterOption={filterSelectOptionBySearchText}
+              {...searchableSelectProps}
               onChange={(groupIds) => {
                 const existing = new Map(groupGrants.map((grant) => [grant.group_id, grant]));
                 setField(

--- a/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/PermissionsTab.tsx
@@ -14,6 +14,7 @@ import { UserOutlined, WarningOutlined } from '@ant-design/icons';
 import { Alert, Form, Select, Space, Switch, Typography } from 'antd';
 import { useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
+import { filterSelectOptionBySearchText, groupSelectSearchText } from '../../../utils/selectSearch';
 import { Tag } from '../../Tag';
 import type { FsAccessLevel, GroupGrantsStatus, PermissionsFormState } from '../useBranchModalForm';
 
@@ -179,8 +180,16 @@ export const PermissionsTab: React.FC<PermissionsTabProps> = ({
               loading={groupGrantsLoading}
               disabled={!canEditGroups}
               options={allGroups
-                .map((group) => ({ value: group.group_id, label: group.name }))
+                .map((group) => ({
+                  value: group.group_id,
+                  label: group.name,
+                  searchText: groupSelectSearchText(group),
+                }))
                 .sort((a, b) => a.label.localeCompare(b.label))}
+              showSearch
+              optionFilterProp="searchText"
+              optionLabelProp="label"
+              filterOption={filterSelectOptionBySearchText}
               onChange={(groupIds) => {
                 const existing = new Map(groupGrants.map((grant) => [grant.group_id, grant]));
                 setField(

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
@@ -16,11 +16,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { slugify } from '@/utils/repoSlug';
-import {
-  filterSelectOptionBySearchText,
-  userSelectLabel,
-  userSelectSearchText,
-} from '@/utils/selectSearch';
+import { searchableSelectProps, toUserSelectOption } from '@/utils/selectSearch';
 import { useThemedMessage } from '../../utils/message';
 import { syncGroupMembersForGroup } from './groupMembershipSync';
 
@@ -158,11 +154,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
   }
 
   const userOptions = mapToSortedArray(userById, (a, b) => a.email.localeCompare(b.email)).map(
-    (u) => ({
-      value: u.user_id,
-      label: userSelectLabel(u),
-      searchText: userSelectSearchText(u),
-    })
+    toUserSelectOption
   );
   return (
     <div>
@@ -199,10 +191,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
                 style={{ minWidth: 320 }}
                 value={membershipsByGroup.get(group.group_id) || []}
                 options={userOptions}
-                showSearch
-                optionFilterProp="searchText"
-                optionLabelProp="label"
-                filterOption={filterSelectOptionBySearchText}
+                {...searchableSelectProps}
                 onChange={(ids) => setGroupMembers(group, ids)}
               />
             ),
@@ -270,10 +259,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
               style={{ width: '100%' }}
               value={editingMemberIds}
               options={userOptions}
-              showSearch
-              optionFilterProp="searchText"
-              optionLabelProp="label"
-              filterOption={filterSelectOptionBySearchText}
+              {...searchableSelectProps}
               onChange={setEditingMemberIds}
               placeholder="Select users..."
             />

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
@@ -16,6 +16,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { slugify } from '@/utils/repoSlug';
+import { filterSelectOptionBySearchText, userSelectSearchText } from '@/utils/selectSearch';
 import { useThemedMessage } from '../../utils/message';
 import { syncGroupMembersForGroup } from './groupMembershipSync';
 
@@ -156,6 +157,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
     (u) => ({
       value: u.user_id,
       label: u.email,
+      searchText: userSelectSearchText(u),
     })
   );
   return (
@@ -193,6 +195,10 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
                 style={{ minWidth: 320 }}
                 value={membershipsByGroup.get(group.group_id) || []}
                 options={userOptions}
+                showSearch
+                optionFilterProp="searchText"
+                optionLabelProp="label"
+                filterOption={filterSelectOptionBySearchText}
                 onChange={(ids) => setGroupMembers(group, ids)}
               />
             ),
@@ -260,6 +266,10 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
               style={{ width: '100%' }}
               value={editingMemberIds}
               options={userOptions}
+              showSearch
+              optionFilterProp="searchText"
+              optionLabelProp="label"
+              filterOption={filterSelectOptionBySearchText}
               onChange={setEditingMemberIds}
               placeholder="Select users..."
             />

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
@@ -16,7 +16,11 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { slugify } from '@/utils/repoSlug';
-import { filterSelectOptionBySearchText, userSelectSearchText } from '@/utils/selectSearch';
+import {
+  filterSelectOptionBySearchText,
+  userSelectLabel,
+  userSelectSearchText,
+} from '@/utils/selectSearch';
 import { useThemedMessage } from '../../utils/message';
 import { syncGroupMembersForGroup } from './groupMembershipSync';
 
@@ -156,7 +160,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
   const userOptions = mapToSortedArray(userById, (a, b) => a.email.localeCompare(b.email)).map(
     (u) => ({
       value: u.user_id,
-      label: u.email,
+      label: userSelectLabel(u),
       searchText: userSelectSearchText(u),
     })
   );

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -38,8 +38,9 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
+import { filterSelectOptionBySearchText, groupSelectSearchText } from '../../utils/selectSearch';
 import {
   AgenticToolConfigForm,
   buildConfigFromFormValues,
@@ -109,6 +110,17 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [userGroupIds, setUserGroupIds] = useState<string[]>([]);
   const [loadingGroups, setLoadingGroups] = useState(false);
   const [groupsLoaded, setGroupsLoaded] = useState(false);
+  const groupSelectOptions = useMemo(
+    () =>
+      [...availableGroups]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((group) => ({
+          value: group.group_id,
+          label: group.name,
+          searchText: groupSelectSearchText(group),
+        })),
+    [availableGroups]
+  );
 
   // Saving state for agentic tool tabs
   const [savingAgenticConfig, setSavingAgenticConfig] = useState<Record<AgenticToolName, boolean>>({
@@ -698,9 +710,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   loading={loadingGroups}
                   disabled={!groupsLoaded && !loadingGroups}
                   placeholder="Select groups..."
-                  options={[...availableGroups]
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((group) => ({ value: group.group_id, label: group.name }))}
+                  options={groupSelectOptions}
+                  showSearch
+                  optionFilterProp="searchText"
+                  optionLabelProp="label"
+                  filterOption={filterSelectOptionBySearchText}
                 />
               </Form.Item>
             )}
@@ -764,9 +778,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   loading={loadingGroups}
                   disabled={!groupsLoaded && !loadingGroups}
                   placeholder="Select groups..."
-                  options={[...availableGroups]
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((group) => ({ value: group.group_id, label: group.name }))}
+                  options={groupSelectOptions}
+                  showSearch
+                  optionFilterProp="searchText"
+                  optionLabelProp="label"
+                  filterOption={filterSelectOptionBySearchText}
                 />
               </Form.Item>
             </Form>

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -40,11 +40,7 @@ import {
 } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
-import {
-  filterSelectOptionBySearchText,
-  groupSelectLabel,
-  groupSelectSearchText,
-} from '../../utils/selectSearch';
+import { searchableSelectProps, toGroupSelectOption } from '../../utils/selectSearch';
 import {
   AgenticToolConfigForm,
   buildConfigFromFormValues,
@@ -116,13 +112,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const [groupsLoaded, setGroupsLoaded] = useState(false);
   const groupSelectOptions = useMemo(
     () =>
-      [...availableGroups]
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((group) => ({
-          value: group.group_id,
-          label: groupSelectLabel(group),
-          searchText: groupSelectSearchText(group),
-        })),
+      [...availableGroups].sort((a, b) => a.name.localeCompare(b.name)).map(toGroupSelectOption),
     [availableGroups]
   );
 
@@ -715,10 +705,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   disabled={!groupsLoaded && !loadingGroups}
                   placeholder="Select groups..."
                   options={groupSelectOptions}
-                  showSearch
-                  optionFilterProp="searchText"
-                  optionLabelProp="label"
-                  filterOption={filterSelectOptionBySearchText}
+                  {...searchableSelectProps}
                 />
               </Form.Item>
             )}
@@ -783,10 +770,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   disabled={!groupsLoaded && !loadingGroups}
                   placeholder="Select groups..."
                   options={groupSelectOptions}
-                  showSearch
-                  optionFilterProp="searchText"
-                  optionLabelProp="label"
-                  filterOption={filterSelectOptionBySearchText}
+                  {...searchableSelectProps}
                 />
               </Form.Item>
             </Form>

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -40,7 +40,11 @@ import {
 } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
-import { filterSelectOptionBySearchText, groupSelectSearchText } from '../../utils/selectSearch';
+import {
+  filterSelectOptionBySearchText,
+  groupSelectLabel,
+  groupSelectSearchText,
+} from '../../utils/selectSearch';
 import {
   AgenticToolConfigForm,
   buildConfigFromFormValues,
@@ -116,7 +120,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((group) => ({
           value: group.group_id,
-          label: group.name,
+          label: groupSelectLabel(group),
           searchText: groupSelectSearchText(group),
         })),
     [availableGroups]

--- a/apps/agor-ui/src/utils/selectSearch.test.tsx
+++ b/apps/agor-ui/src/utils/selectSearch.test.tsx
@@ -2,7 +2,9 @@ import type { Group, User } from '@agor-live/client';
 import { describe, expect, it } from 'vitest';
 import {
   filterSelectOptionBySearchText,
+  groupSelectLabel,
   groupSelectSearchText,
+  userSelectLabel,
   userSelectSearchText,
 } from './selectSearch';
 
@@ -32,62 +34,81 @@ const makeGroup = (overrides: Partial<Group>): Group =>
   }) as Group;
 
 describe('Select search helpers', () => {
-  it('Settings → Groups user select filters by name and email', () => {
-    const searchText = userSelectSearchText(
-      makeUser({ name: 'Grace Hopper', email: 'grace@example.com', unix_username: 'ghopper' })
-    );
+  it('Settings → Groups user select filters by visible name/email label', () => {
+    const user = makeUser({
+      name: 'Grace Hopper',
+      email: 'grace@example.com',
+      unix_username: 'ghopper',
+    });
+    const label = userSelectLabel(user);
+    const searchText = userSelectSearchText(user);
 
-    expect(
-      filterSelectOptionBySearchText('grace', { value: 'user-1', label: 'JSX', searchText })
-    ).toBe(true);
+    expect(label).toBe('Grace Hopper (grace@example.com)');
+    expect(filterSelectOptionBySearchText('grace', { value: 'user-1', label, searchText })).toBe(
+      true
+    );
     expect(
       filterSelectOptionBySearchText('example.com', {
         value: 'user-1',
-        label: 'JSX',
+        label,
         searchText,
       })
     ).toBe(true);
-    expect(
-      filterSelectOptionBySearchText('ghopper', { value: 'user-1', label: 'JSX', searchText })
-    ).toBe(true);
+    expect(filterSelectOptionBySearchText('ghopper', { value: 'user-1', label, searchText })).toBe(
+      false
+    );
     expect(
       filterSelectOptionBySearchText('unrelated', {
         value: 'user-1',
-        label: 'JSX',
+        label,
         searchText,
       })
     ).toBe(false);
   });
 
-  it('Settings → Groups group select filters by group name', () => {
-    const searchText = groupSelectSearchText(makeGroup({ name: 'Design Systems' }));
+  it('Settings → Groups group select filters by visible name/slug label', () => {
+    const group = makeGroup({ name: 'Design Systems', slug: 'design-systems' });
+    const label = groupSelectLabel(group);
+    const searchText = groupSelectSearchText(group);
 
-    expect(
-      filterSelectOptionBySearchText('design', { value: 'group-1', label: 'JSX', searchText })
-    ).toBe(true);
-    expect(
-      filterSelectOptionBySearchText('systems', { value: 'group-1', label: 'JSX', searchText })
-    ).toBe(true);
-    expect(
-      filterSelectOptionBySearchText('finance', { value: 'group-1', label: 'JSX', searchText })
-    ).toBe(false);
+    expect(label).toBe('Design Systems (design-systems)');
+    expect(filterSelectOptionBySearchText('design', { value: 'group-1', label, searchText })).toBe(
+      true
+    );
+    expect(filterSelectOptionBySearchText('systems', { value: 'group-1', label, searchText })).toBe(
+      true
+    );
+    expect(filterSelectOptionBySearchText('finance', { value: 'group-1', label, searchText })).toBe(
+      false
+    );
   });
 
-  it('BranchModal Permissions group select filters by group name when labels are JSX', () => {
-    const searchText = groupSelectSearchText(makeGroup({ name: 'Release Managers' }));
+  it('BranchModal Permissions group select filters by visible group label when labels are JSX', () => {
+    const group = makeGroup({ name: 'Release Managers', slug: 'release-managers' });
+    const searchText = groupSelectSearchText(group);
 
     expect(
       filterSelectOptionBySearchText('release', {
         value: 'group-1',
-        label: <span>Release Managers</span>,
+        label: <span>{groupSelectLabel(group)}</span>,
         searchText,
       })
     ).toBe(true);
     expect(
       filterSelectOptionBySearchText('security', {
         value: 'group-1',
-        label: <span>Release Managers</span>,
+        label: <span>{groupSelectLabel(group)}</span>,
         searchText,
+      })
+    ).toBe(false);
+  });
+
+  it('does not match hidden option values that are not in the visible label', () => {
+    expect(
+      filterSelectOptionBySearchText('hidden-id', {
+        value: 'hidden-id',
+        label: 'Visible Label',
+        searchText: 'visible label',
       })
     ).toBe(false);
   });

--- a/apps/agor-ui/src/utils/selectSearch.test.tsx
+++ b/apps/agor-ui/src/utils/selectSearch.test.tsx
@@ -1,0 +1,94 @@
+import type { Group, User } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import {
+  filterSelectOptionBySearchText,
+  groupSelectSearchText,
+  userSelectSearchText,
+} from './selectSearch';
+
+const makeUser = (overrides: Partial<User>): User =>
+  ({
+    user_id: 'user-1',
+    email: 'ada@example.com',
+    name: 'Ada Lovelace',
+    role: 'member',
+    unix_username: 'ada_l',
+    onboarding_completed: true,
+    must_change_password: false,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }) as User;
+
+const makeGroup = (overrides: Partial<Group>): Group =>
+  ({
+    group_id: 'group-1',
+    name: 'Platform Engineers',
+    slug: 'platform-eng',
+    description: 'People who maintain the platform',
+    archived: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }) as Group;
+
+describe('Select search helpers', () => {
+  it('Settings → Groups user select filters by name and email', () => {
+    const searchText = userSelectSearchText(
+      makeUser({ name: 'Grace Hopper', email: 'grace@example.com', unix_username: 'ghopper' })
+    );
+
+    expect(
+      filterSelectOptionBySearchText('grace', { value: 'user-1', label: 'JSX', searchText })
+    ).toBe(true);
+    expect(
+      filterSelectOptionBySearchText('example.com', {
+        value: 'user-1',
+        label: 'JSX',
+        searchText,
+      })
+    ).toBe(true);
+    expect(
+      filterSelectOptionBySearchText('ghopper', { value: 'user-1', label: 'JSX', searchText })
+    ).toBe(true);
+    expect(
+      filterSelectOptionBySearchText('unrelated', {
+        value: 'user-1',
+        label: 'JSX',
+        searchText,
+      })
+    ).toBe(false);
+  });
+
+  it('Settings → Groups group select filters by group name', () => {
+    const searchText = groupSelectSearchText(makeGroup({ name: 'Design Systems' }));
+
+    expect(
+      filterSelectOptionBySearchText('design', { value: 'group-1', label: 'JSX', searchText })
+    ).toBe(true);
+    expect(
+      filterSelectOptionBySearchText('systems', { value: 'group-1', label: 'JSX', searchText })
+    ).toBe(true);
+    expect(
+      filterSelectOptionBySearchText('finance', { value: 'group-1', label: 'JSX', searchText })
+    ).toBe(false);
+  });
+
+  it('BranchModal Permissions group select filters by group name when labels are JSX', () => {
+    const searchText = groupSelectSearchText(makeGroup({ name: 'Release Managers' }));
+
+    expect(
+      filterSelectOptionBySearchText('release', {
+        value: 'group-1',
+        label: <span>Release Managers</span>,
+        searchText,
+      })
+    ).toBe(true);
+    expect(
+      filterSelectOptionBySearchText('security', {
+        value: 'group-1',
+        label: <span>Release Managers</span>,
+        searchText,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/agor-ui/src/utils/selectSearch.test.tsx
+++ b/apps/agor-ui/src/utils/selectSearch.test.tsx
@@ -4,6 +4,9 @@ import {
   filterSelectOptionBySearchText,
   groupSelectLabel,
   groupSelectSearchText,
+  searchableSelectProps,
+  toGroupSelectOption,
+  toUserSelectOption,
   userSelectLabel,
   userSelectSearchText,
 } from './selectSearch';
@@ -66,6 +69,23 @@ describe('Select search helpers', () => {
     ).toBe(false);
   });
 
+  it('builds user options with email-only fallback labels', () => {
+    const user = makeUser({ name: undefined, email: 'solo@example.com' });
+
+    expect(toUserSelectOption(user)).toEqual({
+      value: 'user-1',
+      label: 'solo@example.com',
+      searchText: 'solo@example.com',
+    });
+  });
+
+  it('does not duplicate user name when it matches email', () => {
+    const user = makeUser({ name: 'same@example.com', email: 'same@example.com' });
+
+    expect(userSelectLabel(user)).toBe('same@example.com');
+    expect(userSelectSearchText(user)).toBe('same@example.com');
+  });
+
   it('Settings → Groups group select filters by visible name/slug label', () => {
     const group = makeGroup({ name: 'Design Systems', slug: 'design-systems' });
     const label = groupSelectLabel(group);
@@ -81,6 +101,16 @@ describe('Select search helpers', () => {
     expect(filterSelectOptionBySearchText('finance', { value: 'group-1', label, searchText })).toBe(
       false
     );
+  });
+
+  it('builds group options from the visible name/slug label', () => {
+    const group = makeGroup({ name: 'Platform Engineers', slug: 'platform-eng' });
+
+    expect(toGroupSelectOption(group)).toEqual({
+      value: 'group-1',
+      label: 'Platform Engineers (platform-eng)',
+      searchText: 'platform engineers (platform-eng)',
+    });
   });
 
   it('BranchModal Permissions group select filters by visible group label when labels are JSX', () => {
@@ -111,5 +141,14 @@ describe('Select search helpers', () => {
         searchText: 'visible label',
       })
     ).toBe(false);
+  });
+
+  it('exports shared Ant Design Select search props', () => {
+    expect(searchableSelectProps).toMatchObject({
+      showSearch: true,
+      optionFilterProp: 'searchText',
+      optionLabelProp: 'label',
+    });
+    expect(searchableSelectProps.filterOption).toBe(filterSelectOptionBySearchText);
   });
 });

--- a/apps/agor-ui/src/utils/selectSearch.ts
+++ b/apps/agor-ui/src/utils/selectSearch.ts
@@ -1,0 +1,45 @@
+import type { Group, User } from '@agor-live/client';
+import type { ReactNode } from 'react';
+
+export interface SearchableSelectOption<Value extends string = string> {
+  value: Value;
+  label: ReactNode;
+  searchText: string;
+}
+
+const normalizeSearchText = (value: unknown): string =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase();
+
+const compactSearchText = (parts: Array<string | null | undefined>): string =>
+  parts.filter(Boolean).join(' ').toLowerCase();
+
+export const userSelectSearchText = (user: Pick<User, 'email' | 'name' | 'unix_username'>) =>
+  compactSearchText([user.name, user.email, user.unix_username]);
+
+export const groupSelectSearchText = (group: Pick<Group, 'name' | 'slug' | 'description'>) =>
+  compactSearchText([group.name, group.slug, group.description]);
+
+/**
+ * Ant Design Select's default filtering can search `value` instead of the
+ * human-readable option label when `options` are used, and JSX labels stringify
+ * poorly. Search a dedicated text field first, with string fallbacks for older
+ * options.
+ */
+export const filterSelectOptionBySearchText = (
+  input: string,
+  option?: {
+    searchText?: string;
+    label?: ReactNode;
+    value?: unknown;
+  } | null
+): boolean => {
+  const needle = normalizeSearchText(input);
+  if (!needle) return true;
+
+  const labelText = typeof option?.label === 'string' ? option.label : '';
+  return compactSearchText([option?.searchText, labelText, String(option?.value ?? '')]).includes(
+    needle
+  );
+};

--- a/apps/agor-ui/src/utils/selectSearch.ts
+++ b/apps/agor-ui/src/utils/selectSearch.ts
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 export interface SearchableSelectOption<Value extends string = string> {
   value: Value;
-  label: ReactNode;
+  label: string;
   searchText: string;
 }
 
@@ -31,6 +31,30 @@ export const userSelectSearchText = (user: Pick<User, 'email' | 'name'>) =>
 export const groupSelectSearchText = (group: Pick<Group, 'name' | 'slug'>) =>
   normalizeSearchText(groupSelectLabel(group));
 
+export const selectSearchTextFromLabel = (label: string) => normalizeSearchText(label);
+
+export const toUserSelectOption = (
+  user: Pick<User, 'user_id' | 'email' | 'name'>
+): SearchableSelectOption<User['user_id']> => {
+  const label = userSelectLabel(user);
+  return {
+    value: user.user_id,
+    label,
+    searchText: selectSearchTextFromLabel(label),
+  };
+};
+
+export const toGroupSelectOption = (
+  group: Pick<Group, 'group_id' | 'name' | 'slug'>
+): SearchableSelectOption<Group['group_id']> => {
+  const label = groupSelectLabel(group);
+  return {
+    value: group.group_id,
+    label,
+    searchText: selectSearchTextFromLabel(label),
+  };
+};
+
 /**
  * Ant Design Select's default filtering can search `value` instead of the
  * human-readable option label when `options` are used, and JSX labels stringify
@@ -42,6 +66,7 @@ export const filterSelectOptionBySearchText = (
   option?: {
     searchText?: string;
     label?: ReactNode;
+    value?: unknown;
   } | null
 ): boolean => {
   const needle = normalizeSearchText(input);
@@ -50,3 +75,10 @@ export const filterSelectOptionBySearchText = (
   const labelText = typeof option?.label === 'string' ? option.label : '';
   return compactSearchText([option?.searchText, labelText]).includes(needle);
 };
+
+export const searchableSelectProps = {
+  showSearch: true,
+  optionFilterProp: 'searchText',
+  optionLabelProp: 'label',
+  filterOption: filterSelectOptionBySearchText,
+} as const;

--- a/apps/agor-ui/src/utils/selectSearch.ts
+++ b/apps/agor-ui/src/utils/selectSearch.ts
@@ -15,31 +15,38 @@ const normalizeSearchText = (value: unknown): string =>
 const compactSearchText = (parts: Array<string | null | undefined>): string =>
   parts.filter(Boolean).join(' ').toLowerCase();
 
-export const userSelectSearchText = (user: Pick<User, 'email' | 'name' | 'unix_username'>) =>
-  compactSearchText([user.name, user.email, user.unix_username]);
+export const userSelectLabel = (user: Pick<User, 'email' | 'name'>): string => {
+  const name = user.name?.trim();
+  return name && name !== user.email ? `${name} (${user.email})` : user.email;
+};
 
-export const groupSelectSearchText = (group: Pick<Group, 'name' | 'slug' | 'description'>) =>
-  compactSearchText([group.name, group.slug, group.description]);
+export const groupSelectLabel = (group: Pick<Group, 'name' | 'slug'>): string => {
+  const slug = group.slug?.trim();
+  return slug && slug !== group.name ? `${group.name} (${slug})` : group.name;
+};
+
+export const userSelectSearchText = (user: Pick<User, 'email' | 'name'>) =>
+  normalizeSearchText(userSelectLabel(user));
+
+export const groupSelectSearchText = (group: Pick<Group, 'name' | 'slug'>) =>
+  normalizeSearchText(groupSelectLabel(group));
 
 /**
  * Ant Design Select's default filtering can search `value` instead of the
  * human-readable option label when `options` are used, and JSX labels stringify
- * poorly. Search a dedicated text field first, with string fallbacks for older
- * options.
+ * poorly. Search a dedicated text field that should match visible option text,
+ * with a string-label fallback for older options.
  */
 export const filterSelectOptionBySearchText = (
   input: string,
   option?: {
     searchText?: string;
     label?: ReactNode;
-    value?: unknown;
   } | null
 ): boolean => {
   const needle = normalizeSearchText(input);
   if (!needle) return true;
 
   const labelText = typeof option?.label === 'string' ? option.label : '';
-  return compactSearchText([option?.searchText, labelText, String(option?.value ?? '')]).includes(
-    needle
-  );
+  return compactSearchText([option?.searchText, labelText]).includes(needle);
 };


### PR DESCRIPTION
## Summary

- Add explicit Select search helpers so Ant Design does not search opaque IDs or stringify JSX labels.
- Make searchable option text match visible option labels.
- Display user options as `Name (email)` when a name is available, otherwise `email`.
- Display group options as `Group Name (slug)`.
- Share user/group option builders and common searchable Select props across Settings and BranchModal selectors.
- Apply the same user label/search behavior to BranchModal owners, Settings group membership, Settings user group membership, and BranchModal group grant selectors.
- Add focused tests for visible label search, hidden-value non-matches, fallback labels, duplicate label handling, option builders, and shared Select props.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-ui exec vitest run src/utils/selectSearch.test.tsx src/components/BranchModal/tabs/PermissionsTab.test.tsx`