### PR TITLE
Scope runtime tokens by purpose and resource

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -1,6 +1,6 @@
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { executorRuntimeScopeGuard } from './executor-runtime-scope';
+import { executorRuntimeScopeGuard, scopeExecutorRuntimeAuth } from './executor-runtime-scope';
 
 const payload = {
   type: 'executor-session',
@@ -160,6 +160,47 @@ describe('executorRuntimeScopeGuard', () => {
     });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+      /not valid for this endpoint/
+    );
+  });
+
+  it('allows scoped read-only session MCP server resolution', async () => {
+    const context = ctx({
+      path: 'sessions/:id/mcp-servers',
+      method: 'find',
+      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
+  it('rejects session MCP server writes under executor token auth', async () => {
+    const context = ctx({
+      path: 'sessions/:id/mcp-servers',
+      method: 'create',
+      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+      /not valid for this endpoint/
+    );
+  });
+
+  it('rejects session MCP server reads for another session', async () => {
+    const context = ctx({
+      path: 'sessions/:id/mcp-servers',
+      method: 'find',
+      params: { authentication: { payload }, query: {}, route: { id: 'session-2' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);
+  });
+
+  it('wraps auth hooks with executor runtime scope validation', async () => {
+    const requireAuth = async (context: HookContext) => context;
+    const context = ctx({ path: 'config/resolve-api-key', method: 'create' });
+
+    await expect(scopeExecutorRuntimeAuth(requireAuth)(context)).rejects.toThrow(
       /not valid for this endpoint/
     );
   });

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -31,6 +31,40 @@ describe('executorRuntimeScopeGuard', () => {
     });
   });
 
+  it('allows session-wide message history reads for the scoped session', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'find',
+      params: { authentication: { payload }, query: { session_id: 'session-1' } },
+    });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect(context.params.query).toEqual({ session_id: 'session-1' });
+  });
+
+  it('rejects session-wide message reads for another session', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'find',
+      params: { authentication: { payload }, query: { session_id: 'session-2' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);
+  });
+
+  it('keeps explicit message task reads scoped to the executor task', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'find',
+      params: { authentication: { payload }, query: { task_id: 'task-1' } },
+    });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect(context.params.query).toEqual({ task_id: 'task-1', session_id: 'session-1' });
+  });
+
   it('rejects find queries that request a different scoped object', async () => {
     const context = ctx({
       path: 'tasks',

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -74,4 +74,93 @@ describe('executorRuntimeScopeGuard', () => {
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/messages request/);
   });
+
+  it('rejects executor tokens on unrecognized endpoints', async () => {
+    const context = ctx({ path: 'repos', method: 'find' });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+      /not valid for this endpoint/
+    );
+  });
+
+  it('validates every bulk message payload item against task scope', async () => {
+    const context = ctx({
+      path: 'messages/bulk',
+      method: 'create',
+      data: [
+        { message_id: 'message-1', task_id: 'task-1', session_id: 'session-1' },
+        { message_id: 'message-2' },
+      ],
+    });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect(context.data).toEqual([
+      { message_id: 'message-1', task_id: 'task-1', session_id: 'session-1' },
+      { message_id: 'message-2', task_id: 'task-1', session_id: 'session-1' },
+    ]);
+  });
+
+  it('rejects bulk message payloads for another task', async () => {
+    const context = ctx({
+      path: 'messages/bulk',
+      method: 'create',
+      data: [{ message_id: 'message-1', task_id: 'task-2', session_id: 'session-1' }],
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
+  });
+
+  it('validates streaming event payload scope', async () => {
+    const context = ctx({
+      path: 'tasks/streaming',
+      method: 'create',
+      data: {
+        event: 'thinking:chunk',
+        data: { task_id: 'task-1', session_id: 'session-1', text: 'chunk' },
+      },
+    });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect((context.data as { data: Record<string, unknown> }).data).toMatchObject({
+      task_id: 'task-1',
+      session_id: 'session-1',
+    });
+  });
+
+  it('rejects streaming events for another session', async () => {
+    const context = ctx({
+      path: 'messages/streaming',
+      method: 'create',
+      data: {
+        event: 'message:chunk',
+        data: { task_id: 'task-1', session_id: 'session-2' },
+      },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);
+  });
+
+  it('allows scoped session genealogy route only for the scoped session', async () => {
+    const context = ctx({
+      path: 'sessions/:id/genealogy',
+      method: 'find',
+      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
+  it('rejects session custom routes that are not explicitly allowed', async () => {
+    const context = ctx({
+      path: 'sessions/:id/fork',
+      method: 'create',
+      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
+      /not valid for this endpoint/
+    );
+  });
 });

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -1,0 +1,77 @@
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { executorRuntimeScopeGuard } from './executor-runtime-scope';
+
+const payload = {
+  type: 'executor-session',
+  purpose: 'executor-task',
+  session_id: 'session-1',
+  task_id: 'task-1',
+  branch_id: 'branch-1',
+};
+
+function ctx(overrides: Partial<HookContext>): HookContext {
+  return {
+    path: 'tasks',
+    method: 'find',
+    params: { authentication: { payload }, query: {} },
+    ...overrides,
+  } as HookContext;
+}
+
+describe('executorRuntimeScopeGuard', () => {
+  it('narrows find queries to executor token scope', async () => {
+    const context = ctx({ path: 'messages', method: 'find' });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect(context.params.query).toMatchObject({
+      task_id: 'task-1',
+      session_id: 'session-1',
+    });
+  });
+
+  it('rejects find queries that request a different scoped object', async () => {
+    const context = ctx({
+      path: 'tasks',
+      method: 'find',
+      params: { authentication: { payload }, query: { task_id: 'task-2' } },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
+  });
+
+  it('rejects task/message services when token has no task scope', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'find',
+      params: {
+        authentication: {
+          payload: {
+            type: 'executor-session',
+            purpose: 'executor-task',
+            session_id: 'branch-clean',
+            branch_id: 'branch-1',
+          },
+        },
+        query: {},
+      },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/missing task scope/);
+  });
+
+  it('narrows branch find queries to branch scope', async () => {
+    const context = ctx({ path: 'branches', method: 'find' });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect(context.params.query).toMatchObject({ branch_id: 'branch-1' });
+  });
+
+  it('rejects message get by opaque message id under executor token auth', async () => {
+    const context = ctx({ path: 'messages', method: 'get', id: 'message-1' });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/messages request/);
+  });
+});

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -109,6 +109,46 @@ describe('executorRuntimeScopeGuard', () => {
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/messages request/);
   });
 
+  it('allows message patch when the existing message belongs to the scoped task', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'patch',
+      id: 'message-1',
+      data: { content_preview: 'done' },
+      service: {
+        messagesRepo: {
+          findById: async () => ({
+            message_id: 'message-1',
+            task_id: 'task-1',
+            session_id: 'session-1',
+          }),
+        },
+      },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
+  it('rejects message patch when the existing message belongs to another task', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'patch',
+      id: 'message-1',
+      data: { content_preview: 'done' },
+      service: {
+        messagesRepo: {
+          findById: async () => ({
+            message_id: 'message-1',
+            task_id: 'task-2',
+            session_id: 'session-1',
+          }),
+        },
+      },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
+  });
+
   it('rejects executor tokens on unrecognized endpoints', async () => {
     const context = ctx({ path: 'repos', method: 'find' });
 

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -103,10 +103,38 @@ describe('executorRuntimeScopeGuard', () => {
     expect(context.params.query).toMatchObject({ branch_id: 'branch-1' });
   });
 
-  it('rejects message get by opaque message id under executor token auth', async () => {
-    const context = ctx({ path: 'messages', method: 'get', id: 'message-1' });
+  it('allows message get when the existing message belongs to the scoped session', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'get',
+      id: 'message-1',
+      service: {
+        findByIdForScopeCheck: async () => ({
+          message_id: 'message-1',
+          task_id: 'previous-task',
+          session_id: 'session-1',
+        }),
+      },
+    });
 
-    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/messages request/);
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
+  it('rejects message get when the existing message belongs to another session', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'get',
+      id: 'message-1',
+      service: {
+        findByIdForScopeCheck: async () => ({
+          message_id: 'message-1',
+          task_id: 'task-1',
+          session_id: 'session-2',
+        }),
+      },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);
   });
 
   it('allows message patch when the existing message belongs to the scoped task', async () => {
@@ -116,13 +144,11 @@ describe('executorRuntimeScopeGuard', () => {
       id: 'message-1',
       data: { content_preview: 'done' },
       service: {
-        messagesRepo: {
-          findById: async () => ({
-            message_id: 'message-1',
-            task_id: 'task-1',
-            session_id: 'session-1',
-          }),
-        },
+        findByIdForScopeCheck: async () => ({
+          message_id: 'message-1',
+          task_id: 'task-1',
+          session_id: 'session-1',
+        }),
       },
     });
 
@@ -136,13 +162,28 @@ describe('executorRuntimeScopeGuard', () => {
       id: 'message-1',
       data: { content_preview: 'done' },
       service: {
-        messagesRepo: {
-          findById: async () => ({
-            message_id: 'message-1',
-            task_id: 'task-2',
-            session_id: 'session-1',
-          }),
-        },
+        findByIdForScopeCheck: async () => ({
+          message_id: 'message-1',
+          task_id: 'task-2',
+          session_id: 'session-1',
+        }),
+      },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
+  });
+
+  it('rejects message patch when the existing message has no task scope', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'patch',
+      id: 'message-1',
+      data: { content_preview: 'done' },
+      service: {
+        findByIdForScopeCheck: async () => ({
+          message_id: 'message-1',
+          session_id: 'session-1',
+        }),
       },
     });
 

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -182,11 +182,22 @@ export function executorRuntimeScopeGuard() {
     } else if (path === 'messages') {
       const taskId = expectClaim(scope.taskId, 'task');
       if (context.method === 'find') {
-        expectMatch(taskId, query.task_id, 'task');
-        setIfAbsent(query, 'task_id', taskId);
-        if (scope.sessionId) {
-          expectMatch(scope.sessionId, query.session_id, 'session');
-          setIfAbsent(query, 'session_id', scope.sessionId);
+        const hasTaskQuery = query.task_id !== undefined && query.task_id !== null;
+        const hasSessionQuery = query.session_id !== undefined && query.session_id !== null;
+        if (hasTaskQuery) {
+          expectMatch(taskId, query.task_id, 'task');
+          if (scope.sessionId) {
+            expectMatch(scope.sessionId, query.session_id, 'session');
+            setIfAbsent(query, 'session_id', scope.sessionId);
+          }
+        } else if (hasSessionQuery) {
+          const sessionId = expectClaim(scope.sessionId, 'session');
+          expectMatch(sessionId, query.session_id, 'session');
+        } else {
+          setIfAbsent(query, 'task_id', taskId);
+          if (scope.sessionId) {
+            setIfAbsent(query, 'session_id', scope.sessionId);
+          }
         }
       } else if (context.method === 'create') {
         for (const record of recordsFromData(context.data)) {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -102,6 +102,20 @@ function scopeStreamingEnvelope(data: unknown, scope: Scope): void {
   scopeTaskRecord(eventData, scope);
 }
 
+async function loadMessageRecord(
+  context: HookContext,
+  id: string
+): Promise<Record<string, unknown>> {
+  const service = context.service as unknown as {
+    messagesRepo?: { findById(id: string): Promise<unknown> };
+  };
+  const record = asRecord(await service.messagesRepo?.findById(id));
+  if (!record) {
+    throw new Forbidden('Executor token message scope is required for this request');
+  }
+  return record;
+}
+
 function requireMatchingSessionRoute(context: HookContext, scope: Scope): void {
   const sessionId = expectClaim(scope.sessionId, 'session');
   const query = ((context.params as Params).query ?? {}) as Record<string, unknown>;
@@ -205,6 +219,17 @@ export function executorRuntimeScopeGuard() {
           setIfAbsent(record, 'task_id', taskId);
           if (scope.sessionId)
             expectMatch(scope.sessionId, record.session_id ?? query.session_id, 'session');
+        }
+      } else if (context.method === 'patch') {
+        if (!id) {
+          throw new Forbidden('Executor token message scope is required for this request');
+        }
+        const existing = await loadMessageRecord(context, id);
+        expectMatch(taskId, existing.task_id, 'task');
+        expectMatch(taskId, data.task_id ?? query.task_id, 'task');
+        if (scope.sessionId) {
+          expectMatch(scope.sessionId, existing.session_id, 'session');
+          expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
         }
       } else {
         throw new Forbidden('Executor token is not valid for this messages request');

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -59,6 +59,10 @@ function routeId(context: HookContext): string | undefined {
   return (context.params as Params & { route?: { id?: string } }).route?.id;
 }
 
+function routeSessionId(context: HookContext): string | undefined {
+  return routeId(context) ?? (typeof context.id === 'string' ? context.id : undefined);
+}
+
 function recordsFromData(data: unknown): Record<string, unknown>[] {
   if (Array.isArray(data)) {
     return data.map((item) => {
@@ -96,6 +100,25 @@ function scopeStreamingEnvelope(data: unknown, scope: Scope): void {
     throw new Forbidden('Executor token requires scoped streaming event data');
   }
   scopeTaskRecord(eventData, scope);
+}
+
+function requireMatchingSessionRoute(context: HookContext, scope: Scope): void {
+  const sessionId = expectClaim(scope.sessionId, 'session');
+  const query = ((context.params as Params).query ?? {}) as Record<string, unknown>;
+  const requestedSessionId = routeSessionId(context) ?? query.session_id;
+  expectMatch(sessionId, requestedSessionId, 'session');
+  if (requestedSessionId === undefined || requestedSessionId === null) {
+    throw new Forbidden('Executor token session scope is required for this request');
+  }
+}
+
+type AuthHook = (context: HookContext) => Promise<HookContext>;
+
+export function scopeExecutorRuntimeAuth(requireAuth: AuthHook): AuthHook {
+  return async (context: HookContext): Promise<HookContext> => {
+    const authenticated = await requireAuth(context);
+    return executorRuntimeScopeGuard()(authenticated);
+  };
 }
 
 /**
@@ -199,11 +222,12 @@ export function executorRuntimeScopeGuard() {
       }
       scopeStreamingEnvelope(context.data, scope);
     } else if (path === 'sessions/:id/genealogy' || path === 'sessions/genealogy') {
-      const sessionId = expectClaim(scope.sessionId, 'session');
-      expectMatch(sessionId, routeId(context) ?? id ?? query.session_id, 'session');
-      if (routeId(context) === undefined && id === undefined && query.session_id === undefined) {
-        throw new Forbidden('Executor token session scope is required for this request');
+      requireMatchingSessionRoute(context, scope);
+    } else if (path === 'sessions/:id/mcp-servers' || path === 'sessions/mcp-servers') {
+      if (context.method !== 'find') {
+        throw new Forbidden('Executor token is not valid for this endpoint');
       }
+      requireMatchingSessionRoute(context, scope);
     } else {
       throw new Forbidden('Executor token is not valid for this endpoint');
     }

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -10,6 +10,12 @@ type ExecutorTokenPayload = {
   branch_id?: string;
 };
 
+type Scope = {
+  sessionId?: string;
+  taskId?: string;
+  branchId?: string;
+};
+
 function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
   const payload = (context.params as AuthenticatedParams).authentication?.payload as
     | ExecutorTokenPayload
@@ -39,6 +45,59 @@ function setIfAbsent(target: Record<string, unknown>, key: string, value: string
   if (target[key] === undefined || target[key] === null) target[key] = value;
 }
 
+function normalizePath(path: string | undefined): string {
+  return (path ?? '').replace(/^\/+/, '');
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function routeId(context: HookContext): string | undefined {
+  return (context.params as Params & { route?: { id?: string } }).route?.id;
+}
+
+function recordsFromData(data: unknown): Record<string, unknown>[] {
+  if (Array.isArray(data)) {
+    return data.map((item) => {
+      const record = asRecord(item);
+      if (!record) {
+        throw new Forbidden('Executor token requires scoped object payloads');
+      }
+      return record;
+    });
+  }
+  const record = asRecord(data);
+  if (!record) {
+    throw new Forbidden('Executor token requires a scoped object payload');
+  }
+  return [record];
+}
+
+function scopeTaskRecord(record: Record<string, unknown>, scope: Scope): void {
+  const taskId = expectClaim(scope.taskId, 'task');
+  expectMatch(taskId, record.task_id, 'task');
+  setIfAbsent(record, 'task_id', taskId);
+  if (scope.sessionId) {
+    expectMatch(scope.sessionId, record.session_id, 'session');
+    setIfAbsent(record, 'session_id', scope.sessionId);
+  }
+}
+
+function scopeStreamingEnvelope(data: unknown, scope: Scope): void {
+  const envelope = asRecord(data);
+  if (!envelope) {
+    throw new Forbidden('Executor token requires a scoped streaming payload');
+  }
+  const eventData = asRecord(envelope.data);
+  if (!eventData) {
+    throw new Forbidden('Executor token requires scoped streaming event data');
+  }
+  scopeTaskRecord(eventData, scope);
+}
+
 /**
  * Restrict executor-session JWTs to the resource claims minted for the
  * executor turn. Normal user/API-key/service auth is intentionally ignored.
@@ -61,8 +120,9 @@ export function executorRuntimeScopeGuard() {
     const query = ((context.params as Params).query ?? {}) as Record<string, unknown>;
     (context.params as Params).query = query;
     const id = typeof context.id === 'string' ? context.id : undefined;
+    const path = normalizePath(context.path);
 
-    if (context.path === 'sessions') {
+    if (path === 'sessions') {
       const sessionId = expectClaim(scope.sessionId, 'session');
       if (context.method === 'find') {
         expectMatch(sessionId, query.session_id, 'session');
@@ -79,7 +139,7 @@ export function executorRuntimeScopeGuard() {
         if (scope.branchId)
           expectMatch(scope.branchId, data.branch_id ?? query.branch_id, 'branch');
       }
-    } else if (context.path === 'tasks') {
+    } else if (path === 'tasks') {
       const taskId = expectClaim(scope.taskId, 'task');
       if (context.method === 'find') {
         expectMatch(taskId, query.task_id, 'task');
@@ -96,7 +156,7 @@ export function executorRuntimeScopeGuard() {
         if (scope.sessionId)
           expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
       }
-    } else if (context.path === 'messages') {
+    } else if (path === 'messages') {
       const taskId = expectClaim(scope.taskId, 'task');
       if (context.method === 'find') {
         expectMatch(taskId, query.task_id, 'task');
@@ -106,14 +166,16 @@ export function executorRuntimeScopeGuard() {
           setIfAbsent(query, 'session_id', scope.sessionId);
         }
       } else if (context.method === 'create') {
-        expectMatch(taskId, data.task_id ?? query.task_id, 'task');
-        setIfAbsent(data, 'task_id', taskId);
-        if (scope.sessionId)
-          expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
+        for (const record of recordsFromData(context.data)) {
+          expectMatch(taskId, record.task_id ?? query.task_id, 'task');
+          setIfAbsent(record, 'task_id', taskId);
+          if (scope.sessionId)
+            expectMatch(scope.sessionId, record.session_id ?? query.session_id, 'session');
+        }
       } else {
         throw new Forbidden('Executor token is not valid for this messages request');
       }
-    } else if (context.path === 'branches') {
+    } else if (path === 'branches') {
       const branchId = expectClaim(scope.branchId, 'branch');
       if (context.method === 'find') {
         expectMatch(branchId, query.branch_id, 'branch');
@@ -124,6 +186,26 @@ export function executorRuntimeScopeGuard() {
           throw new Forbidden('Executor token branch scope is required for this request');
         }
       }
+    } else if (path === 'messages/bulk') {
+      if (context.method !== 'create') {
+        throw new Forbidden('Executor token is not valid for this endpoint');
+      }
+      for (const record of recordsFromData(context.data)) {
+        scopeTaskRecord(record, scope);
+      }
+    } else if (path === 'messages/streaming' || path === 'tasks/streaming') {
+      if (context.method !== 'create') {
+        throw new Forbidden('Executor token is not valid for this endpoint');
+      }
+      scopeStreamingEnvelope(context.data, scope);
+    } else if (path === 'sessions/:id/genealogy' || path === 'sessions/genealogy') {
+      const sessionId = expectClaim(scope.sessionId, 'session');
+      expectMatch(sessionId, routeId(context) ?? id ?? query.session_id, 'session');
+      if (routeId(context) === undefined && id === undefined && query.session_id === undefined) {
+        throw new Forbidden('Executor token session scope is required for this request');
+      }
+    } else {
+      throw new Forbidden('Executor token is not valid for this endpoint');
     }
 
     return context;

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -80,6 +80,12 @@ function recordsFromData(data: unknown): Record<string, unknown>[] {
   return [record];
 }
 
+function expectExistingMatch(claim: string, value: unknown, label: string): void {
+  if (String(value) !== claim) {
+    throw new Forbidden(`Executor token ${label} scope does not match this request`);
+  }
+}
+
 function scopeTaskRecord(record: Record<string, unknown>, scope: Scope): void {
   const taskId = expectClaim(scope.taskId, 'task');
   expectMatch(taskId, record.task_id, 'task');
@@ -107,9 +113,9 @@ async function loadMessageRecord(
   id: string
 ): Promise<Record<string, unknown>> {
   const service = context.service as unknown as {
-    messagesRepo?: { findById(id: string): Promise<unknown> };
+    findByIdForScopeCheck?: (id: string) => Promise<unknown>;
   };
-  const record = asRecord(await service.messagesRepo?.findById(id));
+  const record = asRecord(await service.findByIdForScopeCheck?.(id));
   if (!record) {
     throw new Forbidden('Executor token message scope is required for this request');
   }
@@ -124,6 +130,22 @@ function requireMatchingSessionRoute(context: HookContext, scope: Scope): void {
   if (requestedSessionId === undefined || requestedSessionId === null) {
     throw new Forbidden('Executor token session scope is required for this request');
   }
+}
+
+async function requireMessageReadScope(
+  context: HookContext,
+  id: string,
+  scope: Scope
+): Promise<void> {
+  const existing = await loadMessageRecord(context, id);
+
+  if (scope.sessionId) {
+    expectExistingMatch(scope.sessionId, existing.session_id, 'session');
+    return;
+  }
+
+  const taskId = expectClaim(scope.taskId, 'task');
+  expectExistingMatch(taskId, existing.task_id, 'task');
 }
 
 type AuthHook = (context: HookContext) => Promise<HookContext>;
@@ -220,15 +242,20 @@ export function executorRuntimeScopeGuard() {
           if (scope.sessionId)
             expectMatch(scope.sessionId, record.session_id ?? query.session_id, 'session');
         }
+      } else if (context.method === 'get') {
+        if (!id) {
+          throw new Forbidden('Executor token message scope is required for this request');
+        }
+        await requireMessageReadScope(context, id, scope);
       } else if (context.method === 'patch') {
         if (!id) {
           throw new Forbidden('Executor token message scope is required for this request');
         }
         const existing = await loadMessageRecord(context, id);
-        expectMatch(taskId, existing.task_id, 'task');
+        expectExistingMatch(taskId, existing.task_id, 'task');
         expectMatch(taskId, data.task_id ?? query.task_id, 'task');
         if (scope.sessionId) {
-          expectMatch(scope.sessionId, existing.session_id, 'session');
+          expectExistingMatch(scope.sessionId, existing.session_id, 'session');
           expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
         }
       } else {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -1,0 +1,131 @@
+import { Forbidden } from '@agor/core/feathers';
+import type { AuthenticatedParams, HookContext, Params } from '@agor/core/types';
+
+type ExecutorTokenPayload = {
+  type?: string;
+  purpose?: string;
+  session_id?: string;
+  sessionId?: string;
+  task_id?: string;
+  branch_id?: string;
+};
+
+function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
+  const payload = (context.params as AuthenticatedParams).authentication?.payload as
+    | ExecutorTokenPayload
+    | undefined;
+  if (payload?.type !== 'executor-session') return null;
+  if (payload.purpose !== 'executor-task') {
+    throw new Forbidden('Executor token is not valid for this request');
+  }
+  return payload;
+}
+
+function expectClaim(claim: string | undefined, label: string): string {
+  if (!claim) {
+    throw new Forbidden(`Executor token is missing ${label} scope`);
+  }
+  return claim;
+}
+
+function expectMatch(claim: string, value: unknown, label: string): void {
+  if (value === undefined || value === null) return;
+  if (String(value) !== claim) {
+    throw new Forbidden(`Executor token ${label} scope does not match this request`);
+  }
+}
+
+function setIfAbsent(target: Record<string, unknown>, key: string, value: string): void {
+  if (target[key] === undefined || target[key] === null) target[key] = value;
+}
+
+/**
+ * Restrict executor-session JWTs to the resource claims minted for the
+ * executor turn. Normal user/API-key/service auth is intentionally ignored.
+ *
+ * For list endpoints, this fail-closes by injecting the token scope into the
+ * service query. For object mutations, the request must either address the
+ * scoped object directly or carry matching parent identifiers.
+ */
+export function executorRuntimeScopeGuard() {
+  return async (context: HookContext): Promise<HookContext> => {
+    const payload = scopedPayload(context);
+    if (!payload) return context;
+
+    const scope = {
+      sessionId: payload.session_id ?? payload.sessionId,
+      taskId: payload.task_id,
+      branchId: payload.branch_id,
+    };
+    const data = (context.data ?? {}) as Record<string, unknown>;
+    const query = ((context.params as Params).query ?? {}) as Record<string, unknown>;
+    (context.params as Params).query = query;
+    const id = typeof context.id === 'string' ? context.id : undefined;
+
+    if (context.path === 'sessions') {
+      const sessionId = expectClaim(scope.sessionId, 'session');
+      if (context.method === 'find') {
+        expectMatch(sessionId, query.session_id, 'session');
+        setIfAbsent(query, 'session_id', sessionId);
+        if (scope.branchId) {
+          expectMatch(scope.branchId, query.branch_id, 'branch');
+          setIfAbsent(query, 'branch_id', scope.branchId);
+        }
+      } else {
+        expectMatch(sessionId, id ?? data.session_id ?? query.session_id, 'session');
+        if (!id && data.session_id === undefined && query.session_id === undefined) {
+          throw new Forbidden('Executor token session scope is required for this request');
+        }
+        if (scope.branchId)
+          expectMatch(scope.branchId, data.branch_id ?? query.branch_id, 'branch');
+      }
+    } else if (context.path === 'tasks') {
+      const taskId = expectClaim(scope.taskId, 'task');
+      if (context.method === 'find') {
+        expectMatch(taskId, query.task_id, 'task');
+        setIfAbsent(query, 'task_id', taskId);
+        if (scope.sessionId) {
+          expectMatch(scope.sessionId, query.session_id, 'session');
+          setIfAbsent(query, 'session_id', scope.sessionId);
+        }
+      } else {
+        expectMatch(taskId, id ?? data.task_id ?? query.task_id, 'task');
+        if (!id && data.task_id === undefined && query.task_id === undefined) {
+          throw new Forbidden('Executor token task scope is required for this request');
+        }
+        if (scope.sessionId)
+          expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
+      }
+    } else if (context.path === 'messages') {
+      const taskId = expectClaim(scope.taskId, 'task');
+      if (context.method === 'find') {
+        expectMatch(taskId, query.task_id, 'task');
+        setIfAbsent(query, 'task_id', taskId);
+        if (scope.sessionId) {
+          expectMatch(scope.sessionId, query.session_id, 'session');
+          setIfAbsent(query, 'session_id', scope.sessionId);
+        }
+      } else if (context.method === 'create') {
+        expectMatch(taskId, data.task_id ?? query.task_id, 'task');
+        setIfAbsent(data, 'task_id', taskId);
+        if (scope.sessionId)
+          expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
+      } else {
+        throw new Forbidden('Executor token is not valid for this messages request');
+      }
+    } else if (context.path === 'branches') {
+      const branchId = expectClaim(scope.branchId, 'branch');
+      if (context.method === 'find') {
+        expectMatch(branchId, query.branch_id, 'branch');
+        setIfAbsent(query, 'branch_id', branchId);
+      } else {
+        expectMatch(branchId, id ?? data.branch_id ?? query.branch_id, 'branch');
+        if (!id && data.branch_id === undefined && query.branch_id === undefined) {
+          throw new Forbidden('Executor token branch scope is required for this request');
+        }
+      }
+    }
+
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/auth/runtime-tokens.ts
+++ b/apps/agor-daemon/src/auth/runtime-tokens.ts
@@ -3,8 +3,9 @@ import jwt, { type SignOptions } from 'jsonwebtoken';
 
 export const RUNTIME_JWT_ISSUER = 'agor';
 export const RUNTIME_JWT_AUDIENCE = 'https://agor.dev';
+export const ARTIFACT_RUNTIME_JWT_AUDIENCE = 'agor:artifact-runtime';
 
-export type RuntimeTokenType = 'access' | 'refresh' | 'service';
+export type RuntimeTokenType = 'access' | 'refresh' | 'service' | 'executor-session' | 'artifact';
 
 export interface RuntimeTokenPayload {
   sub: UserID | string;
@@ -20,12 +21,13 @@ export interface RuntimeTokenPair {
 export function issueRuntimeToken(
   payload: RuntimeTokenPayload,
   jwtSecret: string,
-  expiresIn: SignOptions['expiresIn']
+  expiresIn: SignOptions['expiresIn'],
+  options: Pick<SignOptions, 'audience'> = {}
 ): string {
   return jwt.sign(payload, jwtSecret, {
     expiresIn,
     issuer: RUNTIME_JWT_ISSUER,
-    audience: RUNTIME_JWT_AUDIENCE,
+    audience: options.audience ?? RUNTIME_JWT_AUDIENCE,
   });
 }
 

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -12,6 +12,7 @@
 
 import { JWTStrategy } from '@agor/core/feathers';
 import type { Params } from '@agor/core/types';
+import type { SessionTokenService } from '../services/session-token-service.js';
 
 /**
  * Extended JWT Strategy that handles service tokens
@@ -20,6 +21,9 @@ import type { Params } from '@agor/core/types';
  * for privileged operations (unix.sync-*, git.*, etc.)
  */
 export class ServiceJWTStrategy extends JWTStrategy {
+  constructor(private sessionTokenService?: SessionTokenService) {
+    super();
+  }
   /**
    * Override getEntity to handle service tokens
    *
@@ -55,9 +59,22 @@ export class ServiceJWTStrategy extends JWTStrategy {
     const result = await super.authenticate(authentication, params);
 
     // Check if this is a service token by looking at the decoded payload
-    const payload = result.authentication?.payload as { sub?: string; type?: string } | undefined;
+    const payload = result.authentication?.payload as
+      | {
+          sub?: string;
+          type?: string;
+          session_id?: string;
+          sessionId?: string;
+          task_id?: string;
+          branch_id?: string;
+          purpose?: string;
+        }
+      | undefined;
 
     if (payload?.type === 'service' && payload?.sub === 'executor-service') {
+      if (payload.purpose !== undefined && payload.purpose !== 'executor-service') {
+        throw new Error('Invalid service token purpose');
+      }
       // Override user in result with service account
       return {
         ...result,
@@ -68,6 +85,38 @@ export class ServiceJWTStrategy extends JWTStrategy {
           _isServiceAccount: true,
         },
       };
+    }
+
+    if (payload?.type === 'executor-session') {
+      if (payload.purpose !== 'executor-task') {
+        throw new Error('Invalid executor token purpose');
+      }
+      const token = authentication?.accessToken;
+      if (!token || !this.sessionTokenService) {
+        throw new Error('Executor token validation unavailable');
+      }
+      const sessionId = payload.session_id ?? payload.sessionId;
+      const sessionInfo = await this.sessionTokenService.validateToken(token, {
+        sessionId,
+        taskId: payload.task_id,
+        branchId: payload.branch_id,
+      });
+      if (!sessionInfo) {
+        throw new Error('Invalid or expired executor token');
+      }
+      return {
+        ...result,
+        session_id: sessionInfo.session_id,
+        task_id: sessionInfo.task_id,
+        branch_id: sessionInfo.branch_id,
+      };
+    }
+
+    if (
+      payload?.type !== undefined &&
+      !['access', 'refresh', 'service', 'executor-session'].includes(payload.type)
+    ) {
+      throw new Error('JWT type is not valid for daemon API authentication');
     }
 
     return result;

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -114,7 +114,7 @@ export class ServiceJWTStrategy extends JWTStrategy {
 
     if (
       payload?.type !== undefined &&
-      !['access', 'refresh', 'service', 'executor-session'].includes(payload.type)
+      !['access', 'service', 'executor-session'].includes(payload.type)
     ) {
       throw new Error('JWT type is not valid for daemon API authentication');
     }

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -46,6 +46,7 @@ import { getServiceTier, isServiceEnabled } from '@agor/core/types';
 import cors from 'cors';
 import express from 'express';
 import expressStaticGzip from 'express-static-gzip';
+import { scopeExecutorRuntimeAuth } from './auth/executor-runtime-scope.js';
 import { registerHooks } from './register-hooks.js';
 import { registerRoutes } from './register-routes.js';
 import { registerServices } from './register-services.js';
@@ -189,7 +190,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // --------------------------------------------------------------------------
   // Auth configuration
   // --------------------------------------------------------------------------
-  const requireAuth = authenticate({ strategies: ['api-key', 'jwt'] });
+  const requireAuth = scopeExecutorRuntimeAuth(authenticate({ strategies: ['api-key', 'jwt'] }));
 
   const enforcePasswordChange = async (context: HookContext) => {
     const user = context.params?.user as User | undefined;

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -118,7 +118,7 @@ Recommended: create the folder inside your branch so files can be version-contro
 DECLARATIVE CONFIG:
 - \`requiredEnvVars\`: array of env var NAMES the artifact needs (e.g. ["OPENAI_KEY", "STRIPE_KEY"]). The daemon synthesizes a per-viewer \`.env\` at render time using values from the viewer's stored env vars (Settings → Environment Variables). Names are stored without prefix; the daemon prefixes per template at render time. Currently only the \`react\` / \`react-ts\` mapping is verified end-to-end: those are CRA-backed (sandpack-react v2), so use \`process.env.REACT_APP_X\`. Other templates are best-effort and may need to be audited the first time an artifact publishes against them — the table in apps/agor-docs/pages/guide/artifacts.mdx tracks status. \`vanilla\` / \`vanilla-ts\` have no dotenv path (daemon warns and injects nothing).
 - \`agorGrants\`: declarative daemon capabilities. Each grant maps to a fixed env var:
-    \`agor_token: true\`     → mints a 15-min daemon JWT for the viewer; injected as \`AGOR_TOKEN\`. ARTIFACT-SCOPED CONSENT ONLY — author/instance grants don't auto-cover this.
+    \`agor_token: true\`     → mints a 15-min artifact-runtime token for the viewer; injected as \`AGOR_TOKEN\`. Accepted by artifact/proxy runtime paths, not as a general daemon API credential. ARTIFACT-SCOPED CONSENT ONLY — author/instance grants don't auto-cover this.
     \`agor_api_url: true\`   → injects the daemon URL as \`AGOR_API_URL\`.
     \`agor_user_email: true\` → injects viewer's email as \`AGOR_USER_EMAIL\`.
     \`agor_artifact_id: true\` → \`AGOR_ARTIFACT_ID\` (informational, no consent).

--- a/apps/agor-daemon/src/mcp/tools/proxies.ts
+++ b/apps/agor-daemon/src/mcp/tools/proxies.ts
@@ -54,7 +54,7 @@ Each proxy forwards requests from /proxies/<vendor>/X to <upstream>/X so Sandpac
 
 EVERY request to a proxy needs TWO credentials, in the same headers object:
 
-  1. Authorization: Bearer <AGOR_TOKEN>     ← daemon JWT (15-min TTL), protects the proxy from being an open relay
+  1. Authorization: Bearer <AGOR_TOKEN>     ← artifact-runtime token (15-min TTL), protects the proxy from being an open relay and is scoped to declared proxy vendors
   2. <Vendor's auth header>                  ← whatever the upstream API actually wants
 
 Both come from the synthesized .env. Declare what your artifact needs at publish time:

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -135,6 +135,59 @@ function itemHasAnyField(item: Record<string, unknown>, fields: readonly string[
   return fields.some((field) => Object.hasOwn(item, field));
 }
 
+type ExecutorTokenPayload = {
+  type?: string;
+  purpose?: string;
+  session_id?: string;
+  sessionId?: string;
+  task_id?: string;
+  branch_id?: string;
+};
+
+function executorRuntimeScopeGuard() {
+  return async (context: HookContext): Promise<HookContext> => {
+    const payload = (context.params as AuthenticatedParams).authentication?.payload as
+      | ExecutorTokenPayload
+      | undefined;
+    if (payload?.type !== 'executor-session') return context;
+
+    if (payload.purpose !== 'executor-task') {
+      throw new Forbidden('Executor token is not valid for this request');
+    }
+
+    const scope = {
+      sessionId: payload.session_id ?? payload.sessionId,
+      taskId: payload.task_id,
+      branchId: payload.branch_id,
+    };
+    const data = (context.data ?? {}) as Record<string, unknown>;
+    const query = ((context.params as Params).query ?? {}) as Record<string, unknown>;
+    const id = typeof context.id === 'string' ? context.id : undefined;
+
+    const expectMatch = (claim: string | undefined, value: unknown, label: string) => {
+      if (!claim || value === undefined || value === null) return;
+      if (String(value) !== claim) {
+        throw new Forbidden(`Executor token ${label} scope does not match this request`);
+      }
+    };
+
+    if (context.path === 'sessions') {
+      expectMatch(scope.sessionId, id ?? data.session_id ?? query.session_id, 'session');
+      expectMatch(scope.branchId, data.branch_id ?? query.branch_id, 'branch');
+    } else if (context.path === 'tasks') {
+      expectMatch(scope.taskId, id ?? data.task_id ?? query.task_id, 'task');
+      expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
+    } else if (context.path === 'messages') {
+      expectMatch(scope.taskId, data.task_id ?? query.task_id, 'task');
+      expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
+    } else if (context.path === 'branches') {
+      expectMatch(scope.branchId, id ?? data.branch_id ?? query.branch_id, 'branch');
+    }
+
+    return context;
+  };
+}
+
 async function getManagedEnvExecutionMode() {
   const config = await loadConfig();
   return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
@@ -334,7 +387,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   app.service('messages').hooks({
     before: {
-      all: [requireAuth],
+      all: [requireAuth, executorRuntimeScopeGuard()],
       find: [
         // RBAC: Scope messages.find() to sessions the caller can access.
         // Without this backstop, any authenticated member could list messages
@@ -835,6 +888,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [
         typedValidateQuery(branchQueryValidator),
         requireAuth,
+        executorRuntimeScopeGuard(),
         requireMinimumRole(ROLES.MEMBER, 'access branches'),
       ],
       find: [
@@ -973,7 +1027,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                   console.log(
                     `[Unix Integration] Syncing permissions for branch ${shortId(branch.branch_id)} (others_fs_access: ${previousValue} -> ${branch.others_fs_access})`
                   );
-                  const serviceToken = createServiceToken(jwtSecret);
+                  const serviceToken = createServiceToken(jwtSecret, undefined, {
+                    branch_id: branch.branch_id,
+                    command: 'unix.sync-branch',
+                  });
                   spawnExecutorFireAndForget(
                     {
                       command: 'unix.sync-branch',
@@ -1002,7 +1059,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
                 // Fire-and-forget sync with delete flag to executor
                 if (jwtSecret) {
-                  const serviceToken = createServiceToken(jwtSecret);
+                  const serviceToken = createServiceToken(jwtSecret, undefined, {
+                    branch_id: branchId,
+                    command: 'unix.sync-branch',
+                  });
                   spawnExecutorFireAndForget(
                     {
                       command: 'unix.sync-branch',
@@ -1752,7 +1812,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
           // Fire-and-forget sync to executor
           console.log(`[Unix Integration] Syncing Unix user for: ${user.unix_username}`);
-          const serviceToken = createServiceToken(jwtSecret);
+          const serviceToken = createServiceToken(jwtSecret, undefined, {
+            user_id: user.user_id,
+            command: 'unix.sync-user',
+          });
           spawnExecutorFireAndForget(
             {
               command: 'unix.sync-user',
@@ -1800,7 +1863,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
           // Fire-and-forget sync to executor
           console.log(`[Unix Integration] Syncing Unix user for: ${user.unix_username}`);
-          const serviceToken = createServiceToken(jwtSecret);
+          const serviceToken = createServiceToken(jwtSecret, undefined, {
+            user_id: user.user_id,
+            command: 'unix.sync-user',
+          });
           spawnExecutorFireAndForget(
             {
               command: 'unix.sync-user',
@@ -1852,7 +1918,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   app.service('sessions').hooks({
     before: {
-      all: [typedValidateQuery(sessionQueryValidator), requireAuth],
+      all: [typedValidateQuery(sessionQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
         // RBAC: Optimized SQL-based filtering (single query with JOIN on branches, no N+1)
         ...(branchRbacEnabled ? [scopeSessionQuery(sessionsRepository, superadminOpts)] : []),
@@ -2198,7 +2264,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                       `[Unix Integration] Non-owner session created in branch ${shortId(session.branch_id)} ` +
                         `by ${session.unix_username} (others_fs_access: ${branch.others_fs_access}), syncing group membership`
                     );
-                    const serviceToken = createServiceToken(jwtSecret);
+                    const serviceToken = createServiceToken(jwtSecret, undefined, {
+                      branch_id: branch.branch_id,
+                      session_id: session.session_id,
+                      command: 'unix.sync-branch',
+                    });
                     spawnExecutorFireAndForget(
                       {
                         command: 'unix.sync-branch',
@@ -2352,7 +2422,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   app.service('tasks').hooks({
     before: {
-      all: [typedValidateQuery(taskQueryValidator), requireAuth],
+      all: [typedValidateQuery(taskQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
         // RBAC: Scope tasks.find() to sessions the caller can access.
         ...(branchRbacEnabled

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -307,7 +307,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     svcEnabled,
     jwtSecret,
     branchRbacEnabled,
-    requireAuth,
+    requireAuth: baseRequireAuth,
     superadminOpts,
     sessionsService,
     boardsService,
@@ -315,6 +315,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     usersRepository,
     sessionsRepository,
   } = ctx;
+
+  const requireAuth = async (context: HookContext): Promise<HookContext> => {
+    const authenticated = await baseRequireAuth(context);
+    return executorRuntimeScopeGuard()(authenticated);
+  };
 
   // Helper: safely get a service (returns undefined if not registered due to tier=off)
   const safeService = (path: string) => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -307,7 +307,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     svcEnabled,
     jwtSecret,
     branchRbacEnabled,
-    requireAuth: baseRequireAuth,
+    requireAuth,
     superadminOpts,
     sessionsService,
     boardsService,
@@ -315,11 +315,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     usersRepository,
     sessionsRepository,
   } = ctx;
-
-  const requireAuth = async (context: HookContext): Promise<HookContext> => {
-    const authenticated = await baseRequireAuth(context);
-    return executorRuntimeScopeGuard()(authenticated);
-  };
 
   // Helper: safely get a service (returns undefined if not registered due to tier=off)
   const safeService = (path: string) => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -59,12 +59,12 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { executorRuntimeScopeGuard } from './auth/executor-runtime-scope.js';
 import type {
   BoardsServiceImpl,
   MessagesServiceImpl,
   SessionsServiceImpl,
 } from './declarations.js';
-
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
@@ -133,59 +133,6 @@ const BRANCH_ENV_FIELDS = [
 
 function itemHasAnyField(item: Record<string, unknown>, fields: readonly string[]): boolean {
   return fields.some((field) => Object.hasOwn(item, field));
-}
-
-type ExecutorTokenPayload = {
-  type?: string;
-  purpose?: string;
-  session_id?: string;
-  sessionId?: string;
-  task_id?: string;
-  branch_id?: string;
-};
-
-function executorRuntimeScopeGuard() {
-  return async (context: HookContext): Promise<HookContext> => {
-    const payload = (context.params as AuthenticatedParams).authentication?.payload as
-      | ExecutorTokenPayload
-      | undefined;
-    if (payload?.type !== 'executor-session') return context;
-
-    if (payload.purpose !== 'executor-task') {
-      throw new Forbidden('Executor token is not valid for this request');
-    }
-
-    const scope = {
-      sessionId: payload.session_id ?? payload.sessionId,
-      taskId: payload.task_id,
-      branchId: payload.branch_id,
-    };
-    const data = (context.data ?? {}) as Record<string, unknown>;
-    const query = ((context.params as Params).query ?? {}) as Record<string, unknown>;
-    const id = typeof context.id === 'string' ? context.id : undefined;
-
-    const expectMatch = (claim: string | undefined, value: unknown, label: string) => {
-      if (!claim || value === undefined || value === null) return;
-      if (String(value) !== claim) {
-        throw new Forbidden(`Executor token ${label} scope does not match this request`);
-      }
-    };
-
-    if (context.path === 'sessions') {
-      expectMatch(scope.sessionId, id ?? data.session_id ?? query.session_id, 'session');
-      expectMatch(scope.branchId, data.branch_id ?? query.branch_id, 'branch');
-    } else if (context.path === 'tasks') {
-      expectMatch(scope.taskId, id ?? data.task_id ?? query.task_id, 'task');
-      expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
-    } else if (context.path === 'messages') {
-      expectMatch(scope.taskId, data.task_id ?? query.task_id, 'task');
-      expectMatch(scope.sessionId, data.session_id ?? query.session_id, 'session');
-    } else if (context.path === 'branches') {
-      expectMatch(scope.branchId, id ?? data.branch_id ?? query.branch_id, 'branch');
-    }
-
-    return context;
-  };
 }
 
 async function getManagedEnvExecutionMode() {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -292,7 +292,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const { ServiceJWTStrategy } = await import('./auth/service-jwt-strategy.js');
 
   // Register authentication strategies
-  authentication.register('jwt', new ServiceJWTStrategy());
+  authentication.register('jwt', new ServiceJWTStrategy(sessionTokenService));
   authentication.register('local', new AgorLocalStrategy());
 
   // Register API key authentication strategy

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -66,6 +66,7 @@ import { NotFoundError } from '@agor/core/utils/errors';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
+import { executorRuntimeScopeGuard } from './auth/executor-runtime-scope.js';
 import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './auth/launch-auth.js';
 import {
   issueRuntimeToken,
@@ -209,7 +210,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     svcTier,
     jwtSecret,
     branchRbacEnabled,
-    requireAuth,
+    requireAuth: baseRequireAuth,
     enforcePasswordChange,
     superadminOpts,
     DB_PATH,
@@ -228,6 +229,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     sessionEnvSelectionsService,
     terminalsService: _terminalsService,
   } = ctx;
+
+  const requireAuth = async (context: HookContext): Promise<HookContext> => {
+    const authenticated = await baseRequireAuth(context);
+    return executorRuntimeScopeGuard()(authenticated);
+  };
 
   const usersService = app.service('users');
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -47,6 +47,7 @@ import type {
   ServiceGroupName,
   ServiceTier,
   SessionID,
+  SessionMCPServer,
   StreamingEventType,
   Task,
   TaskID,
@@ -66,7 +67,6 @@ import { NotFoundError } from '@agor/core/utils/errors';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
-import { executorRuntimeScopeGuard } from './auth/executor-runtime-scope.js';
 import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './auth/launch-auth.js';
 import {
   issueRuntimeToken,
@@ -210,7 +210,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     svcTier,
     jwtSecret,
     branchRbacEnabled,
-    requireAuth: baseRequireAuth,
+    requireAuth,
     enforcePasswordChange,
     superadminOpts,
     DB_PATH,
@@ -229,11 +229,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     sessionEnvSelectionsService,
     terminalsService: _terminalsService,
   } = ctx;
-
-  const requireAuth = async (context: HookContext): Promise<HookContext> => {
-    const authenticated = await baseRequireAuth(context);
-    return executorRuntimeScopeGuard()(authenticated);
-  };
 
   const usersService = app.service('users');
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
@@ -3152,11 +3147,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             params.query?.enabledOnly === 'true' || params.query?.enabledOnly === true;
           const includeGlobal =
             params.query?.includeGlobal === 'true' || params.query?.includeGlobal === true;
-          const sessionServerRefs = await sessionMCPServersService.listServers(
-            id as import('@agor/core/types').SessionID,
-            enabledOnly,
-            params
-          );
+          const includeMetadata =
+            params.query?.includeMetadata === 'true' || params.query?.includeMetadata === true;
           const mcpService = app.service('mcp-servers');
           const userId = params.user?.user_id;
           const rawLookupParams = {
@@ -3166,6 +3158,40 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               ...(userId ? { forUserId: userId } : {}),
             },
           };
+          if (includeMetadata) {
+            const linksResult = await app.service('session-mcp-servers').find({
+              ...params,
+              provider: undefined,
+              query: {
+                session_id: id,
+                ...(enabledOnly ? { enabled: true } : {}),
+                $limit: 1000,
+              },
+            });
+            const links = (Array.isArray(linksResult) ? linksResult : linksResult.data) as Array<
+              SessionMCPServer & { added_at: Date | string | number }
+            >;
+            const withMetadata = await Promise.all(
+              links.map(async (link) => {
+                try {
+                  const server = await mcpService.get(link.mcp_server_id, rawLookupParams);
+                  return {
+                    server,
+                    added_at: new Date(link.added_at).getTime(),
+                    enabled: Boolean(link.enabled),
+                  };
+                } catch (_error) {
+                  return null;
+                }
+              })
+            );
+            return withMetadata.filter((entry) => entry !== null);
+          }
+          const sessionServerRefs = await sessionMCPServersService.listServers(
+            id as import('@agor/core/types').SessionID,
+            enabledOnly,
+            params
+          );
           const sessionServers = await Promise.all(
             sessionServerRefs.map(async (server) => {
               try {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3185,7 +3185,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 }
               })
             );
-            return withMetadata.filter((entry) => entry !== null);
+            const entries = withMetadata.filter(
+              (entry): entry is Exclude<(typeof withMetadata)[number], null> => entry !== null
+            );
+            return shouldExposeMCPServerSecrets(params, {
+              allowSessionToken: true,
+              sessionId: id,
+            })
+              ? entries
+              : entries.map((entry) => ({
+                  ...entry,
+                  server: redactMCPServerSecrets(entry.server),
+                }));
           }
           const sessionServerRefs = await sessionMCPServersService.listServers(
             id as import('@agor/core/types').SessionID,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -662,7 +662,16 @@ function createExecuteHandler(
     const sessionToken = await appWithExecutor.sessionTokenService.generateToken(
       sessionId,
       (params as AuthenticatedParams).user!.user_id,
-      { taskId: data.taskId, branchId: session.branch_id }
+      {
+        taskId: data.taskId,
+        branchId: session.branch_id,
+        // Executor JWTs authenticate on every daemon API call over the runtime
+        // connection, so low per-call max-use limits make normal execution
+        // fail after startup. Keep expiry + in-memory revocation for these
+        // scoped runtime credentials; revisit max-use semantics once they can
+        // be counted per connection/task instead of per service method.
+        maxUses: -1,
+      }
     );
 
     const taskId = data.taskId;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -661,7 +661,8 @@ function createExecuteHandler(
     // Hook chain enforces auth before we get here.
     const sessionToken = await appWithExecutor.sessionTokenService.generateToken(
       sessionId,
-      (params as AuthenticatedParams).user!.user_id
+      (params as AuthenticatedParams).user!.user_id,
+      { taskId: data.taskId, branchId: session.branch_id }
     );
 
     const taskId = data.taskId;

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Artifact, BoardID, BranchID, UUID } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
 import { afterEach, beforeEach, describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { ArtifactsService } from './artifacts';
@@ -31,7 +32,11 @@ import { ArtifactsService } from './artifacts';
  */
 function makeFakeApp(): Application {
   const service = () => ({ emit: () => {} });
-  return { service } as unknown as Application;
+  return {
+    service,
+    get: (key: string) =>
+      key === 'authentication' ? { secret: 'artifact-test-secret' } : undefined,
+  } as unknown as Application;
 }
 
 /** Create a board directly via the repository, since the artifacts service
@@ -656,6 +661,37 @@ describe('ArtifactsService.getPayload trust + .env synthesis', () => {
     // .env is synthesized even though the user has no env var stored — value is empty.
     // `react` template is CRA-backed, so the prefix is `REACT_APP_`.
     expect(payload.files['/.env']).toMatch(/REACT_APP_OPENAI_KEY=/);
+  });
+
+  dbTest('agor_token renders as artifact-runtime scoped token for author', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'scoped-token-render',
+      template: 'react',
+      files: { '/index.js': 'console.log("token")' },
+      agor_grants: { agor_token: true, agor_proxies: ['shortcut'] },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const payload = await service.getPayload(created.artifact_id, 'user-owner' as never);
+    const env = payload.files['/.env'];
+    const token = String(env)
+      .match(/REACT_APP_AGOR_TOKEN=(.+)/)?.[1]
+      ?.replace(/^"|"$/g, '');
+    expect(token).toBeTruthy();
+    const decoded = jwt.verify(token!, 'artifact-test-secret', {
+      issuer: 'agor',
+      audience: 'agor:artifact-runtime',
+    }) as jwt.JwtPayload;
+    expect(decoded.type).toBe('artifact');
+    expect(decoded.purpose).toBe('artifact-runtime');
+    expect(decoded.artifact_id).toBe(created.artifact_id);
+    expect(decoded.proxies).toEqual(['shortcut']);
   });
 
   dbTest(

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -60,7 +60,7 @@ import {
   ROLES,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle.js';
-import { issueRuntimeToken } from '../auth/runtime-tokens.js';
+import { ARTIFACT_RUNTIME_JWT_AUDIENCE, issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
 import {
   canonicalizeExistingPrefix,
@@ -1142,7 +1142,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const { grants, artifact, userId } = input;
 
     if (grants.agor_token && userId) {
-      out[GRANT_ENV_VAR_NAMES.agor_token] = await this.mintViewerJwt(userId);
+      out[GRANT_ENV_VAR_NAMES.agor_token] = await this.mintViewerJwt(userId, artifact, grants);
     }
     if (grants.agor_api_url) {
       out[GRANT_ENV_VAR_NAMES.agor_api_url] = await getBaseUrl();
@@ -1182,14 +1182,30 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     return out;
   }
 
-  private async mintViewerJwt(userId: string): Promise<string> {
+  private async mintViewerJwt(
+    userId: string,
+    artifact: Artifact,
+    grants: AgorGrants
+  ): Promise<string> {
     const authConfig = this.app.get('authentication') as { secret?: string } | undefined;
     const jwtSecret = authConfig?.secret;
     if (!jwtSecret) {
       console.warn('[artifacts] no auth.secret set — AGOR_TOKEN will render empty');
       return '';
     }
-    return issueRuntimeToken({ sub: userId, type: 'access' }, jwtSecret, '15m');
+    return issueRuntimeToken(
+      {
+        sub: userId,
+        type: 'artifact',
+        purpose: 'artifact-runtime',
+        artifact_id: artifact.artifact_id,
+        board_id: artifact.board_id,
+        proxies: grants.agor_proxies ?? [],
+      },
+      jwtSecret,
+      '15m',
+      { audience: ARTIFACT_RUNTIME_JWT_AUDIENCE }
+    );
   }
 
   private async resolveEnvVarValues(

--- a/apps/agor-daemon/src/services/branch-owners.ts
+++ b/apps/agor-daemon/src/services/branch-owners.ts
@@ -256,7 +256,10 @@ export function setupBranchOwnersService(
           // Fire-and-forget sync to executor
           // Syncing the branch will pick up the new owner from the DB
           console.log(`[Unix Integration] Syncing branch ${shortId(branchId)} after owner added`);
-          const serviceToken = createServiceToken(config.jwtSecret);
+          const serviceToken = createServiceToken(config.jwtSecret, undefined, {
+            branch_id: branchId,
+            command: 'unix.sync-branch',
+          });
           spawnExecutorFireAndForget(
             {
               command: 'unix.sync-branch',
@@ -287,7 +290,10 @@ export function setupBranchOwnersService(
           // Fire-and-forget sync to executor
           // Syncing the branch will handle the removed owner
           console.log(`[Unix Integration] Syncing branch ${shortId(branchId)} after owner removed`);
-          const serviceToken = createServiceToken(config.jwtSecret);
+          const serviceToken = createServiceToken(config.jwtSecret, undefined, {
+            branch_id: branchId,
+            command: 'unix.sync-branch',
+          });
           spawnExecutorFireAndForget(
             {
               command: 'unix.sync-branch',

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -778,7 +778,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
       // Generate token and spawn executor (fire-and-forget)
       appWithToken.sessionTokenService
-        ?.generateToken('branch-remove', userId)
+        ?.generateToken('branch-remove', userId, { branchId: branch.branch_id })
         .then((sessionToken) => {
           spawnExecutor(
             {
@@ -867,7 +867,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // to the wrong home directory, causing safety check failures.
 
       appWithToken.sessionTokenService
-        ?.generateToken('branch-clean', userId ?? currentUserId)
+        ?.generateToken('branch-clean', userId ?? currentUserId, { branchId: branch.branch_id })
         .then((sessionToken) => {
           spawnExecutor(
             {
@@ -897,7 +897,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // to the wrong home directory, causing safety check failures.
 
       appWithToken.sessionTokenService
-        ?.generateToken('branch-delete', userId ?? currentUserId)
+        ?.generateToken('branch-delete', userId ?? currentUserId, { branchId: branch.branch_id })
         .then((sessionToken) => {
           spawnExecutor(
             {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -778,7 +778,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
       // Generate token and spawn executor (fire-and-forget)
       appWithToken.sessionTokenService
-        ?.generateToken('branch-remove', userId, { branchId: branch.branch_id })
+        ?.generateToken('branch-remove', userId, { branchId: branch.branch_id, maxUses: -1 })
         .then((sessionToken) => {
           spawnExecutor(
             {
@@ -867,7 +867,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // to the wrong home directory, causing safety check failures.
 
       appWithToken.sessionTokenService
-        ?.generateToken('branch-clean', userId ?? currentUserId, { branchId: branch.branch_id })
+        ?.generateToken('branch-clean', userId ?? currentUserId, {
+          branchId: branch.branch_id,
+          maxUses: -1,
+        })
         .then((sessionToken) => {
           spawnExecutor(
             {
@@ -897,7 +900,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // to the wrong home directory, causing safety check failures.
 
       appWithToken.sessionTokenService
-        ?.generateToken('branch-delete', userId ?? currentUserId, { branchId: branch.branch_id })
+        ?.generateToken('branch-delete', userId ?? currentUserId, {
+          branchId: branch.branch_id,
+          maxUses: -1,
+        })
         .then((sessionToken) => {
           spawnExecutor(
             {

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -7,7 +7,14 @@
 
 import { PAGINATION } from '@agor/core/config';
 import { type Database, MessagesRepository } from '@agor/core/db';
-import type { Message, Paginated, QueryParams, SessionID, TaskID } from '@agor/core/types';
+import type {
+  Message,
+  MessageID,
+  Paginated,
+  QueryParams,
+  SessionID,
+  TaskID,
+} from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
 /**
@@ -118,6 +125,14 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
    */
   async findByTask(taskId: TaskID): Promise<Message[]> {
     return this.messagesRepo.findByTaskId(taskId);
+  }
+
+  /**
+   * Internal helper for auth/scope checks that need to validate the current
+   * owner fields of a message before allowing a partial update.
+   */
+  async findByIdForScopeCheck(messageId: MessageID): Promise<Message | null> {
+    return this.messagesRepo.findById(messageId);
   }
 
   /**

--- a/apps/agor-daemon/src/services/session-token-service.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.test.ts
@@ -1,0 +1,35 @@
+import jwt from 'jsonwebtoken';
+import { describe, expect, it } from 'vitest';
+import { SessionTokenService } from './session-token-service';
+
+describe('SessionTokenService runtime scoping', () => {
+  it('issues executor-purpose tokens with task/session/branch scope and enforces max uses', async () => {
+    const service = new SessionTokenService({ expiration_ms: 60_000, max_uses: 1 });
+    service.setJwtSecret('session-token-test-secret');
+
+    const token = await service.generateToken('session-1', 'user-1', {
+      taskId: 'task-1',
+      branchId: 'branch-1',
+    });
+    const decoded = jwt.verify(token, 'session-token-test-secret', {
+      issuer: 'agor',
+      audience: 'https://agor.dev',
+    }) as jwt.JwtPayload;
+
+    expect(decoded.type).toBe('executor-session');
+    expect(decoded.purpose).toBe('executor-task');
+    expect(decoded.session_id).toBe('session-1');
+    expect(decoded.task_id).toBe('task-1');
+    expect(decoded.branch_id).toBe('branch-1');
+
+    await expect(
+      service.validateToken(token, { sessionId: 'session-1', taskId: 'task-other' })
+    ).resolves.toBeNull();
+    await expect(
+      service.validateToken(token, { sessionId: 'session-1', taskId: 'task-1' })
+    ).resolves.toMatchObject({ session_id: 'session-1', task_id: 'task-1' });
+    await expect(
+      service.validateToken(token, { sessionId: 'session-1', taskId: 'task-1' })
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/agor-daemon/src/services/session-token-service.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.test.ts
@@ -32,4 +32,30 @@ describe('SessionTokenService runtime scoping', () => {
       service.validateToken(token, { sessionId: 'session-1', taskId: 'task-1' })
     ).resolves.toBeNull();
   });
+
+  it('can issue reusable scoped runtime tokens when per-call max-use counting is not suitable', async () => {
+    const service = new SessionTokenService({ expiration_ms: 60_000, max_uses: 1 });
+    service.setJwtSecret('session-token-test-secret');
+
+    const token = await service.generateToken('session-1', 'user-1', {
+      taskId: 'task-1',
+      branchId: 'branch-1',
+      maxUses: -1,
+    });
+
+    await expect(
+      service.validateToken(token, {
+        sessionId: 'session-1',
+        taskId: 'task-1',
+        branchId: 'branch-1',
+      })
+    ).resolves.toMatchObject({ session_id: 'session-1', task_id: 'task-1' });
+    await expect(
+      service.validateToken(token, {
+        sessionId: 'session-1',
+        taskId: 'task-1',
+        branchId: 'branch-1',
+      })
+    ).resolves.toMatchObject({ session_id: 'session-1', task_id: 'task-1' });
+  });
 });

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -15,6 +15,8 @@ import jwt from 'jsonwebtoken';
 
 interface SessionTokenData {
   session_id: string;
+  task_id?: string;
+  branch_id?: string;
   user_id: string;
   created_at: Date;
   expires_at: Date;
@@ -22,8 +24,10 @@ interface SessionTokenData {
   use_count: number;
 }
 
-interface SessionInfo {
+export interface SessionInfo {
   session_id: string;
+  task_id?: string;
+  branch_id?: string;
   user_id: string;
 }
 
@@ -53,7 +57,11 @@ export class SessionTokenService {
    * Generate a new session token (JWT)
    * Returns a JWT that works with Feathers' standard JWT authentication
    */
-  async generateToken(sessionId: string, userId: string): Promise<string> {
+  async generateToken(
+    sessionId: string,
+    userId: string,
+    scope: { taskId?: string; branchId?: string } = {}
+  ): Promise<string> {
     if (!this.jwtSecret) {
       throw new Error('SessionTokenService: JWT secret not set. Call setJwtSecret() first.');
     }
@@ -65,7 +73,12 @@ export class SessionTokenService {
     // This JWT will work seamlessly with the standard JWT strategy
     const payload = {
       sub: userId, // Standard JWT subject claim (used by Feathers for user lookup)
+      type: 'executor-session',
+      purpose: 'executor-task',
       sessionId: sessionId, // Custom claim for session tracking
+      session_id: sessionId,
+      task_id: scope.taskId,
+      branch_id: scope.branchId,
       iat: Math.floor(now.getTime() / 1000), // Issued at
       exp: Math.floor(expiresAt.getTime() / 1000), // Expiration
       aud: 'https://agor.dev', // Must match Feathers jwtOptions.audience
@@ -82,6 +95,8 @@ export class SessionTokenService {
     // Track this token for revocation and use counting
     this.tokens.set(token, {
       session_id: sessionId,
+      task_id: scope.taskId,
+      branch_id: scope.branchId,
       user_id: userId,
       created_at: now,
       expires_at: expiresAt,
@@ -103,7 +118,10 @@ export class SessionTokenService {
    * NOTE: JWT signature/expiration validation is handled by Feathers automatically.
    * This method only checks revocation and use counting.
    */
-  async validateToken(token: string): Promise<SessionInfo | null> {
+  async validateToken(
+    token: string,
+    expected?: { sessionId?: string; taskId?: string; branchId?: string }
+  ): Promise<SessionInfo | null> {
     // Get tracking data for this token
     const data = this.tokens.get(token);
 
@@ -117,6 +135,15 @@ export class SessionTokenService {
     if (new Date() > data.expires_at) {
       console.warn(`[SessionTokenService] Token expired`);
       this.tokens.delete(token);
+      return null;
+    }
+
+    if (
+      (expected?.sessionId && data.session_id !== expected.sessionId) ||
+      (expected?.taskId && data.task_id !== expected.taskId) ||
+      (expected?.branchId && data.branch_id !== expected.branchId)
+    ) {
+      console.warn(`[SessionTokenService] Token scope mismatch`);
       return null;
     }
 
@@ -136,6 +163,8 @@ export class SessionTokenService {
 
     return {
       session_id: data.session_id,
+      task_id: data.task_id,
+      branch_id: data.branch_id,
       user_id: data.user_id,
     };
   }
@@ -145,7 +174,7 @@ export class SessionTokenService {
    */
   revokeToken(token: string): void {
     if (this.tokens.delete(token)) {
-      console.log(`[SessionTokenService] Token revoked: ${token.slice(0, 8)}...`);
+      console.log(`[SessionTokenService] Token revoked`);
     }
   }
 
@@ -198,11 +227,12 @@ export class SessionTokenService {
    */
   private startCleanupTimer(): void {
     // Clean up every hour
-    setInterval(
+    const timer = setInterval(
       () => {
         this.cleanupExpiredTokens();
       },
       60 * 60 * 1000
     );
+    timer.unref?.();
   }
 }

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -60,7 +60,7 @@ export class SessionTokenService {
   async generateToken(
     sessionId: string,
     userId: string,
-    scope: { taskId?: string; branchId?: string } = {}
+    scope: { taskId?: string; branchId?: string; maxUses?: number } = {}
   ): Promise<string> {
     if (!this.jwtSecret) {
       throw new Error('SessionTokenService: JWT secret not set. Call setJwtSecret() first.');
@@ -100,7 +100,7 @@ export class SessionTokenService {
       user_id: userId,
       created_at: now,
       expires_at: expiresAt,
-      max_uses: this.config.max_uses,
+      max_uses: scope.maxUses ?? this.config.max_uses,
       use_count: 0,
     });
 

--- a/apps/agor-daemon/src/setup/proxies.test.ts
+++ b/apps/agor-daemon/src/setup/proxies.test.ts
@@ -29,6 +29,17 @@ const VALID_TOKEN = jwt.sign({ sub: 'user-abc', type: 'access' }, JWT_SECRET, {
   issuer: 'agor',
   audience: 'https://agor.dev',
 });
+const ARTIFACT_SHORTCUT_TOKEN = jwt.sign(
+  {
+    sub: 'user-abc',
+    type: 'artifact',
+    purpose: 'artifact-runtime',
+    artifact_id: 'artifact-1',
+    proxies: ['shortcut'],
+  },
+  JWT_SECRET,
+  { issuer: 'agor', audience: 'agor:artifact-runtime', expiresIn: '15m' }
+);
 
 /**
  * Build a test app with a stub `app.service('users').get()` so the proxy's
@@ -178,5 +189,22 @@ describe('registerProxies — request gating', () => {
     });
     expect(r.status).toBe(405);
     expect(r.headers.allow).toBe('GET');
+  });
+
+  it('accepts artifact-runtime tokens only for vendors in token scope', async () => {
+    const app = makeProxyApp({
+      proxies: {
+        shortcut: { upstream: 'https://api.app.shortcut.com', allowed_methods: ['POST'] },
+        linear: { upstream: 'https://api.linear.app', allowed_methods: ['POST'] },
+      },
+    });
+    const accepted = await call(app, 'GET', '/proxies/shortcut/x', {
+      Authorization: `Bearer ${ARTIFACT_SHORTCUT_TOKEN}`,
+    });
+    expect(accepted.status).toBe(405);
+    const rejected = await call(app, 'GET', '/proxies/linear/x', {
+      Authorization: `Bearer ${ARTIFACT_SHORTCUT_TOKEN}`,
+    });
+    expect(rejected.status).toBe(401);
   });
 });

--- a/apps/agor-daemon/src/setup/proxies.ts
+++ b/apps/agor-daemon/src/setup/proxies.ts
@@ -32,7 +32,11 @@ import type { UUID } from '@agor/core/types';
 import type { NextFunction, Request, Response } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
-import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
+import {
+  ARTIFACT_RUNTIME_JWT_AUDIENCE,
+  RUNTIME_JWT_AUDIENCE,
+  RUNTIME_JWT_ISSUER,
+} from '../auth/runtime-tokens.js';
 
 /**
  * Default per-(user, vendor) rate limit. In-memory bucket; no redis.
@@ -97,6 +101,8 @@ const RESPONSE_HEADER_STRIP = new Set([
 
 interface AuthedUser {
   user_id: string;
+  token_type?: 'access' | 'artifact';
+  proxies?: string[];
 }
 
 /**
@@ -121,22 +127,32 @@ async function authenticateRequest(
   if (!header || typeof header !== 'string') return null;
   const match = header.match(/^Bearer\s+(.+)$/i);
   if (!match) return null;
-  let decoded: { sub?: string; type?: string };
+  let decoded: { sub?: string; type?: string; purpose?: string; proxies?: unknown };
   try {
     decoded = jwt.verify(match[1], jwtSecret, {
       issuer: RUNTIME_JWT_ISSUER,
-      audience: RUNTIME_JWT_AUDIENCE,
+      audience: [RUNTIME_JWT_AUDIENCE, ARTIFACT_RUNTIME_JWT_AUDIENCE],
     }) as { sub?: string; type?: string };
   } catch {
     return null;
   }
-  // Reject service tokens; only end-user access tokens are accepted here.
-  if (decoded.type !== undefined && decoded.type !== 'access') return null;
+  // Browser artifacts may use either the legacy short-lived access token or
+  // the newer artifact-runtime token. Service/executor tokens are not accepted
+  // by this proxy path.
+  if (decoded.type === 'artifact') {
+    if (decoded.purpose !== 'artifact-runtime') return null;
+  } else if (decoded.type !== undefined && decoded.type !== 'access') {
+    return null;
+  }
   if (!decoded.sub) return null;
   try {
     const user = await app.service('users').get(decoded.sub as UUID);
     if (!user) return null;
-    return { user_id: decoded.sub };
+    return {
+      user_id: decoded.sub,
+      token_type: decoded.type === 'artifact' ? 'artifact' : 'access',
+      proxies: Array.isArray(decoded.proxies) ? decoded.proxies.map(String) : undefined,
+    };
   } catch {
     // User not found / lookup error → reject the request.
     return null;
@@ -281,6 +297,11 @@ export function registerProxies(
     const proxy = byVendor.get(vendor);
     if (!proxy) {
       res.status(404).json({ error: 'unknown_vendor', vendor });
+      return;
+    }
+
+    if (user.token_type === 'artifact' && !user.proxies?.includes(vendor)) {
+      res.status(401).json({ error: 'unauthorized' });
       return;
     }
 

--- a/apps/agor-daemon/src/utils/authorization.test.ts
+++ b/apps/agor-daemon/src/utils/authorization.test.ts
@@ -6,10 +6,15 @@
  */
 
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
-import type { AuthenticatedParams } from '@agor/core/types';
+import type { AuthenticatedParams, HookContext } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { ensureCanTriggerManagedEnv, ensureMinimumRole, requireMinimumRole } from './authorization';
+import {
+  ensureCanTriggerManagedEnv,
+  ensureMinimumRole,
+  registerAuthenticatedRoute,
+  requireMinimumRole,
+} from './authorization';
 
 /** Helper to create authenticated params for a given role and provider */
 function makeParams(role: string, provider: string | undefined = 'rest'): AuthenticatedParams {
@@ -220,5 +225,50 @@ describe('requireMinimumRole (hook factory)', () => {
     } as import('@agor/core/types').HookContext;
 
     expect(() => hook(context)).toThrow(Forbidden);
+  });
+});
+
+describe('registerAuthenticatedRoute', () => {
+  it('installs executor runtime scope validation on custom routes', async () => {
+    const installed: { before?: Record<string, Array<(context: HookContext) => unknown>> } = {};
+    const app = {
+      use: () => undefined,
+      service: () => ({
+        hooks: (hooks: { before: Record<string, Array<(context: HookContext) => unknown>> }) => {
+          installed.before = hooks.before;
+        },
+      }),
+    };
+    const requireAuth = async (context: HookContext) => context;
+
+    registerAuthenticatedRoute(
+      app,
+      '/messages/bulk',
+      { async create() {} },
+      { create: { role: ROLES.MEMBER, action: 'create messages' } },
+      requireAuth
+    );
+
+    const context = {
+      path: 'messages/bulk',
+      method: 'create',
+      data: [{ task_id: 'other-task' }],
+      params: {
+        provider: 'rest',
+        user: { user_id: 'u1', email: 'a@b.c', role: ROLES.MEMBER },
+        authentication: {
+          payload: {
+            type: 'executor-session',
+            purpose: 'executor-task',
+            session_id: 'session-1',
+            task_id: 'task-1',
+          },
+        },
+      },
+    } as HookContext;
+
+    const hooks = installed.before?.create ?? [];
+    expect(hooks).toHaveLength(3);
+    await expect(hooks[1](context)).rejects.toThrow(/task scope/);
   });
 });

--- a/apps/agor-daemon/src/utils/authorization.ts
+++ b/apps/agor-daemon/src/utils/authorization.ts
@@ -6,6 +6,7 @@ import type { ManagedEnvsMinimumRole } from '@agor/core/config';
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext, UserRole } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { executorRuntimeScopeGuard } from '../auth/executor-runtime-scope.js';
 
 export type Role = UserRole;
 
@@ -185,7 +186,11 @@ export function registerAuthenticatedRoute(
   > = {};
 
   for (const [method, config] of Object.entries(authConfig)) {
-    hooks[method] = [requireAuth, requireMinimumRole(config.role, config.action)];
+    hooks[method] = [
+      requireAuth,
+      executorRuntimeScopeGuard(),
+      requireMinimumRole(config.role, config.action),
+    ];
   }
 
   // Apply hooks

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
@@ -83,6 +83,53 @@ describe('MCP server secret redaction', () => {
     ).toBe(false);
   });
 
+  it('exposes executor-session JWT secrets only when scoped to the same session', () => {
+    const executorParams = {
+      provider: 'socketio',
+      authentication: {
+        strategy: 'jwt',
+        payload: {
+          type: 'executor-session',
+          session_id: 'session-a',
+        },
+      },
+      session_id: 'session-a',
+    } as never;
+
+    expect(
+      shouldExposeMCPServerSecrets(executorParams, {
+        allowSessionToken: true,
+        sessionId: 'session-a',
+      })
+    ).toBe(true);
+    expect(
+      shouldExposeMCPServerSecretsForSessionToken(executorParams, { sessionId: 'session-a' })
+    ).toBe(true);
+
+    expect(
+      shouldExposeMCPServerSecrets(executorParams, {
+        allowSessionToken: true,
+        sessionId: 'session-b',
+      })
+    ).toBe(false);
+  });
+
+  it('does not expose executor-session JWT secrets without explicit route opt-in', () => {
+    expect(
+      shouldExposeMCPServerSecrets({
+        provider: 'socketio',
+        authentication: {
+          strategy: 'jwt',
+          payload: {
+            type: 'executor-session',
+            session_id: 'session-a',
+          },
+        },
+        session_id: 'session-a',
+      } as never)
+    ).toBe(false);
+  });
+
   it('does not treat internal or service callers as session-token scoped callers', () => {
     expect(shouldExposeMCPServerSecrets({} as never)).toBe(true);
     expect(shouldExposeMCPServerSecretsForSessionToken({} as never)).toBe(false);

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.ts
@@ -3,7 +3,14 @@ import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer, Params } from '@agor/core/types';
 
 export type MCPSecretParams = Params & {
-  authentication?: { strategy?: string };
+  authentication?: {
+    strategy?: string;
+    payload?: {
+      type?: string;
+      session_id?: string;
+      sessionId?: string;
+    };
+  };
   user?: { role?: string; _isServiceAccount?: boolean };
   session_id?: string;
 };
@@ -22,11 +29,13 @@ export function shouldExposeMCPServerSecretsForSessionToken(
   params?: MCPSecretParams,
   options: { sessionId?: string } = {}
 ): boolean {
+  const payload = params?.authentication?.payload;
+  const sessionId = params?.session_id ?? payload?.session_id ?? payload?.sessionId;
   return (
     !!params?.provider &&
-    params.authentication?.strategy === 'session-token' &&
-    !!params.session_id &&
-    (!options.sessionId || params.session_id === options.sessionId)
+    (params.authentication?.strategy === 'session-token' || payload?.type === 'executor-session') &&
+    !!sessionId &&
+    (!options.sessionId || sessionId === options.sessionId)
   );
 }
 

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -759,14 +759,17 @@ export function getDaemonUrl(): string {
  */
 export function createServiceToken(
   jwtSecret: string,
-  expiresIn?: SignOptions['expiresIn']
+  expiresIn?: SignOptions['expiresIn'],
+  scope: Record<string, unknown> = {}
 ): string {
   return issueRuntimeToken(
     {
       sub: 'executor-service',
       type: 'service',
+      purpose: 'executor-service',
       // Service tokens can perform privileged operations
       role: 'service',
+      ...scope,
     },
     jwtSecret,
     expiresIn || '5m'

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -227,7 +227,7 @@ if (!apiKey) {
 
 | Grant | Env var name | Behavior |
 |---|---|---|
-| `agor_token: true` | `AGOR_TOKEN` | Mints a 15-min daemon JWT for the viewer. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
+| `agor_token: true` | `AGOR_TOKEN` | Mints a 15-min artifact-runtime token for the viewer. It is accepted by artifact/proxy runtime paths, not as a general daemon API credential. **Artifact-scoped consent only** — author/instance grants don't auto-cover this. |
 | `agor_api_url: true` | `AGOR_API_URL` | Daemon base URL. |
 | `agor_proxies: ["openai", ...]` | `AGOR_PROXY_OPENAI`, … | HTTP proxy URLs for listed vendors (see [API Proxies](/guide/api-proxies)). |
 | `agor_user_email: true` | `AGOR_USER_EMAIL` | Viewer's email. |

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -1,0 +1,39 @@
+import type { AgorClient } from '@agor/core/api';
+import type { SessionID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { FeathersSessionMCPServersRepository } from './feathers-repositories';
+
+describe('FeathersSessionMCPServersRepository', () => {
+  it('resolves MCP metadata through the session-scoped route', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        server: { mcp_server_id: 'mcp-1', name: 'server one' },
+        added_at: 123,
+        enabled: true,
+      },
+    ]);
+    const service = vi.fn((path: string) => {
+      if (path !== '/sessions/session-1/mcp-servers') {
+        throw new Error(`unexpected service path: ${path}`);
+      }
+      return { find };
+    });
+    const repo = new FeathersSessionMCPServersRepository({
+      service,
+    } as unknown as AgorClient);
+
+    const result = await repo.listServersWithMetadata('session-1' as SessionID, true);
+
+    expect(service).toHaveBeenCalledWith('/sessions/session-1/mcp-servers');
+    expect(find).toHaveBeenCalledWith({
+      query: { includeMetadata: true, enabledOnly: true },
+    });
+    expect(result).toEqual([
+      {
+        server: { mcp_server_id: 'mcp-1', name: 'server one' },
+        added_at: 123,
+        enabled: true,
+      },
+    ]);
+  });
+});

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -1,7 +1,35 @@
 import type { AgorClient } from '@agor/core/api';
 import type { SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
-import { FeathersSessionMCPServersRepository } from './feathers-repositories';
+import {
+  FeathersMessagesRepository,
+  FeathersSessionMCPServersRepository,
+} from './feathers-repositories';
+
+describe('FeathersMessagesRepository', () => {
+  it('requests session-wide history without adding a task filter', async () => {
+    const find = vi.fn().mockResolvedValue([]);
+    const service = vi.fn((path: string) => {
+      if (path !== 'messages') {
+        throw new Error(`unexpected service path: ${path}`);
+      }
+      return { find };
+    });
+    const repo = new FeathersMessagesRepository({
+      service,
+    } as unknown as AgorClient);
+
+    await repo.findBySessionId('session-1' as SessionID);
+
+    expect(find).toHaveBeenCalledWith({
+      query: {
+        session_id: 'session-1',
+        $sort: { index: 1 },
+        $limit: 10000,
+      },
+    });
+  });
+});
 
 describe('FeathersSessionMCPServersRepository', () => {
   it('resolves MCP metadata through the session-scoped route', async () => {

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -230,38 +230,19 @@ export class FeathersSessionMCPServersRepository {
     sessionId: SessionID,
     enabledOnly = false
   ): Promise<Array<{ server: MCPServer; added_at: number; enabled: boolean }>> {
-    // Get session-mcp-server join records
-    const query: Record<string, unknown> = {
-      session_id: sessionId,
-      $limit: 1000,
-    };
+    const service = this.client.service(`/sessions/${sessionId}/mcp-servers`);
+    const query: Record<string, unknown> = { includeMetadata: true };
 
     if (enabledOnly) {
-      query.enabled = true;
+      query.enabledOnly = true;
     }
 
-    const sessionMCPService = this.client.service('session-mcp-servers');
-    const result = await sessionMCPService.find({ query });
-    const sessionMCPServers = (Array.isArray(result) ? result : result.data) as SessionMCPServer[];
-
-    // Get full MCPServer objects with metadata for each join record
-    const mcpServerService = this.client.service('mcp-servers');
-    const results: Array<{ server: MCPServer; added_at: number; enabled: boolean }> = [];
-
-    for (const link of sessionMCPServers) {
-      try {
-        const server = await mcpServerService.get(link.mcp_server_id);
-        results.push({
-          server,
-          added_at: new Date(link.added_at).getTime(), // Convert to timestamp
-          enabled: Boolean(link.enabled),
-        });
-      } catch (_error) {
-        // Skip servers that can't be fetched
-      }
-    }
-
-    return results;
+    const result = await service.find({ query });
+    return (Array.isArray(result) ? result : result.data) as Array<{
+      server: MCPServer;
+      added_at: number;
+      enabled: boolean;
+    }>;
   }
 }
 

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
@@ -51,6 +51,7 @@ describe('createCanUseToolCallback', () => {
       } as any,
       sessionMCPRepo: {
         findBySessionId: vi.fn().mockResolvedValue([]),
+        listServers: vi.fn().mockResolvedValue([]),
       } as any,
     };
   }
@@ -73,6 +74,7 @@ describe('createCanUseToolCallback', () => {
       expect(result.updatedPermissions?.[0]?.destination).toBe('session');
       // The agor server is added dynamically — should NOT round-trip through the DB.
       expect(deps.sessionMCPRepo.findBySessionId).not.toHaveBeenCalled();
+      expect(deps.sessionMCPRepo.listServers).not.toHaveBeenCalled();
       expect(deps.mcpServerRepo.findById).not.toHaveBeenCalled();
       // No permission UI involved.
       expect(deps.permissionService.emitRequest).not.toHaveBeenCalled();
@@ -80,19 +82,21 @@ describe('createCanUseToolCallback', () => {
 
     it('auto-allows tools from MCP servers that ARE attached to the session', async () => {
       const deps = createBaseDeps();
-      deps.sessionMCPRepo.findBySessionId.mockResolvedValue([{ mcp_server_id: 'srv-1' }]);
-      deps.mcpServerRepo.findById.mockResolvedValue({ name: 'shortcut' });
+      deps.sessionMCPRepo.listServers.mockResolvedValue([{ name: 'shortcut' }]);
 
       const callback = createCanUseToolCallback(sessionId, taskId, deps);
       const result = await callback('mcp__shortcut__list_stories', {}, noopOptions);
 
       expect(result.behavior).toBe('allow');
+      expect(deps.sessionMCPRepo.listServers).toHaveBeenCalledWith(sessionId, true);
+      expect(deps.sessionMCPRepo.findBySessionId).not.toHaveBeenCalled();
+      expect(deps.mcpServerRepo.findById).not.toHaveBeenCalled();
       expect(deps.permissionService.emitRequest).not.toHaveBeenCalled();
     });
 
     it('falls through to permission flow when an MCP server is NOT attached', async () => {
       const deps = createBaseDeps();
-      deps.sessionMCPRepo.findBySessionId.mockResolvedValue([]); // no attached servers
+      deps.sessionMCPRepo.listServers.mockResolvedValue([]); // no attached servers
       deps.permissionService.waitForDecision.mockResolvedValue({
         allow: false,
         timedOut: false,

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -86,19 +86,8 @@ export function createCanUseToolCallback(
         }
 
         try {
-          // Get the session's attached MCP servers
-          const sessionMCPs = await deps.sessionMCPRepo.findBySessionId(sessionId);
-          const attachedServerIds = sessionMCPs.map((s) => s.mcp_server_id);
-
-          // Look up the MCP servers to check their names
-          let serverVerified = false;
-          for (const serverId of attachedServerIds) {
-            const server = await deps.mcpServerRepo.findById(serverId);
-            if (server && server.name === serverName) {
-              serverVerified = true;
-              break;
-            }
-          }
+          const attachedServers = await deps.sessionMCPRepo.listServers(sessionId, true);
+          const serverVerified = attachedServers.some((server) => server.name === serverName);
 
           if (serverVerified) {
             console.log(

--- a/packages/executor/src/sdk-handlers/copilot/permission-mapper.ts
+++ b/packages/executor/src/sdk-handlers/copilot/permission-mapper.ts
@@ -140,19 +140,12 @@ async function isAttachedMcpServer(
   // Built-in "agor" server is always auto-approved
   if (serverName === 'agor') return true;
 
-  // Check if server is attached to session
-  if (!deps.sessionMCPRepo || !deps.mcpServerRepo) return false;
+  // Check if server is attached to session via the session-scoped MCP route.
+  if (!deps.sessionMCPRepo) return false;
 
   try {
-    const sessionMCPs = await deps.sessionMCPRepo.findBySessionId(sessionId);
-    const attachedServerIds = sessionMCPs.map((s) => s.mcp_server_id);
-
-    for (const serverId of attachedServerIds) {
-      const server = await deps.mcpServerRepo.findById(serverId);
-      if (server && server.name === serverName) {
-        return true;
-      }
-    }
+    const attachedServers = await deps.sessionMCPRepo.listServers(sessionId, true);
+    return attachedServers.some((server) => server.name === serverName);
   } catch (error) {
     console.error(`[Copilot Permission] Error verifying MCP server "${serverName}":`, error);
   }


### PR DESCRIPTION
## Summary

- Adds explicit purpose and resource scope claims to executor session tokens.
- Enforces executor token scope on task/session/message/branch service access.
- Mints artifact runtime tokens with a distinct audience and proxy vendor scope.
- Preserves legacy artifact proxy access-token compatibility while accepting the narrower token shape.

## Validation

- `pnpm i`
- `pnpm check` *(passes; existing lint warnings remain)*
- `pnpm --filter @agor/daemon test src/services/session-token-service.test.ts src/setup/proxies.test.ts src/services/artifacts.test.ts`
