### PR TITLE
Add assistant Knowledge namespace memory

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -48,6 +48,20 @@ const CLEANUP_CANDIDATE_FILESYSTEM_STATUSES = [
 ] as const satisfies readonly CleanupCandidateFilesystemStatus[];
 const CLEANUP_CANDIDATE_STORAGE_MODES = ['worktree', 'clone'] as const;
 
+function containsAssistantKnowledgeConfigMutation(customContext: unknown): boolean {
+  if (!customContext || typeof customContext !== 'object' || Array.isArray(customContext)) {
+    return false;
+  }
+  const record = customContext as Record<string, unknown>;
+  for (const key of ['assistant', 'agent']) {
+    const value = record[key];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      if (Object.hasOwn(value as Record<string, unknown>, 'kb')) return true;
+    }
+  }
+  return false;
+}
+
 function normalizeFilesystemStatus(branch: Branch): CleanupCandidateFilesystemStatus {
   return branch.filesystem_status ?? 'ready';
 }
@@ -807,6 +821,11 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         updates.board_id = boardIdStr ? await resolveBoardId(ctx, boardIdStr) : null;
       }
       if (args.customContext !== undefined) {
+        if (containsAssistantKnowledgeConfigMutation(args.customContext)) {
+          throw new Error(
+            'Assistant Knowledge namespace configuration cannot be changed through MCP. Use the BranchModal Knowledge tab or API-only assistant Knowledge config endpoint.'
+          );
+        }
         fieldsProvided++;
         updates.custom_context = args.customContext === null ? null : args.customContext;
       }

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -1,10 +1,12 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { BranchRepository } from '@agor/core/db';
+import { BranchRepository, KnowledgeNamespaceRepository } from '@agor/core/db';
 import { NotFound } from '@agor/core/feathers';
 import type {
+  AssistantKnowledgeGrantAccess,
+  Branch,
   BranchID,
   KnowledgeDocumentKind,
   KnowledgeDocumentStatus,
@@ -12,11 +14,15 @@ import type {
   KnowledgeEditPolicy,
   KnowledgeGraphEdgeType,
   KnowledgeGraphNodeType,
+  KnowledgeNamespace,
   KnowledgeVisibility,
+  User,
   UserRole,
 } from '@agor/core/types';
 import {
   buildKnowledgeDocumentUri,
+  getAssistantConfig,
+  isAssistant,
   KNOWLEDGE_DOCUMENT_KINDS,
   KNOWLEDGE_DOCUMENT_STATUSES,
   KNOWLEDGE_DOCUMENT_URI_PREFIX,
@@ -34,10 +40,23 @@ import {
   resolveHeadingRange,
   splitMarkdownLines,
 } from '../../knowledge/markdown-outline.js';
+import {
+  ASSISTANT_MEMORY_PATH_TEMPLATE,
+  ASSISTANT_NAMESPACE_MISSING_MESSAGE,
+} from '../../services/assistant-knowledge.js';
+import {
+  hasKnowledgeNamespacePermission,
+  resolveKnowledgeNamespacePermission,
+} from '../../services/knowledge-access.js';
 import { resolveBranchWorkspacePath } from '../../utils/branch-workspace-path.js';
 import { resolveBranchId } from '../resolve-ids.js';
 import type { McpContext } from '../server.js';
-import { coerceJsonRecord, coerceString, textResult } from '../server.js';
+import {
+  coerceJsonRecord,
+  coerceString,
+  sessionContextRequiredResult,
+  textResult,
+} from '../server.js';
 
 const KnowledgeDocumentKindSchema = z.enum(KNOWLEDGE_DOCUMENT_KINDS);
 const KnowledgeDocumentStatusSchema = z.enum(KNOWLEDGE_DOCUMENT_STATUSES);
@@ -352,7 +371,350 @@ async function writeKnowledgeMaterializationSidecar(
   );
 }
 
+function renderAssistantMemoryPath(template: string | undefined, date: string): string {
+  return (template || ASSISTANT_MEMORY_PATH_TEMPLATE).replace('{{YYYY-MM-DD}}', date);
+}
+
+function normalizeMemoryBullets(input: string | string[]): string[] {
+  const raw = Array.isArray(input) ? input : input.split('\n');
+  return raw.map((item) => item.replace(/^\s*[-*]\s+/, '').trim()).filter(Boolean);
+}
+
+function memoryEntryHash(text: string): string {
+  return `sha256:${createHash('sha256').update(text).digest('hex')}`;
+}
+
+function escapeHtmlAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+const ASSISTANT_POLICY_RANK: Record<AssistantKnowledgeGrantAccess, number> = {
+  none: 0,
+  read: 1,
+  write: 2,
+};
+
+function assistantPolicyAllows(
+  branch: Branch,
+  namespace: KnowledgeNamespace,
+  required: Exclude<AssistantKnowledgeGrantAccess, 'none'>
+): boolean {
+  const assistant = getAssistantConfig(branch);
+  const kb = assistant?.kb;
+  if (!kb) return false;
+  if (
+    namespace.namespace_id === kb.primary_namespace_id ||
+    namespace.slug === kb.primary_namespace_slug
+  ) {
+    return true;
+  }
+  const grant = (kb.grants ?? []).find(
+    (entry) =>
+      entry.namespace_id === namespace.namespace_id || entry.namespace_slug === namespace.slug
+  );
+  const access = grant?.access ?? kb.global_access ?? 'write';
+  return ASSISTANT_POLICY_RANK[access] >= ASSISTANT_POLICY_RANK[required];
+}
+
+async function resolveAssistantKnowledgeContext(ctx: McpContext): Promise<{
+  branch: Branch;
+  namespace: KnowledgeNamespace;
+}> {
+  if (!ctx.sessionId) throw new Error(ASSISTANT_NAMESPACE_MISSING_MESSAGE);
+  const session = (await ctx.app.service('sessions').get(ctx.sessionId, ctx.baseServiceParams)) as {
+    branch_id?: string;
+  };
+  const branch = (await ctx.app
+    .service('branches')
+    .get(String(session.branch_id), ctx.baseServiceParams)) as Branch;
+  if (!isAssistant(branch)) {
+    throw new Error('This tool only works from an assistant branch/session');
+  }
+  const assistant = getAssistantConfig(branch);
+  const namespaceId = assistant?.kb?.primary_namespace_id;
+  if (!namespaceId) throw new Error(ASSISTANT_NAMESPACE_MISSING_MESSAGE);
+  let namespace: KnowledgeNamespace;
+  try {
+    namespace = (await ctx.app
+      .service('kb/namespaces')
+      .get(namespaceId, ctx.baseServiceParams)) as KnowledgeNamespace;
+  } catch (error) {
+    if (isNotFoundError(error)) throw new Error(ASSISTANT_NAMESPACE_MISSING_MESSAGE);
+    throw error;
+  }
+  if (!namespace || namespace.archived) throw new Error(ASSISTANT_NAMESPACE_MISSING_MESSAGE);
+  return { branch, namespace };
+}
+
+async function resolveKnowledgeNamespaceBySlug(
+  ctx: McpContext,
+  slug: string
+): Promise<KnowledgeNamespace | null> {
+  const service = getOptionalService(ctx, 'kb/namespaces');
+  if (!service?.find) return null;
+  const result = await service.find(mcpParams(ctx, { slug, archived: false }));
+  const rows = Array.isArray(result)
+    ? result
+    : Array.isArray((result as { data?: unknown[] })?.data)
+      ? (result as { data: unknown[] }).data
+      : [];
+  return (rows[0] as KnowledgeNamespace | undefined) ?? null;
+}
+
 export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'agor_assistant_context',
+    {
+      description:
+        "Read the current assistant branch's Knowledge memory/context namespace and recent memory documents. Does not mutate assistant Knowledge config or grants.",
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        includeMemory: z.boolean().optional().describe('Include memory documents (default: true)'),
+        limit: z.number().int().min(1).max(50).optional().describe('Maximum memory docs to list'),
+      }),
+    },
+    async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const { branch, namespace } = await resolveAssistantKnowledgeContext(ctx);
+      const docsService = getOptionalService(ctx, 'kb/documents');
+      const memory =
+        args.includeMemory === false || !docsService?.find
+          ? []
+          : await docsService.find(
+              mcpParams(ctx, {
+                namespace_id: namespace.namespace_id,
+                kind: 'memory',
+                include_content: true,
+                include_my_drafts: true,
+                limit: args.limit ?? 10,
+              })
+            );
+      return textResult({
+        branch_id: branch.branch_id,
+        assistant: getAssistantConfig(branch),
+        namespace,
+        memory,
+      });
+    }
+  );
+
+  server.registerTool(
+    'agor_assistant_memory_search',
+    {
+      description:
+        "Search the current assistant branch's primary Knowledge memory namespace. Does not mutate assistant Knowledge config or grants.",
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        query: z.string().describe('Search text. Use an empty string to browse memory.'),
+        limit: z.number().int().min(1).max(50).optional(),
+        mode: z.enum(['text', 'semantic', 'hybrid']).optional(),
+      }),
+    },
+    async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const { namespace } = await resolveAssistantKnowledgeContext(ctx);
+      const service = getOptionalService(ctx, 'kb/search');
+      if (!service?.find) {
+        return knowledgeNotImplementedResult('agor_assistant_memory_search', ['kb/search.find']);
+      }
+      return textResult(
+        enrichWithReferenceUri(
+          await service.find(
+            mcpParams(ctx, {
+              q: coerceString(args.query) ?? '',
+              namespace_slug: namespace.slug,
+              path_prefix: 'memory/',
+              limit: args.limit ?? 10,
+              mode: args.mode,
+            })
+          )
+        )
+      );
+    }
+  );
+
+  server.registerTool(
+    'agor_assistant_knowledge_search',
+    {
+      description:
+        'Search Knowledge through the current assistant branch policy. The assistant policy (whole-KB fallback plus namespace overrides) is checked before the normal user namespace permissions.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        query: z.string().describe('Search text. Use an empty string to browse.'),
+        namespace: z
+          .string()
+          .optional()
+          .describe('Optional namespace slug. Required unless whole-KB fallback is read/write.'),
+        pathPrefix: z.string().optional().describe('Optional path prefix filter.'),
+        limit: z.number().int().min(1).max(50).optional(),
+        mode: z.enum(['text', 'semantic', 'hybrid']).optional(),
+      }),
+    },
+    async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const { branch } = await resolveAssistantKnowledgeContext(ctx);
+      const assistant = getAssistantConfig(branch);
+      const globalAccess = assistant?.kb?.global_access ?? 'write';
+      const service = getOptionalService(ctx, 'kb/search');
+      if (!service?.find) {
+        return knowledgeNotImplementedResult('agor_assistant_knowledge_search', ['kb/search.find']);
+      }
+
+      const namespaceSlug = coerceString(args.namespace);
+      if (namespaceSlug) {
+        const namespace = await resolveKnowledgeNamespaceBySlug(ctx, namespaceSlug);
+        if (!namespace || !assistantPolicyAllows(branch, namespace, 'read')) {
+          throw new Error(
+            `Assistant Knowledge policy does not grant read access to namespace ${namespaceSlug}`
+          );
+        }
+      } else if (ASSISTANT_POLICY_RANK[globalAccess] < ASSISTANT_POLICY_RANK.read) {
+        throw new Error(
+          'Assistant Knowledge policy does not grant whole-Knowledge-Base read access. Choose a namespace with an explicit read grant or update the assistant Knowledge policy.'
+        );
+      }
+
+      return textResult(
+        enrichWithReferenceUri(
+          await service.find(
+            mcpParams(ctx, {
+              q: coerceString(args.query) ?? '',
+              ...(namespaceSlug ? { namespace_slug: namespaceSlug } : {}),
+              ...(args.pathPrefix ? { path_prefix: coerceString(args.pathPrefix) } : {}),
+              limit: args.limit ?? 10,
+              mode: args.mode,
+            })
+          )
+        )
+      );
+    }
+  );
+
+  server.registerTool(
+    'agor_assistant_memory_append',
+    {
+      description:
+        "Append one or more memory bullets to the current assistant branch's daily Knowledge memory document.",
+      annotations: { idempotentHint: true },
+      inputSchema: z.object({
+        bullets: z.union([z.string(), z.array(z.string())]).describe('Memory bullet(s) to append'),
+        date: z
+          .string()
+          .regex(/^\d{4}-\d{2}-\d{2}$/)
+          .optional(),
+        category: z
+          .enum(['note', 'decision', 'preference', 'project', 'learning', 'task', 'other'])
+          .optional(),
+        tags: z.array(z.string()).optional(),
+        importance: z.enum(['low', 'normal', 'high']).optional(),
+        idempotencyKey: z.string().optional(),
+      }),
+    },
+    async (args) => {
+      if (!ctx.sessionId) return sessionContextRequiredResult();
+      const { branch, namespace } = await resolveAssistantKnowledgeContext(ctx);
+      const namespaceRepo = new KnowledgeNamespaceRepository(ctx.db);
+      const permission = await resolveKnowledgeNamespacePermission(
+        namespaceRepo,
+        namespace.namespace_id,
+        ctx.authenticatedUser as unknown as User
+      );
+      if (!hasKnowledgeNamespacePermission(permission, 'write')) {
+        throw new Error(
+          `You don't have write access to namespace ${namespace.slug}. Ask a namespace owner to grant write access in Knowledge -> Settings -> Namespaces.`
+        );
+      }
+
+      const bullets = normalizeMemoryBullets(args.bullets);
+      if (bullets.length === 0) throw new Error('No memory bullets provided');
+      const date = args.date ?? new Date().toISOString().slice(0, 10);
+      const assistant = getAssistantConfig(branch);
+      const docPath = renderAssistantMemoryPath(assistant?.kb?.memory_path_template, date);
+      const docsService = getOptionalService(ctx, 'kb/documents');
+      if (!docsService) throw new Error('Knowledge documents service is not registered');
+
+      let existingContent = `# ${date}\n`;
+      let expectedVersion: string | number | undefined;
+      try {
+        const existing = (await callCustomMethod(
+          docsService,
+          'getDocument',
+          {
+            namespace_slug: namespace.slug,
+            path: docPath,
+            include_content: true,
+          },
+          mcpParams(ctx)
+        )) as HydratedKnowledgeDocumentResult | undefined;
+        if (existing) {
+          existingContent =
+            typeof existing.content === 'string' ? existing.content : existingContent;
+          expectedVersion = existing.current_version?.version_id;
+        }
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error;
+      }
+
+      const now = new Date().toISOString();
+      const category = args.category ?? 'note';
+      const tags = (args.tags ?? []).map((tag) => tag.trim()).filter(Boolean);
+      const appended: Array<{ text: string; hash: string; deduped: boolean }> = [];
+      const blocks: string[] = [];
+      bullets.forEach((bullet, index) => {
+        const key = args.idempotencyKey
+          ? `${args.idempotencyKey}:${index}`
+          : `${category}:${bullet}`;
+        const hash = memoryEntryHash(key);
+        if (existingContent.includes(`hash="${hash}"`)) {
+          appended.push({ text: bullet, hash, deduped: true });
+          return;
+        }
+        const id = args.idempotencyKey
+          ? createHash('sha256').update(key).digest('hex').slice(0, 24)
+          : randomUUID();
+        const tagText = tags.map((tag) => ` #${tag.replace(/\s+/g, '-')}`).join('');
+        const importance =
+          args.importance && args.importance !== 'normal' ? ` (${args.importance})` : '';
+        blocks.push(
+          `<!-- agor-memory-entry id="${escapeHtmlAttr(id)}" hash="${hash}" -->\n` +
+            `- [${now}] ${category}${importance}: ${bullet}${tagText}\n` +
+            `  - source: agor://session/${ctx.sessionId}\n` +
+            '<!-- /agor-memory-entry -->'
+        );
+        appended.push({ text: bullet, hash, deduped: false });
+      });
+
+      const nextContent = blocks.length
+        ? `${existingContent.replace(/\s*$/, '\n\n')}${blocks.join('\n\n')}\n`
+        : existingContent;
+      if (blocks.length > 0) {
+        const result = await callCustomMethod(
+          docsService,
+          'putDocument',
+          {
+            namespace_slug: namespace.slug,
+            path: docPath,
+            title: date,
+            kind: 'memory',
+            visibility: assistant?.kb?.default_visibility ?? namespace.visibility_default,
+            edit_policy: 'public',
+            status: 'published',
+            content_text: nextContent,
+            expected_version: expectedVersion,
+            metadata: {
+              assistant_memory: true,
+              assistant_branch_id: branch.branch_id,
+              memory_date: date,
+            },
+          },
+          mcpParams(ctx)
+        );
+        return textResult({ namespace: namespace.slug, path: docPath, appended, document: result });
+      }
+      return textResult({ namespace: namespace.slug, path: docPath, appended });
+    }
+  );
+
   server.registerTool(
     'agor_kb_namespaces_list',
     {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -316,7 +316,16 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // ============================================================================
 
   app.use('/branches', createBranchesService(db, app), {
-    methods: ['find', 'get', 'create', 'update', 'patch', 'remove', 'initializeUnixGroup'],
+    methods: [
+      'find',
+      'get',
+      'create',
+      'update',
+      'patch',
+      'remove',
+      'initializeUnixGroup',
+      'ensureAssistantKnowledgeNamespace',
+    ],
   });
 
   console.log(`[RBAC] Branch RBAC ${branchRbacEnabled ? 'Enabled' : 'Disabled'}`);

--- a/apps/agor-daemon/src/services/assistant-knowledge.test.ts
+++ b/apps/agor-daemon/src/services/assistant-knowledge.test.ts
@@ -1,0 +1,81 @@
+import {
+  BranchRepository,
+  generateId,
+  KnowledgeNamespaceRepository,
+  RepoRepository,
+  shortId,
+  UsersRepository,
+} from '@agor/core/db';
+import type { BranchID, UserID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { ensureAssistantKnowledgeNamespace } from './assistant-knowledge';
+
+describe('ensureAssistantKnowledgeNamespace', () => {
+  dbTest('creates an open primary namespace and stores assistant kb config', async ({ db }) => {
+    const user = await new UsersRepository(db).create({
+      user_id: generateId() as UserID,
+      email: `assistant-kb-${Date.now()}@test.local`,
+      name: 'Assistant Owner',
+      role: 'member',
+    });
+    const repo = await new RepoRepository(db).create({
+      repo_id: generateId(),
+      slug: `assistant-kb-repo-${Date.now()}`,
+      name: 'Assistant KB Repo',
+      repo_type: 'remote',
+      remote_url: 'https://github.com/test/repo.git',
+      local_path: '/tmp/repo',
+      default_branch: 'main',
+    });
+    const branch = await new BranchRepository(db).create({
+      branch_id: generateId() as BranchID,
+      repo_id: repo.repo_id,
+      name: 'assistant-branch',
+      ref: 'assistant-branch',
+      branch_unique_id: 1,
+      created_by: user.user_id,
+      custom_context: {
+        assistant: { kind: 'assistant', displayName: 'Helper' },
+      },
+    });
+
+    const result = await ensureAssistantKnowledgeNamespace(db, branch.branch_id, user.user_id);
+
+    expect(result.namespace).toMatchObject({
+      slug: `assistant-${shortId(branch.branch_id)}`,
+      display_name: 'Helper Memory',
+      kind: 'branch',
+      branch_id: branch.branch_id,
+      repo_id: repo.repo_id,
+      visibility_default: 'public',
+      others_can: 'write',
+      owner_user_id: user.user_id,
+    });
+    expect(result.branch.custom_context?.assistant).toMatchObject({
+      kind: 'assistant',
+      displayName: 'Helper',
+      kb: {
+        primary_namespace_id: result.namespace.namespace_id,
+        primary_namespace_slug: result.namespace.slug,
+        memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+        default_visibility: 'public',
+        global_access: 'write',
+      },
+    });
+
+    const acl = await new KnowledgeNamespaceRepository(db).listNamespaceAcl(
+      result.namespace.namespace_id
+    );
+    expect(acl).toEqual([
+      expect.objectContaining({
+        subject_type: 'user',
+        subject_id: user.user_id,
+        permission: 'own',
+      }),
+    ]);
+
+    const again = await ensureAssistantKnowledgeNamespace(db, branch.branch_id, user.user_id);
+    expect(again.namespace.namespace_id).toBe(result.namespace.namespace_id);
+  });
+});

--- a/apps/agor-daemon/src/services/assistant-knowledge.ts
+++ b/apps/agor-daemon/src/services/assistant-knowledge.ts
@@ -1,0 +1,132 @@
+import {
+  BranchRepository,
+  type Database,
+  KnowledgeNamespaceRepository,
+  shortId,
+} from '@agor/core/db';
+import type {
+  AssistantKnowledgeConfig,
+  Branch,
+  BranchID,
+  KnowledgeNamespace,
+  UserID,
+} from '@agor/core/types';
+import { getAssistantConfig, isAssistant } from '@agor/core/types';
+
+export const ASSISTANT_MEMORY_PATH_TEMPLATE = 'memory/{{YYYY-MM-DD}}.md' as const;
+export const ASSISTANT_NAMESPACE_MISSING_MESSAGE = 'namespace for this agent is not set up';
+
+function assistantNamespaceMetadata(branchId: BranchID) {
+  return {
+    assistant: {
+      primary: true,
+      branch_id: branchId,
+      memory_path_template: ASSISTANT_MEMORY_PATH_TEMPLATE,
+      docs_root: 'docs/',
+      scratchpad_root: 'scratchpad/',
+      skills_root: 'skills/',
+    },
+  };
+}
+
+function isPrimaryAssistantNamespace(namespace: KnowledgeNamespace, branchId: BranchID): boolean {
+  const assistant = namespace.metadata?.assistant;
+  return (
+    namespace.branch_id === branchId &&
+    assistant !== null &&
+    typeof assistant === 'object' &&
+    (assistant as Record<string, unknown>).primary === true
+  );
+}
+
+function assistantKbPatch(namespace: KnowledgeNamespace, previous?: AssistantKnowledgeConfig) {
+  return {
+    primary_namespace_id: namespace.namespace_id,
+    primary_namespace_slug: namespace.slug,
+    memory_path_template: ASSISTANT_MEMORY_PATH_TEMPLATE,
+    default_visibility: namespace.visibility_default,
+    global_access: previous?.global_access ?? ('write' as const),
+  };
+}
+
+async function uniqueAssistantNamespaceSlug(
+  namespaces: KnowledgeNamespaceRepository,
+  branchId: BranchID
+): Promise<string> {
+  const base = `assistant-${shortId(branchId)}`;
+  let slug = base;
+  for (let suffix = 2; await namespaces.findBySlug(slug); suffix += 1) {
+    slug = `${base}-${suffix}`;
+  }
+  return slug;
+}
+
+export async function ensureAssistantKnowledgeNamespace(
+  db: Database,
+  branchId: BranchID,
+  userId?: UserID | null
+): Promise<{ namespace: KnowledgeNamespace; branch: Branch }> {
+  const branches = new BranchRepository(db);
+  const namespaces = new KnowledgeNamespaceRepository(db);
+  const branch = await branches.findById(branchId);
+  if (!branch) throw new Error(`Branch not found: ${branchId}`);
+  if (!isAssistant(branch)) throw new Error('Branch is not an assistant');
+
+  const assistant = getAssistantConfig(branch);
+  const configuredNamespaceId = assistant?.kb?.primary_namespace_id;
+  const configuredNamespace = configuredNamespaceId
+    ? await namespaces.findById(configuredNamespaceId)
+    : null;
+
+  if (configuredNamespace && !configuredNamespace.archived) {
+    return { namespace: configuredNamespace, branch };
+  }
+
+  const existing = (await namespaces.findAll({ branch_id: branch.branch_id, kind: 'branch' })).find(
+    (namespace) => !namespace.archived && isPrimaryAssistantNamespace(namespace, branch.branch_id)
+  );
+
+  const createdBy = (userId ?? branch.created_by ?? null) as UserID | null;
+  const namespace =
+    existing ??
+    (
+      await namespaces.createWithAcl(
+        {
+          slug: await uniqueAssistantNamespaceSlug(namespaces, branch.branch_id),
+          display_name: `${assistant?.displayName?.trim() || branch.name} Memory`,
+          kind: 'branch',
+          branch_id: branch.branch_id,
+          repo_id: branch.repo_id,
+          owner_user_id: createdBy,
+          created_by: createdBy,
+          visibility_default: 'public',
+          others_can: 'write',
+          metadata: assistantNamespaceMetadata(branch.branch_id),
+        },
+        createdBy
+          ? [
+              {
+                subject_type: 'user',
+                subject_id: createdBy,
+                permission: 'own',
+                created_by: createdBy,
+              },
+            ]
+          : []
+      )
+    ).namespace;
+
+  const updatedBranch = await branches.update(branch.branch_id, {
+    custom_context: {
+      assistant: {
+        ...assistant,
+        kb: {
+          ...(assistant?.kb?.grants ? { grants: assistant.kb.grants } : {}),
+          ...assistantKbPatch(namespace, assistant?.kb),
+        },
+      },
+    },
+  });
+
+  return { namespace, branch: updatedBranch };
+}

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -35,6 +35,7 @@ import type {
   BoardID,
   Branch,
   BranchID,
+  KnowledgeNamespace,
   QueryParams,
   Repo,
   UserID,
@@ -51,6 +52,8 @@ import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { resolveGitImpersonationForBranch } from '../utils/git-impersonation.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
 import { generateSessionToken, getDaemonUrl, spawnExecutor } from '../utils/spawn-executor.js';
+import { ensureAssistantKnowledgeNamespace as ensureAssistantKnowledgeNamespaceForBranch } from './assistant-knowledge.js';
+import { isKnowledgeAdmin } from './knowledge-access.js';
 import type { InternalEnrichmentParams } from './sessions';
 
 /**
@@ -66,6 +69,7 @@ export type BranchParams = QueryParams<{
   include_sessions?: boolean | 'true' | 'false'; // Opt-in session activity enrichment
   last_message_truncation_length?: number; // Default: 500 chars, min: 50, max: 10000
 }> &
+  AuthenticatedParams &
   InternalEnrichmentParams & {
     /** Root-level include_sessions flag (bypasses Feathers query filtering, used by internal service calls) */
     _include_sessions?: boolean | 'true' | 'false';
@@ -429,17 +433,21 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         data.map((item) => this.applyBranchCreateDefaults(item))
       );
       const created = (await super.create(withDefaults, params)) as Branch[];
-      await Promise.all(created.map((branch) => this.maybeSetBoardPrimaryAssistant(branch)));
-      for (const branch of created) {
+      const readyBranches = await Promise.all(
+        created.map((branch) => this.maybeEnsureAssistantKnowledgeNamespace(branch, params))
+      );
+      await Promise.all(readyBranches.map((branch) => this.maybeSetBoardPrimaryAssistant(branch)));
+      for (const branch of readyBranches) {
         this.trackBranchCreated(branch);
       }
-      return created;
+      return readyBranches;
     }
     const withDefaults = await this.applyBranchCreateDefaults(data);
     const created = (await super.create(withDefaults, params)) as Branch;
-    await this.maybeSetBoardPrimaryAssistant(created);
-    this.trackBranchCreated(created);
-    return created;
+    const readyBranch = await this.maybeEnsureAssistantKnowledgeNamespace(created, params);
+    await this.maybeSetBoardPrimaryAssistant(readyBranch);
+    this.trackBranchCreated(readyBranch);
+    return readyBranch;
   }
 
   private trackBranchCreated(branch: Branch): void {
@@ -465,6 +473,74 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         error instanceof Error ? error.message : String(error)
       );
     }
+  }
+
+  private async maybeEnsureAssistantKnowledgeNamespace(
+    branch: Branch,
+    params?: BranchParams
+  ): Promise<Branch> {
+    if (!isAssistant(branch)) return branch;
+    const userId = (params?.user?.user_id as UserID | undefined) ?? (branch.created_by as UserID);
+    const result = await ensureAssistantKnowledgeNamespaceForBranch(
+      this.db,
+      branch.branch_id,
+      userId
+    );
+    return result.branch;
+  }
+
+  private async assertCanManageAssistantKnowledge(branch: Branch, params?: BranchParams) {
+    const user = params?.user;
+    const userId = user?.user_id as UserID | undefined;
+    if (isKnowledgeAdmin(user as never)) return;
+    if (!userId) throw new NotAuthenticated('Authentication required');
+    if (branch.created_by === userId) return;
+    if (await this.branchRepo.isOwner(branch.branch_id, userId)) {
+      return;
+    }
+    throw new Forbidden('Only branch owners or admins can manage assistant knowledge');
+  }
+
+  private containsAssistantKnowledgeConfigMutation(data: Partial<Branch>): boolean {
+    if (!Object.hasOwn(data, 'custom_context')) return false;
+    const customContext = data.custom_context;
+    if (customContext === null) return true;
+    if (!customContext || typeof customContext !== 'object' || Array.isArray(customContext)) {
+      return false;
+    }
+    for (const key of ['assistant', 'agent']) {
+      const value = customContext[key];
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        if (Object.hasOwn(value as Record<string, unknown>, 'kb')) return true;
+      }
+    }
+    return false;
+  }
+
+  private async assertCanMutateAssistantKnowledgeConfig(
+    branch: Branch,
+    data: Partial<Branch>,
+    params?: BranchParams
+  ): Promise<void> {
+    if (!this.containsAssistantKnowledgeConfigMutation(data)) return;
+    await this.assertCanManageAssistantKnowledge(branch, params);
+  }
+
+  async ensureAssistantKnowledgeNamespace(
+    data: { branchId?: string; branch_id?: string } | string,
+    params?: BranchParams
+  ): Promise<{ namespace: KnowledgeNamespace; branch: Branch }> {
+    const branchId = String(typeof data === 'string' ? data : (data.branchId ?? data.branch_id));
+    if (!branchId || branchId === 'undefined') throw new BadRequest('branchId is required');
+    const branch = await this.branchRepo.findById(branchId);
+    if (!branch) throw new BadRequest(`Branch not found: ${branchId}`);
+    if (!isAssistant(branch)) throw new BadRequest('Branch is not an assistant');
+    await this.assertCanManageAssistantKnowledge(branch, params);
+    return ensureAssistantKnowledgeNamespaceForBranch(
+      this.db,
+      branch.branch_id,
+      (params?.user?.user_id as UserID | undefined) ?? (branch.created_by as UserID)
+    );
   }
 
   private isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -588,6 +664,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   ): Promise<BranchWithZoneAndSessions> {
     // Get current branch to check type/board changes
     const currentBranch = await super.get(id, params);
+    await this.assertCanMutateAssistantKnowledgeConfig(currentBranch, data, params);
     this.assertAssistantKindIsStable(currentBranch, data);
 
     const oldBoardId = currentBranch.board_id;
@@ -656,6 +733,13 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     return withZone as BranchWithZoneAndSessions;
+  }
+
+  async update(id: BranchID, data: Partial<Branch>, params?: BranchParams): Promise<Branch> {
+    const currentBranch = await super.get(id, params);
+    await this.assertCanMutateAssistantKnowledgeConfig(currentBranch, data, params);
+    this.assertAssistantKindIsStable(currentBranch, data);
+    return super.update(id, data, params) as Promise<Branch>;
   }
 
   /**

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -522,6 +522,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     data: Partial<Branch>,
     params?: BranchParams
   ): Promise<void> {
+    if (!isAssistant(branch)) return;
     if (!this.containsAssistantKnowledgeConfigMutation(data)) return;
     await this.assertCanManageAssistantKnowledge(branch, params);
   }

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -149,13 +149,6 @@ export const BranchModal: React.FC<BranchModalProps> = ({
               />
             ),
           },
-          {
-            key: 'knowledge',
-            label: 'Knowledge',
-            children: (
-              <KnowledgeTab branch={branch} client={client} canEdit={form.canEditGeneral} />
-            ),
-          },
         ]
       : []),
     {
@@ -260,6 +253,19 @@ export const BranchModal: React.FC<BranchModalProps> = ({
         />
       ),
     },
+    // Knowledge is assistant-only and intentionally last for now: it is
+    // configuration-adjacent but less central than the primary branch/session tabs.
+    ...(isAnAssistant
+      ? [
+          {
+            key: 'knowledge',
+            label: 'Knowledge',
+            children: (
+              <KnowledgeTab branch={branch} client={client} canEdit={form.canEditGeneral} />
+            ),
+          },
+        ]
+      : []),
   ];
 
   // Modal-level footer: one Save action for all form-contributing tabs

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -153,7 +153,16 @@ export const BranchModal: React.FC<BranchModalProps> = ({
             key: 'knowledge',
             label: 'Knowledge',
             children: (
-              <KnowledgeTab branch={branch} client={client} canEdit={form.canEditGeneral} />
+              <KnowledgeTab
+                branch={branch}
+                client={client}
+                canEdit={form.canEditGeneral}
+                onBranchUpdated={(updatedBranch) =>
+                  onUpdateBranch?.(updatedBranch.branch_id, {
+                    custom_context: updatedBranch.custom_context,
+                  })
+                }
+              />
             ),
           },
         ]

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -17,6 +17,7 @@ import { AssistantTab } from './tabs/AssistantTab';
 import { EnvironmentTab } from './tabs/EnvironmentTab';
 import { FilesTab } from './tabs/FilesTab';
 import { GeneralTab } from './tabs/GeneralTab';
+import { KnowledgeTab } from './tabs/KnowledgeTab';
 import { PermissionsTab } from './tabs/PermissionsTab';
 import { ScheduleTab } from './tabs/ScheduleTab';
 import { SessionsTab } from './tabs/SessionsTab';
@@ -25,6 +26,7 @@ import { type BranchUpdate, useBranchModalForm } from './useBranchModalForm';
 export type BranchModalTab =
   | 'general'
   | 'assistant'
+  | 'knowledge'
   | 'sessions'
   | 'environment'
   | 'files'
@@ -145,6 +147,13 @@ export const BranchModal: React.FC<BranchModalProps> = ({
                 state={form.assistant}
                 setField={form.setAssistant}
               />
+            ),
+          },
+          {
+            key: 'knowledge',
+            label: 'Knowledge',
+            children: (
+              <KnowledgeTab branch={branch} client={client} canEdit={form.canEditGeneral} />
             ),
           },
         ]

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -153,16 +153,7 @@ export const BranchModal: React.FC<BranchModalProps> = ({
             key: 'knowledge',
             label: 'Knowledge',
             children: (
-              <KnowledgeTab
-                branch={branch}
-                client={client}
-                canEdit={form.canEditGeneral}
-                onBranchUpdated={(updatedBranch) =>
-                  onUpdateBranch?.(updatedBranch.branch_id, {
-                    custom_context: updatedBranch.custom_context,
-                  })
-                }
-              />
+              <KnowledgeTab branch={branch} client={client} canEdit={form.canEditGeneral} />
             ),
           },
         ]

--- a/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
@@ -1,0 +1,390 @@
+import type {
+  AgorClient,
+  AssistantKnowledgeConfig,
+  AssistantKnowledgeGrant,
+  AssistantKnowledgeGrantAccess,
+  Branch,
+  KnowledgeNamespace,
+} from '@agor-live/client';
+import { getAssistantConfig } from '@agor-live/client';
+import {
+  Alert,
+  Button,
+  Card,
+  Descriptions,
+  Empty,
+  Select,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+} from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { useThemedMessage } from '@/utils/message';
+
+interface KnowledgeTabProps {
+  branch: Branch;
+  client: AgorClient | null;
+  canEdit: boolean;
+  onBranchUpdated?: (branch: Branch) => void;
+}
+
+type EditableGrant = AssistantKnowledgeGrant & { key: string };
+
+const ACCESS_OPTIONS: Array<{ label: string; value: AssistantKnowledgeGrantAccess }> = [
+  { label: 'No access', value: 'none' },
+  { label: 'Read', value: 'read' },
+  { label: 'Write', value: 'write' },
+];
+
+function emptyKbConfig(): Partial<AssistantKnowledgeConfig> {
+  return {
+    memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+    default_visibility: 'public',
+    global_access: 'write',
+    grants: [],
+  };
+}
+
+function grantKey(grant: Pick<AssistantKnowledgeGrant, 'namespace_id' | 'namespace_slug'>) {
+  return grant.namespace_id || grant.namespace_slug;
+}
+
+export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
+  branch,
+  client,
+  canEdit,
+  onBranchUpdated,
+}) => {
+  const { showSuccess, showError } = useThemedMessage();
+  const assistant = useMemo(() => getAssistantConfig(branch), [branch]);
+  const initialKb = assistant?.kb;
+  const [kb, setKb] = useState<Partial<AssistantKnowledgeConfig>>(initialKb ?? emptyKbConfig());
+  const [namespace, setNamespace] = useState<KnowledgeNamespace | null>(null);
+  const [namespaces, setNamespaces] = useState<KnowledgeNamespace[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [repairing, setRepairing] = useState(false);
+  const [savingPolicy, setSavingPolicy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setKb(initialKb ?? emptyKbConfig());
+  }, [initialKb]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setNamespace(null);
+      setError(null);
+      if (!client) return;
+      setLoading(true);
+      try {
+        const rows = (await client.service('kb/namespaces').find({
+          query: { archived: false, $limit: 1000 },
+        })) as KnowledgeNamespace[] | { data?: KnowledgeNamespace[] };
+        if (!cancelled) setNamespaces(Array.isArray(rows) ? rows : (rows.data ?? []));
+
+        if (kb.primary_namespace_id) {
+          const result = (await client
+            .service('kb/namespaces')
+            .get(kb.primary_namespace_id)) as KnowledgeNamespace;
+          if (!cancelled) setNamespace(result);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, kb.primary_namespace_id]);
+
+  const editableGrants: EditableGrant[] = useMemo(
+    () =>
+      (kb.grants ?? []).map((grant) => ({
+        ...grant,
+        key: grantKey(grant),
+      })),
+    [kb.grants]
+  );
+
+  const namespaceById = useMemo(
+    () => new Map(namespaces.map((item) => [String(item.namespace_id), item])),
+    [namespaces]
+  );
+
+  const handleRepair = async () => {
+    if (!client) return;
+    setRepairing(true);
+    setError(null);
+    try {
+      const result = await client
+        .service('branches')
+        .ensureAssistantKnowledgeNamespace({ branchId: branch.branch_id });
+      setNamespace(result.namespace);
+      const nextKb = getAssistantConfig(result.branch)?.kb ?? kb;
+      setKb(nextKb);
+      onBranchUpdated?.(result.branch);
+      showSuccess('Assistant Knowledge namespace is ready');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      showError(message);
+    } finally {
+      setRepairing(false);
+    }
+  };
+
+  const patchKb = async (nextKb: Partial<AssistantKnowledgeConfig>) => {
+    if (!client) return;
+    setSavingPolicy(true);
+    try {
+      const updated = (await client.service('branches').patch(branch.branch_id, {
+        custom_context: {
+          assistant: {
+            ...assistant,
+            kb: nextKb,
+          },
+        },
+      } as Partial<Branch>)) as Branch;
+      const savedKb = getAssistantConfig(updated)?.kb ?? nextKb;
+      setKb(savedKb);
+      onBranchUpdated?.(updated);
+      showSuccess('Assistant Knowledge policy saved');
+    } catch (err) {
+      showError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSavingPolicy(false);
+    }
+  };
+
+  const updateGrant = (key: string, patch: Partial<AssistantKnowledgeGrant>) => {
+    setKb((current) => ({
+      ...current,
+      grants: (current.grants ?? []).map((grant) =>
+        grantKey(grant) === key ? { ...grant, ...patch } : grant
+      ),
+    }));
+  };
+
+  const addGrant = (namespaceId: string) => {
+    const selected = namespaceById.get(namespaceId);
+    if (!selected) return;
+    setKb((current) => {
+      const grants = current.grants ?? [];
+      if (grants.some((grant) => grant.namespace_id === selected.namespace_id)) return current;
+      return {
+        ...current,
+        grants: [
+          ...grants,
+          {
+            namespace_id: selected.namespace_id,
+            namespace_slug: selected.slug,
+            access: 'read',
+          },
+        ],
+      };
+    });
+  };
+
+  const removeGrant = (key: string) => {
+    setKb((current) => ({
+      ...current,
+      grants: (current.grants ?? []).filter((grant) => grantKey(grant) !== key),
+    }));
+  };
+
+  if (!assistant) {
+    return <Empty description="Knowledge memory is only available for assistant branches." />;
+  }
+
+  const missing = !namespace && (!kb.primary_namespace_id || error);
+  const configuredGrantIds = new Set((kb.grants ?? []).map((grant) => grant.namespace_id));
+  if (kb.primary_namespace_id) configuredGrantIds.add(kb.primary_namespace_id);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Alert
+          type="info"
+          showIcon
+          message="Assistant Knowledge"
+          description="Assistant tools always use the home namespace for memory. Beyond that, this policy controls which Knowledge namespaces assistant-specific MCP tools may search. Effective access is still limited by the current user's namespace permissions."
+        />
+
+        <Card
+          title="Home namespace"
+          extra={
+            <Space>
+              {namespace?.slug && (
+                <Button href={`/kb/${encodeURIComponent(namespace.slug)}/`} target="_blank">
+                  Open in Knowledge
+                </Button>
+              )}
+              {canEdit && (
+                <Button onClick={handleRepair} loading={repairing} disabled={!client}>
+                  {kb.primary_namespace_id ? 'Repair namespace' : 'Create namespace'}
+                </Button>
+              )}
+            </Space>
+          }
+        >
+          {loading ? (
+            <Spin />
+          ) : missing ? (
+            <Alert
+              type="warning"
+              showIcon
+              message="Home namespace is missing or unavailable"
+              description={error || 'namespace for this agent is not set up'}
+            />
+          ) : (
+            <Descriptions column={1} size="small">
+              <Descriptions.Item label="Name">{namespace?.display_name}</Descriptions.Item>
+              <Descriptions.Item label="Slug">
+                <Typography.Text code>
+                  {namespace?.slug ?? kb.primary_namespace_slug}
+                </Typography.Text>
+              </Descriptions.Item>
+              <Descriptions.Item label="Your permission">
+                <Tag>{namespace?.effective_permission ?? 'unknown'}</Tag>
+              </Descriptions.Item>
+              <Descriptions.Item label="Default document visibility">
+                <Tag>{namespace?.visibility_default ?? kb.default_visibility}</Tag>
+              </Descriptions.Item>
+              <Descriptions.Item label="Others can">
+                <Tag>{namespace?.others_can ?? 'unknown'}</Tag>
+              </Descriptions.Item>
+              <Descriptions.Item label="Memory path">
+                <Typography.Text code>
+                  {kb.memory_path_template ?? 'memory/{{YYYY-MM-DD}}.md'}
+                </Typography.Text>
+              </Descriptions.Item>
+            </Descriptions>
+          )}
+        </Card>
+
+        <Card
+          title="Assistant Knowledge access"
+          extra={
+            canEdit ? (
+              <Button
+                type="primary"
+                onClick={() => patchKb(kb)}
+                loading={savingPolicy}
+                disabled={!client || !kb.primary_namespace_id}
+              >
+                Save policy
+              </Button>
+            ) : null
+          }
+        >
+          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <div>
+              <Typography.Text strong>Entire Knowledge Base fallback</Typography.Text>
+              <Typography.Paragraph type="secondary" style={{ marginBottom: 8 }}>
+                Applies to any namespace that is not listed below. Choose none for a locked-down
+                assistant, read for broad context, or write for assistant tools that may update any
+                namespace the current user can write.
+              </Typography.Paragraph>
+              <Select
+                value={kb.global_access ?? 'write'}
+                options={ACCESS_OPTIONS}
+                disabled={!canEdit}
+                style={{ width: 220 }}
+                onChange={(value) => setKb((current) => ({ ...current, global_access: value }))}
+              />
+            </div>
+
+            <div>
+              <Typography.Text strong>Per-namespace overrides</Typography.Text>
+              <Typography.Paragraph type="secondary" style={{ marginBottom: 8 }}>
+                Add namespaces to narrow or expand the fallback policy for specific spaces. The home
+                namespace is always available to assistant memory tools.
+              </Typography.Paragraph>
+              {canEdit && (
+                <Select
+                  showSearch
+                  placeholder="Add namespace override"
+                  style={{ minWidth: 320, marginBottom: 12 }}
+                  disabled={!client}
+                  value={undefined}
+                  optionFilterProp="label"
+                  onChange={addGrant}
+                  options={namespaces
+                    .filter((item) => !configuredGrantIds.has(item.namespace_id))
+                    .map((item) => ({
+                      label: `${item.display_name} (${item.slug})`,
+                      value: item.namespace_id,
+                    }))}
+                />
+              )}
+              <Table<EditableGrant>
+                size="small"
+                pagination={false}
+                rowKey="key"
+                dataSource={editableGrants}
+                locale={{ emptyText: 'No per-namespace overrides' }}
+                columns={[
+                  {
+                    title: 'Namespace',
+                    dataIndex: 'namespace_slug',
+                    render: (_value, grant) => {
+                      const row = namespaceById.get(grant.namespace_id);
+                      return (
+                        <Space direction="vertical" size={0}>
+                          <Typography.Text>
+                            {row?.display_name ?? grant.namespace_slug}
+                          </Typography.Text>
+                          <Typography.Text type="secondary" code>
+                            {grant.namespace_slug}
+                          </Typography.Text>
+                        </Space>
+                      );
+                    },
+                  },
+                  {
+                    title: 'Access',
+                    dataIndex: 'access',
+                    width: 150,
+                    render: (_value, grant) => (
+                      <Select
+                        value={grant.access}
+                        options={ACCESS_OPTIONS}
+                        disabled={!canEdit}
+                        style={{ width: 130 }}
+                        onChange={(access) => updateGrant(grant.key, { access })}
+                      />
+                    ),
+                  },
+                  {
+                    title: 'Effective now',
+                    width: 150,
+                    render: (_value, grant) => {
+                      const row = namespaceById.get(grant.namespace_id);
+                      return <Tag>{row?.effective_permission ?? 'unknown'}</Tag>;
+                    },
+                  },
+                  {
+                    title: '',
+                    width: 90,
+                    render: (_value, grant) =>
+                      canEdit ? (
+                        <Button type="link" danger onClick={() => removeGrant(grant.key)}>
+                          Remove
+                        </Button>
+                      ) : null,
+                  },
+                ]}
+              />
+            </div>
+          </Space>
+        </Card>
+      </Space>
+    </div>
+  );
+};

--- a/context/README.md
+++ b/context/README.md
@@ -53,6 +53,7 @@ Designs that are referenced from code or in flight. Anything here is either stil
 - [`env-var-access.md`](explorations/env-var-access.md) — per-user / per-session env var access model (referenced from schemas, types, and migrations).
 - [`kb-agent-targeted-edits.md`](explorations/kb-agent-targeted-edits.md) — design proposal for small, version-checked agent edits to large Knowledge Base markdown documents.
 - [`kb-assistant-framework-integration.md`](explorations/kb-assistant-framework-integration.md) — options for backing Agor Assistant framework memory/docs/skills with Knowledge Base namespaces and tools.
+- [`assistant-kb-namespace-memory-plan.md`](explorations/assistant-kb-namespace-memory-plan.md) — implementation plan for Assistant primary KB namespaces, memory append tools, and branch-scoped namespace grants.
 - [`kb-namespace-rbac-v1.md`](explorations/kb-namespace-rbac-v1.md) — directed V1 plan for Knowledge namespace RBAC and Assistant home namespaces.
 - [`session-sharing.md`](explorations/session-sharing.md) — `dangerously_allow_session_sharing` security contract (referenced from `AGENTS.md` and `apps/agor-docs/pages/security.mdx`).
 - [`parent-session-callbacks.md`](explorations/parent-session-callbacks.md) — child-session completion notifications (referenced from `docs/never-lose-prompt-design.md`).

--- a/context/explorations/assistant-kb-namespace-memory-plan.md
+++ b/context/explorations/assistant-kb-namespace-memory-plan.md
@@ -1,0 +1,324 @@
+# Assistant KB namespace memory plan
+
+**Date:** 2026-06-08
+**Scope:** Concise implementation plan for using Agor Knowledge Base namespaces as the backend for Agor Assistants' memory, scratchpad, docs, skills, and file-like storage. This is a planning doc; do not implement from here without a follow-up task.
+
+## Current state inspected
+
+- PR #1382 is merged at `b38fe21a` and added namespace RBAC plumbing: `kb_namespaces.others_can`, `kb_namespace_acl`, permission resolution, Knowledge namespace Settings UI, and read/write/own enforcement across namespace, document, edit, version, search, and graph services.
+- Existing assistant identity is branch-backed: `AssistantConfig` lives under `branch.custom_context.assistant`; `isAssistant()` gates assistant behavior.
+- Assistant creation currently happens in UI flows (`createAssistantBranch`, onboarding) by creating a normal branch with assistant metadata, then starting a bootstrap session.
+- Knowledge namespaces already support `kind`, `branch_id`, `repo_id`, `owner_user_id`, defaults, metadata, and slug-addressed document URIs.
+- Existing KB MCP tools are explicit/global (`agor_kb_put`, `agor_kb_edit`, `agor_kb_search`, etc.) and already receive `McpContext` with `userId`, optional `sessionId`, and Feathers service params.
+
+## Recommendation summary
+
+1. Give every assistant branch a **primary KB namespace during assistant creation**; keep lazy repair only for legacy assistants or failed partial setup.
+2. Store the binding in `branch.custom_context.assistant.kb` and mirror it on the namespace row (`kind: "branch"`, `branch_id`, `metadata.assistant = true`).
+3. Add a **BranchModal -> Knowledge** tab for assistant branches that shows the primary namespace and an accumulator of additional namespace grants: `none | read | write`.
+4. Make this configuration **API/UI-only, never MCP-mutatable**; assistant MCP tools may read effective context but must not create/edit the grant list or change the primary namespace.
+5. Add assistant-specific MCP/API tools that infer current session -> branch -> assistant namespace, instead of asking agents to pass namespace slugs.
+6. Keep existing generic KB tools explicit and admin/global-capable; add optional context defaults but do not silently rewrite namespaces.
+7. Use append-only daily memory docs with deterministic entry blocks so only new/changed chunks need embeddings.
+
+## Settled decisions for first build
+
+- Assistant creation fails hard if namespace setup fails; let the error bubble.
+- Missing namespace remains an allowed undefined state for legacy/failed setup; tools fail with `namespace for this agent is not set up`.
+- Assistant namespaces and assistant-specific Knowledge search are open by default: `others_can: write`, public document default, `global_access: write`. Owners can narrow later.
+- Store assistant KB config/grants as a blob in `branch.custom_context.assistant.kb` for the first build.
+- Memory path default is `memory/YYYY-MM-DD.md`.
+- Branch owners/admins can edit assistant KB config through API/UI; MCP cannot mutate it.
+
+## 1. First-boot namespace setup
+
+### Where to create or assign the namespace
+
+Use a server-side helper, not prompt instructions, as the source of truth:
+
+```ts
+ensureAssistantKnowledgeNamespace(branchId, userId): Promise<{ namespace, branch }>
+```
+
+Call it from two places, with creation as the required path:
+
+1. **Assistant creation path (required):** after the assistant branch row exists and before starting the bootstrap session. This covers `createAssistantBranch` and onboarding. If namespace setup fails, fail hard: raise the error and let it bubble through the assistant creation flow.
+2. **No lazy repair:** an undefined/missing namespace is a valid persisted state for legacy or failed setup. Read/write assistant tools that require it should fail with the exact actionable error: `namespace for this agent is not set up`.
+
+The helper should be idempotent:
+
+- If `branch.custom_context.assistant.kb.primary_namespace_id` resolves to an active namespace, return it.
+- Else find an active namespace with `branch_id = branch.branch_id` and `metadata.assistant.primary = true`.
+- Else create one with defaults below and patch the branch custom context.
+
+### Namespace defaults
+
+- Slug: `assistant-<branchShortId>`; if taken, suffix `-2`, `-3`, etc. Keep slug stable and use display name for human labels.
+- `display_name`: `<Assistant display name> Memory`.
+- `kind`: `branch`.
+- `branch_id`: assistant branch ID.
+- `repo_id`: branch repo ID.
+- `owner_user_id` / `created_by`: assistant branch creator or effective creator.
+- `visibility_default`: `public`.
+- `others_can`: `write` so the default matches Agor's open collaboration model: agents can see and write to each other's assistant namespaces unless an owner narrows access.
+- Initial ACL: creator gets `own`; branch owners can configure assistant KB binding/grants.
+- Metadata:
+
+```ts
+{
+  assistant: {
+    primary: true,
+    branch_id,
+    memory_path_template: "memory/{{YYYY-MM-DD}}.md",
+    docs_root: "docs/",
+    scratchpad_root: "scratchpad/",
+    skills_root: "skills/"
+  }
+}
+```
+
+### Branch association shape
+
+Extend `AssistantConfig` with a typed optional KB subobject:
+
+```ts
+interface AssistantKnowledgeConfig {
+  primary_namespace_id: KnowledgeNamespaceID;
+  primary_namespace_slug: string;
+  memory_path_template: 'memory/{{YYYY-MM-DD}}.md';
+  default_visibility: 'public' | 'private';
+  grants?: Array<{
+    namespace_id: KnowledgeNamespaceID;
+    namespace_slug: string;
+    access: 'none' | 'read' | 'write';
+  }>;
+}
+```
+
+V1 can keep this in `custom_context` to avoid a migration. If the tab grows, normalize to a `branch_knowledge_namespace_grants` table.
+
+### BranchModal -> Knowledge tab
+
+Show for assistant branches first; later it can apply to any branch.
+
+Fields/actions:
+
+- Primary namespace summary: display name, slug, effective user permission, visibility default, document count, link to open in Knowledge.
+- "Create/repair namespace" action if missing or archived.
+- "Change primary namespace" selector, gated by branch-owner/admin permission. This is a UI/API operation, not an MCP tool operation.
+- Additional namespace access accumulator:
+  - namespace selector
+  - access: `none | read | write`
+  - effective permission preview for the current user
+- Shortcut to Knowledge namespace Settings for ACL edits when the user has `own`.
+- Help text: assistant tools use the primary namespace by default; generic KB tools remain explicit.
+- Security note: MCP can expose read-only assistant Knowledge context, but must not expose tools that patch `branch.custom_context.assistant.kb`, change the primary namespace, or add grants. Those mutations must go through authenticated REST/Feathers APIs used by the UI/CLI, where normal human/admin authorization and audit semantics apply.
+
+## 2. Assistant-focused memory tool
+
+Prefer product-facing names:
+
+- `agor_assistant_context` (read-only)
+- `agor_assistant_memory_append` (mutating)
+- Optional alias later: `agor_assistant_memory_file` if product language lands on "file".
+
+### `agor_assistant_memory_append`
+
+Input:
+
+```ts
+{
+  bullets: string | string[];
+  date?: string; // YYYY-MM-DD; default server date
+  category?: "note" | "decision" | "preference" | "project" | "learning" | "task" | "other";
+  tags?: string[];
+  importance?: "low" | "normal" | "high";
+  source?: { sessionId?: string; taskId?: string; branchId?: string; uri?: string };
+  idempotencyKey?: string;
+}
+```
+
+Resolution:
+
+1. Require MCP session context; otherwise return the existing session-context help pattern.
+2. Load current session, then branch.
+3. Require `isAssistant(branch)`; otherwise say this tool only works from an assistant branch/session.
+4. Resolve the assistant primary namespace. Do not create or reconfigure it from this mutating memory tool. If missing, fail with `namespace for this agent is not set up`.
+5. Check branch policy grant for the namespace is `write` and user's KB permission is `write` or `own`.
+6. Append to `memory/YYYY-MM-DD.md` by default.
+
+Helpful failure examples:
+
+- `namespace for this agent is not set up`
+- `You don't have write access to namespace assistant-03b62447. Ask a namespace owner to grant write access in Knowledge -> Settings -> Namespaces.`
+
+### Deterministic append and chunking
+
+Daily memory docs should be append-only markdown with stable blocks:
+
+```md
+# 2026-06-08
+
+<!-- agor-memory-entry id="<uuid-or-idempotency-hash>" hash="sha256:..." -->
+
+- [2026-06-08T15:20:00Z] note: Memory text here. #tag
+  - source: agor://session/<id>
+  <!-- /agor-memory-entry -->
+```
+
+Implementation notes:
+
+- Normalize bullets, trim blanks, and generate one block per bullet.
+- If `idempotencyKey` or normalized block hash already appears, skip that block and return `deduped: true` for it.
+- Use a repository/service append helper rather than asking the model to generate `KnowledgeEditOp[]`.
+- Preserve one KB version per append call, not one version per bullet.
+- Follow-up: teach `knowledgeUnitsForMarkdown` to split on `agor-memory-entry` comments before heading/auto-split fallback, and reuse unit `content_md5`/embedding hashes so unchanged entries do not re-embed.
+
+## 3. Namespace access model
+
+### Product model
+
+- Each assistant branch has exactly one **primary namespace**.
+- BranchModal Knowledge tab manages an assistant policy grant list over namespaces.
+- Effective assistant access is:
+
+```text
+assistant_branch_grant(namespace) ∩ effective_user_namespace_permission(namespace)
+```
+
+The assistant is not a separate KB principal in V1. It runs as a real Agor user/session, then the assistant branch grant list narrows where assistant-specific tools can read/write. Crucially, the assistant cannot edit that grant list through MCP; otherwise it could grant itself write access to new namespaces and elevate its own effective scope.
+
+### Defaults
+
+- Primary assistant namespace: open by default (`others_can: write`, docs `visibility: public` by default), matching Agor's default collaboration model.
+- Additional namespaces: assistant-specific tools have write fallback by default through `global_access: write`, still intersected with the current user's normal KB permissions. Per-namespace overrides can narrow access to `none` or `read`.
+- Owners can narrow namespace access later in Knowledge settings and BranchModal -> Knowledge.
+
+### Accumulator/list
+
+V1 storage options:
+
+1. **Small first PR:** store grants in `branch.custom_context.assistant.kb.grants`.
+2. **Follow-up if needed:** add `branch_knowledge_namespace_grants` with:
+   - `branch_id`
+   - `namespace_id`
+   - `access: none | read | write`
+   - `is_primary`
+   - audit fields
+
+- Do not overload `kb_namespace_acl` with branch subjects in V1. PR #1382 intentionally models namespace ACL subjects as users/groups.
+- Do not register MCP tools that mutate this accumulator. Branch/assistant Knowledge policy is controlled by UI/API-only services, not by the assistant's own tool surface.
+
+## 4. Existing KB tools/API context behavior
+
+### Generic KB tools
+
+Keep generic tools backward-compatible:
+
+- `agor_kb_put`, `agor_kb_edit`, `agor_kb_get`, `agor_kb_search` continue accepting explicit `namespace`/`uri`.
+- Do not force the assistant namespace for generic tools.
+- Improve error text by including namespace slug and required permission when the service can identify it.
+- Optional later: if no namespace is supplied and MCP has a current assistant context, generic tools may suggest `Use agor_assistant_memory_append or pass namespace: <primarySlug>` rather than guessing.
+
+### Assistant-aware wrappers
+
+Add wrappers that are context-aware and bounded:
+
+- `agor_assistant_kb_search`: default search scopes are primary namespace plus branch-granted read namespaces. Accept optional `includeShared: boolean` or explicit `namespaces`, but reject any namespace outside the grant list.
+- `agor_assistant_memory_search`: hard-default `kind: memory`, `pathPrefix: memory/`, primary namespace.
+- `agor_assistant_memory_append`: write only to primary namespace unless a future `target` is explicitly allowed.
+- `agor_assistant_context`: read-only; may return primary namespace and grants, but must not accept mutation arguments.
+
+Explicit non-goal for MCP: no `agor_assistant_namespace_set`, no `agor_assistant_grant_put`, and no generic MCP path that patches `custom_context.assistant.kb`. If MCP needs repair diagnostics, return instructions for a human/API caller instead of performing the mutation.
+
+### Context resolver
+
+Create a shared daemon helper for MCP/services:
+
+```ts
+resolveAssistantKnowledgeContext(ctx): {
+  session;
+  branch;
+  assistantConfig;
+  primaryNamespace;
+  grants;
+  effectiveUserPermission;
+}
+```
+
+Use existing `ctx.sessionId`, `sessions.get`, `branches.get`, and `KnowledgeNamespaceRepository.resolveNamespacePermission`.
+
+## 5. Data model, migrations, services
+
+### Smallest viable data changes
+
+No required migration for the first PR if we use:
+
+- `branch.custom_context.assistant.kb` for the branch binding/policy.
+- Existing `kb_namespaces.branch_id`, `kind`, `metadata`, `visibility_default`, `others_can` for namespace metadata.
+- Existing `kb_namespace_acl` for user/group security.
+
+Type changes still needed:
+
+- Add `AssistantKnowledgeConfig` to `packages/core/src/types/branch.ts` and include `kb?: AssistantKnowledgeConfig` in `AssistantConfig`.
+- Add tests for `getAssistantConfig` preserving `kb` metadata.
+
+### Services/helpers likely needed
+
+- New helper module near branches/knowledge services: `assistant-knowledge.ts`.
+- API-only custom methods for configuration, e.g. `/branches/:id/assistant-knowledge` or `/assistant/knowledge/config`, used by UI/CLI and protected by branch-owner/admin checks. Do not expose these as MCP tools.
+- Optional read-only Feathers/service method for context: `/assistant/knowledge/context` or `/kb/assistant-context`.
+- MCP registrations in a new `apps/agor-daemon/src/mcp/tools/assistant-knowledge.ts` or in `knowledge.ts` if kept small; MCP registrations should be read/append/search only, not configuration mutation.
+- BranchModal Knowledge tab UI slice and client calls to `kb/namespaces`/`kb/documents` plus the API-only assistant Knowledge config method.
+
+### Follow-up normalized table
+
+If custom context becomes hard to query or audit, add `branch_knowledge_namespace_grants` rather than changing PR #1382 ACL semantics. This table is an assistant/branch **policy allowlist**, not the KB security ACL itself.
+
+## 6. Phased implementation plan
+
+### PR 1: foundation and visible binding
+
+- Add typed `AssistantKnowledgeConfig`.
+- Add idempotent `ensureAssistantKnowledgeNamespace` helper.
+- Invoke it from assistant creation before the bootstrap session starts; use `agor_assistant_context` only for read/diagnostic legacy missing-namespace reporting.
+- Add BranchModal -> Knowledge tab that can display/create/repair/select the primary namespace via API/UI-only calls.
+- Store binding in `branch.custom_context.assistant.kb` and mirror on namespace metadata.
+- Tests:
+  - helper creates an open namespace (`others_can: write`, `visibility_default: public`) with creator `own` ACL
+  - helper is idempotent
+  - namespace setup failure during assistant creation bubbles as a hard failure
+  - existing assistant without binding is left undefined and MCP tools fail with `namespace for this agent is not set up`
+  - MCP cannot mutate assistant KB config or grant itself namespace access
+  - BranchModal tab renders missing/configured namespace states
+
+### PR 2: memory append tool
+
+- Add `agor_assistant_memory_append` and `agor_assistant_memory_search`.
+- Implement deterministic append blocks, idempotency, and helpful permission errors.
+- Use existing KB document write/version/indexing path.
+- Tests:
+  - requires session context
+  - rejects non-assistant branches
+  - rejects missing namespace with `namespace for this agent is not set up`
+  - rejects no write access
+  - appends multiple bullets into one version
+  - duplicate idempotency key/hash does not duplicate content
+
+### PR 3: branch namespace grant accumulator
+
+- Add BranchModal Knowledge grants list over namespaces.
+- Initially store in `custom_context.assistant.kb.grants`.
+- Add `agor_assistant_kb_search` bounded by grants.
+- Tests for read/write narrowing as intersection with user KB ACL.
+
+### PR 4: chunk reuse and optional normalization
+
+- Split memory docs into units by `agor-memory-entry` blocks.
+- Reuse unchanged unit hashes/embeddings across versions.
+- Consider `branch_knowledge_namespace_grants` migration if queries/UI need stronger auditability.
+
+## Open design questions
+
+- Should BranchModal Knowledge appear for all branches after assistant V1, making branch namespaces a general feature?
+- Should "scratchpad" be KB documents under `scratchpad/` or remain temporary filesystem state with optional publish-to-KB?

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -578,7 +578,10 @@ describe('createClient', () => {
       const branchesService = client.service('branches') as unknown as {
         methods: MockedFunction<(...names: string[]) => unknown>;
       };
-      expect(branchesService.methods).toHaveBeenCalledWith('initializeUnixGroup');
+      expect(branchesService.methods).toHaveBeenCalledWith(
+        'initializeUnixGroup',
+        'ensureAssistantKnowledgeNamespace'
+      );
     });
 
     it('does not register custom methods on services without any', () => {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -452,6 +452,15 @@ export interface BranchesService extends AgorService<Branch> {
   ): Promise<{ unixGroup: string }>;
 
   /**
+   * Create or repair the primary Knowledge namespace for an assistant branch.
+   * API/UI-only; not exposed through assistant MCP config mutation tools.
+   */
+  ensureAssistantKnowledgeNamespace(
+    data: { branchId?: string; branch_id?: string } | string,
+    params?: Params
+  ): Promise<{ namespace: KnowledgeNamespace; branch: Branch }>;
+
+  /**
    * Find branch by repo_id and name
    */
   findByRepoAndName(repoId: string, name: string, params?: Params): Promise<Branch | null>;
