### PR TITLE
Improve MCP tool discovery and validation

### DIFF
--- a/apps/agor-daemon/src/mcp/schema.ts
+++ b/apps/agor-daemon/src/mcp/schema.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+
+type RequiredStringOptions = {
+  /** Example object or field value to include in validation failures. */
+  example?: string;
+};
+
+function suffixExample(example: string | undefined): string {
+  return example ? ` Example: ${example}` : '';
+}
+
+/**
+ * Required non-empty string for MCP tool inputs.
+ *
+ * Prefer this over bare `z.string()` for required tool arguments so malformed
+ * MCP calls fail with caller-oriented messages instead of raw Zod type text.
+ */
+export function mcpRequiredString(
+  fieldName: string,
+  description: string,
+  options: RequiredStringOptions = {}
+) {
+  return z
+    .string({
+      error: `${fieldName} is required and must be a string.${suffixExample(options.example)}`,
+    })
+    .min(1, `${fieldName} cannot be empty.${suffixExample(options.example)}`)
+    .describe(description);
+}
+
+/**
+ * Optional string with a caller-oriented wrong-type error.
+ */
+export function mcpOptionalString(fieldName: string, description: string) {
+  return z
+    .string({
+      error: `${fieldName} must be a string when provided.`,
+    })
+    .optional()
+    .describe(description);
+}
+
+/**
+ * Optional string that must be non-empty when present. Use for optional
+ * labels/titles/names where an empty string is almost always an accidental
+ * malformed MCP call rather than an intentional clear operation.
+ */
+export function mcpOptionalNonEmptyString(fieldName: string, description: string) {
+  return z
+    .string({
+      error: `${fieldName} must be a string when provided.`,
+    })
+    .min(1, `${fieldName} cannot be empty when provided.`)
+    .optional()
+    .describe(description);
+}
+
+export function mcpRequiredId(fieldName: string, entityName: string, description?: string) {
+  return mcpRequiredString(fieldName, description ?? `${entityName} ID (UUIDv7 or short ID)`, {
+    example: `{ "${fieldName}": "01abcdef" }`,
+  });
+}
+
+export function mcpOptionalId(fieldName: string, entityName: string, description?: string) {
+  return z
+    .string({
+      error: `${fieldName} must be a string when provided.`,
+    })
+    .min(1, `${fieldName} cannot be empty when provided.`)
+    .optional()
+    .describe(description ?? `${entityName} ID (UUIDv7 or short ID)`);
+}
+
+export function mcpOptionalNumber(fieldName: string, description: string) {
+  return z
+    .number({
+      error: `${fieldName} must be a number when provided.`,
+    })
+    .optional()
+    .describe(description);
+}
+
+export function mcpRequiredNumber(fieldName: string, description: string) {
+  return z
+    .number({
+      error: `${fieldName} is required and must be a number.`,
+    })
+    .describe(description);
+}
+
+export function mcpOptionalPositiveInt(fieldName: string, description: string) {
+  return z
+    .number({
+      error: `${fieldName} must be a positive integer when provided.`,
+    })
+    .int(`${fieldName} must be an integer.`)
+    .positive(`${fieldName} must be greater than 0.`)
+    .optional()
+    .describe(description);
+}
+
+export function mcpOptionalNonNegativeInt(fieldName: string, description: string) {
+  return z
+    .number({
+      error: `${fieldName} must be a non-negative integer when provided.`,
+    })
+    .int(`${fieldName} must be an integer.`)
+    .nonnegative(`${fieldName} must be greater than or equal to 0.`)
+    .optional()
+    .describe(description);
+}
+
+export function mcpLimit(defaultValue = 50) {
+  return mcpOptionalPositiveInt('limit', `Maximum number of results (default: ${defaultValue})`);
+}
+
+export function mcpOffset(defaultValue = 0) {
+  return mcpOptionalNonNegativeInt(
+    'offset',
+    `Number of results to skip (default: ${defaultValue})`
+  );
+}

--- a/apps/agor-daemon/src/mcp/schema.ts
+++ b/apps/agor-daemon/src/mcp/schema.ts
@@ -55,6 +55,19 @@ export function mcpOptionalNonEmptyString(fieldName: string, description: string
     .describe(description);
 }
 
