### PR TITLE
Fix archived branch zone entity queries

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -121,7 +121,10 @@ describe('agor_boards_get', () => {
     },
   };
 
-  function makeApp(options?: { boardObjectsFind?: ReturnType<typeof vi.fn> }) {
+  function makeApp(options?: {
+    boardObjectsFind?: ReturnType<typeof vi.fn>;
+    branchesFind?: ReturnType<typeof vi.fn>;
+  }) {
     const boardsGet = vi.fn(async () => board);
     const boardObjectsFind =
       options?.boardObjectsFind ??
@@ -131,14 +134,21 @@ describe('agor_boards_get', () => {
         limit: 100,
         skip: 0,
       }));
+    const branchesFind =
+      options?.branchesFind ??
+      vi.fn(async (params?: { query?: { branch_id?: { $in?: string[] } } }) =>
+        (params?.query?.branch_id?.$in ?? []).map((branch_id) => ({ branch_id, archived: false }))
+      );
 
     return {
       boardsGet,
       boardObjectsFind,
+      branchesFind,
       app: {
         service(name: string) {
           if (name === 'boards') return { get: boardsGet };
           if (name === 'board-objects') return { find: boardObjectsFind };
+          if (name === 'branches') return { find: branchesFind };
           throw new Error(`Unexpected service call: ${name}`);
         },
       },
@@ -198,7 +208,12 @@ describe('agor_boards_get', () => {
       limit: 100,
       skip: 0,
     }));
-    const { app } = makeApp({ boardObjectsFind });
+    const branchesFind = vi.fn(async () => [
+      { branch_id: 'branch-0', archived: false },
+      { branch_id: 'branch-1', archived: false },
+      { branch_id: 'branch-2', archived: false },
+    ]);
+    const { app } = makeApp({ boardObjectsFind, branchesFind });
     const getBoard = registerAndCaptureHandler('agor_boards_get', {
       app,
       userId: 'user-1',
@@ -223,12 +238,74 @@ describe('agor_boards_get', () => {
       },
       ...baseServiceParams,
     });
+    expect(branchesFind).toHaveBeenCalledWith({
+      query: {
+        branch_id: { $in: ['branch-0', 'branch-1', 'branch-2'] },
+        archived: false,
+      },
+      paginate: false,
+      ...baseServiceParams,
+    });
     expect(parsed.entities).toHaveLength(1);
     expect(parsed.entities[0].branch_id).toBe('branch-1');
     expect(parsed.entities_pagination).toEqual({ total: 3, limit: 1, skip: 1 });
   });
 
