### PR TITLE
fix(ui): refresh markdown preview on content edits

### DIFF
--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+// Regression harness for Streamdown's internal memoization behavior: this fake
+// renderer intentionally keeps the first children it receives until React
+// remounts it. MarkdownRenderer should force a remount for non-streaming content
+// changes so editor previews cannot get stuck on stale markdown.
+vi.mock('streamdown', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    Streamdown: ({ children }: { children: React.ReactNode }) => {
+      const [initialChildren] = ReactModule.useState(children);
+      return ReactModule.createElement('div', { 'data-testid': 'streamdown' }, initialChildren);
+    },
+  };
+});
+
+describe('MarkdownRenderer', () => {
+  it('remounts the non-streaming markdown renderer when content changes', () => {
+    const { rerender } = render(<MarkdownRenderer content="- and reusable prompts." />);
+
+    expect(screen.getByTestId('streamdown')).toHaveTextContent('- and reusable prompts.');
+
+    rerender(<MarkdownRenderer content="- and reusable prompts.updated" />);
+
+    expect(screen.getByTestId('streamdown')).toHaveTextContent('- and reusable prompts.updated');
+  });
+});

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -96,9 +96,18 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   // Always use Streamdown for rich features (Mermaid, math, GFM, copy/download buttons)
   // Only enable incomplete markdown parsing during active streaming
   // Security: Streamdown sanitizes HTML by default to prevent XSS
+  //
+  // Streamdown memoizes several internal markdown element components by source
+  // position. For non-streaming editor previews, some in-place edits can keep a
+  // stable internal block/component identity and leave old rendered text on
+  // screen. Key non-streaming renders by the normalized markdown text so every
+  // committed content change remounts Streamdown and refreshes the preview. Keep
+  // streaming renders on a stable key to avoid resetting animation/highlighting
+  // state on every chunk.
   return (
     <Typography style={mergedStyles} className={compact ? 'markdown-compact' : undefined}>
       <Streamdown
+        key={isStreaming ? 'streaming' : text}
         parseIncompleteMarkdown={isStreaming} // Parse incomplete syntax only while streaming
         className={inline ? 'inline-markdown' : 'markdown-content'}
         isAnimating={isStreaming} // Disable buttons during streaming


### PR DESCRIPTION
## Summary
- force non-streaming markdown renders to remount when content changes so editor previews do not retain stale Streamdown output
- add a focused regression test that simulates Streamdown retaining its initial children unless remounted

## Validation
- pnpm --filter agor-ui exec vitest run src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
- pnpm exec biome check apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx

## Notes
- UI typecheck was attempted, but this checkout lacks built workspace package declarations and source-condition typecheck hits existing core erasableSyntaxOnly errors; no errors were specific to the touched files.
