### PR TITLE
Fix group RBAC for environment actions

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -110,6 +110,32 @@ const fakeRepo = {
   },
 };
 
+describe('environment tool authorization plumbing', () => {
+  it('passes MCP base service params to environment actions for service-layer RBAC', async () => {
+    const params = { provider: 'mcp', user: { user_id: 'user-1', role: 'member' } };
+    const startCalls: unknown[][] = [];
+    const ctx = {
+      ...makeCtx({
+        branches: {
+          startEnvironment: async (...args: unknown[]) => {
+            startCalls.push(args);
+            throw new Error("You need 'all' branch permission or admin access to start");
+          },
+        },
+      }),
+      baseServiceParams: params,
+    };
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ branchId: 'wt-1' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/'all' branch permission/);
+    expect(startCalls).toEqual([['wt-1', params]]);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // agor_environment_set
 // ---------------------------------------------------------------------------

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -79,6 +79,7 @@ import {
   requireMinimumRole,
 } from './utils/authorization.js';
 import {
+  cacheBranchAccess,
   ensureBranchPermission,
   ensureCanCreateSession,
   ensureCanModifySchedule,
@@ -522,10 +523,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                       continue; // Skip if branch doesn't exist
                     }
 
-                    const isOwner = await branchRepository.isOwner(branch.branch_id, userId);
-                    const effectivePermission = branch.others_can ?? 'session';
-                    const hasAccess =
-                      isOwner || PERMISSION_RANK[effectivePermission] >= PERMISSION_RANK.view;
+                    const effectivePermission = await branchRepository.resolveUserPermission(
+                      branch,
+                      userId
+                    );
+                    const hasAccess = PERMISSION_RANK[effectivePermission] >= PERMISSION_RANK.view;
 
                     if (hasAccess) {
                       authorizedBoardObjects.push(boardObject);
@@ -1949,16 +1951,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                     if (!branch) {
                       throw new Forbidden(`Branch not found: ${data.branch_id}`);
                     }
-                    const userId = context.params.user?.user_id as
-                      | import('@agor/core/types').UUID
-                      | undefined;
-                    const isOwner = userId
-                      ? await branchRepository.isOwner(branch.branch_id, userId)
-                      : false;
-
                     // Cache for later hooks (RBACParams fields)
-                    context.params.branch = branch;
-                    context.params.isBranchOwner = isOwner;
+                    await cacheBranchAccess(context.params, branchRepository, branch);
                   } catch (error) {
                     console.error('Failed to load branch for RBAC check:', error);
                     throw error;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -101,6 +101,7 @@ import {
   requireMinimumRole,
 } from './utils/authorization.js';
 import {
+  cacheBranchAccess,
   checkSessionOwnerOrAdmin,
   ensureBranchPermission,
   loadScheduleAndBranch,
@@ -1504,12 +1505,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               throw new NotFound(`Branch ${session.branch_id} not found`);
             }
             const isOwner = await branchRepository.isOwner(wt.branch_id, userId);
+            const branchPermission = await branchRepository.resolveUserPermission(wt, userId);
             const effectiveLevel = resolveBranchPermission(
               wt,
               userId,
               isOwner,
               params.user?.role,
-              superadminOpts.allowSuperadmin
+              superadminOpts.allowSuperadmin,
+              branchPermission
             );
             const canRun =
               PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.prompt ||
@@ -1774,12 +1777,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           return res.status(404).json({ error: 'Branch not found' });
         }
         const isOwner = await branchRepo.isOwner(wt.branch_id, userId);
+        const branchPermission = await branchRepo.resolveUserPermission(wt, userId);
         const effectiveLevel = resolveBranchPermission(
           wt,
           userId,
           isOwner,
           params.user?.role,
-          superadminOpts.allowSuperadmin
+          superadminOpts.allowSuperadmin,
+          branchPermission
         );
 
         const canUpload =
@@ -2324,6 +2329,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     app: app as any,
     isBranchOwner: async (branchId: string, userId: UUID) =>
       branchRepository.isOwner(branchId as import('@agor/core/types').BranchID, userId),
+    resolveBranchPermission: async (branch: import('@agor/core/types').Branch, userId: UUID) =>
+      branchRepository.resolveUserPermission(branch, userId),
   };
 
   registerAuthenticatedRoute(
@@ -2804,13 +2811,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             throw new Forbidden(`Branch not found: ${id}`);
           }
 
-          const userId = context.params.user?.user_id as
-            | import('@agor/core/types').UUID
-            | undefined;
-          const isOwner = userId ? await branchRepository.isOwner(branch.branch_id, userId) : false;
-
-          context.params.branch = branch;
-          context.params.isBranchOwner = isOwner;
+          await cacheBranchAccess(context.params, branchRepository, branch);
 
           return context;
         },
@@ -2855,13 +2856,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             throw new Forbidden(`Branch not found: ${id}`);
           }
 
