### PR TITLE
fix(ui): respect branch storage config

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -6,7 +6,7 @@
  * Extracted from index.ts for maintainability.
  */
 
-import { type AgorConfig, loadConfig } from '@agor/core/config';
+import { type AgorConfig, loadConfig, resolveBranchStorageConfig } from '@agor/core/config';
 import {
   BranchRepository,
   type Database,
@@ -3391,6 +3391,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // cursor_sdk_enabled flag is retained in config for compatibility but
           // no longer gates provider visibility.
           cursorSdk: true,
+          // Resolved branch storage policy. The daemon still enforces this at
+          // create time; the UI uses it to pick the right default and disable
+          // unavailable storage modes before submit.
+          branchStorage: resolveBranchStorageConfig(),
         },
       };
 

--- a/apps/agor-docs/pages/guide/branches.mdx
+++ b/apps/agor-docs/pages/guide/branches.mdx
@@ -74,6 +74,27 @@ Sessions, tasks, comments, and artifacts all reference a branch. **The branch is
 
 ---
 
+## Storage modes
+
+When you create a branch, Agor can materialize its working directory in two ways:
+
+- **Worktree** — native `git worktree add`, using the repo's shared `.git` metadata.
+- **Clone** — a self-standing `git clone` with its own `.git/` directory, isolating branch-local git config and credentials from sibling branches.
+
+Operators can choose which modes are available and which one the UI selects by default:
+
+```yaml
+execution:
+  branch_storage:
+    default_mode: clone
+    allowed_modes:
+      - clone
+```
+
+If `branch_storage` is omitted, Agor keeps the backwards-compatible default: `worktree` is selected by default and both `worktree` and `clone` are available. When an operator restricts `allowed_modes`, the create-branch UI disables unavailable options and the daemon rejects disallowed API/MCP requests.
+
+---
+
 ## GitHub-native workflow
 
 Because each branch carries `issue_url` and `pull_request_url`, AI agents have unambiguous context for what they're working on. Zones can use that context directly:

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1466,6 +1466,7 @@ function AppContent() {
       instanceLabel={instanceConfig?.label}
       instanceDescription={instanceConfig?.description}
       webTerminalEnabled={featuresConfig?.webTerminal === true}
+      branchStorageConfig={featuresConfig?.branchStorage}
     />
   );
 

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -31,7 +31,7 @@ import {
   PanelResizeHandle,
 } from 'react-resizable-panels';
 import { useParams } from 'react-router-dom';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { AppEntityDataProvider, AppLiveDataProvider } from '../../contexts/AppDataContext';

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -31,6 +31,7 @@ import {
   PanelResizeHandle,
 } from 'react-resizable-panels';
 import { useParams } from 'react-router-dom';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { AppEntityDataProvider, AppLiveDataProvider } from '../../contexts/AppDataContext';
