### PR TITLE
Fix optional pgvector knowledge migrations

### DIFF
--- a/apps/agor-daemon/src/knowledge/pgvector.test.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.test.ts
@@ -1,0 +1,41 @@
+import type { Database } from '@agor/core/db';
+import { describe, expect, it, vi } from 'vitest';
+import { ensureKnowledgePgvectorStorage, getKnowledgePgvectorCapability } from './pgvector';
+
+function fakePostgresDb(execute: (query: unknown) => unknown | Promise<unknown>): Database {
+  return {
+    execute,
+  } as unknown as Database;
+}
+
+describe('Knowledge pgvector capability detection', () => {
+  it('treats postgres-js array results as available when extension and storage exist', async () => {
+    const db = fakePostgresDb(() => [
+      { extension_installed: true, extension_available: true, storage_ready: true },
+    ]);
+
+    await expect(getKnowledgePgvectorCapability(db)).resolves.toMatchObject({
+      available: true,
+      extensionInstalled: true,
+      extensionAvailable: true,
+      storageReady: true,
+      reason: null,
+    });
+  });
+
+  it('does not throw when CREATE EXTENSION is denied', async () => {
+    let calls = 0;
+    const execute = vi.fn(() => {
+      calls += 1;
+      if (calls === 2) throw new Error('permission denied');
+      return [{ extension_installed: false, extension_available: true, storage_ready: false }];
+    });
+    const db = fakePostgresDb(execute);
+
+    await expect(ensureKnowledgePgvectorStorage(db)).resolves.toMatchObject({
+      available: false,
+      reason: expect.stringContaining('permission denied'),
+      setupHint: expect.stringContaining('CREATE EXTENSION vector'),
+    });
+  });
+});

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -1,0 +1,150 @@
+import { type Database, executeRaw, isPostgresDatabase, sql } from '@agor/core/db';
+
+export interface KnowledgePgvectorCapability {
+  available: boolean;
+  extensionInstalled: boolean;
+  extensionAvailable: boolean;
+  storageReady: boolean;
+  reason: string | null;
+  setupHint: string | null;
+}
+
+const SETUP_HINT =
+  'Install the pgvector package on the Postgres server and have a database owner run `CREATE EXTENSION vector;`, or grant the Agor database user permission to create the extension, then re-enable/reindex Knowledge semantic search.';
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+function boolValue(value: unknown): boolean {
+  return value === true || value === 't' || value === 'true' || value === 1 || value === '1';
+}
+
+export function semanticUnavailableMessage(reason?: string | null): string {
+  return `Semantic Knowledge search is unavailable${reason ? `: ${reason}` : ''}. ${SETUP_HINT}`;
+}
+
+async function readCapability(db: Database): Promise<KnowledgePgvectorCapability> {
+  if (!isPostgresDatabase(db)) {
+    return {
+      available: false,
+      extensionInstalled: false,
+      extensionAvailable: false,
+      storageReady: false,
+      reason: 'the configured database is not PostgreSQL',
+      setupHint: 'Use text Knowledge search, or switch Agor to PostgreSQL and enable pgvector.',
+    };
+  }
+
+  try {
+    const result = await executeRaw(
+      db,
+      sql`SELECT
+          EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS extension_installed,
+          EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS extension_available,
+          to_regclass('public.kb_unit_embeddings') IS NOT NULL AS storage_ready`
+    );
+    const first = rowsOf(result)[0] ?? {};
+    const extensionInstalled = boolValue(first.extension_installed);
+    const extensionAvailable = boolValue(first.extension_available);
+    const storageReady = boolValue(first.storage_ready);
+    const reason = !extensionInstalled
+      ? extensionAvailable
+        ? 'the pgvector extension is available on the server but is not enabled in this database'
+        : 'the pgvector extension is not installed on this Postgres server'
+      : !storageReady
+        ? 'the Knowledge vector storage table has not been created yet'
+        : null;
+    return {
+      available: extensionInstalled && storageReady,
+      extensionInstalled,
+      extensionAvailable,
+      storageReady,
+      reason,
+      setupHint: reason ? SETUP_HINT : null,
+    };
+  } catch (error) {
+    return {
+      available: false,
+      extensionInstalled: false,
+      extensionAvailable: false,
+      storageReady: false,
+      reason: `unable to inspect pgvector capability (${error instanceof Error ? error.message : String(error)})`,
+      setupHint: SETUP_HINT,
+    };
+  }
+}
+
+export async function getKnowledgePgvectorCapability(
+  db: Database
+): Promise<KnowledgePgvectorCapability> {
+  return readCapability(db);
+}
+
+export async function ensureKnowledgePgvectorStorage(
+  db: Database
+): Promise<KnowledgePgvectorCapability> {
+  if (!isPostgresDatabase(db)) return readCapability(db);
+
+  let capability = await readCapability(db);
+  if (!capability.extensionInstalled) {
+    try {
+      await executeRaw(db, sql`CREATE EXTENSION IF NOT EXISTS vector`);
+    } catch (error) {
+      return {
+        ...capability,
+        available: false,
+        reason: `pgvector could not be enabled (${error instanceof Error ? error.message : String(error)})`,
+        setupHint: SETUP_HINT,
+      };
+    }
+    capability = await readCapability(db);
+    if (!capability.extensionInstalled) return capability;
+  }
+
+  try {
+    await executeRaw(
+      db,
+      sql`CREATE TABLE IF NOT EXISTS kb_unit_embeddings (
+          unit_id varchar(36) NOT NULL REFERENCES public.kb_document_units(unit_id) ON DELETE cascade,
+          embedding_space_id varchar(36) NOT NULL REFERENCES public.kb_embedding_spaces(embedding_space_id) ON DELETE cascade,
+          content_sha256 text NOT NULL,
+          embedding vector NOT NULL,
+          token_count integer,
+          created_at timestamp with time zone NOT NULL,
+          updated_at timestamp with time zone NOT NULL,
+          CONSTRAINT kb_unit_embeddings_unit_id_embedding_space_id_pk PRIMARY KEY(unit_id, embedding_space_id)
+        )`
+    );
+    await executeRaw(
+      db,
+      sql`CREATE INDEX IF NOT EXISTS kb_unit_embeddings_space_idx ON kb_unit_embeddings USING btree (embedding_space_id)`
+    );
+
+    try {
+      await executeRaw(
+        db,
+        sql`CREATE INDEX IF NOT EXISTS kb_unit_embeddings_embedding_1536_hnsw_idx
+            ON kb_unit_embeddings USING hnsw ((embedding::vector(1536)) vector_cosine_ops)
+            WHERE vector_dims(embedding) = 1536`
+      );
+    } catch (error) {
+      console.warn(
+        '[knowledge-pgvector] vector storage is available, but creating the HNSW index failed:',
+        error instanceof Error ? error.message : error
+      );
+    }
+  } catch (error) {
+    return {
+      ...capability,
+      available: false,
+      storageReady: false,
+      reason: `Knowledge vector storage could not be created (${error instanceof Error ? error.message : String(error)})`,
+      setupHint: SETUP_HINT,
+    };
+  }
+
+  return readCapability(db);
+}

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -44,6 +44,7 @@ import {
   KNOWLEDGE_EMBEDDINGS_API_KEY,
   KNOWLEDGE_EMBEDDINGS_NAMESPACE,
 } from '../knowledge/embeddings.js';