+/**
+ * Optional string that must contain non-whitespace text when present.
+ */
+export function mcpOptionalNonBlankString(fieldName: string, description: string) {
+  return z
+    .string({
+      error: `${fieldName} must be a string when provided.`,
+    })
+    .refine((value) => value.trim().length > 0, `${fieldName} cannot be blank when provided.`)
+    .optional()
+    .describe(description);
+}
+
 export function mcpRequiredId(fieldName: string, entityName: string, description?: string) {
   return mcpRequiredString(fieldName, description ?? `${entityName} ID (UUIDv7 or short ID)`, {
     example: `{ "${fieldName}": "01abcdef" }`,
@@ -85,6 +98,16 @@ export function mcpRequiredNumber(fieldName: string, description: string) {
     .number({
       error: `${fieldName} is required and must be a number.`,
     })
+    .describe(description);
+}
+
+export function mcpRequiredPositiveInt(fieldName: string, description: string) {
+  return z
+    .number({
+      error: `${fieldName} is required and must be a positive integer.`,
+    })
+    .int(`${fieldName} must be an integer.`)
+    .positive(`${fieldName} must be greater than 0.`)
     .describe(description);
 }
 

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express';
 import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { coerceJsonRecord, setupMCPRoutes } from './server.js';
+import { buildRegistry, coerceJsonRecord, setupMCPRoutes } from './server.js';
 
 describe('coerceJsonRecord', () => {
   it('passes through a plain object unchanged', () => {
@@ -57,6 +57,44 @@ describe('coerceJsonRecord', () => {
 
   it('returns non-JSON string unchanged', () => {
     expect(coerceJsonRecord('hello world')).toBe('hello world');
+  });
+});
+
+describe('MCP tool registry', () => {
+  it('mirrors runtime read-only service tier filtering', () => {
+    const registry = buildRegistry({ boards: 'readonly' });
+
+    expect(registry.get('agor_boards_get')).toBeDefined();
+    expect(registry.get('agor_boards_list')).toBeDefined();
+    expect(registry.get('agor_boards_update')).toBeUndefined();
+    expect(registry.get('agor_boards_create')).toBeUndefined();
+  });
+
+  it('keeps representative tool detail schemas from degrading to bare object schemas', () => {
+    const registry = buildRegistry();
+    const expectedPropertiesByTool: Record<string, string[]> = {
+      agor_sessions_prompt: ['sessionId', 'prompt', 'mode'],
+      agor_boards_get: ['boardId'],
+      agor_branches_create: ['repoId', 'branchName', 'boardId'],
+      agor_kb_get: ['uri', 'namespace', 'path'],
+      agor_execute_tool: ['tool_name', 'arguments'],
+    };
+
+    for (const [toolName, expectedProperties] of Object.entries(expectedPropertiesByTool)) {
+      const schema = registry.get(toolName)?.inputSchema;
+      expect(schema, `${toolName} should be registered`).toBeDefined();
+      expect(schema, `${toolName} should not degrade to { type: "object" }`).toMatchObject({
+        type: 'object',
+        properties: expect.any(Object),
+      });
+
+      for (const property of expectedProperties) {
+        expect(
+          (schema?.properties as Record<string, unknown> | undefined)?.[property],
+          `${toolName} should expose ${property} in JSON schema`
+        ).toBeDefined();
+      }
+    }
   });
 });
 

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -28,7 +28,7 @@ import { toJSONSchema } from 'zod/v4-mini';
 import type { AuthenticatedParams, AuthenticatedUser } from '../declarations.js';
 import { wrapRegisterTool } from './register-tool-proxy.js';
 import { validateSessionToken } from './tokens.js';
-import { ToolRegistry } from './tool-registry.js';
+import { formatDomainDescriptionsForInstructions, ToolRegistry } from './tool-registry.js';
 import { registerAnalyticsTools } from './tools/analytics.js';
 import { registerArtifactTools } from './tools/artifacts.js';
 import { registerBoardTools } from './tools/boards.js';
@@ -119,18 +119,7 @@ This server uses progressive tool discovery. Only 3 tools are listed directly �
 - agor_execute_tool: Call one discovered tool by name with arguments matching its schema.
 
 Domains:
-- sessions: Agent conversations with genealogy (fork/spawn), task tracking, and message history
-- repos: Repository registration and management
-- branches: Branches with isolated git refs, board placement, zone pinning, and assistant discovery.
-- environment: Start/stop/health/logs for branch dev environments
-- boards: Spatial canvases with zones for organizing branches and cards
-- cards: Kanban-style cards and card type definitions on boards
-- users: User accounts, profiles, preferences, and administration
-- analytics: Usage and cost tracking leaderboard
-- mcp-servers: External MCP server configuration and OAuth management
-- schedules: First-class CRUD for branch schedules — cron-based prompts that spawn sessions
-- widgets: In-conversation interactive widgets (forms/buttons rendered inline; values never enter your context)
-- knowledge: DB-backed markdown knowledge documents, version history, and graph links
+${formatDomainDescriptionsForInstructions()}
 
 Common workflows:
 
@@ -180,12 +169,61 @@ function logQueryParamDeprecation(req: Request): void {
 let cachedRegistry: ToolRegistry | null = null;
 let cachedToolsList: { tools: Array<Record<string, unknown>> } | null = null;
 
+type DomainToolRegistrar = {
+  domain: string;
+  register: (server: McpServer, ctx: McpContext) => void;
+};
+
+const DOMAIN_TOOL_REGISTRARS: DomainToolRegistrar[] = [
+  {
+    domain: 'sessions',
+    register: (server, ctx) => {
+      registerSessionTools(server, ctx);
+      registerTaskTools(server, ctx);
+      registerMessageTools(server, ctx);
+    },
+  },
+  { domain: 'widgets', register: registerWidgetTools },
+  { domain: 'repos', register: registerRepoTools },
+  { domain: 'branches', register: registerBranchTools },
+  { domain: 'environment', register: registerEnvironmentTools },
+  { domain: 'boards', register: registerBoardTools },
+  {
+    domain: 'cards',
+    register: (server, ctx) => {
+      registerCardTools(server, ctx);
+      registerCardTypeTools(server, ctx);
+    },
+  },
+  { domain: 'artifacts', register: registerArtifactTools },
+  { domain: 'proxies', register: registerProxyTools },
+  { domain: 'users', register: registerUserTools },
+  { domain: 'analytics', register: registerAnalyticsTools },
+  { domain: 'mcp-servers', register: registerMcpServerTools },
+  { domain: 'knowledge', register: registerKnowledgeTools },
+  { domain: 'schedules', register: registerScheduleTools },
+];
+
+function registerDomainTools(
+  server: McpServer,
+  ctx: McpContext,
+  servicesConfig?: DaemonServicesConfig,
+  beforeRegister?: (domain: string) => void
+): void {
+  for (const { domain, register } of DOMAIN_TOOL_REGISTRARS) {
+    const access = getDomainAccess(domain, servicesConfig);
+    if (!access) continue;
+    beforeRegister?.(domain);
+    register(access === 'readonly' ? readOnlyProxy(server) : server, ctx);
+  }
+}
+
 /**
  * Build the tool registry by registering tools against a temporary server.
  * Captures metadata (name, description, JSON Schema, annotations, domain)
  * without creating real handlers. Called once, cached forever.
  */
-function buildRegistry(servicesConfig?: DaemonServicesConfig): ToolRegistry {
+export function buildRegistry(servicesConfig?: DaemonServicesConfig): ToolRegistry {
   const registry = new ToolRegistry();
 
   // Create a throwaway server just to run the registration code.
@@ -230,81 +268,13 @@ function buildRegistry(servicesConfig?: DaemonServicesConfig): ToolRegistry {
 
   // Register all domain tools with domain tracking.
   // Handlers receive a dummy context — they won't be called.
-  // Only register tools for enabled service domains.
+  // The registry uses the same service-tier filtering as runtime registration,
+  // including read-only proxying, so search/details never advertise tools that
+  // agor_execute_tool cannot actually call in this server configuration.
   const dummyCtx = {} as McpContext;
-
-  if (isDomainEnabled('sessions', servicesConfig)) {
-    registry.setCurrentDomain('sessions');
-    registerSessionTools(tempServer, dummyCtx);
-    registerTaskTools(tempServer, dummyCtx);
-    registerMessageTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('widgets', servicesConfig)) {
-    registry.setCurrentDomain('widgets');
-    registerWidgetTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('repos', servicesConfig)) {
-    registry.setCurrentDomain('repos');
-    registerRepoTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('branches', servicesConfig)) {
-    registry.setCurrentDomain('branches');
-    registerBranchTools(tempServer, dummyCtx);
-    registry.setCurrentDomain('environment');
-    registerEnvironmentTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('boards', servicesConfig)) {
-    registry.setCurrentDomain('boards');
-    registerBoardTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('cards', servicesConfig)) {
-    registry.setCurrentDomain('cards');
-    registerCardTools(tempServer, dummyCtx);
-    registerCardTypeTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('artifacts', servicesConfig)) {
-    registry.setCurrentDomain('artifacts');
-    registerArtifactTools(tempServer, dummyCtx);
-  }
-
-  // 'proxies' is always registered when 'artifacts' domain is on — the two
-  // are tightly coupled (proxies exist to serve artifacts). Read-only by
-  // construction, so registering them here is safe regardless of tier.
-  if (isDomainEnabled('artifacts', servicesConfig)) {
-    registry.setCurrentDomain('proxies');
-    registerProxyTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('users', servicesConfig)) {
-    registry.setCurrentDomain('users');
-    registerUserTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('analytics', servicesConfig)) {
-    registry.setCurrentDomain('analytics');
-    registerAnalyticsTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('mcp-servers', servicesConfig)) {
-    registry.setCurrentDomain('mcp-servers');
-    registerMcpServerTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('knowledge', servicesConfig)) {
-    registry.setCurrentDomain('knowledge');
-    registerKnowledgeTools(tempServer, dummyCtx);
-  }
-
-  if (isDomainEnabled('schedules', servicesConfig)) {
-    registry.setCurrentDomain('schedules');
-    registerScheduleTools(tempServer, dummyCtx);
-  }
+  registerDomainTools(tempServer, dummyCtx, servicesConfig, (domain) =>
+    registry.setCurrentDomain(domain)
+  );
 
   // Search/execute tools always registered (meta-tools)
   registry.setCurrentDomain('discovery');
@@ -362,11 +332,6 @@ function getDomainAccess(
   return 'full'; // unknown domain = full access
 }
 
-/** Backwards-compatible wrapper */
-function isDomainEnabled(domain: string, servicesConfig?: DaemonServicesConfig): boolean {
-  return getDomainAccess(domain, servicesConfig) !== false;
-}
-
 /**
  * Create a proxy McpServer that silently skips tools without
  * `readOnlyHint: true`. Backs the read-only service tier where mutating
@@ -405,37 +370,7 @@ function createMcpServer(
   // 'off' / 'internal': no MCP tools
   // 'readonly': only tools with readOnlyHint: true
   // 'on': all tools
-  const domainRegister = (domain: string, fn: (s: McpServer, c: McpContext) => void) => {
-    const access = getDomainAccess(domain, servicesConfig);
-    if (!access) return;
-    fn(access === 'readonly' ? readOnlyProxy(server) : server, ctx);
-  };
-
-  domainRegister('sessions', (s, c) => {
-    registerSessionTools(s, c);
-    registerTaskTools(s, c);
-    registerMessageTools(s, c);
-  });
-  domainRegister('widgets', registerWidgetTools);
-  domainRegister('repos', registerRepoTools);
-  domainRegister('branches', (s, c) => {
-    registerBranchTools(s, c);
-    registerEnvironmentTools(s, c);
-  });
-  domainRegister('boards', registerBoardTools);
-  domainRegister('cards', (s, c) => {
-    registerCardTools(s, c);
-    registerCardTypeTools(s, c);
-  });
-  domainRegister('artifacts', (s, c) => {
-    registerArtifactTools(s, c);
-    registerProxyTools(s, c);
-  });
-  domainRegister('users', registerUserTools);
-  domainRegister('analytics', registerAnalyticsTools);
-  domainRegister('mcp-servers', registerMcpServerTools);
-  domainRegister('knowledge', registerKnowledgeTools);
-  domainRegister('schedules', registerScheduleTools);
+  registerDomainTools(server, ctx, servicesConfig);
 
   if (toolSearchEnabled) {
     const { registry, toolsList } = getRegistry(servicesConfig);

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -112,10 +112,11 @@ export function sessionContextRequiredResult() {
 /** Server instructions shown to agents when tool search is enabled. */
 const SERVER_INSTRUCTIONS = `Agor is a multiplayer canvas for orchestrating AI coding agents. It manages branches (isolated workspaces backed by git branches), tracks AI conversations, visualizes work on spatial boards, and enables real-time collaboration.
 
-This server uses progressive tool discovery. Only 2 tools are listed directly — use them to discover and call all available tools:
+This server uses progressive tool discovery. Only 3 tools are listed directly — use them to discover and call all available tools:
 
-- agor_search_tools: Browse/search tools by keyword, domain, or annotation. Call with no args for a domains overview.
-- agor_execute_tool: Call any discovered tool by name with arguments.
+- agor_search_tools: Browse domains and search concise tool summaries. Call with no args for a domain overview.
+- agor_get_tool_details: Get the exact input schema for one selected tool.
+- agor_execute_tool: Call one discovered tool by name with arguments matching its schema.
 
 Domains:
 - sessions: Agent conversations with genealogy (fork/spawn), task tracking, and message history
@@ -145,7 +146,7 @@ Delegate a subtask to a child agent:
 Continue or fork an existing session:
 1. agor_sessions_prompt(sessionId, prompt, mode:"continue"|"fork"|"subsession")
 
-Discover tools: search (list detail) → search (full detail for schemas) → execute`;
+Discover tools: search domains/summaries → get details for one tool → execute`;
 
 /**
  * One-time-per-caller deprecation warning for clients that still send the

--- a/apps/agor-daemon/src/mcp/tool-registry.ts
+++ b/apps/agor-daemon/src/mcp/tool-registry.ts
@@ -48,6 +48,7 @@ const DOMAIN_DESCRIPTIONS: Record<string, string> = {
   environment: 'Start/stop/health/logs/nuke for branch dev environments',
   boards: 'Spatial canvases with zones for organizing branches and cards',
   cards: 'Kanban-style cards and card type definitions on boards',
+  artifacts: 'Live Sandpack-style apps and DOM inspection/materialization for board artifacts',
   users: 'User accounts, profiles, preferences, and administration',
   analytics: 'Usage and cost tracking leaderboard',
   'mcp-servers': 'External MCP server configuration and OAuth management',
@@ -55,10 +56,11 @@ const DOMAIN_DESCRIPTIONS: Record<string, string> = {
   widgets:
     'In-conversation interactive widgets — agents render small forms/buttons inline in the transcript to capture user input that never enters the LLM context',
   knowledge: 'DB-backed markdown knowledge documents, version history, search, and graph links',
+  schedules: 'Cron-based branch schedules that create sessions from prompt templates',
 };
 
 /** Tools always visible in `tools/list` even when search mode is enabled. */
-const ALWAYS_VISIBLE = new Set(['agor_search_tools', 'agor_execute_tool']);
+const ALWAYS_VISIBLE = new Set(['agor_search_tools', 'agor_get_tool_details', 'agor_execute_tool']);
 
 export class ToolRegistry {
   private tools: Map<string, ToolEntry> = new Map();
@@ -75,6 +77,10 @@ export class ToolRegistry {
 
   get size(): number {
     return this.tools.size;
+  }
+
+  get(name: string): ToolEntry | undefined {
+    return this.tools.get(name);
   }
 
   /** Return only the always-visible tools (for filtered tools/list). */

--- a/apps/agor-daemon/src/mcp/tool-registry.ts
+++ b/apps/agor-daemon/src/mcp/tool-registry.ts
@@ -40,7 +40,7 @@ export interface SearchOptions {
 }
 
 /** Domain descriptions for the domain listing. */
-const DOMAIN_DESCRIPTIONS: Record<string, string> = {
+export const DOMAIN_DESCRIPTIONS: Record<string, string> = {
   sessions: 'Agent conversations with genealogy (fork/spawn), task tracking, and message history',
   repos: 'Repository registration and management',
   branches:
@@ -58,6 +58,12 @@ const DOMAIN_DESCRIPTIONS: Record<string, string> = {
   knowledge: 'DB-backed markdown knowledge documents, version history, search, and graph links',
   schedules: 'Cron-based branch schedules that create sessions from prompt templates',
 };
+
+export function formatDomainDescriptionsForInstructions(): string {
+  return Object.entries(DOMAIN_DESCRIPTIONS)
+    .map(([domain, description]) => `- ${domain}: ${description}`)
+    .join('\n');
+}
 
 /** Tools always visible in `tools/list` even when search mode is enabled. */
 const ALWAYS_VISIBLE = new Set(['agor_search_tools', 'agor_get_tool_details', 'agor_execute_tool']);

--- a/apps/agor-daemon/src/mcp/tools/analytics.ts
+++ b/apps/agor-daemon/src/mcp/tools/analytics.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { resolveBranchId, resolveRepoId, resolveUserId } from '../resolve-ids.js';
+import { mcpLimit, mcpOffset, mcpOptionalId, mcpOptionalString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -17,21 +18,19 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
       description:
         'Get usage analytics leaderboard showing token, cost, session, and duration breakdown. Supports dynamic grouping by user, branch, repo, model, and/or tool (freely combined), plus optional time bucketing (hour/day/week/month) for time-series reports.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        userId: z.string().optional().describe('Filter by user ID (optional)'),
-        branchId: z.string().optional().describe('Filter by branch ID (optional)'),
-        repoId: z.string().optional().describe('Filter by repository ID (optional)'),
-        startDate: z
-          .string()
-          .optional()
-          .describe('Filter by start date (ISO 8601 format, optional)'),
-        endDate: z.string().optional().describe('Filter by end date (ISO 8601 format, optional)'),
-        groupBy: z
-          .string()
-          .optional()
-          .describe(
-            'Comma-separated list of dimensions to group by. Supported: user, branch, repo, model, tool. Examples: "user", "user,model", "tool,branch". Default: "user,branch,repo".'
-          ),
+      inputSchema: z.strictObject({
+        userId: mcpOptionalId('userId', 'User', 'Filter by user ID (optional)'),
+        branchId: mcpOptionalId('branchId', 'Branch', 'Filter by branch ID (optional)'),
+        repoId: mcpOptionalId('repoId', 'Repository', 'Filter by repository ID (optional)'),
+        startDate: mcpOptionalString(
+          'startDate',
+          'Filter by start date (ISO 8601 format, optional)'
+        ),
+        endDate: mcpOptionalString('endDate', 'Filter by end date (ISO 8601 format, optional)'),
+        groupBy: mcpOptionalString(
+          'groupBy',
+          'Comma-separated list of dimensions to group by. Supported: user, branch, repo, model, tool. Examples: "user", "user,model", "tool,branch". Default: "user,branch,repo".'
+        ),
         bucket: z
           .enum(['hour', 'day', 'week', 'month'])
           .optional()
@@ -46,11 +45,8 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
           .enum(['asc', 'desc'])
           .optional()
           .describe('Sort order ascending or descending (default: desc)'),
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
-        offset: z
-          .number()
-          .optional()
-          .describe('Number of results to skip for pagination (default: 0)'),
+        limit: mcpLimit(50),
+        offset: mcpOffset(0).describe('Number of results to skip for pagination (default: 0)'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/artifacts.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.test.ts
@@ -1,0 +1,95 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core/db', () => ({
+  BranchRepository: class BranchRepository {},
+}));
+
+vi.mock('@agor/core/utils/errors', () => ({
+  NotFoundError: class NotFoundError extends Error {},
+}));
+
+vi.mock('../../utils/branch-authorization.js', () => ({
+  hasBranchPermission: () => true,
+}));
+
+vi.mock('../server.js', () => ({
+  coerceString: (value: unknown) =>
+    typeof value === 'string' && value.trim() ? value.trim() : undefined,
+  textResult: (data: unknown) => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  }),
+}));
+
+const { registerArtifactTools } = await import('./artifacts.js');
+
+type ToolConfig = {
+  inputSchema?: {
+    safeParse: (value: unknown) => {
+      success: boolean;
+      error?: { issues?: Array<{ path: Array<string | number>; message: string }> };
+    };
+  };
+};
+
+function captureConfig(toolName: string): ToolConfig {
+  let config: ToolConfig | undefined;
+  const fakeServer = {
+    registerTool: (name: string, cfg: ToolConfig) => {
+      if (name === toolName) config = cfg;
+    },
+  } as unknown as McpServer;
+
+  registerArtifactTools(fakeServer, {} as Parameters<typeof registerArtifactTools>[1]);
+
+  if (!config) throw new Error(`${toolName} was not registered`);
+  return config;
+}
+
+describe('artifact MCP tool input schemas', () => {
+  it('rejects missing required artifact IDs with a field-specific message', () => {
+    const parsed = captureConfig('agor_artifacts_get').inputSchema?.safeParse({});
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['artifactId'],
+    });
+    expect(parsed?.error?.issues?.[0]?.message).toMatch(/artifactId is required/);
+  });
+
+  it('rejects empty required DOM selectors', () => {
+    const parsed = captureConfig('agor_artifacts_query_dom').inputSchema?.safeParse({
+      artifactId: 'artifact-1',
+      selector: '',
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['selector'],
+      message: 'selector cannot be empty.',
+    });
+  });
+
+  it('validates artifact list limits as positive integers', () => {
+    const parsed = captureConfig('agor_artifacts_list').inputSchema?.safeParse({ limit: -1 });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['limit'],
+      message: 'limit must be greater than 0.',
+    });
+  });
+
+  it('rejects empty requiredEnvVars entries', () => {
+    const parsed = captureConfig('agor_artifacts_publish').inputSchema?.safeParse({
+      folderPath: '/tmp/artifact',
+      requiredEnvVars: [''],
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['requiredEnvVars', 0],
+      message: 'requiredEnvVars[] cannot be empty.',
+    });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -28,6 +28,15 @@ import { z } from 'zod';
 import type { ArtifactsService } from '../../services/artifacts.js';
 import { hasBranchPermission } from '../../utils/branch-authorization.js';
 import { resolveArtifactId, resolveBoardId, resolveBranchId } from '../resolve-ids.js';
+import {
+  mcpLimit,
+  mcpOptionalId,
+  mcpOptionalNumber,
+  mcpOptionalPositiveInt,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -50,11 +59,19 @@ const SandpackConfigSchema = z
       .object({
         dependencies: z.record(z.string(), z.string()).optional(),
         devDependencies: z.record(z.string(), z.string()).optional(),
-        entry: z.string().optional(),
-        environment: z.string().optional(),
+        entry: mcpOptionalString('sandpackConfig.customSetup.entry', 'Custom Sandpack entry file'),
+        environment: mcpOptionalString(
+          'sandpackConfig.customSetup.environment',
+          'Custom Sandpack environment'
+        ),
       })
       .optional(),
-    theme: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
+    theme: z
+      .union([
+        mcpRequiredString('sandpackConfig.theme', 'Sandpack theme name'),
+        z.record(z.string(), z.unknown()),
+      ])
+      .optional(),
     options: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough()
@@ -67,7 +84,9 @@ const AgorGrantsSchema = z
     agor_user_email: z.boolean().optional(),
     agor_artifact_id: z.boolean().optional(),
     agor_board_id: z.boolean().optional(),
-    agor_proxies: z.array(z.string()).optional(),
+    agor_proxies: z
+      .array(mcpRequiredString('agorGrants.agor_proxies[]', 'Configured proxy vendor slug'))
+      .optional(),
   })
   .optional();
 
@@ -114,38 +133,33 @@ IMPORTANT:
 - Missing user env vars render as "" — your app should detect that and surface a "configure SOMETHING in Settings" message rather than calling APIs with empty creds.
 - For node.js / static templates without a dotenv path, env vars are NOT injected; the daemon emits a warning if you declared any.`,
       inputSchema: z.object({
-        folderPath: z
-          .string()
-          .optional()
-          .describe(
-            'Legacy absolute path to folder containing artifact files. Prefer branchId + subpath. If this resolves inside a registered branch, branch session permission is required.'
-          ),
-        branchId: z
-          .string()
-          .optional()
-          .describe(
-            'Branch ID (UUID or short ID). Prefer this with subpath to publish from a branch worktree.'
-          ),
-        subpath: z
-          .string()
-          .optional()
-          .describe('Branch-relative subpath to the artifact folder (required with branchId).'),
-        boardId: z
-          .string()
-          .optional()
-          .describe(
-            'Board to place the artifact on. REQUIRED when creating. IGNORED when updating (artifactId given) — to move an artifact between boards use agor_artifacts_update.'
-          ),
-        name: z
-          .string()
-          .optional()
-          .describe(
-            'Artifact display name. REQUIRED when creating; on update (artifactId given) defaults to the existing name if omitted. PASSING A DIFFERENT NAME ON UPDATE WILL RENAME THE ARTIFACT.'
-          ),
-        artifactId: z
-          .string()
-          .optional()
-          .describe('If provided, update existing artifact (must be owned by you)'),
+        folderPath: mcpOptionalString(
+          'folderPath',
+          'Legacy absolute path to folder containing artifact files. Prefer branchId + subpath. If this resolves inside a registered branch, branch session permission is required.'
+        ),
+        branchId: mcpOptionalId(
+          'branchId',
+          'Branch',
+          'Branch ID (UUID or short ID). Prefer this with subpath to publish from a branch worktree.'
+        ),
+        subpath: mcpOptionalString(
+          'subpath',
+          'Branch-relative subpath to the artifact folder (required with branchId).'
+        ),
+        boardId: mcpOptionalId(
+          'boardId',
+          'Board',
+          'Board to place the artifact on. REQUIRED when creating. IGNORED when updating (artifactId given) — to move an artifact between boards use agor_artifacts_update.'
+        ),
+        name: mcpOptionalString(
+          'name',
+          'Artifact display name. REQUIRED when creating; on update (artifactId given) defaults to the existing name if omitted. PASSING A DIFFERENT NAME ON UPDATE WILL RENAME THE ARTIFACT.'
+        ),
+        artifactId: mcpOptionalId(
+          'artifactId',
+          'Artifact',
+          'If provided, update existing artifact (must be owned by you)'
+        ),
         template: z
           .enum(SANDPACK_TEMPLATES)
           .optional()
@@ -160,7 +174,7 @@ IMPORTANT:
           'Author-controlled Sandpack provider config (sanitized on write).'
         ),
         requiredEnvVars: z
-          .array(z.string())
+          .array(mcpRequiredString('requiredEnvVars[]', 'Env var name without template prefix'))
           .optional()
           .describe(
             'Env var NAMES (no prefix) the artifact needs. Daemon synthesizes a per-viewer .env at render time.'
@@ -171,12 +185,9 @@ IMPORTANT:
         agorRuntime: AgorRuntimeSchema.describe(
           'Controls injection of the daemon-side `agor-runtime.js` (which powers agent DOM introspection via agor_artifacts_query_dom). Default: enabled.'
         ),
-        x: z.number().optional().describe('X position on board (default: 0, only used on create)'),
-        y: z.number().optional().describe('Y position on board (default: 0, only used on create)'),
-        width: z
-          .number()
-          .optional()
-          .describe('Width in pixels (default: 600, only used on create)'),
+        x: mcpOptionalNumber('x', 'X position on board (default: 0, only used on create)'),
+        y: mcpOptionalNumber('y', 'Y position on board (default: 0, only used on create)'),
+        width: mcpOptionalNumber('width', 'Width in pixels (default: 600, only used on create)'),
         height: z
           .number()
           .optional()
@@ -239,24 +250,19 @@ IMPORTANT:
       description:
         'Check build readiness of artifact files in a branch-relative folder (branchId + subpath preferred) or legacy absolute folderPath. Verifies source files exist and are non-empty (does not run a real build or syntax check). Use this before publishing to verify basic structure.',
       inputSchema: z.object({
-        folderPath: z
-          .string()
-          .optional()
-          .describe(
-            'Legacy absolute path to the folder containing artifact files to check. Prefer branchId + subpath. If this resolves inside a registered branch, branch session permission is required.'
-          ),
-        branchId: z
-          .string()
-          .optional()
-          .describe(
-            'Branch ID (UUID or short ID). Prefer this with subpath to check a branch worktree path.'
-          ),
-        subpath: z
-          .string()
-          .optional()
-          .describe(
-            'Branch-relative subpath pointing at the artifact folder (required with branchId).'
-          ),
+        folderPath: mcpOptionalString(
+          'folderPath',
+          'Legacy absolute path to the folder containing artifact files to check. Prefer branchId + subpath. If this resolves inside a registered branch, branch session permission is required.'
+        ),
+        branchId: mcpOptionalId(
+          'branchId',
+          'Branch',
+          'Branch ID (UUID or short ID). Prefer this with subpath to check a branch worktree path.'
+        ),
+        subpath: mcpOptionalString(
+          'subpath',
+          'Branch-relative subpath pointing at the artifact folder (required with branchId).'
+        ),
       }),
     },
     async (args) => {
@@ -307,7 +313,7 @@ Fields:
 NOTE: sandpack_error and console_logs require a browser to be viewing the artifact. They are scoped to the calling user's render — you only see your own console output, never another viewer's.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID'),
+        artifactId: mcpRequiredId('artifactId', 'Artifact', 'Artifact ID'),
       }),
     },
     async (args) => {
@@ -325,7 +331,7 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
         "Delete an artifact. Owner or admin only — calling as a different user returns 'Forbidden'. Removes database record and board placement. Does not touch the filesystem.",
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID to delete'),
+        artifactId: mcpRequiredId('artifactId', 'Artifact', 'Artifact ID to delete'),
       }),
     },
     async (args) => {
@@ -356,7 +362,11 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
         'Get a single artifact by ID, including its full file map (path → content) and declarative metadata (sandpack_config, required_env_vars, agor_grants). Use this to read artifact source code from another branch without filesystem access. Respects visibility: public artifacts are readable by anyone; private artifacts are only readable by their creator.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
+        artifactId: mcpRequiredId(
+          'artifactId',
+          'Artifact',
+          'Artifact ID (full UUID or short prefix)'
+        ),
       }),
     },
     async (args) => {
@@ -397,24 +407,28 @@ Placement (x, y, width, height) is preserved across board moves unless you expli
 
 Caller must own the artifact (or be an admin).`,
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID to update (full UUID or short prefix)'),
-        boardId: z.string().optional().describe('Move the artifact to a different board'),
-        name: z.string().optional().describe('Rename the artifact'),
-        description: z.string().optional().describe('Update the description'),
+        artifactId: mcpRequiredId(
+          'artifactId',
+          'Artifact',
+          'Artifact ID to update (full UUID or short prefix)'
+        ),
+        boardId: mcpOptionalId('boardId', 'Board', 'Move the artifact to a different board'),
+        name: mcpOptionalString('name', 'Rename the artifact'),
+        description: mcpOptionalString('description', 'Update the description'),
         public: z
           .boolean()
           .optional()
           .describe('Change visibility (true = visible to all board viewers, false = owner only)'),
         archived: z.boolean().optional().describe('Archive or unarchive the artifact'),
-        x: z.number().optional().describe('New X position on board'),
-        y: z.number().optional().describe('New Y position on board'),
-        width: z.number().optional().describe('New width in pixels'),
-        height: z.number().optional().describe('New height in pixels'),
+        x: mcpOptionalNumber('x', 'New X position on board'),
+        y: mcpOptionalNumber('y', 'New Y position on board'),
+        width: mcpOptionalNumber('width', 'New width in pixels'),
+        height: mcpOptionalNumber('height', 'New height in pixels'),
         sandpackConfig: SandpackConfigSchema.describe(
           "Replace the artifact's sandpack_config (sanitized on write)."
         ),
         requiredEnvVars: z
-          .array(z.string())
+          .array(mcpRequiredString('requiredEnvVars[]', 'Env var name without template prefix'))
           .optional()
           .describe("Replace the artifact's required_env_vars list."),
         agorGrants: AgorGrantsSchema.describe("Replace the artifact's agor_grants object."),
@@ -477,14 +491,20 @@ Safety:
 
 Visibility: public artifacts are readable by anyone; private artifacts are only landable by their owner.`,
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID to materialize (full UUID or short prefix)'),
-        branchId: z.string().describe('Destination branch ID (full UUID or short prefix)'),
-        subpath: z
-          .string()
-          .optional()
-          .describe(
-            'Branch-relative path for the destination folder. Default: .agor/artifacts/<slug>-<short-id> derived from the artifact name. Must not be absolute or escape the branch.'
-          ),
+        artifactId: mcpRequiredId(
+          'artifactId',
+          'Artifact',
+          'Artifact ID to materialize (full UUID or short prefix)'
+        ),
+        branchId: mcpRequiredId(
+          'branchId',
+          'Branch',
+          'Destination branch ID (full UUID or short prefix)'
+        ),
+        subpath: mcpOptionalString(
+          'subpath',
+          'Branch-relative path for the destination folder. Default: .agor/artifacts/<slug>-<short-id> derived from the artifact name. Must not be absolute or escape the branch.'
+        ),
         overwrite: z
           .boolean()
           .optional()
@@ -568,8 +588,8 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
         'List artifacts, optionally filtered by board. Respects visibility: shows public artifacts plus private artifacts owned by you.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        boardId: z.string().optional().describe('Filter by board ID'),
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        boardId: mcpOptionalId('boardId', 'Board', 'Filter by board ID'),
+        limit: mcpLimit(50),
       }),
     },
     async (args) => {
@@ -603,7 +623,11 @@ Visibility: public artifacts are readable by anyone; private artifacts are only 
 
 CAVEAT: daemon-supplied capabilities (\`AGOR_TOKEN\`, \`AGOR_PROXY_*\`, etc.) won't work on CodeSandbox. The exported sandbox can read \`required_env_vars\` from CodeSandbox's "Secret Keys" UI — the names match because both sides use the same prefix-per-template convention (Vite → \`VITE_\`, CRA → \`REACT_APP_\`, etc.).`,
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID to export (full UUID or short prefix)'),
+        artifactId: mcpRequiredId(
+          'artifactId',
+          'Artifact',
+          'Artifact ID to export (full UUID or short prefix)'
+        ),
       }),
     },
     async (args) => {
@@ -641,22 +665,27 @@ Use cases:
 - "Get the full document" — use \`{ selector: 'html' }\`, or call \`agor_artifacts_query_document_html\` for an unstructured dump of the entire \`document.documentElement.outerHTML\`.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
-        selector: z
-          .string()
-          .describe('CSS selector to match (e.g. "h1", ".card", "[data-test=\'submit\']")'),
+        artifactId: mcpRequiredId(
+          'artifactId',
+          'Artifact',
+          'Artifact ID (full UUID or short prefix)'
+        ),
+        selector: mcpRequiredString(
+          'selector',
+          'CSS selector to match (e.g. "h1", ".card", "[data-test=\'submit\']")'
+        ),
         multiple: z
           .boolean()
           .optional()
           .describe('querySelectorAll vs querySelector. Default: false (single match).'),
-        maxNodes: z
-          .number()
-          .optional()
-          .describe('Max nodes to return (capped at 50 by the runtime). Default: 50.'),
-        timeoutMs: z
-          .number()
-          .optional()
-          .describe('How long to wait for the browser to answer (500-30000). Default: 5000.'),
+        maxNodes: mcpOptionalPositiveInt(
+          'maxNodes',
+          'Max nodes to return (capped at 50 by the runtime). Default: 50.'
+        ),
+        timeoutMs: mcpOptionalPositiveInt(
+          'timeoutMs',
+          'How long to wait for the browser to answer (500-30000). Default: 5000.'
+        ),
       }),
     },
     async (args) => {
@@ -694,11 +723,15 @@ Same round-trip as agor_artifacts_query_dom: requires \`agor_runtime.enabled\` a
 Capped at 200KB. Truncated output ends with \`... [truncated]\`. For targeted queries prefer agor_artifacts_query_dom with a CSS selector — this tool is the "give me everything" escape hatch when you don't know what to look for yet.`,
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        artifactId: z.string().describe('Artifact ID (full UUID or short prefix)'),
-        timeoutMs: z
-          .number()
-          .optional()
-          .describe('How long to wait for the browser to answer (500-30000). Default: 5000.'),
+        artifactId: mcpRequiredId(
+          'artifactId',
+          'Artifact',
+          'Artifact ID (full UUID or short prefix)'
+        ),
+        timeoutMs: mcpOptionalPositiveInt(
+          'timeoutMs',
+          'How long to wait for the browser to answer (500-30000). Default: 5000.'
+        ),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -9,7 +9,11 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
 
 type ToolConfig = {
   inputSchema?: {
-    safeParse: (value: unknown) => { success: boolean };
+    safeParse: (
+      value: unknown
+    ) =>
+      | { success: true; data: unknown }
+      | { success: false; error: { issues: Array<{ message: string }> } };
   };
 };
 
@@ -335,8 +339,47 @@ describe('agor_boards_get', () => {
       config.inputSchema?.safeParse({
         boardId: 'board-1',
         includeEntities: true,
+        entitiesLimit: 0,
+      }).success
+    ).toBe(false);
+    expect(
+      config.inputSchema?.safeParse({
+        boardId: 'board-1',
+        includeEntities: true,
         entitiesSkip: 10001,
       }).success
     ).toBe(false);
+  });
+
+  it('rejects empty required boardId with a clear field-specific message', () => {
+    const { app } = makeApp();
+    const config = registerAndCaptureConfig('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = config.inputSchema?.safeParse({ boardId: '' });
+
+    expect(result?.success).toBe(false);
+    if (result?.success === false) {
+      expect(result.error.issues[0]?.message).toMatch(/boardId cannot be empty/i);
+    }
+  });
+});
+
+describe('agor_boards_create schema', () => {
+  it('rejects an empty required board name with a clear message', () => {
+    const config = registerAndCaptureConfig('agor_boards_create', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    const result = config.inputSchema?.safeParse({ name: '' });
+
+    expect(result?.success).toBe(false);
+    if (result?.success === false) {
+      expect(result.error.issues[0]?.message).toMatch(/name cannot be empty/i);
+    }
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -2,6 +2,14 @@ import type { Board, BoardEntityType, BoardObject, BoardObjectType } from '@agor
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BoardsServiceImpl } from '../../declarations.js';
+import {
+  mcpLimit,
+  mcpOptionalNonNegativeInt,
+  mcpOptionalPositiveInt,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -40,7 +48,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         'Set includeEntities=true to include positioned branch/card entities, optionally filtered by entityZoneId/entityType and paginated with entitiesLimit/entitiesSkip.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        boardId: z.string().describe('Board ID (UUIDv7 or short ID)'),
+        boardId: mcpRequiredId('boardId', 'Board'),
         objectTypes: z
           .array(z.enum(BOARD_OBJECT_TYPES))
           .optional()
@@ -53,33 +61,35 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Include positioned entities (branches, cards) with their x/y coordinates and zone assignments (default: false). Enable when you need to know where branches are placed on the canvas.'
           ),
-        entityZoneId: z
-          .string()
-          .optional()
-          .describe(
-            'When includeEntities=true, only return positioned entities pinned to this board zone ID.'
-          ),
+        entityZoneId: mcpOptionalString(
+          'entityZoneId',
+          'When includeEntities=true, only return positioned entities pinned to this board zone ID.'
+        ),
         entityType: z
           .enum(BOARD_ENTITY_TYPES)
           .optional()
           .describe(
             'When includeEntities=true, only return positioned entities of this type ("branch" or "card").'
           ),
-        entitiesLimit: z
-          .number()
-          .int()
-          .min(0)
-          .max(10000)
-          .optional()
+        entitiesLimit: mcpOptionalPositiveInt(
+          'entitiesLimit',
+          'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.'
+        )
+          .refine(
+            (value) => value === undefined || value <= 10000,
+            'entitiesLimit must be less than or equal to 10000.'
+          )
           .describe(
             'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.'
           ),
-        entitiesSkip: z
-          .number()
-          .int()
-          .min(0)
-          .max(10000)
-          .optional()
+        entitiesSkip: mcpOptionalNonNegativeInt(
+          'entitiesSkip',
+          'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).'
+        )
+          .refine(
+            (value) => value === undefined || value <= 10000,
+            'entitiesSkip must be less than or equal to 10000.'
+          )
           .describe(
             'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).'
           ),
@@ -136,7 +146,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         'List all boards accessible to the current user. Each board includes a `url` field with a clickable link to view the board in the UI. By default, archived boards are excluded.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        limit: mcpLimit(50),
         includeArchived: z
           .boolean()
           .optional()
@@ -172,22 +182,20 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         'Update board metadata and manage zones/objects. Can update name, icon, background, and create/update zones for organizing branches. Zone objects have: type="zone", x, y, width, height, label, borderColor, backgroundColor, borderStyle (optional), trigger (optional: "always_new" auto-creates sessions, "show_picker" shows agent selection). Text objects have: type="text", x, y, text, fontSize, color. Markdown objects have: type="markdown", x, y, width, height, content.',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        boardId: z.string().describe('Board ID (UUIDv7 or short ID)'),
-        name: z.string().optional().describe('Board name (optional)'),
-        description: z.string().optional().describe('Board description (optional)'),
-        icon: z.string().optional().describe('Board icon/emoji (optional)'),
-        color: z.string().optional().describe('Board color (hex format, optional)'),
-        backgroundColor: z
-          .string()
-          .optional()
-          .describe('Board background color (hex format, optional)'),
-        customCss: z
-          .string()
-          .optional()
-          .describe(
-            'Custom CSS for board canvas animations (@keyframes, animation, background-size, etc.). Rendered in a scoped <style> tag. Dangerous patterns like url(), expression(), @import are blocked.'
-          ),
-        slug: z.string().optional().describe('URL-friendly slug (optional)'),
+        boardId: mcpRequiredId('boardId', 'Board'),
+        name: mcpOptionalString('name', 'Board name (optional)'),
+        description: mcpOptionalString('description', 'Board description (optional)'),
+        icon: mcpOptionalString('icon', 'Board icon/emoji (optional)'),
+        color: mcpOptionalString('color', 'Board color (hex format, optional)'),
+        backgroundColor: mcpOptionalString(
+          'backgroundColor',
+          'Board background color (hex format, optional)'
+        ),
+        customCss: mcpOptionalString(
+          'customCss',
+          'Custom CSS for board canvas animations (@keyframes, animation, background-size, etc.). Rendered in a scoped <style> tag. Dangerous patterns like url(), expression(), @import are blocked.'
+        ),
+        slug: mcpOptionalString('slug', 'URL-friendly slug (optional)'),
         customContext: z
           .object({})
           .passthrough()
@@ -201,7 +209,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
             'Board objects to upsert (zones, text, markdown). Keys are object IDs, values are object data.'
           ),
         removeObjects: z
-          .array(z.string())
+          .array(mcpRequiredString('removeObjects[]', 'Board object ID to remove'))
           .optional()
           .describe('Array of object IDs to remove from the board'),
       }),
@@ -262,24 +270,22 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
     {
       description: 'Create a new board. Returns the created board object with its ID and URL.',
       inputSchema: z.object({
-        name: z.string().describe('Board name (required)'),
-        slug: z
-          .string()
-          .optional()
-          .describe('URL-friendly slug (optional, auto-derived from name if not provided)'),
-        description: z.string().optional().describe('Board description (optional)'),
-        icon: z.string().optional().describe('Board icon/emoji (optional, e.g. "📋")'),
-        color: z.string().optional().describe('Board color in hex format (optional)'),
-        backgroundColor: z
-          .string()
-          .optional()
-          .describe('Board background color in hex format (optional)'),
-        customCss: z
-          .string()
-          .optional()
-          .describe(
-            'Custom CSS for board canvas animations (@keyframes, animation, etc.). Optional.'
-          ),
+        name: mcpRequiredString('name', 'Board name (required)'),
+        slug: mcpOptionalString(
+          'slug',
+          'URL-friendly slug (optional, auto-derived from name if not provided)'
+        ),
+        description: mcpOptionalString('description', 'Board description (optional)'),
+        icon: mcpOptionalString('icon', 'Board icon/emoji (optional, e.g. "📋")'),
+        color: mcpOptionalString('color', 'Board color in hex format (optional)'),
+        backgroundColor: mcpOptionalString(
+          'backgroundColor',
+          'Board background color in hex format (optional)'
+        ),
+        customCss: mcpOptionalString(
+          'customCss',
+          'Custom CSS for board canvas animations (@keyframes, animation, etc.). Optional.'
+        ),
       }),
     },
     async (args) => {
@@ -311,7 +317,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         'Archive a board (soft delete). Archived boards are hidden from listings by default. Use agor_boards_unarchive to restore.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        boardId: z.string().describe('Board ID to archive (UUIDv7 or short ID)'),
+        boardId: mcpRequiredId('boardId', 'Board', 'Board ID to archive (UUIDv7 or short ID)'),
       }),
     },
     async (args) => {
@@ -332,7 +338,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
     {
       description: 'Restore a previously archived board. The board will appear in listings again.',
       inputSchema: z.object({
-        boardId: z.string().describe('Board ID to unarchive (UUIDv7 or short ID)'),
+        boardId: mcpRequiredId('boardId', 'Board', 'Board ID to unarchive (UUIDv7 or short ID)'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -7,6 +7,16 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 
+type ToolConfig = {
+  inputSchema?: {
+    safeParse: (
+      value: unknown
+    ) =>
+      | { success: true; data: unknown }
+      | { success: false; error: { issues: Array<{ message: string }> } };
+  };
+};
+
 function registerAndCaptureHandler(
   toolName: string,
   ctx: {
@@ -38,6 +48,39 @@ function registerAndCaptureHandler(
 
   if (!handler) throw new Error(`${toolName} was not registered`);
   return handler;
+}
+
+function registerAndCaptureConfig(
+  toolName: string,
+  ctx: {
+    app: unknown;
+    userId: string;
+    sessionId?: string;
+    baseServiceParams?: Record<string, unknown>;
+  }
+): ToolConfig {
+  let config: ToolConfig | undefined;
+  const fakeServer = {
+    registerTool: (name: string, cfg: ToolConfig, _cb: ToolHandler) => {
+      if (name === toolName) config = cfg;
+    },
+  } as unknown as McpServer;
+
+  registerBranchTools(fakeServer, {
+    app: ctx.app as Parameters<typeof registerBranchTools>[1]['app'],
+    db: {} as Parameters<typeof registerBranchTools>[1]['db'],
+    userId: ctx.userId as Parameters<typeof registerBranchTools>[1]['userId'],
+    sessionId: ctx.sessionId as Parameters<typeof registerBranchTools>[1]['sessionId'],
+    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
+      typeof registerBranchTools
+    >[1]['authenticatedUser'],
+    baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
+      typeof registerBranchTools
+    >[1]['baseServiceParams'],
+  });
+
+  if (!config) throw new Error(`${toolName} was not registered`);
+  return config;
 }
 
 function registerAndCaptureUpdate(ctx: {
@@ -100,6 +143,43 @@ describe('agor_branches_update', () => {
     expect(parsed.error).toMatch(/requires current Agor session context/i);
     expect(parsed.error).toMatch(/X-Agor-Session-Id/);
     expect(sessionsGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('branch MCP input schemas', () => {
+  it('rejects empty required IDs/names with field-specific messages', () => {
+    const config = registerAndCaptureConfig('agor_branches_create', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    const result = config.inputSchema?.safeParse({
+      repoId: '',
+      branchName: '',
+      boardId: '',
+    });
+
+    expect(result?.success).toBe(false);
+    if (result?.success === false) {
+      expect(result.error.issues.map((issue) => issue.message)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/repoId cannot be empty/i),
+          expect.stringMatching(/branchName cannot be empty/i),
+          expect.stringMatching(/boardId cannot be empty/i),
+        ])
+      );
+    }
+  });
+
+  it('rejects malformed pagination values before handler execution', () => {
+    const config = registerAndCaptureConfig('agor_branches_cleanup_candidates', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    expect(config.inputSchema?.safeParse({ limit: 0 }).success).toBe(false);
+    expect(config.inputSchema?.safeParse({ skip: -1 }).success).toBe(false);
+    expect(config.inputSchema?.safeParse({ limit: 1, skip: 0 }).success).toBe(true);
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -24,6 +24,15 @@ import {
   resolveRepoId,
   resolveSessionId,
 } from '../resolve-ids.js';
+import {
+  mcpLimit,
+  mcpOptionalId,
+  mcpOptionalNonNegativeInt,
+  mcpOptionalPositiveInt,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, sessionContextRequiredResult, textResult } from '../server.js';
 import { assertValidVariant } from './_environment-helpers.js';
@@ -134,7 +143,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'Get detailed information about a branch, including path, git ref, and git state',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {
@@ -161,8 +170,8 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'pull_request_url, issue_url, board_object_id, and position when set.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        repoId: z.string().optional().describe('Repository ID to filter by'),
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        repoId: mcpOptionalId('repoId', 'Repository', 'Repository ID to filter by'),
+        limit: mcpLimit(50),
         includeArchived: z
           .boolean()
           .optional()
@@ -175,13 +184,11 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Filter to show ONLY archived branches. When true, returns only archived branches. Overrides includeArchived.'
           ),
-        zoneId: z
-          .string()
-          .optional()
-          .describe(
-            'Filter results to branches in a specific board zone (e.g. "zone-1776863814461"). ' +
-              'Avoids the need to call agor_branches_get on each branch to check zone membership.'
-          ),
+        zoneId: mcpOptionalString(
+          'zoneId',
+          'Filter results to branches in a specific board zone (e.g. "zone-1776863814461"). ' +
+            'Avoids the need to call agor_branches_get on each branch to check zone membership.'
+        ),
       }),
     },
     async (args) => {
@@ -213,21 +220,15 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'filesystem/storage status, path, and a path_exists boolean computed from the recorded branch path only.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        repoId: z.string().optional().describe('Repository ID to filter by'),
-        archivedBefore: z
-          .string()
-          .optional()
-          .describe(
-            'Only include branches archived before this ISO-8601 date/time. Overrides the default archivedOlderThanDays=7 cutoff.'
-          ),
-        archivedOlderThanDays: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe(
-            'Only include branches archived more than this many days ago. Must be at least 1. Default: 7. Ignored when archivedBefore is provided.'
-          ),
+        repoId: mcpOptionalId('repoId', 'Repository', 'Repository ID to filter by'),
+        archivedBefore: mcpOptionalString(
+          'archivedBefore',
+          'Only include branches archived before this ISO-8601 date/time. Overrides the default archivedOlderThanDays=7 cutoff.'
+        ),
+        archivedOlderThanDays: mcpOptionalPositiveInt(
+          'archivedOlderThanDays',
+          'Only include branches archived more than this many days ago. Must be at least 1. Default: 7. Ignored when archivedBefore is provided.'
+        ),
         filesystemStatus: z
           .enum(CLEANUP_CANDIDATE_FILESYSTEM_STATUSES)
           .optional()
@@ -258,18 +259,11 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Filter by whether the recorded branch path currently exists. This checks the exact stored path; it does not scan the filesystem.'
           ),
-        limit: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe('Maximum number of results (default: 50)'),
-        skip: z
-          .number()
-          .int()
-          .nonnegative()
-          .optional()
-          .describe('Number of filtered candidates to skip (default: 0)'),
+        limit: mcpLimit(50),
+        skip: mcpOptionalNonNegativeInt(
+          'skip',
+          'Number of filtered candidates to skip (default: 0)'
+        ),
       }),
     },
     async (args) => {
@@ -399,27 +393,28 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'Use zoneId to place the branch in a specific zone (pin only, no trigger). ' +
         'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation.',
       inputSchema: z.object({
-        repoId: z.string().describe('Repository ID where the branch will be created'),
-        branchName: z
-          .string()
-          .describe(
-            'Slug name for the branch directory (lowercase letters, numbers, hyphens). ' +
-              'If the name conflicts with an existing branch, a numeric suffix is auto-appended (e.g., "my-feature-2"). ' +
-              'Set autoSuffix=false to get an error on conflict instead.'
-          ),
-        boardId: z
-          .string()
-          .describe(
-            'Board ID to place the branch on (positions to default coordinates). Required to ensure branches are visible in the UI.'
-          ),
-        ref: z
-          .string()
-          .optional()
-          .describe(
-            'Git ref name to create or checkout. Defaults to branchName when creating a new git branch. ' +
-              'Set this to create a git branch with a different name than the branch directory. ' +
-              'Example: branchName="review-1", ref="issue-282-review-1" creates directory "review-1" on git branch "issue-282-review-1".'
-          ),
+        repoId: mcpRequiredId(
+          'repoId',
+          'Repository',
+          'Repository ID where the branch will be created'
+        ),
+        branchName: mcpRequiredString(
+          'branchName',
+          'Slug name for the branch directory (lowercase letters, numbers, hyphens). ' +
+            'If the name conflicts with an existing branch, a numeric suffix is auto-appended (e.g., "my-feature-2"). ' +
+            'Set autoSuffix=false to get an error on conflict instead.'
+        ),
+        boardId: mcpRequiredId(
+          'boardId',
+          'Board',
+          'Board ID to place the branch on (positions to default coordinates). Required to ensure branches are visible in the UI.'
+        ),
+        ref: mcpOptionalString(
+          'ref',
+          'Git ref name to create or checkout. Defaults to branchName when creating a new git branch. ' +
+            'Set this to create a git branch with a different name than the branch directory. ' +
+            'Example: branchName="review-1", ref="issue-282-review-1" creates directory "review-1" on git branch "issue-282-review-1".'
+        ),
         refType: z
           .enum(['branch', 'tag'])
           .optional()
@@ -437,14 +432,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Pull latest from remote before creating the branch (defaults to true for new branches).'
           ),
-        sourceBranch: z
-          .string()
-          .optional()
-          .describe(
-            'Base branch to fork from when creating a new branch (defaults to the repo default branch, usually "main"). ' +
-              'The new branch will be created from the tip of this branch. ' +
-              'Must exist on the remote (origin) or locally.'
-          ),
+        sourceBranch: mcpOptionalString(
+          'sourceBranch',
+          'Base branch to fork from when creating a new branch (defaults to the repo default branch, usually "main"). ' +
+            'The new branch will be created from the tip of this branch. ' +
+            'Must exist on the remote (origin) or locally.'
+        ),
         autoSuffix: z
           .boolean()
           .optional()
@@ -452,19 +445,17 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
             'If branchName conflicts with an existing branch, automatically append a numeric suffix ' +
               '(e.g., "my-feature" → "my-feature-2", "my-feature-3"). Defaults to true. Set to false to get an error on conflict instead.'
           ),
-        zoneId: z
-          .string()
-          .optional()
-          .describe(
-            'Zone ID to pin the branch to (e.g., "zone-1770152859108"). ' +
-              'Places the branch inside the zone with automatic positioning (pin only, no trigger). ' +
-              'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation.'
-          ),
-        issueUrl: z.string().optional().describe('Issue URL to associate with the branch.'),
-        pullRequestUrl: z
-          .string()
-          .optional()
-          .describe('Pull request URL to associate with the branch.'),
+        zoneId: mcpOptionalString(
+          'zoneId',
+          'Zone ID to pin the branch to (e.g., "zone-1770152859108"). ' +
+            'Places the branch inside the zone with automatic positioning (pin only, no trigger). ' +
+            'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation.'
+        ),
+        issueUrl: mcpOptionalString('issueUrl', 'Issue URL to associate with the branch.'),
+        pullRequestUrl: mcpOptionalString(
+          'pullRequestUrl',
+          'Pull request URL to associate with the branch.'
+        ),
         // RBAC fields (optional, sensible defaults, safe to ignore for single-user setups)
         othersCan: z
           .enum(BRANCH_PERMISSION_LEVELS)
@@ -485,22 +476,20 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
               'Has no effect in simple mode. Single-user setups can ignore this.'
           ),
         ownerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('ownerIds[]', 'User', 'User ID'))
           .optional()
           .describe(
             'Additional user IDs to add as owners of this branch. ' +
               'The creating user is always added as owner automatically. ' +
               'Owners have full access regardless of othersCan/othersFsAccess settings.'
           ),
-        variant: z
-          .string()
-          .optional()
-          .describe(
-            'Environment variant name to use for this branch. ' +
-              'Must be a key in the repo environment config variants. ' +
-              'When omitted, the repo default variant is used. ' +
-              'Use agor_environment_set later to switch variants on an existing branch.'
-          ),
+        variant: mcpOptionalString(
+          'variant',
+          'Environment variant name to use for this branch. ' +
+            'Must be a key in the repo environment config variants. ' +
+            'When omitted, the repo default variant is used. ' +
+            'Use agor_environment_set later to switch variants on an existing branch.'
+        ),
         storage_mode: z
           .enum(['worktree', 'clone'])
           .optional()
@@ -512,17 +501,13 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
               'closes cross-branch credential/config leak vectors. ' +
               'See context/explorations/clone-redesign.md.'
           ),
-        clone_depth: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe(
-            'Shallow-clone depth (only meaningful when storage_mode="clone"). ' +
-              'Positive integer → `git clone --depth N`. Omit for a full clone. ' +
-              'Common shallow value: 100. Trade-off: smaller disk footprint, but ' +
-              '`git log` past N commits is broken and some rebase operations fail.'
-          ),
+        clone_depth: mcpOptionalPositiveInt(
+          'clone_depth',
+          'Shallow-clone depth (only meaningful when storage_mode="clone"). ' +
+            'Positive integer → `git clone --depth N`. Omit for a full clone. ' +
+            'Common shallow value: 100. Trade-off: smaller disk footprint, but ' +
+            '`git log` past N commits is broken and some rebase operations fail.'
+        ),
       }),
     },
     async (args) => {
@@ -680,33 +665,32 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'Update metadata for an existing branch (issue/PR URLs, notes, board placement, custom context, RBAC permissions, owners)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        branchId: z
-          .string()
-          .optional()
-          .describe(
-            'Branch ID to update. Optional when calling from a session with a bound branch.'
-          ),
+        branchId: mcpOptionalId(
+          'branchId',
+          'Branch',
+          'Branch ID to update. Optional when calling from a session with a bound branch.'
+        ),
         issueUrl: z
-          .string()
+          .string({ error: 'issueUrl must be a string or null when provided.' })
           .nullable()
           .optional()
           .describe('Issue URL to associate. Pass null to clear. Must be http(s) when provided.'),
         pullRequestUrl: z
-          .string()
+          .string({ error: 'pullRequestUrl must be a string or null when provided.' })
           .nullable()
           .optional()
           .describe(
             'Pull request URL to associate. Pass null to clear. Must be http(s) when provided.'
           ),
         notes: z
-          .string()
+          .string({ error: 'notes must be a string or null when provided.' })
           .nullable()
           .optional()
           .describe(
             'Freeform notes about the branch (markdown supported). Pass null or empty string to clear.'
           ),
         boardId: z
-          .string()
+          .string({ error: 'boardId must be a string or null when provided.' })
           .nullable()
           .optional()
           .describe('Board ID to place this branch on. Pass null to remove from any board.'),
@@ -718,7 +702,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
             'Custom context object for templates and automations. Pass null to clear existing context.'
           ),
         mcpServerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('mcpServerIds[]', 'MCP server', 'MCP server ID'))
           .nullable()
           .optional()
           .describe(
@@ -744,7 +728,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
               'Has no effect in simple mode. Single-user setups can ignore this.'
           ),
         addOwnerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('addOwnerIds[]', 'User', 'User ID'))
           .optional()
           .describe(
             'User IDs to ADD as owners of this branch. ' +
@@ -752,7 +736,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
               'Idempotent — adding an existing owner is a no-op.'
           ),
         removeOwnerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('removeOwnerIds[]', 'User', 'User ID'))
           .optional()
           .describe(
             'User IDs to REMOVE as owners of this branch. ' +
@@ -904,14 +888,20 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       description:
         "Pin a branch to a zone on a board and optionally trigger the zone's prompt template. Calculates zone center position automatically and creates board association. If the zone has an 'always_new' trigger, a new session is automatically created and the prompt template is executed (matching UI drag-drop behavior). For 'show_picker' zones, use triggerTemplate + targetSessionId to send to an existing session.",
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID to pin to the zone (UUIDv7 or short ID)'),
-        zoneId: z.string().describe('Zone ID to pin the branch to (e.g., "zone-1770152859108")'),
-        targetSessionId: z
-          .string()
-          .optional()
-          .describe(
-            'Session ID to send the zone trigger prompt to (required if triggerTemplate is true)'
-          ),
+        branchId: mcpRequiredId(
+          'branchId',
+          'Branch',
+          'Branch ID to pin to the zone (UUIDv7 or short ID)'
+        ),
+        zoneId: mcpRequiredString(
+          'zoneId',
+          'Zone ID to pin the branch to (e.g., "zone-1770152859108")'
+        ),
+        targetSessionId: mcpOptionalId(
+          'targetSessionId',
+          'Session',
+          'Session ID to send the zone trigger prompt to (required if triggerTemplate is true)'
+        ),
         triggerTemplate: z
           .boolean()
           .optional()
@@ -1154,7 +1144,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'Archive a branch (soft delete). Stops the environment if running, optionally cleans or deletes the filesystem, archives the branch metadata and all its sessions, and removes it from the board. Use agor_branches_unarchive to restore.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID to archive (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch', 'Branch ID to archive (UUIDv7 or short ID)'),
         filesystemAction: z
           .enum(['preserved', 'cleaned', 'deleted'])
           .optional()
@@ -1188,8 +1178,16 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       description:
         'Restore a previously archived branch. Optionally place it back on a board. Also unarchives all sessions that were archived as part of the branch archival.',
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID to unarchive (UUIDv7 or short ID)'),
-        boardId: z.string().optional().describe('Board ID to restore the branch onto (optional)'),
+        branchId: mcpRequiredId(
+          'branchId',
+          'Branch',
+          'Branch ID to unarchive (UUIDv7 or short ID)'
+        ),
+        boardId: mcpOptionalId(
+          'boardId',
+          'Board',
+          'Board ID to restore the branch onto (optional)'
+        ),
       }),
     },
     async (args) => {
@@ -1218,7 +1216,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'Permanently delete a branch and all its sessions, messages, and tasks. This action cannot be undone. Stops the environment if running and optionally removes files from disk.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID to delete (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch', 'Branch ID to delete (UUIDv7 or short ID)'),
         filesystemAction: z
           .enum(['preserved', 'deleted'])
           .optional()
