### PR TITLE
Validate clone branch source refs before create

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -436,7 +436,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           'sourceBranch',
           'Base branch to fork from when creating a new branch (defaults to the repo default branch, usually "main"). ' +
             'The new branch will be created from the tip of this branch. ' +
-            'Must exist on the remote (origin) or locally.'
+            'Must exist on the remote (origin) for clone storage mode; worktree storage mode may also use local refs.'
         ),
         autoSuffix: z
           .boolean()

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -1,0 +1,88 @@
+import { assertRemoteRefVisibleForClone } from '@agor/core/git';
+import type { Application } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { ReposService } from './repos';
+
+vi.mock('@agor/core/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/db')>();
+
+  return {
+    ...actual,
+    BranchRepository: vi.fn().mockImplementation(function BranchRepository() {
+      return {
+        findActiveByRepoAndName: vi.fn(async () => null),
+        getAllUsedUniqueIds: vi.fn(async () => []),
+        addOwner: vi.fn(async () => undefined),
+      };
+    }),
+    RepoRepository: vi.fn().mockImplementation(function RepoRepository() {
+      return {
+        create: vi.fn(),
+        findById: vi.fn(),
+        findAll: vi.fn(async () => []),
+        update: vi.fn(),
+        delete: vi.fn(),
+        findBySlug: vi.fn(),
+      };
+    }),
+  };
+});
+
+vi.mock('@agor/core/git', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/git')>();
+
+  return {
+    ...actual,
+    assertRemoteRefVisibleForClone: vi.fn(),
+  };
+});
+
+describe('ReposService.createBranch clone preflight', () => {
+  it('rejects clone-mode local-only source refs before persisting branch state', async () => {
+    const branchesCreate = vi.fn();
+    const getGitEnvironment = vi.fn(async () => ({ GITHUB_TOKEN: 'gh_test_token_for_preflight' }));
+    vi.mocked(assertRemoteRefVisibleForClone).mockRejectedValueOnce(
+      new Error("Clone mode cannot clone local-only or missing branch 'local-only'")
+    );
+
+    const app = {
+      service(path: string) {
+        if (path === 'branches') return { create: branchesCreate };
+        if (path === 'users') return { getGitEnvironment };
+        throw new Error(`Unexpected service: ${path}`);
+      },
+    } as unknown as Application;
+
+    const service = new ReposService({} as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue({
+      repo_id: 'repo-1',
+      slug: 'org/repo',
+      remote_url: 'https://github.com/org/repo.git',
+      local_path: undefined,
+      default_branch: 'main',
+    } as never);
+
+    await expect(
+      service.createBranch(
+        'repo-1',
+        {
+          name: 'new-branch',
+          ref: 'new-branch',
+          createBranch: true,
+          sourceBranch: 'local-only',
+          storage_mode: 'clone',
+        },
+        { user: { user_id: 'user-1' } } as never
+      )
+    ).rejects.toThrow(/Clone mode cannot clone local-only/);
+
+    expect(getGitEnvironment).toHaveBeenCalledWith({ userId: 'user-1' }, expect.any(Object));
+    expect(assertRemoteRefVisibleForClone).toHaveBeenCalledWith({
+      remoteUrl: 'https://github.com/org/repo.git',
+      ref: 'local-only',
+      refType: 'branch',
+      env: { GITHUB_TOKEN: 'gh_test_token_for_preflight' },
+    });
+    expect(branchesCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -26,6 +26,7 @@ import { BranchRepository, type Database, RepoRepository, shortId } from '@agor/
 import { autoAssignBranchUniqueId } from '@agor/core/environment/variable-resolver';
 import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
+  assertRemoteRefVisibleForClone,
   getBranchPath,
   getDefaultBranch,
   getRemoteUrl,
@@ -649,11 +650,34 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         );
       }
     }
-    if (storageMode === 'clone' && !repo.remote_url) {
-      throw new Error(
-        `Cannot create a clone-mode branch for repo '${repo.slug}': repo has no remote_url. ` +
-          `Use storage_mode='worktree' or register the repo with a remote first.`
-      );
+    // Auth hooks (`requireMinimumRole`) guarantee `params.user` exists by
+    // the time we get here. Resolve it before clone preflight so private
+    // remotes can use the same per-user git credentials the executor will
+    // use for the eventual clone.
+    const userId = (params as AuthenticatedParams).user!.user_id as UserID;
+
+    if (storageMode === 'clone') {
+      if (!repo.remote_url) {
+        throw new Error(
+          `Cannot create a clone-mode branch for repo '${repo.slug}': repo has no remote_url. ` +
+            `Use storage_mode='worktree' or register the repo with a remote first.`
+        );
+      }
+      const cloneRemoteUrl = repo.remote_url;
+      const cloneRef = data.createBranch ? data.sourceBranch || data.ref : data.ref;
+      const usersService = this.app.service('users') as unknown as {
+        getGitEnvironment(
+          data: { userId: string },
+          params?: RepoParams
+        ): Promise<Record<string, string>>;
+      };
+      const gitEnv = await usersService.getGitEnvironment({ userId }, params);
+      await assertRemoteRefVisibleForClone({
+        remoteUrl: cloneRemoteUrl,
+        ref: cloneRef,
+        refType: data.refType || 'branch',
+        env: gitEnv,
+      });
     }
 
     if (repo.local_path) {
@@ -665,10 +689,13 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       }
     }
 
-    // NOTE: Filesystem / git-state preflights (target-dir-exists, source-ref
-    // existence, branch-already-checked-out) used to live here. They have
-    // moved to the executor / core helpers — they're git/filesystem facts,
-    // not DB facts. The executor surfaces failures via
+    // NOTE: Filesystem preflights (target-dir-exists,
+    // branch-already-checked-out) live in the executor / core helpers —
+    // they're filesystem facts, not DB facts. Clone-mode remote-ref
+    // visibility is deliberately checked above before persisting, because
+    // clone-mode cannot materialize local-only base branches and the async
+    // executor failure path otherwise leaves confusing placeholder state.
+    // The executor surfaces other materialization failures via
     // `filesystem_status='failed'` + `error_message`, which the UI already
     // renders cleanly. Daemon stays focused on DB/auth/config validation.
     // See `core.createBranch` / `createBranchAsClone` for the equivalent
@@ -711,10 +738,6 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       branchPath,
       repoLocalPath: repo.local_path,
     });
-
-    // Auth hooks (`requireMinimumRole`) guarantee `params.user` exists by
-    // the time we get here. Asserting non-null rather than re-checking.
-    const userId = (params as AuthenticatedParams).user!.user_id as UserID;
 
     // Get ALL used unique IDs (including archived branches) to avoid collisions.
     // Previously this queried via Feathers which excluded archived branches by default,

--- a/packages/core/src/git/index.test.ts
+++ b/packages/core/src/git/index.test.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { simpleGit } from 'simple-git';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  assertRemoteRefVisibleForClone,
   categorizeGitError,
   cloneRepo,
   createBranch,
@@ -1310,6 +1311,28 @@ describe('createBranchAsClone', () => {
     await git.commit('feature marker');
     await git.push('origin', 'feature-x');
   }
+
+  describe('assertRemoteRefVisibleForClone', () => {
+    it('accepts branches visible from the clone remote', async () => {
+      await seedRemoteWithBranches();
+
+      await expect(
+        assertRemoteRefVisibleForClone({ remoteUrl: remoteDir, ref: 'feature-x' })
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects local-only branches before clone-mode materialization', async () => {
+      await seedRemoteWithBranches();
+      const sourceDir = path.join(tempDir, 'local-only-source');
+      await simpleGit().clone(remoteDir, sourceDir);
+      const git = simpleGit(sourceDir);
+      await git.checkoutLocalBranch('local-only');
+
+      await expect(
+        assertRemoteRefVisibleForClone({ remoteUrl: remoteDir, ref: 'local-only' })
+      ).rejects.toThrow(/Clone mode cannot clone local-only or missing branch 'local-only'/);
+    });
+  });
 
   it('clones the requested branch into targetPath with a real .git/ directory', async () => {
     await seedRemoteWithBranches();

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -35,21 +35,29 @@ import { httpUrlHasUserinfo, redactUrlUserinfo, stripHttpUrlUserinfo } from '../
  * Callers must await this and bail out on rejection.
  */
 export async function validateGitRef(ref: unknown): Promise<void> {
+  await validateNamespacedGitRef(ref, 'heads', 'Invalid git ref');
+}
+
+async function validateNamespacedGitRef(
+  ref: unknown,
+  namespace: 'heads' | 'tags',
+  errorPrefix: string
+): Promise<void> {
   if (typeof ref !== 'string') {
-    throw new Error(`Invalid git ref: expected string, got ${typeof ref}`);
+    throw new Error(`${errorPrefix}: expected string, got ${typeof ref}`);
   }
   if (ref.length === 0) {
-    throw new Error('Invalid git ref: empty string');
+    throw new Error(`${errorPrefix}: empty string`);
   }
   if (ref.startsWith('-')) {
     throw new Error(
-      `Invalid git ref: refs starting with '-' are rejected to prevent option injection`
+      `${errorPrefix}: refs starting with '-' are rejected to prevent option injection`
     );
   }
   // Whitespace, newlines, NUL — none of these are valid in refs, and a
   // newline in particular lets an attacker smuggle a second command.
   if (/[\s\0]/.test(ref)) {
-    throw new Error('Invalid git ref: contains whitespace, newline, or NUL byte');
+    throw new Error(`${errorPrefix}: contains whitespace, newline, or NUL byte`);
   }
 
   // Final authoritative check: ask git itself.
@@ -66,9 +74,9 @@ export async function validateGitRef(ref: unknown): Promise<void> {
   // out of what is meant to be a pure syntactic check.
   const { git } = createGit();
   try {
-    await git.raw(['check-ref-format', `refs/heads/${ref}`]);
+    await git.raw(['check-ref-format', `refs/${namespace}/${ref}`]);
   } catch {
-    throw new Error(`Invalid git ref: rejected by git check-ref-format: ${ref}`);
+    throw new Error(`${errorPrefix}: rejected by git check-ref-format: ${ref}`);
   }
 }
 
@@ -1309,6 +1317,65 @@ export interface CreateBranchAsCloneResult {
    * `newBranchName` when set (post-checkout); otherwise equal to `ref`.
    */
   ref: string;
+}
+
+export interface AssertRemoteRefVisibleForCloneOptions {
+  /** Remote URL/path that clone-mode will pass to `git clone`. */
+  remoteUrl: string;
+  /** Branch/tag name that clone-mode will pass to `git clone --branch`. */
+  ref: string;
+  /** Which namespace to check. Defaults to branch refs. */
+  refType?: 'branch' | 'tag';
+  /** Per-user environment variables (GITHUB_TOKEN, GH_TOKEN, …). */
+  env?: Record<string, string>;
+}
+
+/**
+ * Preflight a clone-mode base ref before Agor persists any branch/session
+ * records. Clone mode can only materialise refs visible from the clone remote
+ * (typically `origin`); a local-only branch in the daemon's base clone is not
+ * cloneable via `git clone --branch`.
+ */
+export async function assertRemoteRefVisibleForClone(
+  options: AssertRemoteRefVisibleForCloneOptions
+): Promise<void> {
+  const remoteUrl = stripGitUrlCredentials(options.remoteUrl);
+  const refType = options.refType ?? 'branch';
+  const ref = options.ref;
+
+  if (!remoteUrl) {
+    throw new Error('remoteUrl is required');
+  }
+  if (refType === 'branch') {
+    await validateGitRef(ref);
+  } else {
+    await validateNamespacedGitRef(ref, 'tags', 'Invalid git tag ref');
+  }
+
+  const { git } = createGitForRemote(remoteUrl, options.env);
+  const namespace = refType === 'tag' ? 'refs/tags' : 'refs/heads';
+  let output: string;
+  try {
+    output = await git.listRemote([
+      refType === 'tag' ? '--tags' : '--heads',
+      remoteUrl,
+      `${namespace}/${ref}`,
+    ]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Cannot validate clone-mode ${refType} '${ref}' against remote ` +
+        `${redactGitUrlCredentials(remoteUrl)}: ${message}`
+    );
+  }
+
+  if (output.trim().length === 0) {
+    throw new Error(
+      `Clone mode cannot clone local-only or missing ${refType} '${ref}' because it is not visible on ` +
+        `the remote ${redactGitUrlCredentials(remoteUrl)}. Push '${ref}' to origin, choose a remote ` +
+        `${refType}, or use storage_mode='worktree' if it is enabled.`
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- add a clone-mode preflight that validates the requested clone base ref is visible from the repo remote before persisting branch state
- use the caller's resolved git environment for the preflight so private remotes follow the same credential path as executor clone operations
- surface a clear local-only/missing ref error with suggestions to push to origin, choose a remote ref, or use worktree mode when enabled
- update MCP branch tool copy and add focused git helper coverage for remote-visible vs local-only branches

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test src/git/index.test.ts -- -t assertRemoteRefVisibleForClone`
- `pnpm --filter @agor/core test src/git/index.test.ts`