+import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
 import {
   knowledgeChunkerOptionsFromConfig,
   knowledgeUnitsForMarkdown,
@@ -240,9 +241,11 @@ export class KnowledgeDocumentsService extends DrizzleService<
       KNOWLEDGE_EMBEDDINGS_NAMESPACE,
       KNOWLEDGE_EMBEDDINGS_API_KEY
     );
-    return isUsableOpenAIEmbeddingConfig(
-      config.knowledge?.semantic_search ?? {},
-      Boolean(apiKey?.value_encrypted)
+    return (
+      isUsableOpenAIEmbeddingConfig(
+        config.knowledge?.semantic_search ?? {},
+        Boolean(apiKey?.value_encrypted)
+      ) && (await ensureKnowledgePgvectorStorage(this.db)).available
     );
   }
 

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -81,6 +81,11 @@ export class KnowledgeEmbeddingIndexer {
     return this.lastIndexedAt;
   }
 
+  private idle(): 0 {
+    this.lastError = null;
+    return 0;
+  }
+
   private async ensureEmbeddingSpace(params: {
     provider: string;
     model: string;
@@ -130,17 +135,17 @@ export class KnowledgeEmbeddingIndexer {
   async indexBatch(): Promise<number> {
     const config = await loadConfig();
     const semantic = config.knowledge?.semantic_search;
-    if (semantic?.enabled !== true) return 0;
-    if (semantic.indexing?.paused === true) return 0;
-    if (!isPostgresDatabase(this.db)) return 0;
+    if (semantic?.enabled !== true) return this.idle();
+    if (semantic.indexing?.paused === true) return this.idle();
+    if (!isPostgresDatabase(this.db)) return this.idle();
     const provider = semantic.provider ?? 'openai';
-    if (provider !== 'openai') return 0;
+    if (provider !== 'openai') return this.idle();
 
     const apiKey = await this.variables.getPlain(
       KNOWLEDGE_EMBEDDINGS_NAMESPACE,
       KNOWLEDGE_EMBEDDINGS_API_KEY
     );
-    if (!apiKey) return 0;
+    if (!apiKey) return this.idle();
 
     const model = semantic.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL;
     if (!SUPPORTED_OPENAI_EMBEDDING_MODELS.has(model)) {
@@ -170,7 +175,7 @@ export class KnowledgeEmbeddingIndexer {
       .orderBy(kbDocumentUnits.created_at)
       .limit(batchSize)
       .all()) as PendingUnitRow[];
-    if (rows.length === 0) return 0;
+    if (rows.length === 0) return this.idle();
 
     const embeddingSpaceId = await this.ensureEmbeddingSpace({ provider, model, dimensions });
     let results: Awaited<ReturnType<OpenAIEmbeddingProvider['embed']>>;

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -24,6 +24,7 @@ import {
   SUPPORTED_OPENAI_EMBEDDING_MODELS,
   sha256Text,
 } from '../knowledge/embeddings.js';
+import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
 
 const DEFAULT_TICK_MS = 30_000;
 
@@ -116,8 +117,8 @@ export class KnowledgeEmbeddingIndexer {
     if (this.running) return;
     this.running = true;
     try {
-      await this.indexBatch();
-      this.lastError = null;
+      const indexed = await this.indexBatch();
+      if (indexed > 0 || !this.lastError) this.lastError = null;
     } catch (error) {
       this.lastError = error instanceof Error ? error.message : String(error);
       throw error;
@@ -152,7 +153,15 @@ export class KnowledgeEmbeddingIndexer {
       );
     }
 
+    const pgvector = await ensureKnowledgePgvectorStorage(this.db);
+    if (!pgvector.available) {
+      this.lastError = pgvector.reason ?? 'Knowledge pgvector storage is unavailable';
+      return 0;
+    }
+
     const batchSize = Math.min(Math.max(semantic.indexing?.batch_size ?? 32, 1), 128);
+    this.lastError = null;
+
     const rows = (await select(this.db)
       .from(kbDocumentUnits)
       .where(

--- a/apps/agor-daemon/src/services/knowledge-indexing.ts
+++ b/apps/agor-daemon/src/services/knowledge-indexing.ts
@@ -67,17 +67,24 @@ export class KnowledgeIndexingStatusService {
     }
 
     const pgvector = await getKnowledgePgvectorCapability(this.db);
+    const semanticEnabled = semantic.enabled === true;
+    const embeddingConfigUsable = isUsableOpenAIEmbeddingConfig(
+      semantic,
+      Boolean(apiKey?.value_encrypted)
+    );
+    const configured = isPostgresDatabase(this.db) && pgvector.available && embeddingConfigUsable;
 
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'
     ) as { getLastIndexedAt?: () => Date | null; getLastError?: () => string | null } | undefined;
+    const lastError = semanticEnabled
+      ? ((configured ? indexer?.getLastError?.() : null) ??
+        (!pgvector.available ? pgvector.reason : null))
+      : null;
 
     return {
-      enabled: semantic.enabled === true,
-      configured:
-        isPostgresDatabase(this.db) &&
-        pgvector.available &&
-        isUsableOpenAIEmbeddingConfig(semantic, Boolean(apiKey?.value_encrypted)),
+      enabled: semanticEnabled,
+      configured,
       dialect: isPostgresDatabase(this.db) ? 'postgresql' : 'sqlite',
       pgvector_available: pgvector.available,
       pgvector_extension_installed: pgvector.extensionInstalled,
@@ -90,9 +97,7 @@ export class KnowledgeIndexingStatusService {
       chunks: counts,
       queue_depth: counts.pending + counts.stale,
       last_indexed_at: indexer?.getLastIndexedAt?.() ?? null,
-      last_error:
-        indexer?.getLastError?.() ??
-        (semantic.enabled === true && !pgvector.available ? pgvector.reason : null),
+      last_error: lastError,
     };
   }
 }

--- a/apps/agor-daemon/src/services/knowledge-indexing.ts
+++ b/apps/agor-daemon/src/services/knowledge-indexing.ts
@@ -2,7 +2,6 @@ import { loadConfig } from '@agor/core/config';
 import {
   AppVariableRepository,
   type Database,
-  executeRaw,
   isPostgresDatabase,
   kbDocumentUnits,
   select,
@@ -22,6 +21,7 @@ import {
   KNOWLEDGE_EMBEDDINGS_API_KEY,
   KNOWLEDGE_EMBEDDINGS_NAMESPACE,
 } from '../knowledge/embeddings.js';
+import { getKnowledgePgvectorCapability } from '../knowledge/pgvector.js';
 
 const STATUSES: KnowledgeEmbeddingStatus[] = [
   'not_configured',
@@ -66,19 +66,7 @@ export class KnowledgeIndexingStatusService {
       counts[row.status] = Number(row.count) || 0;
     }
 
-    let pgvectorAvailable = false;
-    if (isPostgresDatabase(this.db)) {
-      try {
-        const pgvectorRows = await executeRaw(
-          this.db,
-          sql`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS available`
-        );
-        const first = pgvectorRows.rows?.[0] as { available?: boolean } | undefined;
-        pgvectorAvailable = Boolean(first?.available);
-      } catch {
-        pgvectorAvailable = false;
-      }
-    }
+    const pgvector = await getKnowledgePgvectorCapability(this.db);
 
     const indexer = (this.app as unknown as { get?: (key: string) => unknown } | undefined)?.get?.(
       'knowledgeEmbeddingIndexer'
@@ -88,17 +76,19 @@ export class KnowledgeIndexingStatusService {
       enabled: semantic.enabled === true,
       configured:
         isPostgresDatabase(this.db) &&
-        pgvectorAvailable &&
+        pgvector.available &&
         isUsableOpenAIEmbeddingConfig(semantic, Boolean(apiKey?.value_encrypted)),
       dialect: isPostgresDatabase(this.db) ? 'postgresql' : 'sqlite',
-      pgvector_available: pgvectorAvailable,
+      pgvector_available: pgvector.extensionInstalled,
       provider: semantic.provider ?? 'openai',
       model: semantic.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL,
       dimensions: semantic.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
       chunks: counts,
       queue_depth: counts.pending + counts.stale,
       last_indexed_at: indexer?.getLastIndexedAt?.() ?? null,
-      last_error: indexer?.getLastError?.() ?? null,
+      last_error:
+        indexer?.getLastError?.() ??
+        (semantic.enabled === true && !pgvector.available ? pgvector.reason : null),
     };
   }
 }

--- a/apps/agor-daemon/src/services/knowledge-indexing.ts
+++ b/apps/agor-daemon/src/services/knowledge-indexing.ts
@@ -79,7 +79,11 @@ export class KnowledgeIndexingStatusService {
         pgvector.available &&
         isUsableOpenAIEmbeddingConfig(semantic, Boolean(apiKey?.value_encrypted)),
       dialect: isPostgresDatabase(this.db) ? 'postgresql' : 'sqlite',
-      pgvector_available: pgvector.extensionInstalled,
+      pgvector_available: pgvector.available,
+      pgvector_extension_installed: pgvector.extensionInstalled,
+      pgvector_storage_ready: pgvector.storageReady,
+      pgvector_reason: pgvector.reason,
+      pgvector_setup_hint: pgvector.setupHint,
       provider: semantic.provider ?? 'openai',
       model: semantic.model ?? DEFAULT_OPENAI_EMBEDDING_MODEL,
       dimensions: semantic.dimensions ?? DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,

--- a/apps/agor-daemon/src/services/knowledge-reindex.ts
+++ b/apps/agor-daemon/src/services/knowledge-reindex.ts
@@ -7,6 +7,7 @@ import {
   KNOWLEDGE_EMBEDDINGS_API_KEY,
   KNOWLEDGE_EMBEDDINGS_NAMESPACE,
 } from '../knowledge/embeddings.js';
+import { ensureKnowledgePgvectorStorage } from '../knowledge/pgvector.js';
 import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 
 export interface KnowledgeReindexResult {
@@ -35,7 +36,8 @@ export class KnowledgeReindexService {
     );
     const embeddingConfigured =
       isPostgresDatabase(this.db) &&
-      isUsableOpenAIEmbeddingConfig(semantic, Boolean(apiKey?.value_encrypted));
+      isUsableOpenAIEmbeddingConfig(semantic, Boolean(apiKey?.value_encrypted)) &&
+      (await ensureKnowledgePgvectorStorage(this.db)).available;
     const status: KnowledgeEmbeddingStatus = embeddingConfigured ? 'pending' : 'not_configured';
 
     const queued = await rebuildCurrentKnowledgeUnits(this.db, config, { embeddingConfigured });

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -33,6 +33,10 @@ import {
   OpenAIEmbeddingProvider,
   SUPPORTED_OPENAI_EMBEDDING_MODELS,
 } from '../knowledge/embeddings.js';
+import {
+  getKnowledgePgvectorCapability,
+  semanticUnavailableMessage,
+} from '../knowledge/pgvector.js';
 
 export type KnowledgeSearchParams = QueryParams<KnowledgeSearchQuery> & AuthenticatedParams;
 
@@ -60,7 +64,10 @@ export class KnowledgeSearchService {
   private assertSupportedMode(query?: KnowledgeSearchQuery): void {
     const mode = query?.mode ?? 'text';
     if (mode !== 'text' && !isPostgresDatabase(this.db)) {
-      throw new BadRequest('Semantic Knowledge search requires Postgres with pgvector.');
+      throw new BadRequest(
+        semanticUnavailableMessage('the configured database is not PostgreSQL'),
+        { code: 'semantic_unavailable' }
+      );
     }
   }
 
@@ -95,7 +102,18 @@ export class KnowledgeSearchService {
     user?: User
   ): Promise<KnowledgeSearchResult[]> {
     if (!isPostgresDatabase(this.db)) {
-      throw new BadRequest('Semantic Knowledge search requires Postgres with pgvector.');
+      throw new BadRequest(
+        semanticUnavailableMessage('the configured database is not PostgreSQL'),
+        { code: 'semantic_unavailable' }
+      );
+    }
+    const pgvector = await getKnowledgePgvectorCapability(this.db);
+    if (!pgvector.available) {
+      throw new BadRequest(semanticUnavailableMessage(pgvector.reason), {
+        code: 'semantic_unavailable',
+        reason: pgvector.reason,
+        setup_hint: pgvector.setupHint,
+      });
     }
     const config = await loadConfig();
     const semantic = config.knowledge?.semantic_search ?? {};

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -30,6 +30,10 @@ import {
   normalizeKnowledgeEmbeddingApiKey,
   SUPPORTED_OPENAI_EMBEDDING_MODELS,
 } from '../knowledge/embeddings.js';
+import {
+  ensureKnowledgePgvectorStorage,
+  getKnowledgePgvectorCapability,
+} from '../knowledge/pgvector.js';
 import { rebuildCurrentKnowledgeUnits } from '../knowledge/units.js';
 
 const DEFAULT_PROVIDER: KnowledgeEmbeddingProvider = 'openai';
@@ -133,10 +137,13 @@ export class KnowledgeSettingsService {
       .all();
 
     if (isPostgresDatabase(this.db) && rows.length > 0) {
-      await executeRaw(
-        this.db,
-        sql`DELETE FROM kb_unit_embeddings WHERE unit_id IN (SELECT unit_id FROM kb_document_units WHERE version_id IN (SELECT current_version_id FROM kb_documents WHERE current_version_id IS NOT NULL AND archived = false))`
-      );
+      const pgvector = await getKnowledgePgvectorCapability(this.db);
+      if (pgvector.storageReady) {
+        await executeRaw(
+          this.db,
+          sql`DELETE FROM kb_unit_embeddings WHERE unit_id IN (SELECT unit_id FROM kb_document_units WHERE version_id IN (SELECT current_version_id FROM kb_documents WHERE current_version_id IS NOT NULL AND archived = false))`
+        );
+      }
     }
     return rows.length;
   }
@@ -234,7 +241,8 @@ export class KnowledgeSettingsService {
       );
       const configured =
         isPostgresDatabase(this.db) &&
-        isUsableOpenAIEmbeddingConfig(next, Boolean(apiKey?.value_encrypted));
+        isUsableOpenAIEmbeddingConfig(next, Boolean(apiKey?.value_encrypted)) &&
+        (await ensureKnowledgePgvectorStorage(this.db)).available;
       const queued = chunkingChanged
         ? await rebuildCurrentKnowledgeUnits(this.db, config, { embeddingConfigured: configured })
         : await this.markCurrentUnitsForEmbedding(configured ? 'pending' : 'not_configured');

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -291,6 +291,25 @@ describe('Knowledge semantic indexing lifecycle', () => {
   });
 
   dbTest(
+    'indexing status hides stale indexer errors when semantic search is disabled',
+    async ({ db }) => {
+      await withTempConfig({}, async () => {
+        const app = {
+          get: (key: string) =>
+            key === 'knowledgeEmbeddingIndexer'
+              ? { getLastError: () => 'old pgvector error', getLastIndexedAt: () => null }
+              : undefined,
+        } as never;
+
+        const status = await new KnowledgeIndexingStatusService(db, app).find();
+
+        expect(status.enabled).toBe(false);
+        expect(status.last_error).toBeNull();
+      });
+    }
+  );
+
+  dbTest(
     'indexer clears stale pgvector errors when semantic indexing is disabled',
     async ({ db }) => {
       await withTempConfig({}, async () => {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -18,7 +18,9 @@ import { ROLES } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { KnowledgeDocumentsService } from './knowledge-documents';
+import { KnowledgeEmbeddingIndexer } from './knowledge-embedding-indexer';
 import { KnowledgeGraphService } from './knowledge-graph';
+import { KnowledgeIndexingStatusService } from './knowledge-indexing';
 import { KnowledgeReindexService } from './knowledge-reindex';
 import { KnowledgeSearchService } from './knowledge-search';
 import { KnowledgeSettingsService } from './knowledge-settings';
@@ -273,6 +275,33 @@ describe('Knowledge semantic indexing lifecycle', () => {
       }
     );
   });
+
+  dbTest('indexing status separates pgvector extension from usable storage', async ({ db }) => {
+    await withTempConfig(
+      { knowledge: { semantic_search: { enabled: true, provider: 'openai' } } },
+      async () => {
+        const status = await new KnowledgeIndexingStatusService(db).find();
+
+        expect(status.pgvector_available).toBe(false);
+        expect(status.pgvector_extension_installed).toBe(false);
+        expect(status.pgvector_storage_ready).toBe(false);
+        expect(status.last_error).toContain('not PostgreSQL');
+      }
+    );
+  });
+
+  dbTest(
+    'indexer clears stale pgvector errors when semantic indexing is disabled',
+    async ({ db }) => {
+      await withTempConfig({}, async () => {
+        const indexer = new KnowledgeEmbeddingIndexer(db);
+        (indexer as unknown as { lastError: string | null }).lastError = 'old pgvector error';
+
+        await expect(indexer.indexBatch()).resolves.toBe(0);
+        expect(indexer.getLastError()).toBeNull();
+      });
+    }
+  );
 
   dbTest(
     'document content writes wake the embedding indexer through the app reference',

--- a/apps/agor-docs/pages/guide/extended-install.mdx
+++ b/apps/agor-docs/pages/guide/extended-install.mdx
@@ -40,6 +40,22 @@ The daemon detects Zellij at startup and logs whether it's available.
 
 ---
 
+## Optional: pgvector (for Knowledge semantic search)
+
+Agor does **not** require pgvector to install, upgrade, or run. Knowledge text search works without it.
+
+If you want Knowledge semantic or hybrid search on PostgreSQL, install the `pgvector` package on the Postgres server and enable the extension in the Agor database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+Run that as a database owner or another role with permission to create extensions. After pgvector is enabled, configure Knowledge semantic search in Agor and run a Knowledge reindex; the daemon creates the vector storage table and index idempotently when the feature is enabled.
+
+If pgvector is missing or the Agor DB user cannot enable it, semantic search returns a clear `semantic_unavailable` error and text search continues to work.
+
+---
+
 ## Authentication
 
 Agor supports Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot. The [onboarding wizard](/guide/getting-started#meet-your-first-assistant) handles the simple case — paste an API key, done. This section covers the alternatives: subscription-based auth, server-side CLI login, workspace-wide fallbacks, and how Agor resolves them when several are present.

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -2281,8 +2281,12 @@ export function KnowledgePage({
                   <Text strong>Indexing status</Text>
                   <Text type="secondary">
                     {indexingStatus.dialect} · pgvector{' '}
-                    {indexingStatus.pgvector_available ? 'available' : 'not available'} · queue{' '}
-                    {indexingStatus.queue_depth}
+                    {indexingStatus.pgvector_available
+                      ? 'ready'
+                      : indexingStatus.pgvector_extension_installed
+                        ? 'extension installed, storage not ready'
+                        : 'not available'}{' '}
+                    · queue {indexingStatus.queue_depth}
                   </Text>
                   <Space wrap>
                     {Object.entries(indexingStatus.chunks).map(([status, count]) => (

--- a/packages/core/drizzle/postgres/0043_kb_embeddings.sql
+++ b/packages/core/drizzle/postgres/0043_kb_embeddings.sql
@@ -1,6 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS vector;
---> statement-breakpoint
-CREATE TABLE "kb_embedding_spaces" (
+CREATE TABLE IF NOT EXISTS "kb_embedding_spaces" (
   "embedding_space_id" varchar(36) PRIMARY KEY NOT NULL,
   "provider" text NOT NULL,
   "model" text NOT NULL,
@@ -13,23 +11,6 @@ CREATE TABLE "kb_embedding_spaces" (
   "updated_at" timestamp with time zone
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX "kb_embedding_spaces_provider_model_idx" ON "kb_embedding_spaces" USING btree ("provider","model","dimensions","storage_type","distance");
+CREATE UNIQUE INDEX IF NOT EXISTS "kb_embedding_spaces_provider_model_idx" ON "kb_embedding_spaces" USING btree ("provider","model","dimensions","storage_type","distance");
 --> statement-breakpoint
-CREATE INDEX "kb_embedding_spaces_active_idx" ON "kb_embedding_spaces" USING btree ("active");
---> statement-breakpoint
-CREATE TABLE "kb_unit_embeddings" (
-  "unit_id" varchar(36) NOT NULL,
-  "embedding_space_id" varchar(36) NOT NULL,
-  "content_sha256" text NOT NULL,
-  "embedding" vector NOT NULL,
-  "token_count" integer,
-  "created_at" timestamp with time zone NOT NULL,
-  "updated_at" timestamp with time zone NOT NULL,
-  CONSTRAINT "kb_unit_embeddings_unit_id_embedding_space_id_pk" PRIMARY KEY("unit_id","embedding_space_id"),
-  CONSTRAINT "kb_unit_embeddings_unit_id_kb_document_units_unit_id_fk" FOREIGN KEY ("unit_id") REFERENCES "public"."kb_document_units"("unit_id") ON DELETE cascade ON UPDATE no action,
-  CONSTRAINT "kb_unit_embeddings_embedding_space_id_kb_embedding_spaces_embedding_space_id_fk" FOREIGN KEY ("embedding_space_id") REFERENCES "public"."kb_embedding_spaces"("embedding_space_id") ON DELETE cascade ON UPDATE no action
-);
---> statement-breakpoint
-CREATE INDEX "kb_unit_embeddings_space_idx" ON "kb_unit_embeddings" USING btree ("embedding_space_id");
---> statement-breakpoint
-CREATE INDEX "kb_unit_embeddings_embedding_1536_hnsw_idx" ON "kb_unit_embeddings" USING hnsw (("embedding"::vector(1536)) vector_cosine_ops) WHERE vector_dims("embedding") = 1536;
+CREATE INDEX IF NOT EXISTS "kb_embedding_spaces_active_idx" ON "kb_embedding_spaces" USING btree ("active");

--- a/packages/core/src/db/migrations.test.ts
+++ b/packages/core/src/db/migrations.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('Postgres migrations', () => {
+  it('keeps Knowledge pgvector storage out of required base migrations', async () => {
+    const migration = await readFile(
+      new URL('../../drizzle/postgres/0043_kb_embeddings.sql', import.meta.url),
+      'utf8'
+    );
+
+    expect(migration).not.toMatch(/CREATE\s+EXTENSION\s+IF\s+NOT\s+EXISTS\s+vector/i);
+    expect(migration).not.toContain('kb_unit_embeddings');
+    expect(migration).not.toMatch(/\bembedding\s+vector\b/i);
+    expect(migration).toContain('kb_embedding_spaces');
+  });
+});

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -43,24 +43,6 @@ const bytea = customType<{ data: Buffer | null; driverData: Buffer | null }>({
   },
 });
 
-const vector = customType<{ data: number[]; driverData: string; config?: { dimensions?: number } }>(
-  {
-    dataType(config) {
-      return config?.dimensions ? `vector(${config.dimensions})` : 'vector';
-    },
-    toDriver(value: number[]) {
-      return `[${value.join(',')}]`;
-    },
-    fromDriver(value: string) {
-      return value
-        .replace(/^\[|\]$/g, '')
-        .split(',')
-        .filter(Boolean)
-        .map((item) => Number(item));
-    },
-  }
-);
-
 // PostgreSQL-specific type helpers (inline to avoid factory pattern type issues)
 const t = {
   timestamp: (name: string) => timestamp(name, { mode: 'date', withTimezone: true }),
@@ -1872,27 +1854,12 @@ export const kbEmbeddingSpaces = pgTable(
   })
 );
 
-/** OpenAI-small V1 vector storage for Knowledge units. */
-export const kbUnitEmbeddings = pgTable(
-  'kb_unit_embeddings',
-  {
-    unit_id: varchar('unit_id', { length: 36 })
-      .notNull()
-      .references(() => kbDocumentUnits.unit_id, { onDelete: 'cascade' }),
-    embedding_space_id: varchar('embedding_space_id', { length: 36 })
-      .notNull()
-      .references(() => kbEmbeddingSpaces.embedding_space_id, { onDelete: 'cascade' }),
-    content_sha256: text('content_sha256').notNull(),
-    embedding: vector('embedding').notNull(),
-    token_count: integer('token_count'),
-    created_at: t.timestamp('created_at').notNull(),
-    updated_at: t.timestamp('updated_at').notNull(),
-  },
-  (table) => ({
-    pk: primaryKey({ columns: [table.unit_id, table.embedding_space_id] }),
-    spaceIdx: index('kb_unit_embeddings_space_idx').on(table.embedding_space_id),
-  })
-);
+/**
+ * Optional pgvector-backed Knowledge embeddings storage is created by the daemon
+ * at runtime when semantic search is enabled and pgvector is available. It is
+ * deliberately not part of the required Drizzle schema/migrations so Agor can
+ * install and upgrade on PostgreSQL instances without pgvector.
+ */
 
 /**
  * Graph nodes for knowledge documents, document units, core Agor objects, tags,
@@ -2099,8 +2066,6 @@ export type KBDocumentUnitRow = typeof kbDocumentUnits.$inferSelect;
 export type KBDocumentUnitInsert = typeof kbDocumentUnits.$inferInsert;
 export type KBEmbeddingSpaceRow = typeof kbEmbeddingSpaces.$inferSelect;
 export type KBEmbeddingSpaceInsert = typeof kbEmbeddingSpaces.$inferInsert;
-export type KBUnitEmbeddingRow = typeof kbUnitEmbeddings.$inferSelect;
-export type KBUnitEmbeddingInsert = typeof kbUnitEmbeddings.$inferInsert;
 export type KBGraphNodeRow = typeof kbGraphNodes.$inferSelect;
 export type KBGraphNodeInsert = typeof kbGraphNodes.$inferInsert;
 export type KBGraphEdgeRow = typeof kbGraphEdges.$inferSelect;

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -415,7 +415,16 @@ export interface KnowledgeIndexingStatus {
   enabled: boolean;
   configured: boolean;
   dialect: 'sqlite' | 'postgresql' | 'unknown';
+  /** True only when semantic search can use pgvector storage end-to-end. */
   pgvector_available: boolean;
+  /** Whether the Postgres pgvector extension is installed in this database. */
+  pgvector_extension_installed?: boolean;
+  /** Whether Agor's optional Knowledge vector table exists and is usable. */
+  pgvector_storage_ready?: boolean;
+  /** Human-readable reason semantic pgvector storage is unavailable, when known. */
+  pgvector_reason?: string | null;
+  /** Admin setup hint for enabling pgvector, when unavailable. */
+  pgvector_setup_hint?: string | null;
   provider?: KnowledgeEmbeddingProvider | null;
   model?: string | null;
   dimensions?: number | null;


### PR DESCRIPTION
## Summary

- Make pgvector optional for Knowledge semantic search by removing vector extension/table creation from the required Postgres migration path.
- Add runtime pgvector capability detection + idempotent optional vector storage bootstrap when semantic search is enabled/configured.
- Return clear `semantic_unavailable` errors and status guidance when pgvector is missing or cannot be enabled.
- Document optional pgvector setup and add targeted tests for migration safety and capability detection.

## Root cause

The Postgres Knowledge embeddings migration ran `CREATE EXTENSION IF NOT EXISTS vector;` and created a required `vector` column unconditionally. On Postgres instances where pgvector is not installed or the Agor DB user cannot create extensions, this blocks all installs/upgrades even though semantic Knowledge search is optional.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/db/migrations.test.ts src/db/repositories/knowledge.test.ts`
- `pnpm --filter @agor/daemon test -- src/knowledge/pgvector.test.ts src/services/knowledge.test.ts`

## Rollout notes

- Instances that failed on the broken migration can retry upgrade; the required migration no longer needs pgvector.
- Instances that already applied the old migration keep their existing `kb_unit_embeddings` table and continue to use it.
- To enable semantic/hybrid Knowledge search, install pgvector on the Postgres server and run `CREATE EXTENSION IF NOT EXISTS vector;` as a DB owner or grant the Agor DB user permission to create the extension, then re-enable/reindex Knowledge semantic search.
