### PR TITLE
Polish Knowledge Base layout

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -50,6 +50,7 @@ import {
   useSessionActions,
 } from './hooks';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
+import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
 import {
   ARTIFACT_FULLSCREEN_ROUTE_PATHS,
   KNOWLEDGE_ROUTE_PATHS,
@@ -59,23 +60,75 @@ import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLife
 import { isMobileDevice } from './utils/deviceDetection';
 import { useThemedMessage } from './utils/message';
 
-const AgorApp = lazy(() => import('./components/App').then((module) => ({ default: module.App })));
-const KnowledgePage = lazy(() =>
-  import('./pages/KnowledgePage').then((module) => ({ default: module.KnowledgePage }))
+type RouteModuleKey = RouteSurfaceId | 'mobile';
+
+const loadedRouteModuleKeys = new Set<RouteModuleKey>();
+
+function cacheRouteLoader<TModule, TRouteModule>(
+  moduleKey: RouteModuleKey,
+  importModule: () => Promise<TModule>,
+  selectDefault: (module: TModule) => TRouteModule
+) {
+  let promise: Promise<TRouteModule> | null = null;
+
+  return () => {
+    promise ??= importModule().then((module) => {
+      loadedRouteModuleKeys.add(moduleKey);
+      return selectDefault(module);
+    });
+    return promise;
+  };
+}
+
+const loadAgorApp = cacheRouteLoader(
+  'workspace',
+  () => import('./components/App'),
+  (module) => ({ default: module.App })
 );
-const ArtifactFullscreenPage = lazy(() =>
-  import('./pages/ArtifactFullscreenPage').then((module) => ({
-    default: module.ArtifactFullscreenPage,
-  }))
+const loadKnowledgePage = cacheRouteLoader(
+  'knowledge',
+  () => import('./pages/KnowledgePage'),
+  (module) => ({ default: module.KnowledgePage })
 );
-const MobileApp = lazy(() =>
-  import('./components/mobile/MobileApp').then((module) => ({ default: module.MobileApp }))
+const loadArtifactFullscreenPage = cacheRouteLoader(
+  'artifact-fullscreen',
+  () => import('./pages/ArtifactFullscreenPage'),
+  (module) => ({ default: module.ArtifactFullscreenPage })
 );
-const StreamdownDemoPage = lazy(() =>
-  import('./pages/StreamdownDemoPage').then((module) => ({
-    default: module.StreamdownDemoPage,
-  }))
+const loadMobileApp = cacheRouteLoader(
+  'mobile',
+  () => import('./components/mobile/MobileApp'),
+  (module) => ({ default: module.MobileApp })
 );
+const loadStreamdownDemoPage = cacheRouteLoader(
+  'demo',
+  () => import('./pages/StreamdownDemoPage'),
+  (module) => ({ default: module.StreamdownDemoPage })
+);
+
+const AgorApp = lazy(loadAgorApp);
+const KnowledgePage = lazy(loadKnowledgePage);
+const ArtifactFullscreenPage = lazy(loadArtifactFullscreenPage);
+const MobileApp = lazy(loadMobileApp);
+const StreamdownDemoPage = lazy(loadStreamdownDemoPage);
+
+const routeModuleLoaders = {
+  workspace: loadAgorApp,
+  knowledge: loadKnowledgePage,
+  'artifact-fullscreen': loadArtifactFullscreenPage,
+  demo: loadStreamdownDemoPage,
+  mobile: loadMobileApp,
+} satisfies Record<RouteModuleKey, () => Promise<unknown>>;
+
+function getRouteModuleKey(surfaceId: RouteSurfaceId, pathname: string): RouteModuleKey {
+  if (pathname.startsWith('/m')) return 'mobile';
+  return surfaceId;
+}
+
+function preloadRouteModule(moduleKey: RouteModuleKey): Promise<unknown> {
+  if (loadedRouteModuleKeys.has(moduleKey)) return Promise.resolve();
+  return routeModuleLoaders[moduleKey]();
+}
 
 /**
  * DeviceRouter - Redirects users to mobile or desktop site based on device detection
@@ -133,22 +186,30 @@ function AppContent() {
     location.pathname
   );
   const sharedSurfaceOwnsUserSettings = currentSurface.usesSharedUserSettings;
-
-  const routeFallback = (
-    <div
-      style={{
-        height: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: token.colorBgLayout,
-      }}
-    >
-      <Spin size="large" />
-      <div style={{ marginTop: 16, color: token.colorTextSecondary }}>Loading surface...</div>
-    </div>
+  const routeModuleKey = getRouteModuleKey(currentSurface.id, location.pathname);
+  const [routeModuleReady, setRouteModuleReady] = useState(() =>
+    loadedRouteModuleKeys.has(routeModuleKey)
   );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!loadedRouteModuleKeys.has(routeModuleKey)) {
+      setRouteModuleReady(false);
+    }
+
+    preloadRouteModule(routeModuleKey)
+      .catch(() => {
+        // Let React.lazy/ErrorBoundary surface the route-load failure.
+      })
+      .finally(() => {
+        if (!cancelled) setRouteModuleReady(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [routeModuleKey]);
 
   // Fetch daemon auth and instance configuration
   const {
@@ -268,8 +329,37 @@ function AppContent() {
     loading,
     dataError,
     mustChangePassword,
-    initialLoadComplete,
+    // Treat the route surface chunk as part of the initial load so the loader
+    // only performs its fade-out once. Otherwise the data loader can fade to 0
+    // and then pop back to opacity 1 while the lazy route module finishes.
+    initialLoadComplete: initialLoadComplete && routeModuleReady,
   });
+
+  const workspaceLoadingFallback = (
+    <InitialLoadingScreen
+      phase={loaderPhase === 'done' ? 'fading' : loaderPhase}
+      connecting={connecting}
+      items={initialLoadItems}
+    />
+  );
+
+  const routeFallback = workspaceSurfaceShouldRun ? (
+    workspaceLoadingFallback
+  ) : (
+    <div
+      style={{
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: token.colorBgLayout,
+      }}
+    >
+      <Spin size="large" />
+      <div style={{ marginTop: 16, color: token.colorTextSecondary }}>Loading surface...</div>
+    </div>
+  );
 
   // Get current user from users Map (real-time updates via WebSocket)
   // This ensures we get the latest onboarding_completed status
@@ -506,10 +596,8 @@ function AppContent() {
 
   // Show loading state ONLY on initial load, not during reconnections
   // Once data is loaded, keep UI mounted and show connection status in header instead
-  if (workspaceSurfaceShouldRun && loaderPhase !== 'done') {
-    return (
-      <InitialLoadingScreen phase={loaderPhase} connecting={connecting} items={initialLoadItems} />
-    );
+  if (workspaceSurfaceShouldRun && (loaderPhase !== 'done' || !routeModuleReady)) {
+    return workspaceLoadingFallback;
   }
 
   // Show data error (but not if user needs to change password - let the modal render)

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppHeader } from './AppHeader';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../contexts/ConnectionContext', () => ({
+  useConnectionDisabled: () => false,
+}));
+
+vi.mock('../BoardSwitcher', () => ({
+  BoardSwitcher: () => <div data-testid="board-switcher" />,
+}));
+vi.mock('../BrandLogo', () => ({
+  BrandLogo: () => <div data-testid="brand-logo" />,
+}));
+vi.mock('../ConnectionStatus', () => ({
+  ConnectionStatus: () => null,
+}));
+vi.mock('../GlobalSearch', () => ({
+  GlobalSearch: () => <div data-testid="global-search" />,
+}));
+vi.mock('../GlobalUserMenu', () => ({
+  GlobalUserMenu: () => <div data-testid="global-user-menu" />,
+}));
+vi.mock('../MarkdownRenderer', () => ({
+  MarkdownRenderer: () => <div data-testid="markdown-renderer" />,
+}));
+vi.mock('../ThemeSwitcher', () => ({
+  ThemeSwitcher: () => <div data-testid="theme-switcher" />,
+}));
+vi.mock('./GlobalPresenceFacepile', () => ({
+  GlobalPresenceFacepile: () => <div data-testid="presence-facepile" />,
+}));
+
+function renderHeader() {
+  return render(
+    <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
+      <AppHeader
+        branchById={new Map()}
+        boardById={new Map()}
+        sessionById={new Map()}
+        artifactById={new Map()}
+        mcpServerById={new Map()}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('AppHeader Knowledge link', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders a basename-aware href for modified clicks and new tabs', () => {
+    renderHeader();
+
+    expect(screen.getByRole('link', { name: 'Knowledge' })).toHaveAttribute(
+      'href',
+      '/ui/knowledge'
+    );
+  });
+
+  it('uses SPA navigation and prevents default for plain left clicks', () => {
+    renderHeader();
+
+    const eventWasNotCancelled = fireEvent.click(screen.getByRole('link', { name: 'Knowledge' }));
+
+    expect(eventWasNotCancelled).toBe(false);
+    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/knowledge');
+  });
+
+  it('lets modified clicks fall through to the browser', () => {
+    renderHeader();
+
+    const knowledgeLink = screen.getByRole('link', { name: 'Knowledge' });
+    // Remove the href after locating the link so jsdom does not attempt real navigation.
+    // This still exercises the click handler's modified-click behavior.
+    knowledgeLink.removeAttribute('href');
+
+    const eventWasNotCancelled = fireEvent.click(knowledgeLink, { metaKey: true });
+
+    expect(eventWasNotCancelled).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -17,7 +17,7 @@ import {
   UnorderedListOutlined,
 } from '@ant-design/icons';
 import { Badge, Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
-import { useNavigate } from 'react-router-dom';
+import { useHref, useNavigate } from 'react-router-dom';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { BoardSwitcher } from '../BoardSwitcher';
 import { BrandLogo } from '../BrandLogo';
@@ -147,6 +147,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
+  const knowledgeHref = useHref('/knowledge');
   // Single source of truth for "is the daemon usable right now?". Captures
   // disconnected, the 1.5s reconnect grace window, and out-of-sync. Don't
   // gate off raw `connected` — it stays true through the grace window.
@@ -299,7 +300,22 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             type="text"
             icon={<BookOutlined style={{ fontSize: token.fontSizeLG }} />}
             style={headerIconButtonStyle}
-            onClick={() => navigate('/knowledge')}
+            href={knowledgeHref}
+            aria-label="Knowledge"
+            onClick={(event) => {
+              if (event.defaultPrevented) return;
+              if (
+                event.button !== 0 ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey
+              ) {
+                return;
+              }
+              event.preventDefault();
+              navigate('/knowledge');
+            }}
           />
         </Tooltip>
         <Tooltip title="Documentation" placement="bottom">

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BranchTab.test.tsx
@@ -27,7 +27,7 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
   } as unknown as Repo;
 }
 
-describe('BranchTab — source-branch preservation', { timeout: 10_000 }, () => {
+describe('BranchTab — source-branch preservation', () => {
   it('preserves user-typed sourceBranch across `repoById` Map reference churn (WebSocket patches)', () => {
     const formRef: React.MutableRefObject<(() => Promise<BranchTabConfig | null>) | null> = {
       current: null,
@@ -63,7 +63,7 @@ describe('BranchTab — source-branch preservation', { timeout: 10_000 }, () => 
   });
 });
 
-describe('BranchTab — branch storage policy', { timeout: 10_000 }, () => {
+describe('BranchTab — branch storage policy', () => {
   async function renderBranchTab(
     branchStorageConfig?: React.ComponentProps<typeof BranchTab>['branchStorageConfig']
   ) {

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -68,6 +68,12 @@ import {
 import type { DataNode } from 'antd/es/tree';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ImperativePanelHandle,
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+} from 'react-resizable-panels';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArchiveActionButton } from '../components/ArchiveButton';
 import {
@@ -81,6 +87,7 @@ import { KnowledgeGraph } from '../components/KnowledgeGraph';
 import { MarkdownRenderer } from '../components/MarkdownRenderer';
 import { ThemeSwitcher } from '../components/ThemeSwitcher';
 import { DiffBlock } from '../components/ToolUseRenderer/renderers/DiffBlock';
+import { useUserLocalStorage } from '../hooks/useUserLocalStorage';
 import { useThemedModal } from '../utils/modal';
 
 const { Header, Content } = Layout;
@@ -150,6 +157,17 @@ const DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS: KnowledgeSemanticSettings = {
     concurrency: 1,
   },
 };
+
+const KNOWLEDGE_SIDEBAR_MIN_WIDTH_PX = 280;
+const KNOWLEDGE_SIDEBAR_MAX_WIDTH_PX = 780;
+const KNOWLEDGE_SIDEBAR_DEFAULT_SIZE_PERCENT = 24;
+const KNOWLEDGE_SIDEBAR_MAX_SIZE_PERCENT = 60;
+
+const clampPercent = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const widthToPercent = (widthPx: number, viewportWidth: number) =>
+  (widthPx / Math.max(viewportWidth, 1)) * 100;
 
 const OPENAI_EMBEDDING_MODEL_OPTIONS = [
   {
@@ -586,9 +604,27 @@ export function KnowledgePage({
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsApiKeyDraft, setSettingsApiKeyDraft] = useState('');
   const [settingsForm] = Form.useForm<KnowledgeSemanticSettings>();
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window === 'undefined' ? 1440 : window.innerWidth
+  );
+  const [sidebarSize, setSidebarSize] = useUserLocalStorage<number>(
+    currentUser?.user_id,
+    'knowledge:sidebar:size',
+    KNOWLEDGE_SIDEBAR_DEFAULT_SIZE_PERCENT
+  );
+  const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
+  const sidebarResizeDraggingRef = useRef(false);
 
   useEffect(() => {
     document.title = 'Knowledge · Agor';
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   useEffect(() => {
@@ -611,6 +647,31 @@ export function KnowledgePage({
     () => namespaces.find((ns) => ns.slug === activeSpace) ?? namespaces[0] ?? null,
     [namespaces, activeSpace]
   );
+
+  const sidebarMinSize = useMemo(
+    () =>
+      Math.min(
+        KNOWLEDGE_SIDEBAR_MAX_SIZE_PERCENT,
+        widthToPercent(KNOWLEDGE_SIDEBAR_MIN_WIDTH_PX, viewportWidth)
+      ),
+    [viewportWidth]
+  );
+  const sidebarMaxSize = useMemo(
+    () =>
+      Math.max(
+        sidebarMinSize,
+        Math.min(
+          KNOWLEDGE_SIDEBAR_MAX_SIZE_PERCENT,
+          widthToPercent(KNOWLEDGE_SIDEBAR_MAX_WIDTH_PX, viewportWidth)
+        )
+      ),
+    [sidebarMinSize, viewportWidth]
+  );
+  const effectiveSidebarSize = clampPercent(sidebarSize, sidebarMinSize, sidebarMaxSize);
+
+  useEffect(() => {
+    sidebarPanelRef.current?.resize(effectiveSidebarSize);
+  }, [effectiveSidebarSize]);
 
   const namespaceSlugById = useMemo(() => {
     const map = new Map<string, string>();
@@ -1836,7 +1897,6 @@ export function KnowledgePage({
             Draft
           </Tag>
         )}
-        <IndexingStatusCue status={doc.indexing_status} />
       </button>
     );
   };
@@ -2012,9 +2072,16 @@ export function KnowledgePage({
           </Tooltip>
         </Space>
         <Space>
-          <Button icon={<ReloadOutlined />} onClick={loadDocuments} loading={loading}>
-            Refresh
-          </Button>
+          <Tooltip title="Refresh Knowledge" placement="bottom">
+            <Button
+              type="text"
+              aria-label="Refresh Knowledge"
+              icon={<ReloadOutlined style={{ fontSize: token.fontSizeLG }} />}
+              onClick={loadDocuments}
+              loading={loading}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+            />
+          </Tooltip>
           <Tooltip title="Documentation" placement="bottom">
             <Button
               type="text"
@@ -2044,449 +2111,492 @@ export function KnowledgePage({
         </Space>
       </Header>
 
-      <Content
-        style={{ height: 'calc(100vh - 56px)', display: 'flex', overflow: 'hidden', padding: 0 }}
-      >
-        <aside
-          style={{
-            width: 340,
-            flexShrink: 0,
-            borderRight: `1px solid ${token.colorBorderSecondary}`,
-            background: token.colorBgContainer,
-            padding: 16,
-            overflow: 'auto',
+      <Content style={{ height: 'calc(100vh - 56px)', overflow: 'hidden', padding: 0 }}>
+        <PanelGroup
+          id="knowledge-layout"
+          direction="horizontal"
+          style={{ height: '100%' }}
+          onLayout={(sizes) => {
+            if (sidebarResizeDraggingRef.current && sizes.length >= 2) {
+              setSidebarSize(clampPercent(sizes[0], sidebarMinSize, sidebarMaxSize));
+            }
           }}
         >
-          <Space orientation="vertical" size={12} style={{ width: '100%' }}>
-            {!client && <Alert type="warning" title="Knowledge requires a daemon connection." />}
-            <Space orientation="vertical" size={4} style={{ width: '100%' }}>
-              <Text type="secondary" style={{ fontSize: 11, textTransform: 'uppercase' }}>
-                Space
-              </Text>
-              <Select
-                value={activeSpace}
-                onChange={changeKnowledgeSpace}
-                style={{ width: '100%' }}
-                options={spaceOptions}
-              />
-            </Space>
-            <Input
-              allowClear
-              prefix={<SearchOutlined />}
-              placeholder="Search Knowledge"
-              value={searchQuery}
-              onChange={(event) => {
-                const nextQuery = event.target.value;
-                setSearchQuery(nextQuery);
-                navigate(`${location.pathname}${buildKnowledgeSearch({ query: nextQuery })}`, {
-                  replace: true,
-                });
-              }}
-            />
-            <Segmented
-              block
-              size="small"
-              value={searchMode}
-              onChange={(value) => setSearchMode(value as KnowledgeSearchMode)}
-              options={[
-                { label: 'Text', value: 'text' },
-                { label: 'Semantic', value: 'semantic' },
-                { label: 'Hybrid', value: 'hybrid' },
-              ]}
-            />
-            <Flex gap={8}>
-              <Button
-                block
-                type="primary"
-                icon={<FileAddOutlined />}
-                onClick={() => openCreateModal('doc')}
-                disabled={!client}
-              >
-                New Page
-              </Button>
-              <Button icon={<FolderAddOutlined />} onClick={openFolderModal} />
-            </Flex>
-            <Segmented
-              block
-              size="small"
-              value={kindFilter}
-              onChange={(value) => {
-                const nextKind = String(value);
-                setKindFilter(nextKind);
-                navigate(`${location.pathname}${buildKnowledgeSearch({ kind: nextKind })}`, {
-                  replace: true,
-                });
-              }}
-              options={['All', 'Pages', 'Skills', 'Memories']}
-            />
-            <Spin spinning={loading}>
-              <div
-                style={{
-                  background: token.colorFillQuaternary,
-                  borderRadius: token.borderRadiusLG,
-                  padding: 4,
-                }}
-              >
-                <button
-                  type="button"
-                  onClick={goToGraphHome}
-                  style={{
-                    width: '100%',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    minHeight: 30,
-                    margin: '1px 0',
-                    padding: '5px 10px',
-                    border: 0,
-                    borderRadius: token.borderRadius,
-                    background: !activeDoc ? token.colorPrimaryBg : 'transparent',
-                    color: token.colorText,
-                    cursor: 'pointer',
-                    textAlign: 'left',
-                    fontWeight: !activeDoc ? 600 : 400,
-                  }}
-                >
-                  <ApartmentOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
-                  <span>Graph</span>
-                </button>
-                {renderRootContents()}
-              </div>
-            </Spin>
-          </Space>
-        </aside>
-
-        <main
-          style={{
-            flex: 1,
-            minWidth: 0,
-            overflow: fillMain ? 'hidden' : 'auto',
-            background: token.colorBgLayout,
-          }}
-        >
-          <div
-            style={{
-              maxWidth: fillMain ? 'none' : 1040,
-              height: fillMain ? '100%' : undefined,
-              margin: fillMain ? 0 : '0 auto',
-              padding: showGraph ? 0 : isEditing ? 24 : '40px 56px',
-              boxSizing: 'border-box',
-              display: fillMain ? 'flex' : undefined,
-              flexDirection: fillMain ? 'column' : undefined,
-              minHeight: 0,
-            }}
+          <Panel
+            id="knowledge-sidebar"
+            order={1}
+            ref={sidebarPanelRef}
+            defaultSize={effectiveSidebarSize}
+            minSize={sidebarMinSize}
+            maxSize={sidebarMaxSize}
+            style={{ minWidth: KNOWLEDGE_SIDEBAR_MIN_WIDTH_PX }}
           >
-            {error && (
-              <Alert
-                type="error"
-                title="Knowledge error"
-                description={error}
-                closable
-                onClose={() => setError(null)}
-                style={{ marginBottom: 16 }}
-              />
-            )}
-
-            {activeDoc ? (
+            <aside
+              style={{
+                height: '100%',
+                boxSizing: 'border-box',
+                borderRight: `1px solid ${token.colorBorderSecondary}`,
+                background: token.colorBgContainer,
+                padding: 16,
+                overflow: 'auto',
+              }}
+            >
+              <Space orientation="vertical" size={12} style={{ width: '100%' }}>
+                {!client && (
+                  <Alert type="warning" title="Knowledge requires a daemon connection." />
+                )}
+                <Space orientation="vertical" size={4} style={{ width: '100%' }}>
+                  <Text type="secondary" style={{ fontSize: 11, textTransform: 'uppercase' }}>
+                    Space
+                  </Text>
+                  <Select
+                    value={activeSpace}
+                    onChange={changeKnowledgeSpace}
+                    style={{ width: '100%' }}
+                    options={spaceOptions}
+                  />
+                </Space>
+                <Input
+                  allowClear
+                  prefix={<SearchOutlined />}
+                  placeholder="Search Knowledge"
+                  value={searchQuery}
+                  onChange={(event) => {
+                    const nextQuery = event.target.value;
+                    setSearchQuery(nextQuery);
+                    navigate(`${location.pathname}${buildKnowledgeSearch({ query: nextQuery })}`, {
+                      replace: true,
+                    });
+                  }}
+                />
+                <Segmented
+                  block
+                  size="small"
+                  value={searchMode}
+                  onChange={(value) => setSearchMode(value as KnowledgeSearchMode)}
+                  options={[
+                    { label: 'Text', value: 'text' },
+                    { label: 'Semantic', value: 'semantic' },
+                    { label: 'Hybrid', value: 'hybrid' },
+                  ]}
+                />
+                <Flex gap={8}>
+                  <Button
+                    block
+                    type="primary"
+                    icon={<FileAddOutlined />}
+                    onClick={() => openCreateModal('doc')}
+                    disabled={!client}
+                  >
+                    New Page
+                  </Button>
+                  <Button icon={<FolderAddOutlined />} onClick={openFolderModal} />
+                </Flex>
+                <Segmented
+                  block
+                  size="small"
+                  value={kindFilter}
+                  onChange={(value) => {
+                    const nextKind = String(value);
+                    setKindFilter(nextKind);
+                    navigate(`${location.pathname}${buildKnowledgeSearch({ kind: nextKind })}`, {
+                      replace: true,
+                    });
+                  }}
+                  options={['All', 'Pages', 'Skills', 'Memories']}
+                />
+                <Spin spinning={loading}>
+                  <div
+                    style={{
+                      background: token.colorFillQuaternary,
+                      borderRadius: token.borderRadiusLG,
+                      padding: 4,
+                    }}
+                  >
+                    <button
+                      type="button"
+                      onClick={goToGraphHome}
+                      style={{
+                        width: '100%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        minHeight: 30,
+                        margin: '1px 0',
+                        padding: '5px 10px',
+                        border: 0,
+                        borderRadius: token.borderRadius,
+                        background: !activeDoc ? token.colorPrimaryBg : 'transparent',
+                        color: token.colorText,
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        fontWeight: !activeDoc ? 600 : 400,
+                      }}
+                    >
+                      <ApartmentOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
+                      <span>Graph</span>
+                    </button>
+                    {renderRootContents()}
+                  </div>
+                </Spin>
+              </Space>
+            </aside>
+          </Panel>
+          <PanelResizeHandle
+            style={{
+              width: '4px',
+              background: token.colorBorderSecondary,
+              cursor: 'col-resize',
+              transition: 'background 0.2s',
+            }}
+            onDragging={(isDragging) => {
+              sidebarResizeDraggingRef.current = isDragging;
+            }}
+            onMouseEnter={(event) => {
+              (event.currentTarget as unknown as HTMLDivElement).style.background =
+                token.colorPrimary;
+            }}
+            onMouseLeave={(event) => {
+              (event.currentTarget as unknown as HTMLDivElement).style.background =
+                token.colorBorderSecondary;
+            }}
+          />
+          <Panel id="knowledge-main" order={2} minSize={30}>
+            <main
+              style={{
+                height: '100%',
+                minWidth: 0,
+                overflow: fillMain ? 'hidden' : 'auto',
+                background: token.colorBgLayout,
+              }}
+            >
               <div
                 style={{
-                  width: '100%',
-                  height: isEditing ? '100%' : undefined,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 20,
+                  maxWidth: fillMain ? 'none' : 1040,
+                  height: fillMain ? '100%' : undefined,
+                  margin: fillMain ? 0 : '0 auto',
+                  padding: showGraph ? 0 : isEditing ? 24 : '40px 56px',
+                  boxSizing: 'border-box',
+                  display: fillMain ? 'flex' : undefined,
+                  flexDirection: fillMain ? 'column' : undefined,
                   minHeight: 0,
                 }}
               >
-                <div
-                  onMouseEnter={() => setTitleActionsVisible(true)}
-                  onMouseLeave={() => setTitleActionsVisible(false)}
-                  onFocus={() => setTitleActionsVisible(true)}
-                  onBlur={(event) => {
-                    const nextTarget = event.relatedTarget as Node | null;
-                    if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
-                      setTitleActionsVisible(false);
-                    }
-                  }}
-                  style={{
-                    position: 'relative',
-                    display: isEditing ? 'flex' : 'block',
-                    alignItems: 'flex-start',
-                    gap: 16,
-                  }}
-                >
-                  <Space
-                    orientation="vertical"
-                    size={8}
-                    style={{ width: '100%', minWidth: 0, flex: 1 }}
+                {error && (
+                  <Alert
+                    type="error"
+                    title="Knowledge error"
+                    description={error}
+                    closable
+                    onClose={() => setError(null)}
+                    style={{ marginBottom: 16 }}
+                  />
+                )}
+
+                {activeDoc ? (
+                  <div
+                    style={{
+                      width: '100%',
+                      height: isEditing ? '100%' : undefined,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 20,
+                      minHeight: 0,
+                    }}
                   >
-                    {isEditing && !titleFromContent ? (
-                      <Input
-                        value={titleDraft}
-                        onChange={(event) => setTitleDraft(event.target.value)}
-                        placeholder="Page title"
-                        size="large"
-                        variant="borderless"
-                        style={{ fontSize: 32, fontWeight: 700, paddingInline: 0 }}
-                      />
-                    ) : (
-                      <Title level={1} style={{ margin: 0 }}>
-                        {isEditing ? titleDraft : activeDoc.title}
-                      </Title>
-                    )}
-                    <Space wrap>
-                      {isEditing ? (
-                        <Select
-                          size="small"
-                          value={visibilityDraft}
-                          disabled={!canManageActiveVisibility}
-                          onChange={setVisibilityDraft}
-                          style={{ width: 104 }}
-                          options={[
-                            { label: 'Public', value: 'public' },
-                            { label: 'Private', value: 'private' },
-                          ]}
-                        />
-                      ) : (
-                        <Tag color={activeDoc.visibility === 'public' ? 'green' : 'default'}>
-                          {activeDoc.visibility}
-                        </Tag>
-                      )}
-                      {isEditing ? (
-                        <Select
-                          size="small"
-                          value={statusDraft}
-                          disabled={!canManageActiveVisibility}
-                          onChange={setStatusDraft}
-                          style={{ width: 118 }}
-                          options={[
-                            { label: 'Published', value: 'published' },
-                            { label: 'Draft', value: 'draft' },
-                          ]}
-                        />
-                      ) : activeDoc.status === 'draft' ? (
-                        <Tag color="gold">Draft</Tag>
-                      ) : (
-                        <Tag color="blue">Published</Tag>
-                      )}
-                      <IndexingStatusCue status={activeDoc.indexing_status} size={16} />
-                      {isEditing ? (
-                        <Select
-                          size="small"
-                          value={kindDraft}
-                          onChange={setKindDraft}
-                          style={{ width: 128 }}
-                          options={KNOWLEDGE_DOCUMENT_KINDS.map((kind) => ({
-                            label: kindLabels[kind],
-                            value: kind,
-                          }))}
-                        />
-                      ) : (
-                        <Tag>{kindLabels[activeDoc.kind] ?? activeDoc.kind}</Tag>
-                      )}
-                      <Text type="secondary">{activeDoc.path}</Text>
-                    </Space>
-                    {isEditing && (
-                      <Space orientation="vertical" size={4}>
-                        <Checkbox
-                          checked={titleFromContent}
-                          onChange={(event) => setTitleFromContent(event.target.checked)}
-                        >
-                          Use first heading as title
-                        </Checkbox>
-                        <Checkbox
-                          checked={renamePathOnTitleChange}
-                          disabled={!titleChanged}
-                          onChange={(event) => setRenamePathOnTitleChange(event.target.checked)}
-                        >
-                          Rename page path to match title
-                        </Checkbox>
-                        {titleChanged && (
-                          <Text type="secondary" style={{ fontSize: 12 }}>
-                            Current path: {activeDoc.path}
-                            {renamePathOnTitleChange && ` → ${suggestedRenamePath}`}
-                          </Text>
+                    <div
+                      onMouseEnter={() => setTitleActionsVisible(true)}
+                      onMouseLeave={() => setTitleActionsVisible(false)}
+                      onFocus={() => setTitleActionsVisible(true)}
+                      onBlur={(event) => {
+                        const nextTarget = event.relatedTarget as Node | null;
+                        if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+                          setTitleActionsVisible(false);
+                        }
+                      }}
+                      style={{
+                        position: 'relative',
+                        display: isEditing ? 'flex' : 'block',
+                        alignItems: 'flex-start',
+                        gap: 16,
+                      }}
+                    >
+                      <Space
+                        orientation="vertical"
+                        size={8}
+                        style={{ width: '100%', minWidth: 0, flex: 1 }}
+                      >
+                        {isEditing && !titleFromContent ? (
+                          <Input
+                            value={titleDraft}
+                            onChange={(event) => setTitleDraft(event.target.value)}
+                            placeholder="Page title"
+                            size="large"
+                            variant="borderless"
+                            style={{ fontSize: 32, fontWeight: 700, paddingInline: 0 }}
+                          />
+                        ) : (
+                          <Title level={1} style={{ margin: 0 }}>
+                            {isEditing ? titleDraft : activeDoc.title}
+                          </Title>
+                        )}
+                        <Space wrap>
+                          {isEditing ? (
+                            <Select
+                              size="small"
+                              value={visibilityDraft}
+                              disabled={!canManageActiveVisibility}
+                              onChange={setVisibilityDraft}
+                              style={{ width: 104 }}
+                              options={[
+                                { label: 'Public', value: 'public' },
+                                { label: 'Private', value: 'private' },
+                              ]}
+                            />
+                          ) : (
+                            <Tag color={activeDoc.visibility === 'public' ? 'green' : 'default'}>
+                              {activeDoc.visibility}
+                            </Tag>
+                          )}
+                          {isEditing ? (
+                            <Select
+                              size="small"
+                              value={statusDraft}
+                              disabled={!canManageActiveVisibility}
+                              onChange={setStatusDraft}
+                              style={{ width: 118 }}
+                              options={[
+                                { label: 'Published', value: 'published' },
+                                { label: 'Draft', value: 'draft' },
+                              ]}
+                            />
+                          ) : activeDoc.status === 'draft' ? (
+                            <Tag color="gold">Draft</Tag>
+                          ) : (
+                            <Tag color="blue">Published</Tag>
+                          )}
+                          <IndexingStatusCue status={activeDoc.indexing_status} size={16} />
+                          {isEditing ? (
+                            <Select
+                              size="small"
+                              value={kindDraft}
+                              onChange={setKindDraft}
+                              style={{ width: 128 }}
+                              options={KNOWLEDGE_DOCUMENT_KINDS.map((kind) => ({
+                                label: kindLabels[kind],
+                                value: kind,
+                              }))}
+                            />
+                          ) : (
+                            <Tag>{kindLabels[activeDoc.kind] ?? activeDoc.kind}</Tag>
+                          )}
+                          <Text type="secondary">{activeDoc.path}</Text>
+                        </Space>
+                        {isEditing && (
+                          <Space orientation="vertical" size={4}>
+                            <Checkbox
+                              checked={titleFromContent}
+                              onChange={(event) => setTitleFromContent(event.target.checked)}
+                            >
+                              Use first heading as title
+                            </Checkbox>
+                            <Checkbox
+                              checked={renamePathOnTitleChange}
+                              disabled={!titleChanged}
+                              onChange={(event) => setRenamePathOnTitleChange(event.target.checked)}
+                            >
+                              Rename page path to match title
+                            </Checkbox>
+                            {titleChanged && (
+                              <Text type="secondary" style={{ fontSize: 12 }}>
+                                Current path: {activeDoc.path}
+                                {renamePathOnTitleChange && ` → ${suggestedRenamePath}`}
+                              </Text>
+                            )}
+                          </Space>
                         )}
                       </Space>
-                    )}
-                  </Space>
 
-                  <Space
-                    style={
-                      isEditing
-                        ? undefined
-                        : {
-                            position: 'absolute',
-                            top: 0,
-                            right: 0,
-                            zIndex: 2,
-                            padding: 4,
-                            borderRadius: token.borderRadiusLG,
-                            background: token.colorBgContainer,
-                            boxShadow: titleActionsVisible ? token.boxShadowSecondary : undefined,
-                          }
-                    }
-                  >
-                    {!isEditing ? (
-                      <>
-                        {showReadActions && (
+                      <Space
+                        style={
+                          isEditing
+                            ? undefined
+                            : {
+                                position: 'absolute',
+                                top: 0,
+                                right: 0,
+                                zIndex: 2,
+                                padding: 4,
+                                borderRadius: token.borderRadiusLG,
+                                background: token.colorBgContainer,
+                                boxShadow: titleActionsVisible
+                                  ? token.boxShadowSecondary
+                                  : undefined,
+                              }
+                        }
+                      >
+                        {!isEditing ? (
                           <>
-                            <Button
-                              icon={<HistoryOutlined />}
-                              disabled={!client}
-                              onClick={openHistory}
-                            >
-                              History
-                              {editCount > 0 && (
-                                <Tag
-                                  color="blue"
-                                  variant="filled"
-                                  style={{ marginInlineStart: 6, marginInlineEnd: 0 }}
+                            {showReadActions && (
+                              <>
+                                <Button
+                                  icon={<HistoryOutlined />}
+                                  disabled={!client}
+                                  onClick={openHistory}
                                 >
-                                  {editCount}
-                                </Tag>
-                              )}
-                            </Button>
+                                  History
+                                  {editCount > 0 && (
+                                    <Tag
+                                      color="blue"
+                                      variant="filled"
+                                      style={{ marginInlineStart: 6, marginInlineEnd: 0 }}
+                                    >
+                                      {editCount}
+                                    </Tag>
+                                  )}
+                                </Button>
+                                <Button
+                                  icon={<FolderOpenOutlined />}
+                                  disabled={!client}
+                                  onClick={() => {
+                                    setRelocateFolder(parentFolderForPath(activeDoc.path));
+                                    setRelocateModalOpen(true);
+                                  }}
+                                >
+                                  Relocate
+                                </Button>
+                                <ArchiveActionButton
+                                  tooltip=""
+                                  size="middle"
+                                  disabled={!client}
+                                  onClick={archiveActiveDocument}
+                                >
+                                  Archive
+                                </ArchiveActionButton>
+                              </>
+                            )}
                             <Button
-                              icon={<FolderOpenOutlined />}
+                              icon={<EditOutlined />}
                               disabled={!client}
-                              onClick={() => {
-                                setRelocateFolder(parentFolderForPath(activeDoc.path));
-                                setRelocateModalOpen(true);
-                              }}
+                              onClick={() => setKnowledgeEditMode(true)}
                             >
-                              Relocate
+                              Edit
                             </Button>
-                            <ArchiveActionButton
-                              tooltip=""
-                              size="middle"
+                          </>
+                        ) : (
+                          <>
+                            <Button onClick={cancelEdit}>Cancel</Button>
+                            <Button
+                              type="primary"
+                              icon={<SaveOutlined />}
+                              loading={saving}
                               disabled={!client}
-                              onClick={archiveActiveDocument}
+                              onClick={saveActiveDocument}
                             >
-                              Archive
-                            </ArchiveActionButton>
+                              Save
+                            </Button>
                           </>
                         )}
-                        <Button
-                          icon={<EditOutlined />}
-                          disabled={!client}
-                          onClick={() => setKnowledgeEditMode(true)}
-                        >
-                          Edit
-                        </Button>
-                      </>
-                    ) : (
-                      <>
-                        <Button onClick={cancelEdit}>Cancel</Button>
-                        <Button
-                          type="primary"
-                          icon={<SaveOutlined />}
-                          loading={saving}
-                          disabled={!client}
-                          onClick={saveActiveDocument}
-                        >
-                          Save
-                        </Button>
-                      </>
-                    )}
-                  </Space>
-                </div>
-
-                {isEditing ? (
-                  <Flex gap={16} align="stretch" style={{ flex: 1, minHeight: 0 }}>
-                    <div
-                      style={{
-                        width: '50%',
-                        minWidth: 0,
-                        minHeight: 0,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 8,
-                      }}
-                    >
-                      <Text strong>Markdown</Text>
-                      <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-                        <AutocompleteTextarea
-                          key={activeDoc.document_id}
-                          value={markdownDraft}
-                          onChange={setMarkdownDraft}
-                          client={client}
-                          sessionId={null}
-                          userById={userById}
-                          kbDocs={mentionDocs}
-                          placeholder={
-                            '# Page title\n\nWrite markdown here. Type @ to link a doc or mention a user, : for emoji.'
-                          }
-                          autoSize={{ minRows: 24 }}
-                        />
-                      </div>
+                      </Space>
                     </div>
-                    <div
-                      style={{
-                        width: '50%',
-                        minWidth: 0,
-                        minHeight: 0,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 8,
-                      }}
-                    >
-                      <Text strong>Preview</Text>
+
+                    {isEditing ? (
+                      <Flex gap={16} align="stretch" style={{ flex: 1, minHeight: 0 }}>
+                        <div
+                          style={{
+                            width: '50%',
+                            minWidth: 0,
+                            minHeight: 0,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 8,
+                          }}
+                        >
+                          <Text strong>Markdown</Text>
+                          <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+                            <AutocompleteTextarea
+                              key={activeDoc.document_id}
+                              value={markdownDraft}
+                              onChange={setMarkdownDraft}
+                              client={client}
+                              sessionId={null}
+                              userById={userById}
+                              kbDocs={mentionDocs}
+                              placeholder={
+                                '# Page title\n\nWrite markdown here. Type @ to link a doc or mention a user, : for emoji.'
+                              }
+                              autoSize={{ minRows: 24 }}
+                            />
+                          </div>
+                        </div>
+                        <div
+                          style={{
+                            width: '50%',
+                            minWidth: 0,
+                            minHeight: 0,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: 8,
+                          }}
+                        >
+                          <Text strong>Preview</Text>
+                          <div
+                            onClick={handleKbContentClick}
+                            style={{
+                              flex: 1,
+                              minHeight: 0,
+                              overflow: 'auto',
+                              padding: 24,
+                              border: `1px solid ${token.colorBorderSecondary}`,
+                              borderRadius: token.borderRadiusLG,
+                              background: token.colorBgContainer,
+                            }}
+                          >
+                            <MarkdownRenderer content={hydrateKbLinks(markdownDraft)} />
+                          </div>
+                        </div>
+                      </Flex>
+                    ) : (
                       <div
                         onClick={handleKbContentClick}
                         style={{
-                          flex: 1,
-                          minHeight: 0,
-                          overflow: 'auto',
-                          padding: 24,
-                          border: `1px solid ${token.colorBorderSecondary}`,
-                          borderRadius: token.borderRadiusLG,
-                          background: token.colorBgContainer,
+                          padding: '8px 0 80px',
+                          fontSize: 16,
+                          lineHeight: 1.7,
                         }}
                       >
-                        <MarkdownRenderer content={hydrateKbLinks(markdownDraft)} />
+                        <MarkdownRenderer
+                          content={hydrateKbLinks(
+                            titleFromContent
+                              ? stripFirstMarkdownTitleLine(markdownDraft)
+                              : markdownDraft
+                          )}
+                        />
                       </div>
-                    </div>
-                  </Flex>
+                    )}
+                  </div>
                 ) : (
-                  <div
-                    onClick={handleKbContentClick}
-                    style={{
-                      padding: '8px 0 80px',
-                      fontSize: 16,
-                      lineHeight: 1.7,
-                    }}
-                  >
-                    <MarkdownRenderer
-                      content={hydrateKbLinks(
-                        titleFromContent
-                          ? stripFirstMarkdownTitleLine(markdownDraft)
-                          : markdownDraft
-                      )}
+                  <div style={{ flex: 1, minHeight: 0, width: '100%' }}>
+                    <KnowledgeGraph
+                      nodes={graphData?.nodes ?? []}
+                      edges={graphData?.edges ?? []}
+                      activeDocId={activeDocId}
+                      hoverDocId={hoverDocId}
+                      onSelectDoc={openGraphDoc}
+                      onHoverDoc={setHoverDocId}
+                      loading={graphLoading}
+                      emptyText={
+                        activeSpace === 'all'
+                          ? 'Pick a Space to see its document graph.'
+                          : 'No linked documents in this Space yet.'
+                      }
                     />
                   </div>
                 )}
               </div>
-            ) : (
-              <div style={{ flex: 1, minHeight: 0, width: '100%' }}>
-                <KnowledgeGraph
-                  nodes={graphData?.nodes ?? []}
-                  edges={graphData?.edges ?? []}
-                  activeDocId={activeDocId}
-                  hoverDocId={hoverDocId}
-                  onSelectDoc={openGraphDoc}
-                  onHoverDoc={setHoverDocId}
-                  loading={graphLoading}
-                  emptyText={
-                    activeSpace === 'all'
-                      ? 'Pick a Space to see its document graph.'
-                      : 'No linked documents in this Space yet.'
-                  }
-                />
-              </div>
-            )}
-          </div>
-        </main>
+            </main>
+          </Panel>
+        </PanelGroup>
       </Content>
 
       <Drawer


### PR DESCRIPTION
## Summary
- Use the existing `react-resizable-panels` pattern for the Knowledge Base doctree sidebar, with persisted user sizing and guarded min/max widths.
- Remove the flask/scientific icon from doctree rows while preserving active-document metadata status.
- Make the Knowledge Base refresh control icon-only with tooltip/accessible label.
- Make the header Knowledge affordance a normal basename-aware link for modified/open-new-tab clicks while preserving SPA navigation for plain clicks.
- Preload active route modules during initial loading to avoid a separate “Loading surface…” phase and reduce loader flash.
- Let an existing BranchTab test use the suite's global Vitest timeout so CI cold full-suite runs do not time out under a narrower per-describe timeout.

## Validation
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- KnowledgePage.test.tsx`
- `pnpm --filter agor-ui test -- App.test.tsx`
- `pnpm --filter agor-ui test -- AppHeader.test.tsx`
- `pnpm --filter agor-ui test -- src/components/CreateDialog/tabs/BranchTab.test.tsx src/components/AppHeader/AppHeader.test.tsx`
- `pnpm turbo run test --filter=agor-ui`