### PR TITLE
Clean up user lookup response handling

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -69,6 +69,7 @@ import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
+import { isLocalAuthenticationLookup } from './services/users.js';
 import { buildSessionCreatedAnalyticsProperties } from './utils/analytics-payloads.js';
 import { applySessionConfigDefaults } from './utils/apply-session-config-defaults.js';
 import {
@@ -1599,8 +1600,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           }
 
           const query = params.query || {};
-          if (query.email) {
-            // Allow local authentication lookup, ensure we only return minimal results
+          if (query.email && isLocalAuthenticationLookup(params)) {
+            // Allow only the Feathers local authentication pipeline to perform
+            // unauthenticated exact-email lookup. Direct external /users?email
+            // calls are denied below so hashes/private auth fields cannot leak
+            // through lookup/enumeration responses.
             params.query = { ...query, $limit: 1 };
             return context;
           }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -89,6 +89,7 @@ import {
 } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { createUserApiKeysService } from './services/user-api-keys.js';
+import { markLocalAuthenticationLookup } from './services/users.js';
 import { registerProxies } from './setup/proxies.js';
 import { applyTierHooks } from './setup/service-tiers.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
@@ -122,6 +123,13 @@ import {
   enforceTotalUploadSize,
 } from './utils/upload.js';
 import { resolveWidget } from './widgets/submissions.js';
+
+export class AgorLocalStrategy extends LocalStrategy {
+  async findEntity(username: string, params: Params) {
+    markLocalAuthenticationLookup(params);
+    return super.findEntity(username, params);
+  }
+}
 
 /**
  * Extended Params with route ID parameter.
@@ -285,7 +293,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   // Register authentication strategies
   authentication.register('jwt', new ServiceJWTStrategy());
-  authentication.register('local', new LocalStrategy());
+  authentication.register('local', new AgorLocalStrategy());
 
   // Register API key authentication strategy
   const { ApiKeyStrategy } = await import('./auth/api-key-strategy.js');

--- a/apps/agor-daemon/src/services/users.find.test.ts
+++ b/apps/agor-daemon/src/services/users.find.test.ts
@@ -1,6 +1,8 @@
+import { AuthenticationService, feathers } from '@agor/core/feathers';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
-import { UsersService } from './users';
+import { AgorLocalStrategy } from '../register-routes';
+import { createUsersService, LOCAL_AUTH_LOOKUP_PARAM, UsersService } from './users';
 
 describe('UsersService.find', () => {
   dbTest('respects limit/skip pagination and reports total matches', async ({ db }) => {
@@ -68,4 +70,126 @@ describe('UsersService.find', () => {
       expect(byUnix.data[0].unix_username).toBe('rthompson');
     }
   );
+});
+
+describe('UsersService.find exact-email hardening', () => {
+  dbTest('rejects unauthenticated external exact-email lookup', async ({ db }) => {
+    const service = new UsersService(db);
+    await service.create({ email: 'target@example.com', password: 'password-123' });
+
+    await expect(
+      service.find({ provider: 'rest', query: { email: 'target@example.com' } })
+    ).rejects.toThrow(/Authentication required/);
+  });
+
+  dbTest('rejects authenticated non-admin lookup for another user email', async ({ db }) => {
+    const service = new UsersService(db);
+    const requester = await service.create({
+      email: 'requester@example.com',
+      password: 'password-123',
+    });
+    await service.create({ email: 'target@example.com', password: 'password-123' });
+
+    await expect(
+      service.find({
+        provider: 'rest',
+        user: { user_id: requester.user_id, email: requester.email, role: 'member' },
+        query: { email: 'target@example.com' },
+      })
+    ).rejects.toThrow(/Exact email user lookup is restricted/);
+  });
+
+  dbTest('allows self exact-email lookup without exposing password', async ({ db }) => {
+    const service = new UsersService(db);
+    const user = await service.create({ email: 'self@example.com', password: 'password-123' });
+
+    const page = await service.find({
+      provider: 'rest',
+      user: { user_id: user.user_id, email: user.email, role: 'member' },
+      query: { email: 'self@example.com' },
+    });
+
+    expect(page.total).toBe(1);
+    expect(page.data[0].email).toBe('self@example.com');
+    expect(page.data[0]).not.toHaveProperty('password');
+  });
+
+  dbTest('allows admin exact-email lookup without exposing password', async ({ db }) => {
+    const service = new UsersService(db);
+    await service.create({ email: 'target@example.com', password: 'password-123' });
+
+    const page = await service.find({
+      provider: 'rest',
+      user: { user_id: 'admin-user', email: 'admin@example.com', role: 'admin' },
+      query: { email: 'target@example.com' },
+    });
+
+    expect(page.total).toBe(1);
+    expect(page.data[0].email).toBe('target@example.com');
+    expect(page.data[0]).not.toHaveProperty('password');
+  });
+
+  dbTest('keeps password hash scoped to the local authentication pipeline', async ({ db }) => {
+    const service = new UsersService(db);
+    await service.create({ email: 'login@example.com', password: 'password-123' });
+
+    const externalSelf = await service.find({
+      provider: 'rest',
+      user: { user_id: 'login-user', email: 'login@example.com', role: 'member' },
+      query: { email: 'login@example.com' },
+    });
+    expect(externalSelf.data[0]).not.toHaveProperty('password');
+
+    const authLookup = await service.find({
+      provider: 'rest',
+      [LOCAL_AUTH_LOOKUP_PARAM]: true,
+      query: { email: 'login@example.com' },
+    } as any);
+    expect(authLookup.data[0]).toHaveProperty('password');
+  });
+
+  dbTest('local authentication succeeds through the registered strategy marker', async ({ db }) => {
+    const app = feathers();
+    app.set('authentication', {
+      secret: 'test-jwt-secret',
+      entity: 'user',
+      entityId: 'user_id',
+      service: 'users',
+      authStrategies: ['local'],
+      jwtOptions: {
+        header: { typ: 'access' },
+        audience: 'https://agor.dev',
+        issuer: 'agor',
+        algorithm: 'HS256',
+        expiresIn: '15m',
+      },
+      local: {
+        usernameField: 'email',
+        passwordField: 'password',
+      },
+    });
+
+    app.use('users', createUsersService(db));
+
+    const authentication = new AuthenticationService(app);
+    authentication.register('local', new AgorLocalStrategy());
+    app.use('authentication', authentication);
+
+    await app.service('users').create({
+      email: 'strategy-login@example.com',
+      password: 'password-123',
+    });
+
+    const result = await app.service('authentication').create(
+      {
+        strategy: 'local',
+        email: 'strategy-login@example.com',
+        password: 'password-123',
+      },
+      { provider: 'rest' }
+    );
+
+    expect(result.user.email).toBe('strategy-login@example.com');
+    expect(result.user).not.toHaveProperty('password');
+  });
 });

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -46,6 +46,7 @@ import type {
 } from '@agor/core/types';
 import {
   extractAgenticToolsPublicValues,
+  hasMinimumRole,
   normalizeRole,
   ROLES,
   toAgenticToolsStatus,
@@ -62,6 +63,54 @@ function queryString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const LOCAL_AUTH_LOOKUP_PARAM = Symbol('agor.users.local-auth-lookup');
+
+export interface LocalAuthenticationLookupParams extends Params {
+  [LOCAL_AUTH_LOOKUP_PARAM]?: true;
+}
+
+export function markLocalAuthenticationLookup(params: Params): void {
+  (params as LocalAuthenticationLookupParams)[LOCAL_AUTH_LOOKUP_PARAM] = true;
+}
+
+export function isLocalAuthenticationLookup(params: Params | undefined): boolean {
+  return (
+    (params as LocalAuthenticationLookupParams | undefined)?.[LOCAL_AUTH_LOOKUP_PARAM] === true
+  );
+}
+
+function isServiceAccount(params: Params | undefined): boolean {
+  return !!(params as AuthenticatedParams | undefined)?.user?._isServiceAccount;
+}
+
+function isAdmin(params: Params | undefined): boolean {
+  return hasMinimumRole((params as AuthenticatedParams | undefined)?.user?.role, ROLES.ADMIN);
+}
+
+function isSelfEmailLookup(params: Params | undefined, email: string): boolean {
+  const requesterEmail = (params as AuthenticatedParams | undefined)?.user?.email;
+  return !!requesterEmail && requesterEmail.toLowerCase() === email.toLowerCase();
+}
+
+function ensureCanExactEmailLookup(params: Params | undefined, email: string): void {
+  // Internal service calls are trusted and may perform exact-email lookups for
+  // auth/session bootstrap paths. External callers need an authenticated admin,
+  // service account, or a self lookup. The Feathers local strategy is the lone
+  // unauthenticated external path; it receives the password hash only inside the
+  // authentication pipeline and must never be exposed by /users responses.
+  if (!params?.provider || isLocalAuthenticationLookup(params)) return;
+
+  if (!(params as AuthenticatedParams | undefined)?.user) {
+    throw new NotAuthenticated('Authentication required');
+  }
+
+  if (isServiceAccount(params) || isAdmin(params) || isSelfEmailLookup(params, email)) {
+    return;
+  }
+
+  throw new Forbidden('Exact email user lookup is restricted');
 }
 
 /**
@@ -159,7 +208,8 @@ export class UsersService {
    * Find all users.
    *
    * Supports:
-   * - `email` exact lookup for authentication (includes password, legacy behavior)
+   * - `email` exact lookup for authorized callers; password is included only
+   *   for the internal local-authentication lookup marker
    * - `search` / `query` / `q` case-insensitive substring lookup across
    *   name, email, and unix_username
    * - Feathers-style `$limit` / `$skip`, plus plain `limit` / `skip` /
@@ -169,15 +219,16 @@ export class UsersService {
     const rawQuery = (params?.query ?? {}) as Record<string, unknown>;
 
     // Check if filtering by email (for authentication)
-    const email = rawQuery.email as string | undefined;
-    const includePassword = !!email; // Include password when looking up by email (for authentication)
+    const email = queryString(rawQuery.email);
+    const includePassword = !!email && isLocalAuthenticationLookup(params);
     const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
       | UserID
       | undefined;
 
     let rows: (typeof users.$inferSelect)[];
     if (email) {
-      // Find by email (for LocalStrategy)
+      ensureCanExactEmailLookup(params, email);
+      // Find by email (for LocalStrategy / authorized exact lookup)
       const row = await select(this.db).from(users).where(eq(users.email, email)).one();
       rows = row ? [row] : [];
     } else {


### PR DESCRIPTION
## Summary

- Clean up user lookup response handling.
- Scope internal login-only fields to the login flow.
- Add focused coverage for caller role and self lookup behavior.

## Checks

- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/users.find.test.ts src/services/users.security.test.ts`