@@ -186,6 +187,7 @@ export interface AppProps {
   instanceDescription?: string;
   /** Whether the web terminal is enabled on this instance (execution.allow_web_terminal) */
   webTerminalEnabled?: boolean;
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 // Stable empty-array sentinel: keeps prop refs equal across renders for the
@@ -279,6 +281,7 @@ export const App: React.FC<AppProps> = ({
   instanceLabel,
   instanceDescription,
   webTerminalEnabled = false,
+  branchStorageConfig,
 }) => {
   const { showWarning } = useThemedMessage();
   const routeParams = useParams<{
@@ -1361,6 +1364,7 @@ export const App: React.FC<AppProps> = ({
               artifactById={artifactById}
               onUpdateArtifact={onUpdateArtifact}
               onDeleteArtifact={onDeleteArtifact}
+              branchStorageConfig={branchStorageConfig}
             />
             {sessionSettingsSession && (
               <SessionSettingsModal
@@ -1430,6 +1434,7 @@ export const App: React.FC<AppProps> = ({
               mcpServerById={mcpServerById}
               currentUser={user}
               client={client}
+              branchStorageConfig={branchStorageConfig}
             />
             {logsModalBranchId && (
               <EnvironmentLogsModal

--- a/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
+++ b/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
@@ -6,7 +6,7 @@
  * - BranchesTable (create standalone branch)
  */
 
-import type { BranchStorageMode } from '@agor/core/config';
+import { BRANCH_STORAGE_MODES, type BranchStorageMode } from '@agor/core/config/browser';
 import type { Board, Repo } from '@agor-live/client';
 import {
   Checkbox,
@@ -20,7 +20,11 @@ import {
   Typography,
 } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import {
+  type BranchStorageConfig,
+  getStorageModeLabel,
+  resolveUiBranchStorageConfig,
+} from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 
 /**
@@ -31,42 +35,6 @@ import { mapToArray } from '@/utils/mapHelpers';
  * a different positive integer.
  */
 const DEFAULT_CLONE_DEPTH = 100;
-
-const BRANCH_STORAGE_MODES: BranchStorageMode[] = ['worktree', 'clone'];
-
-export interface ResolvedBranchStorageConfig {
-  defaultMode: BranchStorageMode;
-  allowedModes: BranchStorageMode[];
-}
-
-export function resolveUiBranchStorageConfig(
-  config?: BranchStorageConfig
-): ResolvedBranchStorageConfig {
-  const allowedModes =
-    config?.allowedModes?.filter((mode): mode is BranchStorageMode =>
-      BRANCH_STORAGE_MODES.includes(mode)
-    ) ?? BRANCH_STORAGE_MODES;
-  const nonEmptyAllowedModes = allowedModes.length > 0 ? allowedModes : BRANCH_STORAGE_MODES;
-  const requestedDefault = config?.defaultMode ?? 'worktree';
-  return {
-    defaultMode: nonEmptyAllowedModes.includes(requestedDefault)
-      ? requestedDefault
-      : nonEmptyAllowedModes[0],
-    allowedModes: nonEmptyAllowedModes,
-  };
-}
-
-export function normalizeBranchStorageMode(
-  mode: BranchStorageMode | undefined,
-  config?: BranchStorageConfig
-): BranchStorageMode {
-  const resolved = resolveUiBranchStorageConfig(config);
-  return mode && resolved.allowedModes.includes(mode) ? mode : resolved.defaultMode;
-}
-
-function getStorageModeLabel(mode: BranchStorageMode): string {
-  return mode === 'worktree' ? 'Worktree' : 'Clone';
-}
 
 export interface BranchFormFieldsProps {
   repoById: Map<string, Repo>;

--- a/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
+++ b/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
@@ -6,9 +6,21 @@
  * - BranchesTable (create standalone branch)
  */
 
+import type { BranchStorageMode } from '@agor/core/config';
 import type { Board, Repo } from '@agor-live/client';
-import { Checkbox, Form, Input, InputNumber, Radio, Select, Space, Typography } from 'antd';
-import { useState } from 'react';
+import {
+  Checkbox,
+  Form,
+  Input,
+  InputNumber,
+  Radio,
+  Select,
+  Space,
+  Tooltip,
+  Typography,
+} from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import { mapToArray } from '@/utils/mapHelpers';
 
 /**
@@ -19,6 +31,42 @@ import { mapToArray } from '@/utils/mapHelpers';
  * a different positive integer.
  */
 const DEFAULT_CLONE_DEPTH = 100;
+
+const BRANCH_STORAGE_MODES: BranchStorageMode[] = ['worktree', 'clone'];
+
+export interface ResolvedBranchStorageConfig {
+  defaultMode: BranchStorageMode;
+  allowedModes: BranchStorageMode[];
+}
+
+export function resolveUiBranchStorageConfig(
+  config?: BranchStorageConfig
+): ResolvedBranchStorageConfig {
+  const allowedModes =
+    config?.allowedModes?.filter((mode): mode is BranchStorageMode =>
+      BRANCH_STORAGE_MODES.includes(mode)
+    ) ?? BRANCH_STORAGE_MODES;
+  const nonEmptyAllowedModes = allowedModes.length > 0 ? allowedModes : BRANCH_STORAGE_MODES;
+  const requestedDefault = config?.defaultMode ?? 'worktree';
+  return {
+    defaultMode: nonEmptyAllowedModes.includes(requestedDefault)
+      ? requestedDefault
+      : nonEmptyAllowedModes[0],
+    allowedModes: nonEmptyAllowedModes,
+  };
+}
+
+export function normalizeBranchStorageMode(
+  mode: BranchStorageMode | undefined,
+  config?: BranchStorageConfig
+): BranchStorageMode {
+  const resolved = resolveUiBranchStorageConfig(config);
+  return mode && resolved.allowedModes.includes(mode) ? mode : resolved.defaultMode;
+}
+
+function getStorageModeLabel(mode: BranchStorageMode): string {
+  return mode === 'worktree' ? 'Worktree' : 'Clone';
+}
 
 export interface BranchFormFieldsProps {
   repoById: Map<string, Repo>;
@@ -38,6 +86,8 @@ export interface BranchFormFieldsProps {
   useSameBranchName?: boolean;
   /** Callback when checkbox changes */
   onUseSameBranchNameChange?: (checked: boolean) => void;
+  /** Resolved server branch storage policy from /health features.branchStorage. */
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
@@ -52,6 +102,7 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
   onFormChange,
   useSameBranchName: controlledUseSameBranchName,
   onUseSameBranchNameChange,
+  branchStorageConfig,
 }) => {
   const [internalUseSameBranchName, setInternalUseSameBranchName] = useState(true);
   const [refType, setRefType] = useState<'branch' | 'tag'>('branch');
@@ -61,6 +112,27 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
   const setUseSameBranchName = onUseSameBranchNameChange ?? setInternalUseSameBranchName;
 
   const form = Form.useFormInstance();
+  const storageFieldName = `${fieldPrefix}storage_mode`;
+  const { defaultMode: defaultStorageMode, allowedModes: allowedStorageModes } = useMemo(
+    () => resolveUiBranchStorageConfig(branchStorageConfig),
+    [branchStorageConfig]
+  );
+  const previousDefaultStorageMode = useRef<BranchStorageMode | undefined>(undefined);
+
+  useEffect(() => {
+    const current = form.getFieldValue(storageFieldName) as BranchStorageMode | undefined;
+    const previousDefault = previousDefaultStorageMode.current;
+    if (
+      !current ||
+      !allowedStorageModes.includes(current) ||
+      (previousDefault !== undefined &&
+        current === previousDefault &&
+        current !== defaultStorageMode)
+    ) {
+      form.setFieldValue(storageFieldName, defaultStorageMode);
+    }
+    previousDefaultStorageMode.current = defaultStorageMode;
+  }, [allowedStorageModes, defaultStorageMode, form, storageFieldName]);
 
   const handleCheckboxChange = (checked: boolean) => {
     setUseSameBranchName(checked);
@@ -191,9 +263,9 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
       )}
 
       <Form.Item
-        name={`${fieldPrefix}storage_mode`}
+        name={storageFieldName}
         label="Storage"
-        initialValue="worktree"
+        initialValue={defaultStorageMode}
         tooltip={
           'How the branch is materialised on disk. ' +
           '"Worktree" uses git\'s native shared-base model (legacy default). ' +
@@ -201,10 +273,34 @@ export const BranchFormFields: React.FC<BranchFormFieldsProps> = ({
           'git clone — credentials and config are isolated from sibling branches. ' +
           'See context/explorations/clone-redesign.md.'
         }
+        extra={
+          allowedStorageModes.length === 1
+            ? `${getStorageModeLabel(allowedStorageModes[0])} is the only storage mode enabled on this Agor instance. Administrators configure this with execution.branch_storage.allowed_modes.`
+            : `Default on this Agor instance: ${getStorageModeLabel(defaultStorageMode)}.`
+        }
       >
         <Radio.Group onChange={() => onFormChange?.()}>
-          <Radio value="worktree">Worktree (default)</Radio>
-          <Radio value="clone">Clone</Radio>
+          {BRANCH_STORAGE_MODES.map((mode) => {
+            const disabled = !allowedStorageModes.includes(mode);
+            const defaultSuffix = mode === defaultStorageMode ? ' (default)' : '';
+            const label = `${getStorageModeLabel(mode)}${defaultSuffix}`;
+            return (
+              <Tooltip
+                key={mode}
+                title={
+                  disabled
+                    ? `${getStorageModeLabel(mode)} storage is disabled on this Agor instance by execution.branch_storage.allowed_modes.`
+                    : undefined
+                }
+              >
+                <span>
+                  <Radio value={mode} disabled={disabled}>
+                    {label}
+                  </Radio>
+                </span>
+              </Tooltip>
+            );
+          })}
         </Radio.Group>
       </Form.Item>
 

--- a/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
+++ b/apps/agor-ui/src/components/BranchFormFields/BranchFormFields.tsx
@@ -6,7 +6,6 @@
  * - BranchesTable (create standalone branch)
  */
 
-import { BRANCH_STORAGE_MODES, type BranchStorageMode } from '@agor/core/config/browser';
 import type { Board, Repo } from '@agor-live/client';
 import {
   Checkbox,
@@ -21,7 +20,9 @@ import {
 } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  BRANCH_STORAGE_MODES,
   type BranchStorageConfig,
+  type BranchStorageMode,
   getStorageModeLabel,
   resolveUiBranchStorageConfig,
 } from '@/utils/branchStorage';

--- a/apps/agor-ui/src/components/BranchFormFields/index.ts
+++ b/apps/agor-ui/src/components/BranchFormFields/index.ts
@@ -1,2 +1,7 @@
-export type { BranchFormFieldsProps } from './BranchFormFields';
-export { BranchFormFields, useBranchBranchName } from './BranchFormFields';
+export type { BranchFormFieldsProps, ResolvedBranchStorageConfig } from './BranchFormFields';
+export {
+  BranchFormFields,
+  normalizeBranchStorageMode,
+  resolveUiBranchStorageConfig,
+  useBranchBranchName,
+} from './BranchFormFields';

--- a/apps/agor-ui/src/components/BranchFormFields/index.ts
+++ b/apps/agor-ui/src/components/BranchFormFields/index.ts
@@ -1,7 +1,2 @@
-export type { BranchFormFieldsProps, ResolvedBranchStorageConfig } from './BranchFormFields';
-export {
-  BranchFormFields,
-  normalizeBranchStorageMode,
-  resolveUiBranchStorageConfig,
-  useBranchBranchName,
-} from './BranchFormFields';
+export type { BranchFormFieldsProps } from './BranchFormFields';
+export { BranchFormFields, useBranchBranchName } from './BranchFormFields';

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '@ant-design/icons';
 import { Alert, Button, Modal, Tabs } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import type { AgenticToolOption } from '../../types';
 import type { AssistantTabResult } from './tabs/AssistantTab';
 import { AssistantTab } from './tabs/AssistantTab';
@@ -83,6 +84,7 @@ export interface CreateDialogProps {
     result: AssistantTabResult,
     progress?: CreateDialogProgress
   ) => void | Promise<void>;
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 /** Fire the parent handler and close the dialog. We don't `await` here
@@ -110,6 +112,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
   onCreateRepo,
   onCreateLocalRepo,
   onCreateAssistant,
+  branchStorageConfig,
 }) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>(defaultTab);
   // Validity is tracked per tab so a sibling tab's empty-form state (or a
@@ -268,6 +271,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
             defaultPosition={defaultPosition}
             onValidityChange={handleBranchValid}
             formRef={branchFormRef}
+            branchStorageConfig={branchStorageConfig}
           />
         </div>
       ),

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -15,7 +15,7 @@ import {
 } from '@ant-design/icons';
 import { Alert, Button, Modal, Tabs } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import type { BranchStorageConfig } from '@/utils/branchStorage';
 import type { AgenticToolOption } from '../../types';
 import type { AssistantTabResult } from './tabs/AssistantTab';
 import { AssistantTab } from './tabs/AssistantTab';

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import type { Repo } from '@agor-live/client';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { BranchTab, type BranchTabConfig } from './BranchTab';
 
@@ -60,5 +60,73 @@ describe('BranchTab — source-branch preservation', { timeout: 10_000 }, () => 
     expect((screen.getByLabelText(/Source Branch/i) as HTMLInputElement).value).toBe(
       'release/2024-q1'
     );
+  });
+});
+
+describe('BranchTab — branch storage policy', { timeout: 10_000 }, () => {
+  async function renderBranchTab(
+    branchStorageConfig?: React.ComponentProps<typeof BranchTab>['branchStorageConfig']
+  ) {
+    const formRef: React.MutableRefObject<(() => Promise<BranchTabConfig | null>) | null> = {
+      current: null,
+    };
+    const repo = makeRepo({ default_branch: 'main' });
+
+    render(
+      <BranchTab
+        repoById={new Map([[repo.repo_id, repo]])}
+        onValidityChange={vi.fn()}
+        formRef={formRef}
+        branchStorageConfig={branchStorageConfig}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByLabelText(/Source Branch/i)).toHaveValue('main'));
+    fireEvent.change(screen.getByLabelText(/Branch Name/i), {
+      target: { value: 'feat-storage' },
+    });
+
+    return { formRef };
+  }
+
+  it('defaults to clone and disables worktree when the server only allows clone', async () => {
+    const { formRef } = await renderBranchTab({
+      defaultMode: 'clone',
+      allowedModes: ['clone'],
+    });
+
+    expect(screen.getByRole('radio', { name: /Clone \(default\)/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Worktree/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('radio', { name: /Worktree/i }));
+    expect(screen.getByRole('radio', { name: /Clone \(default\)/i })).toBeChecked();
+    const result = await formRef.current?.();
+    expect(result).toBeTruthy();
+    expect(result!.storage_mode).toBe('clone');
+  });
+
+  it('allows both modes and respects a server default of clone', async () => {
+    const { formRef } = await renderBranchTab({
+      defaultMode: 'clone',
+      allowedModes: ['worktree', 'clone'],
+    });
+
+    expect(screen.getByRole('radio', { name: /Clone \(default\)/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Worktree/i })).not.toBeDisabled();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Worktree/i }));
+    expect(screen.getByRole('radio', { name: /Worktree/i })).toBeChecked();
+    const result = await formRef.current?.();
+    expect(result).toBeTruthy();
+    expect(result!.storage_mode).toBe('worktree');
+  });
+
+  it('keeps existing/default behavior when branch storage config is absent', async () => {
+    const { formRef } = await renderBranchTab();
+
+    expect(screen.getByRole('radio', { name: /Worktree \(default\)/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Clone/i })).not.toBeDisabled();
+    const result = await formRef.current?.();
+    expect(result).toBeTruthy();
+    expect(result!.storage_mode).toBe('worktree');
   });
 });

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
@@ -102,6 +102,7 @@ describe('BranchTab — branch storage policy', { timeout: 10_000 }, () => {
     const result = await formRef.current?.();
     expect(result).toBeTruthy();
     expect(result!.storage_mode).toBe('clone');
+    expect(result!.clone_depth).toBe(100);
   });
 
   it('allows both modes and respects a server default of clone', async () => {

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.tsx
@@ -1,8 +1,9 @@
 import type { Repo } from '@agor-live/client';
 import { Form } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import { mapToArray } from '@/utils/mapHelpers';
-import { BranchFormFields } from '../../BranchFormFields';
+import { BranchFormFields, normalizeBranchStorageMode } from '../../BranchFormFields';
 
 export interface BranchTabConfig {
   repoId: string;
@@ -32,6 +33,7 @@ export interface BranchTabProps {
   defaultPosition?: { x: number; y: number };
   onValidityChange: (valid: boolean) => void;
   formRef: React.MutableRefObject<(() => Promise<BranchTabConfig | null>) | null>;
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 export const BranchTab: React.FC<BranchTabProps> = ({
@@ -40,6 +42,7 @@ export const BranchTab: React.FC<BranchTabProps> = ({
   defaultPosition,
   onValidityChange,
   formRef,
+  branchStorageConfig,
 }) => {
   const [form] = Form.useForm();
   const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
@@ -98,7 +101,7 @@ export const BranchTab: React.FC<BranchTabProps> = ({
     try {
       const values = await form.validateFields();
       const refType = values.refType || 'branch';
-      const storageMode: 'worktree' | 'clone' = values.storage_mode ?? 'worktree';
+      const storageMode = normalizeBranchStorageMode(values.storage_mode, branchStorageConfig);
       const cloneDepth =
         storageMode === 'clone' && typeof values.clone_depth === 'number' && values.clone_depth > 0
           ? values.clone_depth
@@ -138,6 +141,7 @@ export const BranchTab: React.FC<BranchTabProps> = ({
         defaultBranch={selectedRepo?.default_branch || 'main'}
         showUrlFields={true}
         onFormChange={handleValuesChange}
+        branchStorageConfig={branchStorageConfig}
       />
     </Form>
   );

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.tsx
@@ -1,9 +1,10 @@
 import type { Repo } from '@agor-live/client';
 import { Form } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import type { BranchStorageConfig } from '@/utils/branchStorage';
+import { normalizeBranchStorageMode } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
-import { BranchFormFields, normalizeBranchStorageMode } from '../../BranchFormFields';
+import { BranchFormFields } from '../../BranchFormFields';
 
 export interface BranchTabConfig {
   repoId: string;

--- a/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.tsx
+++ b/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.tsx
@@ -1,8 +1,9 @@
 import type { Repo } from '@agor-live/client';
 import { Button, Form, Modal } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import { mapToArray } from '@/utils/mapHelpers';
-import { BranchFormFields } from '../BranchFormFields';
+import { BranchFormFields, normalizeBranchStorageMode } from '../BranchFormFields';
 import type { BranchTabConfig } from '../CreateDialog/tabs/BranchTab';
 
 /** @deprecated Use BranchTabConfig directly. Kept as alias for backward compat. */
@@ -15,6 +16,7 @@ export interface NewBranchModalProps {
   repoById: Map<string, Repo>;
   currentBoardId?: string; // Auto-fill board if provided
   defaultPosition?: { x: number; y: number }; // Default position on canvas (center of viewport)
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 export const NewBranchModal: React.FC<NewBranchModalProps> = ({
@@ -24,6 +26,7 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
   repoById,
   currentBoardId,
   defaultPosition,
+  branchStorageConfig,
 }) => {
   const [form] = Form.useForm();
   const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
@@ -97,7 +100,7 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
     const values = await form.validateFields();
 
     const refType = values.refType || 'branch';
-    const storageMode: 'worktree' | 'clone' = values.storage_mode ?? 'worktree';
+    const storageMode = normalizeBranchStorageMode(values.storage_mode, branchStorageConfig);
     // Depth only applies to clone-mode and only when the input has a
     // positive value. The form's validator already rejects bad numbers;
     // empty / cleared input → undefined → full clone at the daemon layer.
@@ -170,6 +173,7 @@ export const NewBranchModal: React.FC<NewBranchModalProps> = ({
           defaultBranch={selectedRepo?.default_branch || 'main'}
           showUrlFields={true}
           onFormChange={handleValuesChange}
+          branchStorageConfig={branchStorageConfig}
         />
       </Form>
     </Modal>

--- a/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.tsx
+++ b/apps/agor-ui/src/components/NewBranchModal/NewBranchModal.tsx
@@ -1,9 +1,10 @@
 import type { Repo } from '@agor-live/client';
 import { Button, Form, Modal } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import type { BranchStorageConfig } from '@/utils/branchStorage';
+import { normalizeBranchStorageMode } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
-import { BranchFormFields, normalizeBranchStorageMode } from '../BranchFormFields';
+import { BranchFormFields } from '../BranchFormFields';
 import type { BranchTabConfig } from '../CreateDialog/tabs/BranchTab';
 
 /** @deprecated Use BranchTabConfig directly. Kept as alias for backward compat. */

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -23,11 +23,12 @@ import {
   theme,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import { mapToArray } from '@/utils/mapHelpers';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { ArchiveToggleButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
-import { BranchFormFields } from '../BranchFormFields';
+import { BranchFormFields, normalizeBranchStorageMode } from '../BranchFormFields';
 import { renderEnvCell } from './BranchEnvColumn';
 
 interface BranchesTableProps {
@@ -63,6 +64,7 @@ interface BranchesTableProps {
   /** Close the parent Settings modal. Used by the recenter action so the
    *  canvas isn't obscured by the modal after pan/zoom. */
   onClose?: () => void;
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 export const BranchesTable: React.FC<BranchesTableProps> = ({
@@ -78,6 +80,7 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
   onStartEnvironment,
   onStopEnvironment,
   onClose,
+  branchStorageConfig,
 }) => {
   const repos = mapToArray(repoById);
   const boards = mapToArray(boardById);
@@ -277,7 +280,7 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
         localStorage.setItem('agor:lastUsedBoardId', values.boardId);
       }
 
-      const storageMode: 'worktree' | 'clone' = values.storage_mode ?? 'worktree';
+      const storageMode = normalizeBranchStorageMode(values.storage_mode, branchStorageConfig);
       const cloneDepth =
         storageMode === 'clone' && typeof values.clone_depth === 'number' && values.clone_depth > 0
           ? values.clone_depth
@@ -623,6 +626,7 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
             onFormChange={validateForm}
             useSameBranchName={useSameBranchName}
             onUseSameBranchNameChange={setUseSameBranchName}
+            branchStorageConfig={branchStorageConfig}
           />
         </Form>
       </Modal>

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -23,12 +23,13 @@ import {
   theme,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import type { BranchStorageConfig } from '@/utils/branchStorage';
+import { normalizeBranchStorageMode } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { ArchiveToggleButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
-import { BranchFormFields, normalizeBranchStorageMode } from '../BranchFormFields';
+import { BranchFormFields } from '../BranchFormFields';
 import { renderEnvCell } from './BranchEnvColumn';
 
 interface BranchesTableProps {

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -35,7 +35,7 @@ import {
 import type { MenuProps } from 'antd';
 import { Layout, Menu, Modal, theme } from 'antd';
 import { useMemo, useState } from 'react';
-import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
+import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { SETTINGS_SECTIONS, type SettingsSection } from '../../hooks/useSettingsRoute';
 import { BranchModal } from '../BranchModal';

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -35,6 +35,7 @@ import {
 import type { MenuProps } from 'antd';
 import { Layout, Menu, Modal, theme } from 'antd';
 import { useMemo, useState } from 'react';
+import type { BranchStorageConfig } from '@/hooks/useAuthConfig';
 import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { SETTINGS_SECTIONS, type SettingsSection } from '../../hooks/useSettingsRoute';
 import { BranchModal } from '../BranchModal';
@@ -117,6 +118,7 @@ export interface SettingsModalProps {
   artifactById?: Map<string, Artifact>;
   onUpdateArtifact?: (artifactId: string, updates: Partial<Artifact>) => void;
   onDeleteArtifact?: (artifactId: string) => void;
+  branchStorageConfig?: BranchStorageConfig;
 }
 
 export const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -162,6 +164,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   artifactById = new Map(),
   onUpdateArtifact,
   onDeleteArtifact,
+  branchStorageConfig,
 }) => {
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
@@ -387,6 +390,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             onStartEnvironment={onStartEnvironment}
             onStopEnvironment={onStopEnvironment}
             onClose={onClose}
+            branchStorageConfig={branchStorageConfig}
           />
         );
       case 'assistants':

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -5,6 +5,7 @@
  * Used on app startup to determine if login page should be shown and display instance label.
  */
 
+import type { BranchStorageMode } from '@agor/core/config';
 import type { ManagedEnvExecutionMode } from '@agor/core/environment/webhook';
 import type { DaemonServicesConfig } from '@agor-live/client';
 import { useEffect, useState } from 'react';
@@ -38,7 +39,12 @@ interface OnboardingConfig {
   systemCredentials?: SystemCredentials;
 }
 
-interface FeaturesConfig {
+export interface BranchStorageConfig {
+  defaultMode?: BranchStorageMode;
+  allowedModes?: BranchStorageMode[];
+}
+
+export interface FeaturesConfig {
   /**
    * Whether the web terminal is enabled for members (execution.allow_web_terminal).
    * Defaults to true when the daemon config key is unset.
@@ -66,6 +72,12 @@ interface FeaturesConfig {
   multiUser?: boolean;
   /** Experimental Cursor SDK provider enabled on the daemon. */
   cursorSdk?: boolean;
+  /**
+   * Resolved branch storage policy from execution.branch_storage.
+   * Defaults server-side to { defaultMode: 'worktree',
+   * allowedModes: ['worktree', 'clone'] } when unset.
+   */
+  branchStorage?: BranchStorageConfig;
 }
 
 interface HealthResponse {

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -5,11 +5,11 @@
  * Used on app startup to determine if login page should be shown and display instance label.
  */
 
-import type { BranchStorageMode } from '@agor/core/config';
 import type { ManagedEnvExecutionMode } from '@agor/core/environment/webhook';
 import type { DaemonServicesConfig } from '@agor-live/client';
 import { useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
+import type { BranchStorageConfig } from '../utils/branchStorage';
 
 interface AuthConfig {
   requireAuth: boolean;
@@ -37,11 +37,6 @@ interface OnboardingConfig {
   persistedAgentPending?: boolean;
   frameworkRepoUrl?: string;
   systemCredentials?: SystemCredentials;
-}
-
-export interface BranchStorageConfig {
-  defaultMode?: BranchStorageMode;
-  allowedModes?: BranchStorageMode[];
 }
 
 export interface FeaturesConfig {

--- a/apps/agor-ui/src/utils/branchStorage.ts
+++ b/apps/agor-ui/src/utils/branchStorage.ts
@@ -1,0 +1,45 @@
+import {
+  BRANCH_STORAGE_MODES,
+  type BranchStorageMode,
+  DEFAULT_BRANCH_STORAGE_MODE,
+  type ResolvedBranchStorageConfig,
+} from '@agor/core/config/browser';
+
+export type BranchStorageConfig = Partial<ResolvedBranchStorageConfig>;
+
+export function isBranchStorageMode(value: unknown): value is BranchStorageMode {
+  return typeof value === 'string' && (BRANCH_STORAGE_MODES as readonly string[]).includes(value);
+}
+
+export function resolveUiBranchStorageConfig(
+  config?: BranchStorageConfig
+): ResolvedBranchStorageConfig {
+  const allowedModes = Array.isArray(config?.allowedModes)
+    ? config.allowedModes.filter(isBranchStorageMode)
+    : [...BRANCH_STORAGE_MODES];
+  const nonEmptyAllowedModes = allowedModes.length > 0 ? allowedModes : [...BRANCH_STORAGE_MODES];
+  const requestedDefault = isBranchStorageMode(config?.defaultMode)
+    ? config.defaultMode
+    : DEFAULT_BRANCH_STORAGE_MODE;
+
+  return {
+    defaultMode: nonEmptyAllowedModes.includes(requestedDefault)
+      ? requestedDefault
+      : nonEmptyAllowedModes[0],
+    allowedModes: nonEmptyAllowedModes,
+  };
+}
+
+export function normalizeBranchStorageMode(
+  mode: unknown,
+  config?: BranchStorageConfig
+): BranchStorageMode {
+  const resolved = resolveUiBranchStorageConfig(config);
+  return isBranchStorageMode(mode) && resolved.allowedModes.includes(mode)
+    ? mode
+    : resolved.defaultMode;
+}
+
+export function getStorageModeLabel(mode: BranchStorageMode): string {
+  return mode === 'worktree' ? 'Worktree' : 'Clone';
+}

--- a/apps/agor-ui/src/utils/branchStorage.ts
+++ b/apps/agor-ui/src/utils/branchStorage.ts
@@ -5,6 +5,7 @@ import {
   type ResolvedBranchStorageConfig,
 } from '@agor/core/config/browser';
 
+export { BRANCH_STORAGE_MODES, type BranchStorageMode };
 export type BranchStorageConfig = Partial<ResolvedBranchStorageConfig>;
 
 export function isBranchStorageMode(value: unknown): value is BranchStorageMode {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -12,7 +12,14 @@ import yaml from 'js-yaml';
 import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
 import { DAEMON, MCP_TOKEN } from './constants';
 import { resolveExecutorHeartbeatConfig } from './executor-heartbeat';
-import type { AgorConfig, UnknownJson } from './types';
+import {
+  type AgorConfig,
+  BRANCH_STORAGE_MODES,
+  type BranchStorageMode,
+  DEFAULT_BRANCH_STORAGE_MODE,
+  type ResolvedBranchStorageConfig,
+  type UnknownJson,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // In-memory cache for the default-path config
@@ -848,10 +855,7 @@ export function isUnixImpersonationEnabled(): boolean {
  * forgot to add `clone` to `allowed_modes`) — load-time normalisation
  * keeps service code from needing to defensively re-validate.
  */
-export function resolveBranchStorageConfig(): {
-  defaultMode: import('./types').BranchStorageMode;
-  allowedModes: import('./types').BranchStorageMode[];
-} {
+export function resolveBranchStorageConfig(): ResolvedBranchStorageConfig {
   let raw: import('./types').AgorBranchStorageSettings | undefined;
   try {
     raw = loadConfigSync().execution?.branch_storage;
@@ -860,9 +864,11 @@ export function resolveBranchStorageConfig(): {
     // the safe legacy default.
     raw = undefined;
   }
-  const allowed: import('./types').BranchStorageMode[] =
-    raw?.allowed_modes && raw.allowed_modes.length > 0 ? raw.allowed_modes : ['worktree', 'clone'];
-  const requestedDefault = raw?.default_mode ?? 'worktree';
+  const allowed: BranchStorageMode[] =
+    raw?.allowed_modes && raw.allowed_modes.length > 0
+      ? raw.allowed_modes
+      : [...BRANCH_STORAGE_MODES];
+  const requestedDefault = raw?.default_mode ?? DEFAULT_BRANCH_STORAGE_MODE;
   // Normalise: if the operator's default_mode isn't in allowed_modes, fall
   // back to the first allowed mode so we never hand out a default that the
   // gate would immediately reject.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -582,7 +582,14 @@ export interface AgorExecutionSettings {
  * - `'clone'` — self-standing `git clone` with its own `.git/` directory;
  *   closes cross-branch credential/config leak vectors.
  */
-export type BranchStorageMode = 'worktree' | 'clone';
+export const BRANCH_STORAGE_MODES = ['worktree', 'clone'] as const;
+export type BranchStorageMode = (typeof BRANCH_STORAGE_MODES)[number];
+export const DEFAULT_BRANCH_STORAGE_MODE: BranchStorageMode = 'worktree';
+
+export interface ResolvedBranchStorageConfig {
+  defaultMode: BranchStorageMode;
+  allowedModes: BranchStorageMode[];
+}
 
 /**
  * Operator gate for which storage modes can be selected at branch-create

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -588,7 +588,7 @@ export const DEFAULT_BRANCH_STORAGE_MODE: BranchStorageMode = 'worktree';
 
 export interface ResolvedBranchStorageConfig {
   defaultMode: BranchStorageMode;
-  allowedModes: BranchStorageMode[];
+  allowedModes: readonly BranchStorageMode[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- expose resolved branch storage policy on `/health` as `features.branchStorage`
- make branch creation UI default to the server-configured storage mode
- disable disallowed storage options with explanatory copy/tooltips
- add focused BranchTab coverage for clone-only, both-modes, and absent-config behavior
- document `execution.branch_storage` in the branches guide

## Validation

- `pnpm check`
- `pnpm --filter agor-ui test -- src/components/CreateDialog/tabs/BranchTab.test.tsx`

## Notes

The daemon remains the source of truth for enforcement; this change mirrors the resolved policy into the UI so users do not select a mode that the backend will reject.
