### PR TITLE
Remove compact branch pill nuke action

### DIFF
--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -1,0 +1,100 @@
+import type { Branch, Repo } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('antd', async () => {
+  const React = await import('react');
+
+  return {
+    Button: ({
+      children,
+      icon,
+      ...props
+    }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) =>
+      React.createElement('button', props, icon, children),
+    Spin: () => React.createElement('span', null, 'loading'),
+    Tooltip: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    Tag: Object.assign(
+      ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) =>
+        React.createElement('span', props, children),
+      {
+        CheckableTag: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) =>
+          React.createElement('span', props, children),
+      }
+    ),
+    theme: {
+      useToken: () => ({
+        token: {
+          colorBorderSecondary: '#ddd',
+          colorError: '#f00',
+          colorInfo: '#00f',
+          colorSuccess: '#0a0',
+          colorTextDisabled: '#999',
+          colorWarning: '#fa0',
+          fontFamilyCode: 'monospace',
+          fontSizeSM: 12,
+        },
+      }),
+    },
+  };
+});
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    role: 'admin',
+    isAdmin: true,
+    isSuperAdmin: false,
+    hasRole: () => true,
+  }),
+}));
+
+vi.mock('../../hooks/useConfirmNukeEnvironment', () => ({
+  useConfirmNukeEnvironment: () => vi.fn(),
+}));
+
+import { BranchHeaderPill } from './BranchHeaderPill';
+
+const repo = {
+  repo_id: 'repo-1',
+  slug: 'preset-io/agor',
+  environment_config: {
+    up_command: 'pnpm dev',
+    down_command: 'pnpm stop',
+    nuke_command: 'docker compose down -v',
+    logs_command: 'docker compose logs',
+  },
+} as Repo;
+
+const branch = {
+  branch_id: 'branch-1',
+  repo_id: repo.repo_id,
+  name: 'feature/remove-nuke',
+  nuke_command: 'docker compose down -v',
+  others_can: 'all',
+  environment_instance: { status: 'stopped' },
+} as Branch;
+
+const defaultProps = {
+  repo,
+  branch,
+  onOpenBranch: vi.fn(),
+  onStartEnvironment: vi.fn(),
+  onStopEnvironment: vi.fn(),
+  onViewLogs: vi.fn(),
+  onNukeEnvironment: vi.fn(),
+};
+
+describe('BranchHeaderPill', () => {
+  it('hides the destructive nuke action in compact mode', () => {
+    render(<BranchHeaderPill {...defaultProps} compact />);
+
+    expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the destructive nuke action in non-compact mode', () => {
+    render(<BranchHeaderPill {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Nuke environment' })).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -89,6 +89,9 @@ describe('BranchHeaderPill', () => {
   it('hides the destructive nuke action in compact mode', () => {
     render(<BranchHeaderPill {...defaultProps} compact />);
 
+    expect(screen.getByRole('button', { name: 'Start environment' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Stop environment' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View environment logs' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
   });
 

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -346,7 +346,7 @@ export function BranchHeaderPill({
               )}
 
               {/* Nuke button */}
-              {onNukeEnvironment && branch.nuke_command && (
+              {!compact && onNukeEnvironment && branch.nuke_command && (
                 <Tooltip title={controlDisabledTooltip ?? 'Nuke environment (destructive)'}>
                   <Button
                     type="text"

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -36,7 +36,10 @@ interface BranchHeaderPillProps {
   connectionDisabled?: boolean;
   /** Show environment status/controls and environment shortcut. Defaults to true. */
   showEnvButtons?: boolean;
-  /** Compact identity section for constrained side panels. Hides the repo slug but keeps it in the tooltip. */
+  /**
+   * Compact rendering for constrained side panels.
+   * Hides the repo slug in the identity section and omits destructive environment actions.
+   */
   compact?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Hide the destructive nuke environment action when `BranchHeaderPill` renders in compact mode.
- Keep the nuke action available in the full/non-compact branch pill controls.
- Add focused component coverage for compact vs non-compact rendering.

## Validation
- `pnpm i`
- `pnpm exec biome format --write apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx`
- `pnpm check` (passes with existing repository warnings)
- `pnpm --filter agor-ui test -- src/components/BranchHeaderPill/BranchHeaderPill.test.tsx`
- `git diff --check`
