### PR TITLE
Improve assistant onboarding flow

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -379,6 +379,7 @@ function AppContent() {
 
   // Onboarding wizard state
   const [onboardingWizardOpen, setOnboardingWizardOpen] = useState(false);
+  const [onboardingWizardInstance, setOnboardingWizardInstance] = useState(0);
 
   // Trigger wizard when user is loaded and hasn't completed onboarding
   useEffect(() => {
@@ -826,6 +827,24 @@ function AppContent() {
       }
       throw error;
     }
+  };
+
+  const handleRestartOnboarding = async () => {
+    if (!currentUser) return;
+
+    const preferences = { ...(currentUser.preferences ?? {}) } as NonNullable<User['preferences']>;
+    delete preferences.onboarding;
+
+    try {
+      await handleUpdateUser(currentUser.user_id, { preferences }, { silent: true });
+    } catch {
+      // handleUpdateUser already surfaces the error when not silent; keep restart best-effort.
+      return;
+    }
+
+    setOpenUserSettings(false);
+    setOnboardingWizardInstance((value) => value + 1);
+    setOnboardingWizardOpen(true);
   };
 
   // Handle delete user
@@ -1573,6 +1592,7 @@ function AppContent() {
       instanceDescription={instanceConfig?.description}
       webTerminalEnabled={featuresConfig?.webTerminal === true}
       branchStorageConfig={featuresConfig?.branchStorage}
+      onRestartOnboarding={handleRestartOnboarding}
     />
   );
 
@@ -1600,6 +1620,7 @@ function AppContent() {
             mcpServerById={mcpServerById}
             onUpdateUser={handleUpdateUser}
             onRefreshCurrentUser={reAuthenticate}
+            onRestartOnboarding={handleRestartOnboarding}
           />
         )}
 
