### PR TITLE
Refine realtime event delivery filtering

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -109,6 +109,10 @@ import {
 } from './utils/mcp-header-secrets.js';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
+import {
+  type RealtimeAccessBranchRepository,
+  RealtimeAccessCache,
+} from './utils/realtime-access-cache.js';
 import { configureRealtimePublish } from './utils/realtime-publish.js';
 import {
   ensureCurrentScheduleLoaded,
@@ -323,6 +327,39 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     } catch {
       return undefined;
     }
+  };
+
+  const realtimeAccessCache = new RealtimeAccessCache({
+    branchRepository: branchRepository as unknown as RealtimeAccessBranchRepository,
+    sessionsRepository,
+  });
+
+  const invalidateRealtimeBranchAccess = async (branchId: unknown): Promise<void> => {
+    if (typeof branchId !== 'string' || branchId.length === 0) return;
+    realtimeAccessCache.invalidateBranch(branchId);
+    try {
+      const branch = await branchRepository.findById(branchId);
+      if (branch) realtimeAccessCache.invalidateBranch(branch.branch_id);
+    } catch {
+      // Best-effort cache invalidation only.
+    }
+  };
+
+  const invalidateRealtimeBranchFromResult = async (context: HookContext): Promise<HookContext> => {
+    const branchId =
+      (context.result as { branch_id?: unknown } | undefined)?.branch_id ?? context.id;
+    await invalidateRealtimeBranchAccess(branchId);
+    return context;
+  };
+
+  const invalidateRealtimeBranchFromRoute = async (context: HookContext): Promise<HookContext> => {
+    await invalidateRealtimeBranchAccess(context.params.route?.id);
+    return context;
+  };
+
+  const clearRealtimeBranchVisibility = (context: HookContext): HookContext => {
+    realtimeAccessCache.clearVisibility();
+    return context;
   };
 
   // Helper to get usersService from app
@@ -926,8 +963,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               },
             ]
           : []),
