### PR TITLE
Harden git remote credential handling and startup repair

### DIFF
--- a/apps/agor-cli/src/commands/admin/scrub-git-remotes.ts
+++ b/apps/agor-cli/src/commands/admin/scrub-git-remotes.ts
@@ -1,0 +1,92 @@
+import {
+  BranchRepository,
+  createDatabase,
+  getDatabaseUrl,
+  RepoRepository,
+  shortId,
+} from '@agor/core/db';
+import { scanGitConfigRemoteCredentials, scrubGitConfigRemoteCredentials } from '@agor/core/git';
+import { Command, Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+export default class ScrubGitRemotes extends Command {
+  static override description =
+    'Scan managed repos/branches for credential-bearing git remote URLs and optionally scrub them.';
+
+  static override flags = {
+    write: Flags.boolean({
+      char: 'w',
+      default: false,
+      description: 'Rewrite unsafe remote URLs in .git/config by removing URL userinfo',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(ScrubGitRemotes);
+    const db = createDatabase({ url: getDatabaseUrl() });
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const repos = await repoRepo.findAll();
+    const branches = await branchRepo.findAll({ includeArchived: true });
+
+    const seen = new Set<string>();
+    let unsafeUrls = 0;
+    let changedConfigs = 0;
+
+    for (const item of [
+      ...repos.map((repo) => ({
+        kind: 'repo' as const,
+        label: `${repo.slug} (${shortId(repo.repo_id)})`,
+        path: repo.local_path,
+      })),
+      ...branches.map((branch) => ({
+        kind: 'branch' as const,
+        label: `${branch.name} (${shortId(branch.branch_id)})`,
+        path: branch.path,
+      })),
+    ]) {
+      if (!item.path) continue;
+      const result = flags.write
+        ? await scrubGitConfigRemoteCredentials(item.path)
+        : await scanGitConfigRemoteCredentials(item.path);
+      const findings = result.findings.filter((finding) => {
+        const key = `${finding.configPath}\0${finding.remote}\0${finding.key}\0${finding.sanitizedUrl}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      if (findings.length === 0) continue;
+
+      unsafeUrls += findings.length;
+      if ('changed' in result && result.changed) {
+        changedConfigs += new Set(findings.map((finding) => finding.configPath)).size;
+      }
+
+      this.log(chalk.yellow(`${item.kind} ${item.label}: ${findings.length} unsafe remote URL(s)`));
+      for (const finding of findings) {
+        this.log(
+          `  ${finding.configPath}: remote "${finding.remote}" ${finding.key} = ${finding.redactedUrl}`
+        );
+      }
+    }
+
+    if (unsafeUrls === 0) {
+      this.log(chalk.green('No credential-bearing git remote URLs found.'));
+      return;
+    }
+
+    if (flags.write) {
+      this.log(
+        chalk.green(
+          `Scrubbed ${unsafeUrls} credential-bearing remote URL(s) across ${changedConfigs} config file(s).`
+        )
+      );
+    } else {
+      this.log(
+        chalk.yellow(
+          `Found ${unsafeUrls} credential-bearing remote URL(s). Re-run with --write to remove URL userinfo. Rotate any exposed token(s).`
+        )
+      );
+    }
+  }
+}

--- a/apps/agor-cli/src/commands/admin/scrub-git-remotes.ts
+++ b/apps/agor-cli/src/commands/admin/scrub-git-remotes.ts
@@ -11,13 +11,14 @@ import chalk from 'chalk';
 
 export default class ScrubGitRemotes extends Command {
   static override description =
-    'Scan managed repos/branches for credential-bearing git remote URLs and optionally scrub them.';
+    'Scan registered repos/branches for credential-bearing git remote URLs and optionally scrub them.';
 
   static override flags = {
     write: Flags.boolean({
       char: 'w',
       default: false,
-      description: 'Rewrite unsafe remote URLs in .git/config by removing URL userinfo',
+      description:
+        'Rewrite unsafe remote URLs in .git/config and persisted repo rows by removing URL userinfo',
     }),
   };
 
@@ -32,6 +33,19 @@ export default class ScrubGitRemotes extends Command {
     const seen = new Set<string>();
     let unsafeUrls = 0;
     let changedConfigs = 0;
+
+    if (flags.write) {
+      const dbScrub = await repoRepo.scrubRemoteUrls();
+      if (dbScrub.changed > 0) {
+        this.log(
+          chalk.green(
+            `Scrubbed ${dbScrub.changed} persisted repo remote URL entr${
+              dbScrub.changed === 1 ? 'y' : 'ies'
+            }.`
+          )
+        );
+      }
+    }
 
     for (const item of [
       ...repos.map((repo) => ({

--- a/apps/agor-cli/src/commands/admin/scrub-git-remotes.ts
+++ b/apps/agor-cli/src/commands/admin/scrub-git-remotes.ts
@@ -31,11 +31,22 @@ export default class ScrubGitRemotes extends Command {
     const branches = await branchRepo.findAll({ includeArchived: true });
 
     const seen = new Set<string>();
-    let unsafeUrls = 0;
+    let unsafeConfigUrls = 0;
     let changedConfigs = 0;
+    let changedDbRows = 0;
+
+    const dbScan = await repoRepo.scanRemoteUrls();
+    const unsafeDbRows = dbScan.findings.length;
+    if (unsafeDbRows > 0) {
+      this.log(chalk.yellow(`persisted repo rows: ${unsafeDbRows} unsafe remote URL(s)`));
+      for (const finding of dbScan.findings) {
+        this.log(`  repo ${finding.slug} (${shortId(finding.repo_id)}): remote_url = <redacted>`);
+      }
+    }
 
     if (flags.write) {
       const dbScrub = await repoRepo.scrubRemoteUrls();
+      changedDbRows = dbScrub.changed;
       if (dbScrub.changed > 0) {
         this.log(
           chalk.green(
@@ -71,7 +82,7 @@ export default class ScrubGitRemotes extends Command {
       });
       if (findings.length === 0) continue;
 
-      unsafeUrls += findings.length;
+      unsafeConfigUrls += findings.length;
       if ('changed' in result && result.changed) {
         changedConfigs += new Set(findings.map((finding) => finding.configPath)).size;
       }
@@ -84,7 +95,7 @@ export default class ScrubGitRemotes extends Command {
       }
     }
 
-    if (unsafeUrls === 0) {
+    if (unsafeDbRows === 0 && unsafeConfigUrls === 0) {
       this.log(chalk.green('No credential-bearing git remote URLs found.'));
       return;
     }
@@ -92,13 +103,13 @@ export default class ScrubGitRemotes extends Command {
     if (flags.write) {
       this.log(
         chalk.green(
-          `Scrubbed ${unsafeUrls} credential-bearing remote URL(s) across ${changedConfigs} config file(s).`
+          `Scrubbed ${changedDbRows} persisted repo row(s) and ${unsafeConfigUrls} credential-bearing remote URL(s) across ${changedConfigs} config file(s).`
         )
       );
     } else {
       this.log(
         chalk.yellow(
-          `Found ${unsafeUrls} credential-bearing remote URL(s). Re-run with --write to remove URL userinfo. Rotate any exposed token(s).`
+          `Found ${unsafeDbRows} persisted repo row(s) and ${unsafeConfigUrls} git config remote URL(s) with credential-bearing HTTP(S) userinfo. Re-run with --write to remove URL userinfo. Rotate any exposed token(s).`
         )
       );
     }

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -65,7 +65,7 @@ import { configureChannels, createSocketIOConfig } from './setup/socketio.js';
 import { setBundledUiFallbackHeaders, setBundledUiStaticHeaders } from './setup/static-assets.js';
 import { configureSwagger } from './setup/swagger.js';
 import { loadDaemonVersion } from './setup/version.js';
-import { startup } from './startup.js';
+import { runPostStartJob, startup } from './startup.js';
 import { configureDaemonUrl, configureExecutor } from './utils/spawn-executor.js';
 import { registerAllWidgets } from './widgets/index.js';
 
@@ -683,7 +683,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // stale-task watchdog re-started, so a Ctrl-D'd REPL that straddled
   // the restart is detected and the task is closed.
   // --------------------------------------------------------------------------
-  try {
+  runPostStartJob('cli-watcher-rehydrate', async () => {
     const { rehydrateCliWatchers } = await import('./services/claude-cli-integration.js');
     await rehydrateCliWatchers(app, async (branchId) => {
       try {
@@ -693,7 +693,5 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
         return null;
       }
     });
-  } catch (err) {
-    console.warn('[startup] rehydrateCliWatchers failed (non-fatal):', err);
-  }
+  });
 }

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -29,6 +29,7 @@ import {
   validateRenderedManagedEnvUrlFields,
 } from '@agor/core/environment/webhook';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { stripGitUrlCredentials } from '@agor/core/git';
 import type {
   AuthenticatedParams,
   BoardID,
@@ -1058,6 +1059,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         );
         return unarchivedBranch;
       }
+      const safeRemoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
 
       try {
         // Use a service JWT so the executor can patch rendered env command
@@ -1095,7 +1097,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               // storage_mode across archive → delete → unarchive.
               storageMode,
               ...(branch.clone_depth !== undefined ? { cloneDepth: branch.clone_depth } : {}),
-              ...(storageMode === 'clone' && repo.remote_url ? { remoteUrl: repo.remote_url } : {}),
+              ...(storageMode === 'clone' && safeRemoteUrl ? { remoteUrl: safeRemoteUrl } : {}),
               // `--reference` hint: see the create-path call site in
               // ReposService.createBranch for the rationale and strict-mode
               // exception.

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -31,6 +31,10 @@ import {
   getRemoteUrl,
   getReposDir,
   isValidGitRepo,
+  redactGitUrlCredentials,
+  scanGitConfigRemoteCredentials,
+  scrubGitConfigRemoteCredentials,
+  stripGitUrlCredentials,
 } from '@agor/core/git';
 import type {
   AuthenticatedParams,
@@ -158,13 +162,20 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     data: { url: string; slug?: string; name?: string; default_branch?: string },
     params?: RepoParams
   ): Promise<CloneRepositoryResult> {
+    const remoteUrl = stripGitUrlCredentials(data.url);
+    if (remoteUrl !== data.url) {
+      console.warn(
+        `[repos.clone] Stripped credentials from submitted remote URL: ${redactGitUrlCredentials(data.url)}`
+      );
+    }
+
     // Note: `||` (not `??`) is intentional — we want an empty `data.slug`
     // to fall through to derivation rather than be treated as "explicit".
     let slug = data.slug || data.name;
     if (!slug) {
       // Normalize URL (strip trailing slashes and `.git`) using the shared
       // canonical form, so UI and daemon cannot drift.
-      slug = extractSlugFromUrl(normalizeRepoUrl(data.url));
+      slug = extractSlugFromUrl(normalizeRepoUrl(remoteUrl));
     }
     if (!slug || !isValidSlug(slug)) {
       throw new Error('Could not derive a valid slug from URL. Please provide a slug.');
@@ -240,7 +251,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         slug: slug as RepoSlug,
         name: data.name || slug,
         repo_type: 'remote',
-        remote_url: data.url,
+        remote_url: remoteUrl,
         local_path: expectedLocalPath,
         ...(data.default_branch ? { default_branch: data.default_branch } : {}),
         clone_status: 'cloning',
@@ -264,7 +275,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         sessionToken,
         daemonUrl: getDaemonUrl(),
         params: {
-          url: data.url,
+          url: remoteUrl,
           slug,
           repoId,
           outputPath: expectedLocalPath,
@@ -302,7 +313,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
                 : '';
               io.emit('repo:cloneError', {
                 slug,
-                url: data.url,
+                url: remoteUrl,
                 error: `Clone failed (exit code ${code}). Check that the repository URL is correct and accessible.${branchHint}`,
                 repo_id: repoId,
               });
@@ -420,10 +431,16 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     }
 
     if (patch.remote_url !== undefined) {
-      if (patch.remote_url && !isValidGitUrl(patch.remote_url)) {
+      const safeRemoteUrl = patch.remote_url ? stripGitUrlCredentials(patch.remote_url) : '';
+      if (safeRemoteUrl !== patch.remote_url) {
+        console.warn(
+          `[repos.updateMetadata] Stripped credentials from submitted remote URL: ${redactGitUrlCredentials(patch.remote_url)}`
+        );
+      }
+      if (safeRemoteUrl && !isValidGitUrl(safeRemoteUrl)) {
         throw new Error('remote_url must be a valid git URL (https:// or git@)');
       }
-      cleanPatch.remote_url = patch.remote_url;
+      cleanPatch.remote_url = safeRemoteUrl;
     }
 
     if (patch.default_branch !== undefined) cleanPatch.default_branch = patch.default_branch;
@@ -518,7 +535,13 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       );
     }
 
-    const remoteUrl = (await getRemoteUrl(repoPath)) ?? undefined;
+    const remoteUrl = stripGitUrlCredentials((await getRemoteUrl(repoPath)) ?? '') || undefined;
+    const scanResult = await scanGitConfigRemoteCredentials(repoPath);
+    if (scanResult.findings.length > 0) {
+      console.warn(
+        `[repos.local] Registered local repo has ${scanResult.findings.length} credential-bearing remote URL(s) in git config; persisted remote_url was sanitized. Run the repair utility if this repo is managed/shared.`
+      );
+    }
     const name = slug.split('/').pop() ?? slug;
 
     const repo = (await this.create(
@@ -631,6 +654,15 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         `Cannot create a clone-mode branch for repo '${repo.slug}': repo has no remote_url. ` +
           `Use storage_mode='worktree' or register the repo with a remote first.`
       );
+    }
+
+    if (repo.local_path) {
+      const scrubResult = await scrubGitConfigRemoteCredentials(repo.local_path);
+      if (scrubResult.findings.length > 0) {
+        console.warn(
+          `[ReposService.createBranch] Scrubbed ${scrubResult.findings.length} credential-bearing git remote URL(s) from repo '${repo.slug}' before branch creation.`
+        );
+      }
     }
 
     // NOTE: Filesystem / git-state preflights (target-dir-exists, source-ref

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -894,6 +894,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       // in simple/no-RBAC mode so hosts without passwordless sudoers work
       // (#1140, #1143). Callers no longer duplicate the gate.
       const asUser = await resolveGitImpersonationForUser(this.db, userId);
+      const safeRemoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
 
       spawnExecutorFireAndForget(
         {
@@ -917,7 +918,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             // Branch storage mode (forwarded for the clone-mode code path)
             storageMode,
             ...(cloneDepth !== undefined ? { cloneDepth } : {}),
-            ...(storageMode === 'clone' && repo.remote_url ? { remoteUrl: repo.remote_url } : {}),
+            ...(storageMode === 'clone' && safeRemoteUrl ? { remoteUrl: safeRemoteUrl } : {}),
             // Hand the executor the per-repo base clone as a `--reference`
             // hint only when that object cache is readable by the eventual
             // session identity. In strict mode, per-user sessions need fully

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -614,7 +614,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       repo_id: repo.repo_id,
       slug: repo.slug,
       local_path: repo.local_path,
-      remote_url: repo.remote_url,
+      remote_url: repo.remote_url ? redactGitUrlCredentials(repo.remote_url) : repo.remote_url,
     });
 
     // Check for duplicate branch name in this repo (non-archived only)

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -21,7 +21,7 @@ import { KnowledgeEmbeddingIndexer } from './services/knowledge-embedding-indexe
 import { SchedulerService } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
-import { warnOnManagedGitRemoteCredentials } from './utils/git-remote-credential-scan.js';
+import { scrubManagedGitRemoteCredentials } from './utils/git-remote-credential-scan.js';
 
 // ---------------------------------------------------------------------------
 // Context
@@ -371,16 +371,13 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // 1. Cleanup orphaned tasks/sessions from previous daemon instance
   await cleanupOrphans(ctx);
 
-  // 2. Warn on credential-bearing git remote URLs in managed repo/branch configs.
-  await warnOnManagedGitRemoteCredentials(db);
-
-  // 3. Initialize Health Monitor for periodic environment health checks
+  // 2. Initialize Health Monitor for periodic environment health checks
   const healthMonitor = await createHealthMonitor(app);
 
-  // 4. Validate/generate master secret for API key encryption
+  // 3. Validate/generate master secret for API key encryption
   await ensureMasterSecret(config);
 
-  // 5. Start server
+  // 4. Start server
   const server = await app.listen(DAEMON_PORT, DAEMON_HOST);
 
   const displayHost = DAEMON_HOST === '0.0.0.0' ? 'localhost' : DAEMON_HOST;
@@ -400,6 +397,13 @@ export async function startup(ctx: StartupContext): Promise<void> {
   console.log(`     - /config`);
   console.log(`     - /context`);
   console.log(`     - /users`);
+
+  // Non-blocking credential spill repair. If an agent/user wrote a PAT into a
+  // managed repo remote URL while the daemon was down, scrub it after the API
+  // is already accepting requests. This is best-effort and deliberately skips
+  // registered local repos to avoid surprising writes outside Agor-managed
+  // storage.
+  void scrubManagedGitRemoteCredentials(db);
 
   // Log the host IP that will be frozen into env command templates as
   // {{host.ip_address}}. Explicit config overrides autodetection.

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -16,7 +16,7 @@ import { SessionStatus, TaskStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
 import { ExecutorHeartbeatSupervisor } from './services/executor-heartbeat-supervisor.js';
 import type { GatewayService } from './services/gateway.js';
-import { createHealthMonitor } from './services/health-monitor.js';
+import { HealthMonitor } from './services/health-monitor.js';
 import { KnowledgeEmbeddingIndexer } from './services/knowledge-embedding-indexer.js';
 import { SchedulerService } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
@@ -97,13 +97,20 @@ async function readAndClearSentinel(): Promise<boolean> {
 // Orphan cleanup
 // ---------------------------------------------------------------------------
 
-async function cleanupOrphans(ctx: StartupContext): Promise<void> {
-  const { app, db, sessionsService } = ctx;
+interface OrphanCleanupResult {
+  wasGraceful: boolean;
+  orphanedTasks: Task[];
+  orphanedSessions: Session[];
+  sessionIdsWithOrphanedTasks: Set<string>;
+}
+
+async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanupResult> {
+  const { app, sessionsService } = ctx;
 
   // Get tasks service from the app (registered during services phase)
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
 
-  console.log('🧹 Cleaning up orphaned tasks and sessions...');
+  console.log('🧹 Cleaning up orphaned task/session state...');
 
   // Determine restart type before touching anything — sentinel is consumed here
   const wasGraceful = await readAndClearSentinel();
@@ -187,109 +194,6 @@ async function cleanupOrphans(ctx: StartupContext): Promise<void> {
     }
   }
 
-  // Inject a system message into every affected session so the user (and the
-  // agent on resume) see an in-transcript explanation — not a toast, a
-  // persistent record in the conversation. Contrast with PR #1116 (filtered
-  // high-frequency SDK lifecycle noise): this is intentional, low-frequency,
-  // and user-meaningful.
-  //
-  // The message MUST be attached to a task: the reactive client drops taskless
-  // messages (ReactiveSessionState groups messages by task_id), so a notice
-  // with no task_id would be silently invisible in the UI.
-  const affectedSessionIds = new Set<string>([
-    ...orphanedSessions.map((s) => s.session_id as string),
-    ...Array.from(sessionIdsWithOrphanedTasks),
-  ]);
-
-  if (affectedSessionIds.size > 0) {
-    const restartType = wasGraceful ? 'daemon_restart' : ('daemon_crash' as const);
-    const messageText = wasGraceful
-      ? 'The Agor daemon was restarted while this session was running. Ask the agent to resume where it left off.'
-      : 'The Agor daemon restarted unexpectedly while this session was running. Ask the agent to resume where it left off.';
-
-    // Build session → last orphaned task map so we can attach notices to a task_id.
-    // Prefer orphaned tasks (they were the active tasks at shutdown); fall back to
-    // querying the session's most-recent task if none was orphaned.
-    const lastOrphanedTaskBySession = new Map<string, Task>();
-    for (const task of orphanedTasks) {
-      const sid = task.session_id as string;
-      const existing = lastOrphanedTaskBySession.get(sid);
-      if (!existing || task.created_at > existing.created_at) {
-        lastOrphanedTaskBySession.set(sid, task);
-      }
-    }
-
-    const sessionRepo = new SessionRepository(db);
-    const messageRepo = new MessagesRepository(db);
-
-    for (const sessionId of affectedSessionIds) {
-      try {
-        // Resolve the task to attach the notice to
-        let attachTask = lastOrphanedTaskBySession.get(sessionId);
-        if (!attachTask) {
-          // Sessions maintain an ordered task-ID list; the last entry is the most
-          // recent task without relying on TasksService.find() sort behavior.
-          const session = await sessionsService.get(sessionId as Id);
-          const latestTaskId = session.tasks?.at(-1);
-          if (latestTaskId) {
-            attachTask = await tasksService.get(latestTaskId);
-          }
-        }
-        if (!attachTask) {
-          // No task exists — message would be invisible (transcript is task-scoped).
-          // This session has never had any work, so there is nothing for the user to resume.
-          console.log(`   ⏭  Session ${shortId(sessionId)} has no tasks — skipping restart notice`);
-          continue;
-        }
-
-        // Idempotency: skip if the last message is already a daemon restart notice
-        // (guards against rapid restart cycles piling up notices before the user responds)
-        const messageCount = await sessionRepo.countMessages(sessionId);
-        if (messageCount > 0) {
-          const lastMessages = await messageRepo.findByRange(
-            sessionId as SessionID,
-            messageCount - 1,
-            messageCount - 1
-          );
-          const last = lastMessages[0];
-          if (last?.type === 'daemon_restart' || last?.type === 'daemon_crash') {
-            console.log(
-              `   ⏭  Session ${shortId(sessionId)} already has a restart notice — skipping`
-            );
-            continue;
-          }
-        }
-
-        const injectedMessage = await appendSystemMessage({
-          app,
-          db,
-          sessionId,
-          taskId: attachTask.task_id,
-          type: restartType,
-          content: messageText,
-          metadata: { source: 'agor' },
-        });
-
-        // Extend the task's message_range.end_index so the notice is counted
-        // and loaded within the task's window in the UI.
-        // Pass only end_index: TaskRepository.update() deep-merges with the live
-        // DB row, preserving fields written by the STOPPED patch (e.g. end_timestamp).
-        if (attachTask.message_range) {
-          await tasksService.patch(attachTask.task_id, {
-            message_range: { end_index: injectedMessage.index } as Task['message_range'],
-          });
-        }
-
-        console.log(`   ✉  Injected ${restartType} notice into session ${shortId(sessionId)}`);
-      } catch (err) {
-        console.warn(
-          `   ⚠️  Failed to inject restart notice into session ${shortId(sessionId)}:`,
-          err
-        );
-      }
-    }
-  }
-
   // Wipe the queue. Running tasks are marked STOPPED above, which invalidates
   // the ordering premise of anything that was waiting behind them — a queued
   // prompt typically depends on whatever was running first. Rather than carry
@@ -313,6 +217,143 @@ async function cleanupOrphans(ctx: StartupContext): Promise<void> {
   if (orphanedTasks.length === 0 && orphanedSessions.length === 0 && queuedTasks.length === 0) {
     console.log('   No orphaned tasks or sessions found');
   }
+
+  return {
+    wasGraceful,
+    orphanedTasks,
+    orphanedSessions,
+    sessionIdsWithOrphanedTasks,
+  };
+}
+
+async function injectRestartNotices(
+  ctx: StartupContext,
+  cleanupResult: OrphanCleanupResult
+): Promise<void> {
+  const { app, db, sessionsService } = ctx;
+  const { wasGraceful, orphanedTasks, orphanedSessions, sessionIdsWithOrphanedTasks } =
+    cleanupResult;
+
+  // Get tasks service from the app (registered during services phase)
+  const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
+
+  // Inject a system message into every affected session so the user (and the
+  // agent on resume) see an in-transcript explanation — not a toast, a
+  // persistent record in the conversation. Contrast with PR #1116 (filtered
+  // high-frequency SDK lifecycle noise): this is intentional, low-frequency,
+  // and user-meaningful.
+  //
+  // The message MUST be attached to a task: the reactive client drops taskless
+  // messages (ReactiveSessionState groups messages by task_id), so a notice
+  // with no task_id would be silently invisible in the UI.
+  const affectedSessionIds = new Set<string>([
+    ...orphanedSessions.map((s) => s.session_id as string),
+    ...Array.from(sessionIdsWithOrphanedTasks),
+  ]);
+
+  if (affectedSessionIds.size === 0) {
+    return;
+  }
+
+  console.log(`🧹 Injecting daemon restart notices for ${affectedSessionIds.size} session(s)...`);
+
+  const restartType = wasGraceful ? ('daemon_restart' as const) : ('daemon_crash' as const);
+  const messageText = wasGraceful
+    ? 'The Agor daemon was restarted while this session was running. Ask the agent to resume where it left off.'
+    : 'The Agor daemon restarted unexpectedly while this session was running. Ask the agent to resume where it left off.';
+
+  // Build session → last orphaned task map so we can attach notices to a task_id.
+  // Prefer orphaned tasks (they were the active tasks at shutdown); fall back to
+  // querying the session's most-recent task if none was orphaned.
+  const lastOrphanedTaskBySession = new Map<string, Task>();
+  for (const task of orphanedTasks) {
+    const sid = task.session_id as string;
+    const existing = lastOrphanedTaskBySession.get(sid);
+    if (!existing || task.created_at > existing.created_at) {
+      lastOrphanedTaskBySession.set(sid, task);
+    }
+  }
+
+  const sessionRepo = new SessionRepository(db);
+  const messageRepo = new MessagesRepository(db);
+
+  for (const sessionId of affectedSessionIds) {
+    try {
+      // Resolve the task to attach the notice to
+      let attachTask = lastOrphanedTaskBySession.get(sessionId);
+      if (!attachTask) {
+        // Sessions maintain an ordered task-ID list; the last entry is the most
+        // recent task without relying on TasksService.find() sort behavior.
+        const session = await sessionsService.get(sessionId as Id);
+        const latestTaskId = session.tasks?.at(-1);
+        if (latestTaskId) {
+          attachTask = await tasksService.get(latestTaskId);
+        }
+      }
+      if (!attachTask) {
+        // No task exists — message would be invisible (transcript is task-scoped).
+        // This session has never had any work, so there is nothing for the user to resume.
+        console.log(`   ⏭  Session ${shortId(sessionId)} has no tasks — skipping restart notice`);
+        continue;
+      }
+
+      // Idempotency: skip if the last message is already a daemon restart notice
+      // (guards against rapid restart cycles piling up notices before the user responds)
+      const messageCount = await sessionRepo.countMessages(sessionId);
+      if (messageCount > 0) {
+        const lastMessages = await messageRepo.findByRange(
+          sessionId as SessionID,
+          messageCount - 1,
+          messageCount - 1
+        );
+        const last = lastMessages[0];
+        if (last?.type === 'daemon_restart' || last?.type === 'daemon_crash') {
+          console.log(
+            `   ⏭  Session ${shortId(sessionId)} already has a restart notice — skipping`
+          );
+          continue;
+        }
+      }
+
+      const injectedMessage = await appendSystemMessage({
+        app,
+        db,
+        sessionId,
+        taskId: attachTask.task_id,
+        type: restartType,
+        content: messageText,
+        metadata: { source: 'agor' },
+      });
+
+      // Extend the task's message_range.end_index so the notice is counted
+      // and loaded within the task's window in the UI.
+      // Pass only end_index: TaskRepository.update() deep-merges with the live
+      // DB row, preserving fields written by the STOPPED patch (e.g. end_timestamp).
+      if (attachTask.message_range) {
+        await tasksService.patch(attachTask.task_id, {
+          message_range: { end_index: injectedMessage.index } as Task['message_range'],
+        });
+      }
+
+      console.log(`   ✉  Injected ${restartType} notice into session ${shortId(sessionId)}`);
+    } catch (err) {
+      console.warn(
+        `   ⚠️  Failed to inject restart notice into session ${shortId(sessionId)}:`,
+        err
+      );
+    }
+  }
+}
+
+export function runPostStartJob(name: string, job: () => Promise<void> | void): void {
+  void Promise.resolve()
+    .then(() => job())
+    .then(() => {
+      console.log(`[startup] post-start job completed: ${name}`);
+    })
+    .catch((error: unknown) => {
+      console.warn(`[startup] post-start job failed: ${name}`, error);
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -368,11 +409,14 @@ export async function startup(ctx: StartupContext): Promise<void> {
     terminalsService,
   } = ctx;
 
-  // 1. Cleanup orphaned tasks/sessions from previous daemon instance
-  await cleanupOrphans(ctx);
+  // 1. Correct orphaned task/session state from previous daemon instance.
+  // Keep this blocking so clients never see stale RUNNING/AWAITING states from
+  // a previous process. More expensive UX/audit follow-ups are post-start jobs.
+  const orphanCleanupResult = await cleanupOrphanStatuses(ctx);
 
-  // 2. Initialize Health Monitor for periodic environment health checks
-  const healthMonitor = await createHealthMonitor(app);
+  // 2. Register Health Monitor listeners before serving requests. The initial
+  // full scan of already-running environments is deferred until after listen.
+  const healthMonitor = new HealthMonitor(app);
 
   // 3. Validate/generate master secret for API key encryption
   await ensureMasterSecret(config);
@@ -398,23 +442,24 @@ export async function startup(ctx: StartupContext): Promise<void> {
   console.log(`     - /context`);
   console.log(`     - /users`);
 
+  runPostStartJob('health-monitor-initialize', () => healthMonitor.initialize());
+  runPostStartJob('daemon-restart-notices', () => injectRestartNotices(ctx, orphanCleanupResult));
+
   // Non-blocking credential spill repair. If an agent/user wrote a PAT into a
   // managed repo remote URL while the daemon was down, scrub it after the API
   // is already accepting requests. This is best-effort and deliberately skips
   // registered local repos to avoid surprising writes outside Agor-managed
   // storage.
-  void scrubManagedGitRemoteCredentials(db);
+  runPostStartJob('git-remote-credential-scrub', () => scrubManagedGitRemoteCredentials(db));
 
   // Log the host IP that will be frozen into env command templates as
   // {{host.ip_address}}. Explicit config overrides autodetection.
-  try {
+  runPostStartJob('host-ip-log', async () => {
     const { resolveHostIpAddress } = await import('@agor/core/utils/host-ip');
     const hostIp = resolveHostIpAddress(config.daemon?.host_ip_address);
     const source = config.daemon?.host_ip_address ? 'config' : hostIp ? 'autodetected' : 'unknown';
     console.log(`🌐 Host IP for env templates: ${hostIp ?? '(none)'} (source: ${source})`);
-  } catch (err) {
-    console.warn('⚠️  Failed to resolve host IP for env templates:', err);
-  }
+  });
 
   // Security warning: web terminal + simple unix mode = daemon-user shell access.
   // `allow_web_terminal` defaults to true, so the check treats undefined as enabled.

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -446,10 +446,11 @@ export async function startup(ctx: StartupContext): Promise<void> {
   runPostStartJob('daemon-restart-notices', () => injectRestartNotices(ctx, orphanCleanupResult));
 
   // Non-blocking credential spill repair. If an agent/user wrote a PAT into a
-  // managed repo remote URL while the daemon was down, scrub it after the API
-  // is already accepting requests. This is best-effort and deliberately skips
-  // registered local repos to avoid surprising writes outside Agor-managed
-  // storage.
+  // git remote URL while the daemon was down, scrub persisted repo metadata
+  // and Agor-managed repo/worktree git configs after the API is already
+  // accepting requests. This is best-effort; filesystem config scrubbing
+  // deliberately skips registered local repos to avoid surprising writes
+  // outside Agor-managed storage.
   runPostStartJob('git-remote-credential-scrub', () => scrubManagedGitRemoteCredentials(db));
 
   // Log the host IP that will be frozen into env command templates as

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -21,6 +21,7 @@ import { KnowledgeEmbeddingIndexer } from './services/knowledge-embedding-indexe
 import { SchedulerService } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
+import { warnOnManagedGitRemoteCredentials } from './utils/git-remote-credential-scan.js';
 
 // ---------------------------------------------------------------------------
 // Context
@@ -370,13 +371,16 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // 1. Cleanup orphaned tasks/sessions from previous daemon instance
   await cleanupOrphans(ctx);
 
-  // 2. Initialize Health Monitor for periodic environment health checks
+  // 2. Warn on credential-bearing git remote URLs in managed repo/branch configs.
+  await warnOnManagedGitRemoteCredentials(db);
+
+  // 3. Initialize Health Monitor for periodic environment health checks
   const healthMonitor = await createHealthMonitor(app);
 
-  // 3. Validate/generate master secret for API key encryption
+  // 4. Validate/generate master secret for API key encryption
   await ensureMasterSecret(config);
 
-  // 4. Start server
+  // 5. Start server
   const server = await app.listen(DAEMON_PORT, DAEMON_HOST);
 
   const displayHost = DAEMON_HOST === '0.0.0.0' ? 'localhost' : DAEMON_HOST;

--- a/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
+++ b/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
@@ -4,10 +4,12 @@ import { scrubGitConfigRemoteCredentials } from '@agor/core/git';
 /**
  * Best-effort startup repair for credential-bearing git remote URLs.
  *
- * This runs only against remote repos managed by Agor and their branches. It
- * deliberately skips `repo_type: local` entries because those may point at an
- * operator's pre-existing repository outside `~/.agor`; mutating those configs
- * during daemon boot would be surprising. Local repos still get opportunistic
+ * This repairs persisted repo.remote_url rows for all registered repos, because
+ * those values are Agor-owned metadata. Filesystem .git/config scrubbing runs
+ * only against remote repos managed by Agor and their branches; it deliberately
+ * skips `repo_type: local` entries because those may point at an operator's
+ * pre-existing repository outside `~/.agor`, and mutating those configs during
+ * daemon boot would be surprising. Local repos still get opportunistically
  * scrubbed at Agor git-operation boundaries and can be repaired explicitly via
  * `agor admin scrub-git-remotes --write`.
  */

--- a/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
+++ b/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
@@ -1,0 +1,68 @@
+import { BranchRepository, type Database, RepoRepository, shortId } from '@agor/core/db';
+import { scanGitConfigRemoteCredentials } from '@agor/core/git';
+
+/**
+ * Startup health check for credential-bearing git remote URLs.
+ *
+ * This intentionally warns only. Repair is available through the core scrubber
+ * and admin CLI; doing unexpected writes during daemon startup would be a
+ * surprising side effect for operators.
+ */
+export async function warnOnManagedGitRemoteCredentials(db: Database): Promise<void> {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+
+  const repos = await repoRepo.findAll();
+  const branches = await branchRepo.findAll({ includeArchived: true });
+  const scannedConfigPaths = new Set<string>();
+  let unsafeConfigs = 0;
+  let unsafeUrls = 0;
+
+  for (const item of [
+    ...repos.map((repo) => ({
+      kind: 'repo' as const,
+      label: `${repo.slug} (${shortId(repo.repo_id)})`,
+      path: repo.local_path,
+    })),
+    ...branches.map((branch) => ({
+      kind: 'branch' as const,
+      label: `${branch.name} (${shortId(branch.branch_id)})`,
+      path: branch.path,
+    })),
+  ]) {
+    if (!item.path) continue;
+    try {
+      const result = await scanGitConfigRemoteCredentials(item.path);
+      const newFindings = result.findings.filter((finding) => {
+        const key = `${finding.configPath}\0${finding.remote}\0${finding.key}\0${finding.sanitizedUrl}`;
+        if (scannedConfigPaths.has(key)) return false;
+        scannedConfigPaths.add(key);
+        return true;
+      });
+      if (newFindings.length === 0) continue;
+
+      unsafeConfigs += new Set(newFindings.map((f) => f.configPath)).size;
+      unsafeUrls += newFindings.length;
+      const details = newFindings
+        .map((finding) => `${finding.remote}.${finding.key}=${finding.redactedUrl}`)
+        .join(', ');
+      console.warn(
+        `🔒 SECURITY: ${item.kind} ${item.label} has credential-bearing git remote URL(s) in ${newFindings.length} config entr${newFindings.length === 1 ? 'y' : 'ies'}; ${details}. ` +
+          `Remove the embedded credentials and rotate the token(s).`
+      );
+    } catch (error) {
+      console.warn(
+        `[git-remote-scan] Failed to scan ${item.kind} ${item.label}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  if (unsafeUrls > 0) {
+    console.warn(
+      `🔒 SECURITY: found ${unsafeUrls} credential-bearing git remote URL(s) across ${unsafeConfigs} git config file(s). ` +
+        `Run the admin repair utility or remove credentials from remotes manually; rotate any exposed tokens.`
+    );
+  }
+}

--- a/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
+++ b/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
@@ -1,68 +1,78 @@
 import { BranchRepository, type Database, RepoRepository, shortId } from '@agor/core/db';
-import { scanGitConfigRemoteCredentials } from '@agor/core/git';
+import { scrubGitConfigRemoteCredentials } from '@agor/core/git';
 
 /**
- * Startup health check for credential-bearing git remote URLs.
+ * Best-effort startup repair for credential-bearing git remote URLs.
  *
- * This intentionally warns only. Repair is available through the core scrubber
- * and admin CLI; doing unexpected writes during daemon startup would be a
- * surprising side effect for operators.
+ * This runs only against remote repos managed by Agor and their branches. It
+ * deliberately skips `repo_type: local` entries because those may point at an
+ * operator's pre-existing repository outside `~/.agor`; mutating those configs
+ * during daemon boot would be surprising. Local repos still get opportunistic
+ * scrubbed at Agor git-operation boundaries and can be repaired explicitly via
+ * `agor admin scrub-git-remotes --write`.
  */
-export async function warnOnManagedGitRemoteCredentials(db: Database): Promise<void> {
+export async function scrubManagedGitRemoteCredentials(db: Database): Promise<void> {
   const repoRepo = new RepoRepository(db);
   const branchRepo = new BranchRepository(db);
 
   const repos = await repoRepo.findAll();
-  const branches = await branchRepo.findAll({ includeArchived: true });
-  const scannedConfigPaths = new Set<string>();
-  let unsafeConfigs = 0;
-  let unsafeUrls = 0;
+  const repoById = new Map(repos.map((repo) => [repo.repo_id, repo]));
+  const remoteRepos = repos.filter((repo) => repo.repo_type === 'remote');
+  const remoteRepoIds = new Set(remoteRepos.map((repo) => repo.repo_id));
+  const branches = (await branchRepo.findAll({ includeArchived: true })).filter((branch) =>
+    remoteRepoIds.has(branch.repo_id)
+  );
+
+  const repairedConfigPaths = new Set<string>();
+  let repairedEntries = 0;
 
   for (const item of [
-    ...repos.map((repo) => ({
+    ...remoteRepos.map((repo) => ({
       kind: 'repo' as const,
       label: `${repo.slug} (${shortId(repo.repo_id)})`,
       path: repo.local_path,
     })),
-    ...branches.map((branch) => ({
-      kind: 'branch' as const,
-      label: `${branch.name} (${shortId(branch.branch_id)})`,
-      path: branch.path,
-    })),
+    ...branches.map((branch) => {
+      const repo = repoById.get(branch.repo_id);
+      return {
+        kind: 'branch' as const,
+        label: `${branch.name} (${shortId(branch.branch_id)}, repo=${repo?.slug ?? branch.repo_id})`,
+        path: branch.path,
+      };
+    }),
   ]) {
     if (!item.path) continue;
     try {
-      const result = await scanGitConfigRemoteCredentials(item.path);
-      const newFindings = result.findings.filter((finding) => {
-        const key = `${finding.configPath}\0${finding.remote}\0${finding.key}\0${finding.sanitizedUrl}`;
-        if (scannedConfigPaths.has(key)) return false;
-        scannedConfigPaths.add(key);
-        return true;
-      });
-      if (newFindings.length === 0) continue;
+      const result = await scrubGitConfigRemoteCredentials(item.path);
+      if (result.findings.length === 0) continue;
 
-      unsafeConfigs += new Set(newFindings.map((f) => f.configPath)).size;
-      unsafeUrls += newFindings.length;
-      const details = newFindings
-        .map((finding) => `${finding.remote}.${finding.key}=${finding.redactedUrl}`)
-        .join(', ');
+      const newConfigPaths = result.findings
+        .map((finding) => finding.configPath)
+        .filter((configPath) => {
+          if (repairedConfigPaths.has(configPath)) return false;
+          repairedConfigPaths.add(configPath);
+          return true;
+        });
+
+      repairedEntries += result.findings.length;
       console.warn(
-        `🔒 SECURITY: ${item.kind} ${item.label} has credential-bearing git remote URL(s) in ${newFindings.length} config entr${newFindings.length === 1 ? 'y' : 'ies'}; ${details}. ` +
-          `Remove the embedded credentials and rotate the token(s).`
+        `🔒 SECURITY: scrubbed ${result.findings.length} credential-bearing git remote URL(s) from ${item.kind} ${item.label}. ` +
+          `Affected git config file(s): ${newConfigPaths.length}. Rotate any exposed token(s).`
       );
     } catch (error) {
       console.warn(
-        `[git-remote-scan] Failed to scan ${item.kind} ${item.label}: ${
+        `[git-remote-scrub] Failed to scrub ${item.kind} ${item.label}: ${
           error instanceof Error ? error.message : String(error)
         }`
       );
     }
   }
 
-  if (unsafeUrls > 0) {
+  if (repairedEntries > 0) {
     console.warn(
-      `🔒 SECURITY: found ${unsafeUrls} credential-bearing git remote URL(s) across ${unsafeConfigs} git config file(s). ` +
-        `Run the admin repair utility or remove credentials from remotes manually; rotate any exposed tokens.`
+      `🔒 SECURITY: startup scrub removed URL userinfo from ${repairedEntries} git remote config entr${
+        repairedEntries === 1 ? 'y' : 'ies'
+      }. Rotate any token(s) that may have been exposed.`
     );
   }
 }

--- a/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
+++ b/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
@@ -26,6 +26,23 @@ export async function scrubManagedGitRemoteCredentials(db: Database): Promise<vo
   const repairedConfigPaths = new Set<string>();
   let repairedEntries = 0;
 
+  try {
+    const dbScrub = await repoRepo.scrubRemoteUrls();
+    if (dbScrub.changed > 0) {
+      console.warn(
+        `🔒 SECURITY: scrubbed credential-bearing URL userinfo from ${dbScrub.changed} persisted repo remote URL entr${
+          dbScrub.changed === 1 ? 'y' : 'ies'
+        }. Rotate any token(s) that may have been exposed.`
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `[git-remote-scrub] Failed to scrub persisted repo remote URLs: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
   for (const item of [
     ...remoteRepos.map((repo) => ({
       kind: 'repo' as const,

--- a/context/explorations/git-remote-credential-spillover.md
+++ b/context/explorations/git-remote-credential-spillover.md
@@ -37,7 +37,10 @@ agent/user git commands.
 - Branch creation/restore scrubs the base repo config before `fetch` /
   `worktree add`.
 - Clone-mode branch creation scrubs the new clone's `.git/config` after clone.
-- Daemon startup warns if managed repos/branches contain unsafe remote URLs.
+- Daemon startup launches a best-effort post-start scrub for managed remote
+  repos/branches if they contain unsafe remote URLs. It runs after the API is
+  listening to avoid extending the boot critical path, so it is not a hard
+  pre-listen exposure barrier.
 - CLI repair: `agor admin scrub-git-remotes` scans; add `--write` to remove
   userinfo from remote `url` / `pushurl` entries.
 

--- a/context/explorations/git-remote-credential-spillover.md
+++ b/context/explorations/git-remote-credential-spillover.md
@@ -29,20 +29,25 @@ agent/user git commands.
 
 ## Mitigations added
 
-- Core URL helpers detect, redact, and strip URL userinfo.
+- Core URL helpers redact URL userinfo for logs. Mutation/detection helpers
+  strip **HTTP(S)** userinfo only, so legitimate SSH remotes like
+  `ssh://git@example.com/org/repo.git` remain intact.
 - Core `.git/config` scanner/repair reads config files directly (no git
   subprocess), including worktree pointer files and shared `commondir` configs.
-- Repo clone/metadata paths strip credentials before persisting `remote_url` or
-  invoking `git clone`.
+- Repo clone/metadata paths strip credentials before persisting `remote_url`,
+  returning repo data through APIs, or invoking `git clone`.
 - Branch creation/restore scrubs the base repo config before `fetch` /
   `worktree add`.
 - Clone-mode branch creation scrubs the new clone's `.git/config` after clone.
 - Daemon startup launches a best-effort post-start scrub for managed remote
-  repos/branches if they contain unsafe remote URLs. It runs after the API is
+  repos/branches if they contain unsafe remote URLs. It repairs both persisted
+  repo `remote_url` rows and managed git config files. It runs after the API is
   listening to avoid extending the boot critical path, so it is not a hard
   pre-listen exposure barrier.
-- CLI repair: `agor admin scrub-git-remotes` scans; add `--write` to remove
-  userinfo from remote `url` / `pushurl` entries.
+- CLI repair: `agor admin scrub-git-remotes` scans registered repos/branches;
+  add `--write` to remove userinfo from persisted repo rows and remote
+  `url` / `pushurl` config entries. Unlike daemon startup repair, the explicit
+  admin command includes registered local repos/branches too.
 
 ## Operational guidance
 

--- a/context/explorations/git-remote-credential-spillover.md
+++ b/context/explorations/git-remote-credential-spillover.md
@@ -1,0 +1,65 @@
+# Git remote credential spillover
+
+Status: implemented first-pass mitigations after Preset incident report.
+
+## Problem
+
+Agor's legacy branch storage mode uses `git worktree add`. A worktree's `.git`
+file points back into the base repo under `~/.agor/repos/<slug>/.git`, so
+remote configuration is shared. If any actor runs a command like:
+
+```bash
+git remote add extra https://user:REDACTED@example.com/org/repo.git
+```
+
+then the credential-bearing URL is persisted in the shared `.git/config` and is
+visible to every Agor branch/worktree for that repo.
+
+## Existing protection and gap
+
+Agor already sets process-wide `GIT_CONFIG_PARAMETERS` with
+`transfer.credentialsInUrl=die`. That is useful for transfer operations
+(`clone`, `fetch`, `push`) on supported Git versions, but it does **not** block
+plain config writes such as `git remote add` because no network transfer occurs.
+
+Agor-managed clone flows also pass user tokens via scoped
+`http.<host>.extraheader` environment config instead of embedding tokens in
+argv/URLs. The missing layer was persisted remote-config hygiene after arbitrary
+agent/user git commands.
+
+## Mitigations added
+
+- Core URL helpers detect, redact, and strip URL userinfo.
+- Core `.git/config` scanner/repair reads config files directly (no git
+  subprocess), including worktree pointer files and shared `commondir` configs.
+- Repo clone/metadata paths strip credentials before persisting `remote_url` or
+  invoking `git clone`.
+- Branch creation/restore scrubs the base repo config before `fetch` /
+  `worktree add`.
+- Clone-mode branch creation scrubs the new clone's `.git/config` after clone.
+- Daemon startup warns if managed repos/branches contain unsafe remote URLs.
+- CLI repair: `agor admin scrub-git-remotes` scans; add `--write` to remove
+  userinfo from remote `url` / `pushurl` entries.
+
+## Operational guidance
+
+1. Remove embedded credentials from all shared repo configs:
+   `agor admin scrub-git-remotes --write`.
+2. Rotate any token that was ever embedded in a git remote URL.
+3. Prefer credential helpers or Agor's per-user git token flow; never persist
+   PATs in remotes.
+4. For multi-user or security-sensitive repos, set new branches to clone mode:
+
+```yaml
+execution:
+  branch_storage:
+    default_mode: clone
+    allowed_modes:
+      - clone
+      - worktree
+```
+
+Changing the default affects future branch creation only. Existing branch rows
+keep their stored `storage_mode`, and existing worktree directories remain
+usable. Removing `worktree` from `allowed_modes` only blocks new worktree-mode
+creates; it does not migrate or delete existing worktrees.

--- a/packages/core/src/config/security-resolver.test.ts
+++ b/packages/core/src/config/security-resolver.test.ts
@@ -499,6 +499,18 @@ describe('redactUrlUserinfo', () => {
     );
   });
 
+  it('redacts through the last raw @ before the host', () => {
+    expect(redactUrlUserinfo('https://USER:PASS@WORD@host/repo.git')).toBe(
+      'https://<redacted>@host/repo.git'
+    );
+  });
+
+  it('redacts encoded @ in userinfo', () => {
+    expect(redactUrlUserinfo('https://USER:PASS%40WORD@host/repo.git')).toBe(
+      'https://<redacted>@host/repo.git'
+    );
+  });
+
   it('redacts userinfo embedded in a config KEY (the Codex-found case)', () => {
     expect(
       redactUrlUserinfo('url.https://USER:TOK@github.com/.insteadOf=https://github.com/')

--- a/packages/core/src/config/security-resolver.ts
+++ b/packages/core/src/config/security-resolver.ts
@@ -14,6 +14,7 @@
  * rather than emitting a subtly-broken header and failing at request time.
  */
 
+import { redactUrlUserinfo as redactUrlUserinfoShared } from '../utils/url';
 import type {
   AgorConfig,
   AgorCorsMode,
@@ -22,6 +23,7 @@ import type {
   AgorSecuritySettings,
 } from './types';
 
+export { redactUrlUserinfo } from '../utils/url';
 export type { AgorGitConfigParametersSettings } from './types';
 
 /**
@@ -547,17 +549,6 @@ export function resolveGitConfigParameters(
   return [...byKey.values()];
 }
 
-/**
- * Replace userinfo in any URL with `<redacted>`. Catches creds embedded in
- * either the value (e.g. `http.proxy=http://USER:TOK@host/`) or the config
- * KEY (git config keys can carry URLs as subsections, e.g.
- * `url."https://USER:TOK@host/".insteadOf=…`). Anchored to `://` so SCP-form
- * `git@host:path` URLs aren't false-positively matched.
- */
-export function redactUrlUserinfo(s: string): string {
-  return s.replace(/:\/\/[^/@\s]+@/g, '://<redacted>@');
-}
-
 /** True when a pair still looks credential-bearing AFTER URL-userinfo redaction. */
 export function gitConfigParameterLooksSecret(pair: string): boolean {
   return /authorization:/i.test(pair);
@@ -571,7 +562,7 @@ export function renderGitConfigParametersForLog(pairs: readonly string[]): strin
   return pairs
     .filter((p) => p.trim().length > 0)
     .map((pair) => {
-      const scrubbed = redactUrlUserinfo(pair);
+      const scrubbed = redactUrlUserinfoShared(pair);
       if (!gitConfigParameterLooksSecret(scrubbed)) return scrubbed;
       return `${gitConfigParameterKey(scrubbed)}=<redacted>`;
     })

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -5,8 +5,11 @@
  */
 
 import type { UUID } from '@agor/core/types';
+import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
 import { generateId, shortId } from '../../lib/ids';
+import { select, update } from '../database-wrapper';
+import { repos } from '../schema';
 import { dbTest } from '../test-helpers';
 import { AmbiguousIdError, EntityNotFoundError, RepositoryError } from './base';
 import { RepoRepository } from './repos';
@@ -109,6 +112,59 @@ describe('RepoRepository.create', () => {
 
     expect(created.repo_type).toBe('local');
     expect(created.remote_url).toBeUndefined();
+  });
+
+  dbTest('should strip HTTP(S) userinfo from persisted remote_url values', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const created = await repo.create(
+      createRepoData({ remote_url: 'https://user:REDACTED@example.com/org/repo.git' })
+    );
+
+    expect(created.remote_url).toBe('https://example.com/org/repo.git');
+
+    const row = await select(db).from(repos).where(eq(repos.repo_id, created.repo_id)).one();
+    expect((row?.data as { remote_url?: string } | undefined)?.remote_url).toBe(
+      'https://example.com/org/repo.git'
+    );
+  });
+
+  dbTest('should preserve ssh:// remote_url usernames', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const created = await repo.create(
+      createRepoData({ remote_url: 'ssh://git@example.com/org/repo.git' })
+    );
+
+    expect(created.remote_url).toBe('ssh://git@example.com/org/repo.git');
+  });
+
+  dbTest('should scrub legacy credential-bearing remote_url rows', async ({ db }) => {
+    const repo = new RepoRepository(db);
+    const created = await repo.create(createRepoData({ slug: 'legacy/remote-url' }));
+    const rawLegacyUrl = 'https://user:REDACTED@example.com/org/repo.git';
+
+    await update(db, repos)
+      .set({
+        data: {
+          name: created.name,
+          remote_url: rawLegacyUrl,
+          local_path: created.local_path,
+          default_branch: created.default_branch,
+        },
+      })
+      .where(eq(repos.repo_id, created.repo_id))
+      .run();
+
+    await expect(repo.findById(created.repo_id)).resolves.toMatchObject({
+      remote_url: 'https://example.com/org/repo.git',
+    });
+
+    const result = await repo.scrubRemoteUrls();
+    expect(result.changed).toBe(1);
+
+    const row = await select(db).from(repos).where(eq(repos.repo_id, created.repo_id)).one();
+    expect((row?.data as { remote_url?: string } | undefined)?.remote_url).toBe(
+      'https://example.com/org/repo.git'
+    );
   });
 
   dbTest('should throw error if repo_type is missing', async ({ db }) => {

--- a/packages/core/src/db/repositories/repos.test.ts
+++ b/packages/core/src/db/repositories/repos.test.ts
@@ -158,6 +158,9 @@ describe('RepoRepository.create', () => {
       remote_url: 'https://example.com/org/repo.git',
     });
 
+    const scan = await repo.scanRemoteUrls();
+    expect(scan.findings).toEqual([{ repo_id: created.repo_id, slug: 'legacy/remote-url' }]);
+
     const result = await repo.scrubRemoteUrls();
     expect(result.changed).toBe(1);
 

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -8,6 +8,7 @@ import type { Repo, RepoEnvironment, RepoEnvironmentConfigV1, UUID } from '@agor
 import { eq, like, sql } from 'drizzle-orm';
 import { resolveVariant, wrapV1AsV2 } from '../../config/variant-resolver.js';
 import { generateId } from '../../lib/ids';
+import { httpUrlHasUserinfo, stripHttpUrlUserinfo } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
 import { type RepoInsert, type RepoRow, repos } from '../schema';
@@ -70,6 +71,9 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
     };
     const environment = data.environment ?? wrapV1AsV2(data.environment_config);
     const environment_config = data.environment_config ?? deriveV1FromV2(environment);
+    const remote_url =
+      typeof data.remote_url === 'string' ? stripHttpUrlUserinfo(data.remote_url) : data.remote_url;
+
     return {
       repo_id: row.repo_id as UUID,
       slug: row.slug,
@@ -80,6 +84,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         ? new Date(row.updated_at).toISOString()
         : new Date(row.created_at).toISOString(),
       ...data,
+      remote_url,
       environment,
       environment_config,
       clone_status: data.clone_status,
@@ -127,7 +132,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
       unix_group: repo.unix_group ?? null,
       data: {
         name: repo.name ?? repo.slug,
-        remote_url: repo.remote_url || undefined,
+        remote_url: repo.remote_url ? stripHttpUrlUserinfo(repo.remote_url) : undefined,
         local_path: repo.local_path,
         default_branch: repo.default_branch,
         environment,
@@ -243,6 +248,46 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
   }
 
   /**
+   * Remove HTTP(S) userinfo from persisted repo.remote_url values.
+   *
+   * `rowToRepo()` sanitizes reads so legacy credential-bearing values are not
+   * returned through APIs or reused by daemon/executor code, but this method
+   * repairs the stored rows as a startup/admin hygiene pass.
+   */
+  async scrubRemoteUrls(): Promise<{ checked: number; changed: number }> {
+    try {
+      const rows = await select(this.db).from(repos).all();
+      let changed = 0;
+
+      for (const row of rows as RepoRow[]) {
+        const data = row.data as typeof row.data & { remote_url?: unknown };
+        if (typeof data.remote_url !== 'string' || !httpUrlHasUserinfo(data.remote_url)) {
+          continue;
+        }
+
+        await update(this.db, repos)
+          .set({
+            updated_at: new Date(),
+            data: {
+              ...data,
+              remote_url: stripHttpUrlUserinfo(data.remote_url),
+            },
+          })
+          .where(eq(repos.repo_id, row.repo_id))
+          .run();
+        changed += 1;
+      }
+
+      return { checked: rows.length, changed };
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to scrub repo remote URLs: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Update repo by ID (atomic with database-level transaction)
    *
    * Uses a transaction to ensure read-merge-write is atomic, preventing race conditions
@@ -295,6 +340,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         // to `undefined`; without this sync the caller sees the un-coerced
         // null and the type invariant lies.
         merged.clone_error = insertData.data.clone_error;
+        merged.remote_url = insertData.data.remote_url;
         merged.last_updated = newUpdatedAt.toISOString();
         return merged;
       });
@@ -362,6 +408,7 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
         // field we explicitly undefined'd in `patch`.
         next.environment = insertData.data.environment;
         next.environment_config = insertData.data.environment_config;
+        next.remote_url = insertData.data.remote_url;
         next.last_updated = newUpdatedAt.toISOString();
         return next;
       });

--- a/packages/core/src/db/repositories/repos.ts
+++ b/packages/core/src/db/repositories/repos.ts
@@ -49,6 +49,11 @@ function deriveV1FromV2(env: RepoEnvironment | undefined): RepoEnvironmentConfig
   return v1;
 }
 
+export interface RepoRemoteUrlCredentialFinding {
+  repo_id: UUID;
+  slug: string;
+}
+
 /**
  * Repo repository implementation
  */
@@ -248,6 +253,32 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
   }
 
   /**
+   * Find persisted repo.remote_url rows that still contain HTTP(S) userinfo.
+   *
+   * This intentionally reads raw rows rather than `rowToRepo()` because reads
+   * sanitize `remote_url` before returning repo objects.
+   */
+  async scanRemoteUrls(): Promise<{ checked: number; findings: RepoRemoteUrlCredentialFinding[] }> {
+    try {
+      const rows = (await select(this.db).from(repos).all()) as RepoRow[];
+      const findings = rows.flatMap((row) => {
+        const data = row.data as typeof row.data & { remote_url?: unknown };
+        if (typeof data.remote_url !== 'string' || !httpUrlHasUserinfo(data.remote_url)) {
+          return [];
+        }
+        return [{ repo_id: row.repo_id as UUID, slug: row.slug }];
+      });
+
+      return { checked: rows.length, findings };
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to scan repo remote URLs: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Remove HTTP(S) userinfo from persisted repo.remote_url values.
    *
    * `rowToRepo()` sanitizes reads so legacy credential-bearing values are not
@@ -256,29 +287,39 @@ export class RepoRepository implements BaseRepository<Repo, Partial<Repo>> {
    */
   async scrubRemoteUrls(): Promise<{ checked: number; changed: number }> {
     try {
-      const rows = await select(this.db).from(repos).all();
+      const scan = await this.scanRemoteUrls();
       let changed = 0;
 
-      for (const row of rows as RepoRow[]) {
-        const data = row.data as typeof row.data & { remote_url?: unknown };
-        if (typeof data.remote_url !== 'string' || !httpUrlHasUserinfo(data.remote_url)) {
-          continue;
-        }
+      for (const finding of scan.findings) {
+        await this.db.transaction(async (tx) => {
+          await lockRowForUpdate(txAsDb(tx), this.db, repos, eq(repos.repo_id, finding.repo_id));
 
-        await update(this.db, repos)
-          .set({
-            updated_at: new Date(),
-            data: {
-              ...data,
-              remote_url: stripHttpUrlUserinfo(data.remote_url),
-            },
-          })
-          .where(eq(repos.repo_id, row.repo_id))
-          .run();
-        changed += 1;
+          const currentRow = await select(txAsDb(tx))
+            .from(repos)
+            .where(eq(repos.repo_id, finding.repo_id))
+            .one();
+          if (!currentRow) return;
+
+          const data = currentRow.data as typeof currentRow.data & { remote_url?: unknown };
+          if (typeof data.remote_url !== 'string' || !httpUrlHasUserinfo(data.remote_url)) {
+            return;
+          }
+
+          await update(txAsDb(tx), repos)
+            .set({
+              updated_at: new Date(),
+              data: {
+                ...data,
+                remote_url: stripHttpUrlUserinfo(data.remote_url),
+              },
+            })
+            .where(eq(repos.repo_id, finding.repo_id))
+            .run();
+          changed += 1;
+        });
       }
 
-      return { checked: rows.length, changed };
+      return { checked: scan.checked, changed };
     } catch (error) {
       throw new RepositoryError(
         `Failed to scrub repo remote URLs: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -8,9 +8,9 @@
  * fresh Unix group memberships (groups are cached at login time).
  */
 
-import { existsSync } from 'node:fs';
-import { mkdir, stat } from 'node:fs/promises';
-import { basename, dirname, join } from 'node:path';
+import { existsSync, type Stats } from 'node:fs';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { simpleGit } from 'simple-git';
 import { getBranchesDir, getReposDir } from '../config/config-manager';
 import type { RepoCloneErrorCategory } from '../types/repo';
@@ -189,6 +189,215 @@ export function parseHostFromGitUrl(url: string): string | undefined {
   // URL parser rejects this shape, so we still need a regex.
   // Reject paths starting with `/` — that's a local filesystem path.
   return url.match(/^(?:[^@\s:]+@)?([^/:\s]+):(?!\/)/)?.[1];
+}
+
+/**
+ * True when a git URL embeds URL userinfo (`scheme://USER[:PASS]@host/...`).
+ *
+ * For Agor's purposes any URL userinfo in a persisted remote is unsafe, even
+ * if it is "just" a username: users commonly paste PATs as either the username
+ * or password, and shared worktree repos expose `.git/config` to every branch.
+ * SCP-like SSH URLs (`git@github.com:org/repo.git`) are intentionally not
+ * treated as credential-bearing.
+ */
+export function gitUrlHasUserinfo(rawUrl: string): boolean {
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return false;
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.username.length > 0 || parsed.password.length > 0;
+  } catch {
+    return /:\/\/[^/@\s]+@/.test(rawUrl);
+  }
+}
+
+/**
+ * Redact URL userinfo for logs/errors. Keeps host/path visible for diagnosis
+ * without exposing the embedded secret.
+ */
+export function redactGitUrlCredentials(rawUrl: string): string {
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return rawUrl;
+  return rawUrl.replace(/:\/\/[^/@\s]+@/g, '://<redacted>@');
+}
+
+/**
+ * Remove URL userinfo from a git URL before persisting it or handing it to
+ * `git clone`. If parsing fails, fall back to a conservative regex scrub.
+ */
+export function stripGitUrlCredentials(rawUrl: string): string {
+  if (!/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return rawUrl;
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.username || parsed.password) {
+      parsed.username = '';
+      parsed.password = '';
+      return parsed.toString();
+    }
+    return rawUrl;
+  } catch {
+    return rawUrl.replace(/:\/\/[^/@\s]+@/g, '://');
+  }
+}
+
+export interface GitRemoteCredentialFinding {
+  configPath: string;
+  remote: string;
+  key: 'url' | 'pushurl';
+  redactedUrl: string;
+  sanitizedUrl: string;
+}
+
+export interface GitRemoteCredentialScanResult {
+  repoPath: string;
+  configPaths: string[];
+  findings: GitRemoteCredentialFinding[];
+}
+
+export interface GitRemoteCredentialScrubResult extends GitRemoteCredentialScanResult {
+  changed: boolean;
+}
+
+function parseGitdirPointer(raw: string): string | undefined {
+  const match = raw.match(/^gitdir:\s*(.+?)\s*$/m);
+  return match?.[1];
+}
+
+async function findGitConfigPaths(repoPath: string): Promise<string[]> {
+  const dotGit = join(repoPath, '.git');
+  const paths = new Set<string>();
+
+  let dotGitStat: Stats;
+  try {
+    dotGitStat = await stat(dotGit);
+  } catch {
+    return [];
+  }
+
+  if (dotGitStat.isDirectory()) {
+    paths.add(join(dotGit, 'config'));
+  } else if (dotGitStat.isFile()) {
+    const pointer = parseGitdirPointer(await readFile(dotGit, 'utf8'));
+    if (pointer) {
+      const gitDir = isAbsolute(pointer) ? pointer : resolve(repoPath, pointer);
+      paths.add(join(gitDir, 'config'));
+
+      // Git worktrees keep remotes in the common dir's config, while the
+      // per-worktree gitdir may also have config.worktree. Check both.
+      try {
+        const commonDirRaw = (await readFile(join(gitDir, 'commondir'), 'utf8')).trim();
+        if (commonDirRaw) {
+          const commonDir = isAbsolute(commonDirRaw) ? commonDirRaw : resolve(gitDir, commonDirRaw);
+          paths.add(join(commonDir, 'config'));
+        }
+      } catch {
+        // No commondir (or unreadable) — candidate above is enough.
+      }
+    }
+  }
+
+  const existing: string[] = [];
+  for (const candidate of paths) {
+    try {
+      const candidateStat = await stat(candidate);
+      if (candidateStat.isFile()) existing.push(candidate);
+    } catch {
+      // Ignore missing candidate configs.
+    }
+  }
+  return existing;
+}
+
+function parseRemoteSection(line: string): string | undefined {
+  const match = line.match(/^\s*\[remote\s+"((?:\\.|[^"])*)"\]\s*(?:[#;].*)?$/);
+  return match?.[1]?.replace(/\\"/g, '"');
+}
+
+function scrubGitConfigText(
+  configPath: string,
+  text: string,
+  writeChanges: boolean
+): { text: string; findings: GitRemoteCredentialFinding[]; changed: boolean } {
+  const lines = text.split('\n');
+  const findings: GitRemoteCredentialFinding[] = [];
+  let currentRemote: string | undefined;
+  let changed = false;
+
+  const nextLines = lines.map((line) => {
+    const remote = parseRemoteSection(line);
+    if (remote !== undefined) {
+      currentRemote = remote;
+      return line;
+    }
+    if (/^\s*\[/.test(line)) {
+      currentRemote = undefined;
+      return line;
+    }
+    if (!currentRemote) return line;
+
+    const match = line.match(/^(\s*)(url|pushurl)(\s*=\s*)(.*?)(\r?)$/i);
+    if (!match) return line;
+
+    const [, indent, rawKey, sep, rawValue, cr] = match;
+    const value = rawValue.trim();
+    if (!gitUrlHasUserinfo(value)) return line;
+
+    const key = rawKey.toLowerCase() as 'url' | 'pushurl';
+    const sanitizedUrl = stripGitUrlCredentials(value);
+    findings.push({
+      configPath,
+      remote: currentRemote,
+      key,
+      redactedUrl: redactGitUrlCredentials(value),
+      sanitizedUrl,
+    });
+    changed = true;
+    return writeChanges ? `${indent}${rawKey}${sep}${sanitizedUrl}${cr}` : line;
+  });
+
+  return { text: nextLines.join('\n'), findings, changed };
+}
+
+/**
+ * Scan a repo or worktree for credential-bearing remote URLs in its git config
+ * without invoking git. For worktree pointer files, this checks both the
+ * per-worktree gitdir and the shared common `.git/config`.
+ */
+export async function scanGitConfigRemoteCredentials(
+  repoPath: string
+): Promise<GitRemoteCredentialScanResult> {
+  const configPaths = await findGitConfigPaths(repoPath);
+  const findings: GitRemoteCredentialFinding[] = [];
+
+  for (const configPath of configPaths) {
+    const text = await readFile(configPath, 'utf8');
+    findings.push(...scrubGitConfigText(configPath, text, false).findings);
+  }
+
+  return { repoPath, configPaths, findings };
+}
+
+/**
+ * Repair credential-bearing remote URL entries in `.git/config` by replacing
+ * each `remote.<name>.url` / `pushurl` value with the same URL minus userinfo.
+ * Findings contain only redacted/sanitized values.
+ */
+export async function scrubGitConfigRemoteCredentials(
+  repoPath: string
+): Promise<GitRemoteCredentialScrubResult> {
+  const configPaths = await findGitConfigPaths(repoPath);
+  const findings: GitRemoteCredentialFinding[] = [];
+  let changed = false;
+
+  for (const configPath of configPaths) {
+    const text = await readFile(configPath, 'utf8');
+    const result = scrubGitConfigText(configPath, text, true);
+    findings.push(...result.findings);
+    if (result.changed) {
+      await writeFile(configPath, result.text, 'utf8');
+      changed = true;
+    }
+  }
+
+  return { repoPath, configPaths, findings, changed };
 }
 
 /**
@@ -551,7 +760,12 @@ export function extractRepoName(url: string): string {
  * Clone a Git repository to ~/.agor/repos/<name>
  */
 export async function cloneRepo(options: CloneOptions): Promise<CloneResult> {
-  const cloneUrl = options.url;
+  const cloneUrl = stripGitUrlCredentials(options.url);
+  if (cloneUrl !== options.url) {
+    console.warn(
+      `🔒 Stripped credentials from clone URL before use: ${redactGitUrlCredentials(options.url)}`
+    );
+  }
 
   const repoName = extractRepoName(cloneUrl);
   const reposDir = getReposDir();
@@ -573,6 +787,7 @@ export async function cloneRepo(options: CloneOptions): Promise<CloneResult> {
     const isValid = await isGitRepo(targetPath);
 
     if (isValid) {
+      await scrubGitConfigRemoteCredentials(targetPath);
       // Repository already exists and is valid — reuse it. If the caller
       // pinned a branch, the working tree has to actually be on that branch
       // before we return: skipping the checkout silently leaves disk on the
@@ -660,9 +875,11 @@ export async function cloneRepo(options: CloneOptions): Promise<CloneResult> {
   if (options.bare) cloneArgs.push('--bare');
   if (options.branch) cloneArgs.push('--branch', options.branch);
   console.log(
-    `Cloning ${options.url} to ${targetPath}${options.branch ? ` (branch: ${options.branch})` : ''}...`
+    `Cloning ${redactGitUrlCredentials(cloneUrl)} to ${targetPath}${options.branch ? ` (branch: ${options.branch})` : ''}...`
   );
   await git.clone(cloneUrl, targetPath, cloneArgs);
+
+  await scrubGitConfigRemoteCredentials(targetPath);
 
   // Default branch: prefer the explicit pin (so the DB record matches what's
   // on disk); fall back to the remote's HEAD when the caller didn't pin one.
@@ -783,7 +1000,7 @@ export async function getRemoteUrl(
     const { git } = createGit(repoPath);
     const remotes = await git.getRemotes(true);
     const remoteObj = remotes.find((r) => r.name === remote);
-    return remoteObj?.refs.fetch ?? null;
+    return remoteObj?.refs.fetch ? stripGitUrlCredentials(remoteObj.refs.fetch) : null;
   } catch {
     return null;
   }
@@ -815,6 +1032,7 @@ export async function ensureGitRemoteUrl(
   env?: Record<string, string>
 ): Promise<EnsureRemoteUrlResult> {
   const { git } = createGit(repoPath, env);
+  const safeExpectedUrl = stripGitUrlCredentials(expectedUrl);
   const configKey = `remote.${remoteName}.url`;
 
   // `--get-all` exits 1 when the key is unset; absence ≡ "no remote".
@@ -832,11 +1050,11 @@ export async function ensureGitRemoteUrl(
   if (currentUrls.length === 0) {
     return { changed: false, previousUrl: undefined };
   }
-  if (currentUrls.length === 1 && currentUrls[0] === expectedUrl) {
+  if (currentUrls.length === 1 && currentUrls[0] === safeExpectedUrl) {
     return { changed: false, previousUrl: currentUrls[0] };
   }
 
-  await git.raw(['config', '--replace-all', configKey, expectedUrl]);
+  await git.raw(['config', '--replace-all', configKey, safeExpectedUrl]);
   return { changed: true, previousUrl: currentUrls.join('\n') };
 }
 
@@ -878,6 +1096,13 @@ export async function createBranch(
 
   if (!repoPath) {
     throw new Error('repoPath is required but was null/undefined');
+  }
+
+  const scrubResult = await scrubGitConfigRemoteCredentials(repoPath);
+  if (scrubResult.findings.length > 0) {
+    console.warn(
+      `🔒 Scrubbed ${scrubResult.findings.length} credential-bearing git remote URL(s) from ${scrubResult.configPaths.length} git config file(s) before creating a worktree branch.`
+    );
   }
 
   // Refuse to clobber an existing directory. Matches createBranchAsClone's
@@ -1127,11 +1352,17 @@ export interface CreateBranchAsCloneResult {
 export async function createBranchAsClone(
   options: CreateBranchAsCloneOptions
 ): Promise<CreateBranchAsCloneResult> {
-  const { remoteUrl, targetPath, ref, newBranchName, depth, referencePath, env } = options;
+  const { targetPath, ref, newBranchName, depth, referencePath, env } = options;
+  const remoteUrl = stripGitUrlCredentials(options.remoteUrl);
   const singleBranch = options.singleBranch ?? true;
 
   if (!remoteUrl) {
     throw new Error('remoteUrl is required');
+  }
+  if (remoteUrl !== options.remoteUrl) {
+    console.warn(
+      `🔒 Stripped credentials from clone-mode remote URL before use: ${redactGitUrlCredentials(options.remoteUrl)}`
+    );
   }
   if (!targetPath) {
     throw new Error('targetPath is required');
@@ -1184,12 +1415,13 @@ export async function createBranchAsClone(
   if (useReference && referencePath) cloneArgs.push('--reference', referencePath);
 
   console.log(
-    `[createBranchAsClone] Cloning ${remoteUrl} → ${targetPath} ` +
+    `[createBranchAsClone] Cloning ${redactGitUrlCredentials(remoteUrl)} → ${targetPath} ` +
       `(ref=${ref}${newBranchName ? `, newBranch=${newBranchName}` : ''}, ` +
       `depth=${depth ?? 'full'}, singleBranch=${singleBranch}, ` +
       `reference=${useReference ? referencePath : 'none'})`
   );
   await git.clone(remoteUrl, targetPath, cloneArgs);
+  await scrubGitConfigRemoteCredentials(targetPath);
 
   // Optional post-clone fork: create the new branch off the cloned tip.
   // simple-git's `.checkoutLocalBranch` issues `git checkout -b <name>`.
@@ -1255,6 +1487,13 @@ export async function restoreBranchFilesystem(
   // (which re-validates) and to ls-remote (which does not).
   await validateGitRef(ref);
   await validateGitRef(baseRef);
+
+  const scrubResult = await scrubGitConfigRemoteCredentials(repoPath);
+  if (scrubResult.findings.length > 0) {
+    console.warn(
+      `[restoreBranch] Scrubbed ${scrubResult.findings.length} credential-bearing git remote URL(s) before restore.`
+    );
+  }
 
   const hasToken = !!(env?.GITHUB_TOKEN ?? env?.GH_TOKEN);
   const authHost = hasToken ? await resolveAuthHost(repoPath) : undefined;

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -15,7 +15,7 @@ import { simpleGit } from 'simple-git';
 import { getBranchesDir, getReposDir } from '../config/config-manager';
 import type { RepoCloneErrorCategory } from '../types/repo';
 import { escapeShellArg } from '../unix/run-as-user';
-import { redactUrlUserinfo } from '../utils/url';
+import { httpUrlHasUserinfo, redactUrlUserinfo, stripHttpUrlUserinfo } from '../utils/url';
 
 /**
  * Validate a user-supplied git ref (branch name, tag) before it is passed to
@@ -204,14 +204,7 @@ export function parseHostFromGitUrl(url: string): string | undefined {
  * username and stripping it can break legitimate remotes.
  */
 export function gitUrlHasUserinfo(rawUrl: string): boolean {
-  if (!/^https?:\/\//i.test(rawUrl)) return false;
-  try {
-    const parsed = new URL(rawUrl);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-    return parsed.username.length > 0 || parsed.password.length > 0;
-  } catch {
-    return /^https?:\/\/[^/?#\s]*@[^/?#\s]+/i.test(rawUrl);
-  }
+  return httpUrlHasUserinfo(rawUrl);
 }
 
 /**
@@ -229,19 +222,7 @@ export function redactGitUrlCredentials(rawUrl: string): string {
  * uses userinfo for the login name, not an embedded credential.
  */
 export function stripGitUrlCredentials(rawUrl: string): string {
-  if (!/^https?:\/\//i.test(rawUrl)) return rawUrl;
-  try {
-    const parsed = new URL(rawUrl);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return rawUrl;
-    if (parsed.username || parsed.password) {
-      parsed.username = '';
-      parsed.password = '';
-      return parsed.toString();
-    }
-    return rawUrl;
-  } catch {
-    return rawUrl.replace(/^(https?:\/\/)([^/?#\s]*@)([^/?#\s]+)/i, '$1$3');
-  }
+  return stripHttpUrlUserinfo(rawUrl);
 }
 
 export interface GitRemoteCredentialFinding {

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -15,6 +15,7 @@ import { simpleGit } from 'simple-git';
 import { getBranchesDir, getReposDir } from '../config/config-manager';
 import type { RepoCloneErrorCategory } from '../types/repo';
 import { escapeShellArg } from '../unix/run-as-user';
+import { redactUrlUserinfo } from '../utils/url';
 
 /**
  * Validate a user-supplied git ref (branch name, tag) before it is passed to
@@ -192,21 +193,24 @@ export function parseHostFromGitUrl(url: string): string | undefined {
 }
 
 /**
- * True when a git URL embeds URL userinfo (`scheme://USER[:PASS]@host/...`).
+ * True when an HTTP(S) git URL embeds URL userinfo
+ * (`https://USER[:PASS]@host/...`).
  *
- * For Agor's purposes any URL userinfo in a persisted remote is unsafe, even
+ * For Agor's purposes HTTP(S) userinfo in a persisted remote is unsafe, even
  * if it is "just" a username: users commonly paste PATs as either the username
  * or password, and shared worktree repos expose `.git/config` to every branch.
- * SCP-like SSH URLs (`git@github.com:org/repo.git`) are intentionally not
- * treated as credential-bearing.
+ * SSH remotes are intentionally not mutated: `ssh://git@host/org/repo.git`
+ * and SCP-like `git@host:org/repo.git` use the userinfo position for the SSH
+ * username and stripping it can break legitimate remotes.
  */
 export function gitUrlHasUserinfo(rawUrl: string): boolean {
-  if (!/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return false;
+  if (!/^https?:\/\//i.test(rawUrl)) return false;
   try {
     const parsed = new URL(rawUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
     return parsed.username.length > 0 || parsed.password.length > 0;
   } catch {
-    return /:\/\/[^/@\s]+@/.test(rawUrl);
+    return /^https?:\/\/[^/?#\s]*@[^/?#\s]+/i.test(rawUrl);
   }
 }
 
@@ -216,17 +220,19 @@ export function gitUrlHasUserinfo(rawUrl: string): boolean {
  */
 export function redactGitUrlCredentials(rawUrl: string): string {
   if (!/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return rawUrl;
-  return rawUrl.replace(/:\/\/[^/@\s]+@/g, '://<redacted>@');
+  return redactUrlUserinfo(rawUrl);
 }
 
 /**
- * Remove URL userinfo from a git URL before persisting it or handing it to
- * `git clone`. If parsing fails, fall back to a conservative regex scrub.
+ * Remove HTTP(S) URL userinfo from a git URL before persisting it or handing
+ * it to `git clone`. SSH remotes are preserved because `ssh://git@host/...`
+ * uses userinfo for the login name, not an embedded credential.
  */
 export function stripGitUrlCredentials(rawUrl: string): string {
-  if (!/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(rawUrl)) return rawUrl;
+  if (!/^https?:\/\//i.test(rawUrl)) return rawUrl;
   try {
     const parsed = new URL(rawUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return rawUrl;
     if (parsed.username || parsed.password) {
       parsed.username = '';
       parsed.password = '';
@@ -234,7 +240,7 @@ export function stripGitUrlCredentials(rawUrl: string): string {
     }
     return rawUrl;
   } catch {
-    return rawUrl.replace(/:\/\/[^/@\s]+@/g, '://');
+    return rawUrl.replace(/^(https?:\/\/)([^/?#\s]*@)([^/?#\s]+)/i, '$1$3');
   }
 }
 
@@ -279,6 +285,7 @@ async function findGitConfigPaths(repoPath: string): Promise<string[]> {
     if (pointer) {
       const gitDir = isAbsolute(pointer) ? pointer : resolve(repoPath, pointer);
       paths.add(join(gitDir, 'config'));
+      paths.add(join(gitDir, 'config.worktree'));
 
       // Git worktrees keep remotes in the common dir's config, while the
       // per-worktree gitdir may also have config.worktree. Check both.

--- a/packages/core/src/git/security.test.ts
+++ b/packages/core/src/git/security.test.ts
@@ -19,7 +19,12 @@ import {
   buildWorktreeAddArgs,
   createBranch,
   deleteBranch,
+  gitUrlHasUserinfo,
   isLikelyGitToken,
+  redactGitUrlCredentials,
+  scanGitConfigRemoteCredentials,
+  scrubGitConfigRemoteCredentials,
+  stripGitUrlCredentials,
   validateGitRef,
 } from './index';
 
@@ -199,6 +204,86 @@ describe('isLikelyGitToken — credential helper shape check', () => {
     expect(isLikelyGitToken(`ghp_${'a'.repeat(36)}`)).toBe(true);
     expect(isLikelyGitToken(`github_pat_${'A'.repeat(40)}`)).toBe(true);
     expect(isLikelyGitToken('a'.repeat(40))).toBe(true);
+  });
+});
+
+describe('credential-bearing remote URL utilities', () => {
+  it('detects, redacts, and strips URL userinfo without treating SSH scp syntax as credentials', () => {
+    const unsafe = 'https://user:REDACTED@example.com/org/repo.git';
+    expect(gitUrlHasUserinfo(unsafe)).toBe(true);
+    expect(redactGitUrlCredentials(unsafe)).toBe('https://<redacted>@example.com/org/repo.git');
+    expect(stripGitUrlCredentials(unsafe)).toBe('https://example.com/org/repo.git');
+
+    expect(gitUrlHasUserinfo('git@example.com:org/repo.git')).toBe(false);
+    expect(stripGitUrlCredentials('git@example.com:org/repo.git')).toBe(
+      'git@example.com:org/repo.git'
+    );
+  });
+
+  it('scans and repairs remote url and pushurl entries in .git/config', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-git-remote-sec-'));
+    try {
+      const repoPath = path.join(tmpRoot, 'repo');
+      await fs.mkdir(path.join(repoPath, '.git'), { recursive: true });
+      const configPath = path.join(repoPath, '.git', 'config');
+      await fs.writeFile(
+        configPath,
+        [
+          '[core]',
+          '\trepositoryformatversion = 0',
+          '[remote "origin"]',
+          '\turl = https://user:REDACTED@example.com/org/repo.git',
+          '\tpushurl = https://user:REDACTED@example.com/org/repo-push.git',
+          '[remote "ssh"]',
+          '\turl = git@example.com:org/repo.git',
+          '',
+        ].join('\n')
+      );
+
+      const scan = await scanGitConfigRemoteCredentials(repoPath);
+      expect(scan.findings).toHaveLength(2);
+      expect(scan.findings.map((f) => `${f.remote}.${f.key}`)).toEqual([
+        'origin.url',
+        'origin.pushurl',
+      ]);
+
+      const scrub = await scrubGitConfigRemoteCredentials(repoPath);
+      expect(scrub.changed).toBe(true);
+      expect(scrub.findings).toHaveLength(2);
+
+      const repaired = await fs.readFile(configPath, 'utf8');
+      expect(repaired).toContain('url = https://example.com/org/repo.git');
+      expect(repaired).toContain('pushurl = https://example.com/org/repo-push.git');
+      expect(repaired).toContain('url = git@example.com:org/repo.git');
+      expect(repaired).not.toContain('user:REDACTED@');
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('follows worktree .git pointer files to the shared common config', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-git-remote-sec-'));
+    try {
+      const baseGit = path.join(tmpRoot, 'base.git');
+      const worktreeGit = path.join(baseGit, 'worktrees', 'feature');
+      const branchPath = path.join(tmpRoot, 'branch');
+      await fs.mkdir(worktreeGit, { recursive: true });
+      await fs.mkdir(branchPath, { recursive: true });
+      await fs.writeFile(path.join(branchPath, '.git'), `gitdir: ${worktreeGit}\n`);
+      await fs.writeFile(path.join(worktreeGit, 'commondir'), '../..\n');
+      await fs.writeFile(
+        path.join(baseGit, 'config'),
+        ['[remote "origin"]', '\turl = https://user:REDACTED@example.com/org/repo.git', ''].join(
+          '\n'
+        )
+      );
+
+      const scan = await scanGitConfigRemoteCredentials(branchPath);
+      expect(scan.findings).toHaveLength(1);
+      expect(scan.findings[0].configPath).toBe(path.join(baseGit, 'config'));
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/git/security.test.ts
+++ b/packages/core/src/git/security.test.ts
@@ -208,15 +208,41 @@ describe('isLikelyGitToken — credential helper shape check', () => {
 });
 
 describe('credential-bearing remote URL utilities', () => {
-  it('detects, redacts, and strips URL userinfo without treating SSH scp syntax as credentials', () => {
+  it('detects, redacts, and strips HTTP(S) userinfo without treating SSH syntax as credentials', () => {
     const unsafe = 'https://user:REDACTED@example.com/org/repo.git';
     expect(gitUrlHasUserinfo(unsafe)).toBe(true);
     expect(redactGitUrlCredentials(unsafe)).toBe('https://<redacted>@example.com/org/repo.git');
     expect(stripGitUrlCredentials(unsafe)).toBe('https://example.com/org/repo.git');
 
+    expect(gitUrlHasUserinfo('https://user@example.com/org/repo.git')).toBe(true);
+    expect(stripGitUrlCredentials('https://user@example.com/org/repo.git')).toBe(
+      'https://example.com/org/repo.git'
+    );
+
+    const rawAtInUserinfo = 'https://user:PASS@WORD@example.com/org/repo.git';
+    expect(gitUrlHasUserinfo(rawAtInUserinfo)).toBe(true);
+    expect(redactGitUrlCredentials(rawAtInUserinfo)).toBe(
+      'https://<redacted>@example.com/org/repo.git'
+    );
+    expect(stripGitUrlCredentials(rawAtInUserinfo)).toBe('https://example.com/org/repo.git');
+
+    const encodedAtInUserinfo = 'https://user:PASS%40WORD@example.com/org/repo.git';
+    expect(gitUrlHasUserinfo(encodedAtInUserinfo)).toBe(true);
+    expect(redactGitUrlCredentials(encodedAtInUserinfo)).toBe(
+      'https://<redacted>@example.com/org/repo.git'
+    );
+    expect(stripGitUrlCredentials(encodedAtInUserinfo)).toBe('https://example.com/org/repo.git');
+
     expect(gitUrlHasUserinfo('git@example.com:org/repo.git')).toBe(false);
     expect(stripGitUrlCredentials('git@example.com:org/repo.git')).toBe(
       'git@example.com:org/repo.git'
+    );
+    expect(gitUrlHasUserinfo('ssh://git@example.com/org/repo.git')).toBe(false);
+    expect(stripGitUrlCredentials('ssh://git@example.com/org/repo.git')).toBe(
+      'ssh://git@example.com/org/repo.git'
+    );
+    expect(redactGitUrlCredentials('ssh://git@example.com/org/repo.git')).toBe(
+      'ssh://<redacted>@example.com/org/repo.git'
     );
   });
 
@@ -236,6 +262,8 @@ describe('credential-bearing remote URL utilities', () => {
           '\tpushurl = https://user:REDACTED@example.com/org/repo-push.git',
           '[remote "ssh"]',
           '\turl = git@example.com:org/repo.git',
+          '[remote "ssh-protocol"]',
+          '\turl = ssh://git@example.com/org/repo.git',
           '',
         ].join('\n')
       );
@@ -255,6 +283,7 @@ describe('credential-bearing remote URL utilities', () => {
       expect(repaired).toContain('url = https://example.com/org/repo.git');
       expect(repaired).toContain('pushurl = https://example.com/org/repo-push.git');
       expect(repaired).toContain('url = git@example.com:org/repo.git');
+      expect(repaired).toContain('url = ssh://git@example.com/org/repo.git');
       expect(repaired).not.toContain('user:REDACTED@');
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
@@ -281,6 +310,31 @@ describe('credential-bearing remote URL utilities', () => {
       const scan = await scanGitConfigRemoteCredentials(branchPath);
       expect(scan.findings).toHaveLength(1);
       expect(scan.findings[0].configPath).toBe(path.join(baseGit, 'config'));
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('scans per-worktree config.worktree files', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-git-remote-sec-'));
+    try {
+      const baseGit = path.join(tmpRoot, 'base.git');
+      const worktreeGit = path.join(baseGit, 'worktrees', 'feature');
+      const branchPath = path.join(tmpRoot, 'branch');
+      await fs.mkdir(worktreeGit, { recursive: true });
+      await fs.mkdir(branchPath, { recursive: true });
+      await fs.writeFile(path.join(branchPath, '.git'), `gitdir: ${worktreeGit}\n`);
+      await fs.writeFile(path.join(worktreeGit, 'commondir'), '../..\n');
+      await fs.writeFile(
+        path.join(worktreeGit, 'config.worktree'),
+        ['[remote "local"]', '\turl = https://user:REDACTED@example.com/org/repo.git', ''].join(
+          '\n'
+        )
+      );
+
+      const scan = await scanGitConfigRemoteCredentials(branchPath);
+      expect(scan.findings).toHaveLength(1);
+      expect(scan.findings[0].configPath).toBe(path.join(worktreeGit, 'config.worktree'));
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -199,6 +199,39 @@ export function redactUrlUserinfo(input: string): string {
   );
 }
 
+/** True when an HTTP(S) URL embeds URL userinfo (`https://USER[:PASS]@host/...`). */
+export function httpUrlHasUserinfo(rawUrl: string): boolean {
+  if (!/^https?:\/\//i.test(rawUrl)) return false;
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    return parsed.username.length > 0 || parsed.password.length > 0;
+  } catch {
+    return /^https?:\/\/[^/?#\s]*@[^/?#\s]+/i.test(rawUrl);
+  }
+}
+
+/**
+ * Remove userinfo from HTTP(S) URLs. Non-HTTP(S) URLs, including SSH Git
+ * remotes like `ssh://git@host/org/repo.git`, are returned unchanged because
+ * their userinfo position may be a legitimate login name rather than a secret.
+ */
+export function stripHttpUrlUserinfo(rawUrl: string): string {
+  if (!/^https?:\/\//i.test(rawUrl)) return rawUrl;
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return rawUrl;
+    if (parsed.username || parsed.password) {
+      parsed.username = '';
+      parsed.password = '';
+      return parsed.toString();
+    }
+    return rawUrl;
+  } catch {
+    return rawUrl.replace(/^(https?:\/\/)([^/?#\s]*@)([^/?#\s]+)/i, '$1$3');
+  }
+}
+
 /**
  * Normalize an optional HTTP(S) URL string.
  *

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -181,6 +181,25 @@ export function getKnowledgeUrl(
 // ---------------------------------------------------------------------------
 
 /**
+ * Replace URL userinfo with `<redacted>` for logs/errors.
+ *
+ * This is intentionally string-based rather than `new URL(...)` only:
+ * defensive redaction has to work even when a user pasted a malformed URL
+ * such as one with an unescaped `@` inside the password. The userinfo match is
+ * greedy within the URL authority, so it redacts through the last `@` before a
+ * path/query/hash delimiter.
+ *
+ * SCP-like Git remotes (`git@host:org/repo.git`) do not contain `://`, so they
+ * are left untouched.
+ */
+export function redactUrlUserinfo(input: string): string {
+  return input.replace(
+    /([A-Za-z][A-Za-z0-9+.-]*:\/\/)([^/?#\s]*@)([^/?#\s]+)/g,
+    (_match, prefix: string, _userinfo: string, host: string) => `${prefix}<redacted>@${host}`
+  );
+}
+
+/**
  * Normalize an optional HTTP(S) URL string.
  *
  * - Trims whitespace

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -33,8 +33,10 @@ import {
   deleteRepoDirectory,
   ensureGitRemoteUrl,
   getReposDir,
+  redactGitUrlCredentials,
   removeGitWorktree,
   restoreBranchFilesystem,
+  stripGitUrlCredentials,
 } from '@agor/core/git';
 import type {
   BranchAgorYmlExportPayload,
@@ -674,6 +676,7 @@ export async function handleGitClone(
   options: CommandOptions
 ): Promise<ExecutorResult> {
   const createDbRecord = payload.params.createDbRecord ?? true;
+  const safeCloneUrl = stripGitUrlCredentials(payload.params.url);
 
   // Dry run mode - just validate and return
   if (options.dryRun) {
@@ -682,7 +685,7 @@ export async function handleGitClone(
       data: {
         dryRun: true,
         command: 'git.clone',
-        url: payload.params.url,
+        url: safeCloneUrl,
         outputPath: payload.params.outputPath,
         branch: payload.params.branch,
         bare: payload.params.bare,
@@ -723,12 +726,12 @@ export async function handleGitClone(
     // below.
     const pinnedBranch = payload.params.default_branch?.trim() || undefined;
     console.log(
-      `[git.clone] Cloning ${payload.params.url} to ${outputPath || reposDir}` +
+      `[git.clone] Cloning ${redactGitUrlCredentials(safeCloneUrl)} to ${outputPath || reposDir}` +
         (pinnedBranch ? ` (branch: ${pinnedBranch})` : '') +
         '...'
     );
     const cloneResult = await cloneRepo({
-      url: payload.params.url,
+      url: safeCloneUrl,
       targetDir: outputPath, // undefined = let cloneRepo compute path
       bare: payload.params.bare,
       branch: pinnedBranch,
@@ -738,7 +741,7 @@ export async function handleGitClone(
     console.log(`[git.clone] Clone successful: ${cloneResult.path}`);
 
     // Compute slug for the repo
-    const slug = payload.params.slug || computeRepoSlug(payload.params.url);
+    const slug = payload.params.slug || computeRepoSlug(safeCloneUrl);
     const repoName = extractRepoName(slug);
 
     // Create DB record if requested (default: true)
@@ -807,7 +810,7 @@ export async function handleGitClone(
           repo_type: 'remote',
           slug,
           name: repoName,
-          remote_url: payload.params.url,
+          remote_url: safeCloneUrl,
           local_path: cloneResult.path,
           default_branch: defaultBranch,
           clone_status: 'ready',
@@ -894,7 +897,7 @@ export async function handleGitClone(
         code: 'GIT_CLONE_FAILED',
         message: errorMessage,
         details: {
-          url: payload.params.url,
+          url: safeCloneUrl,
           outputPath: cloneOutputPath,
         },
       },
@@ -1085,7 +1088,7 @@ export async function handleGitBranchAdd(
       // the executor handler doesn't have to orchestrate post-clone git ops.
       const cloneRef = shouldCreateBranch ? sourceBranch || branch : branch;
       console.log(
-        `[git.branch.add] Using createBranchAsClone (remote=${remoteUrl}, ` +
+        `[git.branch.add] Using createBranchAsClone (remote=${redactGitUrlCredentials(remoteUrl)}, ` +
           `ref=${cloneRef}${shouldCreateBranch && branch !== cloneRef ? `, newBranch=${branch}` : ''}, ` +
           `depth=${cloneDepth ?? 'full'}, referenceHint=${referencePath ?? 'none'})`
       );

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -1031,7 +1031,9 @@ export async function handleGitBranchAdd(
         createBranch: payload.params.createBranch,
         storageMode: payload.params.storageMode,
         cloneDepth: payload.params.cloneDepth,
-        remoteUrl: payload.params.remoteUrl,
+        remoteUrl: payload.params.remoteUrl
+          ? stripGitUrlCredentials(payload.params.remoteUrl)
+          : payload.params.remoteUrl,
         referencePath: payload.params.referencePath,
       },
     };


### PR DESCRIPTION
## Summary

This PR hardens Agor against credential-bearing Git remote URLs leaking through shared repo `.git/config` files, especially when branches are backed by standard Git worktrees.

- add git remote URL userinfo detection/redaction/stripping helpers
- add direct `.git/config` scanner/repair utilities that handle both normal repos and worktree pointer/common-dir layouts
- scrub credential-bearing remote `url` / `pushurl` values during repo clone/register/update, branch/worktree creation, clone-mode branch creation, restore flows, and origin realignment
- sanitize clone URLs before executor logging / dry-run output / legacy DB writes
- add `agor admin scrub-git-remotes` plus `--write` repair mode
- add daemon post-start managed-repo auto-scrub so credential spills written while the daemon was down are repaired after the API is listening
- document the shared-config spillover risk, storage-mode tradeoffs, operational remediation, and Preset rollout guidance
- defer non-critical daemon startup work after listen via a common post-start job helper

## Security notes

- does not print, copy, or persist embedded remote credentials; warnings/logs use redacted URLs only
- `transfer.credentialsInUrl=die` remains useful for transfer operations, but it does not prevent plain config writes like `git remote add`; this PR closes that gap with sanitization, scanning, repair, and post-start cleanup
- users/agents can still run arbitrary Git and write bad config directly; the realistic mitigation is layered repair plus storage-mode isolation
- clone mode remains the stronger isolation path for multi-user/security-sensitive repos because each branch has its own `.git/config`
- startup auto-scrub intentionally targets Agor-managed remote repos/branches and skips registered local repos to avoid surprising writes outside Agor-managed storage

## Daemon startup behavior

After this PR, daemon boot keeps only correctness-critical work blocking before `listen`:

- orphaned task/session state correction stays blocking so clients do not see stale active state from a previous daemon
- master secret setup remains blocking
- service/hook/route registration remains blocking

Non-critical follow-up work now runs as post-start jobs:

- managed Git remote credential scrub
- daemon restart/crash transcript notice injection
- health monitor initial scan of already-running environments
- host IP template logging
- Claude CLI watcher rehydration

## Validation

- `pnpm i`
- `pnpm --filter @agor/core test -- src/git/credential-env.test.ts src/git/security.test.ts`
- `pnpm --filter @agor/core test -- src/git/security.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `git diff --check`
- `pnpm check`

`pnpm check` passed with existing Biome warnings unrelated to this change.
