### PR TITLE
Add managed environment webhook-only mode

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -11,7 +11,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
   server.registerTool(
     'agor_environment_start',
     {
-      description: 'Start the environment for a branch by running its configured start command',
+      description:
+        'Start the environment for a branch using its configured start action (shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
         branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
@@ -45,7 +46,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
   server.registerTool(
     'agor_environment_stop',
     {
-      description: 'Stop the environment for a branch by running its configured stop command',
+      description:
+        'Stop the environment for a branch using its configured stop action (shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
         branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
@@ -108,7 +110,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
   server.registerTool(
     'agor_environment_logs',
     {
-      description: 'Fetch recent logs from a branch environment (non-streaming, last ~100 lines)',
+      description:
+        'Fetch recent logs from a branch environment (non-streaming, last ~100 lines; shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
@@ -278,7 +281,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
     'agor_environment_nuke',
     {
       description:
-        'Nuke the environment for a branch (destructive operation - typically removes volumes and all data)',
+        'Nuke the environment for a branch (destructive operation - typically removes volumes and all data; shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
         branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -7,7 +7,14 @@
  */
 
 import { analyticsLogger } from '@agor/core/analytics';
-import { type AgorConfig, isUnixImpersonationEnabled, type UnknownJson } from '@agor/core/config';
+import {
+  type AgorConfig,
+  isUnixImpersonationEnabled,
+  loadConfig,
+  type UnknownJson,
+  validateRepoEnvironment,
+  wrapV1AsV2,
+} from '@agor/core/config';
 import {
   ArtifactRepository,
   BoardRepository,
@@ -19,6 +26,12 @@ import {
   UserMCPOAuthTokenRepository,
   type UsersRepository,
 } from '@agor/core/db';
+import {
+  MANAGED_ENV_EXECUTION_MODE_DEFAULT,
+  validateManagedEnvLifecyclePolicy,
+  validateRenderedManagedEnvUrlFields,
+  validateRepoEnvironmentLifecyclePolicy,
+} from '@agor/core/environment/webhook';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
@@ -36,6 +49,7 @@ import {
 import type {
   AuthenticatedParams,
   Board,
+  Branch,
   HookContext,
   MCPServer,
   Paginated,
@@ -102,6 +116,99 @@ import {
   getDaemonUrl,
   spawnExecutorFireAndForget,
 } from './utils/spawn-executor.js';
+
+const BRANCH_ENV_FIELDS = [
+  'start_command',
+  'stop_command',
+  'nuke_command',
+  'logs_command',
+  'health_check_url',
+  'app_url',
+] as const;
+
+function itemHasAnyField(item: Record<string, unknown>, fields: readonly string[]): boolean {
+  return fields.some((field) => Object.hasOwn(item, field));
+}
+
+async function getManagedEnvExecutionMode() {
+  const config = await loadConfig();
+  return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
+}
+
+function validateRepoEnvPolicyHook() {
+  return async (context: HookContext) => {
+    const mode = await getManagedEnvExecutionMode();
+    const items = Array.isArray(context.data) ? context.data : [context.data];
+
+    for (const item of items as Array<Record<string, unknown>>) {
+      if (Object.hasOwn(item, 'environment') && item.environment !== null) {
+        try {
+          const env = validateRepoEnvironment(item.environment);
+          validateRepoEnvironmentLifecyclePolicy(env, mode);
+        } catch (error) {
+          throw new BadRequest(error instanceof Error ? error.message : 'Invalid repo environment');
+        }
+      }
+
+      if (Object.hasOwn(item, 'environment_config') && item.environment_config !== null) {
+        try {
+          const env = wrapV1AsV2(item.environment_config as Parameters<typeof wrapV1AsV2>[0]);
+          if (env) validateRepoEnvironmentLifecyclePolicy(env, mode, 'legacy repo environment');
+        } catch (error) {
+          throw new BadRequest(
+            error instanceof Error ? error.message : 'Invalid legacy repo environment'
+          );
+        }
+      }
+    }
+
+    return context;
+  };
+}
+
+function branchEnvFieldsFromItem(item: Partial<Branch>) {
+  return {
+    start: item.start_command,
+    stop: item.stop_command,
+    nuke: item.nuke_command,
+    logs: item.logs_command,
+  };
+}
+
+function validateBranchEnvPolicyHook() {
+  return async (context: HookContext) => {
+    const items = Array.isArray(context.data) ? context.data : [context.data];
+    const shouldValidate = (items as Array<Record<string, unknown>>).some((item) =>
+      itemHasAnyField(item, BRANCH_ENV_FIELDS)
+    );
+    if (!shouldValidate) return context;
+
+    const mode = await getManagedEnvExecutionMode();
+    for (const raw of items as Array<Partial<Branch>>) {
+      let item = raw;
+      if (context.method === 'patch' && context.id !== null && context.id !== undefined) {
+        const existing = (await context.service.get(context.id, context.params)) as Branch;
+        item = { ...existing, ...raw };
+      }
+
+      try {
+        validateManagedEnvLifecyclePolicy(
+          branchEnvFieldsFromItem(item),
+          mode,
+          'branch environment'
+        );
+        validateRenderedManagedEnvUrlFields({
+          health: item.health_check_url,
+          app: item.app_url,
+        });
+      } catch (error) {
+        throw new BadRequest(error instanceof Error ? error.message : 'Invalid branch environment');
+      }
+    }
+
+    return context;
+  };
+}
 
 /**
  * Session fields written as runtime bookkeeping during the prompt/execution
@@ -696,9 +803,21 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireAuth,
         requireMinimumRole(ROLES.MEMBER, 'access repositories'),
       ],
-      create: [requireMinimumRole(ROLES.MEMBER, 'create repositories'), requireAdminForEnvConfig()],
-      update: [requireMinimumRole(ROLES.MEMBER, 'update repositories'), requireAdminForEnvConfig()],
-      patch: [requireMinimumRole(ROLES.MEMBER, 'update repositories'), requireAdminForEnvConfig()],
+      create: [
+        requireMinimumRole(ROLES.MEMBER, 'create repositories'),
+        requireAdminForEnvConfig(),
+        validateRepoEnvPolicyHook(),
+      ],
+      update: [
+        requireMinimumRole(ROLES.MEMBER, 'update repositories'),
+        requireAdminForEnvConfig(),
+        validateRepoEnvPolicyHook(),
+      ],
+      patch: [
+        requireMinimumRole(ROLES.MEMBER, 'update repositories'),
+        requireAdminForEnvConfig(),
+        validateRepoEnvPolicyHook(),
+      ],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete repositories')],
     },
     after: {
@@ -731,11 +850,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create branches'),
         requireAdminForEnvConfig(),
+        validateBranchEnvPolicyHook(),
         injectCreatedBy(),
       ],
-      update: [requireMinimumRole(ROLES.MEMBER, 'update branches'), requireAdminForEnvConfig()],
+      update: [
+        requireMinimumRole(ROLES.MEMBER, 'update branches'),
+        requireAdminForEnvConfig(),
+        validateBranchEnvPolicyHook(),
+      ],
       patch: [
         requireAdminForEnvConfig(),
+        validateBranchEnvPolicyHook(),
         ...(branchRbacEnabled
           ? [
               loadBranch(branchRepository),

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3376,6 +3376,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // Value: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin'.
           // Defaults to 'member' when unset.
           managedEnvsMinimumRole: config.execution?.managed_envs_minimum_role ?? 'member',
+          // How managed environment lifecycle fields execute. In
+          // webhook-only mode the UI/MCP may still show env controls, but
+          // non-URL rendered commands are rejected server-side.
+          managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'command',
           // True when the daemon runs in a multi-user Unix isolation mode
           // (insulated/strict). UI hides "trust everyone on this instance"
           // surfaces when true. Server-side gates (e.g. ArtifactsService.
@@ -3423,6 +3427,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           execution: {
             branchRbac: config.execution?.branch_rbac === true,
             unixUserMode: config.execution?.unix_user_mode ?? 'simple',
+            managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'command',
           },
           // Resolved security posture — admins can confirm in Settings → About
           // which CSP/CORS policy the daemon booted with, without tailing logs

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -21,6 +21,7 @@ import {
   TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
+import { MANAGED_ENV_EXECUTION_MODE_DEFAULT } from '@agor/core/environment/webhook';
 import type { Application } from '@agor/core/feathers';
 import {
   AuthenticationService,
@@ -3379,7 +3380,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // How managed environment lifecycle fields execute. In
           // webhook-only mode the UI/MCP may still show env controls, but
           // non-URL rendered commands are rejected server-side.
-          managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'hybrid',
+          managedEnvsExecutionMode:
+            config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT,
           // True when the daemon runs in a multi-user Unix isolation mode
           // (insulated/strict). UI hides "trust everyone on this instance"
           // surfaces when true. Server-side gates (e.g. ArtifactsService.
@@ -3427,7 +3429,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           execution: {
             branchRbac: config.execution?.branch_rbac === true,
             unixUserMode: config.execution?.unix_user_mode ?? 'simple',
-            managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'hybrid',
+            managedEnvsExecutionMode:
+              config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT,
           },
           // Resolved security posture — admins can confirm in Settings → About
           // which CSP/CORS policy the daemon booted with, without tailing logs

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3379,7 +3379,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // How managed environment lifecycle fields execute. In
           // webhook-only mode the UI/MCP may still show env controls, but
           // non-URL rendered commands are rejected server-side.
-          managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'command',
+          managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'hybrid',
           // True when the daemon runs in a multi-user Unix isolation mode
           // (insulated/strict). UI hides "trust everyone on this instance"
           // surfaces when true. Server-side gates (e.g. ArtifactsService.
@@ -3427,7 +3427,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           execution: {
             branchRbac: config.execution?.branch_rbac === true,
             unixUserMode: config.execution?.unix_user_mode ?? 'simple',
-            managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'command',
+            managedEnvsExecutionMode: config.execution?.managed_envs_execution_mode ?? 'hybrid',
           },
           // Resolved security posture — admins can confirm in Settings → About
           // which CSP/CORS policy the daemon booted with, without tailing logs

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -20,9 +20,12 @@ import {
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
 import {
+  MANAGED_ENV_EXECUTION_MODE_DEFAULT,
   type ManagedEnvExecutionMode,
   redactManagedEnvWebhookUrlForAudit,
   resolveManagedEnvCommandExecution,
+  validateManagedEnvLifecyclePolicy,
+  validateRenderedManagedEnvUrlFields,
 } from '@agor/core/environment/webhook';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
@@ -131,7 +134,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
   private async getManagedEnvExecutionMode(): Promise<ManagedEnvExecutionMode> {
     const config = await loadConfig();
-    return config.execution?.managed_envs_execution_mode ?? 'hybrid';
+    return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
   }
 
   private async resolveEnvironmentCommand(command: string, commandType: EnvironmentCommandType) {
@@ -149,10 +152,16 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     logs?: string;
   }): Promise<void> {
     const mode = await this.getManagedEnvExecutionMode();
-    resolveManagedEnvCommandExecution(snapshot.start ?? '', mode, 'start');
-    resolveManagedEnvCommandExecution(snapshot.stop ?? '', mode, 'stop');
-    if (snapshot.nuke) resolveManagedEnvCommandExecution(snapshot.nuke, mode, 'nuke');
-    if (snapshot.logs) resolveManagedEnvCommandExecution(snapshot.logs, mode, 'logs');
+    validateManagedEnvLifecyclePolicy(
+      {
+        start: snapshot.start,
+        stop: snapshot.stop,
+        nuke: snapshot.nuke,
+        logs: snapshot.logs,
+      },
+      mode,
+      'rendered branch environment'
+    );
   }
 
   private async executeEnvironmentWebhook(options: {
@@ -2064,6 +2073,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     await this.validateRenderedEnvironmentActions(snapshot);
+    validateRenderedManagedEnvUrlFields({
+      health: snapshot.health,
+      app: snapshot.app,
+    });
 
     return await this.patch(
       id,

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -19,6 +19,11 @@ import {
   type Database,
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
+import {
+  type ManagedEnvExecutionMode,
+  redactManagedEnvWebhookUrlForAudit,
+  resolveManagedEnvCommandExecution,
+} from '@agor/core/environment/webhook';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
@@ -31,7 +36,11 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { isAssistant, ROLES } from '@agor/core/types';
-import { getGidFromGroupName, spawnEnvironmentCommand } from '@agor/core/unix';
+import {
+  type EnvironmentCommandType,
+  getGidFromGroupName,
+  spawnEnvironmentCommand,
+} from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService } from '../adapters/drizzle';
@@ -118,6 +127,137 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   ): Promise<void> {
     const config = await loadConfig();
     ensureCanTriggerManagedEnv(config.execution?.managed_envs_minimum_role, params, action);
+  }
+
+  private async getManagedEnvExecutionMode(): Promise<ManagedEnvExecutionMode> {
+    const config = await loadConfig();
+    return config.execution?.managed_envs_execution_mode ?? 'command';
+  }
+
+  private async resolveEnvironmentCommand(command: string, commandType: EnvironmentCommandType) {
+    return resolveManagedEnvCommandExecution(
+      command,
+      await this.getManagedEnvExecutionMode(),
+      commandType
+    );
+  }
+
+  private async validateRenderedEnvironmentActions(snapshot: {
+    start?: string;
+    stop?: string;
+    nuke?: string;
+    logs?: string;
+  }): Promise<void> {
+    const mode = await this.getManagedEnvExecutionMode();
+    resolveManagedEnvCommandExecution(snapshot.start ?? '', mode, 'start');
+    resolveManagedEnvCommandExecution(snapshot.stop ?? '', mode, 'stop');
+    if (snapshot.nuke) resolveManagedEnvCommandExecution(snapshot.nuke, mode, 'nuke');
+    if (snapshot.logs) resolveManagedEnvCommandExecution(snapshot.logs, mode, 'logs');
+  }
+
+  private async executeEnvironmentWebhook(options: {
+    url: string;
+    branch: Branch;
+    commandType: EnvironmentCommandType;
+    triggeredBy?: { user_id?: string; email?: string };
+    maxBytes?: number;
+  }): Promise<{ body: string; truncated: boolean; status: number }> {
+    const {
+      url,
+      branch,
+      commandType,
+      triggeredBy,
+      maxBytes = ENVIRONMENT.LOGS_MAX_BYTES,
+    } = options;
+    const redactedUrl = redactManagedEnvWebhookUrlForAudit(url);
+
+    console.log(
+      `🔗 Calling environment ${commandType} webhook for branch ${branch.name}: ${redactedUrl}`
+    );
+    console.log(
+      `AUDIT ${JSON.stringify({
+        event: 'agor.env_webhook.get',
+        timestamp: new Date().toISOString(),
+        branch_id: branch.branch_id,
+        branch_name: branch.name,
+        command_type: commandType,
+        url: redactedUrl,
+        triggered_by_user_id: triggeredBy?.user_id,
+        triggered_by_email: triggeredBy?.email,
+      })}`
+    );
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ENVIRONMENT.LOGS_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'Agor managed-environment webhook',
+        },
+      });
+
+      const { body, truncated } = await this.readLimitedWebhookBody(response, maxBytes);
+
+      if (!response.ok) {
+        throw new Error(`Environment ${commandType} webhook returned HTTP ${response.status}`);
+      }
+
+      return { body, truncated, status: response.status };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(
+          `Environment ${commandType} webhook timed out after ${ENVIRONMENT.LOGS_TIMEOUT_MS / 1000}s`
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async readLimitedWebhookBody(
+    response: Response,
+    maxBytes: number
+  ): Promise<{ body: string; truncated: boolean }> {
+    const reader = response.body?.getReader();
+    if (!reader) return { body: '', truncated: false };
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let truncated = false;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      const remaining = maxBytes - total;
+      if (remaining <= 0) {
+        truncated = true;
+        await reader.cancel();
+        break;
+      }
+
+      if (value.byteLength <= remaining) {
+        chunks.push(value);
+        total += value.byteLength;
+      } else {
+        chunks.push(value.slice(0, remaining));
+        total += remaining;
+        truncated = true;
+        await reader.cancel();
+        break;
+      }
+    }
+
+    return {
+      body: Buffer.concat(chunks, total).toString('utf8'),
+      truncated,
+    };
   }
 
   /**
@@ -1191,8 +1331,15 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     try {
       // Use static start_command (initialized from template at branch creation)
       const command = branch.start_command;
+      const execution = await this.resolveEnvironmentCommand(command, 'start');
 
-      console.log(`🚀 Starting environment for branch ${branch.name}: ${command}`);
+      console.log(
+        `🚀 Starting environment for branch ${branch.name}: ${
+          execution.kind === 'webhook'
+            ? redactManagedEnvWebhookUrlForAudit(execution.url)
+            : execution.command
+        }`
+      );
 
       // Create log directory
       const logPath = join(
@@ -1205,61 +1352,72 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       );
       await mkdir(dirname(logPath), { recursive: true });
 
-      // Execute command and wait for it to complete
-      // Use stdio: 'pipe' to capture output for error reporting
-      const childProcess = await spawnEnvironmentCommand({
-        command,
-        branch,
-        db: this.db,
-        commandType: 'start',
-        stdio: 'pipe',
-        triggeredBy: this.extractTriggeredBy(params),
-      });
-
-      // Collect stdout/stderr for error reporting (last ~100 lines)
-      const outputChunks: string[] = [];
-      const MAX_OUTPUT_LINES = 100;
-
-      const collectOutput = (stream: NodeJS.ReadableStream | null, prefix?: string) => {
-        if (!stream) return;
-        stream.on('data', (chunk: Buffer) => {
-          const text = chunk.toString();
-          // Also forward to daemon console so logs aren't lost
-          if (prefix) {
-            process.stderr.write(text);
-          } else {
-            process.stdout.write(text);
-          }
-          outputChunks.push(text);
+      if (execution.kind === 'webhook') {
+        await this.executeEnvironmentWebhook({
+          url: execution.url,
+          branch,
+          commandType: 'start',
+          triggeredBy: this.extractTriggeredBy(params),
+          maxBytes: 16 * 1024,
         });
-      };
-      collectOutput(childProcess.stdout);
-      collectOutput(childProcess.stderr, 'stderr');
-
-      await new Promise<void>((resolve, reject) => {
-        childProcess.on('exit', (code: number | null) => {
-          if (code === 0) {
-            console.log(`✅ Start command completed successfully for ${branch.name}`);
-            resolve();
-          } else {
-            // Combine collected output and truncate to last ~100 lines
-            const fullOutput = outputChunks.join('');
-            const lines = fullOutput.split('\n');
-            const truncated =
-              lines.length > MAX_OUTPUT_LINES
-                ? `... (truncated ${lines.length - MAX_OUTPUT_LINES} lines)\n${lines.slice(-MAX_OUTPUT_LINES).join('\n')}`
-                : fullOutput;
-            const output = truncated.trim();
-            const err = new Error(`Start command exited with code ${code}`) as Error & {
-              commandOutput?: string;
-            };
-            err.commandOutput = output || undefined;
-            reject(err);
-          }
+        console.log(`✅ Start webhook completed successfully for ${branch.name}`);
+      } else {
+        // Execute command and wait for it to complete
+        // Use stdio: 'pipe' to capture output for error reporting
+        const childProcess = await spawnEnvironmentCommand({
+          command: execution.command,
+          branch,
+          db: this.db,
+          commandType: 'start',
+          stdio: 'pipe',
+          triggeredBy: this.extractTriggeredBy(params),
         });
 
-        childProcess.on('error', (error: Error) => reject(error));
-      });
+        // Collect stdout/stderr for error reporting (last ~100 lines)
+        const outputChunks: string[] = [];
+        const MAX_OUTPUT_LINES = 100;
+
+        const collectOutput = (stream: NodeJS.ReadableStream | null, prefix?: string) => {
+          if (!stream) return;
+          stream.on('data', (chunk: Buffer) => {
+            const text = chunk.toString();
+            // Also forward to daemon console so logs aren't lost
+            if (prefix) {
+              process.stderr.write(text);
+            } else {
+              process.stdout.write(text);
+            }
+            outputChunks.push(text);
+          });
+        };
+        collectOutput(childProcess.stdout);
+        collectOutput(childProcess.stderr, 'stderr');
+
+        await new Promise<void>((resolve, reject) => {
+          childProcess.on('exit', (code: number | null) => {
+            if (code === 0) {
+              console.log(`✅ Start command completed successfully for ${branch.name}`);
+              resolve();
+            } else {
+              // Combine collected output and truncate to last ~100 lines
+              const fullOutput = outputChunks.join('');
+              const lines = fullOutput.split('\n');
+              const truncated =
+                lines.length > MAX_OUTPUT_LINES
+                  ? `... (truncated ${lines.length - MAX_OUTPUT_LINES} lines)\n${lines.slice(-MAX_OUTPUT_LINES).join('\n')}`
+                  : fullOutput;
+              const output = truncated.trim();
+              const err = new Error(`Start command exited with code ${code}`) as Error & {
+                commandOutput?: string;
+              };
+              err.commandOutput = output || undefined;
+              reject(err);
+            }
+          });
+
+          childProcess.on('error', (error: Error) => reject(error));
+        });
+      }
 
       // Use static app_url (initialized from template at branch creation)
       let access_urls: Array<{ name: string; url: string }> | undefined;
@@ -1325,29 +1483,46 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       if (branch.stop_command) {
         // Use static stop_command (initialized from template at branch creation)
         const command = branch.stop_command;
+        const execution = await this.resolveEnvironmentCommand(command, 'stop');
 
-        console.log(`🛑 Stopping environment for branch ${branch.name}: ${command}`);
+        console.log(
+          `🛑 Stopping environment for branch ${branch.name}: ${
+            execution.kind === 'webhook'
+              ? redactManagedEnvWebhookUrlForAudit(execution.url)
+              : execution.command
+          }`
+        );
 
-        // Execute down command
-        const stopProcess = await spawnEnvironmentCommand({
-          command,
-          branch,
-          db: this.db,
-          commandType: 'stop',
-          triggeredBy: this.extractTriggeredBy(params),
-        });
-
-        await new Promise<void>((resolve, reject) => {
-          stopProcess.on('exit', (code: number | null) => {
-            if (code === 0) {
-              resolve();
-            } else {
-              reject(new Error(`Down command exited with code ${code}`));
-            }
+        if (execution.kind === 'webhook') {
+          await this.executeEnvironmentWebhook({
+            url: execution.url,
+            branch,
+            commandType: 'stop',
+            triggeredBy: this.extractTriggeredBy(params),
+            maxBytes: 16 * 1024,
+          });
+        } else {
+          // Execute down command
+          const stopProcess = await spawnEnvironmentCommand({
+            command: execution.command,
+            branch,
+            db: this.db,
+            commandType: 'stop',
+            triggeredBy: this.extractTriggeredBy(params),
           });
 
-          stopProcess.on('error', (error: Error) => reject(error));
-        });
+          await new Promise<void>((resolve, reject) => {
+            stopProcess.on('exit', (code: number | null) => {
+              if (code === 0) {
+                resolve();
+              } else {
+                reject(new Error(`Down command exited with code ${code}`));
+              }
+            });
+
+            stopProcess.on('error', (error: Error) => reject(error));
+          });
+        }
       } else {
         // No down command - kill the managed process if we have it
         const managedProcess = this.processes.get(id);
@@ -1443,30 +1618,47 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     try {
       const command = branch.nuke_command;
+      const execution = await this.resolveEnvironmentCommand(command, 'nuke');
 
-      console.log(`💣 NUKING environment for branch ${branch.name}: ${command}`);
+      console.log(
+        `💣 NUKING environment for branch ${branch.name}: ${
+          execution.kind === 'webhook'
+            ? redactManagedEnvWebhookUrlForAudit(execution.url)
+            : execution.command
+        }`
+      );
       console.warn('⚠️  This is a destructive operation!');
 
-      // Execute nuke command
-      const nukeProcess = await spawnEnvironmentCommand({
-        command,
-        branch,
-        db: this.db,
-        commandType: 'nuke',
-        triggeredBy: this.extractTriggeredBy(params),
-      });
-
-      await new Promise<void>((resolve, reject) => {
-        nukeProcess.on('exit', (code: number | null) => {
-          if (code === 0) {
-            resolve();
-          } else {
-            reject(new Error(`Nuke command exited with code ${code}`));
-          }
+      if (execution.kind === 'webhook') {
+        await this.executeEnvironmentWebhook({
+          url: execution.url,
+          branch,
+          commandType: 'nuke',
+          triggeredBy: this.extractTriggeredBy(params),
+          maxBytes: 16 * 1024,
+        });
+      } else {
+        // Execute nuke command
+        const nukeProcess = await spawnEnvironmentCommand({
+          command: execution.command,
+          branch,
+          db: this.db,
+          commandType: 'nuke',
+          triggeredBy: this.extractTriggeredBy(params),
         });
 
-        nukeProcess.on('error', (error: Error) => reject(error));
-      });
+        await new Promise<void>((resolve, reject) => {
+          nukeProcess.on('exit', (code: number | null) => {
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(new Error(`Nuke command exited with code ${code}`));
+            }
+          });
+
+          nukeProcess.on('error', (error: Error) => reject(error));
+        });
+      }
 
       // Clean up any managed process references
       const managedProcess = this.processes.get(id);
@@ -1674,66 +1866,88 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     try {
       // Use static logs_command (initialized from template at branch creation)
       const command = branch.logs_command;
+      const execution = await this.resolveEnvironmentCommand(command, 'logs');
 
-      console.log(`📋 Fetching logs for branch ${branch.name}: ${command}`);
+      console.log(
+        `📋 Fetching logs for branch ${branch.name}: ${
+          execution.kind === 'webhook'
+            ? redactManagedEnvWebhookUrlForAudit(execution.url)
+            : execution.command
+        }`
+      );
 
-      // Execute command with timeout and output limits
-      const childProcess = await spawnEnvironmentCommand({
-        command,
-        branch,
-        db: this.db,
-        commandType: 'logs',
-        stdio: 'pipe', // Need to capture output for logs
-        triggeredBy: this.extractTriggeredBy(params),
-      });
+      const result =
+        execution.kind === 'webhook'
+          ? await this.executeEnvironmentWebhook({
+              url: execution.url,
+              branch,
+              commandType: 'logs',
+              triggeredBy: this.extractTriggeredBy(params),
+              maxBytes: ENVIRONMENT.LOGS_MAX_BYTES,
+            }).then(({ body, truncated }) => ({ stdout: body, stderr: '', truncated }))
+          : await new Promise<{
+              stdout: string;
+              stderr: string;
+              truncated: boolean;
+            }>((resolve, reject) => {
+              // Execute command with timeout and output limits
+              spawnEnvironmentCommand({
+                command: execution.command,
+                branch,
+                db: this.db,
+                commandType: 'logs',
+                stdio: 'pipe', // Need to capture output for logs
+                triggeredBy: this.extractTriggeredBy(params),
+              })
+                .then((childProcess) => {
+                  let stdout = '';
+                  let stderr = '';
+                  let truncated = false;
 
-      const result = await new Promise<{
-        stdout: string;
-        stderr: string;
-        truncated: boolean;
-      }>((resolve, reject) => {
-        let stdout = '';
-        let stderr = '';
-        let truncated = false;
+                  // Set timeout
+                  const timeout = setTimeout(() => {
+                    childProcess.kill('SIGTERM');
+                    reject(
+                      new Error(
+                        `Logs command timed out after ${ENVIRONMENT.LOGS_TIMEOUT_MS / 1000}s`
+                      )
+                    );
+                  }, ENVIRONMENT.LOGS_TIMEOUT_MS);
 
-        // Set timeout
-        const timeout = setTimeout(() => {
-          childProcess.kill('SIGTERM');
-          reject(new Error(`Logs command timed out after ${ENVIRONMENT.LOGS_TIMEOUT_MS / 1000}s`));
-        }, ENVIRONMENT.LOGS_TIMEOUT_MS);
+                  // Capture stdout with size limit
+                  childProcess.stdout?.on('data', (data: Buffer) => {
+                    const chunk = data.toString();
+                    if (stdout.length + chunk.length <= ENVIRONMENT.LOGS_MAX_BYTES) {
+                      stdout += chunk;
+                    } else {
+                      // Truncate to max bytes
+                      stdout += chunk.substring(0, ENVIRONMENT.LOGS_MAX_BYTES - stdout.length);
+                      truncated = true;
+                      childProcess.kill('SIGTERM');
+                    }
+                  });
 
-        // Capture stdout with size limit
-        childProcess.stdout?.on('data', (data: Buffer) => {
-          const chunk = data.toString();
-          if (stdout.length + chunk.length <= ENVIRONMENT.LOGS_MAX_BYTES) {
-            stdout += chunk;
-          } else {
-            // Truncate to max bytes
-            stdout += chunk.substring(0, ENVIRONMENT.LOGS_MAX_BYTES - stdout.length);
-            truncated = true;
-            childProcess.kill('SIGTERM');
-          }
-        });
+                  // Capture stderr
+                  childProcess.stderr?.on('data', (data: Buffer) => {
+                    stderr += data.toString();
+                  });
 
-        // Capture stderr
-        childProcess.stderr?.on('data', (data: Buffer) => {
-          stderr += data.toString();
-        });
+                  childProcess.on('exit', (code: number | null) => {
+                    clearTimeout(timeout);
+                    if (code === 0 || stdout.length > 0) {
+                      resolve({ stdout, stderr, truncated });
+                    } else {
+                      reject(new Error(stderr || `Logs command exited with code ${code}`));
+                    }
+                  });
 
-        childProcess.on('exit', (code: number | null) => {
-          clearTimeout(timeout);
-          if (code === 0 || stdout.length > 0) {
-            resolve({ stdout, stderr, truncated });
-          } else {
-            reject(new Error(stderr || `Logs command exited with code ${code}`));
-          }
-        });
-
-        childProcess.on('error', (error: Error) => {
-          clearTimeout(timeout);
-          reject(error);
-        });
-      });
+                  childProcess.on('error', (error: Error) => {
+                    clearTimeout(timeout);
+                    reject(error);
+                  });
+                })
+                .catch(reject);
+            });
 
       // Process output: split into lines and keep last N lines
       const allLines = result.stdout.split('\n');
@@ -1848,6 +2062,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // returns null when env is absent. Defensive throw keeps types honest.
       throw new Error('Failed to render environment snapshot');
     }
+
+    await this.validateRenderedEnvironmentActions(snapshot);
 
     return await this.patch(
       id,

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -131,7 +131,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
   private async getManagedEnvExecutionMode(): Promise<ManagedEnvExecutionMode> {
     const config = await loadConfig();
-    return config.execution?.managed_envs_execution_mode ?? 'command';
+    return config.execution?.managed_envs_execution_mode ?? 'hybrid';
   }
 
   private async resolveEnvironmentCommand(command: string, commandType: EnvironmentCommandType) {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -21,6 +21,7 @@ import {
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
 import {
   MANAGED_ENV_EXECUTION_MODE_DEFAULT,
+  type ManagedEnvCommandType,
   type ManagedEnvExecutionMode,
   redactManagedEnvWebhookUrlForAudit,
   resolveManagedEnvCommandExecution,
@@ -39,11 +40,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { isAssistant, ROLES } from '@agor/core/types';
-import {
-  type EnvironmentCommandType,
-  getGidFromGroupName,
-  spawnEnvironmentCommand,
-} from '@agor/core/unix';
+import { getGidFromGroupName, spawnEnvironmentCommand } from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService } from '../adapters/drizzle';
@@ -137,7 +134,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
   }
 
-  private async resolveEnvironmentCommand(command: string, commandType: EnvironmentCommandType) {
+  private async resolveEnvironmentCommand(command: string, commandType: ManagedEnvCommandType) {
     return resolveManagedEnvCommandExecution(
       command,
       await this.getManagedEnvExecutionMode(),
@@ -167,7 +164,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   private async executeEnvironmentWebhook(options: {
     url: string;
     branch: Branch;
-    commandType: EnvironmentCommandType;
+    commandType: ManagedEnvCommandType;
     triggeredBy?: { user_id?: string; email?: string };
     maxBytes?: number;
   }): Promise<{ body: string; truncated: boolean; status: number }> {

--- a/apps/agor-docs/pages/guide/environment-configuration.mdx
+++ b/apps/agor-docs/pages/guide/environment-configuration.mdx
@@ -395,14 +395,14 @@ infrastructure logs may expose them. If you need authentication, put it behind
 network policy or a future signed-webhook layer rather than embedding tokens in
 `.agor.yml`.
 
-Default mode remains `command` for backwards compatibility:
+Default mode is `hybrid` for backwards compatibility:
 
 ```yaml
 execution:
-  managed_envs_execution_mode: command
+  managed_envs_execution_mode: hybrid
 ```
 
-In command mode, existing shell commands continue to work. URL-shaped lifecycle
+In hybrid mode, existing shell commands continue to work. URL-shaped lifecycle
 fields still use webhook execution so a repo can migrate one action at a time.
 
 ---

--- a/apps/agor-docs/pages/guide/environment-configuration.mdx
+++ b/apps/agor-docs/pages/guide/environment-configuration.mdx
@@ -127,6 +127,11 @@ environment:
       app:    "<url template>"             # optional
 ```
 
+`start`, `stop`, `nuke`, and `logs` are rendered lifecycle fields. In the
+default server mode they are shell commands, except an explicit `http://` or
+`https://` value is treated as a webhook and invoked with HTTP GET. `health`
+and `app` are always URL templates, not shell commands.
+
 ### Required fields
 
 - `version: 2` at the top level.
@@ -350,6 +355,55 @@ Restating the callout from above because it's the single most common mistake:
 - Values get **baked into shell strings** at render time — anyone who can read the branch snapshot sees them.
 - Use it for IPs, hostnames, registries, profile names. **Not** for API keys, tokens, or passwords.
 - For secrets, use the per-session env-var system. Scope is per-session, access is limited to the session owner, and values never land in a rendered command.
+
+### 3. Webhook-only execution mode {/* #webhook-only-mode */}
+
+Operators who do not want Agor to run arbitrary shell/Docker/Kubernetes
+commands from repo-managed environment variants can lock managed environments
+down to webhooks:
+
+```yaml
+# ~/.agor/config.yaml
+execution:
+  managed_envs_execution_mode: webhook-only
+```
+
+In webhook-only mode, rendered `start`, `stop`, `nuke`, and `logs` fields must
+be explicit `http://` or `https://` URLs. Agor sends a GET request to the URL.
+Non-URL values fail before execution with a clear error that points back to this
+section. The server policy is authoritative: a repo's `.agor.yml` cannot opt out
+of webhook-only mode.
+
+```yaml
+environment:
+  default: remote
+  variants:
+    remote:
+      start: "https://orchestrator.example.com/agor/start?branch={{branch.name}}"
+      stop:  "https://orchestrator.example.com/agor/stop?branch={{branch.name}}"
+      logs:  "https://orchestrator.example.com/agor/logs?branch={{branch.name}}"
+      health: "https://apps.example.com/{{branch.name}}/health"
+      app:    "https://apps.example.com/{{branch.name}}"
+```
+
+V1 webhooks are intentionally simple: GET only, no custom headers, no request
+body, no signing, and redirects are not followed. Agor blocks obvious cloud
+metadata/link-local targets and URL credentials, but webhooks are still outbound
+server-side HTTP requests. Point them at a trusted orchestration service and
+avoid putting secrets in query strings because rendered branch snapshots and
+infrastructure logs may expose them. If you need authentication, put it behind
+network policy or a future signed-webhook layer rather than embedding tokens in
+`.agor.yml`.
+
+Default mode remains `command` for backwards compatibility:
+
+```yaml
+execution:
+  managed_envs_execution_mode: command
+```
+
+In command mode, existing shell commands continue to work. URL-shaped lifecycle
+fields still use webhook execution so a repo can migrate one action at a time.
 
 ---
 

--- a/apps/agor-docs/pages/guide/environment-configuration.mdx
+++ b/apps/agor-docs/pages/guide/environment-configuration.mdx
@@ -128,9 +128,9 @@ environment:
 ```
 
 `start`, `stop`, `nuke`, and `logs` are rendered lifecycle fields. In the
-default server mode they are shell commands, except an explicit `http://` or
-`https://` value is treated as a webhook and invoked with HTTP GET. `health`
-and `app` are always URL templates, not shell commands.
+default `hybrid` mode they can be shell commands or explicit `http://` /
+`https://` webhooks. Webhooks are invoked with HTTP GET. `health` and `app` are
+always URL templates, not shell commands.
 
 ### Required fields
 
@@ -356,11 +356,22 @@ Restating the callout from above because it's the single most common mistake:
 - Use it for IPs, hostnames, registries, profile names. **Not** for API keys, tokens, or passwords.
 - For secrets, use the per-session env-var system. Scope is per-session, access is limited to the session owner, and values never land in a rendered command.
 
-### 3. Webhook-only execution mode {/* #webhook-only-mode */}
+### 3. Managed environment execution mode {/* #webhook-only-mode */}
 
-Operators who do not want Agor to run arbitrary shell/Docker/Kubernetes
-commands from repo-managed environment variants can lock managed environments
-down to webhooks:
+Agor instances choose how lifecycle fields are handled. The default is
+`hybrid`:
+
+```yaml
+# ~/.agor/config.yaml
+execution:
+  managed_envs_execution_mode: hybrid
+```
+
+In `hybrid` mode, lifecycle fields can be shell commands or explicit
+`http://` / `https://` webhooks. URL-shaped fields use webhook execution, so a
+repo can use webhooks for one action and commands for another.
+
+Some instances are configured for webhook-managed environments:
 
 ```yaml
 # ~/.agor/config.yaml
@@ -368,11 +379,8 @@ execution:
   managed_envs_execution_mode: webhook-only
 ```
 
-In webhook-only mode, rendered `start`, `stop`, `nuke`, and `logs` fields must
-be explicit `http://` or `https://` URLs. Agor sends a GET request to the URL.
-Non-URL values fail before execution with a clear error that points back to this
-section. The server policy is authoritative: a repo's `.agor.yml` cannot opt out
-of webhook-only mode.
+In `webhook-only` mode, rendered `start`, `stop`, `nuke`, and `logs` fields are
+explicit `http://` or `https://` URLs. Agor sends a GET request to the URL.
 
 ```yaml
 environment:
@@ -387,23 +395,9 @@ environment:
 ```
 
 V1 webhooks are intentionally simple: GET only, no custom headers, no request
-body, no signing, and redirects are not followed. Agor blocks obvious cloud
-metadata/link-local targets and URL credentials, but webhooks are still outbound
-server-side HTTP requests. Point them at a trusted orchestration service and
-avoid putting secrets in query strings because rendered branch snapshots and
-infrastructure logs may expose them. If you need authentication, put it behind
-network policy or a future signed-webhook layer rather than embedding tokens in
-`.agor.yml`.
-
-Default mode is `hybrid` for backwards compatibility:
-
-```yaml
-execution:
-  managed_envs_execution_mode: hybrid
-```
-
-In hybrid mode, existing shell commands continue to work. URL-shaped lifecycle
-fields still use webhook execution so a repo can migrate one action at a time.
+body, no signing, and redirects are not followed. Use a trusted orchestration
+service, and avoid secrets in query strings because rendered branch snapshots and
+infrastructure logs may expose them.
 
 ---
 

--- a/apps/agor-docs/pages/guide/environment-configuration.mdx
+++ b/apps/agor-docs/pages/guide/environment-configuration.mdx
@@ -379,8 +379,9 @@ execution:
   managed_envs_execution_mode: webhook-only
 ```
 
-In `webhook-only` mode, rendered `start`, `stop`, `nuke`, and `logs` fields are
-explicit `http://` or `https://` URLs. Agor sends a GET request to the URL.
+In `webhook-only` mode, rendered `start`, `stop`, `nuke`, and `logs` fields
+must render to explicit `http://` or `https://` URLs. Agor sends a GET request
+to the URL.
 
 ```yaml
 environment:
@@ -395,9 +396,11 @@ environment:
 ```
 
 V1 webhooks are intentionally simple: GET only, no custom headers, no request
-body, no signing, and redirects are not followed. Use a trusted orchestration
-service, and avoid secrets in query strings because rendered branch snapshots and
-infrastructure logs may expose them.
+body, no signing, and redirects are not followed. V1 webhook targets must be
+public HTTP(S) destinations; localhost, private/link-local ranges, and URL
+credentials are rejected. Use a trusted orchestration service, and avoid secrets
+in query strings because rendered branch snapshots and infrastructure logs may
+expose them.
 
 ---
 

--- a/apps/agor-docs/pages/guide/internal-mcp.mdx
+++ b/apps/agor-docs/pages/guide/internal-mcp.mdx
@@ -80,6 +80,12 @@ This self-awareness is what lets agents behave like team members instead of deta
 
 Because MCP calls are just JSON-RPC, complex workflows can be scripted once and reused by any tool that speaks the protocol.
 
+Environment MCP tools call the same branch environment service as the UI. If an
+operator sets `execution.managed_envs_execution_mode: webhook-only`, MCP
+`agor_environment_start`, `agor_environment_stop`, `agor_environment_logs`, and
+`agor_environment_nuke` reject rendered shell commands and only invoke explicit
+HTTP(S) webhook URLs. See [Environments: webhook-only mode](/guide/environment-configuration#webhook-only-mode).
+
 ## External Agent Access
 
 External agents can use the same MCP endpoint:

--- a/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
@@ -15,6 +15,12 @@
  */
 
 import {
+  MANAGED_ENV_EXECUTION_MODE_DEFAULT,
+  type ManagedEnvExecutionMode,
+  validateManagedEnvLifecyclePolicy,
+  validateRepoEnvironmentLifecyclePolicy,
+} from '@agor/core/environment/webhook';
+import {
   type AgorClient,
   type Branch,
   type Repo,
@@ -77,12 +83,6 @@ interface BranchRenderedSnapshot {
   app?: string;
 }
 
-type ManagedEnvsExecutionMode = 'hybrid' | 'webhook-only';
-
-const LIFECYCLE_FIELDS: Array<
-  keyof Pick<BranchRenderedSnapshot, 'start' | 'stop' | 'nuke' | 'logs'>
-> = ['start', 'stop', 'nuke', 'logs'];
-
 function snapshotFromBranch(wt: Branch): BranchRenderedSnapshot {
   return {
     start: wt.start_command || undefined,
@@ -102,10 +102,6 @@ function prettyYaml(value: unknown): string {
   }
 }
 
-function isHttpUrl(value: string): boolean {
-  return /^https?:\/\//i.test(value.trim());
-}
-
 export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
   branch,
   repo,
@@ -122,8 +118,8 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
 
   // ----- Permission gating -----
   const managedEnvsMinimumRole = featuresConfig?.managedEnvsMinimumRole ?? 'member';
-  const managedEnvsExecutionMode: ManagedEnvsExecutionMode =
-    featuresConfig?.managedEnvsExecutionMode ?? 'hybrid';
+  const managedEnvsExecutionMode: ManagedEnvExecutionMode =
+    featuresConfig?.managedEnvsExecutionMode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
   const isWebhookMode = managedEnvsExecutionMode === 'webhook-only';
   const canTriggerEnv =
     managedEnvsMinimumRole !== 'none' &&
@@ -134,7 +130,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
       ? 'Managed environments are disabled on this instance'
       : `Requires ${managedEnvsMinimumRole} role or higher`;
   const lifecycleFieldHelp = isWebhookMode
-    ? 'This instance uses webhook-managed environments. Use absolute http(s) URLs for start, stop, nuke, and logs.'
+    ? 'This instance uses webhook-managed environments. Use public http(s) URLs for start, stop, nuke, and logs.'
     : 'This instance supports shell commands and URL webhooks for start, stop, nuke, and logs.';
   const repoPlaceholder = isWebhookMode
     ? 'version: 2\ndefault: remote\nvariants:\n  remote:\n    start: https://env.example.com/start?branch={{branch.name}}\n    stop: https://env.example.com/stop?branch={{branch.name}}\n    health: https://apps.example.com/{{branch.name}}/health\n    app: https://apps.example.com/{{branch.name}}\n'
@@ -362,16 +358,11 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     try {
       const validated = validateRepoEnvironment(parsed);
       if (isWebhookMode) {
-        for (const [variantName, variant] of Object.entries(validated.variants)) {
-          for (const field of LIFECYCLE_FIELDS) {
-            const value = variant[field];
-            if (typeof value === 'string' && value.trim() && !isHttpUrl(value)) {
-              setRepoYamlError(
-                `In webhook mode, variants.${variantName}.${field} should be an absolute http(s) URL`
-              );
-              return null;
-            }
-          }
+        try {
+          validateRepoEnvironmentLifecyclePolicy(validated, managedEnvsExecutionMode);
+        } catch (err) {
+          setRepoYamlError(err instanceof Error ? err.message : 'Invalid webhook lifecycle URL');
+          return null;
         }
       }
       setRepoYamlError(null);
@@ -423,12 +414,20 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
       return null;
     }
     if (isWebhookMode) {
-      for (const field of LIFECYCLE_FIELDS) {
-        const value = obj[field];
-        if (typeof value === 'string' && value.trim() && !isHttpUrl(value)) {
-          setSnapshotYamlError(`In webhook mode, ${field} should be an absolute http(s) URL`);
-          return null;
-        }
+      try {
+        validateManagedEnvLifecyclePolicy(
+          {
+            start: obj.start,
+            stop: obj.stop,
+            nuke: obj.nuke,
+            logs: obj.logs,
+          },
+          managedEnvsExecutionMode,
+          'branch environment'
+        );
+      } catch (err) {
+        setSnapshotYamlError(err instanceof Error ? err.message : 'Invalid webhook lifecycle URL');
+        return null;
       }
     }
     setSnapshotYamlError(null);

--- a/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
@@ -77,6 +77,12 @@ interface BranchRenderedSnapshot {
   app?: string;
 }
 
+type ManagedEnvsExecutionMode = 'hybrid' | 'webhook-only';
+
+const LIFECYCLE_FIELDS: Array<
+  keyof Pick<BranchRenderedSnapshot, 'start' | 'stop' | 'nuke' | 'logs'>
+> = ['start', 'stop', 'nuke', 'logs'];
+
 function snapshotFromBranch(wt: Branch): BranchRenderedSnapshot {
   return {
     start: wt.start_command || undefined,
@@ -96,6 +102,10 @@ function prettyYaml(value: unknown): string {
   }
 }
 
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
+}
+
 export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
   branch,
   repo,
@@ -112,6 +122,9 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
 
   // ----- Permission gating -----
   const managedEnvsMinimumRole = featuresConfig?.managedEnvsMinimumRole ?? 'member';
+  const managedEnvsExecutionMode: ManagedEnvsExecutionMode =
+    featuresConfig?.managedEnvsExecutionMode ?? 'hybrid';
+  const isWebhookMode = managedEnvsExecutionMode === 'webhook-only';
   const canTriggerEnv =
     managedEnvsMinimumRole !== 'none' &&
     hasRole(managedEnvsMinimumRole as Exclude<typeof managedEnvsMinimumRole, 'none'>);
@@ -120,6 +133,12 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     : managedEnvsMinimumRole === 'none'
       ? 'Managed environments are disabled on this instance'
       : `Requires ${managedEnvsMinimumRole} role or higher`;
+  const lifecycleFieldHelp = isWebhookMode
+    ? 'This instance uses webhook-managed environments. Use absolute http(s) URLs for start, stop, nuke, and logs.'
+    : 'This instance supports shell commands and URL webhooks for start, stop, nuke, and logs.';
+  const repoPlaceholder = isWebhookMode
+    ? 'version: 2\ndefault: remote\nvariants:\n  remote:\n    start: https://env.example.com/start?branch={{branch.name}}\n    stop: https://env.example.com/stop?branch={{branch.name}}\n    health: https://apps.example.com/{{branch.name}}/health\n    app: https://apps.example.com/{{branch.name}}\n'
+    : 'version: 2\ndefault: lean\nvariants:\n  lean:\n    start: docker compose up -d\n    stop: docker compose down\n';
 
   // ----- Repo-level editor state (YAML representation of repo.environment) -----
   const [isEditingRepo, setIsEditingRepo] = useState(false);
@@ -342,6 +361,19 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     }
     try {
       const validated = validateRepoEnvironment(parsed);
+      if (isWebhookMode) {
+        for (const [variantName, variant] of Object.entries(validated.variants)) {
+          for (const field of LIFECYCLE_FIELDS) {
+            const value = variant[field];
+            if (typeof value === 'string' && value.trim() && !isHttpUrl(value)) {
+              setRepoYamlError(
+                `In webhook mode, variants.${variantName}.${field} should be an absolute http(s) URL`
+              );
+              return null;
+            }
+          }
+        }
+      }
       setRepoYamlError(null);
       return validated;
     } catch (err) {
@@ -389,6 +421,15 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     if (!obj.stop || typeof obj.stop !== 'string') {
       setSnapshotYamlError('`stop` is required and must be a string');
       return null;
+    }
+    if (isWebhookMode) {
+      for (const field of LIFECYCLE_FIELDS) {
+        const value = obj[field];
+        if (typeof value === 'string' && value.trim() && !isHttpUrl(value)) {
+          setSnapshotYamlError(`In webhook mode, ${field} should be an absolute http(s) URL`);
+          return null;
+        }
+      }
     }
     setSnapshotYamlError(null);
     return obj;
@@ -794,6 +835,13 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
           }
         >
           <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+            <Alert
+              type="info"
+              showIcon
+              message={isWebhookMode ? 'Webhook-managed environments' : 'Managed environments'}
+              description={lifecycleFieldHelp}
+              style={{ fontSize: 12 }}
+            />
             <Typography.Text type="secondary" style={{ fontSize: 11 }}>
               YAML representation of <code>repo.environment</code>. Includes <code>version</code>,{' '}
               <code>default</code>, <code>variants</code>, and optional{' '}
@@ -806,11 +854,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                 if (repoYamlError) setRepoYamlError(null);
               }}
               language="yaml"
-              placeholder={
-                noVariantsConfigured && isAdmin
-                  ? 'version: 2\ndefault: lean\nvariants:\n  lean:\n    start: docker compose up -d\n    stop: docker compose down\n'
-                  : ''
-              }
+              placeholder={noVariantsConfigured && isAdmin ? repoPlaceholder : ''}
               readOnly={!isEditingRepo}
               rows={10}
               maxHeight="480px"
@@ -916,7 +960,8 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
             <Typography.Text type="secondary" style={{ fontSize: 11 }}>
               Rendered snapshot persisted on this branch (fields: <code>start</code>,{' '}
               <code>stop</code>, <code>nuke</code>, <code>logs</code>, <code>health</code>,{' '}
-              <code>app</code>). Click Render above to regenerate from the variant.
+              <code>app</code>). {lifecycleFieldHelp} Click Render above to regenerate from the
+              variant.
             </Typography.Text>
             <CodeEditor
               value={snapshotYamlText}

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -52,6 +52,11 @@ interface FeaturesConfig {
    */
   managedEnvsMinimumRole?: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin';
   /**
+   * How managed environment lifecycle fields are handled by this instance.
+   * Defaults to 'hybrid': shell commands and URL webhooks are both supported.
+   */
+  managedEnvsExecutionMode?: 'hybrid' | 'webhook-only';
+  /**
    * True when the daemon runs in a multi-user Unix isolation mode
    * (insulated/strict). The UI uses this to hide "trust everyone on this
    * instance" surfaces (e.g. the `instance` scope option in the artifact

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -5,6 +5,7 @@
  * Used on app startup to determine if login page should be shown and display instance label.
  */
 
+import type { ManagedEnvExecutionMode } from '@agor/core/environment/webhook';
 import type { DaemonServicesConfig } from '@agor-live/client';
 import { useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
@@ -55,7 +56,7 @@ interface FeaturesConfig {
    * How managed environment lifecycle fields are handled by this instance.
    * Defaults to 'hybrid': shell commands and URL webhooks are both supported.
    */
-  managedEnvsExecutionMode?: 'hybrid' | 'webhook-only';
+  managedEnvsExecutionMode?: ManagedEnvExecutionMode;
   /**
    * True when the daemon runs in a multi-user Unix isolation mode
    * (insulated/strict). The UI uses this to hide "trust everyone on this

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -321,6 +321,12 @@
       "types": "./dist/git/exec.d.ts",
       "import": "./dist/git/exec.js",
       "require": "./dist/git/exec.cjs"
+    },
+    "./environment/webhook": {
+      "source": "./src/environment/webhook.ts",
+      "types": "./dist/environment/webhook.d.ts",
+      "import": "./dist/environment/webhook.js",
+      "require": "./dist/environment/webhook.cjs"
     }
   },
   "scripts": {

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -169,6 +169,38 @@ describe('loadConfig', () => {
     await expect(loadConfig()).rejects.toThrow('Failed to load config');
   });
 
+  it('accepts managed environment webhook-only execution mode', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({ execution: { managed_envs_execution_mode: 'webhook-only' } }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).resolves.toMatchObject({
+      execution: { managed_envs_execution_mode: 'webhook-only' },
+    });
+  });
+
+  it('rejects invalid managed environment execution modes', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({ execution: { managed_envs_execution_mode: 'docker' } }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).rejects.toThrow(
+      /execution\.managed_envs_execution_mode must be one of: command, webhook-only/
+    );
+  });
+
   it('should handle partial config with missing sections', async () => {
     const partialConfig: AgorConfig = {
       daemon: { port: 4040 },

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -197,7 +197,7 @@ describe('loadConfig', () => {
     );
 
     await expect(loadConfig()).rejects.toThrow(
-      /execution\.managed_envs_execution_mode must be one of: command, webhook-only/
+      /execution\.managed_envs_execution_mode must be one of: hybrid, webhook-only/
     );
   });
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -180,6 +180,17 @@ function validateConfig(config: AgorConfig): void {
     );
   }
 
+  const managedEnvExecutionMode = config.execution?.managed_envs_execution_mode;
+  if (
+    managedEnvExecutionMode !== undefined &&
+    managedEnvExecutionMode !== 'command' &&
+    managedEnvExecutionMode !== 'webhook-only'
+  ) {
+    throw new Error(
+      `Config error: execution.managed_envs_execution_mode must be one of: command, webhook-only`
+    );
+  }
+
   validateOptionalHttpUrl(
     config.external_launch as Record<string, unknown> | undefined,
     'login_redirect_url',

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -183,11 +183,11 @@ function validateConfig(config: AgorConfig): void {
   const managedEnvExecutionMode = config.execution?.managed_envs_execution_mode;
   if (
     managedEnvExecutionMode !== undefined &&
-    managedEnvExecutionMode !== 'command' &&
+    managedEnvExecutionMode !== 'hybrid' &&
     managedEnvExecutionMode !== 'webhook-only'
   ) {
     throw new Error(
-      `Config error: execution.managed_envs_execution_mode must be one of: command, webhook-only`
+      `Config error: execution.managed_envs_execution_mode must be one of: hybrid, webhook-only`
     );
   }
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -39,3 +39,4 @@ export {
   SANDPACK_CSP_WORKER_SRC,
 } from './security-resolver';
 export * from './types';
+export * from './variant-resolver';

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -13,6 +13,16 @@ import type { UserRole } from '../types/user';
 export type ManagedEnvsMinimumRole = 'none' | UserRole;
 
 /**
+ * Operator policy for managed environment lifecycle execution.
+ *
+ * - `command` (default): rendered start/stop/nuke/logs fields execute as shell
+ *   commands, except explicit HTTP(S) URLs are invoked as GET webhooks.
+ * - `webhook-only`: rendered lifecycle fields must be HTTP(S) URLs; shell
+ *   commands are rejected before execution.
+ */
+export type ManagedEnvsExecutionMode = 'command' | 'webhook-only';
+
+/**
  * Type for user-provided JSON data where structure is unknown or dynamic
  *
  * Use this instead of `any` when dealing with user input or dynamic data structures.
@@ -519,6 +529,23 @@ export interface AgorExecutionSettings {
    * of this flag when `branch_rbac: true`.
    */
   managed_envs_minimum_role?: ManagedEnvsMinimumRole;
+
+  /**
+   * Managed environment lifecycle execution policy.
+   *
+   * - `'command'` — default/backwards-compatible mode. Rendered lifecycle
+   *   fields run as shell commands, except fields that are explicit `http://`
+   *   or `https://` URLs are invoked as GET webhooks.
+   * - `'webhook-only'` — lockdown mode for deployments that must not let
+   *   `.agor.yml` run arbitrary shell/Docker/Kubernetes commands through Agor.
+   *   `start`, `stop`, `nuke`, and `logs` must render to HTTP(S) URLs.
+   *
+   * Server policy wins over repo-authored `.agor.yml`: a repo cannot opt out
+   * of webhook-only mode.
+   *
+   * Default: `'command'`.
+   */
+  managed_envs_execution_mode?: ManagedEnvsExecutionMode;
 
   /**
    * Branch storage configuration — operator gate for which storage modes a

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -15,12 +15,12 @@ export type ManagedEnvsMinimumRole = 'none' | UserRole;
 /**
  * Operator policy for managed environment lifecycle execution.
  *
- * - `command` (default): rendered start/stop/nuke/logs fields execute as shell
+ * - `hybrid` (default): rendered start/stop/nuke/logs fields execute as shell
  *   commands, except explicit HTTP(S) URLs are invoked as GET webhooks.
  * - `webhook-only`: rendered lifecycle fields must be HTTP(S) URLs; shell
  *   commands are rejected before execution.
  */
-export type ManagedEnvsExecutionMode = 'command' | 'webhook-only';
+export type ManagedEnvsExecutionMode = 'hybrid' | 'webhook-only';
 
 /**
  * Type for user-provided JSON data where structure is unknown or dynamic
@@ -533,7 +533,7 @@ export interface AgorExecutionSettings {
   /**
    * Managed environment lifecycle execution policy.
    *
-   * - `'command'` — default/backwards-compatible mode. Rendered lifecycle
+   * - `'hybrid'` — default/backwards-compatible mode. Rendered lifecycle
    *   fields run as shell commands, except fields that are explicit `http://`
    *   or `https://` URLs are invoked as GET webhooks.
    * - `'webhook-only'` — lockdown mode for deployments that must not let
@@ -543,7 +543,7 @@ export interface AgorExecutionSettings {
    * Server policy wins over repo-authored `.agor.yml`: a repo cannot opt out
    * of webhook-only mode.
    *
-   * Default: `'command'`.
+   * Default: `'hybrid'`.
    */
   managed_envs_execution_mode?: ManagedEnvsExecutionMode;
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -2,25 +2,19 @@
  * Agor Configuration Types
  */
 
+import type { ManagedEnvExecutionMode } from '../environment/webhook';
 import type { BranchPermissionLevel } from '../types/branch';
 import type { DaemonResourcesConfig } from '../types/config-resources';
 import type { UserRole } from '../types/user';
+
+export type { ManagedEnvExecutionMode };
+export type ManagedEnvsExecutionMode = ManagedEnvExecutionMode;
 
 /**
  * Minimum role allowed to trigger managed environment commands
  * (start/stop/nuke/logs). `'none'` disables the feature entirely.
  */
 export type ManagedEnvsMinimumRole = 'none' | UserRole;
-
-/**
- * Operator policy for managed environment lifecycle execution.
- *
- * - `hybrid` (default): rendered start/stop/nuke/logs fields execute as shell
- *   commands, except explicit HTTP(S) URLs are invoked as GET webhooks.
- * - `webhook-only`: rendered lifecycle fields must be HTTP(S) URLs; shell
- *   commands are rejected before execution.
- */
-export type ManagedEnvsExecutionMode = 'hybrid' | 'webhook-only';
 
 /**
  * Type for user-provided JSON data where structure is unknown or dynamic

--- a/packages/core/src/environment/webhook.test.ts
+++ b/packages/core/src/environment/webhook.test.ts
@@ -38,6 +38,10 @@ describe('managed environment webhook URL detection', () => {
     expect(isAllowedManagedEnvWebhookUrl('http://192.168.1.20/start')).toBe(false);
     expect(isAllowedManagedEnvWebhookUrl('http://172.16.0.1/start')).toBe(false);
     expect(isAllowedManagedEnvWebhookUrl('http://metadata.google.internal/')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://[::ffff:127.0.0.1]/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://[::ffff:169.254.169.254]/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://[fe90::1]/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://[fea0::1]/start')).toBe(false);
   });
 
   it('redacts query strings for audit logging', () => {
@@ -83,6 +87,24 @@ describe('managed environment policy validation', () => {
         'webhook-only'
       )
     ).toThrow(/variant "base" start must render to an http\(s\) URL webhook/);
+  });
+
+  it('allows unresolved repo lifecycle templates for rendered branch-state validation', () => {
+    expect(() =>
+      validateRepoEnvironmentLifecyclePolicy(
+        {
+          version: 2,
+          default: 'default',
+          variants: {
+            default: {
+              start: '{{custom.webhook_base}}/start?branch={{branch.name}}',
+              stop: 'https://hooks.example.com/stop',
+            },
+          },
+        },
+        'webhook-only'
+      )
+    ).not.toThrow();
   });
 
   it('validates rendered health and app as URL-only fields', () => {

--- a/packages/core/src/environment/webhook.test.ts
+++ b/packages/core/src/environment/webhook.test.ts
@@ -34,18 +34,18 @@ describe('managed environment webhook URL detection', () => {
 });
 
 describe('resolveManagedEnvCommandExecution', () => {
-  it('preserves shell command execution in default command mode', () => {
-    expect(resolveManagedEnvCommandExecution('docker compose up -d', 'command', 'start')).toEqual({
+  it('preserves shell command execution in default hybrid mode', () => {
+    expect(resolveManagedEnvCommandExecution('docker compose up -d', 'hybrid', 'start')).toEqual({
       kind: 'command',
       command: 'docker compose up -d',
     });
   });
 
-  it('uses GET webhook execution for URL-shaped fields in command mode', () => {
+  it('uses GET webhook execution for URL-shaped fields in hybrid mode', () => {
     expect(
       resolveManagedEnvCommandExecution(
         'https://hooks.example.com/start?token=secret',
-        'command',
+        'hybrid',
         'start'
       )
     ).toEqual({

--- a/packages/core/src/environment/webhook.test.ts
+++ b/packages/core/src/environment/webhook.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isAllowedManagedEnvWebhookUrl,
   isUrlShapedManagedEnvCommand,
   normalizeManagedEnvWebhookUrl,
   redactManagedEnvWebhookUrlForAudit,
   resolveManagedEnvCommandExecution,
+  validateManagedEnvLifecyclePolicy,
+  validateRenderedManagedEnvUrlFields,
+  validateRepoEnvironmentLifecyclePolicy,
 } from './webhook.js';
 
 describe('managed environment webhook URL detection', () => {
@@ -26,10 +30,74 @@ describe('managed environment webhook URL detection', () => {
     );
   });
 
+  it('uses a stricter webhook destination policy than health checks', () => {
+    expect(isAllowedManagedEnvWebhookUrl('https://hooks.example.com/start')).toBe(true);
+    expect(isAllowedManagedEnvWebhookUrl('http://localhost:3000/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://127.0.0.1:3000/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://10.0.0.5/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://192.168.1.20/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://172.16.0.1/start')).toBe(false);
+    expect(isAllowedManagedEnvWebhookUrl('http://metadata.google.internal/')).toBe(false);
+  });
+
   it('redacts query strings for audit logging', () => {
     expect(redactManagedEnvWebhookUrlForAudit('https://hooks.example.com/start?token=secret')).toBe(
       'https://hooks.example.com/start?[redacted]'
     );
+  });
+});
+
+describe('managed environment policy validation', () => {
+  it('allows shell commands in hybrid mode and URL webhooks in both modes', () => {
+    expect(() =>
+      validateManagedEnvLifecyclePolicy(
+        { start: 'docker compose up -d', stop: 'https://hooks.example.com/stop' },
+        'hybrid'
+      )
+    ).not.toThrow();
+    expect(() =>
+      validateManagedEnvLifecyclePolicy(
+        { start: 'https://hooks.example.com/start', stop: 'https://hooks.example.com/stop' },
+        'webhook-only'
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects shell commands in webhook-only repo environments', () => {
+    expect(() =>
+      validateRepoEnvironmentLifecyclePolicy(
+        {
+          version: 2,
+          default: 'child',
+          variants: {
+            base: {
+              start: 'docker compose up -d',
+              stop: 'https://hooks.example.com/stop',
+            },
+            child: {
+              extends: 'base',
+              stop: 'https://hooks.example.com/child-stop',
+            },
+          },
+        },
+        'webhook-only'
+      )
+    ).toThrow(/variant "base" start must render to an http\(s\) URL webhook/);
+  });
+
+  it('validates rendered health and app as URL-only fields', () => {
+    expect(() =>
+      validateRenderedManagedEnvUrlFields({
+        health: 'http://localhost:3000/health',
+        app: 'http://localhost:3000',
+      })
+    ).not.toThrow();
+    expect(() => validateRenderedManagedEnvUrlFields({ app: 'javascript:alert(1)' })).toThrow(
+      /app URL must use http or https/
+    );
+    expect(() =>
+      validateRenderedManagedEnvUrlFields({ health: 'http://169.254.169.254/latest/meta-data' })
+    ).toThrow(/health must render to an allowed http\(s\) URL/);
   });
 });
 

--- a/packages/core/src/environment/webhook.test.ts
+++ b/packages/core/src/environment/webhook.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isUrlShapedManagedEnvCommand,
+  normalizeManagedEnvWebhookUrl,
+  redactManagedEnvWebhookUrlForAudit,
+  resolveManagedEnvCommandExecution,
+} from './webhook.js';
+
+describe('managed environment webhook URL detection', () => {
+  it('treats explicit http(s) strings as URL-shaped only', () => {
+    expect(isUrlShapedManagedEnvCommand('https://hooks.example.com/start')).toBe(true);
+    expect(isUrlShapedManagedEnvCommand('  HTTP://localhost:3000/start')).toBe(true);
+    expect(isUrlShapedManagedEnvCommand('hooks.example.com/start')).toBe(false);
+    expect(isUrlShapedManagedEnvCommand('docker compose up -d')).toBe(false);
+  });
+
+  it('normalizes allowed URLs and rejects credentials or metadata targets', () => {
+    expect(normalizeManagedEnvWebhookUrl(' https://Example.com/path ')).toBe(
+      'https://example.com/path'
+    );
+    expect(() => normalizeManagedEnvWebhookUrl('https://user:pass@example.com/hook')).toThrow(
+      /must not include URL credentials/
+    );
+    expect(() => normalizeManagedEnvWebhookUrl('http://169.254.169.254/latest/meta-data/')).toThrow(
+      /blocked/
+    );
+  });
+
+  it('redacts query strings for audit logging', () => {
+    expect(redactManagedEnvWebhookUrlForAudit('https://hooks.example.com/start?token=secret')).toBe(
+      'https://hooks.example.com/start?[redacted]'
+    );
+  });
+});
+
+describe('resolveManagedEnvCommandExecution', () => {
+  it('preserves shell command execution in default command mode', () => {
+    expect(resolveManagedEnvCommandExecution('docker compose up -d', 'command', 'start')).toEqual({
+      kind: 'command',
+      command: 'docker compose up -d',
+    });
+  });
+
+  it('uses GET webhook execution for URL-shaped fields in command mode', () => {
+    expect(
+      resolveManagedEnvCommandExecution(
+        'https://hooks.example.com/start?token=secret',
+        'command',
+        'start'
+      )
+    ).toEqual({
+      kind: 'webhook',
+      url: 'https://hooks.example.com/start?token=secret',
+    });
+  });
+
+  it('rejects non-URL commands in webhook-only mode with a docs pointer', () => {
+    expect(() =>
+      resolveManagedEnvCommandExecution('docker compose up -d', 'webhook-only', 'start')
+    ).toThrow(
+      /execution\.managed_envs_execution_mode: webhook-only.*environment-configuration#webhook-only-mode/s
+    );
+  });
+});

--- a/packages/core/src/environment/webhook.ts
+++ b/packages/core/src/environment/webhook.ts
@@ -1,0 +1,113 @@
+import type { EnvironmentCommandType } from '../unix/environment-command-spawn.js';
+import { isAllowedHealthCheckUrl, normalizeOptionalHttpUrl } from '../utils/url.js';
+
+/**
+ * How Agor executes rendered managed-environment lifecycle fields.
+ *
+ * - `command`: backwards-compatible shell command execution. URL-shaped fields
+ *   are treated as webhooks instead of shell strings.
+ * - `webhook-only`: operator lockdown mode. Every executable lifecycle field
+ *   must be an HTTP(S) URL and is invoked with GET; shell commands are rejected.
+ */
+export type ManagedEnvExecutionMode = 'command' | 'webhook-only';
+
+export type ManagedEnvCommandExecution =
+  | { kind: 'command'; command: string }
+  | { kind: 'webhook'; url: string };
+
+export const MANAGED_ENV_EXECUTION_MODE_DEFAULT: ManagedEnvExecutionMode = 'command';
+
+export const MANAGED_ENV_WEBHOOK_DOCS_PATH = '/guide/environment-configuration#webhook-only-mode';
+
+const HTTP_URL_PREFIX = /^https?:\/\//i;
+
+/**
+ * "URL-shaped" intentionally means explicit HTTP(S) URL. Bare hostnames like
+ * `example.com/hook` remain shell commands in default mode and are rejected in
+ * webhook-only mode so execution semantics are never guessed.
+ */
+export function isUrlShapedManagedEnvCommand(value: string): boolean {
+  return HTTP_URL_PREFIX.test(value.trim());
+}
+
+/**
+ * Normalize and validate a managed-environment webhook URL.
+ *
+ * V1 deliberately supports only GET to HTTP(S) URLs. It blocks obvious cloud
+ * metadata/link-local targets and URL credentials, but it is not a complete
+ * SSRF sandbox; operators should point webhooks at trusted orchestration
+ * services and avoid embedding secrets in query strings.
+ */
+export function normalizeManagedEnvWebhookUrl(value: string, fieldName = 'environment webhook') {
+  const normalized = normalizeOptionalHttpUrl(value, fieldName);
+  if (!normalized) {
+    throw new Error(`${fieldName} must be a valid http(s) URL`);
+  }
+
+  const parsed = new URL(normalized);
+  if (parsed.username || parsed.password) {
+    throw new Error(`${fieldName} must not include URL credentials`);
+  }
+
+  if (!isAllowedHealthCheckUrl(normalized)) {
+    throw new Error(`${fieldName} is blocked by Agor's managed-environment webhook policy`);
+  }
+
+  return normalized;
+}
+
+export function redactManagedEnvWebhookUrlForAudit(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const queryMarker = parsed.search ? '?[redacted]' : '';
+    return `${parsed.origin}${parsed.pathname}${queryMarker}`;
+  } catch {
+    return '[invalid-url]';
+  }
+}
+
+function commandTypeLabel(commandType: EnvironmentCommandType): string {
+  switch (commandType) {
+    case 'start':
+      return 'start';
+    case 'stop':
+      return 'stop';
+    case 'nuke':
+      return 'nuke';
+    case 'logs':
+      return 'logs';
+    case 'health':
+      return 'health';
+  }
+}
+
+/**
+ * Resolve the execution strategy for a rendered environment lifecycle field.
+ * Pure helper used by the daemon service and tests.
+ */
+export function resolveManagedEnvCommandExecution(
+  command: string,
+  mode: ManagedEnvExecutionMode,
+  commandType: EnvironmentCommandType
+): ManagedEnvCommandExecution {
+  if (isUrlShapedManagedEnvCommand(command)) {
+    return {
+      kind: 'webhook',
+      url: normalizeManagedEnvWebhookUrl(
+        command,
+        `environment ${commandTypeLabel(commandType)} webhook`
+      ),
+    };
+  }
+
+  if (mode === 'webhook-only') {
+    throw new Error(
+      `Managed environment ${commandTypeLabel(commandType)} is blocked: this Agor instance is configured for ` +
+        `execution.managed_envs_execution_mode: webhook-only, so the rendered ${commandTypeLabel(commandType)} field ` +
+        `must be an http(s) URL webhook. Re-render or update the repo's .agor.yml environment variant. ` +
+        `Docs: ${MANAGED_ENV_WEBHOOK_DOCS_PATH}`
+    );
+  }
+
+  return { kind: 'command', command };
+}

--- a/packages/core/src/environment/webhook.ts
+++ b/packages/core/src/environment/webhook.ts
@@ -4,18 +4,18 @@ import { isAllowedHealthCheckUrl, normalizeOptionalHttpUrl } from '../utils/url.
 /**
  * How Agor executes rendered managed-environment lifecycle fields.
  *
- * - `command`: backwards-compatible shell command execution. URL-shaped fields
+ * - `hybrid`: backwards-compatible shell command execution. URL-shaped fields
  *   are treated as webhooks instead of shell strings.
  * - `webhook-only`: operator lockdown mode. Every executable lifecycle field
  *   must be an HTTP(S) URL and is invoked with GET; shell commands are rejected.
  */
-export type ManagedEnvExecutionMode = 'command' | 'webhook-only';
+export type ManagedEnvExecutionMode = 'hybrid' | 'webhook-only';
 
 export type ManagedEnvCommandExecution =
   | { kind: 'command'; command: string }
   | { kind: 'webhook'; url: string };
 
-export const MANAGED_ENV_EXECUTION_MODE_DEFAULT: ManagedEnvExecutionMode = 'command';
+export const MANAGED_ENV_EXECUTION_MODE_DEFAULT: ManagedEnvExecutionMode = 'hybrid';
 
 export const MANAGED_ENV_WEBHOOK_DOCS_PATH = '/guide/environment-configuration#webhook-only-mode';
 

--- a/packages/core/src/environment/webhook.ts
+++ b/packages/core/src/environment/webhook.ts
@@ -11,11 +11,11 @@ import { isAllowedHealthCheckUrl, normalizeOptionalHttpUrl } from '../utils/url.
  *   must be an HTTP(S) URL and is invoked with GET; shell commands are rejected.
  */
 export type ManagedEnvExecutionMode = 'hybrid' | 'webhook-only';
-export type ManagedEnvCommandType = 'start' | 'stop' | 'nuke' | 'logs' | 'health';
 
 export const MANAGED_ENV_LIFECYCLE_FIELDS = ['start', 'stop', 'nuke', 'logs'] as const;
 
 export type ManagedEnvLifecycleField = (typeof MANAGED_ENV_LIFECYCLE_FIELDS)[number];
+export type ManagedEnvCommandType = ManagedEnvLifecycleField;
 
 export type ManagedEnvCommandExecution =
   | { kind: 'command'; command: string }
@@ -64,12 +64,31 @@ function isBlockedIPv6(hostname: string): boolean {
   if (!normalized.includes(':')) return false;
   const mappedIPv4 = normalized.match(/:ffff:(\d+\.\d+\.\d+\.\d+)$/);
   if (mappedIPv4) return isBlockedIPv4(mappedIPv4[1]);
+
+  const hextets = normalized.split(':').filter(Boolean);
+  const mappedIndex = hextets.lastIndexOf('ffff');
+  if (mappedIndex >= 0 && hextets.length - mappedIndex === 3) {
+    const high = Number.parseInt(hextets[mappedIndex + 1], 16);
+    const low = Number.parseInt(hextets[mappedIndex + 2], 16);
+    if (
+      Number.isInteger(high) &&
+      Number.isInteger(low) &&
+      high >= 0 &&
+      high <= 0xffff &&
+      low >= 0 &&
+      low <= 0xffff
+    ) {
+      const ipv4 = `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+      return isBlockedIPv4(ipv4);
+    }
+  }
+
+  const firstHextet = Number.parseInt(hextets[0] ?? '', 16);
   return (
     normalized === '::1' ||
     normalized === '::' ||
-    normalized.startsWith('fe80:') ||
-    normalized.startsWith('fc') ||
-    normalized.startsWith('fd')
+    (Number.isInteger(firstHextet) && firstHextet >= 0xfe80 && firstHextet <= 0xfebf) ||
+    (Number.isInteger(firstHextet) && firstHextet >= 0xfc00 && firstHextet <= 0xfdff)
   );
 }
 
@@ -161,16 +180,22 @@ export function validateRepoEnvironmentLifecyclePolicy(
   for (const variantName of Object.keys(env.variants)) {
     const resolved = resolveVariant(env, variantName);
     if (!resolved) continue;
-    validateManagedEnvLifecyclePolicy(
-      {
-        start: resolved.start,
-        stop: resolved.stop,
-        nuke: resolved.nuke,
-        logs: resolved.logs,
-      },
-      mode,
-      `${context} variant "${variantName}"`
-    );
+    const lifecycleFields = {
+      start: resolved.start,
+      stop: resolved.stop,
+      nuke: resolved.nuke,
+      logs: resolved.logs,
+    } satisfies Partial<Record<ManagedEnvLifecycleField, string | null | undefined>>;
+
+    for (const field of MANAGED_ENV_LIFECYCLE_FIELDS) {
+      const value = lifecycleFields[field];
+      if (value?.includes('{{')) continue;
+      validateManagedEnvLifecyclePolicy(
+        { [field]: value },
+        mode,
+        `${context} variant "${variantName}"`
+      );
+    }
   }
 }
 
@@ -204,8 +229,6 @@ function commandTypeLabel(commandType: ManagedEnvCommandType): string {
       return 'nuke';
     case 'logs':
       return 'logs';
-    case 'health':
-      return 'health';
   }
 }
 

--- a/packages/core/src/environment/webhook.ts
+++ b/packages/core/src/environment/webhook.ts
@@ -1,4 +1,5 @@
-import type { EnvironmentCommandType } from '../unix/environment-command-spawn.js';
+import { resolveVariant } from '../config/variant-resolver.js';
+import type { RepoEnvironment } from '../types/branch.js';
 import { isAllowedHealthCheckUrl, normalizeOptionalHttpUrl } from '../utils/url.js';
 
 /**
@@ -10,6 +11,11 @@ import { isAllowedHealthCheckUrl, normalizeOptionalHttpUrl } from '../utils/url.
  *   must be an HTTP(S) URL and is invoked with GET; shell commands are rejected.
  */
 export type ManagedEnvExecutionMode = 'hybrid' | 'webhook-only';
+export type ManagedEnvCommandType = 'start' | 'stop' | 'nuke' | 'logs' | 'health';
+
+export const MANAGED_ENV_LIFECYCLE_FIELDS = ['start', 'stop', 'nuke', 'logs'] as const;
+
+export type ManagedEnvLifecycleField = (typeof MANAGED_ENV_LIFECYCLE_FIELDS)[number];
 
 export type ManagedEnvCommandExecution =
   | { kind: 'command'; command: string }
@@ -28,6 +34,75 @@ const HTTP_URL_PREFIX = /^https?:\/\//i;
  */
 export function isUrlShapedManagedEnvCommand(value: string): boolean {
   return HTTP_URL_PREFIX.test(value.trim());
+}
+
+function hostnameEqualsOrEndsWith(hostname: string, suffix: string): boolean {
+  return hostname === suffix || hostname.endsWith(`.${suffix}`);
+}
+
+function isBlockedIPv4(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+  const octets = parts.map((part) => Number(part));
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a >= 224
+  );
+}
+
+function isBlockedIPv6(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (!normalized.includes(':')) return false;
+  const mappedIPv4 = normalized.match(/:ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedIPv4) return isBlockedIPv4(mappedIPv4[1]);
+  return (
+    normalized === '::1' ||
+    normalized === '::' ||
+    normalized.startsWith('fe80:') ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd')
+  );
+}
+
+/**
+ * Webhook destinations have a stricter SSRF posture than health checks.
+ *
+ * Health checks intentionally allow localhost/private networks because they
+ * often probe branch-local services. Managed environment webhooks are outbound
+ * orchestration calls, so V1 allows public HTTP(S) destinations only. This is
+ * a syntactic guard (no DNS resolution); operators should still point webhooks
+ * at trusted orchestration services.
+ */
+export function isAllowedManagedEnvWebhookUrl(urlString: string): boolean {
+  let normalized: string | undefined;
+  try {
+    normalized = normalizeOptionalHttpUrl(urlString, 'managed environment webhook');
+  } catch {
+    return false;
+  }
+  if (!normalized) return false;
+
+  const url = new URL(normalized);
+  const hostname = url.hostname.toLowerCase();
+
+  if (url.username || url.password) return false;
+  if (hostname === 'localhost' || hostnameEqualsOrEndsWith(hostname, 'localhost')) return false;
+  if (hostname === 'metadata.google.internal') return false;
+  if (hostnameEqualsOrEndsWith(hostname, 'internal')) return false;
+  if (hostname.endsWith('.local')) return false;
+  if (isBlockedIPv4(hostname)) return false;
+  if (isBlockedIPv6(hostname)) return false;
+
+  return true;
 }
 
 /**
@@ -49,11 +124,64 @@ export function normalizeManagedEnvWebhookUrl(value: string, fieldName = 'enviro
     throw new Error(`${fieldName} must not include URL credentials`);
   }
 
-  if (!isAllowedHealthCheckUrl(normalized)) {
+  if (!isAllowedManagedEnvWebhookUrl(normalized)) {
     throw new Error(`${fieldName} is blocked by Agor's managed-environment webhook policy`);
   }
 
   return normalized;
+}
+
+export function validateManagedEnvLifecyclePolicy(
+  lifecycleFields: Partial<Record<ManagedEnvLifecycleField, string | null | undefined>>,
+  mode: ManagedEnvExecutionMode,
+  context = 'managed environment'
+): void {
+  for (const field of MANAGED_ENV_LIFECYCLE_FIELDS) {
+    const value = lifecycleFields[field];
+    if (!value?.trim()) continue;
+
+    if (isUrlShapedManagedEnvCommand(value)) {
+      normalizeManagedEnvWebhookUrl(value, `${context} ${field} webhook`);
+      continue;
+    }
+
+    if (mode === 'webhook-only') {
+      throw new Error(
+        `${context} ${field} must render to an http(s) URL webhook on this Agor instance`
+      );
+    }
+  }
+}
+
+export function validateRepoEnvironmentLifecyclePolicy(
+  env: RepoEnvironment,
+  mode: ManagedEnvExecutionMode,
+  context = 'repo environment'
+): void {
+  for (const variantName of Object.keys(env.variants)) {
+    const resolved = resolveVariant(env, variantName);
+    if (!resolved) continue;
+    validateManagedEnvLifecyclePolicy(
+      {
+        start: resolved.start,
+        stop: resolved.stop,
+        nuke: resolved.nuke,
+        logs: resolved.logs,
+      },
+      mode,
+      `${context} variant "${variantName}"`
+    );
+  }
+}
+
+export function validateRenderedManagedEnvUrlFields(fields: {
+  health?: string | null;
+  app?: string | null;
+}): void {
+  if (fields.health?.trim() && !isAllowedHealthCheckUrl(fields.health)) {
+    throw new Error('managed environment health must render to an allowed http(s) URL');
+  }
+  normalizeOptionalHttpUrl(fields.app, 'managed environment app URL');
 }
 
 export function redactManagedEnvWebhookUrlForAudit(url: string): string {
@@ -66,7 +194,7 @@ export function redactManagedEnvWebhookUrlForAudit(url: string): string {
   }
 }
 
-function commandTypeLabel(commandType: EnvironmentCommandType): string {
+function commandTypeLabel(commandType: ManagedEnvCommandType): string {
   switch (commandType) {
     case 'start':
       return 'start';
@@ -88,7 +216,7 @@ function commandTypeLabel(commandType: EnvironmentCommandType): string {
 export function resolveManagedEnvCommandExecution(
   command: string,
   mode: ManagedEnvExecutionMode,
-  commandType: EnvironmentCommandType
+  commandType: ManagedEnvCommandType
 ): ManagedEnvCommandExecution {
   if (isUrlShapedManagedEnvCommand(command)) {
     return {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     'templates/zone-trigger-context': 'src/templates/zone-trigger-context.ts', // Canonical zone-trigger context builder
     'environment/variable-resolver': 'src/environment/variable-resolver.ts', // Environment variable resolution
     'environment/render-snapshot': 'src/environment/render-snapshot.ts', // v2 branch env snapshot rendering
+    'environment/webhook': 'src/environment/webhook.ts', // Managed environment webhook execution policy
     'utils/errors': 'src/utils/errors.ts', // Error handling and formatting utilities
     'utils/url': 'src/utils/url.ts', // Shared URL validation helpers
     'utils/permission-mode-mapper': 'src/utils/permission-mode-mapper.ts', // Permission mode mapping for cross-agent compatibility


### PR DESCRIPTION
## Summary

- Adds `execution.managed_envs_execution_mode` with default `hybrid` and `webhook-only` modes.
- In hybrid mode, explicit HTTP(S) lifecycle fields run as GET webhooks while existing non-URL lifecycle fields keep shell command behavior.
- In webhook-only mode, rendered lifecycle fields are handled as URL webhooks and non-URL rendered values are rejected before execution.
- Centralizes managed-environment lifecycle policy helpers/types/defaults in core and reuses them from daemon/UI.
- Enforces policy on repo/branch writes and rendered branch snapshots, including executor materialization via the branch patch hook.
- Allows unresolved repo-level lifecycle templates to be saved while keeping rendered branch-state validation authoritative.
- Adds a distinct public-destination webhook URL policy and keeps health/app as URL-only non-command fields.
- Updates the Environment tab with mode-aware guidance/placeholders and shared policy validation.
- Documents the execution modes, updates MCP descriptions/docs, and exposes the execution mode in daemon config/about responses.

## Security notes

- URL webhooks must be absolute `http`/`https` URLs and cannot include credentials.
- Managed-environment webhooks use a stricter destination policy than health checks: localhost, private/link-local ranges, multicast, IPv4-mapped local IPv6, `.local`, `.internal`, and known metadata hosts are rejected.
- Webhook audit logs redact query strings and response bodies are size-limited.
- Status/log/nuke are subject to the same policy as start/stop so webhook-only mode does not accidentally preserve arbitrary command execution.
- `health` remains on the existing health-check URL path; `app` remains display/link metadata and is validated as http(s) on persisted snapshots.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/environment/webhook.test.ts src/config/config-manager.test.ts`
- `pnpm --filter @agor/core test -- src/environment/webhook.test.ts`
- `pnpm --filter @agor/core build && pnpm --filter @agor/daemon typecheck && pnpm --filter agor-ui typecheck && git diff --check`

## Review

- Reviewed by spawned Codex session twice after initial implementation.
- Final review found no PR-blocking correctness, security, modeling, or DRY issues.
- Known V1 caveat: webhook destination filtering is syntactic/no-DNS; future hardening could add DNS-backed checks or operator allowlists.
