### PR TITLE
Add fullscreen artifact surface

### DIFF
--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -119,6 +119,38 @@ async function seedArtifact(
   return created;
 }
 
+describe('ArtifactRepository URL fields', () => {
+  dbTest('returns both board url and fullscreen_url from repository reads', async ({ db }) => {
+    const previousBaseUrl = process.env.AGOR_BASE_URL;
+    process.env.AGOR_BASE_URL = 'https://agor.example.com/ui';
+    try {
+      const artifactRepo = new ArtifactRepository(db);
+      const board = await seedBoard(db);
+      const artifact = await seedArtifact(db, board.board_id, { userId: 'user-owner' });
+      const artifactShortId = shortId(artifact.artifact_id);
+
+      expect(artifact.url).toBe(`https://agor.example.com/ui/a/${artifactShortId}/`);
+      expect(artifact.fullscreen_url).toBe(
+        `https://agor.example.com/ui/a/${artifactShortId}/fullscreen`
+      );
+
+      const fetched = await artifactRepo.findById(artifact.artifact_id);
+      expect(fetched?.url).toBe(artifact.url);
+      expect(fetched?.fullscreen_url).toBe(artifact.fullscreen_url);
+
+      const listed = await artifactRepo.findAll();
+      expect(listed[0]?.url).toBe(artifact.url);
+      expect(listed[0]?.fullscreen_url).toBe(artifact.fullscreen_url);
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env.AGOR_BASE_URL;
+      } else {
+        process.env.AGOR_BASE_URL = previousBaseUrl;
+      }
+    }
+  });
+});
+
 describe('ArtifactsService.updateMetadata', () => {
   dbTest('moves artifact to a new board and preserves placement', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -50,7 +50,11 @@ import {
   useSessionActions,
 } from './hooks';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
-import { KNOWLEDGE_ROUTE_PATHS, routeUsesDeviceRouter } from './surfaces/surfaceRegistry';
+import {
+  ARTIFACT_FULLSCREEN_ROUTE_PATHS,
+  KNOWLEDGE_ROUTE_PATHS,
+  routeUsesDeviceRouter,
+} from './surfaces/surfaceRegistry';
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
 import { isMobileDevice } from './utils/deviceDetection';
 import { useThemedMessage } from './utils/message';
@@ -58,6 +62,11 @@ import { useThemedMessage } from './utils/message';
 const AgorApp = lazy(() => import('./components/App').then((module) => ({ default: module.App })));
 const KnowledgePage = lazy(() =>
   import('./pages/KnowledgePage').then((module) => ({ default: module.KnowledgePage }))
+);
+const ArtifactFullscreenPage = lazy(() =>
+  import('./pages/ArtifactFullscreenPage').then((module) => ({
+    default: module.ArtifactFullscreenPage,
+  }))
 );
 const MobileApp = lazy(() =>
   import('./components/mobile/MobileApp').then((module) => ({ default: module.MobileApp }))
@@ -1385,6 +1394,15 @@ function AppContent() {
     />
   );
 
+  const artifactFullscreenElement = (
+    <ArtifactFullscreenPage
+      client={client}
+      currentUser={currentUser}
+      onUserSettingsClick={() => setOpenUserSettings(true)}
+      onLogout={logout}
+    />
+  );
+
   // All desktop entity URLs (/b/, /s/, /w/, /a/) render the same
   // AgorApp — the multiple routes exist so react-router's useParams
   // (read inside useUrlState) populates the right named params for
@@ -1549,6 +1567,12 @@ function AppContent() {
             {/* Knowledge route shell. `/kb` is a short alias for the same surface. */}
             {KNOWLEDGE_ROUTE_PATHS.map((path) => (
               <Route key={path} path={path} element={knowledgePageElement} />
+            ))}
+
+            {/* Lightweight artifact fullscreen surface. Uses the shared auth shell,
+                but does not start the Workspace board/session store on fresh loads. */}
+            {ARTIFACT_FULLSCREEN_ROUTE_PATHS.map((path) => (
+              <Route key={path} path={path} element={artifactFullscreenElement} />
             ))}
 
             {/* Mobile routes */}

--- a/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
+++ b/apps/agor-ui/src/components/ArtifactConsentModal/ArtifactConsentModal.tsx
@@ -28,6 +28,7 @@ import { useMemo, useState } from 'react';
 import { ThemedSyntaxHighlighter } from '@/components/ThemedSyntaxHighlighter';
 import { getDaemonUrl } from '@/config/daemon';
 import { useAuthConfig } from '@/hooks/useAuthConfig';
+import { getAuthHeaders } from '@/utils/authHeaders';
 import { getLanguageFromPath } from '@/utils/language';
 import { useThemedMessage } from '@/utils/message';
 import { FileCollection, type FileItem } from '../FileCollection/FileCollection';
@@ -50,14 +51,6 @@ interface ArtifactConsentModalProps {
 }
 
 const HIGH_POWER_GRANT_KEYS = new Set<keyof AgorGrants>(['agor_token']);
-
-function getAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
-  return {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
 
 export function ArtifactConsentModal({
   open,

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -1,39 +1,10 @@
-/**
- * ArtifactNode — Board canvas node for live Sandpack artifacts
- *
- * Fetches artifact payload from the daemon REST API, renders via Sandpack,
- * captures console events, and reloads when a WebSocket 'patched' event
- * signals a content_hash change.
- */
-
-// Polyfill crypto.subtle for non-secure contexts (HTTP).
-// Sandpack uses crypto.subtle.digest() to generate short IDs, which is only
-// available in secure contexts (HTTPS/localhost). On plain HTTP, we provide
-// a simple fallback using Math.random.
-if (typeof globalThis.crypto !== 'undefined' && !globalThis.crypto.subtle) {
-  // biome-ignore lint/suspicious/noExplicitAny: minimal polyfill for Sandpack compatibility
-  (globalThis.crypto as any).subtle = {
-    async digest(_algo: string, data: ArrayBuffer) {
-      // Simple hash fallback — not cryptographically secure, only used for Sandpack IDs
-      const bytes = new Uint8Array(data);
-      let hash = 0;
-      for (const b of bytes) {
-        hash = (hash * 31 + b) | 0;
-      }
-      const result = new ArrayBuffer(4);
-      new DataView(result).setInt32(0, hash);
-      return result;
-    },
-  };
-}
-
 import type {
   ArtifactBoardObject,
   ArtifactID,
   ArtifactPayload,
   BoardObject,
 } from '@agor-live/client';
-import { shortId } from '@agor-live/client';
+import { artifactFullscreenPath, shortId } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -41,10 +12,10 @@ import {
   DeleteOutlined,
   ExportOutlined,
   EyeOutlined,
+  FullscreenOutlined,
   LoadingOutlined,
   LockOutlined,
   ReloadOutlined,
-  SafetyOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
 import {
@@ -52,28 +23,27 @@ import {
   SandpackProvider,
   type SandpackSetup,
   useSandpack,
-  useSandpackConsole,
 } from '@codesandbox/sandpack-react';
-import {
-  Alert,
-  Badge,
-  Button,
-  Card,
-  Popconfirm,
-  Spin,
-  Tag,
-  Tooltip,
-  Typography,
-  theme,
-} from 'antd';
+import { Alert, Badge, Button, Card, Popconfirm, Spin, Tooltip, Typography, theme } from 'antd';
 import { compressToBase64 } from 'lz-string';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
+import {
+  ArtifactConsoleReporter,
+  ArtifactRuntimeBridge,
+  ArtifactSandpackErrorReporter,
+  renderArtifactTrustBadge,
+} from '@/components/artifacts/ArtifactRenderSupport';
 import { getDaemonUrl } from '@/config/daemon';
+import { getAuthHeaders } from '@/utils/authHeaders';
 import { copyToClipboard } from '@/utils/clipboard';
 import { useThemedMessage } from '@/utils/message';
+import { ensureSandpackCryptoSubtle } from '@/utils/sandpackCrypto';
+import { uiRouteHref } from '@/utils/uiRoutes';
 import { ArtifactConsentModal } from '../../ArtifactConsentModal/ArtifactConsentModal';
 import { withBodyReset } from './utils/sandpackDefaults';
+
+ensureSandpackCryptoSubtle();
 
 interface ArtifactNodeData {
   objectId: string;
@@ -93,247 +63,6 @@ interface ArtifactNodeData {
 
 const MIN_WIDTH = 300;
 const MIN_HEIGHT = 200;
-
-/** Get auth headers for daemon REST calls (reads JWT from FeathersJS storage) */
-function getAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
-  return {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
-
-/**
- * Decode the current user's id from the Feathers JWT in localStorage.
- *
- * Used by the runtime-query bridge to filter out queries the daemon emits
- * for OTHER users — without this, every authenticated browser tab would
- * run the agent's selector against its own (potentially secret-bearing)
- * render. The server-side correlation already drops cross-user response
- * POSTs, but the actual DOM query still ran in the wrong tab. Filtering
- * client-side prevents the query from executing at all.
- *
- * Returns null on any parse failure — callers should treat that as
- * "don't run this query" (safe default).
- */
-function getCurrentUserIdFromJwt(): string | null {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('feathers-jwt') : null;
-  if (!token) return null;
-  try {
-    const parts = token.split('.');
-    if (parts.length < 2) return null;
-    // base64url → base64. atob requires `=` padding to a multiple of 4;
-    // base64url payloads are usually unpadded, so add it back before
-    // decoding. Without this, decode can throw on perfectly valid JWTs
-    // and we'd fail open (see the bridge's requester filter).
-    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    while (b64.length % 4 !== 0) b64 += '=';
-    const payload = JSON.parse(atob(b64));
-    return typeof payload.sub === 'string' ? payload.sub : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Inner component that captures Sandpack console events and forwards them to the daemon.
- * Must be inside SandpackProvider.
- */
-/** Max console entries to send per batch, and minimum interval between sends. */
-const CONSOLE_BATCH_MAX = 50;
-const CONSOLE_THROTTLE_MS = 2000;
-
-function ConsoleReporter({ artifactId }: { artifactId: string }) {
-  const { logs } = useSandpackConsole({ resetOnPreviewRestart: false });
-  const lastSentRef = useRef(0);
-  const lastSendTimeRef = useRef(0);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    if (logs.length <= lastSentRef.current) return;
-
-    const sendBatch = () => {
-      const newLogs = logs.slice(lastSentRef.current, lastSentRef.current + CONSOLE_BATCH_MAX);
-      lastSentRef.current = Math.min(logs.length, lastSentRef.current + CONSOLE_BATCH_MAX);
-      lastSendTimeRef.current = Date.now();
-
-      const entries = newLogs.map((log) => ({
-        timestamp: Date.now(),
-        level:
-          log.method === 'warn'
-            ? 'warn'
-            : log.method === 'error'
-              ? 'error'
-              : log.method === 'info'
-                ? 'info'
-                : 'log',
-        message:
-          log.data
-            ?.map((d: unknown) => (typeof d === 'string' ? d : JSON.stringify(d)))
-            .join(' ') ?? '',
-      }));
-
-      fetch(`${getDaemonUrl()}/artifacts/${artifactId}/console`, {
-        method: 'POST',
-        headers: getAuthHeaders(),
-        body: JSON.stringify({ entries }),
-      }).catch(() => {});
-    };
-
-    const elapsed = Date.now() - lastSendTimeRef.current;
-    if (elapsed >= CONSOLE_THROTTLE_MS) {
-      sendBatch();
-    } else if (!timerRef.current) {
-      timerRef.current = setTimeout(() => {
-        timerRef.current = null;
-        sendBatch();
-      }, CONSOLE_THROTTLE_MS - elapsed);
-    }
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    };
-  }, [logs, artifactId]);
-
-  return null;
-}
-
-/**
- * Inner component that captures Sandpack bundler/runtime errors and forwards them to the daemon.
- * These errors (e.g. "Could not find module './data'") happen inside Sandpack's bundler
- * before any user JS executes, so they never reach console.error.
- * Must be inside SandpackProvider.
- */
-const SANDPACK_ERROR_THROTTLE_MS = 1000;
-
-/**
- * Bridges agent-driven runtime queries: WS event from the daemon → postMessage
- * to the iframe → reply postMessage from `agor-runtime.js` → POST back to
- * the daemon's `/artifacts/:id/runtime-response/:requestId`. Must be inside
- * `<SandpackProvider>` so it can grab the iframe ref via `useSandpackClient`.
- *
- * Multiple ArtifactNode instances can be on the same board. Each registers
- * its own bridge; the one whose `artifactId` matches the incoming event
- * answers, the rest ignore. Server-side correlation also enforces that
- * the responding user matches the requester, so even if multiple tabs
- * answered the same query (one per ArtifactNode for the same artifact),
- * only the first response wins.
- */
-const RUNTIME_QUERY_DEFAULT_TIMEOUT_MS = 6000;
-function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
-  // CRITICAL: must be `useSandpack` (read existing clients) rather than
-  // `useSandpackClient` — the latter "registers a new sandpack client"
-  // and expects the caller to render its own <iframe> and pass the ref;
-  // because we don't render one, the ref stays null forever and the
-  // bridge can never postMessage to the actual preview iframe. By going
-  // through `sandpack.clients`, we grab the iframe the sibling
-  // <SandpackPreview> already registered with the provider.
-  const { sandpack } = useSandpack();
-  // Park the current sandpack state in a ref so the window-event handler
-  // can read the latest `clients` without re-attaching on every Sandpack
-  // re-render (status ticks, file updates, etc). Re-attaching would
-  // leave a brief gap where a daemon emit could miss the listener.
-  const sandpackRef = useRef(sandpack);
-  sandpackRef.current = sandpack;
-
-  useEffect(() => {
-    const handleQuery = (event: Event) => {
-      const detail = (event as CustomEvent).detail as {
-        request_id: string;
-        artifact_id: string;
-        requested_by_user_id?: string;
-        kind: string;
-        args: Record<string, unknown>;
-      };
-      if (!detail || detail.artifact_id !== artifactId) return;
-
-      // Requester filter: the daemon's `agor-query` event broadcasts on
-      // the global authenticated channel, so EVERY logged-in tab receives
-      // it. Without this client-side check, every tab would run the DOM
-      // query against its own (possibly secret-bearing) render — the
-      // server would later drop the wrong-user response, but the query
-      // would have already executed. Fail closed (skip the query) if we
-      // can't establish the viewer's identity — falling open here would
-      // re-introduce the cross-user privacy leak this filter exists to
-      // prevent.
-      if (detail.requested_by_user_id) {
-        const currentUserId = getCurrentUserIdFromJwt();
-        if (!currentUserId || currentUserId !== detail.requested_by_user_id) return;
-      }
-
-      const requestId = detail.request_id;
-      // Pick the first registered Sandpack client's iframe. In practice
-      // each ArtifactNode has one preview (one client). If multiple
-      // existed we'd target the first; the agor-runtime listener is
-      // identical across them so the choice is arbitrary.
-      const currentSandpack = sandpackRef.current;
-      const clientIds = Object.keys(currentSandpack.clients);
-      const firstClient = clientIds.length > 0 ? currentSandpack.clients[clientIds[0]] : null;
-      const target = firstClient?.iframe?.contentWindow ?? null;
-      if (!target) {
-        // Sandpack hasn't registered a client yet (still booting, or
-        // initMode='user-visible' is waiting for visibility). The
-        // daemon's pending entry will time out cleanly. The agent's
-        // retry will land after Sandpack is ready.
-        return;
-      }
-
-      const messageHandler = (msgEvent: MessageEvent) => {
-        const data = msgEvent.data;
-        if (!data || typeof data !== 'object') return;
-        if (data.type !== 'agor:result' || data.requestId !== requestId) return;
-        // Source check (defense in depth): only accept replies from the
-        // iframe we just dispatched to, not from any other postMessage
-        // source that happens to know our requestId.
-        if (msgEvent.source !== target) return;
-        cleanup();
-        void postResult({ ok: !!data.ok, result: data.result, error: data.error });
-      };
-      const timeout = setTimeout(() => {
-        cleanup();
-        void postResult({
-          ok: false,
-          error: 'Iframe did not respond before timeout (agor-runtime.js may be missing).',
-        });
-      }, RUNTIME_QUERY_DEFAULT_TIMEOUT_MS);
-      const cleanup = () => {
-        window.removeEventListener('message', messageHandler);
-        clearTimeout(timeout);
-      };
-
-      const postResult = async (body: { ok: boolean; result?: unknown; error?: string }) => {
-        try {
-          await fetch(`${getDaemonUrl()}/artifacts/${artifactId}/runtime-response/${requestId}`, {
-            method: 'POST',
-            headers: getAuthHeaders(),
-            body: JSON.stringify(body),
-          });
-        } catch {
-          // The daemon's pending entry will time out on its own — nothing
-          // we can do client-side if the response POST itself fails.
-        }
-      };
-
-      window.addEventListener('message', messageHandler);
-      // Forward to the iframe. Cross-origin so target origin is '*';
-      // payload carries no secrets, just a query for the iframe to run.
-      target.postMessage(
-        { type: 'agor:query', requestId, kind: detail.kind, args: detail.args },
-        '*'
-      );
-    };
-    window.addEventListener('agor:artifact-runtime-query', handleQuery);
-    return () => window.removeEventListener('agor:artifact-runtime-query', handleQuery);
-    // `sandpack` is read via sandpackRef at query time, so we don't need
-    // it in deps — the handler attaches once per artifact and keeps
-    // working as Sandpack re-renders.
-  }, [artifactId]);
-
-  return null;
-}
 
 /**
  * Eject the rendered artifact to a fresh CodeSandbox sandbox in a new tab.
@@ -427,75 +156,6 @@ function CodeSandboxExporter({ artifactId }: { artifactId: string }) {
   return null;
 }
 
-function SandpackErrorReporter({ artifactId }: { artifactId: string }) {
-  const { sandpack } = useSandpack();
-  const lastSentRef = useRef<string | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingSendRef = useRef<(() => void) | null>(null);
-
-  useEffect(() => {
-    // Serialize current state for comparison (includes status so status-only changes are sent)
-    const stateKey = `${sandpack.error?.message ?? ''}\0${sandpack.status}`;
-
-    // Skip if we already sent this exact state
-    if (stateKey === lastSentRef.current) return;
-
-    const sendError = () => {
-      lastSentRef.current = stateKey;
-      pendingSendRef.current = null;
-
-      const payload: {
-        error: {
-          message: string;
-          title?: string;
-          path?: string;
-          line?: number;
-          column?: number;
-        } | null;
-        status: string;
-      } = {
-        error: sandpack.error
-          ? {
-              message: sandpack.error.message,
-              ...(sandpack.error.title ? { title: sandpack.error.title } : {}),
-              ...(sandpack.error.path ? { path: sandpack.error.path } : {}),
-              ...(sandpack.error.line != null ? { line: sandpack.error.line } : {}),
-              ...(sandpack.error.column != null ? { column: sandpack.error.column } : {}),
-            }
-          : null,
-        status: sandpack.status,
-      };
-
-      fetch(`${getDaemonUrl()}/artifacts/${artifactId}/sandpack-error`, {
-        method: 'POST',
-        headers: getAuthHeaders(),
-        body: JSON.stringify(payload),
-      }).catch(() => {});
-    };
-
-    // Throttle to avoid spamming during rapid state changes
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-    pendingSendRef.current = sendError;
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null;
-      sendError();
-    }, SANDPACK_ERROR_THROTTLE_MS);
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-        // Flush pending update on unmount to avoid stale backend state
-        pendingSendRef.current?.();
-      }
-    };
-  }, [sandpack.error, sandpack.status, artifactId]);
-
-  return null;
-}
-
 export const ArtifactNode = ({
   data,
   selected,
@@ -575,6 +235,14 @@ export const ArtifactNode = ({
     window.dispatchEvent(new CustomEvent(`agor:export-codesandbox-${data.artifactId}`));
   }, [data.artifactId]);
 
+  const handleOpenFullscreen = useCallback(() => {
+    window.open(
+      uiRouteHref(artifactFullscreenPath(data.artifactId as ArtifactID)),
+      '_blank',
+      'noopener,noreferrer'
+    );
+  }, [data.artifactId]);
+
   // Title bar — always rendered, regardless of load state. When the
   // payload hasn't come back yet (initial fetch in flight, or the row's
   // files column got corrupted and getPayload threw), the user still
@@ -593,7 +261,9 @@ export const ArtifactNode = ({
       ? 'processing'
       : 'success';
   const headerBadgeTitle = error ? 'Failed to load' : loading ? 'Reloading...' : 'Live';
-  const trustBadge = payload ? renderTrustBadge(payload, () => setConsentOpen(true)) : null;
+  const trustBadge = payload
+    ? renderArtifactTrustBadge(payload, () => setConsentOpen(true), { className: 'nodrag nopan' })
+    : null;
   // A loaded payload that's also in the error state is stale — the body
   // renders the error placeholder, so the header shouldn't expose
   // payload-acting controls (Export / Interact / Consent) that operate
@@ -642,6 +312,17 @@ export const ArtifactNode = ({
             />
           </Tooltip>
         )}
+        <Tooltip title="Open fullscreen">
+          <Button
+            type="text"
+            size="small"
+            icon={<FullscreenOutlined />}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleOpenFullscreen();
+            }}
+          />
+        </Tooltip>
         {hasUsablePayload && (
           <Tooltip title="Open in CodeSandbox (eject — daemon-injected env vars/AGOR_TOKEN won't carry over)">
             <Button
@@ -916,8 +597,8 @@ export const ArtifactNode = ({
               showOpenInCodeSandbox={false}
               showRefreshButton={interactMode}
             />
-            <ConsoleReporter artifactId={data.artifactId} />
-            <SandpackErrorReporter artifactId={data.artifactId} />
+            <ArtifactConsoleReporter artifactId={data.artifactId} />
+            <ArtifactSandpackErrorReporter artifactId={data.artifactId} />
             <ArtifactRuntimeBridge artifactId={data.artifactId} />
             <CodeSandboxExporter artifactId={data.artifactId} />
           </SandpackProvider>
@@ -941,64 +622,6 @@ export const ArtifactNode = ({
     </>
   );
 };
-
-function renderTrustBadge(payload: ArtifactPayload, onTrustClick?: () => void) {
-  const state = payload.trust_state;
-  if (state === 'no_secrets_needed') return null;
-  if (state === 'self') {
-    return (
-      <Tag color="blue" icon={<SafetyOutlined />} style={{ fontSize: 10, marginLeft: 4 }}>
-        Yours
-      </Tag>
-    );
-  }
-  if (state === 'trusted') {
-    const scopeLabel =
-      payload.trust_scope === 'instance'
-        ? 'instance-wide'
-        : payload.trust_scope === 'author'
-          ? 'this author'
-          : payload.trust_scope === 'session'
-            ? 'just-once'
-            : 'this artifact';
-    return (
-      <Tooltip title={`Secrets injected — trust granted for ${scopeLabel}`}>
-        <Tag color="green" icon={<SafetyOutlined />} style={{ fontSize: 10, marginLeft: 4 }}>
-          Trusted
-        </Tag>
-      </Tooltip>
-    );
-  }
-  // 'untrusted' — the badge itself is the affordance. `nodrag nopan` is
-  // required because React Flow's drag handler arms on mousedown at the
-  // parent node level, which would swallow the click before onClick fires
-  // (stopPropagation on click is too late, same gotcha as the controls
-  // row above).
-  return (
-    <Tooltip title="Click to review and grant trust so secrets are injected">
-      <Tag
-        color="orange"
-        icon={<LockOutlined />}
-        className={onTrustClick ? 'nodrag nopan' : undefined}
-        style={{
-          fontSize: 10,
-          marginLeft: 4,
-          cursor: onTrustClick ? 'pointer' : undefined,
-        }}
-        onClick={
-          onTrustClick
-            ? (e) => {
-                e.stopPropagation();
-                onTrustClick();
-              }
-            : undefined
-        }
-      >
-        Untrusted
-      </Tag>
-    </Tooltip>
-  );
-}
 
 function LegacyBanner({ upgradeInstructions }: { upgradeInstructions: string }) {
   const { token } = theme.useToken();

--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -1,6 +1,6 @@
-import type { Artifact, Board, Branch } from '@agor-live/client';
-import { shortId } from '@agor-live/client';
-import { AimOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import type { Artifact, ArtifactID, Board, Branch } from '@agor-live/client';
+import { artifactFullscreenPath, shortId } from '@agor-live/client';
+import { AimOutlined, DeleteOutlined, EditOutlined, ExportOutlined } from '@ant-design/icons';
 import {
   Badge,
   Button,
@@ -18,6 +18,7 @@ import {
 } from 'antd';
 import { useCallback, useState } from 'react';
 import { mapToArray, mapToSortedArray } from '@/utils/mapHelpers';
+import { uiRouteHref } from '@/utils/uiRoutes';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 
 interface ArtifactsTableProps {
@@ -188,7 +189,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 120,
+      width: 150,
       render: (_: unknown, artifact: Artifact) => (
         <Space size="small">
           {artifact.board_id && (
@@ -204,6 +205,17 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
               />
             </Tooltip>
           )}
+          <Tooltip title="Open fullscreen">
+            <Button
+              type="text"
+              size="small"
+              icon={<ExportOutlined />}
+              href={uiRouteHref(artifactFullscreenPath(artifact.artifact_id as ArtifactID))}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </Tooltip>
           <Tooltip title="Edit artifact">
             <Button
               type="text"

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -1,0 +1,288 @@
+import type { ArtifactPayload } from '@agor-live/client';
+import { LockOutlined, SafetyOutlined } from '@ant-design/icons';
+import { useSandpack, useSandpackConsole } from '@codesandbox/sandpack-react';
+import { Tag, Tooltip } from 'antd';
+import type { CSSProperties } from 'react';
+import { useEffect, useRef } from 'react';
+import { getDaemonUrl } from '@/config/daemon';
+import { getAuthHeaders, getCurrentUserIdFromJwt } from '@/utils/authHeaders';
+
+/** Max console entries to send per batch, and minimum interval between sends. */
+const CONSOLE_BATCH_MAX = 50;
+const CONSOLE_THROTTLE_MS = 2000;
+const SANDPACK_ERROR_THROTTLE_MS = 1000;
+const RUNTIME_QUERY_DEFAULT_TIMEOUT_MS = 6000;
+
+/**
+ * Captures Sandpack console events and forwards them to the daemon.
+ * Must be rendered inside a SandpackProvider.
+ */
+export function ArtifactConsoleReporter({ artifactId }: { artifactId: string }) {
+  const { logs } = useSandpackConsole({ resetOnPreviewRestart: false });
+  const lastSentRef = useRef(0);
+  const lastSendTimeRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (logs.length <= lastSentRef.current) return;
+
+    const sendBatch = () => {
+      const newLogs = logs.slice(lastSentRef.current, lastSentRef.current + CONSOLE_BATCH_MAX);
+      lastSentRef.current = Math.min(logs.length, lastSentRef.current + CONSOLE_BATCH_MAX);
+      lastSendTimeRef.current = Date.now();
+
+      const entries = newLogs.map((log) => ({
+        timestamp: Date.now(),
+        level:
+          log.method === 'warn'
+            ? 'warn'
+            : log.method === 'error'
+              ? 'error'
+              : log.method === 'info'
+                ? 'info'
+                : 'log',
+        message:
+          log.data
+            ?.map((d: unknown) => (typeof d === 'string' ? d : JSON.stringify(d)))
+            .join(' ') ?? '',
+      }));
+
+      fetch(`${getDaemonUrl()}/artifacts/${artifactId}/console`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ entries }),
+      }).catch(() => {});
+    };
+
+    const elapsed = Date.now() - lastSendTimeRef.current;
+    if (elapsed >= CONSOLE_THROTTLE_MS) {
+      sendBatch();
+    } else if (!timerRef.current) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        sendBatch();
+      }, CONSOLE_THROTTLE_MS - elapsed);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [logs, artifactId]);
+
+  return null;
+}
+
+/**
+ * Captures Sandpack bundler/runtime errors and forwards them to the daemon.
+ * Must be rendered inside a SandpackProvider.
+ */
+export function ArtifactSandpackErrorReporter({ artifactId }: { artifactId: string }) {
+  const { sandpack } = useSandpack();
+  const lastSentRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSendRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const stateKey = `${sandpack.error?.message ?? ''}\0${sandpack.status}`;
+    if (stateKey === lastSentRef.current) return;
+
+    const sendError = () => {
+      lastSentRef.current = stateKey;
+      pendingSendRef.current = null;
+
+      const payload: {
+        error: {
+          message: string;
+          title?: string;
+          path?: string;
+          line?: number;
+          column?: number;
+        } | null;
+        status: string;
+      } = {
+        error: sandpack.error
+          ? {
+              message: sandpack.error.message,
+              ...(sandpack.error.title ? { title: sandpack.error.title } : {}),
+              ...(sandpack.error.path ? { path: sandpack.error.path } : {}),
+              ...(sandpack.error.line != null ? { line: sandpack.error.line } : {}),
+              ...(sandpack.error.column != null ? { column: sandpack.error.column } : {}),
+            }
+          : null,
+        status: sandpack.status,
+      };
+
+      fetch(`${getDaemonUrl()}/artifacts/${artifactId}/sandpack-error`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+      }).catch(() => {});
+    };
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    pendingSendRef.current = sendError;
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      sendError();
+    }, SANDPACK_ERROR_THROTTLE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        pendingSendRef.current?.();
+      }
+    };
+  }, [sandpack.error, sandpack.status, artifactId]);
+
+  return null;
+}
+
+/**
+ * Bridges agent-driven runtime queries: daemon WebSocket event → parent page →
+ * Sandpack iframe via postMessage → daemon response endpoint.
+ * Must be rendered inside a SandpackProvider.
+ */
+export function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
+  // CRITICAL: read existing clients rather than registering a new Sandpack client;
+  // the sibling SandpackPreview owns the actual iframe ref.
+  const { sandpack } = useSandpack();
+  const sandpackRef = useRef(sandpack);
+  sandpackRef.current = sandpack;
+
+  useEffect(() => {
+    const handleQuery = (event: Event) => {
+      const detail = (event as CustomEvent).detail as {
+        request_id: string;
+        artifact_id: string;
+        requested_by_user_id?: string;
+        kind: string;
+        args: Record<string, unknown>;
+      };
+      if (!detail || detail.artifact_id !== artifactId) return;
+
+      // Fail closed before executing a query meant for another user. The daemon
+      // also validates the responder, but this prevents a private DOM query from
+      // running in the wrong tab at all.
+      if (detail.requested_by_user_id) {
+        const currentUserId = getCurrentUserIdFromJwt();
+        if (!currentUserId || currentUserId !== detail.requested_by_user_id) return;
+      }
+
+      const requestId = detail.request_id;
+      const currentSandpack = sandpackRef.current;
+      const clientIds = Object.keys(currentSandpack.clients);
+      const firstClient = clientIds.length > 0 ? currentSandpack.clients[clientIds[0]] : null;
+      const target = firstClient?.iframe?.contentWindow ?? null;
+      if (!target) return;
+
+      const postResult = async (body: { ok: boolean; result?: unknown; error?: string }) => {
+        try {
+          await fetch(`${getDaemonUrl()}/artifacts/${artifactId}/runtime-response/${requestId}`, {
+            method: 'POST',
+            headers: getAuthHeaders(),
+            body: JSON.stringify(body),
+          });
+        } catch {
+          // The daemon's pending query will time out on its own.
+        }
+      };
+
+      const cleanup = () => {
+        window.removeEventListener('message', messageHandler);
+        clearTimeout(timeout);
+      };
+
+      const messageHandler = (msgEvent: MessageEvent) => {
+        const data = msgEvent.data;
+        if (!data || typeof data !== 'object') return;
+        if (data.type !== 'agor:result' || data.requestId !== requestId) return;
+        if (msgEvent.source !== target) return;
+        cleanup();
+        void postResult({ ok: !!data.ok, result: data.result, error: data.error });
+      };
+
+      const timeout = setTimeout(() => {
+        cleanup();
+        void postResult({
+          ok: false,
+          error: 'Iframe did not respond before timeout (agor-runtime.js may be missing).',
+        });
+      }, RUNTIME_QUERY_DEFAULT_TIMEOUT_MS);
+
+      window.addEventListener('message', messageHandler);
+      target.postMessage(
+        { type: 'agor:query', requestId, kind: detail.kind, args: detail.args },
+        '*'
+      );
+    };
+
+    window.addEventListener('agor:artifact-runtime-query', handleQuery);
+    return () => window.removeEventListener('agor:artifact-runtime-query', handleQuery);
+  }, [artifactId]);
+
+  return null;
+}
+
+interface ArtifactTrustBadgeOptions {
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function renderArtifactTrustBadge(
+  payload: ArtifactPayload,
+  onTrustClick?: () => void,
+  options: ArtifactTrustBadgeOptions = {}
+) {
+  const tagStyle = { fontSize: 10, marginLeft: 4, ...options.style };
+  const state = payload.trust_state;
+  if (state === 'no_secrets_needed') return null;
+  if (state === 'self') {
+    return (
+      <Tag color="blue" icon={<SafetyOutlined />} style={tagStyle}>
+        Yours
+      </Tag>
+    );
+  }
+  if (state === 'trusted') {
+    const scopeLabel =
+      payload.trust_scope === 'instance'
+        ? 'instance-wide'
+        : payload.trust_scope === 'author'
+          ? 'this author'
+          : payload.trust_scope === 'session'
+            ? 'just-once'
+            : 'this artifact';
+    return (
+      <Tooltip title={`Secrets injected — trust granted for ${scopeLabel}`}>
+        <Tag color="green" icon={<SafetyOutlined />} style={tagStyle}>
+          Trusted
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title="Click to review and grant trust so secrets are injected">
+      <Tag
+        color="orange"
+        icon={<LockOutlined />}
+        className={onTrustClick ? options.className : undefined}
+        style={{ ...tagStyle, cursor: onTrustClick ? 'pointer' : undefined }}
+        onClick={
+          onTrustClick
+            ? (e) => {
+                e.stopPropagation();
+                onTrustClick();
+              }
+            : undefined
+        }
+      >
+        Untrusted
+      </Tag>
+    </Tooltip>
+  );
+}

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -1,0 +1,390 @@
+import type { AgorClient, Artifact, ArtifactPayload, User } from '@agor-live/client';
+import {
+  ArrowLeftOutlined,
+  EyeInvisibleOutlined,
+  ReloadOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
+import { SandpackPreview, SandpackProvider, type SandpackSetup } from '@codesandbox/sandpack-react';
+import { Alert, Button, Layout, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import {
+  ArtifactConsoleReporter,
+  ArtifactRuntimeBridge,
+  ArtifactSandpackErrorReporter,
+  renderArtifactTrustBadge,
+} from '@/components/artifacts/ArtifactRenderSupport';
+import { getDaemonUrl } from '@/config/daemon';
+import { getAuthHeaders } from '@/utils/authHeaders';
+import { ensureSandpackCryptoSubtle } from '@/utils/sandpackCrypto';
+import { ArtifactConsentModal } from '../components/ArtifactConsentModal/ArtifactConsentModal';
+import { BrandLogo } from '../components/BrandLogo';
+import { GlobalUserMenu } from '../components/GlobalUserMenu';
+import { withBodyReset } from '../components/SessionCanvas/canvas/utils/sandpackDefaults';
+import { ThemeSwitcher } from '../components/ThemeSwitcher';
+
+ensureSandpackCryptoSubtle();
+
+const { Header, Content } = Layout;
+const { Title } = Typography;
+
+interface ArtifactFullscreenPageProps {
+  client: AgorClient | null;
+  currentUser?: User | null;
+  onUserSettingsClick?: () => void;
+  onLogout?: () => void;
+}
+
+interface ArtifactFullscreenNavbarProps {
+  artifact: Artifact | null;
+  payload: ArtifactPayload | null;
+  title: string;
+  loading: boolean;
+  currentUser?: User | null;
+  onReload: () => void;
+  onTrustClick: () => void;
+  onHideNavbar: () => void;
+  onUserSettingsClick?: () => void;
+  onLogout?: () => void;
+}
+
+function ArtifactFullscreenNavbar({
+  artifact,
+  payload,
+  title,
+  loading,
+  currentUser,
+  onReload,
+  onTrustClick,
+  onHideNavbar,
+  onUserSettingsClick,
+  onLogout,
+}: ArtifactFullscreenNavbarProps) {
+  const { token } = theme.useToken();
+  const trustBadge = payload ? renderArtifactTrustBadge(payload, onTrustClick) : null;
+
+  return (
+    <Header
+      style={{
+        height: 56,
+        padding: '0 16px',
+        background: token.colorBgContainer,
+        borderBottom: `1px solid ${token.colorBorderSecondary}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 16,
+      }}
+    >
+      <Space size={12} style={{ minWidth: 0, flex: 1, overflow: 'hidden' }}>
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          href={artifact?.url ?? undefined}
+          disabled={!artifact?.url}
+        >
+          Board
+        </Button>
+        <BrandLogo level={5} />
+        <div
+          style={{
+            minWidth: 0,
+            maxWidth: 420,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+          }}
+        >
+          <Title
+            level={5}
+            style={{ margin: 0, lineHeight: 1.2, minWidth: 0, flex: '1 1 auto' }}
+            ellipsis
+          >
+            {title}
+          </Title>
+          <Tooltip title="Hide navbar">
+            <Button
+              type="text"
+              size="small"
+              aria-label="Hide navbar"
+              icon={<EyeInvisibleOutlined />}
+              onClick={onHideNavbar}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            />
+          </Tooltip>
+        </div>
+        {trustBadge}
+      </Space>
+      <Space style={{ flexShrink: 0 }}>
+        {artifact?.url && (
+          <Button href={artifact.url} target="_blank" rel="noopener noreferrer">
+            Open board link
+          </Button>
+        )}
+        <Button icon={<ReloadOutlined />} onClick={onReload} loading={loading}>
+          Reload
+        </Button>
+        <ThemeSwitcher />
+        <GlobalUserMenu
+          user={currentUser}
+          onUserSettingsClick={onUserSettingsClick}
+          onLogout={onLogout}
+        />
+      </Space>
+    </Header>
+  );
+}
+
+export function ArtifactFullscreenPage({
+  client,
+  currentUser,
+  onUserSettingsClick,
+  onLogout,
+}: ArtifactFullscreenPageProps) {
+  const { token } = theme.useToken();
+  const { artifactShortId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const showNavbar =
+    searchParams.get('show_navbar') !== 'false' &&
+    searchParams.get('chrome') !== '0' &&
+    searchParams.get('navbar') !== '0';
+  const [artifact, setArtifact] = useState<Artifact | null>(null);
+  const [payload, setPayload] = useState<ArtifactPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [consentOpen, setConsentOpen] = useState(false);
+  const lastHashRef = useRef<string | null>(null);
+
+  const artifactIdParam = artifactShortId ?? '';
+
+  const fetchArtifact = useCallback(async () => {
+    if (!artifactIdParam) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const payloadResponse = await fetch(
+        `${getDaemonUrl()}/artifacts/${artifactIdParam}/payload`,
+        {
+          headers: getAuthHeaders(),
+        }
+      );
+      if (!payloadResponse.ok) {
+        throw new Error(`Failed to load artifact: ${payloadResponse.statusText}`);
+      }
+      const nextPayload = (await payloadResponse.json()) as ArtifactPayload;
+      setPayload(nextPayload);
+      if (client) {
+        try {
+          const metadata = await client.service('artifacts').get(nextPayload.artifact_id);
+          setArtifact(metadata as Artifact);
+        } catch {
+          // Metadata only powers the optional "back to board" link; payload
+          // access is the authoritative visibility/trust check for rendering.
+          setArtifact(null);
+        }
+      }
+      lastHashRef.current = nextPayload.content_hash;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [artifactIdParam, client]);
+
+  useEffect(() => {
+    fetchArtifact();
+  }, [fetchArtifact]);
+
+  // Lightweight equivalent of useAgorData's artifact runtime bridge wiring.
+  // The fullscreen surface intentionally does not hydrate Workspace data, but
+  // MCP DOM-query tools still need the artifacts service event forwarded to
+  // the Sandpack iframe bridge when this tab is the active viewer.
+  useEffect(() => {
+    if (!client) return;
+    const service = client.service('artifacts');
+    const handleAgorQuery = (event: unknown) => {
+      window.dispatchEvent(new CustomEvent('agor:artifact-runtime-query', { detail: event }));
+    };
+    service.on('agor-query', handleAgorQuery);
+    return () => {
+      service.removeListener('agor-query', handleAgorQuery);
+    };
+  }, [client]);
+
+  useEffect(() => {
+    if (!client) return;
+    const service = client.service('artifacts');
+    const handler = (updated: Artifact) => {
+      const currentId = payload?.artifact_id ?? artifact?.artifact_id;
+      if (!currentId || updated.artifact_id !== currentId) return;
+      setArtifact(updated);
+      if (updated.content_hash && updated.content_hash !== lastHashRef.current) {
+        fetchArtifact();
+      }
+    };
+    service.on('patched', handler);
+    service.on('updated', handler);
+    return () => {
+      service.removeListener('patched', handler);
+      service.removeListener('updated', handler);
+    };
+  }, [artifact?.artifact_id, client, fetchArtifact, payload?.artifact_id]);
+
+  const sandpackConfig = payload?.sandpack_config ?? {};
+  const sandpackOptions = sandpackConfig.options ?? {};
+  const customSetup = payload
+    ? {
+        ...(sandpackConfig.customSetup ?? {}),
+        ...(payload.dependencies && !sandpackConfig.customSetup?.dependencies
+          ? { dependencies: payload.dependencies }
+          : {}),
+      }
+    : {};
+  const sandpackTemplate = (sandpackConfig.template ?? payload?.template ?? 'react') as 'react';
+  const title = payload?.name ?? artifact?.name ?? `Artifact ${artifactIdParam}`;
+
+  const hideNavbar = useCallback(() => {
+    const next = new URLSearchParams(searchParams);
+    next.set('show_navbar', 'false');
+    next.delete('chrome');
+    next.delete('navbar');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const showNavbarAgain = useCallback(() => {
+    const next = new URLSearchParams(searchParams);
+    next.delete('show_navbar');
+    next.delete('chrome');
+    next.delete('navbar');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const body = (() => {
+    if (loading && !payload) {
+      return <Spin size="large" tip="Loading artifact..." />;
+    }
+    if (error) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          title="Failed to load artifact"
+          description={error}
+          action={<Button onClick={fetchArtifact}>Retry</Button>}
+        />
+      );
+    }
+    if (!payload) return null;
+    return (
+      <div style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column' }}>
+        {payload.legacy?.is_legacy && (
+          <Alert
+            type="warning"
+            showIcon
+            icon={<WarningOutlined />}
+            message="Legacy artifact — may not render correctly"
+            description="Open the board artifact card for the copyable upgrade prompt."
+            style={{ borderRadius: 0 }}
+          />
+        )}
+        <style>{`
+          .artifact-fullscreen-sandpack .sp-wrapper,
+          .artifact-fullscreen-sandpack .sp-layout,
+          .artifact-fullscreen-sandpack .sp-stack,
+          .artifact-fullscreen-sandpack .sp-preview,
+          .artifact-fullscreen-sandpack .sp-preview-container {
+            height: 100% !important;
+          }
+        `}</style>
+        <div className="artifact-fullscreen-sandpack" style={{ flex: 1, minHeight: 0 }}>
+          <SandpackProvider
+            key={payload.content_hash}
+            template={sandpackTemplate}
+            files={withBodyReset(payload.files)}
+            customSetup={
+              Object.keys(customSetup).length > 0 ? (customSetup as SandpackSetup) : undefined
+            }
+            theme={sandpackConfig.theme as never}
+            options={{
+              initMode: 'user-visible',
+              ...sandpackOptions,
+              ...(payload.entry && !sandpackOptions.activeFile
+                ? { activeFile: payload.entry }
+                : {}),
+            }}
+          >
+            <SandpackPreview
+              style={{ height: '100%', border: 'none' }}
+              showNavigator={false}
+              showOpenInCodeSandbox={false}
+              showRefreshButton
+            />
+            <ArtifactConsoleReporter artifactId={payload.artifact_id} />
+            <ArtifactSandpackErrorReporter artifactId={payload.artifact_id} />
+            <ArtifactRuntimeBridge artifactId={payload.artifact_id} />
+          </SandpackProvider>
+        </div>
+      </div>
+    );
+  })();
+
+  return (
+    <Layout style={{ minHeight: '100vh', background: token.colorBgLayout }}>
+      {showNavbar ? (
+        <ArtifactFullscreenNavbar
+          artifact={artifact}
+          payload={payload}
+          title={title}
+          loading={loading}
+          currentUser={currentUser}
+          onReload={fetchArtifact}
+          onTrustClick={() => setConsentOpen(true)}
+          onHideNavbar={hideNavbar}
+          onUserSettingsClick={onUserSettingsClick}
+          onLogout={onLogout}
+        />
+      ) : (
+        <Button
+          size="small"
+          onClick={showNavbarAgain}
+          style={{ position: 'fixed', top: 12, right: 12, zIndex: 10 }}
+        >
+          Show navbar
+        </Button>
+      )}
+      <Content
+        style={{
+          height: showNavbar ? 'calc(100vh - 56px)' : '100vh',
+          display: 'flex',
+          alignItems: loading && !payload ? 'center' : 'stretch',
+          justifyContent: loading && !payload ? 'center' : 'stretch',
+          overflow: 'hidden',
+          background: token.colorBgContainer,
+        }}
+      >
+        {body}
+      </Content>
+      {payload && consentOpen && (
+        <ArtifactConsentModal
+          open={consentOpen}
+          artifactId={payload.artifact_id}
+          name={payload.name}
+          files={payload.files}
+          requiredEnvVars={payload.required_env_vars ?? []}
+          grants={payload.agor_grants ?? {}}
+          onClose={() => setConsentOpen(false)}
+          onGranted={() => {
+            setConsentOpen(false);
+            fetchArtifact();
+          }}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
@@ -43,6 +43,15 @@ describe('surface route registry', () => {
     expect(routeUsesSharedUserSettings(path)).toBe(false);
   });
 
+  it.each(['/a/artifact/fullscreen'])('classifies %s as Artifact fullscreen', (path) => {
+    expect(getRouteSurface(path).id).toBe('artifact-fullscreen');
+    expect(isKnowledgeRoutePath(path)).toBe(false);
+    expect(isWorkspaceRoutePath(path)).toBe(false);
+    expect(routeStartsWorkspaceRuntime(path)).toBe(false);
+    expect(routeUsesDeviceRouter(path)).toBe(false);
+    expect(routeUsesSharedUserSettings(path)).toBe(true);
+  });
+
   it('keeps the registered standalone demo route lightweight', () => {
     expect(getRouteSurface('/demo/streamdown').id).toBe('demo');
     expect(routeStartsWorkspaceRuntime('/demo/streamdown')).toBe(false);

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.ts
@@ -1,6 +1,6 @@
 import { matchPath } from 'react-router-dom';
 
-export type RouteSurfaceId = 'workspace' | 'knowledge' | 'demo';
+export type RouteSurfaceId = 'workspace' | 'knowledge' | 'artifact-fullscreen' | 'demo';
 
 export interface RouteSurfaceDefinition {
   id: RouteSurfaceId;
@@ -47,6 +47,17 @@ export const KNOWLEDGE_SURFACE = defineSurface({
   usesSharedUserSettings: true,
 });
 
+export const ARTIFACT_FULLSCREEN_ROUTE_PATHS = ['/a/:artifactShortId/fullscreen'] as const;
+
+export const ARTIFACT_FULLSCREEN_SURFACE = defineSurface({
+  id: 'artifact-fullscreen',
+  label: 'Artifact fullscreen',
+  routePaths: ARTIFACT_FULLSCREEN_ROUTE_PATHS,
+  startsWorkspaceRuntime: false,
+  usesDeviceRouter: false,
+  usesSharedUserSettings: true,
+});
+
 export const DEMO_SURFACE = defineSurface({
   id: 'demo',
   label: 'Demo',
@@ -65,7 +76,12 @@ export const WORKSPACE_SURFACE = defineSurface({
   usesSharedUserSettings: false,
 });
 
-export const SURFACE_REGISTRY = [KNOWLEDGE_SURFACE, DEMO_SURFACE, WORKSPACE_SURFACE] as const;
+export const SURFACE_REGISTRY = [
+  KNOWLEDGE_SURFACE,
+  ARTIFACT_FULLSCREEN_SURFACE,
+  DEMO_SURFACE,
+  WORKSPACE_SURFACE,
+] as const;
 
 export function getRouteSurface(pathname: string): RouteSurfaceDefinition {
   return (

--- a/apps/agor-ui/src/utils/authHeaders.test.ts
+++ b/apps/agor-ui/src/utils/authHeaders.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getAgorAccessToken, getAuthHeaders, getCurrentUserIdFromJwt } from './authHeaders';
+
+function jwtWithPayload(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString('base64url').replace(/=+$/, '');
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.`;
+}
+
+describe('authHeaders', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('prefers the active Agor access token over the legacy Feathers token', () => {
+    localStorage.setItem('agor-access-token', 'access-token');
+    localStorage.setItem('feathers-jwt', 'legacy-token');
+
+    expect(getAgorAccessToken()).toBe('access-token');
+    expect(getAuthHeaders()).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer access-token',
+    });
+  });
+
+  it('falls back to the legacy Feathers token', () => {
+    localStorage.setItem('feathers-jwt', 'legacy-token');
+
+    expect(getAgorAccessToken()).toBe('legacy-token');
+    expect(getAuthHeaders()).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer legacy-token',
+    });
+  });
+
+  it('decodes the current user id from the active token', () => {
+    localStorage.setItem('agor-access-token', jwtWithPayload({ sub: 'user-123' }));
+    localStorage.setItem('feathers-jwt', jwtWithPayload({ sub: 'legacy-user' }));
+
+    expect(getCurrentUserIdFromJwt()).toBe('user-123');
+  });
+
+  it('fails closed on malformed tokens', () => {
+    localStorage.setItem('agor-access-token', 'not-a-jwt');
+
+    expect(getCurrentUserIdFromJwt()).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/utils/authHeaders.ts
+++ b/apps/agor-ui/src/utils/authHeaders.ts
@@ -1,0 +1,37 @@
+import { getStoredAccessToken } from './tokenRefresh';
+
+export function getAgorAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return getStoredAccessToken() ?? localStorage.getItem('feathers-jwt');
+}
+
+/** Get auth headers for daemon REST calls. */
+export function getAuthHeaders(): HeadersInit {
+  const token = getAgorAccessToken();
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+/**
+ * Decode the current user's id from the active Agor access token.
+ *
+ * Used by artifact runtime-query bridges to fail closed before executing a
+ * query intended for another user. Falls back to the legacy Feathers token for
+ * older sessions that have not migrated to the access/refresh token pair yet.
+ */
+export function getCurrentUserIdFromJwt(): string | null {
+  const token = getAgorAccessToken();
+  if (!token) return null;
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) b64 += '=';
+    const payload = JSON.parse(atob(b64));
+    return typeof payload.sub === 'string' ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/agor-ui/src/utils/sandpackCrypto.ts
+++ b/apps/agor-ui/src/utils/sandpackCrypto.ts
@@ -1,0 +1,20 @@
+/**
+ * Sandpack uses crypto.subtle.digest() to generate short IDs. Plain HTTP
+ * contexts do not expose WebCrypto subtle, so provide the same lightweight
+ * non-cryptographic fallback everywhere Agor renders Sandpack artifacts.
+ */
+export function ensureSandpackCryptoSubtle(): void {
+  if (typeof globalThis.crypto === 'undefined' || globalThis.crypto.subtle) return;
+
+  // biome-ignore lint/suspicious/noExplicitAny: minimal polyfill for Sandpack compatibility
+  (globalThis.crypto as any).subtle = {
+    async digest(_algo: string, data: ArrayBuffer) {
+      const bytes = new Uint8Array(data);
+      let hash = 0;
+      for (const b of bytes) hash = (hash * 31 + b) | 0;
+      const result = new ArrayBuffer(4);
+      new DataView(result).setInt32(0, hash);
+      return result;
+    },
+  };
+}

--- a/apps/agor-ui/src/utils/uiRoutes.test.ts
+++ b/apps/agor-ui/src/utils/uiRoutes.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { getRouterBasename, uiRouteHref } from './uiRoutes';
+
+describe('uiRoutes', () => {
+  it('uses the /ui basename when the UI is mounted under /ui', () => {
+    expect(getRouterBasename('/ui/')).toBe('/ui');
+    expect(uiRouteHref('/a/artifact/fullscreen', '/ui/')).toBe('/ui/a/artifact/fullscreen');
+  });
+
+  it('omits the basename for dev-root mounted UI routes', () => {
+    expect(getRouterBasename('/')).toBe('');
+    expect(uiRouteHref('a/artifact/fullscreen', '/')).toBe('/a/artifact/fullscreen');
+  });
+});

--- a/apps/agor-ui/src/utils/uiRoutes.ts
+++ b/apps/agor-ui/src/utils/uiRoutes.ts
@@ -1,0 +1,9 @@
+import { UI_MOUNT_PATH } from '@agor-live/client';
+
+export function getRouterBasename(baseUrl = import.meta.env.BASE_URL): string {
+  return baseUrl === `${UI_MOUNT_PATH}/` ? UI_MOUNT_PATH : '';
+}
+
+export function uiRouteHref(path: string, baseUrl = import.meta.env.BASE_URL): string {
+  return `${getRouterBasename(baseUrl)}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -80,10 +80,12 @@ export {
 // agent share-link generation. See `packages/core/src/utils/url.ts` for
 // the path shape and `UI_MOUNT_PATH` convention.
 export {
+  artifactFullscreenPath,
   artifactPath,
   boardPath,
   branchPath,
   ENTITY_PATH_SEGMENTS,
+  getArtifactFullscreenUrl,
   getArtifactUrl,
   getBoardUrl,
   getBranchUrl,

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -19,7 +19,7 @@ import type {
 import { and, eq, like, or } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
-import { getArtifactUrl } from '../../utils/url';
+import { getArtifactFullscreenUrl, getArtifactUrl } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type ArtifactInsert, type ArtifactRow, artifacts } from '../schema';
@@ -46,6 +46,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
   private rowToArtifact(row: ArtifactRow, baseUrl?: string): Artifact {
     const artifactId = row.artifact_id as ArtifactID;
     const url = baseUrl && row.board_id ? getArtifactUrl(artifactId, baseUrl) : null;
+    const fullscreenUrl = baseUrl ? getArtifactFullscreenUrl(artifactId, baseUrl) : null;
     return {
       artifact_id: artifactId as UUID,
       branch_id: (row.branch_id as BranchID) ?? null,
@@ -70,6 +71,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       updated_at: new Date(row.updated_at).toISOString(),
       archived: Boolean(row.archived),
       archived_at: row.archived_at ? new Date(row.archived_at).toISOString() : undefined,
+      fullscreen_url: fullscreenUrl,
       url,
     };
   }

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -214,6 +214,13 @@ export interface Artifact {
   archived_at?: string | null;
 
   /**
+   * External/user-facing URL for viewing this artifact fullscreen, outside
+   * board canvas/card chrome. Format: `{baseUrl}/ui/a/{artifactShortId}/fullscreen`
+   * Append `?show_navbar=false` client-side to hide the compact navbar.
+   */
+  fullscreen_url?: string | null;
+
+  /**
    * External/user-facing URL for viewing this artifact in the UI.
    *
    * Computed property added by the repository layer. Optional —

--- a/packages/core/src/utils/url.test.ts
+++ b/packages/core/src/utils/url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ArtifactID, BoardID, BranchID, SessionID } from '../types/id';
 import {
+  getArtifactFullscreenUrl,
   getArtifactUrl,
   getBoardUrl,
   getBranchUrl,
@@ -48,6 +49,13 @@ describe('entity URL builders — fullUrl double-prefix regression', () => {
   it('produces correct artifact URL when baseUrl has /ui suffix', () => {
     const url = getArtifactUrl(ARTIFACT_ID, 'https://agor.example.com/ui');
     expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/a\//);
+    expect(url).not.toContain('/ui/ui/');
+  });
+
+  it('produces correct artifact fullscreen URL when baseUrl has /ui suffix', () => {
+    const url = getArtifactFullscreenUrl(ARTIFACT_ID, 'https://agor.example.com/ui');
+    expect(url).toMatch(/^https:\/\/agor\.example\.com\/ui\/a\//);
+    expect(url).toMatch(/\/fullscreen$/);
     expect(url).not.toContain('/ui/ui/');
   });
 

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -94,6 +94,12 @@ export function artifactPath(artifactId: ArtifactID): string {
   return `/${ENTITY_PATH_SEGMENTS.artifact}/${shortId(artifactId)}/`;
 }
 
+/** `/a/<artifactShort>/fullscreen` — lightweight fullscreen artifact surface.
+ *  Optional UI chrome is controlled client-side with `?show_navbar=false`. */
+export function artifactFullscreenPath(artifactId: ArtifactID): string {
+  return `/${ENTITY_PATH_SEGMENTS.artifact}/${shortId(artifactId)}/fullscreen`;
+}
+
 function encodePathSegments(path: string): string {
   return path
     .split('/')
@@ -163,6 +169,13 @@ export function getBranchUrl(branchId: BranchID, baseUrl: string): string {
  *  resolves to its board at click time. */
 export function getArtifactUrl(artifactId: ArtifactID, baseUrl: string): string {
   return fullUrl(artifactPath(artifactId), baseUrl);
+}
+
+/** Generate a lightweight fullscreen artifact URL. Renders the artifact
+ *  outside the board canvas/card chrome. Append `?show_navbar=false` to hide the
+ *  compact navbar. */
+export function getArtifactFullscreenUrl(artifactId: ArtifactID, baseUrl: string): string {
+  return fullUrl(artifactFullscreenPath(artifactId), baseUrl);
 }
 
 /** Generate a Knowledge URL from namespace + optional document path. */


### PR DESCRIPTION
## Summary
- Add a lightweight fullscreen artifact route at `/a/:artifactShortId/fullscreen`
- Expose `fullscreen_url` on artifact responses and shared client URL helpers
- Add a fullscreen action to the artifact card header
- Add an open-fullscreen link-out action to the Settings → Artifacts CRUD table
- Add a default fullscreen artifact navbar with board/reload/theme/user controls and trust badge/modal access
- Route fullscreen artifacts through the lightweight surface registry so fresh loads avoid hydrating full board/session workspace state
- Preserve artifact auth/trust/env/runtime behavior by fetching the authenticated payload route and forwarding artifact runtime MCP query events directly on the fullscreen surface
- Refactor shared artifact render support (console reporting, Sandpack error reporting, runtime bridge, trust badge, Sandpack HTTP crypto fallback) so board and fullscreen surfaces do not drift
- Centralize raw REST auth headers to prefer the active `agor-access-token`, falling back to legacy `feathers-jwt`
- Add focused tests for token header selection, UI route basename handling, and `fullscreen_url` propagation

## Route / navbar behavior
- Default fullscreen URL: `/ui/a/<artifactShortId>/fullscreen`
- The navbar is shown by default so users can see and act on trust state
- The navbar has a hide/visibility icon next to the artifact title with a tooltip; when hidden, a small “Show navbar” affordance lets users recover the trust controls
- Navbar can also be hidden directly with `?show_navbar=false`; legacy `?chrome=0` / `?navbar=0` are still accepted

## Validation
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui typecheck`
- `pnpm --filter @agor/core test -- src/utils/url.test.ts`
- `pnpm --filter agor-ui test -- src/surfaces/surfaceRegistry.test.ts`
- `pnpm --filter agor-ui test -- src/utils/authHeaders.test.ts`
- `pnpm --filter agor-ui test -- src/utils/uiRoutes.test.ts`
- `pnpm --filter @agor/daemon test -- src/services/artifacts.test.ts`
- `git diff --check`

Note: `pnpm check` emitted existing Biome warnings in unrelated files, but completed successfully.
