### PR TITLE
Fix knowledge markdown table chunking

### DIFF
--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -38,6 +38,7 @@
     "feathers-swagger": "^3.0.0",
     "handlebars": "^4.7.8",
     "jsonwebtoken": "^9.0.3",
+    "mdast-util-gfm": "^3.1.0",
     "mdast-util-to-markdown": "^2.1.2",
     "multer": "^2.1.1",
     "remark-gfm": "^4.0.1",

--- a/apps/agor-daemon/src/knowledge/markdown-chunker.test.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-chunker.test.ts
@@ -17,4 +17,15 @@ describe('chunkMarkdownForKnowledge', () => {
     expect(chunks[0].content_text).toBe('Body');
     expect(chunks[0].heading_path).toBeNull();
   });
+
+  it('serializes GFM tables while rebuilding knowledge chunks', () => {
+    const chunks = chunkMarkdownForKnowledge(
+      ['# Data', '', '| Name | Value |', '| --- | --- |', '| alpha | 1 |'].join('\n'),
+      { minTokens: 1 }
+    );
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content_text).toContain('| Name  | Value |');
+    expect(chunks[0].content_text).toContain('| alpha | 1     |');
+  });
 });

--- a/apps/agor-daemon/src/knowledge/markdown-chunker.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-chunker.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { RootContent } from 'mdast';
+import { gfmToMarkdown } from 'mdast-util-gfm';
 import { toMarkdown } from 'mdast-util-to-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
@@ -76,7 +77,10 @@ function nodeText(node: RootContent): string {
 }
 
 function nodeMarkdown(node: RootContent): string {
-  return toMarkdown({ type: 'root', children: [node] }, { bullet: '-', fences: true }).trim();
+  return toMarkdown(
+    { type: 'root', children: [node] },
+    { bullet: '-', extensions: [gfmToMarkdown()], fences: true }
+  ).trim();
 }
 
 function offsetsFor(nodes: RootContent[]): { start: number | null; end: number | null } {

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -95,6 +95,7 @@
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "md-to-slack": "^1.1.7",
+    "mdast-util-gfm": "^3.1.0",
     "mdast-util-to-markdown": "^2.1.2",
     "multer": "^2.1.1",
     "node-pty": "^1.2.0-beta.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      mdast-util-gfm:
+        specifier: ^3.1.0
+        version: 3.1.0
       mdast-util-to-markdown:
         specifier: ^2.1.2
         version: 2.1.2
@@ -625,6 +628,9 @@ importers:
       md-to-slack:
         specifier: ^1.1.7
         version: 1.1.7
+      mdast-util-gfm:
+        specifier: ^3.1.0
+        version: 3.1.0
       mdast-util-to-markdown:
         specifier: ^2.1.2
         version: 2.1.2


### PR DESCRIPTION
## Summary

- Fix Knowledge markdown chunk rebuilding for documents containing GitHub-Flavored Markdown tables.
- Add the GFM `toMarkdown` extension when serializing parsed mdast nodes.
- Add a regression test covering table-containing Knowledge markdown.

## Root cause

Knowledge settings save can rebuild existing Knowledge units. The chunker parses markdown with `remark-gfm`, so tables become `table` mdast nodes, but serialization used `mdast-util-to-markdown` without GFM serializers. Documents containing tables therefore threw `Cannot handle unknown node \`table\`` during rebuild.

## Validation

- `pnpm --filter @agor/daemon test -- markdown-chunker.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `git diff --check` via simple-git
- Manual repro with table markdown through `chunkMarkdownForKnowledge`
