### PR TITLE
feat: add targeted KB edit MCP flow

### DIFF
--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -31,6 +31,7 @@
     "@types/mdast": "^4.0.4",
     "compression": "^1.8.1",
     "cors": "^2.8.6",
+    "diff": "^7.0.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.0",
     "express-rate-limit": "^8.5.2",

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -113,7 +113,22 @@ IMPORTANT:
 - Missing user env vars render as "" — your app should detect that and surface a "configure SOMETHING in Settings" message rather than calling APIs with empty creds.
 - For node.js / static templates without a dotenv path, env vars are NOT injected; the daemon emits a warning if you declared any.`,
       inputSchema: z.object({
-        folderPath: z.string().describe('Absolute path to folder containing artifact files'),
+        folderPath: z
+          .string()
+          .optional()
+          .describe(
+            'Absolute path to folder containing artifact files. Optional when branchId + subpath are provided.'
+          ),
+        branchId: z
+          .string()
+          .optional()
+          .describe(
+            'Branch ID (UUID or short ID). Prefer this with subpath to publish from a branch worktree.'
+          ),
+        subpath: z
+          .string()
+          .optional()
+          .describe('Branch-relative subpath to the artifact folder (requires branchId).'),
         boardId: z
           .string()
           .optional()
@@ -171,12 +186,23 @@ IMPORTANT:
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const boardIdRaw = coerceString(args.boardId);
       const resolvedBoardId = boardIdRaw ? await resolveBoardId(ctx, boardIdRaw) : undefined;
+      const branchIdRaw = coerceString(args.branchId);
+      const resolvedBranchId = branchIdRaw ? await resolveBranchId(ctx, branchIdRaw) : undefined;
+      const subpath = coerceString(args.subpath);
+      const folderPath = coerceString(args.folderPath);
       const resolvedArtifactId = coerceString(args.artifactId)
         ? await resolveArtifactId(ctx, coerceString(args.artifactId)!)
         : undefined;
+      if (!folderPath && !resolvedBranchId) {
+        throw new Error(
+          'Provide either folderPath or branchId (with optional subpath) to publish artifacts.'
+        );
+      }
       const artifact = await service.publishArtifact(
         {
-          folderPath: coerceString(args.folderPath)!,
+          folderPath,
+          branch_id: resolvedBranchId,
+          subpath,
           board_id: resolvedBoardId,
           name: coerceString(args.name),
           artifact_id: resolvedArtifactId,
@@ -191,7 +217,8 @@ IMPORTANT:
           width: args.width,
           height: args.height,
         },
-        ctx.userId
+        ctx.userId,
+        ctx.authenticatedUser.role as UserRole
       );
 
       const { files: _files, ...artifactSummary } = artifact;
@@ -213,12 +240,42 @@ IMPORTANT:
       inputSchema: z.object({
         folderPath: z
           .string()
-          .describe('Absolute path to the folder containing artifact files to check'),
+          .optional()
+          .describe(
+            'Absolute path to the folder containing artifact files to check. Optional when branchId + subpath are provided.'
+          ),
+        branchId: z
+          .string()
+          .optional()
+          .describe(
+            'Branch ID (UUID or short ID). Prefer this with subpath to check a branch worktree path.'
+          ),
+        subpath: z
+          .string()
+          .optional()
+          .describe('Branch-relative subpath pointing at the artifact folder (requires branchId).'),
       }),
     },
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
-      const result = await service.checkBuildFromFolder(coerceString(args.folderPath)!);
+      const branchIdRaw = coerceString(args.branchId);
+      const resolvedBranchId = branchIdRaw ? await resolveBranchId(ctx, branchIdRaw) : undefined;
+      const folderPath = coerceString(args.folderPath);
+      const subpath = coerceString(args.subpath);
+      if (!folderPath && !resolvedBranchId) {
+        throw new Error(
+          'Provide either folderPath or branchId (with optional subpath) to check artifact files.'
+        );
+      }
+      const result = await service.checkBuildFromFolder(
+        {
+          folderPath,
+          branch_id: resolvedBranchId,
+          subpath,
+        },
+        ctx.userId,
+        ctx.authenticatedUser.role as UserRole
+      );
       // Mirror getStatus shape — `build_status` (not `status`) and `build_errors`
       // (always an array, never undefined) so agents can parse one schema across
       // both tools.

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -29,6 +29,79 @@ const KnowledgeEditPolicySchema = z.enum(KNOWLEDGE_EDIT_POLICIES);
 const KnowledgeGraphNodeTypeSchema = z.enum(KNOWLEDGE_GRAPH_NODE_TYPES);
 const KnowledgeGraphEdgeTypeSchema = z.enum(KNOWLEDGE_GRAPH_EDGE_TYPES);
 
+const KnowledgeReplaceLineRangeOpSchema = z.object({
+  type: z.literal('replace_line_range'),
+  startLine: z.number().int().min(1),
+  endLine: z.number().int().min(1),
+  replacement: z.string(),
+  expectedText: z.string().optional(),
+  expectedMd5: z.string().optional(),
+});
+
+const KnowledgeInsertAtLineOpSchema = z.object({
+  type: z.literal('insert_at_line'),
+  line: z.number().int().min(1),
+  position: z.enum(['before', 'after']).optional(),
+  content: z.string(),
+  expectedNeighborText: z.string().optional(),
+});
+
+const KnowledgeDeleteLineRangeOpSchema = z.object({
+  type: z.literal('delete_line_range'),
+  startLine: z.number().int().min(1),
+  endLine: z.number().int().min(1),
+  expectedText: z.string().optional(),
+  expectedMd5: z.string().optional(),
+});
+
+const KnowledgeReplaceLiteralOpSchema = z.object({
+  type: z.literal('replace_literal'),
+  find: z.string().min(1),
+  replace: z.string(),
+  expectedCount: z.number().int().min(0),
+});
+
+const KnowledgeEditOpSchema = z.discriminatedUnion('type', [
+  KnowledgeReplaceLineRangeOpSchema,
+  KnowledgeInsertAtLineOpSchema,
+  KnowledgeDeleteLineRangeOpSchema,
+  KnowledgeReplaceLiteralOpSchema,
+]);
+
+const KnowledgeEditRequestSchema = z.object({
+  documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
+  uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
+  namespace: z.string().optional().describe('Namespace/space slug; use with path'),
+  path: z.string().optional().describe('Document path inside namespace; use with namespace'),
+  expectedVersion: z
+    .union([z.number(), z.string()])
+    .optional()
+    .describe(
+      'Optimistic concurrency check: current version number or version ID expected by the caller'
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe('When true, validate and preview without creating a new version'),
+  changeSummary: z.string().optional().describe('Optional change summary for version history'),
+  versionMetadata: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Additional metadata to merge into the new version record'),
+  ops: z
+    .array(KnowledgeEditOpSchema)
+    .min(1)
+    .describe(
+      'Deterministic operations to apply in order. Provide the full batch; one successful call creates one immutable KB version.'
+    ),
+  returnContent: z
+    .enum(['none', 'full'])
+    .optional()
+    .describe(
+      'Set to "full" to include the post-edit content in the response (default: exclude content).'
+    ),
+});
+
 const KnowledgeNodeRefSchema = z
   .object({
     nodeId: z.string().optional().describe('Knowledge graph node ID (UUIDv7 or short ID)'),
@@ -529,6 +602,40 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'kb/documents.patch',
         'kb/documents.create',
       ]);
+    }
+  );
+
+  server.registerTool(
+    'agor_kb_edit',
+    {
+      description:
+        'Apply a batch of deterministic edits to a Knowledge document. One successful call creates exactly one new immutable KB version — collect related micro-edits into a single ops[] batch instead of calling this tool repeatedly. Supports dry-run previews for validation.',
+      annotations: { idempotentHint: false },
+      inputSchema: KnowledgeEditRequestSchema,
+    },
+    async (args) => {
+      const service = getOptionalService(ctx, 'kb/document-edits');
+      if (!service) {
+        return knowledgeNotImplementedResult('agor_kb_edit', ['kb/document-edits']);
+      }
+
+      const data = {
+        documentId: coerceString(args.documentId),
+        uri: coerceString(args.uri),
+        namespace: coerceString(args.namespace),
+        path: coerceString(args.path),
+        expectedVersion: args.expectedVersion,
+        dryRun: args.dryRun === true,
+        changeSummary: coerceString(args.changeSummary),
+        versionMetadata: coerceJsonRecord(args.versionMetadata),
+        ops: args.ops,
+        returnContent: args.returnContent ?? undefined,
+      } as Record<string, unknown>;
+
+      if (service.create) {
+        return textResult(await service.create(data, mcpParams(ctx)));
+      }
+      return knowledgeNotImplementedResult('agor_kb_edit', ['kb/document-edits.create']);
     }
   );
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1045,6 +1045,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     },
   });
 
+  safeService('kb/document-edits')?.hooks({
+    before: {
+      all: [requireAuth, requireMinimumRole(ROLES.MEMBER, 'edit knowledge documents')],
+    },
+  });
+
   safeService('kb/versions')?.hooks({
     before: {
       all: [requireAuth],

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -73,6 +73,7 @@ import {
   createGroupsService,
   setupBranchGroupGrantsService,
 } from './services/groups.js';
+import { createKnowledgeDocumentEditsService } from './services/knowledge-document-edits.js';
 import { createKnowledgeDocumentsService } from './services/knowledge-documents.js';
 import { createKnowledgeGraphService } from './services/knowledge-graph.js';
 import { createKnowledgeIndexingStatusService } from './services/knowledge-indexing.js';
@@ -364,9 +365,17 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   app.use('/kb/namespaces', createKnowledgeNamespacesService(db), {
     methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
   });
-  app.use('/kb/documents', createKnowledgeDocumentsService(db, app), {
+  const knowledgeDocumentsService = createKnowledgeDocumentsService(db, app);
+  app.use('/kb/documents', knowledgeDocumentsService, {
     methods: ['find', 'get', 'create', 'update', 'patch', 'remove', 'getDocument', 'putDocument'],
   });
+  app.use(
+    '/kb/document-edits',
+    createKnowledgeDocumentEditsService(db, app, knowledgeDocumentsService),
+    {
+      methods: ['create'],
+    }
+  );
   app.use('/kb/versions', createKnowledgeVersionsService(db), {
     methods: ['find'],
   });

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -59,10 +59,10 @@ import {
   proxyGrantEnvName,
   ROLES,
 } from '@agor/core/types';
-
 import { DrizzleService } from '../adapters/drizzle.js';
 import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
+import { hasBranchPermission } from '../utils/branch-authorization.js';
 import {
   detectLegacyFormat,
   effectiveTemplateForArtifact,
@@ -202,6 +202,18 @@ function readArtifactSidecar(folderPath: string): ArtifactSidecar | null {
   }
 }
 
+function normalizeBranchSubpath(subpath: string | undefined | null): string {
+  if (!subpath) return '';
+  const normalized = subpath.replace(/\\+/g, '/');
+  const segments = normalized.split('/').filter((segment) => segment.length > 0);
+  for (const segment of segments) {
+    if (segment === '.' || segment === '..') {
+      throw new Error('branch subpath must not include "." or ".." segments');
+    }
+  }
+  return segments.join('/');
+}
+
 export type ArtifactParams = QueryParams<{
   board_id?: BoardID;
   branch_id?: BranchID;
@@ -267,6 +279,65 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       requesterId: string;
     }
   > = new Map();
+
+  private async ensureBranchFilesystemAccess(
+    branchId: BranchID,
+    userId?: string,
+    userRole?: UserRole
+  ): Promise<void> {
+    const branch = await this.branchRepo.findById(branchId);
+    if (!branch) {
+      throw new Error(`Branch not found: ${branchId}`);
+    }
+    if (!userId) {
+      throw new Error('Authentication required to access branch workspace files');
+    }
+    const isOwner = await this.branchRepo.isOwner(branch.branch_id, userId as UserID);
+    const effective = await this.branchRepo.resolveUserPermission(branch, userId as UserID);
+    if (
+      !hasBranchPermission(branch, userId as UserID, isOwner, 'session', userRole, true, effective)
+    ) {
+      throw new Error('Forbidden: branch session permission required to read artifact files');
+    }
+  }
+
+  private async resolveArtifactSource(
+    input: { folderPath?: string; branch_id?: string; subpath?: string },
+    userId?: string,
+    userRole?: UserRole
+  ): Promise<{ folderPath: string; matchedBranchId: BranchID | null }> {
+    let folderPath: string;
+    let hintBranchId: BranchID | null = null;
+
+    if (input.branch_id) {
+      const branch = await this.branchRepo.findById(input.branch_id);
+      if (!branch) {
+        throw new Error(`Branch not found: ${input.branch_id}`);
+      }
+      const branchRoot = path.resolve(branch.path);
+      const relative = normalizeBranchSubpath(input.subpath);
+      folderPath = relative ? path.join(branchRoot, relative) : branchRoot;
+      hintBranchId = branch.branch_id as BranchID;
+    } else {
+      if (input.subpath) {
+        throw new Error('branchId is required when subpath is provided');
+      }
+      if (!input.folderPath) {
+        throw new Error('folderPath or branchId + subpath is required');
+      }
+      folderPath = path.resolve(input.folderPath);
+    }
+
+    const matchedBranchId = await this.validatePublishPath(folderPath);
+    if (hintBranchId && matchedBranchId && hintBranchId !== matchedBranchId) {
+      throw new Error('Resolved branch subpath does not match known branch root');
+    }
+    const branchId = hintBranchId ?? matchedBranchId;
+    if (branchId) {
+      await this.ensureBranchFilesystemAccess(branchId, userId, userRole);
+    }
+    return { folderPath, matchedBranchId: branchId };
+  }
 
   constructor(db: Database, app: Application) {
     const artifactRepo = new ArtifactRepository(db);
@@ -382,7 +453,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    */
   async publishArtifact(
     data: {
-      folderPath: string;
+      folderPath?: string;
+      branch_id?: string;
+      subpath?: string;
       board_id?: string;
       name?: string;
       artifact_id?: string;
@@ -397,14 +470,18 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       width?: number;
       height?: number;
     },
-    userId?: string
+    userId?: string,
+    userRole?: UserRole
   ): Promise<Artifact> {
-    const folderPath = path.resolve(data.folderPath);
-
-    // Path containment: only allow reading from branch paths or temp dirs.
-    // The matching branch id (if any) is stored on the row for provenance
-    // + future "list artifacts I published from branch X" filtering.
-    const matchedBranchId = await this.validatePublishPath(folderPath);
+    const { folderPath, matchedBranchId } = await this.resolveArtifactSource(
+      {
+        folderPath: data.folderPath,
+        branch_id: data.branch_id,
+        subpath: data.subpath,
+      },
+      userId,
+      userRole
+    );
 
     if (!fs.existsSync(folderPath)) {
       throw new Error(`Folder not found: ${folderPath}`);
@@ -1519,16 +1596,19 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   // ── Build / status / console / find helpers (mostly unchanged) ──
 
-  async checkBuildFromFolder(folderPath: string): Promise<{
+  async checkBuildFromFolder(
+    input: { folderPath?: string; branch_id?: string; subpath?: string },
+    userId?: string,
+    userRole?: UserRole
+  ): Promise<{
     status: ArtifactBuildStatus;
     errors: string[];
   }> {
-    const resolved = path.resolve(folderPath);
-    await this.validatePublishPath(resolved);
-    if (!fs.existsSync(resolved)) {
+    const { folderPath } = await this.resolveArtifactSource(input, userId, userRole);
+    if (!fs.existsSync(folderPath)) {
       return { status: 'error', errors: [`Folder not found: ${folderPath}`] };
     }
-    const files = this.readFilesRecursive(resolved, resolved);
+    const files = this.readFilesRecursive(folderPath, folderPath);
     return this.validateFiles(files);
   }
 

--- a/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
@@ -1,0 +1,163 @@
+import {
+  generateId,
+  KnowledgeDocumentRepository,
+  KnowledgeDocumentVersionRepository,
+  KnowledgeNamespaceRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { KnowledgeDocument, User, UserID } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { createKnowledgeDocumentEditsService } from './knowledge-document-edits';
+import { KnowledgeDocumentsService } from './knowledge-documents';
+
+async function seedUser(
+  db: Parameters<typeof dbTest>[0]['db'],
+  label: string,
+  role = ROLES.MEMBER
+) {
+  const users = new UsersRepository(db);
+  return users.create({
+    user_id: generateId() as UserID,
+    email: `${label}-${Date.now()}-${Math.random()}@test.local`,
+    name: label,
+    role,
+  }) as Promise<User>;
+}
+
+async function seedNamespace(db: Parameters<typeof dbTest>[0]['db']) {
+  return new KnowledgeNamespaceRepository(db).create({
+    slug: `kb-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    display_name: 'Test KB',
+  });
+}
+
+async function seedDocument(
+  db: Parameters<typeof dbTest>[0]['db'],
+  owner: User,
+  content = '# Title\nLine 1\nLine 2'
+): Promise<KnowledgeDocument> {
+  const namespace = await seedNamespace(db);
+  const documents = new KnowledgeDocumentRepository(db);
+  return documents.create({
+    namespace_id: namespace.namespace_id,
+    path: 'page.md',
+    title: 'Page',
+    visibility: 'public',
+    edit_policy: 'owner',
+    content_text: content,
+    created_by: owner.user_id as UserID,
+  });
+}
+
+describe('KnowledgeDocumentEditsService', () => {
+  dbTest('returns dry-run diff and leaves document unchanged', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const document = await seedDocument(db, owner);
+    const documentsService = new KnowledgeDocumentsService(db);
+    const editsService = createKnowledgeDocumentEditsService(
+      db,
+      {} as Application,
+      documentsService
+    );
+
+    const response = await editsService.create(
+      {
+        documentId: document.document_id,
+        dryRun: true,
+        ops: [
+          {
+            type: 'replace_line_range',
+            startLine: 2,
+            endLine: 2,
+            replacement: 'Line 1 updated',
+          },
+        ],
+        returnContent: 'full',
+      },
+      { user: owner }
+    );
+
+    expect(response.dryRun).toBe(true);
+    expect(response.newVersion).toBeUndefined();
+    expect(response.content).toContain('Line 1 updated');
+
+    const versions = await new KnowledgeDocumentVersionRepository(db).findAll({
+      document_id: document.document_id,
+    });
+    expect(versions).toHaveLength(1);
+  });
+
+  dbTest('applies edits and creates a new immutable version', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const document = await seedDocument(db, owner);
+    const documentsService = new KnowledgeDocumentsService(db);
+    const editsService = createKnowledgeDocumentEditsService(
+      db,
+      {} as Application,
+      documentsService
+    );
+
+    const versionsRepo = new KnowledgeDocumentVersionRepository(db);
+    const initialVersion = await versionsRepo.findLatestForDocument(document.document_id);
+    expect(initialVersion).not.toBeNull();
+
+    const response = await editsService.create(
+      {
+        documentId: document.document_id,
+        expectedVersion: initialVersion?.version_number,
+        changeSummary: 'Apply targeted edits',
+        returnContent: 'full',
+        ops: [
+          {
+            type: 'replace_line_range',
+            startLine: 2,
+            endLine: 2,
+            replacement: 'Line 1 updated',
+          },
+          {
+            type: 'insert_at_line',
+            line: 3,
+            position: 'after',
+            content: 'New tail',
+          },
+        ],
+      },
+      { user: owner }
+    );
+
+    expect(response.dryRun).toBe(false);
+    expect(response.newVersion?.version_number).toBe((initialVersion?.version_number ?? 0) + 1);
+    expect(response.content).toContain('New tail');
+
+    const finalVersion = await versionsRepo.findLatestForDocument(document.document_id);
+    expect(finalVersion?.content_text).toContain('New tail');
+  });
+
+  dbTest('rejects edits when caller lacks permission', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const document = await seedDocument(db, owner);
+    const documentsService = new KnowledgeDocumentsService(db);
+    const editsService = createKnowledgeDocumentEditsService(
+      db,
+      {} as Application,
+      documentsService
+    );
+
+    await expect(
+      editsService.create(
+        {
+          documentId: document.document_id,
+          dryRun: true,
+          ops: [
+            { type: 'replace_line_range', startLine: 2, endLine: 2, replacement: 'Unauthorized' },
+          ],
+        },
+        { user: other }
+      )
+    ).rejects.toThrowError();
+  });
+});

