### PR TITLE
Fix global facepile presence on home

### DIFF
--- a/apps/agor-ui/src/hooks/usePresence.test.tsx
+++ b/apps/agor-ui/src/hooks/usePresence.test.tsx
@@ -1,4 +1,4 @@
-import type { CursorMovedEvent, PresenceUpdatedEvent, User } from '@agor-live/client';
+import type { BoardID, CursorMovedEvent, PresenceUpdatedEvent, User } from '@agor-live/client';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { usePresence } from './usePresence';
@@ -42,6 +42,10 @@ function makeUser(overrides: Partial<User> = {}): User {
   } as User;
 }
 
+function boardId(value: string): BoardID {
+  return value as BoardID;
+}
+
 describe('usePresence', () => {
   it('ignores cursor events for other boards without re-rendering board-scoped consumers', () => {
     const { client, emit } = makeMockClient();
@@ -52,7 +56,7 @@ describe('usePresence', () => {
       renders += 1;
       return usePresence({
         client,
-        boardId: 'board-a' as never,
+        boardId: boardId('board-a'),
         users,
       });
     });
@@ -63,7 +67,7 @@ describe('usePresence', () => {
     act(() => {
       emit('cursor-moved', {
         userId: 'user-1',
-        boardId: 'board-b',
+        boardId: boardId('board-b'),
         x: 120,
         y: 80,
         timestamp: 1_000,
@@ -83,7 +87,7 @@ describe('usePresence', () => {
     const { result } = renderHook(() => {
       return usePresence({
         client,
-        boardId: 'board-a' as never,
+        boardId: boardId('board-a'),
         users,
         globalPresence: true,
         presenceMinUpdateIntervalMs: 10_000,
@@ -93,7 +97,7 @@ describe('usePresence', () => {
     act(() => {
       emit('presence-updated', {
         userId: 'user-1',
-        boardId: 'board-b',
+        boardId: boardId('board-b'),
         timestamp: 1_000,
       } satisfies PresenceUpdatedEvent);
     });
@@ -103,14 +107,14 @@ describe('usePresence', () => {
     act(() => {
       emit('presence-updated', {
         userId: 'user-1',
-        boardId: 'board-b',
+        boardId: boardId('board-b'),
         timestamp: 5_000,
       } satisfies PresenceUpdatedEvent);
     });
 
     expect(result.current.activeUsers).toBe(firstActiveUsers);
     expect(result.current.activeUsers[0]).toMatchObject({
-      boardId: 'board-b',
+      boardId: boardId('board-b'),
       lastSeen: 1_000,
     });
     expect(result.current.activeUsers[0]?.cursor).toBeUndefined();
@@ -118,13 +122,13 @@ describe('usePresence', () => {
     act(() => {
       emit('presence-updated', {
         userId: 'user-1',
-        boardId: 'board-b',
+        boardId: boardId('board-b'),
         timestamp: 12_000,
       } satisfies PresenceUpdatedEvent);
     });
 
     expect(result.current.activeUsers[0]).toMatchObject({
-      boardId: 'board-b',
+      boardId: boardId('board-b'),
       lastSeen: 12_000,
     });
     expect(result.current.activeUsers[0]?.cursor).toBeUndefined();
@@ -135,51 +139,51 @@ describe('usePresence', () => {
     const users = [makeUser()];
 
     const { result, rerender } = renderHook(
-      ({ boardId }: { boardId: string | null }) =>
+      ({ currentBoardId }: { currentBoardId: BoardID | null }) =>
         usePresence({
           client,
-          boardId: boardId as never,
+          boardId: currentBoardId,
           users,
           globalPresence: true,
           presenceMinUpdateIntervalMs: 10_000,
         }),
       {
-        initialProps: { boardId: 'board-a' },
+        initialProps: { currentBoardId: boardId('board-a') },
       }
     );
 
     act(() => {
       emit('presence-updated', {
         userId: 'user-1',
-        boardId: 'board-b',
+        boardId: boardId('board-b'),
         timestamp: 1_000,
       } satisfies PresenceUpdatedEvent);
     });
 
     expect(result.current.activeUsers).toHaveLength(1);
     expect(result.current.activeUsers[0]).toMatchObject({
-      boardId: 'board-b',
+      boardId: boardId('board-b'),
       lastSeen: 1_000,
     });
 
-    rerender({ boardId: null });
+    rerender({ currentBoardId: null });
 
     expect(result.current.activeUsers).toHaveLength(1);
     expect(result.current.activeUsers[0]).toMatchObject({
-      boardId: 'board-b',
+      boardId: boardId('board-b'),
       lastSeen: 1_000,
     });
 
     act(() => {
       emit('presence-updated', {
         userId: 'user-1',
-        boardId: 'board-c',
+        boardId: boardId('board-c'),
         timestamp: 20_000,
       } satisfies PresenceUpdatedEvent);
     });
 
     expect(result.current.activeUsers[0]).toMatchObject({
-      boardId: 'board-c',
+      boardId: boardId('board-c'),
       lastSeen: 20_000,
     });
   });

--- a/apps/agor-ui/src/hooks/usePresence.test.tsx
+++ b/apps/agor-ui/src/hooks/usePresence.test.tsx
@@ -129,4 +129,58 @@ describe('usePresence', () => {
     });
     expect(result.current.activeUsers[0]?.cursor).toBeUndefined();
   });
+
+  it('keeps global facepile presence when the current route has no board', () => {
+    const { client, emit } = makeMockClient();
+    const users = [makeUser()];
+
+    const { result, rerender } = renderHook(
+      ({ boardId }: { boardId: string | null }) =>
+        usePresence({
+          client,
+          boardId: boardId as never,
+          users,
+          globalPresence: true,
+          presenceMinUpdateIntervalMs: 10_000,
+        }),
+      {
+        initialProps: { boardId: 'board-a' },
+      }
+    );
+
+    act(() => {
+      emit('presence-updated', {
+        userId: 'user-1',
+        boardId: 'board-b',
+        timestamp: 1_000,
+      } satisfies PresenceUpdatedEvent);
+    });
+
+    expect(result.current.activeUsers).toHaveLength(1);
+    expect(result.current.activeUsers[0]).toMatchObject({
+      boardId: 'board-b',
+      lastSeen: 1_000,
+    });
+
+    rerender({ boardId: null });
+
+    expect(result.current.activeUsers).toHaveLength(1);
+    expect(result.current.activeUsers[0]).toMatchObject({
+      boardId: 'board-b',
+      lastSeen: 1_000,
+    });
+
+    act(() => {
+      emit('presence-updated', {
+        userId: 'user-1',
+        boardId: 'board-c',
+        timestamp: 20_000,
+      } satisfies PresenceUpdatedEvent);
+    });
+
+    expect(result.current.activeUsers[0]).toMatchObject({
+      boardId: 'board-c',
+      lastSeen: 20_000,
+    });
+  });
 });

--- a/apps/agor-ui/src/hooks/usePresence.ts
+++ b/apps/agor-ui/src/hooks/usePresence.ts
@@ -26,9 +26,9 @@ interface UsePresenceOptions {
   enabled?: boolean;
   globalPresence?: boolean; // If true, track users across all boards (for navbar facepile)
   /**
-   * Optional coalescing window for presenceMap updates. When set, repeated
-   * cursor-moved events for the same user on the same board within this window
-   * are treated as no-ops for facepile state.
+   * Optional coalescing window for facepile presence updates. When set, repeated
+   * board-scoped `cursor-moved` or global `presence-updated` events for the
+   * same user on the same board within this window are treated as no-ops.
    */
   presenceMinUpdateIntervalMs?: number;
 }

--- a/apps/agor-ui/src/hooks/usePresence.ts
+++ b/apps/agor-ui/src/hooks/usePresence.ts
@@ -70,7 +70,13 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
   >(new Map());
 
   useEffect(() => {
-    if (!enabled || !client?.io || !boardId) {
+    if (!enabled || !client?.io) {
+      setCursorMap(new Map());
+      setPresenceMap(new Map());
+      return;
+    }
+
+    if (!globalPresence && !boardId) {
       setCursorMap(new Map());
       setPresenceMap(new Map());
       return;
@@ -79,7 +85,7 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
     // Handle cursor-moved events
     const handleCursorMoved = (event: CursorMovedEvent) => {
       // For cursor rendering, only track cursors for the current board
-      if (event.boardId === boardId) {
+      if (boardId && event.boardId === boardId) {
         const updateData = {
           x: event.x,
           y: event.y,
@@ -204,7 +210,7 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
     // Handle cursor-left events (user navigated away)
     const handleCursorLeft = (event: { userId: string; boardId: BoardID }) => {
       // For cursor rendering, only handle current board
-      if (event.boardId === boardId) {
+      if (boardId && event.boardId === boardId) {
         setCursorMap((prev) => {
           if (!prev.has(event.userId)) return prev; // No-op if user not tracked
           const next = new Map(prev);


### PR DESCRIPTION
## Summary

- Keep global/header facepile presence active when the current workspace route has no board (Home)
- Preserve board-scoped cursor/presence behavior for board-local consumers
- Add a regression test covering board → Home/no-board route transitions for global presence

## Root cause

The header facepile uses `usePresence({ globalPresence: true })`, but `usePresence` previously treated a missing `boardId` as disabled for all consumers. Home intentionally passes no current board, so navigating there cleared the global `presenceMap` and the facepile fell back to only the synthetic current-user entry.

## Validation

- `pnpm i`
- `pnpm check` — passed; existing Biome warnings only
- `pnpm --filter agor-ui test -- src/hooks/usePresence.test.tsx src/hooks/useBoardPresenceRoom.test.tsx`
- `git diff --check`
