### PR TITLE
Restrict config key resolution

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -31,6 +31,7 @@ import type {
   MCPAuth,
   MCPServerID,
   MessageSource,
+  Params,
   SessionID,
   UserID,
 } from '@agor/core/types';
@@ -443,8 +444,13 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
 
   app.use('/config/resolve-api-key', {
     // biome-ignore lint/suspicious/noExplicitAny: taskId is branded UUID at runtime
-    async create(data: any) {
-      return await configService.resolveApiKey(data);
+    async create(data: any, params?: Params) {
+      return await configService.resolveApiKey(data, params);
+    },
+  });
+  app.service('/config/resolve-api-key').hooks({
+    before: {
+      create: [ctx.requireAuth],
     },
   });
 

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configMocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(async () => ({})),
+  saveConfig: vi.fn(async () => undefined),
+  resolveApiKey: vi.fn(),
+}));
+
+vi.mock('@agor/core/config', () => configMocks);
+
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import type { TaskID, UserID } from '@agor/core/types';
+import { ConfigService } from './config.js';
+
+describe('ConfigService.resolveApiKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMocks.resolveApiKey.mockResolvedValue({
+      apiKey: 'resolved-test-key',
+      source: 'user',
+      useNativeAuth: false,
+    });
+  });
+
+  it('rejects unauthenticated external callers before resolving secrets', async () => {
+    const service = new ConfigService({} as never);
+
+    await expect(
+      service.resolveApiKey({ taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY' }, {
+        provider: 'rest',
+      } as never)
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+
+    expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects authenticated non-service external callers before resolving secrets', async () => {
+    const service = new ConfigService({} as never);
+
+    await expect(
+      service.resolveApiKey({ taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY' }, {
+        provider: 'rest',
+        user: { user_id: 'user-1' },
+      } as never)
+    ).rejects.toBeInstanceOf(Forbidden);
+
+    expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('allows executor service accounts and resolves for the task creator', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      service(name: string) {
+        expect(name).toBe('tasks');
+        return {
+          get: vi.fn(async () => ({ created_by: 'creator-1' as UserID })),
+        };
+      },
+    } as never;
+
+    const result = await service.resolveApiKey(
+      { taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY', tool: 'codex' },
+      {
+        provider: 'socketio',
+        user: { user_id: 'executor-service', _isServiceAccount: true },
+      } as never
+    );
+
+    expect(result).toEqual({
+      apiKey: 'resolved-test-key',
+      source: 'user',
+      useNativeAuth: false,
+    });
+    expect(configMocks.resolveApiKey).toHaveBeenCalledWith('OPENAI_API_KEY', {
+      userId: 'creator-1',
+      db: {},
+      tool: 'codex',
+    });
+  });
+});

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -8,7 +8,7 @@ const configMocks = vi.hoisted(() => ({
 
 vi.mock('@agor/core/config', () => configMocks);
 
-import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { TaskID, UserID } from '@agor/core/types';
 import { ConfigService } from './config.js';
 
@@ -43,6 +43,19 @@ describe('ConfigService.resolveApiKey', () => {
         user: { user_id: 'user-1' },
       } as never)
     ).rejects.toBeInstanceOf(Forbidden);
+
+    expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported key names before resolving secrets', async () => {
+    const service = new ConfigService({} as never);
+
+    await expect(
+      service.resolveApiKey({ taskId: 'task-1' as TaskID, keyName: 'UNRELATED_ENV_VAR' }, {
+        provider: 'socketio',
+        user: { user_id: 'executor-service', _isServiceAccount: true },
+      } as never)
+    ).rejects.toBeInstanceOf(BadRequest);
 
     expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
   });

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -14,8 +14,28 @@ import {
 } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
