### PR TITLE
Fix MCP server resolution and per-prompt user attribution

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -720,7 +720,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     app,
     '/sessions/:id/genealogy',
     {
-      async find(_data: unknown, params: RouteParams) {
+      async find(params: RouteParams) {
         const id = params.route?.id;
         if (!id) throw new Error('Session ID required');
         return sessionsService.getGenealogy(id, params);
@@ -2767,7 +2767,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     app,
     '/branches/:id/health',
     {
-      async find(_data: unknown, params: RouteParams) {
+      async find(params: RouteParams) {
         const id = params.route?.id;
         if (!id) throw new Error('Branch ID required');
         return branchesService.checkHealth(id as import('@agor/core/types').BranchID, params);
@@ -3127,7 +3127,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       app,
       '/sessions/:id/mcp-servers',
       {
-        async find(_data: unknown, params: RouteParams) {
+        async find(params: RouteParams) {
           const id = params.route?.id;
           if (!id) throw new Error('Session ID required');
           await requireSessionScopedConfigOwnerOrAdmin(id, params);
@@ -3342,7 +3342,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     {
       // GET returns the selected env var names as a plain `string[]` — both
       // the comment above and the UI consumer expect names, not full rows.
-      async find(_data: unknown, params: RouteParams): Promise<string[]> {
+      async find(params: RouteParams): Promise<string[]> {
         const id = params.route?.id;
         if (!id) throw new BadRequest('Session ID required');
         // Read permission: session creator OR admin (no branch tier).

--- a/packages/executor/src/sdk-handlers/base/context-user.test.ts
+++ b/packages/executor/src/sdk-handlers/base/context-user.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskID } from '../../types.js';
+import { resolveContextUserId } from './context-user';
+
+describe('resolveContextUserId', () => {
+  it('prefers the task creator over the session owner', async () => {
+    const tasksService = { get: vi.fn().mockResolvedValue({ created_by: 'prompter' }) };
+
+    const result = await resolveContextUserId({
+      session: { created_by: 'owner' },
+      taskId: 'task-1' as TaskID,
+      tasksService: tasksService as never,
+    });
+
+    expect(tasksService.get).toHaveBeenCalledWith('task-1');
+    expect(result).toBe('prompter');
+  });
+
+  it('falls back to the session owner when there is no task id', async () => {
+    const tasksService = { get: vi.fn() };
+
+    const result = await resolveContextUserId({
+      session: { created_by: 'owner' },
+      tasksService: tasksService as never,
+    });
+
+    expect(tasksService.get).not.toHaveBeenCalled();
+    expect(result).toBe('owner');
+  });
+
+  it('falls back to the session owner when the task lookup throws', async () => {
+    const tasksService = { get: vi.fn().mockRejectedValue(new Error('not found')) };
+
+    const result = await resolveContextUserId({
+      session: { created_by: 'owner' },
+      taskId: 'task-1' as TaskID,
+      tasksService: tasksService as never,
+    });
+
+    expect(result).toBe('owner');
+  });
+
+  it('falls back to the session owner when the task has no creator', async () => {
+    const tasksService = { get: vi.fn().mockResolvedValue({ created_by: null }) };
+
+    const result = await resolveContextUserId({
+      session: { created_by: 'owner' },
+      taskId: 'task-1' as TaskID,
+      tasksService: tasksService as never,
+    });
+
+    expect(result).toBe('owner');
+  });
+
+  it('returns undefined when neither task creator nor session owner is known', async () => {
+    const result = await resolveContextUserId({
+      session: { created_by: null },
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/executor/src/sdk-handlers/base/context-user.ts
+++ b/packages/executor/src/sdk-handlers/base/context-user.ts
@@ -1,0 +1,53 @@
+/**
+ * Context User Resolution
+ *
+ * Shared logic for deciding which user a prompt executes "as" — used for
+ * per-user OAuth token injection, API keys, and environment variables.
+ *
+ * A session can be prompted by multiple users over its lifetime: each Task is
+ * a distinct prompt that may come from a different user. Credentials must
+ * attribute to the user who issued the CURRENT prompt (the task creator), not
+ * the session owner. We fall back to the session owner when the task lookup is
+ * unavailable (no task id, no tasks service, or a failed fetch).
+ *
+ * All SDK handlers (Claude, Codex, Gemini) resolve context this way so the
+ * behavior cannot drift between agents.
+ */
+
+import type { TaskID, UserID } from '../../types.js';
+import type { TasksService } from './service-clients.js';
+
+export interface ResolveContextUserParams {
+  /** The session being prompted (only `created_by` is read). */
+  session: { created_by?: string | null };
+  /** The task representing the current prompt, if known. */
+  taskId?: TaskID;
+  /** Service used to look up the task's creator. */
+  tasksService?: TasksService;
+}
+
+/**
+ * Resolve the user whose credentials/context a prompt should run under.
+ *
+ * Priority: task creator (the prompter) > session owner (fallback).
+ */
+export async function resolveContextUserId(
+  params: ResolveContextUserParams
+): Promise<UserID | undefined> {
+  const { session, taskId, tasksService } = params;
+
+  let contextUserId = (session.created_by ?? undefined) as UserID | undefined;
+
+  if (taskId && tasksService) {
+    try {
+      const task = await tasksService.get(taskId);
+      if (task?.created_by) {
+        contextUserId = task.created_by as UserID;
+      }
+    } catch {
+      // Fall back to the session owner if the task lookup fails.
+    }
+  }
+
+  return contextUserId;
+}

--- a/packages/executor/src/sdk-handlers/base/index.ts
+++ b/packages/executor/src/sdk-handlers/base/index.ts
@@ -6,6 +6,7 @@
 
 // Re-export normalizer factory from parent directory for convenience
 export { normalizeRawSdkResponse } from '../normalizer-factory.js';
+export * from './context-user.js';
 export * from './mcp-scoping.js';
 export * from './model-recording.js';
 export * from './normalizer.interface.js';

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -28,7 +28,8 @@ import type {
   UsersRepository,
 } from '../../db/feathers-repositories.js';
 import type { PermissionService } from '../../permissions/permission-service.js';
-import type { MCPServersConfig, SessionID, TaskID, UserID } from '../../types.js';
+import type { MCPServersConfig, SessionID, TaskID } from '../../types.js';
+import { resolveContextUserId } from '../base/context-user.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { CLAUDE_CODE_DISALLOWED_TOOLS } from './constants.js';
@@ -162,25 +163,14 @@ export async function setupQuery(
     throw new Error(`Session not found: ${sessionId}`);
   }
 
-  // Determine which user's context to use for environment variables and API keys
-  // Priority: task creator (if task exists) > session owner (fallback)
-  let contextUserId = session.created_by as UserID | undefined;
-  console.log(
-    `[Query Builder] Initial contextUserId from session.created_by: ${contextUserId || 'NOT SET'}`
-  );
-
-  if (taskId && deps.tasksService) {
-    try {
-      const task = await deps.tasksService.get(taskId);
-      if (task?.created_by) {
-        contextUserId = task.created_by as UserID;
-        console.log(`[Query Builder] Updated contextUserId from task.created_by: ${contextUserId}`);
-      }
-    } catch (_err) {
-      // Fall back to session owner if task not found
-    }
-  }
-  console.log(`[Query Builder] Final contextUserId: ${contextUserId || 'NOT SET'}`);
+  // Determine which user's context to use for environment variables and API
+  // keys: the task creator (prompter) when known, else the session owner.
+  const contextUserId = await resolveContextUserId({
+    session,
+    taskId,
+    tasksService: deps.tasksService,
+  });
+  console.log(`[Query Builder] Resolved contextUserId: ${contextUserId || 'NOT SET'}`);
 
   // Determine model to use (session config or default)
   // Models may include [1m] suffix for extended context — strip it for SDK and add beta flag

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -116,7 +116,8 @@ export class CodexTool implements ITool {
         apiKey,
         mcpServerRepo,
         usersRepo,
-        useNativeAuth ?? false
+        useNativeAuth ?? false,
+        tasksService
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -46,6 +46,7 @@ import type {
 } from '../../db/feathers-repositories.js';
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
+import { resolveContextUserId } from '../base/context-user.js';
 import type { TasksService } from '../base/index.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { forkCodexThreadViaAppServer } from './app-server-client.js';
@@ -896,22 +897,12 @@ export class CodexPromptService {
     }
 
     // forUserId enables per-user OAuth token injection at the MCP scoping
-    // layer — mirrors Claude's contextUserId pattern so personal OAuth-
-    // protected MCP servers work for Codex too. Prefer the task creator (the
-    // user who issued THIS prompt) over the session owner, since a session can
-    // be prompted by multiple users and credentials must attribute to the
-    // prompter.
-    let forUserId = (session.created_by ?? undefined) as UserID | undefined;
-    if (taskId && this.tasksService) {
-      try {
-        const task = await this.tasksService.get(taskId);
-        if (task?.created_by) {
-          forUserId = task.created_by as UserID;
-        }
-      } catch {
-        // Fall back to session owner if task lookup fails.
-      }
-    }
+    // layer — the task creator (prompter) when known, else the session owner.
+    const forUserId = await resolveContextUserId({
+      session,
+      taskId,
+      tasksService: this.tasksService,
+    });
     const { servers: mcpServersConfig, total: mcpServerCount } = await this.buildMcpServersConfig(
       sessionId,
       mcpToken,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -46,6 +46,7 @@ import type {
 } from '../../db/feathers-repositories.js';
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
+import type { TasksService } from '../base/index.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { forkCodexThreadViaAppServer } from './app-server-client.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
@@ -205,7 +206,8 @@ export class CodexPromptService {
     apiKey?: string,
     private mcpServerRepo?: MCPServerRepository,
     private usersRepo?: UsersRepository,
-    useNativeAuth: boolean = false
+    useNativeAuth: boolean = false,
+    private tasksService?: TasksService
   ) {
     // Store API key from base-executor (already resolved with proper precedence)
     this.apiKey = apiKey || '';
@@ -895,8 +897,21 @@ export class CodexPromptService {
 
     // forUserId enables per-user OAuth token injection at the MCP scoping
     // layer — mirrors Claude's contextUserId pattern so personal OAuth-
-    // protected MCP servers work for Codex too.
-    const forUserId = (session.created_by ?? undefined) as UserID | undefined;
+    // protected MCP servers work for Codex too. Prefer the task creator (the
+    // user who issued THIS prompt) over the session owner, since a session can
+    // be prompted by multiple users and credentials must attribute to the
+    // prompter.
+    let forUserId = (session.created_by ?? undefined) as UserID | undefined;
+    if (taskId && this.tasksService) {
+      try {
+        const task = await this.tasksService.get(taskId);
+        if (task?.created_by) {
+          forUserId = task.created_by as UserID;
+        }
+      } catch {
+        // Fall back to session owner if task lookup fails.
+      }
+    }
     const { servers: mcpServersConfig, total: mcpServerCount } = await this.buildMcpServersConfig(
       sessionId,
       mcpToken,

--- a/packages/executor/src/sdk-handlers/gemini/gemini-tool.ts
+++ b/packages/executor/src/sdk-handlers/gemini/gemini-tool.ts
@@ -85,7 +85,8 @@ export class GeminiTool implements ITool {
         sessionMCPRepo,
         mcpEnabled,
         useNativeAuth,
-        usersRepo
+        usersRepo,
+        this.tasksService
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -35,6 +35,7 @@ import type {
 } from '../../db/feathers-repositories.js';
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
+import { resolveContextUserId } from '../base/context-user.js';
 import type { TasksService } from '../base/index.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { convertConversationToHistory } from './conversation-converter.js';
@@ -140,21 +141,13 @@ export class GeminiPromptService {
       throw new Error(`Session ${sessionId} not found`);
     }
 
-    // Context user for per-user OAuth/API-key resolution. Prefer the task
-    // creator (the user who issued THIS prompt) over the session owner, since
-    // a session can be prompted by multiple users and credentials must
-    // attribute to the prompter.
-    let contextUserId = session.created_by as UserID | undefined;
-    if (taskId && this.tasksService) {
-      try {
-        const task = await this.tasksService.get(taskId);
-        if (task?.created_by) {
-          contextUserId = task.created_by as UserID;
-        }
-      } catch {
-        // Fall back to session owner if task lookup fails.
-      }
-    }
+    // Context user for per-user OAuth/API-key resolution — the task creator
+    // (prompter) when known, else the session owner.
+    const contextUserId = await resolveContextUserId({
+      session,
+      taskId,
+      tasksService: this.tasksService,
+    });
 
     // Get or create Gemini client for this session
     const client = await this.getOrCreateClient(sessionId, permissionMode, contextUserId);
@@ -559,7 +552,7 @@ export class GeminiPromptService {
   private async getOrCreateClient(
     sessionId: SessionID,
     permissionMode?: PermissionMode,
-    contextUserId?: import('../../types').UserID
+    contextUserId?: UserID
   ): Promise<InstanceType<typeof Gemini.GeminiClient>> {
     // Resolve per-user API key FIRST, before checking for existing client
     // This ensures we use the correct key even when reusing a cached client
@@ -724,10 +717,12 @@ export class GeminiPromptService {
     // Fetch user-configured MCP servers
     if (this.sessionMCPRepo && this.mcpServerRepo) {
       try {
-        // Use shared MCP scoping utility
+        // Use shared MCP scoping utility. forUserId injects the prompter's
+        // per-user OAuth tokens for personal OAuth-protected MCP servers.
         const serversWithSource = await getMcpServersForSession(sessionId, {
           sessionMCPRepo: this.sessionMCPRepo,
           mcpServerRepo: this.mcpServerRepo,
+          forUserId: contextUserId,
         });
 
         // Convert to Gemini SDK format

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -35,6 +35,7 @@ import type {
 } from '../../db/feathers-repositories.js';
 import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
+import type { TasksService } from '../base/index.js';
 import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { convertConversationToHistory } from './conversation-converter.js';
 import { DEFAULT_GEMINI_MODEL, type GeminiModel } from './models.js';
@@ -111,7 +112,8 @@ export class GeminiPromptService {
     private sessionMCPRepo?: SessionMCPServerRepository,
     private mcpEnabled?: boolean,
     useNativeAuth?: boolean, // Flag from base-executor indicating OAuth should be used
-    private usersRepo?: UsersRepository
+    private usersRepo?: UsersRepository,
+    private tasksService?: TasksService
   ) {
     this.apiKey = apiKey;
     this.useNativeAuth = useNativeAuth ?? false; // Default to false if not provided
@@ -138,8 +140,21 @@ export class GeminiPromptService {
       throw new Error(`Session ${sessionId} not found`);
     }
 
-    // Use session owner as context user (API key resolution happens in base-executor)
-    const contextUserId = session.created_by as UserID | undefined;
+    // Context user for per-user OAuth/API-key resolution. Prefer the task
+    // creator (the user who issued THIS prompt) over the session owner, since
+    // a session can be prompted by multiple users and credentials must
+    // attribute to the prompter.
+    let contextUserId = session.created_by as UserID | undefined;
+    if (taskId && this.tasksService) {
+      try {
+        const task = await this.tasksService.get(taskId);
+        if (task?.created_by) {
+          contextUserId = task.created_by as UserID;
+        }
+      } catch {
+        // Fall back to session owner if task lookup fails.
+      }
+    }
 
     // Get or create Gemini client for this session
     const client = await this.getOrCreateClient(sessionId, permissionMode, contextUserId);


### PR DESCRIPTION
## Summary

Two related fixes for session-assigned MCP servers (e.g. **Fellow**) silently failing to show up for agents, plus correcting which user identity per-prompt OAuth resolution attributes to.

### 1. Broken Feathers custom-route `find` signature dropped MCP servers

Four daemon custom routes declared their handler as `async find(_data, params)`. Feathers invokes custom-route `find` with a **single** argument (`find(params)`), so `params` was `undefined` and the handlers threw on `params.route?.id`.

The most damaging case was `/sessions/:id/mcp-servers`: when it threw, the executor's `getMcpServersForSession` caught the error and returned an **empty list**, silently dropping *every* resolved MCP server for the session — including OAuth-backed ones like Fellow. This regressed when MCP resolution was routed through the custom route.

Fixed handlers:
- `/sessions/:id/mcp-servers`
- `/sessions/:id/genealogy`
- `/branches/:id/health`
- `/sessions/:id/env-selections`

### 2. Per-prompt user attribution uses `task.created_by`, not `session.created_by`

A session can be prompted by multiple users — each Task is a distinct prompt that may come from a different user. The Codex and Gemini prompt services resolved the per-user OAuth/credential context from `session.created_by` (the session owner), so if user A prompted user B's session, MCP OAuth tokens resolved as B instead of A.

Both now prefer `task.created_by` (the prompter) and fall back to the session owner when the task lookup is unavailable — matching Claude's existing behavior in `query-builder.ts`. The daemon-side executor-session JWT already attributes to the prompter (`sub = prompting user`), so this closes the executor-side gap.

## Test plan

- [x] `pnpm i`
- [x] `pnpm check` (typecheck + lint + shortid + build) — green
- [x] Codex + Gemini `prompt-service` test suites — 39/39 passing
- [ ] Validate end-to-end in a docker env (session MCP servers resolve; cross-user prompt attributes to prompter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)