### PR TITLE
Fix board panel tab navbar actions

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -70,6 +70,7 @@ import { SessionSettingsModal } from '../SessionSettingsModal';
 import { SettingsModal, UserSettingsModal } from '../SettingsModal';
 import { TerminalModal, WEB_TERMINAL_MIN_ROLE } from '../TerminalModal';
 import { ThemeEditorModal } from '../ThemeEditorModal';
+import { getShowCommentsPanelState, getToggleBoardPanelState } from './boardPanelActions';
 import { getPrimaryAssistantSessionToRestore } from './primaryAssistantRestore';
 
 const { Content } = Layout;
@@ -551,14 +552,30 @@ export const App: React.FC<AppProps> = ({
     setTerminalOpen(true);
   }, []);
 
+  const applyLeftPanelState = useCallback(
+    (state: { collapsed: boolean; activeTab: BoardAssistantPanelTab }) => {
+      setLeftPanelTab(state.activeTab);
+      setCommentsPanelCollapsed(state.collapsed);
+    },
+    [setCommentsPanelCollapsed]
+  );
+
+  const handleToggleBoardPanel = useCallback(() => {
+    applyLeftPanelState(
+      getToggleBoardPanelState({
+        collapsed: leftPanelCollapsed,
+        activeTab: leftPanelTab,
+      })
+    );
+  }, [applyLeftPanelState, leftPanelCollapsed, leftPanelTab]);
+
   // Stable callbacks passed into SessionCanvas. These previously lived as
   // inline arrows in JSX, which gave them a fresh identity on every App
   // render — that propagated into the canvas's `initialNodes` useMemo deps
   // and triggered a full node-list recompute on every socket event.
   const handleOpenCommentsPanel = useCallback(() => {
-    setLeftPanelTab('comments');
-    setCommentsPanelCollapsed(false);
-  }, [setCommentsPanelCollapsed]);
+    applyLeftPanelState(getShowCommentsPanelState({ collapsed: true, activeTab: 'assistant' }));
+  }, [applyLeftPanelState]);
 
   const handleCommentSelect = useCallback((commentId: string | null) => {
     // Toggle selection: if clicking same comment, deselect
@@ -814,6 +831,13 @@ export const App: React.FC<AppProps> = ({
     : undefined;
   const primaryAssistantInaccessible = Boolean(primaryAssistantId && !primaryAssistantBranch);
 
+  // Preserve the historical board-switch behavior now that the panel itself
+  // no longer pushes a default tab into controlled parent state on mount.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset the tab when switching boards, even if the default tab string is unchanged.
+  useEffect(() => {
+    setLeftPanelTab(primaryAssistantInaccessible ? 'all-sessions' : 'assistant');
+  }, [currentBoard?.board_id, primaryAssistantInaccessible]);
+
   useEffect(() => {
     const latestSessionId = getPrimaryAssistantSessionToRestore({
       currentBoardId: currentBoard?.board_id,
@@ -964,11 +988,8 @@ export const App: React.FC<AppProps> = ({
               currentUserId={user?.user_id}
               connected={connected}
               connecting={connecting}
-              onMenuClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
-              onCommentsClick={() => {
-                setLeftPanelTab('comments');
-                setCommentsPanelCollapsed(false);
-              }}
+              onMenuClick={handleToggleBoardPanel}
+              onCommentsClick={handleOpenCommentsPanel}
               onEventStreamClick={() => {
                 // If session is open, close it and show event stream
                 if (effectiveSelectedSessionId) {

--- a/apps/agor-ui/src/components/App/boardPanelActions.test.ts
+++ b/apps/agor-ui/src/components/App/boardPanelActions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getShowCommentsPanelState, getToggleBoardPanelState } from './boardPanelActions';
+
+describe('board panel navbar actions', () => {
+  it('opens a closed panel on the Comments tab from Show comments tab', () => {
+    expect(getShowCommentsPanelState({ collapsed: true, activeTab: 'assistant' })).toEqual({
+      collapsed: false,
+      activeTab: 'comments',
+    });
+  });
+
+  it('selects Comments when Show comments tab is used from another open tab', () => {
+    expect(getShowCommentsPanelState({ collapsed: false, activeTab: 'all-sessions' })).toEqual({
+      collapsed: false,
+      activeTab: 'comments',
+    });
+  });
+
+  it('opens a closed panel on the Assistant tab from Toggle board panel', () => {
+    expect(getToggleBoardPanelState({ collapsed: true, activeTab: 'comments' })).toEqual({
+      collapsed: false,
+      activeTab: 'assistant',
+    });
+  });
+
+  it('preserves close behavior when Toggle board panel is used while open', () => {
+    expect(getToggleBoardPanelState({ collapsed: false, activeTab: 'comments' })).toEqual({
+      collapsed: true,
+      activeTab: 'comments',
+    });
+  });
+});

--- a/apps/agor-ui/src/components/App/boardPanelActions.ts
+++ b/apps/agor-ui/src/components/App/boardPanelActions.ts
@@ -1,0 +1,26 @@
+import type { BoardAssistantPanelTab } from '../BoardAssistantPanel';
+
+export interface BoardLeftPanelState {
+  collapsed: boolean;
+  activeTab: BoardAssistantPanelTab;
+}
+
+export const getShowCommentsPanelState = (state: BoardLeftPanelState): BoardLeftPanelState => ({
+  ...state,
+  collapsed: false,
+  activeTab: 'comments',
+});
+
+export const getToggleBoardPanelState = (state: BoardLeftPanelState): BoardLeftPanelState => {
+  if (state.collapsed) {
+    return {
+      collapsed: false,
+      activeTab: 'assistant',
+    };
+  }
+
+  return {
+    ...state,
+    collapsed: true,
+  };
+};

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx
@@ -1,0 +1,38 @@
+import type { Board } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { BoardAssistantPanel } from './BoardAssistantPanel';
+
+const board = { board_id: 'board-1' } as Board;
+
+const renderPanel = (props: Partial<ComponentProps<typeof BoardAssistantPanel>> = {}) =>
+  render(
+    <AntApp>
+      <BoardAssistantPanel
+        board={board}
+        activeTab="comments"
+        onTabChange={vi.fn()}
+        primaryAssistantInaccessible={false}
+        sessionsByBranch={new Map()}
+        branchById={new Map()}
+        repoById={new Map()}
+        userById={new Map()}
+        onSessionClick={vi.fn()}
+        client={null}
+        {...props}
+      />
+    </AntApp>
+  );
+
+describe('BoardAssistantPanel controlled tabs', () => {
+  it('does not reset a controlled Comments tab to the default tab on mount', () => {
+    const onTabChange = vi.fn();
+
+    renderPanel({ onTabChange });
+
+    expect(screen.getByRole('tab', { name: 'Comments' })).toHaveAttribute('aria-selected', 'true');
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -117,6 +117,7 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
     : 'assistant';
   const [uncontrolledActiveTab, setUncontrolledActiveTab] =
     useState<BoardAssistantPanelTab>(defaultTab);
+  const isControlled = controlledActiveTab !== undefined;
   const activeTab = controlledActiveTab ?? uncontrolledActiveTab;
   const setActiveTab = (tab: BoardAssistantPanelTab) => {
     setUncontrolledActiveTab(tab);
@@ -126,8 +127,10 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset the tab when switching boards, even if the default tab string is unchanged.
   useEffect(() => {
     setUncontrolledActiveTab(defaultTab);
-    onTabChange?.(defaultTab);
-  }, [defaultTab, board?.board_id, onTabChange]);
+    if (!isControlled) {
+      onTabChange?.(defaultTab);
+    }
+  }, [defaultTab, board?.board_id, isControlled, onTabChange]);
 
   const assistantOptions = useMemo(
     () =>


### PR DESCRIPTION
## Summary

- Fix board navbar actions so **Show comments tab** always opens the left panel and selects Comments.
- Make **Toggle board panel** reset to Assistant when reopening from a closed/collapsed state while preserving close behavior when already open.
- Prevent the controlled `BoardAssistantPanel` from overwriting the parent-selected tab with its default tab on mount.

## Tests

- `pnpm check`
- `pnpm --filter agor-ui test -- src/components/App/boardPanelActions.test.ts src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx`

## Notes

`pnpm check` currently emits existing lint warnings outside this change, but completed successfully.
