### PR TITLE
Support custom MCP HTTP headers

### DIFF
--- a/apps/agor-cli/src/commands/mcp/add.ts
+++ b/apps/agor-cli/src/commands/mcp/add.ts
@@ -2,6 +2,7 @@
  * `agor mcp add` - Add a new MCP server
  */
 
+import { normalizeMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import { shortId } from '@agor-live/client';
 import { Args, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -128,17 +129,30 @@ export default class McpAdd extends BaseCommand {
 
       // Add custom HTTP headers
       if (flags.headers) {
+        if (flags.transport === 'stdio') {
+          this.warn('--headers only applies to http/sse transports; ignoring for stdio');
+        }
         const headerPairs = flags.headers.split(',').map((pair) => pair.trim());
         const headersObject: Record<string, string> = {};
         for (const pair of headerPairs) {
           const [key, ...valueParts] = pair.split('=');
           const value = valueParts.join('=');
-          if (key && value && key.trim().toLowerCase() !== 'authorization') {
+          if (key && value) {
             headersObject[key.trim()] = value.trim();
           }
         }
-        if (Object.keys(headersObject).length > 0) {
-          data.headers = headersObject;
+        const normalizedHeaders =
+          flags.transport === 'stdio' ? undefined : normalizeMCPCustomHeaders(headersObject);
+        const droppedHeaderNames = Object.keys(headersObject).filter(
+          (key) => !normalizedHeaders || !(key.trim() in normalizedHeaders)
+        );
+        if (droppedHeaderNames.length > 0) {
+          this.warn(
+            `Ignoring reserved or invalid custom headers: ${droppedHeaderNames.join(', ')}`
+          );
+        }
+        if (normalizedHeaders && Object.keys(normalizedHeaders).length > 0) {
+          data.headers = normalizedHeaders;
         }
       }
 

--- a/apps/agor-cli/src/commands/mcp/add.ts
+++ b/apps/agor-cli/src/commands/mcp/add.ts
@@ -66,6 +66,10 @@ export default class McpAdd extends BaseCommand {
       char: 'e',
       description: 'Environment variables (key=value pairs, comma-separated)',
     }),
+    headers: Flags.string({
+      description:
+        'Custom HTTP headers for remote transports (key=value pairs, comma-separated). Authorization is configured via auth, not here.',
+    }),
   };
 
   async run(): Promise<void> {
@@ -122,6 +126,22 @@ export default class McpAdd extends BaseCommand {
         }
       }
 
+      // Add custom HTTP headers
+      if (flags.headers) {
+        const headerPairs = flags.headers.split(',').map((pair) => pair.trim());
+        const headersObject: Record<string, string> = {};
+        for (const pair of headerPairs) {
+          const [key, ...valueParts] = pair.split('=');
+          const value = valueParts.join('=');
+          if (key && value && key.trim().toLowerCase() !== 'authorization') {
+            headersObject[key.trim()] = value.trim();
+          }
+        }
+        if (Object.keys(headersObject).length > 0) {
+          data.headers = headersObject;
+        }
+      }
+
       // Add scope-specific IDs
       if (flags['session-id']) data.session_id = flags['session-id'];
 
@@ -151,6 +171,10 @@ export default class McpAdd extends BaseCommand {
       if (server.env) {
         const envKeys = Object.keys(server.env);
         this.log(`  ${chalk.cyan('Environment')}: ${envKeys.join(', ')}`);
+      }
+      if (server.headers) {
+        const headerKeys = Object.keys(server.headers);
+        this.log(`  ${chalk.cyan('Custom Headers')}: ${headerKeys.join(', ')}`);
       }
 
       this.log('');

--- a/apps/agor-cli/src/commands/mcp/show.ts
+++ b/apps/agor-cli/src/commands/mcp/show.ts
@@ -87,8 +87,8 @@ export default class McpShow extends BaseCommand {
 
       if (server.headers && Object.keys(server.headers).length > 0) {
         this.log(`${chalk.cyan('Custom HTTP Headers')}:`);
-        for (const [key, value] of Object.entries(server.headers)) {
-          this.log(`  ${key}: ${value}`);
+        for (const key of Object.keys(server.headers)) {
+          this.log(`  ${key}: ••••••••`);
         }
       }
 

--- a/apps/agor-cli/src/commands/mcp/show.ts
+++ b/apps/agor-cli/src/commands/mcp/show.ts
@@ -85,6 +85,13 @@ export default class McpShow extends BaseCommand {
         this.log(`${chalk.cyan('URL')}: ${server.url}`);
       }
 
+      if (server.headers && Object.keys(server.headers).length > 0) {
+        this.log(`${chalk.cyan('Custom HTTP Headers')}:`);
+        for (const [key, value] of Object.entries(server.headers)) {
+          this.log(`  ${key}: ${value}`);
+        }
+      }
+
       if (server.env && Object.keys(server.env).length > 0) {
         this.log(`${chalk.cyan('Environment Variables')}:`);
         for (const [key, value] of Object.entries(server.env)) {

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -19,6 +19,7 @@ export interface McpServerSummary {
   auth_type: string;
   oauth_mode?: string;
   oauth_authenticated: boolean;
+  has_custom_headers: boolean;
   enabled: boolean;
 }
 
@@ -67,6 +68,7 @@ export async function summarizeMcpServer(
     auth_type: authType,
     oauth_mode: oauthMode,
     oauth_authenticated: authenticated,
+    has_custom_headers: !!mcpServer.headers && Object.keys(mcpServer.headers).length > 0,
     enabled: mcpServer.enabled,
   };
 }
@@ -110,7 +112,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
     'agor_mcp_servers_list',
     {
       description:
-        'List the MCP-server catalog the current user can access (i.e. servers eligible to attach to a session). Each entry includes name, transport, auth type, and OAuth status. Use this to discover IDs to pass to `agor_sessions_create({ mcpServerIds })`. To see which servers are currently ATTACHED to a session, read `attached_mcp_servers` from `agor_sessions_get_current` or `agor_sessions_get`.',
+        'List the MCP-server catalog the current user can access (i.e. servers eligible to attach to a session). Each entry includes name, transport, auth type, custom-header presence, and OAuth status. Use this to discover IDs to pass to `agor_sessions_create({ mcpServerIds })`. To see which servers are currently ATTACHED to a session, read `attached_mcp_servers` from `agor_sessions_get_current` or `agor_sessions_get`.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         includeDisabled: z

--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -3,17 +3,23 @@ import { describe, expect, it } from 'vitest';
 
 describe('register-hooks MCP custom header redaction', () => {
   const source = readFileSync(new URL('./register-hooks.ts', import.meta.url), 'utf8');
+  const routesSource = readFileSync(new URL('./register-routes.ts', import.meta.url), 'utf8');
 
   it('redacts MCP custom header values in mcp-servers responses', () => {
     expect(source).toContain('redactMCPHeaderSecrets');
-    expect(source).toContain(
-      "headers: Object.fromEntries(Object.keys(server.headers).map((key) => [key, '••••••••']))"
-    );
+    expect(source).toContain('redactMCPCustomHeaders(server.headers)');
     expect(source).toMatch(/find:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
     expect(source).toMatch(/get:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
   });
 
+  it('redacts session MCP server route responses that bypass service hooks', () => {
+    expect(routesSource).toContain("'/sessions/:id/mcp-servers'");
+    expect(routesSource).toContain('redactMCPServerHeaderSecrets');
+    expect(routesSource).toContain('servers.map(redactMCPServerHeaderSecrets)');
+  });
+
   it('keeps raw headers available to executor session-token calls', () => {
     expect(source).toContain("auth?.strategy === 'session-token'");
+    expect(routesSource).toContain("auth?.strategy === 'session-token'");
   });
 });

--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('register-hooks MCP custom header redaction', () => {
+  const source = readFileSync(new URL('./register-hooks.ts', import.meta.url), 'utf8');
+
+  it('redacts MCP custom header values in mcp-servers responses', () => {
+    expect(source).toContain('redactMCPHeaderSecrets');
+    expect(source).toContain(
+      "headers: Object.fromEntries(Object.keys(server.headers).map((key) => [key, '••••••••']))"
+    );
+    expect(source).toMatch(/find:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
+    expect(source).toMatch(/get:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
+  });
+
+  it('keeps raw headers available to executor session-token calls', () => {
+    expect(source).toContain("auth?.strategy === 'session-token'");
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -4,10 +4,15 @@ import { describe, expect, it } from 'vitest';
 describe('register-hooks MCP custom header redaction', () => {
   const source = readFileSync(new URL('./register-hooks.ts', import.meta.url), 'utf8');
   const routesSource = readFileSync(new URL('./register-routes.ts', import.meta.url), 'utf8');
+  const utilSource = readFileSync(
+    new URL('./utils/mcp-header-secrets.ts', import.meta.url),
+    'utf8'
+  );
 
   it('redacts MCP custom header values in mcp-servers responses', () => {
     expect(source).toContain('redactMCPHeaderSecrets');
-    expect(source).toContain('redactMCPCustomHeaders(server.headers)');
+    expect(source).toContain('redactMCPServerHeaderSecrets');
+    expect(utilSource).toContain('redactMCPCustomHeaders(server.headers)');
     expect(source).toMatch(/find:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
     expect(source).toMatch(/get:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
   });
@@ -19,7 +24,8 @@ describe('register-hooks MCP custom header redaction', () => {
   });
 
   it('keeps raw headers available to executor session-token calls', () => {
-    expect(source).toContain("auth?.strategy === 'session-token'");
-    expect(routesSource).toContain("auth?.strategy === 'session-token'");
+    expect(source).toContain('shouldExposeMCPHeaderSecrets(context.params)');
+    expect(routesSource).toContain('shouldExposeMCPHeaderSecrets(params)');
+    expect(utilSource).toContain("params.authentication?.strategy === 'session-token'");
   });
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -46,7 +46,6 @@ import {
   typedValidateQuery,
   userQueryValidator,
 } from '@agor/core/lib/feathers-validation';
-import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type {
   AuthenticatedParams,
   Board,
@@ -104,6 +103,10 @@ import {
 import { inspectBranchViaExecutor } from './utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from './utils/executor-read-impersonation.js';
 import { injectCreatedBy } from './utils/inject-created-by.js';
+import {
+  redactMCPServerHeaderSecrets,
+  shouldExposeMCPHeaderSecrets,
+} from './utils/mcp-header-secrets.js';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
 import {
@@ -1211,33 +1214,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  const shouldExposeMCPHeaderSecrets = (context: HookContext) => {
-    if (!context.params?.provider) return true;
-    const auth = (context.params as Record<string, unknown>).authentication as
-      | { strategy?: string }
-      | undefined;
-    const role = (context.params.user as { role?: string } | undefined)?.role;
-    return auth?.strategy === 'session-token' || role === 'service';
-  };
-
   const redactMCPHeaderSecrets = async (context: HookContext) => {
-    if (shouldExposeMCPHeaderSecrets(context)) return context;
-
-    const redactServer = (server: MCPServer) => {
-      if (!server?.headers || Object.keys(server.headers).length === 0) return server;
-      const headers = redactMCPCustomHeaders(server.headers);
-      return {
-        ...server,
-        headers,
-      };
-    };
+    if (shouldExposeMCPHeaderSecrets(context.params)) return context;
 
     if (Array.isArray(context.result)) {
-      context.result = context.result.map(redactServer);
+      context.result = context.result.map(redactMCPServerHeaderSecrets);
     } else if (context.result?.data && Array.isArray(context.result.data)) {
-      context.result.data = context.result.data.map(redactServer);
+      context.result.data = context.result.data.map(redactMCPServerHeaderSecrets);
     } else if (context.result?.mcp_server_id) {
-      context.result = redactServer(context.result);
+      context.result = redactMCPServerHeaderSecrets(context.result);
     }
 
     return context;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -46,6 +46,7 @@ import {
   typedValidateQuery,
   userQueryValidator,
 } from '@agor/core/lib/feathers-validation';
+import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type {
   AuthenticatedParams,
   Board,
@@ -1224,9 +1225,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
     const redactServer = (server: MCPServer) => {
       if (!server?.headers || Object.keys(server.headers).length === 0) return server;
+      const headers = redactMCPCustomHeaders(server.headers);
       return {
         ...server,
-        headers: Object.fromEntries(Object.keys(server.headers).map((key) => [key, '••••••••'])),
+        headers,
       };
     };
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1210,6 +1210,37 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
+  const shouldExposeMCPHeaderSecrets = (context: HookContext) => {
+    if (!context.params?.provider) return true;
+    const auth = (context.params as Record<string, unknown>).authentication as
+      | { strategy?: string }
+      | undefined;
+    const role = (context.params.user as { role?: string } | undefined)?.role;
+    return auth?.strategy === 'session-token' || role === 'service';
+  };
+
+  const redactMCPHeaderSecrets = async (context: HookContext) => {
+    if (shouldExposeMCPHeaderSecrets(context)) return context;
+
+    const redactServer = (server: MCPServer) => {
+      if (!server?.headers || Object.keys(server.headers).length === 0) return server;
+      return {
+        ...server,
+        headers: Object.fromEntries(Object.keys(server.headers).map((key) => [key, '••••••••'])),
+      };
+    };
+
+    if (Array.isArray(context.result)) {
+      context.result = context.result.map(redactServer);
+    } else if (context.result?.data && Array.isArray(context.result.data)) {
+      context.result.data = context.result.data.map(redactServer);
+    } else if (context.result?.mcp_server_id) {
+      context.result = redactServer(context.result);
+    }
+
+    return context;
+  };
+
   // NOTE: mcp-servers is global admin-managed configuration. These rows are
   // not branch- or session-scoped, so no RBAC find() scoping is applied.
   // Creation/update/removal remain gated by requireMinimumRole(ADMIN).
@@ -1221,8 +1252,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       remove: [requireMinimumRole(ROLES.ADMIN, 'delete MCP servers')],
     },
     after: {
-      find: [injectPerUserOAuthTokens],
-      get: [injectPerUserOAuthTokens],
+      find: [injectPerUserOAuthTokens, redactMCPHeaderSecrets],
+      get: [injectPerUserOAuthTokens, redactMCPHeaderSecrets],
+      create: [redactMCPHeaderSecrets],
+      patch: [redactMCPHeaderSecrets],
+      update: [redactMCPHeaderSecrets],
     },
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -34,10 +34,12 @@ import {
   NotFound,
 } from '@agor/core/feathers';
 import { type PermissionDecision, PermissionService } from '@agor/core/permissions';
+import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type {
   AuthenticatedParams,
   DaemonServicesConfig,
   HookContext,
+  MCPServer,
   Message,
   MessageSource,
   Paginated,
@@ -218,6 +220,23 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   } = ctx;
 
   const usersService = app.service('users');
+
+  const shouldExposeMCPHeaderSecrets = (params?: RouteParams) => {
+    if (!params?.provider) return true;
+    const auth = (params as Record<string, unknown>).authentication as
+      | { strategy?: string }
+      | undefined;
+    const role = (params.user as { role?: string } | undefined)?.role;
+    return auth?.strategy === 'session-token' || role === 'service';
+  };
+
+  const redactMCPServerHeaderSecrets = (server: MCPServer): MCPServer => {
+    if (!server.headers || Object.keys(server.headers).length === 0) return server;
+    return {
+      ...server,
+      headers: redactMCPCustomHeaders(server.headers),
+    };
+  };
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
   const reposService = app.service('repos') as unknown as ReposServiceImpl;
 
@@ -3108,11 +3127,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           if (!id) throw new Error('Session ID required');
           const enabledOnly =
             params.query?.enabledOnly === 'true' || params.query?.enabledOnly === true;
-          return sessionMCPServersService.listServers(
+          const servers = await sessionMCPServersService.listServers(
             id as import('@agor/core/types').SessionID,
             enabledOnly,
             params
           );
+          return shouldExposeMCPHeaderSecrets(params)
+            ? servers
+            : servers.map(redactMCPServerHeaderSecrets);
         },
         async create(data: { mcpServerId: string }, params: RouteParams) {
           const id = params.route?.id;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -34,12 +34,10 @@ import {
   NotFound,
 } from '@agor/core/feathers';
 import { type PermissionDecision, PermissionService } from '@agor/core/permissions';
-import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type {
   AuthenticatedParams,
   DaemonServicesConfig,
   HookContext,
-  MCPServer,
   Message,
   MessageSource,
   Paginated,
@@ -109,6 +107,10 @@ import {
 } from './utils/branch-authorization.js';
 import { buildInitialUserMessage } from './utils/build-initial-user-message.js';
 import { buildPrompterPrefixedPrompt } from './utils/build-prompter-prefix.js';
+import {
+  redactMCPServerHeaderSecrets,
+  shouldExposeMCPHeaderSecrets,
+} from './utils/mcp-header-secrets.js';
 import { canControlCliSession } from './utils/mcp-token-authorization.js';
 import { ensureScheduleRunsAsCaller } from './utils/schedule-hooks.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
@@ -220,23 +222,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   } = ctx;
 
   const usersService = app.service('users');
-
-  const shouldExposeMCPHeaderSecrets = (params?: RouteParams) => {
-    if (!params?.provider) return true;
-    const auth = (params as Record<string, unknown>).authentication as
-      | { strategy?: string }
-      | undefined;
-    const role = (params.user as { role?: string } | undefined)?.role;
-    return auth?.strategy === 'session-token' || role === 'service';
-  };
-
-  const redactMCPServerHeaderSecrets = (server: MCPServer): MCPServer => {
-    if (!server.headers || Object.keys(server.headers).length === 0) return server;
-    return {
-      ...server,
-      headers: redactMCPCustomHeaders(server.headers),
-    };
-  };
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
   const reposService = app.service('repos') as unknown as ReposServiceImpl;
 

--- a/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('register-services /mcp-servers/discover custom headers wiring', () => {
+  const source = readFileSync(new URL('./register-services.ts', import.meta.url), 'utf8');
+  const discoverStart = source.indexOf("app.use('/mcp-servers/discover'");
+  const afterDiscover = source.slice(discoverStart + 1);
+  const discoverBlock =
+    discoverStart === -1
+      ? ''
+      : source.slice(
+          discoverStart,
+          discoverStart + 1 + afterDiscover.indexOf("app.service('mcp-servers/discover')")
+        );
+
+  it('accepts custom headers and resolves templates before probing', () => {
+    expect(discoverBlock).toContain('headers?: Record<string, string>');
+    expect(discoverBlock).toContain('headers: serverConfig.headers');
+    expect(discoverBlock).toContain('serverConfig.headers = resolution.resolved.headers');
+  });
+
+  it('passes merged custom/auth headers to Streamable HTTP transport', () => {
+    expect(discoverBlock).toContain('mergeMCPRemoteHeaders');
+    expect(discoverBlock).toContain('requestInit: { headers: connHeaders }');
+    expect(discoverBlock).toContain('custom: serverConfig.headers');
+    expect(discoverBlock).toContain('auth: authHeaders');
+  });
+});

--- a/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
@@ -19,6 +19,12 @@ describe('register-services /mcp-servers/discover custom headers wiring', () => 
     expect(discoverBlock).toContain('serverConfig.headers = resolution.resolved.headers');
   });
 
+  it('restores redacted edit-form header values from the saved server before probing', () => {
+    expect(discoverBlock).toContain('restoreRedactedMCPCustomHeaders');
+    expect(discoverBlock).toContain('current: server.headers');
+    expect(discoverBlock).toContain('next: data.headers');
+  });
+
   it('passes merged custom/auth headers to Streamable HTTP transport', () => {
     expect(discoverBlock).toContain('mergeMCPRemoteHeaders');
     expect(discoverBlock).toContain('requestInit: { headers: connHeaders }');

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2162,6 +2162,7 @@ async function registerMCPServices(
           oauth_grant_type?: string;
           oauth_mode?: 'per_user' | 'shared';
         };
+        headers?: Record<string, string>;
       },
       params?: AuthenticatedParams
     ) {
@@ -2171,6 +2172,7 @@ async function registerMCPServices(
           '@modelcontextprotocol/sdk/client/streamableHttp.js'
         );
         const { resolveMCPAuthHeaders } = await import('@agor/core/tools/mcp/jwt-auth');
+        const { mergeMCPRemoteHeaders } = await import('@agor/core/tools/mcp/http-headers');
         const { hasMinimumRole, ROLES } = await import('@agor/core/types');
 
         const mcpServerRepo = new MCPServerRepository(db);
@@ -2202,6 +2204,7 @@ async function registerMCPServices(
           url: string;
           transport: 'http' | 'sse' | 'stdio';
           auth?: MCPAuth;
+          headers?: Record<string, string>;
           name?: string;
           scope?: string;
           owner_user_id?: string;
@@ -2217,6 +2220,7 @@ async function registerMCPServices(
             url: data.url!,
             transport: data.transport || 'http',
             auth: data.auth,
+            headers: data.headers,
             name: 'inline-test',
           };
           if (data.mcp_server_id) {
@@ -2267,6 +2271,7 @@ async function registerMCPServices(
             url: server.url || '',
             transport: (server.transport as 'http' | 'sse') || (server.url ? 'http' : 'stdio'),
             auth: server.auth,
+            headers: server.headers,
             name: server.name,
             scope: server.scope,
             owner_user_id: server.owner_user_id,
@@ -2309,6 +2314,7 @@ async function registerMCPServices(
             url: serverConfig.url,
             transport: serverConfig.transport,
             auth: serverConfig.auth,
+            headers: serverConfig.headers,
             name: serverConfig.name,
             mcpServerId: serverId,
           },
@@ -2320,6 +2326,7 @@ async function registerMCPServices(
         }
 
         serverConfig.auth = resolution.resolved.auth;
+        serverConfig.headers = resolution.resolved.headers;
         // Re-validate whenever the input URL was templated, even if the
         // resolved string happens to match the input (e.g., a user env
         // value that itself looks like the template). Pre-resolution
@@ -2339,7 +2346,10 @@ async function registerMCPServices(
           try {
             const probeResponse = await fetch(mcpUrl, {
               method: 'GET',
-              headers: { Accept: 'application/json' },
+              headers: mergeMCPRemoteHeaders({
+                base: { Accept: 'application/json' },
+                custom: serverConfig.headers,
+              }) ?? { Accept: 'application/json' },
             });
             const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
             if (probeResponse.status !== 401) return undefined;
@@ -2416,8 +2426,11 @@ async function registerMCPServices(
           if (cachedToken) authHeaders = { Authorization: `Bearer ${cachedToken}` };
         }
 
-        const headers: Record<string, string> = { Accept: 'application/json, text/event-stream' };
-        if (authHeaders) Object.assign(headers, authHeaders);
+        const headers = mergeMCPRemoteHeaders({
+          base: { Accept: 'application/json, text/event-stream' },
+          custom: serverConfig.headers,
+          auth: authHeaders,
+        }) ?? { Accept: 'application/json, text/event-stream' };
 
         const createMCPConnection = (connHeaders: Record<string, string>) => {
           let sessionId: string | undefined;
@@ -2469,10 +2482,11 @@ async function registerMCPServices(
               clearOAuth21Token(serverConfig.url);
               const freshToken = await probeAndAcquireOAuthToken(serverConfig.url);
               if (freshToken) {
-                const freshHeaders: Record<string, string> = {
-                  Accept: 'application/json, text/event-stream',
-                  Authorization: `Bearer ${freshToken}`,
-                };
+                const freshHeaders = mergeMCPRemoteHeaders({
+                  base: { Accept: 'application/json, text/event-stream' },
+                  custom: serverConfig.headers,
+                  auth: { Authorization: `Bearer ${freshToken}` },
+                }) ?? { Accept: 'application/json, text/event-stream' };
                 const retry = createMCPConnection(freshHeaders);
                 httpTransport = retry.transport;
                 client = retry.client;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2172,7 +2172,9 @@ async function registerMCPServices(
           '@modelcontextprotocol/sdk/client/streamableHttp.js'
         );
         const { resolveMCPAuthHeaders } = await import('@agor/core/tools/mcp/jwt-auth');
-        const { mergeMCPRemoteHeaders } = await import('@agor/core/tools/mcp/http-headers');
+        const { mergeMCPRemoteHeaders, restoreRedactedMCPCustomHeaders } = await import(
+          '@agor/core/tools/mcp/http-headers'
+        );
         const { hasMinimumRole, ROLES } = await import('@agor/core/types');
 
         const mcpServerRepo = new MCPServerRepository(db);
@@ -2242,6 +2244,10 @@ async function registerMCPServices(
                   error: 'Access denied: admin role required to update session-scoped MCP servers',
                 };
             }
+            serverConfig.headers = restoreRedactedMCPCustomHeaders({
+              current: server.headers,
+              next: data.headers,
+            });
             serverId = data.mcp_server_id;
           }
         } else if (data.mcp_server_id) {

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.ts
@@ -1,0 +1,21 @@
+import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
+import type { MCPServer, Params } from '@agor/core/types';
+
+type HeaderSecretParams = Params & {
+  authentication?: { strategy?: string };
+  user?: { role?: string };
+};
+
+export function shouldExposeMCPHeaderSecrets(params?: HeaderSecretParams): boolean {
+  if (!params?.provider) return true;
+  const role = params.user?.role;
+  return params.authentication?.strategy === 'session-token' || role === 'service';
+}
+
+export function redactMCPServerHeaderSecrets(server: MCPServer): MCPServer {
+  if (!server.headers || Object.keys(server.headers).length === 0) return server;
+  return {
+    ...server,
+    headers: redactMCPCustomHeaders(server.headers),
+  };
+}

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.ts
@@ -23,6 +23,7 @@ export interface ProbeServerConfig {
   url: string;
   transport: MCPTransport;
   auth?: MCPAuth;
+  headers?: Record<string, string>;
   name?: string;
   /** Optional MCP server id (when probing an existing saved server). */
   mcpServerId?: string;
@@ -62,6 +63,7 @@ export function resolveProbeServerTemplates(
     transport: serverConfig.transport,
     url: serverConfig.url,
     auth: serverConfig.auth,
+    headers: serverConfig.headers,
     scope: 'global',
     source: 'user',
     enabled: true,
@@ -85,7 +87,9 @@ export function resolveProbeServerTemplates(
   // Test Connection a templated `oauth_client_secret` that resolves to
   // empty still means the OAuth flow is about to fail upstream with a
   // confusing error, so detect those locally and add them to the list.
-  const unresolvedAuth = [...result.unresolvedFields.filter((f) => f.startsWith('auth.'))];
+  const unresolvedAuth = [
+    ...result.unresolvedFields.filter((f) => f.startsWith('auth.') || f.startsWith('headers.')),
+  ];
   if (serverConfig.auth?.type === 'oauth') {
     const oauthTemplatedFields = [
       'oauth_token_url',
@@ -113,6 +117,7 @@ export function resolveProbeServerTemplates(
     resolved: {
       ...serverConfig,
       auth: result.server.auth,
+      headers: result.server.headers,
       url: result.server.url ?? serverConfig.url,
     },
   };

--- a/apps/agor-docs/pages/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/pages/guide/sdk-comparison.mdx
@@ -210,6 +210,8 @@ In every case Agor tracks `genealogy.forked_from_session_id` and `fork_point_mes
 - User-defined MCP servers injected per-session from Agor UI
 - OpenCode tries Streamable HTTP first, then falls back to SSE for remote servers
 
+**Remote MCP headers:** For HTTP/SSE MCP servers that require service-account headers (for example `DD-API-KEY`), configure **Custom HTTP Headers** in Settings → MCP Servers. Header values can be literals or templates such as `{{ user.env.DATADOG_API_KEY }}`. Values are treated as secrets in UI/API responses, and `Authorization` is reserved for the Auth Type field so bearer/JWT/OAuth headers cannot be accidentally overridden.
+
 **See [Architecture Guide: Agor as an MCP Server](/guide/architecture#agor-as-an-mcp-server) for details on using MCP with all agents.**
 
 ---

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -3,7 +3,7 @@ import { Form, Modal } from 'antd';
 import { useEffect, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { MCPServerFormFields } from './MCPServerFormFields';
-import { buildAuthFromValues, parseEnvJSON } from './mcp-oauth-utils';
+import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from './mcp-oauth-utils';
 
 export interface MCPServerEditModalProps {
   /** The server being edited. Modal opens when this is non-null and `open` is true. */
@@ -71,6 +71,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       scope: server.scope,
       enabled: server.enabled,
       env: server.env ? JSON.stringify(server.env, null, 2) : undefined,
+      headers: server.headers ? JSON.stringify(server.headers, null, 2) : undefined,
       auth_type: serverAuthType,
     };
 
@@ -131,6 +132,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         url: values.url,
         transport: values.transport || 'http',
         auth: buildAuthFromValues(values),
+        headers: parseHeadersJSON(values.headers),
       })) as {
         success: boolean;
         error?: string;
@@ -193,6 +195,7 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
         updates.args = values.args?.split(',').map((arg: string) => arg.trim()) || [];
       } else {
         updates.url = values.url;
+        updates.headers = parseHeadersJSON(values.headers);
       }
 
       const env = parseEnvJSON(values.env);

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -122,6 +122,12 @@ export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = ({
       showError('Connection test is not available for stdio transport');
       return;
     }
+    try {
+      await form.validateFields(['headers']);
+    } catch {
+      showError('Please fix custom HTTP headers before testing');
+      return;
+    }
 
     setTesting(true);
     setTestResult(null);

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -20,7 +20,7 @@ import {
 } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
-import { extractOAuthConfigForTesting } from './mcp-oauth-utils';
+import { extractOAuthConfigForTesting, validateHeadersJSON } from './mcp-oauth-utils';
 
 const { TextArea } = Input;
 
@@ -458,6 +458,14 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             label="Custom HTTP Headers"
             name="headers"
             tooltip="JSON object of additional headers for HTTP/SSE transports. Values support templates like {{ user.env.DATADOG_API_KEY }}. Authorization is configured via Auth Type, not here."
+            rules={[
+              {
+                validator: async (_, value) => {
+                  const error = validateHeadersJSON(value);
+                  if (error) throw new Error(error);
+                },
+              },
+            ]}
           >
             <TextArea
               placeholder='{"DD-API-KEY": "{{ user.env.DATADOG_API_KEY }}", "X-Datadog-Parent-Org-Id": "123"}'

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -24,6 +24,10 @@ import { extractOAuthConfigForTesting, validateHeadersJSON } from './mcp-oauth-u
 
 const { TextArea } = Input;
 
+function isRemoteTransportValue(transport?: 'stdio' | 'http' | 'sse'): boolean {
+  return transport !== 'stdio';
+}
+
 export interface MCPServerFormFieldsProps {
   mode: 'create' | 'edit';
   transport?: 'stdio' | 'http' | 'sse';
@@ -106,7 +110,12 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   const watchedClientSecret = Form.useWatch('oauth_client_secret', form);
   const watchedOauthMode = Form.useWatch('oauth_mode', form);
   const watchedEnv = Form.useWatch('env', form);
+  const watchedHeaders = Form.useWatch('headers', form);
   const hasEnvConfigured = typeof watchedEnv === 'string' && watchedEnv.trim().length > 0;
+  const hasHeadersConfigured =
+    isRemoteTransportValue(transport) &&
+    typeof watchedHeaders === 'string' &&
+    watchedHeaders.trim().length > 0;
   const hasCustomizedAdvanced =
     [
       watchedAuthorizationUrl,
@@ -325,7 +334,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     }
   };
 
-  const isRemoteTransport = transport !== 'stdio';
+  const isRemoteTransport = isRemoteTransportValue(transport);
   const showAdvancedSection = isRemoteTransport && authType === 'oauth';
 
   // ── Basic Information section ──────────────────────────────────────
@@ -452,25 +461,6 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             tooltip="Server URL. Supports templates like {{ user.env.MCP_URL }}"
           >
             <Input placeholder="https://mcp.example.com" />
-          </Form.Item>
-
-          <Form.Item
-            label="Custom HTTP Headers"
-            name="headers"
-            tooltip="JSON object of additional headers for HTTP/SSE transports. Values support templates like {{ user.env.DATADOG_API_KEY }}. Authorization is configured via Auth Type, not here."
-            rules={[
-              {
-                validator: async (_, value) => {
-                  const error = validateHeadersJSON(value);
-                  if (error) throw new Error(error);
-                },
-              },
-            ]}
-          >
-            <TextArea
-              placeholder='{"DD-API-KEY": "{{ user.env.DATADOG_API_KEY }}", "X-Datadog-Parent-Org-Id": "123"}'
-              rows={3}
-            />
           </Form.Item>
 
           <Form.Item
@@ -831,30 +821,54 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
       children: connectionChildren,
     },
     {
-      key: 'env-vars',
+      key: 'advanced-config',
       label: (
         <Space size={8}>
-          <Typography.Text strong>Environment variables</Typography.Text>
+          <Typography.Text strong>Advanced Configuration</Typography.Text>
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            (JSON, supports {`{{ user.env.VAR }}`} templates)
+            (headers and environment variables)
           </Typography.Text>
-          {hasEnvConfigured && (
-            <Tooltip title="One or more environment variables configured">
+          {(hasHeadersConfigured || hasEnvConfigured) && (
+            <Tooltip title="Advanced configuration set">
               <Badge color="orange" />
             </Tooltip>
           )}
         </Space>
       ),
       children: (
-        <Form.Item
-          name="env"
-          tooltip="JSON object of environment variables. Values support templates like {{ user.env.VAR_NAME }}"
-        >
-          <TextArea
-            placeholder='{"GITHUB_TOKEN": "{{ user.env.GITHUB_TOKEN }}", "ALLOWED_PATHS": "/path"}'
-            rows={3}
-          />
-        </Form.Item>
+        <>
+          {isRemoteTransport && (
+            <Form.Item
+              label="Custom HTTP Headers"
+              name="headers"
+              tooltip="JSON object of additional headers for HTTP/SSE transports. Values support templates like {{ user.env.DATADOG_API_KEY }}. Authorization is configured via Auth Type, not here."
+              rules={[
+                {
+                  validator: async (_, value) => {
+                    const error = validateHeadersJSON(value);
+                    if (error) throw new Error(error);
+                  },
+                },
+              ]}
+            >
+              <TextArea
+                placeholder='{"DD-API-KEY": "{{ user.env.DATADOG_API_KEY }}", "X-Datadog-Parent-Org-Id": "123"}'
+                rows={3}
+              />
+            </Form.Item>
+          )}
+
+          <Form.Item
+            label="Environment Variables"
+            name="env"
+            tooltip="JSON object of environment variables. Values support templates like {{ user.env.VAR_NAME }}"
+          >
+            <TextArea
+              placeholder='{"GITHUB_TOKEN": "{{ user.env.GITHUB_TOKEN }}", "ALLOWED_PATHS": "/path"}'
+              rows={3}
+            />
+          </Form.Item>
+        </>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -455,6 +455,17 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           </Form.Item>
 
           <Form.Item
+            label="Custom HTTP Headers"
+            name="headers"
+            tooltip="JSON object of additional headers for HTTP/SSE transports. Values support templates like {{ user.env.DATADOG_API_KEY }}. Authorization is configured via Auth Type, not here."
+          >
+            <TextArea
+              placeholder='{"DD-API-KEY": "{{ user.env.DATADOG_API_KEY }}", "X-Datadog-Parent-Org-Id": "123"}'
+              rows={3}
+            />
+          </Form.Item>
+
+          <Form.Item
             label="Auth Type"
             name="auth_type"
             initialValue="none"

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -242,6 +242,12 @@ describe('validateHeadersJSON', () => {
     expect(validateHeadersJSON('{not json')).toBe('Custom HTTP headers must be valid JSON');
     expect(validateHeadersJSON('[]')).toBe('Custom HTTP headers must be a JSON object');
     expect(validateHeadersJSON('{"": "value"}')).toBe('Custom HTTP header names cannot be empty');
+    expect(validateHeadersJSON('{"bad header": "value"}')).toBe(
+      'Invalid custom HTTP header name: bad header'
+    );
+    expect(validateHeadersJSON('{"Cookie": "session=secret"}')).toBe(
+      'Custom HTTP header Cookie is reserved and cannot be configured here'
+    );
     expect(validateHeadersJSON('{"X-Count": 42}')).toBe(
       'Custom HTTP header values must be strings'
     );

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -5,6 +5,7 @@ import {
   extractOAuthConfigForTesting,
   isTemplateValue,
   parseEnvJSON,
+  validateHeadersJSON,
 } from './mcp-oauth-utils';
 
 describe('isTemplateValue', () => {
@@ -227,5 +228,22 @@ describe('parseHeadersJSON', () => {
       'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
       'X-Org': '123',
     });
+  });
+});
+
+describe('validateHeadersJSON', () => {
+  it('accepts empty and valid object input', () => {
+    expect(validateHeadersJSON(undefined)).toBeUndefined();
+    expect(validateHeadersJSON('')).toBeUndefined();
+    expect(validateHeadersJSON('{"DD-API-KEY": "{{ user.env.DD_API_KEY }}"}')).toBeUndefined();
+  });
+
+  it('rejects invalid JSON, non-object input, empty names, and non-string values', () => {
+    expect(validateHeadersJSON('{not json')).toBe('Custom HTTP headers must be valid JSON');
+    expect(validateHeadersJSON('[]')).toBe('Custom HTTP headers must be a JSON object');
+    expect(validateHeadersJSON('{"": "value"}')).toBe('Custom HTTP header names cannot be empty');
+    expect(validateHeadersJSON('{"X-Count": 42}')).toBe(
+      'Custom HTTP header values must be strings'
+    );
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -209,3 +209,23 @@ describe('parseEnvJSON', () => {
     expect(parseEnvJSON('{not json')).toBeUndefined();
   });
 });
+
+describe('parseHeadersJSON', () => {
+  it('parses string-valued custom headers and drops Authorization', async () => {
+    const { parseHeadersJSON } = await import('./mcp-oauth-utils');
+
+    expect(
+      parseHeadersJSON(
+        JSON.stringify({
+          'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
+          Authorization: 'Bearer should-not-persist-here',
+          'X-Org': '123',
+          Count: 42,
+        })
+      )
+    ).toEqual({
+      'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
+      'X-Org': '123',
+    });
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -200,3 +200,25 @@ export function parseHeadersJSON(headersValue: unknown): Record<string, string> 
     return undefined;
   }
 }
+
+export function validateHeadersJSON(headersValue: unknown): string | undefined {
+  if (typeof headersValue !== 'string' || !headersValue.trim()) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(headersValue);
+  } catch {
+    return 'Custom HTTP headers must be valid JSON';
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return 'Custom HTTP headers must be a JSON object';
+  }
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!key.trim()) return 'Custom HTTP header names cannot be empty';
+    if (typeof value !== 'string') return 'Custom HTTP header values must be strings';
+  }
+
+  return undefined;
+}

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -181,3 +181,22 @@ export function parseEnvJSON(envValue: unknown): Record<string, string> | undefi
     return undefined;
   }
 }
+
+/**
+ * Parse the custom HTTP headers JSON textarea value. Returns undefined for
+ * empty / invalid input and strips Authorization because auth config owns it.
+ */
+export function parseHeadersJSON(headersValue: unknown): Record<string, string> | undefined {
+  if (typeof headersValue !== 'string' || !headersValue.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(headersValue) as Record<string, unknown>;
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key.toLowerCase() === 'authorization') continue;
+      if (typeof value === 'string') headers[key] = value;
+    }
+    return headers;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -1,3 +1,8 @@
+import {
+  isReservedMCPCustomHeaderName,
+  isValidMCPHeaderName,
+} from '@agor/core/tools/mcp/http-headers';
+
 /**
  * OAuth utility functions extracted from MCPServersTable for testability.
  *
@@ -216,7 +221,11 @@ export function validateHeadersJSON(headersValue: unknown): string | undefined {
   }
 
   for (const [key, value] of Object.entries(parsed)) {
-    if (!key.trim()) return 'Custom HTTP header names cannot be empty';
+    const name = key.trim();
+    if (!name) return 'Custom HTTP header names cannot be empty';
+    if (!isValidMCPHeaderName(name)) return `Invalid custom HTTP header name: ${key}`;
+    if (isReservedMCPCustomHeaderName(name))
+      return `Custom HTTP header ${name} is reserved and cannot be configured here`;
     if (typeof value !== 'string') return 'Custom HTTP header values must be strings';
   }
 

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -157,6 +157,12 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       showError('Connection test is not available for stdio transport');
       return;
     }
+    try {
+      await createForm.validateFields(['headers']);
+    } catch {
+      showError('Please fix custom HTTP headers before testing');
+      return;
+    }
 
     setTesting(true);
     setTestResult(null);

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
 import { MCPServerEditModal, MCPServerFormFields } from '../MCPServer';
-import { buildAuthFromValues, parseEnvJSON } from '../MCPServer/mcp-oauth-utils';
+import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from '../MCPServer/mcp-oauth-utils';
 
 interface MCPServersTableProps {
   mcpServerById: Map<string, MCPServer>;
@@ -82,6 +82,8 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       data.args = (values.args as string)?.split(',').map((arg: string) => arg.trim()) || [];
     } else {
       data.url = values.url as string;
+      const headers = parseHeadersJSON(values.headers);
+      if (headers) data.headers = headers;
     }
 
     const auth = buildAuthFromValues(values);
@@ -164,6 +166,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         url: values.url,
         transport: values.transport || 'http',
         auth: buildAuthFromValues(values),
+        headers: parseHeadersJSON(values.headers),
       })) as {
         success: boolean;
         error?: string;
@@ -478,6 +481,14 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
             )}
             {viewingServer.url && (
               <Descriptions.Item label="URL">{viewingServer.url}</Descriptions.Item>
+            )}
+
+            {viewingServer.headers && Object.keys(viewingServer.headers).length > 0 && (
+              <Descriptions.Item label="Custom HTTP Headers">
+                <pre style={{ margin: 0, fontSize: 12 }}>
+                  {JSON.stringify(viewingServer.headers, null, 2)}
+                </pre>
+              </Descriptions.Item>
             )}
 
             {viewingServer.env && Object.keys(viewingServer.env).length > 0 && (

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -262,6 +262,12 @@
       "import": "./dist/client/claude-system-suppression.js",
       "require": "./dist/client/claude-system-suppression.cjs"
     },
+    "./tools/mcp/http-headers": {
+      "source": "./src/tools/mcp/http-headers.ts",
+      "types": "./dist/tools/mcp/http-headers.d.ts",
+      "import": "./dist/tools/mcp/http-headers.js",
+      "require": "./dist/tools/mcp/http-headers.cjs"
+    },
     "./tools/mcp/jwt-auth": {
       "source": "./src/tools/mcp/jwt-auth.ts",
       "types": "./dist/tools/mcp/jwt-auth.d.ts",

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -327,3 +327,57 @@ describe('MCPServerRepository scope model', () => {
     expect(user2Servers[0].name).toBe('user2-fs');
   });
 });
+
+describe('MCPServerRepository custom headers', () => {
+  dbTest('should store and retrieve custom HTTP headers', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'datadog',
+        transport: 'http',
+        url: 'https://mcp.datadog.example/mcp',
+        headers: {
+          'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
+          'X-Datadog-Parent-Org-Id': '1234',
+        },
+      })
+    );
+
+    const found = await repo.findById(created.mcp_server_id);
+
+    expect(found?.headers).toEqual({
+      'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
+      'X-Datadog-Parent-Org-Id': '1234',
+    });
+  });
+
+  dbTest(
+    'should preserve existing header values when update sends redacted sentinel',
+    async ({ db }) => {
+      const repo = new MCPServerRepository(db);
+      const created = await repo.create(
+        createMCPServerData({
+          name: 'datadog',
+          transport: 'http',
+          url: 'https://mcp.datadog.example/mcp',
+          headers: {
+            'DD-API-KEY': 'secret-value',
+            'X-Datadog-Parent-Org-Id': '1234',
+          },
+        })
+      );
+
+      const updated = await repo.update(created.mcp_server_id, {
+        headers: {
+          'DD-API-KEY': '••••••••',
+          'X-Datadog-Parent-Org-Id': '5678',
+        },
+      });
+
+      expect(updated.headers).toEqual({
+        'DD-API-KEY': 'secret-value',
+        'X-Datadog-Parent-Org-Id': '5678',
+      });
+    }
+  );
+});

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -8,6 +8,7 @@
 import type { MCPServer, MCPServerID, UserID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId } from '../../lib/ids';
+import { MCP_HEADER_REDACTED_SENTINEL } from '../../tools/mcp/http-headers';
 import { dbTest } from '../test-helpers';
 import { EntityNotFoundError } from './base';
 import { MCPServerRepository } from './mcp-servers';
@@ -339,6 +340,8 @@ describe('MCPServerRepository custom headers', () => {
         headers: {
           'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
           'X-Datadog-Parent-Org-Id': '1234',
+          Authorization: 'Bearer should-not-persist',
+          Cookie: 'session=should-not-persist',
         },
       })
     );
@@ -349,6 +352,23 @@ describe('MCPServerRepository custom headers', () => {
       'DD-API-KEY': '{{ user.env.DD_API_KEY }}',
       'X-Datadog-Parent-Org-Id': '1234',
     });
+  });
+
+  dbTest('should drop custom headers for stdio servers', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'filesystem',
+        transport: 'stdio',
+        headers: {
+          'X-Should-Not-Persist': 'value',
+        },
+      })
+    );
+
+    const found = await repo.findById(created.mcp_server_id);
+
+    expect(found?.headers).toBeUndefined();
   });
 
   dbTest(
@@ -369,7 +389,7 @@ describe('MCPServerRepository custom headers', () => {
 
       const updated = await repo.update(created.mcp_server_id, {
         headers: {
-          'DD-API-KEY': '••••••••',
+          'DD-API-KEY': MCP_HEADER_REDACTED_SENTINEL,
           'X-Datadog-Parent-Org-Id': '5678',
         },
       });
@@ -380,4 +400,25 @@ describe('MCPServerRepository custom headers', () => {
       });
     }
   );
+
+  dbTest('should clear custom headers when updating to stdio transport', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'datadog',
+        transport: 'http',
+        url: 'https://mcp.datadog.example/mcp',
+        headers: {
+          'DD-API-KEY': 'secret-value',
+        },
+      })
+    );
+
+    const updated = await repo.update(created.mcp_server_id, {
+      transport: 'stdio',
+      command: 'npx',
+    });
+
+    expect(updated.headers).toBeUndefined();
+  });
 });

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -15,6 +15,10 @@ import type {
 } from '@agor/core/types';
 import { and, eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
+import {
+  normalizeMCPCustomHeaders,
+  restoreRedactedMCPCustomHeaders,
+} from '../../tools/mcp/http-headers';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type MCPServerInsert, type MCPServerRow, mcpServers } from '../schema';
@@ -26,8 +30,6 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
-
-const REDACTED_SENTINEL = '••••••••';
 
 /**
  * MCP Server repository implementation
@@ -84,6 +86,10 @@ export class MCPServerRepository
     const now = Date.now();
     const serverId =
       'mcp_server_id' in data && data.mcp_server_id ? data.mcp_server_id : generateId();
+    const headers =
+      data.transport === 'stdio'
+        ? undefined
+        : normalizeMCPCustomHeaders('headers' in data ? data.headers : undefined);
 
     return {
       mcp_server_id: serverId as string,
@@ -110,7 +116,7 @@ export class MCPServerRepository
         command: data.command,
         args: data.args,
         url: data.url,
-        headers: 'headers' in data ? data.headers : undefined,
+        headers,
         env: data.env,
         auth: 'auth' in data ? data.auth : undefined,
         tools: 'tools' in data ? data.tools : undefined,
@@ -253,15 +259,11 @@ export class MCPServerRepository
       }
 
       const merged = { ...current, ...updates };
-      if (updates.headers && current.headers) {
-        merged.headers = Object.fromEntries(
-          Object.entries(updates.headers).map(([key, value]) => [
-            key,
-            value === REDACTED_SENTINEL && current.headers?.[key] !== undefined
-              ? current.headers[key]
-              : value,
-          ])
-        );
+      if ('headers' in updates) {
+        merged.headers = restoreRedactedMCPCustomHeaders({
+          current: current.headers,
+          next: updates.headers,
+        });
       }
       const insertData = this.mcpServerToInsert(merged);
 

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -27,6 +27,8 @@ import {
   resolveByShortIdPrefix,
 } from './base';
 
+const REDACTED_SENTINEL = '••••••••';
+
 /**
  * MCP Server repository implementation
  */
@@ -58,6 +60,7 @@ export class MCPServerRepository
       command: row.data.command,
       args: row.data.args,
       url: row.data.url,
+      headers: row.data.headers,
       env: row.data.env,
       auth: row.data.auth,
 
@@ -107,6 +110,7 @@ export class MCPServerRepository
         command: data.command,
         args: data.args,
         url: data.url,
+        headers: 'headers' in data ? data.headers : undefined,
         env: data.env,
         auth: 'auth' in data ? data.auth : undefined,
         tools: 'tools' in data ? data.tools : undefined,
@@ -249,6 +253,16 @@ export class MCPServerRepository
       }
 
       const merged = { ...current, ...updates };
+      if (updates.headers && current.headers) {
+        merged.headers = Object.fromEntries(
+          Object.entries(updates.headers).map(([key, value]) => [
+            key,
+            value === REDACTED_SENTINEL && current.headers?.[key] !== undefined
+              ? current.headers[key]
+              : value,
+          ])
+        );
+      }
       const insertData = this.mcpServerToInsert(merged);
 
       await update(this.db, mcpServers)

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1135,6 +1135,7 @@ export const mcpServers = pgTable(
         command?: string;
         args?: string[];
         url?: string;
+        headers?: Record<string, string>;
         env?: Record<string, string>;
 
         // Authentication config (for HTTP/SSE transports)

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1157,6 +1157,7 @@ export const mcpServers = sqliteTable(
         command?: string;
         args?: string[];
         url?: string;
+        headers?: Record<string, string>;
         env?: Record<string, string>;
 
         // Authentication config (for HTTP/SSE transports)

--- a/packages/core/src/mcp/template-resolver.test.ts
+++ b/packages/core/src/mcp/template-resolver.test.ts
@@ -165,6 +165,26 @@ describe('resolveMcpServerTemplates', () => {
     expect(result.server.auth?.token).toBe('bearer_xyz');
   });
 
+  it('should resolve custom HTTP header templates', () => {
+    const server = createTestServer({
+      name: 'datadog',
+      transport: 'http',
+      url: 'https://mcp.example.com',
+      headers: {
+        'DD-API-KEY': '{{ user.env.BEARER_TOKEN }}',
+        'X-Static': 'static',
+      },
+    });
+
+    const result = resolveMcpServerTemplates(server, context);
+
+    expect(result.isValid).toBe(true);
+    expect(result.server.headers).toEqual({
+      'DD-API-KEY': 'bearer_xyz',
+      'X-Static': 'static',
+    });
+  });
+
   it('should mark server as invalid when required url template fails to resolve', () => {
     const server = createTestServer({
       name: 'broken-server',

--- a/packages/core/src/mcp/template-resolver.ts
+++ b/packages/core/src/mcp/template-resolver.ts
@@ -7,6 +7,7 @@
  * Templatable fields:
  * - `url` - Server URL (for HTTP/SSE transport)
  * - `env.*` - Environment variables
+ * - `headers.*` - Custom HTTP headers for remote transports
  * - `auth.token` - Bearer token
  * - `auth.api_url` - JWT API URL
  * - `auth.api_token` - JWT API token
@@ -22,6 +23,9 @@
  *   "url": "https://mcp.example.com/{{ user.env.TENANT_ID }}",
  *   "env": {
  *     "GITHUB_TOKEN": "{{ user.env.GITHUB_TOKEN }}"
+ *   },
+ *   "headers": {
+ *     "DD-API-KEY": "{{ user.env.DATADOG_API_KEY }}"
  *   },
  *   "auth": {
  *     "type": "bearer",
@@ -198,6 +202,7 @@ export function resolveMcpServerEnv(
  * Resolves templates in these fields:
  * - `url` - Server URL
  * - `env.*` - Environment variables
+ * - `headers.*` - Custom HTTP headers for remote transports
  * - `auth.token` - Bearer token
  * - `auth.api_url` - JWT API URL
  * - `auth.api_token` - JWT API token
@@ -245,6 +250,21 @@ export function resolveMcpServerTemplates(
       }
     }
     resolved.env = Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined;
+  }
+
+  // Resolve custom HTTP headers (track individual unresolved vars)
+  if (server.headers) {
+    const resolvedHeaders: Record<string, string> = {};
+    for (const [key, templateValue] of Object.entries(server.headers)) {
+      const hadTemplate = containsTemplate(templateValue);
+      const resolvedValue = resolveStringValue(`headers.${key}`, templateValue, context);
+      if (resolvedValue !== undefined) {
+        resolvedHeaders[key] = resolvedValue;
+      } else if (hadTemplate) {
+        unresolvedFields.push(`headers.${key}`);
+      }
+    }
+    resolved.headers = Object.keys(resolvedHeaders).length > 0 ? resolvedHeaders : undefined;
   }
 
   // Resolve auth fields
@@ -354,6 +374,8 @@ export function resolveMcpServerTemplates(
           originalValue = server.url;
         } else if (f.startsWith('env.')) {
           originalValue = server.env?.[f.slice(4)];
+        } else if (f.startsWith('headers.')) {
+          originalValue = server.headers?.[f.slice(8)];
         } else if (f.startsWith('auth.') && server.auth) {
           const authKey = f.slice(5) as keyof MCPAuth;
           const authValue = server.auth[authKey];

--- a/packages/core/src/tools/mcp/http-headers.test.ts
+++ b/packages/core/src/tools/mcp/http-headers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { mergeMCPRemoteHeaders, normalizeMCPCustomHeaders } from './http-headers';
+
+describe('MCP HTTP header helpers', () => {
+  it('filters invalid and reserved custom header names', () => {
+    expect(
+      normalizeMCPCustomHeaders({
+        'DD-API-KEY': 'dummy-api-key',
+        Authorization: 'Bearer custom-should-not-win',
+        'bad header': 'nope',
+        '': 'empty',
+      })
+    ).toEqual({ 'DD-API-KEY': 'dummy-api-key' });
+  });
+
+  it('merges base, custom, and auth headers with auth taking precedence', () => {
+    expect(
+      mergeMCPRemoteHeaders({
+        base: { Accept: 'application/json' },
+        custom: { 'DD-API-KEY': 'dummy-api-key', Authorization: 'Bearer custom' },
+        auth: { Authorization: 'Bearer auth' },
+      })
+    ).toEqual({
+      Accept: 'application/json',
+      'DD-API-KEY': 'dummy-api-key',
+      Authorization: 'Bearer auth',
+    });
+  });
+});

--- a/packages/core/src/tools/mcp/http-headers.test.ts
+++ b/packages/core/src/tools/mcp/http-headers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isReservedMCPCustomHeaderName,
+  isValidMCPHeaderName,
   MCP_HEADER_REDACTED_SENTINEL,
   mergeMCPRemoteHeaders,
   normalizeMCPCustomHeaders,
@@ -8,6 +10,13 @@ import {
 } from './http-headers';
 
 describe('MCP HTTP header helpers', () => {
+  it('validates custom header names', () => {
+    expect(isValidMCPHeaderName('DD-API-KEY')).toBe(true);
+    expect(isValidMCPHeaderName('bad header')).toBe(false);
+    expect(isReservedMCPCustomHeaderName('Authorization')).toBe(true);
+    expect(isReservedMCPCustomHeaderName('X-Custom')).toBe(false);
+  });
+
   it('filters invalid and reserved custom header names', () => {
     expect(
       normalizeMCPCustomHeaders({

--- a/packages/core/src/tools/mcp/http-headers.test.ts
+++ b/packages/core/src/tools/mcp/http-headers.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { mergeMCPRemoteHeaders, normalizeMCPCustomHeaders } from './http-headers';
+import {
+  MCP_HEADER_REDACTED_SENTINEL,
+  mergeMCPRemoteHeaders,
+  normalizeMCPCustomHeaders,
+  redactMCPCustomHeaders,
+  restoreRedactedMCPCustomHeaders,
+} from './http-headers';
 
 describe('MCP HTTP header helpers', () => {
   it('filters invalid and reserved custom header names', () => {
@@ -7,6 +13,8 @@ describe('MCP HTTP header helpers', () => {
       normalizeMCPCustomHeaders({
         'DD-API-KEY': 'dummy-api-key',
         Authorization: 'Bearer custom-should-not-win',
+        Cookie: 'session=secret',
+        'Mcp-Session-Id': 'session-id',
         'bad header': 'nope',
         '': 'empty',
       })
@@ -24,6 +32,37 @@ describe('MCP HTTP header helpers', () => {
       Accept: 'application/json',
       'DD-API-KEY': 'dummy-api-key',
       Authorization: 'Bearer auth',
+    });
+  });
+
+  it('redacts custom header values while preserving names', () => {
+    expect(
+      redactMCPCustomHeaders({
+        'DD-API-KEY': 'dummy-api-key',
+        'X-Datadog-Parent-Org-Id': '1234',
+      })
+    ).toEqual({
+      'DD-API-KEY': MCP_HEADER_REDACTED_SENTINEL,
+      'X-Datadog-Parent-Org-Id': MCP_HEADER_REDACTED_SENTINEL,
+    });
+  });
+
+  it('restores redacted values from existing headers and normalizes the result', () => {
+    expect(
+      restoreRedactedMCPCustomHeaders({
+        current: {
+          'DD-API-KEY': 'secret-value',
+          'X-Datadog-Parent-Org-Id': '1234',
+        },
+        next: {
+          'DD-API-KEY': MCP_HEADER_REDACTED_SENTINEL,
+          'X-Datadog-Parent-Org-Id': '5678',
+          Authorization: 'Bearer should-not-persist',
+        },
+      })
+    ).toEqual({
+      'DD-API-KEY': 'secret-value',
+      'X-Datadog-Parent-Org-Id': '5678',
     });
   });
 });

--- a/packages/core/src/tools/mcp/http-headers.ts
+++ b/packages/core/src/tools/mcp/http-headers.ts
@@ -7,7 +7,23 @@
  * OAuth/JWT/bearer credentials.
  */
 
-export const RESERVED_MCP_CUSTOM_HEADER_NAMES = new Set(['authorization']);
+export const MCP_HEADER_REDACTED_SENTINEL = '••••••••';
+
+export const RESERVED_MCP_CUSTOM_HEADER_NAMES = new Set([
+  'authorization',
+  // Hop-by-hop / transport-controlled headers. These are managed by fetch,
+  // the MCP SDK transport, or the auth configuration and should not be stored
+  // as custom MCP service-account headers.
+  'connection',
+  'content-length',
+  'cookie',
+  'host',
+  'mcp-session-id',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
 
 const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
@@ -26,6 +42,33 @@ export function normalizeMCPCustomHeaders(
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function redactMCPCustomHeaders(
+  headers?: Record<string, string>
+): Record<string, string> | undefined {
+  const normalized = normalizeMCPCustomHeaders(headers);
+  if (!normalized) return undefined;
+  return Object.fromEntries(
+    Object.keys(normalized).map((key) => [key, MCP_HEADER_REDACTED_SENTINEL])
+  );
+}
+
+export function restoreRedactedMCPCustomHeaders(options: {
+  current?: Record<string, string>;
+  next?: Record<string, string>;
+}): Record<string, string> | undefined {
+  if (!options.next) return undefined;
+
+  const restored: Record<string, string> = {};
+  for (const [key, value] of Object.entries(options.next)) {
+    restored[key] =
+      value === MCP_HEADER_REDACTED_SENTINEL && options.current?.[key] !== undefined
+        ? options.current[key]
+        : value;
+  }
+
+  return normalizeMCPCustomHeaders(restored);
 }
 
 export function mergeMCPRemoteHeaders(options: {

--- a/packages/core/src/tools/mcp/http-headers.ts
+++ b/packages/core/src/tools/mcp/http-headers.ts
@@ -1,0 +1,42 @@
+/**
+ * Utilities for MCP remote-transport HTTP headers.
+ *
+ * Custom headers can be secret-bearing (for service-account access) and may
+ * coexist with Agor-managed auth headers. Authorization is intentionally
+ * reserved for the `auth` config so custom headers cannot accidentally shadow
+ * OAuth/JWT/bearer credentials.
+ */
+
+export const RESERVED_MCP_CUSTOM_HEADER_NAMES = new Set(['authorization']);
+
+const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
+export function normalizeMCPCustomHeaders(
+  headers?: Record<string, string>
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+
+  const normalized: Record<string, string> = {};
+  for (const [rawName, rawValue] of Object.entries(headers)) {
+    const name = rawName.trim();
+    if (!name || !HEADER_NAME_RE.test(name)) continue;
+    if (RESERVED_MCP_CUSTOM_HEADER_NAMES.has(name.toLowerCase())) continue;
+    if (typeof rawValue !== 'string') continue;
+    normalized[name] = rawValue;
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function mergeMCPRemoteHeaders(options: {
+  base?: Record<string, string>;
+  custom?: Record<string, string>;
+  auth?: Record<string, string>;
+}): Record<string, string> | undefined {
+  const merged: Record<string, string> = {
+    ...(options.base ?? {}),
+    ...(normalizeMCPCustomHeaders(options.custom) ?? {}),
+    ...(options.auth ?? {}),
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}

--- a/packages/core/src/tools/mcp/http-headers.ts
+++ b/packages/core/src/tools/mcp/http-headers.ts
@@ -27,6 +27,14 @@ export const RESERVED_MCP_CUSTOM_HEADER_NAMES = new Set([
 
 const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
+export function isValidMCPHeaderName(name: string): boolean {
+  return HEADER_NAME_RE.test(name);
+}
+
+export function isReservedMCPCustomHeaderName(name: string): boolean {
+  return RESERVED_MCP_CUSTOM_HEADER_NAMES.has(name.toLowerCase());
+}
+
 export function normalizeMCPCustomHeaders(
   headers?: Record<string, string>
 ): Record<string, string> | undefined {
@@ -35,8 +43,8 @@ export function normalizeMCPCustomHeaders(
   const normalized: Record<string, string> = {};
   for (const [rawName, rawValue] of Object.entries(headers)) {
     const name = rawName.trim();
-    if (!name || !HEADER_NAME_RE.test(name)) continue;
-    if (RESERVED_MCP_CUSTOM_HEADER_NAMES.has(name.toLowerCase())) continue;
+    if (!name || !isValidMCPHeaderName(name)) continue;
+    if (isReservedMCPCustomHeaderName(name)) continue;
     if (typeof rawValue !== 'string') continue;
     normalized[name] = rawValue;
   }

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -135,6 +135,12 @@ export interface MCPServer {
 
   // HTTP/SSE config
   url?: string; // e.g., "https://mcp.sentry.dev/mcp"
+  /**
+   * Custom HTTP headers for remote HTTP/SSE transports. Values may be
+   * secret-bearing and can use templates such as {{ user.env.DATADOG_API_KEY }}.
+   * Not applied to stdio transports. Authorization is reserved for auth.*.
+   */
+  headers?: Record<string, string>;
 
   // Environment variables
   env?: Record<string, string>; // e.g., { "ALLOWED_PATHS": "/Users/me/projects" }
@@ -197,6 +203,7 @@ export interface CreateMCPServerInput {
   command?: string;
   args?: string[];
   url?: string;
+  headers?: Record<string, string>;
   env?: Record<string, string>;
   auth?: MCPAuth;
   scope: MCPScope;
@@ -215,6 +222,7 @@ export interface UpdateMCPServerInput {
   command?: string;
   args?: string[];
   url?: string;
+  headers?: Record<string, string>;
   env?: Record<string, string>;
   auth?: MCPAuth;
   scope?: MCPScope;
@@ -246,6 +254,7 @@ export interface MCPConfigFile {
       args?: string[];
       transport?: 'http' | 'sse';
       url?: string;
+      headers?: Record<string, string>;
       env?: Record<string, string>;
     };
   };
@@ -262,6 +271,7 @@ export type MCPServersConfig = Record<
     command?: string;
     args?: string[];
     url?: string;
+    headers?: Record<string, string>;
     env?: Record<string, string>;
   }
 >;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
     'sessions/index': 'src/sessions/index.ts', // Session config defaults resolution
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
     'client/claude-system-suppression': 'src/client/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
+    'tools/mcp/http-headers': 'src/tools/mcp/http-headers.ts', // MCP custom HTTP header utilities
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -10,6 +10,7 @@
 
 import { generateId, shortId } from '@agor/core/db';
 import { DEFAULT_CURSOR_MODEL } from '@agor/core/models';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type {
   ContentBlock,
@@ -229,7 +230,8 @@ async function buildCursorMcpServers(args: {
     }
 
     if ((server.transport === 'http' || server.transport === 'sse') && server.url) {
-      const headers = await resolveMCPAuthHeaders(server.auth, server.url);
+      const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+      const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
       mcpServers[name] = {
         type: server.transport,
         url: server.url,

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -156,7 +156,9 @@ export async function getMcpServersForSession(
 
       // Check if any templatable field contains templates
       const envValues = Object.values(original.env ?? {}) as string[];
+      const headerValues = Object.values(original.headers ?? {}) as string[];
       const hasEnvTemplates = envValues.some(containsTemplate);
+      const hasHeaderTemplates = headerValues.some(containsTemplate);
       const hasUrlTemplate = containsTemplate(original.url);
       const hasAuthTemplates =
         containsTemplate(original.auth?.token) ||
@@ -164,7 +166,7 @@ export async function getMcpServersForSession(
         containsTemplate(original.auth?.api_token) ||
         containsTemplate(original.auth?.api_secret);
 
-      if (hasEnvTemplates || hasUrlTemplate || hasAuthTemplates) {
+      if (hasEnvTemplates || hasHeaderTemplates || hasUrlTemplate || hasAuthTemplates) {
         const result = resolveMcpServerTemplates(original, templateContext);
 
         if (!result.isValid) {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs/promises';
 import { shortId, validateDirectory } from '@agor/core';
 import { Claude } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 
 const { query } = Claude;
@@ -558,10 +559,13 @@ export async function setupQuery(
 
           try {
             // Pass mcpUrl for OAuth token cache lookup
-            const headers = await resolveMCPAuthHeaders(server.auth, server.url);
+            const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+            const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
             if (headers && transport !== 'stdio') {
               serverConfig.headers = headers;
-              console.log(`     🔐 Added Authorization header for ${server.name}`);
+              console.log(
+                `     🔐 Added ${Object.keys(headers).length} HTTP header(s) for ${server.name}`
+              );
             } else if (server.auth?.type === 'oauth' && transport !== 'stdio') {
               // OAuth server but no token - track for notification
               console.warn(

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -30,6 +30,7 @@ import { shortId } from '@agor/core/db';
 import type { CodexOptions, Thread, ThreadItem } from '@agor/core/sdk';
 import { Codex } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { CodexSandboxMode, ContextUsageSnapshot, EffortLevel } from '@agor/core/types';
 import { getDefaultCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
@@ -588,8 +589,15 @@ export class CodexPromptService {
       // an env var. Non-bearer schemes log a warning since Codex's CLI
       // only supports bearer auth.
       try {
-        const headers = await resolveMCPAuthHeaders(server.auth, server.url);
+        const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+        const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
         const authHeader = headers?.Authorization;
+        const customHeaders = headers ? { ...headers } : undefined;
+        if (customHeaders) delete customHeaders.Authorization;
+        if (customHeaders && Object.keys(customHeaders).length > 0) {
+          serverConfig.headers = customHeaders;
+          console.log(`      custom headers: ${Object.keys(customHeaders).length} header(s)`);
+        }
         if (authHeader) {
           const bearerToken = /^Bearer\s+(.+)$/i.exec(authHeader)?.[1];
           if (bearerToken) {

--- a/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
@@ -13,6 +13,8 @@
 
 import { shortId } from '@agor/core/db';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
+import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { CopilotSession } from '@github/copilot-sdk';
 import { CopilotClient } from '@github/copilot-sdk';
 import { getDaemonUrl } from '../../config.js';
@@ -176,12 +178,9 @@ export class CopilotPromptService {
           tools: ['*'],
         };
 
-        // Add auth headers for bearer token
-        if (server.auth?.type === 'bearer' && server.auth.token) {
-          serverConfig.headers = {
-            Authorization: `Bearer ${server.auth.token}`,
-          };
-        }
+        const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+        const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
+        if (headers) serverConfig.headers = headers;
 
         copilotMcpServers[serverName] = serverConfig;
         console.log(`   📝 [Copilot MCP] Configured HTTP server: ${server.name}`);

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import type { GenAI } from '@agor/core/sdk';
 import { Gemini } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 
 type ResumedSessionData = Gemini.ResumedSessionData;
@@ -718,7 +719,8 @@ export class GeminiPromptService {
         for (const { server } of serversWithSource) {
           let headers: Record<string, string> | undefined;
           try {
-            headers = await resolveMCPAuthHeaders(server.auth);
+            const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+            headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
           } catch (error) {
             console.warn(
               `   ⚠️  Failed to resolve MCP auth headers for ${server.name}:`,
@@ -759,7 +761,9 @@ export class GeminiPromptService {
           }
 
           if (headers && server.transport !== 'stdio') {
-            console.log(`     🔐 Added Authorization header for ${server.name}`);
+            console.log(
+              `     🔐 Added ${Object.keys(headers).length} HTTP header(s) for ${server.name}`
+            );
           }
         }
 

--- a/packages/executor/src/sdk-handlers/mcp-custom-headers-wiring.test.ts
+++ b/packages/executor/src/sdk-handlers/mcp-custom-headers-wiring.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('executor MCP custom headers wiring', () => {
+  it('merges custom headers with auth headers for Claude remote MCP servers', () => {
+    const source = readFileSync(new URL('./claude/query-builder.ts', import.meta.url), 'utf8');
+    expect(source).toContain(
+      'mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders })'
+    );
+    expect(source).toContain('serverConfig.headers = headers');
+  });
+
+  it('merges custom headers with auth headers for Cursor remote MCP servers', () => {
+    const source = readFileSync(new URL('../handlers/sdk/cursor.ts', import.meta.url), 'utf8');
+    expect(source).toContain(
+      'mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders })'
+    );
+    expect(source).toContain('...(headers ? { headers } : {})');
+  });
+});

--- a/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
+++ b/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
@@ -15,6 +15,8 @@
  */
 
 import { generateId, shortId } from '@agor/core';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
+import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import type { Part as OpenCodePart } from '@opencode-ai/sdk';
@@ -257,10 +259,8 @@ export class OpenCodeTool implements ITool {
                 query: branchPath ? { directory: branchPath } : undefined,
               });
             } else if (server.transport === 'http' || server.transport === 'sse') {
-              const headers: Record<string, string> = {};
-              if (server.auth?.token) {
-                headers.Authorization = `Bearer ${server.auth.token}`;
-              }
+              const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+              const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
               await client.mcp.add({
                 body: {
                   name: sanitizedName,
@@ -268,7 +268,7 @@ export class OpenCodeTool implements ITool {
                     type: 'remote' as const,
                     url: server.url!,
                     enabled: true,
-                    headers: Object.keys(headers).length > 0 ? headers : undefined,
+                    headers,
                   },
                 },
                 query: branchPath ? { directory: branchPath } : undefined,


### PR DESCRIPTION
## Summary

- Add custom HTTP header support to MCP server config for remote HTTP/SSE transports.
- Apply configured headers across daemon discovery and agent runtime MCP setup (Claude, Codex, Gemini, Cursor, Copilot, OpenCode).
- Resolve `{{ user.env.* }}` templates in custom header values and redact header values from external MCP server API responses.
- Expose custom headers in Settings → MCP Servers and `agor mcp add --headers`.

## Security notes

- Custom `Authorization` headers are intentionally ignored/reserved; bearer/JWT/OAuth auth continues to own `Authorization`.
- Header values are treated as secret-bearing in UI/service responses and displayed as `••••••••` unless fetched by executor/session-token paths that need raw values at runtime.
- Existing redacted header values are preserved on edit unless changed.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/tools/mcp/http-headers.test.ts src/mcp/template-resolver.test.ts src/db/repositories/mcp-servers.test.ts`
- `pnpm --filter @agor/daemon test -- src/register-services.mcp-custom-headers.test.ts src/register-hooks.mcp-headers-redaction.test.ts`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/mcp-custom-headers-wiring.test.ts`
- `pnpm --filter agor-ui test -- src/components/MCPServer/mcp-oauth-utils.test.ts`

Closes #1385