--- a/apps/agor-daemon/src/services/knowledge-document-edits.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.ts
@@ -1,0 +1,227 @@
+import type { Database } from '@agor/core/db';
+import { KnowledgeDocumentVersionRepository } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
+import { applyKnowledgeEditOps, KnowledgeEditError } from '@agor/core/knowledge';
+import type {
+  AuthenticatedParams,
+  KnowledgeDocument,
+  KnowledgeDocumentVersion,
+  KnowledgeEditChangedRange,
+  KnowledgeEditOp,
+  KnowledgeVersionToken,
+  User,
+} from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { createTwoFilesPatch, structuredPatch } from 'diff';
+import type { KnowledgeDocumentParams, KnowledgeDocumentsService } from './knowledge-documents.js';
+
+interface KnowledgeDocumentEditInput {
+  documentId?: string;
+  uri?: string;
+  namespace?: string;
+  path?: string;
+  expectedVersion?: string | number;
+  dryRun?: boolean;
+  changeSummary?: string;
+  versionMetadata?: Record<string, unknown> | null;
+  ops: KnowledgeEditOp[];
+  returnContent?: 'none' | 'full';
+}
+
+interface KnowledgeDocumentEditResponse {
+  dryRun: boolean;
+  document: KnowledgeDocument;
+  baseVersion: KnowledgeVersionToken;
+  newVersion?: KnowledgeVersionToken;
+  diff: string;
+  changedRanges: KnowledgeEditChangedRange[];
+  content?: string;
+}
+
+function versionToToken(version: KnowledgeDocumentVersion): KnowledgeVersionToken {
+  return {
+    version_id: version.version_id,
+    version_number: version.version_number,
+    content_sha256: version.content_sha256 ?? null,
+    etag: `kbv:${version.version_id}`,
+  };
+}
+
+function ensureCanEdit(document: KnowledgeDocument, user: User | undefined) {
+  const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
+  const isOwner = Boolean(user?.user_id && document.created_by === user.user_id);
+  const publicEditable = document.visibility === 'public' && document.edit_policy === 'public';
+  if (isAdmin || isOwner || publicEditable) return;
+  throw new Forbidden('You do not have permission to edit this knowledge document');
+}
+
+function extractChangedRanges(
+  baseContent: string,
+  updatedContent: string
+): KnowledgeEditChangedRange[] {
+  const patch = structuredPatch('', '', baseContent, updatedContent, '', '');
+  return patch.hunks
+    .filter((hunk) => hunk.newLines > 0)
+    .map((hunk) => {
+      const content = hunk.lines
+        .filter((line) => line.startsWith('+'))
+        .map((line) => line.slice(1))
+        .join('\n');
+      return {
+        start_line: hunk.newStart,
+        end_line: hunk.newStart + Math.max(hunk.newLines - 1, 0),
+        content,
+      } satisfies KnowledgeEditChangedRange;
+    });
+}
+
+export class KnowledgeDocumentEditsService {
+  constructor(
+    db: Database,
+    private readonly documentsService: KnowledgeDocumentsService,
+    private readonly versionRepo = new KnowledgeDocumentVersionRepository(db)
+  ) {}
+
+  async create(
+    data: KnowledgeDocumentEditInput,
+    params?: AuthenticatedParams
+  ): Promise<KnowledgeDocumentEditResponse> {
+    if (!data || !Array.isArray(data.ops) || data.ops.length === 0) {
+      throw new BadRequest('ops must be a non-empty array');
+    }
+
+    const dryRun = data.dryRun === true;
+
+    const ref: Record<string, unknown> = { include_content: true };
+    if (data.documentId) ref.document_id = data.documentId;
+    if (data.uri) ref.uri = data.uri;
+    if (data.namespace) ref.namespace_slug = data.namespace;
+    if (data.path) ref.path = data.path;
+
+    const baseParams = (params ?? {}) as KnowledgeDocumentParams;
+    const documentParams: KnowledgeDocumentParams = {
+      ...baseParams,
+      query: {
+        ...(baseParams.query ?? {}),
+        include_content: true,
+        include_links: false,
+        include_indexing: false,
+      },
+    };
+
+    const documentResult = await this.documentsService.getDocument(ref, documentParams);
+
+    if (!('document' in documentResult) || !documentResult.document) {
+      throw new NotFound('Knowledge document not found');
+    }
+
+    const document = documentResult.document;
+    ensureCanEdit(document, params?.user as User | undefined);
+
+    const currentVersion = documentResult.current_version;
+    if (!currentVersion) {
+      throw new BadRequest('Knowledge document has no current version to edit');
+    }
+
+    const expectedVersion = data.expectedVersion;
+    if (expectedVersion !== undefined && expectedVersion !== null && expectedVersion !== '') {
+      const matches =
+        String(expectedVersion) === currentVersion.version_id ||
+        String(expectedVersion) === String(currentVersion.version_number);
+      if (!matches) {
+        throw new BadRequest(
+          `Knowledge document version mismatch: expected ${expectedVersion}, current is ${currentVersion.version_number}`
+        );
+      }
+    } else if (!dryRun) {
+      throw new BadRequest('expectedVersion is required for knowledge document edits');
+    }
+
+    const baseContent = typeof documentResult.content === 'string' ? documentResult.content : '';
+
+    let updatedContent: string;
+    try {
+      const applied = applyKnowledgeEditOps(baseContent, data.ops);
+      updatedContent = applied.content;
+    } catch (error) {
+      if (error instanceof KnowledgeEditError) {
+        throw new BadRequest(error.message);
+      }
+      throw error;
+    }
+
+    const diff = createTwoFilesPatch('base', 'updated', baseContent, updatedContent, '', '');
+    const changedRanges = extractChangedRanges(baseContent, updatedContent);
+    const baseToken = versionToToken(currentVersion);
+
+    const includeContent = data.returnContent === 'full' || dryRun;
+
+    if (updatedContent === baseContent) {
+      return {
+        dryRun,
+        document,
+        baseVersion: baseToken,
+        diff,
+        changedRanges: [],
+        content: includeContent ? baseContent : undefined,
+      };
+    }
+
+    if (dryRun) {
+      return {
+        dryRun: true,
+        document,
+        baseVersion: baseToken,
+        diff,
+        changedRanges,
+        content: includeContent ? updatedContent : undefined,
+      };
+    }
+
+    const metadata = {
+      edit_source: 'mcp:agor_kb_edit',
+      base_version_id: currentVersion.version_id,
+      base_version_number: currentVersion.version_number,
+      ops: data.ops,
+      session_id: (params as { sessionId?: string } | undefined)?.sessionId ?? null,
+    } satisfies Record<string, unknown>;
+
+    const versionMetadata = {
+      ...(data.versionMetadata ?? {}),
+      ...metadata,
+    };
+
+    const updatedDocument = await this.documentsService.putDocument(
+      {
+        document_id: document.document_id,
+        content_text: updatedContent,
+        expected_version: expectedVersion ?? currentVersion.version_number,
+        change_summary: data.changeSummary,
+        version_metadata: versionMetadata,
+      },
+      baseParams
+    );
+
+    const latestVersion = await this.versionRepo.findLatestForDocument(document.document_id);
+    const newToken = latestVersion ? versionToToken(latestVersion) : undefined;
+
+    return {
+      dryRun: false,
+      document: updatedDocument,
+      baseVersion: baseToken,
+      newVersion: newToken,
+      diff,
+      changedRanges,
+      content: includeContent ? updatedContent : undefined,
+    };
+  }
+}
+
+export function createKnowledgeDocumentEditsService(
+  db: Database,
+  _app: Application,
+  documentsService: KnowledgeDocumentsService
+) {
+  return new KnowledgeDocumentEditsService(db, documentsService);
+}