-          const userId = context.params.user?.user_id as
-            | import('@agor/core/types').UUID
-            | undefined;
-          const isOwner = userId ? await branchRepository.isOwner(branch.branch_id, userId) : false;
-
-          context.params.branch = branch;
-          context.params.isBranchOwner = isOwner;
+          await cacheBranchAccess(context.params, branchRepository, branch);
 
           return context;
         },
@@ -3035,11 +3030,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             throw new NotFound(`Branch not found: ${id}`);
           }
 
-          const userId = context.params.user?.user_id as UUID | undefined;
-          const isOwner = userId ? await branchRepository.isOwner(branch.branch_id, userId) : false;
-
-          context.params.branch = branch;
-          context.params.isBranchOwner = isOwner;
+          await cacheBranchAccess(context.params, branchRepository, branch);
           return context;
         },
         branchRbacEnabled

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -1,5 +1,7 @@
-import type { Application, BoardID, BranchID } from '@agor/core/types';
+import { BranchRepository, GroupRepository, RepoRepository, UsersRepository } from '@agor/core/db';
+import type { Application, BoardID, BranchID, UUID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { BranchesService } from './branches';
 
 function createRenderEnvHarness(opts: {
@@ -574,5 +576,157 @@ describe('BranchesService managed environment control authorization', () => {
       branch_id: branchId,
     });
     expect(branchRepo.findById).not.toHaveBeenCalled();
+  });
+
+  dbTest('allows a group grant with effective all to start/stop environments', async ({ db }) => {
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+    const groups = new GroupRepository(db);
+
+    const owner = await users.create({
+      email: 'env-owner@example.com',
+      name: 'Env Owner',
+      role: 'member',
+    });
+    const member = await users.create({
+      email: 'env-group-all@example.com',
+      name: 'Env Group All',
+      role: 'member',
+    });
+    const repo = await repos.create({
+      name: 'env-rbac-repo',
+      slug: 'env-rbac-repo',
+      repo_type: 'local',
+      local_path: '/tmp/env-rbac-repo',
+      default_branch: 'main',
+    });
+    const branch = await branches.create({
+      branch_id: '019f0000-0000-7000-8000-00000000e001' as BranchID,
+      repo_id: repo.repo_id,
+      name: 'env-group-all',
+      ref: 'env-group-all',
+      path: '/tmp/env-rbac-repo/env-group-all',
+      created_by: owner.user_id as UUID,
+      branch_unique_id: 9001,
+      new_branch: true,
+      others_can: 'none',
+    });
+    const group = await groups.create({ name: 'Env Controllers', created_by: owner.user_id });
+    await groups.addMember(group.group_id, member.user_id, owner.user_id);
+    await groups.upsertBranchGrant({
+      branch_id: branch.branch_id,
+      group_id: group.group_id,
+      can: 'all',
+      created_by: owner.user_id,
+    });
+
+    const service = new BranchesService(db, { service: vi.fn() } as unknown as Application);
+    const getSpy = vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    const updateEnvironmentSpy = vi
+      .spyOn(service, 'updateEnvironment')
+      .mockResolvedValue(branch as never);
+
+    await expect(
+      service.startEnvironment(branch.branch_id, paramsFor(member.user_id, 'member'))
+    ).rejects.toThrow(/No start command configured/);
+    expect(getSpy).toHaveBeenCalled();
+
+    getSpy.mockClear();
+    await expect(
+      service.stopEnvironment(branch.branch_id, paramsFor(member.user_id, 'member'))
+    ).resolves.toMatchObject({ branch_id: branch.branch_id });
+    expect(getSpy).toHaveBeenCalled();
+    expect(updateEnvironmentSpy).toHaveBeenCalled();
+  });
+
+  dbTest('allows direct owners to start environments', async ({ db }) => {
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+
+    const owner = await users.create({
+      email: 'env-direct-owner@example.com',
+      name: 'Env Direct Owner',
+      role: 'member',
+    });
+    const repo = await repos.create({
+      name: 'env-direct-owner-repo',
+      slug: 'env-direct-owner-repo',
+      repo_type: 'local',
+      local_path: '/tmp/env-direct-owner-repo',
+      default_branch: 'main',
+    });
+    const branch = await branches.create({
+      branch_id: '019f0000-0000-7000-8000-00000000e002' as BranchID,
+      repo_id: repo.repo_id,
+      name: 'env-direct-owner',
+      ref: 'env-direct-owner',
+      path: '/tmp/env-direct-owner-repo/env-direct-owner',
+      created_by: owner.user_id as UUID,
+      branch_unique_id: 9002,
+      new_branch: true,
+      others_can: 'none',
+    });
+    await branches.addOwner(branch.branch_id, owner.user_id as UUID);
+
+    const service = new BranchesService(db, { service: vi.fn() } as unknown as Application);
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+
+    await expect(
+      service.startEnvironment(branch.branch_id, paramsFor(owner.user_id, 'member'))
+    ).rejects.toThrow(/No start command configured/);
+  });
+
+  dbTest('rejects insufficient group grants before environment actions run', async ({ db }) => {
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+    const groups = new GroupRepository(db);
+
+    const owner = await users.create({
+      email: 'env-owner-view@example.com',
+      name: 'Env Owner View',
+      role: 'member',
+    });
+    const member = await users.create({
+      email: 'env-group-view@example.com',
+      name: 'Env Group View',
+      role: 'member',
+    });
+    const repo = await repos.create({
+      name: 'env-rbac-view-repo',
+      slug: 'env-rbac-view-repo',
+      repo_type: 'local',
+      local_path: '/tmp/env-rbac-view-repo',
+      default_branch: 'main',
+    });
+    const branch = await branches.create({
+      branch_id: '019f0000-0000-7000-8000-00000000e003' as BranchID,
+      repo_id: repo.repo_id,
+      name: 'env-group-view',
+      ref: 'env-group-view',
+      path: '/tmp/env-rbac-view-repo/env-group-view',
+      created_by: owner.user_id as UUID,
+      branch_unique_id: 9003,
+      new_branch: true,
+      others_can: 'none',
+    });
+    const group = await groups.create({ name: 'Env Viewers', created_by: owner.user_id });
+    await groups.addMember(group.group_id, member.user_id, owner.user_id);
+    await groups.upsertBranchGrant({
+      branch_id: branch.branch_id,
+      group_id: group.group_id,
+      can: 'prompt',
+      created_by: owner.user_id,
+    });
+
+    const service = new BranchesService(db, { service: vi.fn() } as unknown as Application);
+    const getSpy = vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+
+    await expect(
+      service.startEnvironment(branch.branch_id, paramsFor(member.user_id, 'member'))
+    ).rejects.toThrow(/'all' branch permission or admin access/);
+    expect(getSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -246,9 +246,20 @@ export class TerminalsService {
           throw new Forbidden(`Branch not found: ${data.branchId}`);
         }
         const isOwner = await branchRepo.isOwner(branch.branch_id, userId);
+        const effectivePermission = await branchRepo.resolveUserPermission(branch, userId);
         const allowSuperadmin = config.execution?.allow_superadmin === true;
         const userRole = params?.user?.role as string | undefined;
-        if (!hasBranchPermission(branch, userId, isOwner, 'session', userRole, allowSuperadmin)) {
+        if (
+          !hasBranchPermission(
+            branch,
+            userId,
+            isOwner,
+            'session',
+            userRole,
+            allowSuperadmin,
+            effectivePermission
+          )
+        ) {
           throw new Forbidden(
             `You need 'session' permission on branch ${branch.name} to open a terminal there.`
           );
@@ -401,10 +412,19 @@ export class TerminalsService {
             throw new Forbidden(`Session's branch not found: ${session.branch_id}`);
           }
           const isOwner = await branchRepo.isOwner(wt.branch_id, callerUserId);
+          const effectivePermission = await branchRepo.resolveUserPermission(wt, callerUserId);
           const allowSuperadmin = config.execution?.allow_superadmin === true;
           const userRole = params?.user?.role as string | undefined;
           if (
-            !hasBranchPermission(wt, callerUserId, isOwner, 'session', userRole, allowSuperadmin)
+            !hasBranchPermission(
+              wt,
+              callerUserId,
+              isOwner,
+              'session',
+              userRole,
+              allowSuperadmin,
+              effectivePermission
+            )
           ) {
             throw new Forbidden(
               `You need 'session' permission on the session's branch to ensure its CLI tab.`

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -126,6 +126,32 @@ export function resolveBranchPermission(
 }
 
 /**
+ * Cache branch access fields on Feathers params for downstream authorization
+ * hooks. Keep this as the single place that translates "current user + branch"
+ * into the direct-owner bit and the group-aware effective permission.
+ */
+export async function cacheBranchAccess(
+  params: AuthenticatedParams,
+  branchRepo: BranchRepository,
+  branch: Branch
+): Promise<void> {
+  const userId = params.user?.user_id as UUID | undefined;
+  const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
+  const branchPermission = userId
+    ? await branchRepo.resolveUserPermission(branch, userId)
+    : (branch.others_can ?? 'session');
+
+  const rbacParams = params as AuthenticatedParams & {
+    branch?: Branch;
+    isBranchOwner?: boolean;
+    branchPermission?: BranchPermissionLevel;
+  };
+  rbacParams.branch = branch;
+  rbacParams.isBranchOwner = isOwner;
+  rbacParams.branchPermission = branchPermission;
+}
+
+/**
  * Ensure the caller can control or mutate a branch's managed environment.
  *
  * Managed environment controls may run shell/webhook actions with impact tied
@@ -227,17 +253,8 @@ export function loadBranch(branchRepo: BranchRepository, branchIdField = 'branch
       throw new Forbidden(`Branch not found: ${branchId}`);
     }
 
-    // Check ownership
-    const userId = context.params.user?.user_id as UUID | undefined;
-    const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
-    const branchPermission = userId
-      ? await branchRepo.resolveUserPermission(branch, userId)
-      : (branch.others_can ?? 'session');
-
     // Cache on context for downstream hooks (type-safe via RBACParams)
-    context.params.branch = branch;
-    context.params.isBranchOwner = isOwner;
-    context.params.branchPermission = branchPermission;
+    await cacheBranchAccess(context.params, branchRepo, branch);
 
     return context;
   };
@@ -673,14 +690,9 @@ export function loadSessionBranch(
       throw new Forbidden(`Branch not found: ${session.branch_id}`);
     }
 
-    // Check ownership
-    const userId = context.params.user?.user_id as UUID | undefined;
-    const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
-
     // Cache on context for downstream hooks (type-safe via RBACParams)
     context.params.session = session;
-    context.params.branch = branch;
-    context.params.isBranchOwner = isOwner;
+    await cacheBranchAccess(context.params, branchRepo, branch);
 
     return context;
   };
@@ -848,17 +860,8 @@ export function loadBranchFromSession(branchRepo: BranchRepository) {
       throw new Forbidden(`Branch not found: ${session.branch_id}`);
     }
 
-    // Check ownership
-    const userId = context.params.user?.user_id as UUID | undefined;
-    const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
-    const branchPermission = userId
-      ? await branchRepo.resolveUserPermission(branch, userId)
-      : (branch.others_can ?? 'session');
-
     // Cache on context for downstream hooks (type-safe via RBACParams)
-    context.params.branch = branch;
-    context.params.isBranchOwner = isOwner;
-    context.params.branchPermission = branchPermission;
+    await cacheBranchAccess(context.params, branchRepo, branch);
 
     return context;
   };
@@ -1732,16 +1735,8 @@ export function loadScheduleAndBranch(
       throw new NotFound(`Branch not found for schedule: ${schedule.schedule_id}`);
     }
 
-    const userId = context.params.user?.user_id as UUID | undefined;
-    const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
-    const branchPermission = userId
-      ? await branchRepo.resolveUserPermission(branch, userId)
-      : (branch.others_can ?? 'session');
-
     context.params.schedule = schedule;
-    context.params.branch = branch;
-    context.params.isBranchOwner = isOwner;
-    context.params.branchPermission = branchPermission;
+    await cacheBranchAccess(context.params, branchRepo, branch);
     return context;
   };
 }

--- a/apps/agor-daemon/src/widgets/submissions.ts
+++ b/apps/agor-daemon/src/widgets/submissions.ts
@@ -54,6 +54,8 @@ export interface WidgetResolverDeps {
   app: WidgetResolverApp;
   /** Branch ownership lookup — pulled out so tests can stub without RBAC plumbing. */
   isBranchOwner(branchId: string, userId: UserID): Promise<boolean>;
+  /** Optional group-aware effective branch permission lookup. */
+  resolveBranchPermission?(branch: Branch, userId: UserID): Promise<Branch['others_can']>;
 }
 
 export interface AuthenticatedCaller {
@@ -81,10 +83,18 @@ export function canResolveWidget(
   caller: AuthenticatedCaller,
   session: Pick<Session, 'created_by'>,
   branch: Branch,
-  isOwner: boolean
+  isOwner: boolean,
+  effectivePermission?: Branch['others_can']
 ): boolean {
   if (session.created_by === caller.user_id) return true;
-  const effective = resolveBranchPermission(branch, caller.user_id, isOwner, caller.role);
+  const effective = resolveBranchPermission(
+    branch,
+    caller.user_id,
+    isOwner,
+    caller.role,
+    true,
+    effectivePermission
+  );
   return PERMISSION_RANK[effective] >= PERMISSION_RANK.prompt;
 }
 
@@ -162,8 +172,9 @@ async function doResolveWidget(
   const session = (await deps.app.service('sessions').get(message.session_id)) as Session;
   const branch = (await deps.app.service('branches').get(session.branch_id)) as Branch;
   const isOwner = await deps.isBranchOwner(branch.branch_id, caller.user_id);
+  const effectivePermission = await deps.resolveBranchPermission?.(branch, caller.user_id);
 
-  if (!canResolveWidget(caller, session, branch, isOwner)) {
+  if (!canResolveWidget(caller, session, branch, isOwner, effectivePermission)) {
     throw new Forbidden(
       `You need to be the session creator, a branch owner, or have 'prompt' permission on the branch to resolve this widget.`
     );

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -13,7 +13,6 @@ import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
-import { usePermissions } from '../../hooks/usePermissions';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
@@ -101,7 +100,6 @@ const BranchCardComponent = ({
   client,
 }: BranchCardProps) => {
   const { token } = theme.useToken();
-  const { isAdmin } = usePermissions();
   const connectionDisabled = useConnectionDisabled();
 
   // Archive/Delete modal state
@@ -502,9 +500,6 @@ const BranchCardComponent = ({
             onStopEnvironment={onStopEnvironment}
             onViewLogs={onViewLogs}
             onNukeEnvironment={onNukeEnvironment}
-            canControlEnvironment={
-              isAdmin || branch.others_can === 'all' || branch.created_by === currentUserId
-            }
             connectionDisabled={connectionDisabled}
           />
         </Space>

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -17,7 +17,6 @@ import {
 } from '@ant-design/icons';
 import { Button, Spin, Tooltip, theme } from 'antd';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
-import { usePermissions } from '../../hooks/usePermissions';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import type { BranchModalTab } from '../BranchModal/BranchModal';
@@ -67,15 +66,17 @@ export function BranchHeaderPill({
   compact = false,
 }: BranchHeaderPillProps) {
   const { token } = theme.useToken();
-  const { isAdmin } = usePermissions();
   const confirmNuke = useConfirmNukeEnvironment();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = branch.environment_instance;
   const inferredState = getEnvironmentState(env);
   const environmentUrl = branch.app_url;
-  const resolvedCanControlEnvironment =
-    canControlEnvironment ?? (isAdmin || branch.others_can === 'all');
+  // If a parent has loaded effective branch access (e.g. BranchModal), honor
+  // that explicit decision. Otherwise do not infer from direct ownership or
+  // `others_can`: group grants are not present on this branch payload, and the
+  // daemon is the source of truth for environment authorization.
+  const resolvedCanControlEnvironment = canControlEnvironment ?? true;
   const controlDisabledTooltip = resolvedCanControlEnvironment
     ? undefined
     : "Requires branch 'all' permission or admin access";

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -12,7 +12,6 @@ import {
 } from '@ant-design/icons';
 import { Button, Space, Spin, Tooltip, theme } from 'antd';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
-import { usePermissions } from '../../hooks/usePermissions';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
@@ -41,13 +40,15 @@ export function EnvironmentPill({
   connectionDisabled = false,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
-  const { isAdmin } = usePermissions();
   const confirmNuke = useConfirmNukeEnvironment();
   const effectiveEnv = getEffectiveEnv(repo);
   const hasConfig = effectiveEnv.hasConfig;
   const env = branch.environment_instance;
-  const resolvedCanControlEnvironment =
-    canControlEnvironment ?? (isAdmin || branch.others_can === 'all');
+  // If a parent has loaded effective branch access (e.g. BranchModal), honor
+  // that explicit decision. Otherwise do not try to infer from direct owners or
+  // `others_can`: group grants are not present on the branch payload, and the
+  // daemon is the source of truth for environment authorization.
+  const resolvedCanControlEnvironment = canControlEnvironment ?? true;
   const controlDisabledTooltip = resolvedCanControlEnvironment
     ? undefined
     : "Requires branch 'all' permission or admin access";

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -13,7 +13,6 @@ import { Button, Divider, Space, Tabs, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppMcpData, useAppRepoData, useAppUserData } from '../../contexts/AppDataContext';
-import { usePermissions } from '../../hooks/usePermissions';
 import { copyToClipboard } from '../../utils/clipboard';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -71,7 +70,6 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     setCliViewMode,
   }) => {
     const { token } = theme.useToken();
-    const { isAdmin } = usePermissions();
     const { showSuccess, showError } = useThemedMessage();
 
     // Subscribe only to the entity families this panel needs. This keeps the
@@ -128,9 +126,6 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                   onStopEnvironment={onStopEnvironment}
                   onNukeEnvironment={onNukeEnvironment}
                   onViewLogs={onViewLogs}
-                  canControlEnvironment={
-                    isAdmin || branch.others_can === 'all' || branch.created_by === currentUserId
-                  }
                 />
               )}
               {/* Issue and PR Pills */}


### PR DESCRIPTION
## Summary

- Centralize branch access caching so direct ownership and group-derived effective permissions are cached together.
- Ensure managed environment controls honor group grants with effective branch `all` permission.
- Patch nearby RBAC checks that were still deriving access from direct ownership / `others_can` only.
- Avoid client-side false negatives for environment controls where group grants are not present in branch payloads.

## Details

The environment service already gates start/stop/restart/nuke/logs/render through a shared service-layer authorization check, but several RBAC preloading paths cached only `isBranchOwner` and omitted the group-aware effective permission. Downstream checks could then fall back to `others_can` and ignore branch group grants.

This adds a shared `cacheBranchAccess(...)` helper that stores:

- `params.branch`
- `params.isBranchOwner`
- `params.branchPermission` via `BranchRepository.resolveUserPermission(...)`

It is reused by branch/session/schedule loaders and custom route preloads.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts src/mcp/tools/environment.test.ts src/widgets/submissions.test.ts src/services/terminals.test.ts`
- `pnpm --filter @agor/core test -- src/db/repositories/groups.test.ts`
- `git diff --check`

Note: `pnpm check` reports existing Biome warnings in unrelated files, but completed successfully.
