### PR TITLE
Add Knowledge namespace RBAC

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1029,11 +1029,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [requireAuth],
       create: [requireMinimumRole(ROLES.MEMBER, 'create knowledge namespaces')],
-      patch: [requireMinimumRole(ROLES.ADMIN, 'update knowledge namespaces')],
-      update: [requireMinimumRole(ROLES.ADMIN, 'update knowledge namespaces')],
-      remove: [requireMinimumRole(ROLES.ADMIN, 'delete knowledge namespaces')],
+      patch: [requireMinimumRole(ROLES.MEMBER, 'update knowledge namespaces')],
+      update: [requireMinimumRole(ROLES.MEMBER, 'update knowledge namespaces')],
+      remove: [requireMinimumRole(ROLES.MEMBER, 'delete knowledge namespaces')],
+      saveWithAcl: [requireMinimumRole(ROLES.MEMBER, 'save knowledge namespace permissions')],
+      listAcl: [requireMinimumRole(ROLES.MEMBER, 'manage knowledge namespace permissions')],
+      setAcl: [requireMinimumRole(ROLES.MEMBER, 'manage knowledge namespace permissions')],
+      removeAcl: [requireMinimumRole(ROLES.MEMBER, 'manage knowledge namespace permissions')],
     },
-  });
+  } as never);
 
   safeService('kb/documents')?.hooks({
     before: {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -363,7 +363,18 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // ============================================================================
 
   app.use('/kb/namespaces', createKnowledgeNamespacesService(db), {
-    methods: ['find', 'get', 'create', 'update', 'patch', 'remove'],
+    methods: [
+      'find',
+      'get',
+      'create',
+      'update',
+      'patch',
+      'remove',
+      'saveWithAcl',
+      'listAcl',
+      'setAcl',
+      'removeAcl',
+    ],
   });
   const knowledgeDocumentsService = createKnowledgeDocumentsService(db, app);
   app.use('/kb/documents', knowledgeDocumentsService, {

--- a/apps/agor-daemon/src/services/knowledge-access.ts
+++ b/apps/agor-daemon/src/services/knowledge-access.ts
@@ -1,0 +1,108 @@
+import type { KnowledgeNamespaceRepository, KnowledgeSearchRepository } from '@agor/core/db';
+import type {
+  KnowledgeDocument,
+  KnowledgeNamespaceEffectivePermission,
+  KnowledgeNamespaceID,
+  User,
+} from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+
+const KNOWLEDGE_NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+export type KnowledgeNamespaceRequiredPermission = Exclude<
+  KnowledgeNamespaceEffectivePermission,
+  'none'
+>;
+
+export function isKnowledgeAdmin(user?: User): boolean {
+  return hasMinimumRole(user?.role, ROLES.ADMIN);
+}
+
+export function hasKnowledgeNamespacePermission(
+  actual: KnowledgeNamespaceEffectivePermission,
+  required: KnowledgeNamespaceRequiredPermission
+): boolean {
+  return (
+    KNOWLEDGE_NAMESPACE_PERMISSION_RANK[actual] >= KNOWLEDGE_NAMESPACE_PERMISSION_RANK[required]
+  );
+}
+
+export async function resolveKnowledgeNamespacePermission(
+  namespaces: KnowledgeNamespaceRepository,
+  namespaceId: KnowledgeNamespaceID | string,
+  user?: User
+): Promise<KnowledgeNamespaceEffectivePermission> {
+  return namespaces.resolveNamespacePermission(namespaceId, String(user?.user_id ?? ''), {
+    isAdmin: isKnowledgeAdmin(user),
+  });
+}
+
+/**
+ * Document visibility is a narrower overlay on top of namespace read access.
+ */
+export function canReadKnowledgeDocumentOverlay(document: KnowledgeDocument, user?: User): boolean {
+  return (
+    document.visibility === 'public' ||
+    isKnowledgeAdmin(user) ||
+    Boolean(user?.user_id && document.created_by === user.user_id)
+  );
+}
+
+/**
+ * Document edit policy is a narrower overlay on top of namespace write access.
+ */
+export function canWriteKnowledgeDocumentOverlay(
+  document: KnowledgeDocument,
+  user?: User
+): boolean {
+  return (
+    isKnowledgeAdmin(user) ||
+    Boolean(user?.user_id && document.created_by === user.user_id) ||
+    (document.visibility === 'public' && document.edit_policy === 'public')
+  );
+}
+
+export async function canReadKnowledgeDocument(
+  namespaces: KnowledgeNamespaceRepository,
+  document: KnowledgeDocument,
+  user?: User
+): Promise<boolean> {
+  const namespacePermission = await resolveKnowledgeNamespacePermission(
+    namespaces,
+    document.namespace_id,
+    user
+  );
+  return (
+    hasKnowledgeNamespacePermission(namespacePermission, 'read') &&
+    canReadKnowledgeDocumentOverlay(document, user)
+  );
+}
+
+export async function canWriteKnowledgeDocument(
+  namespaces: KnowledgeNamespaceRepository,
+  document: KnowledgeDocument,
+  user?: User
+): Promise<boolean> {
+  const namespacePermission = await resolveKnowledgeNamespacePermission(
+    namespaces,
+    document.namespace_id,
+    user
+  );
+  return (
+    hasKnowledgeNamespacePermission(namespacePermission, 'write') &&
+    canWriteKnowledgeDocumentOverlay(document, user)
+  );
+}
+
+export async function canReadKnowledgeSearchResult(
+  namespaces: KnowledgeNamespaceRepository,
+  result: Awaited<ReturnType<KnowledgeSearchRepository['search']>>[number],
+  user?: User
+): Promise<boolean> {
+  return canReadKnowledgeDocument(namespaces, result.document, user);
+}

--- a/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.test.ts
@@ -52,16 +52,17 @@ async function seedDocument(
   });
 }
 
+function createServices(db: Parameters<typeof dbTest>[0]['db']) {
+  const documentsService = new KnowledgeDocumentsService(db);
+  const editsService = createKnowledgeDocumentEditsService(db, {} as Application, documentsService);
+  return { documentsService, editsService };
+}
+
 describe('KnowledgeDocumentEditsService', () => {
   dbTest('returns dry-run diff and leaves document unchanged', async ({ db }) => {
     const owner = await seedUser(db, 'owner');
     const document = await seedDocument(db, owner);
-    const documentsService = new KnowledgeDocumentsService(db);
-    const editsService = createKnowledgeDocumentEditsService(
-      db,
-      {} as Application,
-      documentsService
-    );
+    const { editsService } = createServices(db);
 
     const response = await editsService.create(
       {
@@ -93,12 +94,7 @@ describe('KnowledgeDocumentEditsService', () => {
   dbTest('applies edits and creates a new immutable version', async ({ db }) => {
     const owner = await seedUser(db, 'owner');
     const document = await seedDocument(db, owner);
-    const documentsService = new KnowledgeDocumentsService(db);
-    const editsService = createKnowledgeDocumentEditsService(
-      db,
-      {} as Application,
-      documentsService
-    );
+    const { editsService } = createServices(db);
 
     const versionsRepo = new KnowledgeDocumentVersionRepository(db);
     const initialVersion = await versionsRepo.findLatestForDocument(document.document_id);
@@ -140,12 +136,7 @@ describe('KnowledgeDocumentEditsService', () => {
     const owner = await seedUser(db, 'owner');
     const other = await seedUser(db, 'other');
     const document = await seedDocument(db, owner);
-    const documentsService = new KnowledgeDocumentsService(db);
-    const editsService = createKnowledgeDocumentEditsService(
-      db,
-      {} as Application,
-      documentsService
-    );
+    const { editsService } = createServices(db);
 
     await expect(
       editsService.create(
@@ -159,5 +150,61 @@ describe('KnowledgeDocumentEditsService', () => {
         { user: other }
       )
     ).rejects.toThrowError();
+  });
+
+  dbTest('requires namespace write even for public-editable dry runs', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const namespaceRepo = new KnowledgeNamespaceRepository(db);
+    const namespace = await namespaceRepo.create({
+      slug: `closed-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      display_name: 'Closed KB',
+      owner_user_id: owner.user_id as UserID,
+      others_can: 'none',
+    });
+    const document = await new KnowledgeDocumentRepository(db).create({
+      namespace_id: namespace.namespace_id,
+      path: 'page.md',
+      title: 'Page',
+      visibility: 'public',
+      edit_policy: 'public',
+      content_text: '# Title\nLine 1',
+      created_by: owner.user_id as UserID,
+    });
+    const { editsService } = createServices(db);
+
+    await namespaceRepo.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: other.user_id,
+      permission: 'read',
+    });
+    await expect(
+      editsService.create(
+        {
+          documentId: document.document_id,
+          dryRun: true,
+          ops: [{ type: 'replace_line_range', startLine: 2, endLine: 2, replacement: 'No write' }],
+        },
+        { user: other }
+      )
+    ).rejects.toThrowError();
+
+    await namespaceRepo.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: other.user_id,
+      permission: 'write',
+    });
+    await expect(
+      editsService.create(
+        {
+          documentId: document.document_id,
+          dryRun: true,
+          ops: [{ type: 'replace_line_range', startLine: 2, endLine: 2, replacement: 'Allowed' }],
+        },
+        { user: other }
+      )
+    ).resolves.toMatchObject({ dryRun: true });
   });
 });

--- a/apps/agor-daemon/src/services/knowledge-document-edits.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.ts
@@ -9,12 +9,11 @@ import type {
   KnowledgeDocumentVersion,
   KnowledgeEditChangedRange,
   KnowledgeEditOp,
-  KnowledgeNamespaceEffectivePermission,
   KnowledgeVersionToken,
   User,
 } from '@agor/core/types';
-import { hasMinimumRole, ROLES } from '@agor/core/types';
 import { createTwoFilesPatch, structuredPatch } from 'diff';
+import { canWriteKnowledgeDocument } from './knowledge-access.js';
 import type { KnowledgeDocumentParams, KnowledgeDocumentsService } from './knowledge-documents.js';
 
 interface KnowledgeDocumentEditInput {
@@ -49,17 +48,6 @@ function versionToToken(version: KnowledgeDocumentVersion): KnowledgeVersionToke
   };
 }
 
-const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
-  none: 0,
-  read: 1,
-  write: 2,
-  own: 3,
-};
-
-function hasNamespaceWrite(permission: KnowledgeNamespaceEffectivePermission): boolean {
-  return NAMESPACE_PERMISSION_RANK[permission] >= NAMESPACE_PERMISSION_RANK.write;
-}
-
 function extractChangedRanges(
   baseContent: string,
   updatedContent: string
@@ -89,15 +77,7 @@ export class KnowledgeDocumentEditsService {
   ) {}
 
   private async ensureCanEdit(document: KnowledgeDocument, user: User | undefined) {
-    const namespacePermission = await this.namespaceRepo.resolveNamespacePermission(
-      document.namespace_id,
-      String(user?.user_id ?? ''),
-      { isAdmin: hasMinimumRole(user?.role, ROLES.ADMIN) }
-    );
-    const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
-    const isOwner = Boolean(user?.user_id && document.created_by === user.user_id);
-    const publicEditable = document.visibility === 'public' && document.edit_policy === 'public';
-    if (hasNamespaceWrite(namespacePermission) && (isAdmin || isOwner || publicEditable)) return;
+    if (await canWriteKnowledgeDocument(this.namespaceRepo, document, user)) return;
     throw new Forbidden('You do not have permission to edit this knowledge document');
   }
 

--- a/apps/agor-daemon/src/services/knowledge-document-edits.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.ts
@@ -1,5 +1,5 @@
 import type { Database } from '@agor/core/db';
-import { KnowledgeDocumentVersionRepository } from '@agor/core/db';
+import { KnowledgeDocumentVersionRepository, KnowledgeNamespaceRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import { applyKnowledgeEditOps, KnowledgeEditError } from '@agor/core/knowledge';
@@ -9,6 +9,7 @@ import type {
   KnowledgeDocumentVersion,
   KnowledgeEditChangedRange,
   KnowledgeEditOp,
+  KnowledgeNamespaceEffectivePermission,
   KnowledgeVersionToken,
   User,
 } from '@agor/core/types';
@@ -48,12 +49,15 @@ function versionToToken(version: KnowledgeDocumentVersion): KnowledgeVersionToke
   };
 }
 
-function ensureCanEdit(document: KnowledgeDocument, user: User | undefined) {
-  const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
-  const isOwner = Boolean(user?.user_id && document.created_by === user.user_id);
-  const publicEditable = document.visibility === 'public' && document.edit_policy === 'public';
-  if (isAdmin || isOwner || publicEditable) return;
-  throw new Forbidden('You do not have permission to edit this knowledge document');
+const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+function hasNamespaceWrite(permission: KnowledgeNamespaceEffectivePermission): boolean {
+  return NAMESPACE_PERMISSION_RANK[permission] >= NAMESPACE_PERMISSION_RANK.write;
 }
 
 function extractChangedRanges(
@@ -80,8 +84,22 @@ export class KnowledgeDocumentEditsService {
   constructor(
     db: Database,
     private readonly documentsService: KnowledgeDocumentsService,
-    private readonly versionRepo = new KnowledgeDocumentVersionRepository(db)
+    private readonly versionRepo = new KnowledgeDocumentVersionRepository(db),
+    private readonly namespaceRepo = new KnowledgeNamespaceRepository(db)
   ) {}
+
+  private async ensureCanEdit(document: KnowledgeDocument, user: User | undefined) {
+    const namespacePermission = await this.namespaceRepo.resolveNamespacePermission(
+      document.namespace_id,
+      String(user?.user_id ?? ''),
+      { isAdmin: hasMinimumRole(user?.role, ROLES.ADMIN) }
+    );
+    const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
+    const isOwner = Boolean(user?.user_id && document.created_by === user.user_id);
+    const publicEditable = document.visibility === 'public' && document.edit_policy === 'public';
+    if (hasNamespaceWrite(namespacePermission) && (isAdmin || isOwner || publicEditable)) return;
+    throw new Forbidden('You do not have permission to edit this knowledge document');
+  }
 
   async create(
     data: KnowledgeDocumentEditInput,
@@ -117,7 +135,7 @@ export class KnowledgeDocumentEditsService {
     }
 
     const document = documentResult.document;
-    ensureCanEdit(document, params?.user as User | undefined);
+    await this.ensureCanEdit(document, params?.user as User | undefined);
 
     const currentVersion = documentResult.current_version;
     if (!currentVersion) {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -24,6 +24,7 @@ import type {
   Id,
   KnowledgeDocument,
   KnowledgeDocumentVersion,
+  KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespaceID,
   NullableId,
   QueryParams,
@@ -107,6 +108,20 @@ type HydrateOptions = Pick<
   'include_content' | 'include_links' | 'include_indexing' | 'includeIndexing' | 'version'
 >;
 
+const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+function hasNamespacePermission(
+  actual: KnowledgeNamespaceEffectivePermission,
+  required: 'read' | 'write' | 'own'
+): boolean {
+  return NAMESPACE_PERMISSION_RANK[actual] >= NAMESPACE_PERMISSION_RANK[required];
+}
+
 function wantsFirstLineTitle(data: KnowledgeDocumentWriteData): boolean {
   if (typeof data.first_line_is_title === 'boolean') return data.first_line_is_title;
   return data.metadata?.title_from_content === true;
@@ -147,7 +162,16 @@ export class KnowledgeDocumentsService extends DrizzleService<
     return hasMinimumRole(user?.role, ROLES.ADMIN);
   }
 
-  private canRead(document: KnowledgeDocument, user?: User): boolean {
+  private async namespacePermission(
+    namespaceId: KnowledgeNamespaceID,
+    user?: User
+  ): Promise<KnowledgeNamespaceEffectivePermission> {
+    return this.namespaces.resolveNamespacePermission(namespaceId, String(user?.user_id ?? ''), {
+      isAdmin: this.isAdmin(user),
+    });
+  }
+
+  private documentReadOverlay(document: KnowledgeDocument, user?: User): boolean {
     return (
       document.visibility === 'public' ||
       this.isAdmin(user) ||
@@ -155,12 +179,22 @@ export class KnowledgeDocumentsService extends DrizzleService<
     );
   }
 
-  private canEdit(document: KnowledgeDocument, user?: User): boolean {
+  private documentEditOverlay(document: KnowledgeDocument, user?: User): boolean {
     return (
       this.isAdmin(user) ||
       Boolean(user?.user_id && document.created_by === user.user_id) ||
       (document.visibility === 'public' && document.edit_policy === 'public')
     );
+  }
+
+  private async canRead(document: KnowledgeDocument, user?: User): Promise<boolean> {
+    const permission = await this.namespacePermission(document.namespace_id, user);
+    return hasNamespacePermission(permission, 'read') && this.documentReadOverlay(document, user);
+  }
+
+  private async canEdit(document: KnowledgeDocument, user?: User): Promise<boolean> {
+    const permission = await this.namespacePermission(document.namespace_id, user);
+    return hasNamespacePermission(permission, 'write') && this.documentEditOverlay(document, user);
   }
 
   private canManageDocument(document: KnowledgeDocument, user?: User): boolean {
@@ -198,6 +232,16 @@ export class KnowledgeDocumentsService extends DrizzleService<
     const namespace = await this.namespaces.findById(document.namespace_id);
     if (!namespace || namespace.archived) {
       throw new NotFound('Knowledge document not found');
+    }
+  }
+
+  private async assertCanWriteNamespace(
+    namespaceId: KnowledgeNamespaceID,
+    user?: User
+  ): Promise<void> {
+    const permission = await this.namespacePermission(namespaceId, user);
+    if (!hasNamespacePermission(permission, 'write')) {
+      throw new Forbidden('You do not have permission to write to this knowledge namespace');
     }
   }
 
@@ -411,7 +455,10 @@ export class KnowledgeDocumentsService extends DrizzleService<
           draft_filter_user_id: user?.user_id as UserID | undefined,
         };
     const rows = await this.repo.findAll(filters);
-    const readable = rows.filter((doc) => this.canRead(doc, user));
+    const readable: KnowledgeDocument[] = [];
+    for (const doc of rows) {
+      if (await this.canRead(doc, user)) readable.push(doc);
+    }
     if (params?.query?.include_content !== true && params?.query?.include_links !== true) {
       if (params?.query?.include_indexing === true || params?.query?.includeIndexing === true) {
         return this.repo.attachIndexingStatus(readable) as Promise<KnowledgeDocument[]>;
@@ -435,7 +482,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     const doc = await this.repo.findById(String(id));
     if (!doc) throw new NotFound(`Knowledge document not found: ${id}`);
     await this.assertActiveDocument(doc);
-    if (!this.canRead(doc, params?.user as User | undefined)) {
+    if (!(await this.canRead(doc, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document');
     }
     return this.hydrateDocument(doc, params?.query);
@@ -448,7 +495,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     const doc = await this.resolveDocumentRef(data);
     if (!doc) throw new NotFound('Knowledge document not found');
     await this.assertActiveDocument(doc);
-    if (!this.canRead(doc, params?.user as User | undefined)) {
+    if (!(await this.canRead(doc, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document');
     }
     return this.hydrateDocument(doc, data);
@@ -473,7 +520,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (existing) {
       await this.assertActiveDocument(existing);
       this.assertCanChangeGovernance(existing, data, params?.user as User | undefined);
-      if (!this.canEdit(existing, params?.user as User | undefined)) {
+      if (!(await this.canEdit(existing, params?.user as User | undefined))) {
         throw new Forbidden('You do not have permission to update this knowledge document');
       }
       await this.assertExpectedVersion(existing, data.expected_version);
@@ -510,10 +557,21 @@ export class KnowledgeDocumentsService extends DrizzleService<
         kind: 'global',
         visibility_default: data.visibility ?? 'public',
         created_by: userId,
+        owner_user_id: userId,
       });
+      if (userId) {
+        await this.namespaces.upsertNamespaceAclEntry({
+          namespace_id: namespace.namespace_id,
+          subject_type: 'user',
+          subject_id: userId,
+          permission: 'own',
+          created_by: userId,
+        });
+      }
     }
     if (!namespace) throw new NotFound(`Knowledge namespace not found: ${namespaceSlug}`);
     if (namespace.archived) throw new NotFound(`Knowledge namespace not found: ${namespaceSlug}`);
+    await this.assertCanWriteNamespace(namespace.namespace_id, params?.user as User | undefined);
 
     const result = await this.repo.create(
       this.prepareWriteData({
@@ -544,8 +602,17 @@ export class KnowledgeDocumentsService extends DrizzleService<
       },
       null
     );
+    const namespace = prepared.namespace_id
+      ? await this.namespaces.findById(prepared.namespace_id)
+      : prepared.namespace_slug
+        ? await this.namespaces.findBySlug(prepared.namespace_slug)
+        : null;
+    if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
+    await this.assertCanWriteNamespace(namespace.namespace_id, params?.user as User | undefined);
     const result = await this.repo.create({
       ...prepared,
+      namespace_id: namespace.namespace_id,
+      namespace_slug: namespace.slug,
     });
     await this.replaceSearchUnitsForContent(result, data.content_text);
     await this.syncGraphReferences(result, data.content_text, userId);
@@ -576,7 +643,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!existing) throw new NotFound(`Knowledge document not found: ${id}`);
     await this.assertActiveDocument(existing);
     this.assertCanChangeGovernance(existing, data, params?.user as User | undefined);
-    if (!this.canEdit(existing, params?.user as User | undefined)) {
+    if (!(await this.canEdit(existing, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to update this knowledge document');
     }
     const result = await this.repo.update(String(id), {
@@ -606,7 +673,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     if (!existing) throw new NotFound(`Knowledge document not found: ${id}`);
     await this.assertActiveDocument(existing);
     this.assertCanChangeGovernance(existing, data, params?.user as User | undefined);
-    if (!this.canEdit(existing, params?.user as User | undefined)) {
+    if (!(await this.canEdit(existing, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to update this knowledge document');
     }
     const result = await this.repo.update(String(id), {
@@ -632,6 +699,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     const existing = await this.repo.findById(String(id));
     if (!existing) throw new NotFound(`Knowledge document not found: ${id}`);
     await this.assertActiveDocument(existing);
+    await this.assertCanWriteNamespace(existing.namespace_id, params?.user as User | undefined);
     if (!this.canManageDocument(existing, params?.user as User | undefined)) {
       throw new Forbidden('You do not have permission to delete this knowledge document');
     }

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -24,7 +24,6 @@ import type {
   Id,
   KnowledgeDocument,
   KnowledgeDocumentVersion,
-  KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespaceID,
   NullableId,
   QueryParams,
@@ -34,9 +33,7 @@ import type {
 import {
   buildKnowledgeDocumentUri,
   extractKnowledgeLinks,
-  hasMinimumRole,
   parseKnowledgeUri,
-  ROLES,
   titleFromKnowledgeContent,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
@@ -50,6 +47,13 @@ import {
   knowledgeChunkerOptionsFromConfig,
   knowledgeUnitsForMarkdown,
 } from '../knowledge/units.js';
+import {
+  canReadKnowledgeDocument,
+  canWriteKnowledgeDocument,
+  hasKnowledgeNamespacePermission,
+  isKnowledgeAdmin,
+  resolveKnowledgeNamespacePermission,
+} from './knowledge-access.js';
 
 export type KnowledgeDocumentParams = QueryParams<{
   namespace_id?: KnowledgeNamespaceID;
@@ -108,20 +112,6 @@ type HydrateOptions = Pick<
   'include_content' | 'include_links' | 'include_indexing' | 'includeIndexing' | 'version'
 >;
 
-const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
-  none: 0,
-  read: 1,
-  write: 2,
-  own: 3,
-};
-
-function hasNamespacePermission(
-  actual: KnowledgeNamespaceEffectivePermission,
-  required: 'read' | 'write' | 'own'
-): boolean {
-  return NAMESPACE_PERMISSION_RANK[actual] >= NAMESPACE_PERMISSION_RANK[required];
-}
-
 function wantsFirstLineTitle(data: KnowledgeDocumentWriteData): boolean {
   if (typeof data.first_line_is_title === 'boolean') return data.first_line_is_title;
   return data.metadata?.title_from_content === true;
@@ -159,42 +149,15 @@ export class KnowledgeDocumentsService extends DrizzleService<
   }
 
   private isAdmin(user?: User): boolean {
-    return hasMinimumRole(user?.role, ROLES.ADMIN);
-  }
-
-  private async namespacePermission(
-    namespaceId: KnowledgeNamespaceID,
-    user?: User
-  ): Promise<KnowledgeNamespaceEffectivePermission> {
-    return this.namespaces.resolveNamespacePermission(namespaceId, String(user?.user_id ?? ''), {
-      isAdmin: this.isAdmin(user),
-    });
-  }
-
-  private documentReadOverlay(document: KnowledgeDocument, user?: User): boolean {
-    return (
-      document.visibility === 'public' ||
-      this.isAdmin(user) ||
-      Boolean(user?.user_id && document.created_by === user.user_id)
-    );
-  }
-
-  private documentEditOverlay(document: KnowledgeDocument, user?: User): boolean {
-    return (
-      this.isAdmin(user) ||
-      Boolean(user?.user_id && document.created_by === user.user_id) ||
-      (document.visibility === 'public' && document.edit_policy === 'public')
-    );
+    return isKnowledgeAdmin(user);
   }
 
   private async canRead(document: KnowledgeDocument, user?: User): Promise<boolean> {
-    const permission = await this.namespacePermission(document.namespace_id, user);
-    return hasNamespacePermission(permission, 'read') && this.documentReadOverlay(document, user);
+    return canReadKnowledgeDocument(this.namespaces, document, user);
   }
 
   private async canEdit(document: KnowledgeDocument, user?: User): Promise<boolean> {
-    const permission = await this.namespacePermission(document.namespace_id, user);
-    return hasNamespacePermission(permission, 'write') && this.documentEditOverlay(document, user);
+    return canWriteKnowledgeDocument(this.namespaces, document, user);
   }
 
   private canManageDocument(document: KnowledgeDocument, user?: User): boolean {
@@ -239,8 +202,12 @@ export class KnowledgeDocumentsService extends DrizzleService<
     namespaceId: KnowledgeNamespaceID,
     user?: User
   ): Promise<void> {
-    const permission = await this.namespacePermission(namespaceId, user);
-    if (!hasNamespacePermission(permission, 'write')) {
+    const permission = await resolveKnowledgeNamespacePermission(
+      this.namespaces,
+      namespaceId,
+      user
+    );
+    if (!hasKnowledgeNamespacePermission(permission, 'write')) {
       throw new Forbidden('You do not have permission to write to this knowledge namespace');
     }
   }

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -18,6 +18,7 @@ import type {
   KnowledgeGraphDocNode,
   KnowledgeGraphEdgeType,
   KnowledgeGraphNode,
+  KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespaceGraph,
   QueryParams,
   User,
@@ -40,6 +41,20 @@ export interface KnowledgeNamespaceGraphRequest {
   includeMyDrafts?: boolean;
   include_other_user_drafts?: boolean;
   includeOtherUserDrafts?: boolean;
+}
+
+const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+function hasNamespacePermission(
+  actual: KnowledgeNamespaceEffectivePermission,
+  required: 'read' | 'write' | 'own'
+): boolean {
+  return NAMESPACE_PERMISSION_RANK[actual] >= NAMESPACE_PERMISSION_RANK[required];
 }
 
 export type KnowledgeGraphParams = QueryParams<
@@ -92,6 +107,11 @@ export class KnowledgeGraphService {
       return { namespace_id: null, nodes: [], edges: [] };
     }
 
+    const namespacePermission = await this.namespacePermission(namespace.namespace_id, user);
+    if (!hasNamespacePermission(namespacePermission, 'read')) {
+      return { namespace_id: null, nodes: [], edges: [] };
+    }
+
     const docs = await this.documents.findAll({
       namespace_id: namespace.namespace_id,
       include_my_drafts: request.include_my_drafts ?? request.includeMyDrafts ?? true,
@@ -99,7 +119,10 @@ export class KnowledgeGraphService {
         request.include_other_user_drafts ?? request.includeOtherUserDrafts ?? false,
       draft_filter_user_id: user?.user_id as UserID | undefined,
     });
-    const readable = docs.filter((doc) => this.canRead(doc, user));
+    const readable: KnowledgeDocument[] = [];
+    for (const doc of docs) {
+      if (await this.canRead(doc, user)) readable.push(doc);
+    }
     const readableIds = new Set<string>(readable.map((doc) => doc.document_id));
 
     const nodes: KnowledgeGraphDocNode[] = readable.map((doc) => ({
@@ -127,22 +150,33 @@ export class KnowledgeGraphService {
     return hasMinimumRole(user?.role, ROLES.ADMIN);
   }
 
-  private canRead(document: KnowledgeDocument, user?: User): boolean {
-    return (
-      !document.archived &&
-      (document.visibility === 'public' ||
-        this.isAdmin(user) ||
-        Boolean(user?.user_id && document.created_by === user.user_id))
-    );
+  private async namespacePermission(
+    namespaceId: string,
+    user?: User
+  ): Promise<KnowledgeNamespaceEffectivePermission> {
+    return this.namespaces.resolveNamespacePermission(namespaceId, String(user?.user_id ?? ''), {
+      isAdmin: this.isAdmin(user),
+    });
   }
 
-  private canWrite(document: KnowledgeDocument, user?: User): boolean {
-    return (
-      !document.archived &&
-      (this.isAdmin(user) ||
-        Boolean(user?.user_id && document.created_by === user.user_id) ||
-        (document.visibility === 'public' && document.edit_policy === 'public'))
-    );
+  private async canRead(document: KnowledgeDocument, user?: User): Promise<boolean> {
+    if (document.archived) return false;
+    const namespacePermission = await this.namespacePermission(document.namespace_id, user);
+    const documentReadable =
+      document.visibility === 'public' ||
+      this.isAdmin(user) ||
+      Boolean(user?.user_id && document.created_by === user.user_id);
+    return hasNamespacePermission(namespacePermission, 'read') && documentReadable;
+  }
+
+  private async canWrite(document: KnowledgeDocument, user?: User): Promise<boolean> {
+    if (document.archived) return false;
+    const namespacePermission = await this.namespacePermission(document.namespace_id, user);
+    const documentWritable =
+      this.isAdmin(user) ||
+      Boolean(user?.user_id && document.created_by === user.user_id) ||
+      (document.visibility === 'public' && document.edit_policy === 'public');
+    return hasNamespacePermission(namespacePermission, 'write') && documentWritable;
   }
 
   private async activeDocument(
@@ -233,7 +267,7 @@ export class KnowledgeGraphService {
       throw new NotFound('Knowledge document not found');
     }
     if (!document) return;
-    if (!this.canWrite(document, user)) {
+    if (!(await this.canWrite(document, user))) {
       throw new Forbidden('You do not have permission to link this knowledge document');
     }
   }

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -18,19 +18,23 @@ import type {
   KnowledgeGraphDocNode,
   KnowledgeGraphEdgeType,
   KnowledgeGraphNode,
-  KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespaceGraph,
   QueryParams,
   User,
   UserID,
 } from '@agor/core/types';
 import {
-  hasMinimumRole,
   KNOWLEDGE_DOCUMENT_URI_PREFIX,
   KNOWLEDGE_UNIT_URI_PREFIX,
   parseKnowledgeUri,
-  ROLES,
 } from '@agor/core/types';
+import {
+  canReadKnowledgeDocument,
+  canWriteKnowledgeDocument,
+  hasKnowledgeNamespacePermission,
+  isKnowledgeAdmin,
+  resolveKnowledgeNamespacePermission,
+} from './knowledge-access.js';
 
 /** Query for the namespace-wide graph view (whole-namespace document graph). */
 export interface KnowledgeNamespaceGraphRequest {
@@ -41,20 +45,6 @@ export interface KnowledgeNamespaceGraphRequest {
   includeMyDrafts?: boolean;
   include_other_user_drafts?: boolean;
   includeOtherUserDrafts?: boolean;
-}
-
-const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
-  none: 0,
-  read: 1,
-  write: 2,
-  own: 3,
-};
-
-function hasNamespacePermission(
-  actual: KnowledgeNamespaceEffectivePermission,
-  required: 'read' | 'write' | 'own'
-): boolean {
-  return NAMESPACE_PERMISSION_RANK[actual] >= NAMESPACE_PERMISSION_RANK[required];
 }
 
 export type KnowledgeGraphParams = QueryParams<
@@ -108,7 +98,7 @@ export class KnowledgeGraphService {
     }
 
     const namespacePermission = await this.namespacePermission(namespace.namespace_id, user);
-    if (!hasNamespacePermission(namespacePermission, 'read')) {
+    if (!hasKnowledgeNamespacePermission(namespacePermission, 'read')) {
       return { namespace_id: null, nodes: [], edges: [] };
     }
 
@@ -146,37 +136,18 @@ export class KnowledgeGraphService {
     return { namespace_id: namespace.namespace_id, nodes, edges };
   }
 
-  private isAdmin(user?: User): boolean {
-    return hasMinimumRole(user?.role, ROLES.ADMIN);
-  }
-
-  private async namespacePermission(
-    namespaceId: string,
-    user?: User
-  ): Promise<KnowledgeNamespaceEffectivePermission> {
-    return this.namespaces.resolveNamespacePermission(namespaceId, String(user?.user_id ?? ''), {
-      isAdmin: this.isAdmin(user),
-    });
+  private async namespacePermission(namespaceId: string, user?: User) {
+    return resolveKnowledgeNamespacePermission(this.namespaces, namespaceId, user);
   }
 
   private async canRead(document: KnowledgeDocument, user?: User): Promise<boolean> {
     if (document.archived) return false;
-    const namespacePermission = await this.namespacePermission(document.namespace_id, user);
-    const documentReadable =
-      document.visibility === 'public' ||
-      this.isAdmin(user) ||
-      Boolean(user?.user_id && document.created_by === user.user_id);
-    return hasNamespacePermission(namespacePermission, 'read') && documentReadable;
+    return canReadKnowledgeDocument(this.namespaces, document, user);
   }
 
   private async canWrite(document: KnowledgeDocument, user?: User): Promise<boolean> {
     if (document.archived) return false;
-    const namespacePermission = await this.namespacePermission(document.namespace_id, user);
-    const documentWritable =
-      this.isAdmin(user) ||
-      Boolean(user?.user_id && document.created_by === user.user_id) ||
-      (document.visibility === 'public' && document.edit_policy === 'public');
-    return hasNamespacePermission(namespacePermission, 'write') && documentWritable;
+    return canWriteKnowledgeDocument(this.namespaces, document, user);
   }
 
   private async activeDocument(
@@ -294,7 +265,7 @@ export class KnowledgeGraphService {
 
   private attributionUserId(params?: KnowledgeGraphParams, requestedUserId?: UserID | null) {
     const user = params?.user as User | undefined;
-    if (this.isAdmin(user) && requestedUserId) return requestedUserId;
+    if (isKnowledgeAdmin(user) && requestedUserId) return requestedUserId;
     return (user?.user_id as UserID | undefined) ?? null;
   }
 

--- a/apps/agor-daemon/src/services/knowledge-namespaces.ts
+++ b/apps/agor-daemon/src/services/knowledge-namespaces.ts
@@ -9,6 +9,9 @@ import type {
   AuthenticatedParams,
   Id,
   KnowledgeNamespace,
+  KnowledgeNamespaceAclEntry,
+  KnowledgeNamespacePermission,
+  KnowledgeNamespaceSubjectType,
   NullableId,
   QueryParams,
   User,
@@ -26,6 +29,19 @@ export type KnowledgeNamespaceParams = QueryParams<{
   archived?: boolean;
 }> &
   AuthenticatedParams;
+
+type KnowledgeNamespaceAclDraftEntry = {
+  subject_type?: KnowledgeNamespaceSubjectType;
+  subjectType?: KnowledgeNamespaceSubjectType;
+  subject_id?: string;
+  subjectId?: string;
+  permission?: KnowledgeNamespacePermission;
+};
+
+type KnowledgeNamespaceWithAclResult = {
+  namespace: KnowledgeNamespace;
+  acl: KnowledgeNamespaceAclEntry[];
+};
 
 export class KnowledgeNamespacesService extends DrizzleService<
   KnowledgeNamespace,
@@ -48,16 +64,63 @@ export class KnowledgeNamespacesService extends DrizzleService<
   }
 
   async find(params?: KnowledgeNamespaceParams): Promise<KnowledgeNamespace[]> {
-    return this.repo.findAll(params?.query);
+    const user = params?.user as User | undefined;
+    const namespaces = await this.repo.findAll(params?.query);
+    if (this.isAdmin(user)) return namespaces;
+    const userId = user?.user_id;
+    if (!userId) return [];
+
+    const readable: KnowledgeNamespace[] = [];
+    for (const namespace of namespaces) {
+      const permission = await this.repo.resolveNamespacePermission(namespace.namespace_id, userId);
+      if (permission !== 'none') readable.push(namespace);
+    }
+    return readable;
+  }
+
+  async get(id: Id, params?: KnowledgeNamespaceParams): Promise<KnowledgeNamespace> {
+    const namespace = await this.repo.findById(String(id));
+    if (!namespace || namespace.archived)
+      throw new NotFound(`Knowledge namespace not found: ${id}`);
+    await this.assertCanReadNamespace(namespace, params);
+    return namespace;
   }
 
   private isAdmin(user?: User): boolean {
     return hasMinimumRole(user?.role, ROLES.ADMIN);
   }
 
-  private assertCanManage(params?: KnowledgeNamespaceParams): void {
-    if (!this.isAdmin(params?.user as User | undefined)) {
-      throw new Forbidden('Only admins can update or delete knowledge namespaces');
+  private async namespacePermission(
+    namespace: KnowledgeNamespace,
+    params?: KnowledgeNamespaceParams
+  ) {
+    const user = params?.user as User | undefined;
+    return this.repo.resolveNamespacePermission(
+      namespace.namespace_id,
+      String(user?.user_id ?? ''),
+      {
+        isAdmin: this.isAdmin(user),
+      }
+    );
+  }
+
+  private async assertCanReadNamespace(
+    namespace: KnowledgeNamespace,
+    params?: KnowledgeNamespaceParams
+  ): Promise<void> {
+    const permission = await this.namespacePermission(namespace, params);
+    if (permission === 'none') {
+      throw new Forbidden('You do not have permission to view this knowledge namespace');
+    }
+  }
+
+  private async assertCanManage(
+    namespace: KnowledgeNamespace,
+    params?: KnowledgeNamespaceParams
+  ): Promise<void> {
+    const permission = await this.namespacePermission(namespace, params);
+    if (permission !== 'own') {
+      throw new Forbidden('You do not have permission to manage this knowledge namespace');
     }
   }
 
@@ -76,16 +139,79 @@ export class KnowledgeNamespacesService extends DrizzleService<
     }
   }
 
+  private normalizeAclEntries(
+    entries: KnowledgeNamespaceAclDraftEntry[] | undefined,
+    params?: KnowledgeNamespaceParams
+  ) {
+    const createdBy = (params?.user?.user_id as UserID | undefined) ?? null;
+    const deduped = new Map<
+      string,
+      {
+        subject_type: KnowledgeNamespaceSubjectType;
+        subject_id: string;
+        permission: KnowledgeNamespacePermission;
+        created_by: UserID | null;
+      }
+    >();
+    for (const entry of entries ?? []) {
+      const subjectType = entry.subject_type ?? entry.subjectType;
+      const subjectId = entry.subject_id ?? entry.subjectId;
+      if (!subjectType || !subjectId || !entry.permission) {
+        throw new BadRequest('ACL entries require subject_type, subject_id, and permission');
+      }
+      deduped.set(`${subjectType}:${subjectId}`, {
+        subject_type: subjectType,
+        subject_id: subjectId,
+        permission: entry.permission,
+        created_by: createdBy,
+      });
+    }
+    return [...deduped.values()];
+  }
+
+  private ensureCallerOwnAcl(
+    entries: ReturnType<KnowledgeNamespacesService['normalizeAclEntries']>,
+    params?: KnowledgeNamespaceParams
+  ) {
+    const userId = params?.user?.user_id as UserID | undefined;
+    if (!userId) return entries;
+    const key = `user:${userId}`;
+    const existing = entries.find((entry) => `${entry.subject_type}:${entry.subject_id}` === key);
+    if (existing) {
+      existing.permission = 'own';
+      return entries;
+    }
+    return [
+      ...entries,
+      {
+        subject_type: 'user' as const,
+        subject_id: userId,
+        permission: 'own' as const,
+        created_by: userId,
+      },
+    ];
+  }
+
   private async createOne(
     data: Partial<KnowledgeNamespace>,
     params?: KnowledgeNamespaceParams
   ): Promise<KnowledgeNamespace> {
     const userId = params?.user?.user_id as UserID | undefined;
+    const createdBy = this.attributionUserId(params, data.created_by);
     const result = await this.repo.create({
       ...data,
-      created_by: this.attributionUserId(params, data.created_by),
+      created_by: createdBy,
       owner_user_id: data.owner_user_id ?? userId ?? null,
     });
+    if (userId) {
+      await this.repo.upsertNamespaceAclEntry({
+        namespace_id: result.namespace_id,
+        subject_type: 'user',
+        subject_id: userId,
+        permission: 'own',
+        created_by: createdBy,
+      });
+    }
     this.emit?.('created', result, params);
     return result;
   }
@@ -106,9 +232,9 @@ export class KnowledgeNamespacesService extends DrizzleService<
     params?: KnowledgeNamespaceParams
   ): Promise<KnowledgeNamespace> {
     if (id === null) throw new Error('Bulk patch is not supported for knowledge namespaces');
-    this.assertCanManage(params);
     const existing = await this.repo.findById(String(id));
     if (!existing) throw new NotFound(`Knowledge namespace not found: ${id}`);
+    await this.assertCanManage(existing, params);
     this.assertSlugUnchanged(existing, data);
     const result = await this.repo.update(String(id), {
       ...data,
@@ -126,9 +252,9 @@ export class KnowledgeNamespacesService extends DrizzleService<
     data: Partial<KnowledgeNamespace>,
     params?: KnowledgeNamespaceParams
   ): Promise<KnowledgeNamespace> {
-    this.assertCanManage(params);
     const existing = await this.repo.findById(String(id));
     if (!existing) throw new NotFound(`Knowledge namespace not found: ${id}`);
+    await this.assertCanManage(existing, params);
     this.assertSlugUnchanged(existing, data);
     const result = await this.repo.update(String(id), {
       ...data,
@@ -143,12 +269,124 @@ export class KnowledgeNamespacesService extends DrizzleService<
 
   async remove(id: NullableId, params?: KnowledgeNamespaceParams): Promise<KnowledgeNamespace> {
     if (id === null) throw new Error('Bulk remove is not supported for knowledge namespaces');
-    this.assertCanManage(params);
     const existing = await this.repo.findById(String(id));
     if (!existing) throw new NotFound(`Knowledge namespace not found: ${id}`);
+    await this.assertCanManage(existing, params);
     await this.repo.delete(String(id));
     this.emit?.('removed', existing, params);
     return existing;
+  }
+
+  async saveWithAcl(
+    data: {
+      namespace_id?: string;
+      namespaceId?: string;
+      namespace?: Partial<KnowledgeNamespace>;
+      acl?: KnowledgeNamespaceAclDraftEntry[];
+    },
+    params?: KnowledgeNamespaceParams
+  ): Promise<KnowledgeNamespaceWithAclResult> {
+    const namespaceId = data.namespace_id ?? data.namespaceId;
+    const namespaceData = data.namespace ?? {};
+    const acl = this.ensureCallerOwnAcl(this.normalizeAclEntries(data.acl, params), params);
+
+    if (namespaceId) {
+      const existing = await this.repo.findById(String(namespaceId));
+      if (!existing) throw new NotFound(`Knowledge namespace not found: ${namespaceId}`);
+      await this.assertCanManage(existing, params);
+      this.assertSlugUnchanged(existing, namespaceData);
+      const result = await this.repo.updateWithAcl(
+        existing.namespace_id,
+        {
+          ...namespaceData,
+          namespace_id: existing.namespace_id,
+          slug: existing.slug,
+          created_by: existing.created_by,
+          owner_user_id: namespaceData.owner_user_id ?? existing.owner_user_id,
+        },
+        acl
+      );
+      this.emit?.('patched', result.namespace, params);
+      return result;
+    }
+
+    const userId = params?.user?.user_id as UserID | undefined;
+    const createdBy = this.attributionUserId(params, namespaceData.created_by);
+    const result = await this.repo.createWithAcl(
+      {
+        ...namespaceData,
+        created_by: createdBy,
+        owner_user_id: namespaceData.owner_user_id ?? userId ?? null,
+      },
+      acl
+    );
+    this.emit?.('created', result.namespace, params);
+    return result;
+  }
+
+  async listAcl(
+    data: { namespace_id?: string; namespaceId?: string } | string,
+    params?: KnowledgeNamespaceParams
+  ): Promise<KnowledgeNamespaceAclEntry[]> {
+    const namespaceId = typeof data === 'string' ? data : (data.namespace_id ?? data.namespaceId);
+    if (!namespaceId) throw new BadRequest('namespace_id is required');
+    const namespace = await this.repo.findById(String(namespaceId));
+    if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
+    await this.assertCanManage(namespace, params);
+    return this.repo.listNamespaceAcl(namespace.namespace_id);
+  }
+
+  async setAcl(
+    data: {
+      namespace_id?: string;
+      namespaceId?: string;
+      subject_type?: KnowledgeNamespaceSubjectType;
+      subjectType?: KnowledgeNamespaceSubjectType;
+      subject_id?: string;
+      subjectId?: string;
+      permission?: KnowledgeNamespacePermission;
+    },
+    params?: KnowledgeNamespaceParams
+  ): Promise<KnowledgeNamespaceAclEntry> {
+    const namespaceId = data.namespace_id ?? data.namespaceId;
+    const subjectType = data.subject_type ?? data.subjectType;
+    const subjectId = data.subject_id ?? data.subjectId;
+    if (!namespaceId || !subjectType || !subjectId || !data.permission) {
+      throw new BadRequest('namespace_id, subject_type, subject_id, and permission are required');
+    }
+    const namespace = await this.repo.findById(String(namespaceId));
+    if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
+    await this.assertCanManage(namespace, params);
+    return this.repo.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: subjectType,
+      subject_id: subjectId,
+      permission: data.permission,
+      created_by: (params?.user?.user_id as UserID | undefined) ?? null,
+    });
+  }
+
+  async removeAcl(
+    data: {
+      namespace_id?: string;
+      namespaceId?: string;
+      subject_type?: KnowledgeNamespaceSubjectType;
+      subjectType?: KnowledgeNamespaceSubjectType;
+      subject_id?: string;
+      subjectId?: string;
+    },
+    params?: KnowledgeNamespaceParams
+  ): Promise<KnowledgeNamespaceAclEntry | null> {
+    const namespaceId = data.namespace_id ?? data.namespaceId;
+    const subjectType = data.subject_type ?? data.subjectType;
+    const subjectId = data.subject_id ?? data.subjectId;
+    if (!namespaceId || !subjectType || !subjectId) {
+      throw new BadRequest('namespace_id, subject_type, and subject_id are required');
+    }
+    const namespace = await this.repo.findById(String(namespaceId));
+    if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
+    await this.assertCanManage(namespace, params);
+    return this.repo.removeNamespaceAclEntry(namespace.namespace_id, subjectType, subjectId);
   }
 }
 

--- a/apps/agor-daemon/src/services/knowledge-namespaces.ts
+++ b/apps/agor-daemon/src/services/knowledge-namespaces.ts
@@ -3,13 +3,15 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, KnowledgeNamespaceRepository } from '@agor/core/db';
+import { type Database, GroupRepository, KnowledgeNamespaceRepository } from '@agor/core/db';
 import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
+  GroupID,
   Id,
   KnowledgeNamespace,
   KnowledgeNamespaceAclEntry,
+  KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespacePermission,
   KnowledgeNamespaceSubjectType,
   NullableId,
@@ -17,8 +19,8 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import { hasMinimumRole, ROLES } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
+import { isKnowledgeAdmin } from './knowledge-access.js';
 
 export type KnowledgeNamespaceParams = QueryParams<{
   slug?: string;
@@ -49,6 +51,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
   KnowledgeNamespaceParams
 > {
   private repo: KnowledgeNamespaceRepository;
+  private groups: GroupRepository;
 
   constructor(db: Database) {
     const repo = new KnowledgeNamespaceRepository(db);
@@ -61,19 +64,29 @@ export class KnowledgeNamespacesService extends DrizzleService<
       },
     });
     this.repo = repo;
+    this.groups = new GroupRepository(db);
+  }
+
+  private withEffectivePermission(
+    namespace: KnowledgeNamespace,
+    permission: KnowledgeNamespaceEffectivePermission
+  ): KnowledgeNamespace {
+    return { ...namespace, effective_permission: permission };
   }
 
   async find(params?: KnowledgeNamespaceParams): Promise<KnowledgeNamespace[]> {
     const user = params?.user as User | undefined;
     const namespaces = await this.repo.findAll(params?.query);
-    if (this.isAdmin(user)) return namespaces;
+    if (this.isAdmin(user)) {
+      return namespaces.map((namespace) => this.withEffectivePermission(namespace, 'own'));
+    }
     const userId = user?.user_id;
     if (!userId) return [];
 
     const readable: KnowledgeNamespace[] = [];
     for (const namespace of namespaces) {
       const permission = await this.repo.resolveNamespacePermission(namespace.namespace_id, userId);
-      if (permission !== 'none') readable.push(namespace);
+      if (permission !== 'none') readable.push(this.withEffectivePermission(namespace, permission));
     }
     return readable;
   }
@@ -87,7 +100,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
   }
 
   private isAdmin(user?: User): boolean {
-    return hasMinimumRole(user?.role, ROLES.ADMIN);
+    return isKnowledgeAdmin(user);
   }
 
   private async namespacePermission(
@@ -190,6 +203,66 @@ export class KnowledgeNamespacesService extends DrizzleService<
         created_by: userId,
       },
     ];
+  }
+
+  private async callerOwnsOutsideAclSubject(
+    namespace: KnowledgeNamespace,
+    params: KnowledgeNamespaceParams | undefined,
+    subject: { subject_type: KnowledgeNamespaceSubjectType; subject_id: string }
+  ): Promise<boolean> {
+    const user = params?.user as User | undefined;
+    if (this.isAdmin(user)) return true;
+    const userId = user?.user_id as UserID | undefined;
+    if (!userId) return false;
+    if (namespace.owner_user_id === userId) return true;
+
+    const groupIds = new Set<GroupID>(await this.groups.getGroupIdsForUser(userId));
+    const acl = await this.repo.listNamespaceAcl(namespace.namespace_id);
+    for (const entry of acl) {
+      if (entry.permission !== 'own') continue;
+      if (entry.subject_type === subject.subject_type && entry.subject_id === subject.subject_id) {
+        continue;
+      }
+      if (entry.subject_type === 'user' && entry.subject_id === userId) return true;
+      if (groupIds.has(entry.subject_id as GroupID)) {
+        const group = await this.groups.findById(entry.subject_id);
+        if (group && !group.archived) return true;
+      }
+    }
+    return false;
+  }
+
+  private async callerDependsOnAclSubject(
+    params: KnowledgeNamespaceParams | undefined,
+    subjectType: KnowledgeNamespaceSubjectType,
+    subjectId: string
+  ): Promise<boolean> {
+    const userId = params?.user?.user_id as UserID | undefined;
+    if (!userId) return false;
+    if (subjectType === 'user') return subjectId === userId;
+    const groupIds = await this.groups.getGroupIdsForUser(userId);
+    return groupIds.includes(subjectId as GroupID);
+  }
+
+  private async assertAclChangeKeepsCallerOwner(
+    namespace: KnowledgeNamespace,
+    params: KnowledgeNamespaceParams | undefined,
+    subjectType: KnowledgeNamespaceSubjectType,
+    subjectId: string,
+    nextPermission?: KnowledgeNamespacePermission
+  ): Promise<void> {
+    if (this.isAdmin(params?.user as User | undefined)) return;
+    if (nextPermission === 'own') return;
+    if (!(await this.callerDependsOnAclSubject(params, subjectType, subjectId))) return;
+    if (
+      await this.callerOwnsOutsideAclSubject(namespace, params, {
+        subject_type: subjectType,
+        subject_id: subjectId,
+      })
+    ) {
+      return;
+    }
+    throw new BadRequest('Cannot remove your last owner access to this knowledge namespace');
   }
 
   private async createOne(
@@ -357,6 +430,13 @@ export class KnowledgeNamespacesService extends DrizzleService<
     const namespace = await this.repo.findById(String(namespaceId));
     if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
     await this.assertCanManage(namespace, params);
+    await this.assertAclChangeKeepsCallerOwner(
+      namespace,
+      params,
+      subjectType,
+      subjectId,
+      data.permission
+    );
     return this.repo.upsertNamespaceAclEntry({
       namespace_id: namespace.namespace_id,
       subject_type: subjectType,
@@ -386,6 +466,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
     const namespace = await this.repo.findById(String(namespaceId));
     if (!namespace || namespace.archived) throw new NotFound('Knowledge namespace not found');
     await this.assertCanManage(namespace, params);
+    await this.assertAclChangeKeepsCallerOwner(namespace, params, subjectType, subjectId);
     return this.repo.removeNamespaceAclEntry(namespace.namespace_id, subjectType, subjectId);
   }
 }

--- a/apps/agor-daemon/src/services/knowledge-namespaces.ts
+++ b/apps/agor-daemon/src/services/knowledge-namespaces.ts
@@ -96,7 +96,10 @@ export class KnowledgeNamespacesService extends DrizzleService<
     if (!namespace || namespace.archived)
       throw new NotFound(`Knowledge namespace not found: ${id}`);
     await this.assertCanReadNamespace(namespace, params);
-    return namespace;
+    return this.withEffectivePermission(
+      namespace,
+      await this.namespacePermission(namespace, params)
+    );
   }
 
   private isAdmin(user?: User): boolean {
@@ -232,6 +235,25 @@ export class KnowledgeNamespacesService extends DrizzleService<
     return false;
   }
 
+  private async callerOwnsThroughAcl(
+    namespace: KnowledgeNamespace,
+    params: KnowledgeNamespaceParams | undefined
+  ): Promise<boolean> {
+    const userId = params?.user?.user_id as UserID | undefined;
+    if (!userId) return false;
+    const groupIds = new Set<GroupID>(await this.groups.getGroupIdsForUser(userId));
+    const acl = await this.repo.listNamespaceAcl(namespace.namespace_id);
+    for (const entry of acl) {
+      if (entry.permission !== 'own') continue;
+      if (entry.subject_type === 'user' && entry.subject_id === userId) return true;
+      if (groupIds.has(entry.subject_id as GroupID)) {
+        const group = await this.groups.findById(entry.subject_id);
+        if (group && !group.archived) return true;
+      }
+    }
+    return false;
+  }
+
   private async callerDependsOnAclSubject(
     params: KnowledgeNamespaceParams | undefined,
     subjectType: KnowledgeNamespaceSubjectType,
@@ -262,6 +284,20 @@ export class KnowledgeNamespacesService extends DrizzleService<
     ) {
       return;
     }
+    throw new BadRequest('Cannot remove your last owner access to this knowledge namespace');
+  }
+
+  private async assertOwnerUserChangeKeepsCallerOwner(
+    existing: KnowledgeNamespace,
+    data: Partial<KnowledgeNamespace>,
+    params?: KnowledgeNamespaceParams
+  ): Promise<void> {
+    if (data.owner_user_id === undefined || data.owner_user_id === existing.owner_user_id) return;
+    const user = params?.user as User | undefined;
+    if (this.isAdmin(user)) return;
+    const userId = user?.user_id as UserID | undefined;
+    if (!userId || existing.owner_user_id !== userId) return;
+    if (await this.callerOwnsThroughAcl(existing, params)) return;
     throw new BadRequest('Cannot remove your last owner access to this knowledge namespace');
   }
 
@@ -308,6 +344,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
     const existing = await this.repo.findById(String(id));
     if (!existing) throw new NotFound(`Knowledge namespace not found: ${id}`);
     await this.assertCanManage(existing, params);
+    await this.assertOwnerUserChangeKeepsCallerOwner(existing, data, params);
     this.assertSlugUnchanged(existing, data);
     const result = await this.repo.update(String(id), {
       ...data,
@@ -328,6 +365,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
     const existing = await this.repo.findById(String(id));
     if (!existing) throw new NotFound(`Knowledge namespace not found: ${id}`);
     await this.assertCanManage(existing, params);
+    await this.assertOwnerUserChangeKeepsCallerOwner(existing, data, params);
     this.assertSlugUnchanged(existing, data);
     const result = await this.repo.update(String(id), {
       ...data,

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -9,6 +9,7 @@ import {
   executeRaw,
   isPostgresDatabase,
   KnowledgeDocumentRepository,
+  KnowledgeNamespaceRepository,
   type KnowledgeSearchQuery,
   KnowledgeSearchRepository,
   sql,
@@ -18,6 +19,7 @@ import {
   type AuthenticatedParams,
   buildKnowledgeUnitUri,
   hasMinimumRole,
+  type KnowledgeNamespaceEffectivePermission,
   type KnowledgeSearchResult,
   normalizeKnowledgeFolderPath,
   type QueryParams,
@@ -41,27 +43,56 @@ import {
 
 export type KnowledgeSearchParams = QueryParams<KnowledgeSearchQuery> & AuthenticatedParams;
 
+const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+function hasNamespaceRead(permission: KnowledgeNamespaceEffectivePermission): boolean {
+  return NAMESPACE_PERMISSION_RANK[permission] >= NAMESPACE_PERMISSION_RANK.read;
+}
+
 export class KnowledgeSearchService {
   private repo: KnowledgeSearchRepository;
   private documents: KnowledgeDocumentRepository;
+  private namespaces: KnowledgeNamespaceRepository;
   private variables: AppVariableRepository;
   private embeddingProvider = new OpenAIEmbeddingProvider();
 
   constructor(private db: Database) {
     this.repo = new KnowledgeSearchRepository(db);
     this.documents = new KnowledgeDocumentRepository(db);
+    this.namespaces = new KnowledgeNamespaceRepository(db);
     this.variables = new AppVariableRepository(db);
   }
 
-  private canRead(
+  private async canRead(
     result: Awaited<ReturnType<KnowledgeSearchRepository['search']>>[number],
     user?: User
-  ): boolean {
-    return (
+  ): Promise<boolean> {
+    const namespacePermission = await this.namespaces.resolveNamespacePermission(
+      result.document.namespace_id,
+      String(user?.user_id ?? ''),
+      { isAdmin: hasMinimumRole(user?.role, ROLES.ADMIN) }
+    );
+    const documentReadable =
       result.document.visibility === 'public' ||
       hasMinimumRole(user?.role, ROLES.ADMIN) ||
-      Boolean(user?.user_id && result.document.created_by === user.user_id)
-    );
+      Boolean(user?.user_id && result.document.created_by === user.user_id);
+    return hasNamespaceRead(namespacePermission) && documentReadable;
+  }
+
+  private async filterReadable(
+    results: KnowledgeSearchResult[],
+    user?: User
+  ): Promise<KnowledgeSearchResult[]> {
+    const readable: KnowledgeSearchResult[] = [];
+    for (const result of results) {
+      if (await this.canRead(result, user)) readable.push(result);
+    }
+    return readable;
   }
 
   private assertSupportedMode(query?: KnowledgeSearchQuery): void {
@@ -209,6 +240,7 @@ export class KnowledgeSearchService {
           ns.repo_id AS namespace_repo_id,
           ns.branch_id AS namespace_branch_id,
           ns.visibility_default AS namespace_visibility_default,
+          ns.others_can AS namespace_others_can,
           ns.metadata AS namespace_metadata,
           ns.created_by AS namespace_created_by,
           ns.created_at AS namespace_created_at,
@@ -303,6 +335,7 @@ export class KnowledgeSearchService {
           repo_id: (row.namespace_repo_id as never) ?? null,
           branch_id: (row.namespace_branch_id as never) ?? null,
           visibility_default: row.namespace_visibility_default as never,
+          others_can: row.namespace_others_can as never,
           metadata: (row.namespace_metadata as Record<string, unknown> | null) ?? null,
           created_by: (row.namespace_created_by as never) ?? null,
           created_at: new Date(row.namespace_created_at as string | number | Date),
@@ -319,8 +352,8 @@ export class KnowledgeSearchService {
         chunks: [chunk],
       });
     }
-    const values = [...byDoc.values()].slice(0, rawQuery.limit ?? 25);
-    return this.attachIndexingToResults(values, rawQuery);
+    const values = await this.filterReadable([...byDoc.values()], user);
+    return this.attachIndexingToResults(values.slice(0, rawQuery.limit ?? 25), rawQuery);
   }
 
   private hybridMerge(
@@ -349,8 +382,9 @@ export class KnowledgeSearchService {
     const query = this.scopedQuery(params?.query, user);
     if ((query.mode ?? 'text') === 'semantic') return this.semanticSearch(query, user);
 
-    const textResults = (await this.repo.search({ ...query, mode: 'text' })).filter((result) =>
-      this.canRead(result, user)
+    const textResults = await this.filterReadable(
+      await this.repo.search({ ...query, mode: 'text' }),
+      user
     );
     const textResultsWithIndexing = await this.attachIndexingToResults(textResults, query);
     if (query.mode === 'hybrid') {
@@ -365,8 +399,9 @@ export class KnowledgeSearchService {
     const query = this.scopedQuery(data, user);
     if ((query.mode ?? 'text') === 'semantic') return this.semanticSearch(query, user);
 
-    const textResults = (await this.repo.search({ ...query, mode: 'text' })).filter((result) =>
-      this.canRead(result, user)
+    const textResults = await this.filterReadable(
+      await this.repo.search({ ...query, mode: 'text' }),
+      user
     );
     const textResultsWithIndexing = await this.attachIndexingToResults(textResults, query);
     if (query.mode === 'hybrid') {

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -18,12 +18,9 @@ import { BadRequest } from '@agor/core/feathers';
 import {
   type AuthenticatedParams,
   buildKnowledgeUnitUri,
-  hasMinimumRole,
-  type KnowledgeNamespaceEffectivePermission,
   type KnowledgeSearchResult,
   normalizeKnowledgeFolderPath,
   type QueryParams,
-  ROLES,
   type User,
 } from '@agor/core/types';
 import { getKnowledgeUrl } from '@agor/core/utils/url';
@@ -40,19 +37,9 @@ import {
   getKnowledgePgvectorCapability,
   semanticUnavailableMessage,
 } from '../knowledge/pgvector.js';
+import { canReadKnowledgeSearchResult, isKnowledgeAdmin } from './knowledge-access.js';
 
 export type KnowledgeSearchParams = QueryParams<KnowledgeSearchQuery> & AuthenticatedParams;
-
-const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
-  none: 0,
-  read: 1,
-  write: 2,
-  own: 3,
-};
-
-function hasNamespaceRead(permission: KnowledgeNamespaceEffectivePermission): boolean {
-  return NAMESPACE_PERMISSION_RANK[permission] >= NAMESPACE_PERMISSION_RANK.read;
-}
 
 export class KnowledgeSearchService {
   private repo: KnowledgeSearchRepository;
@@ -72,16 +59,7 @@ export class KnowledgeSearchService {
     result: Awaited<ReturnType<KnowledgeSearchRepository['search']>>[number],
     user?: User
   ): Promise<boolean> {
-    const namespacePermission = await this.namespaces.resolveNamespacePermission(
-      result.document.namespace_id,
-      String(user?.user_id ?? ''),
-      { isAdmin: hasMinimumRole(user?.role, ROLES.ADMIN) }
-    );
-    const documentReadable =
-      result.document.visibility === 'public' ||
-      hasMinimumRole(user?.role, ROLES.ADMIN) ||
-      Boolean(user?.user_id && result.document.created_by === user.user_id);
-    return hasNamespaceRead(namespacePermission) && documentReadable;
+    return canReadKnowledgeSearchResult(this.namespaces, result, user);
   }
 
   private async filterReadable(
@@ -107,7 +85,7 @@ export class KnowledgeSearchService {
 
   private scopedQuery(query: KnowledgeSearchQuery | undefined, user?: User): KnowledgeSearchQuery {
     this.assertSupportedMode(query);
-    const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
+    const isAdmin = isKnowledgeAdmin(user);
     const rawQuery = (query ?? {}) as KnowledgeSearchQuery & {
       includeMyDrafts?: boolean;
       includeOtherUserDrafts?: boolean;
@@ -204,7 +182,7 @@ export class KnowledgeSearchService {
     );
     const vector = embeddingToPgvector(queryEmbedding.embedding);
     const limit = Math.min(Math.max(rawQuery.rerank_limit ?? rawQuery.limit ?? 25, 1), 100);
-    const isAdmin = hasMinimumRole(user?.role, ROLES.ADMIN);
+    const isAdmin = isKnowledgeAdmin(user);
     const normalizedPathPrefix = rawQuery.path_prefix?.trim()
       ? normalizeKnowledgeFolderPath(rawQuery.path_prefix)
       : '';
@@ -212,6 +190,15 @@ export class KnowledgeSearchService {
     const minSimilarity = this.parseMinSimilarity(rawQuery.min_similarity);
     const includeMyDrafts = rawQuery.include_my_drafts !== false;
     const includeOtherUserDrafts = rawQuery.include_other_user_drafts === true;
+    const readableNamespaceIds = await this.namespaces.findReadableNamespaceIds(
+      String(user?.user_id ?? ''),
+      { isAdmin }
+    );
+    if (readableNamespaceIds.length === 0) return [];
+    const readableNamespaceIdList = sql.join(
+      readableNamespaceIds.map((id) => sql`${id}`),
+      sql`, `
+    );
 
     const baseUrl = await getBaseUrl();
     const result = await executeRaw(
@@ -262,6 +249,8 @@ export class KnowledgeSearchService {
           AND sp.provider = ${provider}
           AND sp.model = ${model}
           AND sp.dimensions = ${dimensions}
+          AND d.namespace_id IN (${readableNamespaceIdList})
+          AND (${rawQuery.namespace_id ?? null}::text IS NULL OR d.namespace_id = ${rawQuery.namespace_id ?? null})
           AND (${rawQuery.namespace_slug ?? null}::text IS NULL OR ns.slug = ${rawQuery.namespace_slug ?? null})
           AND (${pathPrefix}::text IS NULL OR d.path = ${pathPrefix} OR d.path LIKE (${pathPrefix} || '/%'))
           AND (${rawQuery.kind ?? null}::text IS NULL OR d.kind = ${rawQuery.kind ?? null})

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -83,13 +83,19 @@ export class KnowledgeSearchService {
     }
   }
 
-  private scopedQuery(query: KnowledgeSearchQuery | undefined, user?: User): KnowledgeSearchQuery {
+  private async scopedQuery(
+    query: KnowledgeSearchQuery | undefined,
+    user?: User
+  ): Promise<KnowledgeSearchQuery> {
     this.assertSupportedMode(query);
     const isAdmin = isKnowledgeAdmin(user);
     const rawQuery = (query ?? {}) as KnowledgeSearchQuery & {
       includeMyDrafts?: boolean;
       includeOtherUserDrafts?: boolean;
     };
+    const readableNamespaceIds = isAdmin
+      ? undefined
+      : await this.namespaces.findReadableNamespaceIds(String(user?.user_id ?? ''));
     return {
       ...(query ?? {}),
       include_archived: isAdmin && rawQuery.include_archived === true,
@@ -98,6 +104,7 @@ export class KnowledgeSearchService {
         rawQuery.include_other_user_drafts ?? rawQuery.includeOtherUserDrafts ?? false,
       readable_as_admin: isAdmin,
       readable_by_user_id: user?.user_id,
+      readable_namespace_ids: readableNamespaceIds,
     };
   }
 
@@ -190,15 +197,18 @@ export class KnowledgeSearchService {
     const minSimilarity = this.parseMinSimilarity(rawQuery.min_similarity);
     const includeMyDrafts = rawQuery.include_my_drafts !== false;
     const includeOtherUserDrafts = rawQuery.include_other_user_drafts === true;
-    const readableNamespaceIds = await this.namespaces.findReadableNamespaceIds(
-      String(user?.user_id ?? ''),
-      { isAdmin }
-    );
-    if (readableNamespaceIds.length === 0) return [];
-    const readableNamespaceIdList = sql.join(
-      readableNamespaceIds.map((id) => sql`${id}`),
-      sql`, `
-    );
+    const readableNamespaceIds =
+      rawQuery.readable_namespace_ids ??
+      (isAdmin
+        ? undefined
+        : await this.namespaces.findReadableNamespaceIds(String(user?.user_id ?? '')));
+    if (readableNamespaceIds?.length === 0) return [];
+    const readableNamespaceFilter = readableNamespaceIds
+      ? sql`AND d.namespace_id IN (${sql.join(
+          readableNamespaceIds.map((id) => sql`${id}`),
+          sql`, `
+        )})`
+      : sql``;
 
     const baseUrl = await getBaseUrl();
     const result = await executeRaw(
@@ -249,7 +259,7 @@ export class KnowledgeSearchService {
           AND sp.provider = ${provider}
           AND sp.model = ${model}
           AND sp.dimensions = ${dimensions}
-          AND d.namespace_id IN (${readableNamespaceIdList})
+          ${readableNamespaceFilter}
           AND (${rawQuery.namespace_id ?? null}::text IS NULL OR d.namespace_id = ${rawQuery.namespace_id ?? null})
           AND (${rawQuery.namespace_slug ?? null}::text IS NULL OR ns.slug = ${rawQuery.namespace_slug ?? null})
           AND (${pathPrefix}::text IS NULL OR d.path = ${pathPrefix} OR d.path LIKE (${pathPrefix} || '/%'))
@@ -368,7 +378,7 @@ export class KnowledgeSearchService {
 
   async find(params?: KnowledgeSearchParams) {
     const user = params?.user as User | undefined;
-    const query = this.scopedQuery(params?.query, user);
+    const query = await this.scopedQuery(params?.query, user);
     if ((query.mode ?? 'text') === 'semantic') return this.semanticSearch(query, user);
 
     const textResults = await this.filterReadable(
@@ -385,7 +395,7 @@ export class KnowledgeSearchService {
 
   async create(data: KnowledgeSearchQuery, params?: KnowledgeSearchParams) {
     const user = params?.user as User | undefined;
-    const query = this.scopedQuery(data, user);
+    const query = await this.scopedQuery(data, user);
     if ((query.mode ?? 'text') === 'semantic') return this.semanticSearch(query, user);
 
     const textResults = await this.filterReadable(

--- a/apps/agor-daemon/src/services/knowledge-versions.ts
+++ b/apps/agor-daemon/src/services/knowledge-versions.ts
@@ -15,12 +15,24 @@ import {
   hasMinimumRole,
   type KnowledgeDocument,
   type KnowledgeDocumentVersion,
+  type KnowledgeNamespaceEffectivePermission,
   parseKnowledgeUri,
   type QueryParams,
   ROLES,
   type User,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
+
+const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+function hasNamespaceRead(permission: KnowledgeNamespaceEffectivePermission): boolean {
+  return NAMESPACE_PERMISSION_RANK[permission] >= NAMESPACE_PERMISSION_RANK.read;
+}
 
 export type KnowledgeVersionParams = QueryParams<{
   document_id?: string;
@@ -58,12 +70,17 @@ export class KnowledgeVersionsService extends DrizzleService<
     this.namespaces = new KnowledgeNamespaceRepository(db);
   }
 
-  private canRead(document: KnowledgeDocument, user?: User): boolean {
-    return (
+  private async canRead(document: KnowledgeDocument, user?: User): Promise<boolean> {
+    const namespacePermission = await this.namespaces.resolveNamespacePermission(
+      document.namespace_id,
+      String(user?.user_id ?? ''),
+      { isAdmin: hasMinimumRole(user?.role, ROLES.ADMIN) }
+    );
+    const documentReadable =
       document.visibility === 'public' ||
       hasMinimumRole(user?.role, ROLES.ADMIN) ||
-      Boolean(user?.user_id && document.created_by === user.user_id)
-    );
+      Boolean(user?.user_id && document.created_by === user.user_id);
+    return hasNamespaceRead(namespacePermission) && documentReadable;
   }
 
   async find(params?: KnowledgeVersionParams) {
@@ -85,7 +102,7 @@ export class KnowledgeVersionsService extends DrizzleService<
     if (document.archived) return [];
     const namespace = await this.namespaces.findById(document.namespace_id);
     if (!namespace || namespace.archived) return [];
-    if (!this.canRead(document, params?.user as User | undefined)) {
+    if (!(await this.canRead(document, params?.user as User | undefined))) {
       throw new Forbidden('You do not have permission to view this knowledge document history');
     }
 

--- a/apps/agor-daemon/src/services/knowledge-versions.ts
+++ b/apps/agor-daemon/src/services/knowledge-versions.ts
@@ -12,27 +12,14 @@ import {
 import { BadRequest, Forbidden } from '@agor/core/feathers';
 import {
   type AuthenticatedParams,
-  hasMinimumRole,
   type KnowledgeDocument,
   type KnowledgeDocumentVersion,
-  type KnowledgeNamespaceEffectivePermission,
   parseKnowledgeUri,
   type QueryParams,
-  ROLES,
   type User,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
-
-const NAMESPACE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
-  none: 0,
-  read: 1,
-  write: 2,
-  own: 3,
-};
-
-function hasNamespaceRead(permission: KnowledgeNamespaceEffectivePermission): boolean {
-  return NAMESPACE_PERMISSION_RANK[permission] >= NAMESPACE_PERMISSION_RANK.read;
-}
+import { canReadKnowledgeDocument } from './knowledge-access.js';
 
 export type KnowledgeVersionParams = QueryParams<{
   document_id?: string;
@@ -71,16 +58,7 @@ export class KnowledgeVersionsService extends DrizzleService<
   }
 
   private async canRead(document: KnowledgeDocument, user?: User): Promise<boolean> {
-    const namespacePermission = await this.namespaces.resolveNamespacePermission(
-      document.namespace_id,
-      String(user?.user_id ?? ''),
-      { isAdmin: hasMinimumRole(user?.role, ROLES.ADMIN) }
-    );
-    const documentReadable =
-      document.visibility === 'public' ||
-      hasMinimumRole(user?.role, ROLES.ADMIN) ||
-      Boolean(user?.user_id && document.created_by === user.user_id);
-    return hasNamespaceRead(namespacePermission) && documentReadable;
+    return canReadKnowledgeDocument(this.namespaces, document, user);
   }
 
   async find(params?: KnowledgeVersionParams) {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -5,6 +5,7 @@ import { __resetConfigCacheForTests, type AgorConfig, saveConfig } from '@agor/c
 import type { Database } from '@agor/core/db';
 import {
   eq,
+  GroupRepository,
   generateId,
   KnowledgeDocumentRepository,
   KnowledgeNamespaceRepository,
@@ -164,6 +165,135 @@ describe('KnowledgeNamespacesService permissions', () => {
       ])
     );
   });
+
+  dbTest('reports effective permissions when listing readable namespaces', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const reader = await seedUser(db, 'reader');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const readable = await namespaces.create({
+      slug: 'list-readable',
+      display_name: 'List Readable',
+      others_can: 'none',
+      owner_user_id: owner.user_id as UserID,
+    });
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: readable.namespace_id,
+      subject_type: 'user',
+      subject_id: reader.user_id,
+      permission: 'read',
+    });
+
+    const service = new KnowledgeNamespacesService(db);
+    await expect(service.find(params(reader))).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          namespace_id: readable.namespace_id,
+          effective_permission: 'read',
+        }),
+      ])
+    );
+    await expect(service.find(params(owner))).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          namespace_id: readable.namespace_id,
+          effective_permission: 'own',
+        }),
+      ])
+    );
+  });
+
+  dbTest('prevents ACL methods from removing the caller last owner path', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const service = new KnowledgeNamespacesService(db);
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const namespace = await namespaces.create({
+      slug: 'no-self-lock',
+      display_name: 'No Self Lock',
+      others_can: 'none',
+      owner_user_id: null,
+    });
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: owner.user_id,
+      permission: 'own',
+    });
+
+    await expect(
+      service.setAcl(
+        {
+          namespace_id: namespace.namespace_id,
+          subject_type: 'user',
+          subject_id: owner.user_id,
+          permission: 'write',
+        },
+        params(owner)
+      )
+    ).rejects.toBeInstanceOf(BadRequest);
+    await expect(
+      service.removeAcl(
+        {
+          namespace_id: namespace.namespace_id,
+          subject_type: 'user',
+          subject_id: owner.user_id,
+        },
+        params(owner)
+      )
+    ).rejects.toBeInstanceOf(BadRequest);
+  });
+
+  dbTest(
+    'allows ACL owner changes when the caller keeps owner access through a group',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const service = new KnowledgeNamespacesService(db);
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      const groups = new GroupRepository(db);
+      const group = await groups.create({ name: 'Namespace Owners', slug: 'namespace-owners' });
+      await groups.addMember(group.group_id, owner.user_id);
+      const namespace = await namespaces.create({
+        slug: 'group-owned-acl',
+        display_name: 'Group Owned ACL',
+        others_can: 'none',
+        owner_user_id: null,
+      });
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: owner.user_id,
+        permission: 'own',
+      });
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'group',
+        subject_id: group.group_id,
+        permission: 'own',
+      });
+
+      await expect(
+        service.setAcl(
+          {
+            namespace_id: namespace.namespace_id,
+            subject_type: 'user',
+            subject_id: owner.user_id,
+            permission: 'read',
+          },
+          params(owner)
+        )
+      ).resolves.toMatchObject({ permission: 'read' });
+      await expect(
+        service.listAcl({ namespace_id: namespace.namespace_id }, params(owner))
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            subject_type: 'group',
+            subject_id: group.group_id,
+            permission: 'own',
+          }),
+        ])
+      );
+    }
+  );
 });
 
 describe('KnowledgeDocumentsService permissions', () => {
@@ -344,6 +474,51 @@ describe('KnowledgeDocumentsService permissions', () => {
     });
     await expect(
       service.patch(doc.document_id, { content_text: 'v2' }, params(other))
+    ).resolves.toMatchObject({ document_id: doc.document_id });
+  });
+
+  dbTest('enforces group namespace grants through document services', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const groupMember = await seedUser(db, 'group-member');
+    const groups = new GroupRepository(db);
+    const group = await groups.create({ name: 'KB Editors', slug: 'kb-editors' });
+    await groups.addMember(group.group_id, groupMember.user_id);
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const namespace = await namespaces.create({
+      slug: 'group-gated-docs',
+      display_name: 'Group Gated Docs',
+      owner_user_id: owner.user_id as UserID,
+      others_can: 'none',
+    });
+    const service = new KnowledgeDocumentsService(db);
+    const doc = await service.create(
+      {
+        namespace_id: namespace.namespace_id,
+        path: 'group.md',
+        title: 'Group',
+        visibility: 'public',
+        edit_policy: 'public',
+        content_text: 'v1',
+      },
+      params(owner)
+    );
+
+    await expect(service.get(doc.document_id, params(groupMember))).rejects.toBeInstanceOf(
+      Forbidden
+    );
+
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'group',
+      subject_id: group.group_id,
+      permission: 'write',
+    });
+
+    await expect(service.get(doc.document_id, params(groupMember))).resolves.toMatchObject({
+      document_id: doc.document_id,
+    });
+    await expect(
+      service.patch(doc.document_id, { content_text: 'v2' }, params(groupMember))
     ).resolves.toMatchObject({ document_id: doc.document_id });
   });
 

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -21,6 +21,7 @@ import { KnowledgeDocumentsService } from './knowledge-documents';
 import { KnowledgeEmbeddingIndexer } from './knowledge-embedding-indexer';
 import { KnowledgeGraphService } from './knowledge-graph';
 import { KnowledgeIndexingStatusService } from './knowledge-indexing';
+import { KnowledgeNamespacesService } from './knowledge-namespaces';
 import { KnowledgeReindexService } from './knowledge-reindex';
 import { KnowledgeSearchService } from './knowledge-search';
 import { KnowledgeSettingsService } from './knowledge-settings';
@@ -86,6 +87,84 @@ async function withTempConfig<T>(config: AgorConfig, run: () => Promise<T>): Pro
     await fs.rm(tempDir, { recursive: true, force: true });
   }
 }
+
+describe('KnowledgeNamespacesService permissions', () => {
+  dbTest('saves namespace fields and ACL draft through one service method', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const service = new KnowledgeNamespacesService(db);
+
+    const created = await service.saveWithAcl(
+      {
+        namespace: {
+          slug: 'atomic-acl',
+          display_name: 'Atomic ACL',
+          others_can: 'none',
+        },
+        acl: [
+          {
+            subject_type: 'user',
+            subject_id: other.user_id,
+            permission: 'read',
+          },
+        ],
+      },
+      params(owner)
+    );
+
+    expect(created.namespace.display_name).toBe('Atomic ACL');
+    expect(created.acl).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject_type: 'user',
+          subject_id: owner.user_id,
+          permission: 'own',
+        }),
+        expect.objectContaining({
+          subject_type: 'user',
+          subject_id: other.user_id,
+          permission: 'read',
+        }),
+      ])
+    );
+
+    const updated = await service.saveWithAcl(
+      {
+        namespace_id: created.namespace.namespace_id,
+        namespace: {
+          display_name: 'Updated ACL',
+          slug: created.namespace.slug,
+          others_can: 'read',
+        },
+        acl: [
+          {
+            subject_type: 'user',
+            subject_id: other.user_id,
+            permission: 'write',
+          },
+        ],
+      },
+      params(owner)
+    );
+
+    expect(updated.namespace.display_name).toBe('Updated ACL');
+    expect(updated.namespace.others_can).toBe('read');
+    expect(updated.acl).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject_type: 'user',
+          subject_id: owner.user_id,
+          permission: 'own',
+        }),
+        expect.objectContaining({
+          subject_type: 'user',
+          subject_id: other.user_id,
+          permission: 'write',
+        }),
+      ])
+    );
+  });
+});
 
 describe('KnowledgeDocumentsService permissions', () => {
   dbTest(
@@ -218,6 +297,93 @@ describe('KnowledgeDocumentsService permissions', () => {
       expect(recreated.document_id).not.toBe(created.document_id);
     }
   );
+
+  dbTest('enforces namespace read/write as outer gate for documents', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const namespace = await namespaces.create({
+      slug: 'namespace-gated-docs',
+      display_name: 'Namespace Gated Docs',
+      owner_user_id: owner.user_id as UserID,
+      others_can: 'none',
+    });
+    const service = new KnowledgeDocumentsService(db);
+    const doc = await service.create(
+      {
+        namespace_id: namespace.namespace_id,
+        path: 'shared.md',
+        title: 'Shared',
+        visibility: 'public',
+        edit_policy: 'public',
+        content_text: 'v1',
+      },
+      params(owner)
+    );
+
+    await expect(service.get(doc.document_id, params(other))).rejects.toBeInstanceOf(Forbidden);
+
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: other.user_id,
+      permission: 'read',
+    });
+    await expect(service.get(doc.document_id, params(other))).resolves.toMatchObject({
+      document_id: doc.document_id,
+    });
+    await expect(
+      service.patch(doc.document_id, { content_text: 'v2' }, params(other))
+    ).rejects.toBeInstanceOf(Forbidden);
+
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: other.user_id,
+      permission: 'write',
+    });
+    await expect(
+      service.patch(doc.document_id, { content_text: 'v2' }, params(other))
+    ).resolves.toMatchObject({ document_id: doc.document_id });
+  });
+
+  dbTest('filters search results by readable namespaces', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const openNamespace = await namespaces.create({
+      slug: 'search-open-namespace',
+      display_name: 'Search Open Namespace',
+      others_can: 'read',
+    });
+    const closedNamespace = await namespaces.create({
+      slug: 'search-closed-namespace',
+      display_name: 'Search Closed Namespace',
+      owner_user_id: owner.user_id as UserID,
+      others_can: 'none',
+    });
+    const documents = new KnowledgeDocumentRepository(db);
+    await documents.create({
+      namespace_id: openNamespace.namespace_id,
+      path: 'open.md',
+      title: 'Open',
+      visibility: 'public',
+      content_text: 'namespaceneedle open',
+      created_by: owner.user_id as UserID,
+    });
+    await documents.create({
+      namespace_id: closedNamespace.namespace_id,
+      path: 'closed.md',
+      title: 'Closed',
+      visibility: 'public',
+      content_text: 'namespaceneedle closed',
+      created_by: owner.user_id as UserID,
+    });
+
+    const search = new KnowledgeSearchService(db);
+    const results = await search.create({ q: 'namespaceneedle' }, params(other));
+    expect(results.map((result) => result.namespace.slug)).toEqual(['search-open-namespace']);
+  });
 });
 
 describe('Knowledge semantic indexing lifecycle', () => {
@@ -492,6 +658,44 @@ describe('KnowledgeSearchService and KnowledgeVersionsService permissions', () =
       expect(await versions.find(params(owner, { document_id: doc.document_id }))).toEqual([]);
     }
   );
+
+  dbTest(
+    'requires namespace read for version history even when document is public',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const other = await seedUser(db, 'other');
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      const namespace = await namespaces.create({
+        slug: 'history-closed-namespace',
+        display_name: 'History Closed Namespace',
+        owner_user_id: owner.user_id as UserID,
+        others_can: 'none',
+      });
+      const doc = await new KnowledgeDocumentRepository(db).create({
+        namespace_id: namespace.namespace_id,
+        path: 'history.md',
+        title: 'History',
+        visibility: 'public',
+        content_text: 'history body',
+        created_by: owner.user_id as UserID,
+      });
+      const versions = new KnowledgeVersionsService(db);
+
+      await expect(
+        versions.find(params(other, { document_id: doc.document_id }))
+      ).rejects.toBeInstanceOf(Forbidden);
+
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: other.user_id,
+        permission: 'read',
+      });
+      await expect(
+        versions.find(params(other, { document_id: doc.document_id }))
+      ).resolves.toHaveLength(1);
+    }
+  );
 });
 
 describe('KnowledgeGraphService permissions', () => {
@@ -542,6 +746,75 @@ describe('KnowledgeGraphService permissions', () => {
         params(other)
       )
     ).rejects.toBeInstanceOf(Forbidden);
+  });
+
+  dbTest('requires namespace read/write for graph reads and links', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const namespace = await namespaces.create({
+      slug: 'graph-closed-namespace',
+      display_name: 'Graph Closed Namespace',
+      owner_user_id: owner.user_id as UserID,
+      others_can: 'none',
+    });
+    const doc = await new KnowledgeDocumentRepository(db).create({
+      namespace_id: namespace.namespace_id,
+      path: 'graph.md',
+      title: 'Graph',
+      visibility: 'public',
+      edit_policy: 'public',
+      content_text: 'graph body',
+      created_by: owner.user_id as UserID,
+    });
+    const graph = new KnowledgeGraphService(db);
+
+    expect(
+      await graph.namespaceGraph({ namespace_id: namespace.namespace_id }, params(other))
+    ).toEqual({
+      namespace_id: null,
+      nodes: [],
+      edges: [],
+    });
+
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: other.user_id,
+      permission: 'read',
+    });
+    const readableGraph = await graph.namespaceGraph(
+      { namespace_id: namespace.namespace_id },
+      params(other)
+    );
+    expect(readableGraph.nodes.map((node) => node.document_id)).toEqual([doc.document_id]);
+    await expect(
+      graph.link(
+        {
+          source: { documentId: doc.document_id },
+          target: { externalUri: 'https://example.com/no-write', label: 'No write' },
+          edge_type: 'references',
+        },
+        params(other)
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+
+    await namespaces.upsertNamespaceAclEntry({
+      namespace_id: namespace.namespace_id,
+      subject_type: 'user',
+      subject_id: other.user_id,
+      permission: 'write',
+    });
+    await expect(
+      graph.link(
+        {
+          source: { documentId: doc.document_id },
+          target: { externalUri: 'https://example.com/write', label: 'Write' },
+          edge_type: 'references',
+        },
+        params(other)
+      )
+    ).resolves.toMatchObject({ edge_type: 'references' });
   });
 
   dbTest('filters unreadable private neighbors from public graph queries', async ({ db }) => {

--- a/apps/agor-daemon/src/services/knowledge.test.ts
+++ b/apps/agor-daemon/src/services/knowledge.test.ts
@@ -200,6 +200,10 @@ describe('KnowledgeNamespacesService permissions', () => {
         }),
       ])
     );
+    await expect(service.get(readable.namespace_id, params(reader))).resolves.toMatchObject({
+      namespace_id: readable.namespace_id,
+      effective_permission: 'read',
+    });
   });
 
   dbTest('prevents ACL methods from removing the caller last owner path', async ({ db }) => {
@@ -241,6 +245,44 @@ describe('KnowledgeNamespacesService permissions', () => {
       )
     ).rejects.toBeInstanceOf(BadRequest);
   });
+
+  dbTest(
+    'prevents owner_user_id changes from removing the caller last owner path',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const replacement = await seedUser(db, 'replacement');
+      const service = new KnowledgeNamespacesService(db);
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      const namespace = await namespaces.create({
+        slug: 'owner-user-self-lock',
+        display_name: 'Owner User Self Lock',
+        others_can: 'none',
+        owner_user_id: owner.user_id as UserID,
+      });
+
+      await expect(
+        service.patch(
+          namespace.namespace_id,
+          { owner_user_id: replacement.user_id as UserID },
+          params(owner)
+        )
+      ).rejects.toBeInstanceOf(BadRequest);
+
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: owner.user_id,
+        permission: 'own',
+      });
+      await expect(
+        service.patch(
+          namespace.namespace_id,
+          { owner_user_id: replacement.user_id as UserID },
+          params(owner)
+        )
+      ).resolves.toMatchObject({ owner_user_id: replacement.user_id });
+    }
+  );
 
   dbTest(
     'allows ACL owner changes when the caller keeps owner access through a group',
@@ -558,6 +600,48 @@ describe('KnowledgeDocumentsService permissions', () => {
     const search = new KnowledgeSearchService(db);
     const results = await search.create({ q: 'namespaceneedle' }, params(other));
     expect(results.map((result) => result.namespace.slug)).toEqual(['search-open-namespace']);
+  });
+
+  dbTest('filters text search by readable namespaces before applying row cap', async ({ db }) => {
+    const owner = await seedUser(db, 'owner');
+    const other = await seedUser(db, 'other');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+    const openNamespace = await namespaces.create({
+      slug: 'search-starvation-open',
+      display_name: 'Search Starvation Open',
+      others_can: 'read',
+    });
+    const closedNamespace = await namespaces.create({
+      slug: 'search-starvation-closed',
+      display_name: 'Search Starvation Closed',
+      owner_user_id: owner.user_id as UserID,
+      others_can: 'none',
+    });
+    const documents = new KnowledgeDocumentRepository(db);
+    await documents.create({
+      namespace_id: openNamespace.namespace_id,
+      path: 'open-starvation.md',
+      title: 'Open Starvation',
+      visibility: 'public',
+      content_text: 'starvationneedle readable',
+      created_by: owner.user_id as UserID,
+      updated_at: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    for (let index = 0; index < 120; index += 1) {
+      await documents.create({
+        namespace_id: closedNamespace.namespace_id,
+        path: `closed-${index}.md`,
+        title: `Closed ${index}`,
+        visibility: 'public',
+        content_text: `starvationneedle closed ${index}`,
+        created_by: owner.user_id as UserID,
+        updated_at: new Date(Date.UTC(2026, 0, 2, 0, 0, index)),
+      });
+    }
+
+    const search = new KnowledgeSearchService(db);
+    const results = await search.create({ q: 'starvationneedle', limit: 10 }, params(other));
+    expect(results.map((result) => result.namespace.slug)).toEqual(['search-starvation-open']);
   });
 });
 

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -2,11 +2,14 @@ import type {
   KnowledgeDocument as CoreKnowledgeDocument,
   KnowledgeIndexingStatus as CoreKnowledgeIndexingStatus,
   KnowledgeNamespace as CoreKnowledgeNamespace,
+  KnowledgeNamespaceAclEntry as CoreKnowledgeNamespaceAclEntry,
   KnowledgeDocumentVersion as CoreKnowledgeVersion,
   KnowledgeDocumentIndexingStatus,
   KnowledgeDocumentKind,
   KnowledgeDocumentStatus,
   KnowledgeNamespaceGraph,
+  KnowledgeNamespacePermission,
+  KnowledgeNamespaceSubjectType,
   KnowledgeSearchMode,
   KnowledgeSemanticSettingsPublic,
 } from '@agor/core/types';
@@ -18,10 +21,11 @@ import {
   titleFromKnowledgeContent,
   validateKnowledgePath as validateSharedKnowledgePath,
 } from '@agor/core/types';
-import type { AgorClient, User } from '@agor-live/client';
+import type { AgorClient, Group, User } from '@agor-live/client';
 import {
   ApartmentOutlined,
   ArrowLeftOutlined,
+  DeleteOutlined,
   DownOutlined,
   EditOutlined,
   ExperimentOutlined,
@@ -37,7 +41,9 @@ import {
   SaveOutlined,
   SearchOutlined,
   SettingOutlined,
+  TeamOutlined,
   UpOutlined,
+  UserOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
 import {
@@ -60,6 +66,7 @@ import {
   Space,
   Spin,
   Switch,
+  Tabs,
   Tag,
   Tooltip,
   Tree,
@@ -91,6 +98,7 @@ import { ThemeSwitcher } from '../components/ThemeSwitcher';
 import { DiffBlock } from '../components/ToolUseRenderer/renderers/DiffBlock';
 import { useUserLocalStorage } from '../hooks/useUserLocalStorage';
 import { useThemedModal } from '../utils/modal';
+import { slugify } from '../utils/repoSlug';
 
 const { Header, Content } = Layout;
 const { Text, Title } = Typography;
@@ -124,7 +132,37 @@ interface KnowledgeSearchResult {
 }
 
 type KnowledgeSemanticSettings = KnowledgeSemanticSettingsPublic & { api_key?: string | null };
+
+type KnowledgeNamespaceAclEntry = Pick<
+  CoreKnowledgeNamespaceAclEntry,
+  'namespace_acl_id' | 'namespace_id' | 'subject_type' | 'subject_id' | 'permission'
+>;
+
+interface KnowledgeNamespaceAclDraftEntry {
+  subject_type: KnowledgeNamespaceSubjectType;
+  subject_id: string;
+  permission: KnowledgeNamespacePermission;
+}
+
+type KnowledgeNamespaceFormValues = Pick<
+  KnowledgeNamespace,
+  'slug' | 'display_name' | 'description' | 'kind' | 'visibility_default' | 'others_can'
+>;
 type KnowledgeIndexingStatus = CoreKnowledgeIndexingStatus;
+
+type KnowledgeNamespacesClientService = ReturnType<AgorClient['service']> & {
+  listAcl(data: { namespace_id: string }): Promise<KnowledgeNamespaceAclEntry[]>;
+  saveWithAcl(data: {
+    namespace_id?: string;
+    namespace: Partial<KnowledgeNamespace>;
+    acl: KnowledgeNamespaceAclDraftEntry[];
+  }): Promise<{ namespace: KnowledgeNamespace; acl: KnowledgeNamespaceAclEntry[] }>;
+};
+
+type KnowledgeNamespacesClientServiceWithMethods = KnowledgeNamespacesClientService & {
+  methods?: (...names: string[]) => unknown;
+  __knowledgeNamespaceMethodsRegistered?: boolean;
+};
 
 interface KnowledgePageProps {
   client: AgorClient | null;
@@ -378,6 +416,17 @@ const leafTitleFromPath = (path: string): string => {
 const normalizeFindResult = <T,>(result: T[] | { data?: T[] }): T[] =>
   Array.isArray(result) ? result : (result.data ?? []);
 
+const getKnowledgeNamespacesService = (client: AgorClient): KnowledgeNamespacesClientService => {
+  const service = client.service(
+    'kb/namespaces'
+  ) as unknown as KnowledgeNamespacesClientServiceWithMethods;
+  if (!service.__knowledgeNamespaceMethodsRegistered) {
+    service.methods?.('listAcl', 'setAcl', 'removeAcl', 'saveWithAcl');
+    service.__knowledgeNamespaceMethodsRegistered = true;
+  }
+  return service;
+};
+
 const normalizeFolderPath = (folder?: string | null) => {
   try {
     return normalizeKnowledgeFolderPath(folder);
@@ -495,6 +544,21 @@ const slugifyFileName = (value: string) => {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
   return `${slug || 'untitled'}.md`;
+};
+
+const encodeNamespaceSubjectValue = (
+  subjectType: KnowledgeNamespaceSubjectType,
+  subjectId: string
+) => `${subjectType}:${subjectId}`;
+
+const parseNamespaceSubjectValue = (
+  value?: string | null
+): { subjectType: KnowledgeNamespaceSubjectType; subjectId: string } | null => {
+  if (!value) return null;
+  const [subjectType, ...rest] = value.split(':');
+  const subjectId = rest.join(':');
+  if ((subjectType !== 'user' && subjectType !== 'group') || !subjectId) return null;
+  return { subjectType, subjectId };
 };
 
 const inferTitleFromMarkdown = (markdown: string, fallback = 'Untitled') =>
@@ -649,6 +713,19 @@ export function KnowledgePage({
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsApiKeyDraft, setSettingsApiKeyDraft] = useState('');
   const [settingsForm] = Form.useForm<KnowledgeSemanticSettings>();
+  const [namespaceEditorOpen, setNamespaceEditorOpen] = useState(false);
+  const [namespaceEditing, setNamespaceEditing] = useState<KnowledgeNamespace | null>(null);
+  const [namespaceSaving, setNamespaceSaving] = useState(false);
+  const [namespaceError, setNamespaceError] = useState<string | null>(null);
+  const [namespaceForm] = Form.useForm<KnowledgeNamespaceFormValues>();
+  const namespaceSlugEditedRef = useRef(false);
+  const [namespaceUsers, setNamespaceUsers] = useState<User[]>([]);
+  const [namespaceGroups, setNamespaceGroups] = useState<Group[]>([]);
+  const [namespaceAclDraft, setNamespaceAclDraft] = useState<KnowledgeNamespaceAclDraftEntry[]>([]);
+  const [namespaceAclLoading, setNamespaceAclLoading] = useState(false);
+  const [namespaceAclSubject, setNamespaceAclSubject] = useState<string | null>(null);
+  const [namespaceAclPermission, setNamespaceAclPermission] =
+    useState<KnowledgeNamespacePermission>('read');
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window === 'undefined' ? 1440 : window.innerWidth
   );
@@ -744,6 +821,54 @@ export function KnowledgePage({
       (activeSpace !== 'all' ? activeSpace : selectedNamespace?.slug) ??
       'global',
     [activeSpace, namespaceSlugById, selectedNamespace?.slug]
+  );
+
+  const namespaceAclSubjectOptions = useMemo(() => {
+    const users = new Map(userById);
+    for (const user of namespaceUsers) users.set(user.user_id, user);
+    if (currentUser) users.set(currentUser.user_id, currentUser);
+    return [
+      {
+        label: 'Users',
+        options: [...users.values()]
+          .sort((a, b) => (a.name || a.email).localeCompare(b.name || b.email))
+          .map((user) => ({
+            label: `${user.name || user.email}${user.email ? ` <${user.email}>` : ''}`,
+            value: encodeNamespaceSubjectValue('user', user.user_id),
+          })),
+      },
+      {
+        label: 'Groups',
+        options: namespaceGroups
+          .filter((group) => !group.archived)
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((group) => ({
+            label: `${group.name} group`,
+            value: encodeNamespaceSubjectValue('group', group.group_id),
+          })),
+      },
+    ];
+  }, [currentUser, namespaceGroups, namespaceUsers, userById]);
+
+  const namespaceUserById = useMemo(() => {
+    const users = new Map(userById);
+    for (const user of namespaceUsers) users.set(user.user_id, user);
+    if (currentUser) users.set(currentUser.user_id, currentUser);
+    return users;
+  }, [currentUser, namespaceUsers, userById]);
+
+  const namespaceSubjectLabel = useCallback(
+    (entry: KnowledgeNamespaceAclDraftEntry) => {
+      if (entry.subject_type === 'user') {
+        const user = namespaceUserById.get(entry.subject_id);
+        return user
+          ? `${user.name || user.email}${user.email ? ` <${user.email}>` : ''}`
+          : entry.subject_id;
+      }
+      const group = namespaceGroups.find((item) => item.group_id === entry.subject_id);
+      return group ? `${group.name} group` : entry.subject_id;
+    },
+    [namespaceGroups, namespaceUserById]
   );
 
   // Resolve rename-proof `agor://kb/document/<uuid>` links to clickable links for
@@ -1078,12 +1203,38 @@ export function KnowledgePage({
     }
   }, [client, settingsForm]);
 
+  const loadNamespaceGroups = useCallback(async () => {
+    if (!client) return;
+    try {
+      const result = await client.service('groups').findAll({ query: { archived: false } });
+      setNamespaceGroups(normalizeFindResult<Group>(result as Group[]));
+    } catch (err) {
+      console.error('Failed to load Knowledge namespace groups:', err);
+      setNamespaceGroups([]);
+    }
+  }, [client]);
+
+  const loadNamespaceUsers = useCallback(async () => {
+    if (!client) return;
+    try {
+      const result = await client.service('users').findAll({});
+      setNamespaceUsers(normalizeFindResult<User>(result as User[]));
+    } catch (err) {
+      console.error('Failed to load Knowledge namespace users:', err);
+      setNamespaceUsers([]);
+    }
+  }, [client]);
+
   const openKnowledgeSettings = useCallback(() => {
     setKnowledgeSettingsOpen(true);
     setSettingsApiKeyDraft('');
     setSettingsError(null);
+    setNamespaceError(null);
     void refreshKnowledgeSettings();
-  }, [refreshKnowledgeSettings]);
+    void loadNamespaces();
+    void loadNamespaceGroups();
+    void loadNamespaceUsers();
+  }, [loadNamespaceGroups, loadNamespaceUsers, loadNamespaces, refreshKnowledgeSettings]);
 
   const saveKnowledgeSettings = useCallback(async () => {
     if (!client) return;
@@ -1133,6 +1284,202 @@ export function KnowledgePage({
       setSettingsSaving(false);
     }
   }, [client, refreshKnowledgeSettings]);
+
+  const openNamespaceEditor = useCallback(
+    (namespace?: KnowledgeNamespace | null) => {
+      namespaceSlugEditedRef.current = Boolean(namespace);
+      setNamespaceEditing(namespace ?? null);
+      setNamespaceError(null);
+      setNamespaceAclSubject(null);
+      setNamespaceAclPermission('read');
+      setNamespaceAclDraft(
+        !namespace && currentUser?.user_id
+          ? [
+              {
+                subject_type: 'user',
+                subject_id: currentUser.user_id,
+                permission: 'own',
+              },
+            ]
+          : []
+      );
+      namespaceForm.setFieldsValue(
+        namespace
+          ? {
+              slug: namespace.slug,
+              display_name: namespace.display_name,
+              description: namespace.description ?? '',
+              kind: namespace.kind,
+              visibility_default: namespace.visibility_default,
+              others_can: namespace.others_can,
+            }
+          : {
+              slug: '',
+              display_name: '',
+              description: '',
+              kind: 'team',
+              visibility_default: 'public',
+              others_can: 'none',
+            }
+      );
+      setNamespaceEditorOpen(true);
+      if (namespace && client) {
+        setNamespaceAclLoading(true);
+        const service = getKnowledgeNamespacesService(client);
+        service
+          .listAcl({ namespace_id: namespace.namespace_id })
+          .then((entries) => {
+            setNamespaceAclDraft(
+              entries.map((entry) => ({
+                subject_type: entry.subject_type,
+                subject_id: entry.subject_id,
+                permission: entry.permission,
+              }))
+            );
+          })
+          .catch((err) => {
+            console.error('Failed to load Knowledge namespace ACL:', err);
+            setNamespaceError(err instanceof Error ? err.message : String(err));
+          })
+          .finally(() => setNamespaceAclLoading(false));
+      }
+    },
+    [client, currentUser?.user_id, namespaceForm]
+  );
+
+  const handleNamespaceValuesChange = useCallback(
+    (changedValues: Partial<KnowledgeNamespaceFormValues>) => {
+      if (Object.hasOwn(changedValues, 'slug')) {
+        namespaceSlugEditedRef.current = true;
+        return;
+      }
+
+      if (
+        !namespaceEditing &&
+        Object.hasOwn(changedValues, 'display_name') &&
+        !namespaceSlugEditedRef.current
+      ) {
+        namespaceForm.setFieldsValue({ slug: slugify(changedValues.display_name || '') });
+      }
+    },
+    [namespaceEditing, namespaceForm]
+  );
+
+  const addNamespaceAclDraftEntry = useCallback(() => {
+    const parsed = parseNamespaceSubjectValue(namespaceAclSubject);
+    if (!parsed) return;
+    setNamespaceAclDraft((prev) => {
+      const nextEntry: KnowledgeNamespaceAclDraftEntry = {
+        subject_type: parsed.subjectType,
+        subject_id: parsed.subjectId,
+        permission: namespaceAclPermission,
+      };
+      const existingIndex = prev.findIndex(
+        (entry) =>
+          entry.subject_type === parsed.subjectType && entry.subject_id === parsed.subjectId
+      );
+      if (existingIndex === -1) return [...prev, nextEntry];
+      return prev.map((entry, index) => (index === existingIndex ? nextEntry : entry));
+    });
+    setNamespaceAclSubject(null);
+    setNamespaceAclPermission('read');
+  }, [namespaceAclPermission, namespaceAclSubject]);
+
+  const updateNamespaceAclDraftPermission = useCallback(
+    (entry: KnowledgeNamespaceAclDraftEntry, permission: KnowledgeNamespacePermission) => {
+      setNamespaceAclDraft((prev) =>
+        prev.map((item) =>
+          item.subject_type === entry.subject_type && item.subject_id === entry.subject_id
+            ? { ...item, permission }
+            : item
+        )
+      );
+    },
+    []
+  );
+
+  const removeNamespaceAclDraftEntry = useCallback((entry: KnowledgeNamespaceAclDraftEntry) => {
+    setNamespaceAclDraft((prev) =>
+      prev.filter(
+        (item) => item.subject_type !== entry.subject_type || item.subject_id !== entry.subject_id
+      )
+    );
+  }, []);
+
+  const saveNamespace = useCallback(async () => {
+    if (!client) return;
+    setNamespaceSaving(true);
+    setNamespaceError(null);
+    try {
+      const values = await namespaceForm.validateFields();
+      const payload = {
+        ...values,
+        slug: values.slug.trim(),
+        display_name: values.display_name.trim(),
+        description: values.description?.trim() || null,
+      };
+      const service = getKnowledgeNamespacesService(client);
+      const result = await service.saveWithAcl({
+        namespace_id: namespaceEditing?.namespace_id,
+        namespace: namespaceEditing
+          ? {
+              ...payload,
+              slug: namespaceEditing.slug,
+            }
+          : payload,
+        acl: namespaceAclDraft,
+      });
+      setNamespaceAclDraft(
+        result.acl.map((entry) => ({
+          subject_type: entry.subject_type,
+          subject_id: entry.subject_id,
+          permission: entry.permission,
+        }))
+      );
+      if (namespaceEditing) {
+        setNamespaces((prev) =>
+          prev.map((namespace) =>
+            namespace.namespace_id === result.namespace.namespace_id ? result.namespace : namespace
+          )
+        );
+      } else {
+        setNamespaces((prev) => [result.namespace, ...prev]);
+      }
+      await loadNamespaces();
+      setNamespaceEditorOpen(false);
+      setNamespaceEditing(null);
+    } catch (err) {
+      console.error('Failed to save Knowledge namespace:', err);
+      setNamespaceError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setNamespaceSaving(false);
+    }
+  }, [client, loadNamespaces, namespaceAclDraft, namespaceEditing, namespaceForm]);
+
+  const archiveNamespace = useCallback(
+    (namespace: KnowledgeNamespace) => {
+      if (!client) return;
+      confirm({
+        title: `Archive ${namespace.display_name || namespace.slug}?`,
+        content:
+          'Archiving a namespace also archives its documents. This can disrupt Knowledge links and search.',
+        okText: 'Archive namespace',
+        okButtonProps: { danger: true },
+        onOk: async () => {
+          setNamespaceError(null);
+          try {
+            await client.service('kb/namespaces').remove(namespace.namespace_id);
+            await loadNamespaces();
+            if (activeSpace === namespace.slug) setActiveSpace('all');
+          } catch (err) {
+            console.error('Failed to archive Knowledge namespace:', err);
+            setNamespaceError(err instanceof Error ? err.message : String(err));
+          }
+        },
+      });
+    },
+    [activeSpace, client, confirm, loadNamespaces]
+  );
 
   // The namespace graph is scoped to a single Space; "All Spaces" has no graph.
   const loadGraph = useCallback(async () => {
@@ -3010,152 +3357,394 @@ export function KnowledgePage({
       </Drawer>
 
       <Modal
-        title="Knowledge semantic search"
+        title="Knowledge settings"
         open={knowledgeSettingsOpen}
         onCancel={() => setKnowledgeSettingsOpen(false)}
-        okText="Save settings"
-        onOk={saveKnowledgeSettings}
-        confirmLoading={settingsSaving}
-        width={720}
+        footer={null}
+        width={760}
       >
         <Spin spinning={settingsLoading}>
-          <Space direction="vertical" size={16} style={{ width: '100%' }}>
-            {settingsError && <Alert type="error" showIcon message={settingsError} />}
-            <Alert
-              type="info"
-              showIcon
-              message="Semantic search uses markdown-aware chunks stored in Postgres/pgvector. SQLite can save settings and chunks, but vector search requires Postgres."
-            />
-            {indexingStatus && (
-              <div
-                style={{
-                  border: `1px solid ${token.colorBorderSecondary}`,
-                  borderRadius: token.borderRadiusLG,
-                  padding: 12,
-                  background: token.colorFillQuaternary,
-                }}
-              >
-                <Space direction="vertical" size={4} style={{ width: '100%' }}>
-                  <Text strong>Indexing status</Text>
-                  <Text type="secondary">
-                    {indexingStatus.dialect} · pgvector{' '}
-                    {indexingStatus.pgvector_available
-                      ? 'ready'
-                      : indexingStatus.pgvector_extension_installed
-                        ? 'extension installed, storage not ready'
-                        : 'not available'}{' '}
-                    · queue {indexingStatus.queue_depth}
-                  </Text>
-                  <Space wrap>
-                    {Object.entries(indexingStatus.chunks).map(([status, count]) => (
-                      <Tag key={status}>
-                        {status}: {Number(count)}
-                      </Tag>
-                    ))}
+          <Tabs
+            defaultActiveKey="namespaces"
+            items={[
+              {
+                key: 'namespaces',
+                label: 'Namespaces',
+                children: (
+                  <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                    <Alert
+                      type="info"
+                      showIcon
+                      message="Namespaces are the Knowledge RBAC boundary. Use the workspace fallback for broad access; user/group-specific grants are available through the backend and will get a richer UI next."
+                    />
+                    {namespaceError && <Alert type="error" showIcon message={namespaceError} />}
+                    <Flex justify="space-between" align="center">
+                      <Space direction="vertical" size={0}>
+                        <Text strong>Knowledge namespaces</Text>
+                        <Text type="secondary">
+                          Create and manage Knowledge spaces, defaults, and broad workspace access.
+                        </Text>
+                      </Space>
+                      <Button type="primary" onClick={() => openNamespaceEditor(null)}>
+                        New namespace
+                      </Button>
+                    </Flex>
+                    <List
+                      size="small"
+                      dataSource={namespaces}
+                      locale={{ emptyText: 'No readable namespaces' }}
+                      renderItem={(namespace) => (
+                        <List.Item
+                          actions={[
+                            <Button
+                              key="edit"
+                              size="small"
+                              onClick={() => openNamespaceEditor(namespace)}
+                            >
+                              Edit
+                            </Button>,
+                            <Button
+                              key="archive"
+                              size="small"
+                              danger
+                              disabled={namespace.kind === 'system'}
+                              onClick={() => archiveNamespace(namespace)}
+                            >
+                              Archive
+                            </Button>,
+                          ]}
+                        >
+                          <List.Item.Meta
+                            title={
+                              <Space wrap>
+                                <Text strong>{namespace.display_name || namespace.slug}</Text>
+                                <Tag>{namespace.slug}</Tag>
+                                <Tag color={namespace.others_can === 'none' ? 'default' : 'blue'}>
+                                  others: {namespace.others_can}
+                                </Tag>
+                              </Space>
+                            }
+                            description={namespace.description || 'No description'}
+                          />
+                        </List.Item>
+                      )}
+                    />
                   </Space>
-                  {indexingStatus.last_error && (
-                    <Alert type="warning" message={indexingStatus.last_error} />
-                  )}
-                </Space>
-              </div>
-            )}
-            <Form
-              form={settingsForm}
-              layout="vertical"
-              initialValues={knowledgeSettings ?? DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS}
-            >
+                ),
+              },
+              {
+                key: 'semantic',
+                label: 'Semantic search',
+                children: (
+                  <Space direction="vertical" size={16} style={{ width: '100%' }}>
+                    {settingsError && <Alert type="error" showIcon message={settingsError} />}
+                    <Alert
+                      type="info"
+                      showIcon
+                      message="Semantic search uses markdown-aware chunks stored in Postgres/pgvector. SQLite can save settings and chunks, but vector search requires Postgres."
+                    />
+                    {indexingStatus && (
+                      <div
+                        style={{
+                          border: `1px solid ${token.colorBorderSecondary}`,
+                          borderRadius: token.borderRadiusLG,
+                          padding: 12,
+                          background: token.colorFillQuaternary,
+                        }}
+                      >
+                        <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                          <Text strong>Indexing status</Text>
+                          <Text type="secondary">
+                            {indexingStatus.dialect} · pgvector{' '}
+                            {indexingStatus.pgvector_available
+                              ? 'ready'
+                              : indexingStatus.pgvector_extension_installed
+                                ? 'extension installed, storage not ready'
+                                : 'not available'}{' '}
+                            · queue {indexingStatus.queue_depth}
+                          </Text>
+                          <Space wrap>
+                            {Object.entries(indexingStatus.chunks).map(([status, count]) => (
+                              <Tag key={status}>
+                                {status}: {Number(count)}
+                              </Tag>
+                            ))}
+                          </Space>
+                          {indexingStatus.last_error && (
+                            <Alert type="warning" message={indexingStatus.last_error} />
+                          )}
+                        </Space>
+                      </div>
+                    )}
+                    <Form
+                      form={settingsForm}
+                      layout="vertical"
+                      initialValues={knowledgeSettings ?? DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS}
+                    >
+                      <Form.Item
+                        name="enabled"
+                        label="Enable semantic / hybrid search"
+                        valuePropName="checked"
+                      >
+                        <Switch />
+                      </Form.Item>
+                      <Flex gap={12} wrap="wrap">
+                        <Form.Item
+                          name="provider"
+                          label="Provider"
+                          style={{ minWidth: 180, flex: 1 }}
+                        >
+                          <Select options={[{ label: 'OpenAI', value: 'openai' }]} />
+                        </Form.Item>
+                        <Form.Item name="model" label="Model" style={{ minWidth: 240, flex: 2 }}>
+                          <Select
+                            options={OPENAI_EMBEDDING_MODEL_OPTIONS}
+                            onChange={() => settingsForm.setFieldValue('dimensions', 1536)}
+                          />
+                        </Form.Item>
+                        <Form.Item
+                          name="dimensions"
+                          label="Dimensions"
+                          tooltip="Agor V1 indexes 1536-dimensional embeddings. text-embedding-3-large is requested with dimensions=1536."
+                          style={{ width: 140 }}
+                        >
+                          <InputNumber
+                            disabled
+                            min={1536}
+                            max={1536}
+                            precision={0}
+                            style={{ width: '100%' }}
+                          />
+                        </Form.Item>
+                      </Flex>
+                      <Form.Item label="OpenAI API key">
+                        <Input.Password
+                          value={settingsApiKeyDraft}
+                          onChange={(event) => setSettingsApiKeyDraft(event.target.value)}
+                          placeholder={
+                            knowledgeSettings?.api_key_configured
+                              ? 'Configured — enter a new key to replace'
+                              : 'sk-...'
+                          }
+                          autoComplete="off"
+                        />
+                      </Form.Item>
+                      <Flex gap={12} wrap="wrap">
+                        <Form.Item
+                          name={['chunking', 'target_tokens']}
+                          label="Target tokens"
+                          style={{ width: 150 }}
+                        >
+                          <InputNumber min={100} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item
+                          name={['chunking', 'max_tokens']}
+                          label="Max tokens"
+                          style={{ width: 150 }}
+                        >
+                          <InputNumber min={100} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item
+                          name={['chunking', 'overlap_tokens']}
+                          label="Overlap"
+                          style={{ width: 130 }}
+                        >
+                          <InputNumber min={0} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item
+                          name={['chunking', 'min_tokens']}
+                          label="Min tokens"
+                          style={{ width: 130 }}
+                        >
+                          <InputNumber min={0} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                        <Form.Item
+                          name={['indexing', 'batch_size']}
+                          label="Batch size"
+                          style={{ width: 130 }}
+                        >
+                          <InputNumber min={1} max={256} precision={0} style={{ width: '100%' }} />
+                        </Form.Item>
+                      </Flex>
+                    </Form>
+                    <Flex justify="space-between" align="center">
+                      <Text type="secondary">
+                        Reindexing queues current Knowledge chunks and wakes the background indexer.
+                      </Text>
+                      <Space>
+                        <Button onClick={reindexKnowledge} loading={settingsSaving}>
+                          Reindex now
+                        </Button>
+                        <Button
+                          type="primary"
+                          onClick={saveKnowledgeSettings}
+                          loading={settingsSaving}
+                        >
+                          Save semantic settings
+                        </Button>
+                      </Space>
+                    </Flex>
+                  </Space>
+                ),
+              },
+            ]}
+          />
+        </Spin>
+      </Modal>
+
+      <Modal
+        title={namespaceEditing ? 'Edit namespace' : 'Create namespace'}
+        open={namespaceEditorOpen}
+        onCancel={() => setNamespaceEditorOpen(false)}
+        okText={namespaceEditing ? 'Save namespace' : 'Create namespace'}
+        onOk={saveNamespace}
+        confirmLoading={namespaceSaving}
+        destroyOnHidden
+      >
+        <Form form={namespaceForm} layout="vertical" onValuesChange={handleNamespaceValuesChange}>
+          <Form.Item
+            name="display_name"
+            label="Name"
+            rules={[{ required: true, message: 'Name is required' }]}
+          >
+            <Input placeholder="Team docs" />
+          </Form.Item>
+          <Form.Item
+            name="slug"
+            label="Slug"
+            rules={[
+              { required: true, message: 'Namespace slug is required' },
+              {
+                pattern: /^[a-z0-9][a-z0-9._-]*$/,
+                message: 'Use lowercase letters, numbers, dots, underscores, or dashes',
+              },
+            ]}
+          >
+            <Input disabled={Boolean(namespaceEditing)} placeholder="team-docs" />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input.TextArea rows={3} placeholder="What belongs in this namespace?" />
+          </Form.Item>
+          <Form.Item name="kind" hidden>
+            <Input />
+          </Form.Item>
+          <Space direction="vertical" size={12} style={{ width: '100%' }}>
+            <Space direction="vertical" size={0}>
+              <Text strong>Default access</Text>
+              <Text type="secondary">
+                These defaults apply across the namespace before user or group-specific grants.
+              </Text>
+            </Space>
+            <Flex gap={12} wrap="wrap">
               <Form.Item
-                name="enabled"
-                label="Enable semantic / hybrid search"
-                valuePropName="checked"
+                name="visibility_default"
+                label="Default document visibility"
+                style={{ minWidth: 180, flex: 1 }}
               >
-                <Switch />
-              </Form.Item>
-              <Flex gap={12} wrap="wrap">
-                <Form.Item name="provider" label="Provider" style={{ minWidth: 180, flex: 1 }}>
-                  <Select options={[{ label: 'OpenAI', value: 'openai' }]} />
-                </Form.Item>
-                <Form.Item name="model" label="Model" style={{ minWidth: 240, flex: 2 }}>
-                  <Select
-                    options={OPENAI_EMBEDDING_MODEL_OPTIONS}
-                    onChange={() => settingsForm.setFieldValue('dimensions', 1536)}
-                  />
-                </Form.Item>
-                <Form.Item
-                  name="dimensions"
-                  label="Dimensions"
-                  tooltip="Agor V1 indexes 1536-dimensional embeddings. text-embedding-3-large is requested with dimensions=1536."
-                  style={{ width: 140 }}
-                >
-                  <InputNumber
-                    disabled
-                    min={1536}
-                    max={1536}
-                    precision={0}
-                    style={{ width: '100%' }}
-                  />
-                </Form.Item>
-              </Flex>
-              <Form.Item label="OpenAI API key">
-                <Input.Password
-                  value={settingsApiKeyDraft}
-                  onChange={(event) => setSettingsApiKeyDraft(event.target.value)}
-                  placeholder={
-                    knowledgeSettings?.api_key_configured
-                      ? 'Configured — enter a new key to replace'
-                      : 'sk-...'
-                  }
-                  autoComplete="off"
+                <Select
+                  options={[
+                    { label: 'Public in namespace', value: 'public' },
+                    { label: 'Private to creator', value: 'private' },
+                  ]}
                 />
               </Form.Item>
-              <Flex gap={12} wrap="wrap">
-                <Form.Item
-                  name={['chunking', 'target_tokens']}
-                  label="Target tokens"
-                  style={{ width: 150 }}
-                >
-                  <InputNumber min={100} precision={0} style={{ width: '100%' }} />
-                </Form.Item>
-                <Form.Item
-                  name={['chunking', 'max_tokens']}
-                  label="Max tokens"
-                  style={{ width: 150 }}
-                >
-                  <InputNumber min={100} precision={0} style={{ width: '100%' }} />
-                </Form.Item>
-                <Form.Item
-                  name={['chunking', 'overlap_tokens']}
-                  label="Overlap"
-                  style={{ width: 130 }}
-                >
-                  <InputNumber min={0} precision={0} style={{ width: '100%' }} />
-                </Form.Item>
-                <Form.Item
-                  name={['chunking', 'min_tokens']}
-                  label="Min tokens"
-                  style={{ width: 130 }}
-                >
-                  <InputNumber min={0} precision={0} style={{ width: '100%' }} />
-                </Form.Item>
-                <Form.Item
-                  name={['indexing', 'batch_size']}
-                  label="Batch size"
-                  style={{ width: 130 }}
-                >
-                  <InputNumber min={1} max={256} precision={0} style={{ width: '100%' }} />
-                </Form.Item>
-              </Flex>
-            </Form>
-            <Flex justify="space-between" align="center">
-              <Text type="secondary">
-                Reindexing queues current Knowledge chunks and wakes the background indexer.
-              </Text>
-              <Button onClick={reindexKnowledge} loading={settingsSaving}>
-                Reindex now
-              </Button>
+              <Form.Item
+                name="others_can"
+                label="Everyone else in workspace"
+                tooltip="Fallback for users not listed in specific namespace access."
+                style={{ minWidth: 180, flex: 1 }}
+              >
+                <Select
+                  options={[
+                    { label: 'No access', value: 'none' },
+                    { label: 'Read', value: 'read' },
+                    { label: 'Write', value: 'write' },
+                  ]}
+                />
+              </Form.Item>
             </Flex>
           </Space>
-        </Spin>
+          <Space direction="vertical" size={12} style={{ width: '100%' }}>
+            <Space direction="vertical" size={0}>
+              <Text strong>Specific access</Text>
+              <Text type="secondary">
+                Add users or groups that should override the default access above.
+              </Text>
+            </Space>
+            <Flex gap={8} wrap="wrap">
+              <Select
+                showSearch
+                allowClear
+                placeholder="User or group"
+                value={namespaceAclSubject}
+                onChange={(value) => setNamespaceAclSubject(value ?? null)}
+                options={namespaceAclSubjectOptions}
+                optionFilterProp="label"
+                style={{ minWidth: 280, flex: 1 }}
+              />
+              <Select
+                value={namespaceAclPermission}
+                onChange={setNamespaceAclPermission}
+                options={[
+                  { label: 'Read', value: 'read' },
+                  { label: 'Write', value: 'write' },
+                  { label: 'Own', value: 'own' },
+                ]}
+                style={{ width: 120 }}
+              />
+              <Button onClick={addNamespaceAclDraftEntry} disabled={!namespaceAclSubject}>
+                + Add
+              </Button>
+            </Flex>
+            <Spin spinning={namespaceAclLoading}>
+              <List
+                size="small"
+                dataSource={namespaceAclDraft}
+                locale={{ emptyText: 'No specific user or group grants' }}
+                renderItem={(entry) => (
+                  <List.Item
+                    actions={[
+                      <Select
+                        key="permission"
+                        size="small"
+                        value={entry.permission}
+                        onChange={(permission) =>
+                          updateNamespaceAclDraftPermission(entry, permission)
+                        }
+                        options={[
+                          { label: 'Read', value: 'read' },
+                          { label: 'Write', value: 'write' },
+                          { label: 'Own', value: 'own' },
+                        ]}
+                        style={{ width: 110 }}
+                      />,
+                      <Button
+                        key="remove"
+                        type="text"
+                        size="small"
+                        danger
+                        icon={<DeleteOutlined />}
+                        aria-label={`Remove ${namespaceSubjectLabel(entry)}`}
+                        onClick={() => removeNamespaceAclDraftEntry(entry)}
+                      />,
+                    ]}
+                  >
+                    <List.Item.Meta
+                      title={
+                        <Space>
+                          <Tooltip title={entry.subject_type === 'user' ? 'User' : 'Group'}>
+                            {entry.subject_type === 'user' ? <UserOutlined /> : <TeamOutlined />}
+                          </Tooltip>
+                          <Text>{namespaceSubjectLabel(entry)}</Text>
+                        </Space>
+                      }
+                    />
+                  </List.Item>
+                )}
+              />
+            </Spin>
+          </Space>
+        </Form>
       </Modal>
 
       <Modal

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -3375,7 +3375,7 @@ export function KnowledgePage({
                     <Alert
                       type="info"
                       showIcon
-                      message="Namespaces are the Knowledge RBAC boundary. Use the workspace fallback for broad access; user/group-specific grants are available through the backend and will get a richer UI next."
+                      message="Namespaces are the Knowledge RBAC boundary. Use the workspace fallback for broad access, and add specific user or group grants below when access should be narrower."
                     />
                     {namespaceError && <Alert type="error" showIcon message={namespaceError} />}
                     <Flex justify="space-between" align="center">
@@ -3393,41 +3393,45 @@ export function KnowledgePage({
                       size="small"
                       dataSource={namespaces}
                       locale={{ emptyText: 'No readable namespaces' }}
-                      renderItem={(namespace) => (
-                        <List.Item
-                          actions={[
-                            <Button
-                              key="edit"
-                              size="small"
-                              onClick={() => openNamespaceEditor(namespace)}
-                            >
-                              Edit
-                            </Button>,
-                            <Button
-                              key="archive"
-                              size="small"
-                              danger
-                              disabled={namespace.kind === 'system'}
-                              onClick={() => archiveNamespace(namespace)}
-                            >
-                              Archive
-                            </Button>,
-                          ]}
-                        >
-                          <List.Item.Meta
-                            title={
-                              <Space wrap>
-                                <Text strong>{namespace.display_name || namespace.slug}</Text>
-                                <Tag>{namespace.slug}</Tag>
-                                <Tag color={namespace.others_can === 'none' ? 'default' : 'blue'}>
-                                  others: {namespace.others_can}
-                                </Tag>
-                              </Space>
-                            }
-                            description={namespace.description || 'No description'}
-                          />
-                        </List.Item>
-                      )}
+                      renderItem={(namespace) => {
+                        const canManageNamespace = namespace.effective_permission === 'own';
+                        return (
+                          <List.Item
+                            actions={[
+                              <Button
+                                key="edit"
+                                size="small"
+                                disabled={!canManageNamespace}
+                                onClick={() => openNamespaceEditor(namespace)}
+                              >
+                                Edit
+                              </Button>,
+                              <Button
+                                key="archive"
+                                size="small"
+                                danger
+                                disabled={!canManageNamespace || namespace.kind === 'system'}
+                                onClick={() => archiveNamespace(namespace)}
+                              >
+                                Archive
+                              </Button>,
+                            ]}
+                          >
+                            <List.Item.Meta
+                              title={
+                                <Space wrap>
+                                  <Text strong>{namespace.display_name || namespace.slug}</Text>
+                                  <Tag>{namespace.slug}</Tag>
+                                  <Tag color={namespace.others_can === 'none' ? 'default' : 'blue'}>
+                                    others: {namespace.others_can}
+                                  </Tag>
+                                </Space>
+                              }
+                              description={namespace.description || 'No description'}
+                            />
+                          </List.Item>
+                        );
+                      }}
                     />
                   </Space>
                 ),

--- a/context/README.md
+++ b/context/README.md
@@ -52,6 +52,8 @@ Designs that are referenced from code or in flight. Anything here is either stil
 - [`executor-implementation-plan.md`](explorations/executor-implementation-plan.md) — phased plan for executor work.
 - [`env-var-access.md`](explorations/env-var-access.md) — per-user / per-session env var access model (referenced from schemas, types, and migrations).
 - [`kb-agent-targeted-edits.md`](explorations/kb-agent-targeted-edits.md) — design proposal for small, version-checked agent edits to large Knowledge Base markdown documents.
+- [`kb-assistant-framework-integration.md`](explorations/kb-assistant-framework-integration.md) — options for backing Agor Assistant framework memory/docs/skills with Knowledge Base namespaces and tools.
+- [`kb-namespace-rbac-v1.md`](explorations/kb-namespace-rbac-v1.md) — directed V1 plan for Knowledge namespace RBAC and Assistant home namespaces.
 - [`session-sharing.md`](explorations/session-sharing.md) — `dangerously_allow_session_sharing` security contract (referenced from `AGENTS.md` and `apps/agor-docs/pages/security.mdx`).
 - [`parent-session-callbacks.md`](explorations/parent-session-callbacks.md) — child-session completion notifications (referenced from `docs/never-lose-prompt-design.md`).
 

--- a/context/explorations/kb-assistant-framework-integration.md
+++ b/context/explorations/kb-assistant-framework-integration.md
@@ -1,0 +1,456 @@
+# Knowledge Base Assistant Framework Integration
+
+**Date:** 2026-06-07  
+**Scope:** How Agor Knowledge Base should support the `preset-io/agor-assistant` file-based assistant framework. This is an options/design note, not an implementation PR.
+
+## Current state inspected
+
+Agor KB today is DB-backed markdown with namespaces, immutable document versions, internal search units, optional semantic embeddings, graph links, MCP tools, and a UI page:
+
+- Types: `packages/core/src/types/knowledge.ts`
+- Schema/repositories: `packages/core/src/db/schema.{sqlite,postgres}.ts`, `packages/core/src/db/repositories/knowledge.ts`
+- Services: `apps/agor-daemon/src/services/knowledge-*.ts`
+- MCP tools: `apps/agor-daemon/src/mcp/tools/knowledge.ts`
+- UI: `apps/agor-ui/src/pages/KnowledgePage.tsx`, `components/KnowledgeGraph/`, `AutocompleteTextarea/kbMentions.ts`
+- Existing agent-editing design: `context/explorations/kb-agent-targeted-edits.md`
+
+The public `preset-io/agor-assistant` framework is a markdown file manifold. Its core files are `AGENTS.md`, `BOOT.md`, `BOOTSTRAP.md`, `IDENTITY.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, `BOARD.md`, `HEARTBEAT.md`, `TOOLS.md`, `skills/`, and daily logs under `memory/YYYY-MM-DD.md`. It currently tells agents that filesystem files are state/memory, and git is backup.
+
+## Recommendation summary
+
+1. **Give every Agor Assistant branch an assigned KB namespace.** Store the namespace slug/id in `branch.custom_context.assistant.kb` and mirror it on the KB namespace as `kind: "branch"`, `branch_id`, and metadata identifying it as assistant-owned.
+2. **Make context-aware assistant tools the default write path.** Generic `agor_kb_put`, `agor_kb_edit`, and `agor_kb_search` should remain, but assistants should mostly call higher-level tools such as `agor_assistant_memory_append` and `agor_assistant_kb_search` that infer the assistant namespace from the current MCP session's branch.
+3. **Default assistant operational KB to private.** Public assistants/docs should be opt-in. If an assistant/branch is private, assistant memory writes should force `visibility: "private"` and `edit_policy: "owner"` or a branch-scoped equivalent once KB ACLs exist.
+4. **Seed, then decouple KB ACLs from branch ACLs.** Assistant namespaces should be initialized from branch ownership/visibility, but KB should own its own permission model after that. Branch changes may offer an explicit sync/apply action, but KB reads/writes should not virtualize every decision through branch RBAC forever.
+5. **Migrate by layering KB over files, not replacing files immediately.** Keep the framework repo as portable bootstrap/instructions/skills scaffolding. Move volatile/personal memory and curated docs into KB gradually, with a filesystem fallback/export path.
+6. **Use append-only daily memory docs with deterministic block IDs.** Append one logical memory entry as one stable markdown block under `memory/YYYY-MM-DD.md`. Chunk/index by explicit block boundaries first, then headings/auto-split as fallback. Reuse unchanged block hashes across versions so only new/changed chunks require embeddings.
+
+## Product model
+
+### Assistant namespace
+
+**Recommended shape:** one operational namespace per assistant branch.
+
+```ts
+// branch.custom_context.assistant.kb (proposed)
+{
+  namespace_id: string;
+  namespace_slug: string; // e.g. assistant-private-coachbot or assistant-<branch-short-id>
+  visibility_default: 'private' | 'public';
+  memory_path_template: 'memory/{{YYYY-MM-DD}}.md';
+  docs_root: 'docs/';
+  skills_root: 'skills/';
+  policy: 'private' | 'branch' | 'public';
+}
+```
+
+Use the existing `kb_namespaces` columns where possible:
+
+- `kind: "branch"` for assistant namespaces in V1 because assistants are branch-backed today.
+- `branch_id` set to the assistant branch.
+- `owner_user_id` and `created_by` from the assistant creator.
+- `visibility_default: "private"` unless explicitly public/team.
+- `metadata.assistant = { displayName, frameworkRepo, branchId }` for discovery and migrations.
+
+**Slug:** deterministic and stable, preferably `assistant-<branchShortId>` or `assistant-<sanitized-branch-name>-<branchShortId>`. Human display name can change; slugs should not.
+
+### Namespace assignment options
+
+| Option                                     | Summary                                                                                                       | Pros                                            | Cons                                                                         | Recommendation                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------- |
+| A. Instruction-driven only                 | Tell agents to use a namespace in `AGENTS.md`/bootstrap prompt.                                               | No backend work.                                | Easy to forget, unsafe defaults, brittle across tools/models.                | Not enough.                   |
+| B. Configured per assistant                | Store namespace in assistant config and show it in UI.                                                        | Explicit, portable, discoverable.               | Generic tools can still write elsewhere by mistake.                          | Necessary but not sufficient. |
+| C. Tool-enforced context                   | Assistant tools infer namespace from current session/branch and do not accept arbitrary namespace by default. | Safest UX; fewer prompt tokens; better privacy. | Needs session context and resolver.                                          | Recommended default.          |
+| D. Fully forced namespace for all KB tools | Generic KB tools silently rewrite/force namespace.                                                            | Strong isolation.                               | Surprising for legitimate cross-namespace docs/search; bad admin/tooling UX. | Avoid.                        |
+
+**Answer:** assign/configure the namespace and make assistant-specific tools enforce it by default. Leave generic KB tools explicit.
+
+### Discovery
+
+Agents should discover their namespace in three ways, in order:
+
+1. **Context-aware MCP:** `agor_assistant_context` returns assistant branch config, board, namespace, privacy policy, and canonical roots.
+2. **Session/branch reads:** existing `agor_sessions_get_current` / branch tools can expose `branch.custom_context.assistant.kb` once populated.
+3. **Bootstrap instructions:** `BOOT.md` / `AGENTS.md` in the framework should say: first call assistant context; do not hard-code namespace slugs.
+
+### Assistant Knowledge settings
+
+The product control point should be an Assistant/Branch modal **Knowledge** tab, with a compact summary also reachable from `BranchCard -> Permissions`. This tab should configure the assistant's KB capability envelope, not just display a namespace.
+
+Suggested settings:
+
+- **Primary namespace:** assigned assistant namespace and deep link.
+- **Namespace visibility:** private/public/default sharing policy for new documents.
+- **Write confinement:** whether the assistant can write only to its namespace, to selected namespaces, or anywhere the operator/user can write.
+- **Read scope:** own namespace only, own + selected shared namespaces, or all namespaces the caller can read.
+- **Publish policy:** whether the assistant may publish analysis/docs to shared/public namespaces, and whether that requires confirmation.
+- **Search scope default:** own namespace first, selected shared namespaces, or all readable KB.
+- **ACL sync action:** optional "seed/update from branch permissions" button, instead of invisible virtual coupling.
+
+This gives operators an explicit way to tighten guarantees for high-trust assistants. A personal assistant can be confined to its private namespace. A documentation assistant can be allowed to publish into a team namespace. A repo assistant can read a broad corpus but only write under its assigned branch/assistant namespace.
+
+### Effective operating user
+
+The assistant KB policy should be evaluated against an **effective operating user**. Agor already has this concept in practice:
+
+- Interactive sessions run as the session creator/caller.
+- Schedules run as `schedules.created_by`; schedule creation injects the caller as `created_by`, and run/patch guards prevent normal users from changing or manually running another user's schedule.
+- Gateway sessions resolve an effective user from platform-user alignment when enabled; otherwise they use the configured channel `agor_user_id` ("Post messages as"). Alignment failures are rejected rather than silently falling back.
+
+That means assistant KB grants are not independent capabilities. They are an assistant-specific **allowlist intersected with the effective user's KB rights**:
+
+```text
+effective_access = assistant_policy_scope ∩ effective_user_kb_access
+```
+
+If an operator grants the assistant "Super Private Namespace" but the effective operating user cannot read it, the assistant cannot read it either. If the assistant is set to "same as operating user", the assistant policy scope is effectively unbounded, but the user's own KB permissions still apply.
+
+## Memory API/tooling
+
+The assistant framework should not ask agents to manually edit a large markdown file for every memory write. Agents are better at “remember this one thing” than at deterministic append/chunk hygiene.
+
+### Proposed MCP/API surface
+
+Add assistant-scoped tools layered on top of the generic KB services:
+
+```ts
+type AssistantMemoryAppendInput = {
+  text: string; // one bullet/observation/decision, plain text or markdown
+  category?: 'note' | 'decision' | 'preference' | 'project' | 'learning' | 'task' | 'other';
+  importance?: 'low' | 'normal' | 'high';
+  date?: string; // YYYY-MM-DD, default server/current session date
+  source?: {
+    sessionId?: string;
+    taskId?: string;
+    branchId?: string;
+    documentId?: string;
+    uri?: string;
+  };
+  tags?: string[];
+  visibility?: 'private' | 'public'; // optional, but bounded by assistant policy
+  idempotencyKey?: string; // optional caller-supplied de-dupe key
+};
+
+type AssistantMemoryAppendResult = {
+  namespace: { namespace_id: string; slug: string };
+  document: { document_id: string; path: string; uri: string; visibility: string };
+  entry: {
+    entry_id: string;
+    block_hash: string;
+    date: string;
+    ordinal: number;
+  };
+  baseVersion?: KnowledgeVersionToken;
+  newVersion: KnowledgeVersionToken;
+};
+```
+
+MCP tool names:
+
+- `agor_assistant_context` — read-only, current session required.
+- `agor_assistant_memory_append` — append one memory entry to the current assistant namespace.
+- `agor_assistant_memory_search` — search current assistant memories, defaulting to `kind: "memory"` and `pathPrefix: "memory/"`.
+- `agor_assistant_kb_search` — search current assistant namespace plus optional explicitly named shared namespaces.
+- Later: `agor_assistant_memory_promote` to curate daily notes into `MEMORY.md`/`memory/curated.md` style docs.
+
+REST/service shape can be `/assistant/context`, `/assistant/memory` or `/kb/assistant-memory`. Prefer a KB-adjacent service if it mainly wraps KB documents, but use “assistant” in MCP names because that is the agent-facing product concept.
+
+### Relationship to generic KB tools
+
+- `agor_kb_put`: create/update whole documents. Good for docs, guides, skills, and imports.
+- `agor_kb_edit`: deterministic targeted edits. Good for curated memory or docs.
+- `agor_assistant_memory_append`: append-only semantic memory primitive. It should internally call repository/service helpers, not ask the model for `KnowledgeEditOp[]`.
+- `agor_kb_search`: cross-KB explicit search.
+- `agor_assistant_*_search`: opinionated search with namespace and privacy defaults.
+
+The generic tools should remain available because assistants sometimes need shared/team docs. The assistant tools should be the happy path and should return enough URI/reference metadata for graph links.
+
+## Privacy and visibility defaults
+
+### Recommended defaults
+
+- Assistant operational namespace: **private by default**.
+- Daily memories: **private by default**.
+- `IDENTITY`, `SOUL`, `USER`, long-term memory, and learned preferences: **private by default**.
+- Framework/template docs and generic skills: public or shared only when intentionally published outside the assistant namespace.
+- If an assistant branch is private or `others_can: "none"`, assistant memory writes should **force private**.
+- If an assistant is configured as team/shared, writes may default to private-to-team/branch once KB has richer ACLs; until then, use document `visibility: "private"` plus owner/admin access or `public` only by explicit config.
+
+### Why private by default
+
+The assistant framework accumulates `USER.md`, preferences, operational logs, repo names, external-system notes, PR context, and sometimes personal data. The public `agor-assistant` repo itself warns that public backup of assistant state is unsafe. KB should not recreate that footgun with public default visibility.
+
+### Context-aware defaults
+
+Assistant MCP tools should infer defaults from current context:
+
+1. Resolve current session (`ctx.sessionId`).
+2. Load its branch.
+3. If branch is an assistant, load `branch.custom_context.assistant.kb`.
+4. Apply namespace and visibility policy.
+5. Reject or warn on attempted broadening (`visibility: public`) unless config permits it.
+
+If there is no current session context, assistant-scoped write tools should fail with the same style of actionable error as existing session-context tools.
+
+## Operational area, ACLs, and search scope
+
+### Namespace/place
+
+Create a special KB operational area per assistant namespace:
+
+```text
+agor://kb/assistant-<branch-short-id>/
+  identity/identity.md      # optional migrated IDENTITY.md
+  identity/soul.md          # optional migrated SOUL.md
+  identity/user.md          # optional migrated USER.md
+  memory/YYYY-MM-DD.md      # append-only daily notes
+  memory/curated.md         # optional distilled long-term memory
+  memory/learnings/*.md     # optional lessons
+  docs/*.md                 # assistant-owned docs
+  skills/*.md               # assistant-owned markdown skills
+  prompts/*.md              # reusable prompts/templates
+  ops/board.md              # optional migrated BOARD.md
+  ops/tools.md              # optional migrated TOOLS.md
+```
+
+Do **not** create a new namespace per branch the assistant works on by default. Most delegated coding branches are work products, not the assistant's own mind. Use links/graph edges from memory entries to branch/session/task nodes instead.
+
+Per-work branch namespaces can still exist for project docs (`kind: "branch"`, `branch_id`), but they should be separate from the assistant operational namespace.
+
+### Access coupling
+
+Current KB permissions are document-level `visibility` plus owner/admin/public-edit. Namespaces have `owner_user_id`, `repo_id`, `branch_id`, and visibility defaults, but no ACL table. Branch RBAC has richer semantics behind `execution.branch_rbac`.
+
+**Recommendation:** do **not** virtualize KB ACLs entirely through branch RBAC. Use branch context to seed namespace ACLs and for helpful UI affordances, but let KB have its own durable security model.
+
+Why:
+
+- KB documents can outlive or move beyond a branch.
+- Assistants may intentionally publish docs into team/global spaces.
+- A collaborator may have access to an assistant without being its primary owner.
+- Search needs a simple rule: return everything the searching user can read, regardless of which branch originally seeded access.
+- Branch visibility changes should not silently expose or hide sensitive KB memories unless the operator intentionally applies that policy.
+
+**Current limitation:** KB has only document-level `public`/`private`, owner/admin checks, and public-edit policy. It does not yet have real namespace ACLs. That makes "explicit namespace grants" impossible to model precisely without adding ACL tables or a permission resolver.
+
+**V1 pragmatic rule before KB ACL tables exist:**
+
+- To read/write assistant-scoped KB through assistant tools, caller must be able to access the current assistant session/branch and satisfy document ownership/visibility checks.
+- Assistant-owned private docs are created by the assistant branch/session creator. Admins can read/manage.
+- For shared assistants, add an explicit assistant KB policy in `AssistantConfig` rather than assuming branch access means memory access.
+
+**V2 target:** add KB namespace/document ACLs or namespace owners/members, seeded from branch owners but not permanently virtualized from them:
+
+- `owner`: creator/admins and explicit namespace owners.
+- `read`: branch owners and possibly users with branch `view`, depending on assistant policy.
+- `write-memory`: assistant sessions and users with branch `prompt`/`all`, or explicit namespace write.
+- `manage`: owners/admins.
+
+Branch UI can include "Apply branch permissions to KB namespace" or "Keep in sync" as an explicit policy, but the default should be **seed-on-create** plus independent KB management.
+
+### Search scope
+
+Search should be user-access scoped, not assistant-owner scoped:
+
+- A normal KB search returns documents the current user can read across all namespaces.
+- Assistant-scoped search applies the assistant's configured read scope first, then the user's KB ACLs.
+- If a user has access to an assistant but is not the primary assistant owner, they should still find that assistant's shared/readable memories/docs according to the assistant namespace ACL.
+- Private assistant memories should not appear in broad search unless the user has explicit KB read access to that namespace/document.
+
+This implies KB search cannot rely only on `document.visibility === public OR created_by === user`. It eventually needs namespace/document ACL joins (or a permission resolver) so shared assistant access is represented without making documents public.
+
+### Capability guarantees
+
+Generic KB tools are intentionally loosely coupled: an assistant can publish a design note into `global`, a team namespace, or its own namespace if the caller has permission. That flexibility is useful, but it is not a strong safety boundary.
+
+Stronger guarantees should come from an assistant KB capability policy enforced by assistant-aware tools:
+
+```ts
+type AssistantKnowledgePolicy = {
+  primaryNamespaceId: string;
+  defaultVisibility: 'private' | 'public';
+  readScope:
+    | { mode: 'own_namespace' }
+    | { mode: 'selected_namespaces'; namespaceIds: string[] }
+    | { mode: 'all_user_readable' };
+  writeScope:
+    | { mode: 'own_namespace' }
+    | { mode: 'selected_namespaces'; namespaceIds: string[] }
+    | { mode: 'all_user_writable' };
+  publicPublish: 'forbidden' | 'confirm' | 'allowed';
+};
+```
+
+Assistant tools should use this policy to choose defaults and reject out-of-scope writes. Generic `agor_kb_*` tools can remain powerful/admin-like, but assistants should be instructed and UI-configured to prefer the assistant tools when operating on memory or assistant-owned docs.
+
+Selected namespace grants should carry desired assistant capability (`read` or `read_write`) but must still be checked against the effective user's actual KB capability at request time. They are not a way to mint rights the user does not have.
+
+## Deterministic memory append and chunking
+
+### Document format
+
+Daily memory docs should be valid markdown, append-mostly, and deterministic. Proposed format:
+
+```markdown
+# Memory — 2026-06-07
+
+<!-- agor-memory:v1 date=2026-06-07 -->
+
+<!-- agor-memory-entry id=01J... ordinal=000001 sha256=... -->
+
+- 2026-06-07T14:23:11Z [decision] User prefers review-first PR workflow. (source: agor://session/...)
+<!-- /agor-memory-entry -->
+
+<!-- agor-memory-entry id=01J... ordinal=000002 sha256=... -->
+
+- 2026-06-07T15:01:04Z [learning] For repo preset-io/agor, do not run `pnpm build` unless asked.
+<!-- /agor-memory-entry -->
+```
+
+Rules:
+
+- One API call appends one block.
+- Server assigns `entry_id`, timestamp, ordinal, and `sha256` over normalized block payload.
+- Server creates the daily document if missing: path `memory/YYYY-MM-DD.md`, kind `memory`, title from date.
+- Existing blocks are never rewritten except for explicit repair/migration tools.
+- Repeated calls with the same `idempotencyKey` return the prior entry.
+- If concurrent appends race, the service retries against the latest version and preserves both entries.
+
+### Chunking/indexing implications
+
+Current indexing regenerates units per new document version and unit IDs include `version_id`, so unchanged chunks in a new version become new unit IDs and are re-embedded. That is acceptable for small docs but inefficient for daily append logs.
+
+For assistant memory, use explicit block-aware units:
+
+```ts
+unit.identity_key = `memory-entry:${entry_id}`;
+unit.content_sha256 = sha256(normalizedEntryText);
+unit.metadata = {
+  chunker_version: 'agor-memory-v1',
+  entry_id,
+  date,
+  ordinal,
+  category,
+  source,
+};
+```
+
+Recommended indexing evolution:
+
+1. Add a memory-specific chunker that recognizes `agor-memory-entry` blocks and produces one unit per entry or per small batch of adjacent entries.
+2. Make unit identity independent of `version_id` for block-addressed append-only units, or add a reuse step that copies embedding rows from the previous unit with the same `identity_key + content_sha256 + embedding_space`.
+3. Mark only new/changed units as `pending`; unchanged units should be `ready` immediately by reusing previous embedding metadata/vector.
+4. Keep the existing markdown heading/auto-split chunker as fallback for normal docs and legacy memory files.
+
+This avoids recomputing embeddings for yesterday's unchanged entries every time today gets one more note.
+
+## Framework migration
+
+### What should stay file-based
+
+Keep the assistant repo useful without Agor KB:
+
+- `AGENTS.md` / `BOOT.md`: startup instructions and fallback behavior.
+- `BOOTSTRAP.md`: first-run ritual, updated to initialize KB when available.
+- Minimal `IDENTITY.md`, `SOUL.md`, `USER.md`, `BOARD.md`, `TOOLS.md`: local bootstrap/cache/export for agent platforms that do not have Agor KB.
+- `skills/`: portable markdown skills and any platform-native skill packaging.
+- Git backup docs: still useful for file-mode and for framework/template evolution.
+
+### What should move to KB first
+
+- Daily raw memory (`memory/YYYY-MM-DD.md`) via `agor_assistant_memory_append`.
+- Curated long-term memory (`MEMORY.md`) as KB docs, edited with `agor_kb_edit` or future curate/promote tools.
+- Assistant-specific docs/prompts/board notes that benefit from search/graph links.
+- Assistant-specific markdown skills that should be searchable/discoverable across sessions.
+
+### Compatibility strategy
+
+1. **Dual-read, KB-preferred:** BOOT says: call `agor_assistant_context`; if KB is configured, read/search KB memory; otherwise read files.
+2. **Dual-write optional:** During migration, append memory to KB and optionally materialize/export to files for backup/local readability.
+3. **Filesystem export:** Provide `agor_assistant_kb_export` or reuse `agor_kb_materialize` to write KB snapshots into the assistant worktree for offline/local agents.
+4. **Import path:** On first KB enablement, import existing `MEMORY.md`, `memory/*.md`, and selected identity files into the assigned namespace with provenance metadata.
+5. **No breaking local workflows:** If Agor KB is off or unavailable, the public framework continues exactly as file-mode today.
+
+## Options and tradeoffs
+
+### Memory storage options
+
+| Option                      | Pros                                                    | Cons                                                                       | Verdict                     |
+| --------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------- | --------------------------- |
+| Continue file-only          | Portable; simple; git backup works.                     | Poor cross-session search; public-backup footgun; no graph/ACL/version UI. | Keep as fallback only.      |
+| Whole-doc KB put from agent | Uses existing API.                                      | Model must manage append formatting/concurrency; re-embeds too much.       | Not recommended for memory. |
+| Targeted KB edit append     | Uses `agor_kb_edit`; version-checked.                   | Still exposes markdown mechanics to agent; concurrency retries awkward.    | Useful intermediate.        |
+| Dedicated memory append API | Safe, small inputs, deterministic chunks, policy-aware. | New service/tool.                                                          | Recommended.                |
+
+### Namespace options
+
+| Option                         | Pros                                              | Cons                                                             | Verdict                                           |
+| ------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------- |
+| One global assistant namespace | Easy browsing.                                    | Cross-assistant privacy and collisions.                          | Avoid.                                            |
+| Per-user namespace             | Good for personal memories.                       | Assistants become folders; hard to delegate/share one assistant. | Useful shared search scope, not operational home. |
+| Per-assistant branch namespace | Matches current assistant model; isolates memory. | Needs namespace provisioning and config.                         | Recommended.                                      |
+| Per-working-branch namespace   | Good for project docs.                            | Fragments assistant identity/memory.                             | Supplemental only.                                |
+
+## Implementation phases
+
+### Smallest first PR
+
+1. Extend `AssistantConfig` with optional `kb` metadata in `packages/core/src/types/branch.ts`.
+2. On assistant creation, create or ensure a private KB namespace linked to the assistant branch (`kind: "branch"`, `branch_id`, metadata) and store it in `custom_context.assistant.kb`.
+3. Add a minimal assistant KB policy object: primary namespace, default visibility, read scope, write scope, public publish policy.
+4. Add `agor_assistant_context` MCP tool that resolves current session → branch → assistant config → namespace and returns policy/default roots.
+5. Update assistant bootstrap prompt/framework docs to prefer `agor_assistant_context` and KB when present, while preserving file fallback.
+
+This gives agents a stable namespace without changing memory writes yet.
+
+### Phase 2: Assistant Knowledge UI
+
+- Add a Branch/Assistant modal **Knowledge** tab.
+- Surface namespace, visibility, read/write scope, public publish policy, and search defaults.
+- Add a compact KB section/link under permissions so branch owners understand the relationship.
+- Add explicit seed/sync action from branch permissions to KB namespace ACLs once ACLs exist.
+
+### Phase 3: memory append
+
+- Add `/kb/assistant-memory` or `/assistant/memory` service.
+- Add `agor_assistant_memory_append` and `agor_assistant_memory_search` MCP tools.
+- Server creates `memory/YYYY-MM-DD.md` docs and appends deterministic blocks.
+- Use existing document versioning/search units initially, even if embeddings are not yet optimized.
+
+### Phase 4: deterministic unit reuse
+
+- Add memory-block chunker.
+- Add reusable unit identity / embedding reuse strategy.
+- Ensure reindex only queues new or changed memory blocks.
+- Add tests proving appending entry N+1 does not enqueue embeddings for entries 1..N.
+
+### Phase 5: migration/export UI
+
+- Assistant settings: show namespace, privacy policy, import/export status.
+- One-click import from assistant worktree memory files to KB.
+- Optional materialize/export for local framework backup.
+- Knowledge page filters/views for Assistant namespaces and Memories.
+
+### Phase 6: ACLs and sharing
+
+- Add namespace/document ACLs or branch-seeded KB memberships. This is likely required to support Assistant Knowledge explicit namespace grants without making documents public.
+- Model team/shared assistants without making personal memories public.
+- Add audit/reporting for assistant KB writes.
+
+## Open questions
+
+1. Is “assistant” ready to become a first-class DB entity, or should it remain branch metadata for now? This design assumes branch metadata for smallest PR.
+2. What exact policy names should assistant KB use: `private`, `branch`, `team`, `public`, or a dedicated read/write scope vocabulary?
+3. Should assistant sessions write memory as the session creator, the assistant owner, or a future assistant principal/service identity?
+4. What is the minimal namespace ACL model: namespace members with `read`/`write`/`manage`, document ACLs, or both?
+5. Should `SOUL.md`/`USER.md` be imported into KB automatically, or only after explicit user confirmation because of sensitivity?
+6. What is the right UI home: Knowledge page filtered by namespace, Assistant settings tab, or both?
+7. How much filesystem materialization is needed for non-Agor agents and local IDE workflows?
+8. Should memory append accept only one bullet by design, or also allow batch append for heartbeat summaries?
+9. Should graph links to sessions/tasks/branches be explicit metadata only in V1, or rendered into markdown as `agor://` URIs?
+10. How should assistant namespace backup/export interact with git backup of the assistant branch?
+11. Should generic `agor_kb_*` tools be policy-aware when called from an assistant session, or should enforcement live only in `agor_assistant_*` tools?
+
+## Bottom line
+
+Make KB the assistant's managed memory substrate, not just a place where agents manually edit markdown. Assign each assistant a private operational namespace, expose context-aware assistant MCP tools, keep generic KB tools for deliberate cross-namespace work, and migrate the file framework gradually so local/file workflows continue to work. Seed KB permissions from branch/assistant ownership, but let KB have its own ACLs and search semantics. The first useful slice is namespace provisioning plus `agor_assistant_context`; the highest-leverage follow-up is an Assistant Knowledge settings tab and deterministic `agor_assistant_memory_append`.

--- a/context/explorations/kb-namespace-rbac-v1.md
+++ b/context/explorations/kb-namespace-rbac-v1.md
@@ -1,0 +1,412 @@
+# Knowledge Namespace RBAC V1
+
+**Date:** 2026-06-07  
+**Scope:** Directed V1 design/implementation plan for Knowledge namespace RBAC and Assistant home namespaces.
+
+## Recommendation
+
+Build V1 around **Knowledge namespaces as the RBAC boundary**.
+
+Do **not** make assistants first-class KB ACL subjects in V1. Do **not** add per-document ACLs in V1. Do **not** implement assistant-vs-user permission intersections in V1 beyond the existing fact that every session already runs as a concrete user.
+
+Instead:
+
+1. Add namespace-level permissions for **users and groups**.
+2. Give each namespace an `others_can` fallback for everyone else in the workspace: `none | read | write`.
+3. Keep document-level `visibility` / `edit_policy` as a narrower document-level overlay for now.
+4. Add **Knowledge -> Settings -> Namespaces** CRUD and permission UI.
+5. Add **BranchModal -> Knowledge** for assistant branches, with a configurable **home namespace**.
+6. Treat assistant-specific namespace access restrictions as future work.
+
+This keeps the V1 mental model simple:
+
+```text
+Can this user access this namespace?
+  yes -> apply document visibility/edit policy
+  no  -> no KB access
+```
+
+For assistant sessions, the operating user already exists. In V1, assistants borrow that user's KB permissions, and the assistant's home namespace is a default operating location, not a separate security principal.
+
+## Goals
+
+- Make KB namespace ownership and sharing explicit.
+- Support private/team/shared KB spaces without relying on doc-level `public/private` alone.
+- Make namespace management visible in the product UI.
+- Give every assistant a clear home namespace for memory/docs/skills.
+- Avoid a complex dual-principal user+assistant RBAC model in V1.
+- Avoid “RBAC on RBAC” and nested authority debates.
+
+## Non-goals for V1
+
+- Assistants as namespace ACL subjects.
+- Mixed groups containing assistants.
+- Assistant-specific read/write restrictions outside home namespace.
+- Per-document ACL overrides beyond the existing document fields.
+- Branch/worktree RBAC changes.
+- Namespace permission inheritance from arbitrary org structures.
+
+## Current state
+
+Current KB permissions are document-centric:
+
+- `kb_namespaces` has identity/metadata fields (`slug`, `display_name`, `description`, `kind`, `owner_user_id`, `repo_id`, `branch_id`, `visibility_default`) but no real ACL table.
+- `kb_documents.visibility` is `public | private`.
+- `kb_documents.edit_policy` is `owner | public | admins`.
+- Services generally allow reads when a document is public, the caller is admin, or the caller created it.
+- Services generally allow edits when caller is admin, creator, or the document is public-editable.
+- Search similarly scopes by document visibility/creator/admin.
+
+This is not enough to model “private namespace readable/writable by this group.”
+
+## Namespace permission model
+
+### Namespace fields
+
+Add an `others_can`-style permission to namespaces:
+
+```ts
+type KnowledgeNamespaceOthersCan = 'none' | 'read' | 'write';
+```
+
+Suggested namespace additions:
+
+```ts
+interface KnowledgeNamespace {
+  // existing fields...
+  others_can: 'none' | 'read' | 'write';
+}
+```
+
+Semantics:
+
+| Level   | Meaning                                                                                         |
+| ------- | ----------------------------------------------------------------------------------------------- |
+| `none`  | Users not named in ACL cannot read/search/write namespace docs.                                 |
+| `read`  | Everyone in the workspace can read/search namespace docs, subject to doc visibility.            |
+| `write` | Everyone in the workspace can read/search and write namespace docs, subject to doc edit policy. |
+
+`write` implies `read`. `own` is not available as an `others_can` value.
+
+### Namespace ACL entries
+
+Add a namespace ACL table for users and groups:
+
+```ts
+type KnowledgeNamespaceSubjectType = 'user' | 'group';
+type KnowledgeNamespacePermission = 'read' | 'write' | 'own';
+
+interface KnowledgeNamespaceAclEntry {
+  namespace_acl_id: UUID;
+  namespace_id: KnowledgeNamespaceID;
+  subject_type: KnowledgeNamespaceSubjectType;
+  subject_id: UserID | GroupID;
+  permission: KnowledgeNamespacePermission;
+  created_by?: UserID | null;
+  created_at: Date;
+  updated_at?: Date | null;
+}
+```
+
+Permission semantics:
+
+| Permission | Meaning                                                               |
+| ---------- | --------------------------------------------------------------------- |
+| `read`     | List/search/get public docs in the namespace.                         |
+| `write`    | Read plus create/update/archive docs allowed by document edit policy. |
+| `own`      | Write plus manage namespace metadata and namespace ACLs.              |
+
+`own` implies `write`; `write` implies `read`.
+
+### Effective namespace permission
+
+For a given user:
+
+```text
+effective_namespace_permission = max(
+  direct user ACL,
+  ACLs from groups containing user,
+  namespace.others_can,
+  admin override
+)
+```
+
+Admins/superadmins retain manage access.
+
+### Groups
+
+V1 should reuse or extend existing user groups only if they are already a workspace-level user collection. Groups remain **user groups** in V1.
+
+Do not add assistants to groups in V1. If future KB-specific mixed groups are needed, add them intentionally rather than expanding every product's group semantics implicitly.
+
+## Document permissions under namespace RBAC
+
+Namespace RBAC is the outer gate. Existing document fields remain a narrower overlay.
+
+### Read
+
+A user can read a document when:
+
+1. User has namespace `read` or higher; and
+2. Document is readable by existing document rule:
+   - `visibility = public`, or
+   - caller created it, or
+   - caller is admin.
+
+This preserves current private-document semantics.
+
+Product note: in a private/team namespace, most shared docs should use `visibility = public`; the namespace ACL is what makes the doc non-public to the broader workspace. The word `public` becomes “public within this namespace's allowed audience,” not necessarily internet/workspace public.
+
+Possible future cleanup: rename document `visibility` to something less globally loaded, such as `scope = namespace | owner`, but do not do that in V1.
+
+### Write
+
+A user can write a document when:
+
+1. User has namespace `write` or `own`; and
+2. Existing document edit rule permits the write:
+   - caller created it, or
+   - caller is admin, or
+   - document is namespace-public-editable (`visibility = public` and `edit_policy = public`).
+
+Interpret `edit_policy = public` as “editable by namespace writers,” not literally any authenticated user, once namespace RBAC exists.
+
+### Manage namespace
+
+A user can manage namespace settings and permissions when:
+
+- user has namespace `own`, or
+- user is admin/superadmin.
+
+Namespace creator should receive `own` automatically.
+
+## UI: Knowledge -> Settings -> Namespaces
+
+Add namespace CRUD under Knowledge settings.
+
+### Namespace list
+
+Show:
+
+- Display name
+- Slug
+- Kind
+- Description preview
+- `others_can`
+- Current user's effective permission
+- Document count
+- Updated time
+
+Actions:
+
+- Create namespace
+- Edit namespace
+- Archive namespace
+- Open namespace
+
+### Namespace editor
+
+Two tabs:
+
+#### General
+
+- Name/display name
+- Slug (immutable after create)
+- Description as markdown
+- Kind (`global`, `team`, `repo`, `branch`, etc.)
+- Optional owner/repo/branch linkage where relevant
+- Default document visibility/status/edit policy
+
+#### Permissions
+
+- `Everyone else in workspace`: `none | read | write`
+- Accumulator of users and groups
+- Each entry has permission: `read | write | own`
+- Effective permission preview for current user
+
+Validation:
+
+- At least one owner/admin path must remain.
+- Cannot remove your own last `own` path unless admin.
+- `write` and `own` imply read in UI.
+
+## UI: Assistant BranchModal -> Knowledge tab
+
+For assistant branches, add a new `Knowledge` tab.
+
+V1 fields:
+
+- **Home namespace** selector/creator.
+- Namespace display summary: slug, visibility/defaults, current user's permission.
+- Link to open namespace in Knowledge.
+- Link to edit namespace permissions if user has `own`.
+- Explanatory note:
+  > This assistant uses its home namespace as the default place for memory, docs, skills, and prompts. In V1, assistant sessions use the operating user's Knowledge permissions. Future versions may allow assistant-specific namespace restrictions.
+
+Behavior:
+
+- On assistant creation, create a home namespace by default.
+- Store home namespace on `branch.custom_context.assistant.kb`.
+- Assistant-aware tools use home namespace as default destination.
+- Generic KB tools remain namespace-explicit.
+
+### Assistant home namespace defaults
+
+Default slug:
+
+```text
+assistant-<branch-short-id>
+```
+
+Default display name:
+
+```text
+<Assistant display name> Knowledge
+```
+
+Default permissions should be conservative:
+
+- `others_can = none`
+- assistant branch creator/owner gets namespace `own`
+- optionally seed branch owners as namespace `own` when branch RBAC is enabled
+
+Do not attempt to mirror branch `others_can` automatically in V1. Provide explicit UI to change namespace permissions.
+
+## Services/API changes
+
+### Core types
+
+Update `packages/core/src/types/knowledge.ts`:
+
+- Add `KnowledgeNamespaceOthersCan`.
+- Add `KnowledgeNamespacePermission`.
+- Add `KnowledgeNamespaceAclEntry`.
+- Add optional namespace permission summaries for API/UI.
+
+### Database
+
+Add migrations for sqlite/postgres:
+
+- `kb_namespaces.others_can` defaulting to `read` or `write` for existing global-like namespaces, but `none` for newly created assistant namespaces.
+- `kb_namespace_acl` table.
+- Indexes on `(namespace_id)`, `(subject_type, subject_id)`, and unique `(namespace_id, subject_type, subject_id)`.
+
+Migration question: what should existing namespaces default to? To preserve current open-ish behavior, `global` may need `others_can = read` or `write` depending on how much public-edit behavior exists. New assistant namespaces should default to `none`.
+
+### Repositories
+
+Add repository methods:
+
+- `listNamespaceAcl(namespaceId)`
+- `upsertNamespaceAclEntry(namespaceId, subjectType, subjectId, permission)`
+- `removeNamespaceAclEntry(namespaceId, subjectType, subjectId)`
+- `resolveNamespacePermission(namespaceId, userId)`
+- `findReadableNamespaceIds(userId)` or query helper for search
+
+### Services
+
+Update KB services to enforce namespace permission:
+
+- `kb/namespaces`
+  - create: creator gets `own`
+  - patch/update/remove: require `own` or admin
+  - find/get: return namespaces caller can read/manage, plus permission summaries
+- `kb/documents`
+  - create: require namespace `write`
+  - get/find: require namespace `read` plus doc visibility
+  - patch/update/remove: require namespace `write` plus doc edit policy
+- `kb/search`
+  - filter by namespaces user can read
+- `kb/graph`
+  - only include nodes/edges for readable documents/namespaces
+- `kb/document-edits`
+  - require namespace `write` plus doc edit policy
+
+### MCP tools
+
+Existing tools should continue to work but respect namespace RBAC:
+
+- `agor_kb_namespaces_list`: list readable namespaces and effective permission.
+- `agor_kb_namespace_put`: create/update when permitted.
+- `agor_kb_put`, `agor_kb_edit`, `agor_kb_publish_from_worktree`: require namespace write.
+- `agor_kb_search`: search all readable namespaces by default.
+
+Add or extend tools for namespace permissions only if useful for agents/admins:
+
+- `agor_kb_namespace_acl_get`
+- `agor_kb_namespace_acl_set`
+
+These should require namespace `own` or admin.
+
+## Search behavior
+
+Default KB search should search **everything the current user can read**.
+
+Filters:
+
+- namespace slug/id
+- path prefix
+- kind/status/visibility
+- mode text/semantic/hybrid
+
+Search must apply namespace permissions before document visibility.
+
+For assistant sessions in V1, search is still user-scoped because assistant-specific restrictions are future work. Assistant-aware search tools can default to the assistant's home namespace first, but they should not introduce a separate security model yet.
+
+## Implementation phases
+
+### Phase 1: namespace RBAC data model
+
+- Add types.
+- Add schema/migrations.
+- Add repository helpers.
+- Add tests for permission resolution.
+
+### Phase 2: service enforcement
+
+- Enforce namespace read/write/own in `kb/namespaces`, `kb/documents`, `kb/search`, `kb/graph`, and `kb/document-edits`.
+- Preserve current document visibility/edit-policy behavior as an overlay.
+- Add tests for namespace ACL + document visibility combinations.
+
+### Phase 3: Knowledge settings UI
+
+- Add Namespaces CRUD under Knowledge settings.
+- Add General and Permissions tabs.
+- Add users/groups accumulator with read/write/own.
+- Add effective permission display.
+
+### Phase 4: Assistant home namespace
+
+- Extend `AssistantConfig` with optional KB home namespace metadata.
+- Create default home namespace on assistant creation.
+- Add BranchModal Assistant `Knowledge` tab.
+- Make assistant-aware prompts/tools use home namespace as default.
+
+### Phase 5: docs and migration polish
+
+- Update user-facing docs for Knowledge namespaces and assistant home namespaces.
+- Add migration notes for existing public/private docs.
+- Add admin guidance for choosing `others_can` defaults.
+
+## Future work
+
+- Assistant principals in namespace ACLs.
+- Mixed groups containing users and assistants.
+- Assistant-specific namespace access restrictions.
+- Per-document ACL overrides or deviations from namespace inheritance.
+- Better terminology for document `visibility = public` inside restricted namespaces.
+- Namespace templates/presets: personal, team, assistant-private, docs-public.
+
+## Open questions
+
+1. Should existing `global` default to `others_can = read` or `write` during migration?
+2. Should namespace `write` bypass document `created_by` for non-public-edit docs, or should document edit policy stay as a second gate? Recommendation: keep second gate in V1.
+3. Should group management remain global Settings -> Groups, or should KB namespace permissions have an inline lightweight group creation flow?
+4. Should assistant home namespace be mandatory for assistant branches, or lazily created on first KB use?
+5. Should namespace owners be separate ACL entries, or should `owner_user_id` continue to have special meaning? Recommendation: use ACL entries for actual authority; keep `owner_user_id` as metadata/back-compat.
+6. Should namespaces have markdown descriptions rendered in the Knowledge UI home view?
+7. What is the best UI location for Knowledge Settings: top-level Settings tab, Knowledge page settings drawer, or both?
+
+## Bottom line
+
+V1 should make **Knowledge namespace RBAC** real and visible. Users and groups get read/write/own on namespaces; everyone else gets a simple `none/read/write` fallback. Assistants get a home namespace in BranchModal, but assistant-specific access constraints stay future work. This is enough to make KB sharing understandable without introducing a dual user+assistant RBAC model too early.

--- a/packages/core/drizzle/postgres/0045_kb_namespace_rbac.sql
+++ b/packages/core/drizzle/postgres/0045_kb_namespace_rbac.sql
@@ -1,0 +1,18 @@
+-- Add Knowledge namespace RBAC boundary. Existing namespaces stay workspace-writable
+-- to preserve current document-centric sharing behavior until service enforcement lands.
+ALTER TABLE "kb_namespaces" ADD COLUMN "others_can" text DEFAULT 'write' NOT NULL;--> statement-breakpoint
+CREATE TABLE "kb_namespace_acl" (
+	"namespace_acl_id" varchar(36) PRIMARY KEY NOT NULL,
+	"namespace_id" varchar(36) NOT NULL,
+	"subject_type" text NOT NULL,
+	"subject_id" varchar(36) NOT NULL,
+	"permission" text NOT NULL,
+	"created_by" varchar(36),
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone,
+	CONSTRAINT "kb_namespace_acl_namespace_id_kb_namespaces_namespace_id_fk" FOREIGN KEY ("namespace_id") REFERENCES "kb_namespaces"("namespace_id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "kb_namespace_acl_created_by_users_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "users"("user_id") ON DELETE set null ON UPDATE no action
+);--> statement-breakpoint
+CREATE INDEX "kb_namespace_acl_namespace_idx" ON "kb_namespace_acl" ("namespace_id");--> statement-breakpoint
+CREATE INDEX "kb_namespace_acl_subject_idx" ON "kb_namespace_acl" ("subject_type","subject_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "kb_namespace_acl_namespace_subject_idx" ON "kb_namespace_acl" ("namespace_id","subject_type","subject_id");

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1781000000000,
       "tag": "0044_kb_document_status",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1781100000000,
+      "tag": "0045_kb_namespace_rbac",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0054_kb_namespace_rbac.sql
+++ b/packages/core/drizzle/sqlite/0054_kb_namespace_rbac.sql
@@ -1,0 +1,18 @@
+-- Add Knowledge namespace RBAC boundary. Existing namespaces stay workspace-writable
+-- to preserve current document-centric sharing behavior until service enforcement lands.
+ALTER TABLE `kb_namespaces` ADD COLUMN `others_can` text DEFAULT 'write' NOT NULL;--> statement-breakpoint
+CREATE TABLE `kb_namespace_acl` (
+	`namespace_acl_id` text(36) PRIMARY KEY NOT NULL,
+	`namespace_id` text(36) NOT NULL,
+	`subject_type` text NOT NULL,
+	`subject_id` text(36) NOT NULL,
+	`permission` text NOT NULL,
+	`created_by` text(36),
+	`created_at` integer NOT NULL,
+	`updated_at` integer,
+	FOREIGN KEY (`namespace_id`) REFERENCES `kb_namespaces`(`namespace_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`user_id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE INDEX `kb_namespace_acl_namespace_idx` ON `kb_namespace_acl` (`namespace_id`);--> statement-breakpoint
+CREATE INDEX `kb_namespace_acl_subject_idx` ON `kb_namespace_acl` (`subject_type`,`subject_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `kb_namespace_acl_namespace_subject_idx` ON `kb_namespace_acl` (`namespace_id`,`subject_type`,`subject_id`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1781000000000,
       "tag": "0053_kb_document_status",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "6",
+      "when": 1781100000000,
+      "tag": "0054_kb_namespace_rbac",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/knowledge.test.ts
+++ b/packages/core/src/db/repositories/knowledge.test.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
 import { generateId } from '../../lib/ids';
-import type { UserID } from '../../types';
+import type { GroupID, UserID } from '../../types';
 import {
   buildKnowledgeUri,
   normalizeKnowledgePath,
@@ -12,6 +12,7 @@ import type { Database } from '../client';
 import { select, update } from '../database-wrapper';
 import { kbDocumentUnits } from '../schema';
 import { dbTest } from '../test-helpers';
+import { GroupRepository } from './groups';
 import {
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
@@ -46,6 +47,116 @@ describe('Knowledge path and URI helpers', () => {
 });
 
 describe('Knowledge repositories', () => {
+  dbTest(
+    'resolves namespace permissions from others, users, groups, owners, and admins',
+    async ({ db }) => {
+      const owner = await seedUser(db, 'owner');
+      const alice = await seedUser(db, 'alice');
+      const bob = await seedUser(db, 'bob');
+      const carol = await seedUser(db, 'carol');
+      const namespaces = new KnowledgeNamespaceRepository(db);
+      const groups = new GroupRepository(db);
+
+      const namespace = await namespaces.create({
+        slug: 'acl-test',
+        display_name: 'ACL Test',
+        owner_user_id: owner.user_id as UserID,
+        others_can: 'none',
+      });
+      const group = await groups.create({ name: 'KB Writers', slug: 'kb-writers' });
+      await groups.addMember(group.group_id, bob.user_id as UserID);
+
+      expect(
+        await namespaces.resolveNamespacePermission(namespace.namespace_id, alice.user_id)
+      ).toBe('none');
+      expect(
+        await namespaces.resolveNamespacePermission(namespace.namespace_id, owner.user_id)
+      ).toBe('own');
+      expect(
+        await namespaces.resolveNamespacePermission(namespace.namespace_id, carol.user_id, {
+          isAdmin: true,
+        })
+      ).toBe('own');
+
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'user',
+        subject_id: alice.user_id,
+        permission: 'read',
+      });
+      await namespaces.upsertNamespaceAclEntry({
+        namespace_id: namespace.namespace_id,
+        subject_type: 'group',
+        subject_id: group.group_id as GroupID,
+        permission: 'write',
+      });
+
+      expect(
+        await namespaces.resolveNamespacePermission(namespace.namespace_id, alice.user_id)
+      ).toBe('read');
+      expect(await namespaces.resolveNamespacePermission(namespace.namespace_id, bob.user_id)).toBe(
+        'write'
+      );
+
+      await namespaces.update(namespace.namespace_id, { others_can: 'read' });
+      expect(
+        await namespaces.resolveNamespacePermission(namespace.namespace_id, carol.user_id)
+      ).toBe('read');
+    }
+  );
+
+  dbTest('upserts, lists, removes ACL entries, and reports readable namespaces', async ({ db }) => {
+    const alice = await seedUser(db, 'readable-alice');
+    const bob = await seedUser(db, 'readable-bob');
+    const namespaces = new KnowledgeNamespaceRepository(db);
+
+    const open = await namespaces.create({
+      slug: 'readable-open',
+      display_name: 'Readable Open',
+      others_can: 'read',
+    });
+    const privateNamespace = await namespaces.create({
+      slug: 'readable-private',
+      display_name: 'Readable Private',
+      others_can: 'none',
+    });
+
+    const entry = await namespaces.upsertNamespaceAclEntry({
+      namespace_id: privateNamespace.namespace_id,
+      subject_type: 'user',
+      subject_id: alice.user_id,
+      permission: 'read',
+    });
+    const updated = await namespaces.upsertNamespaceAclEntry({
+      namespace_id: privateNamespace.namespace_id,
+      subject_type: 'user',
+      subject_id: alice.user_id,
+      permission: 'own',
+    });
+
+    expect(updated.namespace_acl_id).toBe(entry.namespace_acl_id);
+    expect(updated.permission).toBe('own');
+    expect(await namespaces.listNamespaceAcl(privateNamespace.namespace_id)).toHaveLength(1);
+
+    const aliceReadable = new Set(await namespaces.findReadableNamespaceIds(alice.user_id));
+    expect(aliceReadable.has(open.namespace_id)).toBe(true);
+    expect(aliceReadable.has(privateNamespace.namespace_id)).toBe(true);
+
+    const bobReadable = new Set(await namespaces.findReadableNamespaceIds(bob.user_id));
+    expect(bobReadable.has(open.namespace_id)).toBe(true);
+    expect(bobReadable.has(privateNamespace.namespace_id)).toBe(false);
+
+    const removed = await namespaces.removeNamespaceAclEntry(
+      privateNamespace.namespace_id,
+      'user',
+      alice.user_id
+    );
+    expect(removed?.permission).toBe('own');
+    expect(
+      await namespaces.resolveNamespacePermission(privateNamespace.namespace_id, alice.user_id)
+    ).toBe('none');
+  });
+
   dbTest('creates markdown documents with version, unit, URI, and browser URL', async ({ db }) => {
     const owner = await seedUser(db, 'kb-owner');
     const namespaces = new KnowledgeNamespaceRepository(db);

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -9,6 +9,7 @@
 
 import { createHash } from 'node:crypto';
 import type {
+  GroupID,
   KnowledgeDocument,
   KnowledgeDocumentID,
   KnowledgeDocumentIndexingStatus,
@@ -26,8 +27,13 @@ import type {
   KnowledgeGraphNodeID,
   KnowledgeGraphNodeType,
   KnowledgeNamespace,
+  KnowledgeNamespaceAclEntry,
+  KnowledgeNamespaceEffectivePermission,
   KnowledgeNamespaceID,
   KnowledgeNamespaceKind,
+  KnowledgeNamespaceOthersCan,
+  KnowledgeNamespacePermission,
+  KnowledgeNamespaceSubjectType,
   KnowledgeSearchMode,
   KnowledgeSearchResult,
   KnowledgeVisibility,
@@ -52,6 +58,8 @@ import { getKnowledgeUrl } from '../../utils/url';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
 import {
+  groupMemberships,
+  groups,
   type KBDocumentInsert,
   type KBDocumentRow,
   type KBDocumentUnitInsert,
@@ -61,6 +69,8 @@ import {
   type KBGraphEdgeRow,
   type KBGraphNodeInsert,
   type KBGraphNodeRow,
+  type KBNamespaceAclInsert,
+  type KBNamespaceAclRow,
   type KBNamespaceInsert,
   type KBNamespaceRow,
   kbDocuments,
@@ -68,6 +78,7 @@ import {
   kbDocumentVersions,
   kbGraphEdges,
   kbGraphNodes,
+  kbNamespaceAcl,
   kbNamespaces,
 } from '../schema';
 import {
@@ -304,6 +315,32 @@ function knowledgeDraftVisibilityCondition(options: {
   return eq(kbDocuments.status, 'published');
 }
 
+const KNOWLEDGE_PERMISSION_RANK: Record<KnowledgeNamespaceEffectivePermission, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+  own: 3,
+};
+
+function maxKnowledgePermission(
+  permissions: Array<KnowledgeNamespaceEffectivePermission | null | undefined>
+): KnowledgeNamespaceEffectivePermission {
+  return permissions.reduce<KnowledgeNamespaceEffectivePermission>((best, current) => {
+    if (!current) return best;
+    return KNOWLEDGE_PERMISSION_RANK[current] > KNOWLEDGE_PERMISSION_RANK[best] ? current : best;
+  }, 'none');
+}
+
+function othersCanToPermission(
+  othersCan: KnowledgeNamespaceOthersCan
+): KnowledgeNamespaceEffectivePermission {
+  return othersCan === 'none' ? 'none' : othersCan;
+}
+
+export interface ResolveKnowledgeNamespacePermissionOptions {
+  isAdmin?: boolean;
+}
+
 export class KnowledgeNamespaceRepository
   implements BaseRepository<KnowledgeNamespace, Partial<KnowledgeNamespace>>
 {
@@ -320,6 +357,7 @@ export class KnowledgeNamespaceRepository
       repo_id: row.repo_id as KnowledgeNamespace['repo_id'],
       branch_id: row.branch_id as KnowledgeNamespace['branch_id'],
       visibility_default: row.visibility_default as KnowledgeVisibility,
+      others_can: row.others_can as KnowledgeNamespaceOthersCan,
       metadata: row.metadata ?? null,
       created_by: (row.created_by as UserID | null) ?? null,
       created_at: new Date(row.created_at),
@@ -349,6 +387,7 @@ export class KnowledgeNamespaceRepository
       repo_id: data.repo_id ?? null,
       branch_id: data.branch_id ?? null,
       visibility_default: data.visibility_default ?? 'public',
+      others_can: data.others_can ?? 'write',
       metadata: data.metadata ?? null,
       created_by: data.created_by ?? null,
       created_at: data.created_at ? new Date(data.created_at) : new Date(now),
@@ -443,6 +482,250 @@ export class KnowledgeNamespaceRepository
       .returning()
       .one();
     return this.rowToNamespace(row);
+  }
+
+  rowToAclEntry(row: KBNamespaceAclRow): KnowledgeNamespaceAclEntry {
+    return {
+      namespace_acl_id: row.namespace_acl_id as KnowledgeNamespaceAclEntry['namespace_acl_id'],
+      namespace_id: row.namespace_id as KnowledgeNamespaceID,
+      subject_type: row.subject_type as KnowledgeNamespaceSubjectType,
+      subject_id: row.subject_id as UserID | GroupID,
+      permission: row.permission as KnowledgeNamespacePermission,
+      created_by: (row.created_by as UserID | null) ?? null,
+      created_at: new Date(row.created_at),
+      updated_at: row.updated_at ? new Date(row.updated_at) : null,
+    };
+  }
+
+  async listNamespaceAcl(namespaceId: string): Promise<KnowledgeNamespaceAclEntry[]> {
+    const fullId = await this.resolveId(namespaceId);
+    const rows = await select(this.db)
+      .from(kbNamespaceAcl)
+      .where(eq(kbNamespaceAcl.namespace_id, fullId))
+      .all();
+    return rows.map((row: KBNamespaceAclRow) => this.rowToAclEntry(row));
+  }
+
+  async upsertNamespaceAclEntry(data: {
+    namespace_id: string;
+    subject_type: KnowledgeNamespaceSubjectType;
+    subject_id: string;
+    permission: KnowledgeNamespacePermission;
+    created_by?: UserID | null;
+  }): Promise<KnowledgeNamespaceAclEntry> {
+    const fullId = await this.resolveId(data.namespace_id);
+    const now = new Date();
+    const existing = await select(this.db)
+      .from(kbNamespaceAcl)
+      .where(
+        and(
+          eq(kbNamespaceAcl.namespace_id, fullId),
+          eq(kbNamespaceAcl.subject_type, data.subject_type),
+          eq(kbNamespaceAcl.subject_id, data.subject_id)
+        )
+      )
+      .one();
+
+    if (existing) {
+      await update(this.db, kbNamespaceAcl)
+        .set({ permission: data.permission, updated_at: now })
+        .where(eq(kbNamespaceAcl.namespace_acl_id, existing.namespace_acl_id))
+        .run();
+      const updated = await select(this.db)
+        .from(kbNamespaceAcl)
+        .where(eq(kbNamespaceAcl.namespace_acl_id, existing.namespace_acl_id))
+        .one();
+      if (!updated) throw new RepositoryError('Failed to retrieve updated namespace ACL entry');
+      return this.rowToAclEntry(updated as KBNamespaceAclRow);
+    }
+
+    const insertRow: KBNamespaceAclInsert = {
+      namespace_acl_id: generateId(),
+      namespace_id: fullId,
+      subject_type: data.subject_type,
+      subject_id: data.subject_id,
+      permission: data.permission,
+      created_by: data.created_by ?? null,
+      created_at: now,
+      updated_at: now,
+    };
+    const row = await insert(this.db, kbNamespaceAcl).values(insertRow).returning().one();
+    return this.rowToAclEntry(row);
+  }
+
+  async removeNamespaceAclEntry(
+    namespaceId: string,
+    subjectType: KnowledgeNamespaceSubjectType,
+    subjectId: string
+  ): Promise<KnowledgeNamespaceAclEntry | null> {
+    const fullId = await this.resolveId(namespaceId);
+    const existing = await select(this.db)
+      .from(kbNamespaceAcl)
+      .where(
+        and(
+          eq(kbNamespaceAcl.namespace_id, fullId),
+          eq(kbNamespaceAcl.subject_type, subjectType),
+          eq(kbNamespaceAcl.subject_id, subjectId)
+        )
+      )
+      .one();
+    if (!existing) return null;
+    await deleteFrom(this.db, kbNamespaceAcl)
+      .where(eq(kbNamespaceAcl.namespace_acl_id, existing.namespace_acl_id))
+      .run();
+    return this.rowToAclEntry(existing as KBNamespaceAclRow);
+  }
+
+  async replaceNamespaceAcl(
+    namespaceId: string,
+    entries: Array<{
+      subject_type: KnowledgeNamespaceSubjectType;
+      subject_id: string;
+      permission: KnowledgeNamespacePermission;
+      created_by?: UserID | null;
+    }>
+  ): Promise<KnowledgeNamespaceAclEntry[]> {
+    const fullId = await this.resolveId(namespaceId);
+    return this.db.transaction(async (tx) => {
+      return this.replaceNamespaceAclInDb(txAsDb(tx), fullId, entries);
+    });
+  }
+
+  private async replaceNamespaceAclInDb(
+    db: Database,
+    namespaceId: string,
+    entries: Array<{
+      subject_type: KnowledgeNamespaceSubjectType;
+      subject_id: string;
+      permission: KnowledgeNamespacePermission;
+      created_by?: UserID | null;
+    }>
+  ): Promise<KnowledgeNamespaceAclEntry[]> {
+    await deleteFrom(db, kbNamespaceAcl).where(eq(kbNamespaceAcl.namespace_id, namespaceId)).run();
+
+    const now = new Date();
+    const uniqueEntries = new Map<string, (typeof entries)[number]>();
+    for (const entry of entries) {
+      uniqueEntries.set(`${entry.subject_type}:${entry.subject_id}`, entry);
+    }
+
+    for (const entry of uniqueEntries.values()) {
+      await insert(db, kbNamespaceAcl)
+        .values({
+          namespace_acl_id: generateId(),
+          namespace_id: namespaceId,
+          subject_type: entry.subject_type,
+          subject_id: entry.subject_id,
+          permission: entry.permission,
+          created_by: entry.created_by ?? null,
+          created_at: now,
+          updated_at: now,
+        })
+        .run();
+    }
+
+    const rows = await select(db)
+      .from(kbNamespaceAcl)
+      .where(eq(kbNamespaceAcl.namespace_id, namespaceId))
+      .all();
+    return rows.map((row: KBNamespaceAclRow) => this.rowToAclEntry(row));
+  }
+
+  async createWithAcl(
+    data: Partial<KnowledgeNamespace>,
+    entries: Array<{
+      subject_type: KnowledgeNamespaceSubjectType;
+      subject_id: string;
+      permission: KnowledgeNamespacePermission;
+      created_by?: UserID | null;
+    }>
+  ): Promise<{ namespace: KnowledgeNamespace; acl: KnowledgeNamespaceAclEntry[] }> {
+    return this.db.transaction(async (tx) => {
+      const txRepo = new KnowledgeNamespaceRepository(txAsDb(tx));
+      const namespace = await txRepo.create(data);
+      const acl = await txRepo.replaceNamespaceAclInDb(txAsDb(tx), namespace.namespace_id, entries);
+      return { namespace, acl };
+    });
+  }
+
+  async updateWithAcl(
+    id: string,
+    updates: Partial<KnowledgeNamespace>,
+    entries: Array<{
+      subject_type: KnowledgeNamespaceSubjectType;
+      subject_id: string;
+      permission: KnowledgeNamespacePermission;
+      created_by?: UserID | null;
+    }>
+  ): Promise<{ namespace: KnowledgeNamespace; acl: KnowledgeNamespaceAclEntry[] }> {
+    return this.db.transaction(async (tx) => {
+      const txRepo = new KnowledgeNamespaceRepository(txAsDb(tx));
+      const namespace = await txRepo.update(id, updates);
+      const acl = await txRepo.replaceNamespaceAclInDb(txAsDb(tx), namespace.namespace_id, entries);
+      return { namespace, acl };
+    });
+  }
+
+  async resolveNamespacePermission(
+    namespaceId: string,
+    userId: string,
+    options: ResolveKnowledgeNamespacePermissionOptions = {}
+  ): Promise<KnowledgeNamespaceEffectivePermission> {
+    if (options.isAdmin) return 'own';
+    const namespace = await this.findById(namespaceId);
+    if (!namespace || namespace.archived) return 'none';
+
+    const directRows = await select(this.db)
+      .from(kbNamespaceAcl)
+      .where(
+        and(
+          eq(kbNamespaceAcl.namespace_id, namespace.namespace_id),
+          eq(kbNamespaceAcl.subject_type, 'user'),
+          eq(kbNamespaceAcl.subject_id, userId)
+        )
+      )
+      .all();
+
+    const groupRows = await select(this.db)
+      .from(kbNamespaceAcl)
+      .innerJoin(groupMemberships, eq(kbNamespaceAcl.subject_id, groupMemberships.group_id))
+      .innerJoin(groups, eq(groupMemberships.group_id, groups.group_id))
+      .where(
+        and(
+          eq(kbNamespaceAcl.namespace_id, namespace.namespace_id),
+          eq(kbNamespaceAcl.subject_type, 'group'),
+          eq(groupMemberships.user_id, userId),
+          eq(groups.archived, false)
+        )
+      )
+      .all();
+
+    return maxKnowledgePermission([
+      othersCanToPermission(namespace.others_can),
+      namespace.owner_user_id === userId ? 'own' : null,
+      ...directRows.map((row: KBNamespaceAclRow) => row.permission as KnowledgeNamespacePermission),
+      ...groupRows.map(
+        (row: { kb_namespace_acl: KBNamespaceAclRow }) =>
+          row.kb_namespace_acl.permission as KnowledgeNamespacePermission
+      ),
+    ]);
+  }
+
+  async findReadableNamespaceIds(
+    userId: string,
+    options: ResolveKnowledgeNamespacePermissionOptions = {}
+  ): Promise<KnowledgeNamespaceID[]> {
+    const namespaces = await this.findAll({ archived: false });
+    if (options.isAdmin) return namespaces.map((namespace) => namespace.namespace_id);
+
+    const readable: KnowledgeNamespaceID[] = [];
+    for (const namespace of namespaces) {
+      const permission = await this.resolveNamespacePermission(namespace.namespace_id, userId);
+      if (KNOWLEDGE_PERMISSION_RANK[permission] >= KNOWLEDGE_PERMISSION_RANK.read) {
+        readable.push(namespace.namespace_id);
+      }
+    }
+    return readable;
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/core/src/db/repositories/knowledge.ts
+++ b/packages/core/src/db/repositories/knowledge.ts
@@ -174,6 +174,7 @@ export interface KnowledgeSearchQuery {
   limit?: number;
   readable_by_user_id?: UserID;
   readable_as_admin?: boolean;
+  readable_namespace_ids?: KnowledgeNamespaceID[];
 }
 
 function deterministicKnowledgeUnitId(
@@ -1444,6 +1445,10 @@ export class KnowledgeSearchRepository {
     if (!query.include_archived) {
       conditions.push(eq(kbDocuments.archived, false));
       conditions.push(eq(kbNamespaces.archived, false));
+    }
+    if (query.readable_namespace_ids) {
+      if (query.readable_namespace_ids.length === 0) return [];
+      conditions.push(inArray(kbDocuments.namespace_id, query.readable_namespace_ids));
     }
     if (namespaceId) conditions.push(eq(kbDocuments.namespace_id, namespaceId));
     if (query.path_prefix) {

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1667,6 +1667,9 @@ export const kbNamespaces = pgTable(
     visibility_default: text('visibility_default', { enum: ['public', 'private'] })
       .notNull()
       .default('public'),
+    others_can: text('others_can', { enum: ['none', 'read', 'write'] })
+      .notNull()
+      .default('write'),
     metadata: t.json<Record<string, unknown>>('metadata'),
     created_by: varchar('created_by', { length: 36 }).references(() => users.user_id, {
       onDelete: 'set null',
@@ -1685,6 +1688,36 @@ export const kbNamespaces = pgTable(
     repoIdx: index('kb_namespaces_repo_idx').on(table.repo_id),
     branchIdx: index('kb_namespaces_branch_idx').on(table.branch_id),
     archivedIdx: index('kb_namespaces_archived_idx').on(table.archived),
+  })
+);
+
+/**
+ * Knowledge namespace ACL entries - explicit user/group grants for namespace RBAC.
+ */
+export const kbNamespaceAcl = pgTable(
+  'kb_namespace_acl',
+  {
+    namespace_acl_id: varchar('namespace_acl_id', { length: 36 }).primaryKey(),
+    namespace_id: varchar('namespace_id', { length: 36 })
+      .notNull()
+      .references(() => kbNamespaces.namespace_id, { onDelete: 'cascade' }),
+    subject_type: text('subject_type', { enum: ['user', 'group'] }).notNull(),
+    subject_id: varchar('subject_id', { length: 36 }).notNull(),
+    permission: text('permission', { enum: ['read', 'write', 'own'] }).notNull(),
+    created_by: varchar('created_by', { length: 36 }).references(() => users.user_id, {
+      onDelete: 'set null',
+    }),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at'),
+  },
+  (table) => ({
+    namespaceIdx: index('kb_namespace_acl_namespace_idx').on(table.namespace_id),
+    subjectIdx: index('kb_namespace_acl_subject_idx').on(table.subject_type, table.subject_id),
+    namespaceSubjectIdx: uniqueIndex('kb_namespace_acl_namespace_subject_idx').on(
+      table.namespace_id,
+      table.subject_type,
+      table.subject_id
+    ),
   })
 );
 
@@ -2062,6 +2095,8 @@ export type SerializedSessionRow = typeof serializedSessions.$inferSelect;
 export type SerializedSessionInsert = typeof serializedSessions.$inferInsert;
 export type KBNamespaceRow = typeof kbNamespaces.$inferSelect;
 export type KBNamespaceInsert = typeof kbNamespaces.$inferInsert;
+export type KBNamespaceAclRow = typeof kbNamespaceAcl.$inferSelect;
+export type KBNamespaceAclInsert = typeof kbNamespaceAcl.$inferInsert;
 export type KBDocumentRow = typeof kbDocuments.$inferSelect;
 export type KBDocumentInsert = typeof kbDocuments.$inferInsert;
 export type KBDocumentVersionRow = typeof kbDocumentVersions.$inferSelect;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1706,6 +1706,9 @@ export const kbNamespaces = sqliteTable(
     visibility_default: text('visibility_default', { enum: ['public', 'private'] })
       .notNull()
       .default('public'),
+    others_can: text('others_can', { enum: ['none', 'read', 'write'] })
+      .notNull()
+      .default('write'),
     metadata: t.json<Record<string, unknown>>('metadata'),
     created_by: text('created_by', { length: 36 }).references(() => users.user_id, {
       onDelete: 'set null',
@@ -1724,6 +1727,36 @@ export const kbNamespaces = sqliteTable(
     repoIdx: index('kb_namespaces_repo_idx').on(table.repo_id),
     branchIdx: index('kb_namespaces_branch_idx').on(table.branch_id),
     archivedIdx: index('kb_namespaces_archived_idx').on(table.archived),
+  })
+);
+
+/**
+ * Knowledge namespace ACL entries - explicit user/group grants for namespace RBAC.
+ */
+export const kbNamespaceAcl = sqliteTable(
+  'kb_namespace_acl',
+  {
+    namespace_acl_id: text('namespace_acl_id', { length: 36 }).primaryKey(),
+    namespace_id: text('namespace_id', { length: 36 })
+      .notNull()
+      .references(() => kbNamespaces.namespace_id, { onDelete: 'cascade' }),
+    subject_type: text('subject_type', { enum: ['user', 'group'] }).notNull(),
+    subject_id: text('subject_id', { length: 36 }).notNull(),
+    permission: text('permission', { enum: ['read', 'write', 'own'] }).notNull(),
+    created_by: text('created_by', { length: 36 }).references(() => users.user_id, {
+      onDelete: 'set null',
+    }),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at'),
+  },
+  (table) => ({
+    namespaceIdx: index('kb_namespace_acl_namespace_idx').on(table.namespace_id),
+    subjectIdx: index('kb_namespace_acl_subject_idx').on(table.subject_type, table.subject_id),
+    namespaceSubjectIdx: uniqueIndex('kb_namespace_acl_namespace_subject_idx').on(
+      table.namespace_id,
+      table.subject_type,
+      table.subject_id
+    ),
   })
 );
 
@@ -2093,6 +2126,8 @@ export type SerializedSessionRow = typeof serializedSessions.$inferSelect;
 export type SerializedSessionInsert = typeof serializedSessions.$inferInsert;
 export type KBNamespaceRow = typeof kbNamespaces.$inferSelect;
 export type KBNamespaceInsert = typeof kbNamespaces.$inferInsert;
+export type KBNamespaceAclRow = typeof kbNamespaceAcl.$inferSelect;
+export type KBNamespaceAclInsert = typeof kbNamespaceAcl.$inferInsert;
 export type KBDocumentRow = typeof kbDocuments.$inferSelect;
 export type KBDocumentInsert = typeof kbDocuments.$inferInsert;
 export type KBDocumentVersionRow = typeof kbDocumentVersions.$inferSelect;

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -48,6 +48,7 @@ export const threadSessionMap = schema.threadSessionMap;
 export const userApiKeys = schema.userApiKeys;
 export const serializedSessions = schema.serializedSessions;
 export const kbNamespaces = schema.kbNamespaces;
+export const kbNamespaceAcl = schema.kbNamespaceAcl;
 export const kbDocuments = schema.kbDocuments;
 export const kbDocumentVersions = schema.kbDocumentVersions;
 export const kbDocumentUnits = schema.kbDocumentUnits;

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -401,6 +401,11 @@ export interface KnowledgeNamespace {
   branch_id?: BranchID | null;
   visibility_default: KnowledgeVisibility;
   others_can: KnowledgeNamespaceOthersCan;
+  /**
+   * Request-scoped permission summary populated by services that list or fetch
+   * namespaces for a specific user. Not stored on the namespace row.
+   */
+  effective_permission?: KnowledgeNamespaceEffectivePermission;
   metadata?: Record<string, unknown> | null;
   created_by?: UserID | null;
   created_at: Date;

--- a/packages/core/src/types/knowledge.ts
+++ b/packages/core/src/types/knowledge.ts
@@ -2,6 +2,7 @@ import type {
   ArtifactID,
   BoardID,
   BranchID,
+  GroupID,
   MessageID,
   RepoID,
   SessionID,
@@ -17,6 +18,7 @@ export type KnowledgeDocumentUnitID = UUID;
 export type KnowledgeEmbeddingSpaceID = UUID;
 export type KnowledgeGraphNodeID = UUID;
 export type KnowledgeGraphEdgeID = UUID;
+export type KnowledgeNamespaceAclEntryID = UUID;
 
 export const KNOWLEDGE_NAMESPACE_KINDS = [
   'system',
@@ -50,6 +52,37 @@ export type KnowledgeDocumentStatus = (typeof KNOWLEDGE_DOCUMENT_STATUSES)[numbe
 
 export const KNOWLEDGE_EDIT_POLICIES = ['owner', 'public', 'admins'] as const;
 export type KnowledgeEditPolicy = (typeof KNOWLEDGE_EDIT_POLICIES)[number];
+
+export const KNOWLEDGE_NAMESPACE_OTHERS_CAN = ['none', 'read', 'write'] as const;
+export type KnowledgeNamespaceOthersCan = (typeof KNOWLEDGE_NAMESPACE_OTHERS_CAN)[number];
+
+export const KNOWLEDGE_NAMESPACE_SUBJECT_TYPES = ['user', 'group'] as const;
+export type KnowledgeNamespaceSubjectType = (typeof KNOWLEDGE_NAMESPACE_SUBJECT_TYPES)[number];
+
+export const KNOWLEDGE_NAMESPACE_PERMISSIONS = ['read', 'write', 'own'] as const;
+export type KnowledgeNamespacePermission = (typeof KNOWLEDGE_NAMESPACE_PERMISSIONS)[number];
+
+export type KnowledgeNamespaceEffectivePermission = KnowledgeNamespacePermission | 'none';
+
+export interface KnowledgeNamespaceAclEntry {
+  namespace_acl_id: KnowledgeNamespaceAclEntryID;
+  namespace_id: KnowledgeNamespaceID;
+  subject_type: KnowledgeNamespaceSubjectType;
+  subject_id: UserID | GroupID;
+  permission: KnowledgeNamespacePermission;
+  created_by?: UserID | null;
+  created_at: Date;
+  updated_at?: Date | null;
+}
+
+export interface KnowledgeNamespacePermissionSummary {
+  effective_permission: KnowledgeNamespaceEffectivePermission;
+  direct_permission?: KnowledgeNamespacePermission | null;
+  group_permission?: KnowledgeNamespacePermission | null;
+  others_can: KnowledgeNamespaceOthersCan;
+  is_admin?: boolean;
+  group_ids?: GroupID[];
+}
 
 /**
  * Internal search/indexing unit. Usually one per document version in V1; can
@@ -367,6 +400,7 @@ export interface KnowledgeNamespace {
   repo_id?: RepoID | null;
   branch_id?: BranchID | null;
   visibility_default: KnowledgeVisibility;
+  others_can: KnowledgeNamespaceOthersCan;
   metadata?: Record<string, unknown> | null;
   created_by?: UserID | null;
   created_at: Date;


### PR DESCRIPTION
## Summary

- Add Knowledge namespace RBAC schema/types/repository helpers, including namespace ACL rows and permission resolution.
- Enforce namespace read/write/own checks across Knowledge namespace, document, search, version, graph, and document-edit services.
- Add Knowledge → Settings namespace CRUD with default access and draft-specific user/group ACL editing saved atomically.
- Capture the directed V1 design docs under `context/explorations/`.

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --dir packages/core exec vitest run src/db/repositories/knowledge.test.ts`
- `pnpm --dir apps/agor-daemon exec vitest run src/services/knowledge.test.ts src/services/knowledge-document-edits.test.ts`
- `pnpm --dir apps/agor-ui exec vitest run src/pages/KnowledgePage.routing.test.ts`

## Notes

- Existing namespaces default to `others_can = 'write'` in migrations to preserve current behavior; new UI-created namespaces default to no workspace fallback unless changed.
- Document-level `visibility` / `edit_policy` remains a narrower overlay on top of namespace permissions.
