### PR TITLE
Fix duplicate subsession callback handling

### DIFF
--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -102,7 +102,11 @@ function makeService(
   });
   const createPending = vi.fn(async (data: Partial<Task>) => ({ ...callbackTask, ...data }));
 
-  const sessionsPatch = vi.fn(async (_id: string, updates: Partial<Session>) => updates);
+  const sessionsPatch = vi.fn(async (id: string, updates: Partial<Session>) => {
+    const target = id === parentSessionId ? parentSession : childSession;
+    Object.assign(target, updates);
+    return { ...target };
+  });
   const triggerQueueProcessing = vi.fn(async () => undefined);
   const messagesFind = vi.fn(async () => [
     {
@@ -187,6 +191,8 @@ describe('TasksService completion callbacks', () => {
     expect(callbackPrompt).toContain('**Result:**');
     expect(callbackPrompt).toContain('Final child result');
     expect(callbackPrompt).toContain(taskId);
+    expect(callbackPrompt).not.toContain('## Original Prompt');
+    expect(callbackPrompt).not.toContain('investigate duplicate callbacks');
     expect(messagesFind).toHaveBeenCalledTimes(1);
     expect(triggerQueueProcessing).toHaveBeenCalledWith(parentSessionId, {});
     expect(sessionsPatch).toHaveBeenCalledWith(
@@ -200,6 +206,101 @@ describe('TasksService completion callbacks', () => {
         queued_task_id: callbackTaskId,
       }),
     ]);
+  });
+
+  it('includeOriginalPrompt=false queues one templated callback without an original prompt section', async () => {
+    const { service, createPending } = makeService({
+      childSession: {
+        callback_config: {
+          enabled: true,
+          callback_session_id: parentSessionId,
+          callback_created_by: userId,
+          callback_mode: 'once',
+          include_original_prompt: false,
+          include_last_message: true,
+        },
+      },
+      task: {
+        full_prompt: 'original prompt should not appear when disabled',
+      },
+    });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
+    expect(callbackPrompt).toContain('[Agor] Child session');
+    expect(callbackPrompt).toContain('**Result:**');
+    expect(callbackPrompt).toContain('Final child result');
+    expect(callbackPrompt).not.toContain('## Original Prompt');
+    expect(callbackPrompt).not.toContain('original prompt should not appear when disabled');
+  });
+
+  it('includeOriginalPrompt=true queues one templated callback with an explicit original prompt section', async () => {
+    const originalPrompt = [
+      'Investigate callback duplication.',
+      'Keep this second line in the callback body.',
+    ].join('\n');
+    const { service, createPending } = makeService({
+      childSession: {
+        callback_config: {
+          enabled: true,
+          callback_session_id: parentSessionId,
+          callback_created_by: userId,
+          callback_mode: 'once',
+          include_original_prompt: true,
+          include_last_message: true,
+        },
+      },
+      task: { full_prompt: originalPrompt },
+    });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
+    expect(callbackPrompt).toContain('[Agor] Child session');
+    expect(callbackPrompt).toContain('## Original Prompt');
+    expect(callbackPrompt).toContain(originalPrompt);
+    expect(callbackPrompt).toContain('**Result:**');
+    expect(callbackPrompt).toContain('Final child result');
+  });
+
+  it('uses the same single templated callback path for sessions.create callbacks without spawn genealogy', async () => {
+    const { service, createPending, childSession } = makeService({
+      childSession: {
+        genealogy: { children: [] },
+        callback_config: {
+          enabled: true,
+          callback_session_id: parentSessionId,
+          callback_created_by: userId,
+          callback_mode: 'once',
+          include_original_prompt: true,
+          include_last_message: true,
+        },
+      },
+      task: { full_prompt: 'remote session initial prompt' },
+    });
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+      full_prompt: 'remote session initial prompt',
+    });
+
+    await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
+    expect(callbackPrompt).toContain('[Agor] Child session');
+    expect(callbackPrompt).toContain('## Original Prompt');
+    expect(callbackPrompt).toContain('remote session initial prompt');
+    expect(callbackPrompt).toContain('Final child result');
   });
 
   it('dedupes concurrent completion callback dispatch for the same task target', async () => {
@@ -257,6 +358,32 @@ describe('TasksService completion callbacks', () => {
           id === childSessionId && (updates as Partial<Session>).callback_config?.enabled === false
       )
     ).toHaveLength(1);
+  });
+
+  it("callbackMode='once' prevents a repeat callback after the first firing", async () => {
+    const { service, createPending, childSession } = makeService();
+    const firstTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await (service as any).dispatchCompletionCallbacks(firstTask, childSession, {});
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    expect(childSession.callback_config?.enabled).toBe(false);
+
+    createPending.mockClear();
+
+    const secondTask = makeTask({
+      task_id: '018f0000-0000-7000-8000-000000000202' as Task['task_id'],
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:01:05.000Z',
+      metadata: undefined,
+    });
+
+    await (service as any).dispatchCompletionCallbacks(secondTask, childSession, {});
+
+    expect(createPending).not.toHaveBeenCalled();
   });
 
   it('does not queue or trigger when callback dispatch metadata already exists', async () => {

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -272,8 +272,8 @@ describe('TasksService completion callbacks', () => {
     expect(callbackPrompt).toContain('Final child result');
   });
 
-  it('uses the same single templated callback path for sessions.create callbacks without spawn genealogy', async () => {
-    const { service, createPending, childSession } = makeService({
+  it('uses the same single templated patch completion path for sessions.create callbacks without spawn genealogy', async () => {
+    const { service, createPending, sessionsPatch } = makeService({
       childSession: {
         genealogy: { children: [] },
         callback_config: {
@@ -287,13 +287,11 @@ describe('TasksService completion callbacks', () => {
       },
       task: { full_prompt: 'remote session initial prompt' },
     });
-    const completedTask = makeTask({
+
+    await service.patch(taskId, {
       status: TaskStatus.COMPLETED,
       completed_at: '2026-01-01T00:00:05.000Z',
-      full_prompt: 'remote session initial prompt',
     });
-
-    await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
 
     expect(createPending).toHaveBeenCalledTimes(1);
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
@@ -301,6 +299,10 @@ describe('TasksService completion callbacks', () => {
     expect(callbackPrompt).toContain('## Original Prompt');
     expect(callbackPrompt).toContain('remote session initial prompt');
     expect(callbackPrompt).toContain('Final child result');
+    expect(sessionsPatch).toHaveBeenCalledWith(
+      childSessionId,
+      expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+    );
   });
 
   it('dedupes concurrent completion callback dispatch for the same task target', async () => {
@@ -384,6 +386,26 @@ describe('TasksService completion callbacks', () => {
     await (service as any).dispatchCompletionCallbacks(secondTask, childSession, {});
 
     expect(createPending).not.toHaveBeenCalled();
+  });
+
+  it("callbackMode='once' does not disable when callback queueing fails before firing", async () => {
+    const { service, createPending, sessionsPatch, childSession } = makeService();
+    createPending.mockRejectedValueOnce(new Error('queue failed'));
+    const completedTask = makeTask({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await (service as any).dispatchCompletionCallbacks(completedTask, childSession, {});
+
+    expect(createPending).toHaveBeenCalledTimes(1);
+    expect(
+      sessionsPatch.mock.calls.filter(
+        ([id, updates]) =>
+          id === childSessionId && (updates as Partial<Session>).callback_config?.enabled === false
+      )
+    ).toHaveLength(0);
+    expect(childSession.callback_config?.enabled).toBe(true);
   });
 
   it('does not queue or trigger when callback dispatch metadata already exists', async () => {

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -856,9 +856,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         targetSession.callback_config?.include_original_prompt ??
         false;
 
-      // Get spawn prompt from task (truncated to 120 chars for the callback template).
+      // Get the original prompt from the completed task. When requested, it is
+      // rendered as a section inside the single templated callback body (never
+      // queued as its own callback/message).
       const spawnPrompt = includeOriginalPrompt
-        ? task.full_prompt?.substring(0, 120) || '(no prompt available)'
+        ? task.full_prompt || '(no prompt available)'
         : undefined;
 
       // Fetch last assistant message from child session (if callback config allows)

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -74,8 +74,6 @@ export type TaskParams = QueryParams<{
 
 interface CompletionCallbackDispatchResult {
   callbackTask?: Task;
-  /** True only for the caller that actually evaluated/attempted dispatch under the lock. */
-  didAttemptDispatch: boolean;
 }
 
 /**
@@ -692,12 +690,13 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       }
     }
 
-    // Post-callback cleanup: runs independently of whether callback was delivered.
-    // "once" mode: auto-disable callback after first delivery attempt.
+    // Post-callback cleanup: only runs after a callback task was actually
+    // queued. "once" means "after firing" — do not permanently disable a
+    // one-shot callback when delivery was skipped or failed before queueing.
     // Default to "persistent" for backward compat — legacy sessions without
     // callback_mode should continue firing on every completion as they always have.
     const callbackMode = childSession.callback_config?.callback_mode ?? 'persistent';
-    if (dispatchResult.didAttemptDispatch && callbackMode === 'once') {
+    if (dispatchResult.callbackTask && callbackMode === 'once') {
       try {
         await this.app.service('sessions').patch(childSession.session_id, {
           callback_config: {
@@ -773,7 +772,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     const existingDispatch = this.completionCallbackDispatches.get(dispatchKey);
     if (existingDispatch) {
       await existingDispatch;
-      return { didAttemptDispatch: false };
+      return {};
     }
 
     const dispatch = (async (): Promise<CompletionCallbackDispatchResult> => {
@@ -782,7 +781,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         console.log(
           `⏭️  [TasksService] Completion callback for task ${shortId(task.task_id)} to ${shortId(targetSessionId)} already dispatched`
         );
-        return { didAttemptDispatch: false };
+        return {};
       }
 
       const queuedCallbackTask = await this.queueCallbackToSession(
@@ -807,7 +806,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         }
       }
 
-      return { callbackTask: queuedCallbackTask, didAttemptDispatch: true };
+      return { callbackTask: queuedCallbackTask };
     })();
 
     this.completionCallbackDispatches.set(dispatchKey, dispatch);

--- a/packages/core/src/callbacks/child-completion-template.ts
+++ b/packages/core/src/callbacks/child-completion-template.ts
@@ -26,7 +26,10 @@ import { renderTemplate } from '../templates/handlebars-helpers';
 
 const DEFAULT_TEMPLATE = `[Agor] Child session {{childSessionId}} has {{#if (eq status "completed")}}completed{{else}}failed{{/if}}.
 
-{{#if spawnPrompt}}**Task:** {{spawnPrompt}}
+{{#if spawnPrompt}}## Original Prompt
+
+{{spawnPrompt}}
+
 {{/if}}**Status:** {{status}}
 **Stats:** {{messageCount}} messages, {{toolUseCount}} tool uses
 
@@ -44,7 +47,7 @@ export interface ChildCompletionContext {
   childTaskFullId: string; // Full UUIDv7 of task
   parentSessionId: string; // Canonical short ID of callback target (kept for backward compat)
   callbackSessionId: string; // Alias: Canonical short ID of callback target session
-  spawnPrompt?: string; // Original prompt from spawn (truncated to 120 chars, optional based on include_original_prompt)
+  spawnPrompt?: string; // Original prompt from spawn (optional based on include_original_prompt)
   status: string; // Task status (COMPLETED, FAILED, etc.)
   completedAt: string; // ISO timestamp
   messageCount: number;


### PR DESCRIPTION
## Summary

- render `includeOriginalPrompt` inside the single completion callback body as an explicit `## Original Prompt` section
- keep subsession and `sessions.create` callback delivery on the shared `TasksService` completion-callback path
- add regression coverage for one-callback behavior, original-prompt inclusion, remote create callbacks, dedupe, and `callbackMode: 'once'`

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/tasks.callbacks.test.ts`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/claude/message-builder.test.ts`
