### PR TITLE
feat: add KB worktree materialization tools

### DIFF
--- a/apps/agor-daemon/src/knowledge/markdown-outline.test.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-outline.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { markdownOutline, resolveHeadingRange } from './markdown-outline';
+
+describe('markdownOutline', () => {
+  it('ignores heading-looking lines inside fenced code blocks', () => {
+    const content = ['# Real', '', '```ts', '# Not a heading', '```', '', '## Child'].join('\n');
+
+    expect(markdownOutline(content).map((heading) => heading.headingPath)).toEqual([
+      'Real',
+      'Real > Child',
+    ]);
+  });
+
+  it('tracks duplicate heading occurrences separately', () => {
+    const headings = markdownOutline(['# Doc', '', '## Repeat', 'a', '## Repeat', 'b'].join('\n'));
+
+    expect(headings.filter((heading) => heading.headingPath === 'Doc > Repeat')).toMatchObject([
+      { occurrence: 1, startLine: 3, endLine: 4 },
+      { occurrence: 2, startLine: 5, endLine: 6 },
+    ]);
+    expect(resolveHeadingRange(headings, 'Doc > Repeat', 2)).toMatchObject({ startLine: 5 });
+  });
+
+  it('extracts heading text recursively through inline markdown and links', () => {
+    const headings = markdownOutline('# Welcome *brave* [reader](https://example.com)');
+
+    expect(headings[0]).toMatchObject({
+      title: 'Welcome brave reader',
+      headingPath: 'Welcome brave reader',
+    });
+  });
+});

