### PR TITLE
Soften failed tool call icon color

### DIFF
--- a/apps/agor-ui/src/components/ToolBlock/ToolBlock.test.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/ToolBlock.test.tsx
@@ -1,0 +1,31 @@
+import { CloseCircleOutlined } from '@ant-design/icons';
+import { render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { describe, expect, it } from 'vitest';
+import { ToolBlock } from './ToolBlock';
+
+describe('ToolBlock', () => {
+  it('renders failed tool-call status icons with the warning tone', () => {
+    render(
+      <ConfigProvider
+        theme={{
+          token: {
+            colorError: 'rgb(255, 0, 0)',
+            colorWarning: 'rgb(255, 170, 0)',
+          },
+        }}
+      >
+        <ToolBlock
+          icon={<CloseCircleOutlined data-testid="tool-failure-icon" />}
+          name="Bash"
+          status="error"
+        />
+      </ConfigProvider>
+    );
+
+    const statusIconWrapper = screen.getByTestId('tool-failure-icon').parentElement as HTMLElement;
+
+    expect(statusIconWrapper).toHaveStyle({ color: 'rgb(255, 170, 0)' });
+    expect(statusIconWrapper).not.toHaveStyle({ color: 'rgb(255, 0, 0)' });
+  });
+});

--- a/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/ToolBlock.tsx
@@ -45,7 +45,7 @@ export const ToolBlock: React.FC<ToolBlockProps> = ({
 
   const statusColor =
     status === 'error'
-      ? token.colorError
+      ? token.colorWarning
       : status === 'pending'
         ? token.colorTextQuaternary
         : status === 'stale'


### PR DESCRIPTION
## Summary

- Change failed tool-call status icons from the error tone to the warning tone.
- Keep the existing circled-X affordance while making expected/recoverable tool failures less alarming.
- Add focused ToolBlock coverage for the warning-tone failed tool-call icon.

## Validation

- `pnpm i`
- `pnpm check` *(passes; existing repo warnings from Biome are still reported)*
- `pnpm --dir apps/agor-ui test src/components/ToolBlock/ToolBlock.test.tsx`
- `git diff --check`
