### PR TITLE
Improve integration auth handling

### DIFF
--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-describe('register-hooks MCP custom header redaction', () => {
+describe('register-hooks MCP server secret redaction', () => {
   const source = readFileSync(new URL('./register-hooks.ts', import.meta.url), 'utf8');
   const routesSource = readFileSync(new URL('./register-routes.ts', import.meta.url), 'utf8');
   const utilSource = readFileSync(
@@ -10,22 +10,28 @@ describe('register-hooks MCP custom header redaction', () => {
   );
 
   it('redacts MCP custom header values in mcp-servers responses', () => {
-    expect(source).toContain('redactMCPHeaderSecrets');
-    expect(source).toContain('redactMCPServerHeaderSecrets');
-    expect(utilSource).toContain('redactMCPCustomHeaders(server.headers)');
-    expect(source).toMatch(/find:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
-    expect(source).toMatch(/get:\s*\[injectPerUserOAuthTokens,\s*redactMCPHeaderSecrets\]/);
+    expect(source).toContain('redactMCPServerSecretFields');
+    expect(source).toContain('redactMCPServerSecrets');
+    expect(utilSource).toContain('redactMCPAuthSecrets(server.auth)');
+    expect(source).toMatch(/find:\s*\[injectPerUserOAuthTokens,\s*redactMCPServerSecretFields\]/);
+    expect(source).toMatch(/get:\s*\[injectPerUserOAuthTokens,\s*redactMCPServerSecretFields\]/);
   });
 
   it('redacts session MCP server route responses that bypass service hooks', () => {
     expect(routesSource).toContain("'/sessions/:id/mcp-servers'");
-    expect(routesSource).toContain('redactMCPServerHeaderSecrets');
-    expect(routesSource).toContain('servers.map(redactMCPServerHeaderSecrets)');
+    expect(routesSource).toContain('redactMCPServerSecrets');
+    expect(routesSource).toContain('servers.map(redactMCPServerSecrets)');
+    expect(routesSource).toContain('await requireSessionScopedConfigOwnerOrAdmin(id, params)');
+    expect(routesSource).toContain('includeGlobal');
+    expect(routesSource).toContain("scope: 'global'");
+    expect(routesSource).toContain('forUserId');
   });
 
-  it('keeps raw headers available to executor session-token calls', () => {
-    expect(source).toContain('shouldExposeMCPHeaderSecrets(context.params)');
-    expect(routesSource).toContain('shouldExposeMCPHeaderSecrets(params)');
-    expect(utilSource).toContain("params.authentication?.strategy === 'session-token'");
+  it('does not expose raw secrets to global session-token service reads', () => {
+    expect(source).toContain('shouldExposeMCPServerSecrets(context.params)');
+    expect(routesSource).toContain('shouldExposeMCPServerSecrets(params, {');
+    expect(routesSource).toContain('allowSessionToken: true');
+    expect(routesSource).toContain('sessionId: id');
+    expect(utilSource).toContain('options.allowSessionToken === true');
   });
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -104,8 +104,8 @@ import { inspectBranchViaExecutor } from './utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from './utils/executor-read-impersonation.js';
 import { injectCreatedBy } from './utils/inject-created-by.js';
 import {
-  redactMCPServerHeaderSecrets,
-  shouldExposeMCPHeaderSecrets,
+  redactMCPServerSecrets,
+  shouldExposeMCPServerSecrets,
 } from './utils/mcp-header-secrets.js';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
@@ -1214,15 +1214,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  const redactMCPHeaderSecrets = async (context: HookContext) => {
-    if (shouldExposeMCPHeaderSecrets(context.params)) return context;
+  const redactMCPServerSecretFields = async (context: HookContext) => {
+    if (shouldExposeMCPServerSecrets(context.params)) return context;
 
     if (Array.isArray(context.result)) {
-      context.result = context.result.map(redactMCPServerHeaderSecrets);
+      context.result = context.result.map(redactMCPServerSecrets);
     } else if (context.result?.data && Array.isArray(context.result.data)) {
-      context.result.data = context.result.data.map(redactMCPServerHeaderSecrets);
+      context.result.data = context.result.data.map(redactMCPServerSecrets);
     } else if (context.result?.mcp_server_id) {
-      context.result = redactMCPServerHeaderSecrets(context.result);
+      context.result = redactMCPServerSecrets(context.result);
     }
 
     return context;
@@ -1239,11 +1239,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       remove: [requireMinimumRole(ROLES.ADMIN, 'delete MCP servers')],
     },
     after: {
-      find: [injectPerUserOAuthTokens, redactMCPHeaderSecrets],
-      get: [injectPerUserOAuthTokens, redactMCPHeaderSecrets],
-      create: [redactMCPHeaderSecrets],
-      patch: [redactMCPHeaderSecrets],
-      update: [redactMCPHeaderSecrets],
+      find: [injectPerUserOAuthTokens, redactMCPServerSecretFields],
+      get: [injectPerUserOAuthTokens, redactMCPServerSecretFields],
+      create: [redactMCPServerSecretFields],
+      patch: [redactMCPServerSecretFields],
+      update: [redactMCPServerSecretFields],
     },
   });
 
@@ -1259,7 +1259,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
     },
     after: {
-      find: [injectPerUserOAuthTokens],
+      find: [injectPerUserOAuthTokens, redactMCPServerSecretFields],
     },
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -108,8 +108,8 @@ import {
 import { buildInitialUserMessage } from './utils/build-initial-user-message.js';
 import { buildPrompterPrefixedPrompt } from './utils/build-prompter-prefix.js';
 import {
-  redactMCPServerHeaderSecrets,
-  shouldExposeMCPHeaderSecrets,
+  redactMCPServerSecrets,
+  shouldExposeMCPServerSecrets,
 } from './utils/mcp-header-secrets.js';
 import { canControlCliSession } from './utils/mcp-token-authorization.js';
 import { ensureScheduleRunsAsCaller } from './utils/schedule-hooks.js';
@@ -3098,6 +3098,29 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     );
   }
 
+  // Route-side wrapper for session-scoped runtime configuration. These
+  // settings can influence what a session process receives, so branch-level
+  // read/write tiers are not enough: only the session creator or a global
+  // admin/superadmin may read or mutate them.
+  const requireSessionScopedConfigOwnerOrAdmin = async (
+    sessionId: string,
+    // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
+    params: any
+  ): Promise<void> => {
+    const user = params?.user;
+    if (!user) {
+      throw new NotAuthenticated('Authentication required');
+    }
+    // Fast-path for service accounts — skip the session lookup entirely.
+    if (user._isServiceAccount) return;
+
+    const session = await sessionsService.get(sessionId, { provider: undefined });
+    if (!session) {
+      throw new NotFound(`Session not found: ${sessionId}`);
+    }
+    checkSessionOwnerOrAdmin(user, session, superadminOpts);
+  };
+
   // ============================================================================
   // Session MCP servers routes
   // ============================================================================
@@ -3110,21 +3133,70 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         async find(_data: unknown, params: RouteParams) {
           const id = params.route?.id;
           if (!id) throw new Error('Session ID required');
+          await requireSessionScopedConfigOwnerOrAdmin(id, params);
           const enabledOnly =
             params.query?.enabledOnly === 'true' || params.query?.enabledOnly === true;
-          const servers = await sessionMCPServersService.listServers(
+          const includeGlobal =
+            params.query?.includeGlobal === 'true' || params.query?.includeGlobal === true;
+          const sessionServerRefs = await sessionMCPServersService.listServers(
             id as import('@agor/core/types').SessionID,
             enabledOnly,
             params
           );
-          return shouldExposeMCPHeaderSecrets(params)
+          const mcpService = app.service('mcp-servers');
+          const userId = params.user?.user_id;
+          const rawLookupParams = {
+            ...params,
+            provider: undefined,
+            query: {
+              ...(userId ? { forUserId: userId } : {}),
+            },
+          };
+          const sessionServers = await Promise.all(
+            sessionServerRefs.map(async (server) => {
+              try {
+                return await mcpService.get(server.mcp_server_id, rawLookupParams);
+              } catch (_error) {
+                return server;
+              }
+            })
+          );
+          const globalQuery = {
+            scope: 'global',
+            ...(enabledOnly ? { enabled: true } : {}),
+            ...(userId ? { forUserId: userId } : {}),
+            $limit: 1000,
+          };
+          const globalResult = includeGlobal
+            ? await mcpService.find({
+                ...params,
+                provider: undefined,
+                query: globalQuery,
+              })
+            : [];
+          const globalServers = Array.isArray(globalResult) ? globalResult : globalResult.data;
+          const servers = includeGlobal
+            ? [
+                ...new Map(
+                  [...globalServers, ...sessionServers].map((server) => [
+                    server.mcp_server_id,
+                    server,
+                  ])
+                ).values(),
+              ]
+            : sessionServers;
+          return shouldExposeMCPServerSecrets(params, {
+            allowSessionToken: true,
+            sessionId: id,
+          })
             ? servers
-            : servers.map(redactMCPServerHeaderSecrets);
+            : servers.map(redactMCPServerSecrets);
         },
         async create(data: { mcpServerId: string }, params: RouteParams) {
           const id = params.route?.id;
           if (!id) throw new Error('Session ID required');
           if (!data.mcpServerId) throw new Error('MCP Server ID required');
+          await requireSessionScopedConfigOwnerOrAdmin(id, params);
 
           await sessionMCPServersService.addServer(
             id as import('@agor/core/types').SessionID,
@@ -3146,6 +3218,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           const id = params.route?.id;
           if (!id) throw new Error('Session ID required');
           if (!mcpId) throw new Error('MCP Server ID required');
+          await requireSessionScopedConfigOwnerOrAdmin(id, params);
 
           await sessionMCPServersService.removeServer(
             id as import('@agor/core/types').SessionID,
@@ -3166,6 +3239,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           if (!id) throw new Error('Session ID required');
           if (!mcpId) throw new Error('MCP Server ID required');
           if (typeof data.enabled !== 'boolean') throw new Error('enabled field required');
+          await requireSessionScopedConfigOwnerOrAdmin(id, params);
           return sessionMCPServersService.toggleServer(
             id as import('@agor/core/types').SessionID,
             mcpId as import('@agor/core/types').MCPServerID,
@@ -3197,29 +3271,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Branch `all` permission does NOT grant access — selections expose the
   // creator's private credentials to the executor process.
   // ============================================================================
-
-  // Route-side RBAC wrapper: loads the session, then delegates to the shared
-  // `checkSessionOwnerOrAdmin` helper used by the Feathers hook. Keeps the
-  // policy in a single place (see `utils/branch-authorization.ts`) and
-  // respects the daemon's configured `allowSuperadmin` via `superadminOpts`.
-  const requireSessionOwnerOrAdmin = async (
-    sessionId: string,
-    // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type
-    params: any
-  ): Promise<void> => {
-    const user = params?.user;
-    if (!user) {
-      throw new NotAuthenticated('Authentication required');
-    }
-    // Fast-path for service accounts — skip the session lookup entirely.
-    if (user._isServiceAccount) return;
-
-    const session = await sessionsService.get(sessionId, { provider: undefined });
-    if (!session) {
-      throw new NotFound(`Session not found: ${sessionId}`);
-    }
-    checkSessionOwnerOrAdmin(user, session, superadminOpts);
-  };
 
   // Validate + normalize an `envVarNames` payload: every entry must be a
   // non-empty string, with leading/trailing whitespace trimmed and duplicates
@@ -3256,7 +3307,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         const id = params.route?.id;
         if (!id) throw new BadRequest('Session ID required');
         // Read permission: session creator OR admin (no branch tier).
-        await requireSessionOwnerOrAdmin(id, params);
+        await requireSessionScopedConfigOwnerOrAdmin(id, params);
         const rows = await sessionEnvSelectionsService.list(id as SessionID, params);
         return rows.map((r) => r.env_var_name);
       },
@@ -3268,7 +3319,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
         const name = data.envVarName.trim();
         if (!name) throw new BadRequest('envVarName must be non-empty');
-        await requireSessionOwnerOrAdmin(id, params);
+        await requireSessionScopedConfigOwnerOrAdmin(id, params);
         await sessionEnvSelectionsService.add(id as SessionID, name, params);
         const relationship = {
           session_id: id,
@@ -3285,7 +3336,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         const id = params.route?.id;
         if (!id) throw new BadRequest('Session ID required');
         if (!name) throw new BadRequest('env var name required');
-        await requireSessionOwnerOrAdmin(id, params);
+        await requireSessionScopedConfigOwnerOrAdmin(id, params);
         await sessionEnvSelectionsService.remove(id as SessionID, name, params);
         const relationship = {
           session_id: id,
@@ -3302,7 +3353,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         const id = params.route?.id;
         if (!id) throw new BadRequest('Session ID required');
         const envVarNames = normalizeEnvVarNames(data?.envVarNames);
-        await requireSessionOwnerOrAdmin(id, params);
+        await requireSessionScopedConfigOwnerOrAdmin(id, params);
         await sessionEnvSelectionsService.setAll(id as SessionID, envVarNames, params);
         try {
           app

--- a/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-custom-headers.test.ts
@@ -19,7 +19,10 @@ describe('register-services /mcp-servers/discover custom headers wiring', () => 
     expect(discoverBlock).toContain('serverConfig.headers = resolution.resolved.headers');
   });
 
-  it('restores redacted edit-form header values from the saved server before probing', () => {
+  it('restores redacted edit-form auth/header values from the saved server before probing', () => {
+    expect(discoverBlock).toContain('restoreRedactedMCPAuthSecrets');
+    expect(discoverBlock).toContain('current: server.auth');
+    expect(discoverBlock).toContain('next: data.auth');
     expect(discoverBlock).toContain('restoreRedactedMCPCustomHeaders');
     expect(discoverBlock).toContain('current: server.headers');
     expect(discoverBlock).toContain('next: data.headers');
@@ -30,5 +33,29 @@ describe('register-services /mcp-servers/discover custom headers wiring', () => 
     expect(discoverBlock).toContain('requestInit: { headers: connHeaders }');
     expect(discoverBlock).toContain('custom: serverConfig.headers');
     expect(discoverBlock).toContain('auth: authHeaders');
+  });
+});
+
+describe('register-services /mcp-servers/oauth-auth-headers authorization', () => {
+  const source = readFileSync(new URL('./register-services.ts', import.meta.url), 'utf8');
+  const authHeadersStart = source.indexOf("app.use('/mcp-servers/oauth-auth-headers'");
+  const afterAuthHeaders = source.slice(authHeadersStart + 1);
+  const authHeadersBlock =
+    authHeadersStart === -1
+      ? ''
+      : source.slice(
+          authHeadersStart,
+          authHeadersStart +
+            1 +
+            afterAuthHeaders.indexOf("app.service('mcp-servers/oauth-auth-headers')")
+        );
+
+  it('rejects normal provider users and checks session-token requests against attached servers', () => {
+    expect(authHeadersBlock).toContain('trusted executor paths');
+    expect(authHeadersBlock).toContain('shouldExposeMCPServerSecretsForSessionToken');
+    expect(authHeadersBlock).toContain('SessionMCPServerRepository');
+    expect(authHeadersBlock).toContain("scope: 'global'");
+    expect(authHeadersBlock).toContain('allowedServerIds');
+    expect(authHeadersBlock).toContain('server_not_in_session_scope');
   });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -17,6 +17,7 @@ import {
   eq,
   inArray,
   MCPServerRepository,
+  SessionMCPServerRepository,
   type SessionMCPServerRow,
   select,
   sessionMcpServers,
@@ -24,7 +25,7 @@ import {
   UserMCPOAuthTokenRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import { NotAuthenticated } from '@agor/core/feathers';
+import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   HookContext,
@@ -99,6 +100,10 @@ import { createUsersService } from './services/users.js';
 import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { escapeHtml } from './utils/html.js';
+import {
+  shouldExposeMCPServerSecrets,
+  shouldExposeMCPServerSecretsForSessionToken,
+} from './utils/mcp-header-secrets.js';
 import {
   computeFileHash,
   findCodexSessionFile,
@@ -1985,7 +1990,7 @@ async function registerMCPServices(
       headers: Record<string, { authorization?: string; error?: string }>;
     }> {
       const userId = params?.user?.user_id;
-      if (!userId) {
+      if (!userId && params?.provider) {
         throw new NotAuthenticated('oauth-auth-headers requires authentication');
       }
 
@@ -1996,14 +2001,39 @@ async function registerMCPServices(
         return { headers };
       }
 
+      const sessionId = (params as (AuthenticatedParams & { session_id?: string }) | undefined)
+        ?.session_id;
+      const trustedInternalOrService = shouldExposeMCPServerSecrets(params);
+      const trustedSessionExecutor = shouldExposeMCPServerSecretsForSessionToken(params, {
+        sessionId,
+      });
+      if (!trustedInternalOrService && !trustedSessionExecutor) {
+        throw new Forbidden('oauth-auth-headers is only available to trusted executor paths');
+      }
+
       const userTokenRepo = new UserMCPOAuthTokenRepository(db);
       const mcpServerRepo = new MCPServerRepository(db);
+      if (trustedSessionExecutor) {
+        const sessionMcpRepo = new SessionMCPServerRepository(db);
+        const attachedServers = await sessionMcpRepo.listServers(sessionId as SessionID, true);
+        const globalServers = await mcpServerRepo.findAll({ scope: 'global', enabled: true });
+        const allowedServerIds = new Set([
+          ...globalServers.map((server) => server.mcp_server_id),
+          ...attachedServers.map((server) => server.mcp_server_id),
+        ]);
+        for (const serverId of serverIds) {
+          if (!allowedServerIds.has(serverId as MCPServerID)) {
+            headers[serverId] = { error: 'server_not_in_session_scope' };
+          }
+        }
+      }
       const { needsRefresh, refreshAndPersistToken, InvalidGrantError } = await import(
         '@agor/core/tools/mcp/oauth-refresh'
       );
 
       await Promise.all(
         serverIds.map(async (serverId) => {
+          if (headers[serverId]) return;
           try {
             const server = await mcpServerRepo.findById(serverId);
             if (!server) {
@@ -2016,6 +2046,10 @@ async function registerMCPServices(
             }
 
             const mode = server.auth.oauth_mode ?? 'per_user';
+            if (mode === 'per_user' && !userId) {
+              headers[serverId] = { error: 'needs_user_context' };
+              return;
+            }
             const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
 
             const row = await userTokenRepo.getToken(tokenUserId, serverId as MCPServerID);
@@ -2054,10 +2088,11 @@ async function registerMCPServices(
 
             headers[serverId] = { authorization: `Bearer ${accessToken}` };
           } catch (err) {
-            console.error(`[OAuth AuthHeaders] Error for ${serverId}:`, err);
-            headers[serverId] = {
-              error: err instanceof Error ? err.message : 'unknown_error',
-            };
+            console.error(
+              `[OAuth AuthHeaders] Error for ${serverId}:`,
+              err instanceof Error ? err.name : 'unknown_error'
+            );
+            headers[serverId] = { error: 'unknown_error' };
           }
         })
       );
@@ -2130,10 +2165,13 @@ async function registerMCPServices(
         if (err instanceof InvalidGrantError || err instanceof MissingRefreshTokenError) {
           return { success: false, error: 'needs_reauth' };
         }
-        console.error(`[OAuth Refresh] ${serverId}:`, err);
+        console.error(
+          `[OAuth Refresh] ${serverId}:`,
+          err instanceof Error ? err.name : 'unknown_error'
+        );
         return {
           success: false,
-          error: err instanceof Error ? err.message : 'unknown_error',
+          error: 'unknown_error',
         };
       }
     },
@@ -2171,6 +2209,7 @@ async function registerMCPServices(
         const { StreamableHTTPClientTransport } = await import(
           '@modelcontextprotocol/sdk/client/streamableHttp.js'
         );
+        const { restoreRedactedMCPAuthSecrets } = await import('@agor/core/tools/mcp/auth-secrets');
         const { resolveMCPAuthHeaders } = await import('@agor/core/tools/mcp/jwt-auth');
         const { mergeMCPRemoteHeaders, restoreRedactedMCPCustomHeaders } = await import(
           '@agor/core/tools/mcp/http-headers'
@@ -2244,6 +2283,10 @@ async function registerMCPServices(
                   error: 'Access denied: admin role required to update session-scoped MCP servers',
                 };
             }
+            serverConfig.auth = restoreRedactedMCPAuthSecrets({
+              current: server.auth,
+              next: data.auth,
+            });
             serverConfig.headers = restoreRedactedMCPCustomHeaders({
               current: server.headers,
               next: data.headers,

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1454,9 +1454,8 @@ export function checkSessionOwnerOrAdmin(
   }
 
   throw new Forbidden(
-    "Only the session's creator or an admin can modify this session's env var selections. " +
-      "Branch 'all' permission does NOT grant access — session env selections expose the " +
-      "creator's private credentials to the executor process."
+    "Only the session's creator or an admin can access this session-scoped runtime configuration. " +
+      "Branch 'all' permission does NOT grant access."
   );
 }
 

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
@@ -1,0 +1,96 @@
+import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
+import type { MCPServer } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  redactMCPServerSecrets,
+  shouldExposeMCPServerSecrets,
+  shouldExposeMCPServerSecretsForSessionToken,
+} from './mcp-header-secrets';
+
+const baseServer = {
+  mcp_server_id: '00000000-0000-0000-0000-000000000001',
+  name: 'remote',
+  transport: 'http',
+  scope: 'global',
+  source: 'user',
+  enabled: true,
+  created_at: new Date(),
+  updated_at: new Date(),
+} as MCPServer;
+
+describe('MCP server secret redaction', () => {
+  it('redacts custom headers and auth secret material while preserving non-secret metadata', () => {
+    const redacted = redactMCPServerSecrets({
+      ...baseServer,
+      headers: { 'X-Api-Key': 'raw-header' },
+      auth: {
+        type: 'oauth',
+        oauth_authorization_url: 'https://auth.example/authorize',
+        oauth_token_url: 'https://auth.example/token',
+        oauth_client_id: 'public-client-id',
+        oauth_client_secret: 'raw-client-secret',
+        oauth_access_token: 'raw-access-token',
+        oauth_refresh_token: 'raw-refresh-token',
+        oauth_scope: 'read',
+        oauth_mode: 'per_user',
+        oauth_token_expires_at: 123,
+      },
+    });
+
+    expect(redacted.headers).toEqual({ 'X-Api-Key': MCP_HEADER_REDACTED_SENTINEL });
+    expect(redacted.auth).toMatchObject({
+      type: 'oauth',
+      oauth_authorization_url: 'https://auth.example/authorize',
+      oauth_token_url: 'https://auth.example/token',
+      oauth_client_id: 'public-client-id',
+      oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+      oauth_access_token: MCP_HEADER_REDACTED_SENTINEL,
+      oauth_refresh_token: MCP_HEADER_REDACTED_SENTINEL,
+      oauth_scope: 'read',
+      oauth_mode: 'per_user',
+      oauth_token_expires_at: 123,
+    });
+  });
+
+  it('does not expose secrets to normal provider users, including admins', () => {
+    expect(
+      shouldExposeMCPServerSecrets({ provider: 'rest', user: { role: 'admin' } } as never)
+    ).toBe(false);
+  });
+
+  it('only exposes session-token secrets when explicitly scoped to the same session', () => {
+    const sessionParams = {
+      provider: 'socketio',
+      authentication: { strategy: 'session-token' },
+      session_id: 'session-a',
+    } as never;
+
+    expect(
+      shouldExposeMCPServerSecrets(sessionParams, {
+        allowSessionToken: true,
+        sessionId: 'session-a',
+      })
+    ).toBe(true);
+    expect(
+      shouldExposeMCPServerSecretsForSessionToken(sessionParams, { sessionId: 'session-a' })
+    ).toBe(true);
+
+    expect(
+      shouldExposeMCPServerSecrets(sessionParams, {
+        allowSessionToken: true,
+        sessionId: 'session-b',
+      })
+    ).toBe(false);
+  });
+
+  it('does not treat internal or service callers as session-token scoped callers', () => {
+    expect(shouldExposeMCPServerSecrets({} as never)).toBe(true);
+    expect(shouldExposeMCPServerSecretsForSessionToken({} as never)).toBe(false);
+    expect(
+      shouldExposeMCPServerSecretsForSessionToken({
+        provider: 'rest',
+        user: { _isServiceAccount: true },
+      } as never)
+    ).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.ts
@@ -1,21 +1,68 @@
+import { redactMCPAuthSecrets } from '@agor/core/tools/mcp/auth-secrets';
 import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer, Params } from '@agor/core/types';
 
-type HeaderSecretParams = Params & {
+export type MCPSecretParams = Params & {
   authentication?: { strategy?: string };
-  user?: { role?: string };
+  user?: { role?: string; _isServiceAccount?: boolean };
+  session_id?: string;
 };
 
-export function shouldExposeMCPHeaderSecrets(params?: HeaderSecretParams): boolean {
-  if (!params?.provider) return true;
-  const role = params.user?.role;
-  return params.authentication?.strategy === 'session-token' || role === 'service';
+export interface MCPSecretExposureOptions {
+  /**
+   * Session-token auth is used by executors. Only allow it on routes that have
+   * already narrowed results to the authenticated session's attached MCP
+   * servers; never on global `/mcp-servers` reads.
+   */
+  allowSessionToken?: boolean;
+  sessionId?: string;
 }
 
-export function redactMCPServerHeaderSecrets(server: MCPServer): MCPServer {
-  if (!server.headers || Object.keys(server.headers).length === 0) return server;
+export function shouldExposeMCPServerSecretsForSessionToken(
+  params?: MCPSecretParams,
+  options: { sessionId?: string } = {}
+): boolean {
+  return (
+    !!params?.provider &&
+    params.authentication?.strategy === 'session-token' &&
+    !!params.session_id &&
+    (!options.sessionId || params.session_id === options.sessionId)
+  );
+}
+
+export function shouldExposeMCPServerSecrets(
+  params?: MCPSecretParams,
+  options: MCPSecretExposureOptions = {}
+): boolean {
+  // Internal service calls are trusted and need raw config to start executors,
+  // discover tools, and resolve auth headers.
+  if (!params?.provider) return true;
+
+  // Service accounts may need raw config across provider boundaries. Ordinary
+  // authenticated users (including admins) must receive redacted API payloads.
+  if (params.user?._isServiceAccount || params.user?.role === 'service') return true;
+
+  return (
+    options.allowSessionToken === true &&
+    shouldExposeMCPServerSecretsForSessionToken(params, { sessionId: options.sessionId })
+  );
+}
+
+// Back-compat alias for older call-sites/tests; now covers auth+headers.
+export const shouldExposeMCPHeaderSecrets = shouldExposeMCPServerSecrets;
+
+export function redactMCPServerSecrets(server: MCPServer): MCPServer {
+  const headers = redactMCPCustomHeaders(server.headers);
+  const auth = redactMCPAuthSecrets(server.auth);
+
+  if (headers === server.headers && auth === server.auth) return server;
+
   return {
     ...server,
-    headers: redactMCPCustomHeaders(server.headers),
+    ...(headers !== server.headers ? { headers } : {}),
+    ...(auth !== server.auth ? { auth } : {}),
   };
 }
+
+// Back-compat alias for older call-sites/tests; now covers auth+headers.
+export const redactMCPServerHeaderSecrets = redactMCPServerSecrets;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -268,6 +268,12 @@
       "import": "./dist/tools/mcp/http-headers.js",
       "require": "./dist/tools/mcp/http-headers.cjs"
     },
+    "./tools/mcp/auth-secrets": {
+      "source": "./src/tools/mcp/auth-secrets.ts",
+      "types": "./dist/tools/mcp/auth-secrets.d.ts",
+      "import": "./dist/tools/mcp/auth-secrets.js",
+      "require": "./dist/tools/mcp/auth-secrets.cjs"
+    },
     "./tools/mcp/jwt-auth": {
       "source": "./src/tools/mcp/jwt-auth.ts",
       "types": "./dist/tools/mcp/jwt-auth.d.ts",

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -15,6 +15,7 @@ import type {
 } from '@agor/core/types';
 import { and, eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
+import { restoreRedactedMCPAuthSecrets } from '../../tools/mcp/auth-secrets';
 import {
   normalizeMCPCustomHeaders,
   restoreRedactedMCPCustomHeaders,
@@ -263,6 +264,12 @@ export class MCPServerRepository
         merged.headers = restoreRedactedMCPCustomHeaders({
           current: current.headers,
           next: updates.headers,
+        });
+      }
+      if ('auth' in updates) {
+        merged.auth = restoreRedactedMCPAuthSecrets({
+          current: current.auth,
+          next: updates.auth,
         });
       }
       const insertData = this.mcpServerToInsert(merged);

--- a/packages/core/src/tools/mcp/auth-secrets.test.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { redactMCPAuthSecrets, restoreRedactedMCPAuthSecrets } from './auth-secrets';
+import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
+
+describe('MCP auth secret helpers', () => {
+  it('redacts secret-bearing auth fields while preserving metadata', () => {
+    const redacted = redactMCPAuthSecrets({
+      type: 'oauth',
+      oauth_token_url: 'https://auth.example/token',
+      oauth_client_id: 'public-client-id',
+      oauth_client_secret: 'raw-client-secret',
+      oauth_access_token: 'raw-access',
+      oauth_refresh_token: 'raw-refresh',
+      oauth_scope: 'read',
+      oauth_mode: 'per_user',
+      oauth_token_expires_at: 123,
+    });
+
+    expect(redacted).toEqual({
+      type: 'oauth',
+      oauth_token_url: 'https://auth.example/token',
+      oauth_client_id: 'public-client-id',
+      oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+      oauth_access_token: MCP_HEADER_REDACTED_SENTINEL,
+      oauth_refresh_token: MCP_HEADER_REDACTED_SENTINEL,
+      oauth_scope: 'read',
+      oauth_mode: 'per_user',
+      oauth_token_expires_at: 123,
+    });
+  });
+
+  it('restores redacted placeholders from current auth config', () => {
+    const restored = restoreRedactedMCPAuthSecrets({
+      current: {
+        type: 'jwt',
+        api_url: 'https://auth.example/token',
+        api_token: 'stored-token-name',
+        api_secret: 'stored-secret',
+      },
+      next: {
+        type: 'jwt',
+        api_url: 'https://auth.example/token',
+        api_token: MCP_HEADER_REDACTED_SENTINEL,
+        api_secret: MCP_HEADER_REDACTED_SENTINEL,
+      },
+    });
+
+    expect(restored).toEqual({
+      type: 'jwt',
+      api_url: 'https://auth.example/token',
+      api_token: 'stored-token-name',
+      api_secret: 'stored-secret',
+    });
+  });
+});

--- a/packages/core/src/tools/mcp/auth-secrets.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.ts
@@ -1,0 +1,56 @@
+/**
+ * Utilities for MCP auth fields that may carry sensitive material.
+ *
+ * Keep the field list centralized so API response redaction and edit-form
+ * sentinel restoration cannot drift.
+ */
+
+import type { MCPAuth } from '../../types/mcp';
+import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
+
+export const MCP_AUTH_SECRET_FIELDS = [
+  'token',
+  'api_token',
+  'api_secret',
+  'oauth_client_secret',
+  'oauth_access_token',
+  'oauth_refresh_token',
+] as const satisfies readonly (keyof MCPAuth)[];
+
+export function redactMCPAuthSecrets(auth?: MCPAuth): MCPAuth | undefined {
+  if (!auth) return undefined;
+
+  let changed = false;
+  const redacted: MCPAuth = { ...auth };
+  const record = redacted as unknown as Record<string, unknown>;
+
+  for (const field of MCP_AUTH_SECRET_FIELDS) {
+    if (redacted[field] !== undefined) {
+      record[field] = MCP_HEADER_REDACTED_SENTINEL;
+      changed = true;
+    }
+  }
+
+  return changed ? redacted : auth;
+}
+
+export function restoreRedactedMCPAuthSecrets(options: {
+  current?: MCPAuth;
+  next?: MCPAuth;
+}): MCPAuth | undefined {
+  if (!options.next) return undefined;
+
+  const restored: MCPAuth = { ...options.next };
+  const record = restored as unknown as Record<string, unknown>;
+
+  for (const field of MCP_AUTH_SECRET_FIELDS) {
+    if (
+      restored[field] === MCP_HEADER_REDACTED_SENTINEL &&
+      options.current?.[field] !== undefined
+    ) {
+      record[field] = options.current[field];
+    }
+  }
+
+  return restored;
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
     'sdk/index': 'src/sdk/index.ts', // AI SDK re-exports (Claude, Codex, Gemini, OpenCode)
     'client/claude-system-suppression': 'src/client/claude-system-suppression.ts', // Browser-safe Claude system event suppression rules
     'tools/mcp/http-headers': 'src/tools/mcp/http-headers.ts', // MCP custom HTTP header utilities
+    'tools/mcp/auth-secrets': 'src/tools/mcp/auth-secrets.ts', // MCP auth secret redaction/restoration utilities
     'tools/mcp/jwt-auth': 'src/tools/mcp/jwt-auth.ts', // MCP JWT authentication utilities
     'tools/mcp/oauth-auth': 'src/tools/mcp/oauth-auth.ts', // MCP OAuth 2.0 authentication utilities
     'tools/mcp/oauth-mcp-transport': 'src/tools/mcp/oauth-mcp-transport.ts', // MCP OAuth 2.1 protocol transport

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -191,32 +191,32 @@ export class FeathersSessionMCPServersRepository {
    * @returns Array of MCPServer objects
    */
   async listServers(sessionId: SessionID, enabledOnly?: boolean): Promise<MCPServer[]> {
-    // Get session-mcp-server join records
-    const query: Record<string, unknown> = {
-      session_id: sessionId,
-      $limit: 1000,
-    };
+    const service = this.client.service(`/sessions/${sessionId}/mcp-servers`);
+    const query: Record<string, unknown> = {};
 
     if (enabledOnly) {
-      query.enabled = true;
+      query.enabledOnly = true;
     }
 
-    const sessionMCPService = this.client.service('session-mcp-servers');
-    const result = await sessionMCPService.find({ query });
-    const sessionMCPServers = (Array.isArray(result) ? result : result.data) as SessionMCPServer[];
+    const result = await service.find({ query });
+    return (Array.isArray(result) ? result : result.data) as MCPServer[];
+  }
 
-    // Get full MCPServer objects for each join record
-    const mcpServerService = this.client.service('mcp-servers');
-    const servers: MCPServer[] = [];
+  /**
+   * List the effective MCP servers for a session (global + session-assigned).
+   * Executors use the session-scoped route so session-token callers can receive
+   * the raw config needed to launch only their own session's MCP servers.
+   */
+  async listEffectiveServers(sessionId: SessionID, enabledOnly?: boolean): Promise<MCPServer[]> {
+    const service = this.client.service(`/sessions/${sessionId}/mcp-servers`);
+    const query: Record<string, unknown> = { includeGlobal: true };
 
-    for (const link of sessionMCPServers) {
-      try {
-        const server = await mcpServerService.get(link.mcp_server_id);
-        servers.push(server);
-      } catch (_error) {}
+    if (enabledOnly) {
+      query.enabledOnly = true;
     }
 
-    return servers;
+    const result = await service.find({ query });
+    return (Array.isArray(result) ? result : result.data) as MCPServer[];
   }
 
   /**

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
@@ -1,0 +1,39 @@
+import type { MCPServer, SessionID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { getMcpServersForSession } from './mcp-scoping';
+
+const makeServer = (id: string, scope: MCPServer['scope'], name = id): MCPServer =>
+  ({
+    mcp_server_id: id,
+    name,
+    transport: 'http',
+    scope,
+    source: 'user',
+    enabled: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    auth: { type: 'token', token: `value-${id}` },
+  }) as MCPServer;
+
+describe('getMcpServersForSession', () => {
+  it('uses session-scoped effective config retrieval when available', async () => {
+    const globalServer = makeServer('global-server', 'global');
+    const sessionServer = makeServer('session-server', 'session');
+    const listEffectiveServers = vi.fn().mockResolvedValue([globalServer, sessionServer]);
+    const findAll = vi.fn();
+    const listServers = vi.fn();
+
+    const servers = await getMcpServersForSession('session-a' as SessionID, {
+      mcpServerRepo: { findAll } as never,
+      sessionMCPRepo: { listEffectiveServers, listServers } as never,
+    });
+
+    expect(listEffectiveServers).toHaveBeenCalledWith('session-a', true);
+    expect(findAll).not.toHaveBeenCalled();
+    expect(listServers).not.toHaveBeenCalled();
+    expect(servers).toEqual([
+      { server: globalServer, source: 'global' },
+      { server: sessionServer, source: 'session-assigned' },
+    ]);
+  });
+});

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -85,49 +85,52 @@ export async function getMcpServersForSession(
     // Track seen server IDs to prevent duplicates
     const seenServerIds = new Set<string>();
 
-    // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
-    // Pass forUserId for per-user OAuth token injection
-    console.log(`   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`);
-    const globalServers = await deps.mcpServerRepo.findAll(
-      {
-        scope: 'global',
-        enabled: true,
-      },
-      deps.forUserId
-    );
-
-    console.log(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
-
-    for (const server of globalServers ?? []) {
+    const addServer = (server: MCPServer, source: MCPServerWithSource['source']) => {
       if (!seenServerIds.has(server.mcp_server_id)) {
         seenServerIds.add(server.mcp_server_id);
-        servers.push({
-          server,
-          source: 'global',
-        });
-      } else {
-        console.warn(
-          `   ⚠️  Skipping duplicate global MCP server: ${server.name} (${server.mcp_server_id})`
-        );
+        servers.push({ server, source });
+        return;
       }
-    }
 
-    // STEP 2: Get session-scoped MCP servers assigned to this specific session
-    const sessionServers = await deps.sessionMCPRepo.listServers(sessionId, true); // enabledOnly
+      console.warn(
+        `   ⚠️  Skipping duplicate ${source} MCP server: ${server.name} (${server.mcp_server_id})`
+      );
+    };
 
-    console.log(`   📍 Session-assigned: ${sessionServers.length} server(s)`);
+    if (typeof deps.sessionMCPRepo.listEffectiveServers === 'function') {
+      const effectiveServers = await deps.sessionMCPRepo.listEffectiveServers(sessionId, true);
+      console.log(`   📍 Effective session scope: ${effectiveServers.length} server(s)`);
 
-    for (const server of sessionServers) {
-      if (!seenServerIds.has(server.mcp_server_id)) {
-        seenServerIds.add(server.mcp_server_id);
-        servers.push({
-          server,
-          source: 'session-assigned',
-        });
-      } else {
-        console.warn(
-          `   ⚠️  Skipping duplicate session-assigned MCP server: ${server.name} (${server.mcp_server_id})`
-        );
+      for (const server of effectiveServers) {
+        addServer(server, server.scope === 'global' ? 'global' : 'session-assigned');
+      }
+    } else {
+      // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
+      // Pass forUserId for per-user OAuth token injection
+      console.log(
+        `   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`
+      );
+      const globalServers = await deps.mcpServerRepo.findAll(
+        {
+          scope: 'global',
+          enabled: true,
+        },
+        deps.forUserId
+      );
+
+      console.log(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
+
+      for (const server of globalServers ?? []) {
+        addServer(server, 'global');
+      }
+
+      // STEP 2: Get session-scoped MCP servers assigned to this specific session
+      const sessionServers = await deps.sessionMCPRepo.listServers(sessionId, true); // enabledOnly
+
+      console.log(`   📍 Session-assigned: ${sessionServers.length} server(s)`);
+
+      for (const server of sessionServers) {
+        addServer(server, 'session-assigned');
       }
     }
 


### PR DESCRIPTION
## Summary

- Improve integration auth response handling.
- Limit raw auth material retrieval to trusted execution contexts.
- Add focused coverage for integration auth handling and response shaping.

## Validation

- `pnpm check`
- `pnpm --filter @agor/daemon exec vitest run src/utils/mcp-header-secrets.test.ts src/register-hooks.mcp-headers-redaction.test.ts src/register-services.mcp-custom-headers.test.ts`
- `pnpm --filter @agor/core exec vitest run src/tools/mcp/http-headers.test.ts`