--- a/apps/agor-daemon/src/knowledge/markdown-outline.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-outline.ts
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+import type { Heading, RootContent } from 'mdast';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+export interface MarkdownHeadingRange {
+  level: number;
+  title: string;
+  headingPath: string;
+  occurrence: number;
+  startLine: number;
+  endLine: number;
+  contentStartLine: number;
+  anchor: string;
+  contentMd5: string;
+}
+
+export function splitMarkdownLines(content: string): string[] {
+  return content.replace(/\r\n/g, '\n').split('\n');
+}
+
+function md5(text: string): string {
+  return createHash('md5').update(text).digest('hex');
+}
+
+function headingAnchor(title: string): string {
+  return (
+    title
+      .trim()
+      .toLowerCase()
+      .replace(/[`*_~[\]()]/g, '')
+      .replace(/[^a-z0-9 -]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'section'
+  );
+}
+
+function nodeText(node: RootContent | Heading | unknown): string {
+  if (!node || typeof node !== 'object') return '';
+  if ('value' in node && typeof node.value === 'string') return node.value;
+  if ('children' in node && Array.isArray(node.children)) {
+    return node.children
+      .map((child) => nodeText(child))
+      .join('')
+      .trim();
+  }
+  return '';
+}
+
+export function markdownOutline(content: string, maxDepth = 6): MarkdownHeadingRange[] {
+  const lines = splitMarkdownLines(content);
+  const tree = unified().use(remarkParse).use(remarkGfm).parse(content);
+  const raw = tree.children
+    .filter((node): node is Heading => node.type === 'heading')
+    .map((node) => ({
+      level: node.depth,
+      title: nodeText(node).trim(),
+      line: node.position?.start.line ?? 1,
+    }))
+    .filter((heading) => heading.title.length > 0 && heading.level <= maxDepth);
+
+  const pathStack: string[] = [];
+  const occurrenceByPath = new Map<string, number>();
+  return raw.map((heading, index) => {
+    pathStack.length = heading.level - 1;
+    pathStack[heading.level - 1] = heading.title;
+    const headingPath = pathStack.filter(Boolean).join(' > ');
+    const occurrence = (occurrenceByPath.get(headingPath) ?? 0) + 1;
+    occurrenceByPath.set(headingPath, occurrence);
+    const next = raw.slice(index + 1).find((candidate) => candidate.level <= heading.level);
+    const endLine = next ? next.line - 1 : lines.length;
+    const sectionContent = lines.slice(heading.line - 1, endLine).join('\n');
+    return {
+      level: heading.level,
+      title: heading.title,
+      headingPath,
+      occurrence,
+      startLine: heading.line,
+      endLine,
+      contentStartLine: Math.min(heading.line + 1, endLine),
+      anchor: headingAnchor(heading.title),
+      contentMd5: md5(sectionContent),
+    };
+  });
+}
+
+export function resolveHeadingRange(
+  headings: MarkdownHeadingRange[],
+  headingPath: string,
+  occurrence = 1
+): MarkdownHeadingRange {
+  const matches = headings.filter((heading) => heading.headingPath === headingPath);
+  if (matches.length === 0) throw new Error(`Heading not found: ${headingPath}`);
+  if (!Number.isInteger(occurrence) || occurrence < 1) {
+    throw new Error('occurrence must be a positive integer');
+  }
+  const match = matches[occurrence - 1];
+  if (!match) {
+    throw new Error(
+      `Heading "${headingPath}" occurrence ${occurrence} not found (matches: ${matches.length})`
+    );
+  }
+  return match;
+}

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -11,6 +11,7 @@
  * and no `sandpack.json`/`agor.config.js` sidecar.
  */
 
+import path from 'node:path';
 import { BranchRepository } from '@agor/core/db';
 import type {
   AgorGrants,
@@ -91,7 +92,7 @@ export function registerArtifactTools(server: McpServer, ctx: McpContext): void 
 If artifactId is omitted, creates a new artifact.
 If artifactId is provided, updates the existing artifact (must be owned by you).
 
-The folder should contain ordinary source files (no \`sandpack.json\`, no \`agor.config.js\`). The agent decides where to create the folder — inside the branch, a temp directory, etc. The folder is only read at publish time; after that, the artifact lives in the database.
+The folder should contain ordinary source files (no \`sandpack.json\`, no \`agor.config.js\`). Prefer \`branchId + subpath\`: \`subpath\` is a branch-relative folder path and the daemon verifies the caller has access to that branch worktree before reading files. Legacy absolute \`folderPath\` is still accepted for compatibility, but if it resolves inside a registered branch it is subject to the same branch access check. The folder is only read at publish time; after that, the artifact lives in the database.
 
 Recommended: create the folder inside your branch so files can be version-controlled.
 
@@ -117,7 +118,7 @@ IMPORTANT:
           .string()
           .optional()
           .describe(
-            'Absolute path to folder containing artifact files. Optional when branchId + subpath are provided.'
+            'Legacy absolute path to folder containing artifact files. Prefer branchId + subpath. If this resolves inside a registered branch, branch session permission is required.'
           ),
         branchId: z
           .string()
@@ -128,7 +129,7 @@ IMPORTANT:
         subpath: z
           .string()
           .optional()
-          .describe('Branch-relative subpath to the artifact folder (requires branchId).'),
+          .describe('Branch-relative subpath to the artifact folder (required with branchId).'),
         boardId: z
           .string()
           .optional()
@@ -193,9 +194,9 @@ IMPORTANT:
       const resolvedArtifactId = coerceString(args.artifactId)
         ? await resolveArtifactId(ctx, coerceString(args.artifactId)!)
         : undefined;
-      if (!folderPath && !resolvedBranchId) {
+      if (!folderPath && (!resolvedBranchId || !subpath)) {
         throw new Error(
-          'Provide either folderPath or branchId (with optional subpath) to publish artifacts.'
+          'Provide either legacy folderPath or branchId + subpath to publish artifacts.'
         );
       }
       const artifact = await service.publishArtifact(
@@ -236,13 +237,13 @@ IMPORTANT:
     'agor_artifacts_check_build',
     {
       description:
-        'Check build readiness of artifact files in a folder. Verifies source files exist and are non-empty (does not run a real build or syntax check). Use this before publishing to verify basic structure.',
+        'Check build readiness of artifact files in a branch-relative folder (branchId + subpath preferred) or legacy absolute folderPath. Verifies source files exist and are non-empty (does not run a real build or syntax check). Use this before publishing to verify basic structure.',
       inputSchema: z.object({
         folderPath: z
           .string()
           .optional()
           .describe(
-            'Absolute path to the folder containing artifact files to check. Optional when branchId + subpath are provided.'
+            'Legacy absolute path to the folder containing artifact files to check. Prefer branchId + subpath. If this resolves inside a registered branch, branch session permission is required.'
           ),
         branchId: z
           .string()
@@ -253,7 +254,9 @@ IMPORTANT:
         subpath: z
           .string()
           .optional()
-          .describe('Branch-relative subpath pointing at the artifact folder (requires branchId).'),
+          .describe(
+            'Branch-relative subpath pointing at the artifact folder (required with branchId).'
+          ),
       }),
     },
     async (args) => {
@@ -262,9 +265,9 @@ IMPORTANT:
       const resolvedBranchId = branchIdRaw ? await resolveBranchId(ctx, branchIdRaw) : undefined;
       const folderPath = coerceString(args.folderPath);
       const subpath = coerceString(args.subpath);
-      if (!folderPath && !resolvedBranchId) {
+      if (!folderPath && (!resolvedBranchId || !subpath)) {
         throw new Error(
-          'Provide either folderPath or branchId (with optional subpath) to check artifact files.'
+          'Provide either legacy folderPath or branchId + subpath to check artifact files.'
         );
       }
       const result = await service.checkBuildFromFolder(
@@ -520,12 +523,15 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
       if (!fullBranch) {
         return textResult({ error: `Branch ${branchId} not found` });
       }
+      const effective = await branchRepo.resolveUserPermission(fullBranch, userIdBranded);
       const canWrite = hasBranchPermission(
         fullBranch,
         userIdBranded,
         isOwner,
         'session',
-        ctx.authenticatedUser.role
+        ctx.authenticatedUser.role,
+        true,
+        effective
       );
       if (!canWrite) {
         return textResult({
@@ -538,13 +544,18 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
         overwrite: args.overwrite,
       });
 
+      const destinationSubpath = path
+        .relative(branch.path, result.destinationPath)
+        .replace(/\\/g, '/');
+
       return textResult({
         artifactId,
         branchId: branch.branch_id,
+        subpath: destinationSubpath,
         destinationPath: result.destinationPath,
         fileCount: result.fileCount,
         bytesWritten: result.bytesWritten,
-        instructions: `Artifact materialized to ${result.destinationPath}. The folder includes \`agor.artifact.json\` — keep it: it carries template/sandpack_config/required_env_vars/agor_grants for round-trip publishing. Edit source files there, then call agor_artifacts_publish with folderPath=${result.destinationPath} and artifactId=${artifactId} to push changes back.`,
+        instructions: `Artifact materialized to branch ${branch.branch_id} at subpath ${destinationSubpath}. The folder includes \`agor.artifact.json\` — keep it: it carries template/sandpack_config/required_env_vars/agor_grants for round-trip publishing. Edit source files there, then call agor_artifacts_publish with branchId=${branch.branch_id}, subpath=${destinationSubpath}, and artifactId=${artifactId} to push changes back.`,
       });
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -1,10 +1,19 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { BranchRepository } from '@agor/core/db';
+import { NotFound } from '@agor/core/feathers';
 import type {
+  BranchID,
   KnowledgeDocumentKind,
   KnowledgeDocumentStatus,
+  KnowledgeDocumentVersion,
   KnowledgeEditPolicy,
   KnowledgeGraphEdgeType,
   KnowledgeGraphNodeType,
   KnowledgeVisibility,
+  UserRole,
 } from '@agor/core/types';
 import {
   buildKnowledgeDocumentUri,
@@ -18,7 +27,15 @@ import {
   parseKnowledgeUri,
 } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createTwoFilesPatch } from 'diff';
 import { z } from 'zod';
+import {
+  markdownOutline,
+  resolveHeadingRange,
+  splitMarkdownLines,
+} from '../../knowledge/markdown-outline.js';
+import { resolveBranchWorkspacePath } from '../../utils/branch-workspace-path.js';
+import { resolveBranchId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
 import { coerceJsonRecord, coerceString, textResult } from '../server.js';
 
@@ -216,6 +233,122 @@ async function callCustomMethod(
     service,
     data,
     params
+  );
+}
+
+type HydratedKnowledgeDocumentResult = Record<string, unknown> & {
+  document?: Record<string, unknown>;
+  current_version?: KnowledgeDocumentVersion | null;
+  content?: string | null;
+};
+
+function md5(text: string): string {
+  return createHash('md5').update(text).digest('hex');
+}
+
+function versionToken(version: KnowledgeDocumentVersion | null | undefined) {
+  if (!version) return null;
+  return {
+    version_id: version.version_id,
+    version_number: version.version_number,
+    content_sha256: version.content_sha256 ?? null,
+    etag: `kbv:${version.version_id}`,
+  };
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof NotFound ||
+    (typeof error === 'object' &&
+      error !== null &&
+      ((error as { code?: unknown }).code === 404 ||
+        (error as { name?: unknown }).name === 'NotFound'))
+  );
+}
+
+function namespaceSlugForDocument(result: HydratedKnowledgeDocumentResult): string | undefined {
+  const doc = result.document ?? result;
+  const uri = typeof doc.uri === 'string' ? doc.uri : undefined;
+  return parseKnowledgeUri(uri)?.namespace_slug;
+}
+
+function documentPathForResult(result: HydratedKnowledgeDocumentResult): string | undefined {
+  const doc = result.document ?? result;
+  return typeof doc.path === 'string' ? doc.path : undefined;
+}
+
+async function fetchKnowledgeDocument(
+  ctx: McpContext,
+  ref: {
+    documentId?: string;
+    uri?: string;
+    namespace?: string;
+    path?: string;
+    includeContent?: boolean;
+    version?: string | number;
+  }
+): Promise<HydratedKnowledgeDocumentResult> {
+  const service = getOptionalService(ctx, 'kb/documents');
+  if (!service) throw new Error('Knowledge documents service is not registered');
+  const includeContent = ref.includeContent !== false;
+
+  const documentId = coerceString(ref.documentId);
+  if (documentId) {
+    if (!service.get) throw new Error('kb/documents.get is not available');
+    return (await service.get(
+      documentId,
+      mcpParams(ctx, { include_content: includeContent, version: ref.version })
+    )) as HydratedKnowledgeDocumentResult;
+  }
+
+  const uri = coerceString(ref.uri);
+  if (uri?.startsWith(KNOWLEDGE_DOCUMENT_URI_PREFIX)) {
+    const idFromUri = uri.slice(KNOWLEDGE_DOCUMENT_URI_PREFIX.length);
+    if (!service.get) throw new Error('kb/documents.get is not available');
+    return (await service.get(
+      idFromUri,
+      mcpParams(ctx, { include_content: includeContent, version: ref.version })
+    )) as HydratedKnowledgeDocumentResult;
+  }
+
+  const parsedUri = parseKnowledgeUri(uri);
+  const namespace = coerceString(ref.namespace) ?? parsedUri?.namespace_slug;
+  const docPath = coerceString(ref.path) ?? parsedUri?.path;
+  if (!namespace || !docPath) {
+    throw new Error(
+      'Provide documentId, a valid agor://kb/<namespace>/<path> uri, or namespace + path.'
+    );
+  }
+
+  const customResult = await callCustomMethod(
+    service,
+    'getDocument',
+    {
+      uri,
+      namespace_slug: namespace,
+      path: docPath,
+      include_content: includeContent,
+      version: ref.version,
+    },
+    mcpParams(ctx)
+  );
+  if (customResult !== undefined) return customResult as HydratedKnowledgeDocumentResult;
+  throw new Error('kb/documents.getDocument is not available');
+}
+
+function materializationSidecarSubpath(markdownSubpath: string): string {
+  return `${markdownSubpath}.agor-kb.json`;
+}
+
+async function writeKnowledgeMaterializationSidecar(
+  sidecarPath: string,
+  sidecar: Record<string, unknown>
+): Promise<void> {
+  await writeFile(
+    sidecarPath,
+    `${JSON.stringify(sidecar, null, 2)}
+`,
+    'utf-8'
   );
 }
 
@@ -475,6 +608,136 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
   );
 
   server.registerTool(
+    'agor_kb_outline',
+    {
+      description:
+        'Return a markdown heading outline for a Knowledge document, including 1-based line ranges and the current version token. Use this before targeted edits to avoid reading the full document.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
+        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
+        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
+        version: z
+          .union([z.number(), z.string()])
+          .optional()
+          .describe('Version number or version ID. Omit for current version.'),
+        maxDepth: z.number().int().min(1).max(6).optional().describe('Maximum heading depth'),
+      }),
+    },
+    async (args) => {
+      const result = await fetchKnowledgeDocument(ctx, {
+        documentId: coerceString(args.documentId),
+        uri: coerceString(args.uri),
+        namespace: coerceString(args.namespace),
+        path: coerceString(args.path),
+        version: args.version,
+        includeContent: true,
+      });
+      const content = typeof result.content === 'string' ? result.content : '';
+      const headings = markdownOutline(content, args.maxDepth ?? 6);
+      return textResult(
+        enrichWithReferenceUri({
+          document: result.document ?? result,
+          version: versionToken(result.current_version),
+          lineCount: splitMarkdownLines(content).length,
+          headings,
+        })
+      );
+    }
+  );
+
+  server.registerTool(
+    'agor_kb_get_range',
+    {
+      description:
+        'Read a bounded line range or heading section from a Knowledge document. Returns current version metadata and optional line numbers so agents can edit without loading the full document.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
+        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
+        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
+        version: z
+          .union([z.number(), z.string()])
+          .optional()
+          .describe('Version number or version ID. Omit for current version.'),
+        startLine: z.number().int().min(1).optional().describe('1-based inclusive start line'),
+        endLine: z.number().int().min(1).optional().describe('1-based inclusive end line'),
+        headingPath: z.string().optional().describe('Heading path from agor_kb_outline'),
+        occurrence: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe('Occurrence for duplicate heading paths (default: 1)'),
+        contextLines: z
+          .number()
+          .int()
+          .min(0)
+          .max(20)
+          .optional()
+          .describe('Extra lines before/after the requested range (default: 2)'),
+        includeLineNumbers: z
+          .boolean()
+          .optional()
+          .describe('Include numberedContent for agent-friendly references (default: true)'),
+      }),
+    },
+    async (args) => {
+      const result = await fetchKnowledgeDocument(ctx, {
+        documentId: coerceString(args.documentId),
+        uri: coerceString(args.uri),
+        namespace: coerceString(args.namespace),
+        path: coerceString(args.path),
+        version: args.version,
+        includeContent: true,
+      });
+      const content = typeof result.content === 'string' ? result.content : '';
+      const lines = splitMarkdownLines(content);
+      let startLine = args.startLine;
+      let endLine = args.endLine;
+      const headingPath = coerceString(args.headingPath);
+      if (headingPath) {
+        const heading = resolveHeadingRange(markdownOutline(content), headingPath, args.occurrence);
+        startLine = heading.startLine;
+        endLine = heading.endLine;
+      }
+      if (!startLine || !endLine) {
+        throw new Error('Provide startLine + endLine, or headingPath.');
+      }
+      if (endLine < startLine)
+        throw new Error('endLine must be greater than or equal to startLine');
+      if (endLine > lines.length) throw new Error('Requested range exceeds document length');
+      const contextLines = args.contextLines ?? 2;
+      const contextStartLine = Math.max(1, startLine - contextLines);
+      const contextEndLine = Math.min(lines.length, endLine + contextLines);
+      const contentLines = lines.slice(contextStartLine - 1, contextEndLine);
+      const rangeContent = contentLines.join('\n');
+      const numberedContent =
+        args.includeLineNumbers === false
+          ? undefined
+          : contentLines.map((line, index) => `${contextStartLine + index}: ${line}`).join('\n');
+      return textResult(
+        enrichWithReferenceUri({
+          document: result.document ?? result,
+          version: versionToken(result.current_version),
+          lineCount: lines.length,
+          range: {
+            startLine,
+            endLine,
+            contextStartLine,
+            contextEndLine,
+            content: rangeContent,
+            numberedContent,
+            contentMd5: md5(lines.slice(startLine - 1, endLine).join('\n')),
+          },
+        })
+      );
+    }
+  );
+
+  server.registerTool(
     'agor_kb_put',
     {
       description:
@@ -636,6 +899,355 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         return textResult(await service.create(data, mcpParams(ctx)));
       }
       return knowledgeNotImplementedResult('agor_kb_edit', ['kb/document-edits.create']);
+    }
+  );
+
+  server.registerTool(
+    'agor_kb_materialize',
+    {
+      description:
+        'Write a Knowledge document version to a markdown file inside a branch worktree. Requires branchId + branch-relative subpath (or defaults to .agor/kb/<namespace>/<path>) and verifies the caller has branch session permission.',
+      inputSchema: z.object({
+        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
+        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
+        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
+        version: z
+          .union([z.number(), z.string()])
+          .optional()
+          .describe('Version number or version ID. Omit for current version.'),
+        branchId: z.string().describe('Destination branch/worktree ID (UUIDv7 or short ID)'),
+        subpath: z
+          .string()
+          .optional()
+          .describe(
+            'Branch-relative destination markdown path. Default: .agor/kb/<namespace>/<document path>.'
+          ),
+        overwrite: z
+          .boolean()
+          .optional()
+          .describe(
+            'Overwrite the destination file and sidecar if they already exist. Default: false.'
+          ),
+      }),
+    },
+    async (args) => {
+      const result = await fetchKnowledgeDocument(ctx, {
+        documentId: coerceString(args.documentId),
+        uri: coerceString(args.uri),
+        namespace: coerceString(args.namespace),
+        path: coerceString(args.path),
+        version: args.version,
+        includeContent: true,
+      });
+      const content = typeof result.content === 'string' ? result.content : '';
+      const namespaceSlug = namespaceSlugForDocument(result) ?? coerceString(args.namespace);
+      const documentPath = documentPathForResult(result);
+      const defaultSubpath =
+        namespaceSlug && documentPath
+          ? path.join('.agor', 'kb', namespaceSlug, documentPath)
+          : null;
+      const requestedSubpath = coerceString(args.subpath) ?? defaultSubpath;
+      if (!requestedSubpath) {
+        throw new Error('subpath is required when the document namespace/path cannot be inferred');
+      }
+      const branchRepo = new BranchRepository(ctx.db);
+      const workspace = await resolveBranchWorkspacePath({
+        branchRepo,
+        branchId: (await resolveBranchId(ctx, coerceString(args.branchId)!)) as BranchID,
+        subpath: requestedSubpath,
+        userId: ctx.userId,
+        userRole: ctx.authenticatedUser.role as UserRole,
+        requiredPermission: 'session',
+      });
+      const sidecarWorkspace = await resolveBranchWorkspacePath({
+        branchRepo,
+        branchId: workspace.branchId,
+        subpath: materializationSidecarSubpath(workspace.relative),
+        userId: ctx.userId,
+        userRole: ctx.authenticatedUser.role as UserRole,
+        requiredPermission: 'session',
+      });
+      const sidecarPath = sidecarWorkspace.canonical;
+      if (!args.overwrite && (fs.existsSync(workspace.absolute) || fs.existsSync(sidecarPath))) {
+        throw new Error(
+          `Destination already exists: ${workspace.relative} (pass overwrite=true to replace)`
+        );
+      }
+      await mkdir(path.dirname(workspace.absolute), { recursive: true });
+      await writeFile(workspace.absolute, content, 'utf-8');
+      const doc = (result.document ?? result) as Record<string, unknown>;
+      const sidecar = {
+        $schema: 'https://agor.live/schemas/kb-materialization/2026-06-06.json',
+        document_id: doc.document_id,
+        uri: doc.uri,
+        namespace: namespaceSlug,
+        path: documentPath,
+        version_id: result.current_version?.version_id ?? null,
+        version_number: result.current_version?.version_number ?? null,
+        content_sha256: result.current_version?.content_sha256 ?? null,
+        materialized_at: new Date().toISOString(),
+        materialized_by: ctx.userId,
+      };
+      await writeKnowledgeMaterializationSidecar(sidecarPath, sidecar);
+      return textResult(
+        enrichWithReferenceUri({
+          document: doc,
+          version: versionToken(result.current_version),
+          branchId: workspace.branchId,
+          subpath: workspace.relative,
+          destinationPath: workspace.absolute,
+          sidecarPath,
+          bytesWritten: Buffer.byteLength(content, 'utf-8'),
+          instructions:
+            'Edit the markdown file, then call agor_kb_publish_from_worktree with the same branchId/subpath. The sidecar preserves the source document and expected version.',
+        })
+      );
+    }
+  );
+
+  server.registerTool(
+    'agor_kb_publish_from_worktree',
+    {
+      description:
+        'Publish a markdown file from a branch worktree into Knowledge. Requires branchId + branch-relative subpath and branch session permission. If a .agor-kb sidecar exists, it supplies documentId and expectedVersion; otherwise provide documentId or namespace + path. Updating an existing document creates one immutable KB version.',
+      inputSchema: z.object({
+        branchId: z.string().describe('Source branch/worktree ID (UUIDv7 or short ID)'),
+        subpath: z.string().describe('Branch-relative source markdown file path'),
+        documentId: z.string().optional().describe('Knowledge document ID to update'),
+        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: z
+          .string()
+          .optional()
+          .describe('Namespace/space slug. Required with path when creating without sidecar.'),
+        path: z
+          .string()
+          .optional()
+          .describe('Document path. Required with namespace when creating without sidecar.'),
+        expectedVersion: z
+          .union([z.number(), z.string()])
+          .optional()
+          .describe(
+            'Expected current version number or ID. Defaults to sidecar version when present.'
+          ),
+        dryRun: z.boolean().optional().describe('Preview without creating/updating a KB version.'),
+        createNamespace: z
+          .boolean()
+          .optional()
+          .describe('Create namespace if missing when creating a new doc (default: false).'),
+        title: z.string().optional().describe('Optional title for newly-created documents'),
+        firstLineIsTitle: z
+          .boolean()
+          .optional()
+          .describe('Derive title from first markdown heading for newly-created docs.'),
+        kind: KnowledgeDocumentKindSchema.optional().describe(
+          'Document kind for newly-created docs'
+        ),
+        visibility: KnowledgeVisibilitySchema.optional().describe(
+          'Visibility for newly-created docs'
+        ),
+        status: KnowledgeDocumentStatusSchema.optional().describe('Lifecycle status'),
+        editPolicy: KnowledgeEditPolicySchema.optional().describe('Edit policy'),
+        changeSummary: z.string().optional().describe('Version history change summary'),
+      }),
+    },
+    async (args) => {
+      const branchRepo = new BranchRepository(ctx.db);
+      const workspace = await resolveBranchWorkspacePath({
+        branchRepo,
+        branchId: (await resolveBranchId(ctx, coerceString(args.branchId)!)) as BranchID,
+        subpath: coerceString(args.subpath),
+        userId: ctx.userId,
+        userRole: ctx.authenticatedUser.role as UserRole,
+        requiredPermission: 'session',
+      });
+      if (!fs.existsSync(workspace.absolute)) {
+        throw new Error(`File not found in branch worktree: ${workspace.relative}`);
+      }
+      const content = await readFile(workspace.absolute, 'utf-8');
+      const sidecarWorkspace = await resolveBranchWorkspacePath({
+        branchRepo,
+        branchId: workspace.branchId,
+        subpath: materializationSidecarSubpath(workspace.relative),
+        userId: ctx.userId,
+        userRole: ctx.authenticatedUser.role as UserRole,
+        requiredPermission: 'session',
+      });
+      const sidecarPath = sidecarWorkspace.canonical;
+      let sidecar: Record<string, unknown> = {};
+      if (fs.existsSync(sidecarPath)) {
+        try {
+          sidecar = JSON.parse(await readFile(sidecarPath, 'utf-8')) as Record<string, unknown>;
+        } catch (error) {
+          throw new Error(
+            `Failed to parse KB sidecar ${path.relative(workspace.branchRoot, sidecarPath)}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+
+      const documentId = coerceString(args.documentId) ?? coerceString(sidecar.document_id);
+      const uri = coerceString(args.uri) ?? coerceString(sidecar.uri);
+      const parsedUri = parseKnowledgeUri(uri);
+      const namespace =
+        coerceString(args.namespace) ??
+        parsedUri?.namespace_slug ??
+        coerceString(sidecar.namespace);
+      const docPath = coerceString(args.path) ?? parsedUri?.path ?? coerceString(sidecar.path);
+      const expectedVersion =
+        args.expectedVersion ??
+        coerceString(sidecar.version_id) ??
+        (typeof sidecar.version_number === 'number' ? sidecar.version_number : undefined);
+
+      const documentService = getOptionalService(ctx, 'kb/documents');
+      if (!documentService) {
+        return knowledgeNotImplementedResult('agor_kb_publish_from_worktree', ['kb/documents']);
+      }
+
+      const dryRun = args.dryRun === true;
+      let existing: HydratedKnowledgeDocumentResult | null = null;
+      try {
+        existing = await fetchKnowledgeDocument(ctx, {
+          documentId,
+          uri,
+          namespace,
+          path: docPath,
+          includeContent: true,
+        });
+      } catch (error) {
+        if (documentId || uri || !isNotFoundError(error)) throw error;
+      }
+
+      if (existing?.current_version) {
+        if (!expectedVersion && !dryRun) {
+          throw new Error('expectedVersion is required to publish over an existing KB document');
+        }
+        const baseContent = typeof existing.content === 'string' ? existing.content : '';
+        const lineCount = splitMarkdownLines(baseContent).length;
+        const editService = getOptionalService(ctx, 'kb/document-edits');
+        if (!editService?.create) {
+          return knowledgeNotImplementedResult('agor_kb_publish_from_worktree', [
+            'kb/document-edits.create',
+          ]);
+        }
+        const editResult = (await editService.create(
+          {
+            documentId: coerceString((existing.document ?? existing).document_id) ?? documentId,
+            expectedVersion: expectedVersion ?? existing.current_version.version_number,
+            dryRun,
+            changeSummary: coerceString(args.changeSummary) ?? `Publish from ${workspace.relative}`,
+            ops: [
+              {
+                type: 'replace_line_range',
+                startLine: 1,
+                endLine: lineCount,
+                replacement: content,
+                expectedText: baseContent,
+              },
+            ],
+            returnContent: dryRun ? 'full' : 'none',
+          },
+          mcpParams(ctx)
+        )) as Record<string, unknown>;
+        const newVersion = editResult.newVersion as Record<string, unknown> | undefined;
+        const editedDocument = editResult.document as Record<string, unknown> | undefined;
+        if (!dryRun && newVersion) {
+          await writeKnowledgeMaterializationSidecar(sidecarPath, {
+            ...sidecar,
+            $schema:
+              sidecar.$schema ?? 'https://agor.live/schemas/kb-materialization/2026-06-06.json',
+            document_id: editedDocument?.document_id ?? sidecar.document_id ?? documentId,
+            uri: editedDocument?.uri ?? sidecar.uri ?? uri,
+            namespace,
+            path: docPath,
+            version_id: newVersion.version_id,
+            version_number: newVersion.version_number,
+            content_sha256: newVersion.content_sha256 ?? null,
+            materialized_at: sidecar.materialized_at ?? null,
+            materialized_by: sidecar.materialized_by ?? null,
+            published_at: new Date().toISOString(),
+            published_by: ctx.userId,
+          });
+        }
+        return textResult({
+          ...editResult,
+          sidecarUpdated: !dryRun && Boolean(newVersion),
+          sidecarPath: !dryRun && newVersion ? sidecarPath : undefined,
+        });
+      }
+
+      if (!namespace || !docPath) {
+        throw new Error(
+          'No existing document or sidecar found. Provide namespace + path to create a new KB document.'
+        );
+      }
+      if (dryRun) {
+        return textResult({
+          dryRun: true,
+          create: true,
+          namespace,
+          path: docPath,
+          branchId: workspace.branchId,
+          subpath: workspace.relative,
+          content,
+          diff: createTwoFilesPatch('empty', workspace.relative, '', content, '', ''),
+        });
+      }
+
+      const customResult = await callCustomMethod(
+        documentService,
+        'putDocument',
+        {
+          namespace_slug: namespace,
+          path: docPath,
+          content_text: content,
+          create_namespace: args.createNamespace === true,
+          title: coerceString(args.title),
+          first_line_is_title: args.firstLineIsTitle,
+          kind: (args.kind as KnowledgeDocumentKind | undefined) ?? 'doc',
+          visibility: args.visibility as KnowledgeVisibility | undefined,
+          status: args.status as KnowledgeDocumentStatus | undefined,
+          edit_policy: args.editPolicy as KnowledgeEditPolicy | undefined,
+          change_summary: coerceString(args.changeSummary) ?? `Publish from ${workspace.relative}`,
+        },
+        mcpParams(ctx)
+      );
+      if (customResult !== undefined) {
+        const hydrated = await fetchKnowledgeDocument(ctx, {
+          namespace,
+          path: docPath,
+          includeContent: true,
+        });
+        const doc = (hydrated.document ?? hydrated) as Record<string, unknown>;
+        await writeKnowledgeMaterializationSidecar(sidecarPath, {
+          ...sidecar,
+          $schema:
+            sidecar.$schema ?? 'https://agor.live/schemas/kb-materialization/2026-06-06.json',
+          document_id: doc.document_id,
+          uri: doc.uri,
+          namespace,
+          path: docPath,
+          version_id: hydrated.current_version?.version_id ?? null,
+          version_number: hydrated.current_version?.version_number ?? null,
+          content_sha256: hydrated.current_version?.content_sha256 ?? null,
+          materialized_at: sidecar.materialized_at ?? null,
+          materialized_by: sidecar.materialized_by ?? null,
+          published_at: new Date().toISOString(),
+          published_by: ctx.userId,
+        });
+        return textResult(
+          enrichWithReferenceUri({
+            result: customResult,
+            sidecarUpdated: true,
+            sidecarPath,
+            version: versionToken(hydrated.current_version),
+          })
+        );
+      }
+      return knowledgeNotImplementedResult('agor_kb_publish_from_worktree', [
+        'kb/documents.putDocument',
+      ]);
     }
   );
 

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -12,12 +12,14 @@ import { generateId } from '@agor/core';
 import {
   ArtifactRepository,
   BoardRepository,
+  BranchRepository,
   type Database,
+  RepoRepository,
   shortId,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Artifact, BoardID } from '@agor/core/types';
+import type { Artifact, BoardID, BranchID, UUID } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { ArtifactsService } from './artifacts';
@@ -40,6 +42,28 @@ async function seedBoard(db: Database) {
     board_id: generateId() as BoardID,
     name: 'Test Board',
     created_by: 'user-owner',
+  });
+}
+
+async function seedRepoAndBranch(db: Database, branchPath: string) {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId() as UUID,
+    slug: `artifact-test-${generateId()}`,
+    name: 'Artifact Test Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: path.dirname(branchPath),
+    default_branch: 'main',
+  });
+  return new BranchRepository(db).create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id,
+    name: `artifact-branch-${generateId()}`,
+    ref: 'refs/heads/artifact-branch',
+    branch_unique_id: 1,
+    path: branchPath,
+    created_by: 'user-owner' as UUID,
+    others_can: 'session',
   });
 }
 
@@ -545,6 +569,50 @@ describe('ArtifactsService.land', () => {
       'console.log("hello")'
     );
   });
+
+  dbTest(
+    'rejects branch-relative publish source that is a symlink to outside the branch',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const branch = await seedRepoAndBranch(db, tmpRoot);
+      const outside = mkdtempSync(path.join(tmpdir(), 'agor-publish-outside-'));
+      try {
+        writeFileSync(path.join(outside, 'index.js'), 'console.log("outside")');
+        symlinkSync(outside, path.join(tmpRoot, 'app'), 'dir');
+
+        await expect(
+          service.checkBuildFromFolder(
+            { branch_id: branch.branch_id, subpath: 'app' },
+            'user-reviewer',
+            'member'
+          )
+        ).rejects.toThrow(/escapes branch root/i);
+      } finally {
+        rmSync(outside, { recursive: true, force: true });
+      }
+    }
+  );
+
+  dbTest(
+    'treats registered branches under temp roots as branches before temp-dir allowance',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const branch = await seedRepoAndBranch(db, tmpRoot);
+      const appDir = path.join(tmpRoot, 'app');
+      mkdirSync(appDir, { recursive: true });
+      writeFileSync(path.join(appDir, 'index.js'), 'console.log("branch")');
+
+      await expect(
+        service.checkBuildFromFolder({ folderPath: appDir }, undefined, 'member')
+      ).rejects.toThrow(/Authentication required/i);
+
+      await expect(
+        service.checkBuildFromFolder({ folderPath: appDir }, 'user-reviewer', 'member')
+      ).resolves.toMatchObject({ status: 'success' });
+
+      expect(branch.path).toBe(tmpRoot);
+    }
+  );
 
   dbTest('errors when artifact has no stored files', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -62,7 +62,12 @@ import {
 import { DrizzleService } from '../adapters/drizzle.js';
 import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
-import { hasBranchPermission } from '../utils/branch-authorization.js';
+import {
+  canonicalizeExistingPrefix,
+  ensureBranchWorkspaceAccess,
+  matchRegisteredBranchPath,
+  resolveBranchWorkspacePath,
+} from '../utils/branch-workspace-path.js';
 import {
   detectLegacyFormat,
   effectiveTemplateForArtifact,
@@ -70,27 +75,6 @@ import {
   sanitizeSandpackConfig,
 } from '../utils/sandpack-config.js';
 import type { UsersService } from './users.js';
-
-/**
- * Resolve a destination path by canonicalizing the longest existing prefix via
- * `realpath` and re-joining the still-nonexistent tail. Used by `land()` to
- * detect symlinked ancestors that would otherwise defeat a lexical
- * containment check.
- */
-async function canonicalizeExistingPrefix(target: string): Promise<string> {
-  const segments = target.split(path.sep);
-  for (let i = segments.length; i >= 1; i--) {
-    const prefix = segments.slice(0, i).join(path.sep) || path.sep;
-    try {
-      const real = await realpath(prefix);
-      const tail = segments.slice(i).join(path.sep);
-      return tail ? path.join(real, tail) : real;
-    } catch {
-      // prefix does not exist yet — shrink and try again
-    }
-  }
-  return target;
-}
 
 /**
  * Lazily-built data URL carrying the agor-runtime IIFE. Sandpack injects
@@ -202,18 +186,6 @@ function readArtifactSidecar(folderPath: string): ArtifactSidecar | null {
   }
 }
 
-function normalizeBranchSubpath(subpath: string | undefined | null): string {
-  if (!subpath) return '';
-  const normalized = subpath.replace(/\\+/g, '/');
-  const segments = normalized.split('/').filter((segment) => segment.length > 0);
-  for (const segment of segments) {
-    if (segment === '.' || segment === '..') {
-      throw new Error('branch subpath must not include "." or ".." segments');
-    }
-  }
-  return segments.join('/');
-}
-
 export type ArtifactParams = QueryParams<{
   board_id?: BoardID;
   branch_id?: BranchID;
@@ -289,16 +261,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     if (!branch) {
       throw new Error(`Branch not found: ${branchId}`);
     }
-    if (!userId) {
-      throw new Error('Authentication required to access branch workspace files');
-    }
-    const isOwner = await this.branchRepo.isOwner(branch.branch_id, userId as UserID);
-    const effective = await this.branchRepo.resolveUserPermission(branch, userId as UserID);
-    if (
-      !hasBranchPermission(branch, userId as UserID, isOwner, 'session', userRole, true, effective)
-    ) {
-      throw new Error('Forbidden: branch session permission required to read artifact files');
-    }
+    await ensureBranchWorkspaceAccess(this.branchRepo, branch, userId, userRole, 'session');
   }
 
   private async resolveArtifactSource(
@@ -310,14 +273,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     let hintBranchId: BranchID | null = null;
 
     if (input.branch_id) {
-      const branch = await this.branchRepo.findById(input.branch_id);
-      if (!branch) {
-        throw new Error(`Branch not found: ${input.branch_id}`);
-      }
-      const branchRoot = path.resolve(branch.path);
-      const relative = normalizeBranchSubpath(input.subpath);
-      folderPath = relative ? path.join(branchRoot, relative) : branchRoot;
-      hintBranchId = branch.branch_id as BranchID;
+      const workspace = await resolveBranchWorkspacePath({
+        branchRepo: this.branchRepo,
+        branchId: input.branch_id,
+        subpath: input.subpath,
+        userId,
+        userRole,
+        requiredPermission: 'session',
+      });
+      folderPath = workspace.canonical;
+      hintBranchId = workspace.branchId;
     } else {
       if (input.subpath) {
         throw new Error('branchId is required when subpath is provided');
@@ -328,15 +293,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       folderPath = path.resolve(input.folderPath);
     }
 
-    const matchedBranchId = await this.validatePublishPath(folderPath);
+    const validated = await this.validatePublishPath(folderPath);
+    const matchedBranchId = validated.branchId;
     if (hintBranchId && matchedBranchId && hintBranchId !== matchedBranchId) {
       throw new Error('Resolved branch subpath does not match known branch root');
     }
     const branchId = hintBranchId ?? matchedBranchId;
-    if (branchId) {
+    if (branchId && !hintBranchId) {
       await this.ensureBranchFilesystemAccess(branchId, userId, userRole);
     }
-    return { folderPath, matchedBranchId: branchId };
+    return { folderPath: validated.folderPath, matchedBranchId: branchId };
   }
 
   constructor(db: Database, app: Application) {
@@ -1762,19 +1728,24 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * artifact row for provenance + by-branch filtering); returns null for
    * temp-dir paths.
    */
-  private async validatePublishPath(folderPath: string): Promise<BranchID | null> {
+  private async validatePublishPath(
+    folderPath: string
+  ): Promise<{ folderPath: string; branchId: BranchID | null }> {
     const resolved = path.resolve(folderPath);
-
-    const allowedTempRoots = ['/tmp', '/var/tmp'];
-    for (const root of allowedTempRoots) {
-      if (resolved.startsWith(root + path.sep) || resolved === root) return null;
+    const matchedBranch = await matchRegisteredBranchPath({
+      branchRepo: this.branchRepo,
+      folderPath: resolved,
+    });
+    if (matchedBranch) {
+      return { folderPath: matchedBranch.canonicalFolderPath, branchId: matchedBranch.branchId };
     }
 
-    const branches = await this.branchRepo.findAll();
-    for (const wt of branches) {
-      const wtPath = path.resolve(wt.path);
-      if (resolved.startsWith(wtPath + path.sep) || resolved === wtPath) {
-        return wt.branch_id as BranchID;
+    const canonical = await canonicalizeExistingPrefix(resolved);
+    const allowedTempRoots = ['/tmp', '/var/tmp'];
+    for (const root of allowedTempRoots) {
+      const rootReal = await canonicalizeExistingPrefix(root);
+      if (canonical.startsWith(rootReal + path.sep) || canonical === rootReal) {
+        return { folderPath: canonical, branchId: null };
       }
     }
 

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -19,7 +19,7 @@ import {
   buildKnowledgeUnitUri,
   hasMinimumRole,
   type KnowledgeSearchResult,
-  normalizeKnowledgePath,
+  normalizeKnowledgeFolderPath,
   type QueryParams,
   ROLES,
   type User,
@@ -174,9 +174,10 @@ export class KnowledgeSearchService {
     const vector = embeddingToPgvector(queryEmbedding.embedding);
     const limit = Math.min(Math.max(rawQuery.rerank_limit ?? rawQuery.limit ?? 25, 1), 100);
     const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
-    const pathPrefix = rawQuery.path_prefix?.trim()
-      ? normalizeKnowledgePath(rawQuery.path_prefix)
-      : null;
+    const normalizedPathPrefix = rawQuery.path_prefix?.trim()
+      ? normalizeKnowledgeFolderPath(rawQuery.path_prefix)
+      : '';
+    const pathPrefix = normalizedPathPrefix || null;
     const minSimilarity = this.parseMinSimilarity(rawQuery.min_similarity);
     const includeMyDrafts = rawQuery.include_my_drafts !== false;
     const includeOtherUserDrafts = rawQuery.include_other_user_drafts === true;

--- a/apps/agor-daemon/src/utils/branch-workspace-path.test.ts
+++ b/apps/agor-daemon/src/utils/branch-workspace-path.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { BranchRepository, type Database, generateId, RepoRepository } from '@agor/core/db';
+import type { BranchID, UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { resolveBranchWorkspacePath } from './branch-workspace-path';
+
+async function seedBranch(db: Database, branchPath: string) {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId() as UUID,
+    slug: `workspace-path-${generateId()}`,
+    name: 'Workspace Path Test Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: path.dirname(branchPath),
+    default_branch: 'main',
+  });
+  return new BranchRepository(db).create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id,
+    name: `workspace-path-${generateId()}`,
+    ref: 'refs/heads/workspace-path',
+    branch_unique_id: 1,
+    path: branchPath,
+    created_by: 'user-owner' as UUID,
+    others_can: 'session',
+  });
+}
+
+describe('resolveBranchWorkspacePath', () => {
+  dbTest('rejects a derived sidecar path that is a symlink outside the branch', async ({ db }) => {
+    const branchRoot = mkdtempSync(path.join(tmpdir(), 'agor-workspace-'));
+    const outside = mkdtempSync(path.join(tmpdir(), 'agor-sidecar-outside-'));
+    try {
+      const branch = await seedBranch(db, branchRoot);
+      writeFileSync(path.join(branchRoot, 'doc.md'), '# Doc');
+      writeFileSync(path.join(outside, 'stolen.json'), '{}');
+      symlinkSync(path.join(outside, 'stolen.json'), path.join(branchRoot, 'doc.md.agor-kb.json'));
+
+      await expect(
+        resolveBranchWorkspacePath({
+          branchRepo: new BranchRepository(db),
+          branchId: branch.branch_id,
+          subpath: 'doc.md.agor-kb.json',
+          userId: 'user-reviewer',
+          userRole: 'member',
+        })
+      ).rejects.toThrow(/escapes branch root/i);
+    } finally {
+      rmSync(branchRoot, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/agor-daemon/src/utils/branch-workspace-path.ts
+++ b/apps/agor-daemon/src/utils/branch-workspace-path.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import path from 'node:path';
+import type { BranchRepository } from '@agor/core/db';
+import type { Branch, BranchID, BranchPermissionLevel, UserID, UserRole } from '@agor/core/types';
+import { hasBranchPermission } from './branch-authorization.js';
+
+export function normalizeBranchWorkspaceSubpath(subpath: string | undefined | null): string {
+  if (!subpath || subpath.trim().length === 0) {
+    throw new Error('subpath is required');
+  }
+  const normalized = subpath
+    .trim()
+    .replace(/\\+/g, '/')
+    .replace(/^\/+|\/+$/g, '');
+  if (!normalized) throw new Error('subpath must identify a path inside the branch root');
+  for (const segment of normalized.split('/')) {
+    if (!segment || segment === '.' || segment === '..') {
+      throw new Error('subpath must not contain empty, "." or ".." segments');
+    }
+  }
+  return normalized;
+}
+
+export async function canonicalizeExistingPrefix(target: string): Promise<string> {
+  const resolved = path.resolve(target);
+  const segments = resolved.split(path.sep);
+  for (let i = segments.length; i >= 1; i -= 1) {
+    const prefix = segments.slice(0, i).join(path.sep) || path.sep;
+    if (!fs.existsSync(prefix)) continue;
+    const real = await realpath(prefix);
+    const tail = segments.slice(i).join(path.sep);
+    return tail ? path.join(real, tail) : real;
+  }
+  return resolved;
+}
+
+export function isPathInsideRoot(
+  root: string,
+  candidate: string,
+  options?: { allowRoot?: boolean }
+) {
+  const rel = path.relative(root, candidate);
+  if (rel === '') return options?.allowRoot === true;
+  return !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+export function assertPathInsideRoot(
+  root: string,
+  candidate: string,
+  reason: string,
+  options?: { allowRoot?: boolean }
+): void {
+  if (!isPathInsideRoot(root, candidate, options)) {
+    throw new Error(`${reason}: escapes branch root`);
+  }
+}
+
+export async function ensureBranchWorkspaceAccess(
+  branchRepo: BranchRepository,
+  branch: Branch,
+  userId?: string,
+  userRole?: UserRole,
+  requiredPermission: BranchPermissionLevel = 'session'
+): Promise<void> {
+  if (!userId) {
+    throw new Error('Authentication required to access branch workspace files');
+  }
+  const userIdBranded = userId as UserID;
+  const isOwner = await branchRepo.isOwner(branch.branch_id, userIdBranded);
+  const effective = await branchRepo.resolveUserPermission(branch, userIdBranded);
+  if (
+    !hasBranchPermission(
+      branch,
+      userIdBranded,
+      isOwner,
+      requiredPermission,
+      userRole,
+      true,
+      effective
+    )
+  ) {
+    throw new Error(
+      `Forbidden: branch ${requiredPermission} permission required to access branch workspace files`
+    );
+  }
+}
+
+export async function resolveBranchWorkspacePath(input: {
+  branchRepo: BranchRepository;
+  branchId: string;
+  subpath: string | undefined | null;
+  userId?: string;
+  userRole?: UserRole;
+  requiredPermission?: BranchPermissionLevel;
+}): Promise<{
+  branch: Branch;
+  branchId: BranchID;
+  branchRoot: string;
+  relative: string;
+  absolute: string;
+  canonical: string;
+}> {
+  const branch = await input.branchRepo.findById(input.branchId);
+  if (!branch) throw new Error(`Branch not found: ${input.branchId}`);
+  await ensureBranchWorkspaceAccess(
+    input.branchRepo,
+    branch,
+    input.userId,
+    input.userRole,
+    input.requiredPermission ?? 'session'
+  );
+
+  const branchRoot = await realpath(branch.path);
+  const relative = normalizeBranchWorkspaceSubpath(input.subpath);
+  const absolute = path.resolve(branchRoot, relative);
+  const canonical = await canonicalizeExistingPrefix(absolute);
+  assertPathInsideRoot(branchRoot, absolute, `subpath ${relative}`);
+  assertPathInsideRoot(branchRoot, canonical, `subpath ${relative} (canonical)`);
+
+  return {
+    branch,
+    branchId: branch.branch_id,
+    branchRoot,
+    relative,
+    absolute,
+    canonical,
+  };
+}
+
+export async function matchRegisteredBranchPath(input: {
+  branchRepo: BranchRepository;
+  folderPath: string;
+}): Promise<{
+  branch: Branch;
+  branchId: BranchID;
+  branchRoot: string;
+  canonicalFolderPath: string;
+} | null> {
+  const resolved = path.resolve(input.folderPath);
+  const canonical = await canonicalizeExistingPrefix(resolved);
+  const branches = await input.branchRepo.findAll();
+  for (const branch of branches) {
+    let branchRoot: string;
+    try {
+      branchRoot = await realpath(branch.path);
+    } catch {
+      continue;
+    }
+    const lexicalBranchRoot = path.resolve(branch.path);
+    const lexicallyInside = isPathInsideRoot(lexicalBranchRoot, resolved, { allowRoot: true });
+    const canonicallyInside = isPathInsideRoot(branchRoot, canonical, { allowRoot: true });
+    if (lexicallyInside && !canonicallyInside) {
+      throw new Error('Resolved path escapes registered branch root');
+    }
+    if (canonicallyInside) {
+      return {
+        branch,
+        branchId: branch.branch_id,
+        branchRoot,
+        canonicalFolderPath: canonical,
+      };
+    }
+  }
+  return null;
+}

--- a/context/explorations/kb-agent-targeted-edits.md
+++ b/context/explorations/kb-agent-targeted-edits.md
@@ -55,6 +55,13 @@ The MCP Knowledge tools currently expose:
 
 The UI follows the same model: `KnowledgePage.tsx` loads content for the active document and saves via `client.service('kb/documents').patch(activeDoc.document_id, { content_text: ... })`.
 
+Markdown link extraction is intentionally KB-document-focused today. Links like
+`agor://kb/document/<id>` or `agor://kb/<namespace>/<path>` create document
+`references` edges on save. Links to other Agor object schemes such as
+`agor://session/...` are not auto-extracted from markdown; agents should use
+explicit `agor_kb_link` calls for session, board, artifact, external URL, or
+other non-KB graph edges.
+
 ### 1.3 Internal KB units are not yet an editing API
 
 `kb_document_units` already represent document/section/file/auto-split units used for search/indexing. The markdown chunking path can produce heading-aware units, and search results can include chunks/snippets.
@@ -879,4 +886,9 @@ Then add filesystem materialization as an explicit Agor workspace feature, not a
 
 - `kb/document-edits` service applies `KnowledgeEditOp[]` sequentially and reuses `putDocument` so only one version is minted per successful call. Dry runs skip the commit and can optionally return the post-edit content via `returnContent:"full"`.
 - The MCP tool `agor_kb_edit` surfaces the same guarantee and encourages batching to avoid version spam.
-- Artifact publish/check now prefer `branchId + subpath` and enforce branch RBAC when paths resolve inside a registered worktree; legacy `folderPath` is still accepted but inherits the same permission gate.
+- Artifact publish/check now prefer `branchId + subpath` and enforce branch RBAC when paths resolve inside a registered worktree; legacy `folderPath` is still accepted but inherits the same permission gate. The service-level `branchId` path now requires a non-empty branch-relative `subpath` so branch-root reads are not implicit.
+- `agor_kb_outline` and `agor_kb_get_range` provide bounded remote reads for large documents, returning line ranges, content hashes, and the current version token.
+- `agor_kb_materialize` writes a KB markdown snapshot plus a `.agor-kb.json` sidecar into a branch worktree after branch `session` permission and containment checks. `agor_kb_publish_from_worktree` reads the branch-relative file back, uses the sidecar for document/version context when present, and updates existing documents through the targeted edit service so one publish creates one KB version.
+- Automatic markdown link extraction is KB-document-link oriented. Links to sessions, boards, branches, external URLs, etc. should be represented with explicit `agor_kb_link` calls until/unless broader auto-link extraction is intentionally added.
+- Review follow-up moved branch workspace path/RBAC/canonical containment into a shared daemon utility used by KB and artifacts, and moved markdown outline/range parsing into a shared daemon knowledge helper backed by the existing remark parser so fenced code blocks do not create false headings.
+- Worktree materialize/publish validates the derived `.agor-kb.json` sidecar path through the same branch-workspace canonical containment helper as the markdown file before reading or writing it. Worktree publish updates the sidecar after successful non-dry publishes so subsequent publishes carry a fresh expected version.

--- a/packages/core/src/db/repositories/knowledge.test.ts
+++ b/packages/core/src/db/repositories/knowledge.test.ts
@@ -250,4 +250,61 @@ describe('Knowledge repositories', () => {
       new Set(['private', 'public'])
     );
   });
+
+  dbTest('search path_prefix accepts trailing folder slashes', async ({ db }) => {
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const documents = new KnowledgeDocumentRepository(db);
+    const search = new KnowledgeSearchRepository(db);
+    const namespace = await namespaces.create({
+      slug: 'path-prefix-test',
+      display_name: 'Path Prefix Test',
+    });
+
+    const guide = await documents.create({
+      namespace_id: namespace.namespace_id,
+      path: 'guides/intro.md',
+      title: 'Intro',
+      content_text: 'prefixneedle guide',
+    });
+    await documents.create({
+      namespace_id: namespace.namespace_id,
+      path: 'notes/intro.md',
+      title: 'Note',
+      content_text: 'prefixneedle note',
+    });
+
+    const withoutSlash = await search.search({
+      q: 'prefixneedle',
+      namespace_slug: namespace.slug,
+      path_prefix: 'guides',
+    });
+    const withSlash = await search.search({
+      q: 'prefixneedle',
+      namespace_slug: namespace.slug,
+      path_prefix: 'guides/',
+    });
+
+    expect(withoutSlash.map((result) => result.document.document_id)).toEqual([guide.document_id]);
+    expect(withSlash.map((result) => result.document.document_id)).toEqual([guide.document_id]);
+  });
+
+  dbTest('namespace kind filtering includes user namespaces', async ({ db }) => {
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const userNamespace = await namespaces.create({
+      slug: 'user-kind-test',
+      display_name: 'User Kind Test',
+      kind: 'user',
+    });
+    await namespaces.create({
+      slug: 'global-kind-test',
+      display_name: 'Global Kind Test',
+      kind: 'global',
+    });
+
+    const userNamespaces = await namespaces.findAll({ kind: 'user' });
+
+    expect(userNamespaces.map((namespace) => namespace.namespace_id)).toEqual([
+      userNamespace.namespace_id,
+    ]);
+  });
 });

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -40,6 +40,7 @@ import {
   KNOWLEDGE_DOCUMENT_URI_PREFIX,
   KNOWLEDGE_EMBEDDING_STATUSES,
   KNOWLEDGE_UNIT_URI_PREFIX,
+  normalizeKnowledgeFolderPath,
   normalizeKnowledgePath,
   parseKnowledgeUri,
   titleFromKnowledgePath,
@@ -1163,8 +1164,10 @@ export class KnowledgeSearchRepository {
     }
     if (namespaceId) conditions.push(eq(kbDocuments.namespace_id, namespaceId));
     if (query.path_prefix) {
-      const prefix = normalizeKnowledgePath(query.path_prefix);
-      conditions.push(or(eq(kbDocuments.path, prefix), like(kbDocuments.path, `${prefix}/%`))!);
+      const prefix = normalizeKnowledgeFolderPath(query.path_prefix);
+      if (prefix) {
+        conditions.push(or(eq(kbDocuments.path, prefix), like(kbDocuments.path, `${prefix}/%`))!);
+      }
     }
     if (query.kind) conditions.push(eq(kbDocuments.kind, query.kind));
     if (query.visibility) conditions.push(eq(kbDocuments.visibility, query.visibility));


### PR DESCRIPTION
## Summary
- add KB MCP outline/range helpers plus branch-worktree materialize and publish-from-worktree flows
- share canonical branch workspace path/RBAC validation across KB and artifact filesystem reads
- harden artifact publish/check source resolution and cover symlink/temp-root regressions
- fix KB search pathPrefix trailing slash handling and document graph-link behavior

## Validation
- pnpm --filter @agor/core test -- src/db/repositories/knowledge.test.ts
- pnpm --filter @agor/daemon test -- src/knowledge/markdown-outline.test.ts src/utils/branch-workspace-path.test.ts src/services/knowledge.test.ts src/services/knowledge-document-edits.test.ts src/mcp/server.test.ts src/services/artifacts.test.ts
- pnpm --filter @agor/core typecheck
- pnpm --filter @agor/daemon typecheck
- pnpm exec biome check apps/agor-daemon/src/mcp/tools/knowledge.ts apps/agor-daemon/src/mcp/tools/artifacts.ts apps/agor-daemon/src/services/artifacts.ts apps/agor-daemon/src/services/artifacts.test.ts apps/agor-daemon/src/utils/branch-workspace-path.ts apps/agor-daemon/src/utils/branch-workspace-path.test.ts apps/agor-daemon/src/knowledge/markdown-outline.ts apps/agor-daemon/src/knowledge/markdown-outline.test.ts apps/agor-daemon/src/services/knowledge-search.ts packages/core/src/db/repositories/knowledge.ts packages/core/src/db/repositories/knowledge.test.ts
- git diff --check