--- a/context/README.md
+++ b/context/README.md
@@ -51,6 +51,7 @@ Designs that are referenced from code or in flight. Anything here is either stil
 - [`executor-expansion.md`](explorations/executor-expansion.md) — referenced from `packages/core/src/config/`.
 - [`executor-implementation-plan.md`](explorations/executor-implementation-plan.md) — phased plan for executor work.
 - [`env-var-access.md`](explorations/env-var-access.md) — per-user / per-session env var access model (referenced from schemas, types, and migrations).
+- [`kb-agent-targeted-edits.md`](explorations/kb-agent-targeted-edits.md) — design proposal for small, version-checked agent edits to large Knowledge Base markdown documents.
 - [`session-sharing.md`](explorations/session-sharing.md) — `dangerously_allow_session_sharing` security contract (referenced from `AGENTS.md` and `apps/agor-docs/pages/security.mdx`).
 - [`parent-session-callbacks.md`](explorations/parent-session-callbacks.md) — child-session completion notifications (referenced from `docs/never-lose-prompt-design.md`).
 

--- a/context/explorations/kb-agent-targeted-edits.md
+++ b/context/explorations/kb-agent-targeted-edits.md
@@ -1,0 +1,882 @@
+# Knowledge Base Agent Targeted Edits
+
+**Status:** 🔬 Exploration / design.
+**Created:** 2026-06-06
+**Scope:** DB-backed Knowledge documents and agent/MCP editing workflows. This is not an implementation plan for artifacts generally, but it borrows lessons from the artifact land/publish round trip.
+
+---
+
+## TL;DR
+
+**Recommendation: make remote, version-checked targeted edits the canonical KB editing path, and treat filesystem materialization as an optional workspace/export convenience.**
+
+For agents, the smallest clean product should be:
+
+1. Read a cheap structural view of a document: outline + line ranges + current version/ETag.
+2. Read a focused range or heading section, not the whole article.
+3. Submit **all desired edits as one `KnowledgeEditOp[]` batch** against an explicit base version.
+4. Let the server apply the batch to the current stored markdown, create **one** normal immutable KB version, reindex/search-sync, update graph references, and return a preview/diff or committed version.
+
+Filesystem round-tripping is still valuable, especially when an agent wants its normal file-edit tools. But it should be modeled as **materializing a KB snapshot into an Agor-managed workspace target** (branch/worktree, environment pod, or temp workspace), not as a generic assumption that the MCP server and client share a local filesystem.
+
+Artifacts are important precedent: Agor already has MCP tools that read/write daemon-visible filesystem paths. That precedent makes a KB filesystem workflow reasonable in self-hosted/local mode, but it also points at a security pattern we should tighten and reuse: filesystem tools should be **branch-scoped and branch-relative** (`branchId` + `subpath`), with branch RBAC checks, instead of accepting arbitrary absolute paths.
+
+---
+
+## 1. Current state summary
+
+### 1.1 Knowledge documents are DB-backed markdown with immutable versions
+
+Code pointers:
+
+- Types: `packages/core/src/types/knowledge.ts`
+- Schemas: `packages/core/src/db/schema.sqlite.ts`, `packages/core/src/db/schema.postgres.ts`
+- Repositories: `packages/core/src/db/repositories/knowledge.ts`
+- Services: `apps/agor-daemon/src/services/knowledge-documents.ts`, `knowledge-versions.ts`, `knowledge-search.ts`, `knowledge-graph.ts`
+- MCP tools: `apps/agor-daemon/src/mcp/tools/knowledge.ts`
+- UI: `apps/agor-ui/src/pages/KnowledgePage.tsx`
+
+The core document row (`kb_documents`) stores stable identity and governance: namespace/path/URI, title, kind, visibility, status, edit policy, owner/updater fields, archived state, and `current_version_id`.
+
+The content itself lives in immutable `kb_document_versions` rows with `version_number`, `content_text`, content hashes, frontmatter, version metadata, change summary, creator, and timestamp.
+
+Writes are already version-producing: `KnowledgeDocumentRepository.update()` inserts a new `kb_document_versions` row when `content_text` is supplied, then advances `kb_documents.current_version_id` in the same transaction.
+
+### 1.2 Current agent edit surface is whole-document
+
+The MCP Knowledge tools currently expose:
+
+- `agor_kb_get`: reads a document by id/URI/namespace+path. It includes full markdown content by default.
+- `agor_kb_put`: creates or updates a markdown document. The `content` input is the full markdown body for the new version.
+- `agor_kb_history`: lists immutable versions; can include full historical content.
+- `agor_kb_search`, namespace tools, and graph tools.
+
+`agor_kb_put` has an `expectedVersion` optimistic concurrency argument, but the caller must still send the complete replacement content. For a large document where only one line changes, today an agent likely has to fetch the full document into context and post the full replacement back.
+
+The UI follows the same model: `KnowledgePage.tsx` loads content for the active document and saves via `client.service('kb/documents').patch(activeDoc.document_id, { content_text: ... })`.
+
+### 1.3 Internal KB units are not yet an editing API
+
+`kb_document_units` already represent document/section/file/auto-split units used for search/indexing. The markdown chunking path can produce heading-aware units, and search results can include chunks/snippets.
+
+However, these units are explicitly internal. They do not currently provide stable editable section IDs, and they are replaced on each version. They are useful as implementation support for outline/range reads, but should not be treated as durable user-facing edit targets without an explicit stability contract.
+
+### 1.4 Artifact land/publish exists but is filesystem-coupled
+
+Artifacts have a mature round-trip workflow:
+
+- `agor_artifacts_publish(folderPath, ...)` reads a folder and stores a DB file map.
+- `agor_artifacts_land(artifactId, branchId, subpath, overwrite)` writes stored files into a branch path, with branch permission checks and path containment.
+- `ArtifactsService.land()` carefully prevents absolute paths, branch-root writes, destination escapes, and artifact file path escapes. It writes a sidecar (`agor.artifact.json`) so metadata survives round trips.
+
+This is a useful precedent, but it also exposes the trap for KB and for artifacts themselves: some artifact tools accept daemon-local absolute paths and assume the daemon can read/write branch paths or temp dirs. That is acceptable for current self-hosted/local deployments only if scoped carefully. A remote MCP client cannot assume that `/tmp/foo.md` means the same machine, namespace, or permissions boundary as the daemon.
+
+Security note: artifact landing already takes `branchId` and checks branch permission. Artifact publishing/checking from arbitrary absolute `folderPath` is more open: if a caller can point the daemon at a readable path inside some registered branch or temp directory, the tool may read/publish content without proving the caller has branch access. KB should not copy that shape. Longer-term, artifacts should align to the safer pattern too:
+
+```ts
+agor_artifacts_publish({
+  branchId,
+  subpath, // branch-relative folder path
+  ...
+})
+```
+
+The service can still support a legacy absolute `folderPath` escape hatch for local/self-hosted compatibility, but new MCP guidance should prefer `branchId + subpath`, branch containment, and branch RBAC.
+
+### 1.5 Existing permissions are document-centric, not branch-centric
+
+Knowledge document access today is handled in `KnowledgeDocumentsService`:
+
+- Read if document is public, user is admin, or user is creator.
+- Edit if user is admin, creator, or document is public with `edit_policy = public`.
+- Governance changes (`visibility`, `status`, `edit_policy`) are owner/admin only.
+- Drafts are not secret by status alone; browsing/search hide other users' drafts by default, while direct reads still use normal visibility checks.
+
+Branch RBAC only applies indirectly today when a tool writes to a branch filesystem, e.g. artifact landing requires `session` permission or higher on the target branch.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Let agents edit small parts of large KB markdown documents without loading full content into model context.
+- Preserve the existing KB write lifecycle: immutable versions, hashes, search units, graph reference sync, realtime events, history UI.
+- Make concurrency explicit and safe via version/ETag checks.
+- Keep MCP tools usable from local and remote clients.
+- Provide a path to normal file-edit workflows without baking in a shared-filesystem assumption.
+- Keep V1 small enough to ship and review.
+
+### Non-goals for the first PR
+
+- Collaborative CRDT editing.
+- A full markdown AST editor.
+- Stable semantic section IDs across arbitrary heading renames.
+- Git sync for KB documents.
+- Replacing the current whole-document UI editor.
+- Solving artifact filesystem decoupling broadly.
+
+---
+
+## 3. Recommended approach
+
+### 3.1 Canonical path: DB-native targeted edits
+
+Add a KB edit service/API that accepts a document reference, an expected base version, and one or more edit operations. The server reads the current version content internally, validates the base version, applies the operations, and writes a new ordinary KB version.
+
+This keeps the source of truth in the KB database and avoids forcing the model to hold a full document. The server can still read the full content in memory; the constraint is model context, not daemon RAM.
+
+Recommended V1 flow:
+
+```text
+agent
+  -> agor_kb_outline(documentId)
+     returns headings, line ranges, version id/number/hash
+
+agent
+  -> agor_kb_get_range(documentId, startLine, endLine, contextLines, version)
+     returns only relevant lines + same version metadata
+
+agent
+  -> agor_kb_edit(documentId, expectedVersion, ops, dryRun=false, changeSummary)
+     server applies the full ops[] batch atomically, creates one KB version, returns diff + new version
+```
+
+### 3.2 Optional path: workspace materialization
+
+Support filesystem workflows as a second layer:
+
+```text
+agor_kb_materialize(documentRef, target={kind:"branch", branchId, subpath})
+agent edits file using normal file tools
+agor_kb_publish_from_workspace(materializationId or sourceRef, expectedVersion)
+```
+
+The important product distinction: this is not "write this file to my local disk." It is "materialize this KB snapshot into an Agor-managed workspace resource." The workspace may happen to be a local worktree in self-hosted mode, or it may be an executor/env pod volume in hosted mode.
+
+If a non-Agor local MCP client wants to edit a local file, it should use download/upload semantics or targeted remote edit tools. It should not pass arbitrary local paths to the daemon and expect them to exist.
+
+### 3.3 Why this recommendation
+
+Remote targeted edits are the best default because they:
+
+- Work for local and remote MCP clients.
+- Reuse existing KB permissions and versioning.
+- Avoid arbitrary daemon filesystem reads/writes.
+- Are auditable as document edits, not opaque file syncs.
+- Produce clean conflict errors before a write.
+- Fit the current DB-backed KB design.
+
+Materialization remains useful because agents are very good at file editing when the source is on disk. But making it optional avoids turning KB into a filesystem staging system by default.
+
+---
+
+## 4. Alternative designs and tradeoffs
+
+### Option A — Whole-document get/put only
+
+**Shape:** Keep `agor_kb_get` and `agor_kb_put` as the only content API.
+
+**Pros**
+
+- Already exists.
+- Simple mental model.
+- Existing versioning and graph sync work.
+
+**Cons**
+
+- Poor for large documents and small edits.
+- High context cost and more opportunities for accidental unrelated changes.
+- Hard for an agent to prove it only changed one line.
+
+**Verdict:** Keep as escape hatch, but not sufficient.
+
+### Option B — Filesystem-first KB editing
+
+**Shape:** Add tools such as `land_markdown_in_my_worktree` and `publish_from_file_in_worktree`.
+
+**Pros**
+
+- Agents can use normal file-edit tools (`apply_patch`, editor buffers, grep, etc.).
+- Familiar workflow for code-oriented agents.
+- Easy to inspect in a branch before publishing.
+
+**Cons**
+
+- Ambiguous over MCP: whose filesystem is "my" worktree?
+- Harder hosted story: daemon may not share FS with branch/env/executor.
+- More RBAC layers: KB read/edit plus branch write plus Unix permissions.
+- Publish must detect stale base version, moved/renamed docs, sidecar loss, and path spoofing.
+- Creates an attractive nuisance: arbitrary path reads if modeled as `folderPath`/`filePath` too loosely.
+
+**Verdict:** Useful as optional materialization into explicit Agor workspace targets. Not clean as the primary API. If implemented, the MCP shape should be branch-relative (`branchId` + `subpath`) and permission-checked, matching the artifact hardening direction.
+
+### Option C — Many tiny remote edit tools
+
+**Shape:** Expose separate tools: replace-in-document, insert-at-line, delete-line-range, replace-line-range, replace-heading-section, apply-unified-diff, etc.
+
+**Pros**
+
+- Easy for simple agents to discover a purpose-built tool.
+- Deterministic line operations are straightforward to validate.
+- Small inputs/outputs.
+
+**Cons**
+
+- Tool sprawl.
+- Hard to compose atomically across multiple edits unless each tool grows batching semantics.
+- Slightly different concurrency semantics per tool if not centralized.
+
+**Verdict:** Avoid many top-level tools. Prefer one `agor_kb_edit` tool with a small set of operation types.
+
+### Option D — Unified diff/patch only
+
+**Shape:** Expose `agor_kb_apply_patch(document, expectedVersion, unifiedDiff)`.
+
+**Pros**
+
+- Very natural for coding agents.
+- Can represent multiple hunks in one atomic edit.
+- Server can return standard conflict/hunk failure diagnostics.
+
+**Cons**
+
+- Unified diff formatting is brittle across LLMs and libraries.
+- Markdown headings/line numbers are easier for humans and simpler agents.
+- Applying fuzzy patches can hide conflicts unless strict by default.
+
+**Verdict:** Include as a supported operation, but not the only V1 path. Make it strict by default.
+
+### Option E — Section-based AST edits
+
+**Shape:** Expose edits by markdown heading path or stable section anchor.
+
+**Pros**
+
+- Better product semantics than line numbers.
+- Resilient to unrelated edits above the target section if the heading is stable.
+- Aligns with KB search units/chunking.
+
+**Cons**
+
+- Heading paths are not unique unless normalized and disambiguated.
+- Heading rename/move semantics are hard.
+- Requires a stable section identity contract if exposed broadly.
+
+**Verdict:** Good Phase 2. In V1, expose outline/ranges and allow a convenience `replace_heading_section` only if it resolves to exactly one current range and still requires `expectedVersion` or `expectedSectionHash`.
+
+---
+
+## 5. Proposed API and MCP shape
+
+### 5.1 Shared document reference
+
+Reuse the existing MCP reference pattern:
+
+```ts
+type KnowledgeDocumentRef = {
+  documentId?: string; // full UUID or short id
+  uri?: string; // agor://kb/<namespace>/<path> or agor://kb/document/<id>
+  namespace?: string;
+  path?: string;
+};
+```
+
+Prefer `documentId` or `agor://kb/document/<id>` for rename-proof edits.
+
+### 5.2 Version / ETag vocabulary
+
+Expose these consistently in read responses:
+
+```ts
+type KnowledgeVersionToken = {
+  versionId: string;
+  versionNumber: number;
+  contentSha256: string | null;
+  etag: string; // e.g. "kbv:<versionId>" or HTTP ETag header
+};
+```
+
+For writes, require one of:
+
+```ts
+expectedVersion: string | number; // current existing style
+// or
+ifMatch: string; // ETag-style alias for HTTP clients
+```
+
+For MCP, keep `expectedVersion` to match `agor_kb_put`, and add `ifMatch` only if REST clients need direct ETag ergonomics.
+
+### 5.3 `agor_kb_outline`
+
+Read-only. Returns document metadata plus a markdown outline with line ranges.
+
+```ts
+agor_kb_outline({
+  documentId?: string;
+  uri?: string;
+  namespace?: string;
+  path?: string;
+  version?: string | number;
+  maxDepth?: number; // default 6
+}) -> {
+  document: KnowledgeDocument;
+  version: KnowledgeVersionToken;
+  lineCount: number;
+  headings: Array<{
+    level: number;
+    title: string;
+    headingPath: string;       // display/convenience, not a permanent id
+    occurrence: number;        // disambiguates duplicate heading paths
+    startLine: number;         // 1-based inclusive
+    endLine: number;           // 1-based inclusive section end
+    contentStartLine: number;  // first line after heading
+    anchor?: string;
+    contentMd5?: string;       // hash of this section in this version
+  }>;
+}
+```
+
+Implementation can reuse/extend `knowledgeUnitsForMarkdown` or add a lightweight markdown-outline utility. Do not expose `kb_document_units.unit_id` as a stable edit id in V1.
+
+### 5.4 `agor_kb_get_range`
+
+Read-only. Returns a bounded slice of content by line range or heading.
+
+```ts
+agor_kb_get_range({
+  documentId?: string;
+  uri?: string;
+  namespace?: string;
+  path?: string;
+  version?: string | number;
+
+  startLine?: number;
+  endLine?: number;
+
+  headingPath?: string;
+  occurrence?: number;
+
+  contextLines?: number; // default 2, cap e.g. 20
+  includeLineNumbers?: boolean; // default true
+}) -> {
+  document: KnowledgeDocument;
+  version: KnowledgeVersionToken;
+  lineCount: number;
+  range: {
+    startLine: number;
+    endLine: number;
+    contextStartLine: number;
+    contextEndLine: number;
+    content: string;
+    numberedContent?: string;
+    contentMd5: string;
+  };
+}
+```
+
+Hard caps should prevent accidental full-document reads via a range tool. If the caller asks for too many lines, return a helpful error suggesting `agor_kb_get` for intentional full reads.
+
+### 5.5 `agor_kb_edit`
+
+Mutating. Applies one or more operations atomically to a document version. **One successful `agor_kb_edit` call creates one new `kb_document_versions` row.** The tool description should tell agents to batch related micro-edits into a single call: if the agent calls this tool 12 times, it will create 12 full-content versions and re-run version side effects 12 times.
+
+```ts
+agor_kb_edit({
+  documentId?: string;
+  uri?: string;
+  namespace?: string;
+  path?: string;
+
+  expectedVersion: string | number; // required for content-changing commits
+  dryRun?: boolean;                 // default false
+  changeSummary?: string;
+  metadata?: Record<string, unknown>;
+
+  ops: KnowledgeEditOp[];
+
+  returnContent?: 'none' | 'changed_ranges' | 'full'; // default changed_ranges
+}) -> {
+  dryRun: boolean;
+  document: KnowledgeDocument;
+  baseVersion: KnowledgeVersionToken;
+  newVersion?: KnowledgeVersionToken;
+  changedRanges: Array<{ startLine: number; endLine: number; content: string }>;
+  diff: string;
+  warnings: string[];
+}
+```
+
+Recommended V1 operation set:
+
+```ts
+type KnowledgeEditOp =
+  | {
+      type: 'replace_line_range';
+      startLine: number;
+      endLine: number; // inclusive
+      replacement: string;
+      expectedText?: string; // exact guard against line drift
+      expectedMd5?: string;
+    }
+  | {
+      type: 'insert_at_line';
+      line: number;
+      position?: 'before' | 'after'; // default before
+      content: string;
+      expectedNeighborText?: string;
+    }
+  | {
+      type: 'delete_line_range';
+      startLine: number;
+      endLine: number;
+      expectedText?: string;
+      expectedMd5?: string;
+    }
+  | {
+      type: 'replace_literal';
+      find: string;
+      replace: string;
+      expectedCount: number;
+      scope?: EditScope;
+    }
+  | {
+      type: 'apply_unified_diff';
+      patch: string;
+      strict?: boolean; // default true: no fuzzy hunk matching in V1
+    };
+```
+
+Phase 2 operation:
+
+```ts
+| {
+    type: 'replace_heading_section';
+    headingPath: string;
+    occurrence?: number;
+    replacement: string;
+    expectedSectionMd5?: string;
+  }
+```
+
+Why this set:
+
+- Line-range ops are deterministic, easy to explain, and small.
+- `expectedText`/`expectedMd5` lets the agent prove it edited the intended slice.
+- Literal find/replace is useful for repeated terminology/link fixes when guarded by `expectedCount` and optional scope.
+- Unified diff covers advanced multi-hunk edits without many tool variants.
+- A single `ops` array makes multi-edit commits atomic.
+
+Regex replace should be a later operation, not V1 default:
+
+```ts
+| {
+    type: 'replace_regex';
+    pattern: string;
+    flags?: string;
+    replace: string;
+    expectedCount: number;
+    maxReplacements?: number;
+    scope?: EditScope;
+  }
+```
+
+Regex risks are mostly reliability and denial-of-service, not privilege escalation: catastrophic backtracking, excessive matches, hard-to-review replacement semantics, and implementation-dependent behavior. If added, use a safe regex engine such as RE2 where possible, cap pattern/replacement/input sizes, require `expectedCount` or `maxReplacements`, support scoping, and return a dry-run match preview.
+
+### 5.6 REST / service shape
+
+Prefer a first-class service over overloading `kb/documents.patch`:
+
+```text
+POST /kb/document-edits
+```
+
+Feathers service: `kb/document-edits` with `create(data, params)`.
+
+Reasons:
+
+- Keeps normal `kb/documents.patch` as metadata/whole-content patch.
+- Gives hooks/audit/rate limits a clean resource name.
+- Lets MCP and UI share exactly one backend path.
+- Avoids adding many custom methods to `KnowledgeDocumentsService`.
+
+The service should internally reuse Knowledge document permission checks and repository update behavior. If those helpers stay private, factor them into shared utilities rather than duplicating authorization logic.
+
+### 5.7 Optional materialization tools
+
+Do not name these as local-only filesystem tools. Use workspace language.
+
+```ts
+agor_kb_materialize({
+  documentId?: string;
+  uri?: string;
+  namespace?: string;
+  path?: string;
+  version?: string | number;
+  target: {
+    kind: 'branch';
+    branchId: string;
+    subpath?: string; // branch-relative; default .agor/kb/<namespace>/<path>
+  } | {
+    kind: 'temp_workspace';
+    ttlMinutes?: number;
+  };
+  overwrite?: boolean;
+}) -> {
+  materializationId: string;
+  document: KnowledgeDocument;
+  version: KnowledgeVersionToken;
+  target: { kind: string; branchId?: string; path?: string; workspaceId?: string };
+  instructions: string;
+}
+```
+
+```ts
+agor_kb_publish_from_workspace({
+  materializationId?: string;
+  source: {
+    kind: 'branch';
+    branchId: string;
+    path: string; // branch-relative path
+  } | {
+    kind: 'temp_workspace';
+    workspaceId: string;
+    path?: string;
+  };
+  documentId?: string;
+  expectedVersion?: string | number; // required unless sidecar supplies it
+  changeSummary?: string;
+  dryRun?: boolean;
+}) -> { ...same as agor_kb_edit-ish result... }
+```
+
+The sidecar should include at least:
+
+```json
+{
+  "$schema": "https://agor.live/schemas/kb-materialization/2026-06-06.json",
+  "document_id": "...",
+  "uri": "agor://kb/document/...",
+  "namespace": "global",
+  "path": "foo.md",
+  "version_id": "...",
+  "version_number": 12,
+  "content_sha256": "...",
+  "materialized_at": "...",
+  "materialized_by": "..."
+}
+```
+
+For hosted/remote execution, the write/read should happen through the executor or environment owner for that workspace. The daemon should not need direct access to branch files in the long-term architecture.
+
+The same branch-relative shape should be the preferred future artifact API:
+
+```ts
+agor_artifacts_publish({
+  branchId,
+  subpath,
+  artifactId?,
+  ...
+})
+```
+
+`agor_artifacts_land` is already close because it requires `branchId`; `agor_artifacts_publish` and `agor_artifacts_check_build` are the bigger alignment targets because they currently accept absolute folders.
+
+---
+
+## 6. Data, versioning, and concurrency model
+
+### 6.1 Existing version table remains the source of truth
+
+V1 does not need a schema change. A targeted edit ultimately produces a normal `kb_document_versions` row with complete `content_text`, hashes, frontmatter, version metadata, and change summary.
+
+Store edit details in `version_metadata` initially:
+
+```json
+{
+  "edit_source": "mcp:agor_kb_edit",
+  "base_version_id": "...",
+  "base_version_number": 11,
+  "ops": [{ "type": "replace_line_range", "startLine": 42, "endLine": 44 }],
+  "dry_run": false
+}
+```
+
+Do not store full replacement snippets in metadata by default if they duplicate the version content. Keep metadata small and audit-oriented.
+
+### 6.2 Future audit table
+
+A later PR can add `kb_document_edit_events` if version metadata becomes insufficient:
+
+```ts
+interface KnowledgeDocumentEditEvent {
+  edit_event_id: string;
+  document_id: string;
+  base_version_id: string;
+  new_version_id?: string | null;
+  actor_user_id?: string | null;
+  session_id?: string | null;
+  task_id?: string | null;
+  tool_name: string;
+  dry_run: boolean;
+  ops_summary: unknown;
+  diff_md5?: string | null;
+  status: 'applied' | 'dry_run' | 'conflict' | 'failed';
+  error?: string | null;
+  created_at: Date;
+}
+```
+
+This table becomes more important for personal API key MCP calls, where there may be no persisted task/message transcript to audit.
+
+### 6.3 Optimistic concurrency
+
+Rules:
+
+- Mutating targeted edits require `expectedVersion` unless `dryRun=true` and explicitly allowed.
+- The server resolves the current document and checks that current version id or number matches.
+- If it does not match, return `409 Conflict` (or MCP error payload) with:
+  - current version id/number/hash,
+  - base version requested,
+  - a hint to re-run `agor_kb_outline`/`agor_kb_get_range`,
+  - optionally the current target range if the operation included line numbers and the range is safe to show.
+
+Line operations also validate their own guards:
+
+- `startLine`/`endLine` within current base content.
+- `expectedText` exact match if supplied.
+- `expectedMd5` exact match if supplied.
+- Multiple ops are compiled against the same base content, then applied deterministically as a batch. V1 should reject overlapping ranges/matches. For line ops, either require non-overlapping sorted input or apply compiled spans from bottom-to-top to avoid line shifts. For find/replace ops, require `expectedCount` so broad accidental replacements fail closed.
+
+### 6.4 Preview/dry-run
+
+`dryRun=true` should perform the same permission, version, operation, markdown, and graph-link preview checks but not write a new version.
+
+Return:
+
+- unified diff,
+- changed ranges,
+- warnings,
+- would-be title if `title_from_content` metadata is active,
+- extracted KB links delta if feasible.
+
+### 6.5 Markdown validity
+
+Markdown is permissive, so "validity" should mean lightweight safety checks, not a full formal validation gate:
+
+- Preserve line endings reasonably; normalize to `\n` unless existing content is CRLF and we decide to preserve it.
+- Ensure content remains UTF-8 text.
+- Keep existing path normalization rules for document identity.
+- If frontmatter is supported in content later, parse frontmatter in preview and return warnings instead of silently corrupting it.
+- Re-run existing link extraction and graph sync on commit.
+- Re-run chunking/search unit replacement exactly as whole-document writes do.
+
+---
+
+## 7. Security, RBAC, and audit considerations
+
+### 7.1 Document permissions
+
+Targeted edits must use the same read/edit rules as whole-document edits:
+
+- Read slices/outline only if `canRead(document, user)`.
+- Commit edits only if `canEdit(document, user)`.
+- Governance changes remain outside targeted edit ops and stay owner/admin only.
+
+Do not let targeted edit tools mutate `visibility`, `status`, `edit_policy`, namespace, or path. Keep those on the existing document management surface.
+
+### 7.2 Branch/workspace permissions
+
+Materialization adds a second authorization layer:
+
+- To materialize into a branch, caller must read the KB doc and have at least branch `session` permission (same threshold artifact land uses today) or a deliberately chosen stronger tier.
+- To publish from a branch/workspace, caller must have KB edit permission and read access to the workspace file. If the source is a branch, they should also have at least branch `session` permission.
+- In strict/insulated Unix modes, filesystem operations should execute as the same identity that owns the workspace/executor context, not as the daemon user.
+
+### 7.3 Avoid arbitrary path APIs
+
+Avoid MCP tools that accept daemon-local absolute paths unless the path is explicitly scoped by an Agor resource id.
+
+Bad universal shape:
+
+```ts
+publish_from_file({ filePath: '/tmp/foo.md' });
+```
+
+Better shape:
+
+```ts
+publish_from_workspace({ source: { kind: 'branch', branchId, path: '.agor/kb/foo.md' } });
+```
+
+The second shape lets Agor validate branch RBAC, path containment, executor locality, and audit provenance.
+
+This should become a shared filesystem-tool contract:
+
+- New KB tools: require `branchId + branchRelativePath` for branch materialization/publish.
+- New artifact tools: prefer `branchId + subpath` for publish/check/build workflows.
+- Legacy artifact absolute paths: keep only as an explicit compatibility path if needed, and consider rejecting paths inside branches unless the caller has access to the matched branch.
+- Temp directories: if supported, use Agor-created temp workspaces or per-call upload/materialization IDs, not arbitrary `/tmp` reads.
+
+### 7.4 MCP local/remote model
+
+MCP calls are authenticated HTTP requests to Agor. They may come from:
+
+- an Agor-launched agent running in a branch worktree,
+- a local desktop client on the same host as the daemon,
+- a remote hosted agent,
+- a third-party orchestrator with a personal API key.
+
+Tool names and schemas should not imply a shared local filesystem. A returned `path` should be described as an Agor workspace path, not necessarily a path the MCP client can open locally.
+
+### 7.5 Direct URL access
+
+Direct document URLs already use `canRead` semantics. Targeted edit previews and materialized workspace files need equivalent care:
+
+- A preview/diff response may include private document text and must require read permission.
+- Materialized files in a branch inherit branch filesystem exposure. That means landing a private KB document into a shared branch can intentionally or accidentally broaden access. The tool should warn when `document.visibility = private` and the target branch is shared.
+- Temp workspaces should have TTLs and owner-scoped access.
+
+### 7.6 Audit trail
+
+V1 audit sources:
+
+- Existing immutable version history (`created_by`, `created_at`, `change_summary`, hashes).
+- `updated_by`/`updated_at` on `kb_documents`.
+- Version metadata with targeted edit source and base version.
+- MCP/task transcripts when the edit happened inside an Agor session.
+
+Recommended improvements:
+
+- Include `ctx.sessionId` in edit metadata when present.
+- Add a future edit-events table for conflict/dry-run/failed attempts and personal API key calls.
+- Surface targeted edit summaries in the Knowledge history UI.
+
+---
+
+## 8. UI affordances
+
+Small, useful UI pieces:
+
+1. **History diff view**: show version-to-version markdown diff. This helps human review of targeted edits even before a richer preview flow.
+2. **Conflict banner**: if a user is editing stale content, show current version changed and offer reload/diff.
+3. **Agent edit preview modal**: for dry-run/proposed edits, show summary, changed ranges, and unified diff; allow owner to apply if permissions allow.
+4. **Line numbers / copy range**: optionally show line numbers in read mode or expose "copy range reference" so humans can ask an agent to edit `global/foo.md lines 120-135`.
+5. **Outline anchors**: headings in the viewer can expose stable-ish anchors and line ranges for agent prompts.
+6. **Materialization warning**: when landing private KB into a shared branch, show/return a warning about branch exposure.
+
+No need to build these in the first PR unless the backend needs a human tester.
+
+---
+
+## 9. Phased implementation plan
+
+### Phase 0 — Refactor support only if needed
+
+- Extract reusable document resolution and permission helpers from `KnowledgeDocumentsService` if the new edit service would otherwise duplicate private methods.
+- Add a markdown line/outline utility with focused unit tests.
+
+### Phase 1 — Smallest useful first PR
+
+Ship remote targeted edits only:
+
+1. Add core types for:
+   - `KnowledgeVersionToken`
+   - `KnowledgeDocumentOutline`
+   - `KnowledgeDocumentRange`
+   - `KnowledgeEditOp`
+   - `KnowledgeEditResult`
+2. Add `kb/document-edits` service with `create()` supporting:
+   - `dryRun`
+   - required `expectedVersion` for commits
+   - `replace_line_range`
+   - `insert_at_line`
+   - `delete_line_range`
+   - `replace_literal` with required `expectedCount`
+   - non-overlap validation
+   - version metadata carrying edit source/base/ops summary
+3. Add read helpers, either as:
+   - `kb/document-ranges` service, or
+   - custom methods on documents service exposed through MCP only initially.
+4. Add MCP tools:
+   - `agor_kb_outline`
+   - `agor_kb_get_range`
+   - `agor_kb_edit`
+5. Tests:
+   - unit tests for line operation application,
+   - service tests for permissions and version mismatch,
+   - MCP tool tests for schema/argument mapping,
+   - graph/search sync still runs because commit delegates to existing document update path.
+
+This PR solves the core agent problem without filesystem complexity.
+
+MCP copy should be explicit: one successful call creates one immutable KB version, so agents should collect related edits and send them as one `ops[]` batch rather than calling the tool repeatedly for micro-edits.
+
+### Phase 1A — Artifact filesystem hardening / alignment
+
+This can ship independently or as a small security-adjacent patch near the KB work:
+
+- Add branch-relative variants to `agor_artifacts_publish` and `agor_artifacts_check_build`:
+  - `branchId`
+  - `subpath`
+  - branch RBAC check (`session` or stronger)
+  - path containment under the resolved branch root
+- Keep `folderPath` temporarily for compatibility, but prefer/describe `branchId + subpath` in MCP docs.
+- If `folderPath` resolves inside a known branch, require the caller to have access to that branch before reading.
+- Consider replacing arbitrary temp-dir publishing with Agor-managed temp workspace IDs.
+
+This aligns artifacts and KB on the same filesystem security contract and reduces the risk that a user can publish files from a branch or temp path they should not be able to read.
+
+### Phase 2 — Unified diff and better previews
+
+- Add `apply_unified_diff` op with strict hunk application.
+- Add richer dry-run response with rendered diff and title/link deltas.
+- UI history diff view.
+
+### Phase 3 — Heading-section convenience
+
+- Add `replace_heading_section` using outline resolution.
+- Return duplicate-heading diagnostics and require `occurrence` when ambiguous.
+- Consider stable generated section anchors if the product starts relying on section identities.
+
+### Phase 4 — Workspace materialization
+
+- Add `kb_materializations` concept or sidecar-only MVP.
+- Materialize into branch target with `branchId + subpath`, branch RBAC, and path containment.
+- Publish from branch target with `branchId + branch-relative path` and sidecar `expectedVersion`.
+- Route filesystem operations through executor/workspace abstraction where available, instead of daemon-local FS.
+
+### Phase 5 — Full audit and collaboration polish
+
+- Add `kb_document_edit_events`.
+- UI proposed-edit review queue.
+- Optional locks/leases if humans and agents frequently collide on long edits.
+
+---
+
+## 10. Open questions
+
+1. Should `expectedVersion` be mandatory for `dryRun`, or only for commits?
+2. Should V1 line numbers be 1-based only? Recommendation: yes, and document it everywhere.
+3. What is the maximum range size for `agor_kb_get_range` before the caller should use `agor_kb_get` intentionally?
+4. Should `replace_line_range` preserve trailing newline exactly, or normalize all KB markdown to `\n`?
+5. Is `branch session` permission sufficient for KB materialization, or should landing private docs require `prompt`/`all` or explicit branch owner confirmation?
+6. Should public-edit KB documents allow any member to use targeted edits, or should MCP targeted edits require a stricter role than the UI? Recommendation: same as whole-document edit to avoid surprising policy divergence.
+7. Do we need a separate `review/apply proposed edit` workflow before agents can commit to high-value namespaces?
+8. Should search units become stable section references eventually, or should editable section IDs be a distinct table?
+9. How much of the edit event audit belongs in version metadata versus a first-class table from day one?
+10. For hosted deployments, what is the canonical "workspace" abstraction shared by branch files, terminals, artifacts, uploads, and KB materializations?
+
+---
+
+## 11. Summary recommendation
+
+Build the KB editing API around **small remote reads + atomic version-checked edit operations**. It is the cleanest fit for Agor's DB-backed Knowledge model and works regardless of where the MCP client runs.
+
+Then add filesystem materialization as an explicit Agor workspace feature, not as a generic local path feature. That keeps the excellent agent file-edit workflow available without compromising RBAC, auditability, or the hosted/remote architecture.
+
+### Implementation notes — June 6, 2026
+
+- `kb/document-edits` service applies `KnowledgeEditOp[]` sequentially and reuses `putDocument` so only one version is minted per successful call. Dry runs skip the commit and can optionally return the post-edit content via `returnContent:"full"`.
+- The MCP tool `agor_kb_edit` surfaces the same guarantee and encourages batching to avoid version spam.
+- Artifact publish/check now prefer `branchId + subpath` and enforce branch RBAC when paths resolve inside a registered worktree; legacy `folderPath` is still accepted but inherits the same permission gate.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -298,6 +298,12 @@
       "import": "./dist/unix/index.js",
       "require": "./dist/unix/index.cjs"
     },