-  it('preserves includeEntities=true behavior when no entity filters are provided', async () => {
+  it('excludes archived branch entities by default while preserving card entities', async () => {
+    const boardObjectsFind = vi.fn(async () => ({
+      data: [
+        {
+          object_id: 'obj-branch-1',
+          board_id: 'board-1',
+          branch_id: 'branch-1',
+          entity_type: 'branch',
+          position: { x: 10, y: 20 },
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+        {
+          object_id: 'obj-branch-2',
+          board_id: 'board-1',
+          branch_id: 'branch-2',
+          entity_type: 'branch',
+          position: { x: 30, y: 40 },
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+        {
+          object_id: 'obj-card-1',
+          board_id: 'board-1',
+          card_id: 'card-1',
+          entity_type: 'card',
+          position: { x: 50, y: 60 },
+          created_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+      total: 3,
+      limit: 100,
+      skip: 0,
+    }));
+    const branchesFind = vi.fn(async () => [{ branch_id: 'branch-1', archived: false }]);
+    const { app } = makeApp({ boardObjectsFind, branchesFind });
+    const getBoard = registerAndCaptureHandler('agor_boards_get', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await getBoard({ boardId: 'board-1', includeEntities: true });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(boardObjectsFind).toHaveBeenCalledWith({
+      query: { board_id: 'board-1' },
+      ...baseServiceParams,
+    });
+    expect(parsed.entities.map((entity: { object_id: string }) => entity.object_id)).toEqual([
+      'obj-branch-1',
+      'obj-card-1',
+    ]);
+    expect(parsed.entities_pagination).toEqual({ total: 2, limit: null, skip: 0 });
+  });
+
+  it('includes archived branch entities when includeArchived=true', async () => {
     const boardObjectsFind = vi.fn(async () => ({
       data: [
         {
@@ -244,21 +321,24 @@ describe('agor_boards_get', () => {
       limit: 100,
       skip: 0,
     }));
-    const { app } = makeApp({ boardObjectsFind });
+    const branchesFind = vi.fn(async () => []);
+    const { app } = makeApp({ boardObjectsFind, branchesFind });
     const getBoard = registerAndCaptureHandler('agor_boards_get', {
       app,
       userId: 'user-1',
       baseServiceParams,
     });
 
-    const result = await getBoard({ boardId: 'board-1', includeEntities: true });
+    const result = await getBoard({
+      boardId: 'board-1',
+      includeEntities: true,
+      includeArchived: true,
+    });
     const parsed = JSON.parse(result.content[0].text);
 
-    expect(boardObjectsFind).toHaveBeenCalledWith({
-      query: { board_id: 'board-1' },
-      ...baseServiceParams,
-    });
+    expect(branchesFind).not.toHaveBeenCalled();
     expect(parsed.entities).toHaveLength(1);
+    expect(parsed.entities[0].branch_id).toBe('branch-1');
     expect(parsed.entities_pagination).toEqual({ total: 1, limit: null, skip: 0 });
   });
 

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -1,4 +1,10 @@
-import type { Board, BoardEntityType, BoardObject, BoardObjectType } from '@agor/core/types';
+import type {
+  Board,
+  BoardEntityType,
+  BoardObject,
+  BoardObjectType,
+  BranchID,
+} from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BoardsServiceImpl } from '../../declarations.js';
@@ -61,6 +67,12 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           .describe(
             'Include positioned entities (branches, cards) with their x/y coordinates and zone assignments (default: false). Enable when you need to know where branches are placed on the canvas.'
           ),
+        includeArchived: z
+          .boolean()
+          .optional()
+          .describe(
+            'When includeEntities=true, include archived branch entities. Default false excludes archived branches while preserving card entities.'
+          ),
         entityZoneId: mcpOptionalString(
           'entityZoneId',
           'When includeEntities=true, only return positioned entities pinned to this board zone ID.'
@@ -116,16 +128,43 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         const matchedEntities = (
           boardObjectsResult as { data: import('@agor/core/types').BoardEntityObject[] }
         ).data;
-        const total = matchedEntities.length;
+        let visibleEntities = matchedEntities;
+
+        if (args.includeArchived !== true) {
+          const branchIds = matchedEntities
+            .map((entity) => entity.branch_id)
+            .filter((branchId): branchId is BranchID => typeof branchId === 'string');
+
+          if (branchIds.length > 0) {
+            const activeBranchesResult = await ctx.app.service('branches').find({
+              query: {
+                branch_id: { $in: Array.from(new Set(branchIds)) },
+                archived: false,
+              },
+              paginate: false,
+              ...ctx.baseServiceParams,
+            });
+            const activeBranches = Array.isArray(activeBranchesResult)
+              ? activeBranchesResult
+              : (activeBranchesResult as { data: Array<{ branch_id: string }> }).data;
+            const activeBranchIds = new Set(activeBranches.map((branch) => branch.branch_id));
+
+            visibleEntities = matchedEntities.filter(
+              (entity) => !entity.branch_id || activeBranchIds.has(entity.branch_id)
+            );
+          }
+        }
+
+        const total = visibleEntities.length;
         const skip = args.entitiesSkip ?? 0;
         const limit = args.entitiesLimit ?? null;
         const entities =
           args.entitiesLimit !== undefined || args.entitiesSkip !== undefined
-            ? matchedEntities.slice(
+            ? visibleEntities.slice(
                 skip,
                 args.entitiesLimit === undefined ? undefined : skip + args.entitiesLimit
               )
-            : matchedEntities;
+            : visibleEntities;
 
         return textResult({
           ...board,

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -183,6 +183,63 @@ describe('branch MCP input schemas', () => {
   });
 });
 
+describe('agor_branches_set_zone', () => {
+  it('accepts zoneId null and clears the existing board object zone pin', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const branch = {
+      branch_id: 'branch-1',
+      board_id: 'board-1',
+      name: 'Branch 1',
+    };
+    const branchesGet = vi.fn(async () => branch);
+    const findByBranchId = vi.fn(async () => ({
+      object_id: 'obj-branch-1',
+      branch_id: 'branch-1',
+      zone_id: 'zone-review',
+    }));
+    const boardObjectsPatch = vi.fn(async () => ({
+      object_id: 'obj-branch-1',
+      branch_id: 'branch-1',
+      zone_id: undefined,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet };
+        if (name === 'board-objects') {
+          return {
+            findByBranchId,
+            patch: boardObjectsPatch,
+          };
+        }
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const setZone = registerAndCaptureHandler('agor_branches_set_zone', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await setZone({ branchId: 'branch-1', zoneId: null });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(branchesGet).toHaveBeenCalledWith('branch-1', baseServiceParams);
+    expect(findByBranchId).toHaveBeenCalledWith('branch-1', baseServiceParams);
+    expect(boardObjectsPatch).toHaveBeenCalledWith(
+      'obj-branch-1',
+      { zone_id: null },
+      baseServiceParams
+    );
+    expect(parsed.zone_id).toBeNull();
+    expect(parsed.note).toMatch(/cleared/i);
+  });
+});
+
 describe('agor_branches_list', () => {
   const baseServiceParams = {
     authenticated: true,

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -238,6 +238,43 @@ describe('agor_branches_set_zone', () => {
     expect(parsed.zone_id).toBeNull();
     expect(parsed.note).toMatch(/cleared/i);
   });
+
+  it('rejects trigger arguments when clearing the zone pin', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const branchesGet = vi.fn(async () => ({
+      branch_id: 'branch-1',
+      board_id: 'board-1',
+      name: 'Branch 1',
+    }));
+    const findByBranchId = vi.fn();
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet };
+        if (name === 'board-objects') {
+          return {
+            findByBranchId,
+            patch: vi.fn(),
+          };
+        }
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const setZone = registerAndCaptureHandler('agor_branches_set_zone', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await expect(
+      setZone({ branchId: 'branch-1', zoneId: null, triggerTemplate: true })
+    ).rejects.toThrow(/cannot be used when zoneId is null/i);
+    expect(findByBranchId).not.toHaveBeenCalled();
+  });
 });
 
 describe('agor_branches_list', () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -273,6 +273,9 @@ describe('agor_branches_set_zone', () => {
     await expect(
       setZone({ branchId: 'branch-1', zoneId: null, triggerTemplate: true })
     ).rejects.toThrow(/cannot be used when zoneId is null/i);
+    await expect(
+      setZone({ branchId: 'branch-1', zoneId: null, targetSessionId: 'bad-session' })
+    ).rejects.toThrow(/cannot be used when zoneId is null/i);
     expect(findByBranchId).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -905,17 +905,22 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     'agor_branches_set_zone',
     {
       description:
-        "Pin a branch to a zone on a board and optionally trigger the zone's prompt template. Calculates zone center position automatically and creates board association. If the zone has an 'always_new' trigger, a new session is automatically created and the prompt template is executed (matching UI drag-drop behavior). For 'show_picker' zones, use triggerTemplate + targetSessionId to send to an existing session.",
+        "Pin a branch to a zone on a board, clear its current zone pin with zoneId:null, and optionally trigger the zone's prompt template. Calculates zone center position automatically and creates board association. If the zone has an 'always_new' trigger, a new session is automatically created and the prompt template is executed (matching UI drag-drop behavior). For 'show_picker' zones, use triggerTemplate + targetSessionId to send to an existing session.",
       inputSchema: z.object({
         branchId: mcpRequiredId(
           'branchId',
           'Branch',
           'Branch ID to pin to the zone (UUIDv7 or short ID)'
         ),
-        zoneId: mcpRequiredString(
-          'zoneId',
-          'Zone ID to pin the branch to (e.g., "zone-1770152859108")'
-        ),
+        zoneId: z
+          .union([
+            mcpRequiredString(
+              'zoneId',
+              'Zone ID to pin the branch to (e.g., "zone-1770152859108")'
+            ),
+            z.null(),
+          ])
+          .describe('Zone ID to pin the branch to, or null to clear the current zone pin.'),
         targetSessionId: mcpOptionalId(
           'targetSessionId',
           'Session',
@@ -931,16 +936,66 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const branchId = await resolveBranchId(ctx, coerceString(args.branchId)!);
-      const zoneId = coerceString(args.zoneId)!;
+      const zoneId = args.zoneId === null ? null : coerceString(args.zoneId)!;
       const targetSessionId = coerceString(args.targetSessionId)
         ? await resolveSessionId(ctx, coerceString(args.targetSessionId)!)
         : undefined;
       const triggerTemplate = args.triggerTemplate === true;
 
-      console.log(`📍 MCP pinning branch ${shortId(branchId)} to zone ${zoneId}`);
+      console.log(
+        zoneId === null
+          ? `📍 MCP clearing zone pin for branch ${shortId(branchId)}`
+          : `📍 MCP pinning branch ${shortId(branchId)} to zone ${zoneId}`
+      );
 
       // Get branch to find its board
       const branch = await ctx.app.service('branches').get(branchId, ctx.baseServiceParams);
+
+      // Find or create board object for this branch
+      const boardObjectsService = ctx.app.service('board-objects') as unknown as {
+        findByBranchId: (
+          branchId: BranchID,
+          params?: unknown
+        ) => Promise<import('@agor/core/types').BoardEntityObject | null>;
+        create: (
+          data: unknown,
+          params?: unknown
+        ) => Promise<import('@agor/core/types').BoardEntityObject>;
+        patch: (
+          objectId: string,
+          data: Partial<Omit<import('@agor/core/types').BoardEntityObject, 'zone_id'>> & {
+            zone_id?: string | null;
+          },
+          params?: unknown
+        ) => Promise<import('@agor/core/types').BoardEntityObject>;
+      };
+
+      if (zoneId === null) {
+        const boardObject = await boardObjectsService.findByBranchId(
+          branchId as BranchID,
+          ctx.baseServiceParams
+        );
+        if (!boardObject) {
+          return textResult({
+            branch,
+            zone_id: null,
+            note: 'Branch has no board object; no zone pin to clear.',
+          });
+        }
+
+        const updatedBoardObject = await boardObjectsService.patch(
+          boardObject.object_id,
+          { zone_id: null },
+          ctx.baseServiceParams
+        );
+
+        return textResult({
+          branch,
+          boardObject: updatedBoardObject,
+          zone_id: null,
+          note: 'Branch zone pin cleared.',
+        });
+      }
 
       if (!branch.board_id) {
         throw new Error('Branch must be on a board before it can be pinned to a zone');
@@ -957,23 +1012,6 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       // Calculate position RELATIVE to zone (not absolute canvas coordinates)
       // The UI expects relative positions and adds zone.x/zone.y when rendering
       const { x: relativeX, y: relativeY } = computeZoneRelativePosition(zone as ZoneBoardObject);
-
-      // Find or create board object for this branch
-      const boardObjectsService = ctx.app.service('board-objects') as unknown as {
-        findByBranchId: (
-          branchId: BranchID,
-          params?: unknown
-        ) => Promise<import('@agor/core/types').BoardEntityObject | null>;
-        create: (
-          data: unknown,
-          params?: unknown
-        ) => Promise<import('@agor/core/types').BoardEntityObject>;
-        patch: (
-          objectId: string,
-          data: Partial<import('@agor/core/types').BoardEntityObject>,
-          params?: unknown
-        ) => Promise<import('@agor/core/types').BoardEntityObject>;
-      };
 
       let boardObject: import('@agor/core/types').BoardEntityObject | null =
         await boardObjectsService.findByBranchId(branchId as BranchID, ctx.baseServiceParams);

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -971,6 +971,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       };
 
       if (zoneId === null) {
+        if (triggerTemplate || targetSessionId) {
+          throw new Error(
+            'triggerTemplate and targetSessionId cannot be used when zoneId is null; clearing a zone pin does not run zone triggers.'
+          );
+        }
+
         const boardObject = await boardObjectsService.findByBranchId(
           branchId as BranchID,
           ctx.baseServiceParams

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -937,10 +937,18 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const branchId = await resolveBranchId(ctx, coerceString(args.branchId)!);
       const zoneId = args.zoneId === null ? null : coerceString(args.zoneId)!;
-      const targetSessionId = coerceString(args.targetSessionId)
-        ? await resolveSessionId(ctx, coerceString(args.targetSessionId)!)
-        : undefined;
+      const rawTargetSessionId = coerceString(args.targetSessionId);
       const triggerTemplate = args.triggerTemplate === true;
+
+      if (zoneId === null && (triggerTemplate || rawTargetSessionId)) {
+        throw new Error(
+          'triggerTemplate and targetSessionId cannot be used when zoneId is null; clearing a zone pin does not run zone triggers.'
+        );
+      }
+
+      const targetSessionId = rawTargetSessionId
+        ? await resolveSessionId(ctx, rawTargetSessionId)
+        : undefined;
 
       console.log(
         zoneId === null
@@ -971,12 +979,6 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       };
 
       if (zoneId === null) {
-        if (triggerTemplate || targetSessionId) {
-          throw new Error(
-            'triggerTemplate and targetSessionId cannot be used when zoneId is null; clearing a zone pin does not run zone triggers.'
-          );
-        }
-
         const boardObject = await boardObjectsService.findByBranchId(
           branchId as BranchID,
           ctx.baseServiceParams

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -54,6 +54,7 @@ function createPatchHarness(opts: {
     findByBranchId: vi.fn(async () => null),
     create: vi.fn(async () => ({ object_id: 'obj-1' })),
     remove: vi.fn(async () => ({})),
+    patch: vi.fn(async () => ({})),
   };
   const boardsService = {
     get: vi.fn(async () => ({ objects: {} })),
@@ -116,6 +117,7 @@ function createServiceHarness() {
     findByBranchId: vi.fn(async () => null),
     create: vi.fn(async () => ({ object_id: 'obj-1' })),
     remove: vi.fn(async () => ({})),
+    patch: vi.fn(async () => ({})),
   };
 
   const sessionsService = {
@@ -235,6 +237,34 @@ describe('BranchesService.patch primary assistant invariants', () => {
 
     expect(boardRepo.clearPrimaryAssistantIfMatches).toHaveBeenCalledWith(boardId, branchId);
     expect(boardRepo.setPrimaryAssistantIfUnset).not.toHaveBeenCalled();
+  });
+
+  it('preserves the board object zone pin when a branch is archived via patch', async () => {
+    const boardId = 'board-a' as BoardID;
+    const branchId = 'branch-archive-zone' as BranchID;
+    const { service, boardObjectsService } = createPatchHarness({
+      current: {
+        branch_id: branchId,
+        board_id: boardId,
+        archived: false,
+        custom_context: {},
+      },
+      updated: {
+        branch_id: branchId,
+        board_id: boardId,
+        archived: true,
+        custom_context: {},
+      },
+    });
+    boardObjectsService.findByBranchId.mockResolvedValue({
+      object_id: 'obj-branch',
+      zone_id: 'zone-review',
+    });
+
+    await service.patch(branchId, { archived: true });
+
+    expect(boardObjectsService.findByBranchId).not.toHaveBeenCalled();
+    expect(boardObjectsService.patch).not.toHaveBeenCalled();
   });
 
   it('rejects converting a normal branch into an assistant', async () => {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -432,6 +432,48 @@ describe('BranchesService.unarchive', () => {
   });
 });
 
+describe('BranchesService.archiveOrDelete', () => {
+  it('preserves a zoned board object when archiving through the archive operation', async () => {
+    const { service, boardObjectsService, sessionsService } = createServiceHarness();
+    const branchId = 'wt-archive-op' as BranchID;
+    const userId = 'user-1' as UUID;
+
+    vi.spyOn(service, 'get').mockResolvedValue({
+      branch_id: branchId,
+      name: 'WT Archive Op',
+      path: '/tmp/wt-archive-op',
+      archived: false,
+      board_id: 'board-a',
+      filesystem_status: 'ready',
+      environment_instance: { status: 'stopped' },
+    } as never);
+    vi.spyOn(service, 'patch').mockResolvedValue({
+      branch_id: branchId,
+      name: 'WT Archive Op',
+      path: '/tmp/wt-archive-op',
+      archived: true,
+      board_id: 'board-a',
+    } as never);
+    boardObjectsService.findByBranchId.mockResolvedValue({
+      object_id: 'obj-branch',
+      zone_id: 'zone-review',
+    });
+
+    await service.archiveOrDelete(
+      branchId,
+      { metadataAction: 'archive', filesystemAction: 'preserved' },
+      { user: { user_id: userId } } as never
+    );
+
+    expect(sessionsService.find).toHaveBeenCalledWith({
+      query: { branch_id: branchId, $limit: 1000 },
+      paginate: false,
+    });
+    expect(boardObjectsService.findByBranchId).not.toHaveBeenCalled();
+    expect(boardObjectsService.patch).not.toHaveBeenCalled();
+  });
+});
+
 describe('BranchesService.find zone filtering', () => {
   it('applies zone_id before pagination', async () => {
     const branch1 = { branch_id: 'branch-1', name: 'outside', board_id: 'board-1' };

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1061,13 +1061,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
       console.log(`✅ Archived branch ${branch.name} and ${sessions.length} session(s)`);
 
-      // Clear zone_id on the board entity so archived branches don't move with zones
-      const boardObjectsService = this.getBoardObjectsService();
-      const boardEntity = await boardObjectsService.findByBranchId(id);
-      if (boardEntity?.zone_id) {
-        await boardObjectsService.patch(boardEntity.object_id, { zone_id: null });
-      }
-
       return archivedBranch;
     } else {
       // Delete: Hard delete (CASCADE will remove sessions, messages, tasks)

--- a/apps/agor-docs/pages/guide/architecture.mdx
+++ b/apps/agor-docs/pages/guide/architecture.mdx
@@ -383,11 +383,12 @@ $ agor session list | grep running | wc -l
 | `agor_branches_list` | List branches, including zone metadata and optional zone filtering | `{ limit: 10, zoneId: 'zone-review' }` |
 | `agor_branches_create` | Create a branch with optional issue/PR links | `{ repoId: '019a...', branchName: 'feat-x', issueUrl: 'https://...' }` |
 | `agor_branches_update` | Update branch metadata (issue/PR URLs, notes) | `{ branchId: '019a...', pullRequestUrl: 'https://...', notes: 'Ready for review' }` |
+| `agor_branches_set_zone` | Pin a branch to a board zone, or clear its zone pin with `zoneId: null` | `{ branchId: '019a...', zoneId: null }` |
 
 **Board Tools:**
 | Tool | Description | Example |
 |------|-------------|---------|
-| `agor_boards_get` | Get board metadata/canvas objects; filter to zones or paginated entities for large boards | `{ boardId: '...', objectTypes: ['zone'], includeEntities: true, entityZoneId: 'zone-review', entitiesLimit: 25 }` |
+| `agor_boards_get` | Get board metadata/canvas objects; filter to zones or paginated active entities for large boards (`includeArchived: true` opts archived branch entities back in) | `{ boardId: '...', objectTypes: ['zone'], includeEntities: true, entityZoneId: 'zone-review', entitiesLimit: 25 }` |
 | `agor_boards_list` | List all boards | `{}` |
 
 **Task Tools:**


### PR DESCRIPTION
## Summary

Fixes #1400 by making zone entity reads archive-aware without mutating archived branch placement state.

- `agor_boards_get(includeEntities: true)` now excludes archived branch entities by default
- adds `includeArchived: true` to opt back into the legacy behavior
- preserves card entities while filtering archived branches
- allows `agor_branches_set_zone` to clear a branch's zone pin explicitly with `zoneId: null`
- keeps archive/unarchive placement state intact so an unarchived branch can return to its prior zone

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts src/mcp/tools/boards.test.ts src/mcp/tools/branches.test.ts`
- `git diff --check`

## Notes

`pnpm i` completed successfully, though the install log included a `node-pty` native rebuild warning because `make` is not available in this environment. The package install still exited 0 and subsequent checks/tests passed.
