### PR TITLE
Update bootstrap defaults and setup flow

### DIFF
--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -10,7 +10,13 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadConfig, setConfigValue } from '@agor/core/config';
-import { createDatabase, createUser, runMigrations, seedInitialData } from '@agor/core/db';
+import {
+  createDatabase,
+  createUser,
+  DEVELOPMENT_DEFAULT_ADMIN_USER,
+  runMigrations,
+  seedInitialData,
+} from '@agor/core/db';
 import { isDaemonRunning } from '@agor-live/client';
 import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -342,23 +348,32 @@ export default class Init extends Command {
     if (!skipPrompts) {
       await this.promptAdminSetup(dbPath);
     } else {
-      // --force: create default admin (admin@agor.live / admin) and warn.
+      // --force: preserve local/dev ergonomics, but refuse to create the
+      // legacy fixed credential in production. Production first-run setup is
+      // owned by the daemon bootstrap, which uses AGOR_ADMIN_PASSWORD or a
+      // generated 0600 credentials file.
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error(
+          [
+            'Refusing to create fixed default admin credentials in production.',
+            'Create an admin explicitly or use daemon first-run bootstrap with AGOR_ADMIN_PASSWORD.',
+          ].join(' ')
+        );
+      }
       try {
         const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
-        const defaultEmail = 'admin@agor.live';
-        const defaultPassword = 'admin';
 
         await createUser(db, {
-          email: defaultEmail,
-          password: defaultPassword,
-          name: 'Admin',
+          email: DEVELOPMENT_DEFAULT_ADMIN_USER.email,
+          password: DEVELOPMENT_DEFAULT_ADMIN_USER.password,
+          name: DEVELOPMENT_DEFAULT_ADMIN_USER.name,
           role: 'admin',
         });
 
-        this.log(`${chalk.green('   ✓')} Default admin user created`);
-        this.log(chalk.dim(`     Email: ${defaultEmail}`));
-        this.log(chalk.dim(`     Password: ${defaultPassword}`));
-        this.log(chalk.yellow(`     ⚠️  Change this password after first login!`));
+        this.log(`${chalk.green('   ✓')} Development admin user created`);
+        this.log(chalk.dim(`     Email: ${DEVELOPMENT_DEFAULT_ADMIN_USER.email}`));
+        this.log(chalk.dim(`     Password: ${DEVELOPMENT_DEFAULT_ADMIN_USER.password}`));
+        this.log(chalk.yellow(`     ⚠️  Development/test credential only.`));
       } catch (error) {
         // Admin user might already exist, which is fine
         if (error instanceof Error && !error.message.includes('UNIQUE constraint failed')) {

--- a/apps/agor-cli/src/commands/init.ts
+++ b/apps/agor-cli/src/commands/init.ts
@@ -348,36 +348,37 @@ export default class Init extends Command {
     if (!skipPrompts) {
       await this.promptAdminSetup(dbPath);
     } else {
-      // --force: preserve local/dev ergonomics, but refuse to create the
-      // legacy fixed credential in production. Production first-run setup is
-      // owned by the daemon bootstrap, which uses AGOR_ADMIN_PASSWORD or a
-      // generated 0600 credentials file.
+      // --force: preserve local/dev ergonomics, but defer production admin
+      // creation to the daemon-owned first-run bootstrap. This avoids
+      // partially failing after destructive re-initialization has already
+      // recreated the database and seeded initial data.
       if (process.env.NODE_ENV === 'production') {
-        throw new Error(
-          [
-            'Refusing to create fixed default admin credentials in production.',
-            'Create an admin explicitly or use daemon first-run bootstrap with AGOR_ADMIN_PASSWORD.',
-          ].join(' ')
+        this.log(`${chalk.green('   ✓')} Admin setup deferred to daemon first-run bootstrap`);
+        this.log(
+          chalk.dim(
+            '     Set AGOR_ADMIN_PASSWORD before daemon start, or use the generated admin-credentials file.'
+          )
         );
-      }
-      try {
-        const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
+      } else {
+        try {
+          const db = createDatabase({ url: `file:${dbPath}`, dialect: 'sqlite' });
 
-        await createUser(db, {
-          email: DEVELOPMENT_DEFAULT_ADMIN_USER.email,
-          password: DEVELOPMENT_DEFAULT_ADMIN_USER.password,
-          name: DEVELOPMENT_DEFAULT_ADMIN_USER.name,
-          role: 'admin',
-        });
+          await createUser(db, {
+            email: DEVELOPMENT_DEFAULT_ADMIN_USER.email,
+            password: DEVELOPMENT_DEFAULT_ADMIN_USER.password,
+            name: DEVELOPMENT_DEFAULT_ADMIN_USER.name,
+            role: 'admin',
+          });
 
-        this.log(`${chalk.green('   ✓')} Development admin user created`);
-        this.log(chalk.dim(`     Email: ${DEVELOPMENT_DEFAULT_ADMIN_USER.email}`));
-        this.log(chalk.dim(`     Password: ${DEVELOPMENT_DEFAULT_ADMIN_USER.password}`));
-        this.log(chalk.yellow(`     ⚠️  Development/test credential only.`));
-      } catch (error) {
-        // Admin user might already exist, which is fine
-        if (error instanceof Error && !error.message.includes('UNIQUE constraint failed')) {
-          throw error;
+          this.log(`${chalk.green('   ✓')} Development admin user created`);
+          this.log(chalk.dim(`     Email: ${DEVELOPMENT_DEFAULT_ADMIN_USER.email}`));
+          this.log(chalk.dim(`     Password: ${DEVELOPMENT_DEFAULT_ADMIN_USER.password}`));
+          this.log(chalk.yellow(`     ⚠️  Development/test credential only.`));
+        } catch (error) {
+          // Admin user might already exist, which is fine
+          if (error instanceof Error && !error.message.includes('UNIQUE constraint failed')) {
+            throw error;
+          }
         }
       }
     }

--- a/apps/agor-cli/src/commands/user/create-admin.ts
+++ b/apps/agor-cli/src/commands/user/create-admin.ts
@@ -1,5 +1,5 @@
 /**
- * `agor user create-admin` - Create default admin user (admin@agor.live / admin)
+ * `agor user create-admin` - Create bootstrap admin user
  */
 
 import { join } from 'node:path';
@@ -7,20 +7,50 @@ import { getConfigPath } from '@agor/core/config';
 import {
   createDatabase,
   createDefaultAdminUser,
-  DEFAULT_ADMIN_USER,
+  DEVELOPMENT_DEFAULT_ADMIN_USER,
   getUserByEmail,
   runMigrations,
   shortId,
 } from '@agor/core/db';
-import { Command } from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 import chalk from 'chalk';
+import inquirer from 'inquirer';
 
 export default class UserCreateAdmin extends Command {
-  static description = 'Create default admin user (admin@agor.live / admin)';
+  static description = 'Create a bootstrap superadmin user';
 
-  static examples = ['<%= config.bin %> <%= command.id %>'];
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --password <password>',
+    '<%= config.bin %> <%= command.id %> --dev-default',
+  ];
+
+  static flags = {
+    email: Flags.string({
+      description: 'Admin email address',
+      default: DEVELOPMENT_DEFAULT_ADMIN_USER.email,
+    }),
+    password: Flags.string({
+      description: 'Admin password. If omitted, prompts interactively.',
+      required: false,
+    }),
+    name: Flags.string({
+      description: 'Admin display name',
+      default: DEVELOPMENT_DEFAULT_ADMIN_USER.name,
+    }),
+    'unix-username': Flags.string({
+      description: 'Unix username for shell access',
+      default: DEVELOPMENT_DEFAULT_ADMIN_USER.unix_username,
+    }),
+    'dev-default': Flags.boolean({
+      description:
+        'Development/test only: use admin@agor.live / admin. Refused when NODE_ENV=production.',
+      default: false,
+    }),
+  };
 
   async run(): Promise<void> {
+    const { flags } = await this.parse(UserCreateAdmin);
+
     try {
       // Get database connection URL
       // Priority: DATABASE_URL env var > default SQLite file path
@@ -43,41 +73,82 @@ export default class UserCreateAdmin extends Command {
       await runMigrations(db);
 
       // Check if admin user already exists
-      const existingAdmin = await getUserByEmail(db, DEFAULT_ADMIN_USER.email);
+      const existingAdmin = await getUserByEmail(db, flags.email);
 
       if (existingAdmin) {
         this.log(chalk.yellow('⚠ Admin user already exists'));
         this.log('');
-        this.log(`  Email: ${chalk.cyan(DEFAULT_ADMIN_USER.email)}`);
+        this.log(`  Email: ${chalk.cyan(flags.email)}`);
         this.log(`  Name:  ${chalk.cyan(existingAdmin.name || '(not set)')}`);
         this.log(`  Role:  ${chalk.cyan(existingAdmin.role)}`);
         this.log(`  ID:    ${chalk.gray(shortId(existingAdmin.user_id))}`);
         this.log('');
         this.log(
           chalk.gray(
-            `To reset password, use: agor user update ${DEFAULT_ADMIN_USER.email} --password newpassword`
+            `To reset password, use: agor user update ${flags.email} --password newpassword`
           )
         );
         process.exit(0);
       }
 
-      // Create default admin user
+      let password = flags.password;
+      if (!password && !flags['dev-default']) {
+        const passwordAnswer = await inquirer.prompt<{ password: string }>([
+          {
+            type: 'password' as const,
+            name: 'password',
+            message: 'Admin password:',
+            validate: (input: string) => {
+              if (!input) return 'Password is required';
+              if (input.length < 8) return 'Password must be at least 8 characters';
+              if (input === DEVELOPMENT_DEFAULT_ADMIN_USER.password) {
+                return 'Use --dev-default for development-only default credentials';
+              }
+              return true;
+            },
+            mask: '*',
+          },
+        ]);
+        await inquirer.prompt<{ confirmPassword: string }>([
+          {
+            type: 'password' as const,
+            name: 'confirmPassword',
+            message: 'Confirm password:',
+            validate: (input: string) => {
+              if (input !== passwordAnswer.password) return 'Passwords do not match';
+              return true;
+            },
+            mask: '*',
+          },
+        ]);
+        password = passwordAnswer.password;
+      }
+
+      // Create admin user
       this.log(chalk.gray('Creating admin user...'));
-      const user = await createDefaultAdminUser(db);
+      const user = await createDefaultAdminUser(db, {
+        email: flags.email,
+        password,
+        name: flags.name,
+        unix_username: flags['unix-username'],
+        allowDevelopmentDefault: flags['dev-default'],
+      });
 
       this.log(`${chalk.green('✓')} Admin user created successfully`);
       this.log('');
-      this.log(`  Email:    ${chalk.cyan(DEFAULT_ADMIN_USER.email)}`);
-      this.log(`  Password: ${chalk.cyan(DEFAULT_ADMIN_USER.password)}`);
+      this.log(`  Email:    ${chalk.cyan(flags.email)}`);
+      if (flags['dev-default']) {
+        this.log(`  Password: ${chalk.cyan(DEVELOPMENT_DEFAULT_ADMIN_USER.password)}`);
+        this.log(chalk.yellow('  ⚠ Development-only default credential enabled'));
+      } else {
+        this.log('  Password: (provided; not printed)');
+      }
       this.log(`  Name:     ${chalk.cyan(user.name)}`);
       this.log(`  Role:     ${chalk.cyan(user.role)}`);
       this.log(`  ID:       ${chalk.gray(shortId(user.user_id))}`);
-      this.log('');
-      this.log(chalk.yellow('⚠ SECURITY WARNING'));
-      this.log(chalk.gray('  Change the password immediately using:'));
-      this.log(
-        chalk.gray(`  agor user update ${DEFAULT_ADMIN_USER.email} --password <new-password>`)
-      );
+      if (user.must_change_password) {
+        this.log(`  ${chalk.yellow('⚠')} User must change password on first login`);
+      }
 
       process.exit(0);
     } catch (error) {

--- a/apps/agor-cli/src/commands/user/create-admin.ts
+++ b/apps/agor-cli/src/commands/user/create-admin.ts
@@ -5,6 +5,7 @@
 import { join } from 'node:path';
 import { getConfigPath } from '@agor/core/config';
 import {
+  assertUsableBootstrapAdminPassword,
   createDatabase,
   createDefaultAdminUser,
   DEVELOPMENT_DEFAULT_ADMIN_USER,
@@ -99,10 +100,11 @@ export default class UserCreateAdmin extends Command {
             name: 'password',
             message: 'Admin password:',
             validate: (input: string) => {
-              if (!input) return 'Password is required';
-              if (input.length < 8) return 'Password must be at least 8 characters';
-              if (input === DEVELOPMENT_DEFAULT_ADMIN_USER.password) {
-                return 'Use --dev-default for development-only default credentials';
+              try {
+                if (!input) return 'Password is required';
+                assertUsableBootstrapAdminPassword(input, 'Admin password');
+              } catch (error) {
+                return error instanceof Error ? error.message : String(error);
               }
               return true;
             },

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -16,6 +16,16 @@ vi.mock('@agor/core/db', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
+    assertUsableBootstrapAdminPassword:
+      actual.assertUsableBootstrapAdminPassword ??
+      ((password: string, label: string = 'Bootstrap admin password') => {
+        if (password === 'admin') {
+          throw new Error(`${label} must not be the legacy fixed default password.`);
+        }
+        if (password.length < 8) {
+          throw new Error(`${label} must be at least 8 characters.`);
+        }
+      }),
     bootstrapFirstRunAdmin: vi.fn(),
     createUser: vi.fn(),
   };

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -185,6 +185,19 @@ describe('runFirstRunAdminBootstrap — capability-driven password resolution', 
     await expect(fs.access(credentialsPath)).rejects.toThrow();
   });
 
+  it('rejects the legacy fixed default password from AGOR_ADMIN_PASSWORD', async () => {
+    process.env.AGOR_ADMIN_PASSWORD = 'admin';
+
+    const { bootstrapFirstRunAdmin } = await loadMocks();
+    bootstrapFirstRunAdmin.mockImplementation(
+      async (_db: unknown, factory: () => Promise<unknown>) => factory()
+    );
+
+    await expect(
+      runFirstRunAdminBootstrap({} as unknown as never, { credentialsBaseDir: tempDir })
+    ).rejects.toThrow(/legacy fixed default password/);
+  });
+
   it('falls back to file-based generation when AGOR_ADMIN_PASSWORD is absent', async () => {
     const { bootstrapFirstRunAdmin, createUser } = await loadMocks();
     bootstrapFirstRunAdmin.mockImplementation(

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -116,8 +116,10 @@ describe('logFirstRunAdminBootstrap', () => {
       credentialsPath: '/etc/agor/admin-credentials',
     });
     expect(written).toContain('First-run admin user created');
+    expect(written).toContain('generated because AGOR_ADMIN_PASSWORD was not set');
     expect(written).toContain('see /etc/agor/admin-credentials (mode 0600)');
-    expect(written).not.toContain('AGOR_ADMIN_PASSWORD');
+    expect(written).toContain('set AGOR_ADMIN_PASSWORD before first startup');
+    expect(written).toContain('will not reset passwords');
   });
 
   it('points operators at AGOR_ADMIN_PASSWORD when no file was written', () => {

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -230,7 +230,18 @@ export function logFirstRunAdminBootstrap(result: DaemonBootstrapResult): void {
     process.stderr.write('----------------------------------------------------------------\n');
     process.stderr.write(`    Email:     ${result.admin.email}\n`);
     if (result.credentialsPath) {
-      process.stderr.write(`    Password:  see ${result.credentialsPath} (mode 0600)\n`);
+      process.stderr.write('    Password:  generated because AGOR_ADMIN_PASSWORD was not set\n');
+      process.stderr.write(`               see ${result.credentialsPath} (mode 0600)\n`);
+      process.stderr.write('\n');
+      process.stderr.write(
+        '    WARNING: Read that file to complete first login, then change the password.\n'
+      );
+      process.stderr.write(
+        '    For future fresh deployments, set AGOR_ADMIN_PASSWORD before first startup.\n'
+      );
+      process.stderr.write(
+        '    Setting AGOR_ADMIN_PASSWORD after users exist will not reset passwords.\n'
+      );
     } else {
       // Env-var path (AGOR_ADMIN_PASSWORD). Don't print the password — the
       // operator set it themselves; logging it would unnecessarily duplicate

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -21,6 +21,7 @@ import { promisify } from 'node:util';
 import type { AgorConfig } from '@agor/core/config';
 import {
   type AdminBootstrapResult,
+  assertUsableBootstrapAdminPassword,
   BOOTSTRAP_ADMIN_EMAIL,
   bootstrapFirstRunAdmin,
   createUser,
@@ -34,22 +35,10 @@ const closeP = promisify(close);
 const unlinkP = promisify(unlink);
 
 const ADMIN_CREDENTIALS_FILENAME = 'admin-credentials';
-const MIN_BOOTSTRAP_PASSWORD_LENGTH = 8;
 
 /** Where the generated admin password is persisted on first run. */
 export function getAdminCredentialsPath(baseDir: string = join(homedir(), '.agor')): string {
   return join(baseDir, ADMIN_CREDENTIALS_FILENAME);
-}
-
-function assertUsableBootstrapPassword(password: string): void {
-  if (password === 'admin') {
-    throw new Error('AGOR_ADMIN_PASSWORD must not be the legacy fixed default password.');
-  }
-  if (password.length < MIN_BOOTSTRAP_PASSWORD_LENGTH) {
-    throw new Error(
-      `AGOR_ADMIN_PASSWORD must be at least ${MIN_BOOTSTRAP_PASSWORD_LENGTH} characters.`
-    );
-  }
 }
 
 /**
@@ -167,7 +156,7 @@ export async function runFirstRunAdminBootstrap(
     // 1) Env-var path: use the operator-provided password verbatim. No file
     // touch, no rollback to worry about.
     if (envPassword && envPassword.length > 0) {
-      assertUsableBootstrapPassword(envPassword);
+      assertUsableBootstrapAdminPassword(envPassword, 'AGOR_ADMIN_PASSWORD');
       return await createUser(db, {
         email: BOOTSTRAP_ADMIN_EMAIL,
         password: envPassword,

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -34,10 +34,22 @@ const closeP = promisify(close);
 const unlinkP = promisify(unlink);
 
 const ADMIN_CREDENTIALS_FILENAME = 'admin-credentials';
+const MIN_BOOTSTRAP_PASSWORD_LENGTH = 8;
 
 /** Where the generated admin password is persisted on first run. */
 export function getAdminCredentialsPath(baseDir: string = join(homedir(), '.agor')): string {
   return join(baseDir, ADMIN_CREDENTIALS_FILENAME);
+}
+
+function assertUsableBootstrapPassword(password: string): void {
+  if (password === 'admin') {
+    throw new Error('AGOR_ADMIN_PASSWORD must not be the legacy fixed default password.');
+  }
+  if (password.length < MIN_BOOTSTRAP_PASSWORD_LENGTH) {
+    throw new Error(
+      `AGOR_ADMIN_PASSWORD must be at least ${MIN_BOOTSTRAP_PASSWORD_LENGTH} characters.`
+    );
+  }
 }
 
 /**
@@ -155,6 +167,7 @@ export async function runFirstRunAdminBootstrap(
     // 1) Env-var path: use the operator-provided password verbatim. No file
     // touch, no rollback to worry about.
     if (envPassword && envPassword.length > 0) {
+      assertUsableBootstrapPassword(envPassword);
       return await createUser(db, {
         email: BOOTSTRAP_ADMIN_EMAIL,
         password: envPassword,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,10 @@ services:
       - DAEMON_PORT=${DAEMON_PORT:-3030}
       - DAEMON_HOST=0.0.0.0
       - CORS_ORIGIN=${CORS_ORIGIN:-*}
+      # Optional first-run bootstrap password. If unset on an empty database,
+      # Agor writes a random password to /home/agor/.agor/admin-credentials
+      # (mode 0600) and logs only that file path.
+      - AGOR_ADMIN_PASSWORD=${AGOR_ADMIN_PASSWORD:-}
 
       # Pass through API keys from host (if set)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}

--- a/docker/.env.prod.example
+++ b/docker/.env.prod.example
@@ -10,6 +10,8 @@ CORS_ORIGIN=*
 # If set on an empty database, this password creates admin@agor.live and is
 # never printed by Agor. If unset, Agor creates a random password in
 # /home/agor/.agor/admin-credentials (0600) and logs only that file path.
+# This is only used before any users exist; setting it on a later restart does
+# not reset an existing user's password.
 # Must be at least 8 characters and must not be the legacy default "admin".
 # AGOR_ADMIN_PASSWORD=replace-with-a-long-random-password
 

--- a/docker/.env.prod.example
+++ b/docker/.env.prod.example
@@ -6,6 +6,13 @@ DAEMON_PORT=3030
 DAEMON_HOST=0.0.0.0
 CORS_ORIGIN=*
 
+# First-run admin bootstrap (optional)
+# If set on an empty database, this password creates admin@agor.live and is
+# never printed by Agor. If unset, Agor creates a random password in
+# /home/agor/.agor/admin-credentials (0600) and logs only that file path.
+# Must be at least 8 characters and must not be the legacy default "admin".
+# AGOR_ADMIN_PASSWORD=replace-with-a-long-random-password
+
 # API Keys (Required for AI agent features)
 ANTHROPIC_API_KEY=sk-ant-your-key-here
 OPENAI_API_KEY=sk-your-key-here

--- a/docker/README.md
+++ b/docker/README.md
@@ -112,21 +112,26 @@ docker run --rm -v agor_agor-home:/data -v $(pwd):/backup \
   alpine tar xzf /backup/agor-backup.tar.gz -C /data
 ```
 
-## Default Credentials (Production)
+## First-Run Admin Bootstrap (Production)
 
-On first startup, production mode creates a default admin user:
+Production images do **not** create a fixed default password.
 
-```
-Email:    admin@agor.live
-Password: admin
-```
+On first startup with an empty users table, the daemon creates
+`admin@agor.live` as the bootstrap superadmin using one of these paths:
 
-**IMPORTANT:** Change this password immediately after first login!
+1. Set `AGOR_ADMIN_PASSWORD` in the container environment. Agor uses that
+   operator-provided password and does not print it.
+2. Leave `AGOR_ADMIN_PASSWORD` unset. Agor generates a random password and
+   writes it to `/home/agor/.agor/admin-credentials` with mode `0600`; logs
+   only point at that file path.
+
+The bootstrap admin is forced to change its password on first login.
 
 ```bash
-# From inside the container
+# Retrieve generated credentials from inside the container when
+# AGOR_ADMIN_PASSWORD was not provided.
 docker compose -f docker-compose.prod.yml exec agor-prod \
-  agor user update admin@agor.live --password <new-password>
+  cat /home/agor/.agor/admin-credentials
 ```
 
 ## Building Images
@@ -327,7 +332,7 @@ Expected image sizes:
 
 - **Development**: Edit code in your editor, changes hot-reload automatically
 - **Production**: Deploy to your server, configure reverse proxy (nginx/caddy)
-- **Security**: Change default admin password, configure HTTPS, set CORS_ORIGIN
+- **Security**: Secure bootstrap credentials, configure HTTPS, set CORS_ORIGIN
 - **Monitoring**: Check `/health` endpoint, monitor logs, set up alerts
 
 ## Architecture Notes

--- a/docker/README.md
+++ b/docker/README.md
@@ -126,6 +126,10 @@ On first startup with an empty users table, the daemon creates
    only point at that file path.
 
 The bootstrap admin is forced to change its password on first login.
+`AGOR_ADMIN_PASSWORD` is only used while the users table is empty. If you
+forget to set it before first startup, read the generated credentials file and
+change the password after logging in; setting `AGOR_ADMIN_PASSWORD` on a later
+restart will not reset an existing user's password.
 
 ```bash
 # Retrieve generated credentials from inside the container when

--- a/docker/README.postgres.md
+++ b/docker/README.postgres.md
@@ -22,6 +22,9 @@ docker compose up
 
 ### Users
 
+These credentials are created only by the development/testing entrypoint and
+must not be used for production deployments.
+
 - **admin@agor.live** (password: `admin`)
   - Role: Admin
   - Default system administrator

--- a/docker/docker-entrypoint-prod.sh
+++ b/docker/docker-entrypoint-prod.sh
@@ -18,18 +18,26 @@ agor init \
   --daemon-port "${DAEMON_PORT:-3030}" \
   --daemon-host "${DAEMON_HOST:-0.0.0.0}"
 
-# Create/update admin user (idempotent: safe to run multiple times)
-# This will skip if admin user already exists
-echo "👤 Ensuring admin user exists..."
-agor user create-admin 2>/dev/null || true
+# Run schema migrations before daemon startup. The production entrypoint creates
+# /home/agor/.agor before `agor init`, so init is intentionally idempotent and
+# may skip DB creation; this migration step replaces the old create-admin side
+# effect that used to run migrations.
+echo "🔄 Running database migrations..."
+agor db migrate --yes
 
-# SECURITY: do not echo the default admin credentials to stdout — container
-# log aggregators ingest stdout and make it searchable across the org.
-# Emit a short warning to stderr only, and only once per container start.
-# Operators can retrieve the bootstrap credentials via an authenticated
-# `agor user ...` CLI invocation inside the container.
->&2 printf '\033[1;31m%s\033[0m\n' "⚠️  Admin user exists with the default bootstrap password."
->&2 printf '\033[1;31m%s\033[0m\n' "⚠️  ROTATE IT NOW via the UI or: docker exec <container> agor user set-password"
+# Do NOT create a fixed default admin here.
+#
+# On first daemon start, the daemon's first-run bootstrap creates the initial
+# superadmin only when the users table is empty:
+#   - If AGOR_ADMIN_PASSWORD is set, that operator-provided password is used
+#     and is never echoed back to logs.
+#   - Otherwise, a random password is written to
+#     /home/agor/.agor/admin-credentials with mode 0600, and logs only point
+#     at that file path.
+#
+# This keeps production images idempotent without shipping a takeover-grade
+# admin@agor.live/admin credential in every fresh deployment.
+echo "👤 Admin bootstrap will be handled by daemon first-run setup."
 
 # Start daemon in foreground (this keeps container alive)
 echo "🚀 Starting daemon on port ${DAEMON_PORT:-3030}..."

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -194,8 +194,8 @@ if [ "$AGOR_SET_RBAC_FLAG" = "true" ] || [ -n "$AGOR_SET_UNIX_MODE" ]; then
 fi
 
 # Always create/update admin user (safe: only upserts)
-echo "👤 Ensuring default admin user exists..."
-ADMIN_OUTPUT=$(pnpm --filter @agor/cli exec tsx bin/dev.ts user create-admin --force 2>&1)
+echo "👤 Ensuring development admin user exists..."
+ADMIN_OUTPUT=$(pnpm --filter @agor/cli exec tsx bin/dev.ts user create-admin --dev-default 2>&1)
 echo "$ADMIN_OUTPUT"
 
 # In strict mode the daemon validates that a session creator's unix_username exists as a

--- a/packages/core/src/db/first-run-bootstrap.test.ts
+++ b/packages/core/src/db/first-run-bootstrap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect } from 'vitest';
+import { select } from './database-wrapper';
+import { bootstrapFirstRunAdmin } from './first-run-bootstrap';
+import { seedInitialData } from './migrate';
+import { boards } from './schema';
+import { dbTest } from './test-helpers';
+import { createUser } from './user-utils';
+
+describe('bootstrapFirstRunAdmin', () => {
+  dbTest('prefers existing superadmins when reattributing legacy rows', async ({ db }) => {
+    const member = await createUser(db, {
+      email: 'member@example.com',
+      password: 'member-password',
+      role: 'member',
+    });
+    const superadmin = await createUser(db, {
+      email: 'superadmin@example.com',
+      password: 'superadmin-password',
+      role: 'superadmin',
+    });
+    await seedInitialData(db);
+
+    const result = await bootstrapFirstRunAdmin(db, async () => {
+      throw new Error('should not create an admin when users already exist');
+    });
+
+    expect(result.createdAdmin).toBe(false);
+    expect(result.admin?.user_id).toBe(superadmin.user_id);
+    expect(result.admin?.user_id).not.toBe(member.user_id);
+    expect(result.reattributedCount).toBe(1);
+
+    const boardRows = await select(db).from(boards).all();
+    expect(boardRows).toHaveLength(1);
+    expect(boardRows[0].created_by).toBe(superadmin.user_id);
+  });
+});

--- a/packages/core/src/db/first-run-bootstrap.ts
+++ b/packages/core/src/db/first-run-bootstrap.ts
@@ -18,7 +18,7 @@
  */
 
 import { randomInt } from 'node:crypto';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import type { User } from '../types';
 import type { Database } from './client';
 import { select, update } from './database-wrapper';
@@ -107,8 +107,8 @@ export async function reattributeLegacyAnonymousRows(
 
 /**
  * Find an admin to use as the legacy-row attribution target. Prefers the
- * oldest admin (stable across runs); falls back to the oldest user when no
- * admins exist. Returns null only on a completely empty users table.
+ * oldest superadmin/admin (stable across runs); falls back to the oldest user
+ * when no admins exist. Returns null only on a completely empty users table.
  */
 async function findFallbackAdmin(db: Database): Promise<User | null> {
   const byCreatedAtAsc = (a: UserRow, b: UserRow) => {
@@ -118,7 +118,7 @@ async function findFallbackAdmin(db: Database): Promise<User | null> {
   };
   const adminRows = (await select(db)
     .from(users)
-    .where(eq(users.role, 'admin'))
+    .where(inArray(users.role, ['superadmin', 'admin']))
     .all()) as UserRow[];
   const pool: UserRow[] =
     adminRows.length > 0 ? adminRows : ((await select(db).from(users).all()) as UserRow[]);

--- a/packages/core/src/db/user-utils.test.ts
+++ b/packages/core/src/db/user-utils.test.ts
@@ -12,7 +12,7 @@ import {
   type CreateUserData,
   createDefaultAdminUser,
   createUser,
-  DEFAULT_ADMIN_USER,
+  DEVELOPMENT_DEFAULT_ADMIN_USER,
   getUserByEmail,
   userExists,
 } from './user-utils';
@@ -419,21 +419,21 @@ describe('getUserByEmail', () => {
 });
 
 // ============================================================================
-// DEFAULT_ADMIN_USER constant
+// DEVELOPMENT_DEFAULT_ADMIN_USER constant
 // ============================================================================
 
-describe('DEFAULT_ADMIN_USER', () => {
-  it('should have expected default values', () => {
-    expect(DEFAULT_ADMIN_USER.email).toBe('admin@agor.live');
-    expect(DEFAULT_ADMIN_USER.password).toBe('admin');
-    expect(DEFAULT_ADMIN_USER.name).toBe('Admin');
-    expect(DEFAULT_ADMIN_USER.role).toBe('superadmin');
-    expect(DEFAULT_ADMIN_USER.unix_username).toBe('admin');
+describe('DEVELOPMENT_DEFAULT_ADMIN_USER', () => {
+  it('should have expected development-only default values', () => {
+    expect(DEVELOPMENT_DEFAULT_ADMIN_USER.email).toBe('admin@agor.live');
+    expect(DEVELOPMENT_DEFAULT_ADMIN_USER.password).toBe('admin');
+    expect(DEVELOPMENT_DEFAULT_ADMIN_USER.name).toBe('Admin');
+    expect(DEVELOPMENT_DEFAULT_ADMIN_USER.role).toBe('superadmin');
+    expect(DEVELOPMENT_DEFAULT_ADMIN_USER.unix_username).toBe('admin');
   });
 
   it('should be a const object', () => {
-    expect(DEFAULT_ADMIN_USER).toBeDefined();
-    expect(typeof DEFAULT_ADMIN_USER).toBe('object');
+    expect(DEVELOPMENT_DEFAULT_ADMIN_USER).toBeDefined();
+    expect(typeof DEVELOPMENT_DEFAULT_ADMIN_USER).toBe('object');
   });
 });
 
@@ -442,8 +442,23 @@ describe('DEFAULT_ADMIN_USER', () => {
 // ============================================================================
 
 describe('createDefaultAdminUser', () => {
-  dbTest('should create admin user with default credentials', async ({ db }) => {
-    const admin = await createDefaultAdminUser(db);
+  dbTest('should refuse fixed defaults unless explicitly development-gated', async ({ db }) => {
+    await expect(createDefaultAdminUser(db)).rejects.toThrow(
+      /Refusing to create admin with fixed default credentials/
+    );
+  });
+
+  dbTest(
+    'should refuse the legacy fixed default password as an explicit password',
+    async ({ db }) => {
+      await expect(createDefaultAdminUser(db, { password: 'admin' })).rejects.toThrow(
+        /legacy fixed default password/
+      );
+    }
+  );
+
+  dbTest('should create admin user with explicit credentials', async ({ db }) => {
+    const admin = await createDefaultAdminUser(db, { password: 'explicit-secret' });
 
     expect(admin.email).toBe('admin@agor.live');
     expect(admin.name).toBe('Admin');
@@ -453,8 +468,8 @@ describe('createDefaultAdminUser', () => {
     expect(admin.user_id).toBeDefined();
   });
 
-  dbTest('should hash default password', async ({ db }) => {
-    await createDefaultAdminUser(db);
+  dbTest('should hash explicit password', async ({ db }) => {
+    await createDefaultAdminUser(db, { password: 'explicit-secret' });
 
     const result = await (db as any).query.users.findFirst({
       where: (users: any, { eq }: any) => eq(users.email, 'admin@agor.live'),
@@ -463,14 +478,14 @@ describe('createDefaultAdminUser', () => {
     expect(result?.password).not.toBe('admin');
     expect(result?.password).toMatch(/^\$2[aby]\$\d{2}\$/);
 
-    const isValid = await bcrypt.compare('admin', result!.password);
+    const isValid = await bcrypt.compare('explicit-secret', result!.password);
     expect(isValid).toBe(true);
   });
 
   dbTest('should throw error if admin user already exists', async ({ db }) => {
-    await createDefaultAdminUser(db);
+    await createDefaultAdminUser(db, { password: 'explicit-secret' });
 
-    await expect(createDefaultAdminUser(db)).rejects.toThrow(
+    await expect(createDefaultAdminUser(db, { password: 'different-secret' })).rejects.toThrow(
       'Admin user already exists (email: admin@agor.live)'
     );
   });
@@ -484,11 +499,13 @@ describe('createDefaultAdminUser', () => {
       role: 'member',
     });
 
-    await expect(createDefaultAdminUser(db)).rejects.toThrow('Admin user already exists');
+    await expect(createDefaultAdminUser(db, { password: 'explicit-secret' })).rejects.toThrow(
+      'Admin user already exists'
+    );
   });
 
   dbTest('should use createUser internally', async ({ db }) => {
-    const admin = await createDefaultAdminUser(db);
+    const admin = await createDefaultAdminUser(db, { password: 'explicit-secret' });
 
     // Should have all the same properties as any user created via createUser
     expect(admin.preferences).toEqual({});
@@ -498,9 +515,9 @@ describe('createDefaultAdminUser', () => {
   });
 
   dbTest('should be idempotent check (fails on second call)', async ({ db }) => {
-    const admin1 = await createDefaultAdminUser(db);
+    const admin1 = await createDefaultAdminUser(db, { password: 'explicit-secret' });
 
-    await expect(createDefaultAdminUser(db)).rejects.toThrow();
+    await expect(createDefaultAdminUser(db, { password: 'different-secret' })).rejects.toThrow();
 
     // Verify original admin still exists unchanged
     const found = await getUserByEmail(db, 'admin@agor.live');
@@ -568,7 +585,7 @@ describe('User utilities integration', () => {
 
   dbTest('should work alongside default admin user', async ({ db }) => {
     // Create default admin
-    const admin = await createDefaultAdminUser(db);
+    const admin = await createDefaultAdminUser(db, { allowDevelopmentDefault: true });
 
     // Create regular users
     const user1 = await createUser(db, createUserData({ email: 'user1@example.com' }));

--- a/packages/core/src/db/user-utils.test.ts
+++ b/packages/core/src/db/user-utils.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 import { generateId } from '../lib/ids';
 import { dbTest } from './test-helpers';
 import {
+  assertUsableBootstrapAdminPassword,
   type CreateUserData,
   createDefaultAdminUser,
   createUser,
@@ -434,6 +435,26 @@ describe('DEVELOPMENT_DEFAULT_ADMIN_USER', () => {
   it('should be a const object', () => {
     expect(DEVELOPMENT_DEFAULT_ADMIN_USER).toBeDefined();
     expect(typeof DEVELOPMENT_DEFAULT_ADMIN_USER).toBe('object');
+  });
+});
+
+// ============================================================================
+// assertUsableBootstrapAdminPassword
+// ============================================================================
+
+describe('assertUsableBootstrapAdminPassword', () => {
+  it('rejects the development default password', () => {
+    expect(() => assertUsableBootstrapAdminPassword('admin')).toThrow(
+      /legacy fixed default password/
+    );
+  });
+
+  it('rejects too-short passwords', () => {
+    expect(() => assertUsableBootstrapAdminPassword('short')).toThrow(/at least 8 characters/);
+  });
+
+  it('accepts a usable password', () => {
+    expect(() => assertUsableBootstrapAdminPassword('explicit-secret')).not.toThrow();
   });
 });
 

--- a/packages/core/src/db/user-utils.ts
+++ b/packages/core/src/db/user-utils.ts
@@ -137,10 +137,13 @@ export async function getUserByEmail(db: Database, email: string): Promise<User 
 }
 
 /**
- * Default admin user credentials
- * Used by both init and user create-admin commands
+ * Development-only admin user credentials.
+ *
+ * Never use this in production/bootstrap paths. Production first-run setup
+ * should use an operator-provided password or a generated one-time credential
+ * file (see first-run-bootstrap / daemon setup).
  */
-export const DEFAULT_ADMIN_USER = {
+export const DEVELOPMENT_DEFAULT_ADMIN_USER = {
   email: 'admin@agor.live',
   password: 'admin',
   name: 'Admin',
@@ -148,23 +151,69 @@ export const DEFAULT_ADMIN_USER = {
   unix_username: 'admin',
 };
 
+export interface CreateDefaultAdminUserOptions {
+  email?: string;
+  password?: string;
+  name?: string;
+  unix_username?: string;
+  /**
+   * Explicitly opt into the legacy admin@agor.live/admin credential for
+   * development/test ergonomics. Refused when NODE_ENV=production.
+   */
+  allowDevelopmentDefault?: boolean;
+}
+
 /**
- * Create default admin user (admin@agor.live / admin)
+ * Create bootstrap admin user.
  *
- * This is a convenience function for creating the default admin user
- * with hardcoded credentials. Use createUser() if you need custom credentials.
+ * Production callers must pass an explicit password. The fixed
+ * admin@agor.live/admin credential is available only behind an explicit
+ * development/test gate.
  *
  * @param db - Database instance
+ * @param options - Admin identity/password options
  * @returns Created user
  * @throws Error if admin user already exists
  */
-export async function createDefaultAdminUser(db: Database): Promise<User> {
-  // Check if admin user already exists
-  const existing = await getUserByEmail(db, DEFAULT_ADMIN_USER.email);
-
-  if (existing) {
-    throw new Error(`Admin user already exists (email: ${DEFAULT_ADMIN_USER.email})`);
+export async function createDefaultAdminUser(
+  db: Database,
+  options: CreateDefaultAdminUserOptions = {}
+): Promise<User> {
+  const useDevelopmentDefault = options.allowDevelopmentDefault === true;
+  if (!options.password && !useDevelopmentDefault) {
+    throw new Error(
+      'Refusing to create admin with fixed default credentials. Pass an explicit password, or set allowDevelopmentDefault only in development/test.'
+    );
+  }
+  if (options.password === DEVELOPMENT_DEFAULT_ADMIN_USER.password && !useDevelopmentDefault) {
+    throw new Error(
+      'Refusing to create admin with the legacy fixed default password. Use a unique password or allowDevelopmentDefault only in development/test.'
+    );
+  }
+  if (useDevelopmentDefault && process.env.NODE_ENV === 'production') {
+    throw new Error('Refusing development default admin credentials when NODE_ENV=production');
   }
 
-  return createUser(db, DEFAULT_ADMIN_USER);
+  const adminData = {
+    ...DEVELOPMENT_DEFAULT_ADMIN_USER,
+    ...options,
+    password: options.password ?? DEVELOPMENT_DEFAULT_ADMIN_USER.password,
+    role: 'superadmin' as const,
+  };
+
+  // Check if admin user already exists
+  const existing = await getUserByEmail(db, adminData.email);
+
+  if (existing) {
+    throw new Error(`Admin user already exists (email: ${adminData.email})`);
+  }
+
+  return createUser(db, {
+    email: adminData.email,
+    password: adminData.password,
+    name: adminData.name,
+    role: adminData.role,
+    unix_username: adminData.unix_username,
+    must_change_password: !useDevelopmentDefault,
+  });
 }

--- a/packages/core/src/db/user-utils.ts
+++ b/packages/core/src/db/user-utils.ts
@@ -151,6 +151,20 @@ export const DEVELOPMENT_DEFAULT_ADMIN_USER = {
   unix_username: 'admin',
 };
 
+export const MIN_BOOTSTRAP_ADMIN_PASSWORD_LENGTH = 8;
+
+export function assertUsableBootstrapAdminPassword(
+  password: string,
+  label: string = 'Bootstrap admin password'
+): void {
+  if (password === DEVELOPMENT_DEFAULT_ADMIN_USER.password) {
+    throw new Error(`${label} must not be the legacy fixed default password.`);
+  }
+  if (password.length < MIN_BOOTSTRAP_ADMIN_PASSWORD_LENGTH) {
+    throw new Error(`${label} must be at least ${MIN_BOOTSTRAP_ADMIN_PASSWORD_LENGTH} characters.`);
+  }
+}
+
 export interface CreateDefaultAdminUserOptions {
   email?: string;
   password?: string;
@@ -185,10 +199,8 @@ export async function createDefaultAdminUser(
       'Refusing to create admin with fixed default credentials. Pass an explicit password, or set allowDevelopmentDefault only in development/test.'
     );
   }
-  if (options.password === DEVELOPMENT_DEFAULT_ADMIN_USER.password && !useDevelopmentDefault) {
-    throw new Error(
-      'Refusing to create admin with the legacy fixed default password. Use a unique password or allowDevelopmentDefault only in development/test.'
-    );
+  if (options.password && !useDevelopmentDefault) {
+    assertUsableBootstrapAdminPassword(options.password);
   }
   if (useDevelopmentDefault && process.env.NODE_ENV === 'production') {
     throw new Error('Refusing development default admin credentials when NODE_ENV=production');


### PR DESCRIPTION
## Summary

- Update production Docker startup to rely on the first-run setup flow instead of creating the initial admin directly.
- Add explicit operator-provided or generated setup value handling for empty installs.
- Keep development defaults available only through an explicit development path.
- Refresh Docker docs and focused coverage for the setup helpers.

## Checks

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/db/user-utils.test.ts`
- `pnpm --filter @agor/daemon test -- src/setup/first-run-admin.test.ts`