+    "./knowledge": {
+      "source": "./src/knowledge/index.ts",
+      "types": "./dist/knowledge/index.d.ts",
+      "import": "./dist/knowledge/index.js",
+      "require": "./dist/knowledge/index.cjs"
+    },
     "./mcp": {
       "source": "./src/mcp/index.ts",
       "types": "./dist/mcp/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export * from './config/index.js';
 export * from './db/index.js';
 export * from './environment/render-snapshot.js';
 export * from './git/index.js';
+export * from './knowledge/index.js';
 export * from './lib/validation.js';
 export * from './mcp/index.js';
 export * from './search/index.js';

--- a/packages/core/src/knowledge/edit-ops.test.ts
+++ b/packages/core/src/knowledge/edit-ops.test.ts
@@ -1,0 +1,103 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import type { KnowledgeEditOp } from '../types/knowledge.js';
+import { applyKnowledgeEditOps, KnowledgeEditError } from './edit-ops.js';
+
+describe('applyKnowledgeEditOps', () => {
+  it('replaces a line range', () => {
+    const base = '# Title\nLine A\nLine B';
+    const ops: KnowledgeEditOp[] = [
+      {
+        type: 'replace_line_range',
+        startLine: 2,
+        endLine: 3,
+        replacement: 'Line B\nLine C',
+        expectedText: 'Line A\nLine B',
+      },
+    ];
+    const result = applyKnowledgeEditOps(base, ops);
+    expect(result.content).toBe('# Title\nLine B\nLine C');
+  });
+
+  it('inserts before and after lines', () => {
+    const base = 'alpha\nbeta';
+    const ops: KnowledgeEditOp[] = [
+      {
+        type: 'insert_at_line',
+        line: 1,
+        position: 'before',
+        content: 'intro',
+      },
+      {
+        type: 'insert_at_line',
+        line: 3,
+        position: 'after',
+        content: 'omega',
+      },
+    ];
+    const result = applyKnowledgeEditOps(base, ops);
+    expect(result.content).toBe('intro\nalpha\nbeta\nomega');
+  });
+
+  it('deletes lines with expected md5', () => {
+    const base = 'keep\nremove\nme';
+    const ops: KnowledgeEditOp[] = [
+      {
+        type: 'delete_line_range',
+        startLine: 2,
+        endLine: 3,
+        expectedMd5: createHash('md5').update('remove\nme').digest('hex'),
+      },
+    ];
+    const result = applyKnowledgeEditOps(base, ops);
+    expect(result.content).toBe('keep');
+  });
+
+  it('replaces literal occurrences with expected count', () => {
+    const base = 'foo bar foo';
+    const ops: KnowledgeEditOp[] = [
+      {
+        type: 'replace_literal',
+        find: 'foo',
+        replace: 'baz',
+        expectedCount: 2,
+      },
+    ];
+    const result = applyKnowledgeEditOps(base, ops);
+    expect(result.content).toBe('baz bar baz');
+  });
+
+  it('throws when expected literal count mismatches', () => {
+    const base = 'foo';
+    const ops: KnowledgeEditOp[] = [
+      { type: 'replace_literal', find: 'foo', replace: 'baz', expectedCount: 2 },
+    ];
+    expect(() => applyKnowledgeEditOps(base, ops)).toThrow(KnowledgeEditError);
+  });
+
+  it('applies sequential mixed operations', () => {
+    const base = 'Line 1\nLine 2\nLine 3';
+    const ops: KnowledgeEditOp[] = [
+      {
+        type: 'replace_line_range',
+        startLine: 2,
+        endLine: 2,
+        replacement: 'Middle',
+      },
+      {
+        type: 'insert_at_line',
+        line: 3,
+        position: 'before',
+        content: 'Inserted',
+      },
+      {
+        type: 'replace_literal',
+        find: 'Line',
+        replace: 'Row',
+        expectedCount: 2,
+      },
+    ];
+    const result = applyKnowledgeEditOps(base, ops);
+    expect(result.content).toBe('Row 1\nMiddle\nInserted\nRow 3');
+  });
+});

--- a/packages/core/src/knowledge/edit-ops.ts
+++ b/packages/core/src/knowledge/edit-ops.ts
@@ -1,0 +1,206 @@
+import { createHash } from 'node:crypto';
+import type { KnowledgeEditOp } from '../types/knowledge.js';
+
+function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n/g, '\n');
+}
+
+function splitLines(text: string): string[] {
+  if (text === '') return [''];
+  return normalizeNewlines(text).split('\n');
+}
+
+function md5(text: string): string {
+  return createHash('md5').update(text).digest('hex');
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle === '') return 0;
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count += 1;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+function joinLines(lines: string[]): string {
+  if (lines.length === 0) return '';
+  // Preserve trailing empty line (which represents trailing newline)
+  const content = lines.join('\n');
+  return content;
+}
+
+function toLineRangeString(lines: string[]): string {
+  return joinLines(lines);
+}
+
+class KnowledgeEditError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KnowledgeEditError';
+  }
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new KnowledgeEditError(message);
+}
+
+function applyReplaceLineRange(
+  lines: string[],
+  op: Extract<KnowledgeEditOp, { type: 'replace_line_range' }>
+): void {
+  const { startLine, endLine } = op;
+  assert(
+    Number.isInteger(startLine) && startLine >= 1,
+    'replace_line_range.startLine must be >= 1'
+  );
+  assert(
+    Number.isInteger(endLine) && endLine >= startLine,
+    'replace_line_range.endLine must be >= startLine'
+  );
+  assert(endLine <= lines.length, 'replace_line_range range exceeds document length');
+
+  const startIdx = startLine - 1;
+  const deleteCount = endLine - startLine + 1;
+  const existingSlice = lines.slice(startIdx, startIdx + deleteCount);
+  const existingText = toLineRangeString(existingSlice);
+
+  if (op.expectedText !== undefined) {
+    const expected = normalizeNewlines(op.expectedText);
+    assert(existingText === expected, 'replace_line_range.expectedText mismatch');
+  }
+  if (op.expectedMd5 !== undefined) {
+    const expectedHash = op.expectedMd5.toLowerCase();
+    assert(md5(existingText) === expectedHash, 'replace_line_range.expectedMd5 mismatch');
+  }
+
+  const replacementLines = normalizeNewlines(op.replacement).split('\n');
+  lines.splice(startIdx, deleteCount, ...replacementLines);
+}
+
+function applyInsertAtLine(
+  lines: string[],
+  op: Extract<KnowledgeEditOp, { type: 'insert_at_line' }>
+): void {
+  const line = op.line;
+  const position = op.position ?? 'before';
+  assert(Number.isInteger(line) && line >= 1, 'insert_at_line.line must be >= 1');
+  assert(
+    position === 'before' || position === 'after',
+    'insert_at_line.position must be before or after'
+  );
+
+  let index: number;
+  if (position === 'before') {
+    assert(line <= lines.length + 1, 'insert_at_line before target out of range');
+    index = Math.min(line - 1, lines.length);
+    if (op.expectedNeighborText !== undefined && line <= lines.length) {
+      assert(
+        normalizeNewlines(op.expectedNeighborText) === lines[line - 1],
+        'insert_at_line.expectedNeighborText mismatch'
+      );
+    }
+  } else {
+    assert(line <= lines.length, 'insert_at_line after target out of range');
+    if (op.expectedNeighborText !== undefined) {
+      assert(
+        normalizeNewlines(op.expectedNeighborText) === lines[line - 1],
+        'insert_at_line.expectedNeighborText mismatch'
+      );
+    }
+    index = line;
+  }
+
+  const contentLines = normalizeNewlines(op.content).split('\n');
+  lines.splice(index, 0, ...contentLines);
+}
+
+function applyDeleteLineRange(
+  lines: string[],
+  op: Extract<KnowledgeEditOp, { type: 'delete_line_range' }>
+): void {
+  const { startLine, endLine } = op;
+  assert(Number.isInteger(startLine) && startLine >= 1, 'delete_line_range.startLine must be >= 1');
+  assert(
+    Number.isInteger(endLine) && endLine >= startLine,
+    'delete_line_range.endLine must be >= startLine'
+  );
+  assert(endLine <= lines.length, 'delete_line_range range exceeds document length');
+
+  const startIdx = startLine - 1;
+  const deleteCount = endLine - startLine + 1;
+  const existingSlice = lines.slice(startIdx, startIdx + deleteCount);
+  const existingText = toLineRangeString(existingSlice);
+
+  if (op.expectedText !== undefined) {
+    const expected = normalizeNewlines(op.expectedText);
+    assert(existingText === expected, 'delete_line_range.expectedText mismatch');
+  }
+  if (op.expectedMd5 !== undefined) {
+    const expectedHash = op.expectedMd5.toLowerCase();
+    assert(md5(existingText) === expectedHash, 'delete_line_range.expectedMd5 mismatch');
+  }
+
+  lines.splice(startIdx, deleteCount);
+}
+
+function applyReplaceLiteral(
+  lines: string[],
+  op: Extract<KnowledgeEditOp, { type: 'replace_literal' }>
+): string[] {
+  const haystack = joinLines(lines);
+  const find = op.find;
+  const replace = op.replace;
+  assert(find.length > 0, 'replace_literal.find must be non-empty');
+  const matches = countOccurrences(haystack, find);
+  assert(matches === op.expectedCount, 'replace_literal.expectedCount mismatch');
+  if (matches === 0) return lines;
+  const updated = haystack.split(find).join(replace);
+  return splitLines(updated);
+}
+
+export interface ApplyKnowledgeEditOpsResult {
+  content: string;
+}
+
+export function applyKnowledgeEditOps(
+  baseContent: string,
+  ops: KnowledgeEditOp[]
+): ApplyKnowledgeEditOpsResult {
+  const normalizedBase = normalizeNewlines(baseContent);
+  let lines = splitLines(normalizedBase);
+
+  for (const op of ops) {
+    switch (op.type) {
+      case 'replace_line_range': {
+        applyReplaceLineRange(lines, op);
+        break;
+      }
+      case 'insert_at_line': {
+        applyInsertAtLine(lines, op);
+        break;
+      }
+      case 'delete_line_range': {
+        applyDeleteLineRange(lines, op);
+        break;
+      }
+      case 'replace_literal': {
+        lines = applyReplaceLiteral(lines, op);
+        break;
+      }
+      default: {
+        const exhaustive: never = op;
+        throw new KnowledgeEditError(
+          `Unsupported KnowledgeEditOp: ${(exhaustive as { type: string }).type}`
+        );
+      }
+    }
+  }
+
+  const content = joinLines(lines);
+  return { content };
+}
+
+export { KnowledgeEditError };

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -1,0 +1,1 @@
+export * from './edit-ops.js';

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -146,6 +146,57 @@ export const KNOWLEDGE_DOCUMENT_URI_PREFIX = 'agor://kb/document/';
  */
 export const KNOWLEDGE_UNIT_URI_PREFIX = 'agor://kb/unit/';
 
