### PR TITLE
Improve docs social image metadata

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -3,7 +3,8 @@ environment:
   variants:
     docs:
       start: >-
-        PORT={{add 7000 branch.unique_id}} docker compose -f apps/agor-docs/docker-compose.yml -p
+        PORT={{add 7000 branch.unique_id}} NEXT_PUBLIC_SITE_URL=http://{{host.ip_address}}:{{add
+        7000 branch.unique_id}} docker compose -f apps/agor-docs/docker-compose.yml -p
         agor-docs-{{branch.name}} up -d --build
       stop: docker compose -f apps/agor-docs/docker-compose.yml -p agor-docs-{{branch.name}} down
       description: >-

--- a/apps/agor-docs/.env.example
+++ b/apps/agor-docs/.env.example
@@ -3,5 +3,8 @@
 # Format: G-XXXXXXXXXX
 NEXT_PUBLIC_GA_ID=
 
+# Public docs origin used for canonical, Open Graph, Twitter, and sitemap URLs.
+NEXT_PUBLIC_SITE_URL=https://agor.live
+
 # Base path (for subdirectory deployments)
 NEXT_PUBLIC_BASE_PATH=

--- a/apps/agor-docs/README.md
+++ b/apps/agor-docs/README.md
@@ -30,6 +30,30 @@ pages/
     └── index.mdx
 ```
 
+## Page metadata and social previews
+
+All page-level social metadata is centralized in `theme.config.tsx`. Authors should set
+frontmatter instead of adding ad hoc `<Head>` tags:
+
+```mdx
+---
+title: Cards
+description: Generic workflow cards that give you spatial oversight of any agentic workflow.
+heroImage: '/screenshots/cards-hero.png'
+---
+```
+
+- `image` is the existing blog-post hero/card image convention.
+- `heroImage` is the docs/feature-page convention for pages with a visible hero screenshot.
+- `socialImage` or `ogImage` may be used only when the social preview should intentionally
+  differ from the visible hero image.
+
+Local image paths must live under `public/` and start with `/`. The metadata layer turns
+them into absolute `og:image` and `twitter:image` URLs using `NEXT_PUBLIC_SITE_URL` plus
+`NEXT_PUBLIC_BASE_PATH` when configured. Pages without any image field fall back to
+`/hero.png`. Add `imageWidth` and `imageHeight` only when you know the exact image
+dimensions.
+
 ## Phase 1 (Complete)
 
 - ✅ Nextra setup with dark mode

--- a/apps/agor-docs/docker-compose.yml
+++ b/apps/agor-docs/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       # Used by canonical, Open Graph, Twitter, and sitemap URLs while
       # previewing docs from Agor's managed dev environment.
-      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3001}
+      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:${PORT:-3001}}
       NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH:-}
     volumes:
       # Bind-mount source for hot reload.

--- a/apps/agor-docs/docker-compose.yml
+++ b/apps/agor-docs/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       dockerfile: Dockerfile
     ports:
       - '${PORT:-3001}:3001'
+    environment:
+      # Used by canonical, Open Graph, Twitter, and sitemap URLs while
+      # previewing docs from Agor's managed dev environment.
+      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-http://localhost:3001}
+      NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH:-}
     volumes:
       # Bind-mount source for hot reload.
       - .:/app

--- a/apps/agor-docs/lib/siteMetadata.ts
+++ b/apps/agor-docs/lib/siteMetadata.ts
@@ -1,0 +1,84 @@
+const DEFAULT_SITE_URL = 'https://agor.live';
+
+export const DEFAULT_DESCRIPTION =
+  'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git branches, with real-time multiplayer and an MCP surface agents drive themselves.';
+
+export const DEFAULT_SOCIAL_IMAGE = '/hero.png';
+
+export type FrontMatterLike = {
+  canonical?: string;
+  description?: string;
+  heroImage?: string;
+  image?: string;
+  imageHeight?: number | string;
+  imageWidth?: number | string;
+  ogImage?: string;
+  socialImage?: string;
+  title?: string;
+  [key: string]: unknown;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+export function getSiteUrl(): string {
+  return trimTrailingSlash(process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL);
+}
+
+export function getBasePath(): string {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+  if (!basePath) {
+    return '';
+  }
+
+  return `/${basePath.replace(/^\/+|\/+$/g, '')}`;
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function withBasePath(path: string): string {
+  const basePath = getBasePath();
+
+  if (!basePath) {
+    return path;
+  }
+
+  if (path === basePath || path.startsWith(`${basePath}/`)) {
+    return path;
+  }
+
+  return `${basePath}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+export function toAbsoluteUrl(value: string): string {
+  if (isAbsoluteUrl(value)) {
+    return value;
+  }
+
+  const path = value.startsWith('/') ? value : `/${value}`;
+  return `${getSiteUrl()}${withBasePath(path)}`;
+}
+
+export function getCanonicalUrl(pathname: string, canonical?: string): string {
+  if (canonical) {
+    return toAbsoluteUrl(canonical);
+  }
+
+  const cleanPathname = pathname === '/' ? '' : pathname;
+  return toAbsoluteUrl(cleanPathname || '/');
+}
+
+export function getSocialImage(frontMatter: FrontMatterLike): string {
+  const image =
+    frontMatter.ogImage ||
+    frontMatter.socialImage ||
+    frontMatter.heroImage ||
+    frontMatter.image ||
+    DEFAULT_SOCIAL_IMAGE;
+
+  return toAbsoluteUrl(String(image));
+}

--- a/apps/agor-docs/lib/siteMetadata.ts
+++ b/apps/agor-docs/lib/siteMetadata.ts
@@ -5,6 +5,8 @@ export const DEFAULT_DESCRIPTION =
 
 export const DEFAULT_SOCIAL_IMAGE = '/hero.png';
 
+export const SOCIAL_IMAGE_FIELDS = ['ogImage', 'socialImage', 'heroImage', 'image'] as const;
+
 export type FrontMatterLike = {
   canonical?: string;
   description?: string;
@@ -36,7 +38,7 @@ export function getBasePath(): string {
   return `/${basePath.replace(/^\/+|\/+$/g, '')}`;
 }
 
-function isAbsoluteUrl(value: string): boolean {
+export function isAbsoluteUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
 }
 
@@ -74,11 +76,7 @@ export function getCanonicalUrl(pathname: string, canonical?: string): string {
 
 export function getSocialImage(frontMatter: FrontMatterLike): string {
   const image =
-    frontMatter.ogImage ||
-    frontMatter.socialImage ||
-    frontMatter.heroImage ||
-    frontMatter.image ||
-    DEFAULT_SOCIAL_IMAGE;
+    SOCIAL_IMAGE_FIELDS.map((field) => frontMatter[field]).find(Boolean) || DEFAULT_SOCIAL_IMAGE;
 
   return toAbsoluteUrl(String(image));
 }

--- a/apps/agor-docs/next-sitemap.config.cjs
+++ b/apps/agor-docs/next-sitemap.config.cjs
@@ -1,4 +1,8 @@
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://agor.live';
+const siteOrigin = (process.env.NEXT_PUBLIC_SITE_URL || 'https://agor.live').replace(/\/+$/, '');
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\/+|\/+$/g, '')}`
+  : '';
+const siteUrl = `${siteOrigin}${basePath}`;
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {

--- a/apps/agor-docs/next-sitemap.config.cjs
+++ b/apps/agor-docs/next-sitemap.config.cjs
@@ -1,6 +1,8 @@
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://agor.live';
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: 'https://agor.live',
+  siteUrl,
   generateRobotsTxt: false, // We use custom robots.txt in public/
   outDir: './out',
   changefreq: 'weekly',

--- a/apps/agor-docs/next.config.mjs
+++ b/apps/agor-docs/next.config.mjs
@@ -7,6 +7,10 @@ const withNextra = nextra({
   defaultShowCopyCode: true,
 });
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+  ? `/${process.env.NEXT_PUBLIC_BASE_PATH.replace(/^\/+|\/+$/g, '')}`
+  : '';
+
 // Deployed to custom domain agor.live (no base path needed)
 export default withNextra({
   reactStrictMode: true,
@@ -14,5 +18,5 @@ export default withNextra({
   images: {
     unoptimized: true,
   },
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
+  basePath,
 });

--- a/apps/agor-docs/package.json
+++ b/apps/agor-docs/package.json
@@ -9,7 +9,7 @@
     "build": "next build && next-sitemap --config next-sitemap.config.cjs",
     "start": "next start",
     "typecheck": "tsc --noEmit --incremental false",
-    "validate:social-metadata": "node scripts/validate-social-metadata.mjs"
+    "validate:social-metadata": "tsx scripts/validate-social-metadata.ts"
   },
   "dependencies": {
     "@theguild/remark-mermaid": "^0.3.0",

--- a/apps/agor-docs/package.json
+++ b/apps/agor-docs/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build && next-sitemap --config next-sitemap.config.cjs",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit --incremental false",
+    "validate:social-metadata": "node scripts/validate-social-metadata.mjs"
   },
   "dependencies": {
     "@theguild/remark-mermaid": "^0.3.0",

--- a/apps/agor-docs/pages/api-reference/index.mdx
+++ b/apps/agor-docs/pages/api-reference/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: API Reference
 description: Interactive REST API documentation for agor daemon. Auto-generated Swagger UI with endpoints for sessions, branches, boards, and real-time WebSocket integration.
+heroImage: '/swagger.png'
 ---
 
 # API Reference

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -9,12 +9,7 @@ heroImage: '/images/artifacts-hero.png'
 <img
   src="/images/artifacts-hero.png"
   alt="Agor board with live artifacts — interactive Sandpack applications built by AI agents directly on the canvas"
-  style={{
-    width: '100%',
-    borderRadius: '12px',
-    marginBottom: '24px',
-    boxShadow: '0 4px 24px rgba(0,0,0,0.15)',
-  }}
+  style={{ width: '100%', borderRadius: '12px', marginBottom: '24px', boxShadow: '0 4px 24px rgba(0,0,0,0.15)' }}
 />
 
 Artifacts are live, interactive applications that agents create and render directly on the board canvas. An agent scaffolds a small app via MCP, writes code into it, and you see it running — no deploy, no preview URL, no context switching.
@@ -38,7 +33,6 @@ Under the hood, artifacts are powered by [Sandpack](https://sandpack.codesandbox
 Each artifact is a stored file map plus a small set of declarative metadata columns. The folder on disk is just the staging area an agent writes before calling `publish` — no Agor-specific sidecars required.
 
 **File map** (shipped to the browser):
-
 ```
 /package.json          # Standard package.json — dependencies live here
 /App.tsx               # Source files (varies by template)