@@ -1252,8 +1250,8 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         "List all assistants (long-lived agents with schedules). Returns each assistant's name, description, schedule status, and last activity timestamp. Use this to discover other assistants on the platform.",
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        repoId: z.string().optional().describe('Filter assistants by repository ID'),
-        limit: z.number().optional().describe('Maximum number of branches to scan (default: 200)'),
+        repoId: mcpOptionalId('repoId', 'Repository', 'Filter assistants by repository ID'),
+        limit: mcpLimit(200),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/card-types.ts
+++ b/apps/agor-daemon/src/mcp/tools/card-types.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { mcpLimit, mcpOptionalString, mcpRequiredId, mcpRequiredString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -11,9 +12,9 @@ export function registerCardTypeTools(server: McpServer, ctx: McpContext): void 
       description:
         'Create a new card type (global, usable on any board). Card types define default emoji, color, and optional JSON Schema for data validation.',
       inputSchema: z.object({
-        name: z.string().describe('Card type name'),
-        emoji: z.string().optional().describe('Default emoji for cards of this type'),
-        color: z.string().optional().describe('Default color for cards of this type (hex format)'),
+        name: mcpRequiredString('name', 'Card type name'),
+        emoji: mcpOptionalString('emoji', 'Default emoji for cards of this type'),
+        color: mcpOptionalString('color', 'Default color for cards of this type (hex format)'),
         jsonSchema: z
           .object({})
           .passthrough()
@@ -44,7 +45,7 @@ export function registerCardTypeTools(server: McpServer, ctx: McpContext): void 
       description: 'Get detailed information about a specific card type.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        cardTypeId: z.string().describe('Card type ID (UUIDv7 or short ID)'),
+        cardTypeId: mcpRequiredId('cardTypeId', 'Card type'),
       }),
     },
     async (args) => {
@@ -62,7 +63,7 @@ export function registerCardTypeTools(server: McpServer, ctx: McpContext): void 
       description: 'List all available card types.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        limit: mcpLimit(50),
       }),
     },
     async (args) => {
@@ -82,10 +83,10 @@ export function registerCardTypeTools(server: McpServer, ctx: McpContext): void 
       description: "Update a card type's metadata.",
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        cardTypeId: z.string().describe('Card type ID to update'),
-        name: z.string().optional().describe('New name'),
-        emoji: z.string().nullable().optional().describe('New emoji (null to clear)'),
-        color: z.string().nullable().optional().describe('New color (null to clear)'),
+        cardTypeId: mcpRequiredId('cardTypeId', 'Card type', 'Card type ID to update'),
+        name: mcpOptionalString('name', 'New name'),
+        emoji: mcpOptionalString('emoji', 'New emoji (null to clear)').nullable(),
+        color: mcpOptionalString('color', 'New color (null to clear)').nullable(),
         jsonSchema: z
           .object({})
           .passthrough()
@@ -115,7 +116,7 @@ export function registerCardTypeTools(server: McpServer, ctx: McpContext): void 
       description: 'Permanently delete a card type.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        cardTypeId: z.string().describe('Card type ID to delete'),
+        cardTypeId: mcpRequiredId('cardTypeId', 'Card type', 'Card type ID to delete'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/cards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.test.ts
@@ -1,0 +1,97 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core/db', () => ({
+  BoardObjectRepository: class BoardObjectRepository {},
+}));
+
+vi.mock('../server.js', () => ({
+  coerceString: (value: unknown) =>
+    typeof value === 'string' && value.trim() ? value.trim() : undefined,
+  textResult: (data: unknown) => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  }),
+}));
+
+const { registerCardTools } = await import('./cards.js');
+
+type ToolConfig = {
+  inputSchema?: {
+    safeParse: (value: unknown) => {
+      success: boolean;
+      error?: { issues?: Array<{ path: Array<string | number>; message: string }> };
+    };
+  };
+};
+
+function captureConfig(toolName: string): ToolConfig {
+  let config: ToolConfig | undefined;
+  const fakeServer = {
+    registerTool: (name: string, cfg: ToolConfig) => {
+      if (name === toolName) config = cfg;
+    },
+  } as unknown as McpServer;
+
+  registerCardTools(fakeServer, {} as Parameters<typeof registerCardTools>[1]);
+
+  if (!config) throw new Error(`${toolName} was not registered`);
+  return config;
+}
+
+describe('card MCP tool input schemas', () => {
+  it('rejects an empty required title with a field-specific message', () => {
+    const parsed = captureConfig('agor_cards_create').inputSchema?.safeParse({
+      boardId: 'board-1',
+      title: '',
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['title'],
+      message: 'title cannot be empty.',
+    });
+  });
+
+  it('validates list pagination as positive/non-negative integers', () => {
+    const schema = captureConfig('agor_cards_list').inputSchema;
+
+    const badLimit = schema?.safeParse({ limit: 0 });
+    expect(badLimit?.success).toBe(false);
+    expect(badLimit?.error?.issues?.[0]).toMatchObject({
+      path: ['limit'],
+      message: 'limit must be greater than 0.',
+    });
+
+    const badOffset = schema?.safeParse({ offset: -1 });
+    expect(badOffset?.success).toBe(false);
+    expect(badOffset?.error?.issues?.[0]).toMatchObject({
+      path: ['offset'],
+      message: 'offset must be greater than or equal to 0.',
+    });
+  });
+
+  it('rejects empty bulk operation arrays in schema before the handler runs', () => {
+    const parsed = captureConfig('agor_cards_bulk_create').inputSchema?.safeParse({
+      boardId: 'board-1',
+      cards: [],
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['cards'],
+      message: 'cards must contain at least one card.',
+    });
+  });
+
+  it('rejects empty nested card IDs in bulk updates', () => {
+    const parsed = captureConfig('agor_cards_bulk_update').inputSchema?.safeParse({
+      updates: [{ cardId: '' }],
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['updates', 0, 'cardId'],
+      message: 'updates[].cardId cannot be empty. Example: { "updates[].cardId": "01abcdef" }',
+    });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -4,6 +4,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { CardsService } from '../../services/cards.js';
 import { resolveBoardId, resolveCardId } from '../resolve-ids.js';
+import {
+  mcpLimit,
+  mcpOffset,
+  mcpOptionalId,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredNumber,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -15,16 +24,16 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description:
         'Create a new card on a board. Creates both the card entity and its board placement in one operation. If zoneId is provided, the card is placed directly in that zone with automatic positioning.',
       inputSchema: z.object({
-        boardId: z.string().describe('Board ID where the card will be created'),
-        title: z.string().describe('Card title'),
-        cardTypeId: z.string().optional().describe('Card type ID (optional)'),
-        zoneId: z.string().optional().describe('Zone ID to place the card in (optional)'),
-        url: z.string().optional().describe('URL associated with the card (optional)'),
-        description: z.string().optional().describe('Card description (optional)'),
-        note: z.string().optional().describe('Card note (optional)'),
+        boardId: mcpRequiredId('boardId', 'Board', 'Board ID where the card will be created'),
+        title: mcpRequiredString('title', 'Card title'),
+        cardTypeId: mcpOptionalId('cardTypeId', 'Card type', 'Card type ID (optional)'),
+        zoneId: mcpOptionalId('zoneId', 'Zone', 'Zone ID to place the card in (optional)'),
+        url: mcpOptionalString('url', 'URL associated with the card (optional)'),
+        description: mcpOptionalString('description', 'Card description (optional)'),
+        note: mcpOptionalString('note', 'Card note (optional)'),
         data: z.object({}).passthrough().optional().describe('Custom data object (optional)'),
-        colorOverride: z.string().optional().describe('Color override (optional)'),
-        emojiOverride: z.string().optional().describe('Emoji override (optional)'),
+        colorOverride: mcpOptionalString('colorOverride', 'Color override (optional)'),
+        emojiOverride: mcpOptionalString('emojiOverride', 'Emoji override (optional)'),
       }),
     },
     async (args) => {
@@ -73,7 +82,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description: 'Get detailed information about a specific card, including its card type.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID (UUIDv7 or short ID)'),
+        cardId: mcpRequiredId('cardId', 'Card'),
       }),
     },
     async (args) => {
@@ -92,13 +101,13 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         'List cards with optional filtering by board, card type, zone, search query, or archive status.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        boardId: z.string().optional().describe('Filter by board ID'),
-        cardTypeId: z.string().optional().describe('Filter by card type ID'),
-        zoneId: z.string().optional().describe('Filter by zone ID (requires boardId)'),
-        search: z.string().optional().describe('Search query for card titles/descriptions'),
+        boardId: mcpOptionalId('boardId', 'Board', 'Filter by board ID'),
+        cardTypeId: mcpOptionalId('cardTypeId', 'Card type', 'Filter by card type ID'),
+        zoneId: mcpOptionalId('zoneId', 'Zone', 'Filter by zone ID (requires boardId)'),
+        search: mcpOptionalString('search', 'Search query for card titles/descriptions'),
         archived: z.boolean().optional().describe('Filter by archive status'),
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
-        offset: z.number().optional().describe('Number of results to skip (default: 0)'),
+        limit: mcpLimit(50),
+        offset: mcpOffset(0),
       }),
     },
     async (args) => {
@@ -151,27 +160,25 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description: "Update a card's metadata.",
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID to update'),
-        title: z.string().optional().describe('New title'),
-        url: z.string().nullable().optional().describe('New URL (null to clear)'),
-        description: z.string().nullable().optional().describe('New description (null to clear)'),
-        note: z.string().nullable().optional().describe('New note (null to clear)'),
+        cardId: mcpRequiredId('cardId', 'Card', 'Card ID to update'),
+        title: mcpOptionalString('title', 'New title'),
+        url: mcpOptionalString('url', 'New URL (null to clear)').nullable(),
+        description: mcpOptionalString('description', 'New description (null to clear)').nullable(),
+        note: mcpOptionalString('note', 'New note (null to clear)').nullable(),
         data: z
           .object({})
           .passthrough()
           .nullable()
           .optional()
           .describe('New data object (null to clear)'),
-        colorOverride: z
-          .string()
-          .nullable()
-          .optional()
-          .describe('New color override (null to clear)'),
-        emojiOverride: z
-          .string()
-          .nullable()
-          .optional()
-          .describe('New emoji override (null to clear)'),
+        colorOverride: mcpOptionalString(
+          'colorOverride',
+          'New color override (null to clear)'
+        ).nullable(),
+        emojiOverride: mcpOptionalString(
+          'emojiOverride',
+          'New emoji override (null to clear)'
+        ).nullable(),
       }),
     },
     async (args) => {
@@ -197,7 +204,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description: 'Permanently delete a card and its board placement.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID to delete'),
+        cardId: mcpRequiredId('cardId', 'Card', 'Card ID to delete'),
       }),
     },
     async (args) => {
@@ -213,7 +220,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description: 'Archive a card (soft delete).',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID to archive'),
+        cardId: mcpRequiredId('cardId', 'Card', 'Card ID to archive'),
       }),
     },
     async (args) => {
@@ -230,7 +237,7 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     {
       description: 'Restore a previously archived card.',
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID to unarchive'),
+        cardId: mcpRequiredId('cardId', 'Card', 'Card ID to unarchive'),
       }),
     },
     async (args) => {
@@ -248,12 +255,12 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description:
         'Move a card to a different zone (or unpin from zone). Updates board_objects placement.',
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID to move'),
-        zoneId: z
-          .string()
-          .nullable()
-          .optional()
-          .describe('Target zone ID (null to unpin from zone)'),
+        cardId: mcpRequiredId('cardId', 'Card', 'Card ID to move'),
+        zoneId: mcpOptionalId(
+          'zoneId',
+          'Zone',
+          'Target zone ID (null to unpin from zone)'
+        ).nullable(),
       }),
     },
     async (args) => {
@@ -282,9 +289,9 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description: 'Set the exact position of a card on its board.',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        cardId: z.string().describe('Card ID to reposition'),
-        x: z.number().describe('X coordinate'),
-        y: z.number().describe('Y coordinate'),
+        cardId: mcpRequiredId('cardId', 'Card', 'Card ID to reposition'),
+        x: mcpRequiredNumber('x', 'X coordinate'),
+        y: mcpRequiredNumber('y', 'Y coordinate'),
       }),
     },
     async (args) => {
@@ -310,21 +317,22 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       description:
         'Create multiple cards on a board in one operation. Each card gets its own board placement.',
       inputSchema: z.object({
-        boardId: z.string().describe('Board ID where cards will be created'),
+        boardId: mcpRequiredId('boardId', 'Board', 'Board ID where cards will be created'),
         cards: z
           .array(
             z.object({
-              title: z.string().describe('Card title'),
-              cardTypeId: z.string().optional().describe('Card type ID'),
-              zoneId: z.string().optional().describe('Zone ID to place the card in'),
-              url: z.string().optional().describe('URL'),
-              description: z.string().optional().describe('Description'),
-              note: z.string().optional().describe('Note'),
+              title: mcpRequiredString('cards[].title', 'Card title'),
+              cardTypeId: mcpOptionalId('cards[].cardTypeId', 'Card type', 'Card type ID'),
+              zoneId: mcpOptionalId('cards[].zoneId', 'Zone', 'Zone ID to place the card in'),
+              url: mcpOptionalString('cards[].url', 'URL'),
+              description: mcpOptionalString('cards[].description', 'Description'),
+              note: mcpOptionalString('cards[].note', 'Note'),
               data: z.object({}).passthrough().optional().describe('Custom data'),
-              colorOverride: z.string().optional().describe('Color override'),
-              emojiOverride: z.string().optional().describe('Emoji override'),
+              colorOverride: mcpOptionalString('cards[].colorOverride', 'Color override'),
+              emojiOverride: mcpOptionalString('cards[].emojiOverride', 'Emoji override'),
             })
           )
+          .min(1, 'cards must contain at least one card.')
           .describe('Array of cards to create'),
       }),
     },