+        invalidateRealtimeBranchFromResult,
       ],
       patch: [
+        invalidateRealtimeBranchFromResult,
         ...(branchRbacEnabled
           ? [
               async (context: HookContext) => {
@@ -994,6 +1033,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
       remove: [
+        invalidateRealtimeBranchFromResult,
         ...(branchRbacEnabled
           ? [
               async (context: HookContext) => {
@@ -1577,7 +1617,32 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // ============================================================================
 
   safeService('groups')?.hooks(groupsHooks);
+  safeService('groups')?.hooks({
+    after: {
+      patch: [clearRealtimeBranchVisibility],
+      remove: [clearRealtimeBranchVisibility],
+    },
+  });
   safeService('group-memberships')?.hooks(groupMembershipsHooks);
+  safeService('group-memberships')?.hooks({
+    after: {
+      create: [clearRealtimeBranchVisibility],
+      remove: [clearRealtimeBranchVisibility],
+    },
+  });
+  safeService('branches/:id/owners')?.hooks({
+    after: {
+      create: [invalidateRealtimeBranchFromRoute],
+      remove: [invalidateRealtimeBranchFromRoute],
+    },
+  });
+  safeService('branches/:id/group-grants')?.hooks({
+    after: {
+      create: [invalidateRealtimeBranchFromRoute],
+      patch: [invalidateRealtimeBranchFromRoute],
+      remove: [invalidateRealtimeBranchFromRoute],
+    },
+  });
 
   // ============================================================================
   // Users hooks
@@ -1827,6 +1892,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     branchRbacEnabled,
     branchRepository,
     sessionsRepository,
+    accessCache: realtimeAccessCache,
     allowSuperadmin: superadminOpts.allowSuperadmin,
   });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -109,6 +109,7 @@ import {
 } from './utils/mcp-header-secrets.js';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
+import { configureRealtimePublish } from './utils/realtime-publish.js';
 import {
   ensureCurrentScheduleLoaded,
   ensureScheduleRunsAsCaller,
@@ -1821,25 +1822,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Publish service events
   // ============================================================================
 
-  // Publish service events to authenticated clients only
-  // SECURITY: Only connections in 'authenticated' channel (joined on login) receive events
-  // This prevents unauthenticated sockets from receiving sensitive data
-  app.publish((data, context) => {
-    // Skip logging for streaming events (too verbose) and internal events without path/method
-    const isStreamingEvent =
-      context.path === 'messages/streaming' ||
-      (context.path === 'messages' && context.event?.startsWith('streaming:'));
-    if (context.path && context.method && !isStreamingEvent) {
-      console.log(
-        `📡 [Publish] ${context.path} ${context.method}`,
-        context.id
-          ? `id: ${typeof context.id === 'string' ? shortId(context.id) : context.id}`
-          : '',
-        `channels: ${app.channel('authenticated').length}`
-      );
-    }
-    // Broadcast only to authenticated clients (joined to channel on login)
-    return app.channel('authenticated');
+  configureRealtimePublish({
+    app,
+    branchRbacEnabled,
+    branchRepository,
+    sessionsRepository,
+    usersRepository,
+    allowSuperadmin: superadminOpts.allowSuperadmin,
   });
 
   // ============================================================================

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1827,7 +1827,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     branchRbacEnabled,
     branchRepository,
     sessionsRepository,
-    usersRepository,
     allowSuperadmin: superadminOpts.allowSuperadmin,
   });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -112,6 +112,7 @@ import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js'
 import {
   type RealtimeAccessBranchRepository,
   RealtimeAccessCache,
+  type RealtimeAccessSessionRepository,
 } from './utils/realtime-access-cache.js';
 import { configureRealtimePublish } from './utils/realtime-publish.js';
 import {
@@ -331,7 +332,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   const realtimeAccessCache = new RealtimeAccessCache({
     branchRepository: branchRepository as unknown as RealtimeAccessBranchRepository,
-    sessionsRepository,
+    sessionsRepository: sessionsRepository as unknown as RealtimeAccessSessionRepository,
   });
 
   const invalidateRealtimeBranchAccess = async (branchId: unknown): Promise<void> => {

--- a/apps/agor-daemon/src/utils/realtime-access-cache.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-access-cache.test.ts
@@ -1,0 +1,96 @@
+import type { SessionRepository } from '@agor/core/db';
+import type { Branch, Session } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { type RealtimeAccessBranchRepository, RealtimeAccessCache } from './realtime-access-cache';
+
+function branch(id: string, others_can: Branch['others_can'] = 'none'): Branch {
+  return { branch_id: id, others_can } as Branch;
+}
+
+function session(id: string, branchId: string): Session {
+  return { session_id: id, branch_id: branchId } as Session;
+}
+
+describe('RealtimeAccessCache', () => {
+  it('caches session branch ids until ttl expiration', async () => {
+    let now = 1_000;
+    const branchRepository = {
+      findById: vi.fn(),
+      findExplicitViewUserIds: vi.fn(),
+    } as unknown as RealtimeAccessBranchRepository;
+    const sessionsRepository = {
+      findById: vi.fn(async () => session('s1', 'b1')),
+    } as unknown as SessionRepository;
+    const cache = new RealtimeAccessCache({
+      branchRepository,
+      sessionsRepository,
+      ttlMs: 60_000,
+      now: () => now,
+    });
+
+    await expect(cache.getBranchIdForSession('s1')).resolves.toBe('b1');
+    await expect(cache.getBranchIdForSession('s1')).resolves.toBe('b1');
+    expect(sessionsRepository.findById).toHaveBeenCalledTimes(1);
+
+    now += 60_001;
+
+    await expect(cache.getBranchIdForSession('s1')).resolves.toBe('b1');
+    expect(sessionsRepository.findById).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches and invalidates restricted branch visibility', async () => {
+    let now = 1_000;
+    const branchRepository = {
+      findById: vi.fn(async () => branch('b1', 'none')),
+      findExplicitViewUserIds: vi.fn(async () => ['u1']),
+    } as unknown as RealtimeAccessBranchRepository;
+    const sessionsRepository = {
+      findById: vi.fn(),
+    } as unknown as SessionRepository;
+    const cache = new RealtimeAccessCache({
+      branchRepository,
+      sessionsRepository,
+      ttlMs: 60_000,
+      now: () => now,
+    });
+
+    const first = await cache.getBranchVisibility('b1');
+    const second = await cache.getBranchVisibility('b1');
+
+    expect(first).toEqual({ mode: 'explicitUsers', userIds: new Set(['u1']) });
+    expect(second).toEqual({ mode: 'explicitUsers', userIds: new Set(['u1']) });
+    expect(branchRepository.findById).toHaveBeenCalledTimes(1);
+    expect(branchRepository.findExplicitViewUserIds).toHaveBeenCalledTimes(1);
+
+    cache.invalidateBranch('b1');
+
+    await cache.getBranchVisibility('b1');
+    expect(branchRepository.findById).toHaveBeenCalledTimes(2);
+    expect(branchRepository.findExplicitViewUserIds).toHaveBeenCalledTimes(2);
+
+    now += 60_001;
+
+    await cache.getBranchVisibility('b1');
+    expect(branchRepository.findById).toHaveBeenCalledTimes(3);
+    expect(branchRepository.findExplicitViewUserIds).toHaveBeenCalledTimes(3);
+  });
+
+  it('represents broadly visible branches without expanding user ids', async () => {
+    const branchRepository = {
+      findById: vi.fn(async () => branch('b1', 'session')),
+      findExplicitViewUserIds: vi.fn(async () => ['u1']),
+    } as unknown as RealtimeAccessBranchRepository;
+    const sessionsRepository = {
+      findById: vi.fn(),
+    } as unknown as SessionRepository;
+    const cache = new RealtimeAccessCache({
+      branchRepository,
+      sessionsRepository,
+    });
+
+    await expect(cache.getBranchVisibility('b1')).resolves.toEqual({
+      mode: 'allAuthenticated',
+    });
+    expect(branchRepository.findExplicitViewUserIds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/utils/realtime-access-cache.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-access-cache.test.ts
@@ -1,26 +1,25 @@
-import type { SessionRepository } from '@agor/core/db';
-import type { Branch, Session } from '@agor/core/types';
+import type { Branch } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
-import { type RealtimeAccessBranchRepository, RealtimeAccessCache } from './realtime-access-cache';
+import {
+  type RealtimeAccessBranchRepository,
+  RealtimeAccessCache,
+  type RealtimeAccessSessionRepository,
+} from './realtime-access-cache';
 
 function branch(id: string, others_can: Branch['others_can'] = 'none'): Branch {
   return { branch_id: id, others_can } as Branch;
-}
-
-function session(id: string, branchId: string): Session {
-  return { session_id: id, branch_id: branchId } as Session;
 }
 
 describe('RealtimeAccessCache', () => {
   it('caches session branch ids until ttl expiration', async () => {
     let now = 1_000;
     const branchRepository = {
-      findById: vi.fn(),
+      findRealtimeVisibilityBranch: vi.fn(),
       findExplicitViewUserIds: vi.fn(),
     } as unknown as RealtimeAccessBranchRepository;
     const sessionsRepository = {
-      findById: vi.fn(async () => session('s1', 'b1')),
-    } as unknown as SessionRepository;
+      findBranchIdBySessionId: vi.fn(async () => 'b1'),
+    } as unknown as RealtimeAccessSessionRepository;
     const cache = new RealtimeAccessCache({
       branchRepository,
       sessionsRepository,
@@ -30,23 +29,51 @@ describe('RealtimeAccessCache', () => {
 
     await expect(cache.getBranchIdForSession('s1')).resolves.toBe('b1');
     await expect(cache.getBranchIdForSession('s1')).resolves.toBe('b1');
-    expect(sessionsRepository.findById).toHaveBeenCalledTimes(1);
+    expect(sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledTimes(1);
 
     now += 60_001;
 
     await expect(cache.getBranchIdForSession('s1')).resolves.toBe('b1');
-    expect(sessionsRepository.findById).toHaveBeenCalledTimes(2);
+    expect(sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses separate ttl values for session and branch caches', async () => {
+    let now = 1_000;
+    const branchRepository = {
+      findRealtimeVisibilityBranch: vi.fn(async () => branch('b1', 'session')),
+      findExplicitViewUserIds: vi.fn(),
+    } as unknown as RealtimeAccessBranchRepository;
+    const sessionsRepository = {
+      findBranchIdBySessionId: vi.fn(async () => 'b1'),
+    } as unknown as RealtimeAccessSessionRepository;
+    const cache = new RealtimeAccessCache({
+      branchRepository,
+      sessionsRepository,
+      branchVisibilityTtlMs: 10,
+      sessionBranchTtlMs: 100,
+      now: () => now,
+    });
+
+    await cache.getBranchVisibility('b1');
+    await cache.getBranchIdForSession('s1');
+
+    now += 11;
+    await cache.getBranchVisibility('b1');
+    await cache.getBranchIdForSession('s1');
+
+    expect(branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledTimes(2);
+    expect(sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledTimes(1);
   });
 
   it('caches and invalidates restricted branch visibility', async () => {
     let now = 1_000;
     const branchRepository = {
-      findById: vi.fn(async () => branch('b1', 'none')),
+      findRealtimeVisibilityBranch: vi.fn(async () => branch('b1', 'none')),
       findExplicitViewUserIds: vi.fn(async () => ['u1']),
     } as unknown as RealtimeAccessBranchRepository;
     const sessionsRepository = {
-      findById: vi.fn(),
-    } as unknown as SessionRepository;
+      findBranchIdBySessionId: vi.fn(),
+    } as unknown as RealtimeAccessSessionRepository;
     const cache = new RealtimeAccessCache({
       branchRepository,
       sessionsRepository,
@@ -59,30 +86,30 @@ describe('RealtimeAccessCache', () => {
 
     expect(first).toEqual({ mode: 'explicitUsers', userIds: new Set(['u1']) });
     expect(second).toEqual({ mode: 'explicitUsers', userIds: new Set(['u1']) });
-    expect(branchRepository.findById).toHaveBeenCalledTimes(1);
+    expect(branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledTimes(1);
     expect(branchRepository.findExplicitViewUserIds).toHaveBeenCalledTimes(1);
 
     cache.invalidateBranch('b1');
 
     await cache.getBranchVisibility('b1');
-    expect(branchRepository.findById).toHaveBeenCalledTimes(2);
+    expect(branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledTimes(2);
     expect(branchRepository.findExplicitViewUserIds).toHaveBeenCalledTimes(2);
 
     now += 60_001;
 
     await cache.getBranchVisibility('b1');
-    expect(branchRepository.findById).toHaveBeenCalledTimes(3);
+    expect(branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledTimes(3);
     expect(branchRepository.findExplicitViewUserIds).toHaveBeenCalledTimes(3);
   });
 
   it('represents broadly visible branches without expanding user ids', async () => {
     const branchRepository = {
-      findById: vi.fn(async () => branch('b1', 'session')),
+      findRealtimeVisibilityBranch: vi.fn(async () => branch('b1', 'session')),
       findExplicitViewUserIds: vi.fn(async () => ['u1']),
     } as unknown as RealtimeAccessBranchRepository;
     const sessionsRepository = {
-      findById: vi.fn(),
-    } as unknown as SessionRepository;
+      findBranchIdBySessionId: vi.fn(),
+    } as unknown as RealtimeAccessSessionRepository;
     const cache = new RealtimeAccessCache({
       branchRepository,
       sessionsRepository,

--- a/apps/agor-daemon/src/utils/realtime-access-cache.ts
+++ b/apps/agor-daemon/src/utils/realtime-access-cache.ts
@@ -1,0 +1,126 @@
+import type { BranchRepository, SessionRepository } from '@agor/core/db';
+import type { Branch, BranchID, Session, UserID, UUID } from '@agor/core/types';
+import { PERMISSION_RANK } from './branch-authorization.js';
+
+export type BranchRealtimeVisibility =
+  | { mode: 'allAuthenticated' }
+  | { mode: 'explicitUsers'; userIds: Set<UserID> };
+
+export type RealtimeAccessBranchRepository = Pick<BranchRepository, 'findById'> & {
+  findExplicitViewUserIds(branchId: BranchID): Promise<UUID[]>;
+};
+
+type BranchVisibilityCacheEntry = BranchRealtimeVisibility & {
+  expiresAt: number;
+};
+
+type SessionBranchCacheEntry = {
+  branchId: BranchID | null;
+  expiresAt: number;
+};
+
+export interface RealtimeAccessCacheOptions {
+  branchRepository: RealtimeAccessBranchRepository;
+  sessionsRepository: SessionRepository;
+  ttlMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_TTL_MS = 60_000;
+
+function branchAllowsAllAuthenticated(branch: Branch): boolean {
+  const othersCan = branch.others_can ?? 'session';
+  return PERMISSION_RANK[othersCan] >= PERMISSION_RANK.view;
+}
+
+/**
+ * Daemon-local cache for realtime delivery visibility. It intentionally caches
+ * branch-level access state, not socket membership, so reconnects are handled by
+ * filtering the current channel connections at publish time.
+ */
+export class RealtimeAccessCache {
+  private readonly branchVisibility = new Map<BranchID, BranchVisibilityCacheEntry>();
+  private readonly sessionBranches = new Map<string, SessionBranchCacheEntry>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(private readonly options: RealtimeAccessCacheOptions) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  async getBranchIdForSession(sessionId: string): Promise<BranchID | null> {
+    const cached = this.sessionBranches.get(sessionId);
+    const now = this.now();
+    if (cached && cached.expiresAt > now) {
+      return cached.branchId;
+    }
+
+    const session = (await this.options.sessionsRepository.findById(sessionId)) as Session | null;
+    const branchId = (session?.branch_id as BranchID | undefined) ?? null;
+    this.sessionBranches.set(sessionId, {
+      branchId,
+      expiresAt: now + this.ttlMs,
+    });
+    return branchId;
+  }
+
+  async getBranchVisibility(branchId: BranchID): Promise<BranchRealtimeVisibility | null> {
+    const cached = this.branchVisibility.get(branchId);
+    const now = this.now();
+    if (cached && cached.expiresAt > now) {
+      return this.visibilityFromEntry(cached);
+    }
+
+    const branch = await this.options.branchRepository.findById(branchId);
+    if (!branch) {
+      this.branchVisibility.delete(branchId);
+      return null;
+    }
+
+    const visibility: BranchRealtimeVisibility = branchAllowsAllAuthenticated(branch)
+      ? { mode: 'allAuthenticated' }
+      : {
+          mode: 'explicitUsers',
+          userIds: new Set(
+            (await this.options.branchRepository.findExplicitViewUserIds(branch.branch_id)).map(
+              (userId) => userId as UserID
+            )
+          ),
+        };
+
+    this.branchVisibility.set(branch.branch_id, {
+      ...visibility,
+      expiresAt: now + this.ttlMs,
+    });
+    return visibility;
+  }
+
+  invalidateBranch(branchId: string): void {
+    this.branchVisibility.delete(branchId as BranchID);
+    for (const [sessionId, entry] of this.sessionBranches.entries()) {
+      if (entry.branchId === branchId) {
+        this.sessionBranches.delete(sessionId);
+      }
+    }
+  }
+
+  invalidateSession(sessionId: string): void {
+    this.sessionBranches.delete(sessionId);
+  }
+
+  clearVisibility(): void {
+    this.branchVisibility.clear();
+  }
+
+  clearAll(): void {
+    this.branchVisibility.clear();
+    this.sessionBranches.clear();
+  }
+
+  private visibilityFromEntry(entry: BranchVisibilityCacheEntry): BranchRealtimeVisibility {
+    return entry.mode === 'allAuthenticated'
+      ? { mode: 'allAuthenticated' }
+      : { mode: 'explicitUsers', userIds: entry.userIds };
+  }
+}

--- a/apps/agor-daemon/src/utils/realtime-access-cache.ts
+++ b/apps/agor-daemon/src/utils/realtime-access-cache.ts
@@ -1,13 +1,19 @@
-import type { BranchRepository, SessionRepository } from '@agor/core/db';
-import type { Branch, BranchID, Session, UserID, UUID } from '@agor/core/types';
+import type { Branch, BranchID, UserID, UUID } from '@agor/core/types';
 import { PERMISSION_RANK } from './branch-authorization.js';
 
 export type BranchRealtimeVisibility =
   | { mode: 'allAuthenticated' }
   | { mode: 'explicitUsers'; userIds: Set<UserID> };
 
-export type RealtimeAccessBranchRepository = Pick<BranchRepository, 'findById'> & {
+export type RealtimeAccessBranchRepository = {
+  findRealtimeVisibilityBranch(
+    branchId: string
+  ): Promise<Pick<Branch, 'branch_id' | 'others_can'> | null>;
   findExplicitViewUserIds(branchId: BranchID): Promise<UUID[]>;
+};
+
+export type RealtimeAccessSessionRepository = {
+  findBranchIdBySessionId(sessionId: string): Promise<BranchID | null>;
 };
 
 type BranchVisibilityCacheEntry = BranchRealtimeVisibility & {
@@ -21,14 +27,17 @@ type SessionBranchCacheEntry = {
 
 export interface RealtimeAccessCacheOptions {
   branchRepository: RealtimeAccessBranchRepository;
-  sessionsRepository: SessionRepository;
+  sessionsRepository: RealtimeAccessSessionRepository;
+  branchVisibilityTtlMs?: number;
+  sessionBranchTtlMs?: number;
   ttlMs?: number;
   now?: () => number;
 }
 
-const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_BRANCH_VISIBILITY_TTL_MS = 5 * 60_000;
+const DEFAULT_SESSION_BRANCH_TTL_MS = 60 * 60_000;
 
-function branchAllowsAllAuthenticated(branch: Branch): boolean {
+function branchAllowsAllAuthenticated(branch: Pick<Branch, 'others_can'>): boolean {
   const othersCan = branch.others_can ?? 'session';
   return PERMISSION_RANK[othersCan] >= PERMISSION_RANK.view;
 }
@@ -41,11 +50,15 @@ function branchAllowsAllAuthenticated(branch: Branch): boolean {
 export class RealtimeAccessCache {
   private readonly branchVisibility = new Map<BranchID, BranchVisibilityCacheEntry>();
   private readonly sessionBranches = new Map<string, SessionBranchCacheEntry>();
-  private readonly ttlMs: number;
+  private readonly branchVisibilityTtlMs: number;
+  private readonly sessionBranchTtlMs: number;
   private readonly now: () => number;
 
   constructor(private readonly options: RealtimeAccessCacheOptions) {
-    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.branchVisibilityTtlMs =
+      options.branchVisibilityTtlMs ?? options.ttlMs ?? DEFAULT_BRANCH_VISIBILITY_TTL_MS;
+    this.sessionBranchTtlMs =
+      options.sessionBranchTtlMs ?? options.ttlMs ?? DEFAULT_SESSION_BRANCH_TTL_MS;
     this.now = options.now ?? Date.now;
   }
 
@@ -56,11 +69,10 @@ export class RealtimeAccessCache {
       return cached.branchId;
     }
 
-    const session = (await this.options.sessionsRepository.findById(sessionId)) as Session | null;
-    const branchId = (session?.branch_id as BranchID | undefined) ?? null;
+    const branchId = await this.options.sessionsRepository.findBranchIdBySessionId(sessionId);
     this.sessionBranches.set(sessionId, {
       branchId,
-      expiresAt: now + this.ttlMs,
+      expiresAt: now + this.sessionBranchTtlMs,
     });
     return branchId;
   }
@@ -72,7 +84,7 @@ export class RealtimeAccessCache {
       return this.visibilityFromEntry(cached);
     }
 
-    const branch = await this.options.branchRepository.findById(branchId);
+    const branch = await this.options.branchRepository.findRealtimeVisibilityBranch(branchId);
     if (!branch) {
       this.branchVisibility.delete(branchId);
       return null;
@@ -91,7 +103,7 @@ export class RealtimeAccessCache {
 
     this.branchVisibility.set(branch.branch_id, {
       ...visibility,
-      expiresAt: now + this.ttlMs,
+      expiresAt: now + this.branchVisibilityTtlMs,
     });
     return visibility;
   }

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1,7 +1,10 @@
-import type { BranchRepository, SessionRepository } from '@agor/core/db';
 import type { Branch, BranchPermissionLevel, Session, User } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import type {
+  RealtimeAccessBranchRepository,
+  RealtimeAccessSessionRepository,
+} from './realtime-access-cache';
 import { configureRealtimePublish } from './realtime-publish';
 
 class FakeChannel {
@@ -60,16 +63,16 @@ function repos(options: {
     )
     .map(([userId]) => userId);
   const branchRepository = {
-    findById: vi.fn(async (id: string) =>
+    findRealtimeVisibilityBranch: vi.fn(async (id: string) =>
       id === options.branch.branch_id ? options.branch : null
     ),
     findExplicitViewUserIds: vi.fn(async () => viewableUserIds),
-  } as unknown as BranchRepository;
+  } as unknown as RealtimeAccessBranchRepository;
   const sessionsRepository = {
-    findById: vi.fn(async (id: string) =>
-      options.session?.session_id === id ? options.session : null
+    findBranchIdBySessionId: vi.fn(async (id: string) =>
+      options.session?.session_id === id ? options.session.branch_id : null
     ),
-  } as unknown as SessionRepository;
+  } as unknown as RealtimeAccessSessionRepository;
   return { branchRepository, sessionsRepository };
 }
 
@@ -210,7 +213,7 @@ describe('configureRealtimePublish', () => {
       { path: 'tasks', method: 'create', event: 'created' }
     );
 
-    expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
+    expect(r.sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledWith('s1');
     expect(channel.connections).toEqual([{ user: allowed }, service]);
   });
 
@@ -236,8 +239,8 @@ describe('configureRealtimePublish', () => {
 
     expect(first.connections).toEqual([{ user: allowed }]);
     expect(second.connections).toEqual([{ user: allowed }]);
-    expect(r.sessionsRepository.findById).toHaveBeenCalledTimes(1);
-    expect(r.branchRepository.findById).toHaveBeenCalledTimes(1);
+    expect(r.sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledTimes(1);
+    expect(r.branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledTimes(1);
     expect(vi.mocked(r.branchRepository.findExplicitViewUserIds)).toHaveBeenCalledTimes(1);
   });
 
@@ -257,7 +260,7 @@ describe('configureRealtimePublish', () => {
       { path: 'sessions', method: 'emit', event: 'permission:request' }
     );
 
-    expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
+    expect(r.sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledWith('s1');
     expect(channel.connections).toEqual([{ user: allowed }]);
   });
 
@@ -277,7 +280,7 @@ describe('configureRealtimePublish', () => {
       { path: 'board-comments', method: 'create', event: 'created' }
     );
 
-    expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
+    expect(r.sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledWith('s1');
     expect(channel.connections).toEqual([{ user: allowed }]);
   });
 

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -106,6 +106,52 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }, { user: admin }]);
   });
 
+  it('scopes nested branch permission service events through the route branch id', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { user_id: 'owner-user' },
+      {
+        path: 'branches/:id/owners',
+        method: 'create',
+        event: 'created',
+        params: { route: { id: 'b1' } },
+      }
+    );
+
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
+  it('scopes nested branch group grant events through the route branch id', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { group_id: 'g1', can: 'view' },
+      {
+        path: 'branches/:id/group-grants',
+        method: 'create',
+        event: 'created',
+        params: { route: { id: 'b1' } },
+      }
+    );
+
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
   it('broadcasts broadly visible branch events without explicit user expansion', async () => {
     const u1 = user('u1');
     const u2 = user('u2');

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1,4 +1,4 @@
-import type { BranchRepository, SessionRepository, UsersRepository } from '@agor/core/db';
+import type { BranchRepository, SessionRepository } from '@agor/core/db';
 import type { Branch, Session, User } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -52,7 +52,6 @@ function session(id: string, branchId: string): Session {
 function repos(options: {
   branch: Branch;
   session?: Session | null;
-  users: User[];
   permissions: Record<string, Branch['others_can']>;
 }) {
   const branchRepository = {
@@ -68,16 +67,13 @@ function repos(options: {
       options.session?.session_id === id ? options.session : null
     ),
   } as unknown as SessionRepository;
-  const usersRepository = {
-    findAll: vi.fn(async () => options.users),
-  } as unknown as UsersRepository;
-  return { branchRepository, sessionsRepository, usersRepository };
+  return { branchRepository, sessionsRepository };
 }
 
 describe('configureRealtimePublish', () => {
   it('preserves legacy authenticated broadcast when branch RBAC is disabled', async () => {
     const app = makeApp([{ user: user('u1') }, { user: user('u2') }]);
-    const r = repos({ branch: branch('b1'), users: [], permissions: {} });
+    const r = repos({ branch: branch('b1'), permissions: {} });
     configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
 
     const channel = await app.runPublish(
@@ -86,7 +82,6 @@ describe('configureRealtimePublish', () => {
     );
 
     expect(channel.connections).toHaveLength(2);
-    expect(r.usersRepository.findAll).not.toHaveBeenCalled();
   });
 
   it('filters branch events to users with view access when RBAC is enabled', async () => {
@@ -96,7 +91,6 @@ describe('configureRealtimePublish', () => {
     const app = makeApp([{ user: allowed }, { user: denied }, { user: admin }]);
     const r = repos({
       branch: branch('b1', 'none'),
-      users: [allowed, denied, admin],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -114,7 +108,6 @@ describe('configureRealtimePublish', () => {
     const app = makeApp([{ user: admin }]);
     const r = repos({
       branch: branch('b1', 'none'),
-      users: [admin],
       permissions: { admin: 'none' },
     });
     configureRealtimePublish({
@@ -140,7 +133,6 @@ describe('configureRealtimePublish', () => {
     const r = repos({
       branch: branch('b1', 'none'),
       session: session('s1', 'b1'),
-      users: [allowed, denied],
       permissions: { allowed: 'session', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -161,7 +153,6 @@ describe('configureRealtimePublish', () => {
     const r = repos({
       branch: branch('b1', 'none'),
       session: session('s1', 'b1'),
-      users: [allowed, denied],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -182,7 +173,6 @@ describe('configureRealtimePublish', () => {
     const r = repos({
       branch: branch('b1', 'none'),
       session: session('s1', 'b1'),
-      users: [allowed, denied],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -205,7 +195,6 @@ describe('configureRealtimePublish', () => {
     const r = repos({
       branch: branch('b1', 'none'),
       session: session('s1', 'b1'),
-      users: [allowed, denied],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -228,7 +217,6 @@ describe('configureRealtimePublish', () => {
     const r = repos({
       branch: branch('b1', 'none'),
       session: session('s1', 'b1'),
-      users: [allowed, denied],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -248,7 +236,6 @@ describe('configureRealtimePublish', () => {
     const app = makeApp([{ user: allowed }, { user: denied }]);
     const r = repos({
       branch: branch('b1', 'none'),
-      users: [allowed, denied],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -267,7 +254,6 @@ describe('configureRealtimePublish', () => {
     const app = makeApp([{ user: allowed }, { user: denied }]);
     const r = repos({
       branch: branch('b1', 'none'),
-      users: [allowed, denied],
       permissions: { allowed: 'view', denied: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -288,7 +274,6 @@ describe('configureRealtimePublish', () => {
     const app = makeApp([{ user: creator }, { user: other }, { user: admin }, service]);
     const r = repos({
       branch: branch('b1', 'none'),
-      users: [creator, other, admin],
       permissions: { creator: 'none', other: 'none', admin: 'none' },
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
@@ -305,7 +290,7 @@ describe('configureRealtimePublish', () => {
     const allowed = user('allowed');
     const service = { user: { _isServiceAccount: true, role: 'service' } };
     const app = makeApp([{ user: allowed }, service]);
-    const r = repos({ branch: branch('b1'), users: [allowed], permissions: { allowed: 'view' } });
+    const r = repos({ branch: branch('b1'), permissions: { allowed: 'view' } });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
 
     const channel = await app.runPublish(
@@ -320,7 +305,7 @@ describe('configureRealtimePublish', () => {
     const allowed = user('allowed');
     const service = { user: { _isServiceAccount: true, role: 'service' } };
     const app = makeApp([{ user: allowed }, service]);
-    const r = repos({ branch: branch('b1'), users: [allowed], permissions: { allowed: 'view' } });
+    const r = repos({ branch: branch('b1'), permissions: { allowed: 'view' } });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
 
     const channel = await app.runPublish(

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1,5 +1,5 @@
 import type { BranchRepository, SessionRepository } from '@agor/core/db';
-import type { Branch, Session, User } from '@agor/core/types';
+import type { Branch, BranchPermissionLevel, Session, User } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { configureRealtimePublish } from './realtime-publish';
@@ -54,13 +54,16 @@ function repos(options: {
   session?: Session | null;
   permissions: Record<string, Branch['others_can']>;
 }) {
+  const viewableUserIds = Object.entries(options.permissions)
+    .filter(([, permission]) =>
+      ['view', 'session', 'prompt', 'all'].includes(permission as BranchPermissionLevel)
+    )
+    .map(([userId]) => userId);
   const branchRepository = {
     findById: vi.fn(async (id: string) =>
       id === options.branch.branch_id ? options.branch : null
     ),
-    resolveUserPermission: vi.fn(
-      async (_branch: Branch, userId: string) => options.permissions[userId] ?? 'none'
-    ),
+    findExplicitViewUserIds: vi.fn(async () => viewableUserIds),
   } as unknown as BranchRepository;
   const sessionsRepository = {
     findById: vi.fn(async (id: string) =>
@@ -101,6 +104,25 @@ describe('configureRealtimePublish', () => {
     );
 
     expect(channel.connections).toEqual([{ user: allowed }, { user: admin }]);
+  });
+
+  it('broadcasts broadly visible branch events without explicit user expansion', async () => {
+    const u1 = user('u1');
+    const u2 = user('u2');
+    const app = makeApp([{ user: u1 }, { user: u2 }]);
+    const r = repos({
+      branch: branch('b1', 'session'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'branches', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([{ user: u1 }, { user: u2 }]);
+    expect(vi.mocked(r.branchRepository.findExplicitViewUserIds)).not.toHaveBeenCalled();
   });
 
   it('honors allowSuperadmin=false for branch events', async () => {
@@ -144,6 +166,33 @@ describe('configureRealtimePublish', () => {
 
     expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
     expect(channel.connections).toEqual([{ user: allowed }, service]);
+  });
+
+  it('caches session branch and branch visibility across streaming events', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const first = await app.runPublish(
+      { message_id: 'm1', session_id: 's1', chunk: 'a' },
+      { path: 'messages', method: 'emit', event: 'streaming:chunk' }
+    );
+    const second = await app.runPublish(
+      { message_id: 'm1', session_id: 's1', chunk: 'b' },
+      { path: 'messages', method: 'emit', event: 'streaming:chunk' }
+    );
+
+    expect(first.connections).toEqual([{ user: allowed }]);
+    expect(second.connections).toEqual([{ user: allowed }]);
+    expect(r.sessionsRepository.findById).toHaveBeenCalledTimes(1);
+    expect(r.branchRepository.findById).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(r.branchRepository.findExplicitViewUserIds)).toHaveBeenCalledTimes(1);
   });
 
   it('resolves custom sessions events through camelCase sessionId', async () => {
@@ -304,7 +353,10 @@ describe('configureRealtimePublish', () => {
   it('fails closed for scoped events without a resolvable session or branch', async () => {
     const allowed = user('allowed');
     const service = { user: { _isServiceAccount: true, role: 'service' } };
-    const app = makeApp([{ user: allowed }, service]);
+    const tasksGet = vi.fn(async () => ({ session_id: 's1' }));
+    const app = makeApp([{ user: allowed }, service], {
+      tasks: { get: tasksGet },
+    });
     const r = repos({ branch: branch('b1'), permissions: { allowed: 'view' } });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
 
@@ -314,5 +366,6 @@ describe('configureRealtimePublish', () => {
     );
 
     expect(channel.connections).toEqual([service]);
+    expect(tasksGet).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1,0 +1,198 @@
+import type { BranchRepository, SessionRepository, UsersRepository } from '@agor/core/db';
+import type { Branch, Session, User } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { configureRealtimePublish } from './realtime-publish';
+
+class FakeChannel {
+  constructor(public connections: unknown[]) {}
+  get length() {
+    return this.connections.length;
+  }
+  filter(fn: (connection: unknown) => boolean) {
+    return new FakeChannel(this.connections.filter(fn));
+  }
+}
+
+function makeApp(connections: unknown[]) {
+  let publishFn: ((data: unknown, context: any) => unknown) | undefined;
+  return {
+    channel: vi.fn(() => new FakeChannel(connections)),
+    publish: vi.fn((fn) => {
+      publishFn = fn;
+    }),
+    async runPublish(data: unknown, context: any) {
+      if (!publishFn) throw new Error('publish not configured');
+      return (await publishFn(data, context)) as FakeChannel;
+    },
+  } as any;
+}
+
+function user(id: string, role = ROLES.MEMBER): User {
+  return { user_id: id, role } as User;
+}
+
+function branch(id: string, others_can: Branch['others_can'] = 'none'): Branch {
+  return { branch_id: id, others_can } as Branch;
+}
+
+function session(id: string, branchId: string): Session {
+  return { session_id: id, branch_id: branchId } as Session;
+}
+
+function repos(options: {
+  branch: Branch;
+  session?: Session | null;
+  users: User[];
+  permissions: Record<string, Branch['others_can']>;
+}) {
+  const branchRepository = {
+    findById: vi.fn(async (id: string) =>
+      id === options.branch.branch_id ? options.branch : null
+    ),
+    resolveUserPermission: vi.fn(
+      async (_branch: Branch, userId: string) => options.permissions[userId] ?? 'none'
+    ),
+  } as unknown as BranchRepository;
+  const sessionsRepository = {
+    findById: vi.fn(async (id: string) =>
+      options.session?.session_id === id ? options.session : null
+    ),
+  } as unknown as SessionRepository;
+  const usersRepository = {
+    findAll: vi.fn(async () => options.users),
+  } as unknown as UsersRepository;
+  return { branchRepository, sessionsRepository, usersRepository };
+}
+
+describe('configureRealtimePublish', () => {
+  it('preserves legacy authenticated broadcast when branch RBAC is disabled', async () => {
+    const app = makeApp([{ user: user('u1') }, { user: user('u2') }]);
+    const r = repos({ branch: branch('b1'), users: [], permissions: {} });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'branches', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toHaveLength(2);
+    expect(r.usersRepository.findAll).not.toHaveBeenCalled();
+  });
+
+  it('filters branch events to users with view access when RBAC is enabled', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const admin = user('admin', ROLES.SUPERADMIN);
+    const app = makeApp([{ user: allowed }, { user: denied }, { user: admin }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      users: [allowed, denied, admin],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'branches', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([{ user: allowed }, { user: admin }]);
+  });
+
+  it('resolves task/message events through session_id before filtering', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([{ user: allowed }, { user: denied }, service]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      users: [allowed, denied],
+      permissions: { allowed: 'session', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { task_id: 't1', session_id: 's1' },
+      { path: 'tasks', method: 'create', event: 'created' }
+    );
+
+    expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
+    expect(channel.connections).toEqual([{ user: allowed }, service]);
+  });
+
+  it('resolves custom sessions events through camelCase sessionId', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      users: [allowed, denied],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { requestId: 'r1', sessionId: 's1' },
+      { path: 'sessions', method: 'emit', event: 'permission:request' }
+    );
+
+    expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
+  it('filters optional branch-scoped events when they carry branch_id', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      users: [allowed, denied],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { artifact_id: 'a1', branch_id: 'b1' },
+      { path: 'artifacts', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
+  it('leaves optional branch-scoped events global when no branch/session is attached', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      users: [allowed, denied],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { card_id: 'card1' },
+      { path: 'board-objects', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([{ user: allowed }, { user: denied }]);
+  });
+
+  it('fails closed for scoped events without a resolvable session or branch', async () => {
+    const allowed = user('allowed');
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([{ user: allowed }, service]);
+    const r = repos({ branch: branch('b1'), users: [allowed], permissions: { allowed: 'view' } });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { task_id: 't1' },
+      { path: 'tasks', method: 'create', event: 'created' }
+    );
+
+    expect(channel.connections).toEqual([service]);
+  });
+});

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -14,18 +14,27 @@ class FakeChannel {
   }
 }
 
-function makeApp(connections: unknown[]) {
+function makeApp(
+  connections: unknown[],
+  services: Record<string, { get: (id: string) => Promise<unknown> }> = {}
+) {
   let publishFn: ((data: unknown, context: any) => unknown) | undefined;
-  return {
+  const app = {
     channel: vi.fn(() => new FakeChannel(connections)),
     publish: vi.fn((fn) => {
       publishFn = fn;
     }),
+    service: vi.fn((path: string) => {
+      const service = services[path];
+      if (!service) throw new Error(`Unexpected service: ${path}`);
+      return service;
+    }),
     async runPublish(data: unknown, context: any) {
       if (!publishFn) throw new Error('publish not configured');
-      return (await publishFn(data, context)) as FakeChannel;
+      return (await publishFn(data, { ...context, app })) as FakeChannel;
     },
   } as any;
+  return app;
 }
 
 function user(id: string, role = ROLES.MEMBER): User {
@@ -100,6 +109,29 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }, { user: admin }]);
   });
 
+  it('honors allowSuperadmin=false for branch events', async () => {
+    const admin = user('admin', ROLES.SUPERADMIN);
+    const app = makeApp([{ user: admin }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      users: [admin],
+      permissions: { admin: 'none' },
+    });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: true,
+      allowSuperadmin: false,
+      ...r,
+    });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      { path: 'branches', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([]);
+  });
+
   it('resolves task/message events through session_id before filtering', async () => {
     const allowed = user('allowed');
     const denied = user('denied');
@@ -143,6 +175,73 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }]);
   });
 
+  it('resolves board comment events through session_id when branch_id is absent', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      users: [allowed, denied],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { comment_id: 'c1', session_id: 's1' },
+      { path: 'board-comments', method: 'create', event: 'created' }
+    );
+
+    expect(r.sessionsRepository.findById).toHaveBeenCalledWith('s1');
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
+  it('resolves board comment events through task_id when branch_id is absent', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }], {
+      tasks: { get: vi.fn(async () => ({ session_id: 's1' })) },
+    });
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      users: [allowed, denied],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { comment_id: 'c1', task_id: 't1' },
+      { path: 'board-comments', method: 'create', event: 'created' }
+    );
+
+    expect(app.service('tasks').get).toHaveBeenCalledWith('t1', { provider: undefined });
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
+  it('resolves board comment events through message_id when branch_id is absent', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }], {
+      messages: { get: vi.fn(async () => ({ session_id: 's1' })) },
+    });
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      users: [allowed, denied],
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { comment_id: 'c1', message_id: 'm1' },
+      { path: 'board-comments', method: 'create', event: 'created' }
+    );
+
+    expect(app.service('messages').get).toHaveBeenCalledWith('m1', { provider: undefined });
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
   it('filters optional branch-scoped events when they carry branch_id', async () => {
     const allowed = user('allowed');
     const denied = user('denied');
@@ -179,6 +278,42 @@ describe('configureRealtimePublish', () => {
     );
 
     expect(channel.connections).toEqual([{ user: allowed }, { user: denied }]);
+  });
+
+  it('keeps null-branch artifact events scoped to creator/admin/service connections', async () => {
+    const creator = user('creator');
+    const other = user('other');
+    const admin = user('admin', ROLES.ADMIN);
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([{ user: creator }, { user: other }, { user: admin }, service]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      users: [creator, other, admin],
+      permissions: { creator: 'none', other: 'none', admin: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { artifact_id: 'a1', branch_id: null, created_by: 'creator', public: false },
+      { path: 'artifacts', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([{ user: creator }, { user: admin }, service]);
+  });
+
+  it('fails closed for null-branch artifact events without a creator', async () => {
+    const allowed = user('allowed');
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp([{ user: allowed }, service]);
+    const r = repos({ branch: branch('b1'), users: [allowed], permissions: { allowed: 'view' } });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { artifact_id: 'a1', branch_id: null, public: false },
+      { path: 'artifacts', method: 'patch', event: 'patched' }
+    );
+
+    expect(channel.connections).toEqual([service]);
   });
 
   it('fails closed for scoped events without a resolvable session or branch', async () => {

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -1,0 +1,249 @@
+import type { BranchRepository, SessionRepository, UsersRepository } from '@agor/core/db';
+import { shortId } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type {
+  Branch,
+  BranchPermissionLevel,
+  HookContext,
+  Session,
+  User,
+  UUID,
+} from '@agor/core/types';
+import { isSuperAdmin, PERMISSION_RANK } from './branch-authorization.js';
+
+type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event'>;
+
+type ConnectionLike = {
+  user?: (Partial<User> & { _isServiceAccount?: boolean }) | undefined;
+  authentication?: { user?: (Partial<User> & { _isServiceAccount?: boolean }) | undefined };
+};
+
+type RealtimePublishOptions = {
+  app: Application;
+  branchRbacEnabled: boolean;
+  branchRepository: BranchRepository;
+  sessionsRepository: SessionRepository;
+  usersRepository: UsersRepository;
+  allowSuperadmin?: boolean;
+};
+
+const BRANCH_ID_SCOPED_PATHS = new Set(['branches', 'schedules']);
+const OPTIONAL_BRANCH_ID_SCOPED_PATHS = new Set(['artifacts', 'board-comments', 'board-objects']);
+const SESSION_ID_SCOPED_PATHS = new Set([
+  'tasks',
+  'messages',
+  'session-mcp-servers',
+  'session-env-selections',
+]);
+const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set([
+  'artifacts',
+  'board-objects',
+  'board-comments',
+]);
+
+function isStreamingEvent(context: PublishContext): boolean {
+  return (
+    context.path === 'messages/streaming' ||
+    (context.path === 'messages' && context.event?.startsWith('streaming:') === true)
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function pickString(obj: Record<string, unknown> | null, ...keys: string[]): string | undefined {
+  if (!obj) return undefined;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function extractBranchId(data: unknown, context: PublishContext): string | undefined {
+  const record = asRecord(data);
+  if (context.path === 'branches') {
+    return (
+      pickString(record, 'branch_id', 'branchId') ??
+      (typeof context.id === 'string' ? context.id : undefined)
+    );
+  }
+  return pickString(record, 'branch_id', 'branchId');
+}
+
+function extractSessionId(data: unknown): string | undefined {
+  const record = asRecord(data);
+  return pickString(record, 'session_id', 'sessionId');
+}
+
+async function resolveBranchForPublish(
+  data: unknown,
+  context: PublishContext,
+  branchRepository: BranchRepository,
+  sessionsRepository: SessionRepository
+): Promise<Branch | null | undefined> {
+  if (!context.path) return undefined;
+
+  if (BRANCH_ID_SCOPED_PATHS.has(context.path)) {
+    const branchId = extractBranchId(data, context);
+    if (!branchId) return null;
+    return await branchRepository.findById(branchId);
+  }
+
+  if (OPTIONAL_BRANCH_ID_SCOPED_PATHS.has(context.path)) {
+    const branchId = extractBranchId(data, context);
+    return branchId ? await branchRepository.findById(branchId) : undefined;
+  }
+
+  if (context.path === 'sessions') {
+    const branchId = extractBranchId(data, context);
+    if (branchId) return await branchRepository.findById(branchId);
+
+    // Custom sessions events (permission:request / permission:timeout) carry
+    // camelCase `sessionId` instead of the session row's `branch_id`.
+    const sessionId = extractSessionId(data);
+    if (!sessionId) return null;
+    const session = (await sessionsRepository.findById(sessionId)) as Session | null;
+    if (!session?.branch_id) return null;
+    return await branchRepository.findById(session.branch_id);
+  }
+
+  if (OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS.has(context.path)) {
+    const branchId = extractBranchId(data, context);
+    if (branchId) return await branchRepository.findById(branchId);
+
+    const sessionId = extractSessionId(data);
+    if (sessionId) {
+      const session = (await sessionsRepository.findById(sessionId)) as Session | null;
+      if (!session?.branch_id) return null;
+      return await branchRepository.findById(session.branch_id);
+    }
+
+    // These services can also emit global/card/board rows with no branch or
+    // session attachment. They are not branch-scoped, so keep normal fan-out.
+    return undefined;
+  }
+
+  if (SESSION_ID_SCOPED_PATHS.has(context.path)) {
+    const sessionId = extractSessionId(data);
+    if (!sessionId) return null;
+    const session = (await sessionsRepository.findById(sessionId)) as Session | null;
+    if (!session?.branch_id) return null;
+    return await branchRepository.findById(session.branch_id);
+  }
+
+  return undefined;
+}
+
+function userFromConnection(
+  connection: unknown
+): (Partial<User> & { _isServiceAccount?: boolean }) | undefined {
+  const c = connection as ConnectionLike | undefined;
+  return c?.user ?? c?.authentication?.user;
+}
+
+async function authorizedUserIdsForBranch(
+  branch: Branch,
+  usersRepository: UsersRepository,
+  branchRepository: BranchRepository,
+  allowSuperadmin: boolean
+): Promise<Set<string>> {
+  const users = await usersRepository.findAll();
+  const allowed = new Set<string>();
+
+  await Promise.all(
+    users.map(async (user) => {
+      if (isSuperAdmin(user.role, allowSuperadmin)) {
+        allowed.add(user.user_id);
+        return;
+      }
+
+      const permission = (await branchRepository.resolveUserPermission(
+        branch,
+        user.user_id as UUID
+      )) as BranchPermissionLevel;
+      if (PERMISSION_RANK[permission] >= PERMISSION_RANK.view) {
+        allowed.add(user.user_id);
+      }
+    })
+  );
+
+  return allowed;
+}
+
+function isServiceConnection(connection: unknown): boolean {
+  const user = userFromConnection(connection);
+  return user?._isServiceAccount === true || (user?.role as string | undefined) === 'service';
+}
+
+/**
+ * Register the single global Feathers publish handler.
+ *
+ * In open-access mode this preserves the legacy behavior: every authenticated
+ * socket receives every service event. When branch RBAC is enabled, events for
+ * branch/session-scoped resources are reduced to authenticated connections whose
+ * user currently has at least `view` permission for the event's branch. Service
+ * executor sockets remain trusted so prompt/permission plumbing keeps working.
+ */
+export function configureRealtimePublish(options: RealtimePublishOptions): void {
+  const {
+    app,
+    branchRbacEnabled,
+    branchRepository,
+    sessionsRepository,
+    usersRepository,
+    allowSuperadmin = true,
+  } = options;
+
+  app.publish(async (data: unknown, context: HookContext) => {
+    if (context.path && context.method && !isStreamingEvent(context)) {
+      console.log(
+        `📡 [Publish] ${context.path} ${context.method}`,
+        context.id
+          ? `id: ${typeof context.id === 'string' ? shortId(context.id) : context.id}`
+          : '',
+        `channels: ${app.channel('authenticated').length}`
+      );
+    }
+
+    const authenticated = app.channel('authenticated');
+    if (!branchRbacEnabled) return authenticated;
+
+    const branch = await resolveBranchForPublish(
+      data,
+      context,
+      branchRepository,
+      sessionsRepository
+    );
+
+    // Undefined means the service is not branch/session scoped, so keep the
+    // regular authenticated fan-out. Null means it should have been scoped but
+    // lacked resolvable branch/session context; fail closed to prevent leakage.
+    if (branch === undefined) return authenticated;
+    if (!branch) {
+      console.warn('[realtime] Suppressing scoped event without resolvable branch context', {
+        path: context.path,
+        event: context.event,
+        method: context.method,
+      });
+      return authenticated.filter((connection: unknown) => isServiceConnection(connection));
+    }
+
+    const allowedUserIds = await authorizedUserIdsForBranch(
+      branch,
+      usersRepository,
+      branchRepository,
+      allowSuperadmin
+    );
+
+    return authenticated.filter((connection: unknown) => {
+      if (isServiceConnection(connection)) return true;
+      const user = userFromConnection(connection);
+      const userId = user?.user_id;
+      return typeof userId === 'string' && allowedUserIds.has(userId);
+    });
+  });
+}

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -9,9 +9,10 @@ import type {
   User,
   UUID,
 } from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
 import { isSuperAdmin, PERMISSION_RANK } from './branch-authorization.js';
 
-type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event'>;
+type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event' | 'app'>;
 
 type ConnectionLike = {
   user?: (Partial<User> & { _isServiceAccount?: boolean }) | undefined;
@@ -27,19 +28,22 @@ type RealtimePublishOptions = {
   allowSuperadmin?: boolean;
 };
 
+type PublishChannel = ReturnType<Application['channel']>;
+
+type PublishScope =
+  | { kind: 'global' }
+  | { kind: 'branch'; branch: Branch | null }
+  | { kind: 'users'; userIds: Set<string> }
+  | { kind: 'serviceOnly' };
+
 const BRANCH_ID_SCOPED_PATHS = new Set(['branches', 'schedules']);
-const OPTIONAL_BRANCH_ID_SCOPED_PATHS = new Set(['artifacts', 'board-comments', 'board-objects']);
 const SESSION_ID_SCOPED_PATHS = new Set([
   'tasks',
   'messages',
   'session-mcp-servers',
   'session-env-selections',
 ]);
-const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set([
-  'artifacts',
-  'board-objects',
-  'board-comments',
-]);
+const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set(['board-objects', 'board-comments']);
 
 function isStreamingEvent(context: PublishContext): boolean {
   return (
@@ -79,63 +83,24 @@ function extractSessionId(data: unknown): string | undefined {
   return pickString(record, 'session_id', 'sessionId');
 }
 
-async function resolveBranchForPublish(
-  data: unknown,
-  context: PublishContext,
-  branchRepository: BranchRepository,
-  sessionsRepository: SessionRepository
-): Promise<Branch | null | undefined> {
-  if (!context.path) return undefined;
+function extractTaskId(data: unknown): string | undefined {
+  const record = asRecord(data);
+  return pickString(record, 'task_id', 'taskId');
+}
 
-  if (BRANCH_ID_SCOPED_PATHS.has(context.path)) {
-    const branchId = extractBranchId(data, context);
-    if (!branchId) return null;
-    return await branchRepository.findById(branchId);
-  }
+function extractMessageId(data: unknown): string | undefined {
+  const record = asRecord(data);
+  return pickString(record, 'message_id', 'messageId');
+}
 
-  if (OPTIONAL_BRANCH_ID_SCOPED_PATHS.has(context.path)) {
-    const branchId = extractBranchId(data, context);
-    return branchId ? await branchRepository.findById(branchId) : undefined;
-  }
+function extractCreatedBy(data: unknown): string | undefined {
+  const record = asRecord(data);
+  return pickString(record, 'created_by', 'createdBy');
+}
 
-  if (context.path === 'sessions') {
-    const branchId = extractBranchId(data, context);
-    if (branchId) return await branchRepository.findById(branchId);
-
-    // Custom sessions events (permission:request / permission:timeout) carry
-    // camelCase `sessionId` instead of the session row's `branch_id`.
-    const sessionId = extractSessionId(data);
-    if (!sessionId) return null;
-    const session = (await sessionsRepository.findById(sessionId)) as Session | null;
-    if (!session?.branch_id) return null;
-    return await branchRepository.findById(session.branch_id);
-  }
-
-  if (OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS.has(context.path)) {
-    const branchId = extractBranchId(data, context);
-    if (branchId) return await branchRepository.findById(branchId);
-
-    const sessionId = extractSessionId(data);
-    if (sessionId) {
-      const session = (await sessionsRepository.findById(sessionId)) as Session | null;
-      if (!session?.branch_id) return null;
-      return await branchRepository.findById(session.branch_id);
-    }
-
-    // These services can also emit global/card/board rows with no branch or
-    // session attachment. They are not branch-scoped, so keep normal fan-out.
-    return undefined;
-  }
-
-  if (SESSION_ID_SCOPED_PATHS.has(context.path)) {
-    const sessionId = extractSessionId(data);
-    if (!sessionId) return null;
-    const session = (await sessionsRepository.findById(sessionId)) as Session | null;
-    if (!session?.branch_id) return null;
-    return await branchRepository.findById(session.branch_id);
-  }
-
-  return undefined;
+function channelConnections(channel: PublishChannel): unknown[] {
+  const connections = (channel as { connections?: unknown[] }).connections;
+  return Array.isArray(connections) ? connections : [];
 }
 
 function userFromConnection(
@@ -145,19 +110,169 @@ function userFromConnection(
   return c?.user ?? c?.authentication?.user;
 }
 
-async function authorizedUserIdsForBranch(
+function isServiceConnection(connection: unknown): boolean {
+  const user = userFromConnection(connection);
+  return user?._isServiceAccount === true || (user?.role as string | undefined) === 'service';
+}
+
+function isAdminConnection(connection: unknown, allowSuperadmin: boolean): boolean {
+  const user = userFromConnection(connection);
+  if (!user?._isServiceAccount && user?.role && hasMinimumRole(user.role, ROLES.ADMIN)) {
+    return true;
+  }
+  return isSuperAdmin(user?.role, allowSuperadmin);
+}
+
+async function sessionBranch(
+  sessionId: string,
+  sessionsRepository: SessionRepository,
+  branchRepository: BranchRepository
+): Promise<Branch | null> {
+  const session = (await sessionsRepository.findById(sessionId)) as Session | null;
+  if (!session?.branch_id) return null;
+  return await branchRepository.findById(session.branch_id);
+}
+
+async function taskSessionId(context: PublishContext, taskId: string): Promise<string | null> {
+  try {
+    const task = (await context.app.service('tasks').get(taskId, {
+      provider: undefined,
+    })) as { session_id?: string } | null;
+    return task?.session_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function messageSessionId(
+  context: PublishContext,
+  messageId: string
+): Promise<string | null> {
+  try {
+    const message = (await context.app.service('messages').get(messageId, {
+      provider: undefined,
+    })) as { session_id?: string } | null;
+    return message?.session_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveBranchFromSessionTaskOrMessage(
+  data: unknown,
+  context: PublishContext,
+  branchRepository: BranchRepository,
+  sessionsRepository: SessionRepository
+): Promise<Branch | null | undefined> {
+  const sessionId = extractSessionId(data);
+  if (sessionId) return await sessionBranch(sessionId, sessionsRepository, branchRepository);
+
+  const taskId = extractTaskId(data);
+  if (taskId) {
+    const resolvedSessionId = await taskSessionId(context, taskId);
+    return resolvedSessionId
+      ? await sessionBranch(resolvedSessionId, sessionsRepository, branchRepository)
+      : null;
+  }
+
+  const messageId = extractMessageId(data);
+  if (messageId) {
+    const resolvedSessionId = await messageSessionId(context, messageId);
+    return resolvedSessionId
+      ? await sessionBranch(resolvedSessionId, sessionsRepository, branchRepository)
+      : null;
+  }
+
+  return undefined;
+}
+
+async function resolvePublishScope(
+  data: unknown,
+  context: PublishContext,
+  branchRepository: BranchRepository,
+  sessionsRepository: SessionRepository
+): Promise<PublishScope> {
+  if (!context.path) return { kind: 'global' };
+
+  if (BRANCH_ID_SCOPED_PATHS.has(context.path)) {
+    const branchId = extractBranchId(data, context);
+    return { kind: 'branch', branch: branchId ? await branchRepository.findById(branchId) : null };
+  }
+
+  if (context.path === 'sessions') {
+    const branchId = extractBranchId(data, context);
+    if (branchId) return { kind: 'branch', branch: await branchRepository.findById(branchId) };
+
+    // Custom sessions events carry camelCase `sessionId` instead of the
+    // session row's `branch_id`.
+    const branch = await resolveBranchFromSessionTaskOrMessage(
+      data,
+      context,
+      branchRepository,
+      sessionsRepository
+    );
+    return { kind: 'branch', branch: branch ?? null };
+  }
+
+  if (SESSION_ID_SCOPED_PATHS.has(context.path)) {
+    const branch = await resolveBranchFromSessionTaskOrMessage(
+      data,
+      context,
+      branchRepository,
+      sessionsRepository
+    );
+    return { kind: 'branch', branch: branch ?? null };
+  }
+
+  if (OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS.has(context.path)) {
+    const branchId = extractBranchId(data, context);
+    if (branchId) return { kind: 'branch', branch: await branchRepository.findById(branchId) };
+
+    const branch = await resolveBranchFromSessionTaskOrMessage(
+      data,
+      context,
+      branchRepository,
+      sessionsRepository
+    );
+    if (branch !== undefined) return { kind: 'branch', branch };
+
+    // These services can also emit global/card/board rows with no branch,
+    // session, task, or message attachment.
+    return { kind: 'global' };
+  }
+
+  if (context.path === 'artifacts') {
+    const branchId = extractBranchId(data, context);
+    if (branchId) return { kind: 'branch', branch: await branchRepository.findById(branchId) };
+
+    // Null-branch artifacts are not covered by branch visibility. Keep delivery
+    // narrow to the creator/admins when the creator is known, otherwise service
+    // connections only.
+    const createdBy = extractCreatedBy(data);
+    return createdBy ? { kind: 'users', userIds: new Set([createdBy]) } : { kind: 'serviceOnly' };
+  }
+
+  return { kind: 'global' };
+}
+
+async function authorizedConnectedUserIdsForBranch(
   branch: Branch,
-  usersRepository: UsersRepository,
+  connections: unknown[],
   branchRepository: BranchRepository,
   allowSuperadmin: boolean
 ): Promise<Set<string>> {
-  const users = await usersRepository.findAll();
   const allowed = new Set<string>();
+  const usersById = new Map<string, Partial<User> & { _isServiceAccount?: boolean }>();
+
+  for (const connection of connections) {
+    const user = userFromConnection(connection);
+    if (typeof user?.user_id === 'string') usersById.set(user.user_id, user);
+  }
 
   await Promise.all(
-    users.map(async (user) => {
+    Array.from(usersById.values()).map(async (user) => {
       if (isSuperAdmin(user.role, allowSuperadmin)) {
-        allowed.add(user.user_id);
+        allowed.add(user.user_id!);
         return;
       }
 
@@ -166,7 +281,7 @@ async function authorizedUserIdsForBranch(
         user.user_id as UUID
       )) as BranchPermissionLevel;
       if (PERMISSION_RANK[permission] >= PERMISSION_RANK.view) {
-        allowed.add(user.user_id);
+        allowed.add(user.user_id!);
       }
     })
   );
@@ -174,9 +289,33 @@ async function authorizedUserIdsForBranch(
   return allowed;
 }
 
-function isServiceConnection(connection: unknown): boolean {
-  const user = userFromConnection(connection);
-  return user?._isServiceAccount === true || (user?.role as string | undefined) === 'service';
+function filterToServiceConnections(authenticated: PublishChannel): PublishChannel {
+  return authenticated.filter((connection: unknown) => isServiceConnection(connection));
+}
+
+function filterToBranchUserIds(
+  authenticated: PublishChannel,
+  userIds: Set<string>
+): PublishChannel {
+  return authenticated.filter((connection: unknown) => {
+    if (isServiceConnection(connection)) return true;
+    const userId = userFromConnection(connection)?.user_id;
+    return typeof userId === 'string' && userIds.has(userId);
+  });
+}
+
+function filterToUserIdsOrAdmins(
+  authenticated: PublishChannel,
+  userIds: Set<string>,
+  allowSuperadmin: boolean
+): PublishChannel {
+  return authenticated.filter((connection: unknown) => {
+    if (isServiceConnection(connection) || isAdminConnection(connection, allowSuperadmin)) {
+      return true;
+    }
+    const userId = userFromConnection(connection)?.user_id;
+    return typeof userId === 'string' && userIds.has(userId);
+  });
 }
 
 /**
@@ -194,7 +333,6 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     branchRbacEnabled,
     branchRepository,
     sessionsRepository,
-    usersRepository,
     allowSuperadmin = true,
   } = options;
 
@@ -212,38 +350,29 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     const authenticated = app.channel('authenticated');
     if (!branchRbacEnabled) return authenticated;
 
-    const branch = await resolveBranchForPublish(
-      data,
-      context,
-      branchRepository,
-      sessionsRepository
-    );
+    const scope = await resolvePublishScope(data, context, branchRepository, sessionsRepository);
+    if (scope.kind === 'global') return authenticated;
+    if (scope.kind === 'serviceOnly') return filterToServiceConnections(authenticated);
+    if (scope.kind === 'users') {
+      return filterToUserIdsOrAdmins(authenticated, scope.userIds, allowSuperadmin);
+    }
 
-    // Undefined means the service is not branch/session scoped, so keep the
-    // regular authenticated fan-out. Null means it should have been scoped but
-    // lacked resolvable branch/session context; fail closed to prevent leakage.
-    if (branch === undefined) return authenticated;
-    if (!branch) {
+    if (!scope.branch) {
       console.warn('[realtime] Suppressing scoped event without resolvable branch context', {
         path: context.path,
         event: context.event,
         method: context.method,
       });
-      return authenticated.filter((connection: unknown) => isServiceConnection(connection));
+      return filterToServiceConnections(authenticated);
     }
 
-    const allowedUserIds = await authorizedUserIdsForBranch(
-      branch,
-      usersRepository,
+    const allowedUserIds = await authorizedConnectedUserIdsForBranch(
+      scope.branch,
+      channelConnections(authenticated),
       branchRepository,
       allowSuperadmin
     );
 
-    return authenticated.filter((connection: unknown) => {
-      if (isServiceConnection(connection)) return true;
-      const user = userFromConnection(connection);
-      const userId = user?.user_id;
-      return typeof userId === 'string' && allowedUserIds.has(userId);
-    });
+    return filterToBranchUserIds(authenticated, allowedUserIds);
   });
 }

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -9,7 +9,7 @@ import {
   RealtimeAccessCache,
 } from './realtime-access-cache.js';
 
-type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event' | 'app'>;
+type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event' | 'app' | 'params'>;
 
 type ConnectionLike = {
   user?: (Partial<User> & { _isServiceAccount?: boolean }) | undefined;
@@ -34,6 +34,7 @@ type PublishScope =
   | { kind: 'serviceOnly' };
 
 const BRANCH_ID_SCOPED_PATHS = new Set(['branches', 'schedules']);
+const ROUTE_BRANCH_ID_SCOPED_PATHS = new Set(['branches/:id/owners', 'branches/:id/group-grants']);
 const SESSION_ID_SCOPED_PATHS = new Set([
   'tasks',
   'messages',
@@ -66,6 +67,15 @@ function pickString(obj: Record<string, unknown> | null, ...keys: string[]): str
 
 function extractBranchId(data: unknown, context: PublishContext): string | undefined {
   const record = asRecord(data);
+  const routeBranchId = (context.params as { route?: { id?: unknown } } | undefined)?.route?.id;
+  if (
+    ROUTE_BRANCH_ID_SCOPED_PATHS.has(context.path ?? '') &&
+    typeof routeBranchId === 'string' &&
+    routeBranchId.length > 0
+  ) {
+    return routeBranchId;
+  }
+
   if (context.path === 'branches') {
     return (
       pickString(record, 'branch_id', 'branchId') ??
@@ -194,7 +204,7 @@ async function resolvePublishScope(
 ): Promise<PublishScope> {
   if (!context.path) return { kind: 'global' };
 
-  if (BRANCH_ID_SCOPED_PATHS.has(context.path)) {
+  if (BRANCH_ID_SCOPED_PATHS.has(context.path) || ROUTE_BRANCH_ID_SCOPED_PATHS.has(context.path)) {
     const branchId = extractBranchId(data, context);
     return { kind: 'branch', branchId: (branchId as BranchID | undefined) ?? null };
   }

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -1,4 +1,4 @@
-import type { BranchRepository, SessionRepository, UsersRepository } from '@agor/core/db';
+import type { BranchRepository, SessionRepository } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -24,7 +24,6 @@ type RealtimePublishOptions = {
   branchRbacEnabled: boolean;
   branchRepository: BranchRepository;
   sessionsRepository: SessionRepository;
-  usersRepository: UsersRepository;
   allowSuperadmin?: boolean;
 };
 

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -7,6 +7,7 @@ import { isSuperAdmin } from './branch-authorization.js';
 import {
   type RealtimeAccessBranchRepository,
   RealtimeAccessCache,
+  type RealtimeAccessSessionRepository,
 } from './realtime-access-cache.js';
 
 type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event' | 'app' | 'params'>;
@@ -300,7 +301,7 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     sessionsRepository,
     accessCache = new RealtimeAccessCache({
       branchRepository: branchRepository as unknown as RealtimeAccessBranchRepository,
-      sessionsRepository,
+      sessionsRepository: sessionsRepository as unknown as RealtimeAccessSessionRepository,
     }),
     allowSuperadmin = true,
   } = options;

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -1,16 +1,13 @@
 import type { BranchRepository, SessionRepository } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type {
-  Branch,
-  BranchPermissionLevel,
-  HookContext,
-  Session,
-  User,
-  UUID,
-} from '@agor/core/types';
+import type { BranchID, HookContext, User, UserID } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
-import { isSuperAdmin, PERMISSION_RANK } from './branch-authorization.js';
+import { isSuperAdmin } from './branch-authorization.js';
+import {
+  type RealtimeAccessBranchRepository,
+  RealtimeAccessCache,
+} from './realtime-access-cache.js';
 
 type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event' | 'app'>;
 
@@ -24,6 +21,7 @@ type RealtimePublishOptions = {
   branchRbacEnabled: boolean;
   branchRepository: BranchRepository;
   sessionsRepository: SessionRepository;
+  accessCache?: RealtimeAccessCache;
   allowSuperadmin?: boolean;
 };
 
@@ -31,7 +29,7 @@ type PublishChannel = ReturnType<Application['channel']>;
 
 type PublishScope =
   | { kind: 'global' }
-  | { kind: 'branch'; branch: Branch | null }
+  | { kind: 'branch'; branchId: BranchID | null }
   | { kind: 'users'; userIds: Set<string> }
   | { kind: 'serviceOnly' };
 
@@ -97,11 +95,6 @@ function extractCreatedBy(data: unknown): string | undefined {
   return pickString(record, 'created_by', 'createdBy');
 }
 
-function channelConnections(channel: PublishChannel): unknown[] {
-  const connections = (channel as { connections?: unknown[] }).connections;
-  return Array.isArray(connections) ? connections : [];
-}
-
 function userFromConnection(
   connection: unknown
 ): (Partial<User> & { _isServiceAccount?: boolean }) | undefined {
@@ -122,14 +115,11 @@ function isAdminConnection(connection: unknown, allowSuperadmin: boolean): boole
   return isSuperAdmin(user?.role, allowSuperadmin);
 }
 
-async function sessionBranch(
+async function sessionBranchId(
   sessionId: string,
-  sessionsRepository: SessionRepository,
-  branchRepository: BranchRepository
-): Promise<Branch | null> {
-  const session = (await sessionsRepository.findById(sessionId)) as Session | null;
-  if (!session?.branch_id) return null;
-  return await branchRepository.findById(session.branch_id);
+  accessCache: RealtimeAccessCache
+): Promise<BranchID | null> {
+  return await accessCache.getBranchIdForSession(sessionId);
 }
 
 async function taskSessionId(context: PublishContext, taskId: string): Promise<string | null> {
@@ -157,30 +147,42 @@ async function messageSessionId(
   }
 }
 
-async function resolveBranchFromSessionTaskOrMessage(
+async function resolveBranchIdFromSessionTaskOrMessage(
   data: unknown,
   context: PublishContext,
-  branchRepository: BranchRepository,
-  sessionsRepository: SessionRepository
-): Promise<Branch | null | undefined> {
+  accessCache: RealtimeAccessCache
+): Promise<BranchID | null | undefined> {
+  const branchId = extractBranchId(data, context);
+  if (branchId) return branchId as BranchID;
+
   const sessionId = extractSessionId(data);
-  if (sessionId) return await sessionBranch(sessionId, sessionsRepository, branchRepository);
+  if (sessionId) return await sessionBranchId(sessionId, accessCache);
 
   const taskId = extractTaskId(data);
   if (taskId) {
     const resolvedSessionId = await taskSessionId(context, taskId);
-    return resolvedSessionId
-      ? await sessionBranch(resolvedSessionId, sessionsRepository, branchRepository)
-      : null;
+    return resolvedSessionId ? await sessionBranchId(resolvedSessionId, accessCache) : null;
   }
 
   const messageId = extractMessageId(data);
   if (messageId) {
     const resolvedSessionId = await messageSessionId(context, messageId);
-    return resolvedSessionId
-      ? await sessionBranch(resolvedSessionId, sessionsRepository, branchRepository)
-      : null;
+    return resolvedSessionId ? await sessionBranchId(resolvedSessionId, accessCache) : null;
   }
+
+  return undefined;
+}
+
+async function resolveBranchIdFromBranchOrSession(
+  data: unknown,
+  context: PublishContext,
+  accessCache: RealtimeAccessCache
+): Promise<BranchID | null | undefined> {
+  const branchId = extractBranchId(data, context);
+  if (branchId) return branchId as BranchID;
+
+  const sessionId = extractSessionId(data);
+  if (sessionId) return await sessionBranchId(sessionId, accessCache);
 
   return undefined;
 }
@@ -188,52 +190,37 @@ async function resolveBranchFromSessionTaskOrMessage(
 async function resolvePublishScope(
   data: unknown,
   context: PublishContext,
-  branchRepository: BranchRepository,
-  sessionsRepository: SessionRepository
+  accessCache: RealtimeAccessCache
 ): Promise<PublishScope> {
   if (!context.path) return { kind: 'global' };
 
   if (BRANCH_ID_SCOPED_PATHS.has(context.path)) {
     const branchId = extractBranchId(data, context);
-    return { kind: 'branch', branch: branchId ? await branchRepository.findById(branchId) : null };
+    return { kind: 'branch', branchId: (branchId as BranchID | undefined) ?? null };
   }
 
   if (context.path === 'sessions') {
-    const branchId = extractBranchId(data, context);
-    if (branchId) return { kind: 'branch', branch: await branchRepository.findById(branchId) };
-
     // Custom sessions events carry camelCase `sessionId` instead of the
     // session row's `branch_id`.
-    const branch = await resolveBranchFromSessionTaskOrMessage(
-      data,
-      context,
-      branchRepository,
-      sessionsRepository
-    );
-    return { kind: 'branch', branch: branch ?? null };
+    const resolvedBranchId = await resolveBranchIdFromBranchOrSession(data, context, accessCache);
+    return { kind: 'branch', branchId: resolvedBranchId ?? null };
   }
 
   if (SESSION_ID_SCOPED_PATHS.has(context.path)) {
-    const branch = await resolveBranchFromSessionTaskOrMessage(
-      data,
-      context,
-      branchRepository,
-      sessionsRepository
-    );
-    return { kind: 'branch', branch: branch ?? null };
+    // Hot message/task paths must carry branch_id or session_id. Avoid
+    // message/task fallback lookups here so malformed streaming events fail
+    // closed instead of doing DB work per chunk.
+    const branchId = await resolveBranchIdFromBranchOrSession(data, context, accessCache);
+    return { kind: 'branch', branchId: branchId ?? null };
   }
 
   if (OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS.has(context.path)) {
-    const branchId = extractBranchId(data, context);
-    if (branchId) return { kind: 'branch', branch: await branchRepository.findById(branchId) };
-
-    const branch = await resolveBranchFromSessionTaskOrMessage(
+    const resolvedBranchId = await resolveBranchIdFromSessionTaskOrMessage(
       data,
       context,
-      branchRepository,
-      sessionsRepository
+      accessCache
     );
-    if (branch !== undefined) return { kind: 'branch', branch };
+    if (resolvedBranchId !== undefined) return { kind: 'branch', branchId: resolvedBranchId };
 
     // These services can also emit global/card/board rows with no branch,
     // session, task, or message attachment.
@@ -242,7 +229,7 @@ async function resolvePublishScope(
 
   if (context.path === 'artifacts') {
     const branchId = extractBranchId(data, context);
-    if (branchId) return { kind: 'branch', branch: await branchRepository.findById(branchId) };
+    if (branchId) return { kind: 'branch', branchId: branchId as BranchID };
 
     // Null-branch artifacts are not covered by branch visibility. Keep delivery
     // narrow to the creator/admins when the creator is known, otherwise service
@@ -254,58 +241,13 @@ async function resolvePublishScope(
   return { kind: 'global' };
 }
 
-async function authorizedConnectedUserIdsForBranch(
-  branch: Branch,
-  connections: unknown[],
-  branchRepository: BranchRepository,
-  allowSuperadmin: boolean
-): Promise<Set<string>> {
-  const allowed = new Set<string>();
-  const usersById = new Map<string, Partial<User> & { _isServiceAccount?: boolean }>();
-
-  for (const connection of connections) {
-    const user = userFromConnection(connection);
-    if (typeof user?.user_id === 'string') usersById.set(user.user_id, user);
-  }
-
-  await Promise.all(
-    Array.from(usersById.values()).map(async (user) => {
-      if (isSuperAdmin(user.role, allowSuperadmin)) {
-        allowed.add(user.user_id!);
-        return;
-      }
-
-      const permission = (await branchRepository.resolveUserPermission(
-        branch,
-        user.user_id as UUID
-      )) as BranchPermissionLevel;
-      if (PERMISSION_RANK[permission] >= PERMISSION_RANK.view) {
-        allowed.add(user.user_id!);
-      }
-    })
-  );
-
-  return allowed;
-}
-
 function filterToServiceConnections(authenticated: PublishChannel): PublishChannel {
   return authenticated.filter((connection: unknown) => isServiceConnection(connection));
 }
 
-function filterToBranchUserIds(
-  authenticated: PublishChannel,
-  userIds: Set<string>
-): PublishChannel {
-  return authenticated.filter((connection: unknown) => {
-    if (isServiceConnection(connection)) return true;
-    const userId = userFromConnection(connection)?.user_id;
-    return typeof userId === 'string' && userIds.has(userId);
-  });
-}
-
 function filterToUserIdsOrAdmins(
   authenticated: PublishChannel,
-  userIds: Set<string>,
+  userIds: Set<string> | Set<UserID>,
   allowSuperadmin: boolean
 ): PublishChannel {
   return authenticated.filter((connection: unknown) => {
@@ -314,6 +256,20 @@ function filterToUserIdsOrAdmins(
     }
     const userId = userFromConnection(connection)?.user_id;
     return typeof userId === 'string' && userIds.has(userId);
+  });
+}
+
+function filterToUserIdsOrSuperadmins(
+  authenticated: PublishChannel,
+  userIds: Set<UserID>,
+  allowSuperadmin: boolean
+): PublishChannel {
+  return authenticated.filter((connection: unknown) => {
+    if (isServiceConnection(connection)) return true;
+    const user = userFromConnection(connection);
+    if (isSuperAdmin(user?.role, allowSuperadmin)) return true;
+    const userId = user?.user_id;
+    return typeof userId === 'string' && userIds.has(userId as UserID);
   });
 }
 
@@ -332,6 +288,10 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     branchRbacEnabled,
     branchRepository,
     sessionsRepository,
+    accessCache = new RealtimeAccessCache({
+      branchRepository: branchRepository as unknown as RealtimeAccessBranchRepository,
+      sessionsRepository,
+    }),
     allowSuperadmin = true,
   } = options;
 
@@ -349,14 +309,14 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     const authenticated = app.channel('authenticated');
     if (!branchRbacEnabled) return authenticated;
 
-    const scope = await resolvePublishScope(data, context, branchRepository, sessionsRepository);
+    const scope = await resolvePublishScope(data, context, accessCache);
     if (scope.kind === 'global') return authenticated;
     if (scope.kind === 'serviceOnly') return filterToServiceConnections(authenticated);
     if (scope.kind === 'users') {
       return filterToUserIdsOrAdmins(authenticated, scope.userIds, allowSuperadmin);
     }
 
-    if (!scope.branch) {
+    if (!scope.branchId) {
       console.warn('[realtime] Suppressing scoped event without resolvable branch context', {
         path: context.path,
         event: context.event,
@@ -365,13 +325,20 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
       return filterToServiceConnections(authenticated);
     }
 
-    const allowedUserIds = await authorizedConnectedUserIdsForBranch(
-      scope.branch,
-      channelConnections(authenticated),
-      branchRepository,
-      allowSuperadmin
-    );
+    const visibility = await accessCache.getBranchVisibility(scope.branchId);
+    if (!visibility) {
+      console.warn('[realtime] Suppressing scoped event without resolvable branch context', {
+        path: context.path,
+        event: context.event,
+        method: context.method,
+      });
+      return filterToServiceConnections(authenticated);
+    }
 
-    return filterToBranchUserIds(authenticated, allowedUserIds);
+    if (visibility.mode === 'allAuthenticated') {
+      return authenticated;
+    }
+
+    return filterToUserIdsOrSuperadmins(authenticated, visibility.userIds, allowSuperadmin);
   });
 }

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -250,6 +250,35 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   }
 
   /**
+   * Find only the fields needed by realtime delivery visibility checks.
+   */
+  async findRealtimeVisibilityBranch(
+    id: string
+  ): Promise<Pick<Branch, 'branch_id' | 'others_can'> | null> {
+    try {
+      const fullId = await resolveByShortIdPrefix(id, 'Branch', async (pattern) => {
+        const rows = await select(this.db, { branch_id: branches.branch_id })
+          .from(branches)
+          .where(like(branches.branch_id, pattern))
+          .limit(RESOLVE_SHORT_ID_FETCH_LIMIT)
+          .all();
+        return rows.map((r: { branch_id: string }) => r.branch_id);
+      });
+      const row = await select(this.db, {
+        branch_id: branches.branch_id,
+        others_can: branches.others_can,
+      })
+        .from(branches)
+        .where(eq(branches.branch_id, fullId))
+        .one();
+      return row ? { branch_id: row.branch_id as BranchID, others_can: row.others_can } : null;
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) return null;
+      throw error;
+    }
+  }
+
+  /**
    * Find all branches (with optional filters)
    *
    * By default, returns ALL branches including archived. This matches the generic

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -42,6 +42,7 @@ import { deepMerge } from './merge-utils';
 const BRANCH_PERMISSION_RANK = Object.fromEntries(
   BRANCH_PERMISSION_LEVELS.map((level, index) => [level, index - 1])
 ) as Record<NonNullable<Branch['others_can']>, number>;
+const VIEW_OR_BETTER_BRANCH_PERMISSIONS = ['view', 'session', 'prompt', 'all'] as const;
 
 /**
  * Session activity summary for a branch
@@ -483,6 +484,43 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     return BRANCH_PERMISSION_RANK[groupGrant.can] >= BRANCH_PERMISSION_RANK[others]
       ? groupGrant.can
       : others;
+  }
+
+  /**
+   * Find users with explicit view-or-better access to a branch through direct
+   * ownership or active group grants. This intentionally does not expand
+   * `others_can`; callers can handle public branch visibility without loading
+   * every user row.
+   */
+  async findExplicitViewUserIds(branchId: BranchID): Promise<UUID[]> {
+    const ownerRows = await select(this.db, { user_id: branchOwners.user_id })
+      .from(branchOwners)
+      .where(eq(branchOwners.branch_id, branchId))
+      .all();
+
+    const groupRows = await select(this.db, { user_id: groupMemberships.user_id })
+      .from(branchGroupGrants)
+      .innerJoin(groupMemberships, eq(groupMemberships.group_id, branchGroupGrants.group_id))
+      .innerJoin(
+        groups,
+        and(eq(groups.group_id, branchGroupGrants.group_id), eq(groups.archived, false))
+      )
+      .where(
+        and(
+          eq(branchGroupGrants.branch_id, branchId),
+          inArray(branchGroupGrants.can, VIEW_OR_BETTER_BRANCH_PERMISSIONS)
+        )
+      )
+      .all();
+
+    const userIds = new Set<UUID>();
+    for (const row of ownerRows as Array<{ user_id: string }>) {
+      userIds.add(row.user_id as UUID);
+    }
+    for (const row of groupRows as Array<{ user_id: string }>) {
+      userIds.add(row.user_id as UUID);
+    }
+    return Array.from(userIds);
   }
 
   /**

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -4,7 +4,7 @@
  * Type-safe CRUD operations for sessions with short ID support.
  */
 
-import type { Session, SessionID, UUID } from '@agor/core/types';
+import type { BranchID, Session, SessionID, UUID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { and, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
@@ -247,6 +247,28 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       if (error instanceof AmbiguousIdError) throw error;
       throw new RepositoryError(
         `Failed to find session: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Find only the branch ID for a session. Used by realtime routing hot paths
+   * to avoid loading/enriching the full session row.
+   */
+  async findBranchIdBySessionId(id: string): Promise<BranchID | null> {
+    try {
+      const fullId = await this.resolveId(id);
+      const row = await select(this.db, { branch_id: sessions.branch_id })
+        .from(sessions)
+        .where(eq(sessions.session_id, fullId))
+        .one();
+      return (row?.branch_id as BranchID | undefined) ?? null;
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) return null;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to find session branch: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }


### PR DESCRIPTION
## Summary
- Route branch-related realtime delivery through a shared filter
- Keep open-access behavior unchanged
- Add focused coverage for delivery decisions

## Checks
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/utils/realtime-publish.test.ts`
- `pnpm --filter @agor/daemon test -- src/utils/rbac-find-scoping.test.ts src/register-hooks.test.ts`