+export interface KnowledgeVersionToken {
+  version_id: KnowledgeDocumentVersionID;
+  version_number: number;
+  content_sha256: string | null;
+  etag: string;
+}
+
+export interface KnowledgeEditChangedRange {
+  start_line: number;
+  end_line: number;
+  content: string;
+}
+
+export type KnowledgeEditOp =
+  | {
+      type: 'replace_line_range';
+      startLine: number;
+      endLine: number;
+      replacement: string;
+      expectedText?: string;
+      expectedMd5?: string;
+    }
+  | {
+      type: 'insert_at_line';
+      line: number;
+      position?: 'before' | 'after';
+      content: string;
+      expectedNeighborText?: string;
+    }
+  | {
+      type: 'delete_line_range';
+      startLine: number;
+      endLine: number;
+      expectedText?: string;
+      expectedMd5?: string;
+    }
+  | {
+      type: 'replace_literal';
+      find: string;
+      replace: string;
+      expectedCount: number;
+    };
+
+export interface KnowledgeEditResultSummary {
+  dryRun: boolean;
+  baseVersion: KnowledgeVersionToken;
+  newVersion?: KnowledgeVersionToken;
+  diff: string;
+  changedRanges: KnowledgeEditChangedRange[];
+}
+
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function buildKnowledgeDocumentUri(documentId: string): string {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
     'mcp/index': 'src/mcp/index.ts', // MCP template resolution utilities
     'gateway/index': 'src/gateway/index.ts', // Gateway platform connectors (Slack, etc.)
     'yaml/index': 'src/yaml/index.ts', // Browser-safe js-yaml re-export
+    'knowledge/index': 'src/knowledge/index.ts', // Knowledge editing helpers
   },
   format: ['cjs', 'esm'],
   dts: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       cors:
         specifier: ^2.8.6
         version: 2.8.6
+      diff:
+        specifier: '>=8.0.3 <9'
+        version: 8.0.3
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2


### PR DESCRIPTION
## Summary
- add KnowledgeEditOp helpers and targeted edit service exposed via /kb/document-edits and agor_kb_edit MCP tool
- wire artifact publish/check hardening for branch-relative paths with RBAC enforcement
- update design context docs and add targeted unit/service coverage

## Testing
- pnpm --filter @agor/core test -- src/knowledge/edit-ops.test.ts
- pnpm --filter @agor/daemon test -- src/services/knowledge-document-edits.test.ts
- pnpm check *(fails: @agor/cli typecheck missing generated @agor-live/client declarations, pre-existing)*