@@ -47,7 +41,6 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 ```
 
 **Stored metadata** (DB columns; not in the file map):
-
 - `template` — Sandpack template (`react`, `react-ts`, `vue3`, …).
 - `sandpack_config` — Author-controlled SandpackProvider props (template, customSetup, options). Sanitized on write.
 - `required_env_vars` — Names of env vars the artifact needs (e.g. `["OPENAI_KEY"]`). The daemon synthesizes a per-viewer `.env` at render time.
@@ -55,7 +48,6 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 - `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`. The runtime ships as an iframe-level `<script>` tag via Sandpack's `externalResources`, so it works regardless of which user files exist (no entry-file detection, no file mutation, no template-specific gotchas).
 
 **On the board:**
-
 - **Header** — Artifact name with a trust badge (`Yours`/`Trusted`/`Untrusted`), an interact toggle (eye icon), and a 🔒 lock affordance to open the consent modal when the artifact is untrusted.
 - **Preview** — Live Sandpack renderer showing the running application.
 - **Legacy banner** — Old-format artifacts (those still carrying `sandpack.json` / `agor.config.js`) render in safe-degraded mode with an inline upgrade prompt you can hand to an agent.
@@ -66,11 +58,11 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 
 The possibilities are genuinely endless. Artifacts are a general-purpose way for agents to express themselves visually and interactively — any time you need something rendered, an artifact can do it.
 
-The key advantage over having an agent build a regular app in a folder is that it's _right there on your board_. No deploy step, no preview URL, no context switching. You ask for a change, the agent writes code, and you see the result update live. It's the tightest iteration loop you can get.
+The key advantage over having an agent build a regular app in a folder is that it's *right there on your board*. No deploy step, no preview URL, no context switching. You ask for a change, the agent writes code, and you see the result update live. It's the tightest iteration loop you can get.
 
 If you've used artifacts in Claude Desktop or ChatGPT Canvas, the concept is similar — rich interactive windows embedded in your conversation. But here they live on a multiplayer spatial canvas where multiple agents and humans collaborate side by side.
 
-The most basic use case is anything where you need visual feedback during agent collaboration. Writing an article and want to see it rendered? Building a form and want to click through it? Sketching a chart and want to see the data? If you need to _see_ it while you work on it, artifacts are the answer.
+The most basic use case is anything where you need visual feedback during agent collaboration. Writing an article and want to see it rendered? Building a form and want to click through it? Sketching a chart and want to see the data? If you need to *see* it while you work on it, artifacts are the answer.
 
 ### Custom data visualization
 
@@ -116,12 +108,12 @@ When you need a custom workflow but your existing tools (HubSpot, Salesforce, Ji
 
 Artifacts support several Sandpack templates:
 
-| Template     | Language         | Entry point               |
-| ------------ | ---------------- | ------------------------- |
-| `react`      | JavaScript + JSX | `App.js`                  |
-| `react-ts`   | TypeScript + TSX | `App.tsx`                 |
-| `vanilla`    | Plain JavaScript | `index.js` + `index.html` |
-| `vanilla-ts` | TypeScript       | `index.ts` + `index.html` |
+| Template | Language | Entry point |
+|----------|----------|-------------|
+| `react` | JavaScript + JSX | `App.js` |
+| `react-ts` | TypeScript + TSX | `App.tsx` |
+| `vanilla` | Plain JavaScript | `index.js` + `index.html` |
+| `vanilla-ts` | TypeScript | `index.ts` + `index.html` |
 
 Agents can also provide custom files and dependencies at creation time — the template just determines the default scaffold.
 
@@ -131,18 +123,18 @@ Agents can also provide custom files and dependencies at creation time — the t
 
 Agents manage artifacts through Agor's [MCP tools](/guide/internal-mcp):
 
-| Tool                                | Purpose                                                                                                                                                                                                               |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agor_artifacts_publish`            | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId`                                                                                                                                   |
-| `agor_artifacts_get`                | Read an artifact's full file map + declarative metadata                                                                                                                                                               |
-| `agor_artifacts_land`               | Materialize an artifact's stored files back into a branch (round-trip with publish)                                                                                                                                   |
-| `agor_artifacts_update`             | Patch metadata only (board move, name, `requiredEnvVars`, `agorGrants`, `sandpackConfig`)                                                                                                                             |
-| `agor_artifacts_check_build`        | Verify source files exist and are non-empty                                                                                                                                                                           |
-| `agor_artifacts_status`             | Get build status + Sandpack errors + console logs for debugging                                                                                                                                                       |
-| `agor_artifacts_list`               | List visible artifacts (optionally filtered by board)                                                                                                                                                                 |
-| `agor_artifacts_delete`             | Remove an artifact (DB record + board placement)                                                                                                                                                                      |
-| `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys                                                          |
-| `agor_artifacts_query_dom`          | Query the rendered DOM via CSS selector. Round-trips through the viewer's open tab (no headless browser). Requires `agor_runtime.enabled !== false` and a browser tab logged in as you currently viewing the artifact |
+| Tool | Purpose |
+|------|---------|
+| `agor_artifacts_publish` | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId` |
+| `agor_artifacts_get` | Read an artifact's full file map + declarative metadata |
+| `agor_artifacts_land` | Materialize an artifact's stored files back into a branch (round-trip with publish) |
+| `agor_artifacts_update` | Patch metadata only (board move, name, `requiredEnvVars`, `agorGrants`, `sandpackConfig`) |
+| `agor_artifacts_check_build` | Verify source files exist and are non-empty |
+| `agor_artifacts_status` | Get build status + Sandpack errors + console logs for debugging |
+| `agor_artifacts_list` | List visible artifacts (optionally filtered by board) |
+| `agor_artifacts_delete` | Remove an artifact (DB record + board placement) |
+| `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys |
+| `agor_artifacts_query_dom` | Query the rendered DOM via CSS selector. Round-trips through the viewer's open tab (no headless browser). Requires `agor_runtime.enabled !== false` and a browser tab logged in as you currently viewing the artifact |
 
 The typical agent workflow: **publish** the folder, **iterate** by editing files locally and republishing with the same `artifactId`. To pick up where you left off from another branch, **land** the artifact back to disk first.
 
@@ -192,12 +184,12 @@ At render time the daemon resolves consent, looks up the **viewing user's** valu
 
 ```ts
 agor_artifacts_publish({
-  folderPath: '.agor/artifacts/staging/openai-chat',
-  boardId: '01924f3b-...',
-  name: 'OpenAI Chat',
-  template: 'react-ts',
-  requiredEnvVars: ['OPENAI_KEY'],
-  agorGrants: { agor_token: true, agor_proxies: ['openai'] },
+  folderPath: ".agor/artifacts/staging/openai-chat",
+  boardId: "01924f3b-...",
+  name: "OpenAI Chat",
+  template: "react-ts",
+  requiredEnvVars: ["OPENAI_KEY"],
+  agorGrants: { agor_token: true, agor_proxies: ["openai"] },
 });
 ```
 
@@ -207,12 +199,12 @@ The daemon prefixes the synthesized `.env` keys per template — each bundler ha
 its own hard-coded allowlist (CRA only inlines `REACT_APP_*`, Vite only inlines
 `VITE_*`, etc.). Apps use the standard idiom for their template:
 
-| Template family           | Bundler                              | `.env` prefix | Read from                 | Status                               |
-| ------------------------- | ------------------------------------ | ------------- | ------------------------- | ------------------------------------ |
-| `react`, `react-ts`       | Create React App (sandpack-react v2) | `REACT_APP_`  | `process.env.REACT_APP_X` | verified                             |
-| `vue3`, `svelte`, `solid` | (depends on template)                | `VITE_`       | `import.meta.env.VITE_X`  | best-effort, not verified end-to-end |
-| `vue`, `angular`          | Vue CLI / Angular CLI                | (none)        | `process.env.X`           | best-effort, not verified end-to-end |
-| `vanilla`, `vanilla-ts`   | Static / Parcel                      | n/a           | not supported             | verified                             |
+| Template family | Bundler | `.env` prefix | Read from | Status |
+|---|---|---|---|---|
+| `react`, `react-ts` | Create React App (sandpack-react v2) | `REACT_APP_` | `process.env.REACT_APP_X` | verified |
+| `vue3`, `svelte`, `solid` | (depends on template) | `VITE_` | `import.meta.env.VITE_X` | best-effort, not verified end-to-end |
+| `vue`, `angular` | Vue CLI / Angular CLI | (none) | `process.env.X` | best-effort, not verified end-to-end |
+| `vanilla`, `vanilla-ts` | Static / Parcel | n/a | not supported | verified |
 
 Right now only the `react` / `react-ts` mapping has been exercised against a live artifact. The other rows are inherited from the original artifact-format proposal and may need adjustment when an artifact in that template family is first published; treat them as a starting point, not a contract.
 