@@ -1611,7 +1632,7 @@ function AppContent() {
             state, eliminating any chance of one user's onboarding progress
             leaking into another user's session. */}
         <OnboardingWizard
-          key={currentUser?.user_id ?? '__anon__'}
+          key={`${currentUser?.user_id ?? '__anon__'}:${onboardingWizardInstance}`}
           open={onboardingWizardOpen}
           onComplete={handleOnboardingComplete}
           repoById={repoById}

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -837,8 +837,10 @@ function AppContent() {
 
     try {
       await handleUpdateUser(currentUser.user_id, { preferences }, { silent: true });
-    } catch {
-      // handleUpdateUser already surfaces the error when not silent; keep restart best-effort.
+    } catch (error) {
+      showError(
+        `Failed to restart onboarding: ${error instanceof Error ? error.message : String(error)}`
+      );
       return;
     }
 

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -109,6 +109,7 @@ export interface AppProps {
   onSettingsClose?: () => void; // Called when settings modal closes
   openUserSettings?: boolean; // Open user settings modal directly (e.g., from onboarding)
   onUserSettingsClose?: () => void; // Called when user settings modal closes
+  onRestartOnboarding?: () => void | Promise<void>;
   openNewBranchModal?: boolean; // Open new branch modal
   onNewBranchModalClose?: () => void; // Called when new branch modal closes
   suppressLeftPanel?: boolean; // Temporarily hide the assistant/comments panel behind modal-first flows
@@ -278,6 +279,7 @@ export const App: React.FC<AppProps> = ({
   onDeleteComment,
   onLogout,
   onRetryConnection,
+  onRestartOnboarding,
   instanceLabel,
   instanceDescription,
   webTerminalEnabled = false,
@@ -1452,9 +1454,15 @@ export const App: React.FC<AppProps> = ({
                 onUserSettingsClose?.();
               }}
               user={user || null}
+              currentUser={user || null}
               mcpServerById={mcpServerById}
               client={client}
               onUpdate={onUpdateUser}
+              onRestartOnboarding={async () => {
+                setUserSettingsOpen(false);
+                onUserSettingsClose?.();
+                await onRestartOnboarding?.();
+              }}
             />
           </Layout>
         </AppActionsProvider>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -103,6 +103,11 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText('Codex')).toBeInTheDocument();
     expect(screen.getByAltText('claude-code logo')).toBeInTheDocument();
     expect(screen.getByAltText('codex logo')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /use a different provider/i })).toBeInTheDocument();
+    expect(screen.queryByText('Other LLM providers')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
+
     expect(screen.getByText('Other LLM providers')).toBeInTheDocument();
     expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
   });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -125,6 +125,8 @@ describe('OnboardingWizard', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
 
     expect(screen.getByText('Other LLM providers')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
+    expect(codexOption).toBeChecked();
     expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
   });
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -56,11 +56,14 @@ describe('OnboardingWizard', () => {
     const onUpdateUser = vi.fn();
     renderWizard({ onUpdateUser });
 
-    expect(screen.getByText('Welcome to Agor')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to Agor/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create your assistant/i })).toBeInTheDocument();
+    expect(screen.getByText('Your assistant can help:')).toBeInTheDocument();
+    expect(screen.getByText(/connect tools and credentials/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /getting started guide/i })).toBeInTheDocument();
     expect(screen.queryByText(/bring your own repository/i)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
 
     expect(await screen.findByText('Name Your Assistant')).toBeInTheDocument();
     expect(onUpdateUser).toHaveBeenCalledWith(
@@ -87,7 +90,7 @@ describe('OnboardingWizard', () => {
   it('shows recommended provider cards plus a secondary selector', async () => {
     renderWizard();
 
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
     fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
 
     expect(await screen.findByText('Connect an LLM Provider')).toBeInTheDocument();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -92,7 +92,7 @@ describe('OnboardingWizard', () => {
   });
 
   it('shows recommended provider cards plus a secondary selector', async () => {
-    renderWizard();
+    const { baseElement } = renderWizard();
 
     fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
     fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
@@ -103,6 +103,22 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText('Codex')).toBeInTheDocument();
     expect(screen.getByAltText('claude-code logo')).toBeInTheDocument();
     expect(screen.getByAltText('codex logo')).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: /onboarding progress/i })).toBeInTheDocument();
+    const providerOptions = Array.from(
+      baseElement.querySelectorAll<HTMLInputElement>('input[name="recommended-agent"]')
+    );
+    const claudeOption = providerOptions.find((option) => option.value === 'claude-code');
+    const codexOption = providerOptions.find((option) => option.value === 'codex');
+    expect(claudeOption).toBeInstanceOf(HTMLInputElement);
+    expect(claudeOption).toBeChecked();
+    expect(codexOption).toBeInstanceOf(HTMLInputElement);
+    expect(codexOption).not.toBeChecked();
+    codexOption?.focus();
+    expect(codexOption).toHaveFocus();
+
+    fireEvent.click(codexOption as HTMLInputElement);
+
+    expect(codexOption).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /use a different provider/i })).toBeInTheDocument();
     expect(screen.queryByText('Other LLM providers')).not.toBeInTheDocument();
 
@@ -110,5 +126,23 @@ describe('OnboardingWizard', () => {
 
     expect(screen.getByText('Other LLM providers')).toBeInTheDocument();
     expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
+  });
+
+  it('detects an existing Cursor credential when selecting Cursor', async () => {
+    renderWizard({
+      user: makeUser({
+        agentic_tools: {
+          cursor: { CURSOR_API_KEY: true },
+        },
+      } as Partial<User>),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+    fireEvent.click(await screen.findByRole('checkbox', { name: /use a different provider/i }));
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(await screen.findByText('Cursor SDK (Beta)'));
+
+    expect(await screen.findByText('Cursor SDK is configured')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -60,6 +60,10 @@ describe('OnboardingWizard', () => {
     expect(screen.getByRole('button', { name: /create your assistant/i })).toBeInTheDocument();
     expect(screen.getByText('Your assistant can help:')).toBeInTheDocument();
     expect(screen.getByText(/connect tools and credentials/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Agor assistant/i })).toHaveAttribute(
+      'href',
+      'https://agor.live/guide/assistants'
+    );
     expect(screen.getByRole('link', { name: /getting started guide/i })).toBeInTheDocument();
     expect(screen.queryByText(/bring your own repository/i)).not.toBeInTheDocument();
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -97,11 +97,13 @@ describe('OnboardingWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
     fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
 
-    expect(await screen.findByText('Connect an LLM Provider')).toBeInTheDocument();
-    expect(screen.getByText(/best-supported onboarding options today/i)).toBeInTheDocument();
+    expect(await screen.findByText('Choose an LLM Provider')).toBeInTheDocument();
+    expect(screen.getByText(/Pick what powers your assistant/i)).toBeInTheDocument();
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
-    expect(screen.getByText('Codex (OpenAI)')).toBeInTheDocument();
-    expect(screen.getByText('Other supported agents')).toBeInTheDocument();
+    expect(screen.getByText('Codex')).toBeInTheDocument();
+    expect(screen.getByAltText('claude-code logo')).toBeInTheDocument();
+    expect(screen.getByAltText('codex logo')).toBeInTheDocument();
+    expect(screen.getByText('Other LLM providers')).toBeInTheDocument();
     expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -1,0 +1,100 @@
+import type { User } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { OnboardingWizard } from './OnboardingWizard';
+
+vi.mock('../EmojiPickerInput/EmojiPickerInput', () => ({
+  EmojiPickerInput: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <button type="button" onClick={() => onChange(value)} aria-label="emoji picker">
+      {value}
+    </button>
+  ),
+}));
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: 'user-1',
+    email: 'new-user@example.com',
+    name: 'New User',
+    role: 'member',
+    onboarding_completed: false,
+    preferences: {},
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as unknown as User;
+}
+
+function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>> = {}) {
+  const reposService = { on: vi.fn(), removeListener: vi.fn() };
+  const client = {
+    io: { on: vi.fn(), off: vi.fn() },
+    service: vi.fn(() => reposService),
+  };
+
+  return render(
+    <OnboardingWizard
+      open={true}
+      onComplete={vi.fn()}
+      repoById={new Map()}
+      branchById={new Map()}
+      boardById={new Map()}
+      user={makeUser()}
+      client={client}
+      onCreateRepo={vi.fn()}
+      onCreateLocalRepo={vi.fn()}
+      onCreateBranch={vi.fn()}
+      onCreateSession={vi.fn()}
+      onUpdateUser={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
+describe('OnboardingWizard', () => {
+  it('starts onboarding through assistant creation only', async () => {
+    const onUpdateUser = vi.fn();
+    renderWizard({ onUpdateUser });
+
+    expect(screen.getByText('Welcome to Agor')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument();
+    expect(screen.queryByText(/bring your own repository/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+
+    expect(await screen.findByText('Name Your Assistant')).toBeInTheDocument();
+    expect(onUpdateUser).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        preferences: expect.objectContaining({
+          onboarding: expect.objectContaining({ path: 'assistant' }),
+        }),
+      })
+    );
+  });
+
+  it('does not resume legacy own-repo onboarding as an alternate path', async () => {
+    renderWizard({
+      user: makeUser({
+        preferences: { onboarding: { path: 'own-repo' } },
+      } as Partial<User>),
+    });
+
+    expect(await screen.findByText('Name Your Assistant')).toBeInTheDocument();
+    expect(screen.queryByText('Add Your Repository')).not.toBeInTheDocument();
+  });
+
+  it('shows recommended provider cards plus a secondary selector', async () => {
+    renderWizard();
+
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+
+    expect(await screen.findByText('Connect an LLM Provider')).toBeInTheDocument();
+    expect(screen.getByText(/best-supported onboarding options today/i)).toBeInTheDocument();
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    expect(screen.getByText('Codex (OpenAI)')).toBeInTheDocument();
+    expect(screen.getByText('Other supported agents')).toBeInTheDocument();
+    expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1,9 +1,8 @@
 /**
  * OnboardingWizard - Multi-step wizard for new user onboarding
  *
- * Two paths:
+ * Assistant-first path:
  * - Assistant: identity -> API keys -> clone assistant framework repo -> create board -> create branch/session
- * - Own Repo: API keys -> add repo -> create board -> create branch/session
  *
  * Replaces GettingStartedPopover entirely.
  */
@@ -239,6 +238,38 @@ function findMatchingRepoId(
   return null;
 }
 
+const RECOMMENDED_AGENT_OPTIONS: Array<{
+  value: AgenticToolName;
+  title: string;
+  eyebrow: string;
+  description: string;
+}> = [
+  {
+    value: 'claude-code',
+    title: 'Claude Code',
+    eyebrow: 'Recommended',
+    description:
+      'Best-tested default for Agor assistants, with API key, CLI auth, and Pro/Max token paths.',
+  },
+  {
+    value: 'codex',
+    title: 'Codex (OpenAI)',
+    eyebrow: 'Recommended',
+    description: 'Strong support for OpenAI API keys and Codex CLI auth inside Agor branches.',
+  },
+];
+
+const OTHER_AGENT_OPTIONS: Array<{ value: AgenticToolName; label: string }> = [
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'copilot', label: 'GitHub Copilot' },
+  { value: 'opencode', label: 'OpenCode' },
+  { value: 'cursor', label: 'Cursor SDK (Beta)' },
+];
+
+const RECOMMENDED_AGENT_VALUES = new Set<AgenticToolName>(
+  RECOMMENDED_AGENT_OPTIONS.map((option) => option.value)
+);
+
 const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string } | null> = {
   'claude-code': { label: 'console.anthropic.com', url: 'https://console.anthropic.com/' },
   // Claude Code CLI uses the same Anthropic credentials.
@@ -410,6 +441,12 @@ export function OnboardingWizard({
       return;
     }
 
+    // Only the assistant path remains an active onboarding route. Legacy saved
+    // non-assistant path preferences are allowed to keep their data shape, but
+    // they resume at the assistant flow instead of exposing the old path.
+    const savedPath = onboarding.path === 'persisted-agent' ? 'assistant' : onboarding.path;
+    const canResumeAssistantResources = savedPath === 'assistant';
+
     // Resource-ownership validation. The resume-step decisions below jump the
     // wizard past the api-keys / board / repo creation steps based on IDs
     // stored in user.preferences. If those IDs ever point at resources NOT
@@ -421,11 +458,15 @@ export function OnboardingWizard({
     // check is treated as if the preference were unset; the fallback chain
     // then routes the user to the right step (typically api-keys).
     const validBranchId =
-      onboarding.branchId && branchById.get(onboarding.branchId)?.created_by === user.user_id
+      canResumeAssistantResources &&
+      onboarding.branchId &&
+      branchById.get(onboarding.branchId)?.created_by === user.user_id
         ? onboarding.branchId
         : undefined;
     const validBoardId =
-      mainBoardId && boardById.get(mainBoardId)?.created_by === user.user_id
+      canResumeAssistantResources &&
+      mainBoardId &&
+      boardById.get(mainBoardId)?.created_by === user.user_id
         ? mainBoardId
         : undefined;
     // Repos are SHARED resources (no created_by attribution). We require a
@@ -435,7 +476,9 @@ export function OnboardingWizard({
     // as that would let a new user inherit any framework repo cloned by a
     // prior user and skip the clone step.
     const validRepoId =
-      onboarding.repoId && repoById.has(onboarding.repoId) ? onboarding.repoId : undefined;
+      canResumeAssistantResources && onboarding.repoId && repoById.has(onboarding.repoId)
+        ? onboarding.repoId
+        : undefined;
 
     if (
       onboarding.branchId !== validBranchId ||
@@ -449,9 +492,9 @@ export function OnboardingWizard({
       });
     }
 
-    // Map legacy 'persisted-agent' to 'assistant'
-    const resumedPath: WizardPath =
-      onboarding.path === 'persisted-agent' ? 'assistant' : (onboarding.path as WizardPath);
+    // Map every saved onboarding path to the assistant flow. 'persisted-agent'
+    // is the old assistant path name; 'own-repo' is no longer an onboarding path.
+    const resumedPath: WizardPath = 'assistant';
     setPath(resumedPath);
 
     if (resumedPath === 'assistant') {
@@ -1199,65 +1242,26 @@ export function OnboardingWizard({
 
   const renderWelcome = () => (
     <div style={{ padding: '8px 0' }}>
-      <Title level={3} style={{ marginBottom: 6 }}>
+      <Title level={3} style={{ marginBottom: 8 }}>
         Welcome to Agor
       </Title>
+      <Paragraph style={{ marginBottom: 12, fontSize: 15 }}>
+        The best way to get started is with an Agor assistant. Agents in Agor can help connect
+        tools, coordinate other agents, set up your board and workflow, and show you around.
+      </Paragraph>
       <Paragraph type="secondary" style={{ marginBottom: 24, fontSize: 15 }}>
-        Let's get you set up with your first AI session.
+        This quick wizard will handle setup and introduce your assistant, who can take it from
+        there. Any questions? Ask your assistant.
       </Paragraph>
 
-      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-        <Card
-          hoverable
-          onClick={() => handleSelectPath('assistant')}
-          style={{ cursor: 'pointer', borderColor: token.colorPrimary }}
-        >
-          <Space align="start" size="middle">
-            <ThunderboltOutlined
-              style={{ fontSize: 24, color: token.colorPrimary, marginTop: 2, flexShrink: 0 }}
-            />
-            <div>
-              <Space style={{ marginBottom: 6 }} align="center">
-                <Text strong style={{ fontSize: 15 }}>
-                  Set up your AI assistant
-                </Text>
-                <Tag color="blue">Recommended</Tag>
-              </Space>
-              <Paragraph type="secondary" style={{ marginBottom: 6 }}>
-                Get a persistent AI assistant with memory, task management, and pre-configured
-                workflows.
-              </Paragraph>
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                Identity → API key → Clone assistant framework → Board → Branch/session
-              </Text>
-            </div>
-          </Space>
-        </Card>
-
-        <Card hoverable onClick={() => handleSelectPath('own-repo')} style={{ cursor: 'pointer' }}>
-          <Space align="start" size="middle">
-            <FolderOpenOutlined
-              style={{
-                fontSize: 24,
-                color: token.colorTextSecondary,
-                marginTop: 2,
-                flexShrink: 0,
-              }}
-            />
-            <div>
-              <Text strong style={{ fontSize: 15 }}>
-                Bring your own repository
-              </Text>
-              <Paragraph type="secondary" style={{ marginBottom: 6, marginTop: 4 }}>
-                Connect an existing Git repository and start coding with AI agents.
-              </Paragraph>
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                API key → Add repository → Board → Branch/session
-              </Text>
-            </div>
-          </Space>
-        </Card>
-      </Space>
+      <Button
+        type="primary"
+        size="large"
+        icon={<ThunderboltOutlined />}
+        onClick={() => handleSelectPath('assistant')}
+      >
+        Get started
+      </Button>
     </div>
   );
 
@@ -1513,8 +1517,12 @@ export function OnboardingWizard({
         <div style={{ textAlign: 'center', padding: '24px 0' }}>
           <Result
             icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
-            title="Branch Created"
-            subTitle="The branch is ready. Create the first session to finish onboarding."
+            title={path === 'assistant' ? 'Assistant Branch Created' : 'Branch Created'}
+            subTitle={
+              path === 'assistant'
+                ? 'Your assistant branch is ready. Create the first session to finish onboarding.'
+                : 'The branch is ready. Create the first session to finish onboarding.'
+            }
           />
           {error && (
             <Alert
@@ -1538,12 +1546,13 @@ export function OnboardingWizard({
 
     return (
       <div style={{ padding: '16px 0' }}>
-        <Title level={4}>Create Your Branch</Title>
+        <Title level={4}>
+          {path === 'assistant' ? 'Create Your Assistant Branch' : 'Create Your Branch'}
+        </Title>
         <Paragraph type="secondary">
-          A branch is an isolated workspace backed by its own git branch.
           {path === 'assistant'
-            ? " We'll set up a branch for your assistant and create its first session."
-            : ' Name it whatever you like. We’ll create the first session after the branch is ready.'}
+            ? 'Your assistant lives in a branch: a safe, isolated workspace where it can use tools, keep setup context, and start helping without mixing with other work.'
+            : 'A branch is an isolated workspace backed by its own git branch. Name it whatever you like. We’ll create the first session after the branch is ready.'}
         </Paragraph>
 
         <Form layout="vertical">
@@ -1551,7 +1560,9 @@ export function OnboardingWizard({
             label="Branch name"
             extra={
               <>
-                Used as both the directory name and the new branch name. Forked from{' '}
+                {path === 'assistant'
+                  ? 'This names the assistant workspace and its underlying git branch. Forked from '
+                  : 'Used as both the directory name and the new branch name. Forked from '}
                 <Text code>{sourceBranch}</Text>.
               </>
             }
@@ -1572,7 +1583,9 @@ export function OnboardingWizard({
           loading={loading}
           disabled={!branchName.trim()}
         >
-          Create Branch & First Session
+          {path === 'assistant'
+            ? 'Create Assistant & First Session'
+            : 'Create Branch & First Session'}
         </Button>
       </div>
     );
@@ -1643,31 +1656,82 @@ export function OnboardingWizard({
 
     return (
       <div style={{ padding: '16px 0' }}>
-        <Title level={4}>Configure Your Agent</Title>
+        <Title level={4}>Connect an LLM Provider</Title>
+        <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+          Choose what will power your assistant. Claude Code and Codex are the best-supported
+          onboarding options today; other supported agents are available below.
+        </Paragraph>
 
-        <Form layout="vertical">
-          <Form.Item label="Agent">
-            <Select
-              value={selectedAgent}
-              onChange={(value) => {
-                setSelectedAgent(value);
-                setApiKey('');
-                setError(null);
-                setManualTestResult(null);
-                setOverrideDetectedAuth(false);
-              }}
-              options={[
-                { value: 'claude-code', label: 'Claude Code (Recommended)' },
-                { value: 'codex', label: 'Codex (OpenAI)' },
-                { value: 'gemini', label: 'Gemini' },
-                { value: 'copilot', label: 'GitHub Copilot' },
-                { value: 'opencode', label: 'OpenCode' },
-                { value: 'cursor', label: 'Cursor SDK (Beta)' },
-              ]}
-              style={{ width: '100%' }}
-            />
-          </Form.Item>
-        </Form>
+        <Space direction="vertical" size="middle" style={{ width: '100%', marginBottom: 16 }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              gap: 12,
+            }}
+          >
+            {RECOMMENDED_AGENT_OPTIONS.map((option) => {
+              const selected = selectedAgent === option.value;
+              return (
+                <Card
+                  key={option.value}
+                  hoverable
+                  size="small"
+                  onClick={() => {
+                    setSelectedAgent(option.value);
+                    setApiKey('');
+                    setError(null);
+                    setManualTestResult(null);
+                    setOverrideDetectedAuth(false);
+                  }}
+                  style={{
+                    cursor: 'pointer',
+                    borderColor: selected ? token.colorPrimary : token.colorBorder,
+                    background: selected ? token.colorPrimaryBg : undefined,
+                    minHeight: 132,
+                  }}
+                >
+                  <Space direction="vertical" size={6} style={{ width: '100%' }}>
+                    <Space align="center">
+                      <Text strong>{option.title}</Text>
+                      <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
+                    </Space>
+                    <Text type="secondary" style={{ fontSize: 13 }}>
+                      {option.description}
+                    </Text>
+                    {selected && <Text type="success">Selected</Text>}
+                  </Space>
+                </Card>
+              );
+            })}
+          </div>
+
+          <Form layout="vertical">
+            <Form.Item label="Other supported agents" style={{ marginBottom: 0 }}>
+              <Select
+                placeholder="Choose another agent"
+                value={RECOMMENDED_AGENT_VALUES.has(selectedAgent) ? undefined : selectedAgent}
+                onChange={(value) => {
+                  setSelectedAgent(value);
+                  setApiKey('');
+                  setError(null);
+                  setManualTestResult(null);
+                  setOverrideDetectedAuth(false);
+                }}
+                options={OTHER_AGENT_OPTIONS}
+                style={{ width: '100%' }}
+                allowClear
+                onClear={() => {
+                  setSelectedAgent('claude-code');
+                  setApiKey('');
+                  setError(null);
+                  setManualTestResult(null);
+                  setOverrideDetectedAuth(false);
+                }}
+              />
+            </Form.Item>
+          </Form>
+        </Space>
 
         {isAuthenticated && !overrideDetectedAuth ? (
           <div style={{ textAlign: 'center', padding: '8px 0' }}>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -27,9 +27,11 @@ import {
   TOOL_API_KEY_NAMES,
 } from '@agor-live/client';
 import {
+  ApiOutlined,
+  AppstoreOutlined,
+  BranchesOutlined,
   CheckCircleOutlined,
   CloudDownloadOutlined,
-  ExperimentOutlined,
   FolderOpenOutlined,
   KeyOutlined,
   RobotOutlined,
@@ -1498,15 +1500,7 @@ export function OnboardingWizard({
 
   const renderBoard = () => (
     <div style={{ textAlign: 'center', padding: '32px 0' }}>
-      <Title level={4}>Create Your Personal Board</Title>
-      <Paragraph type="secondary">
-        Boards are spatial canvases where you organize branches, sessions, and AI agents. We'll
-        create a personal board for you.
-      </Paragraph>
-
-      {loading ? (
-        <Spin size="large" />
-      ) : error ? (
+      {error ? (
         <>
           <Alert
             type="error"
@@ -1518,25 +1512,18 @@ export function OnboardingWizard({
             Retry
           </Button>
         </>
-      ) : createdBoardId ? (
-        <>
-          <Result
-            icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
-            title="Board Created"
-          />
-          <Button type="primary" onClick={() => setCurrentStep('branch')}>
-            Continue
-          </Button>
-        </>
       ) : (
-        <Button
-          type="primary"
-          size="large"
-          icon={<ExperimentOutlined />}
-          onClick={handleCreateBoard}
-        >
-          Create Board
-        </Button>
+        <>
+          <Spin size="large" />
+          <Title level={4} style={{ marginTop: 16 }}>
+            {path === 'assistant' ? "Setting up your assistant's board" : 'Creating your board'}
+          </Title>
+          <Paragraph type="secondary" style={{ marginBottom: 0 }}>
+            {path === 'assistant'
+              ? 'Agor is creating a board where your assistant can organize its work.'
+              : 'Agor is creating a personal board for your work.'}
+          </Paragraph>
+        </>
       )}
     </div>
   );
@@ -1918,12 +1905,12 @@ export function OnboardingWizard({
 
     const labelMap: Record<WizardStep, string> = {
       welcome: 'Welcome',
-      identity: 'Identity',
+      identity: 'Assistant',
       'add-repo': 'Repo',
-      clone: path === 'own-repo' ? 'Repo' : 'Clone',
+      clone: path === 'own-repo' ? 'Repo' : 'Setup',
       board: 'Board',
       branch: 'Branch',
-      'api-keys': 'Keys',
+      'api-keys': 'Provider',
     };
 
     const iconMap: Record<WizardStep, React.ReactNode> = {
@@ -1931,17 +1918,30 @@ export function OnboardingWizard({
       identity: <RobotOutlined />,
       'add-repo': <FolderOpenOutlined />,
       clone: <CloudDownloadOutlined />,
-      board: <ExperimentOutlined />,
-      branch: <FolderOpenOutlined />,
-      'api-keys': <KeyOutlined />,
+      board: <AppstoreOutlined />,
+      branch: <BranchesOutlined />,
+      'api-keys': <ApiOutlined />,
     };
 
-    return displaySteps.map((step) => ({
-      key: step,
-      title: labelMap[step],
-      icon: iconMap[step],
-    }));
-  }, [path]);
+    const mappedStep = currentStep === 'clone' && path === 'own-repo' ? 'add-repo' : currentStep;
+    const activeIndex = displaySteps.indexOf(mappedStep);
+
+    return displaySteps.map((step, index) => {
+      const isActive = index === activeIndex;
+      const stepColor = isActive ? token.colorPrimary : token.colorTextDisabled;
+      return {
+        key: step,
+        title: (
+          <span style={{ color: stepColor, fontWeight: isActive ? 600 : undefined }}>
+            {labelMap[step]}
+          </span>
+        ),
+        icon: (
+          <span style={{ color: stepColor, opacity: isActive ? 1 : 0.55 }}>{iconMap[step]}</span>
+        ),
+      };
+    });
+  }, [path, currentStep, token.colorPrimary, token.colorTextDisabled]);
 
   const currentStepDisplay = useMemo(() => {
     if (!path || currentStep === 'welcome') return -1;

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -28,10 +28,9 @@ import {
 } from '@agor-live/client';
 import {
   ApiOutlined,
-  AppstoreOutlined,
+  ArrowRightOutlined,
   BranchesOutlined,
   CheckCircleOutlined,
-  CloudDownloadOutlined,
   FolderOpenOutlined,
   KeyOutlined,
   RobotOutlined,
@@ -49,7 +48,6 @@ import {
   Select,
   Space,
   Spin,
-  Steps,
   Tag,
   Typography,
   theme,
@@ -1838,72 +1836,105 @@ export function OnboardingWizard({
     }
   };
 
-  // ─── Steps display config ────────────────────────
+  // ─── Progress display config ─────────────────────
 
-  const stepsItems = useMemo(() => {
-    if (!path) return [];
+  const progressItems = useMemo(() => {
+    if (path === 'assistant') {
+      return [
+        { key: 'identity' as const, title: 'Assistant', icon: <RobotOutlined /> },
+        { key: 'api-keys' as const, title: 'LLM Provider', icon: <ApiOutlined /> },
+        { key: 'branch' as const, title: 'Workspace', icon: <BranchesOutlined /> },
+      ];
+    }
 
-    const allSteps = getStepsForPath(path);
-    // Don't include 'welcome' in the steps indicator. For own-repo, also hide
-    // 'clone' since it's visually merged with 'add-repo' (both labelled "Repo").
-    // For assistant there's no 'add-repo' step, so keep 'clone' visible —
-    // otherwise the indicator jumps straight to "Board" while the framework
-    // is still cloning.
-    const displaySteps = allSteps.filter(
-      (s) => s !== 'welcome' && !(path === 'own-repo' && s === 'clone')
-    );
+    if (path === 'own-repo') {
+      return [
+        { key: 'api-keys' as const, title: 'LLM Provider', icon: <ApiOutlined /> },
+        { key: 'add-repo' as const, title: 'Repo', icon: <FolderOpenOutlined /> },
+        { key: 'branch' as const, title: 'Workspace', icon: <BranchesOutlined /> },
+      ];
+    }
 
-    const labelMap: Record<WizardStep, string> = {
-      welcome: 'Welcome',
-      identity: 'Assistant',
-      'add-repo': 'Repo',
-      clone: path === 'own-repo' ? 'Repo' : 'Setup',
-      board: 'Board',
-      branch: 'Branch',
-      'api-keys': 'Provider',
-    };
+    return [];
+  }, [path]);
 
-    const iconMap: Record<WizardStep, React.ReactNode> = {
-      welcome: null,
-      identity: <RobotOutlined />,
-      'add-repo': <FolderOpenOutlined />,
-      clone: <CloudDownloadOutlined />,
-      board: <AppstoreOutlined />,
-      branch: <BranchesOutlined />,
-      'api-keys': <ApiOutlined />,
-    };
-
-    const mappedStep = currentStep === 'clone' && path === 'own-repo' ? 'add-repo' : currentStep;
-    const activeIndex = displaySteps.indexOf(mappedStep);
-
-    return displaySteps.map((step, index) => {
-      const isActive = index === activeIndex;
-      const stepColor = isActive ? token.colorPrimary : token.colorTextDisabled;
-      return {
-        key: step,
-        title: (
-          <span style={{ color: stepColor, fontWeight: isActive ? 600 : undefined }}>
-            {labelMap[step]}
-          </span>
-        ),
-        icon: (
-          <span style={{ color: stepColor, opacity: isActive ? 1 : 0.55 }}>{iconMap[step]}</span>
-        ),
-      };
-    });
-  }, [path, currentStep, token.colorPrimary, token.colorTextDisabled]);
-
-  const currentStepDisplay = useMemo(() => {
+  const currentProgressIndex = useMemo(() => {
     if (!path || currentStep === 'welcome') return -1;
-    // Mirror the filter used by stepsItems: hide 'clone' only for own-repo,
-    // where it's merged into 'add-repo'. Assistant keeps its 'clone' step.
-    const displaySteps = getStepsForPath(path).filter(
-      (s) => s !== 'welcome' && !(path === 'own-repo' && s === 'clone')
-    );
-    // For own-repo, map the internal 'clone' state onto the merged 'add-repo' index.
-    const mappedStep = currentStep === 'clone' && path === 'own-repo' ? 'add-repo' : currentStep;
-    return displaySteps.indexOf(mappedStep);
+    if (path === 'assistant') {
+      if (currentStep === 'identity') return 0;
+      if (currentStep === 'api-keys') return 1;
+      return 2;
+    }
+    if (currentStep === 'api-keys') return 0;
+    if (currentStep === 'add-repo' || currentStep === 'clone') return 1;
+    return 2;
   }, [path, currentStep]);
+
+  const renderProgressIndicator = () => {
+    if (!path || currentStep === 'welcome' || progressItems.length === 0) return null;
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 10,
+          marginBottom: 24,
+        }}
+      >
+        {progressItems.map((item, index) => {
+          const isActive = index === currentProgressIndex;
+          const color = isActive ? token.colorPrimary : token.colorTextDisabled;
+          return (
+            <div
+              key={item.key}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                color,
+              }}
+            >
+              <Space direction="vertical" size={4} align="center">
+                <div
+                  style={{
+                    width: 34,
+                    height: 34,
+                    borderRadius: 999,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color,
+                    background: isActive ? token.colorPrimaryBg : token.colorFillTertiary,
+                    border: `1px solid ${isActive ? token.colorPrimary : token.colorBorder}`,
+                    opacity: isActive ? 1 : 0.55,
+                  }}
+                >
+                  {item.icon}
+                </div>
+                <Text
+                  style={{
+                    color,
+                    fontSize: 12,
+                    fontWeight: isActive ? 600 : undefined,
+                    opacity: isActive ? 1 : 0.65,
+                  }}
+                >
+                  {item.title}
+                </Text>
+              </Space>
+              {index < progressItems.length - 1 && (
+                <ArrowRightOutlined
+                  style={{ color: token.colorTextDisabled, opacity: 0.55, fontSize: 12 }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
 
   // ─── Auto-trigger steps that should auto-start ────
   useEffect(() => {
@@ -1992,15 +2023,8 @@ export function OnboardingWizard({
         },
       }}
     >
-      {/* Steps indicator (only when path is chosen) */}
-      {path && currentStep !== 'welcome' && (
-        <Steps
-          current={currentStepDisplay}
-          size="small"
-          items={stepsItems}
-          style={{ marginBottom: 24 }}
-        />
-      )}
+      {/* Progress indicator (only when path is chosen) */}
+      {renderProgressIndicator()}
 
       {/* Step content */}
       {renderStepContent()}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1247,6 +1247,7 @@ export function OnboardingWizard({
       <Paragraph style={{ marginBottom: 14, fontSize: 15 }}>
         Start by creating your{' '}
         <Typography.Link
+          strong
           href="https://agor.live/guide/assistants"
           target="_blank"
           rel="noopener noreferrer"

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1550,10 +1550,10 @@ export function OnboardingWizard({
         <div style={{ textAlign: 'center', padding: '24px 0' }}>
           <Result
             icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
-            title={path === 'assistant' ? 'Assistant Branch Created' : 'Branch Created'}
+            title={path === 'assistant' ? 'Assistant Branch Ready' : 'Branch Created'}
             subTitle={
               path === 'assistant'
-                ? 'Your assistant branch is ready. Create the first session to finish onboarding.'
+                ? 'Start your assistant to finish onboarding.'
                 : 'The branch is ready. Create the first session to finish onboarding.'
             }
           />
@@ -1571,7 +1571,7 @@ export function OnboardingWizard({
             onClick={() => launchSessionForBranch(createdBranchId, createdBoardId)}
             loading={loading}
           >
-            Create First Session
+            {path === 'assistant' ? 'Start Assistant' : 'Create First Session'}
           </Button>
         </div>
       );
@@ -1580,11 +1580,11 @@ export function OnboardingWizard({
     return (
       <div style={{ padding: '16px 0' }}>
         <Title level={4}>
-          {path === 'assistant' ? 'Create Your Assistant Branch' : 'Create Your Branch'}
+          {path === 'assistant' ? 'Name Your Assistant Branch' : 'Create Your Branch'}
         </Title>
         <Paragraph type="secondary">
           {path === 'assistant'
-            ? 'Your assistant lives in a branch: a safe, isolated workspace where it can use tools, keep setup context, and start helping without mixing with other work.'
+            ? 'Your assistant works from its own branch: a safe place to use tools and keep setup context.'
             : 'A branch is an isolated workspace backed by its own git branch. Name it whatever you like. We’ll create the first session after the branch is ready.'}
         </Paragraph>
 
@@ -1594,7 +1594,7 @@ export function OnboardingWizard({
             extra={
               <>
                 {path === 'assistant'
-                  ? 'This names the assistant workspace and its underlying git branch. Forked from '
+                  ? 'Created from '
                   : 'Used as both the directory name and the new branch name. Forked from '}
                 <Text code>{sourceBranch}</Text>.
               </>
@@ -1617,7 +1617,7 @@ export function OnboardingWizard({
           disabled={!branchName.trim()}
         >
           {path === 'assistant'
-            ? 'Create Assistant & First Session'
+            ? 'Create Branch & Start Assistant'
             : 'Create Branch & First Session'}
         </Button>
       </div>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1245,8 +1245,15 @@ export function OnboardingWizard({
         Welcome to Agor ✨
       </Title>
       <Paragraph style={{ marginBottom: 14, fontSize: 15 }}>
-        Start by creating your Agor assistant: a persistent agent that can help you set up the
-        workspace and keep things moving.
+        Start by creating your{' '}
+        <Typography.Link
+          href="https://agor.live/guide/assistants"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Agor assistant
+        </Typography.Link>
+        : a persistent agent that can help you set up the workspace and keep things moving.
       </Paragraph>
 
       <div

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -38,6 +38,7 @@ import {
   Alert,
   Button,
   Card,
+  Checkbox,
   Form,
   Input,
   Modal,
@@ -331,6 +332,7 @@ export function OnboardingWizard({
   const [assistantEmoji, setAssistantEmoji] = useState('🤖');
   const [apiKey, setApiKey] = useState('');
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
+  const [useDifferentProvider, setUseDifferentProvider] = useState(false);
   const [testAuthLoading, setTestAuthLoading] = useState(false);
   // Inline feedback from the user clicking "Test Connection" on a typed key.
   // Never flips the panel, never advances, never saves. Wiped on agent
@@ -1211,6 +1213,7 @@ export function OnboardingWizard({
     setAssistantEmoji('🤖');
     setApiKey('');
     setSelectedAgent('claude-code');
+    setUseDifferentProvider(false);
     setTestAuthLoading(false);
     setManualTestResult(null);
     setOverrideDetectedAuth(false);
@@ -1708,6 +1711,7 @@ export function OnboardingWizard({
                   size="small"
                   onClick={() => {
                     setSelectedAgent(option.value);
+                    setUseDifferentProvider(false);
                     setApiKey('');
                     setError(null);
                     setManualTestResult(null);
@@ -1727,13 +1731,6 @@ export function OnboardingWizard({
                         <Text strong>{option.title}</Text>
                         <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
                       </Space>
-                      {selected && (
-                        <div>
-                          <Text type="success" style={{ fontSize: 12 }}>
-                            Selected
-                          </Text>
-                        </div>
-                      )}
                     </div>
                   </Space>
                 </Card>
@@ -1741,31 +1738,39 @@ export function OnboardingWizard({
             })}
           </div>
 
-          <Form layout="vertical">
-            <Form.Item label="Other LLM providers" style={{ marginBottom: 0 }}>
-              <Select
-                placeholder="Choose another provider"
-                value={RECOMMENDED_AGENT_VALUES.has(selectedAgent) ? undefined : selectedAgent}
-                onChange={(value) => {
-                  setSelectedAgent(value);
-                  setApiKey('');
-                  setError(null);
-                  setManualTestResult(null);
-                  setOverrideDetectedAuth(false);
-                }}
-                options={OTHER_AGENT_OPTIONS}
-                style={{ width: '100%' }}
-                allowClear
-                onClear={() => {
-                  setSelectedAgent('claude-code');
-                  setApiKey('');
-                  setError(null);
-                  setManualTestResult(null);
-                  setOverrideDetectedAuth(false);
-                }}
-              />
-            </Form.Item>
-          </Form>
+          <Checkbox
+            checked={useDifferentProvider}
+            onChange={(event) => {
+              const checked = event.target.checked;
+              setUseDifferentProvider(checked);
+              setSelectedAgent(checked ? OTHER_AGENT_OPTIONS[0].value : 'claude-code');
+              setApiKey('');
+              setError(null);
+              setManualTestResult(null);
+              setOverrideDetectedAuth(false);
+            }}
+          >
+            Use a different provider
+          </Checkbox>
+
+          {useDifferentProvider && (
+            <Form layout="vertical">
+              <Form.Item label="Other LLM providers" style={{ marginBottom: 0 }}>
+                <Select
+                  value={RECOMMENDED_AGENT_VALUES.has(selectedAgent) ? undefined : selectedAgent}
+                  onChange={(value) => {
+                    setSelectedAgent(value);
+                    setApiKey('');
+                    setError(null);
+                    setManualTestResult(null);
+                    setOverrideDetectedAuth(false);
+                  }}
+                  options={OTHER_AGENT_OPTIONS}
+                  style={{ width: '100%' }}
+                />
+              </Form.Item>
+            </Form>
+          )}
         </Space>
 
         {isAuthenticated && !overrideDetectedAuth ? (

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1647,8 +1647,8 @@ export function OnboardingWizard({
         // Bash/MCP). Users can flip to bypass per-session in Session Settings.
         return (
           <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste an <Text code>ANTHROPIC_API_KEY</Text>, run <Text code>claude auth login</Text>,
-            or set up a Pro/Max token in <Text strong>User Settings → Claude Code</Text>.
+            Paste an <Text code>ANTHROPIC_API_KEY</Text>, or run <Text code>claude auth login</Text>{' '}
+            on the host.
           </Paragraph>
         );
       }
@@ -1727,10 +1727,12 @@ export function OnboardingWizard({
                   <Space align="center" size={10} style={{ width: '100%' }}>
                     <ToolIcon tool={option.value} size={32} />
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      <Space size={6} wrap>
+                      <div>
                         <Text strong>{option.title}</Text>
+                      </div>
+                      <div>
                         <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
-                      </Space>
+                      </div>
                     </div>
                   </Space>
                 </Card>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1189,56 +1189,6 @@ export function OnboardingWizard({
     }
   }, [stepIndex, steps, setCurrentStep]);
 
-  // Dev-only: reset the wizard back to the welcome screen so the flows can be
-  // re-tested without DB surgery. Clears persisted onboarding state but leaves
-  // any repos / boards / branches the user already created intact — those
-  // are easy to clean up manually if needed.
-  const handleReset = useCallback(async () => {
-    if (cloneTimeoutRef.current) {
-      clearTimeout(cloneTimeoutRef.current);
-      cloneTimeoutRef.current = null;
-    }
-    if (cloneIntervalRef.current) {
-      clearInterval(cloneIntervalRef.current);
-      cloneIntervalRef.current = null;
-    }
-    setPath(null);
-    setCurrentStep('welcome');
-    setError(null);
-    setLoading(false);
-    setRepoUrl('');
-    setRepoSlug('');
-    setLocalRepoPath('');
-    setRepoMode('remote');
-    setBranchName('');
-    setAssistantDisplayName('My Assistant');
-    setAssistantEmoji('🤖');
-    setApiKey('');
-    setSelectedAgent('claude-code');
-    setUseDifferentProvider(false);
-    setTestAuthLoading(false);
-    setManualTestResult(null);
-    setOverrideDetectedAuth(false);
-    setCreatedRepoId(null);
-    setCreatedBoardId(null);
-    setCreatedBranchId(null);
-    setCloneElapsedSeconds(0);
-    // Do not allow the resume effect to re-run against the still-stale
-    // user.preferences snapshot before the PATCH clearing onboarding state
-    // comes back over the socket. Otherwise Reset(dev) can appear to need
-    // two clicks: first local reset, then stale prefs immediately resume it.
-    resumedRef.current = true;
-    branchNameInitRef.current = false;
-    knownFailedRepoIdsRef.current = new Set();
-
-    if (user) {
-      const prefs = { ...(user.preferences || {}) } as Record<string, unknown>;
-      delete prefs.onboarding;
-      delete prefs.mainBoardId;
-      await onUpdateUser(user.user_id, { preferences: prefs as UserPreferences });
-    }
-  }, [user, onUpdateUser, setCurrentStep]);
-
   // ─── Render Helpers ───────────────────────────────
 
   const renderWelcome = () => (
@@ -1999,26 +1949,8 @@ export function OnboardingWizard({
         </Typography.Link>
       </Space>
 
-      {/* Right: Dev reset + Skip */}
+      {/* Right: Skip */}
       <Space size="small">
-        {import.meta.env.DEV && (
-          <Popconfirm
-            title="Reset wizard?"
-            description={
-              <div style={{ maxWidth: 280 }}>
-                Clears local state and onboarding progress in your user preferences. Repos, boards,
-                and branches you created stay put.
-              </div>
-            }
-            okText="Reset"
-            cancelText="Cancel"
-            onConfirm={handleReset}
-          >
-            <Button type="text" size="small" style={{ color: token.colorTextTertiary }}>
-              Reset (dev)
-            </Button>
-          </Popconfirm>
-        )}
         <Popconfirm
           title="Skip setup?"
           description={

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -382,6 +382,7 @@ export function OnboardingWizard({
   const codexFields = user?.agentic_tools?.codex;
   const geminiFields = user?.agentic_tools?.gemini;
   const copilotFields = user?.agentic_tools?.copilot;
+  const cursorFields = user?.agentic_tools?.cursor;
   const hasAnthropicKey = !!(
     claudeFields?.ANTHROPIC_API_KEY ||
     claudeFields?.CLAUDE_CODE_OAUTH_TOKEN ||
@@ -392,6 +393,7 @@ export function OnboardingWizard({
   const hasCopilotToken = !!(
     copilotFields?.COPILOT_GITHUB_TOKEN || user?.env_vars?.COPILOT_GITHUB_TOKEN
   );
+  const hasCursorKey = !!(cursorFields?.CURSOR_API_KEY || user?.env_vars?.CURSOR_API_KEY);
 
   const hasKeyForAgent = (agent: AgenticToolName): boolean => {
     switch (agent) {
@@ -403,12 +405,30 @@ export function OnboardingWizard({
         return hasGeminiKey;
       case 'copilot':
         return hasCopilotToken;
+      case 'cursor':
+        return hasCursorKey;
       case 'opencode':
         return hasAnthropicKey || hasOpenAIKey || hasGeminiKey;
       default:
         return false;
     }
   };
+
+  const resetProviderAuthState = useCallback(() => {
+    setApiKey('');
+    setError(null);
+    setManualTestResult(null);
+    setOverrideDetectedAuth(false);
+  }, []);
+
+  const selectAgent = useCallback(
+    (agent: AgenticToolName, options: { useDifferentProvider?: boolean } = {}) => {
+      setSelectedAgent(agent);
+      setUseDifferentProvider(options.useDifferentProvider ?? !RECOMMENDED_AGENT_VALUES.has(agent));
+      resetProviderAuthState();
+    },
+    [resetProviderAuthState]
+  );
 
   // ─── Resume from prior onboarding state ──────────
   //
@@ -1631,6 +1651,8 @@ export function OnboardingWizard({
 
         <Space direction="vertical" size="middle" style={{ width: '100%', marginBottom: 16 }}>
           <div
+            role="radiogroup"
+            aria-label="Recommended LLM providers"
             style={{
               display: 'grid',
               gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
@@ -1642,34 +1664,41 @@ export function OnboardingWizard({
               return (
                 <Card
                   key={option.value}
-                  hoverable
                   size="small"
-                  onClick={() => {
-                    setSelectedAgent(option.value);
-                    setUseDifferentProvider(false);
-                    setApiKey('');
-                    setError(null);
-                    setManualTestResult(null);
-                    setOverrideDetectedAuth(false);
-                  }}
                   style={{
-                    cursor: 'pointer',
                     borderColor: selected ? token.colorPrimary : token.colorBorder,
                     background: selected ? token.colorPrimaryBg : undefined,
                   }}
-                  styles={{ body: { padding: 14 } }}
+                  styles={{ body: { padding: 0 } }}
                 >
-                  <Space align="center" size={10} style={{ width: '100%' }}>
-                    <ToolIcon tool={option.value} size={32} />
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div>
-                        <Text strong>{option.title}</Text>
+                  <label
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      cursor: 'pointer',
+                      padding: 14,
+                    }}
+                  >
+                    <Space align="center" size={10} style={{ width: '100%' }}>
+                      <ToolIcon tool={option.value} size={32} />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div>
+                          <Text strong>{option.title}</Text>
+                        </div>
+                        <div>
+                          <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
+                        </div>
                       </div>
-                      <div>
-                        <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
-                      </div>
-                    </div>
-                  </Space>
+                      <input
+                        type="radio"
+                        name="recommended-agent"
+                        value={option.value}
+                        checked={selected}
+                        onChange={() => selectAgent(option.value, { useDifferentProvider: false })}
+                        style={{ accentColor: token.colorPrimary }}
+                      />
+                    </Space>
+                  </label>
                 </Card>
               );
             })}
@@ -1679,12 +1708,9 @@ export function OnboardingWizard({
             checked={useDifferentProvider}
             onChange={(event) => {
               const checked = event.target.checked;
-              setUseDifferentProvider(checked);
-              setSelectedAgent(checked ? OTHER_AGENT_OPTIONS[0].value : 'claude-code');
-              setApiKey('');
-              setError(null);
-              setManualTestResult(null);
-              setOverrideDetectedAuth(false);
+              selectAgent(checked ? OTHER_AGENT_OPTIONS[0].value : 'claude-code', {
+                useDifferentProvider: checked,
+              });
             }}
           >
             Use a different provider
@@ -1695,13 +1721,7 @@ export function OnboardingWizard({
               <Form.Item label="Other LLM providers" style={{ marginBottom: 0 }}>
                 <Select
                   value={RECOMMENDED_AGENT_VALUES.has(selectedAgent) ? undefined : selectedAgent}
-                  onChange={(value) => {
-                    setSelectedAgent(value);
-                    setApiKey('');
-                    setError(null);
-                    setManualTestResult(null);
-                    setOverrideDetectedAuth(false);
-                  }}
+                  onChange={(value) => selectAgent(value, { useDifferentProvider: true })}
                   options={OTHER_AGENT_OPTIONS}
                   style={{ width: '100%' }}
                 />
@@ -1874,21 +1894,25 @@ export function OnboardingWizard({
     if (!path || currentStep === 'welcome' || progressItems.length === 0) return null;
 
     return (
-      <div
+      <ol
+        aria-label="Onboarding progress"
         style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
           gap: 10,
           marginBottom: 24,
+          padding: 0,
+          listStyle: 'none',
         }}
       >
         {progressItems.map((item, index) => {
           const isActive = index === currentProgressIndex;
           const color = isActive ? token.colorPrimary : token.colorTextDisabled;
           return (
-            <div
+            <li
               key={item.key}
+              aria-current={isActive ? 'step' : undefined}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -1929,10 +1953,10 @@ export function OnboardingWizard({
                   style={{ color: token.colorTextDisabled, opacity: 0.55, fontSize: 12 }}
                 />
               )}
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ol>
     );
   };
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -63,6 +63,7 @@ import { extractSlugFromPath, slugify } from '../../utils/repoSlug';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 import type { NewSessionConfig } from '../NewSessionModal/NewSessionModal';
+import { ToolIcon } from '../ToolIcon';
 
 const { Text, Title, Paragraph } = Typography;
 const { useToken } = theme;
@@ -241,20 +242,16 @@ const RECOMMENDED_AGENT_OPTIONS: Array<{
   value: AgenticToolName;
   title: string;
   eyebrow: string;
-  description: string;
 }> = [
   {
     value: 'claude-code',
     title: 'Claude Code',
     eyebrow: 'Recommended',
-    description:
-      'Best-tested default for Agor assistants, with API key, CLI auth, and Pro/Max token paths.',
   },
   {
     value: 'codex',
-    title: 'Codex (OpenAI)',
+    title: 'Codex',
     eyebrow: 'Recommended',
-    description: 'Strong support for OpenAI API keys and Codex CLI auth inside Agor branches.',
   },
 ];
 
@@ -1689,10 +1686,9 @@ export function OnboardingWizard({
 
     return (
       <div style={{ padding: '16px 0' }}>
-        <Title level={4}>Connect an LLM Provider</Title>
+        <Title level={4}>Choose an LLM Provider</Title>
         <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-          Choose what will power your assistant. Claude Code and Codex are the best-supported
-          onboarding options today; other supported agents are available below.
+          Pick what powers your assistant. You can change this later.
         </Paragraph>
 
         <Space direction="vertical" size="middle" style={{ width: '100%', marginBottom: 16 }}>
@@ -1721,18 +1717,24 @@ export function OnboardingWizard({
                     cursor: 'pointer',
                     borderColor: selected ? token.colorPrimary : token.colorBorder,
                     background: selected ? token.colorPrimaryBg : undefined,
-                    minHeight: 132,
                   }}
+                  styles={{ body: { padding: 14 } }}
                 >
-                  <Space direction="vertical" size={6} style={{ width: '100%' }}>
-                    <Space align="center">
-                      <Text strong>{option.title}</Text>
-                      <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
-                    </Space>
-                    <Text type="secondary" style={{ fontSize: 13 }}>
-                      {option.description}
-                    </Text>
-                    {selected && <Text type="success">Selected</Text>}
+                  <Space align="center" size={10} style={{ width: '100%' }}>
+                    <ToolIcon tool={option.value} size={32} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <Space size={6} wrap>
+                        <Text strong>{option.title}</Text>
+                        <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
+                      </Space>
+                      {selected && (
+                        <div>
+                          <Text type="success" style={{ fontSize: 12 }}>
+                            Selected
+                          </Text>
+                        </div>
+                      )}
+                    </div>
                   </Space>
                 </Card>
               );
@@ -1740,9 +1742,9 @@ export function OnboardingWizard({
           </div>
 
           <Form layout="vertical">
-            <Form.Item label="Other supported agents" style={{ marginBottom: 0 }}>
+            <Form.Item label="Other LLM providers" style={{ marginBottom: 0 }}>
               <Select
-                placeholder="Choose another agent"
+                placeholder="Choose another provider"
                 value={RECOMMENDED_AGENT_VALUES.has(selectedAgent) ? undefined : selectedAgent}
                 onChange={(value) => {
                   setSelectedAgent(value);

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1592,12 +1592,12 @@ export function OnboardingWizard({
           <Form.Item
             label="Branch name"
             extra={
-              <>
-                {path === 'assistant'
-                  ? 'Created from '
-                  : 'Used as both the directory name and the new branch name. Forked from '}
-                <Text code>{sourceBranch}</Text>.
-              </>
+              path === 'assistant' ? undefined : (
+                <>
+                  Used as both the directory name and the new branch name. Forked from{' '}
+                  <Text code>{sourceBranch}</Text>.
+                </>
+              )
             }
           >
             <Input

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -33,7 +33,6 @@ import {
   FolderOpenOutlined,
   KeyOutlined,
   RobotOutlined,
-  ThunderboltOutlined,
 } from '@ant-design/icons';
 import {
   Alert,
@@ -1243,24 +1242,50 @@ export function OnboardingWizard({
   const renderWelcome = () => (
     <div style={{ padding: '8px 0' }}>
       <Title level={3} style={{ marginBottom: 8 }}>
-        Welcome to Agor
+        Welcome to Agor ✨
       </Title>
-      <Paragraph style={{ marginBottom: 12, fontSize: 15 }}>
-        The best way to get started is with an Agor assistant. Agents in Agor can help connect
-        tools, coordinate other agents, set up your board and workflow, and show you around.
+      <Paragraph style={{ marginBottom: 14, fontSize: 15 }}>
+        Start by creating your Agor assistant: a persistent agent that can help you set up the
+        workspace and keep things moving.
       </Paragraph>
-      <Paragraph type="secondary" style={{ marginBottom: 24, fontSize: 15 }}>
-        This quick wizard will handle setup and introduce your assistant, who can take it from
-        there. Any questions? Ask your assistant.
+
+      <div
+        style={{
+          background: token.colorPrimaryBg,
+          border: `1px solid ${token.colorPrimaryBorder}`,
+          borderRadius: 8,
+          padding: '14px 16px',
+          marginBottom: 16,
+        }}
+      >
+        <Text strong>Your assistant can help:</Text>
+        <ul style={{ margin: '10px 0 0', paddingLeft: 20, color: token.colorTextSecondary }}>
+          <li>🧰 Connect tools and credentials</li>
+          <li>🗺️ Set up your board and workflow</li>
+          <li>🤝 Coordinate other agents and sessions</li>
+          <li>💬 Show you around and answer questions</li>
+        </ul>
+      </div>
+
+      <Paragraph type="secondary" style={{ marginBottom: 24, fontSize: 14 }}>
+        Want the bigger picture first? Read the{' '}
+        <Typography.Link
+          href="https://agor.live/guide/getting-started"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          getting started guide
+        </Typography.Link>
+        .
       </Paragraph>
 
       <Button
         type="primary"
         size="large"
-        icon={<ThunderboltOutlined />}
+        icon={<RobotOutlined />}
         onClick={() => handleSelectPath('assistant')}
       >
-        Get started
+        Create your assistant
       </Button>
     </div>
   );

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -332,6 +332,7 @@ export function OnboardingWizard({
   const [assistantEmoji, setAssistantEmoji] = useState('🤖');
   const [apiKey, setApiKey] = useState('');
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
+  const [lastRecommendedAgent, setLastRecommendedAgent] = useState<AgenticToolName>('claude-code');
   const [useDifferentProvider, setUseDifferentProvider] = useState(false);
   const [testAuthLoading, setTestAuthLoading] = useState(false);
   // Inline feedback from the user clicking "Test Connection" on a typed key.
@@ -424,6 +425,9 @@ export function OnboardingWizard({
   const selectAgent = useCallback(
     (agent: AgenticToolName, options: { useDifferentProvider?: boolean } = {}) => {
       setSelectedAgent(agent);
+      if (RECOMMENDED_AGENT_VALUES.has(agent)) {
+        setLastRecommendedAgent(agent);
+      }
       setUseDifferentProvider(options.useDifferentProvider ?? !RECOMMENDED_AGENT_VALUES.has(agent));
       resetProviderAuthState();
     },
@@ -1708,7 +1712,7 @@ export function OnboardingWizard({
             checked={useDifferentProvider}
             onChange={(event) => {
               const checked = event.target.checked;
-              selectAgent(checked ? OTHER_AGENT_OPTIONS[0].value : 'claude-code', {
+              selectAgent(checked ? OTHER_AGENT_OPTIONS[0].value : lastRecommendedAgent, {
                 useDifferentProvider: checked,
               });
             }}

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -30,6 +30,7 @@ import {
   Layout,
   Menu,
   Modal,
+  Popconfirm,
   Select,
   Space,
   Switch,
@@ -77,6 +78,7 @@ export interface UserSettingsModalProps {
   client: AgorClient | null;
   currentUser?: User | null;
   onUpdate?: (userId: string, updates: UpdateUserInput) => void;
+  onRestartOnboarding?: () => void | Promise<void>;
 }
 
 export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
@@ -87,6 +89,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   client,
   currentUser,
   onUpdate,
+  onRestartOnboarding,
 }) => {
   const [form] = Form.useForm();
   const [activeTab, setActiveTab] = useState<string>('general');
@@ -614,118 +617,151 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     switch (activeTab) {
       case 'general':
         return (
-          <Form form={form} layout="vertical">
-            <Form.Item label="Name" style={{ marginBottom: 24 }}>
-              <Flex gap={8}>
-                <Form.Item name="emoji" noStyle>
-                  <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="👤" />
-                </Form.Item>
-                <Form.Item name="name" noStyle style={{ flex: 1 }}>
-                  <Input placeholder="John Doe" style={{ flex: 1 }} />
-                </Form.Item>
-              </Flex>
-            </Form.Item>
+          <>
+            <Form form={form} layout="vertical">
+              <Form.Item label="Name" style={{ marginBottom: 24 }}>
+                <Flex gap={8}>
+                  <Form.Item name="emoji" noStyle>
+                    <FormEmojiPickerInput form={form} fieldName="emoji" defaultEmoji="👤" />
+                  </Form.Item>
+                  <Form.Item name="name" noStyle style={{ flex: 1 }}>
+                    <Input placeholder="John Doe" style={{ flex: 1 }} />
+                  </Form.Item>
+                </Flex>
+              </Form.Item>
 
-            <Form.Item
-              label="Email"
-              name="email"
-              rules={[
-                { required: true, message: 'Please enter an email' },
-                { type: 'email', message: 'Please enter a valid email' },
-              ]}
-            >
-              <Input placeholder="user@example.com" />
-            </Form.Item>
-
-            <Form.Item
-              label="Unix Username"
-              name="unix_username"
-              help={
-                hasMinimumRole(currentUser?.role, ROLES.ADMIN)
-                  ? 'Unix user for process impersonation (alphanumeric, hyphens, underscores only)'
-                  : 'Maintained by administrators'
-              }
-              rules={[
-                {
-                  pattern: /^[a-z0-9_-]+$/,
-                  message: 'Only lowercase letters, numbers, hyphens, and underscores allowed',
-                },
-                { max: 32, message: 'Unix username must be 32 characters or less' },
-              ]}
-            >
-              <Input
-                placeholder="johnsmith"
-                maxLength={32}
-                disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
-              />
-            </Form.Item>
-
-            <Form.Item label="Password" name="password" help="Leave blank to keep current password">
-              <Input.Password placeholder="••••••••" />
-            </Form.Item>
-
-            <Form.Item
-              label={
-                <Space size={4}>
-                  Enable Live Event Stream
-                  <Tag color={token.colorPrimary} style={{ fontSize: 10, marginLeft: 4 }}>
-                    BETA
-                  </Tag>
-                </Space>
-              }
-              name="eventStreamEnabled"
-              valuePropName="checked"
-              tooltip="Show/hide the event stream icon in the navbar. When enabled, you can view live WebSocket events for debugging."
-            >
-              <Switch />
-            </Form.Item>
-
-            <Form.Item
-              label="Role"
-              name="role"
-              rules={[{ required: true, message: 'Please select a role' }]}
-              help={
-                !hasMinimumRole(currentUser?.role, ROLES.ADMIN)
-                  ? 'Maintained by administrators'
-                  : undefined
-              }
-            >
-              <Select
-                disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
-                options={ROLE_OPTIONS.map((opt) => ({
-                  value: opt.value,
-                  label: opt.label,
-                  title: opt.description,
-                }))}
-              />
-            </Form.Item>
-
-            {isAdmin && (
               <Form.Item
-                label="Groups"
-                name="groupIds"
-                help="Group memberships affect group-aware branch permissions."
+                label="Email"
+                name="email"
+                rules={[
+                  { required: true, message: 'Please enter an email' },
+                  { type: 'email', message: 'Please enter a valid email' },
+                ]}
               >
-                <Select
-                  mode="multiple"
-                  loading={loadingGroups}
-                  disabled={!groupsLoaded && !loadingGroups}
-                  placeholder="Select groups..."
-                  options={groupSelectOptions}
-                  {...searchableSelectProps}
+                <Input placeholder="user@example.com" />
+              </Form.Item>
+
+              <Form.Item
+                label="Unix Username"
+                name="unix_username"
+                help={
+                  hasMinimumRole(currentUser?.role, ROLES.ADMIN)
+                    ? 'Unix user for process impersonation (alphanumeric, hyphens, underscores only)'
+                    : 'Maintained by administrators'
+                }
+                rules={[
+                  {
+                    pattern: /^[a-z0-9_-]+$/,
+                    message: 'Only lowercase letters, numbers, hyphens, and underscores allowed',
+                  },
+                  { max: 32, message: 'Unix username must be 32 characters or less' },
+                ]}
+              >
+                <Input
+                  placeholder="johnsmith"
+                  maxLength={32}
+                  disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
                 />
               </Form.Item>
-            )}
 
-            {/* Only show for admins editing other users */}
-            {hasMinimumRole(currentUser?.role, ROLES.ADMIN) &&
-              user &&
-              user.user_id !== currentUser?.user_id && (
-                <Form.Item name="must_change_password" valuePropName="checked">
-                  <Checkbox>Force password change on next login</Checkbox>
+              <Form.Item
+                label="Password"
+                name="password"
+                help="Leave blank to keep current password"
+              >
+                <Input.Password placeholder="••••••••" />
+              </Form.Item>
+
+              <Form.Item
+                label={
+                  <Space size={4}>
+                    Enable Live Event Stream
+                    <Tag color={token.colorPrimary} style={{ fontSize: 10, marginLeft: 4 }}>
+                      BETA
+                    </Tag>
+                  </Space>
+                }
+                name="eventStreamEnabled"
+                valuePropName="checked"
+                tooltip="Show/hide the event stream icon in the navbar. When enabled, you can view live WebSocket events for debugging."
+              >
+                <Switch />
+              </Form.Item>
+
+              <Form.Item
+                label="Role"
+                name="role"
+                rules={[{ required: true, message: 'Please select a role' }]}
+                help={
+                  !hasMinimumRole(currentUser?.role, ROLES.ADMIN)
+                    ? 'Maintained by administrators'
+                    : undefined
+                }
+              >
+                <Select
+                  disabled={!hasMinimumRole(currentUser?.role, ROLES.ADMIN)}
+                  options={ROLE_OPTIONS.map((opt) => ({
+                    value: opt.value,
+                    label: opt.label,
+                    title: opt.description,
+                  }))}
+                />
+              </Form.Item>
+
+              {isAdmin && (
+                <Form.Item
+                  label="Groups"
+                  name="groupIds"
+                  help="Group memberships affect group-aware branch permissions."
+                >
+                  <Select
+                    mode="multiple"
+                    loading={loadingGroups}
+                    disabled={!groupsLoaded && !loadingGroups}
+                    placeholder="Select groups..."
+                    options={groupSelectOptions}
+                    {...searchableSelectProps}
+                  />
                 </Form.Item>
               )}
-          </Form>
+
+              {/* Only show for admins editing other users */}
+              {hasMinimumRole(currentUser?.role, ROLES.ADMIN) &&
+                user &&
+                user.user_id !== currentUser?.user_id && (
+                  <Form.Item name="must_change_password" valuePropName="checked">
+                    <Checkbox>Force password change on next login</Checkbox>
+                  </Form.Item>
+                )}
+            </Form>
+
+            {onRestartOnboarding && user?.user_id === currentUser?.user_id && (
+              <div
+                style={{
+                  marginTop: 24,
+                  paddingTop: 20,
+                  borderTop: `1px solid ${token.colorBorderSecondary}`,
+                }}
+              >
+                <Typography.Title level={5} style={{ marginTop: 0 }}>
+                  Onboarding
+                </Typography.Title>
+                <Typography.Paragraph type="secondary">
+                  Reopen the assistant setup wizard from the beginning. Existing repos, boards,
+                  branches, and credentials stay in place.
+                </Typography.Paragraph>
+                <Popconfirm
+                  title="Restart onboarding?"
+                  description="This clears saved wizard progress and opens onboarding again."
+                  okText="Restart"
+                  cancelText="Cancel"
+                  onConfirm={onRestartOnboarding}
+                >
+                  <Button>Restart onboarding</Button>
+                </Popconfirm>
+              </div>
+            )}
+          </>
         );
       case 'env-vars':
         return (

--- a/apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx
+++ b/apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx
@@ -11,6 +11,7 @@ export interface SharedUserSettingsModalProps {
   onClose: () => void;
   onUpdateUser: (userId: string, updates: UpdateUserInput) => Promise<void>;
   onRefreshCurrentUser: () => Promise<unknown>;
+  onRestartOnboarding?: () => void | Promise<void>;
 }
 
 /**
@@ -29,6 +30,7 @@ export const SharedUserSettingsModal: React.FC<SharedUserSettingsModalProps> = (
   onClose,
   onUpdateUser,
   onRefreshCurrentUser,
+  onRestartOnboarding,
 }) => (
   <UserSettingsModal
     open={open}
@@ -41,5 +43,6 @@ export const SharedUserSettingsModal: React.FC<SharedUserSettingsModalProps> = (
       await onUpdateUser(userId, updates);
       await onRefreshCurrentUser();
     }}
+    onRestartOnboarding={onRestartOnboarding}
   />
 );


### PR DESCRIPTION
## Summary

- Make assistant creation the only active onboarding path
- Replace the initial onboarding choice cards with short assistant-first copy and a single **Get started** CTA
- Add prominent recommended LLM provider cards for Claude Code and Codex, with other supported agents in a secondary selector
- Clarify assistant branch copy so users understand the assistant lives in an isolated branch workspace
- Add a **Restart onboarding** action in User Settings → General that clears saved wizard progress and reopens onboarding from the beginning
- Add focused UI tests for assistant-only onboarding, legacy own-repo resume behavior, and provider selection UI

## Validation

- `pnpm i` ✅
  - Note: `packages/agor-live` postinstall warned that the existing `@agor/core` symlink already exists, then completed successfully.
- `pnpm check` ⚠️
  - Typecheck, lint, and shortid portions completed.
  - Final build phase failed in existing `@agor/executor` / CLI package resolution with `TS7016` errors for `@agor/core/*` declaration files.
- `pnpm -w exec biome check apps/agor-ui/src/App.tsx apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx apps/agor-ui/src/components/App/App.tsx apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx` ✅
- `pnpm --filter agor-ui typecheck` ⚠️
  - Failed with the same workspace declaration-resolution issue, this time for `@agor-live/client` declarations.
- `pnpm --filter agor-ui test -- src/components/OnboardingWizard/OnboardingWizard.test.tsx` ✅
  - 1 file passed, 3 tests passed.
  - jsdom emitted expected Ant Design `getComputedStyle` pseudo-element warnings.