### PR TITLE
fix(ui): make card drag handles easier to grab and fix z-index reset on sync

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -253,6 +253,7 @@ const BranchCardComponent = ({
     >
       {/* Branch header */}
       <div
+        className={!inPopover && !panelMode ? 'drag-handle' : undefined}
         style={{
           display: 'flex',
           justifyContent: 'space-between',
@@ -359,11 +360,10 @@ const BranchCardComponent = ({
           {!inPopover && !panelMode && (
             <Button
               type="text"
-              size="small"
-              icon={<DragOutlined />}
+              icon={<DragOutlined style={{ fontSize: 16 }} />}
               className="drag-handle"
               title="Drag to reposition"
-              style={{ cursor: 'grab' }}
+              style={{ cursor: 'grab', padding: '4px 8px' }}
             />
           )}
           <div className="nodrag">

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -68,3 +68,9 @@
 .drag-handle:active {
   cursor: grabbing;
 }
+
+/* Prevent nodrag children from inheriting grab cursor */
+.nodrag,
+.nodrag * {
+  cursor: auto;
+}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -682,6 +682,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         nodes.push({
           id: branch.branch_id,
           type: 'branchNode',
+          dragHandle: '.drag-handle',
           position, // When pinned (parentId set), this is relative to zone; otherwise absolute
           // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
           zIndex: 500, // Above zones, below comments
@@ -817,6 +818,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         nodes.push({
           id: `card-${cardId}`,
           type: 'cardNode',
+          dragHandle: '.drag-handle',
           position,
           // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
           zIndex: 500, // Same level as branches
@@ -1087,7 +1089,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
             if (positionConfirmed) {
               delete localPositionsRef.current[newNode.id];
-              return { ...newNode, selected: existingNode?.selected };
+              return { ...newNode, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
             }
 
             let positionToUse = localPosition;
@@ -1100,10 +1102,10 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               }
             }
 
-            return { ...newNode, position: positionToUse, selected: existingNode?.selected };
+            return { ...newNode, position: positionToUse, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
           }
 
-          return { ...newNode, selected: existingNode?.selected };
+          return { ...newNode, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
         });
       },
       []
@@ -2199,10 +2201,21 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           return;
         }
 
-        // Branch cards handle their own session clicks internally
-        // (no canvas-level click handler needed for branchNode)
+        // Bring clicked card to front (zones and comments are excluded from this)
+        if (node.type !== 'zone' && node.type !== 'comment') {
+          setNodes((nds) => {
+            const raisable = nds.filter((n) => n.type !== 'zone' && n.type !== 'comment');
+            const currentZ = nds.find((n) => n.id === node.id)?.zIndex ?? 0;
+            const isAlreadyOnTop = raisable.every(
+              (n) => n.id === node.id || (n.zIndex ?? 0) < currentZ
+            );
+            if (isAlreadyOnTop) return nds;
+            const maxZ = Math.max(0, ...raisable.map((n) => n.zIndex ?? 0));
+            return nds.map((n) => (n.id === node.id ? { ...n, zIndex: maxZ + 1 } : n));
+          });
+        }
       },
-      [activeTool, deleteObject, mutationGate.canMutate]
+      [activeTool, deleteObject, mutationGate.canMutate, setNodes]
     );
 
     // Clear comment placement state when switching away from comment tool

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -132,8 +132,9 @@ const SessionCard = ({
         body: { padding: 16 },
       }}
     >
-      {/* Session header */}
+      {/* Session header — full-width drag handle */}
       <div
+        className="drag-handle"
         style={{
           display: 'flex',
           justifyContent: 'space-between',
@@ -184,10 +185,10 @@ const SessionCard = ({
           </div>
           <Button
             type="text"
-            size="small"
-            icon={<DragOutlined />}
+            icon={<DragOutlined style={{ fontSize: 16 }} />}
             className="drag-handle"
             title="Drag to reposition"
+            style={{ cursor: 'grab', padding: '4px 8px' }}
           />
           <div className="nodrag">
             {onSessionClick && (


### PR DESCRIPTION
Improves the drag experience for branch and session cards on the canvas, and adds the ability to bring a card to the front by clicking on it.

## Easier drag handles

Previously, dragging a card required hitting a small icon button. Now the entire card header row acts as a drag target — you can grab anywhere across the top of the card to move it. The drag icon is also slightly larger and has more padding to make it an easier target on its own.

## Click to bring card to front

Clicking any card on the canvas now raises it above overlapping cards. Previously, clicking a card that was stacked behind others would briefly bring it to the front but then snap it back after the next real-time sync (~1s). That snap-back is fixed: the elevated z-index is now preserved across sync updates.