-import type { AgenticToolName, Params, TaskID, UserID } from '@agor/core/types';
+import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import type {
+  AgenticToolName,
+  AuthenticatedParams,
+  Params,
+  TaskID,
+  UserID,
+} from '@agor/core/types';
+
+const RESOLVABLE_API_KEY_NAMES: Record<ApiKeyName, true> = {
+  ANTHROPIC_API_KEY: true,
+  ANTHROPIC_AUTH_TOKEN: true,
+  CLAUDE_CODE_OAUTH_TOKEN: true,
+  OPENAI_API_KEY: true,
+  GEMINI_API_KEY: true,
+  COPILOT_GITHUB_TOKEN: true,
+  CURSOR_API_KEY: true,
+};
+
+function isResolvableApiKeyName(value: string): value is ApiKeyName {
+  return Object.hasOwn(RESOLVABLE_API_KEY_NAMES, value);
+}
 
 /**
  * Mask API keys for secure display
@@ -117,7 +137,7 @@ export class ConfigService {
     // executor service JWT; normal user/API-key auth may read masked config via
     // /config but must not resolve raw configured keys.
     if (params?.provider) {
-      const caller = (params as { user?: { _isServiceAccount?: boolean } }).user;
+      const caller = (params as AuthenticatedParams | undefined)?.user;
       if (!caller) {
         throw new NotAuthenticated('Authentication required');
       }
@@ -127,6 +147,9 @@ export class ConfigService {
     }
 
     const { taskId, keyName, tool } = data;
+    if (!isResolvableApiKeyName(keyName)) {
+      throw new BadRequest('Unsupported API key name');
+    }
 
     // Fetch task to get creator user ID
     let userId: UserID | undefined;
@@ -141,7 +164,7 @@ export class ConfigService {
     }
 
     // Use core resolveApiKey with database access
-    const result = await resolveApiKey(keyName as ApiKeyName, {
+    const result = await resolveApiKey(keyName, {
       userId,
       db: this.db,
       tool,

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -14,6 +14,7 @@ import {
 } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { AgenticToolName, Params, TaskID, UserID } from '@agor/core/types';
 
 /**
@@ -91,23 +92,40 @@ export class ConfigService {
    * This allows executors to request API key resolution without direct database access.
    * The service handles the precedence: user-level > config > env > native auth.
    *
-   * Called via: client.service('config').resolveApiKey({ taskId, keyName })
+   * Called via: client.service('config/resolve-api-key').create({ taskId, keyName })
    */
-  async resolveApiKey(data: {
-    taskId: TaskID;
-    keyName: string;
-    /**
-     * Restrict the per-user lookup to this tool's credential bucket. Executors
-     * always pass this; absent it, the resolver falls back to a cross-tool
-     * sweep (legacy behavior preserved for non-SDK callers).
-     */
-    tool?: AgenticToolName;
-  }): Promise<{
+  async resolveApiKey(
+    data: {
+      taskId: TaskID;
+      keyName: string;
+      /**
+       * Restrict the per-user lookup to this tool's credential bucket. Executors
+       * always pass this; absent it, the resolver falls back to a cross-tool
+       * sweep (legacy behavior preserved for non-SDK callers).
+       */
+      tool?: AgenticToolName;
+    },
+    params?: Params
+  ): Promise<{
     apiKey: string | null;
     source: 'user' | 'config' | 'env' | 'native';
     useNativeAuth: boolean;
     decryptionFailed?: boolean;
   }> {
+    // This method returns plaintext secret material and is only for trusted
+    // daemon/executor flows. External callers must authenticate with an
+    // executor service JWT; normal user/API-key auth may read masked config via
+    // /config but must not resolve raw configured keys.
+    if (params?.provider) {
+      const caller = (params as { user?: { _isServiceAccount?: boolean } }).user;
+      if (!caller) {
+        throw new NotAuthenticated('Authentication required');
+      }
+      if (caller._isServiceAccount !== true) {
+        throw new Forbidden('Only the executor service account may resolve API keys');
+      }
+    }
+
     const { taskId, keyName, tool } = data;
 
     // Fetch task to get creator user ID


### PR DESCRIPTION
## Summary

- require authenticated executor-service access for config key resolution
- keep internal daemon calls working while blocking regular external callers
- add focused coverage for allowed and denied resolver paths

## Checks

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/config.test.ts`
