### PR TITLE
Fix MCP OAuth refresh endpoint persistence

### DIFF
--- a/apps/agor-daemon/src/oauth-cache.test.ts
+++ b/apps/agor-daemon/src/oauth-cache.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSaveToken, mockFindById, mockUpdate } = vi.hoisted(() => ({
+  mockSaveToken: vi.fn(),
+  mockFindById: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@agor/core/db', () => ({
+  UserMCPOAuthTokenRepository: function UserMCPOAuthTokenRepositoryMock() {
+    return { saveToken: mockSaveToken };
+  },
+  MCPServerRepository: function MCPServerRepositoryMock() {
+    return { findById: mockFindById, update: mockUpdate };
+  },
+}));
+
+vi.mock('@agor/core/tools/mcp/oauth-token-expiry', () => ({
+  resolveTokenExpiry: () => ({
+    expiresAt: new Date(Date.now() + 3_600_000),
+    source: 'expires_in',
+  }),
+}));
+
+import { persistOAuthToken } from './oauth-cache';
+
+describe('persistOAuthToken', () => {
+  beforeEach(() => {
+    mockSaveToken.mockReset().mockResolvedValue(undefined);
+    mockFindById.mockReset();
+    mockUpdate.mockReset().mockResolvedValue(undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('backfills a discovered token endpoint so OAuth grants can be refreshed later', async () => {
+    mockFindById.mockResolvedValue({
+      mcp_server_id: 'srv-1',
+      auth: { type: 'oauth', oauth_mode: 'per_user' },
+    });
+
+    await persistOAuthToken(
+      {} as never,
+      { access_token: 'access', expires_in: 3600, refresh_token: 'refresh' },
+      'https://mcp.example.com/mcp',
+      {
+        mcpServerId: 'srv-1',
+        userId: 'user-1',
+        oauthMode: 'per_user',
+        clientId: 'client-1',
+        tokenEndpoint: 'https://auth.example.com/oauth/token',
+      },
+      'Test'
+    );
+
+    expect(mockSaveToken).toHaveBeenCalledWith(
+      'user-1',
+      'srv-1',
+      expect.objectContaining({
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        clientId: 'client-1',
+      })
+    );
+    expect(mockUpdate).toHaveBeenCalledWith('srv-1', {
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_token_url: 'https://auth.example.com/oauth/token',
+      },
+    });
+  });
+
+  it('does not overwrite an explicitly configured token endpoint', async () => {
+    mockFindById.mockResolvedValue({
+      mcp_server_id: 'srv-1',
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_token_url: 'https://configured.example.com/token',
+      },
+    });
+
+    await persistOAuthToken(
+      {} as never,
+      { access_token: 'access', expires_in: 3600, refresh_token: 'refresh' },
+      'https://mcp.example.com/mcp',
+      {
+        mcpServerId: 'srv-1',
+        userId: 'user-1',
+        oauthMode: 'per_user',
+        clientId: 'client-1',
+        tokenEndpoint: 'https://discovered.example.com/token',
+      },
+      'Test'
+    );
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -5,7 +5,7 @@
  * Tokens are also persisted to the database for cross-process access.
  */
 
-import { UserMCPOAuthTokenRepository } from '@agor/core/db';
+import { MCPServerRepository, UserMCPOAuthTokenRepository } from '@agor/core/db';
 import { resolveTokenExpiry } from '@agor/core/tools/mcp/oauth-token-expiry';
 import type { MCPServerID, UserID } from '@agor/core/types';
 
@@ -93,6 +93,12 @@ export async function persistOAuthToken(
     clientId?: string;
     /** client_secret used for the grant (absent for public clients). */
     clientSecret?: string;
+    /**
+     * Token endpoint discovered/used for this grant. Persisted back onto the
+     * server config when it was previously blank so later refreshes do not
+     * have to guess from the MCP resource URL.
+     */
+    tokenEndpoint?: string;
   },
   logPrefix: string
 ): Promise<void> {
@@ -141,6 +147,32 @@ export async function persistOAuthToken(
     clientId: pendingFlow.clientId,
     clientSecret: pendingFlow.clientSecret,
   });
+
+  if (pendingFlow.tokenEndpoint) {
+    try {
+      const mcpServerRepo = new MCPServerRepository(db);
+      const server = await mcpServerRepo.findById(pendingFlow.mcpServerId);
+      if (server?.auth?.type === 'oauth' && !server.auth.oauth_token_url) {
+        await mcpServerRepo.update(pendingFlow.mcpServerId, {
+          auth: {
+            ...server.auth,
+            oauth_token_url: pendingFlow.tokenEndpoint,
+          },
+        });
+        console.log(
+          `[${logPrefix}] Saved discovered OAuth token endpoint for server ${pendingFlow.mcpServerId}`
+        );
+      }
+    } catch (error) {
+      // Token persistence already succeeded; do not fail the OAuth callback.
+      // The manual refresh path will still surface a typed endpoint error if
+      // this best-effort config backfill fails.
+      console.warn(
+        `[${logPrefix}] Failed to save discovered OAuth token endpoint for server ${pendingFlow.mcpServerId}:`,
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
 
   console.log(
     `[${logPrefix}] ${oauthMode === 'per_user' ? 'Per-user' : 'Shared'} token saved ` +

--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -66,6 +66,36 @@ export { oauth21TokenCache };
 // Database Token Storage
 // ============================================================================
 
+async function backfillOAuthTokenEndpoint(
+  // biome-ignore lint/suspicious/noExplicitAny: db type is complex (Drizzle instance), callers always pass the correct value
+  db: any,
+  opts: { mcpServerId: string; tokenEndpoint: string; logPrefix: string }
+): Promise<void> {
+  try {
+    const mcpServerRepo = new MCPServerRepository(db);
+    const server = await mcpServerRepo.findById(opts.mcpServerId);
+    if (server?.auth?.type === 'oauth' && !server.auth.oauth_token_url) {
+      await mcpServerRepo.update(opts.mcpServerId, {
+        auth: {
+          ...server.auth,
+          oauth_token_url: opts.tokenEndpoint,
+        },
+      });
+      console.log(
+        `[${opts.logPrefix}] Saved discovered OAuth token endpoint for server ${opts.mcpServerId}`
+      );
+    }
+  } catch (error) {
+    // Token persistence already succeeded; do not fail the OAuth callback.
+    // The manual refresh path will still surface a typed endpoint error if
+    // this best-effort config backfill fails.
+    console.warn(
+      `[${opts.logPrefix}] Failed to save discovered OAuth token endpoint for server ${opts.mcpServerId}:`,
+      error instanceof Error ? error.message : error
+    );
+  }
+}
+
 /**
  * Cache + persist an OAuth token after a successful flow completion.
  *
@@ -149,29 +179,11 @@ export async function persistOAuthToken(
   });
 
   if (pendingFlow.tokenEndpoint) {
-    try {
-      const mcpServerRepo = new MCPServerRepository(db);
-      const server = await mcpServerRepo.findById(pendingFlow.mcpServerId);
-      if (server?.auth?.type === 'oauth' && !server.auth.oauth_token_url) {
-        await mcpServerRepo.update(pendingFlow.mcpServerId, {
-          auth: {
-            ...server.auth,
-            oauth_token_url: pendingFlow.tokenEndpoint,
-          },
-        });
-        console.log(
-          `[${logPrefix}] Saved discovered OAuth token endpoint for server ${pendingFlow.mcpServerId}`
-        );
-      }
-    } catch (error) {
-      // Token persistence already succeeded; do not fail the OAuth callback.
-      // The manual refresh path will still surface a typed endpoint error if
-      // this best-effort config backfill fails.
-      console.warn(
-        `[${logPrefix}] Failed to save discovered OAuth token endpoint for server ${pendingFlow.mcpServerId}:`,
-        error instanceof Error ? error.message : error
-      );
-    }
+    await backfillOAuthTokenEndpoint(db, {
+      mcpServerId: pendingFlow.mcpServerId,
+      tokenEndpoint: pendingFlow.tokenEndpoint,
+      logPrefix,
+    });
   }
 
   console.log(

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2210,7 +2210,7 @@ async function registerMCPServices(
         );
         return {
           success: false,
-          error: err instanceof Error ? err.message : 'token_refresh_failed',
+          error: 'token_refresh_failed',
         };
       }
     },

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1354,6 +1354,7 @@ async function registerMCPServices(
             ...pendingFlow,
             clientId: pendingFlow.context.clientId,
             clientSecret: pendingFlow.context.clientSecret,
+            tokenEndpoint: pendingFlow.context.tokenEndpoint,
           },
           'OAuth Callback'
         );
@@ -1933,6 +1934,7 @@ async function registerMCPServices(
             ...pendingFlow,
             clientId: pendingFlow.context.clientId,
             clientSecret: pendingFlow.context.clientSecret,
+            tokenEndpoint: pendingFlow.context.tokenEndpoint,
           },
           'OAuth Complete'
         );
@@ -2163,9 +2165,13 @@ async function registerMCPServices(
 
       const userTokenRepo = new UserMCPOAuthTokenRepository(db);
       const mcpServerRepo = new MCPServerRepository(db);
-      const { refreshAndPersistToken, InvalidGrantError, MissingRefreshTokenError } = await import(
-        '@agor/core/tools/mcp/oauth-refresh'
-      );
+      const {
+        refreshAndPersistToken,
+        InvalidGrantError,
+        MissingRefreshTokenError,
+        MissingTokenEndpointError,
+        MissingClientIdError,
+      } = await import('@agor/core/tools/mcp/oauth-refresh');
 
       try {
         const server = await mcpServerRepo.findById(serverId);
@@ -2192,13 +2198,19 @@ async function registerMCPServices(
         if (err instanceof InvalidGrantError || err instanceof MissingRefreshTokenError) {
           return { success: false, error: 'needs_reauth' };
         }
+        if (err instanceof MissingTokenEndpointError) {
+          return { success: false, error: 'missing_token_endpoint' };
+        }
+        if (err instanceof MissingClientIdError) {
+          return { success: false, error: 'missing_client_id' };
+        }
         console.error(
           `[OAuth Refresh] ${serverId}:`,
-          err instanceof Error ? err.name : 'unknown_error'
+          err instanceof Error ? `${err.name}: ${err.message}` : 'unknown_error'
         );
         return {
           success: false,
-          error: 'unknown_error',
+          error: err instanceof Error ? err.message : 'token_refresh_failed',
         };
       }
     },

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -51,6 +51,8 @@ function formatRefreshError(error?: string): string {
       );
     case 'needs_reauth':
       return 'refresh token is no longer valid — sign in again';
+    case 'token_refresh_failed':
+      return 'provider token refresh failed — try again, or sign in again if it keeps failing';
     default:
       return error || 'unknown error';
   }

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -37,6 +37,25 @@ function formatExpiresIn(expiresAtMs: number): { verb: 'Expires' | 'Expired'; ph
     : { verb: 'Expired', phrase: `${value} ago` };
 }
 
+function formatRefreshError(error?: string): string {
+  switch (error) {
+    case 'missing_token_endpoint':
+      return (
+        'missing OAuth token endpoint — re-authenticate, or ask an admin to save the token URL ' +
+        'in this MCP server’s OAuth settings'
+      );
+    case 'missing_client_id':
+      return (
+        'missing OAuth client ID for this grant — re-authenticate, or ask an admin to check ' +
+        'the MCP server OAuth settings'
+      );
+    case 'needs_reauth':
+      return 'refresh token is no longer valid — sign in again';
+    default:
+      return error || 'unknown error';
+  }
+}
+
 /**
  * Clickable MCP server pill.
  *
@@ -120,7 +139,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
         // Fall through to full OAuth flow so the user can re-auth in one click.
         await handleOAuthClick();
       } else {
-        showError(`Refresh failed: ${result.error || 'unknown error'}`);
+        showError(`Refresh failed: ${formatRefreshError(result.error)}`);
       }
     } catch (err) {
       showError(`Refresh error: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -134,8 +134,8 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
             ? `${server.display_name || server.name} refreshed — expires ${formatExpiresIn(result.expires_at).phrase}`
             : `${server.display_name || server.name} refreshed`
         );
-      } else if (result.error === 'needs_reauth') {
-        showWarning('Refresh token is no longer valid — sign in again.');
+      } else if (result.error === 'needs_reauth' || result.error === 'missing_client_id') {
+        showWarning(formatRefreshError(result.error));
         // Fall through to full OAuth flow so the user can re-auth in one click.
         await handleOAuthClick();
       } else {

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -13,6 +13,7 @@ import {
   __refreshMutexSizeForTests,
   __resetRefreshMutexForTests,
   InvalidGrantError,
+  MissingClientIdError,
   MissingRefreshTokenError,
   MissingTokenEndpointError,
   needsRefresh,
@@ -454,6 +455,32 @@ describe('refreshAndPersistToken', () => {
     // Pre-registered with secret → Basic auth
     const expectedAuth = `Basic ${Buffer.from('admin-preregistered:admin-secret').toString('base64')}`;
     expect(init.headers.Authorization).toBe(expectedAuth);
+  });
+
+  it('throws MissingClientIdError when neither token row nor server config has client_id', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: undefined,
+      oauth_client_secret: undefined,
+    });
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_token_url: 'https://auth.example.com/token' },
+    });
+    globalThis.fetch = vi.fn() as unknown as typeof globalThis.fetch;
+
+    await expect(
+      refreshAndPersistToken({
+        db: {} as any,
+        userId: USER_ID,
+        mcpServerId: SERVER_ID,
+      })
+    ).rejects.toBeInstanceOf(MissingClientIdError);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it('mutex: concurrent refreshes for same key collapse to ONE HTTP call', async () => {

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -57,6 +57,16 @@ export class MissingTokenEndpointError extends Error {
   }
 }
 
+export class MissingClientIdError extends Error {
+  readonly code = 'missing_client_id';
+  constructor(
+    message: string = 'Cannot refresh OAuth token: no client_id available for this grant'
+  ) {
+    super(message);
+    this.name = 'MissingClientIdError';
+  }
+}
+
 export interface RefreshMCPTokenOptions {
   tokenEndpoint: string;
   refreshToken: string;
@@ -262,7 +272,7 @@ export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promi
     const clientSecret = row.oauth_client_secret ?? serverAuth?.oauth_client_secret;
 
     if (!clientId) {
-      throw new Error(
+      throw new MissingClientIdError(
         `Cannot refresh OAuth token: no client_id available for server ${deps.mcpServerId}`
       );
     }


### PR DESCRIPTION
## Summary

- Persist the OAuth token endpoint discovered during MCP OAuth auth so later refreshes do not have to infer it from the MCP resource URL.
- Map refresh failures like missing token endpoint/client ID to actionable UI/backend error codes instead of `unknown_error`.
- Add regression coverage for token-endpoint backfill and missing-client-ID refresh failures.

## Root cause

The OAuth authorization flow already had the provider token endpoint in `pendingFlow.context.tokenEndpoint`, but token persistence only saved access/refresh tokens and client credentials. Refresh later fell back to `server.auth.oauth_token_url` or inference from the MCP URL. Providers such as Fellow can use an authorization server/token endpoint that is not inferable from the MCP resource URL, causing refresh to fail and surface as `unknown_error`.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/tools/mcp/oauth-refresh.test.ts`
- `pnpm --filter @agor/daemon test -- src/oauth-cache.test.ts`
