### PR TITLE
feat(ui): collapsible panel caret — fold/unfold assistant panel from within

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1185,7 +1185,7 @@ export const App: React.FC<AppProps> = ({
                 >
                   {currentBoard && (
                     <Tooltip
-                      title={leftPanelCollapsed ? 'Open side panel' : 'Close side panel'}
+                      title={leftPanelCollapsed ? 'Open sidepanel' : 'Close sidepanel'}
                       placement="right"
                       getPopupContainer={() => document.body}
                     >

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -23,7 +23,7 @@ import type {
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
 import { LeftOutlined, RightOutlined } from '@ant-design/icons';
-import { Button, Layout, Upload } from 'antd';
+import { Button, Layout, Tooltip, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   type ImperativePanelHandle,
@@ -1184,35 +1184,41 @@ export const App: React.FC<AppProps> = ({
                   }}
                 >
                   {currentBoard && (
-                    <Button
-                      type="default"
-                      size="small"
-                      shape="circle"
-                      icon={
-                        leftPanelCollapsed ? (
-                          <RightOutlined style={{ fontSize: 10 }} />
-                        ) : (
-                          <LeftOutlined style={{ fontSize: 10 }} />
-                        )
-                      }
-                      onClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
-                      style={{
-                        position: 'absolute',
-                        top: '50%',
-                        left: '50%',
-                        transform: 'translate(-50%, -50%)',
-                        width: 20,
-                        height: 20,
-                        minWidth: 20,
-                        padding: 0,
-                        pointerEvents: 'auto',
-                        boxShadow: '0 1px 4px rgba(0,0,0,0.18)',
-                        zIndex: 10,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    />
+                    <Tooltip
+                      title={leftPanelCollapsed ? 'Open side panel' : 'Close side panel'}
+                      placement="right"
+                      getPopupContainer={() => document.body}
+                    >
+                      <Button
+                        type="default"
+                        size="small"
+                        shape="circle"
+                        icon={
+                          leftPanelCollapsed ? (
+                            <RightOutlined style={{ fontSize: 10 }} />
+                          ) : (
+                            <LeftOutlined style={{ fontSize: 10 }} />
+                          )
+                        }
+                        onClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
+                        style={{
+                          position: 'absolute',
+                          top: '50%',
+                          left: '50%',
+                          transform: 'translate(-50%, -50%)',
+                          width: 20,
+                          height: 20,
+                          minWidth: 20,
+                          padding: 0,
+                          pointerEvents: 'auto',
+                          boxShadow: '0 1px 4px rgba(0,0,0,0.18)',
+                          zIndex: 10,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      />
+                    </Tooltip>
                   )}
                 </PanelResizeHandle>
                 <Panel

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -22,7 +22,8 @@ import type {
   User,
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
-import { Layout, Upload } from 'antd';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+import { Button, Layout, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   type ImperativePanelHandle,
@@ -1151,16 +1152,20 @@ export const App: React.FC<AppProps> = ({
                       onDeleteComment={onDeleteComment}
                       hoveredCommentId={hoveredCommentId}
                       selectedCommentId={selectedCommentId}
+                      onCollapse={() => setCommentsPanelCollapsed(true)}
                     />
                   )}
                 </Panel>
                 <PanelResizeHandle
                   style={{
+                    position: 'relative',
                     width: leftPanelCollapsed ? '0px' : '4px',
                     background: 'var(--ant-color-border-secondary)',
                     cursor: leftPanelCollapsed ? 'default' : 'col-resize',
                     transition: 'background 0.2s',
                     pointerEvents: leftPanelCollapsed ? 'none' : 'auto',
+                    overflow: 'visible',
+                    zIndex: 10,
                   }}
                   onDragging={(isDragging) => {
                     leftPanelResizeDraggingRef.current = isDragging;
@@ -1177,7 +1182,39 @@ export const App: React.FC<AppProps> = ({
                         'var(--ant-color-border-secondary)';
                     }
                   }}
-                />
+                >
+                  {currentBoard && (
+                    <Button
+                      type="default"
+                      size="small"
+                      shape="circle"
+                      icon={
+                        leftPanelCollapsed ? (
+                          <RightOutlined style={{ fontSize: 10 }} />
+                        ) : (
+                          <LeftOutlined style={{ fontSize: 10 }} />
+                        )
+                      }
+                      onClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
+                      style={{
+                        position: 'absolute',
+                        top: '50%',
+                        left: '50%',
+                        transform: 'translate(-50%, -50%)',
+                        width: 20,
+                        height: 20,
+                        minWidth: 20,
+                        padding: 0,
+                        pointerEvents: 'auto',
+                        boxShadow: '0 1px 4px rgba(0,0,0,0.18)',
+                        zIndex: 10,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    />
+                  )}
+                </PanelResizeHandle>
                 <Panel
                   id="content-panel"
                   order={2}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -14,7 +14,6 @@ import {
   CommentOutlined,
   QuestionCircleOutlined,
   SettingOutlined,
-  UnorderedListOutlined,
 } from '@ant-design/icons';
 import { Badge, Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { useHref, useNavigate } from 'react-router-dom';
@@ -120,7 +119,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   currentUserId,
   connected = false,
   connecting = false,
-  onMenuClick,
   onCommentsClick,
   onEventStreamClick,
   onSettingsClick,
@@ -228,17 +226,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             RecentBoardPills, theme, external doc link, presence display)
             stays fully alive — those never depend on the daemon.
             See docs/disconnected-state-design.md. */}
-        {currentBoardName && (
-          <Tooltip title="Toggle board panel" placement="bottom">
-            <Button
-              type="text"
-              icon={<UnorderedListOutlined style={{ fontSize: token.fontSizeLG }} />}
-              style={headerIconButtonStyle}
-              onClick={onMenuClick}
-              disabled={mutationDisabled}
-            />
-          </Tooltip>
-        )}
         <div style={{ minWidth: 200 }}>
           <BoardSwitcher
             boards={boards}

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -10,7 +10,7 @@ import type {
   User,
 } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
-import { RobotOutlined } from '@ant-design/icons';
+import { LeftOutlined, RobotOutlined } from '@ant-design/icons';
 import {
   Alert,
   App as AntApp,
@@ -20,6 +20,7 @@ import {
   Space,
   Spin,
   Tabs,
+  Tooltip,
   Typography,
   theme,
 } from 'antd';
@@ -77,6 +78,7 @@ interface BoardAssistantPanelProps {
   onDeleteComment?: (commentId: string) => void;
   hoveredCommentId?: string | null;
   selectedCommentId?: string | null;
+  onCollapse?: () => void;
   client: AgorClient | null;
 }
 
@@ -108,6 +110,7 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
   onDeleteComment,
   hoveredCommentId,
   selectedCommentId,
+  onCollapse,
   client,
 }) => {
   const { token } = theme.useToken();
@@ -432,6 +435,19 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
         ]}
         style={{ height: '100%' }}
         tabBarStyle={{ margin: 0, padding: '0 12px' }}
+        tabBarExtraContent={{
+          right: onCollapse ? (
+            <Tooltip title="Collapse panel" placement="bottom">
+              <Button
+                type="text"
+                size="small"
+                icon={<LeftOutlined style={{ fontSize: 11 }} />}
+                onClick={onCollapse}
+                style={{ marginRight: 4 }}
+              />
+            </Tooltip>
+          ) : undefined,
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## What changed

The left assistant panel (Assistant / All Sessions / Comments) was previously toggled via a navbar button using the `UnorderedListOutlined` icon — the same icon used for Sessions elsewhere in the UI. This caused real confusion: it wasn't clear what the button did, and it was easy to miss.

This PR replaces that pattern with two clean, discoverable affordances:

### 1. Collapse button inside the panel
A small `←` caret appears in the right corner of the panel's tab bar. It lives *with* the content it controls, which is the standard mental model users expect.

### 2. Floating edge toggle on the panel border
A 20px circle button sits on the resize handle between the panel and the canvas:
- **When expanded** → shows `←`, click to collapse
- **When collapsed** → shows `→`, click to expand (it floats just inside the canvas edge so it stays reachable)

This edge affordance is a well-established pattern (VS Code, Linear, Supabase Studio) and means there's no "lost panel" problem — users always have a visible way to re-open it.

### What was removed
The `UnorderedListOutlined` navbar button is gone. The **Comments badge** in the navbar is kept — it still serves a purpose: it shows the unread count and opens the Comments tab directly.

## Files changed

| File | What |
|---|---|
| `BoardAssistantPanel.tsx` | `onCollapse` prop + `←` button in tab bar extra content |
| `App/App.tsx` | Passes `onCollapse`, floating toggle button on the resize handle |
| `AppHeader/AppHeader.tsx` | Remove confusing `UnorderedListOutlined` toggle + its import |

## Before / After

**Before:** One unlabeled navbar button, same icon as Sessions, no in-panel affordance.
<img width="599" height="796" alt="image" src="https://github.com/user-attachments/assets/be11d548-0667-4fad-918b-2fd54e15f963" />


**After:** Collapse from within the panel. Expand from the edge. Navbar is cleaner.
<img width="599" height="796" alt="image" src="https://github.com/user-attachments/assets/b0b22f6b-23e9-430f-a258-9d807cfafa22" />
<img width="599" height="796" alt="image" src="https://github.com/user-attachments/assets/20aead0e-768d-4d31-9010-ef82167b49ba" />