@@ -807,7 +816,7 @@ function extendBranchesService(client: AgorClient): void {
   };
   if (branchesService[BRANCHES_SERVICE_EXTENDED]) return;
   if (typeof branchesService.methods === 'function') {
-    branchesService.methods('initializeUnixGroup');
+    branchesService.methods('initializeUnixGroup', 'ensureAssistantKnowledgeNamespace');
   }
   branchesService[BRANCHES_SERVICE_EXTENDED] = true;
 }

--- a/packages/core/src/types/branch.ts
+++ b/packages/core/src/types/branch.ts
@@ -1,5 +1,6 @@
 // src/types/branch.ts
 import type { BoardID, BranchID, UUID } from './id';
+import type { KnowledgeNamespaceID, KnowledgeVisibility } from './knowledge';
 import type { BranchName } from './repo';
 
 /**
@@ -681,6 +682,28 @@ export type RepoEnvironmentConfig = RepoEnvironmentConfigV1;
 
 // ===== Assistants =====
 
+export type AssistantKnowledgeGrantAccess = 'none' | 'read' | 'write';
+export interface AssistantKnowledgeGrant {
+  namespace_id: KnowledgeNamespaceID;
+  namespace_slug: string;
+  access: AssistantKnowledgeGrantAccess;
+}
+
+export interface AssistantKnowledgeConfig {
+  primary_namespace_id: KnowledgeNamespaceID;
+  primary_namespace_slug: string;
+  memory_path_template: 'memory/{{YYYY-MM-DD}}.md';
+  default_visibility: KnowledgeVisibility;
+  /**
+   * Assistant-tool policy for namespaces not listed in `grants`.
+   *
+   * This is an assistant-specific ceiling; effective access is still
+   * intersected with the calling user's Knowledge namespace permission.
+   */
+  global_access?: AssistantKnowledgeGrantAccess;
+  grants?: AssistantKnowledgeGrant[];
+}
+
 /**
  * Configuration for an assistant, stored in branch.custom_context.assistant
  *
@@ -700,6 +723,8 @@ export interface AssistantConfig {
   frameworkVersion?: string;
   /** Whether this was created via the onboarding wizard */
   createdViaOnboarding?: boolean;
+  /** Knowledge Base namespace and grant config for assistant memory/context. */
+  kb?: AssistantKnowledgeConfig;
 }
 
 /** @deprecated Use AssistantConfig instead */


### PR DESCRIPTION
## Summary

- Creates an assistant home Knowledge namespace during assistant branch creation and exposes a Branch Modal → Knowledge tab to create/repair and configure assistant KB policy.
- Adds assistant-specific MCP tools for context-aware memory/search, including `agor_assistant_memory_append` writing to `memory/YYYY-MM-DD.md` in the assistant home namespace.
- Enforces that assistant KB configuration is API/UI-owner/admin controlled and cannot be mutated through generic MCP branch updates.
- Documents the design in `context/explorations/assistant-kb-namespace-memory-plan.md`.

## Tests

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- assistant-knowledge.test.ts`