@@ -233,14 +225,14 @@ if (!apiKey) {
 
 ### Available `agor_grants`
 
-| Grant                           | Env var name           | Behavior                                                                                                                   |
-| ------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `agor_token: true`              | `AGOR_TOKEN`           | Mints a 15-min daemon JWT for the viewer. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
-| `agor_api_url: true`            | `AGOR_API_URL`         | Daemon base URL.                                                                                                           |
-| `agor_proxies: ["openai", ...]` | `AGOR_PROXY_OPENAI`, … | HTTP proxy URLs for listed vendors (see [API Proxies](/guide/api-proxies)).                                                |
-| `agor_user_email: true`         | `AGOR_USER_EMAIL`      | Viewer's email.                                                                                                            |
-| `agor_artifact_id: true`        | `AGOR_ARTIFACT_ID`     | Pure metadata — no consent.                                                                                                |
-| `agor_board_id: true`           | `AGOR_BOARD_ID`        | Pure metadata — no consent.                                                                                                |
+| Grant | Env var name | Behavior |
+|---|---|---|
+| `agor_token: true` | `AGOR_TOKEN` | Mints a 15-min daemon JWT for the viewer. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
+| `agor_api_url: true` | `AGOR_API_URL` | Daemon base URL. |
+| `agor_proxies: ["openai", ...]` | `AGOR_PROXY_OPENAI`, … | HTTP proxy URLs for listed vendors (see [API Proxies](/guide/api-proxies)). |
+| `agor_user_email: true` | `AGOR_USER_EMAIL` | Viewer's email. |
+| `agor_artifact_id: true` | `AGOR_ARTIFACT_ID` | Pure metadata — no consent. |
+| `agor_board_id: true` | `AGOR_BOARD_ID` | Pure metadata — no consent. |
 
 ### TOFU consent
 
@@ -270,23 +262,15 @@ Missing values render as empty string, not undefined. Check for that and surface
 - **Encrypted at rest** with AES-256-GCM.
 - **No cross-author injection without consent** — the TOFU flow blocks accidental secret leaks into someone else's code.
 
-<div
-  style={{
-    marginTop: '12px',
-    padding: '12px 16px',
-    border: '1px solid #d4940a',
-    borderRadius: '8px',
-    backgroundColor: 'rgba(212, 148, 10, 0.08)',
-    fontSize: '14px',
-  }}
->
-  **Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and
-  execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via
-  `fetch()`, or render them into the DOM where `agor_artifacts_query_dom` would surface them to a
-  calling agent. Only grant trust to artifacts you've reviewed — the consent modal includes a
-  code-preview pane for exactly that reason. The guarantee is that **no daemon-side secret injection
-  happens without your explicit consent**, not that the artifact JS can't read or expose those
-  values once you opt in.
+<div style={{
+  marginTop: '12px',
+  padding: '12px 16px',
+  border: '1px solid #d4940a',
+  borderRadius: '8px',
+  backgroundColor: 'rgba(212, 148, 10, 0.08)',
+  fontSize: '14px'
+}}>
+**Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via `fetch()`, or render them into the DOM where `agor_artifacts_query_dom` would surface them to a calling agent. Only grant trust to artifacts you've reviewed — the consent modal includes a code-preview pane for exactly that reason. The guarantee is that **no daemon-side secret injection happens without your explicit consent**, not that the artifact JS can't read or expose those values once you opt in.
 </div>
 
 ### Legacy format (`agor.config.js`)

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Artifacts
 description: Live, interactive Sandpack applications that agents build and render directly on boards
+heroImage: '/images/artifacts-hero.png'
 ---
 
 # Artifacts
@@ -8,7 +9,12 @@ description: Live, interactive Sandpack applications that agents build and rende
 <img
   src="/images/artifacts-hero.png"
   alt="Agor board with live artifacts — interactive Sandpack applications built by AI agents directly on the canvas"
-  style={{ width: '100%', borderRadius: '12px', marginBottom: '24px', boxShadow: '0 4px 24px rgba(0,0,0,0.15)' }}
+  style={{
+    width: '100%',
+    borderRadius: '12px',
+    marginBottom: '24px',
+    boxShadow: '0 4px 24px rgba(0,0,0,0.15)',
+  }}
 />
 
 Artifacts are live, interactive applications that agents create and render directly on the board canvas. An agent scaffolds a small app via MCP, writes code into it, and you see it running — no deploy, no preview URL, no context switching.
@@ -32,6 +38,7 @@ Under the hood, artifacts are powered by [Sandpack](https://sandpack.codesandbox
 Each artifact is a stored file map plus a small set of declarative metadata columns. The folder on disk is just the staging area an agent writes before calling `publish` — no Agor-specific sidecars required.
 
 **File map** (shipped to the browser):
+
 ```
 /package.json          # Standard package.json — dependencies live here
 /App.tsx               # Source files (varies by template)
@@ -40,6 +47,7 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 ```
 
 **Stored metadata** (DB columns; not in the file map):
+
 - `template` — Sandpack template (`react`, `react-ts`, `vue3`, …).
 - `sandpack_config` — Author-controlled SandpackProvider props (template, customSetup, options). Sanitized on write.
 - `required_env_vars` — Names of env vars the artifact needs (e.g. `["OPENAI_KEY"]`). The daemon synthesizes a per-viewer `.env` at render time.
@@ -47,6 +55,7 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 - `agor_runtime` — Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via `agor_artifacts_query_dom`). Enabled by default; opt out per-artifact with `{ enabled: false }`. The runtime ships as an iframe-level `<script>` tag via Sandpack's `externalResources`, so it works regardless of which user files exist (no entry-file detection, no file mutation, no template-specific gotchas).
 
 **On the board:**
+
 - **Header** — Artifact name with a trust badge (`Yours`/`Trusted`/`Untrusted`), an interact toggle (eye icon), and a 🔒 lock affordance to open the consent modal when the artifact is untrusted.
 - **Preview** — Live Sandpack renderer showing the running application.
 - **Legacy banner** — Old-format artifacts (those still carrying `sandpack.json` / `agor.config.js`) render in safe-degraded mode with an inline upgrade prompt you can hand to an agent.
@@ -57,11 +66,11 @@ Each artifact is a stored file map plus a small set of declarative metadata colu
 
 The possibilities are genuinely endless. Artifacts are a general-purpose way for agents to express themselves visually and interactively — any time you need something rendered, an artifact can do it.
 
-The key advantage over having an agent build a regular app in a folder is that it's *right there on your board*. No deploy step, no preview URL, no context switching. You ask for a change, the agent writes code, and you see the result update live. It's the tightest iteration loop you can get.
+The key advantage over having an agent build a regular app in a folder is that it's _right there on your board_. No deploy step, no preview URL, no context switching. You ask for a change, the agent writes code, and you see the result update live. It's the tightest iteration loop you can get.
 
 If you've used artifacts in Claude Desktop or ChatGPT Canvas, the concept is similar — rich interactive windows embedded in your conversation. But here they live on a multiplayer spatial canvas where multiple agents and humans collaborate side by side.
 
-The most basic use case is anything where you need visual feedback during agent collaboration. Writing an article and want to see it rendered? Building a form and want to click through it? Sketching a chart and want to see the data? If you need to *see* it while you work on it, artifacts are the answer.
+The most basic use case is anything where you need visual feedback during agent collaboration. Writing an article and want to see it rendered? Building a form and want to click through it? Sketching a chart and want to see the data? If you need to _see_ it while you work on it, artifacts are the answer.
 
 ### Custom data visualization
 
@@ -107,12 +116,12 @@ When you need a custom workflow but your existing tools (HubSpot, Salesforce, Ji
 
 Artifacts support several Sandpack templates:
 
-| Template | Language | Entry point |
-|----------|----------|-------------|
-| `react` | JavaScript + JSX | `App.js` |
-| `react-ts` | TypeScript + TSX | `App.tsx` |
-| `vanilla` | Plain JavaScript | `index.js` + `index.html` |
-| `vanilla-ts` | TypeScript | `index.ts` + `index.html` |
+| Template     | Language         | Entry point               |
+| ------------ | ---------------- | ------------------------- |
+| `react`      | JavaScript + JSX | `App.js`                  |
+| `react-ts`   | TypeScript + TSX | `App.tsx`                 |
+| `vanilla`    | Plain JavaScript | `index.js` + `index.html` |
+| `vanilla-ts` | TypeScript       | `index.ts` + `index.html` |
 
 Agents can also provide custom files and dependencies at creation time — the template just determines the default scaffold.
 
@@ -122,18 +131,18 @@ Agents can also provide custom files and dependencies at creation time — the t
 
 Agents manage artifacts through Agor's [MCP tools](/guide/internal-mcp):
 
-| Tool | Purpose |
-|------|---------|
-| `agor_artifacts_publish` | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId` |
-| `agor_artifacts_get` | Read an artifact's full file map + declarative metadata |
-| `agor_artifacts_land` | Materialize an artifact's stored files back into a branch (round-trip with publish) |
-| `agor_artifacts_update` | Patch metadata only (board move, name, `requiredEnvVars`, `agorGrants`, `sandpackConfig`) |
-| `agor_artifacts_check_build` | Verify source files exist and are non-empty |
-| `agor_artifacts_status` | Get build status + Sandpack errors + console logs for debugging |
-| `agor_artifacts_list` | List visible artifacts (optionally filtered by board) |
-| `agor_artifacts_delete` | Remove an artifact (DB record + board placement) |
-| `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys |
-| `agor_artifacts_query_dom` | Query the rendered DOM via CSS selector. Round-trips through the viewer's open tab (no headless browser). Requires `agor_runtime.enabled !== false` and a browser tab logged in as you currently viewing the artifact |
+| Tool                                | Purpose                                                                                                                                                                                                               |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agor_artifacts_publish`            | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId`                                                                                                                                   |
+| `agor_artifacts_get`                | Read an artifact's full file map + declarative metadata                                                                                                                                                               |
+| `agor_artifacts_land`               | Materialize an artifact's stored files back into a branch (round-trip with publish)                                                                                                                                   |
+| `agor_artifacts_update`             | Patch metadata only (board move, name, `requiredEnvVars`, `agorGrants`, `sandpackConfig`)                                                                                                                             |
+| `agor_artifacts_check_build`        | Verify source files exist and are non-empty                                                                                                                                                                           |
+| `agor_artifacts_status`             | Get build status + Sandpack errors + console logs for debugging                                                                                                                                                       |
+| `agor_artifacts_list`               | List visible artifacts (optionally filtered by board)                                                                                                                                                                 |
+| `agor_artifacts_delete`             | Remove an artifact (DB record + board placement)                                                                                                                                                                      |
+| `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys                                                          |
+| `agor_artifacts_query_dom`          | Query the rendered DOM via CSS selector. Round-trips through the viewer's open tab (no headless browser). Requires `agor_runtime.enabled !== false` and a browser tab logged in as you currently viewing the artifact |
 
 The typical agent workflow: **publish** the folder, **iterate** by editing files locally and republishing with the same `artifactId`. To pick up where you left off from another branch, **land** the artifact back to disk first.
 
@@ -183,12 +192,12 @@ At render time the daemon resolves consent, looks up the **viewing user's** valu
 
 ```ts
 agor_artifacts_publish({
-  folderPath: ".agor/artifacts/staging/openai-chat",
-  boardId: "01924f3b-...",
-  name: "OpenAI Chat",
-  template: "react-ts",
-  requiredEnvVars: ["OPENAI_KEY"],
-  agorGrants: { agor_token: true, agor_proxies: ["openai"] },
+  folderPath: '.agor/artifacts/staging/openai-chat',
+  boardId: '01924f3b-...',
+  name: 'OpenAI Chat',
+  template: 'react-ts',
+  requiredEnvVars: ['OPENAI_KEY'],
+  agorGrants: { agor_token: true, agor_proxies: ['openai'] },
 });
 ```
 
@@ -198,12 +207,12 @@ The daemon prefixes the synthesized `.env` keys per template — each bundler ha
 its own hard-coded allowlist (CRA only inlines `REACT_APP_*`, Vite only inlines
 `VITE_*`, etc.). Apps use the standard idiom for their template:
 
-| Template family | Bundler | `.env` prefix | Read from | Status |
-|---|---|---|---|---|
-| `react`, `react-ts` | Create React App (sandpack-react v2) | `REACT_APP_` | `process.env.REACT_APP_X` | verified |
-| `vue3`, `svelte`, `solid` | (depends on template) | `VITE_` | `import.meta.env.VITE_X` | best-effort, not verified end-to-end |
-| `vue`, `angular` | Vue CLI / Angular CLI | (none) | `process.env.X` | best-effort, not verified end-to-end |
-| `vanilla`, `vanilla-ts` | Static / Parcel | n/a | not supported | verified |
+| Template family           | Bundler                              | `.env` prefix | Read from                 | Status                               |
+| ------------------------- | ------------------------------------ | ------------- | ------------------------- | ------------------------------------ |
+| `react`, `react-ts`       | Create React App (sandpack-react v2) | `REACT_APP_`  | `process.env.REACT_APP_X` | verified                             |
+| `vue3`, `svelte`, `solid` | (depends on template)                | `VITE_`       | `import.meta.env.VITE_X`  | best-effort, not verified end-to-end |
+| `vue`, `angular`          | Vue CLI / Angular CLI                | (none)        | `process.env.X`           | best-effort, not verified end-to-end |
+| `vanilla`, `vanilla-ts`   | Static / Parcel                      | n/a           | not supported             | verified                             |
 
 Right now only the `react` / `react-ts` mapping has been exercised against a live artifact. The other rows are inherited from the original artifact-format proposal and may need adjustment when an artifact in that template family is first published; treat them as a starting point, not a contract.
 
@@ -224,14 +233,14 @@ if (!apiKey) {
 
 ### Available `agor_grants`
 
-| Grant | Env var name | Behavior |
-|---|---|---|
-| `agor_token: true` | `AGOR_TOKEN` | Mints a 15-min daemon JWT for the viewer. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
-| `agor_api_url: true` | `AGOR_API_URL` | Daemon base URL. |
-| `agor_proxies: ["openai", ...]` | `AGOR_PROXY_OPENAI`, … | HTTP proxy URLs for listed vendors (see [API Proxies](/guide/api-proxies)). |
-| `agor_user_email: true` | `AGOR_USER_EMAIL` | Viewer's email. |
-| `agor_artifact_id: true` | `AGOR_ARTIFACT_ID` | Pure metadata — no consent. |
-| `agor_board_id: true` | `AGOR_BOARD_ID` | Pure metadata — no consent. |
+| Grant                           | Env var name           | Behavior                                                                                                                   |
+| ------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `agor_token: true`              | `AGOR_TOKEN`           | Mints a 15-min daemon JWT for the viewer. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
+| `agor_api_url: true`            | `AGOR_API_URL`         | Daemon base URL.                                                                                                           |
+| `agor_proxies: ["openai", ...]` | `AGOR_PROXY_OPENAI`, … | HTTP proxy URLs for listed vendors (see [API Proxies](/guide/api-proxies)).                                                |
+| `agor_user_email: true`         | `AGOR_USER_EMAIL`      | Viewer's email.                                                                                                            |
+| `agor_artifact_id: true`        | `AGOR_ARTIFACT_ID`     | Pure metadata — no consent.                                                                                                |
+| `agor_board_id: true`           | `AGOR_BOARD_ID`        | Pure metadata — no consent.                                                                                                |
 
 ### TOFU consent
 
@@ -261,15 +270,23 @@ Missing values render as empty string, not undefined. Check for that and surface
 - **Encrypted at rest** with AES-256-GCM.
 - **No cross-author injection without consent** — the TOFU flow blocks accidental secret leaks into someone else's code.
 
-<div style={{
-  marginTop: '12px',
-  padding: '12px 16px',
-  border: '1px solid #d4940a',
-  borderRadius: '8px',
-  backgroundColor: 'rgba(212, 148, 10, 0.08)',
-  fontSize: '14px'
-}}>
-**Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via `fetch()`, or render them into the DOM where `agor_artifacts_query_dom` would surface them to a calling agent. Only grant trust to artifacts you've reviewed — the consent modal includes a code-preview pane for exactly that reason. The guarantee is that **no daemon-side secret injection happens without your explicit consent**, not that the artifact JS can't read or expose those values once you opt in.
+<div
+  style={{
+    marginTop: '12px',
+    padding: '12px 16px',
+    border: '1px solid #d4940a',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(212, 148, 10, 0.08)',
+    fontSize: '14px',
+  }}
+>
+  **Trust boundary:** Once you grant trust, secrets are injected into the artifact's JavaScript and
+  execute in the Sandpack iframe. A malicious artifact could exfiltrate injected values via
+  `fetch()`, or render them into the DOM where `agor_artifacts_query_dom` would surface them to a
+  calling agent. Only grant trust to artifacts you've reviewed — the consent modal includes a
+  code-preview pane for exactly that reason. The guarantee is that **no daemon-side secret injection
+  happens without your explicit consent**, not that the artifact JS can't read or expose those
+  values once you opt in.
 </div>
 
 ### Legacy format (`agor.config.js`)

--- a/apps/agor-docs/pages/guide/assistants.mdx
+++ b/apps/agor-docs/pages/guide/assistants.mdx
@@ -1,6 +1,7 @@
 ---
 title: Assistants
 description: Persistent AI companions with memory, skills, orchestration, and scheduled heartbeats
+heroImage: '/screenshots/assistants-list.png'
 ---
 
 # Assistants
@@ -131,14 +132,15 @@ During `agor init`, you'll be prompted to set up an assistant. This queues the s
 
 These terms mean different things in Agor:
 
-| Term | Meaning | Example |
-|------|---------|---------|
+| Term          | Meaning                                                    | Example                    |
+| ------------- | ---------------------------------------------------------- | -------------------------- |
 | **Assistant** | A persistent entity with memory, skills, and orchestration | "My PR Reviewer assistant" |
-| **Agent** | The execution engine that powers a session | Claude Code, Codex, Gemini |
+| **Agent**     | The execution engine that powers a session                 | Claude Code, Codex, Gemini |
 
 An assistant _uses_ an agent to do its work. When you create a session for your assistant, you choose which agent runs it (Claude Code is the default).
 
 Think of it this way:
+
 - "Start my assistant" = open a session on your persistent AI companion's branch
 - "Choose an agent" = pick which AI model/tool runs that session
 

--- a/apps/agor-docs/pages/guide/assistants.mdx
+++ b/apps/agor-docs/pages/guide/assistants.mdx
@@ -132,15 +132,14 @@ During `agor init`, you'll be prompted to set up an assistant. This queues the s
 
 These terms mean different things in Agor:
 
-| Term          | Meaning                                                    | Example                    |
-| ------------- | ---------------------------------------------------------- | -------------------------- |
+| Term | Meaning | Example |
+|------|---------|---------|
 | **Assistant** | A persistent entity with memory, skills, and orchestration | "My PR Reviewer assistant" |
-| **Agent**     | The execution engine that powers a session                 | Claude Code, Codex, Gemini |
+| **Agent** | The execution engine that powers a session | Claude Code, Codex, Gemini |
 
 An assistant _uses_ an agent to do its work. When you create a session for your assistant, you choose which agent runs it (Claude Code is the default).
 
 Think of it this way:
-
 - "Start my assistant" = open a session on your persistent AI companion's branch
 - "Choose an agent" = pick which AI model/tool runs that session
 

--- a/apps/agor-docs/pages/guide/boards.mdx
+++ b/apps/agor-docs/pages/guide/boards.mdx
@@ -24,7 +24,7 @@ _An Agor board with custom-styled zones forming a pipeline. Each branch card sho
 - "Testing sessions cluster on the right."
 - "That failed experiment is way down there."
 
-This is location-based memory — the same reason you remember where you parked but forget a shopping list. A 2D board gives every branch and session a _place_. Linear lists discard that.
+This is location-based memory — the same reason you remember where you parked but forget a shopping list. A 2D board gives every branch and session a *place*. Linear lists discard that.
 
 **Like Figma did for design**, Agor brings spatial collaboration to AI coding:
 
@@ -44,7 +44,7 @@ Drag a branch into "Code Review" → auto-prompts the agent for review.
 Drag into "Needs Tests" → auto-prompts for test generation.
 Drag into "Ship It" → auto-prompts for changelog + PR description.
 
-Zones turn your board into a workflow engine. Spatial position _means something_ — it triggers behavior.
+Zones turn your board into a workflow engine. Spatial position *means something* — it triggers behavior.
 
 ### How zone triggers work
 

--- a/apps/agor-docs/pages/guide/boards.mdx
+++ b/apps/agor-docs/pages/guide/boards.mdx
@@ -1,6 +1,7 @@
 ---
 title: Boards & Zones
 description: Boards are 2D spatial canvases for organizing branches. Zones are spatial regions that trigger templated prompts when branches are dropped into them.
+heroImage: '/screenshots/board-hero.png'
 ---
 
 # Boards & Zones
@@ -23,7 +24,7 @@ _An Agor board with custom-styled zones forming a pipeline. Each branch card sho
 - "Testing sessions cluster on the right."
 - "That failed experiment is way down there."
 
-This is location-based memory — the same reason you remember where you parked but forget a shopping list. A 2D board gives every branch and session a *place*. Linear lists discard that.
+This is location-based memory — the same reason you remember where you parked but forget a shopping list. A 2D board gives every branch and session a _place_. Linear lists discard that.
 
 **Like Figma did for design**, Agor brings spatial collaboration to AI coding:
 
@@ -43,7 +44,7 @@ Drag a branch into "Code Review" → auto-prompts the agent for review.
 Drag into "Needs Tests" → auto-prompts for test generation.
 Drag into "Ship It" → auto-prompts for changelog + PR description.
 
-Zones turn your board into a workflow engine. Spatial position *means something* — it triggers behavior.
+Zones turn your board into a workflow engine. Spatial position _means something_ — it triggers behavior.
 
 ### How zone triggers work
 

--- a/apps/agor-docs/pages/guide/cards.mdx
+++ b/apps/agor-docs/pages/guide/cards.mdx
@@ -12,19 +12,16 @@ heroImage: '/screenshots/cards-hero.png'
   style={{ width: '100%', borderRadius: '12px', marginBottom: '24px' }}
 />
 
-<div
-  style={{
-    marginTop: '16px',
-    marginBottom: '24px',
-    padding: '12px 16px',
-    border: '1px solid #d4940a',
-    borderRadius: '8px',
-    backgroundColor: 'rgba(212, 148, 10, 0.08)',
-    fontSize: '14px',
-  }}
->
-  **Beta** — Cards are a new feature. The data model and MCP tools are stable, but the UI and
-  workflows are evolving based on feedback.
+<div style={{
+  marginTop: '16px',
+  marginBottom: '24px',
+  padding: '12px 16px',
+  border: '1px solid #d4940a',
+  borderRadius: '8px',
+  backgroundColor: 'rgba(212, 148, 10, 0.08)',
+  fontSize: '14px'
+}}>
+**Beta** — Cards are a new feature. The data model and MCP tools are stable, but the UI and workflows are evolving based on feedback.
 </div>
 
 Every entity on an Agor board used to be a **branch** — a git branch tied to a repo. That works for coding, but what about support tickets, sales leads, patient records, or content pipelines?
@@ -100,18 +97,18 @@ A card's **zone is its status**. No separate status field — the board tells th
 
 Assistants manage cards entirely through MCP. The key tools:
 
-| Tool                     | Purpose                                                |
-| ------------------------ | ------------------------------------------------------ |
-| `agor_card_types_create` | Define a new Card Type (emoji, color, schema)          |
-| `agor_card_types_list`   | List all available Card Types                          |
-| `agor_cards_create`      | Create a card on a board, optionally into a zone       |
-| `agor_cards_update`      | Update title, description, note, data, or overrides    |
-| `agor_cards_move`        | Move a card to a different zone                        |
-| `agor_cards_list`        | List cards, filterable by board, type, or zone         |
-| `agor_cards_archive`     | Soft-archive a card (removes from board, retains data) |
-| `agor_cards_delete`      | Permanently delete a card                              |
-| `agor_cards_bulk_create` | Create many cards at once (e.g., importing from Jira)  |
-| `agor_cards_bulk_move`   | Move a batch of cards between zones                    |
+| Tool | Purpose |
+|------|---------|
+| `agor_card_types_create` | Define a new Card Type (emoji, color, schema) |
+| `agor_card_types_list` | List all available Card Types |
+| `agor_cards_create` | Create a card on a board, optionally into a zone |
+| `agor_cards_update` | Update title, description, note, data, or overrides |
+| `agor_cards_move` | Move a card to a different zone |
+| `agor_cards_list` | List cards, filterable by board, type, or zone |
+| `agor_cards_archive` | Soft-archive a card (removes from board, retains data) |
+| `agor_cards_delete` | Permanently delete a card |
+| `agor_cards_bulk_create` | Create many cards at once (e.g., importing from Jira) |
+| `agor_cards_bulk_move` | Move a batch of cards between zones |
 
 ---
 
@@ -119,14 +116,14 @@ Assistants manage cards entirely through MCP. The key tools:
 
 Cards work for any workflow where entities move through stages:
 
-| Domain         | Cards      | Pipeline                                         |
-| -------------- | ---------- | ------------------------------------------------ |
-| **Support**    | Tickets    | New → Triage → In Progress → Resolved            |
-| **Sales**      | Leads      | Pipeline → Qualified → Proposal → Closed         |
-| **DevOps**     | Incidents  | Detected → Investigating → Mitigating → Resolved |
-| **Content**    | Articles   | Draft → Review → Published                       |
-| **Migration**  | Dashboards | Assess → Migrate → Validate → Done               |
-| **Healthcare** | Patients   | Intake → Triage → Treatment → Discharge          |
+| Domain | Cards | Pipeline |
+|--------|-------|----------|
+| **Support** | Tickets | New → Triage → In Progress → Resolved |
+| **Sales** | Leads | Pipeline → Qualified → Proposal → Closed |
+| **DevOps** | Incidents | Detected → Investigating → Mitigating → Resolved |
+| **Content** | Articles | Draft → Review → Published |
+| **Migration** | Dashboards | Assess → Migrate → Validate → Done |
+| **Healthcare** | Patients | Intake → Triage → Treatment → Discharge |
 
 In each case, an assistant processes the work while the board gives you real-time visibility. You see the pipeline without reading chat logs or asking for status updates.
 

--- a/apps/agor-docs/pages/guide/cards.mdx
+++ b/apps/agor-docs/pages/guide/cards.mdx
@@ -1,6 +1,7 @@
 ---
 title: Cards
 description: Generic workflow cards that give you spatial oversight of any agentic workflow — not just code
+heroImage: '/screenshots/cards-hero.png'
 ---
 
 # Cards
@@ -11,16 +12,19 @@ description: Generic workflow cards that give you spatial oversight of any agent
   style={{ width: '100%', borderRadius: '12px', marginBottom: '24px' }}
 />
 
-<div style={{
-  marginTop: '16px',
-  marginBottom: '24px',
-  padding: '12px 16px',
-  border: '1px solid #d4940a',
-  borderRadius: '8px',
-  backgroundColor: 'rgba(212, 148, 10, 0.08)',
-  fontSize: '14px'
-}}>
-**Beta** — Cards are a new feature. The data model and MCP tools are stable, but the UI and workflows are evolving based on feedback.
+<div
+  style={{
+    marginTop: '16px',
+    marginBottom: '24px',
+    padding: '12px 16px',
+    border: '1px solid #d4940a',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(212, 148, 10, 0.08)',
+    fontSize: '14px',
+  }}
+>
+  **Beta** — Cards are a new feature. The data model and MCP tools are stable, but the UI and
+  workflows are evolving based on feedback.
 </div>
 
 Every entity on an Agor board used to be a **branch** — a git branch tied to a repo. That works for coding, but what about support tickets, sales leads, patient records, or content pipelines?
@@ -96,18 +100,18 @@ A card's **zone is its status**. No separate status field — the board tells th
 
 Assistants manage cards entirely through MCP. The key tools:
 
-| Tool | Purpose |
-|------|---------|
-| `agor_card_types_create` | Define a new Card Type (emoji, color, schema) |
-| `agor_card_types_list` | List all available Card Types |
-| `agor_cards_create` | Create a card on a board, optionally into a zone |
-| `agor_cards_update` | Update title, description, note, data, or overrides |
-| `agor_cards_move` | Move a card to a different zone |
-| `agor_cards_list` | List cards, filterable by board, type, or zone |
-| `agor_cards_archive` | Soft-archive a card (removes from board, retains data) |
-| `agor_cards_delete` | Permanently delete a card |
-| `agor_cards_bulk_create` | Create many cards at once (e.g., importing from Jira) |
-| `agor_cards_bulk_move` | Move a batch of cards between zones |
+| Tool                     | Purpose                                                |
+| ------------------------ | ------------------------------------------------------ |
+| `agor_card_types_create` | Define a new Card Type (emoji, color, schema)          |
+| `agor_card_types_list`   | List all available Card Types                          |
+| `agor_cards_create`      | Create a card on a board, optionally into a zone       |
+| `agor_cards_update`      | Update title, description, note, data, or overrides    |
+| `agor_cards_move`        | Move a card to a different zone                        |
+| `agor_cards_list`        | List cards, filterable by board, type, or zone         |
+| `agor_cards_archive`     | Soft-archive a card (removes from board, retains data) |
+| `agor_cards_delete`      | Permanently delete a card                              |
+| `agor_cards_bulk_create` | Create many cards at once (e.g., importing from Jira)  |
+| `agor_cards_bulk_move`   | Move a batch of cards between zones                    |
 
 ---
 
@@ -115,14 +119,14 @@ Assistants manage cards entirely through MCP. The key tools:
 
 Cards work for any workflow where entities move through stages:
 
-| Domain | Cards | Pipeline |
-|--------|-------|----------|
-| **Support** | Tickets | New → Triage → In Progress → Resolved |
-| **Sales** | Leads | Pipeline → Qualified → Proposal → Closed |
-| **DevOps** | Incidents | Detected → Investigating → Mitigating → Resolved |
-| **Content** | Articles | Draft → Review → Published |
-| **Migration** | Dashboards | Assess → Migrate → Validate → Done |
-| **Healthcare** | Patients | Intake → Triage → Treatment → Discharge |
+| Domain         | Cards      | Pipeline                                         |
+| -------------- | ---------- | ------------------------------------------------ |
+| **Support**    | Tickets    | New → Triage → In Progress → Resolved            |
+| **Sales**      | Leads      | Pipeline → Qualified → Proposal → Closed         |
+| **DevOps**     | Incidents  | Detected → Investigating → Mitigating → Resolved |
+| **Content**    | Articles   | Draft → Review → Published                       |
+| **Migration**  | Dashboards | Assess → Migrate → Validate → Done               |
+| **Healthcare** | Patients   | Intake → Triage → Treatment → Discharge          |
 
 In each case, an assistant processes the work while the board gives you real-time visibility. You see the pipeline without reading chat logs or asking for status updates.
 

--- a/apps/agor-docs/pages/guide/internal-mcp.mdx
+++ b/apps/agor-docs/pages/guide/internal-mcp.mdx
@@ -23,7 +23,7 @@ This is the foundational layer: [assistants](/guide/assistants), [scheduled prom
 ## Key Ideas
 
 - **Agents as first-class users:** Every MCP tool wraps a FeathersJS service. Sessions, branches, boards, zones, users, environments — anything you can click or `agor`-CLI is available as JSON-RPC.
-- **Self-aware sessions:** Each session is auto-issued a scoped MCP token, so the agent already knows _which_ session, branch, and board it's in — and can act on that context.
+- **Self-aware sessions:** Each session is auto-issued a scoped MCP token, so the agent already knows *which* session, branch, and board it's in — and can act on that context.
 - **No separate server:** MCP is part of the daemon. Nothing to install, nothing extra to run.
 - **Remote access:** External agents and dashboards can connect over HTTP to drive Agor (create boards, branches, or even invite new users).
 
@@ -31,15 +31,15 @@ This is the foundational layer: [assistants](/guide/assistants), [scheduled prom
 
 ## Capabilities At a Glance
 
-| Domain                | What agents can do                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Sessions**          | Introspect the current session, list siblings, spawn child sessions with prompts, archive/complete work |
-| **Repositories**      | List repositories, clone remote repos, register local repos, manage repo metadata                       |
-| **Branches & Boards** | List or fetch branches, create new ones, assign them to boards, update metadata, move cards spatially   |
-| **Board Zones**       | Create zones on boards, update zone properties (position, size, color), manage zone triggers            |
-| **Tasks & Reports**   | Fetch task history, create follow-up tasks, log progress, generate reports                              |
-| **Users & Teams**     | Create users, update profiles or avatars, assign roles, invite collaborators                            |
-| **Context Resources** | Enumerate context files, load concept docs, ingest repo metadata                                        |
+| Domain                 | What agents can do                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Sessions**           | Introspect the current session, list siblings, spawn child sessions with prompts, archive/complete work |
+| **Repositories**       | List repositories, clone remote repos, register local repos, manage repo metadata                       |
+| **Branches & Boards** | List or fetch branches, create new ones, assign them to boards, update metadata, move cards spatially  |
+| **Board Zones**        | Create zones on boards, update zone properties (position, size, color), manage zone triggers            |
+| **Tasks & Reports**    | Fetch task history, create follow-up tasks, log progress, generate reports                              |
+| **Users & Teams**      | Create users, update profiles or avatars, assign roles, invite collaborators                            |
+| **Context Resources**  | Enumerate context files, load concept docs, ingest repo metadata                                        |
 
 Because tools route through FeathersJS services, every action emits the same events the UI listens to—real-time updates appear instantly for everyone watching the board.
 
@@ -138,16 +138,16 @@ already allowed to act as that creator:
 ```yaml
 execution:
   # Token lifetime — keep short to cap the damage from a leak.
-  mcp_token_expiration_ms: 86400000 # 24h (default)
+  mcp_token_expiration_ms: 86400000            # 24h (default)
 ```
 
 ### Troubleshooting
 
-| Symptom                               | Likely cause                       | Fix                                          |
-| ------------------------------------- | ---------------------------------- | -------------------------------------------- |
-| `token rejected: expired`             | Token past its `exp`               | Session will re-mint on next `GET /sessions` |
-| `token rejected: session … not found` | Token's session was deleted        | Expected — token can no longer be used       |
-| `token rejected: missing jti`         | Pre-rollout token (no `jti`/`exp`) | Re-prompt / restart the session to re-mint   |
+| Symptom                                            | Likely cause                                               | Fix                                           |
+|----------------------------------------------------|------------------------------------------------------------|-----------------------------------------------|
+| `token rejected: expired`                          | Token past its `exp`                                       | Session will re-mint on next `GET /sessions`  |
+| `token rejected: session … not found`              | Token's session was deleted                                | Expected — token can no longer be used        |
+| `token rejected: missing jti`                      | Pre-rollout token (no `jti`/`exp`)                         | Re-prompt / restart the session to re-mint    |
 
 ## Related Reading
 

--- a/apps/agor-docs/pages/guide/internal-mcp.mdx
+++ b/apps/agor-docs/pages/guide/internal-mcp.mdx
@@ -1,6 +1,7 @@
 ---
 title: Agor MCP Server
 description: Agents are first-class users in Agor. The built-in MCP server gives them the same surface area you have in the UI — sessions, branches, boards, zones, users, environments — as structured JSON-RPC.
+heroImage: '/mcp_self_aware.png'
 ---
 
 # Agor MCP Server
@@ -22,7 +23,7 @@ This is the foundational layer: [assistants](/guide/assistants), [scheduled prom
 ## Key Ideas
 
 - **Agents as first-class users:** Every MCP tool wraps a FeathersJS service. Sessions, branches, boards, zones, users, environments — anything you can click or `agor`-CLI is available as JSON-RPC.
-- **Self-aware sessions:** Each session is auto-issued a scoped MCP token, so the agent already knows *which* session, branch, and board it's in — and can act on that context.
+- **Self-aware sessions:** Each session is auto-issued a scoped MCP token, so the agent already knows _which_ session, branch, and board it's in — and can act on that context.
 - **No separate server:** MCP is part of the daemon. Nothing to install, nothing extra to run.
 - **Remote access:** External agents and dashboards can connect over HTTP to drive Agor (create boards, branches, or even invite new users).
 
@@ -30,15 +31,15 @@ This is the foundational layer: [assistants](/guide/assistants), [scheduled prom
 
 ## Capabilities At a Glance
 
-| Domain                 | What agents can do                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Sessions**           | Introspect the current session, list siblings, spawn child sessions with prompts, archive/complete work |
-| **Repositories**       | List repositories, clone remote repos, register local repos, manage repo metadata                       |
-| **Branches & Boards** | List or fetch branches, create new ones, assign them to boards, update metadata, move cards spatially  |
-| **Board Zones**        | Create zones on boards, update zone properties (position, size, color), manage zone triggers            |
-| **Tasks & Reports**    | Fetch task history, create follow-up tasks, log progress, generate reports                              |
-| **Users & Teams**      | Create users, update profiles or avatars, assign roles, invite collaborators                            |
-| **Context Resources**  | Enumerate context files, load concept docs, ingest repo metadata                                        |
+| Domain                | What agents can do                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Sessions**          | Introspect the current session, list siblings, spawn child sessions with prompts, archive/complete work |
+| **Repositories**      | List repositories, clone remote repos, register local repos, manage repo metadata                       |
+| **Branches & Boards** | List or fetch branches, create new ones, assign them to boards, update metadata, move cards spatially   |
+| **Board Zones**       | Create zones on boards, update zone properties (position, size, color), manage zone triggers            |
+| **Tasks & Reports**   | Fetch task history, create follow-up tasks, log progress, generate reports                              |
+| **Users & Teams**     | Create users, update profiles or avatars, assign roles, invite collaborators                            |
+| **Context Resources** | Enumerate context files, load concept docs, ingest repo metadata                                        |
 
 Because tools route through FeathersJS services, every action emits the same events the UI listens to—real-time updates appear instantly for everyone watching the board.
 
@@ -137,16 +138,16 @@ already allowed to act as that creator:
 ```yaml
 execution:
   # Token lifetime — keep short to cap the damage from a leak.
-  mcp_token_expiration_ms: 86400000            # 24h (default)
+  mcp_token_expiration_ms: 86400000 # 24h (default)
 ```
 
 ### Troubleshooting
 
-| Symptom                                            | Likely cause                                               | Fix                                           |
-|----------------------------------------------------|------------------------------------------------------------|-----------------------------------------------|
-| `token rejected: expired`                          | Token past its `exp`                                       | Session will re-mint on next `GET /sessions`  |
-| `token rejected: session … not found`              | Token's session was deleted                                | Expected — token can no longer be used        |
-| `token rejected: missing jti`                      | Pre-rollout token (no `jti`/`exp`)                         | Re-prompt / restart the session to re-mint    |
+| Symptom                               | Likely cause                       | Fix                                          |
+| ------------------------------------- | ---------------------------------- | -------------------------------------------- |
+| `token rejected: expired`             | Token past its `exp`               | Session will re-mint on next `GET /sessions` |
+| `token rejected: session … not found` | Token's session was deleted        | Expected — token can no longer be used       |
+| `token rejected: missing jti`         | Pre-rollout token (no `jti`/`exp`) | Re-prompt / restart the session to re-mint   |
 
 ## Related Reading
 

--- a/apps/agor-docs/pages/guide/knowledge.mdx
+++ b/apps/agor-docs/pages/guide/knowledge.mdx
@@ -1,6 +1,7 @@
 ---
 title: Knowledge
 description: Built-in Knowledge for filing context, searching shared memory, and connecting docs into a graph that humans and agents can use together.
+heroImage: '/images/knowledge-hero.png'
 ---
 
 # Knowledge

--- a/apps/agor-docs/pages/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/pages/guide/rich-chat-ux.mdx
@@ -1,6 +1,7 @@
 ---
 title: Rich Chat UX
 description: Agor's chat surface is objectively richer than any CLI — token and dollar accounting per prompt, live context-window meter, structured tool blocks, queued messages, autocomplete, favicon status, chimes, Streamdown markdown.
+heroImage: '/screenshots/context-meter-timeline.png'
 ---
 
 # Rich Chat UX

--- a/apps/agor-docs/pages/guide/scheduler.mdx
+++ b/apps/agor-docs/pages/guide/scheduler.mdx
@@ -1,6 +1,7 @@
 ---
 title: Branch Scheduler
 description: Automate recurring work in Agor by attaching cron-driven agent sessions to any branch.
+heroImage: '/screenshots/scheduler-modal.png'
 ---
 
 # Branch Scheduler

--- a/apps/agor-docs/pages/security.mdx
+++ b/apps/agor-docs/pages/security.mdx
@@ -12,7 +12,11 @@ This page covers the **four deployment modes** Agor supports, what each enforces
 
 > **Status:** Agor is pre-1.0. The core auth/authorization and execution model are solid; some features (message gateway, web terminal in simple mode) trade safety for ergonomics by design and must be opted into knowingly.
 
-<img src="/security_audit.png" alt="Security audit conducted using Agor itself" width="400" />
+<img
+  src="/security_audit.png"
+  alt="Security audit conducted using Agor itself"
+  width="400"
+/>
 
 ---
 
@@ -20,19 +24,19 @@ This page covers the **four deployment modes** Agor supports, what each enforces
 
 Agor has four canonical modes. Choose based on **who shares the daemon** and **how much you trust them**.
 
-| Mode           | `branch_rbac` | `unix_user_mode` | Who's it for?                                                |
-| -------------- | ------------- | ---------------- | ------------------------------------------------------------ |
-| **Dev / Solo** | `false`       | `simple`         | Personal machine, trusted team of one                        |
-| **Local Team** | `true`        | `simple`         | Small team, RBAC for organization, no Unix isolation         |
-| **Insulated**  | `true`        | `insulated`      | Shared dev box, filesystem protection, no per-user processes |
-| **Strict**     | `true`        | `strict`         | Production / compliance — full per-user OS isolation         |
+| Mode | `branch_rbac` | `unix_user_mode` | Who's it for? |
+|---|---|---|---|
+| **Dev / Solo** | `false` | `simple` | Personal machine, trusted team of one |
+| **Local Team** | `true` | `simple` | Small team, RBAC for organization, no Unix isolation |
+| **Insulated** | `true` | `insulated` | Shared dev box, filesystem protection, no per-user processes |
+| **Strict** | `true` | `strict` | Production / compliance — full per-user OS isolation |
 
 ```yaml
 # ~/.agor/config.yaml
 execution:
-  branch_rbac: false # default: false
-  unix_user_mode: simple # simple | insulated | strict
-  executor_unix_user: agor_executor # required for insulated
+  branch_rbac: false        # default: false
+  unix_user_mode: simple       # simple | insulated | strict
+  executor_unix_user: agor_executor   # required for insulated
 ```
 
 The full setup guide for **Insulated** and **Strict** is in **[Full Multiplayer Mode](/guide/multiplayer-unix-isolation)**.
@@ -50,7 +54,6 @@ execution:
 **What it is:** Open access. All authenticated users can act on all branches. Everything runs as the daemon user.
 
 **What's enforced:**
-
 - ✅ Authentication — REST and WebSocket calls require a JWT
 - ✅ Role checks — privileged endpoints (terminals, env controls) require `admin`
 - ✅ Encrypted credentials at rest (AES-256-GCM with `AGOR_MASTER_SECRET`)
@@ -58,7 +61,6 @@ execution:
 - ✅ Body size limits (10MB)
 
 **What's NOT enforced:**
-
 - ❌ Per-branch permissions
 - ❌ Filesystem isolation between users
 - ❌ Process isolation (everything is the daemon user)
@@ -80,13 +82,11 @@ execution:
 App-layer permission checks for branch ownership and access tiers. No OS-level isolation — all execution still runs as the daemon user.
 
 **Adds:**
-
 - ✅ Branch owners + `others_can` permission tiers (see below)
 - ✅ Settings UI for managing access
 - ✅ API enforcement of view/session/prompt/all permissions
 
 **Still missing:**
-
 - ❌ Filesystem ownership (all files are daemon-owned)
 - ❌ Process identity (sessions don't run as the user who created them)
 - ❌ Credential isolation (one user's API keys are reachable by an admin)
@@ -107,13 +107,11 @@ execution:
 Adds per-branch Unix groups (`agor_wt_*`) and a dedicated executor user. Filesystem permissions naturally enforce branch boundaries.
 
 **Adds (on top of Mode 2):**
-
 - ✅ Per-branch Unix groups, scoped filesystem access
 - ✅ Executors run as a dedicated, less-privileged user
 - ✅ Sessions can't reach files outside their branch
 
 **Still missing:**
-
 - ❌ Per-user identity for processes (everything still runs as the executor user)
 
 **Requires:** [Sudoers configuration](/guide/multiplayer-unix-isolation), executor Unix user.
@@ -133,7 +131,6 @@ execution:
 Each Agor user must have a `unix_username`. Sessions execute as that user. Per-user `$HOME`, SSH keys, GitHub tokens, API credentials.
 
 **Adds (on top of Mode 3):**
-
 - ✅ Each user gets their own Unix account (`agor_alice`, `agor_bob`, …)
 - ✅ Sessions run as the session creator's Unix user
 - ✅ Per-user credential isolation (`~/.ssh/`, `~/.gitconfig`, etc.)
@@ -150,19 +147,19 @@ Each Agor user must have a `unix_username`. Sessions execute as that user. Per-u
 
 When `branch_rbac: true` is set, every branch has owners plus an `others_can` tier that controls what non-owners may do:
 
-| Tier                    | What others can do                                                                                |
-| ----------------------- | ------------------------------------------------------------------------------------------------- |
-| `none`                  | No access — completely private to owners                                                          |
-| `view`                  | Read branches, sessions, tasks, messages                                                          |
-| **`session`** (default) | Create _their own_ sessions; prompt their own sessions only                                       |
-| `prompt`                | Prompt **any** session, including others' (but each session still runs as its creator's identity) |
-| `all`                   | Full control (create/update/delete sessions, change permissions)                                  |
+| Tier | What others can do |
+|---|---|
+| `none` | No access — completely private to owners |
+| `view` | Read branches, sessions, tasks, messages |
+| **`session`** (default) | Create *their own* sessions; prompt their own sessions only |
+| `prompt` | Prompt **any** session, including others' (but each session still runs as its creator's identity) |
+| `all` | Full control (create/update/delete sessions, change permissions) |
 
 The `session` tier is the safe default — collaborators can work independently without impersonating each other's OS identity.
 
 ### Session Sharing (`dangerously_allow_session_sharing`)
 
-A branch-level toggle, **off by default**. When OFF, spawning/forking attributes the new child to the _caller_ — it runs as the caller's Unix user. When ON (legacy behavior), children inherit the parent's `created_by`, meaning a collaborator can effectively spawn agents that execute as the original session owner.
+A branch-level toggle, **off by default**. When OFF, spawning/forking attributes the new child to the *caller* — it runs as the caller's Unix user. When ON (legacy behavior), children inherit the parent's `created_by`, meaning a collaborator can effectively spawn agents that execute as the original session owner.
 
 Cross-user spawns under the legacy path emit `[SECURITY]` warning logs. See `context/explorations/session-sharing.md` for the full discussion.
 

--- a/apps/agor-docs/pages/security.mdx
+++ b/apps/agor-docs/pages/security.mdx
@@ -1,6 +1,7 @@
 ---
 title: Security
 description: How to operate Agor safely — deployment modes, what's enforced, what's not, and what every admin needs to know before sharing access.
+heroImage: '/security_audit.png'
 ---
 
 # Security
@@ -11,11 +12,7 @@ This page covers the **four deployment modes** Agor supports, what each enforces
 
 > **Status:** Agor is pre-1.0. The core auth/authorization and execution model are solid; some features (message gateway, web terminal in simple mode) trade safety for ergonomics by design and must be opted into knowingly.
 
-<img
-  src="/security_audit.png"
-  alt="Security audit conducted using Agor itself"
-  width="400"
-/>
+<img src="/security_audit.png" alt="Security audit conducted using Agor itself" width="400" />
 
 ---
 
@@ -23,19 +20,19 @@ This page covers the **four deployment modes** Agor supports, what each enforces
 
 Agor has four canonical modes. Choose based on **who shares the daemon** and **how much you trust them**.
 
-| Mode | `branch_rbac` | `unix_user_mode` | Who's it for? |
-|---|---|---|---|
-| **Dev / Solo** | `false` | `simple` | Personal machine, trusted team of one |
-| **Local Team** | `true` | `simple` | Small team, RBAC for organization, no Unix isolation |
-| **Insulated** | `true` | `insulated` | Shared dev box, filesystem protection, no per-user processes |
-| **Strict** | `true` | `strict` | Production / compliance — full per-user OS isolation |
+| Mode           | `branch_rbac` | `unix_user_mode` | Who's it for?                                                |
+| -------------- | ------------- | ---------------- | ------------------------------------------------------------ |
+| **Dev / Solo** | `false`       | `simple`         | Personal machine, trusted team of one                        |
+| **Local Team** | `true`        | `simple`         | Small team, RBAC for organization, no Unix isolation         |
+| **Insulated**  | `true`        | `insulated`      | Shared dev box, filesystem protection, no per-user processes |
+| **Strict**     | `true`        | `strict`         | Production / compliance — full per-user OS isolation         |
 
 ```yaml
 # ~/.agor/config.yaml
 execution:
-  branch_rbac: false        # default: false
-  unix_user_mode: simple       # simple | insulated | strict
-  executor_unix_user: agor_executor   # required for insulated
+  branch_rbac: false # default: false
+  unix_user_mode: simple # simple | insulated | strict
+  executor_unix_user: agor_executor # required for insulated
 ```
 
 The full setup guide for **Insulated** and **Strict** is in **[Full Multiplayer Mode](/guide/multiplayer-unix-isolation)**.
@@ -53,6 +50,7 @@ execution:
 **What it is:** Open access. All authenticated users can act on all branches. Everything runs as the daemon user.
 
 **What's enforced:**
+
 - ✅ Authentication — REST and WebSocket calls require a JWT
 - ✅ Role checks — privileged endpoints (terminals, env controls) require `admin`
 - ✅ Encrypted credentials at rest (AES-256-GCM with `AGOR_MASTER_SECRET`)
@@ -60,6 +58,7 @@ execution:
 - ✅ Body size limits (10MB)
 
 **What's NOT enforced:**
+
 - ❌ Per-branch permissions
 - ❌ Filesystem isolation between users
 - ❌ Process isolation (everything is the daemon user)
@@ -81,11 +80,13 @@ execution:
 App-layer permission checks for branch ownership and access tiers. No OS-level isolation — all execution still runs as the daemon user.
 
 **Adds:**
+
 - ✅ Branch owners + `others_can` permission tiers (see below)
 - ✅ Settings UI for managing access
 - ✅ API enforcement of view/session/prompt/all permissions
 
 **Still missing:**
+
 - ❌ Filesystem ownership (all files are daemon-owned)
 - ❌ Process identity (sessions don't run as the user who created them)
 - ❌ Credential isolation (one user's API keys are reachable by an admin)
@@ -106,11 +107,13 @@ execution:
 Adds per-branch Unix groups (`agor_wt_*`) and a dedicated executor user. Filesystem permissions naturally enforce branch boundaries.
 
 **Adds (on top of Mode 2):**
+
 - ✅ Per-branch Unix groups, scoped filesystem access
 - ✅ Executors run as a dedicated, less-privileged user
 - ✅ Sessions can't reach files outside their branch
 
 **Still missing:**
+
 - ❌ Per-user identity for processes (everything still runs as the executor user)
 
 **Requires:** [Sudoers configuration](/guide/multiplayer-unix-isolation), executor Unix user.
@@ -130,6 +133,7 @@ execution:
 Each Agor user must have a `unix_username`. Sessions execute as that user. Per-user `$HOME`, SSH keys, GitHub tokens, API credentials.
 
 **Adds (on top of Mode 3):**
+
 - ✅ Each user gets their own Unix account (`agor_alice`, `agor_bob`, …)
 - ✅ Sessions run as the session creator's Unix user
 - ✅ Per-user credential isolation (`~/.ssh/`, `~/.gitconfig`, etc.)
@@ -146,19 +150,19 @@ Each Agor user must have a `unix_username`. Sessions execute as that user. Per-u
 
 When `branch_rbac: true` is set, every branch has owners plus an `others_can` tier that controls what non-owners may do:
 
-| Tier | What others can do |
-|---|---|
-| `none` | No access — completely private to owners |
-| `view` | Read branches, sessions, tasks, messages |
-| **`session`** (default) | Create *their own* sessions; prompt their own sessions only |
-| `prompt` | Prompt **any** session, including others' (but each session still runs as its creator's identity) |
-| `all` | Full control (create/update/delete sessions, change permissions) |
+| Tier                    | What others can do                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `none`                  | No access — completely private to owners                                                          |
+| `view`                  | Read branches, sessions, tasks, messages                                                          |
+| **`session`** (default) | Create _their own_ sessions; prompt their own sessions only                                       |
+| `prompt`                | Prompt **any** session, including others' (but each session still runs as its creator's identity) |
+| `all`                   | Full control (create/update/delete sessions, change permissions)                                  |
 
 The `session` tier is the safe default — collaborators can work independently without impersonating each other's OS identity.
 
 ### Session Sharing (`dangerously_allow_session_sharing`)
 
-A branch-level toggle, **off by default**. When OFF, spawning/forking attributes the new child to the *caller* — it runs as the caller's Unix user. When ON (legacy behavior), children inherit the parent's `created_by`, meaning a collaborator can effectively spawn agents that execute as the original session owner.
+A branch-level toggle, **off by default**. When OFF, spawning/forking attributes the new child to the _caller_ — it runs as the caller's Unix user. When ON (legacy behavior), children inherit the parent's `created_by`, meaning a collaborator can effectively spawn agents that execute as the original session owner.
 
 Cross-user spawns under the legacy path emit `[SECURITY]` warning logs. See `context/explorations/session-sharing.md` for the full discussion.
 

--- a/apps/agor-docs/scripts/validate-social-metadata.mjs
+++ b/apps/agor-docs/scripts/validate-social-metadata.mjs
@@ -1,0 +1,143 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_SITE_URL = 'https://agor.live';
+const DEFAULT_SOCIAL_IMAGE = '/hero.png';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(__dirname, '..');
+const pagesDir = path.join(appDir, 'pages');
+const publicDir = path.join(appDir, 'public');
+const imageFields = ['ogImage', 'socialImage', 'heroImage', 'image'];
+
+function getSiteUrl() {
+  return (process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL).replace(/\/+$/, '');
+}
+
+function getBasePath() {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  return basePath ? `/${basePath.replace(/^\/+|\/+$/g, '')}` : '';
+}
+
+function withBasePath(pathname) {
+  const basePath = getBasePath();
+
+  if (!basePath || pathname === basePath || pathname.startsWith(`${basePath}/`)) {
+    return pathname;
+  }
+
+  return `${basePath}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
+}
+
+function isAbsoluteUrl(value) {
+  return /^https?:\/\//i.test(value);
+}
+
+function toAbsoluteUrl(value) {
+  if (isAbsoluteUrl(value)) {
+    return value;
+  }
+
+  const pathname = value.startsWith('/') ? value : `/${value}`;
+  return `${getSiteUrl()}${withBasePath(pathname)}`;
+}
+
+function getSocialImage(frontMatter) {
+  return toAbsoluteUrl(
+    frontMatter.ogImage ||
+      frontMatter.socialImage ||
+      frontMatter.heroImage ||
+      frontMatter.image ||
+      DEFAULT_SOCIAL_IMAGE
+  );
+}
+
+function walk(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    const fullPath = path.join(dir, entry);
+    return statSync(fullPath).isDirectory() ? walk(fullPath) : [fullPath];
+  });
+}
+
+function parseFrontMatter(filePath) {
+  const source = readFileSync(filePath, 'utf8');
+
+  if (!source.startsWith('---\n')) {
+    return {};
+  }
+
+  const end = source.indexOf('\n---', 4);
+
+  if (end === -1) {
+    return {};
+  }
+
+  const frontMatter = {};
+
+  for (const line of source.slice(4, end).split('\n')) {
+    const match = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+
+    if (!match) {
+      continue;
+    }
+
+    const [, key, rawValue] = match;
+    frontMatter[key] = rawValue.trim().replace(/^['"]|['"]$/g, '');
+  }
+
+  return frontMatter;
+}
+
+function assertLocalPublicImageExists(value, filePath, errors) {
+  if (!value || isAbsoluteUrl(value)) {
+    return;
+  }
+
+  if (!value.startsWith('/')) {
+    errors.push(`${filePath}: social image paths should start with "/": ${value}`);
+    return;
+  }
+
+  const publicPath = path.join(publicDir, value);
+
+  if (!existsSync(publicPath)) {
+    errors.push(`${filePath}: image does not exist under public/: ${value}`);
+  }
+}
+
+const pages = walk(pagesDir)
+  .filter((filePath) => filePath.endsWith('.mdx'))
+  .map((filePath) => ({
+    filePath: path.relative(appDir, filePath),
+    frontMatter: parseFrontMatter(filePath),
+  }));
+
+const errors = [];
+
+assertLocalPublicImageExists(DEFAULT_SOCIAL_IMAGE, 'default social image', errors);
+
+for (const page of pages) {
+  const socialImage = getSocialImage(page.frontMatter);
+
+  if (!isAbsoluteUrl(socialImage)) {
+    errors.push(`${page.filePath}: generated social image is not absolute: ${socialImage}`);
+  }
+
+  for (const field of imageFields) {
+    const value = page.frontMatter[field];
+
+    if (typeof value === 'string') {
+      assertLocalPublicImageExists(value, page.filePath, errors);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Social metadata validation failed with ${errors.length} error(s):`);
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Validated social metadata for ${pages.length} MDX pages.`);

--- a/apps/agor-docs/scripts/validate-social-metadata.ts
+++ b/apps/agor-docs/scripts/validate-social-metadata.ts
@@ -1,65 +1,32 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_SOCIAL_IMAGE,
+  type FrontMatterLike,
+  getSocialImage,
+  isAbsoluteUrl,
+  SOCIAL_IMAGE_FIELDS,
+} from '../lib/siteMetadata';
 
-const DEFAULT_SITE_URL = 'https://agor.live';
-const DEFAULT_SOCIAL_IMAGE = '/hero.png';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const appDir = path.resolve(__dirname, '..');
 const pagesDir = path.join(appDir, 'pages');
 const publicDir = path.join(appDir, 'public');
-const imageFields = ['ogImage', 'socialImage', 'heroImage', 'image'];
 
-function getSiteUrl() {
-  return (process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL).replace(/\/+$/, '');
-}
+type PageMetadata = {
+  filePath: string;
+  frontMatter: FrontMatterLike;
+};
 
-function getBasePath() {
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-  return basePath ? `/${basePath.replace(/^\/+|\/+$/g, '')}` : '';
-}
-
-function withBasePath(pathname) {
-  const basePath = getBasePath();
-
-  if (!basePath || pathname === basePath || pathname.startsWith(`${basePath}/`)) {
-    return pathname;
-  }
-
-  return `${basePath}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
-}
-
-function isAbsoluteUrl(value) {
-  return /^https?:\/\//i.test(value);
-}
-
-function toAbsoluteUrl(value) {
-  if (isAbsoluteUrl(value)) {
-    return value;
-  }
-
-  const pathname = value.startsWith('/') ? value : `/${value}`;
-  return `${getSiteUrl()}${withBasePath(pathname)}`;
-}
-
-function getSocialImage(frontMatter) {
-  return toAbsoluteUrl(
-    frontMatter.ogImage ||
-      frontMatter.socialImage ||
-      frontMatter.heroImage ||
-      frontMatter.image ||
-      DEFAULT_SOCIAL_IMAGE
-  );
-}
-
-function walk(dir) {
+function walk(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
     const fullPath = path.join(dir, entry);
     return statSync(fullPath).isDirectory() ? walk(fullPath) : [fullPath];
   });
 }
 
-function parseFrontMatter(filePath) {
+function parseFrontMatter(filePath: string): FrontMatterLike {
   const source = readFileSync(filePath, 'utf8');
 
   if (!source.startsWith('---\n')) {
@@ -72,7 +39,7 @@ function parseFrontMatter(filePath) {
     return {};
   }
 
-  const frontMatter = {};
+  const frontMatter: FrontMatterLike = {};
 
   for (const line of source.slice(4, end).split('\n')) {
     const match = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
@@ -88,7 +55,7 @@ function parseFrontMatter(filePath) {
   return frontMatter;
 }
 
-function assertLocalPublicImageExists(value, filePath, errors) {
+function assertLocalPublicImageExists(value: string, filePath: string, errors: string[]): void {
   if (!value || isAbsoluteUrl(value)) {
     return;
   }
@@ -105,14 +72,14 @@ function assertLocalPublicImageExists(value, filePath, errors) {
   }
 }
 
-const pages = walk(pagesDir)
+const pages: PageMetadata[] = walk(pagesDir)
   .filter((filePath) => filePath.endsWith('.mdx'))
   .map((filePath) => ({
     filePath: path.relative(appDir, filePath),
     frontMatter: parseFrontMatter(filePath),
   }));
 
-const errors = [];
+const errors: string[] = [];
 
 assertLocalPublicImageExists(DEFAULT_SOCIAL_IMAGE, 'default social image', errors);
 
@@ -123,7 +90,7 @@ for (const page of pages) {
     errors.push(`${page.filePath}: generated social image is not absolute: ${socialImage}`);
   }
 
-  for (const field of imageFields) {
+  for (const field of SOCIAL_IMAGE_FIELDS) {
     const value = page.frontMatter[field];
 
     if (typeof value === 'string') {

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -3,10 +3,16 @@ import type { DocsThemeConfig } from 'nextra-theme-docs';
 import { useConfig } from 'nextra-theme-docs';
 import { NavbarCloudCTA } from './components/NavbarCloudCTA';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from './lib/links';
+import {
+  DEFAULT_DESCRIPTION,
+  getBasePath,
+  getCanonicalUrl,
+  getSiteUrl,
+  getSocialImage,
+} from './lib/siteMetadata';
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-const defaultSiteUrl = 'https://agor.live';
-const defaultOgImage = `${defaultSiteUrl}/hero.png`;
+const basePath = getBasePath();
+const siteUrl = getSiteUrl();
 
 const config: DocsThemeConfig = {
   logo: (
@@ -79,21 +85,20 @@ const config: DocsThemeConfig = {
     const { asPath } = useRouter();
 
     const pathname = asPath?.split('#')[0]?.split('?')[0] ?? '/';
-    const siteUrl = frontMatter.canonical ?? `${defaultSiteUrl}${pathname === '/' ? '' : pathname}`;
+    const canonicalUrl = getCanonicalUrl(pathname, frontMatter.canonical);
 
     const pageTitle = frontMatter.title ?? title ?? 'agor';
-    const description =
-      frontMatter.description ||
-      'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git branches, with real-time multiplayer and an MCP surface agents drive themselves.';
+    const description = frontMatter.description || DEFAULT_DESCRIPTION;
     const fullTitle =
       pageTitle === 'agor'
         ? 'agor – Team command center for all things agentic'
         : `${pageTitle} – agor`;
-    const rawOgImage = frontMatter.ogImage || frontMatter.image || defaultOgImage;
-    const ogImage = rawOgImage.startsWith('http') ? rawOgImage : `${defaultSiteUrl}${rawOgImage}`;
+    const socialImage = getSocialImage(frontMatter);
     const ogType = frontMatter.date ? 'article' : 'website';
     const publishedTime = frontMatter.date ? new Date(frontMatter.date).toISOString() : undefined;
     const gaId = process.env.NEXT_PUBLIC_GA_ID;
+    const imageWidth = frontMatter.imageWidth ? String(frontMatter.imageWidth) : undefined;
+    const imageHeight = frontMatter.imageHeight ? String(frontMatter.imageHeight) : undefined;
 
     return (
       <>
@@ -133,22 +138,22 @@ const config: DocsThemeConfig = {
         <meta property="og:site_name" content="agor" />
         <meta property="og:title" content={fullTitle} />
         <meta property="og:description" content={description} />
-        <meta property="og:image" content={ogImage} />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-        <meta property="og:url" content={siteUrl} />
+        <meta property="og:image" content={socialImage} />
+        {imageWidth && <meta property="og:image:width" content={imageWidth} />}
+        {imageHeight && <meta property="og:image:height" content={imageHeight} />}
+        <meta property="og:url" content={canonicalUrl} />
         {publishedTime && <meta property="article:published_time" content={publishedTime} />}
 
         {/* Twitter Card */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={fullTitle} />
         <meta name="twitter:description" content={description} />
-        <meta name="twitter:image" content={ogImage} />
+        <meta name="twitter:image" content={socialImage} />
 
         {/* Additional Meta */}
         <meta name="theme-color" content="#2e9a92" />
         <link rel="icon" type="image/png" href={`${basePath}/favicon.png`} />
-        <link rel="canonical" href={siteUrl} />
+        <link rel="canonical" href={canonicalUrl} />
 
         {/* JSON-LD Structured Data */}
         <script
@@ -162,8 +167,8 @@ const config: DocsThemeConfig = {
                     '@type': 'BlogPosting',
                     headline: pageTitle,
                     description,
-                    image: ogImage,
-                    url: siteUrl,
+                    image: socialImage,
+                    url: canonicalUrl,
                     datePublished: new Date(frontMatter.date).toISOString(),
                     author: {
                       '@type': 'Person',
@@ -174,7 +179,7 @@ const config: DocsThemeConfig = {
                       name: 'Agor',
                       logo: {
                         '@type': 'ImageObject',
-                        url: `${defaultSiteUrl}/logo.png`,
+                        url: `${siteUrl}${basePath}/logo.png`,
                       },
                     },
                   }
@@ -182,8 +187,7 @@ const config: DocsThemeConfig = {
                     '@context': 'https://schema.org',
                     '@type': 'SoftwareApplication',
                     name: 'agor',
-                    description:
-                      'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git branches, with real-time multiplayer and an MCP surface agents drive themselves.',
+                    description: DEFAULT_DESCRIPTION,
                     applicationCategory: 'DeveloperApplication',
                     operatingSystem: 'macOS, Linux, Windows',
                     offers: {
@@ -191,13 +195,13 @@ const config: DocsThemeConfig = {
                       price: '0',
                       priceCurrency: 'USD',
                     },
-                    url: siteUrl,
+                    url: canonicalUrl,
                     codeRepository: 'https://github.com/preset-io/agor',
                     author: {
                       '@type': 'Person',
                       name: 'Maxime Beauchemin',
                     },
-                    screenshot: ogImage,
+                    screenshot: socialImage,
                   }
             ),
           }}
@@ -217,7 +221,7 @@ const config: DocsThemeConfig = {
                     '@type': 'ListItem',
                     position: 1,
                     name: 'Home',
-                    item: defaultSiteUrl,
+                    item: `${siteUrl}${basePath || ''}`,
                   },
                   ...pathname
                     .split('/')
@@ -229,7 +233,7 @@ const config: DocsThemeConfig = {
                         index === arr.length - 1
                           ? pageTitle
                           : segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' '),
-                      item: `${defaultSiteUrl}/${arr.slice(0, index + 1).join('/')}`,
+                      item: `${siteUrl}${basePath}/${arr.slice(0, index + 1).join('/')}`,
                     })),
                 ],
               }),


### PR DESCRIPTION
## Summary

- Centralize docs social metadata URL/image handling in `siteMetadata` helpers.
- Use page `ogImage` / `socialImage` / `heroImage` / `image` frontmatter to drive `og:image`, `twitter:image`, JSON-LD image fields, and canonical URLs with absolute URLs.
- Add `heroImage` frontmatter to existing docs feature/reference pages with visible hero imagery, while keeping blog posts on the existing `image` convention.
- Document the authoring convention and add static validation for social image paths.
- Wire `NEXT_PUBLIC_SITE_URL` through docs env examples, sitemap config, Docker compose, and the Agor docs dev environment.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/docs validate:social-metadata`
- `pnpm --filter @agor/docs typecheck`
- YAML parse check for `.agor.yml` and `apps/agor-docs/docker-compose.yml`