@@ -381,16 +389,23 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         updates: z
           .array(
             z.object({
-              cardId: z.string().describe('Card ID to update'),
-              title: z.string().optional().describe('New title'),
-              url: z.string().nullable().optional().describe('New URL'),
-              description: z.string().nullable().optional().describe('New description'),
-              note: z.string().nullable().optional().describe('New note'),
+              cardId: mcpRequiredId('updates[].cardId', 'Card', 'Card ID to update'),
+              title: mcpOptionalString('updates[].title', 'New title'),
+              url: mcpOptionalString('updates[].url', 'New URL').nullable(),
+              description: mcpOptionalString('updates[].description', 'New description').nullable(),
+              note: mcpOptionalString('updates[].note', 'New note').nullable(),
               data: z.object({}).passthrough().nullable().optional().describe('New data'),
-              colorOverride: z.string().nullable().optional().describe('New color override'),
-              emojiOverride: z.string().nullable().optional().describe('New emoji override'),
+              colorOverride: mcpOptionalString(
+                'updates[].colorOverride',
+                'New color override'
+              ).nullable(),
+              emojiOverride: mcpOptionalString(
+                'updates[].emojiOverride',
+                'New emoji override'
+              ).nullable(),
             })
           )
+          .min(1, 'updates must contain at least one update.')
           .describe('Array of card updates'),
       }),
     },
@@ -430,10 +445,15 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
         moves: z
           .array(
             z.object({
-              cardId: z.string().describe('Card ID to move'),
-              zoneId: z.string().nullable().optional().describe('Target zone ID (null to unpin)'),
+              cardId: mcpRequiredId('moves[].cardId', 'Card', 'Card ID to move'),
+              zoneId: mcpOptionalId(
+                'moves[].zoneId',
+                'Zone',
+                'Target zone ID (null to unpin)'
+              ).nullable(),
             })
           )
