### PR TITLE
Tighten managed environment controls

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -171,7 +171,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         "Set the environment variant for a branch and persist it. Re-renders the branch's " +
         'environment commands (start/stop/nuke/logs/health/app) from the repo config so subsequent ' +
         'agor_environment_start/stop/etc. operate on the new variant. ' +
-        'Variant changes require admin permission (rendered commands run as the system user). ' +
+        'Variant changes require effective branch `all` permission or admin access. ' +
         'Refuses to switch variant when the environment is running or starting — stop it first. ' +
         'Pass andStart=true to start the environment after setting; otherwise call agor_environment_start separately. ' +
         'Omit variant to re-render the branch with its current variant (useful for picking up template_overrides changes).',

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2672,11 +2672,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
     },
     {
-      // Role is enforced at the service layer via managed_envs_minimum_role
-      // (default: member). This route-level gate is just "authenticated", so
-      // it accepts the lowest authenticated role (viewer). The service gate
-      // is the single source of truth for whether the user can actually
-      // trigger the command.
+      // Branch `all`/admin control is enforced at the service layer. This
+      // route-level gate is just "authenticated" so the service remains
+      // the single source of truth across REST, WebSocket, and MCP.
       create: { role: ROLES.VIEWER, action: 'start branch environments' },
     },
     requireAuth
@@ -2693,7 +2691,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
     },
     {
-      // Service-layer enforcement via managed_envs_minimum_role
+      // Branch `all`/admin control is enforced at the service layer.
       create: { role: ROLES.VIEWER, action: 'stop branch environments' },
     },
     requireAuth
@@ -2713,7 +2711,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
     },
     {
-      // Service-layer enforcement via managed_envs_minimum_role
+      // Branch `all`/admin control is enforced at the service layer.
       create: { role: ROLES.VIEWER, action: 'restart branch environments' },
     },
     requireAuth
@@ -2730,7 +2728,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
     },
     {
-      // Service-layer enforcement via managed_envs_minimum_role
+      // Branch `all`/admin control is enforced at the service layer.
       create: { role: ROLES.VIEWER, action: 'nuke branch environments' },
     },
     requireAuth
@@ -2751,8 +2749,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
     },
     {
-      // Baseline trigger gate via managed_envs_minimum_role; variant changes
-      // are additionally admin-gated inside the service method.
+      // Branch `all`/admin control is enforced at the service layer.
       create: { role: ROLES.VIEWER, action: 'render branch environment' },
     },
     requireAuth
@@ -2770,7 +2767,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express
     } as any,
     {
-      find: { role: ROLES.MEMBER, action: 'check branch health' },
+      find: { role: ROLES.VIEWER, action: 'check branch health' },
     },
     requireAuth
   );
@@ -3077,7 +3074,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express
     } as any,
     {
-      // Service-layer enforcement via managed_envs_minimum_role
+      // Branch `all`/admin control is enforced at the service layer.
       find: { role: ROLES.VIEWER, action: 'view branch logs' },
     },
     requireAuth
@@ -3436,10 +3433,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // flag exists so the UI can skip rendering buttons that would fail.
           // Defaults to true when the config key is unset.
           webTerminal: config.execution?.allow_web_terminal !== false,
-          // Minimum role required to trigger managed environment commands
-          // (start / stop / nuke / logs). UI uses this to disable + tooltip
-          // the trigger buttons for users below the threshold. The server-side
-          // gate in services/branches.ts is the source of truth.
+          // Legacy managed-environment minimum-role value retained for
+          // compatibility with older clients. Current environment control
+          // authorization is enforced by the branches service from effective
+          // branch `all` permission or admin access.
           // Value: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin'.
           // Defaults to 'member' when unset.
           managedEnvsMinimumRole: config.execution?.managed_envs_minimum_role ?? 'member',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -73,6 +73,7 @@ import { registerGitHubAppSetupRoutes } from './services/github-app-setup.js';
 import {
   createGroupMembershipsService,
   createGroupsService,
+  setupBranchEffectiveAccessService,
   setupBranchGroupGrantsService,
 } from './services/groups.js';
 import { createKnowledgeDocumentEditsService } from './services/knowledge-document-edits.js';
@@ -352,6 +353,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   app.use('/group-memberships', createGroupMembershipsService(db), {
     methods: ['find', 'create', 'remove'],
   });
+  setupBranchEffectiveAccessService(app, new BranchRepository(db));
   if (branchRbacEnabled) {
     setupBranchGroupGrantsService(app, db, new BranchRepository(db));
   }

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -480,3 +480,99 @@ describe('BranchesService.renderEnvironment running-guard', () => {
     );
   });
 });
