### PR TITLE
Fix Knowledge markdown preview refresh for list edits

### DIFF
--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -9,6 +9,14 @@ describe('MarkdownRenderer', () => {
     const { rerender } = render(<MarkdownRenderer content={doc} />);
     expect(screen.getByText(/Git syncing\?/)).toBeInTheDocument();
     rerender(<MarkdownRenderer content={doc.replace('Add semantic', 'Add amazing semantic')} />);
-    expect(await screen.findByText(/Add amazing semantic/)).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(
+        'Add amazing semantic and hybrid search once embeddings are configured.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Add semantic and hybrid search once embeddings are configured.')
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+const doc = `# Knowledge Base: Next Steps\n\n- Add semantic and hybrid search once embeddings are configured.\n- Introduce smart document units/chunking for long pages, without exposing chunking as a user-facing concept.\n- Use Knowledge as durable memory for Agor Assistants: preferences, project context, decisions, and reusable prompts.\n- Support skill bundles and lightweight import/export, including zip export later.\n- Keep polishing authoring: backlinks, better history/diff flows, and safer collaboration defaults.\n- autocomplete referencing from sessions and other places\n- Git syncing?`;
+
+describe('MarkdownRenderer', () => {
+  it('refreshes preview text when an earlier bullet list item changes', async () => {
+    const { rerender } = render(<MarkdownRenderer content={doc} />);
+    expect(screen.getByText(/Git syncing\?/)).toBeInTheDocument();
+    rerender(<MarkdownRenderer content={doc.replace('Add semantic', 'Add amazing semantic')} />);
+    expect(await screen.findByText(/Add amazing semantic/)).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -66,7 +66,8 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   const { token } = theme.useToken();
 
   // Handle array of strings: filter empty, join with double newlines
-  let text = Array.isArray(content) ? content.filter((t) => t.trim()).join('\n\n') : content;
+  const rawText = Array.isArray(content) ? content.filter((t) => t.trim()).join('\n\n') : content;
+  let text = rawText;
 
   // Pre-process text to highlight @ mentions
   text = highlightMentionsInMarkdown(text);
@@ -99,6 +100,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   return (
     <Typography style={mergedStyles} className={compact ? 'markdown-compact' : undefined}>
       <Streamdown
+        key={isStreaming ? undefined : markdownContentKey(rawText)}
         parseIncompleteMarkdown={isStreaming} // Parse incomplete syntax only while streaming
         className={inline ? 'inline-markdown' : 'markdown-content'}
         isAnimating={isStreaming} // Disable buttons during streaming
@@ -114,3 +116,18 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
 
 export const MarkdownRenderer = React.memo(MarkdownRendererInner);
 MarkdownRenderer.displayName = 'MarkdownRenderer';
+
+function markdownContentKey(text: string): string {
+  // Streamdown memoizes several rendered markdown node components by AST
+  // position. Container positions (for example a `<ul>` spanning multiple
+  // bullets) do not change when text changes inside an earlier child line, so
+  // React can skip reconciling that subtree and leave stale preview text. Use a
+  // content-derived key for non-streaming renders to remount Streamdown whenever
+  // the markdown source changes.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${text.length}:${(hash >>> 0).toString(36)}`;
+}

--- a/apps/agor-ui/vitest.config.ts
+++ b/apps/agor-ui/vitest.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    server: {
+      deps: {
+        inline: ['streamdown', 'katex'],
+      },
+    },
     exclude: [...configDefaults.exclude, 'src/utils/theme.test.ts'],
     // Ant Design Form / Select first-mount cost (CSS parse + JSDOM
     // getComputedStyle stubs) blows past vitest's 5s default on CI cold

--- a/apps/agor-ui/vitest.config.ts
+++ b/apps/agor-ui/vitest.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     setupFiles: './src/test/setup.ts',
     server: {
       deps: {
+        // Streamdown dynamically imports KaTeX CSS; inline both packages so
+        // Vite transforms that CSS import in jsdom component tests.
         inline: ['streamdown', 'katex'],
       },
     },


### PR DESCRIPTION
## Summary

- Fix stale Knowledge markdown previews when editing text inside earlier bullet list items.
- Force non-streaming `Streamdown` previews to remount when markdown content changes, avoiding Streamdown's AST-position memoization edge case.
- Add a regression test using the reported Knowledge document shape.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm -C apps/agor-ui test -- src/components/MarkdownRenderer/MarkdownRenderer.test.tsx`