+          .min(1, 'moves must contain at least one move.')
           .describe('Array of card moves'),
       }),
     },

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -2,6 +2,7 @@ import type { BranchID } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BranchesServiceImpl, ReposServiceImpl } from '../../declarations.js';
+import { mcpOptionalString, mcpRequiredId } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 import { assertValidVariant } from './_environment-helpers.js';
@@ -15,7 +16,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         'Start the environment for a branch using its configured start action (shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {
@@ -50,7 +51,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         'Stop the environment for a branch using its configured stop action (shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {
@@ -79,7 +80,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         'Check the health status of a branch environment by running its configured health command. Returns started_at timestamp and uptime_seconds when environment is starting or running.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {
@@ -114,7 +115,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         'Fetch recent logs from a branch environment (non-streaming, last ~100 lines; shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {
@@ -132,7 +133,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
       description: 'Open the application URL for a branch environment in the browser',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {
@@ -176,14 +177,12 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         'Omit variant to re-render the branch with its current variant (useful for picking up template_overrides changes).',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
-        variant: z
-          .string()
-          .optional()
-          .describe(
-            'Environment variant name to set. Must be a key in the repo environment config variants. ' +
-              "When omitted, re-renders using the branch's current variant (or the repo default if unset)."
-          ),
+        branchId: mcpRequiredId('branchId', 'Branch'),
+        variant: mcpOptionalString(
+          'variant',
+          'Environment variant name to set. Must be a key in the repo environment config variants. ' +
+            "When omitted, re-renders using the branch's current variant (or the repo default if unset)."
+        ),
         andStart: z
           .boolean()
           .optional()
@@ -284,7 +283,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         'Nuke the environment for a branch (destructive operation - typically removes volumes and all data; shell command by default, or HTTP(S) GET webhook when URL-shaped / webhook-only mode)',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID (UUIDv7 or short ID)'),
+        branchId: mcpRequiredId('branchId', 'Branch'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -1,0 +1,136 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core/db', () => ({
+  BranchRepository: class FakeBranchRepository {},
+}));
+
+vi.mock('@agor/core/feathers', () => ({
+  NotFound: class NotFound extends Error {},
+}));
+
+vi.mock('../../utils/branch-workspace-path.js', () => ({
+  resolveBranchWorkspacePath: vi.fn(),
+}));
+
+vi.mock('../resolve-ids.js', () => ({
+  resolveBranchId: vi.fn(),
+}));
+
+vi.mock('../server.js', () => ({
+  coerceJsonRecord: (value: unknown) => value,
+  coerceString: (value: unknown) => {
+    if (typeof value !== 'string') return undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  },
+  textResult: (data: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(data) }] }),
+}));
+
+vi.mock('@agor/core/types', () => ({
+  buildKnowledgeDocumentUri: (id: string) => `agor://kb/document/${id}`,
+  KNOWLEDGE_DOCUMENT_KINDS: ['doc', 'note'],
+  KNOWLEDGE_DOCUMENT_STATUSES: ['draft', 'published'],
+  KNOWLEDGE_DOCUMENT_URI_PREFIX: 'agor://kb/document/',
+  KNOWLEDGE_EDIT_POLICIES: ['owner', 'namespace'],
+  KNOWLEDGE_GRAPH_EDGE_TYPES: ['references', 'relates_to'],
+  KNOWLEDGE_GRAPH_NODE_TYPES: ['document', 'external'],
+  KNOWLEDGE_VISIBILITIES: ['public', 'private'],
+  parseKnowledgeUri: () => undefined,
+}));
+
+type CapturedTool = {
+  cfg: { inputSchema?: { safeParse: (v: unknown) => { success: boolean; error?: unknown } } };
+};
+
+async function captureKnowledgeTools(): Promise<Record<string, CapturedTool>> {
+  const { registerKnowledgeTools } = await import('./knowledge.js');
+  const captured: Record<string, CapturedTool> = {};
+  const fakeServer = {
+    registerTool: (name: string, cfg: unknown) => {
+      captured[name] = { cfg: cfg as CapturedTool['cfg'] };
+    },
+  } as unknown as McpServer;
+
+  registerKnowledgeTools(fakeServer, {
+    app: { services: {}, service: () => ({}) } as any,
+    db: {} as any,
+    userId: 'user-1' as any,
+    authenticatedUser: { user_id: 'user-1', role: 'member' } as any,
+    baseServiceParams: {},
+  });
+
+  return captured;
+}
+
+function issueMessages(error: unknown): string[] {
+  if (!error || typeof error !== 'object' || !('issues' in error)) return [];
+  return ((error as { issues: Array<{ message: string }> }).issues ?? []).map(
+    (issue) => issue.message
+  );
+}
+
+describe('Knowledge MCP input schemas', () => {
+  it('rejects renamed branch_id instead of accepting it as an alias', async () => {
+    const tools = await captureKnowledgeTools();
+
+    const parsed = tools.agor_kb_materialize.cfg.inputSchema?.safeParse({
+      branch_id: 'branch-1',
+      namespace: 'global',
+      path: 'foo.md',
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(issueMessages(parsed?.error)).toContain(
+      'branchId is required and must be a string. Example: { "branchId": "01abcdef" }'
+    );
+  });
+
+  it('requires namespace slugs to be non-empty strings', async () => {
+    const tools = await captureKnowledgeTools();
+
+    const missing = tools.agor_kb_namespace_put.cfg.inputSchema?.safeParse({});
+    const empty = tools.agor_kb_namespace_put.cfg.inputSchema?.safeParse({ slug: '' });
+
+    expect(missing?.success).toBe(false);
+    expect(issueMessages(missing?.error)).toContain('slug is required and must be a string.');
+    expect(empty?.success).toBe(false);
+    expect(issueMessages(empty?.error)).toContain('slug cannot be empty.');
+  });
+
+  it('reports required document content clearly without handler fallback errors', async () => {
+    const tools = await captureKnowledgeTools();
+
+    const parsed = tools.agor_kb_put.cfg.inputSchema?.safeParse({
+      namespace: 'global',
+      path: 'foo.md',
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(issueMessages(parsed?.error)).toContain('content is required and must be a string.');
+  });
+
+  it('enforces positive/non-negative integer pagination and range controls', async () => {
+    const tools = await captureKnowledgeTools();
+
+    const badSearchLimit = tools.agor_kb_search.cfg.inputSchema?.safeParse({
+      query: '',
+      limit: 0,
+    });
+    const badRangeControls = tools.agor_kb_get_range.cfg.inputSchema?.safeParse({
+      documentId: 'doc-1',
+      startLine: 1.5,
+      contextLines: -1,
+    });
+
+    expect(badSearchLimit?.success).toBe(false);
+    expect(issueMessages(badSearchLimit?.error)).toContain('limit must be greater than 0.');
+    expect(badRangeControls?.success).toBe(false);
+    expect(issueMessages(badRangeControls?.error)).toEqual(
+      expect.arrayContaining([
+        'startLine must be an integer.',
+        'contextLines must be greater than or equal to 0.',
+      ])
+    );
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -39,9 +39,11 @@ import { resolveBranchId } from '../resolve-ids.js';
 import {
   mcpLimit,
   mcpOptionalId,
+  mcpOptionalNonBlankString,
   mcpOptionalPositiveInt,
   mcpOptionalString,
   mcpRequiredId,
+  mcpRequiredPositiveInt,
   mcpRequiredString,
 } from '../schema.js';
 import type { McpContext } from '../server.js';
@@ -53,23 +55,6 @@ const KnowledgeVisibilitySchema = z.enum(KNOWLEDGE_VISIBILITIES);
 const KnowledgeEditPolicySchema = z.enum(KNOWLEDGE_EDIT_POLICIES);
 const KnowledgeGraphNodeTypeSchema = z.enum(KNOWLEDGE_GRAPH_NODE_TYPES);
 const KnowledgeGraphEdgeTypeSchema = z.enum(KNOWLEDGE_GRAPH_EDGE_TYPES);
-
-function mcpRequiredPositiveInt(fieldName: string, description: string) {
-  return z
-    .number({
-      error: `${fieldName} is required and must be a positive integer.`,
-    })
-    .int(`${fieldName} must be an integer.`)
-    .positive(`${fieldName} must be greater than 0.`)
-    .describe(description);
-}
-
-function mcpOptionalNonEmptyString(fieldName: string, description: string) {
-  return mcpOptionalString(fieldName, description).refine(
-    (value) => value === undefined || value.trim().length > 0,
-    `${fieldName} cannot be empty.`
-  );
-}
 
 function mcpOptionalVersionToken(fieldName: string, description: string) {
   return z
@@ -142,9 +127,9 @@ const KnowledgeEditOpSchema = z.discriminatedUnion('type', [
 
 const KnowledgeEditRequestSchema = z.object({
   documentId: mcpOptionalId('documentId', 'Knowledge document'),
-  uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-  namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
-  path: mcpOptionalNonEmptyString('path', 'Document path inside namespace; use with namespace'),
+  uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+  namespace: mcpOptionalNonBlankString('namespace', 'Namespace/space slug; use with path'),
+  path: mcpOptionalNonBlankString('path', 'Document path inside namespace; use with namespace'),
   expectedVersion: mcpOptionalVersionToken(
     'expectedVersion',
     'Optimistic concurrency check: current version number or version ID expected by the caller'
@@ -176,7 +161,7 @@ const KnowledgeNodeRefSchema = z
   .object(
     {
       nodeId: mcpOptionalId('nodeId', 'Knowledge graph node'),
-      uri: mcpOptionalNonEmptyString(
+      uri: mcpOptionalNonBlankString(
         'uri',
         'Canonical node/document URI, e.g. agor://kb/global/architecture.md'
       ),
@@ -184,9 +169,9 @@ const KnowledgeNodeRefSchema = z
         'Node type to resolve or create when nodeId/uri is not enough.'
       ),
       documentId: mcpOptionalId('documentId', 'Knowledge document'),
-      namespace: mcpOptionalNonEmptyString('namespace', 'Knowledge namespace/space slug'),
-      path: mcpOptionalNonEmptyString('path', 'Document path inside namespace'),
-      externalUri: mcpOptionalNonEmptyString(
+      namespace: mcpOptionalNonBlankString('namespace', 'Knowledge namespace/space slug'),
+      path: mcpOptionalNonBlankString('path', 'Document path inside namespace'),
+      externalUri: mcpOptionalNonBlankString(
         'externalUri',
         'External URL or URI for external nodes'
       ),
@@ -420,7 +405,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       description: 'List Knowledge namespaces/spaces available to the current user.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        slug: mcpOptionalNonEmptyString('slug', 'Filter by namespace/space slug'),
+        slug: mcpOptionalNonBlankString('slug', 'Filter by namespace/space slug'),
         kind: z
           .enum(['system', 'global', 'user', 'repo', 'branch', 'team'])
           .optional()
@@ -519,8 +504,8 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
               'query is required and must be a string. Use an empty string to browse with filters.',
           })
           .describe('Search text. Use an empty string to browse with filters.'),
-        namespace: mcpOptionalNonEmptyString('namespace', 'Filter by namespace/space slug'),
-        pathPrefix: mcpOptionalNonEmptyString(
+        namespace: mcpOptionalNonBlankString('namespace', 'Filter by namespace/space slug'),
+        pathPrefix: mcpOptionalNonBlankString(
           'pathPrefix',
           'Filter to document paths under this prefix'
         ),
@@ -591,9 +576,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
-        path: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path inside namespace; use with namespace'
         ),
@@ -687,9 +672,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
-        path: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path inside namespace; use with namespace'
         ),
@@ -738,9 +723,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
-        path: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path inside namespace; use with namespace'
         ),
@@ -750,7 +735,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         ),
         startLine: mcpOptionalPositiveInt('startLine', '1-based inclusive start line'),
         endLine: mcpOptionalPositiveInt('endLine', '1-based inclusive end line'),
-        headingPath: mcpOptionalNonEmptyString('headingPath', 'Heading path from agor_kb_outline'),
+        headingPath: mcpOptionalNonBlankString('headingPath', 'Heading path from agor_kb_outline'),
         occurrence: mcpOptionalPositiveInt(
           'occurrence',
           'Occurrence for duplicate heading paths (default: 1)'
@@ -831,12 +816,12 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       annotations: { idempotentHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Existing Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString(
           'namespace',
           'Namespace/space slug; required with path for new docs'
         ),
-        path: mcpOptionalNonEmptyString(
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path inside namespace; required with namespace for new docs'
         ),
@@ -993,9 +978,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Write a Knowledge document version to a markdown file inside a branch worktree. Requires branchId + branch-relative subpath (or defaults to .agor/kb/<namespace>/<path>) and verifies the caller has branch session permission.',
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
-        path: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path inside namespace; use with namespace'
         ),
@@ -1004,7 +989,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           'Version number or version ID. Omit for current version.'
         ),
         branchId: mcpRequiredId('branchId', 'Destination branch/worktree'),
-        subpath: mcpOptionalNonEmptyString(
+        subpath: mcpOptionalNonBlankString(
           'subpath',
           'Branch-relative destination markdown path. Default: .agor/kb/<namespace>/<document path>.'
         ),
@@ -1100,12 +1085,12 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         branchId: mcpRequiredId('branchId', 'Source branch/worktree'),
         subpath: mcpRequiredString('subpath', 'Branch-relative source markdown file path'),
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString(
           'namespace',
           'Namespace/space slug. Required with path when creating without sidecar.'
         ),
-        path: mcpOptionalNonEmptyString(
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path. Required with namespace when creating without sidecar.'
         ),
@@ -1341,9 +1326,9 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
-        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
-        path: mcpOptionalNonEmptyString(
+        uri: mcpOptionalNonBlankString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonBlankString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonBlankString(
           'path',
           'Document path inside namespace; use with namespace'
         ),

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -36,6 +36,14 @@ import {
 } from '../../knowledge/markdown-outline.js';
 import { resolveBranchWorkspacePath } from '../../utils/branch-workspace-path.js';
 import { resolveBranchId } from '../resolve-ids.js';
+import {
+  mcpLimit,
+  mcpOptionalId,
+  mcpOptionalPositiveInt,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceJsonRecord, coerceString, textResult } from '../server.js';
 
@@ -46,36 +54,83 @@ const KnowledgeEditPolicySchema = z.enum(KNOWLEDGE_EDIT_POLICIES);
 const KnowledgeGraphNodeTypeSchema = z.enum(KNOWLEDGE_GRAPH_NODE_TYPES);
 const KnowledgeGraphEdgeTypeSchema = z.enum(KNOWLEDGE_GRAPH_EDGE_TYPES);
 
+function mcpRequiredPositiveInt(fieldName: string, description: string) {
+  return z
+    .number({
+      error: `${fieldName} is required and must be a positive integer.`,
+    })
+    .int(`${fieldName} must be an integer.`)
+    .positive(`${fieldName} must be greater than 0.`)
+    .describe(description);
+}
+
+function mcpOptionalNonEmptyString(fieldName: string, description: string) {
+  return mcpOptionalString(fieldName, description).refine(
+    (value) => value === undefined || value.trim().length > 0,
+    `${fieldName} cannot be empty.`
+  );
+}
+
+function mcpOptionalVersionToken(fieldName: string, description: string) {
+  return z
+    .union([
+      z.number({
+        error: `${fieldName} must be a version number or version ID when provided.`,
+      }),
+      z
+        .string({
+          error: `${fieldName} must be a version number or version ID when provided.`,
+        })
+        .min(1, `${fieldName} cannot be empty.`),
+    ])
+    .optional()
+    .describe(description);
+}
+
 const KnowledgeReplaceLineRangeOpSchema = z.object({
   type: z.literal('replace_line_range'),
-  startLine: z.number().int().min(1),
-  endLine: z.number().int().min(1),
-  replacement: z.string(),
-  expectedText: z.string().optional(),
-  expectedMd5: z.string().optional(),
+  startLine: mcpRequiredPositiveInt('startLine', '1-based inclusive start line'),
+  endLine: mcpRequiredPositiveInt('endLine', '1-based inclusive end line'),
+  replacement: z.string({
+    error: 'replacement is required and must be a string.',
+  }),
+  expectedText: mcpOptionalString('expectedText', 'Expected text for optimistic edit checks'),
+  expectedMd5: mcpOptionalString('expectedMd5', 'Expected MD5 for optimistic edit checks'),
 });
 
 const KnowledgeInsertAtLineOpSchema = z.object({
   type: z.literal('insert_at_line'),
-  line: z.number().int().min(1),
+  line: mcpRequiredPositiveInt('line', '1-based line number'),
   position: z.enum(['before', 'after']).optional(),
-  content: z.string(),
-  expectedNeighborText: z.string().optional(),
+  content: z.string({
+    error: 'content is required and must be a string.',
+  }),
+  expectedNeighborText: mcpOptionalString(
+    'expectedNeighborText',
+    'Expected adjacent text for optimistic edit checks'
+  ),
 });
 
 const KnowledgeDeleteLineRangeOpSchema = z.object({
   type: z.literal('delete_line_range'),
-  startLine: z.number().int().min(1),
-  endLine: z.number().int().min(1),
-  expectedText: z.string().optional(),
-  expectedMd5: z.string().optional(),
+  startLine: mcpRequiredPositiveInt('startLine', '1-based inclusive start line'),
+  endLine: mcpRequiredPositiveInt('endLine', '1-based inclusive end line'),
+  expectedText: mcpOptionalString('expectedText', 'Expected text for optimistic edit checks'),
+  expectedMd5: mcpOptionalString('expectedMd5', 'Expected MD5 for optimistic edit checks'),
 });
 
 const KnowledgeReplaceLiteralOpSchema = z.object({
   type: z.literal('replace_literal'),
-  find: z.string().min(1),
-  replace: z.string(),
-  expectedCount: z.number().int().min(0),
+  find: mcpRequiredString('find', 'Literal text to replace'),
+  replace: z.string({
+    error: 'replace is required and must be a string.',
+  }),
+  expectedCount: z
+    .number({
+      error: 'expectedCount is required and must be a non-negative integer.',
+    })
+    .int('expectedCount must be an integer.')
+    .nonnegative('expectedCount must be greater than or equal to 0.'),
 });
 
 const KnowledgeEditOpSchema = z.discriminatedUnion('type', [
@@ -86,21 +141,19 @@ const KnowledgeEditOpSchema = z.discriminatedUnion('type', [
 ]);
 
 const KnowledgeEditRequestSchema = z.object({
-  documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-  uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-  namespace: z.string().optional().describe('Namespace/space slug; use with path'),
-  path: z.string().optional().describe('Document path inside namespace; use with namespace'),
-  expectedVersion: z
-    .union([z.number(), z.string()])
-    .optional()
-    .describe(
-      'Optimistic concurrency check: current version number or version ID expected by the caller'
-    ),
+  documentId: mcpOptionalId('documentId', 'Knowledge document'),
+  uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+  namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
+  path: mcpOptionalNonEmptyString('path', 'Document path inside namespace; use with namespace'),
+  expectedVersion: mcpOptionalVersionToken(
+    'expectedVersion',
+    'Optimistic concurrency check: current version number or version ID expected by the caller'
+  ),
   dryRun: z
     .boolean()
     .optional()
     .describe('When true, validate and preview without creating a new version'),
-  changeSummary: z.string().optional().describe('Optional change summary for version history'),
+  changeSummary: mcpOptionalString('changeSummary', 'Optional change summary for version history'),
   versionMetadata: z
     .record(z.string(), z.unknown())
     .optional()
@@ -120,29 +173,37 @@ const KnowledgeEditRequestSchema = z.object({
 });
 
 const KnowledgeNodeRefSchema = z
-  .object({
-    nodeId: z.string().optional().describe('Knowledge graph node ID (UUIDv7 or short ID)'),
-    uri: z
-      .string()
-      .optional()
-      .describe('Canonical node/document URI, e.g. agor://kb/global/architecture.md'),
-    nodeType: KnowledgeGraphNodeTypeSchema.optional().describe(
-      'Node type to resolve or create when nodeId/uri is not enough.'
-    ),
-    documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-    namespace: z.string().optional().describe('Knowledge namespace/space slug'),
-    path: z.string().optional().describe('Document path inside namespace'),
-    externalUri: z.string().optional().describe('External URL or URI for external nodes'),
-    branchId: z.string().optional().describe('Branch ID (UUIDv7 or short ID)'),
-    sessionId: z.string().optional().describe('Session ID (UUIDv7 or short ID)'),
-    taskId: z.string().optional().describe('Task ID (UUIDv7 or short ID)'),
-    messageId: z.string().optional().describe('Message ID (UUIDv7 or short ID)'),
-    artifactId: z.string().optional().describe('Artifact ID (UUIDv7 or short ID)'),
-    repoId: z.string().optional().describe('Repository ID (UUIDv7 or short ID)'),
-    boardId: z.string().optional().describe('Board ID (UUIDv7 or short ID)'),
-    userId: z.string().optional().describe('User ID (UUIDv7 or short ID)'),
-    label: z.string().optional().describe('Optional label for newly-created graph nodes'),
-  })
+  .object(
+    {
+      nodeId: mcpOptionalId('nodeId', 'Knowledge graph node'),
+      uri: mcpOptionalNonEmptyString(
+        'uri',
+        'Canonical node/document URI, e.g. agor://kb/global/architecture.md'
+      ),
+      nodeType: KnowledgeGraphNodeTypeSchema.optional().describe(
+        'Node type to resolve or create when nodeId/uri is not enough.'
+      ),
+      documentId: mcpOptionalId('documentId', 'Knowledge document'),
+      namespace: mcpOptionalNonEmptyString('namespace', 'Knowledge namespace/space slug'),
+      path: mcpOptionalNonEmptyString('path', 'Document path inside namespace'),
+      externalUri: mcpOptionalNonEmptyString(
+        'externalUri',
+        'External URL or URI for external nodes'
+      ),
+      branchId: mcpOptionalId('branchId', 'Branch'),
+      sessionId: mcpOptionalId('sessionId', 'Session'),
+      taskId: mcpOptionalId('taskId', 'Task'),
+      messageId: mcpOptionalId('messageId', 'Message'),
+      artifactId: mcpOptionalId('artifactId', 'Artifact'),
+      repoId: mcpOptionalId('repoId', 'Repository'),
+      boardId: mcpOptionalId('boardId', 'Board'),
+      userId: mcpOptionalId('userId', 'User'),
+      label: mcpOptionalString('label', 'Optional label for newly-created graph nodes'),
+    },
+    {
+      error: 'node reference is required and must be an object.',
+    }
+  )
   .describe(
     'Reference to an existing or creatable knowledge graph node. Prefer nodeId or uri; use typed IDs for links to Agor core objects.'
   );
@@ -359,7 +420,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       description: 'List Knowledge namespaces/spaces available to the current user.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        slug: z.string().optional().describe('Filter by namespace/space slug'),
+        slug: mcpOptionalNonEmptyString('slug', 'Filter by namespace/space slug'),
         kind: z
           .enum(['system', 'global', 'user', 'repo', 'branch', 'team'])
           .optional()
@@ -388,10 +449,10 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Create or update a Knowledge namespace/space by slug. Namespaces appear in agor://kb/<namespace>/<path> URIs.',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        namespaceId: z.string().optional().describe('Existing namespace ID to update'),
-        slug: z.string().describe('Namespace slug used in agor://kb/<slug>/... URIs'),
-        displayName: z.string().optional().describe('Human-readable display name'),
-        description: z.string().optional().describe('Namespace description'),
+        namespaceId: mcpOptionalId('namespaceId', 'Knowledge namespace'),
+        slug: mcpRequiredString('slug', 'Namespace slug used in agor://kb/<slug>/... URIs'),
+        displayName: mcpOptionalString('displayName', 'Human-readable display name'),
+        description: mcpOptionalString('description', 'Namespace description'),
         kind: z
           .enum(['system', 'global', 'user', 'repo', 'branch', 'team'])
           .optional()
@@ -408,7 +469,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         return knowledgeNotImplementedResult('agor_kb_namespace_put', ['kb/namespaces']);
 
       const slug = coerceString(args.slug);
-      if (!slug) throw new Error('slug is required');
+      if (!slug) throw new Error('slug is required and must be a non-empty string.');
       const data = {
         slug,
         display_name: coerceString(args.displayName),
@@ -452,9 +513,17 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Search Agor Knowledge documents. Supports text, semantic, and hybrid modes when Knowledge embeddings are enabled/configured. Each result carries a `reference_uri` (agor://kb/document/<id>) — embed that link in another doc to create a graph edge to it.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        query: z.string().describe('Search text. Use an empty string to browse with filters.'),
-        namespace: z.string().optional().describe('Filter by namespace/space slug'),
-        pathPrefix: z.string().optional().describe('Filter to document paths under this prefix'),
+        query: z
+          .string({
+            error:
+              'query is required and must be a string. Use an empty string to browse with filters.',
+          })
+          .describe('Search text. Use an empty string to browse with filters.'),
+        namespace: mcpOptionalNonEmptyString('namespace', 'Filter by namespace/space slug'),
+        pathPrefix: mcpOptionalNonEmptyString(
+          'pathPrefix',
+          'Filter to document paths under this prefix'
+        ),
         kind: KnowledgeDocumentKindSchema.optional().describe('Filter by document kind'),
         visibility: KnowledgeVisibilitySchema.optional().describe('Filter by visibility'),
         status: KnowledgeDocumentStatusSchema.optional().describe(
@@ -480,7 +549,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .boolean()
           .optional()
           .describe('Include archived documents (default: false)'),
-        limit: z.number().optional().describe('Maximum number of results (default: 20)'),
+        limit: mcpLimit(20),
         mode: z
           .enum(['text', 'semantic', 'hybrid'])
           .optional()
@@ -521,14 +590,17 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Get a Knowledge document by documentId, canonical URI, or namespace + path. Returns the current version content by default when the backend supports includeContent. The result carries a `reference_uri` (agor://kb/document/<id>) — embed that link in another doc to create a graph edge to it.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
-        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
-        version: z
-          .union([z.number(), z.string()])
-          .optional()
-          .describe('Version number or version ID. Omit for current version.'),
+        documentId: mcpOptionalId('documentId', 'Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path inside namespace; use with namespace'
+        ),
+        version: mcpOptionalVersionToken(
+          'version',
+          'Version number or version ID. Omit for current version.'
+        ),
         includeContent: z
           .boolean()
           .optional()
@@ -614,15 +686,26 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Return a markdown heading outline for a Knowledge document, including 1-based line ranges and the current version token. Use this before targeted edits to avoid reading the full document.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
-        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
-        version: z
-          .union([z.number(), z.string()])
+        documentId: mcpOptionalId('documentId', 'Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path inside namespace; use with namespace'
+        ),
+        version: mcpOptionalVersionToken(
+          'version',
+          'Version number or version ID. Omit for current version.'
+        ),
+        maxDepth: z
+          .number({
+            error: 'maxDepth must be a positive integer between 1 and 6 when provided.',
+          })
+          .int('maxDepth must be an integer.')
+          .min(1, 'maxDepth must be greater than 0.')
+          .max(6, 'maxDepth must be less than or equal to 6.')
           .optional()
-          .describe('Version number or version ID. Omit for current version.'),
-        maxDepth: z.number().int().min(1).max(6).optional().describe('Maximum heading depth'),
+          .describe('Maximum heading depth'),
       }),
     },
     async (args) => {
@@ -654,28 +737,31 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Read a bounded line range or heading section from a Knowledge document. Returns current version metadata and optional line numbers so agents can edit without loading the full document.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
-        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
-        version: z
-          .union([z.number(), z.string()])
-          .optional()
-          .describe('Version number or version ID. Omit for current version.'),
-        startLine: z.number().int().min(1).optional().describe('1-based inclusive start line'),
-        endLine: z.number().int().min(1).optional().describe('1-based inclusive end line'),
-        headingPath: z.string().optional().describe('Heading path from agor_kb_outline'),
-        occurrence: z
-          .number()
-          .int()
-          .min(1)
-          .optional()
-          .describe('Occurrence for duplicate heading paths (default: 1)'),
+        documentId: mcpOptionalId('documentId', 'Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path inside namespace; use with namespace'
+        ),
+        version: mcpOptionalVersionToken(
+          'version',
+          'Version number or version ID. Omit for current version.'
+        ),
+        startLine: mcpOptionalPositiveInt('startLine', '1-based inclusive start line'),
+        endLine: mcpOptionalPositiveInt('endLine', '1-based inclusive end line'),
+        headingPath: mcpOptionalNonEmptyString('headingPath', 'Heading path from agor_kb_outline'),
+        occurrence: mcpOptionalPositiveInt(
+          'occurrence',
+          'Occurrence for duplicate heading paths (default: 1)'
+        ),
         contextLines: z
-          .number()
-          .int()
-          .min(0)
-          .max(20)
+          .number({
+            error: 'contextLines must be a non-negative integer between 0 and 20 when provided.',
+          })
+          .int('contextLines must be an integer.')
+          .min(0, 'contextLines must be greater than or equal to 0.')
+          .max(20, 'contextLines must be less than or equal to 20.')
           .optional()
           .describe('Extra lines before/after the requested range (default: 2)'),
         includeLineNumbers: z
@@ -744,24 +830,24 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         'Create or update a markdown Knowledge document. Idempotent upsert keyed by documentId, URI, or namespace + path when the backend implements putDocument. To build the knowledge graph, embed links to other KB docs in the markdown — each resolvable link becomes a "references" edge automatically on save. Prefer the rename-proof form [label](agor://kb/document/<documentId>); [label](agor://kb/<namespace>/<path>) also works but breaks if the target moves. Get a doc\'s reference_uri from agor_kb_search or agor_kb_get.',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        documentId: z.string().optional().describe('Existing Knowledge document ID to update'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z
-          .string()
-          .optional()
-          .describe('Namespace/space slug; required with path for new docs'),
-        path: z
-          .string()
-          .optional()
-          .describe('Document path inside namespace; required with namespace for new docs'),
-        title: z
-          .string()
-          .optional()
-          .describe(
-            'Optional explicit title. Prefer omitting this when `content` starts with an H1; Agor will derive the title from that heading and hide the duplicate heading in the viewer. Only provide a title when `firstLineIsTitle:false` or the content has no title heading.'
-          ),
+        documentId: mcpOptionalId('documentId', 'Existing Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString(
+          'namespace',
+          'Namespace/space slug; required with path for new docs'
+        ),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path inside namespace; required with namespace for new docs'
+        ),
+        title: mcpOptionalString(
+          'title',
+          'Optional explicit title. Prefer omitting this when `content` starts with an H1; Agor will derive the title from that heading and hide the duplicate heading in the viewer. Only provide a title when `firstLineIsTitle:false` or the content has no title heading.'
+        ),
         content: z
-          .string()
+          .string({
+            error: 'content is required and must be a string.',
+          })
           .describe(
             'Markdown content for the new version. Embed [label](agor://kb/document/<documentId>) links to other KB docs to create graph edges between them.'
           ),
@@ -783,10 +869,10 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .boolean()
           .optional()
           .describe('Create the namespace if it does not already exist (default: false).'),
-        namespaceDisplayName: z
-          .string()
-          .optional()
-          .describe('Display name to use when createNamespace is true.'),
+        namespaceDisplayName: mcpOptionalString(
+          'namespaceDisplayName',
+          'Display name to use when createNamespace is true.'
+        ),
         frontmatter: z
           .record(z.string(), z.unknown())
           .optional()
@@ -795,13 +881,11 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .record(z.string(), z.unknown())
           .optional()
           .describe('Document/version metadata'),
-        changeSummary: z.string().optional().describe('Short summary for version history'),
-        expectedVersion: z
-          .union([z.number(), z.string()])
-          .optional()
-          .describe(
-            'Optional optimistic concurrency check: current version number or version ID expected by the caller'
-          ),
+        changeSummary: mcpOptionalString('changeSummary', 'Short summary for version history'),
+        expectedVersion: mcpOptionalVersionToken(
+          'expectedVersion',
+          'Optional optimistic concurrency check: current version number or version ID expected by the caller'
+        ),
       }),
     },
     async (args) => {
@@ -809,7 +893,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       if (!service) return knowledgeNotImplementedResult('agor_kb_put', ['kb/documents']);
 
       const content = typeof args.content === 'string' ? args.content : undefined;
-      if (content === undefined) throw new Error('content is required');
+      if (content === undefined) throw new Error('content is required and must be a string.');
 
       const uri = coerceString(args.uri);
       const parsedUri = parseKnowledgeUri(uri);
@@ -908,21 +992,22 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       description:
         'Write a Knowledge document version to a markdown file inside a branch worktree. Requires branchId + branch-relative subpath (or defaults to .agor/kb/<namespace>/<path>) and verifies the caller has branch session permission.',
       inputSchema: z.object({
-        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
-        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
-        version: z
-          .union([z.number(), z.string()])
-          .optional()
-          .describe('Version number or version ID. Omit for current version.'),
-        branchId: z.string().describe('Destination branch/worktree ID (UUIDv7 or short ID)'),
-        subpath: z
-          .string()
-          .optional()
-          .describe(
-            'Branch-relative destination markdown path. Default: .agor/kb/<namespace>/<document path>.'
-          ),
+        documentId: mcpOptionalId('documentId', 'Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path inside namespace; use with namespace'
+        ),
+        version: mcpOptionalVersionToken(
+          'version',
+          'Version number or version ID. Omit for current version.'
+        ),
+        branchId: mcpRequiredId('branchId', 'Destination branch/worktree'),
+        subpath: mcpOptionalNonEmptyString(
+          'subpath',
+          'Branch-relative destination markdown path. Default: .agor/kb/<namespace>/<document path>.'
+        ),
         overwrite: z
           .boolean()
           .optional()
@@ -1012,30 +1097,28 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       description:
         'Publish a markdown file from a branch worktree into Knowledge. Requires branchId + branch-relative subpath and branch session permission. If a .agor-kb sidecar exists, it supplies documentId and expectedVersion; otherwise provide documentId or namespace + path. Updating an existing document creates one immutable KB version.',
       inputSchema: z.object({
-        branchId: z.string().describe('Source branch/worktree ID (UUIDv7 or short ID)'),
-        subpath: z.string().describe('Branch-relative source markdown file path'),
-        documentId: z.string().optional().describe('Knowledge document ID to update'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z
-          .string()
-          .optional()
-          .describe('Namespace/space slug. Required with path when creating without sidecar.'),
-        path: z
-          .string()
-          .optional()
-          .describe('Document path. Required with namespace when creating without sidecar.'),
-        expectedVersion: z
-          .union([z.number(), z.string()])
-          .optional()
-          .describe(
-            'Expected current version number or ID. Defaults to sidecar version when present.'
-          ),
+        branchId: mcpRequiredId('branchId', 'Source branch/worktree'),
+        subpath: mcpRequiredString('subpath', 'Branch-relative source markdown file path'),
+        documentId: mcpOptionalId('documentId', 'Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString(
+          'namespace',
+          'Namespace/space slug. Required with path when creating without sidecar.'
+        ),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path. Required with namespace when creating without sidecar.'
+        ),
+        expectedVersion: mcpOptionalVersionToken(
+          'expectedVersion',
+          'Expected current version number or ID. Defaults to sidecar version when present.'
+        ),
         dryRun: z.boolean().optional().describe('Preview without creating/updating a KB version.'),
         createNamespace: z
           .boolean()
           .optional()
           .describe('Create namespace if missing when creating a new doc (default: false).'),
-        title: z.string().optional().describe('Optional title for newly-created documents'),
+        title: mcpOptionalString('title', 'Optional title for newly-created documents'),
         firstLineIsTitle: z
           .boolean()
           .optional()
@@ -1048,7 +1131,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         ),
         status: KnowledgeDocumentStatusSchema.optional().describe('Lifecycle status'),
         editPolicy: KnowledgeEditPolicySchema.optional().describe('Edit policy'),
-        changeSummary: z.string().optional().describe('Version history change summary'),
+        changeSummary: mcpOptionalString('changeSummary', 'Version history change summary'),
       }),
     },
     async (args) => {
@@ -1257,15 +1340,18 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       description: 'List version history for a Knowledge document.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        documentId: z.string().optional().describe('Knowledge document ID (UUIDv7 or short ID)'),
-        uri: z.string().optional().describe('Canonical URI, e.g. agor://kb/global/foo.md'),
-        namespace: z.string().optional().describe('Namespace/space slug; use with path'),
-        path: z.string().optional().describe('Document path inside namespace; use with namespace'),
+        documentId: mcpOptionalId('documentId', 'Knowledge document'),
+        uri: mcpOptionalNonEmptyString('uri', 'Canonical URI, e.g. agor://kb/global/foo.md'),
+        namespace: mcpOptionalNonEmptyString('namespace', 'Namespace/space slug; use with path'),
+        path: mcpOptionalNonEmptyString(
+          'path',
+          'Document path inside namespace; use with namespace'
+        ),
         includeContent: z
           .boolean()
           .optional()
           .describe('Include content text for each version (default: false)'),
-        limit: z.number().optional().describe('Maximum number of versions (default: 20)'),
+        limit: mcpLimit(20).describe('Maximum number of versions (default: 20)'),
       }),
     },
     async (args) => {
@@ -1313,7 +1399,14 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         source: KnowledgeNodeRefSchema,
         target: KnowledgeNodeRefSchema,
         edgeType: KnowledgeGraphEdgeTypeSchema.describe('Relationship type'),
-        confidence: z.number().optional().describe('Optional confidence score from 0 to 1'),
+        confidence: z
+          .number({
+            error: 'confidence must be a number between 0 and 1 when provided.',
+          })
+          .min(0, 'confidence must be greater than or equal to 0.')
+          .max(1, 'confidence must be less than or equal to 1.')
+          .optional()
+          .describe('Optional confidence score from 0 to 1'),
         properties: z
           .record(z.string(), z.unknown())
           .optional()
@@ -1360,8 +1453,8 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .array(KnowledgeGraphNodeTypeSchema)
           .optional()
           .describe('Optional neighbor node types to include'),
-        depth: z.number().optional().describe('Traversal depth (default: 1; V1 may cap at 2)'),
-        limit: z.number().optional().describe('Maximum neighbors/edges to return (default: 50)'),
+        depth: mcpOptionalPositiveInt('depth', 'Traversal depth (default: 1; V1 may cap at 2)'),
+        limit: mcpLimit(50).describe('Maximum neighbors/edges to return (default: 50)'),
         includeArchived: z
           .boolean()
           .optional()

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -1,6 +1,7 @@
 import type { MCPServer } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { mcpRequiredId } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -114,7 +115,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
       description:
         'List the MCP-server catalog the current user can access (i.e. servers eligible to attach to a session). Each entry includes name, transport, auth type, custom-header presence, and OAuth status. Use this to discover IDs to pass to `agor_sessions_create({ mcpServerIds })`. To see which servers are currently ATTACHED to a session, read `attached_mcp_servers` from `agor_sessions_get_current` or `agor_sessions_get`.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
+      inputSchema: z.strictObject({
         includeDisabled: z
           .boolean()
           .optional()
@@ -159,8 +160,12 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
       description:
         'Check the OAuth authentication status for an MCP server. Returns whether the current user is authenticated. If NOT authenticated, returns instructions for the user to complete OAuth via Settings → MCP Servers. Use agor_mcp_servers_list to get server IDs.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        mcpServerId: z.string().describe('MCP server ID to check (UUIDv7 or short ID)'),
+      inputSchema: z.strictObject({
+        mcpServerId: mcpRequiredId(
+          'mcpServerId',
+          'MCP server',
+          'MCP server ID to check (UUIDv7 or short ID)'
+        ),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -62,12 +62,17 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   content: Array<{ type: string; text: string }>;
 }>;
 
-async function registerAndGetHandler(ctx: { userId: string; role?: string }): Promise<ToolHandler> {
+type CapturedTool = {
+  cfg: { inputSchema?: { parse: (v: unknown) => unknown; safeParse: (v: unknown) => any } };
+  cb: ToolHandler;
+};
+
+async function registerAndGetTool(ctx: { userId: string; role?: string }): Promise<CapturedTool> {
   const { registerMessageTools } = await import('./messages.js');
-  let captured: ToolHandler | undefined;
+  let captured: CapturedTool | undefined;
   const fakeServer = {
-    registerTool: (_name: string, _cfg: unknown, cb: ToolHandler) => {
-      captured = cb;
+    registerTool: (_name: string, cfg: unknown, cb: ToolHandler) => {
+      captured = { cfg: cfg as CapturedTool['cfg'], cb };
     },
   } as unknown as McpServer;
 
@@ -84,6 +89,10 @@ async function registerAndGetHandler(ctx: { userId: string; role?: string }): Pr
   return captured;
 }
 
+async function registerAndGetHandler(ctx: { userId: string; role?: string }): Promise<ToolHandler> {
+  return (await registerAndGetTool(ctx)).cb;
+}
+
 describe('agor_messages_list MCP tool', () => {
   beforeEach(() => {
     mockIsBranchRbacEnabled.mockReset();
@@ -97,6 +106,31 @@ describe('agor_messages_list MCP tool', () => {
 
   afterEach(() => {
     vi.resetModules();
+  });
+
+  it('surfaces clearer validation for malformed ids and pagination', async () => {
+    const tool = await registerAndGetTool({ userId: 'user-1' });
+    const schema = tool.cfg.inputSchema!;
+
+    const badSessionId = schema.safeParse({ sessionId: 123 });
+    expect(badSessionId.success).toBe(false);
+    expect(String(badSessionId.error.message)).toMatch(/sessionId must be a string/);
+
+    const badLimit = schema.safeParse({ search: 'secret', limit: -1 });
+    expect(badLimit.success).toBe(false);
+    expect(String(badLimit.error.message)).toMatch(/limit must be greater than 0/);
+
+    const badOffset = schema.safeParse({ search: 'secret', offset: -1 });
+    expect(badOffset.success).toBe(false);
+    expect(String(badOffset.error.message)).toMatch(/offset must be greater than or equal to 0/);
+  });
+
+  it('keeps the handler-level search scope check actionable', async () => {
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    await expect(handler({})).rejects.toThrow(
+      /At least one of sessionId, taskId, or search must be provided as a non-empty string/
+    );
   });
 
   it('does not enforce RBAC when branch_rbac is disabled', async () => {

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -16,6 +16,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isSuperAdmin } from '../../utils/branch-authorization.js';
 import { resolveSessionId, resolveTaskId } from '../resolve-ids.js';
+import { mcpLimit, mcpOffset, mcpOptionalId, mcpOptionalString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -28,17 +29,16 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
         'Page through session conversation messages or search across sessions by keyword. When sessionId is provided, returns messages chronologically (like reading a transcript). When search is provided without sessionId, finds messages across all sessions. Tool calls are filtered out by default for cleaner output.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        sessionId: z
-          .string()
-          .optional()
-          .describe('Session ID to scope messages to (optional when using search)'),
-        taskId: z.string().optional().describe('Task ID to scope messages to (optional)'),
-        search: z
-          .string()
-          .optional()
-          .describe(
-            'Keyword search across message content. Space-separated terms are AND\'d, pipe (|) for OR. Example: "OAuth middleware" requires both; "OAuth | JWT" matches either.'
-          ),
+        sessionId: mcpOptionalId(
+          'sessionId',
+          'Session',
+          'Session ID to scope messages to (optional when using search)'
+        ),
+        taskId: mcpOptionalId('taskId', 'Task', 'Task ID to scope messages to (optional)'),
+        search: mcpOptionalString(
+          'search',
+          'Keyword search across message content. Space-separated terms are AND\'d, pipe (|) for OR. Example: "OAuth middleware" requires both; "OAuth | JWT" matches either.'
+        ),
         includeToolCalls: z
           .boolean()
           .optional()
@@ -51,8 +51,8 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Content detail level. "preview" returns first 200 chars (default). "full" returns complete text content.'
           ),
-        limit: z.number().optional().describe('Maximum number of messages to return (default: 20)'),
-        offset: z.number().optional().describe('Skip first N messages (default: 0)'),
+        limit: mcpLimit(20),
+        offset: mcpOffset(0),
         order: z
           .enum(['asc', 'desc'])
           .optional()
@@ -68,7 +68,9 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       const search = coerceString(args.search);
 
       if (!sessionIdRaw && !taskIdRaw && !search) {
-        throw new Error('at least one of sessionId, taskId, or search is required');
+        throw new Error(
+          'At least one of sessionId, taskId, or search must be provided as a non-empty string. Example: { "sessionId": "01abcdef" } or { "search": "OAuth middleware" }.'
+        );
       }
 
       const sessionId = sessionIdRaw ? await resolveSessionId(ctx, sessionIdRaw) : undefined;

--- a/apps/agor-daemon/src/mcp/tools/proxies.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/proxies.test.ts
@@ -1,0 +1,53 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@agor/core/config', () => ({
+  getBaseUrl: async () => 'http://localhost:3030',
+  loadConfig: async () => ({}),
+  resolveProxies: () => [],
+}));
+
+vi.mock('../server.js', () => ({
+  coerceString: (value: unknown) =>
+    typeof value === 'string' && value.trim() ? value.trim() : undefined,
+  textResult: (data: unknown) => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  }),
+}));
+
+const { registerProxyTools } = await import('./proxies.js');
+
+type ToolConfig = {
+  inputSchema?: {
+    safeParse: (value: unknown) => {
+      success: boolean;
+      error?: { issues?: Array<{ path: Array<string | number>; message: string }> };
+    };
+  };
+};
+
+function captureConfig(toolName: string): ToolConfig {
+  let config: ToolConfig | undefined;
+  const fakeServer = {
+    registerTool: (name: string, cfg: ToolConfig) => {
+      if (name === toolName) config = cfg;
+    },
+  } as unknown as McpServer;
+
+  registerProxyTools(fakeServer, {} as Parameters<typeof registerProxyTools>[1]);
+
+  if (!config) throw new Error(`${toolName} was not registered`);
+  return config;
+}
+
+describe('proxy MCP tool input schemas', () => {
+  it('rejects empty required vendor slugs before the handler runs', () => {
+    const parsed = captureConfig('agor_proxies_get').inputSchema?.safeParse({ vendor: '' });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]).toMatchObject({
+      path: ['vendor'],
+      message: 'vendor cannot be empty.',
+    });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/proxies.ts
+++ b/apps/agor-daemon/src/mcp/tools/proxies.ts
@@ -15,6 +15,7 @@
 import { getBaseUrl, loadConfig, type ResolvedProxy, resolveProxies } from '@agor/core/config';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { mcpRequiredString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -143,9 +144,10 @@ Always check r.ok before JSON.parse, and surface the error JSON to the user — 
         'Get details for a single configured HTTP proxy by vendor slug. Returns 404 if the vendor is not configured.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        vendor: z
-          .string()
-          .describe('Vendor slug as it appears in the route path, e.g. "shortcut" or "linear".'),
+        vendor: mcpRequiredString(
+          'vendor',
+          'Vendor slug as it appears in the route path, e.g. "shortcut" or "linear".'
+        ),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -2,6 +2,7 @@ import { extractSlugFromUrl, isValidGitUrl, isValidSlug } from '@agor/core/confi
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ReposServiceImpl } from '../../declarations.js';
+import { mcpLimit, mcpOptionalString, mcpRequiredId, mcpRequiredString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 
@@ -13,8 +14,8 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       description: 'List all repositories accessible to the current user',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        slug: z.string().optional().describe('Filter by repository slug'),
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        slug: mcpOptionalString('slug', 'Filter by repository slug'),
+        limit: mcpLimit(50),
       }),
     },
     async (args) => {
@@ -39,7 +40,7 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
         'in Settings → API Keys (or it has expired/lost access).',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        repoId: z.string().describe('Repository ID (UUIDv7 or short ID)'),
+        repoId: mcpRequiredId('repoId', 'Repository'),
       }),
     },
     async (args) => {
@@ -61,31 +62,24 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
         '"auth_failed"`. Retrying after a failed clone is supported — the previous failed row ' +
         'is replaced.',
       inputSchema: z.object({
-        url: z
-          .string()
-          .describe(
-            'Git remote URL (https://github.com/user/repo.git or git@github.com:user/repo.git)'
-          ),
-        slug: z
-          .string()
-          .optional()
-          .describe(
-            'URL-friendly slug for the repository in org/name format (e.g., "myorg/myapp"). Required.'
-          ),
-        name: z
-          .string()
-          .optional()
-          .describe(
-            'Human-readable name for the repository. If not provided, defaults to the slug.'
-          ),
-        default_branch: z
-          .string()
-          .optional()
-          .describe(
-            "Pin a non-default branch as the repo's default (overrides origin/HEAD). " +
-              'Used when the repository\'s "default" should be a long-lived feature branch ' +
-              "rather than whatever the remote's HEAD points at."
-          ),
+        url: mcpRequiredString(
+          'url',
+          'Git remote URL (https://github.com/user/repo.git or git@github.com:user/repo.git)'
+        ),
+        slug: mcpOptionalString(
+          'slug',
+          'URL-friendly slug for the repository in org/name format (e.g., "myorg/myapp"). Required.'
+        ),
+        name: mcpOptionalString(
+          'name',
+          'Human-readable name for the repository. If not provided, defaults to the slug.'
+        ),
+        default_branch: mcpOptionalString(
+          'default_branch',
+          "Pin a non-default branch as the repo's default (overrides origin/HEAD). " +
+            'Used when the repository\'s "default" should be a long-lived feature branch ' +
+            "rather than whatever the remote's HEAD points at."
+        ),
       }),
     },
     async (args) => {
@@ -120,15 +114,14 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
     {
       description: 'Register an existing local git repository with Agor',
       inputSchema: z.object({
-        path: z
-          .string()
-          .describe('Absolute path to the local git repository. Supports ~ for home directory.'),
-        slug: z
-          .string()
-          .optional()
-          .describe(
-            'URL-friendly slug for the repository (e.g., "local/myapp"). If not provided, will be auto-derived from the repository name.'
-          ),
+        path: mcpRequiredString(
+          'path',
+          'Absolute path to the local git repository. Supports ~ for home directory.'
+        ),
+        slug: mcpOptionalString(
+          'slug',
+          'URL-friendly slug for the repository (e.g., "local/myapp"). If not provided, will be auto-derived from the repository name.'
+        ),
       }),
     },
     async (args) => {
@@ -156,28 +149,26 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
         'Note: changing `slug` updates the DB only; the on-disk directory at ' +
         '~/.agor/repos/<slug> is NOT moved.',
       inputSchema: z.object({
-        repoId: z.string().describe('Repository ID (UUIDv7 or short ID)'),
-        name: z.string().optional().describe('Human-readable name'),
-        slug: z
-          .string()
-          .optional()
-          .describe('URL-friendly slug in org/name format. Must be unique across all repos.'),
+        repoId: mcpRequiredId('repoId', 'Repository'),
+        name: mcpOptionalString('name', 'Human-readable name'),
+        slug: mcpOptionalString(
+          'slug',
+          'URL-friendly slug in org/name format. Must be unique across all repos.'
+        ),
         repo_type: z
           .enum(['remote', 'local'])
           .optional()
           .describe(
             'Repository management type. Switching to "remote" requires `remote_url` (in this patch or already set on the repo).'
           ),
-        remote_url: z
-          .string()
-          .optional()
-          .describe('Git remote URL. Required when `repo_type` is "remote".'),
-        default_branch: z
-          .string()
-          .optional()
-          .describe(
-            'Default branch name used as the source for new branches that do not specify a sourceBranch.'
-          ),
+        remote_url: mcpOptionalString(
+          'remote_url',
+          'Git remote URL. Required when `repo_type` is "remote".'
+        ),
+        default_branch: mcpOptionalString(
+          'default_branch',
+          'Default branch name used as the source for new branches that do not specify a sourceBranch.'
+        ),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/schedules.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.test.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it } from 'vitest';
+import { registerScheduleTools } from './schedules.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+
+describe('schedule MCP input schemas', () => {
+  it('rejects non-canonical keys and empty required schedule fields', () => {
+    const configs = new Map<string, { inputSchema: { safeParse: (args: unknown) => unknown } }>();
+    const fakeServer = {
+      registerTool: (
+        name: string,
+        cfg: { inputSchema: { safeParse: (args: unknown) => unknown } },
+        _cb: ToolHandler
+      ) => {
+        configs.set(name, cfg);
+      },
+    } as unknown as McpServer;
+
+    registerScheduleTools(fakeServer, {
+      app: { service: () => ({}) } as any,
+      db: {} as any,
+      userId: 'user-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'user-1', email: 'user@example.com', role: 'member' } as any,
+      baseServiceParams: {},
+    });
+
+    const createSchema = configs.get('agor_schedules_create')?.inputSchema;
+    const nonCanonicalBranchId = createSchema?.safeParse({
+      branch_id: 'branch-1',
+      name: 'Heartbeat',
+      cron_expression: '0 9 * * *',
+      timezone_mode: 'utc',
+      prompt: 'Run',
+      agentic_tool_config: { agentic_tool: 'codex' },
+    });
+    expect(nonCanonicalBranchId).toMatchObject({ success: false });
+    expect(JSON.stringify(nonCanonicalBranchId)).toContain('branch_id');
+
+    const emptyName = createSchema?.safeParse({
+      branchId: 'branch-1',
+      name: '',
+      cron_expression: '0 9 * * *',
+      timezone_mode: 'utc',
+      prompt: 'Run',
+      agentic_tool_config: { agentic_tool: 'codex' },
+    });
+    expect(emptyName).toMatchObject({ success: false });
+    expect(JSON.stringify(emptyName)).toContain('name cannot be empty');
+
+    const negativeRetention = createSchema?.safeParse({
+      branchId: 'branch-1',
+      name: 'Heartbeat',
+      cron_expression: '0 9 * * *',
+      timezone_mode: 'utc',
+      prompt: 'Run',
+      agentic_tool_config: { agentic_tool: 'codex' },
+      retention: -1,
+    });
+    expect(negativeRetention).toMatchObject({ success: false });
+    expect(JSON.stringify(negativeRetention)).toContain(
+      'retention must be greater than or equal to 0'
+    );
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -13,6 +13,14 @@ import {
   resolveScheduleId,
   resolveUserId,
 } from '../resolve-ids.js';
+import {
+  mcpLimit,
+  mcpOptionalId,
+  mcpOptionalNonNegativeInt,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -21,11 +29,11 @@ const agenticToolConfigSchema = z
     agentic_tool: z
       .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'])
       .describe('Agent to spawn for runs of this schedule.'),
-    permission_mode: z.string().optional().describe("Permission mode (e.g., 'auto', 'ask')."),
+    permission_mode: mcpOptionalString('permission_mode', "Permission mode (e.g., 'auto', 'ask')."),
     model_config: z
       .object({
         mode: z.enum(['alias', 'exact']).optional(),
-        model: z.string().optional(),
+        model: mcpOptionalString('model_config.model', 'Model name override.'),
         effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
       })
       .optional()
@@ -33,10 +41,13 @@ const agenticToolConfigSchema = z
         'Optional model override (canonical DefaultModelConfig shape). Omit to inherit the agent default; set { model } to override; set { mode, model, effort } for full control.'
       ),
     mcp_server_ids: z
-      .array(z.string())
+      .array(mcpRequiredId('mcp_server_ids[]', 'MCP server'))
       .optional()
       .describe("MCP servers to attach to spawned sessions. Defaults to ['agor']."),
-    context_files: z.array(z.string()).optional().describe('Additional context files to load.'),
+    context_files: z
+      .array(mcpRequiredString('context_files[]', 'Context file path'))
+      .optional()
+      .describe('Additional context files to load.'),
   })
   .describe(
     'Agentic-tool configuration. Bundles the fields that change together (agent + permission + model + MCPs + context).'
@@ -50,18 +61,16 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
       description:
         'List schedules accessible to the current user. Filter by branch, board, creator, or enabled status. Returns rows in newest-first order.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        branchId: z.string().optional().describe('Filter to schedules on this branch'),
-        boardId: z
-          .string()
-          .optional()
-          .describe('Filter to schedules whose branch belongs to this board'),
-        createdBy: z.string().optional().describe('Filter to schedules created by this user'),
+      inputSchema: z.strictObject({
+        branchId: mcpOptionalId('branchId', 'Branch', 'Filter to schedules on this branch'),
+        boardId: mcpOptionalId(
+          'boardId',
+          'Board',
+          'Filter to schedules whose branch belongs to this board'
+        ),
+        createdBy: mcpOptionalId('createdBy', 'User', 'Filter to schedules created by this user'),
         enabled: z.boolean().optional().describe('Filter by enabled flag'),
-        limit: z
-          .number()
-          .optional()
-          .describe('Maximum number of schedules to return (default: 50)'),
+        limit: mcpLimit(50).describe('Maximum number of schedules to return (default: 50)'),
       }),
     },
     async (args) => {
@@ -98,8 +107,8 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
       description:
         'Get a single schedule by ID. Returns full configuration including cron, timezone, agentic_tool_config, last/next run timestamps, and the linked last_run_session_id.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        scheduleId: z.string().describe('Schedule ID (UUIDv7 or short ID)'),
+      inputSchema: z.strictObject({
+        scheduleId: mcpRequiredId('scheduleId', 'Schedule'),
       }),
     },
     async (args) => {
@@ -115,31 +124,32 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
     {
       description:
         "Create a new schedule on a branch. A branch can hold multiple schedules (e.g. 'hourly heartbeat' + 'daily summary'). Cron + prompt + agentic_tool_config are required.",
-      inputSchema: z.object({
-        branchId: z.string().describe('Branch this schedule belongs to'),
-        name: z.string().min(1).describe("Display name, e.g. 'Hourly heartbeat'"),
-        description: z.string().optional().describe('Freeform description'),
-        cron_expression: z.string().describe("Cron expression (5/6 fields), e.g. '0 9 * * 1-5'"),
+      inputSchema: z.strictObject({
+        branchId: mcpRequiredId('branchId', 'Branch', 'Branch this schedule belongs to'),
+        name: mcpRequiredString('name', "Display name, e.g. 'Hourly heartbeat'"),
+        description: mcpOptionalString('description', 'Freeform description'),
+        cron_expression: mcpRequiredString(
+          'cron_expression',
+          "Cron expression (5/6 fields), e.g. '0 9 * * 1-5'"
+        ),
         timezone_mode: z
           .enum(['local', 'utc'])
           .describe("'local' uses `timezone`; 'utc' fires in UTC."),
-        timezone: z
-          .string()
-          .optional()
-          .describe(
-            "IANA timezone (required when timezone_mode='local'), e.g. 'America/Los_Angeles'"
-          ),
-        prompt: z.string().min(1).describe('Handlebars prompt template'),
+        timezone: mcpOptionalString(
+          'timezone',
+          "IANA timezone (required when timezone_mode='local'), e.g. 'America/Los_Angeles'"
+        ),
+        prompt: mcpRequiredString('prompt', 'Handlebars prompt template'),
         agentic_tool_config: agenticToolConfigSchema,
         enabled: z.boolean().optional().describe('Whether to fire (default: true)'),
         allow_concurrent_runs: z
           .boolean()
           .optional()
           .describe('Allow runs to overlap (default: false)'),
-        retention: z
-          .number()
-          .optional()
-          .describe('Number of sessions to keep; 0 = keep all (default: 5)'),
+        retention: mcpOptionalNonNegativeInt(
+          'retention',
+          'Number of sessions to keep; 0 = keep all (default: 5)'
+        ),
       }),
     },
     async (args) => {
@@ -171,18 +181,21 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
     {
       description:
         'Patch a schedule. Only the supplied fields are changed; everything else is preserved. Cron / timezone / prompt changes are re-validated.',
-      inputSchema: z.object({
-        scheduleId: z.string().describe('Schedule ID (UUIDv7 or short ID)'),
-        name: z.string().optional(),
-        description: z.string().optional(),
-        cron_expression: z.string().optional(),
+      inputSchema: z.strictObject({
+        scheduleId: mcpRequiredId('scheduleId', 'Schedule'),
+        name: mcpOptionalString('name', 'Display name'),
+        description: mcpOptionalString('description', 'Freeform description'),
+        cron_expression: mcpOptionalString('cron_expression', 'Cron expression (5/6 fields)'),
         timezone_mode: z.enum(['local', 'utc']).optional(),
-        timezone: z.string().optional(),
-        prompt: z.string().optional(),
+        timezone: mcpOptionalString('timezone', 'IANA timezone'),
+        prompt: mcpOptionalString('prompt', 'Handlebars prompt template'),
         agentic_tool_config: agenticToolConfigSchema.optional(),
         enabled: z.boolean().optional(),
         allow_concurrent_runs: z.boolean().optional(),
-        retention: z.number().optional(),
+        retention: mcpOptionalNonNegativeInt(
+          'retention',
+          'Number of sessions to keep; 0 = keep all'
+        ),
       }),
     },
     async (args) => {
@@ -202,8 +215,8 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
       description:
         'Delete a schedule. Sessions linked via schedule_id are NOT deleted; the FK is SET NULL so historical runs are preserved as orphaned scheduled sessions.',
       annotations: { destructiveHint: true },
-      inputSchema: z.object({
-        scheduleId: z.string().describe('Schedule ID (UUIDv7 or short ID)'),
+      inputSchema: z.strictObject({
+        scheduleId: mcpRequiredId('scheduleId', 'Schedule'),
       }),
     },
     async (args) => {
@@ -219,8 +232,8 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
     {
       description:
         "Trigger a manual run of a schedule. Reuses the cron-tick spawn path so the resulting session is indistinguishable from a scheduled run, except for a 'triggered_manually' marker in custom_context. Requires branch-tier 'all' permission. Returns the new session.",
-      inputSchema: z.object({
-        scheduleId: z.string().describe('Schedule ID (UUIDv7 or short ID)'),
+      inputSchema: z.strictObject({
+        scheduleId: mcpRequiredId('scheduleId', 'Schedule'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/search.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.test.ts
@@ -148,6 +148,24 @@ describe('agor_execute_tool', () => {
     expect(parsed.how_to_find_tools).toMatch(/agor_search_tools/);
     expect(parsed.how_to_find_tools).toMatch(/agor_get_tool_details/);
   });
+
+  it('rejects unknown target-tool arguments instead of silently stripping them', async () => {
+    const { handler, targetHandler } = captureExecuteTool();
+
+    const result = await handler({
+      tool_name: 'agor_sessions_list',
+      arguments: {
+        limit: 1,
+        definitelyNotAParam: 'typo',
+      },
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/unknown argument "definitelyNotAParam"/);
+    expect(parsed.error).toMatch(/agor_get_tool_details/);
+    expect(targetHandler).not.toHaveBeenCalled();
+  });
 });
 
 describe('agor_get_tool_details', () => {

--- a/apps/agor-daemon/src/mcp/tools/search.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.test.ts
@@ -1,0 +1,212 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { ToolRegistry } from '../tool-registry.js';
+import { registerSearchTools } from './search.js';
+
+vi.mock('../server.js', () => ({
+  coerceJsonRecord: (value: unknown) => {
+    if (typeof value !== 'string') return value;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  },
+  textResult: (data: unknown) => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  }),
+}));
+
+function textResult(data: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+type ToolConfig = {
+  inputSchema?: {
+    safeParse: (value: unknown) => {
+      success: boolean;
+      data?: unknown;
+      error?: { issues?: Array<{ path: Array<string | number>; message: string }> };
+    };
+  };
+};
+
+function captureExecuteTool(targetHandler = vi.fn(async (args: unknown) => textResult({ args }))) {
+  let config: ToolConfig | undefined;
+  let handler: ToolHandler | undefined;
+
+  const fakeServer = {
+    _registeredTools: {
+      agor_sessions_list: {
+        enabled: true,
+        inputSchema: z.object({
+          branchId: z.string().optional(),
+          limit: z.number().optional(),
+        }),
+        handler: targetHandler,
+      },
+    },
+    registerTool: (name: string, cfg: ToolConfig, cb: ToolHandler) => {
+      if (name === 'agor_execute_tool') {
+        config = cfg;
+        handler = cb;
+      }
+    },
+  } as unknown as McpServer;
+
+  registerSearchTools(fakeServer, new ToolRegistry());
+
+  if (!config || !handler) throw new Error('agor_execute_tool was not registered');
+  return { config, handler, targetHandler };
+}
+
+function captureSearchTools(registry = new ToolRegistry()) {
+  const captured: Record<string, { config: ToolConfig; handler: ToolHandler }> = {};
+  const fakeServer = {
+    _registeredTools: {},
+    registerTool: (name: string, cfg: ToolConfig, cb: ToolHandler) => {
+      captured[name] = { config: cfg, handler: cb };
+    },
+  } as unknown as McpServer;
+
+  registerSearchTools(fakeServer, registry);
+  return captured;
+}
+
+describe('agor_execute_tool', () => {
+  it('accepts the canonical tool_name field and forwards nested arguments', async () => {
+    const { handler, targetHandler } = captureExecuteTool();
+
+    const result = await handler({
+      tool_name: 'agor_sessions_list',
+      arguments: { branchId: 'branch-1' },
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(targetHandler).toHaveBeenCalledWith({ branchId: 'branch-1' }, {});
+  });
+
+  it('rejects camelCase toolName with a clear schema error', () => {
+    const { config } = captureExecuteTool();
+
+    const parsed = config.inputSchema?.safeParse({
+      toolName: 'agor_sessions_list',
+      arguments: { branchId: 'branch-1' },
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]?.path).toEqual(['tool_name']);
+    expect(parsed?.error?.issues?.[0]?.message).toMatch(/tool_name is required/);
+    expect(parsed?.error?.issues?.[0]?.message).toMatch(/"arguments"/);
+  });
+
+  it('returns an actionable schema error when the tool name is omitted', () => {
+    const { config } = captureExecuteTool();
+
+    const parsed = config.inputSchema?.safeParse({
+      arguments: { branchId: 'branch-1' },
+    });
+
+    expect(parsed?.success).toBe(false);
+    expect(parsed?.error?.issues?.[0]?.path).toEqual(['tool_name']);
+    expect(parsed?.error?.issues?.[0]?.message).toMatch(/tool_name is required/);
+    expect(parsed?.error?.issues?.[0]?.message).toMatch(/"tool_name"/);
+  });
+
+  it('does not leak proxy-only fields into flattened target-tool arguments', async () => {
+    const { handler, targetHandler } = captureExecuteTool();
+
+    const result = await handler({
+      tool_name: 'agor_sessions_list',
+      branchId: 'branch-1',
+      limit: 5,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(targetHandler).toHaveBeenCalledWith({ branchId: 'branch-1', limit: 5 }, {});
+  });
+
+  it('points invalid tool names to search and details discovery flow', async () => {
+    const { handler } = captureExecuteTool();
+
+    const result = await handler({
+      tool_name: 'agor_missing_tool',
+      arguments: {},
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/not found/);
+    expect(parsed.how_to_find_tools).toMatch(/agor_search_tools/);
+    expect(parsed.how_to_find_tools).toMatch(/agor_get_tool_details/);
+  });
+});
+
+describe('agor_get_tool_details', () => {
+  it('returns one exact schema at a time', async () => {
+    const registry = new ToolRegistry();
+    registry.setCurrentDomain('sessions');
+    registry.register({
+      name: 'agor_sessions_list',
+      description: 'List sessions',
+      inputSchema: {
+        type: 'object',
+        properties: { branchId: { type: 'string' } },
+      },
+      annotations: { readOnlyHint: true },
+    });
+    const tools = captureSearchTools(registry);
+
+    const result = await tools.agor_get_tool_details.handler({
+      tool_name: 'agor_sessions_list',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.tool.name).toBe('agor_sessions_list');
+    expect(parsed.tool.inputSchema.properties.branchId.type).toBe('string');
+    expect(parsed.usage.execute_with.tool_name).toBe('agor_sessions_list');
+  });
+});
+
+describe('agor_search_tools', () => {
+  it('keeps full detail responses concise until search narrows to one tool', async () => {
+    const registry = new ToolRegistry();
+    registry.setCurrentDomain('sessions');
+    registry.register({
+      name: 'agor_sessions_list',
+      description: 'List sessions',
+      inputSchema: { type: 'object', properties: { branchId: { type: 'string' } } },
+    });
+    registry.register({
+      name: 'agor_sessions_get',
+      description: 'Get a session',
+      inputSchema: { type: 'object', properties: { sessionId: { type: 'string' } } },
+    });
+    const tools = captureSearchTools(registry);
+
+    const broad = await tools.agor_search_tools.handler({
+      domain: 'sessions',
+      detail: 'full',
+      max_results: 10,
+    });
+    const broadParsed = JSON.parse(broad.content[0].text);
+    expect(broadParsed.tools[0].inputSchema).toBeUndefined();
+    expect(broadParsed.hint).toMatch(/narrowed to one tool/);
+
+    const narrow = await tools.agor_search_tools.handler({
+      query: 'agor_sessions_get',
+      detail: 'full',
+      max_results: 1,
+    });
+    const narrowParsed = JSON.parse(narrow.content[0].text);
+    expect(narrowParsed.tools[0].inputSchema.properties.sessionId.type).toBe('string');
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -62,7 +62,15 @@ function resolveToolArgs(
   if (tool.inputSchema && typeof tool.inputSchema.safeParse === 'function') {
     const parseResult = tool.inputSchema.safeParse(toolArgs);
     if (parseResult.success) {
-      return parseResult.data as Record<string, unknown>;
+      const parsedArgs = parseResult.data as Record<string, unknown>;
+      const unknownArgs = Object.keys(toolArgs).filter((key) => !Object.hasOwn(parsedArgs, key));
+      if (unknownArgs.length > 0) {
+        throw new Error(
+          `Invalid arguments for tool ${toolName}: unknown argument${unknownArgs.length === 1 ? '' : 's'} ${unknownArgs.map((arg) => `"${arg}"`).join(', ')}. ` +
+            `Call agor_get_tool_details({ "tool_name": "${toolName}" }) for the exact schema.`
+        );
+      }
+      return parsedArgs;
     }
     // Surface validation errors instead of letting them manifest as
     // confusing downstream failures (e.g. "Board not found: undefined").

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { mcpLimit, mcpRequiredString } from '../schema.js';
 import { coerceJsonRecord, textResult } from '../server.js';
 import { ToolRegistry } from '../tool-registry.js';
 
@@ -14,6 +15,9 @@ interface RegisteredTool {
   };
   handler: (args: unknown, extra: unknown) => Promise<unknown>;
 }
+
+const DISCOVERY_HINT =
+  'Discover tool names with agor_search_tools (call with no args for domains, or with { "query": "sessions" }). Get an exact schema with agor_get_tool_details({ "tool_name": "..." }).';
 
 /**
  * Resolve tool arguments for the agor_execute_tool proxy.
@@ -72,12 +76,27 @@ function resolveToolArgs(
   return toolArgs;
 }
 
+function resolveProxyToolName(args: Record<string, unknown>): string {
+  const toolName = typeof args.tool_name === 'string' ? args.tool_name : undefined;
+  if (!toolName) {
+    const keys = Object.keys(args);
+    throw new Error(
+      `Missing required agor_execute_tool field "tool_name". ` +
+        `Use { "tool_name": "agor_branches_list", "arguments": { ... } }. ` +
+        `${DISCOVERY_HINT} ` +
+        `Received top-level keys: ${keys.length > 0 ? keys.join(', ') : '(none)'}.`
+    );
+  }
+
+  return toolName;
+}
+
 export function registerSearchTools(server: McpServer, registry: ToolRegistry): void {
   server.registerTool(
     'agor_search_tools',
     {
       description:
-        'Search and browse available Agor MCP tools. Call with no args to see domains overview. Filter by domain, keyword, or annotation. Use detail="full" to get input schemas before calling agor_execute_tool.',
+        'Search and browse available Agor MCP tools. Call with no args to see domain overview. Use query/domain filters to find matching tools. Returns concise tool summaries by default; use agor_get_tool_details for exact input schemas.',
       inputSchema: z.object({
         query: z
           .string()
@@ -95,11 +114,11 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
           .enum(['list', 'full'])
           .optional()
           .describe(
-            'Detail level: "list" returns name+description (default), "full" includes inputSchema and annotations'
+            'Detail level. Prefer "list" (default) for concise results. "full" is retained for compatibility; prefer agor_get_tool_details for exact schemas.'
           ),
         read_only: z.boolean().optional().describe('Filter to read-only tools only'),
         destructive: z.boolean().optional().describe('Filter to destructive tools only'),
-        max_results: z.number().optional().describe('Max results to return (default: 10)'),
+        max_results: mcpLimit(10).describe('Max results to return (default: 10)'),
       }),
       annotations: { readOnlyHint: true },
     },
@@ -117,7 +136,7 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
         return textResult({
           total_available: registry.size,
           domains,
-          hint: 'Use domain or query params to discover specific tools. Use detail="full" to get input schemas.',
+          hint: 'Use query/domain params to find specific tools. Then call agor_get_tool_details with the selected tool_name for the exact schema.',
         });
       }
 
@@ -128,13 +147,68 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
         destructive: args.destructive,
       });
 
-      const tools = detail === 'full' ? results : ToolRegistry.toSummaries(results);
+      const fullDetailsRequested = detail === 'full';
+      const fullDetailsReturned = fullDetailsRequested && results.length === 1;
+      const tools = fullDetailsReturned ? results : ToolRegistry.toSummaries(results);
 
       return textResult({
         total_available: registry.size,
         domains,
         results_count: results.length,
         tools,
+        hint:
+          fullDetailsRequested && !fullDetailsReturned
+            ? 'detail:"full" only returns schemas after the result set is narrowed to one tool. Use max_results:1 or, preferably, agor_get_tool_details({ tool_name }) for one exact schema at a time.'
+            : fullDetailsReturned
+              ? 'Use agor_execute_tool with this tool_name and arguments matching inputSchema.'
+              : 'Call agor_get_tool_details({ tool_name }) for the exact input schema before executing.',
+      });
+    }
+  );
+
+  server.registerTool(
+    'agor_get_tool_details',
+    {
+      description:
+        'Get exact details for one Agor MCP tool, including its input schema and annotations. Use this after agor_search_tools selects a tool and before agor_execute_tool calls it.',
+      inputSchema: z.object({
+        tool_name: mcpRequiredString(
+          'tool_name',
+          'The tool name to inspect (e.g. "agor_sessions_list")',
+          {
+            example: '{ "tool_name": "agor_sessions_list" }',
+          }
+        ),
+      }),
+      annotations: { readOnlyHint: true },
+    },
+    async (args) => {
+      const tool = registry.get(args.tool_name);
+      if (!tool) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: `Tool "${args.tool_name}" not found.`,
+                how_to_find_tools:
+                  'Call agor_search_tools with no args for domains, or with { "query": "keyword" } / { "domain": "sessions" } to find tool names.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return textResult({
+        tool,
+        usage: {
+          execute_with: {
+            tool_name: tool.name,
+            arguments: '<object matching inputSchema>',
+          },
+          note: 'Call agor_execute_tool with this tool_name and arguments matching inputSchema.',
+        },
       });
     }
   );
@@ -143,10 +217,17 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
     'agor_execute_tool',
     {
       description:
-        'Execute an Agor MCP tool by name. Use agor_search_tools first to discover available tools and their input schemas, then call this to invoke them.',
+        'Execute one Agor MCP tool by name. Expected shape: { "tool_name": "agor_sessions_list", "arguments": { ... } }. Use agor_search_tools to find tools and agor_get_tool_details for the exact schema.',
       inputSchema: z
         .object({
-          tool_name: z.string().describe('The tool name to execute (e.g. "agor_branches_list")'),
+          tool_name: mcpRequiredString(
+            'tool_name',
+            'The tool name to execute (e.g. "agor_branches_list")',
+            {
+              example:
+                '{ "tool_name": "agor_branches_list", "arguments": { ... } }. Use agor_search_tools to find tool names and agor_get_tool_details for schemas.',
+            }
+          ),
           arguments: z
             .preprocess(
               // Some MCP clients double-serialize nested objects as JSON strings.
@@ -160,29 +241,34 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
         .passthrough(),
     },
     async (args) => {
-      const toolName = args.tool_name;
-
-      const registeredTools = (
-        server as unknown as { _registeredTools: Record<string, RegisteredTool> }
-      )._registeredTools;
-
-      const tool = registeredTools[toolName];
-      if (!tool) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                error: `Tool "${toolName}" not found. Use agor_search_tools to discover available tools.`,
-              }),
-            },
-          ],
-          isError: true,
-        };
-      }
+      const proxyArgs = args as Record<string, unknown>;
+      let toolName: string | undefined;
 
       try {
-        const toolArgs = resolveToolArgs(args as Record<string, unknown>, tool, toolName);
+        toolName = resolveProxyToolName(proxyArgs);
+
+        const registeredTools = (
+          server as unknown as { _registeredTools: Record<string, RegisteredTool> }
+        )._registeredTools;
+
+        const tool = registeredTools[toolName];
+        if (!tool) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  error: `Tool "${toolName}" not found.`,
+                  how_to_find_tools:
+                    'Call agor_search_tools with no args for domains, or with { "query": "keyword" } / { "domain": "sessions" }. Then call agor_get_tool_details({ "tool_name": "..." }) for the exact schema.',
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const toolArgs = resolveToolArgs(proxyArgs, tool, toolName);
         const result = await tool.handler(toolArgs, {});
         return result as { content: Array<{ type: 'text'; text: string }> };
       } catch (error) {
@@ -192,7 +278,7 @@ export function registerSearchTools(server: McpServer, registry: ToolRegistry): 
               type: 'text' as const,
               text: JSON.stringify({
                 error: error instanceof Error ? error.message : String(error),
-                tool: toolName,
+                ...(toolName && { tool: toolName }),
               }),
             },
           ],

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -57,7 +57,10 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
 /** Cfg captured alongside the handler — includes inputSchema for tests that
  * exercise Zod validation/coercion (the fake server below bypasses the SDK's
  * automatic schema parsing). */
-type CapturedTool = { cfg: { inputSchema?: { parse: (v: unknown) => unknown } }; cb: ToolHandler };
+type CapturedTool = {
+  cfg: { inputSchema?: { parse: (v: unknown) => unknown; safeParse: (v: unknown) => any } };
+  cb: ToolHandler;
+};
 
 async function registerAndCaptureTools(
   ctx: {
@@ -582,6 +585,61 @@ describe('agor_sessions_prompt (subsession mode)', () => {
   });
 });
 
+describe('MCP session input validation clarity', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('rejects missing required ids with field-specific messages', async () => {
+    const tools = await registerAndCaptureTools(
+      { app: {}, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_get']
+    );
+
+    const result = tools.agor_sessions_get.cfg.inputSchema!.safeParse({});
+
+    expect(result.success).toBe(false);
+    expect(String(result.error.message)).toMatch(/sessionId is required and must be a string/);
+  });
+
+  it('rejects empty required prompts and optional titles when provided', async () => {
+    const tools = await registerAndCaptureTools(
+      { app: {}, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_prompt']
+    );
+
+    const emptyPrompt = tools.agor_sessions_prompt.cfg.inputSchema!.safeParse({
+      sessionId: 'sess-target',
+      mode: 'continue',
+      prompt: '',
+    });
+    expect(emptyPrompt.success).toBe(false);
+    expect(String(emptyPrompt.error.message)).toMatch(/prompt cannot be empty/);
+
+    const emptyTitle = tools.agor_sessions_prompt.cfg.inputSchema!.safeParse({
+      sessionId: 'sess-target',
+      mode: 'fork',
+      prompt: 'do work',
+      title: '',
+    });
+    expect(emptyTitle.success).toBe(false);
+    expect(String(emptyTitle.error.message)).toMatch(/title cannot be empty/);
+  });
+
+  it('rejects invalid pagination limits before handlers run', async () => {
+    const tools = await registerAndCaptureTools(
+      { app: {}, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_list']
+    );
+
+    const result = tools.agor_sessions_list.cfg.inputSchema!.safeParse({ limit: 0 });
+
+    expect(result.success).toBe(false);
+    expect(String(result.error.message)).toMatch(/limit must be greater than 0/);
+  });
+});
+
 describe('modelConfig schema (string shorthand coercion)', () => {
   // The MCP-tool boundary historically required `modelConfig` as a structured
   // `{ mode, model, effort, provider }` object. Several MCP clients silently
@@ -603,7 +661,7 @@ describe('modelConfig schema (string shorthand coercion)', () => {
     }) as Record<string, unknown>;
 
     // Schema validates but does NOT transform — coercion happens in handlers
-    // so the JSON Schema export (used by `agor_search_tools(detail:"full")`)
+    // so the JSON Schema export (used by `agor_get_tool_details`)
     // doesn't blow up on a Zod transform.
     expect(parsed.modelConfig).toBe('claude-opus-4-6');
   });
@@ -749,7 +807,7 @@ describe('inputSchema → JSON Schema conversion (MCP discovery)', () => {
   // ("Transforms cannot be represented in JSON Schema"). The catch in
   // `mcp/server.ts` then degraded the *entire* containing tool's schema to
   // `{ type: 'object' }`, hiding every parameter from MCP clients calling
-  // `agor_search_tools(detail:"full")`. Keep this test green to ensure the
+  // `agor_get_tool_details`. Keep this test green to ensure the
   // string-or-object union stays JSON-Schema-representable.
   it('produces a non-empty JSON Schema for tools that accept modelConfig', async () => {
     const { toJSONSchema } = await import('zod/v4-mini');

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -189,6 +189,55 @@ describe('agor_sessions_list', () => {
     expect(parsed.data[0].session_id).toBe('sess-target');
     expect(parsed.data[0]).not.toHaveProperty('mcp_token');
   });
+
+  it('filters boardId using session.branch_board_id instead of legacy sessions.board_id', async () => {
+    const findCalls: unknown[] = [];
+    const app = makeFakeApp({
+      sessions: {
+        find: async (params: unknown) => {
+          findCalls.push(params);
+          return {
+            total: 2,
+            limit: 10000,
+            skip: 0,
+            data: [
+              {
+                session_id: 'sess-on-board',
+                branch_id: 'wt-1',
+                branch_board_id: 'board-1',
+                status: 'idle',
+                mcp_token: 'tok1',
+              },
+              {
+                session_id: 'sess-other-board',
+                branch_id: 'wt-2',
+                branch_board_id: 'board-2',
+                status: 'idle',
+                mcp_token: 'tok2',
+              },
+            ],
+          };
+        },
+      },
+    });
+
+    const { agor_sessions_list } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_list']
+    );
+
+    const result = await agor_sessions_list({ boardId: 'board-1', limit: 10 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(findCalls[0]).toMatchObject({
+      query: { archived: false, $limit: 10000 },
+    });
+    expect(findCalls[0]).not.toMatchObject({ query: { board_id: 'board-1' } });
+    expect(parsed.total).toBe(1);
+    expect(parsed.data).toHaveLength(1);
+    expect(parsed.data[0].session_id).toBe('sess-on-board');
+    expect(parsed.data[0]).not.toHaveProperty('mcp_token');
+  });
 });
 
 describe('agor_sessions_get', () => {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -133,6 +133,18 @@ function filterSessionsByBranch<T extends { branch_id?: string }>(
   return { ...result, data, total: data.length };
 }
 
+function filterSessionsByBoard<T extends { branch_board_id?: string | null }>(
+  result: T[] | { data: T[]; total?: number; [key: string]: unknown },
+  boardId: string
+): T[] | { data: T[]; total?: number; [key: string]: unknown } {
+  if (Array.isArray(result)) {
+    return result.filter((session) => session.branch_board_id === boardId);
+  }
+
+  const data = result.data.filter((session) => session.branch_board_id === boardId);
+  return { ...result, data, total: data.length };
+}
+
 function redactSessionForMcp<T extends { mcp_token?: unknown }>(session: T): Omit<T, 'mcp_token'> {
   const { mcp_token: _mcpToken, ...safeSession } = session;
   return safeSession;
@@ -190,12 +202,14 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const query: Record<string, unknown> = {};
-      // When sessionType is set, skip service-level pagination (it runs before our filter)
-      // and apply the requested limit ourselves after filtering.
+      // When sessionType or boardId is set, skip service-level pagination
+      // (it runs before our post-query filters) and apply the requested limit
+      // ourselves after filtering.
       const requestedLimit = args.limit;
-      if (!args.sessionType && requestedLimit) query.$limit = requestedLimit;
+      const boardId = args.boardId ? await resolveBoardId(ctx, args.boardId) : undefined;
+      const needsPostQueryLimit = Boolean(args.sessionType || boardId);
+      if (!needsPostQueryLimit && requestedLimit) query.$limit = requestedLimit;
       if (args.status) query.status = args.status;
-      if (args.boardId) query.board_id = await resolveBoardId(ctx, args.boardId);
       const branchId = args.branchId ? await resolveBranchId(ctx, args.branchId) : undefined;
       if (branchId) query.branch_id = branchId;
       if (args.archived === true) {
@@ -203,35 +217,44 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       } else if (!args.includeArchived) {
         query.archived = false;
       }
-      const result = await ctx.app.service('sessions').find({ query, ...ctx.baseServiceParams });
+      const result = await ctx.app.service('sessions').find({
+        query: needsPostQueryLimit ? { ...query, $limit: 10000 } : query,
+        ...ctx.baseServiceParams,
+      });
 
       // Defense-in-depth: the sessions service normally handles branch_id in
       // its query filter, but MCP callers rely on this tool contract. Keep the
       // response scoped even if an adapter/hook layer drops or rewrites the
       // query before it reaches the repository.
       const branchScopedResult = branchId ? filterSessionsByBranch(result, branchId) : result;
+      const boardScopedResult = boardId
+        ? filterSessionsByBoard(branchScopedResult, boardId)
+        : branchScopedResult;
 
-      // Apply sessionType filter (post-query since custom_context/scheduled_from_branch aren't in query schema)
-      if (args.sessionType) {
-        const targetType = args.sessionType as SessionType;
-        const filterFn = (s: Session) => getSessionType(s) === targetType;
-        const allData: Session[] = Array.isArray(branchScopedResult)
-          ? branchScopedResult
-          : branchScopedResult.data;
-        const filtered = allData.filter(filterFn);
+      // Apply post-query filters. sessionType is derived from fields that are
+      // not in the query schema. boardId is exposed on Session as
+      // branch_board_id via the branch join, not sessions.board_id (legacy
+      // column is null for branch-backed sessions).
+      if (needsPostQueryLimit) {
+        const allData: Session[] = Array.isArray(boardScopedResult)
+          ? boardScopedResult
+          : boardScopedResult.data;
+        const filtered = args.sessionType
+          ? allData.filter((s) => getSessionType(s) === (args.sessionType as SessionType))
+          : allData;
         const limited = requestedLimit ? filtered.slice(0, requestedLimit) : filtered;
 
-        if (Array.isArray(branchScopedResult)) {
+        if (Array.isArray(boardScopedResult)) {
           return textResult(limited.map(redactSessionForMcp));
         }
         return textResult({
-          ...branchScopedResult,
+          ...boardScopedResult,
           data: limited.map(redactSessionForMcp),
           total: filtered.length,
         });
       }
 
-      return textResult(redactSessionFindResult(branchScopedResult));
+      return textResult(redactSessionFindResult(boardScopedResult));
     }
   );
 
@@ -1243,7 +1266,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // Build service query for non-archived sessions
       const query: Record<string, unknown> = { archived: false };
       if (args.status) query.status = args.status;
-      if (args.boardId) query.board_id = await resolveBoardId(ctx, args.boardId);
+      const boardId = args.boardId ? await resolveBoardId(ctx, args.boardId) : undefined;
       if (args.branchId) query.branch_id = await resolveBranchId(ctx, args.branchId);
 
       // Fetch all matching sessions (paginate through all results)
@@ -1267,6 +1290,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         : null;
 
       const toArchive = allSessions.filter((s) => {
+        if (boardId && s.branch_board_id !== boardId) return false;
         if (args.sessionType && getSessionType(s) !== args.sessionType) return false;
         if (cutoffDate) {
           const lastUpdated = new Date(s.last_updated || s.created_at);

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -34,6 +34,15 @@ import {
   resolveMcpServerId,
   resolveSessionId,
 } from '../resolve-ids.js';
+import {
+  mcpLimit,
+  mcpOptionalId,
+  mcpOptionalNonEmptyString,
+  mcpOptionalPositiveInt,
+  mcpOptionalString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
 import type { McpContext } from '../server.js';
 import { sessionContextRequiredResult, textResult } from '../server.js';
 import { listAttachedMcpServers } from './mcp-servers.js';
@@ -57,7 +66,7 @@ import { listAttachedMcpServers } from './mcp-servers.js';
  *
  * IMPORTANT — no `.transform()` here. Zod's JSON-Schema converter
  * (`zod/v4-mini`'s `toJSONSchema`, used in `mcp/server.ts` to populate the
- * cached registry consumed by `agor_search_tools(detail:"full")`) throws on
+ * cached registry consumed by `agor_get_tool_details`) throws on
  * transforms with "Transforms cannot be represented in JSON Schema". The
  * catch in `server.ts` then degrades the WHOLE containing tool schema to
  * `{ type: 'object' }`, hiding every input parameter from MCP clients. So
@@ -70,25 +79,26 @@ const modelConfigObjectSchema = z.object({
   mode: z.enum(['alias', 'exact']).optional().describe("Model selection mode (default: 'alias')"),
   // .min(1): reject empty-string model explicitly so callers don't silently
   // fall through to user defaults when they meant to pin a specific model.
-  model: z
-    .string()
-    .min(1)
-    .describe("Model identifier (e.g. 'claude-opus-4-6', 'claude-sonnet-4-6')"),
+  model: mcpRequiredString(
+    'modelConfig.model',
+    "Model identifier (e.g. 'claude-opus-4-6', 'claude-sonnet-4-6')"
+  ),
   effort: z
     .enum(['low', 'medium', 'high', 'max'])
     .optional()
     .describe('Reasoning effort level (default: high)'),
-  provider: z.string().optional().describe("Provider ID (OpenCode only, e.g. 'anthropic')"),
+  provider: mcpOptionalString(
+    'modelConfig.provider',
+    "Provider ID (OpenCode only, e.g. 'anthropic')"
+  ),
 });
 
 const modelConfigInputSchema = z
   .union([
-    z
-      .string()
-      .min(1)
-      .describe(
-        "Shorthand: just the model ID string (e.g. 'claude-opus-4-6'). Equivalent to { model: <id> }."
-      ),
+    mcpRequiredString(
+      'modelConfig',
+      "Shorthand: just the model ID string (e.g. 'claude-opus-4-6'). Equivalent to { model: <id> }."
+    ),
     modelConfigObjectSchema,
   ])
   .optional()
@@ -147,13 +157,17 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         'List all sessions accessible to the current user. Each session includes a `url` field with a clickable link to view the session in the UI.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        limit: z.number().optional().describe('Maximum number of sessions to return (default: 50)'),
+        limit: mcpLimit(50),
         status: z
           .enum(['idle', 'running', 'completed', 'failed'])
           .optional()
           .describe('Filter by session status'),
-        boardId: z.string().optional().describe('Filter sessions by board ID (UUIDv7 or short ID)'),
-        branchId: z.string().optional().describe('Filter sessions by branch ID'),
+        boardId: mcpOptionalId(
+          'boardId',
+          'Board',
+          'Filter sessions by board ID (UUIDv7 or short ID)'
+        ),
+        branchId: mcpOptionalId('branchId', 'Branch', 'Filter sessions by branch ID'),
         includeArchived: z
           .boolean()
           .optional()
@@ -229,7 +243,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         'Get detailed information about a specific session, including genealogy, current state, and the MCP servers currently attached to it (with OAuth status — check `attached_mcp_servers[].oauth_authenticated` to spot servers needing auth). The response includes a `url` field with a clickable link to view the session in the UI.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        sessionId: z.string().describe('Session ID (UUIDv7 or short ID like 01a1b2c3)'),
+        sessionId: mcpRequiredId(
+          'sessionId',
+          'Session',
+          'Session ID (UUIDv7 or short ID like 01a1b2c3)'
+        ),
       }),
     },
     async (args) => {
@@ -516,11 +534,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       description:
         'Spawn a child session (subsession) for delegating work to another agent. Inherits the current branch and tracks parent-child genealogy. Use for subtasks like "run tests", "review this code", or "fix linting errors". Configuration is inherited from parent (same agent) or user defaults (different agent).',
       inputSchema: z.object({
-        prompt: z.string().describe('The prompt/task for the subsession agent to execute'),
-        title: z
-          .string()
-          .optional()
-          .describe('Optional title for the session (defaults to first 100 chars of prompt)'),
+        prompt: mcpRequiredString('prompt', 'The prompt/task for the subsession agent to execute'),
+        title: mcpOptionalNonEmptyString(
+          'title',
+          'Optional title for the session (defaults to first 100 chars of prompt)'
+        ),
         agenticTool: z
           .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'cursor'])
           .optional()
@@ -537,13 +555,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .boolean()
           .optional()
           .describe('Include original spawn prompt in callback (default: false)'),
-        extraInstructions: z
-          .string()
-          .optional()
-          .describe('Extra instructions appended to spawn prompt'),
-        taskId: z.string().optional().describe('Optional task ID to link the spawned session to'),
+        extraInstructions: mcpOptionalString(
+          'extraInstructions',
+          'Extra instructions appended to spawn prompt'
+        ),
+        taskId: mcpOptionalId('taskId', 'Task', 'Optional task ID to link the spawned session to'),
         mcpServerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('mcpServerIds[]', 'MCP server'))
           .optional()
           .describe(
             'MCP server IDs to attach. Overrides parent session inheritance. Omit to inherit from parent. Pass empty array for no MCPs.'
@@ -599,8 +617,12 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       description:
         'Prompt an existing session to continue work. Supports four modes: continue (append to conversation), fork (branch at decision point), subsession (delegate to child agent), or btw (ephemeral fork — ask a side question without disrupting the target session, even if running). Configuration is inherited from parent session or user defaults.',
       inputSchema: z.object({
-        sessionId: z.string().describe('Session ID to prompt (UUIDv7 or short ID)'),
-        prompt: z.string().describe('The prompt/task to execute'),
+        sessionId: mcpRequiredId(
+          'sessionId',
+          'Session',
+          'Session ID to prompt (UUIDv7 or short ID)'
+        ),
+        prompt: mcpRequiredString('prompt', 'The prompt/task to execute'),
         mode: z
           .enum(['continue', 'fork', 'subsession', 'btw'])
           .describe(
@@ -612,10 +634,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Agent for subsession (subsession mode only, defaults to parent agent). Fork mode always uses parent agent.'
           ),
-        title: z.string().optional().describe('Session title (for fork/subsession only)'),
-        taskId: z.string().optional().describe('Fork/spawn point task ID (optional)'),
+        title: mcpOptionalNonEmptyString('title', 'Session title (for fork/subsession only)'),
+        taskId: mcpOptionalId('taskId', 'Task', 'Fork/spawn point task ID (optional)'),
         mcpServerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('mcpServerIds[]', 'MCP server'))
           .optional()
           .describe(
             'MCP server IDs for subsession mode. Overrides parent inheritance. Omit to inherit from parent. Pass empty array for no MCPs.'
@@ -764,32 +786,35 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       description:
         'Create a new session in an existing branch. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
       inputSchema: z.object({
-        branchId: z.string().describe('Branch ID where the session will run (required)'),
+        branchId: mcpRequiredId(
+          'branchId',
+          'Branch',
+          'Branch ID where the session will run (required)'
+        ),
         agenticTool: z
           .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'cursor'])
           .describe('Which agent to use for this session (required)'),
-        title: z.string().optional().describe('Session title (optional)'),
-        description: z.string().optional().describe('Session description (optional)'),
+        title: mcpOptionalNonEmptyString('title', 'Session title (optional)'),
+        description: mcpOptionalString('description', 'Session description (optional)'),
         contextFiles: z
-          .array(z.string())
+          .array(mcpRequiredString('contextFiles[]', 'Context file path'))
           .optional()
           .describe('Context file paths to load (optional)'),
-        initialPrompt: z
-          .string()
-          .optional()
-          .describe('Initial prompt to execute immediately after creating the session (optional)'),
+        initialPrompt: mcpRequiredString(
+          'initialPrompt',
+          'Initial prompt to execute immediately after creating the session (optional)'
+        ).optional(),
         enableCallback: z
           .boolean()
           .optional()
           .describe(
             'Enable callback to the creating session when the new session completes (default: false). When true, the creating session will receive a completion notification.'
           ),
-        callbackSessionId: z
-          .string()
-          .optional()
-          .describe(
-            'Session ID to notify on completion (defaults to the current/creating session when enableCallback is true)'
-          ),
+        callbackSessionId: mcpOptionalId(
+          'callbackSessionId',
+          'Session',
+          'Session ID to notify on completion (defaults to the current/creating session when enableCallback is true)'
+        ),
         includeLastMessage: z
           .boolean()
           .optional()
@@ -807,7 +832,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             'Callback firing mode: "once" (default) fires on first completion then auto-disables, "persistent" fires on every completion'
           ),
         mcpServerIds: z
-          .array(z.string())
+          .array(mcpRequiredId('mcpServerIds[]', 'MCP server'))
           .optional()
           .describe(
             'MCP server IDs to attach. Overrides branch and user default inheritance. Omit to use branch config > user defaults.'
@@ -988,9 +1013,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         'Update session metadata (title, description, status, archived, callback config). Useful for agents to self-document their work or manage callback settings.',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
-        sessionId: z.string().describe('Session ID to update (UUIDv7 or short ID)'),
-        title: z.string().optional().describe('New session title (optional)'),
-        description: z.string().optional().describe('New session description (optional)'),
+        sessionId: mcpRequiredId(
+          'sessionId',
+          'Session',
+          'Session ID to update (UUIDv7 or short ID)'
+        ),
+        title: mcpOptionalString('title', 'New session title (optional)'),
+        description: mcpOptionalString('description', 'New session description (optional)'),
         status: z
           .enum(['idle', 'running', 'completed', 'failed'])
           .optional()
@@ -1059,7 +1088,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         'Archive a session (soft delete). Archived sessions are hidden from listings by default but can be restored. By default, all child sessions (forks and subsessions) are also archived. Set includeChildren to false to archive only the target session.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        sessionId: z.string().describe('Session ID to archive (UUIDv7 or short ID)'),
+        sessionId: mcpRequiredId(
+          'sessionId',
+          'Session',
+          'Session ID to archive (UUIDv7 or short ID)'
+        ),
         includeChildren: z
           .boolean()
           .optional()
@@ -1116,7 +1149,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       description:
         'Restore a previously archived session. By default, all child sessions are also unarchived. Set includeChildren to false to unarchive only the target session.',
       inputSchema: z.object({
-        sessionId: z.string().describe('Session ID to unarchive (UUIDv7 or short ID)'),
+        sessionId: mcpRequiredId(
+          'sessionId',
+          'Session',
+          'Session ID to unarchive (UUIDv7 or short ID)'
+        ),
         includeChildren: z
           .boolean()
           .optional()
@@ -1180,19 +1217,18 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .describe(
             "Filter by session type. 'gateway' = messaging integrations, 'scheduled' = cron-triggered, 'agent' = manually created."
           ),
-        olderThanDays: z
-          .number()
-          .int()
-          .positive()
-          .max(365)
-          .optional()
-          .describe('Only archive sessions last updated more than this many days ago'),
+        olderThanDays: mcpOptionalPositiveInt(
+          'olderThanDays',
+          'Only archive sessions last updated more than this many days ago'
+        ).refine((value) => value === undefined || value <= 365, {
+          message: 'olderThanDays must be less than or equal to 365.',
+        }),
         status: z
           .enum(['idle', 'running', 'completed', 'failed'])
           .optional()
           .describe('Only archive sessions with this status'),
-        boardId: z.string().optional().describe('Only archive sessions on this board'),
-        branchId: z.string().optional().describe('Only archive sessions in this branch'),
+        boardId: mcpOptionalId('boardId', 'Board', 'Only archive sessions on this board'),
+        branchId: mcpOptionalId('branchId', 'Branch', 'Only archive sessions in this branch'),
         dryRun: z
           .boolean()
           .optional()
@@ -1299,13 +1335,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         'Stop a running session. Kills the executor process and sets the session to idle. Use this for emergency stops, timeout-based cancellation, or human-in-the-loop gates. Only works on sessions in active states (running, awaiting_permission, stopping).',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
-        sessionId: z.string().describe('Session ID to stop (UUIDv7 or short ID)'),
-        reason: z
-          .string()
-          .optional()
-          .describe(
-            'Audit log reason for the stop (e.g. "timeout", "user requested", "safety gate")'
-          ),
+        sessionId: mcpRequiredId('sessionId', 'Session', 'Session ID to stop (UUIDv7 or short ID)'),
+        reason: mcpOptionalString(
+          'reason',
+          'Audit log reason for the stop (e.g. "timeout", "user requested", "safety gate")'
+        ),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/tasks.ts
+++ b/apps/agor-daemon/src/mcp/tools/tasks.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { resolveSessionId } from '../resolve-ids.js';
+import { mcpLimit, mcpOptionalId, mcpRequiredId } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -12,8 +13,8 @@ export function registerTaskTools(server: McpServer, ctx: McpContext): void {
       description: 'List tasks (user prompts) in a session',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        sessionId: z.string().optional().describe('Session ID to get tasks from'),
-        limit: z.number().optional().describe('Maximum number of results (default: 50)'),
+        sessionId: mcpOptionalId('sessionId', 'Session', 'Session ID to get tasks from'),
+        limit: mcpLimit(50),
       }),
     },
     async (args) => {
@@ -32,7 +33,7 @@ export function registerTaskTools(server: McpServer, ctx: McpContext): void {
       description: 'Get detailed information about a specific task',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
-        taskId: z.string().describe('Task ID (UUIDv7 or short ID)'),
+        taskId: mcpRequiredId('taskId', 'Task'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/mcp/tools/users.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.test.ts
@@ -193,7 +193,7 @@ describe('user MCP tools in sessionless context', () => {
     });
 
     if (!handler) throw new Error('agor_users_find was not registered');
-    const result = await handler({ query: 'Reed' });
+    const result = await handler({ search: 'Reed' });
     const parsed = JSON.parse(result.content[0].text);
 
     expect(findUsers).toHaveBeenCalledWith({
@@ -264,5 +264,49 @@ describe('user MCP tools in sessionless context', () => {
     expect(parsed.total).toBe(1);
     expect(parsed.limit).toBe(5);
     expect(parsed.data.map((user: { user_id: string }) => user.user_id)).toEqual(['user-2']);
+  });
+});
+
+describe('user MCP input schemas', () => {
+  it('rejects aliases and malformed required fields with caller-oriented messages', () => {
+    const configs = new Map<string, { inputSchema: { safeParse: (args: unknown) => unknown } }>();
+    const fakeServer = {
+      registerTool: (
+        name: string,
+        cfg: { inputSchema: { safeParse: (args: unknown) => unknown } },
+        _cb: ToolHandler
+      ) => {
+        configs.set(name, cfg);
+      },
+    } as unknown as McpServer;
+
+    registerUserTools(fakeServer, {
+      app: { service: () => ({}) } as any,
+      db: {} as any,
+      userId: 'admin-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'admin-1', email: 'admin@example.com', role: 'admin' } as any,
+      baseServiceParams: {},
+    });
+
+    const listWithAlias = configs.get('agor_users_list')?.inputSchema.safeParse({ query: 'reed' });
+    expect(listWithAlias).toMatchObject({ success: false });
+    expect(JSON.stringify(listWithAlias)).toContain('query');
+
+    const badLimit = configs
+      .get('agor_users_find')
+      ?.inputSchema.safeParse({ search: 'reed', limit: 0 });
+    expect(badLimit).toMatchObject({ success: false });
+    expect(JSON.stringify(badLimit)).toContain('limit must be greater than 0');
+
+    const emptyCreateEmail = configs
+      .get('agor_user_create')
+      ?.inputSchema.safeParse({ email: '', password: 'secret' });
+    expect(emptyCreateEmail).toMatchObject({ success: false });
+    expect(JSON.stringify(emptyCreateEmail)).toContain('email cannot be empty');
+
+    const emptyUserId = configs.get('agor_users_get')?.inputSchema.safeParse({ userId: '' });
+    expect(emptyUserId).toMatchObject({ success: false });
+    expect(JSON.stringify(emptyUserId)).toContain('userId cannot be empty');
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/users.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.ts
@@ -1,6 +1,7 @@
 import { ROLES, type User } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { mcpOptionalString, mcpRequiredId, mcpRequiredString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
 
@@ -50,36 +51,25 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       description:
         'List users in the system with pagination and optional case-insensitive search across name, email, and unix_username. Returns compact rows by default; pass lean:false for detailed user payloads.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
+      inputSchema: z.strictObject({
         limit: z
-          .number()
-          .int()
-          .nonnegative()
-          .max(USER_QUERY_LIMIT_MAX)
+          .number({ error: 'limit must be a positive integer when provided.' })
+          .int('limit must be an integer.')
+          .positive('limit must be greater than 0.')
+          .max(USER_QUERY_LIMIT_MAX, `limit must be less than or equal to ${USER_QUERY_LIMIT_MAX}.`)
           .optional()
           .describe('Maximum number of results (default: 50)'),
         skip: z
-          .number()
-          .int()
-          .nonnegative()
-          .max(USER_QUERY_LIMIT_MAX)
+          .number({ error: 'skip must be a non-negative integer when provided.' })
+          .int('skip must be an integer.')
+          .nonnegative('skip must be greater than or equal to 0.')
+          .max(USER_QUERY_LIMIT_MAX, `skip must be less than or equal to ${USER_QUERY_LIMIT_MAX}.`)
           .optional()
           .describe('Number of results to skip'),
-        offset: z
-          .number()
-          .int()
-          .nonnegative()
-          .max(USER_QUERY_LIMIT_MAX)
-          .optional()
-          .describe('Alias for skip'),
-        search: z
-          .string()
-          .optional()
-          .describe('Case-insensitive search across name, email, and unix_username'),
-        query: z
-          .string()
-          .optional()
-          .describe('Alias for search; case-insensitive name/email/unix_username lookup'),
+        search: mcpOptionalString(
+          'search',
+          'Case-insensitive search across name, email, and unix_username'
+        ),
         lean: z
           .boolean()
           .optional()
@@ -93,10 +83,9 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const query: Record<string, unknown> = {
         $limit: args.limit ?? 50,
-        $skip: args.skip ?? args.offset ?? 0,
+        $skip: args.skip ?? 0,
       };
       if (args.search) query.search = args.search;
-      if (args.query) query.search = args.query;
 
       const users = (await ctx.app.service('users').find({
         query,
@@ -114,29 +103,28 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       description:
         'Find users by name, email, or unix_username. Useful before admin updates: returns compact matching rows with user_id. Pass email when available; matching is case-insensitive substring.',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        search: z
-          .string()
-          .optional()
-          .describe('Case-insensitive search across name, email, and unix_username'),
-        query: z.string().optional().describe('Alias for search'),
-        email: z.string().optional().describe('Email to search for (case-insensitive substring)'),
-        name: z.string().optional().describe('Name to search for (case-insensitive substring)'),
-        unix_username: z
-          .string()
-          .optional()
-          .describe('Unix username to search for (case-insensitive substring)'),
+      inputSchema: z.strictObject({
+        search: mcpOptionalString(
+          'search',
+          'Case-insensitive search across name, email, and unix_username'
+        ),
+        email: mcpOptionalString('email', 'Email to search for (case-insensitive substring)'),
+        name: mcpOptionalString('name', 'Name to search for (case-insensitive substring)'),
+        unix_username: mcpOptionalString(
+          'unix_username',
+          'Unix username to search for (case-insensitive substring)'
+        ),
         limit: z
-          .number()
-          .int()
-          .nonnegative()
-          .max(USER_QUERY_LIMIT_MAX)
+          .number({ error: 'limit must be a positive integer when provided.' })
+          .int('limit must be an integer.')
+          .positive('limit must be greater than 0.')
+          .max(USER_QUERY_LIMIT_MAX, `limit must be less than or equal to ${USER_QUERY_LIMIT_MAX}.`)
           .optional()
           .describe('Maximum number of matches (default: 10)'),
       }),
     },
     async (args) => {
-      const genericTerms = [args.search, args.query].filter(
+      const genericTerms = [args.search].filter(
         (term): term is string => typeof term === 'string' && term.trim().length > 0
       );
       const fieldFilters = (
@@ -153,7 +141,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       const searchTerm = genericTerms[0] ?? firstFieldTerm;
 
       if (!searchTerm) {
-        throw new Error('Provide search, query, email, name, or unix_username');
+        throw new Error('Provide one of: search, email, name, or unix_username');
       }
 
       const requestedLimit = args.limit ?? 10;
@@ -191,8 +179,8 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     {
       description: 'Get detailed information about a specific user',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        userId: z.string().describe('User ID (UUIDv7)'),
+      inputSchema: z.strictObject({
+        userId: mcpRequiredId('userId', 'User', 'User ID (UUIDv7 or short ID)'),
       }),
     },
     async (args) => {
@@ -208,7 +196,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       description:
         'Get information about the current authenticated user (the user associated with this MCP session)',
       annotations: { readOnlyHint: true },
-      inputSchema: z.object({}),
+      inputSchema: z.strictObject({}),
     },
     async () => {
       const user = await ctx.app.service('users').get(ctx.userId, ctx.baseServiceParams);
@@ -223,10 +211,10 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       description:
         'Update the current user profile (name, emoji, avatar, preferences). Can only update own profile.',
       annotations: { idempotentHint: true },
-      inputSchema: z.object({
-        name: z.string().optional().describe('Display name'),
-        emoji: z.string().optional().describe('User emoji (single emoji character)'),
-        avatar: z.string().optional().describe('Avatar URL'),
+      inputSchema: z.strictObject({
+        name: mcpOptionalString('name', 'Display name'),
+        emoji: mcpOptionalString('emoji', 'User emoji (single emoji character)'),
+        avatar: mcpOptionalString('avatar', 'Avatar URL'),
         preferences: z
           .object({})
           .passthrough()
@@ -254,27 +242,27 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       description:
         'Update any user account (admin operation). Only updates fields that are provided. Can update email, name, role, password, unix_username, must_change_password, emoji, avatar, and preferences.',
       annotations: { idempotentHint: true },
-      inputSchema: z.object({
-        userId: z.string().describe('User ID to update (UUIDv7 or short ID)'),
-        email: z.string().optional().describe('New email address (optional)'),
-        name: z.string().optional().describe('New display name (optional)'),
-        password: z.string().optional().describe('New password (optional, will be hashed)'),
+      inputSchema: z.strictObject({
+        userId: mcpRequiredId('userId', 'User', 'User ID to update (UUIDv7 or short ID)'),
+        email: mcpOptionalString('email', 'New email address (optional)'),
+        name: mcpOptionalString('name', 'New display name (optional)'),
+        password: mcpOptionalString('password', 'New password (optional, will be hashed)'),
         role: z
           .enum([ROLES.SUPERADMIN, ROLES.ADMIN, ROLES.MEMBER, ROLES.VIEWER])
           .optional()
           .describe(
             'New user role (optional). superadmin=full system access + branch RBAC bypass, admin=manage resources, member=standard user, viewer=read-only'
           ),
-        unix_username: z
-          .string()
-          .optional()
-          .describe('New Unix username for shell access (optional)'),
+        unix_username: mcpOptionalString(
+          'unix_username',
+          'New Unix username for shell access (optional)'
+        ),
         must_change_password: z
           .boolean()
           .optional()
           .describe('Force user to change password on next login (optional)'),
-        emoji: z.string().optional().describe('User emoji (optional, single emoji character)'),
-        avatar: z.string().optional().describe('Avatar URL (optional)'),
+        emoji: mcpOptionalString('emoji', 'User emoji (optional, single emoji character)'),
+        avatar: mcpOptionalString('avatar', 'Avatar URL (optional)'),
         preferences: z
           .object({})
           .passthrough()
@@ -296,7 +284,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       if (args.preferences !== undefined) updateData.preferences = args.preferences;
 
       if (Object.keys(updateData).length === 0) {
-        throw new Error('at least one field must be provided to update');
+        throw new Error('Provide at least one update field.');
       }
 
       const updatedUser = await ctx.app
@@ -312,21 +300,19 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
     {
       description:
         'Create a new user account. Requires email and password. Optionally set name, emoji, avatar, unix_username, must_change_password, and role.',
-      inputSchema: z.object({
-        email: z.string().describe('User email address (must be unique)'),
-        password: z.string().describe('User password (will be hashed)'),
-        name: z.string().optional().describe('Display name (optional)'),
-        emoji: z
-          .string()
-          .optional()
-          .describe('User emoji for visual identity (optional, single emoji character)'),
-        avatar: z.string().optional().describe('Avatar URL (optional)'),
-        unix_username: z
-          .string()
-          .optional()
-          .describe(
-            'Unix username for shell access (optional, defaults to email prefix if not specified)'
-          ),
+      inputSchema: z.strictObject({
+        email: mcpRequiredString('email', 'User email address (must be unique)'),
+        password: mcpRequiredString('password', 'User password (will be hashed)'),
+        name: mcpOptionalString('name', 'Display name (optional)'),
+        emoji: mcpOptionalString(
+          'emoji',
+          'User emoji for visual identity (optional, single emoji character)'
+        ),
+        avatar: mcpOptionalString('avatar', 'Avatar URL (optional)'),
+        unix_username: mcpOptionalString(
+          'unix_username',
+          'Unix username for shell access (optional, defaults to email prefix if not specified)'
+        ),
         must_change_password: z
           .boolean()
           .optional()

--- a/apps/agor-daemon/src/utils/sandpack-config.ts
+++ b/apps/agor-daemon/src/utils/sandpack-config.ts
@@ -382,6 +382,6 @@ function renderUpgradeInstructions(input: {
     `  - required_env_vars: ${envVarsLine}`,
     `  - agor_grants: ${grantsLine}`,
     '',
-    'Use agor_search_tools for the full publish/get tool schemas.',
+    'Use agor_get_tool_details for the exact publish/get tool schemas.',
   ].join('\n');
 }


### PR DESCRIPTION
## Summary

Fixes #1347 by improving the MCP wrapper/runtime error path and doing a broader MCP schema pass without adding fuzzy aliases.

- Adds shared MCP Zod schema helpers for required/optional IDs, strings, numbers, limits, and offsets with caller-oriented validation messages.
- Keeps canonical payloads strict (`tool_name`, `arguments`) and improves `agor_execute_tool` runtime errors when `tool_name` is missing or unknown, pointing callers to discovery/detail tools.
- Adds progressive disclosure for MCP tools: `agor_search_tools` for domains/summaries, new `agor_get_tool_details` for exact schemas, and `agor_execute_tool` for invocation.
- Migrates MCP tool domains to the shared schema helpers and adds focused regression coverage across sessions, branches, boards, cards, messages, users, schedules, artifacts, proxies, knowledge, and search.
- Updates prompt/system guidance to keep top-level tools small and guide agents toward search → details → execute.

## Root cause

The reported failure was a malformed `agor_execute_tool` call: the wrapper was invoked without the required canonical `tool_name` string. The old Zod error was technically correct, but not actionable enough for agents. This PR keeps the schema strict rather than accepting aliases, and makes the failure mode point to `agor_search_tools` / `agor_get_tool_details` so callers can recover quickly.

## Validation

- `pnpm i`
- `pnpm check` (passes; existing lint warnings remain warnings)
- `pnpm --filter @agor/daemon test src/mcp/tools/sessions.test.ts src/mcp/tools/search.test.ts src/mcp/tools/boards.test.ts src/mcp/tools/branches.test.ts src/mcp/tools/cards.test.ts src/mcp/tools/messages.test.ts src/mcp/tools/users.test.ts src/mcp/tools/schedules.test.ts src/mcp/tools/artifacts.test.ts src/mcp/tools/proxies.test.ts src/mcp/tools/knowledge.test.ts src/mcp/tools/environment.test.ts src/mcp/tools/mcp-servers.test.ts` — 13 files / 95 tests passed