+
+describe('BranchesService managed environment control authorization', () => {
+  const branchId = 'wt-auth' as BranchID;
+  const allUserId = 'user-all';
+  const otherId = 'user-other';
+
+  function paramsFor(
+    user_id: string,
+    role: 'viewer' | 'member' | 'admin' | 'superadmin' = 'member'
+  ) {
+    return {
+      provider: 'rest',
+      user: { user_id, role },
+    } as never;
+  }
+
+  function createAuthHarness(
+    effectivePermission: 'all' | 'prompt' | 'session' | 'view' = 'session'
+  ) {
+    const { service } = createServiceHarness();
+    const branch = {
+      branch_id: branchId,
+      repo_id: 'repo-1',
+      name: 'wt-auth',
+      path: '/tmp/wt-auth',
+      branch_unique_id: 1,
+      environment_instance: { status: 'stopped' },
+    };
+    const branchRepo = {
+      findById: vi.fn(async () => branch),
+      resolveUserPermission: vi.fn(async () => effectivePermission),
+    };
+    (service as unknown as { branchRepo: typeof branchRepo }).branchRepo = branchRepo;
+    const getSpy = vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    return { service, branchRepo, getSpy };
+  }
+
+  it('denies non-owner members before starting an environment', async () => {
+    const { service, getSpy } = createAuthHarness('session');
+
+    await expect(service.startEnvironment(branchId, paramsFor(otherId, 'member'))).rejects.toThrow(
+      /'all' branch permission or admin access/
+    );
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows users with effective all permission through the control gate', async () => {
+    const { service } = createAuthHarness('all');
+
+    await expect(
+      service.startEnvironment(branchId, paramsFor(allUserId, 'member'))
+    ).rejects.toThrow(/No start command configured/);
+  });
+
+  it('allows admins and superadmins through the control gate', async () => {
+    const adminHarness = createAuthHarness('session');
+    await expect(
+      adminHarness.service.startEnvironment(branchId, paramsFor(otherId, 'admin'))
+    ).rejects.toThrow(/No start command configured/);
+    expect(adminHarness.branchRepo.findById).not.toHaveBeenCalled();
+
+    const superHarness = createAuthHarness('session');
+    await expect(
+      superHarness.service.startEnvironment(branchId, paramsFor(otherId, 'superadmin'))
+    ).rejects.toThrow(/No start command configured/);
+    expect(superHarness.branchRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it('denies non-owner members before rendering environment commands', async () => {
+    const { service, getSpy } = createAuthHarness('session');
+
+    await expect(
+      service.renderEnvironment(branchId, { variant: 'dev' }, paramsFor(otherId, 'member'))
+    ).rejects.toThrow(/'all' branch permission or admin access/);
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows users with effective all permission through the render control gate', async () => {
+    const { service } = createAuthHarness('all');
+
+    await expect(
+      service.renderEnvironment(branchId, { variant: 'dev' }, paramsFor(allUserId, 'member'))
+    ).rejects.toThrow(/Repo has no v2 environment config/);
+  });
+
+  it('keeps health checks available without the control gate', async () => {
+    const { service, branchRepo } = createAuthHarness('session');
+
+    await expect(
+      service.checkHealth(branchId, paramsFor(otherId, 'viewer'))
+    ).resolves.toMatchObject({
+      branch_id: branchId,
+    });
+    expect(branchRepo.findById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -40,13 +40,13 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { isAssistant, ROLES } from '@agor/core/types';
+import { isAssistant } from '@agor/core/types';
 import { getGidFromGroupName, spawnEnvironmentCommand } from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService } from '../adapters/drizzle';
 import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
-import { ensureCanTriggerManagedEnv, ensureMinimumRole } from '../utils/authorization.js';
+import { ensureCanControlBranchEnvironment } from '../utils/branch-authorization.js';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { resolveGitImpersonationForBranch } from '../utils/git-impersonation.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
@@ -118,16 +118,16 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   }
 
   /**
-   * Enforce `execution.managed_envs_minimum_role` on env command triggers.
-   * Canonical enforcement point — runs for REST, WebSocket, *and* MCP callers
-   * since all trigger paths reach this service class.
+   * Canonical control gate for managed environment custom methods.
+   * Runs for REST, WebSocket, and MCP callers since all trigger paths reach
+   * this service class.
    */
   private async ensureCanTriggerEnv(
+    id: BranchID,
     params: BranchParams | undefined,
     action: string
   ): Promise<void> {
-    const config = await loadConfig();
-    ensureCanTriggerManagedEnv(config.execution?.managed_envs_minimum_role, params, action);
+    await ensureCanControlBranchEnvironment(this.branchRepo, id, params, action);
   }
 
   private async getManagedEnvExecutionMode(): Promise<ManagedEnvExecutionMode> {
@@ -1306,7 +1306,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * Custom method: Start environment
    */
   async startEnvironment(id: BranchID, params?: BranchParams): Promise<BranchWithZoneAndSessions> {
-    await this.ensureCanTriggerEnv(params, 'start branch environments');
+    await this.ensureCanTriggerEnv(id, params, 'start branch environments');
     const branch = await this.get(id, params);
 
     // Validate static start command exists
@@ -1474,7 +1474,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * Custom method: Stop environment
    */
   async stopEnvironment(id: BranchID, params?: BranchParams): Promise<BranchWithZoneAndSessions> {
-    await this.ensureCanTriggerEnv(params, 'stop branch environments');
+    await this.ensureCanTriggerEnv(id, params, 'stop branch environments');
     const branch = await this.get(id, params);
 
     // Set status to 'stopping'
@@ -1589,6 +1589,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     id: BranchID,
     params?: BranchParams
   ): Promise<BranchWithZoneAndSessions> {
+    await this.ensureCanTriggerEnv(id, params, 'restart branch environments');
     const branch = await this.get(id, params);
 
     // Stop if running
@@ -1607,7 +1608,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * Custom method: Nuke environment (destructive operation)
    */
   async nukeEnvironment(id: BranchID, params?: BranchParams): Promise<BranchWithZoneAndSessions> {
-    await this.ensureCanTriggerEnv(params, 'nuke branch environments');
+    await this.ensureCanTriggerEnv(id, params, 'nuke branch environments');
     const branch = await this.get(id, params);
 
     // Require nuke_command to be configured
@@ -1859,7 +1860,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     error?: string;
     truncated?: boolean;
   }> {
-    await this.ensureCanTriggerEnv(params, 'fetch branch environment logs');
+    await this.ensureCanTriggerEnv(id, params, 'fetch branch environment logs');
     const branch = await this.get(id, params);
 
     // Check if static logs command is configured
@@ -1998,11 +1999,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * `environment` config and persist the result onto the branch.
    *
    * When no `variant` is supplied, the repo's default variant is used.
-   * Re-rendering with the currently-selected variant is allowed for any
-   * trigger-capable role (see `execution.managed_envs_minimum_role`); changing
-   * the variant requires admin since it replaces executable command strings
-   * that run as the system user (same rationale as `requireAdminForEnvConfig`
-   * in authorization.ts).
+   * Re-rendering and variant changes require effective `all` branch
+   * permission or admin access because the rendered fields are executable command strings. Direct
+   * field edits remain admin-only via `requireAdminForEnvConfig`.
    *
    * Returns the updated branch (with new `environment_variant`, `start_command`,
    * `stop_command`, etc).
@@ -2012,7 +2011,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     data: { variant?: string } | undefined,
     params?: BranchParams
   ): Promise<BranchWithZoneAndSessions> {
-    await this.ensureCanTriggerEnv(params, 'render branch environment');
+    await this.ensureCanTriggerEnv(id, params, 'render branch environment');
 
     const branch = await this.get(id, params);
     const reposService = this.app.service('repos');
@@ -2026,15 +2025,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const requestedVariant = data?.variant ?? env.default;
     const currentVariant = branch.environment_variant;
 
-    // Variant change (including first-time assignment against an existing
-    // branch) replaces executable commands → require admin.
     if (requestedVariant !== currentVariant) {
-      ensureMinimumRole(
-        params,
-        ROLES.ADMIN,
-        `change branch environment variant to "${requestedVariant}"`
-      );
-
       // Refuse to swap variants while the env is live. The current process
       // was started with the old command strings; replacing them out from
       // under it would leave us unable to stop/restart cleanly. This guard

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -11,6 +11,7 @@ import type {
   BranchGroupGrantWithGroup,
   BranchID,
   BranchPermissionLevel,
+  EffectiveBranchAccess,
   Group,
   GroupMembership,
   HookContext,
@@ -254,6 +255,69 @@ export function setupBranchGroupGrantsService(
       remove: [(context: HookContext) => requireBranchGrantManager(branchRepo, context)],
     },
   });
+}
+
+export function setupBranchEffectiveAccessService(
+  app: import('@agor/core/feathers').Application,
+  branchRepo: BranchRepository
+) {
+  app.use(
+    'branches/:id/effective-access',
+    {
+      async find(params?: Params): Promise<EffectiveBranchAccess> {
+        const authParams = params as
+          | (Params & { user?: { user_id: string; role: string; _isServiceAccount?: boolean } })
+          | undefined;
+        if (authParams?.provider && authParams.user?._isServiceAccount) {
+          return { can: 'all', is_owner: false, source: 'superadmin' };
+        }
+
+        const user = authParams?.user;
+        if (!user) throw new NotAuthenticated('Authentication required');
+
+        const branchId = paramsRoute(params)?.id;
+        if (!branchId) throw new BadRequest('Branch ID is required');
+
+        const branch = await branchRepo.findById(branchId);
+        if (!branch) throw new BadRequest(`Branch not found: ${branchId}`);
+
+        if (hasMinimumRole(user.role, ROLES.ADMIN)) {
+          return { can: 'all', is_owner: false, source: 'superadmin' };
+        }
+
+        const userId = user.user_id as UserID;
+        const isOwner = await branchRepo.isOwner(branch.branch_id as BranchID, userId);
+        if (isOwner) {
+          return { can: 'all', is_owner: true, source: 'owner' };
+        }
+
+        const groupGrant = await branchRepo.getBestGroupGrantForUser(
+          branch.branch_id as BranchID,
+          userId
+        );
+        const others = branch.others_can ?? 'session';
+        const can =
+          groupGrant && PERMISSION_RANK[groupGrant.can] >= PERMISSION_RANK[others]
+            ? groupGrant.can
+            : others;
+
+        if (PERMISSION_RANK[can] < PERMISSION_RANK.view) {
+          throw new Forbidden('You need view permission to see branch access');
+        }
+
+        return groupGrant && can === groupGrant.can
+          ? {
+              can,
+              fs_access: undefined,
+              is_owner: false,
+              source: 'group',
+              group_ids: groupGrant.groupIds as EffectiveBranchAccess['group_ids'],
+            }
+          : { can, fs_access: branch.others_fs_access, is_owner: false, source: 'others' };
+      },
+    },
+    { methods: ['find'] }
+  );
 }
 
 export const groupsHooks = {

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -17,8 +17,16 @@ import type {
 } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
-import type { Branch, BranchPermissionLevel, HookContext, Session, UUID } from '@agor/core/types';
-import { BRANCH_PERMISSION_LEVELS, ROLES } from '@agor/core/types';
+import type {
+  AuthenticatedParams,
+  Branch,
+  BranchID,
+  BranchPermissionLevel,
+  HookContext,
+  Session,
+  UUID,
+} from '@agor/core/types';
+import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
 
 /**
  * Check if a user has the superadmin role (or deprecated 'owner' alias).
@@ -115,6 +123,51 @@ export function resolveBranchPermission(
     return 'all';
   }
   return effectivePermission ?? branch.others_can ?? 'session';
+}
+
+/**
+ * Ensure the caller can control or mutate a branch's managed environment.
+ *
+ * Managed environment controls may run shell/webhook actions with impact tied
+ * to the branch rather than the triggering user. Keep these controls limited
+ * to users with effective `all` permission on the branch and global admins.
+ * Internal daemon/service-account calls bypass so health loops and executor
+ * plumbing can continue to operate.
+ */
+export async function ensureCanControlBranchEnvironment(
+  branchRepo: BranchRepository,
+  branchId: BranchID,
+  params: AuthenticatedParams | undefined,
+  action: string = 'control this branch environment'
+): Promise<void> {
+  if (!params?.provider) {
+    return;
+  }
+
+  const user = params.user;
+  if (!user) {
+    throw new NotAuthenticated('Authentication required');
+  }
+
+  if (user._isServiceAccount) {
+    return;
+  }
+
+  if (hasMinimumRole(user.role, ROLES.ADMIN)) {
+    return;
+  }
+
+  const branch = await branchRepo.findById(branchId);
+  if (!branch) {
+    throw new Forbidden(`Branch not found: ${branchId}`);
+  }
+
+  const effectivePermission = await branchRepo.resolveUserPermission(branch, user.user_id as UUID);
+  if (effectivePermission === 'all') {
+    return;
+  }
+
+  throw new Forbidden(`You need 'all' branch permission or admin access to ${action}`);
 }
 
 /**

--- a/apps/agor-docs/pages/guide/environment-configuration.mdx
+++ b/apps/agor-docs/pages/guide/environment-configuration.mdx
@@ -264,7 +264,7 @@ The Environment tab has two stacked editors:
 | **Repo editor** (top) | Admins only | `version`, `environment.variants`, `environment.default`, `template_overrides` as YAML |
 | **Branch editor** (bottom) | Admins only | The 6 rendered commands for this branch |
 
-Members see both editors **read-only**. The controls members can use are the **Variant picker** and the **Render** button in between them.
+Members see both editors **read-only**. Users with branch `all` permission and admins can use the **Variant picker** and the **Render** button in between them.
 
 ### The Render flow
 
@@ -302,21 +302,14 @@ Two orthogonal axes govern access: **who can edit what**, and **who can run Star
 | Edit `environment.variants` / `environment.default` | ❌ | ✅ |
 | Edit `template_overrides` | ❌ | ✅ |
 | Import / export `.agor.yml` | ❌ | ✅ |
-| Pick variant + Render to branch | ✅ | ✅ |
+| Pick variant + Render to branch | Requires branch `all` | ✅ |
 | Hand-edit branch rendered commands | ❌ | ✅ |
 
-The reason members **cannot** hand-edit rendered commands: admins curate the set of commands that can run (the variants), members pick from that list. This makes the variant library the effective allowlist and complements the execution-time deny-list guard.
+The reason members **cannot** hand-edit rendered commands: admins curate the set of commands that can run (the variants), and users with branch `all` permission pick from that list. This makes the variant library the effective allowlist and complements the execution-time deny-list guard.
 
 ### Execution permissions
 
-Start, Stop, Nuke, and Logs buttons are gated separately by the existing daemon config flag:
-
-```yaml
-# ~/.agor/config.yaml
-managed_envs_minimum_role: member   # or 'admin', 'viewer', …
-```
-
-This is **orthogonal** to the edit permissions above — you can grant members Render rights but still require admin role to actually Start an environment, or vice versa.
+Start, Stop, Restart, Nuke, Logs, and Render controls require branch `all` permission or admin access. Health/status reads can remain available to users who can view the branch because they do not run the configured shell/log commands.
 
 ---
 

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -13,6 +13,7 @@ import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { usePermissions } from '../../hooks/usePermissions';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
@@ -100,6 +101,7 @@ const BranchCardComponent = ({
   client,
 }: BranchCardProps) => {
   const { token } = theme.useToken();
+  const { isAdmin } = usePermissions();
   const connectionDisabled = useConnectionDisabled();
 
   // Archive/Delete modal state
@@ -500,6 +502,9 @@ const BranchCardComponent = ({
             onStopEnvironment={onStopEnvironment}
             onViewLogs={onViewLogs}
             onNukeEnvironment={onNukeEnvironment}
+            canControlEnvironment={
+              isAdmin || branch.others_can === 'all' || branch.created_by === currentUserId
+            }
             connectionDisabled={connectionDisabled}
           />
         </Space>

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -17,6 +17,7 @@ import {
 } from '@ant-design/icons';
 import { Button, Spin, Tooltip, theme } from 'antd';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
+import { usePermissions } from '../../hooks/usePermissions';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import type { BranchModalTab } from '../BranchModal/BranchModal';
@@ -31,6 +32,7 @@ interface BranchHeaderPillProps {
   onStopEnvironment?: (branchId: string) => void;
   onNukeEnvironment?: (branchId: string) => void;
   onViewLogs?: (branchId: string) => void;
+  canControlEnvironment?: boolean;
   connectionDisabled?: boolean;
   /** Show environment status/controls and environment shortcut. Defaults to true. */
   showEnvButtons?: boolean;
@@ -56,17 +58,24 @@ export function BranchHeaderPill({
   onStopEnvironment,
   onNukeEnvironment,
   onViewLogs,
+  canControlEnvironment,
   connectionDisabled = false,
   showEnvButtons = true,
   compact = false,
 }: BranchHeaderPillProps) {
   const { token } = theme.useToken();
+  const { isAdmin } = usePermissions();
   const confirmNuke = useConfirmNukeEnvironment();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = branch.environment_instance;
   const inferredState = getEnvironmentState(env);
   const environmentUrl = branch.app_url;
+  const resolvedCanControlEnvironment =
+    canControlEnvironment ?? (isAdmin || branch.others_can === 'all');
+  const controlDisabledTooltip = resolvedCanControlEnvironment
+    ? undefined
+    : "Requires branch 'all' permission or admin access";
 
   const status = env?.status || 'stopped';
   const isRunning = status === 'running';
@@ -75,13 +84,19 @@ export function BranchHeaderPill({
   const canStop = status === 'running' || status === 'starting';
   const startDisabled =
     connectionDisabled ||
+    !resolvedCanControlEnvironment ||
     !hasConfig ||
     !onStartEnvironment ||
     isStarting ||
     isStopping ||
     isRunning;
   const stopDisabled =
-    connectionDisabled || !hasConfig || !onStopEnvironment || isStopping || !canStop;
+    connectionDisabled ||
+    !resolvedCanControlEnvironment ||
+    !hasConfig ||
+    !onStopEnvironment ||
+    isStopping ||
+    !canStop;
 
   const openTab = (tab: BranchModalTab) => (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -262,7 +277,12 @@ export function BranchHeaderPill({
 
               {/* Play button */}
               {onStartEnvironment && (
-                <Tooltip title={isRunning ? 'Environment running' : 'Start environment'}>
+                <Tooltip
+                  title={
+                    controlDisabledTooltip ??
+                    (isRunning ? 'Environment running' : 'Start environment')
+                  }
+                >
                   <Button
                     type="text"
                     size="small"
@@ -282,13 +302,14 @@ export function BranchHeaderPill({
               {onStopEnvironment && (
                 <Tooltip
                   title={
-                    isRunning
+                    controlDisabledTooltip ??
+                    (isRunning
                       ? 'Stop environment'
                       : isStarting
                         ? 'Cancel startup'
                         : isStopping
                           ? 'Stopping...'
-                          : 'Not running'
+                          : 'Not running')
                   }
                 >
                   <Button
@@ -308,7 +329,7 @@ export function BranchHeaderPill({
 
               {/* Logs button */}
               {onViewLogs && effectiveEnv.logs && (
-                <Tooltip title="View logs">
+                <Tooltip title={controlDisabledTooltip ?? 'View logs'}>
                   <Button
                     type="text"
                     size="small"
@@ -316,8 +337,9 @@ export function BranchHeaderPill({
                     icon={<FileTextOutlined />}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onViewLogs(branch.branch_id);
+                      if (resolvedCanControlEnvironment) onViewLogs(branch.branch_id);
                     }}
+                    disabled={!resolvedCanControlEnvironment}
                     style={iconButtonStyle}
                   />
                 </Tooltip>
@@ -325,7 +347,7 @@ export function BranchHeaderPill({
 
               {/* Nuke button */}
               {onNukeEnvironment && branch.nuke_command && (
-                <Tooltip title="Nuke environment (destructive)">
+                <Tooltip title={controlDisabledTooltip ?? 'Nuke environment (destructive)'}>
                   <Button
                     type="text"
                     size="small"
@@ -334,9 +356,11 @@ export function BranchHeaderPill({
                     icon={<FireOutlined />}
                     onClick={(e) => {
                       e.stopPropagation();
-                      confirmNuke(() => onNukeEnvironment(branch.branch_id));
+                      if (resolvedCanControlEnvironment && !connectionDisabled) {
+                        confirmNuke(() => onNukeEnvironment(branch.branch_id));
+                      }
                     }}
-                    disabled={connectionDisabled}
+                    disabled={connectionDisabled || !resolvedCanControlEnvironment}
                     style={iconButtonStyle}
                   />
                 </Tooltip>

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -201,6 +201,7 @@ export const BranchModal: React.FC<BranchModalProps> = ({
           client={client}
           onUpdateRepo={onUpdateRepo}
           onUpdateBranch={onUpdateBranch}
+          canControlEnvironment={form.canControlEnvironment}
         />
       ),
     },

--- a/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
@@ -3,7 +3,7 @@
  *
  * Layout matches `docs/designs/env-command-variants.md` §4:
  *   - Top editor: repo-level `environment` (variants + default). Admin-only to edit.
- *   - Variant picker + Render button (members+ via `managed_envs_minimum_role`).
+ *   - Variant picker + Render button (branch `all`/admins).
  *   - Bottom editor: rendered snapshot on the branch (start, stop, ...).
  *     Admin-only to edit; members see read-only.
  *
@@ -67,6 +67,7 @@ interface EnvironmentTabProps {
   client: AgorClient | null;
   onUpdateRepo?: (repoId: string, updates: Partial<Repo>) => void;
   onUpdateBranch?: (branchId: string, updates: Partial<Branch>) => void;
+  canControlEnvironment?: boolean;
 }
 
 /**
@@ -108,27 +109,23 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
   client,
   onUpdateRepo,
   onUpdateBranch,
+  canControlEnvironment,
 }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
   const { confirm } = useThemedModal();
   const confirmNuke = useConfirmNukeEnvironment();
-  const { isAdmin, hasRole } = usePermissions();
+  const { isAdmin } = usePermissions();
   const { featuresConfig } = useAuthConfig();
 
   // ----- Permission gating -----
-  const managedEnvsMinimumRole = featuresConfig?.managedEnvsMinimumRole ?? 'member';
   const managedEnvsExecutionMode: ManagedEnvExecutionMode =
     featuresConfig?.managedEnvsExecutionMode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
   const isWebhookMode = managedEnvsExecutionMode === 'webhook-only';
-  const canTriggerEnv =
-    managedEnvsMinimumRole !== 'none' &&
-    hasRole(managedEnvsMinimumRole as Exclude<typeof managedEnvsMinimumRole, 'none'>);
+  const canTriggerEnv = canControlEnvironment ?? isAdmin;
   const triggerDisabledTooltip = canTriggerEnv
     ? undefined
-    : managedEnvsMinimumRole === 'none'
-      ? 'Managed environments are disabled on this instance'
-      : `Requires ${managedEnvsMinimumRole} role or higher`;
+    : "Requires branch 'all' permission or admin access";
   const lifecycleFieldHelp = isWebhookMode
     ? 'This instance uses webhook-managed environments. Use public http(s) URLs for start, stop, nuke, and logs.'
     : 'This instance supports shell commands and URL webhooks for start, stop, nuke, and logs.';
@@ -281,18 +278,15 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
     !canTriggerEnv ||
     !repo.environment ||
     !selectedVariant ||
-    (variantChanged && !isAdmin) ||
     (variantChanged && envIsActive) ||
     isRendering;
   const renderDisabledTooltip = !canTriggerEnv
     ? triggerDisabledTooltip
     : !repo.environment
       ? 'Configure repo environment variants first'
-      : variantChanged && !isAdmin
-        ? 'Only admins can change the branch variant'
-        : variantChanged && envIsActive
-          ? `Stop the environment before switching variants (currently ${envStatus})`
-          : undefined;
+      : variantChanged && envIsActive
+        ? `Stop the environment before switching variants (currently ${envStatus})`
+        : undefined;
 
   const performRender = async () => {
     if (!client) return;
@@ -691,11 +685,13 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                 size="small"
                 icon={<FileTextOutlined />}
                 onClick={() => setLogsModalOpen(true)}
-                disabled={!branch.logs_command}
+                disabled={!canTriggerEnv || !branch.logs_command}
                 title={
-                  !branch.logs_command
-                    ? 'Configure a logs command in the variant to enable'
-                    : undefined
+                  !canTriggerEnv
+                    ? triggerDisabledTooltip
+                    : !branch.logs_command
+                      ? 'Configure a logs command in the variant to enable'
+                      : undefined
                 }
               >
                 View Logs

--- a/apps/agor-ui/src/components/BranchModal/testUtils.tsx
+++ b/apps/agor-ui/src/components/BranchModal/testUtils.tsx
@@ -20,6 +20,7 @@ export interface ServiceCall {
 export interface StubClientOptions {
   owners?: User[];
   users?: User[];
+  effectiveAccess?: unknown;
   rbac404?: boolean;
   groupGrants404?: boolean;
   groupGrants?: unknown[];
@@ -65,6 +66,9 @@ export function makeStubClient(opts: StubClientOptions = {}): {
           }
           if (path === 'branches/:id/group-grants') {
             return opts.groupGrants ?? [];
+          }
+          if (path === 'branches/:id/effective-access') {
+            return opts.effectiveAccess ?? { can: 'session', is_owner: false, source: 'others' };
           }
           return [];
         },

--- a/apps/agor-ui/src/components/BranchModal/useBranchModalForm.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/useBranchModalForm.test.tsx
@@ -446,6 +446,31 @@ describe('useBranchModalForm — unified save', () => {
     expect(result.current.canEditPermissions).toBe(false);
   });
 
+  it('allows environment control from server-resolved effective all permission', async () => {
+    const alice = makeUser({ user_id: 'user-1', email: 'alice@example.com', role: 'member' });
+    const bob = makeUser({ user_id: 'user-2', email: 'bob@example.com', role: 'member' });
+    const branch = makeBranch({
+      created_by: 'user-2',
+      others_can: 'view',
+    });
+    const { client } = makeStubClient({
+      owners: [bob],
+      users: [alice, bob],
+      effectiveAccess: { can: 'all', is_owner: false, source: 'group' },
+    });
+
+    const { result } = renderHook(
+      () => useBranchModalForm({ branch, client, currentUser: alice, open: true }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.loadingOwners).toBe(false));
+
+    expect(result.current.canViewPermissions).toBe(false);
+    expect(result.current.canEditPermissions).toBe(false);
+    expect(result.current.canControlEnvironment).toBe(true);
+  });
+
   it('shows permissions for assistant branches when the current admin is an owner', async () => {
     const alice = makeUser({ user_id: 'user-1', email: 'alice@example.com', role: 'admin' });
     const branch = makeAssistantBranch();

--- a/apps/agor-ui/src/components/BranchModal/useBranchModalForm.ts
+++ b/apps/agor-ui/src/components/BranchModal/useBranchModalForm.ts
@@ -23,6 +23,7 @@ import type {
   Branch,
   BranchGroupGrantWithGroup,
   BranchPermissionLevel,
+  EffectiveBranchAccess,
   Group,
   User,
 } from '@agor-live/client';
@@ -109,6 +110,7 @@ export interface BranchModalFormApi {
   // Permissions used for gating UI
   canEditGeneral: boolean;
   canEditPermissions: boolean;
+  canControlEnvironment: boolean;
 
   // Aggregate state
   hasChanges: boolean;
@@ -167,6 +169,7 @@ export function useBranchModalForm({
   const [loadingOwners, setLoadingOwners] = useState<boolean>(true);
   const [groupGrantsStatus, setGroupGrantsStatus] = useState<GroupGrantsStatus>('loading');
   const [groupGrantsError, setGroupGrantsError] = useState<Error | null>(null);
+  const [effectiveAccess, setEffectiveAccess] = useState<EffectiveBranchAccess | null>(null);
   const [ownersLoadError, setOwnersLoadError] = useState<Error | null>(null);
 
   const [saving, setSaving] = useState(false);
@@ -274,10 +277,21 @@ export function useBranchModalForm({
         setOwnersLoadError(null);
         setGroupGrantsStatus('loading');
         setGroupGrantsError(null);
+        setEffectiveAccess(null);
+        const effectiveAccessPromise = client
+          .service('branches/:id/effective-access')
+          .find({ route: { id: branchId } })
+          .catch((error: unknown) => {
+            console.warn('Failed to load effective branch access:', error);
+            return null;
+          });
         const ownersResponse = await client
           .service('branches/:id/owners')
           .find({ route: { id: branchId } });
         if (cancelled) return;
+        const resolvedEffectiveAccess = await effectiveAccessPromise;
+        if (cancelled) return;
+        setEffectiveAccess(resolvedEffectiveAccess as EffectiveBranchAccess | null);
         const ownersData = ownersResponse as User[];
         setOwners(ownersData);
         setRbacEnabled(true);
@@ -427,6 +441,13 @@ export function useBranchModalForm({
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
   const isSuperAdmin = hasMinimumRole(currentUser?.role, ROLES.SUPERADMIN);
   const isOwner = owners.some((o) => o.user_id === currentUserId);
+  const isCreator = branch?.created_by === currentUserId;
+  const canControlEnvironment =
+    isAdmin ||
+    effectiveAccess?.can === 'all' ||
+    isOwner ||
+    branch?.others_can === 'all' ||
+    (!rbacEnabled && isCreator);
   const canViewPermissions = rbacEnabled && (isAdmin || loadingOwners || isOwner);
 
   // Backend branch mutations are authorized by branch ownership or superadmin
@@ -653,6 +674,7 @@ export function useBranchModalForm({
     ownersLoadError,
     canEditGeneral,
     canEditPermissions,
+    canControlEnvironment,
     hasChanges,
     saving,
     save,

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -12,6 +12,7 @@ import {
 } from '@ant-design/icons';
 import { Button, Space, Spin, Tooltip, theme } from 'antd';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
+import { usePermissions } from '../../hooks/usePermissions';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
@@ -24,6 +25,7 @@ interface EnvironmentPillProps {
   onStopEnvironment?: (branchId: string) => void;
   onNukeEnvironment?: (branchId: string) => void;
   onViewLogs?: (branchId: string) => void;
+  canControlEnvironment?: boolean;
   connectionDisabled?: boolean; // Disable actions when disconnected
 }
 
@@ -35,13 +37,20 @@ export function EnvironmentPill({
   onStopEnvironment,
   onNukeEnvironment,
   onViewLogs,
+  canControlEnvironment,
   connectionDisabled = false,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
+  const { isAdmin } = usePermissions();
   const confirmNuke = useConfirmNukeEnvironment();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = branch.environment_instance;
+  const resolvedCanControlEnvironment =
+    canControlEnvironment ?? (isAdmin || branch.others_can === 'all');
+  const controlDisabledTooltip = resolvedCanControlEnvironment
+    ? undefined
+    : "Requires branch 'all' permission or admin access";
 
   // Get static app_url (user-editable, initialized from template)
   const environmentUrl = branch.app_url;
@@ -109,13 +118,19 @@ export function EnvironmentPill({
   const canStop = status === 'running' || status === 'starting';
   const startDisabled =
     connectionDisabled ||
+    !resolvedCanControlEnvironment ||
     !hasConfig ||
     !onStartEnvironment ||
     isStarting ||
     isStopping ||
     isRunning;
   const stopDisabled =
-    connectionDisabled || !hasConfig || !onStopEnvironment || isStopping || !canStop;
+    connectionDisabled ||
+    !resolvedCanControlEnvironment ||
+    !hasConfig ||
+    !onStopEnvironment ||
+    isStopping ||
+    !canStop;
 
   // Build helpful tooltip based on inferred state
   const getTooltipText = () => {
@@ -240,7 +255,12 @@ export function EnvironmentPill({
             }}
           >
             {onStartEnvironment && (
-              <Tooltip title={status === 'running' ? 'Environment running' : 'Start environment'}>
+              <Tooltip
+                title={
+                  controlDisabledTooltip ??
+                  (status === 'running' ? 'Environment running' : 'Start environment')
+                }
+              >
                 <Button
                   type="text"
                   size="small"
@@ -264,13 +284,14 @@ export function EnvironmentPill({
             {onStopEnvironment && (
               <Tooltip
                 title={
-                  status === 'running'
+                  controlDisabledTooltip ??
+                  (status === 'running'
                     ? 'Stop environment'
                     : status === 'starting'
                       ? 'Stop environment (cancel startup)'
                       : status === 'stopping'
                         ? 'Environment is stopping'
-                        : 'Environment not running'
+                        : 'Environment not running')
                 }
               >
                 <Button
@@ -296,7 +317,10 @@ export function EnvironmentPill({
             {onViewLogs && (
               <Tooltip
                 title={
-                  !effectiveEnv.logs ? 'Configure logs command to enable' : 'View environment logs'
+                  controlDisabledTooltip ??
+                  (!effectiveEnv.logs
+                    ? 'Configure logs command to enable'
+                    : 'View environment logs')
                 }
               >
                 <Button
@@ -305,11 +329,11 @@ export function EnvironmentPill({
                   icon={<FileTextOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
-                    if (effectiveEnv.logs) {
+                    if (resolvedCanControlEnvironment && effectiveEnv.logs) {
                       onViewLogs(branch.branch_id);
                     }
                   }}
-                  disabled={!effectiveEnv.logs}
+                  disabled={!resolvedCanControlEnvironment || !effectiveEnv.logs}
                   style={{
                     height: 22,
                     width: 22,
@@ -320,7 +344,12 @@ export function EnvironmentPill({
               </Tooltip>
             )}
             {onNukeEnvironment && branch.nuke_command && (
-              <Tooltip title="Nuke environment (destructive - removes all data and volumes)">
+              <Tooltip
+                title={
+                  controlDisabledTooltip ??
+                  'Nuke environment (destructive - removes all data and volumes)'
+                }
+              >
                 <Button
                   type="text"
                   size="small"
@@ -329,9 +358,11 @@ export function EnvironmentPill({
                   icon={<FireOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
-                    confirmNuke(() => onNukeEnvironment(branch.branch_id));
+                    if (resolvedCanControlEnvironment && !connectionDisabled) {
+                      confirmNuke(() => onNukeEnvironment(branch.branch_id));
+                    }
                   }}
-                  disabled={connectionDisabled}
+                  disabled={connectionDisabled || !resolvedCanControlEnvironment}
                   style={{
                     height: 22,
                     width: 22,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -13,6 +13,7 @@ import { Button, Divider, Space, Tabs, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppMcpData, useAppRepoData, useAppUserData } from '../../contexts/AppDataContext';
+import { usePermissions } from '../../hooks/usePermissions';
 import { copyToClipboard } from '../../utils/clipboard';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -70,6 +71,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     setCliViewMode,
   }) => {
     const { token } = theme.useToken();
+    const { isAdmin } = usePermissions();
     const { showSuccess, showError } = useThemedMessage();
 
     // Subscribe only to the entity families this panel needs. This keeps the
@@ -126,6 +128,9 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                   onStopEnvironment={onStopEnvironment}
                   onNukeEnvironment={onNukeEnvironment}
                   onViewLogs={onViewLogs}
+                  canControlEnvironment={
+                    isAdmin || branch.others_can === 'all' || branch.created_by === currentUserId
+                  }
                 />
               )}
               {/* Issue and PR Pills */}


### PR DESCRIPTION
## Summary
- Limit managed environment control methods to users with effective branch `all` permission or admins.
- Add a request-scoped effective branch access endpoint for the UI so owner/group-grant/others_can checks do not ride on broadcast branch entity payloads.
- Keep environment command/config field editing admin-only while allowing branch `all` users to render/switch variants through the control flow.
- Leave health/status reads available to branch viewers where they do not run shell/log commands.
- Update MCP copy, docs, focused service tests, and UI gating for modal/pill environment controls.

## Validation
- `pnpm i`
- `pnpm check` (passes; existing lint warnings remain outside this change)
- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts src/services/groups.test.ts`
- `pnpm --filter agor-ui test -- BranchModal`
