### PR TITLE
Add KB draft/published lifecycle

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -264,6 +264,12 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .describe(
             "Include other users' draft documents in browsing/search (default: false). Drafts remain directly accessible by URL when visibility permits."
           ),
+        includeIndexing: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include per-document embedding/indexing summary: derived state, chunk counts, queue depth, model, and last error.'
+          ),
         includeArchived: z
           .boolean()
           .optional()
@@ -292,6 +298,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       if (args.status) query.status = args.status as KnowledgeDocumentStatus;
       query.include_my_drafts = args.includeMyDrafts !== false;
       query.include_other_user_drafts = args.includeOtherUserDrafts === true;
+      if (args.includeIndexing === true) query.include_indexing = true;
       if (args.limit) query.limit = args.limit;
       if (args.mode) query.mode = args.mode;
 
@@ -324,6 +331,12 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .boolean()
           .optional()
           .describe('Include graph links/backlinks when supported'),
+        includeIndexing: z
+          .boolean()
+          .optional()
+          .describe(
+            'Include per-document embedding/indexing summary: derived state, chunk counts, queue depth, model, and last error.'
+          ),
       }),
     },
     async (args) => {
@@ -334,6 +347,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       const query: Record<string, unknown> = { include_content: includeContent };
       if (args.version !== undefined) query.version = args.version;
       if (args.includeLinks !== undefined) query.include_links = args.includeLinks;
+      if (args.includeIndexing === true) query.include_indexing = true;
 
       const documentId = coerceString(args.documentId);
       if (documentId) {
@@ -374,6 +388,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           path,
           include_content: includeContent,
           include_links: args.includeLinks === true,
+          include_indexing: args.includeIndexing === true,
           version: args.version,
         },
         mcpParams(ctx)

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -1,5 +1,6 @@
 import type {
   KnowledgeDocumentKind,
+  KnowledgeDocumentStatus,
   KnowledgeEditPolicy,
   KnowledgeGraphEdgeType,
   KnowledgeGraphNodeType,
@@ -8,6 +9,7 @@ import type {
 import {
   buildKnowledgeDocumentUri,
   KNOWLEDGE_DOCUMENT_KINDS,
+  KNOWLEDGE_DOCUMENT_STATUSES,
   KNOWLEDGE_DOCUMENT_URI_PREFIX,
   KNOWLEDGE_EDIT_POLICIES,
   KNOWLEDGE_GRAPH_EDGE_TYPES,
@@ -21,6 +23,7 @@ import type { McpContext } from '../server.js';
 import { coerceJsonRecord, coerceString, textResult } from '../server.js';
 
 const KnowledgeDocumentKindSchema = z.enum(KNOWLEDGE_DOCUMENT_KINDS);
+const KnowledgeDocumentStatusSchema = z.enum(KNOWLEDGE_DOCUMENT_STATUSES);
 const KnowledgeVisibilitySchema = z.enum(KNOWLEDGE_VISIBILITIES);
 const KnowledgeEditPolicySchema = z.enum(KNOWLEDGE_EDIT_POLICIES);
 const KnowledgeGraphNodeTypeSchema = z.enum(KNOWLEDGE_GRAPH_NODE_TYPES);
@@ -248,6 +251,19 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         pathPrefix: z.string().optional().describe('Filter to document paths under this prefix'),
         kind: KnowledgeDocumentKindSchema.optional().describe('Filter by document kind'),
         visibility: KnowledgeVisibilitySchema.optional().describe('Filter by visibility'),
+        status: KnowledgeDocumentStatusSchema.optional().describe(
+          'Filter by lifecycle status: draft or published'
+        ),
+        includeMyDrafts: z
+          .boolean()
+          .optional()
+          .describe('Include documents you authored with status=draft (default: true)'),
+        includeOtherUserDrafts: z
+          .boolean()
+          .optional()
+          .describe(
+            "Include other users' draft documents in browsing/search (default: false). Drafts remain directly accessible by URL when visibility permits."
+          ),
         includeArchived: z
           .boolean()
           .optional()
@@ -273,6 +289,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       if (args.pathPrefix) query.path_prefix = coerceString(args.pathPrefix);
       if (args.kind) query.kind = args.kind as KnowledgeDocumentKind;
       if (args.visibility) query.visibility = args.visibility as KnowledgeVisibility;
+      if (args.status) query.status = args.status as KnowledgeDocumentStatus;
+      query.include_my_drafts = args.includeMyDrafts !== false;
+      query.include_other_user_drafts = args.includeOtherUserDrafts === true;
       if (args.limit) query.limit = args.limit;
       if (args.mode) query.mode = args.mode;
 
@@ -405,6 +424,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         visibility: KnowledgeVisibilitySchema.optional().describe(
           'Visibility (default: namespace default or public)'
         ),
+        status: KnowledgeDocumentStatusSchema.optional().describe(
+          'Lifecycle status (default: published). Drafts are shareable by direct URL, but hidden from other users in browsing/search by default.'
+        ),
         editPolicy: KnowledgeEditPolicySchema.optional().describe('Edit policy (default: owner)'),
         createNamespace: z
           .boolean()
@@ -462,6 +484,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         first_line_is_title: firstLineIsTitle,
         kind: (args.kind as KnowledgeDocumentKind | undefined) ?? 'doc',
         visibility: args.visibility as KnowledgeVisibility | undefined,
+        status: args.status as KnowledgeDocumentStatus | undefined,
         edit_policy: args.editPolicy as KnowledgeEditPolicy | undefined,
         create_namespace: args.createNamespace === true,
         namespace_display_name: coerceString(args.namespaceDisplayName),

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -56,7 +56,12 @@ export type KnowledgeDocumentParams = QueryParams<{
   path?: string;
   kind?: KnowledgeDocument['kind'];
   visibility?: KnowledgeDocument['visibility'];
+  status?: KnowledgeDocument['status'];
   archived?: boolean;
+  include_my_drafts?: boolean;
+  includeMyDrafts?: boolean;
+  include_other_user_drafts?: boolean;
+  includeOtherUserDrafts?: boolean;
   include_content?: boolean;
   include_links?: boolean;
   version?: string | number;
@@ -164,10 +169,11 @@ export class KnowledgeDocumentsService extends DrizzleService<
       data.visibility !== undefined && data.visibility !== existing.visibility;
     const editPolicyChanged =
       data.edit_policy !== undefined && data.edit_policy !== existing.edit_policy;
-    if (!visibilityChanged && !editPolicyChanged) return;
+    const statusChanged = data.status !== undefined && data.status !== existing.status;
+    if (!visibilityChanged && !editPolicyChanged && !statusChanged) return;
     if (!this.canManageDocument(existing, user)) {
       throw new Forbidden(
-        'Only the owner or an admin can change knowledge document visibility or edit policy'
+        'Only the owner or an admin can change knowledge document visibility, lifecycle status, or edit policy'
       );
     }
   }
@@ -381,9 +387,18 @@ export class KnowledgeDocumentsService extends DrizzleService<
           path: query.path,
           kind: query.kind,
           visibility: query.visibility,
+          status: query.status,
           archived: isAdmin ? query.archived : false,
+          include_my_drafts: query.include_my_drafts ?? query.includeMyDrafts ?? true,
+          include_other_user_drafts:
+            query.include_other_user_drafts ?? query.includeOtherUserDrafts ?? false,
+          draft_filter_user_id: user?.user_id as UserID | undefined,
         }
-      : undefined;
+      : {
+          include_my_drafts: true,
+          include_other_user_drafts: false,
+          draft_filter_user_id: user?.user_id as UserID | undefined,
+        };
     const rows = await this.repo.findAll(filters);
     const readable = rows.filter((doc) => this.canRead(doc, user));
     if (params?.query?.include_content !== true && params?.query?.include_links !== true) {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -64,6 +64,8 @@ export type KnowledgeDocumentParams = QueryParams<{
   includeOtherUserDrafts?: boolean;
   include_content?: boolean;
   include_links?: boolean;
+  include_indexing?: boolean;
+  includeIndexing?: boolean;
   version?: string | number;
 }> &
   AuthenticatedParams;
@@ -87,6 +89,8 @@ type KnowledgeDocumentRef = {
   path?: string;
   include_content?: boolean;
   include_links?: boolean;
+  include_indexing?: boolean;
+  includeIndexing?: boolean;
   version?: string | number;
 };
 
@@ -98,7 +102,10 @@ type HydratedKnowledgeDocument = KnowledgeDocument & {
   links?: unknown[];
 };
 
-type HydrateOptions = Pick<KnowledgeDocumentRef, 'include_content' | 'include_links' | 'version'>;
+type HydrateOptions = Pick<
+  KnowledgeDocumentRef,
+  'include_content' | 'include_links' | 'include_indexing' | 'includeIndexing' | 'version'
+>;
 
 function wantsFirstLineTitle(data: KnowledgeDocumentWriteData): boolean {
   if (typeof data.first_line_is_title === 'boolean') return data.first_line_is_title;
@@ -346,14 +353,18 @@ export class KnowledgeDocumentsService extends DrizzleService<
     document: KnowledgeDocument,
     params?: HydrateOptions
   ): Promise<KnowledgeDocument | HydratedKnowledgeDocument> {
-    if (params?.include_content !== true && params?.include_links !== true) return document;
+    const withIndexing =
+      params?.include_indexing === true || params?.includeIndexing === true
+        ? ((await this.repo.attachIndexingStatus(document)) as KnowledgeDocument)
+        : document;
+    if (params?.include_content !== true && params?.include_links !== true) return withIndexing;
     const version = await this.versionFor(document, params?.version);
     return {
-      ...document,
-      document,
+      ...withIndexing,
+      document: withIndexing,
       current_version: version,
       content: version?.content_text ?? null,
-      first_line_is_title: document.metadata?.title_from_content === true,
+      first_line_is_title: withIndexing.metadata?.title_from_content === true,
       ...(params?.include_links
         ? { links: extractKnowledgeLinks(version?.content_text ?? '') }
         : {}),
@@ -402,6 +413,9 @@ export class KnowledgeDocumentsService extends DrizzleService<
     const rows = await this.repo.findAll(filters);
     const readable = rows.filter((doc) => this.canRead(doc, user));
     if (params?.query?.include_content !== true && params?.query?.include_links !== true) {
+      if (params?.query?.include_indexing === true || params?.query?.includeIndexing === true) {
+        return this.repo.attachIndexingStatus(readable) as Promise<KnowledgeDocument[]>;
+      }
       return readable;
     }
     return Promise.all(
@@ -409,6 +423,8 @@ export class KnowledgeDocumentsService extends DrizzleService<
         this.hydrateDocument(doc, {
           include_content: params?.query?.include_content,
           include_links: params?.query?.include_links,
+          include_indexing: params?.query?.include_indexing,
+          includeIndexing: params?.query?.includeIndexing,
           version: params?.query?.version,
         })
       )

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -221,8 +221,9 @@ export class KnowledgeGraphService {
     const path = ref.path ?? parsed?.path;
     if (!namespaceSlug || !path) return null;
 
-    const docs = await this.documents.findAll({ namespace_slug: namespaceSlug, path });
-    return this.activeDocument(docs[0] ?? null);
+    return this.activeDocument(
+      await this.documents.findByNamespaceSlugAndPath(namespaceSlug, path)
+    );
   }
 
   private async assertCanLinkRef(ref: KnowledgeNodeRef, user?: User): Promise<void> {
@@ -246,11 +247,9 @@ export class KnowledgeGraphService {
     if (unitId) return this.activeDocument(await this.documents.findByUnitId(unitId));
     const parsed = parseKnowledgeUri(node.uri);
     if (!parsed) return null;
-    const docs = await this.documents.findAll({
-      namespace_slug: parsed.namespace_slug,
-      path: parsed.path,
-    });
-    return this.activeDocument(docs[0] ?? null);
+    return this.activeDocument(
+      await this.documents.findByNamespaceSlugAndPath(parsed.namespace_slug, parsed.path)
+    );
   }
 
   private async canReadNode(node: KnowledgeGraphNode, user?: User): Promise<boolean> {

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -36,6 +36,10 @@ export interface KnowledgeNamespaceGraphRequest {
   namespace?: string;
   namespace_id?: string;
   edge_types?: KnowledgeGraphEdgeType[];
+  include_my_drafts?: boolean;
+  includeMyDrafts?: boolean;
+  include_other_user_drafts?: boolean;
+  includeOtherUserDrafts?: boolean;
 }
 
 export type KnowledgeGraphParams = QueryParams<
@@ -88,7 +92,13 @@ export class KnowledgeGraphService {
       return { namespace_id: null, nodes: [], edges: [] };
     }
 
-    const docs = await this.documents.findAll({ namespace_id: namespace.namespace_id });
+    const docs = await this.documents.findAll({
+      namespace_id: namespace.namespace_id,
+      include_my_drafts: request.include_my_drafts ?? request.includeMyDrafts ?? true,
+      include_other_user_drafts:
+        request.include_other_user_drafts ?? request.includeOtherUserDrafts ?? false,
+      draft_filter_user_id: user?.user_id as UserID | undefined,
+    });
     const readable = docs.filter((doc) => this.canRead(doc, user));
     const readableIds = new Set<string>(readable.map((doc) => doc.document_id));
 
@@ -99,6 +109,7 @@ export class KnowledgeGraphService {
       uri: doc.uri,
       kind: doc.kind,
       visibility: doc.visibility,
+      status: doc.status,
     }));
 
     const rawEdges = await this.graph.documentEdgesForNamespace({

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -74,11 +74,18 @@ export class KnowledgeSearchService {
   private scopedQuery(query: KnowledgeSearchQuery | undefined, user?: User): KnowledgeSearchQuery {
     this.assertSupportedMode(query);
     const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
+    const rawQuery = (query ?? {}) as KnowledgeSearchQuery & {
+      includeMyDrafts?: boolean;
+      includeOtherUserDrafts?: boolean;
+    };
     return {
       ...(query ?? {}),
-      include_archived: isAdmin && query?.include_archived === true,
+      include_archived: isAdmin && rawQuery.include_archived === true,
+      include_my_drafts: rawQuery.include_my_drafts ?? rawQuery.includeMyDrafts ?? true,
+      include_other_user_drafts:
+        rawQuery.include_other_user_drafts ?? rawQuery.includeOtherUserDrafts ?? false,
       readable_as_admin: isAdmin,
-      readable_by_user_id: isAdmin ? undefined : user?.user_id,
+      readable_by_user_id: user?.user_id,
     };
   }
 
@@ -154,6 +161,8 @@ export class KnowledgeSearchService {
       ? normalizeKnowledgePath(rawQuery.path_prefix)
       : null;
     const minSimilarity = this.parseMinSimilarity(rawQuery.min_similarity);
+    const includeMyDrafts = rawQuery.include_my_drafts !== false;
+    const includeOtherUserDrafts = rawQuery.include_other_user_drafts === true;
 
     const baseUrl = await getBaseUrl();
     const result = await executeRaw(
@@ -166,6 +175,7 @@ export class KnowledgeSearchService {
           d.title,
           d.kind,
           d.visibility,
+          d.status,
           d.edit_policy,
           d.current_version_id,
           d.metadata AS document_metadata,
@@ -206,7 +216,13 @@ export class KnowledgeSearchService {
           AND (${pathPrefix}::text IS NULL OR d.path = ${pathPrefix} OR d.path LIKE (${pathPrefix} || '/%'))
           AND (${rawQuery.kind ?? null}::text IS NULL OR d.kind = ${rawQuery.kind ?? null})
           AND (${rawQuery.visibility ?? null}::text IS NULL OR d.visibility = ${rawQuery.visibility ?? null})
+          AND (${rawQuery.status ?? null}::text IS NULL OR d.status = ${rawQuery.status ?? null})
           AND (${isAdmin}::boolean = true OR d.visibility = 'public' OR d.created_by = ${user?.user_id ?? null})
+          AND (
+            ${includeOtherUserDrafts}::boolean = true
+            OR d.status = 'published'
+            OR (${includeMyDrafts}::boolean = true AND d.created_by = ${user?.user_id ?? null})
+          )
           AND (${minSimilarity}::float IS NULL OR (1 - ((e.embedding::vector(1536)) <=> ${vector}::vector(1536))) >= ${minSimilarity})
         ORDER BY (e.embedding::vector(1536)) <=> ${vector}::vector(1536)
         LIMIT ${limit}`
@@ -248,6 +264,7 @@ export class KnowledgeSearchService {
           title: String(row.title),
           kind: row.kind as never,
           visibility: row.visibility as never,
+          status: (row.status as never) ?? 'published',
           edit_policy: row.edit_policy as never,
           current_version_id: (row.current_version_id as never) ?? null,
           metadata: (row.document_metadata as Record<string, unknown> | null) ?? null,

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -107,6 +107,20 @@ export class KnowledgeSearchService {
     return parsed;
   }
 
+  private async attachIndexingToResults<T extends KnowledgeSearchResult>(
+    results: T[],
+    query: KnowledgeSearchQuery
+  ): Promise<T[]> {
+    if (query.include_indexing !== true && query.includeIndexing !== true) return results;
+    const docsWithIndexing = (await this.documents.attachIndexingStatus(
+      results.map((result) => result.document)
+    )) as T['document'][];
+    return results.map((result, index) => ({
+      ...result,
+      document: docsWithIndexing[index],
+    }));
+  }
+
   private async semanticSearch(
     rawQuery: KnowledgeSearchQuery,
     user?: User
@@ -305,15 +319,7 @@ export class KnowledgeSearchService {
       });
     }
     const values = [...byDoc.values()].slice(0, rawQuery.limit ?? 25);
-    if (rawQuery.include_indexing === true || rawQuery.includeIndexing === true) {
-      const docsWithIndexing = (await this.documents.attachIndexingStatus(
-        values.map((result) => result.document)
-      )) as (typeof values)[number]['document'][];
-      docsWithIndexing.forEach((doc, index) => {
-        values[index].document = doc;
-      });
-    }
-    return values;
+    return this.attachIndexingToResults(values, rawQuery);
   }
 
   private hybridMerge(
@@ -345,19 +351,12 @@ export class KnowledgeSearchService {
     const textResults = (await this.repo.search({ ...query, mode: 'text' })).filter((result) =>
       this.canRead(result, user)
     );
-    if (query.include_indexing === true || query.includeIndexing === true) {
-      const docsWithIndexing = (await this.documents.attachIndexingStatus(
-        textResults.map((result) => result.document)
-      )) as (typeof textResults)[number]['document'][];
-      docsWithIndexing.forEach((doc, index) => {
-        textResults[index].document = doc;
-      });
-    }
+    const textResultsWithIndexing = await this.attachIndexingToResults(textResults, query);
     if (query.mode === 'hybrid') {
       const semanticResults = await this.semanticSearch(query, user);
-      return this.hybridMerge(textResults, semanticResults).slice(0, query.limit ?? 25);
+      return this.hybridMerge(textResultsWithIndexing, semanticResults).slice(0, query.limit ?? 25);
     }
-    return textResults;
+    return textResultsWithIndexing;
   }
 
   async create(data: KnowledgeSearchQuery, params?: KnowledgeSearchParams) {
@@ -368,19 +367,12 @@ export class KnowledgeSearchService {
     const textResults = (await this.repo.search({ ...query, mode: 'text' })).filter((result) =>
       this.canRead(result, user)
     );
-    if (query.include_indexing === true || query.includeIndexing === true) {
-      const docsWithIndexing = (await this.documents.attachIndexingStatus(
-        textResults.map((result) => result.document)
-      )) as (typeof textResults)[number]['document'][];
-      docsWithIndexing.forEach((doc, index) => {
-        textResults[index].document = doc;
-      });
-    }
+    const textResultsWithIndexing = await this.attachIndexingToResults(textResults, query);
     if (query.mode === 'hybrid') {
       const semanticResults = await this.semanticSearch(query, user);
-      return this.hybridMerge(textResults, semanticResults).slice(0, query.limit ?? 25);
+      return this.hybridMerge(textResultsWithIndexing, semanticResults).slice(0, query.limit ?? 25);
     }
-    return textResults;
+    return textResultsWithIndexing;
   }
 }
 

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -8,6 +8,7 @@ import {
   type Database,
   executeRaw,
   isPostgresDatabase,
+  KnowledgeDocumentRepository,
   type KnowledgeSearchQuery,
   KnowledgeSearchRepository,
   sql,
@@ -42,11 +43,13 @@ export type KnowledgeSearchParams = QueryParams<KnowledgeSearchQuery> & Authenti
 
 export class KnowledgeSearchService {
   private repo: KnowledgeSearchRepository;
+  private documents: KnowledgeDocumentRepository;
   private variables: AppVariableRepository;
   private embeddingProvider = new OpenAIEmbeddingProvider();
 
   constructor(private db: Database) {
     this.repo = new KnowledgeSearchRepository(db);
+    this.documents = new KnowledgeDocumentRepository(db);
     this.variables = new AppVariableRepository(db);
   }
 
@@ -301,7 +304,16 @@ export class KnowledgeSearchService {
         chunks: [chunk],
       });
     }
-    return [...byDoc.values()].slice(0, rawQuery.limit ?? 25);
+    const values = [...byDoc.values()].slice(0, rawQuery.limit ?? 25);
+    if (rawQuery.include_indexing === true || rawQuery.includeIndexing === true) {
+      const docsWithIndexing = (await this.documents.attachIndexingStatus(
+        values.map((result) => result.document)
+      )) as (typeof values)[number]['document'][];
+      docsWithIndexing.forEach((doc, index) => {
+        values[index].document = doc;
+      });
+    }
+    return values;
   }
 
   private hybridMerge(
@@ -333,6 +345,14 @@ export class KnowledgeSearchService {
     const textResults = (await this.repo.search({ ...query, mode: 'text' })).filter((result) =>
       this.canRead(result, user)
     );
+    if (query.include_indexing === true || query.includeIndexing === true) {
+      const docsWithIndexing = (await this.documents.attachIndexingStatus(
+        textResults.map((result) => result.document)
+      )) as (typeof textResults)[number]['document'][];
+      docsWithIndexing.forEach((doc, index) => {
+        textResults[index].document = doc;
+      });
+    }
     if (query.mode === 'hybrid') {
       const semanticResults = await this.semanticSearch(query, user);
       return this.hybridMerge(textResults, semanticResults).slice(0, query.limit ?? 25);
@@ -348,6 +368,14 @@ export class KnowledgeSearchService {
     const textResults = (await this.repo.search({ ...query, mode: 'text' })).filter((result) =>
       this.canRead(result, user)
     );
+    if (query.include_indexing === true || query.includeIndexing === true) {
+      const docsWithIndexing = (await this.documents.attachIndexingStatus(
+        textResults.map((result) => result.document)
+      )) as (typeof textResults)[number]['document'][];
+      docsWithIndexing.forEach((doc, index) => {
+        textResults[index].document = doc;
+      });
+    }
     if (query.mode === 'hybrid') {
       const semanticResults = await this.semanticSearch(query, user);
       return this.hybridMerge(textResults, semanticResults).slice(0, query.limit ?? 25);

--- a/apps/agor-daemon/src/services/knowledge-versions.ts
+++ b/apps/agor-daemon/src/services/knowledge-versions.ts
@@ -74,8 +74,8 @@ export class KnowledgeVersionsService extends DrizzleService<
       const namespaceSlug = query.namespace_slug ?? query.namespace ?? parsed?.namespace_slug;
       const path = query.path ?? parsed?.path;
       if (namespaceSlug && path) {
-        const docs = await this.documents.findAll({ namespace_slug: namespaceSlug, path });
-        documentId = docs[0]?.document_id;
+        const document = await this.documents.findByNamespaceSlugAndPath(namespaceSlug, path);
+        documentId = document?.document_id;
       }
     }
     if (!documentId) return [];

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -367,6 +367,14 @@ describe('KnowledgeSearchService and KnowledgeVersionsService permissions', () =
       const ownerTree = await documents.find(params(owner, { archived: false }));
       expect(ownerTree.map((doc) => doc.document_id)).toContain(draftDoc.document_id);
 
+      const ownerTreeWithIndexing = await documents.find(
+        params(owner, { archived: false, include_indexing: true })
+      );
+      expect(
+        ownerTreeWithIndexing.find((doc) => doc.document_id === draftDoc.document_id)
+          ?.indexing_status
+      ).toMatchObject({ state: 'not_configured', total_units: 1 });
+
       const otherTree = await documents.find(params(other, { archived: false }));
       expect(otherTree.map((doc) => doc.document_id)).not.toContain(draftDoc.document_id);
       expect(otherTree.map((doc) => doc.document_id)).toContain(publishedDoc.document_id);
@@ -375,6 +383,15 @@ describe('KnowledgeSearchService and KnowledgeVersionsService permissions', () =
       expect(ownerSearch.map((result) => result.document.document_id)).toContain(
         draftDoc.document_id
       );
+
+      const ownerSearchWithIndexing = await search.find(
+        params(owner, { q: 'draftneedle', include_indexing: true })
+      );
+      expect(
+        ownerSearchWithIndexing.find(
+          (result) => result.document.document_id === draftDoc.document_id
+        )?.document.indexing_status
+      ).toMatchObject({ state: 'not_configured', total_units: 1 });
 
       const otherSearch = await search.find(params(other, { q: 'draftneedle' }));
       expect(otherSearch.map((result) => result.document.document_id)).not.toContain(

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -62,6 +62,7 @@ async function seedDocument(
     path: overrides.path ?? 'page.md',
     title: overrides.title ?? 'Page',
     visibility: overrides.visibility ?? 'public',
+    status: overrides.status ?? 'published',
     edit_policy: overrides.edit_policy ?? 'owner',
     content_text: overrides.content_text ?? '# Page\n\nBody',
     created_by: owner.user_id as UserID,
@@ -343,6 +344,58 @@ describe('Knowledge semantic indexing lifecycle', () => {
 });
 
 describe('KnowledgeSearchService and KnowledgeVersionsService permissions', () => {
+  dbTest(
+    'applies draft lifecycle defaults in tree/list, search, and direct get',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const other = await seedUser(db, 'other');
+      const draftDoc = await seedDocument(db, owner, {
+        status: 'draft',
+        visibility: 'public',
+        path: 'draft.md',
+        content_text: 'draftneedle',
+      });
+      const publishedDoc = await seedDocument(db, owner, {
+        status: 'published',
+        visibility: 'public',
+        path: 'published.md',
+        content_text: 'draftneedle',
+      });
+      const documents = new KnowledgeDocumentsService(db);
+      const search = new KnowledgeSearchService(db);
+
+      const ownerTree = await documents.find(params(owner, { archived: false }));
+      expect(ownerTree.map((doc) => doc.document_id)).toContain(draftDoc.document_id);
+
+      const otherTree = await documents.find(params(other, { archived: false }));
+      expect(otherTree.map((doc) => doc.document_id)).not.toContain(draftDoc.document_id);
+      expect(otherTree.map((doc) => doc.document_id)).toContain(publishedDoc.document_id);
+
+      const ownerSearch = await search.find(params(owner, { q: 'draftneedle' }));
+      expect(ownerSearch.map((result) => result.document.document_id)).toContain(
+        draftDoc.document_id
+      );
+
+      const otherSearch = await search.find(params(other, { q: 'draftneedle' }));
+      expect(otherSearch.map((result) => result.document.document_id)).not.toContain(
+        draftDoc.document_id
+      );
+      expect(otherSearch.map((result) => result.document.document_id)).toContain(
+        publishedDoc.document_id
+      );
+
+      await expect(documents.get(draftDoc.document_id, params(other))).resolves.toMatchObject({
+        document_id: draftDoc.document_id,
+        status: 'draft',
+      });
+
+      const optedIn = await search.find(
+        params(other, { q: 'draftneedle', include_other_user_drafts: true })
+      );
+      expect(optedIn.map((result) => result.document.document_id)).toContain(draftDoc.document_id);
+    }
+  );
+
   dbTest('scopes search results and ignores non-admin include_archived', async ({ db }) => {
     const owner = await seedUser(db, 'owner');
     const other = await seedUser(db, 'other');

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@agor/core/db';
 import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import type { KnowledgeDocument, User, UserID } from '@agor/core/types';
-import { ROLES } from '@agor/core/types';
+import { parseKnowledgeUri, ROLES } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { KnowledgeDocumentsService } from './knowledge-documents';
@@ -406,6 +406,15 @@ describe('KnowledgeSearchService and KnowledgeVersionsService permissions', () =
         status: 'draft',
       });
 
+      const versions = new KnowledgeVersionsService(db);
+      const draftHistoryByUri = await versions.find(
+        params(other, { uri: draftDoc.uri, include_content: true })
+      );
+      expect(draftHistoryByUri[0]).toMatchObject({
+        document_id: draftDoc.document_id,
+        content_text: 'draftneedle',
+      });
+
       const optedIn = await search.find(
         params(other, { q: 'draftneedle', include_other_user_drafts: true })
       );
@@ -486,6 +495,37 @@ describe('KnowledgeSearchService and KnowledgeVersionsService permissions', () =
 });
 
 describe('KnowledgeGraphService permissions', () => {
+  dbTest('resolves draft document refs by URI and path for graph access', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const draftDoc = await seedDocument(db, owner, {
+      status: 'draft',
+      visibility: 'public',
+      path: 'draft-graph.md',
+    });
+    const parsed = parseKnowledgeUri(draftDoc.uri);
+    if (!parsed) throw new Error('Expected seeded draft document to have a KB URI');
+    const graph = new KnowledgeGraphService(db);
+
+    await expect(
+      graph.link(
+        {
+          source: { namespace: parsed.namespace_slug, path: parsed.path },
+          target: { externalUri: 'https://example.com/draft-ref', label: 'Draft ref' },
+          edge_type: 'references',
+        },
+        params(owner)
+      )
+    ).resolves.toMatchObject({ edge_type: 'references' });
+
+    await expect(
+      graph.neighbors({ node: { uri: draftDoc.uri }, direction: 'both' }, params(owner))
+    ).resolves.toMatchObject({
+      center: {
+        uri: draftDoc.uri,
+      },
+    });
+  });
+
   dbTest('prevents linking to private documents the caller cannot write', async ({ db }) => {
     const owner = await seedUser(db, 'owner');
     const other = await seedUser(db, 'other');

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -24,18 +24,21 @@ import {
   ArrowLeftOutlined,
   DownOutlined,
   EditOutlined,
+  ExperimentOutlined,
   FileAddOutlined,
   FileOutlined,
   FolderAddOutlined,
   FolderOpenOutlined,
   FolderOutlined,
   HistoryOutlined,
+  LoadingOutlined,
   QuestionCircleOutlined,
   ReloadOutlined,
   SaveOutlined,
   SearchOutlined,
   SettingOutlined,
   UpOutlined,
+  WarningOutlined,
 } from '@ant-design/icons';
 import {
   Alert,
@@ -175,50 +178,104 @@ const indexingStateMeta: Record<
   { label: string; color: string; tooltip: string }
 > = {
   empty: {
-    label: 'No index',
+    label: 'No semantic index',
     color: 'default',
     tooltip: 'No indexable units exist for the current version yet.',
   },
   not_configured: {
-    label: 'Embeddings off',
+    label: 'Semantic indexing unavailable',
     color: 'default',
-    tooltip: 'Semantic embeddings are not configured for these chunks.',
+    tooltip: 'Semantic indexing is not configured for these chunks.',
   },
   queued: {
-    label: 'Queued',
-    color: 'processing',
-    tooltip: 'Some chunks are queued for embedding.',
+    label: 'Indexing',
+    color: '#1677ff',
+    tooltip: 'Some chunks are queued for semantic indexing.',
   },
   ready: {
-    label: 'Indexed',
-    color: 'green',
-    tooltip: 'Current chunks have ready embeddings.',
+    label: 'Semantic index ready',
+    color: '#52c41a',
+    tooltip: 'Current chunks are available for semantic search.',
   },
   stale: {
-    label: 'Needs reindex',
-    color: 'gold',
-    tooltip: 'Some chunks are stale and queued for refresh.',
+    label: 'Needs semantic refresh',
+    color: '#faad14',
+    tooltip: 'Some chunks are stale and need semantic index refresh.',
   },
   error: {
-    label: 'Index error',
-    color: 'red',
-    tooltip: 'At least one chunk failed embedding.',
+    label: 'Semantic index error',
+    color: '#ff4d4f',
+    tooltip: 'At least one chunk failed semantic indexing.',
   },
   mixed: {
-    label: 'Partial index',
-    color: 'blue',
-    tooltip: 'Chunks have mixed indexing states.',
+    label: 'Partial semantic index',
+    color: '#1677ff',
+    tooltip: 'Chunks have mixed semantic indexing states.',
   },
+};
+
+const indexingChunkLabels: Record<string, string> = {
+  not_configured: 'not configured',
+  pending: 'queued',
+  ready: 'ready',
+  stale: 'stale',
+  error: 'error',
 };
 
 function indexingTooltip(status: KnowledgeDocumentIndexingStatus): string {
   const counts = Object.entries(status.chunks)
     .filter(([, count]) => Number(count) > 0)
-    .map(([state, count]) => `${state}: ${count}`)
+    .map(([state, count]) => `${indexingChunkLabels[state] ?? state}: ${count}`)
     .join(', ');
   const model = status.embedding_model ? ` · ${status.embedding_model}` : '';
+  const queue = status.queue_depth > 0 ? ` · queue ${status.queue_depth}` : '';
   const error = status.last_error ? ` · ${status.last_error}` : '';
-  return `${indexingStateMeta[status.state].tooltip}${model}${counts ? ` · ${counts}` : ''}${error}`;
+  return `${indexingStateMeta[status.state].tooltip}${model}${queue}${counts ? ` · ${counts}` : ''}${error}`;
+}
+
+function shouldShowIndexingCue(status?: KnowledgeDocumentIndexingStatus | null): boolean {
+  return Boolean(status && status.state !== 'empty' && status.state !== 'not_configured');
+}
+
+function IndexingStatusCue({
+  status,
+  size = 14,
+}: {
+  status?: KnowledgeDocumentIndexingStatus | null;
+  size?: number;
+}) {
+  if (!shouldShowIndexingCue(status) || !status) return null;
+
+  const meta = indexingStateMeta[status.state];
+  const iconStyle = { color: meta.color, fontSize: size };
+  const icon =
+    status.state === 'queued' ? (
+      <LoadingOutlined spin style={iconStyle} />
+    ) : status.state === 'error' ? (
+      <WarningOutlined style={iconStyle} />
+    ) : (
+      <ExperimentOutlined style={iconStyle} />
+    );
+
+  return (
+    <Tooltip title={indexingTooltip(status)}>
+      <span
+        aria-label={meta.label}
+        role="img"
+        style={{
+          alignItems: 'center',
+          display: 'inline-flex',
+          flex: '0 0 auto',
+          height: size + 2,
+          justifyContent: 'center',
+          lineHeight: 1,
+          width: size + 2,
+        }}
+      >
+        {icon}
+      </span>
+    </Tooltip>
+  );
 }
 
 const kindForSegment = (segment: string): KnowledgeDocumentKind | undefined => {
@@ -1619,17 +1676,7 @@ export function KnowledgePage({
             Draft
           </Tag>
         )}
-        {doc.indexing_status && (
-          <Tooltip title={indexingTooltip(doc.indexing_status)}>
-            <Tag
-              color={indexingStateMeta[doc.indexing_status.state].color}
-              bordered={false}
-              style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
-            >
-              {indexingStateMeta[doc.indexing_status.state].label}
-            </Tag>
-          </Tooltip>
-        )}
+        <IndexingStatusCue status={doc.indexing_status} />
       </button>
     );
   };
@@ -2062,13 +2109,7 @@ export function KnowledgePage({
                       ) : (
                         <Tag color="blue">Published</Tag>
                       )}
-                      {activeDoc.indexing_status && (
-                        <Tooltip title={indexingTooltip(activeDoc.indexing_status)}>
-                          <Tag color={indexingStateMeta[activeDoc.indexing_status.state].color}>
-                            {indexingStateMeta[activeDoc.indexing_status.state].label}
-                          </Tag>
-                        </Tooltip>
-                      )}
+                      <IndexingStatusCue status={activeDoc.indexing_status} size={16} />
                       {isEditing ? (
                         <Select
                           size="small"

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -4,6 +4,7 @@ import type {
   KnowledgeNamespace as CoreKnowledgeNamespace,
   KnowledgeDocumentVersion as CoreKnowledgeVersion,
   KnowledgeDocumentKind,
+  KnowledgeDocumentStatus,
   KnowledgeNamespaceGraph,
   KnowledgeSearchMode,
   KnowledgeSemanticSettingsPublic,
@@ -378,6 +379,7 @@ export function KnowledgePage({
   ]);
   const [titleDraft, setTitleDraft] = useState('');
   const [visibilityDraft, setVisibilityDraft] = useState<KnowledgeDocument['visibility']>('public');
+  const [statusDraft, setStatusDraft] = useState<KnowledgeDocumentStatus>('published');
   const [kindDraft, setKindDraft] = useState<KnowledgeDocumentKind>('doc');
   const [titleFromContent, setTitleFromContent] = useState(false);
   const [markdownDraft, setMarkdownDraft] = useState(DEFAULT_MARKDOWN);
@@ -637,6 +639,7 @@ export function KnowledgePage({
           (markdownDraft !== savedMarkdown ||
             titleDraft !== activeDoc.title ||
             visibilityDraft !== activeDoc.visibility ||
+            statusDraft !== activeDoc.status ||
             kindDraft !== activeDoc.kind ||
             titleFromContent !== (activeDoc.metadata?.title_from_content === true) ||
             renamePathOnTitleChange))
@@ -928,6 +931,44 @@ export function KnowledgePage({
   }, [activeDocId, documents, namespaceSlugForDocument, routeDocumentPath, routeNamespaceSlug]);
 
   useEffect(() => {
+    if (!client || loading || activeDocIdRef.current === DRAFT_DOCUMENT_ID) return;
+    if (!routeNamespaceSlug || !routeDocumentPath) return;
+    const routedDocument = documents.find(
+      (doc) =>
+        doc.path === routeDocumentPath && namespaceSlugForDocument(doc) === routeNamespaceSlug
+    );
+    if (routedDocument) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const result = await client.service('kb/documents').find({
+          query: {
+            namespace_slug: routeNamespaceSlug,
+            path: routeDocumentPath,
+            archived: false,
+            include_other_user_drafts: true,
+          },
+        });
+        if (cancelled) return;
+        const [directDoc] = normalizeFindResult<KnowledgeDocument>(result as KnowledgeDocument[]);
+        if (!directDoc) return;
+        setDocuments((prev) =>
+          prev.some((doc) => doc.document_id === directDoc.document_id)
+            ? prev
+            : [directDoc, ...prev]
+        );
+        activeDocIdRef.current = directDoc.document_id;
+        setActiveDocId(directDoc.document_id);
+      } catch (err) {
+        if (!cancelled) console.error('Failed to load direct Knowledge document:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, documents, loading, namespaceSlugForDocument, routeDocumentPath, routeNamespaceSlug]);
+
+  useEffect(() => {
     if (activeDocIdRef.current === DRAFT_DOCUMENT_ID) return;
     if (activeDocId && !activeDoc && !loading) {
       activeDocIdRef.current = null;
@@ -940,6 +981,7 @@ export function KnowledgePage({
       setSelectedFolder(parentFolderForPath(activeDoc.path));
       setTitleDraft(activeDoc.title);
       setVisibilityDraft(activeDoc.visibility);
+      setStatusDraft(activeDoc.status ?? 'published');
       setKindDraft(activeDoc.kind);
       setTitleFromContent(activeDoc.metadata?.title_from_content === true);
       setRenamePathOnTitleChange(false);
@@ -1061,6 +1103,7 @@ export function KnowledgePage({
       title,
       kind: 'doc',
       visibility: namespace?.visibility_default ?? 'public',
+      status: 'published',
       edit_policy: 'owner',
       current_version_id: null,
       metadata: { title_from_content: true },
@@ -1078,6 +1121,7 @@ export function KnowledgePage({
     setSelectedFolder(ROOT_FOLDER);
     setTitleDraft(title);
     setVisibilityDraft(draft.visibility);
+    setStatusDraft(draft.status);
     setKindDraft(draft.kind);
     setTitleFromContent(true);
     setRenamePathOnTitleChange(false);
@@ -1154,6 +1198,7 @@ export function KnowledgePage({
           namespaces.find((ns) => ns.slug === namespaceSlug)?.visibility_default ??
           selectedNamespace?.visibility_default ??
           'public',
+        status: 'published',
         metadata: { title_from_content: true },
         content_text: `# ${title}\n\nWrite markdown here.\n`,
         change_summary: 'Initial version',
@@ -1192,6 +1237,7 @@ export function KnowledgePage({
           title: nextTitle,
           kind: kindDraft,
           visibility: visibilityDraft,
+          status: statusDraft,
           metadata: {
             ...(activeDoc.metadata ?? {}),
             title_from_content: titleFromContent,
@@ -1226,6 +1272,7 @@ export function KnowledgePage({
       const updated = (await client.service('kb/documents').patch(activeDoc.document_id, {
         title: nextTitle,
         visibility: visibilityDraft,
+        status: statusDraft,
         kind: kindDraft,
         ...(nextPath ? { path: nextPath } : {}),
         content_text: markdownDraft,
@@ -1498,6 +1545,7 @@ export function KnowledgePage({
         <FileOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
         <span
           style={{
+            flex: 1,
             minWidth: 0,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -1507,6 +1555,15 @@ export function KnowledgePage({
         >
           {doc.title}
         </span>
+        {doc.status === 'draft' && (
+          <Tag
+            color="gold"
+            bordered={false}
+            style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
+          >
+            Draft
+          </Tag>
+        )}
       </button>
     );
   };
@@ -1921,6 +1978,23 @@ export function KnowledgePage({
                         <Tag color={activeDoc.visibility === 'public' ? 'green' : 'default'}>
                           {activeDoc.visibility}
                         </Tag>
+                      )}
+                      {isEditing ? (
+                        <Select
+                          size="small"
+                          value={statusDraft}
+                          disabled={!canManageActiveVisibility}
+                          onChange={setStatusDraft}
+                          style={{ width: 118 }}
+                          options={[
+                            { label: 'Published', value: 'published' },
+                            { label: 'Draft', value: 'draft' },
+                          ]}
+                        />
+                      ) : activeDoc.status === 'draft' ? (
+                        <Tag color="gold">Draft</Tag>
+                      ) : (
+                        <Tag color="blue">Published</Tag>
                       )}
                       {isEditing ? (
                         <Select

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -3,6 +3,7 @@ import type {
   KnowledgeIndexingStatus as CoreKnowledgeIndexingStatus,
   KnowledgeNamespace as CoreKnowledgeNamespace,
   KnowledgeDocumentVersion as CoreKnowledgeVersion,
+  KnowledgeDocumentIndexingStatus,
   KnowledgeDocumentKind,
   KnowledgeDocumentStatus,
   KnowledgeNamespaceGraph,
@@ -168,6 +169,57 @@ const kindLabels: Record<KnowledgeDocumentKind, string> = {
   bundle: 'Bundle',
   external: 'Reference',
 };
+
+const indexingStateMeta: Record<
+  KnowledgeDocumentIndexingStatus['state'],
+  { label: string; color: string; tooltip: string }
+> = {
+  empty: {
+    label: 'No index',
+    color: 'default',
+    tooltip: 'No indexable units exist for the current version yet.',
+  },
+  not_configured: {
+    label: 'Embeddings off',
+    color: 'default',
+    tooltip: 'Semantic embeddings are not configured for these chunks.',
+  },
+  queued: {
+    label: 'Queued',
+    color: 'processing',
+    tooltip: 'Some chunks are queued for embedding.',
+  },
+  ready: {
+    label: 'Indexed',
+    color: 'green',
+    tooltip: 'Current chunks have ready embeddings.',
+  },
+  stale: {
+    label: 'Needs reindex',
+    color: 'gold',
+    tooltip: 'Some chunks are stale and queued for refresh.',
+  },
+  error: {
+    label: 'Index error',
+    color: 'red',
+    tooltip: 'At least one chunk failed embedding.',
+  },
+  mixed: {
+    label: 'Partial index',
+    color: 'blue',
+    tooltip: 'Chunks have mixed indexing states.',
+  },
+};
+
+function indexingTooltip(status: KnowledgeDocumentIndexingStatus): string {
+  const counts = Object.entries(status.chunks)
+    .filter(([, count]) => Number(count) > 0)
+    .map(([state, count]) => `${state}: ${count}`)
+    .join(', ');
+  const model = status.embedding_model ? ` · ${status.embedding_model}` : '';
+  const error = status.last_error ? ` · ${status.last_error}` : '';
+  return `${indexingStateMeta[status.state].tooltip}${model}${counts ? ` · ${counts}` : ''}${error}`;
+}
 
 const kindForSegment = (segment: string): KnowledgeDocumentKind | undefined => {
   if (segment === 'Pages') return 'doc';
@@ -707,6 +759,7 @@ export function KnowledgePage({
             kind,
             limit: 50,
             mode: searchMode,
+            include_indexing: true,
           },
         });
         const rows = normalizeFindResult<KnowledgeSearchResult>(result as KnowledgeSearchResult[]);
@@ -717,6 +770,7 @@ export function KnowledgePage({
             namespace_slug: namespaceFilter,
             kind,
             archived: false,
+            include_indexing: true,
           },
         });
         setDocuments(normalizeFindResult<KnowledgeDocument>(result as KnowledgeDocument[]));
@@ -947,6 +1001,7 @@ export function KnowledgePage({
             path: routeDocumentPath,
             archived: false,
             include_other_user_drafts: true,
+            include_indexing: true,
           },
         });
         if (cancelled) return;
@@ -1564,6 +1619,17 @@ export function KnowledgePage({
             Draft
           </Tag>
         )}
+        {doc.indexing_status && (
+          <Tooltip title={indexingTooltip(doc.indexing_status)}>
+            <Tag
+              color={indexingStateMeta[doc.indexing_status.state].color}
+              bordered={false}
+              style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
+            >
+              {indexingStateMeta[doc.indexing_status.state].label}
+            </Tag>
+          </Tooltip>
+        )}
       </button>
     );
   };
@@ -1995,6 +2061,13 @@ export function KnowledgePage({
                         <Tag color="gold">Draft</Tag>
                       ) : (
                         <Tag color="blue">Published</Tag>
+                      )}
+                      {activeDoc.indexing_status && (
+                        <Tooltip title={indexingTooltip(activeDoc.indexing_status)}>
+                          <Tag color={indexingStateMeta[activeDoc.indexing_status.state].color}>
+                            {indexingStateMeta[activeDoc.indexing_status.state].label}
+                          </Tag>
+                        </Tooltip>
                       )}
                       {isEditing ? (
                         <Select

--- a/packages/core/drizzle/postgres/0044_kb_document_status.sql
+++ b/packages/core/drizzle/postgres/0044_kb_document_status.sql
@@ -1,0 +1,3 @@
+-- Add Knowledge document lifecycle status. Existing documents are published.
+ALTER TABLE "kb_documents" ADD COLUMN "status" text DEFAULT 'published' NOT NULL;--> statement-breakpoint
+CREATE INDEX "kb_documents_status_idx" ON "kb_documents" ("status");

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1780900000000,
       "tag": "0043_kb_embeddings",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1781000000000,
+      "tag": "0044_kb_document_status",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0053_kb_document_status.sql
+++ b/packages/core/drizzle/sqlite/0053_kb_document_status.sql
@@ -1,0 +1,3 @@
+-- Add Knowledge document lifecycle status. Existing documents are published.
+ALTER TABLE `kb_documents` ADD COLUMN `status` text DEFAULT 'published' NOT NULL;--> statement-breakpoint
+CREATE INDEX `kb_documents_status_idx` ON `kb_documents` (`status`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1780900000000,
       "tag": "0052_kb_embedding_spaces",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "6",
+      "when": 1781000000000,
+      "tag": "0053_kb_document_status",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/knowledge.test.ts
+++ b/packages/core/src/db/repositories/knowledge.test.ts
@@ -70,6 +70,7 @@ describe('Knowledge repositories', () => {
     expect(created.uri).toBe('agor://kb/repo-test/guides/intro.md');
     expect(created.url).toContain('/ui/kb/repo-test/guides/intro.md');
     expect(created.current_version_id).toBeTruthy();
+    expect(created.status).toBe('published');
 
     const history = await versions.findAll({ document_id: created.document_id });
     expect(history).toHaveLength(1);

--- a/packages/core/src/db/repositories/knowledge.test.ts
+++ b/packages/core/src/db/repositories/knowledge.test.ts
@@ -9,7 +9,7 @@ import {
   validateKnowledgePath,
 } from '../../types';
 import type { Database } from '../client';
-import { select } from '../database-wrapper';
+import { select, update } from '../database-wrapper';
 import { kbDocumentUnits } from '../schema';
 import { dbTest } from '../test-helpers';
 import {
@@ -127,6 +127,53 @@ describe('Knowledge repositories', () => {
       .where(eq(kbDocumentUnits.document_id, created.document_id))
       .all();
     expect(units).toHaveLength(2);
+  });
+
+  dbTest('summarizes indexing status for current document units', async ({ db }) => {
+    const owner = await seedUser(db, 'kb-owner');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const documents = new KnowledgeDocumentRepository(db);
+
+    const namespace = await namespaces.create({
+      slug: 'indexing-status-test',
+      display_name: 'Indexing Status Test',
+    });
+    const created = await documents.create({
+      namespace_id: namespace.namespace_id,
+      path: 'indexed.md',
+      title: 'Indexed',
+      content_text: 'v1',
+      created_by: owner.user_id as UserID,
+    });
+
+    const initial = (await documents.indexingStatusForDocuments([created.document_id])).get(
+      created.document_id
+    );
+    expect(initial).toMatchObject({
+      state: 'not_configured',
+      total_units: 1,
+      queue_depth: 0,
+    });
+
+    const updated = await documents.update(created.document_id, {
+      content_text: 'v2',
+      updated_by: owner.user_id as UserID,
+    });
+    expect(updated.current_version_id).toBeTruthy();
+    await update(db, kbDocumentUnits)
+      .set({ embedding_status: 'pending', updated_at: new Date() })
+      .where(eq(kbDocumentUnits.version_id, updated.current_version_id as string))
+      .run();
+
+    const status = (await documents.indexingStatusForDocuments([created.document_id])).get(
+      created.document_id
+    );
+    expect(status).toMatchObject({
+      state: 'queued',
+      total_units: 1,
+      queue_depth: 1,
+      chunks: expect.objectContaining({ pending: 1, not_configured: 0 }),
+    });
   });
 
   dbTest('soft-delete allows path reuse while search hides archived documents', async ({ db }) => {

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -12,6 +12,7 @@ import type {
   KnowledgeDocument,
   KnowledgeDocumentID,
   KnowledgeDocumentKind,
+  KnowledgeDocumentStatus,
   KnowledgeDocumentUnitID,
   KnowledgeDocumentVersion,
   KnowledgeDocumentVersionID,
@@ -90,7 +91,16 @@ export interface KnowledgeDocumentFilters {
   path?: string;
   kind?: KnowledgeDocumentKind;
   visibility?: KnowledgeVisibility;
+  status?: KnowledgeDocumentStatus;
   archived?: boolean;
+  /**
+   * Draft browsing policy. Defaults are applied by callers/services, but when
+   * omitted here they are interpreted as include own drafts and hide other
+   * users' drafts.
+   */
+  include_my_drafts?: boolean;
+  include_other_user_drafts?: boolean;
+  draft_filter_user_id?: UserID;
 }
 
 export interface CreateKnowledgeDocumentInput extends Partial<KnowledgeDocument> {
@@ -138,7 +148,12 @@ export interface KnowledgeSearchQuery {
   path_prefix?: string;
   kind?: KnowledgeDocumentKind;
   visibility?: KnowledgeVisibility;
+  status?: KnowledgeDocumentStatus;
   include_archived?: boolean;
+  include_my_drafts?: boolean;
+  includeMyDrafts?: boolean;
+  include_other_user_drafts?: boolean;
+  includeOtherUserDrafts?: boolean;
   limit?: number;
   readable_by_user_id?: UserID;
   readable_as_admin?: boolean;
@@ -256,6 +271,31 @@ function makeSnippet(content: string | null | undefined, q: string): string | nu
   const start = Math.max(0, index - 80);
   const end = Math.min(content.length, index + needle.length + 160);
   return `${start > 0 ? '…' : ''}${content.slice(start, end)}${end < content.length ? '…' : ''}`;
+}
+
+function knowledgeDraftVisibilityCondition(options: {
+  status?: KnowledgeDocumentStatus;
+  userId?: UserID;
+  includeMyDrafts?: boolean;
+  includeOtherUserDrafts?: boolean;
+}) {
+  const includeMyDrafts = options.includeMyDrafts !== false;
+  const includeOtherUserDrafts = options.includeOtherUserDrafts === true;
+
+  if (options.status === 'published') return eq(kbDocuments.status, 'published');
+  if (options.status === 'draft') {
+    if (includeOtherUserDrafts) return eq(kbDocuments.status, 'draft');
+    if (includeMyDrafts && options.userId) {
+      return and(eq(kbDocuments.status, 'draft'), eq(kbDocuments.created_by, options.userId));
+    }
+    return sql`1 = 0`;
+  }
+
+  if (includeOtherUserDrafts) return undefined;
+  if (includeMyDrafts && options.userId) {
+    return or(eq(kbDocuments.status, 'published'), eq(kbDocuments.created_by, options.userId));
+  }
+  return eq(kbDocuments.status, 'published');
 }
 
 export class KnowledgeNamespaceRepository
@@ -563,6 +603,7 @@ export class KnowledgeDocumentRepository
       title: row.title,
       kind: row.kind as KnowledgeDocumentKind,
       visibility: row.visibility as KnowledgeVisibility,
+      status: (row.status ?? 'published') as KnowledgeDocumentStatus,
       edit_policy: row.edit_policy as KnowledgeEditPolicy,
       current_version_id: (row.current_version_id as KnowledgeDocumentVersionID | null) ?? null,
       metadata: row.metadata ?? null,
@@ -615,6 +656,7 @@ export class KnowledgeDocumentRepository
       title: data.title ?? titleFromKnowledgePath(normalizedPath),
       kind: data.kind ?? 'doc',
       visibility: data.visibility ?? 'public',
+      status: data.status ?? 'published',
       edit_policy: data.edit_policy ?? 'owner',
       current_version_id: data.current_version_id ?? null,
       metadata: data.metadata ?? null,
@@ -793,6 +835,13 @@ export class KnowledgeDocumentRepository
     if (filters?.path) conditions.push(eq(kbDocuments.path, normalizeKnowledgePath(filters.path)));
     if (filters?.kind) conditions.push(eq(kbDocuments.kind, filters.kind));
     if (filters?.visibility) conditions.push(eq(kbDocuments.visibility, filters.visibility));
+    const draftCondition = knowledgeDraftVisibilityCondition({
+      status: filters?.status,
+      userId: filters?.draft_filter_user_id,
+      includeMyDrafts: filters?.include_my_drafts,
+      includeOtherUserDrafts: filters?.include_other_user_drafts,
+    });
+    if (draftCondition) conditions.push(draftCondition);
     conditions.push(eq(kbDocuments.archived, filters?.archived ?? false));
     if (filters?.archived !== true) {
       conditions.push(sql`exists (
@@ -1003,6 +1052,13 @@ export class KnowledgeSearchRepository {
     }
     if (query.kind) conditions.push(eq(kbDocuments.kind, query.kind));
     if (query.visibility) conditions.push(eq(kbDocuments.visibility, query.visibility));
+    const draftCondition = knowledgeDraftVisibilityCondition({
+      status: query.status,
+      userId: query.readable_by_user_id,
+      includeMyDrafts: query.include_my_drafts ?? query.includeMyDrafts,
+      includeOtherUserDrafts: query.include_other_user_drafts ?? query.includeOtherUserDrafts,
+    });
+    if (draftCondition) conditions.push(draftCondition);
     if (!query.readable_as_admin) {
       conditions.push(
         query.readable_by_user_id

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -817,6 +817,15 @@ export class KnowledgeDocumentRepository
     return row ? this.rowToDocumentWithUrl(row) : null;
   }
 
+  async findByNamespaceSlugAndPath(
+    namespaceSlug: string,
+    path: string
+  ): Promise<KnowledgeDocument | null> {
+    const namespace = await new KnowledgeNamespaceRepository(this.db).findBySlug(namespaceSlug);
+    if (!namespace) return null;
+    return this.findByNamespaceAndPath(namespace.namespace_id, path);
+  }
+
   async findByUnitId(unitId: string): Promise<KnowledgeDocument | null> {
     const unit = await select(this.db)
       .from(kbDocumentUnits)

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -11,12 +11,14 @@ import { createHash } from 'node:crypto';
 import type {
   KnowledgeDocument,
   KnowledgeDocumentID,
+  KnowledgeDocumentIndexingStatus,
   KnowledgeDocumentKind,
   KnowledgeDocumentStatus,
   KnowledgeDocumentUnitID,
   KnowledgeDocumentVersion,
   KnowledgeDocumentVersionID,
   KnowledgeEditPolicy,
+  KnowledgeEmbeddingStatus,
   KnowledgeGraphEdge,
   KnowledgeGraphEdgeID,
   KnowledgeGraphEdgeType,
@@ -36,6 +38,7 @@ import {
   buildKnowledgeUnitUri,
   buildKnowledgeUri,
   KNOWLEDGE_DOCUMENT_URI_PREFIX,
+  KNOWLEDGE_EMBEDDING_STATUSES,
   KNOWLEDGE_UNIT_URI_PREFIX,
   normalizeKnowledgePath,
   parseKnowledgeUri,
@@ -154,6 +157,8 @@ export interface KnowledgeSearchQuery {
   includeMyDrafts?: boolean;
   include_other_user_drafts?: boolean;
   includeOtherUserDrafts?: boolean;
+  include_indexing?: boolean;
+  includeIndexing?: boolean;
   limit?: number;
   readable_by_user_id?: UserID;
   readable_as_admin?: boolean;
@@ -819,6 +824,108 @@ export class KnowledgeDocumentRepository
       .one();
     if (!unit) return null;
     return this.findById(unit.document_id);
+  }
+
+  async indexingStatusForDocuments(
+    documentIds: KnowledgeDocumentID[]
+  ): Promise<Map<KnowledgeDocumentID, KnowledgeDocumentIndexingStatus>> {
+    const uniqueIds = [...new Set(documentIds)].filter(Boolean);
+    const result = new Map<KnowledgeDocumentID, KnowledgeDocumentIndexingStatus>();
+    if (uniqueIds.length === 0) return result;
+
+    const emptyCounts = () =>
+      Object.fromEntries(KNOWLEDGE_EMBEDDING_STATUSES.map((status) => [status, 0])) as Record<
+        KnowledgeEmbeddingStatus,
+        number
+      >;
+
+    for (const documentId of uniqueIds) {
+      result.set(documentId as KnowledgeDocumentID, {
+        state: 'empty',
+        total_units: 0,
+        chunks: emptyCounts(),
+        queue_depth: 0,
+        embedding_model: null,
+        embedding_dimensions: null,
+        last_error: null,
+        last_updated_at: null,
+      });
+    }
+
+    const rows = await select(this.db, {
+      document_id: kbDocumentUnits.document_id,
+      embedding_status: kbDocumentUnits.embedding_status,
+      embedding_model: kbDocumentUnits.embedding_model,
+      embedding_dimensions: kbDocumentUnits.embedding_dimensions,
+      embedding_error: kbDocumentUnits.embedding_error,
+      updated_at: kbDocumentUnits.updated_at,
+    })
+      .from(kbDocumentUnits)
+      .innerJoin(
+        kbDocuments,
+        and(
+          eq(kbDocumentUnits.document_id, kbDocuments.document_id),
+          eq(kbDocumentUnits.version_id, kbDocuments.current_version_id)
+        )
+      )
+      .where(inArray(kbDocumentUnits.document_id, uniqueIds))
+      .all();
+
+    for (const row of rows) {
+      const documentId = row.document_id as KnowledgeDocumentID;
+      const current =
+        result.get(documentId) ??
+        ({
+          state: 'empty',
+          total_units: 0,
+          chunks: emptyCounts(),
+          queue_depth: 0,
+          embedding_model: null,
+          embedding_dimensions: null,
+          last_error: null,
+          last_updated_at: null,
+        } satisfies KnowledgeDocumentIndexingStatus);
+      const status = row.embedding_status as keyof typeof current.chunks;
+      current.total_units += 1;
+      current.chunks[status] += 1;
+      if (!current.embedding_model && row.embedding_model)
+        current.embedding_model = row.embedding_model;
+      if (!current.embedding_dimensions && row.embedding_dimensions) {
+        current.embedding_dimensions = row.embedding_dimensions;
+      }
+      if (!current.last_error && row.embedding_error) current.last_error = row.embedding_error;
+      const updatedAt = row.updated_at ? new Date(row.updated_at) : null;
+      if (
+        updatedAt &&
+        (!current.last_updated_at || updatedAt.getTime() > current.last_updated_at.getTime())
+      ) {
+        current.last_updated_at = updatedAt;
+      }
+      result.set(documentId, current);
+    }
+
+    for (const status of result.values()) {
+      status.queue_depth = status.chunks.pending + status.chunks.stale;
+      if (status.total_units === 0) status.state = 'empty';
+      else if (status.chunks.error > 0) status.state = 'error';
+      else if (status.chunks.stale > 0) status.state = 'stale';
+      else if (status.chunks.pending > 0) status.state = 'queued';
+      else if (status.chunks.ready === status.total_units) status.state = 'ready';
+      else if (status.chunks.not_configured === status.total_units) status.state = 'not_configured';
+      else status.state = 'mixed';
+    }
+
+    return result;
+  }
+
+  async attachIndexingStatus<T extends KnowledgeDocument>(documents: T | T[]): Promise<T | T[]> {
+    const list = Array.isArray(documents) ? documents : [documents];
+    const statuses = await this.indexingStatusForDocuments(list.map((doc) => doc.document_id));
+    const withStatus = list.map((doc) => ({
+      ...doc,
+      indexing_status: statuses.get(doc.document_id) ?? null,
+    }));
+    return Array.isArray(documents) ? withStatus : withStatus[0];
   }
 
   async findAll(filters?: KnowledgeDocumentFilters): Promise<KnowledgeDocument[]> {

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1709,6 +1709,9 @@ export const kbDocuments = pgTable(
     visibility: text('visibility', { enum: ['public', 'private'] })
       .notNull()
       .default('public'),
+    status: text('status', { enum: ['draft', 'published'] })
+      .notNull()
+      .default('published'),
     edit_policy: text('edit_policy', { enum: ['owner', 'public', 'admins'] })
       .notNull()
       .default('owner'),
@@ -1734,6 +1737,7 @@ export const kbDocuments = pgTable(
     namespaceIdx: index('kb_documents_namespace_idx').on(table.namespace_id),
     kindIdx: index('kb_documents_kind_idx').on(table.kind),
     visibilityIdx: index('kb_documents_visibility_idx').on(table.visibility),
+    statusIdx: index('kb_documents_status_idx').on(table.status),
     createdByIdx: index('kb_documents_created_by_idx').on(table.created_by),
     updatedAtIdx: index('kb_documents_updated_at_idx').on(table.updated_at),
     archivedIdx: index('kb_documents_archived_idx').on(table.archived),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1748,6 +1748,9 @@ export const kbDocuments = sqliteTable(
     visibility: text('visibility', { enum: ['public', 'private'] })
       .notNull()
       .default('public'),
+    status: text('status', { enum: ['draft', 'published'] })
+      .notNull()
+      .default('published'),
     edit_policy: text('edit_policy', { enum: ['owner', 'public', 'admins'] })
       .notNull()
       .default('owner'),
@@ -1773,6 +1776,7 @@ export const kbDocuments = sqliteTable(
     namespaceIdx: index('kb_documents_namespace_idx').on(table.namespace_id),
     kindIdx: index('kb_documents_kind_idx').on(table.kind),
     visibilityIdx: index('kb_documents_visibility_idx').on(table.visibility),
+    statusIdx: index('kb_documents_status_idx').on(table.status),
     createdByIdx: index('kb_documents_created_by_idx').on(table.created_by),
     updatedAtIdx: index('kb_documents_updated_at_idx').on(table.updated_at),
     archivedIdx: index('kb_documents_archived_idx').on(table.archived),

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -70,6 +70,18 @@ export const KNOWLEDGE_EMBEDDING_STATUSES = [
 
 export type KnowledgeEmbeddingStatus = (typeof KNOWLEDGE_EMBEDDING_STATUSES)[number];
 
+export const KNOWLEDGE_DOCUMENT_INDEXING_STATES = [
+  'empty',
+  'not_configured',
+  'queued',
+  'ready',
+  'stale',
+  'error',
+  'mixed',
+] as const;
+
+export type KnowledgeDocumentIndexingState = (typeof KNOWLEDGE_DOCUMENT_INDEXING_STATES)[number];
+
 export const KNOWLEDGE_SEARCH_MODES = ['text', 'semantic', 'hybrid'] as const;
 export type KnowledgeSearchMode = (typeof KNOWLEDGE_SEARCH_MODES)[number];
 
@@ -340,6 +352,11 @@ export interface KnowledgeDocument {
   updated_at?: Date | null;
   archived: boolean;
   archived_at?: Date | null;
+  /**
+   * Optional aggregate over the current version's internal search/indexing
+   * units. Included by API calls that request `include_indexing`.
+   */
+  indexing_status?: KnowledgeDocumentIndexingStatus | null;
 }
 
 export interface KnowledgeDocumentVersion {
@@ -381,6 +398,17 @@ export interface KnowledgeDocumentUnit {
   metadata?: Record<string, unknown> | null;
   created_at: Date;
   updated_at?: Date | null;
+}
+
+export interface KnowledgeDocumentIndexingStatus {
+  state: KnowledgeDocumentIndexingState;
+  total_units: number;
+  chunks: Record<KnowledgeEmbeddingStatus, number>;
+  queue_depth: number;
+  embedding_model?: string | null;
+  embedding_dimensions?: number | null;
+  last_error?: string | null;
+  last_updated_at?: Date | null;
 }
 
 export interface KnowledgeEmbeddingSpace {

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -45,6 +45,9 @@ export type KnowledgeDocumentKind = (typeof KNOWLEDGE_DOCUMENT_KINDS)[number];
 export const KNOWLEDGE_VISIBILITIES = ['public', 'private'] as const;
 export type KnowledgeVisibility = (typeof KNOWLEDGE_VISIBILITIES)[number];
 
+export const KNOWLEDGE_DOCUMENT_STATUSES = ['draft', 'published'] as const;
+export type KnowledgeDocumentStatus = (typeof KNOWLEDGE_DOCUMENT_STATUSES)[number];
+
 export const KNOWLEDGE_EDIT_POLICIES = ['owner', 'public', 'admins'] as const;
 export type KnowledgeEditPolicy = (typeof KNOWLEDGE_EDIT_POLICIES)[number];
 
@@ -323,6 +326,11 @@ export interface KnowledgeDocument {
   title: string;
   kind: KnowledgeDocumentKind;
   visibility: KnowledgeVisibility;
+  /**
+   * Lifecycle status. Drafts are not secret and direct reads still use normal
+   * visibility checks, but browsing/search hide other users' drafts by default.
+   */
+  status: KnowledgeDocumentStatus;
   edit_policy: KnowledgeEditPolicy;
   current_version_id?: KnowledgeDocumentVersionID | null;
   metadata?: Record<string, unknown> | null;
@@ -499,6 +507,7 @@ export interface KnowledgeGraphDocNode {
   uri: string;
   kind: KnowledgeDocumentKind;
   visibility: KnowledgeVisibility;
+  status: KnowledgeDocumentStatus;
 }
 
 /** A doc-to-doc edge in the namespace-wide knowledge graph view. */


### PR DESCRIPTION
## Summary

- Add persistent Knowledge Base document lifecycle status (`draft` / `published`) with existing docs defaulting to `published`.
- Hide other users' drafts from default KB tree/search while keeping authored drafts visible and direct document access shareable when normal visibility/RBAC permits.
- Expose draft controls/badges in the UI and add MCP/API search filters (`includeMyDrafts`, `includeOtherUserDrafts`).
- Add optional document-level indexing/embedding status (`include_indexing` / `includeIndexing`) across KB document/list/search/get flows, MCP tools, and UI cues.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/db/repositories/knowledge.test.ts src/types/knowledge.test.ts`
- `pnpm --filter @agor/daemon test -- src/services/knowledge.test.ts`

## Notes

- Draft status is orthogonal to existing visibility/certified/archived semantics.
- Direct `get`/path access is not blocked solely because a document is a draft.
- Indexing status is opt-in on API/MCP responses to avoid bloating default payloads.